### PR TITLE
feat(jazz): add writable PostgreSQL adapter and transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +131,21 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object 0.39.1",
+]
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayref"
@@ -281,7 +305,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -305,10 +329,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcder"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b593e5aeaf7992d388c08a9831c921cd703718064b3e50ba8e6d666d6cf86ca7"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
 
 [[package]]
 name = "bindgen"
@@ -499,7 +539,11 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -588,6 +632,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -872,6 +922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +993,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "diamond-types"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1043,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1129,6 +1200,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -1359,7 +1436,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1567,7 +1644,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1577,6 +1654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1712,6 +1798,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1937,6 +2047,7 @@ name = "jazz"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "async-trait",
  "axum",
  "base64 0.22.1",
  "blake3",
@@ -1962,7 +2073,9 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
+ "pgwire",
  "postcard",
+ "postgres-types",
  "rand 0.8.5",
  "rcgen",
  "reqwest",
@@ -1974,10 +2087,13 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
+ "sqlparser",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "tokio-tungstenite 0.29.0",
+ "tokio-util",
  "tower",
  "tower-http 0.5.2",
  "tracing",
@@ -2137,7 +2253,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -2160,6 +2276,29 @@ checksum = "829c74fe88dda0d2a5425b022b44921574a65c4eb78e6e39a61b40eb416a4ef8"
 dependencies = [
  "rand 0.8.5",
  "str_indices 0.4.4",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex-lite",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2232,6 +2371,15 @@ checksum = "e8cac9b2d60928163027249a1ebd0ec8e6c58b66dca93cccf58ee618e66fc062"
 dependencies = [
  "cc",
  "cmake",
+ "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
  "libc",
 ]
 
@@ -2334,6 +2482,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,7 +2569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2639,10 +2803,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
 ]
@@ -2878,6 +3069,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pg_interval"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c386dd54fce258fc04e668126ae68589a0d92e03a90ea67881d1300f70fd6170"
+dependencies = [
+ "bytes",
+ "chrono",
+ "postgres-types",
+]
+
+[[package]]
+name = "pgwire"
+version = "0.40.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19cd74bebdf81b891d097ea03cceb32bd7f29728ce66de6e0dba2e3f42c8585d"
+dependencies = [
+ "async-trait",
+ "base64 0.23.0",
+ "bytes",
+ "derive-new",
+ "futures",
+ "hex",
+ "lazy-regex",
+ "md5",
+ "pg_interval",
+ "postgres-types",
+ "rand 0.10.1",
+ "ring",
+ "rustls-pki-types",
+ "ryu",
+ "serde_json",
+ "smol_str",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "x509-certificate",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,6 +3220,37 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless",
  "serde",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "array-init",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "uuid",
 ]
 
 [[package]]
@@ -3091,6 +3373,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3296,6 +3588,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,6 +3675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,7 +3734,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3479,7 +3797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
  "bitflags 2.11.0",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -3551,6 +3869,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3863,6 +4182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,10 +4262,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
+ "recursive",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3965,6 +4313,17 @@ name = "str_stack"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -4207,6 +4566,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -4541,6 +4926,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,6 +4942,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4673,6 +5079,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4688,6 +5103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -4870,6 +5294,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4901,10 +5338,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -5164,6 +5654,25 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-certificate"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9eb9a0c822c67129d5b8fcc2806c6bc4f50496b420825069a440669bcfbf7f"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror 2.0.18",
+ "zeroize",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -219,6 +219,14 @@ impl AntiJoinState {
             keyed_join_deltas(&left_descriptor, left_on, left_delta, comparison)?;
         let keyed_right_delta =
             keyed_join_deltas(&right_descriptor, right_on, right_delta, comparison)?;
+        let left_already_advanced = update_mode == ArrangementUpdateMode::Accumulate
+            && left_arrangement.as_of() == Some(left_sub_tick);
+        let right_already_advanced = update_mode == ArrangementUpdateMode::Accumulate
+            && right_arrangement.as_of() == Some(right_sub_tick);
+        let left_delta_index =
+            left_already_advanced.then(|| build_join_delta_index(&keyed_left_delta));
+        let right_delta_index =
+            right_already_advanced.then(|| build_join_delta_index(&keyed_right_delta));
         let mut affected_keys = HashSet::<JoinKey>::default();
         let mut old_right_counts = HashMap::<JoinKey, i64>::default();
         let mut old_left_buckets = HashMap::<JoinKey, JoinBucket>::default();
@@ -226,28 +234,42 @@ impl AntiJoinState {
             for delta in &keyed_left_delta {
                 let key = &delta.key;
                 if affected_keys.insert(key.clone()) {
-                    old_right_counts.insert(key.clone(), right_arrangement.value().key_count(key));
+                    old_right_counts.insert(
+                        key.clone(),
+                        key_count_before_delta(
+                            right_arrangement.value(),
+                            right_delta_index.as_ref(),
+                            key,
+                        ),
+                    );
                     old_left_buckets.insert(
                         key.clone(),
-                        left_arrangement
-                            .value()
-                            .bucket(key)
-                            .cloned()
-                            .unwrap_or_default(),
+                        bucket_before_delta(
+                            left_arrangement.value(),
+                            left_delta_index.as_ref(),
+                            key,
+                        ),
                     );
                 }
             }
             for delta in &keyed_right_delta {
                 let key = &delta.key;
                 if affected_keys.insert(key.clone()) {
-                    old_right_counts.insert(key.clone(), right_arrangement.value().key_count(key));
+                    old_right_counts.insert(
+                        key.clone(),
+                        key_count_before_delta(
+                            right_arrangement.value(),
+                            right_delta_index.as_ref(),
+                            key,
+                        ),
+                    );
                     old_left_buckets.insert(
                         key.clone(),
-                        left_arrangement
-                            .value()
-                            .bucket(key)
-                            .cloned()
-                            .unwrap_or_default(),
+                        bucket_before_delta(
+                            left_arrangement.value(),
+                            left_delta_index.as_ref(),
+                            key,
+                        ),
                     );
                 }
             }
@@ -329,6 +351,14 @@ impl AntiJoinState {
         let keyed_left_delta = keyed_join_deltas(left_descriptor, left_on, left_delta, comparison)?;
         let keyed_right_delta =
             keyed_join_deltas(right_descriptor, right_on, right_delta, comparison)?;
+        let left_already_advanced = update_mode == ArrangementUpdateMode::Accumulate
+            && left_arrangement.as_of() == Some(left_sub_tick);
+        let right_already_advanced = update_mode == ArrangementUpdateMode::Accumulate
+            && right_arrangement.as_of() == Some(right_sub_tick);
+        let left_delta_index =
+            left_already_advanced.then(|| build_join_delta_index(&keyed_left_delta));
+        let right_delta_index =
+            right_already_advanced.then(|| build_join_delta_index(&keyed_right_delta));
         let mut affected_keys = HashSet::<JoinKey>::default();
         let mut old_right_counts = HashMap::<JoinKey, i64>::default();
         let mut old_left_buckets = HashMap::<JoinKey, JoinBucket>::default();
@@ -336,28 +366,42 @@ impl AntiJoinState {
             for delta in &keyed_left_delta {
                 let key = &delta.key;
                 if affected_keys.insert(key.clone()) {
-                    old_right_counts.insert(key.clone(), right_arrangement.value().key_count(key));
+                    old_right_counts.insert(
+                        key.clone(),
+                        key_count_before_delta(
+                            right_arrangement.value(),
+                            right_delta_index.as_ref(),
+                            key,
+                        ),
+                    );
                     old_left_buckets.insert(
                         key.clone(),
-                        left_arrangement
-                            .value()
-                            .bucket(key)
-                            .cloned()
-                            .unwrap_or_default(),
+                        bucket_before_delta(
+                            left_arrangement.value(),
+                            left_delta_index.as_ref(),
+                            key,
+                        ),
                     );
                 }
             }
             for delta in &keyed_right_delta {
                 let key = &delta.key;
                 if affected_keys.insert(key.clone()) {
-                    old_right_counts.insert(key.clone(), right_arrangement.value().key_count(key));
+                    old_right_counts.insert(
+                        key.clone(),
+                        key_count_before_delta(
+                            right_arrangement.value(),
+                            right_delta_index.as_ref(),
+                            key,
+                        ),
+                    );
                     old_left_buckets.insert(
                         key.clone(),
-                        left_arrangement
-                            .value()
-                            .bucket(key)
-                            .cloned()
-                            .unwrap_or_default(),
+                        bucket_before_delta(
+                            left_arrangement.value(),
+                            left_delta_index.as_ref(),
+                            key,
+                        ),
                     );
                 }
             }
@@ -618,6 +662,47 @@ fn build_join_delta_index(deltas: &[KeyedRecordDelta<'_>]) -> JoinIndex {
     let mut index = HashMap::default();
     apply_join_delta_to_index(&mut index, deltas);
     index
+}
+
+/// Read one arrangement bucket as it was before this tick's delta.
+///
+/// Arrangements are shared across join consumers. A sibling consumer may have
+/// already advanced the shared arrangement to `SubTick`, even though this
+/// anti/semi join still needs the old bucket to calculate its threshold
+/// transition. In that case `delta_index` contains the same input delta that
+/// was already applied, so subtracting it reconstructs the pre-tick bucket
+/// without cloning the whole arrangement or making arrangements consumer-local.
+fn bucket_before_delta(
+    arrangement: &ArrangementState,
+    delta_index: Option<&JoinIndex>,
+    key: &JoinKey,
+) -> JoinBucket {
+    let mut bucket = arrangement.bucket(key).cloned().unwrap_or_default();
+    let Some(delta_bucket) = delta_index.and_then(|index| index.get(key)) else {
+        return bucket;
+    };
+    for (record, delta_weight) in delta_bucket {
+        let previous = bucket.get(record).copied().unwrap_or_default() - delta_weight;
+        if previous == 0 {
+            bucket.remove(record);
+        } else {
+            bucket.insert(record.clone(), previous);
+        }
+    }
+    bucket
+}
+
+fn key_count_before_delta(
+    arrangement: &ArrangementState,
+    delta_index: Option<&JoinIndex>,
+    key: &JoinKey,
+) -> i64 {
+    arrangement.key_count(key)
+        - delta_index
+            .and_then(|index| index.get(key))
+            .into_iter()
+            .flat_map(|bucket| bucket.values())
+            .sum::<i64>()
 }
 
 fn keyed_join_deltas<'a>(

--- a/crates/groove/tests/anti_join_regressions.rs
+++ b/crates/groove/tests/anti_join_regressions.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeMap;
 
-use groove::db::{Database, GraphBuilder, PrimaryKeyValue};
+use groove::db::{Database, GraphBuilder, MultisinkDeltas, PredicateExpr, PrimaryKeyValue};
 use groove::records::Value;
 use groove::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema,
@@ -54,6 +54,46 @@ fn anti_join() -> GraphBuilder {
         ["artist_id"],
         ["artist_id"],
     )
+}
+
+fn assert_sink_values(deltas: &MultisinkDeltas, sinks: [&str; 2], expected: &[(Vec<Value>, i64)]) {
+    for sink in sinks {
+        assert_eq!(
+            deltas.get(sink).unwrap().to_values().unwrap(),
+            expected,
+            "unexpected delta for {sink}"
+        );
+    }
+}
+
+const SHARED_LEFT_SINKS: [&str; 2] = ["a_id_filter", "z_artist_filter"];
+
+fn shared_left_sinks(semi: bool) -> [(&'static str, GraphBuilder); 2] {
+    let left = GraphBuilder::table("albums");
+    let join = |left, right| {
+        if semi {
+            GraphBuilder::semi_join(left, right, ["artist_id"], ["artist_id"])
+        } else {
+            GraphBuilder::anti_join(left, right, ["artist_id"], ["artist_id"])
+        }
+    };
+    [
+        (
+            SHARED_LEFT_SINKS[0],
+            join(
+                left.clone(),
+                GraphBuilder::table("blockers").filter(PredicateExpr::gt("id", Value::U64(0))),
+            ),
+        ),
+        (
+            SHARED_LEFT_SINKS[1],
+            join(
+                left,
+                GraphBuilder::table("blockers")
+                    .filter(PredicateExpr::gt("artist_id", Value::U64(0))),
+            ),
+        ),
+    ]
 }
 
 #[test]
@@ -115,5 +155,217 @@ fn same_tick_left_insert_and_last_blocker_retraction_emit_once() {
             (format!("{:?}", vec![Value::U64(2), Value::U64(11)]), 1),
         ]),
         "both albums must surface with weight exactly 1"
+    );
+}
+
+#[test]
+fn shared_right_arrangement_retracts_every_anti_join_consumer() {
+    let (_dir, mut db) = open_db();
+    let right = GraphBuilder::table("blockers");
+    let sub = db
+        .subscribe([
+            (
+                "a_projected",
+                GraphBuilder::anti_join(
+                    GraphBuilder::table("albums").project(["id", "artist_id"]),
+                    right.clone(),
+                    ["artist_id"],
+                    ["artist_id"],
+                ),
+            ),
+            (
+                "z_filtered",
+                GraphBuilder::anti_join(
+                    GraphBuilder::table("albums").filter(PredicateExpr::gt("id", Value::U64(0))),
+                    right,
+                    ["artist_id"],
+                    ["artist_id"],
+                ),
+            ),
+        ])
+        .unwrap();
+    let _initial = sub.recv().unwrap();
+
+    let mut batch = db.open_batch();
+    batch.insert("albums", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+    let inserted = sub.recv().unwrap();
+    assert_eq!(
+        inserted.get("a_projected").unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(11)], 1)]
+    );
+    assert_eq!(
+        inserted.get("z_filtered").unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(11)], 1)]
+    );
+
+    let mut batch = db.open_batch();
+    batch.insert("blockers", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+    let blocked = sub.recv().unwrap();
+    for sink in ["a_projected", "z_filtered"] {
+        assert_eq!(
+            blocked.get(sink).unwrap().to_values().unwrap(),
+            [(vec![Value::U64(1), Value::U64(11)], -1)],
+            "every anti-join consumer sharing the blocker arrangement must retract"
+        );
+    }
+
+    let mut batch = db.open_batch();
+    batch.delete("blockers", PrimaryKeyValue::U64(1));
+    db.commit_batch(batch).unwrap();
+    let restored = sub.recv().unwrap();
+    for sink in ["a_projected", "z_filtered"] {
+        assert_eq!(
+            restored.get(sink).unwrap().to_values().unwrap(),
+            [(vec![Value::U64(1), Value::U64(11)], 1)],
+            "every anti-join consumer sharing the blocker arrangement must restore"
+        );
+    }
+}
+
+#[test]
+fn shared_right_arrangement_updates_every_semi_join_consumer() {
+    let (_dir, mut db) = open_db();
+    let mut batch = db.open_batch();
+    batch.insert("albums", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+
+    let right = GraphBuilder::table("blockers");
+    let sub = db
+        .subscribe([
+            (
+                "a_projected",
+                GraphBuilder::semi_join(
+                    GraphBuilder::table("albums").project(["id", "artist_id"]),
+                    right.clone(),
+                    ["artist_id"],
+                    ["artist_id"],
+                ),
+            ),
+            (
+                "z_filtered",
+                GraphBuilder::semi_join(
+                    GraphBuilder::table("albums").filter(PredicateExpr::gt("id", Value::U64(0))),
+                    right,
+                    ["artist_id"],
+                    ["artist_id"],
+                ),
+            ),
+        ])
+        .unwrap();
+    let initial = sub.recv().unwrap();
+    assert!(initial.get("a_projected").unwrap().is_empty());
+    assert!(initial.get("z_filtered").unwrap().is_empty());
+
+    let mut batch = db.open_batch();
+    batch.insert("blockers", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+    let unblocked = sub.recv().unwrap();
+    for sink in ["a_projected", "z_filtered"] {
+        assert_eq!(
+            unblocked.get(sink).unwrap().to_values().unwrap(),
+            [(vec![Value::U64(1), Value::U64(11)], 1)],
+            "every semi-join consumer sharing the blocker arrangement must update"
+        );
+    }
+
+    let mut batch = db.open_batch();
+    batch.delete("blockers", PrimaryKeyValue::U64(1));
+    db.commit_batch(batch).unwrap();
+    let blocked = sub.recv().unwrap();
+    for sink in ["a_projected", "z_filtered"] {
+        assert_eq!(
+            blocked.get(sink).unwrap().to_values().unwrap(),
+            [(vec![Value::U64(1), Value::U64(11)], -1)],
+            "every semi-join consumer sharing the blocker arrangement must retract"
+        );
+    }
+}
+
+#[test]
+fn shared_left_arrangement_updates_every_anti_join_consumer() {
+    let (_dir, mut db) = open_db();
+    let sub = db.subscribe(shared_left_sinks(false)).unwrap();
+    let _initial = sub.recv().unwrap();
+
+    let mut batch = db.open_batch();
+    batch.insert("albums", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+    let inserted = sub.recv().unwrap();
+    assert_sink_values(
+        &inserted,
+        SHARED_LEFT_SINKS,
+        &[(vec![Value::U64(1), Value::U64(11)], 1)],
+    );
+
+    // The new album is blocked on arrival, while the previously visible album
+    // retracts. A consumer must not reconstruct the shared left side as if the
+    // new album had been visible before this tick.
+    let mut batch = db.open_batch();
+    batch.insert("albums", vec![Value::U64(2), Value::U64(11)]);
+    batch.insert("blockers", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+    let blocked = sub.recv().unwrap();
+    assert_sink_values(
+        &blocked,
+        SHARED_LEFT_SINKS,
+        &[(vec![Value::U64(1), Value::U64(11)], -1)],
+    );
+
+    let mut batch = db.open_batch();
+    batch.delete("blockers", PrimaryKeyValue::U64(1));
+    batch.delete("albums", PrimaryKeyValue::U64(2));
+    db.commit_batch(batch).unwrap();
+    let restored = sub.recv().unwrap();
+    assert_sink_values(
+        &restored,
+        SHARED_LEFT_SINKS,
+        &[(vec![Value::U64(1), Value::U64(11)], 1)],
+    );
+}
+
+#[test]
+fn shared_left_arrangement_updates_every_semi_join_consumer() {
+    let (_dir, mut db) = open_db();
+    let mut batch = db.open_batch();
+    batch.insert("blockers", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+
+    let sub = db.subscribe(shared_left_sinks(true)).unwrap();
+    let _initial = sub.recv().unwrap();
+
+    let mut batch = db.open_batch();
+    batch.insert("albums", vec![Value::U64(1), Value::U64(11)]);
+    db.commit_batch(batch).unwrap();
+    let inserted = sub.recv().unwrap();
+    assert_sink_values(
+        &inserted,
+        SHARED_LEFT_SINKS,
+        &[(vec![Value::U64(1), Value::U64(11)], 1)],
+    );
+
+    // Removing the match while another left row arrives retracts only the row
+    // that was previously visible; the new row never enters the semi-join.
+    let mut batch = db.open_batch();
+    batch.insert("albums", vec![Value::U64(2), Value::U64(11)]);
+    batch.delete("blockers", PrimaryKeyValue::U64(1));
+    db.commit_batch(batch).unwrap();
+    let unmatched = sub.recv().unwrap();
+    assert_sink_values(
+        &unmatched,
+        SHARED_LEFT_SINKS,
+        &[(vec![Value::U64(1), Value::U64(11)], -1)],
+    );
+
+    let mut batch = db.open_batch();
+    batch.insert("blockers", vec![Value::U64(1), Value::U64(11)]);
+    batch.delete("albums", PrimaryKeyValue::U64(2));
+    db.commit_batch(batch).unwrap();
+    let matched = sub.recv().unwrap();
+    assert_sink_values(
+        &matched,
+        SHARED_LEFT_SINKS,
+        &[(vec![Value::U64(1), Value::U64(11)], 1)],
     );
 }

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -12,7 +12,13 @@ rocksdb = ["groove/rocksdb", "dep:rocksdb"]
 sqlite = ["dep:rusqlite"]
 client = ["server"]
 server = [
+  "dep:async-trait",
   "dep:axum",
+  "dep:bytes",
+  "dep:pgwire",
+  "dep:postgres-types",
+  "dep:sqlparser",
+  "dep:tokio-util",
   "dep:tracing-subscriber",
   "dep:tower-http",
   "dep:async-stream",
@@ -72,11 +78,16 @@ clap = { version = "4", features = ["derive", "env"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 tower-http = { version = "0.5", features = ["cors", "trace"], optional = true }
 async-stream = { version = "0.3", optional = true }
+async-trait = { version = "0.1", optional = true }
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 mimalloc = { version = "0.1", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"], optional = true }
+pgwire = { version = "0.40.5", default-features = false, features = ["server-api-ring"], optional = true }
+postgres-types = { version = "0.2.14", features = ["with-uuid-1"], optional = true }
+sqlparser = { version = "0.62.0", optional = true }
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
 opentelemetry = { version = "0.31", optional = true }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "logs", "metrics"], optional = true }
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-json", "reqwest-blocking-client", "logs", "metrics"], optional = true }
@@ -96,6 +107,7 @@ bytes = "1"
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 futures = "0.3"
 tokio = { version = "1", features = ["test-util", "full"] }
+tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
 tower = { version = "0.5", features = ["util"] }
 rcgen = { version = "0.13", default-features = false, features = ["ring"] }
 
@@ -251,6 +263,10 @@ required-features = ["test"]
 
 [[test]]
 name = "parameterized_subscription_routing"
+required-features = ["test"]
+
+[[test]]
+name = "postgres_interface"
 required-features = ["test"]
 
 [[example]]

--- a/crates/jazz/ENV.md
+++ b/crates/jazz/ENV.md
@@ -6,8 +6,8 @@
 | `JAZZ_JWT_PUBLIC_KEY` | `--jwt-public-key` | — | Single JWK JSON object or PEM public key for JWT validation |
 | `JAZZ_BACKEND_SECRET` | `--backend-secret` | — | Secret for backend session impersonation |
 | `JAZZ_ADMIN_SECRET` | `--admin-secret` | — | Secret for admin operations (schema/policy sync) |
-| `JAZZ_POSTGRES_PORT` | `--postgres-port` | — | Enable the loopback-only, read-only PostgreSQL interface on this port |
-| `JAZZ_POSTGRES_SECRET` | `--postgres-secret` | — | Required password for the read-only PostgreSQL interface |
+| `JAZZ_POSTGRES_PORT` | `--postgres-port` | — | Enable the loopback-only administrative PostgreSQL interface on this port |
+| `JAZZ_POSTGRES_SECRET` | `--postgres-secret` | — | Required password for the PostgreSQL interface |
 | `JAZZ_ALLOW_LOCAL_FIRST_AUTH` | `--allow-local-first-auth` | see NODE_ENV | Allow local-first bearer auth |
 | `JAZZ_JWKS_CACHE_TTL_SECS` | — | `300` | JWKS cache TTL in seconds |
 | `JAZZ_JWKS_MAX_STALE_SECS` | — | `300` | Max time (past TTL) to serve stale JWKS on fetch failure |

--- a/crates/jazz/ENV.md
+++ b/crates/jazz/ENV.md
@@ -6,6 +6,8 @@
 | `JAZZ_JWT_PUBLIC_KEY` | `--jwt-public-key` | — | Single JWK JSON object or PEM public key for JWT validation |
 | `JAZZ_BACKEND_SECRET` | `--backend-secret` | — | Secret for backend session impersonation |
 | `JAZZ_ADMIN_SECRET` | `--admin-secret` | — | Secret for admin operations (schema/policy sync) |
+| `JAZZ_POSTGRES_PORT` | `--postgres-port` | — | Enable the loopback-only, read-only PostgreSQL interface on this port |
+| `JAZZ_POSTGRES_SECRET` | `--postgres-secret` | — | Required password for the read-only PostgreSQL interface |
 | `JAZZ_ALLOW_LOCAL_FIRST_AUTH` | `--allow-local-first-auth` | see NODE_ENV | Allow local-first bearer auth |
 | `JAZZ_JWKS_CACHE_TTL_SECS` | — | `300` | JWKS cache TTL in seconds |
 | `JAZZ_JWKS_MAX_STALE_SECS` | — | `300` | Max time (past TTL) to serve stale JWKS on fetch failure |

--- a/crates/jazz/POSTGRES.md
+++ b/crates/jazz/POSTGRES.md
@@ -1,0 +1,148 @@
+# Read-only PostgreSQL interface
+
+Jazz can expose one app through a PostgreSQL-compatible, read-only endpoint.
+The endpoint is disabled by default, binds only to `127.0.0.1`, and uses a
+dedicated read-only database secret. It is available on core servers only
+because an edge may hold a partial, query-scoped cache.
+
+Start it with an app ID, PostgreSQL secret, and PostgreSQL port:
+
+```sh
+JAZZ_ADMIN_SECRET='replace-admin-me' \
+JAZZ_POSTGRES_SECRET='replace-me' \
+  jazz-tools server 00000000-0000-0000-0000-000000000001 \
+  --postgres-port 5433 \
+  --data-dir ./data
+```
+
+The server uses persistent RocksDB storage in `./data` by default. From this
+repository, build and run the same command with:
+
+```sh
+JAZZ_ADMIN_SECRET='replace-admin-me' \
+JAZZ_POSTGRES_SECRET='replace-me' \
+  cargo run -p jazz --features cli --bin jazz-tools -- \
+  server 00000000-0000-0000-0000-000000000001 \
+  --postgres-port 5433 \
+  --data-dir ./data
+```
+
+Connect with user `jazz`, the PostgreSQL secret as password, and the app ID as
+the database name. Supplying the password separately avoids URI-escaping
+problems; load `PGPASSWORD` from a secret manager or prompt in production:
+
+```sh
+PGPASSWORD='replace-me' \
+  psql 'postgresql://jazz@127.0.0.1:5433/00000000-0000-0000-0000-000000000001?sslmode=disable'
+```
+
+For drivers that require one connection string, the equivalent URL is
+`postgresql://jazz:replace-me@127.0.0.1:5433/00000000-0000-0000-0000-000000000001?sslmode=disable`.
+Percent-encode reserved URI characters in an embedded password.
+
+The backend, admin, and PostgreSQL secrets are intentionally separate. Neither
+`JAZZ_ADMIN_SECRET` nor `JAZZ_BACKEND_SECRET` can authenticate this endpoint.
+Publish the app schema with the admin secret through the inspector link printed
+by the server, then use only `JAZZ_POSTGRES_SECRET` for database connections. A
+fresh app lists its database immediately but has no application tables until a
+schema is published.
+
+The endpoint intentionally has no TLS because it cannot bind beyond loopback.
+It uses PostgreSQL cleartext-password authentication, so the dedicated secret
+is sent unencrypted on that loopback connection; it is not SCRAM. Do not proxy
+it onto a public interface. Use an authenticated encrypted tunnel for remote
+administration.
+
+## Supported reads
+
+The interface supports both PostgreSQL simple and extended/prepared query
+protocols. The SQL subset is deliberately strict:
+
+- one-table `SELECT` from `public`, with column projection or `*` and a
+  required `LIMIT` (maximum 10,000);
+- `WHERE` comparisons on PostgreSQL-native scalar columns, `AND`, `OR`, `NOT`,
+  `IS NULL`, and `IN`;
+- column `ORDER BY`, `LIMIT`, and `OFFSET` (maximum 10,000 each); nullable,
+  large-value, and surrogate-text columns are not orderable yet;
+- up to 1,024 `$n` parameters in filters, `LIMIT`, and `OFFSET`; decoded
+  parameter data is capped at 4 MiB and expanded Jazz bindings at 8 MiB;
+- `version()`, `current_database()`, `current_schema()`, `current_user`, common
+  `SHOW` probes, and transaction framing commands;
+- explicit virtual catalogue reads from `pg_catalog.pg_database`,
+  `information_schema.tables`, and `information_schema.columns`.
+
+A simple-protocol batch may contain at most one application-table `SELECT`;
+send additional table reads as separate queries. Catalogue and session-probe
+batches remain supported, with at most four row-producing statements per
+batch.
+
+Examples:
+
+```sql
+SELECT datname FROM pg_catalog.pg_database;
+
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+ORDER BY table_name;
+
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'documents'
+ORDER BY ordinal_position;
+
+SELECT id, title, created_at
+FROM documents
+WHERE team_id = 'team-a'
+ORDER BY created_at DESC
+LIMIT 100 OFFSET 0;
+
+-- Preferred beyond the bounded OFFSET range. Bind the final row of the
+-- previous page as $2/$3.
+SELECT id, title, created_at
+FROM documents
+WHERE team_id = $1
+  AND (created_at < $2 OR (created_at = $2 AND id < $3))
+ORDER BY created_at DESC, id DESC
+LIMIT 100;
+```
+
+All application-table reads execute as the Jazz system/admin identity through
+the server's existing database-owner thread and storage engine. SQL writes,
+joins, aggregates, subqueries, and unsupported syntax return an error.
+The public `id` column is the Jazz row UUID; treat `id` as reserved in app
+schemas. Unsigned 64-bit integers are exposed as lossless decimal text, while
+tuple and array values are exposed as stable JSON text.
+Unsigned 64-bit, enum, tuple, and array columns are currently projection-only:
+filtering or ordering their text representations is rejected because Jazz's
+native comparison order would not match PostgreSQL text semantics. `IS NULL`
+remains supported.
+
+`psql` metacommands such as `\l`, `\dt`, and `\d`, plus GUI/ORM discovery,
+use broader `pg_catalog` queries that are not implemented yet; use the
+explicit catalogue queries above. Session `SET` commands and cursor/fetch-size
+workflows are also unsupported.
+Filter parameters must be non-`NULL`; use literal `IS NULL` or `IS NOT NULL`
+syntax so SQL three-valued logic remains explicit. Transaction framing accepts
+plain `BEGIN`/`START TRANSACTION`, `COMMIT`, and `ROLLBACK`; isolation/access
+modes, savepoints, modifiers, and chaining are rejected.
+
+## Pagination performance
+
+Application-table reads require `LIMIT`; `OFFSET` is also capped at 10,000, and
+materialized and encoded PostgreSQL results are capped at 16 MiB per response.
+PostgreSQL database jobs are single-flight on the existing owner thread. Up to four
+encoded `SELECT` responses may remain in flight; further reads fail fast until
+a client consumes or closes an existing result, so one slow client does not
+block all database work. Each connection may retain at most 64 prepared
+statements and 64 portals, with additional byte limits on their SQL and bound
+parameters. The listener accepts at most 64 simultaneous connections. SQL
+text is capped at 64 KiB and also has token and nesting limits. PostgreSQL
+cancellation requests cancel queued/asynchronous interface work; a synchronous
+owner-thread scan that has already started may finish in the background.
+
+These bounds prevent accidental unbounded response materialization, but the
+current Jazz query engine still applies general ordering and pagination after
+candidate-row materialization. A bounded page can therefore scan more rows
+than it returns. Prefer indexed, selective filters and keyset pagination until
+Jazz has a bounded ordered cursor.

--- a/crates/jazz/POSTGRES.md
+++ b/crates/jazz/POSTGRES.md
@@ -1,8 +1,8 @@
-# Read-only PostgreSQL interface
+# PostgreSQL interface
 
-Jazz can expose one app through a PostgreSQL-compatible, read-only endpoint.
+Jazz can expose one app through a PostgreSQL-compatible administrative endpoint.
 The endpoint is disabled by default, binds only to `127.0.0.1`, and uses a
-dedicated read-only database secret. It is available on core servers only
+dedicated database secret. It is available on core servers only
 because an edge may hold a partial, query-scoped cache.
 
 Start it with an app ID, PostgreSQL secret, and PostgreSQL port:
@@ -53,7 +53,7 @@ is sent unencrypted on that loopback connection; it is not SCRAM. Do not proxy
 it onto a public interface. Use an authenticated encrypted tunnel for remote
 administration.
 
-## Supported reads
+## Supported SQL
 
 The interface supports both PostgreSQL simple and extended/prepared query
 protocols. The SQL subset is deliberately strict:
@@ -64,12 +64,27 @@ protocols. The SQL subset is deliberately strict:
   `IS NULL`, and `IN`;
 - column `ORDER BY`, `LIMIT`, and `OFFSET` (maximum 10,000 each); nullable,
   large-value, and surrogate-text columns are not orderable yet;
-- up to 1,024 `$n` parameters in filters, `LIMIT`, and `OFFSET`; decoded
+- up to 1,024 `$n` parameters in filters, mutations, `LIMIT`, and `OFFSET`; decoded
   parameter data is capped at 4 MiB and expanded Jazz bindings at 8 MiB;
 - `version()`, `current_database()`, `current_schema()`, `current_user`, common
   `SHOW` probes, and transaction framing commands;
 - explicit virtual catalogue reads from `pg_catalog.pg_database`,
   `information_schema.tables`, and `information_schema.columns`.
+
+Basic single-row mutations are also supported:
+
+- `INSERT` with an explicit column list and exactly one `VALUES` row;
+- optional `INSERT ... RETURNING id [AS alias]` for the generated Jazz row UUID;
+- `UPDATE ... SET ... WHERE id = <UUID or $n>`;
+- `DELETE ... WHERE id = <UUID or $n>`.
+
+Mutations must be sent as individual autocommit statements. Multi-row inserts,
+broader update/delete predicates, mutation batches, mutation transactions,
+`UPDATE ... RETURNING`, `DELETE ... RETURNING`, tuple columns, and array columns
+are rejected. A successful response is returned only after the write reaches
+global durability in the core server. Materialized cell data for one mutation
+is capped at 1 MiB so the resulting Jazz commit remains safely below its wire
+budget.
 
 A simple-protocol batch may contain at most one application-table `SELECT`;
 send additional table reads as separate queries. Catalogue and session-probe
@@ -105,11 +120,22 @@ WHERE team_id = $1
   AND (created_at < $2 OR (created_at = $2 AND id < $3))
 ORDER BY created_at DESC, id DESC
 LIMIT 100;
+
+INSERT INTO documents (team_id, title, created_at)
+VALUES ('team-a', 'Quarterly report', 1710000000)
+RETURNING id;
+
+UPDATE documents
+SET title = 'Final quarterly report'
+WHERE id = '018f1234-5678-7abc-8def-0123456789ab';
+
+DELETE FROM documents
+WHERE id = '018f1234-5678-7abc-8def-0123456789ab';
 ```
 
-All application-table reads execute as the Jazz system/admin identity through
-the server's existing database-owner thread and storage engine. SQL writes,
-joins, aggregates, subqueries, and unsupported syntax return an error.
+All application-table reads and mutations execute as the Jazz system/admin
+identity through the server's existing database-owner thread and storage
+engine. Joins, aggregates, subqueries, and unsupported syntax return an error.
 The public `id` column is the Jazz row UUID; treat `id` as reserved in app
 schemas. Unsigned 64-bit integers are exposed as lossless decimal text, while
 tuple and array values are exposed as stable JSON text.
@@ -125,7 +151,8 @@ workflows are also unsupported.
 Filter parameters must be non-`NULL`; use literal `IS NULL` or `IS NOT NULL`
 syntax so SQL three-valued logic remains explicit. Transaction framing accepts
 plain `BEGIN`/`START TRANSACTION`, `COMMIT`, and `ROLLBACK`; isolation/access
-modes, savepoints, modifiers, and chaining are rejected.
+modes, savepoints, modifiers, and chaining are rejected. Reads may be framed in
+a transaction; mutations are currently autocommit-only.
 
 ## Pagination performance
 

--- a/crates/jazz/README.md
+++ b/crates/jazz/README.md
@@ -26,6 +26,9 @@ cargo run -p jazz --example transactions
 cargo run -p jazz --example permissions
 ```
 
+Server operators can use the [environment reference](ENV.md) and the
+[read-only PostgreSQL interface guide](POSTGRES.md).
+
 Operational and in-flight material now lives _inside_ the spec, in each chapter's
 clearly-marked `In flight` section after its normative content (benchmark
 specifics in [appendix B](SPEC/B_benchmarks.md), the performance backlog in

--- a/crates/jazz/README.md
+++ b/crates/jazz/README.md
@@ -27,7 +27,7 @@ cargo run -p jazz --example permissions
 ```
 
 Server operators can use the [environment reference](ENV.md) and the
-[read-only PostgreSQL interface guide](POSTGRES.md).
+[PostgreSQL interface guide](POSTGRES.md).
 
 Operational and in-flight material now lives _inside_ the spec, in each chapter's
 clearly-marked `In flight` section after its normative content (benchmark

--- a/crates/jazz/src/bin/jazz-tools.rs
+++ b/crates/jazz/src/bin/jazz-tools.rs
@@ -141,11 +141,11 @@ enum Commands {
         #[arg(long, env = "JAZZ_ADMIN_SECRET")]
         admin_secret: Option<String>,
 
-        /// Enable the read-only PostgreSQL interface on this loopback port.
+        /// Enable the administrative PostgreSQL interface on this loopback port.
         #[arg(long, env = "JAZZ_POSTGRES_PORT")]
         postgres_port: Option<u16>,
 
-        /// Password for the read-only PostgreSQL interface.
+        /// Password for the administrative PostgreSQL interface.
         #[arg(long, env = "JAZZ_POSTGRES_SECRET")]
         postgres_secret: Option<String>,
 
@@ -584,7 +584,7 @@ mod tests {
         .expect("server command should parse");
 
         let error = validate_server_cli_options(&cli.command)
-            .expect_err("PostgreSQL without its read-only secret should fail validation");
+            .expect_err("PostgreSQL without its dedicated secret should fail validation");
         assert!(error.contains("--postgres-secret"));
         assert!(error.contains("--postgres-port"));
     }

--- a/crates/jazz/src/bin/jazz-tools.rs
+++ b/crates/jazz/src/bin/jazz-tools.rs
@@ -141,6 +141,14 @@ enum Commands {
         #[arg(long, env = "JAZZ_ADMIN_SECRET")]
         admin_secret: Option<String>,
 
+        /// Enable the read-only PostgreSQL interface on this loopback port.
+        #[arg(long, env = "JAZZ_POSTGRES_PORT")]
+        postgres_port: Option<u16>,
+
+        /// Password for the read-only PostgreSQL interface.
+        #[arg(long, env = "JAZZ_POSTGRES_SECRET")]
+        postgres_secret: Option<String>,
+
         /// Upstream server URL. When set, this server runs as an edge.
         #[arg(long, env = "JAZZ_UPSTREAM_URL")]
         upstream_url: Option<String>,
@@ -161,6 +169,10 @@ enum Commands {
         /// Internal testing hook: write the resolved listen port after binding.
         #[arg(long, env = "JAZZ_BOUND_PORT_FILE", hide = true)]
         bound_port_file: Option<String>,
+
+        /// Internal testing hook: write the resolved PostgreSQL port after binding.
+        #[arg(long, env = "JAZZ_POSTGRES_BOUND_PORT_FILE", hide = true)]
+        postgres_bound_port_file: Option<String>,
     },
 }
 
@@ -203,10 +215,13 @@ async fn main() {
             allow_local_first_auth,
             backend_secret,
             admin_secret,
+            postgres_port,
+            postgres_secret,
             upstream_url,
             edge_cache_budget_bytes,
             shutdown_timeout_secs,
             bound_port_file,
+            postgres_bound_port_file,
         } => {
             let node_env_mode = resolve_node_env_mode();
             let explicitly_allowed = allow_local_first_auth;
@@ -252,6 +267,9 @@ async fn main() {
                 upstream_url,
                 edge_cache_budget,
                 bound_port_file,
+                postgres_port,
+                postgres_secret,
+                postgres_bound_port_file,
                 std::time::Duration::from_secs(shutdown_timeout_secs),
             )
             .await
@@ -269,6 +287,8 @@ fn validate_server_cli_options(command: &Commands) -> Result<(), String> {
     let Commands::Server {
         upstream_url,
         admin_secret,
+        postgres_port,
+        postgres_secret,
         ..
     } = command
     else {
@@ -277,6 +297,16 @@ fn validate_server_cli_options(command: &Commands) -> Result<(), String> {
 
     if upstream_url.is_some() && admin_secret.is_none() {
         return Err("--admin-secret / JAZZ_ADMIN_SECRET is required when --upstream-url / JAZZ_UPSTREAM_URL is set".to_string());
+    }
+
+    if postgres_port.is_some() && postgres_secret.as_deref().is_none_or(str::is_empty) {
+        return Err("--postgres-secret / JAZZ_POSTGRES_SECRET is required when --postgres-port / JAZZ_POSTGRES_PORT is set".to_string());
+    }
+
+    if postgres_port.is_some() && upstream_url.is_some() {
+        return Err(
+            "--postgres-port / JAZZ_POSTGRES_PORT is only supported on a core server".to_string(),
+        );
     }
 
     Ok(())
@@ -512,6 +542,51 @@ mod tests {
 
         assert!(error.contains("--admin-secret"));
         assert!(error.contains("--upstream-url"));
+    }
+
+    #[test]
+    fn server_command_parses_postgres_port() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let cli = Cli::try_parse_from([
+            "jazz-tools",
+            "server",
+            "00000000-0000-0000-0000-000000000001",
+            "--postgres-port",
+            "5433",
+            "--postgres-secret",
+            "postgres-secret",
+        ])
+        .expect("server command should parse");
+
+        match cli.command {
+            Commands::Server {
+                postgres_port,
+                postgres_secret,
+                ..
+            } => {
+                assert_eq!(postgres_port, Some(5433));
+                assert_eq!(postgres_secret.as_deref(), Some("postgres-secret"));
+            }
+            _ => panic!("expected server command"),
+        }
+    }
+
+    #[test]
+    fn server_cli_validation_requires_postgres_secret() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let cli = Cli::try_parse_from([
+            "jazz-tools",
+            "server",
+            "00000000-0000-0000-0000-000000000001",
+            "--postgres-port",
+            "5433",
+        ])
+        .expect("server command should parse");
+
+        let error = validate_server_cli_options(&cli.command)
+            .expect_err("PostgreSQL without its read-only secret should fail validation");
+        assert!(error.contains("--postgres-secret"));
+        assert!(error.contains("--postgres-port"));
     }
 
     #[test]

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -33,13 +33,10 @@ use web_time::Instant;
 /// plain history runs to compact incrementally.
 const POST_TICK_HISTORY_WINDOW_BUDGET: usize = 4;
 
-/// Leave half the commit-unit budget for transaction metadata and encoding
-/// overhead on direct server-adapter writes.
-#[cfg(feature = "server")]
-const MAX_SETTLED_SERVER_WRITE_CELL_BYTES: usize = MAX_COMMIT_UNIT_BYTES / 2;
-
 use crate::ids::{AuthorId, NodeUuid, RowUuid, SchemaVersionId};
 pub use crate::node::CommitUnitTrust;
+#[cfg(feature = "server")]
+use crate::node::OpenTxLargeValueCell;
 use crate::node::{
     CommitUnitIngestContext, CurrentRow, EdgeCacheBudget, LargeValueEditCommit, LargeValueEditOp,
     LocalMaintainedViewSubscription, LocalMaintainedViewSubscriptionUpdate, MergeableCommit,
@@ -54,8 +51,6 @@ use crate::protocol::{
     Subscribe, SubscribeRejectReason, SubscriptionKey, SyncMessage, VersionBundle,
     build_version_carriers_from_singletons, expand_version_carriers,
 };
-#[cfg(feature = "server")]
-use crate::protocol_limits::MAX_COMMIT_UNIT_BYTES;
 use crate::protocol_limits::{
     MAX_WIRE_FRAME_BYTES, validate_content_extents, validate_fetch_row_versions,
     validate_known_state_declaration, validate_shape_ast_size, validate_sync_message_len,
@@ -79,26 +74,6 @@ use crate::wire::{
     WireStreamDecoder, WireStreamEncoder, WireTransport, current_wire_features, decode_frame,
     decode_sync_message_for_receive, encode_frame, encode_sync_message,
 };
-
-#[cfg(feature = "server")]
-fn server_write_value_size(value: &Value) -> Option<usize> {
-    match value {
-        Value::U8(_) | Value::Bool(_) | Value::Enum(_) => Some(1),
-        Value::U16(_) => Some(2),
-        Value::U32(_) | Value::I32(_) => Some(4),
-        Value::U64(_) | Value::I64(_) | Value::F64(_) => Some(8),
-        Value::Uuid(_) => Some(16),
-        Value::String(value) => Some(value.len()),
-        Value::Bytes(value) => Some(value.len()),
-        Value::Tuple(values) | Value::Array(values) => {
-            values.iter().try_fold(0_usize, |sum, value| {
-                sum.checked_add(server_write_value_size(value)?)
-            })
-        }
-        Value::Nullable(None) => Some(1),
-        Value::Nullable(Some(value)) => server_write_value_size(value)?.checked_add(1),
-    }
-}
 
 /// How urgently a runtime should service pending peer-connection work.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -478,126 +453,76 @@ where
         Ok(tx_id)
     }
 
-    /// Insert one administrative row directly into history-complete server state.
-    ///
-    /// Unlike ordinary facade writes, this path self-finalizes the mergeable
-    /// transaction at Global durability before returning. It is restricted to
-    /// the system identity and is used by server-side administrative adapters.
+    /// Open an exclusive transaction for a trusted server-side adapter.
     #[cfg(feature = "server")]
-    pub(crate) fn insert_settled_as_system(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<RowUuid, Error> {
+    pub(crate) fn begin_exclusive_as_system(&self) -> Result<OpenTxId, Error> {
         self.check_catalogue_admin()?;
-        self.current_table_schema_for_server_write(table)?;
-        let (content_parent, deletion_parent) = {
-            let mut node = self.node.node.borrow_mut();
-            (
-                node.local_content_winner_tx_id(table, row)?,
-                node.local_deletion_winner_tx_id(table, row)?,
-            )
-        };
-        if deletion_parent.is_some() {
-            return Err(row_already_deleted(row));
-        }
-        if content_parent.is_some() {
-            return Err(Error::new(
-                ErrorCode::WriteRejected,
-                format!("encoding error: object already exists: {}", row.0),
-            ));
-        }
-        self.write_settled_as_system(table, row, cells, Vec::new(), None)?;
-        Ok(row)
+        self.open_exclusive_handle()
     }
 
-    /// Update one administrative row directly in history-complete server state.
-    ///
-    /// Returns `false` when the row does not currently exist.
+    /// Evaluate a query against an open trusted server-side transaction.
     #[cfg(feature = "server")]
-    pub(crate) fn update_settled_as_system(
+    pub(crate) fn read_exclusive_as_system(
         &self,
+        open_tx_id: OpenTxId,
+        query: &Query,
+        bindings: BTreeMap<String, Value>,
+    ) -> Result<Vec<CurrentRow>, Error> {
+        self.check_catalogue_admin()?;
+        let prepared = self.prepare_query_bound(query, bindings)?;
+        self.node
+            .node
+            .borrow_mut()
+            .tx_query_for_identity_raw(
+                open_tx_id,
+                &prepared.shape,
+                &prepared.binding,
+                AuthorId::SYSTEM,
+            )
+            .map_err(Into::into)
+    }
+
+    /// Resolve one returned large-value cell without inspecting its byte shape.
+    #[cfg(feature = "server")]
+    pub(crate) fn resolve_exclusive_large_value_as_system(
+        &self,
+        open_tx_id: OpenTxId,
         table: &str,
         row: RowUuid,
-        patch: RowCells,
-    ) -> Result<bool, Error> {
+        column: &str,
+    ) -> Result<Option<OpenTxLargeValueCell>, Error> {
+        self.check_catalogue_admin()?;
+        self.node
+            .node
+            .borrow_mut()
+            .tx_large_value_cell(open_tx_id, table, row, column)
+            .map_err(Into::into)
+    }
+
+    /// Stage an all-or-nothing batch of inserts in an open trusted transaction.
+    ///
+    /// Every id is checked before the first write is staged, so a duplicate in
+    /// the input, the transaction overlay, or committed state cannot leave a
+    /// partially staged statement behind.
+    #[cfg(feature = "server")]
+    pub(crate) fn insert_many_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        rows: Vec<(RowUuid, RowCells)>,
+    ) -> Result<Vec<RowUuid>, Error> {
         self.check_catalogue_admin()?;
         let table_schema = self.current_table_schema_for_server_write(table)?;
-        let existing = self.node.node.borrow_mut().local_current_row(table, row)?;
-        let Some(existing) = existing else {
-            return Ok(false);
-        };
-        let mut cells = BTreeMap::new();
-        for column in &table_schema.columns {
-            if column.large_value.is_some() {
-                continue;
-            }
-            if let Some(value) = existing.cell(&table_schema, &column.name) {
-                cells.insert(column.name.clone(), value);
-            }
-        }
-        cells.extend(patch);
-        let parent = self.node.node.borrow_mut().current_row_tx_id(&existing);
-        self.write_settled_as_system(table, row, cells, parent.into_iter().collect(), None)?;
-        Ok(true)
-    }
 
-    /// Soft-delete one administrative row directly in history-complete server state.
-    ///
-    /// Returns `false` when the row does not currently exist.
-    #[cfg(feature = "server")]
-    pub(crate) fn delete_settled_as_system(
-        &self,
-        table: &str,
-        row: RowUuid,
-    ) -> Result<bool, Error> {
-        self.check_catalogue_admin()?;
-        self.current_table_schema_for_server_write(table)?;
-        if self
-            .node
-            .node
-            .borrow_mut()
-            .local_current_row(table, row)?
-            .is_none()
-        {
-            return Ok(false);
-        }
-        let parent = self
-            .node
-            .node
-            .borrow_mut()
-            .local_content_winner_tx_id(table, row)?;
-        self.write_settled_as_system(
-            table,
-            row,
-            BTreeMap::new(),
-            parent.into_iter().collect(),
-            Some(DeletionEvent::Deleted),
-        )?;
-        Ok(true)
-    }
-
-    #[cfg(feature = "server")]
-    fn write_settled_as_system(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        parents: Vec<TxId>,
-        deletion: Option<DeletionEvent>,
-    ) -> Result<TxId, Error> {
-        self.check_catalogue_admin()?;
-        let operation = if deletion == Some(DeletionEvent::Deleted) {
-            "DELETE"
-        } else if parents.is_empty() {
-            "INSERT"
-        } else {
-            "UPDATE"
-        };
-        let cells = if operation == "INSERT" {
-            let table_schema = self.current_table_schema_for_server_write(table)?;
-            let mut cells = cells;
+        let mut ids = BTreeSet::new();
+        let mut prepared = Vec::with_capacity(rows.len());
+        for (row, mut cells) in rows {
+            if !ids.insert(row) {
+                return Err(Error::new(
+                    ErrorCode::WriteRejected,
+                    format!("encoding error: duplicate object id in INSERT: {}", row.0),
+                ));
+            }
             for column in &table_schema.columns {
                 if !cells.contains_key(&column.name)
                     && let Some(default) = &column.default
@@ -608,65 +533,124 @@ where
                     );
                 }
             }
-            cells
-        } else {
-            cells
-        };
-        let cell_bytes = cells.values().try_fold(0_usize, |total, value| {
-            total.checked_add(server_write_value_size(value)?)
-        });
-        if cell_bytes.is_none_or(|bytes| bytes > MAX_SETTLED_SERVER_WRITE_CELL_BYTES) {
-            return Err(Error::new(
-                ErrorCode::WriteRejected,
-                format!(
-                    "server write cell payload exceeds max {MAX_SETTLED_SERVER_WRITE_CELL_BYTES} bytes"
-                ),
-            ));
-        }
-        let mut commit = MergeableCommit::new(table, row, self.next_now_ms())
-            .made_by(AuthorId::SYSTEM)
-            .parents(parents)
-            .cells(cells);
-        if let Some(deletion) = deletion {
-            commit = commit.deletion(deletion);
-        }
-        let allowed = self
-            .node
-            .node
-            .borrow_mut()
-            .dry_run_mergeable_write_allows(commit.clone())
-            .map_err(Error::from)?;
-        if !allowed {
-            return Err(Error::new(
-                ErrorCode::WriteRejected,
-                format!("policy denied {operation} on table {table}"),
-            ));
+            prepared.push((row, cells));
         }
 
-        let tx_id = self.node.node.borrow_mut().commit_mergeable(commit)?;
-        self.node
+        for (row, _) in &prepared {
+            let (content_parent, deletion_parent) = {
+                let mut node = self.node.node.borrow_mut();
+                (
+                    node.local_content_winner_tx_id(table, *row)?,
+                    node.local_deletion_winner_tx_id(table, *row)?,
+                )
+            };
+            if deletion_parent.is_some() {
+                return Err(row_already_deleted(*row));
+            }
+            if content_parent.is_some() {
+                return Err(Error::new(
+                    ErrorCode::WriteRejected,
+                    format!("encoding error: object already exists: {}", row.0),
+                ));
+            }
+            if self.exclusive_read_raw(open_tx_id, table, *row)?.is_some() {
+                return Err(Error::new(
+                    ErrorCode::WriteRejected,
+                    format!("encoding error: object already exists: {}", row.0),
+                ));
+            }
+        }
+
+        for (row, cells) in &prepared {
+            self.node
+                .node
+                .borrow_mut()
+                .tx_write(open_tx_id, table, *row, cells.clone(), None)?;
+        }
+        Ok(prepared.into_iter().map(|(row, _)| row).collect())
+    }
+
+    /// Stage an update in an open trusted transaction.
+    #[cfg(feature = "server")]
+    pub(crate) fn update_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+        patch: RowCells,
+    ) -> Result<bool, Error> {
+        self.check_catalogue_admin()?;
+        self.current_table_schema_for_server_write(table)?;
+        self.stage_exclusive_update(open_tx_id, table, row, patch)
+    }
+
+    /// Stage a soft delete in an open trusted transaction.
+    #[cfg(feature = "server")]
+    pub(crate) fn delete_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+    ) -> Result<bool, Error> {
+        self.check_catalogue_admin()?;
+        self.current_table_schema_for_server_write(table)?;
+        if self.exclusive_read_raw(open_tx_id, table, row)?.is_none() {
+            return Ok(false);
+        }
+        self.stage_exclusive_delete(open_tx_id, table, row)?;
+        Ok(true)
+    }
+
+    /// Commit a trusted exclusive transaction through the local Core authority.
+    ///
+    /// The authority fate is applied before the single subscription refresh,
+    /// so observers see one atomic delta for every row in the transaction.
+    #[cfg(feature = "server")]
+    pub(crate) fn commit_exclusive_settled_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+    ) -> Result<TxId, Error> {
+        self.check_catalogue_admin()?;
+        let (tx_id, unit) = self.node.node.borrow_mut().commit_exclusive(
+            open_tx_id,
+            AuthorId::SYSTEM,
+            self.next_now_ms(),
+        )?;
+        let SyncMessage::CommitUnit { tx, versions } = unit else {
+            return Err(Error::new(
+                ErrorCode::Protocol,
+                "exclusive transaction did not produce a commit unit",
+            ));
+        };
+        let fate = self
+            .node
             .node
             .borrow_mut()
-            .finalize_local_mergeable_commit(tx_id)?;
+            .finalize_local_exclusive_commit(tx, versions)?;
         let state = self.write_state(tx_id)?;
         let refresh_result = self.refresh_subscriptions();
         self.node.mark_subscriber_connections_dirty();
         if let Err(error) = refresh_result {
             tracing::warn!(
-                operation,
-                table,
                 error = %error,
-                "globally committed server write could not refresh subscriptions immediately"
+                "globally committed PostgreSQL transaction could not refresh subscriptions immediately"
             );
         }
-        match state.fate {
+        match fate {
             Fate::Accepted if state.durability >= DurabilityTier::Global => Ok(tx_id),
             Fate::Rejected(reason) => Err(write_rejected(reason)),
             Fate::Pending | Fate::Accepted => Err(Error::new(
                 ErrorCode::NotObserved,
-                format!("{operation} did not reach global durability"),
+                "exclusive transaction did not reach global durability",
             )),
         }
+    }
+
+    /// Abandon a trusted server-side transaction without publishing any writes.
+    #[cfg(feature = "server")]
+    pub(crate) fn rollback_exclusive_as_system(&self, open_tx_id: OpenTxId) -> Result<(), Error> {
+        self.check_catalogue_admin()?;
+        self.abandon_exclusive_handle(open_tx_id)
     }
 
     #[cfg(feature = "server")]
@@ -2516,6 +2500,20 @@ where
             .map_err(Into::into)
     }
 
+    #[cfg(feature = "server")]
+    fn exclusive_read_raw(
+        &self,
+        tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+    ) -> Result<Option<RowCells>, Error> {
+        self.node
+            .node
+            .borrow_mut()
+            .tx_read_raw(tx_id, table, row)
+            .map_err(Into::into)
+    }
+
     fn exclusive_all(
         &self,
         tx_id: OpenTxId,
@@ -2549,6 +2547,20 @@ where
             .node
             .borrow_mut()
             .tx_write(tx_id, table, row, cells, None)
+            .map_err(Into::into)
+    }
+
+    fn stage_exclusive_update(
+        &self,
+        tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+        patch: RowCells,
+    ) -> Result<bool, Error> {
+        self.node
+            .node
+            .borrow_mut()
+            .tx_patch_exclusive(tx_id, table, row, patch)
             .map_err(Into::into)
     }
 
@@ -7548,9 +7560,13 @@ where
 
     /// Stage an update; omitted fields keep the transaction-local value.
     fn update(&self, table: &str, row: RowUuid, patch: RowCells) -> Result<(), Error> {
-        let mut cells = self.read(table, row)?.unwrap_or_default();
-        cells.extend(patch);
-        self.insert_with_id(table, row, cells)
+        if !self
+            .db()
+            .stage_exclusive_update(self.tx_id(), table, row, patch.clone())?
+        {
+            self.insert_with_id(table, row, patch)?;
+        }
+        Ok(())
     }
 
     /// Stage a soft delete.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -33,6 +33,11 @@ use web_time::Instant;
 /// plain history runs to compact incrementally.
 const POST_TICK_HISTORY_WINDOW_BUDGET: usize = 4;
 
+/// Leave half the commit-unit budget for transaction metadata and encoding
+/// overhead on direct server-adapter writes.
+#[cfg(feature = "server")]
+const MAX_SETTLED_SERVER_WRITE_CELL_BYTES: usize = MAX_COMMIT_UNIT_BYTES / 2;
+
 use crate::ids::{AuthorId, NodeUuid, RowUuid, SchemaVersionId};
 pub use crate::node::CommitUnitTrust;
 use crate::node::{
@@ -49,6 +54,8 @@ use crate::protocol::{
     Subscribe, SubscribeRejectReason, SubscriptionKey, SyncMessage, VersionBundle,
     build_version_carriers_from_singletons, expand_version_carriers,
 };
+#[cfg(feature = "server")]
+use crate::protocol_limits::MAX_COMMIT_UNIT_BYTES;
 use crate::protocol_limits::{
     MAX_WIRE_FRAME_BYTES, validate_content_extents, validate_fetch_row_versions,
     validate_known_state_declaration, validate_shape_ast_size, validate_sync_message_len,
@@ -72,6 +79,26 @@ use crate::wire::{
     WireStreamDecoder, WireStreamEncoder, WireTransport, current_wire_features, decode_frame,
     decode_sync_message_for_receive, encode_frame, encode_sync_message,
 };
+
+#[cfg(feature = "server")]
+fn server_write_value_size(value: &Value) -> Option<usize> {
+    match value {
+        Value::U8(_) | Value::Bool(_) | Value::Enum(_) => Some(1),
+        Value::U16(_) => Some(2),
+        Value::U32(_) | Value::I32(_) => Some(4),
+        Value::U64(_) | Value::I64(_) | Value::F64(_) => Some(8),
+        Value::Uuid(_) => Some(16),
+        Value::String(value) => Some(value.len()),
+        Value::Bytes(value) => Some(value.len()),
+        Value::Tuple(values) | Value::Array(values) => {
+            values.iter().try_fold(0_usize, |sum, value| {
+                sum.checked_add(server_write_value_size(value)?)
+            })
+        }
+        Value::Nullable(None) => Some(1),
+        Value::Nullable(Some(value)) => server_write_value_size(value)?.checked_add(1),
+    }
+}
 
 /// How urgently a runtime should service pending peer-connection work.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -449,6 +476,207 @@ where
         self.refresh_subscriptions()?;
         self.node.mark_subscriber_connections_dirty();
         Ok(tx_id)
+    }
+
+    /// Insert one administrative row directly into history-complete server state.
+    ///
+    /// Unlike ordinary facade writes, this path self-finalizes the mergeable
+    /// transaction at Global durability before returning. It is restricted to
+    /// the system identity and is used by server-side administrative adapters.
+    #[cfg(feature = "server")]
+    pub(crate) fn insert_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: RowCells,
+    ) -> Result<RowUuid, Error> {
+        self.check_catalogue_admin()?;
+        self.current_table_schema_for_server_write(table)?;
+        let (content_parent, deletion_parent) = {
+            let mut node = self.node.node.borrow_mut();
+            (
+                node.local_content_winner_tx_id(table, row)?,
+                node.local_deletion_winner_tx_id(table, row)?,
+            )
+        };
+        if deletion_parent.is_some() {
+            return Err(row_already_deleted(row));
+        }
+        if content_parent.is_some() {
+            return Err(Error::new(
+                ErrorCode::WriteRejected,
+                format!("encoding error: object already exists: {}", row.0),
+            ));
+        }
+        self.write_settled_as_system(table, row, cells, Vec::new(), None)?;
+        Ok(row)
+    }
+
+    /// Update one administrative row directly in history-complete server state.
+    ///
+    /// Returns `false` when the row does not currently exist.
+    #[cfg(feature = "server")]
+    pub(crate) fn update_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+        patch: RowCells,
+    ) -> Result<bool, Error> {
+        self.check_catalogue_admin()?;
+        let table_schema = self.current_table_schema_for_server_write(table)?;
+        let existing = self.node.node.borrow_mut().local_current_row(table, row)?;
+        let Some(existing) = existing else {
+            return Ok(false);
+        };
+        let mut cells = BTreeMap::new();
+        for column in &table_schema.columns {
+            if column.large_value.is_some() {
+                continue;
+            }
+            if let Some(value) = existing.cell(&table_schema, &column.name) {
+                cells.insert(column.name.clone(), value);
+            }
+        }
+        cells.extend(patch);
+        let parent = self.node.node.borrow_mut().current_row_tx_id(&existing);
+        self.write_settled_as_system(table, row, cells, parent.into_iter().collect(), None)?;
+        Ok(true)
+    }
+
+    /// Soft-delete one administrative row directly in history-complete server state.
+    ///
+    /// Returns `false` when the row does not currently exist.
+    #[cfg(feature = "server")]
+    pub(crate) fn delete_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+    ) -> Result<bool, Error> {
+        self.check_catalogue_admin()?;
+        self.current_table_schema_for_server_write(table)?;
+        if self
+            .node
+            .node
+            .borrow_mut()
+            .local_current_row(table, row)?
+            .is_none()
+        {
+            return Ok(false);
+        }
+        let parent = self
+            .node
+            .node
+            .borrow_mut()
+            .local_content_winner_tx_id(table, row)?;
+        self.write_settled_as_system(
+            table,
+            row,
+            BTreeMap::new(),
+            parent.into_iter().collect(),
+            Some(DeletionEvent::Deleted),
+        )?;
+        Ok(true)
+    }
+
+    #[cfg(feature = "server")]
+    fn write_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: RowCells,
+        parents: Vec<TxId>,
+        deletion: Option<DeletionEvent>,
+    ) -> Result<TxId, Error> {
+        self.check_catalogue_admin()?;
+        let operation = if deletion == Some(DeletionEvent::Deleted) {
+            "DELETE"
+        } else if parents.is_empty() {
+            "INSERT"
+        } else {
+            "UPDATE"
+        };
+        let cells = if operation == "INSERT" {
+            let table_schema = self.current_table_schema_for_server_write(table)?;
+            let mut cells = cells;
+            for column in &table_schema.columns {
+                if !cells.contains_key(&column.name)
+                    && let Some(default) = &column.default
+                {
+                    cells.insert(
+                        column.name.clone(),
+                        default_cell_for_column_type(&column.column_type, default),
+                    );
+                }
+            }
+            cells
+        } else {
+            cells
+        };
+        let cell_bytes = cells.values().try_fold(0_usize, |total, value| {
+            total.checked_add(server_write_value_size(value)?)
+        });
+        if cell_bytes.is_none_or(|bytes| bytes > MAX_SETTLED_SERVER_WRITE_CELL_BYTES) {
+            return Err(Error::new(
+                ErrorCode::WriteRejected,
+                format!(
+                    "server write cell payload exceeds max {MAX_SETTLED_SERVER_WRITE_CELL_BYTES} bytes"
+                ),
+            ));
+        }
+        let mut commit = MergeableCommit::new(table, row, self.next_now_ms())
+            .made_by(AuthorId::SYSTEM)
+            .parents(parents)
+            .cells(cells);
+        if let Some(deletion) = deletion {
+            commit = commit.deletion(deletion);
+        }
+        let allowed = self
+            .node
+            .node
+            .borrow_mut()
+            .dry_run_mergeable_write_allows(commit.clone())
+            .map_err(Error::from)?;
+        if !allowed {
+            return Err(Error::new(
+                ErrorCode::WriteRejected,
+                format!("policy denied {operation} on table {table}"),
+            ));
+        }
+
+        let tx_id = self.node.node.borrow_mut().commit_mergeable(commit)?;
+        self.node
+            .node
+            .borrow_mut()
+            .finalize_local_mergeable_commit(tx_id)?;
+        let state = self.write_state(tx_id)?;
+        let refresh_result = self.refresh_subscriptions();
+        self.node.mark_subscriber_connections_dirty();
+        if let Err(error) = refresh_result {
+            tracing::warn!(
+                operation,
+                table,
+                error = %error,
+                "globally committed server write could not refresh subscriptions immediately"
+            );
+        }
+        match state.fate {
+            Fate::Accepted if state.durability >= DurabilityTier::Global => Ok(tx_id),
+            Fate::Rejected(reason) => Err(write_rejected(reason)),
+            Fate::Pending | Fate::Accepted => Err(Error::new(
+                ErrorCode::NotObserved,
+                format!("{operation} did not reach global durability"),
+            )),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn current_table_schema_for_server_write(&self, table: &str) -> Result<TableSchema, Error> {
+        self.current_write_schema_for_query()?
+            .0
+            .tables
+            .into_iter()
+            .find(|candidate| candidate.name == table)
+            .ok_or_else(|| Error::new(ErrorCode::Schema, format!("unknown table {table}")))
     }
 
     /// Return the locally observed fate and durability for a write transaction.

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -10750,6 +10750,103 @@ fn db_large_blob_values_round_trip_binary_from_empty_parent() {
     );
 }
 
+/// Contract: public exclusive prepared reads expose handles for inherited
+/// snapshot large values and exact authored bytes for a staged restore.
+///
+/// Actors: alice commits a sparse ordinary-column update, then opens fresh
+/// exclusive transactions to query and restore the Blob.
+///
+/// ```text
+/// alice --sparse UPDATE/COMMIT--> inherited Blob
+/// alice --fresh all_prepared----> hydrateable snapshot handle
+/// alice --restore/all_prepared--> exact staged authored bytes
+/// ```
+#[test]
+fn exclusive_prepared_reads_resolve_inherited_and_restored_large_values() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "assets",
+        [
+            crate::schema::ColumnSchema::new("name", ColumnType::String),
+            crate::schema::ColumnSchema::blob("data"),
+        ],
+    )
+    .with_read_policy(Policy::public())
+    .with_write_policy(Policy::public())]);
+    let dir = tempfile::tempdir().unwrap();
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    let db = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0x71; 16]),
+            author: AuthorId::from_bytes([0x72; 16]),
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0x71))),
+        large_value_checkpoint_op_interval: crate::node::LARGE_VALUE_CHECKPOINT_OP_INTERVAL,
+    }))
+    .unwrap();
+    let table = &schema.tables[0];
+    let original = b"inherited snapshot blob".to_vec();
+    let restored = b"restored authored blob".to_vec();
+    let asset = db
+        .insert(
+            "assets",
+            BTreeMap::from([
+                ("name".to_owned(), Value::String("original".to_owned())),
+                ("data".to_owned(), Value::Bytes(original.clone())),
+            ]),
+        )
+        .unwrap()
+        .row_uuid();
+
+    let update = db.exclusive_tx().unwrap();
+    update
+        .update(
+            "assets",
+            asset,
+            BTreeMap::from([("name".to_owned(), Value::String("renamed".to_owned()))]),
+        )
+        .unwrap();
+    update.commit().unwrap();
+
+    let prepared = db
+        .prepare_query(&Query::from("assets").select(["data"]))
+        .unwrap();
+    let fresh = db.exclusive_tx().unwrap();
+    let rows = fresh.all_prepared(&prepared).unwrap();
+    assert_eq!(rows[0].cell(table, "name"), None);
+    let handle = match rows[0].cell(table, "data") {
+        Some(Value::Bytes(handle)) => handle,
+        other => panic!("expected inherited Blob handle, got {other:?}"),
+    };
+    assert_eq!(db.hydrate_large_value_handle(&handle).unwrap(), original);
+    drop(fresh);
+
+    db.delete("assets", asset).unwrap();
+    let restore = db.exclusive_tx().unwrap();
+    restore
+        .restore(
+            "assets",
+            asset,
+            BTreeMap::from([
+                ("name".to_owned(), Value::String("restored".to_owned())),
+                ("data".to_owned(), Value::Bytes(restored.clone())),
+            ]),
+        )
+        .unwrap();
+    assert_eq!(
+        restore.read("assets", asset).unwrap().unwrap().get("data"),
+        Some(&Value::Bytes(restored.clone()))
+    );
+    assert_eq!(
+        restore.all_prepared(&prepared).unwrap()[0].cell(table, "data"),
+        Some(Value::Bytes(restored))
+    );
+    drop(restore);
+}
+
 #[test]
 fn db_text_edit_ops_materialize_expected_value() {
     let schema =

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -4345,6 +4345,16 @@ pub struct LargeValueMetrics {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpenTxId(u64);
 
+/// Large-value bytes resolved from an open transaction without guessing from
+/// their shape. Authored bytes may deliberately be identical to a Jazz handle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum OpenTxLargeValueCell {
+    /// Logical bytes staged by the open transaction.
+    Authored(Vec<u8>),
+    /// Handle for the value inherited from the pinned snapshot.
+    SnapshotHandle(Vec<u8>),
+}
+
 /// Explicit edit operation for one text/blob column.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LargeValueEditOp {

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -4105,10 +4105,11 @@ impl CurrentRow {
             .iter()
             .find(|candidate| candidate.name == column)?;
         let user_name = user_column_field(column);
-        let idx = self.record.descriptor().fields().iter().position(|field| {
-            field.name.as_deref() == Some(user_name.as_str())
-                || field.name.as_deref() == Some(column)
-        })?;
+        let idx = self
+            .record
+            .descriptor()
+            .field_index(&user_name)
+            .or_else(|| self.record.descriptor().field_index(column))?;
         nullable_value(self.record.borrowed().get_idx(idx).ok()?).ok()?
     }
 

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -4742,6 +4742,13 @@ struct DecodedLargeValueHandle {
     column: String,
     tx_id: TxId,
     kind: LargeValueKind,
+    #[cfg_attr(not(feature = "server"), allow(dead_code))]
+    len: u64,
+}
+
+#[cfg(feature = "server")]
+pub(crate) fn large_value_handle_len(bytes: &[u8]) -> Result<u64, Error> {
+    decode_large_value_handle(bytes).map(|handle| handle.len)
 }
 
 fn decode_large_value_handle(bytes: &[u8]) -> Result<DecodedLargeValueHandle, Error> {
@@ -4760,7 +4767,7 @@ fn decode_large_value_handle(bytes: &[u8]) -> Result<DecodedLargeValueHandle, Er
         2 => LargeValueKind::Blob,
         _ => return Err(Error::InvalidStoredValue("invalid large-value handle kind")),
     };
-    let _len = cursor.read_u64()?;
+    let len = cursor.read_u64()?;
     let refs = cursor.read_u64()?;
     for _ in 0..refs {
         let _writer = AuthorId(uuid::Uuid::from_bytes(cursor.read_array()?));
@@ -4780,6 +4787,7 @@ fn decode_large_value_handle(bytes: &[u8]) -> Result<DecodedLargeValueHandle, Er
         column,
         tx_id: TxId::new(tx_time, tx_node),
         kind,
+        len,
     })
 }
 

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -66,6 +66,35 @@ where
         table: &str,
         row_uuid: RowUuid,
     ) -> Result<Option<BTreeMap<String, Value>>, Error> {
+        let Some(mut cells) = self.tx_read_raw(tx_id, table, row_uuid)? else {
+            return Ok(None);
+        };
+        let table_schema = self.table(table)?.clone();
+        for column in table_schema
+            .columns
+            .iter()
+            .filter(|column| column.large_value.is_some())
+        {
+            match self.tx_large_value_cell(tx_id, table, row_uuid, &column.name)? {
+                Some(OpenTxLargeValueCell::Authored(bytes))
+                | Some(OpenTxLargeValueCell::SnapshotHandle(bytes)) => {
+                    cells.insert(column.name.clone(), Value::Bytes(bytes));
+                }
+                None => {
+                    cells.remove(&column.name);
+                }
+            }
+        }
+        Ok(Some(cells))
+    }
+
+    /// Read a row overlay without resolving large-value cells.
+    pub(crate) fn tx_read_raw(
+        &mut self,
+        tx_id: OpenTxId,
+        table: &str,
+        row_uuid: RowUuid,
+    ) -> Result<Option<BTreeMap<String, Value>>, Error> {
         self.table(table)?;
         let snapshot = self.open_tx(tx_id)?.base_snapshot.clone();
         let snapshot_row = self.snapshot_row(table, row_uuid, &snapshot);
@@ -106,6 +135,72 @@ where
         tx_id: OpenTxId,
         table: &str,
     ) -> Result<Vec<CurrentRow>, Error> {
+        let mut rows = self.tx_current_rows_for_query_source(tx_id, table)?;
+        self.resolve_tx_large_value_rows(tx_id, table, None, &mut rows)?;
+        Ok(rows)
+    }
+
+    /// Replace raw transaction-query large-value cells with authored bytes or
+    /// snapshot handles after filtering, ordering, and pagination.
+    pub(super) fn resolve_tx_large_value_rows(
+        &mut self,
+        tx_id: OpenTxId,
+        table: &str,
+        selected_columns: Option<&[String]>,
+        rows: &mut [CurrentRow],
+    ) -> Result<(), Error> {
+        let table_schema = self.table(table)?.clone();
+        let selected_columns = selected_columns
+            .map(|columns| columns.iter().map(String::as_str).collect::<BTreeSet<_>>());
+        let large_columns = table_schema
+            .columns
+            .iter()
+            .filter(|column| {
+                column.large_value.is_some()
+                    && selected_columns
+                        .as_ref()
+                        .is_none_or(|selected| selected.contains(column.name.as_str()))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if large_columns.is_empty() {
+            return Ok(());
+        }
+        for row in rows {
+            let row_uuid = row.row_uuid();
+            let mut cells = table_schema
+                .columns
+                .iter()
+                .filter_map(|column| {
+                    row.cell(&table_schema, &column.name)
+                        .map(|value| (column.name.clone(), value))
+                })
+                .collect::<BTreeMap<_, _>>();
+            for column in &large_columns {
+                match self.tx_large_value_cell(tx_id, table, row_uuid, &column.name)? {
+                    Some(OpenTxLargeValueCell::Authored(bytes))
+                    | Some(OpenTxLargeValueCell::SnapshotHandle(bytes)) => {
+                        cells.insert(column.name.clone(), Value::Bytes(bytes));
+                    }
+                    None => {
+                        cells.remove(&column.name);
+                    }
+                }
+            }
+            let cells = positional_cells_from_map(&table_schema, &cells)?;
+            *row = current_row_from_positional_cells(&table_schema, row_uuid, &cells)?;
+        }
+        Ok(())
+    }
+
+    /// Build raw snapshot-plus-overlay rows for query evaluation. Large-value
+    /// cells stay as stored payloads or authored bytes here; selected output
+    /// cells are resolved lazily after filtering and pagination.
+    pub(super) fn tx_current_rows_for_query_source(
+        &mut self,
+        tx_id: OpenTxId,
+        table: &str,
+    ) -> Result<Vec<CurrentRow>, Error> {
         self.table(table)?;
         let snapshot = self.open_tx(tx_id)?.base_snapshot.clone();
         let rows = self
@@ -124,7 +219,17 @@ where
         let mut current = Vec::new();
         let table_schema = self.table(table)?.clone();
         for row_uuid in rows {
-            let snapshot_row = self.snapshot_row(table, row_uuid, &snapshot);
+            let mut snapshot_row = self.snapshot_row(table, row_uuid, &snapshot);
+            if snapshot_row.content_version.is_some()
+                && let Some(cells) = snapshot_row.content_cells.as_mut()
+            {
+                for (index, column) in table_schema.columns.iter().enumerate() {
+                    if column.large_value.is_some() && cells.get(index).is_some_and(Option::is_none)
+                    {
+                        cells[index] = Some(Value::Bytes(Vec::new()));
+                    }
+                }
+            }
             if let Some(cells) =
                 self.overlay_pending_writes(tx_id, table, row_uuid, snapshot_row)?
             {
@@ -149,6 +254,120 @@ where
                 binding_values: binding.values().clone(),
             });
         Ok(current)
+    }
+
+    /// Resolve one large-value cell with explicit transaction provenance.
+    /// Pending authored bytes never pass through handle decoding; snapshot
+    /// values become handles only when a returned cell asks for them.
+    pub(crate) fn tx_large_value_cell(
+        &mut self,
+        tx_id: OpenTxId,
+        table: &str,
+        row_uuid: RowUuid,
+        column: &str,
+    ) -> Result<Option<OpenTxLargeValueCell>, Error> {
+        let table_schema = self.table(table)?.clone();
+        let column_schema = table_schema
+            .columns
+            .iter()
+            .find(|candidate| candidate.name == column)
+            .ok_or(Error::InvalidStoredValue(
+                "open transaction large-value column is unknown",
+            ))?;
+        let Some(kind) = column_schema.large_value else {
+            return Err(Error::InvalidStoredValue(
+                "open transaction cell is not a large value",
+            ));
+        };
+
+        enum PendingResolution {
+            NoOverride,
+            Value(Option<Vec<u8>>),
+        }
+        let pending = self
+            .open_tx(tx_id)?
+            .writes
+            .iter()
+            .rev()
+            .filter(|write| {
+                write.table == table && write.row_uuid == row_uuid && write.deletion.is_none()
+            })
+            .find_map(|write| match &write.cells {
+                PendingCells::Replace(cells) => Some(PendingResolution::Value(
+                    cells.get(column).and_then(authored_large_value_bytes),
+                )),
+                PendingCells::Patch(patch) => patch
+                    .get(column)
+                    .map(|value| PendingResolution::Value(authored_large_value_bytes(value))),
+            })
+            .unwrap_or(PendingResolution::NoOverride);
+        match pending {
+            PendingResolution::Value(Some(bytes)) => {
+                return Ok(Some(OpenTxLargeValueCell::Authored(bytes)));
+            }
+            PendingResolution::Value(None) => return Ok(None),
+            PendingResolution::NoOverride => {}
+        }
+
+        let snapshot = self.open_tx(tx_id)?.base_snapshot.clone();
+        let Some(version) =
+            self.snapshot_layer_winner(table, row_uuid, VersionLayer::Content, &snapshot)
+        else {
+            return Ok(None);
+        };
+        if matches!(
+            column_schema.column_type,
+            crate::groove::schema::ColumnType::Nullable(_)
+        ) && self.snapshot_large_value_is_null(&table_schema, &version, column)?
+        {
+            return Ok(None);
+        }
+        Ok(Some(OpenTxLargeValueCell::SnapshotHandle(
+            self.large_value_handle_for_version(
+                &table_schema,
+                &version,
+                &column_schema.name,
+                kind,
+            )?,
+        )))
+    }
+
+    fn snapshot_large_value_is_null(
+        &mut self,
+        table: &TableSchema,
+        winner: &VersionRow,
+        column: &str,
+    ) -> Result<bool, Error> {
+        let mut current = self.version_tx_id(winner)?;
+        loop {
+            let version = self
+                .query_versions_for_tx(current)?
+                .into_iter()
+                .find(|version| {
+                    version.table() == table.name
+                        && version.row_uuid() == winner.row_uuid()
+                        && version.layer() == VersionLayer::Content
+                })
+                .ok_or(Error::MissingTransaction(current))?;
+            match version.cell(table, column)? {
+                Some(Value::Nullable(None)) => return Ok(true),
+                Some(Value::Nullable(Some(value))) if matches!(*value, Value::Bytes(_)) => {
+                    return Ok(false);
+                }
+                Some(Value::Bytes(_)) => return Ok(false),
+                Some(_) => {
+                    return Err(Error::InvalidStoredValue(
+                        "nullable large-value column has an invalid stored value",
+                    ));
+                }
+                None => {}
+            }
+            match version.parents().as_slice() {
+                [] => return Ok(true),
+                [parent] => current = *parent,
+                parents => current = self.large_value_primary_parent(parents)?,
+            }
+        }
     }
 
     /// Stage a row write inside an exclusive transaction.
@@ -212,6 +431,75 @@ where
             open_tx.writes.push(pending);
         }
         Ok(())
+    }
+
+    /// Stage a partial row update inside an exclusive transaction.
+    ///
+    /// Keeping the patch distinct from a replacement matters for large-value
+    /// columns: an untouched column inherits through the content parent instead
+    /// of materializing and re-encoding its stored operation payload.
+    pub(crate) fn tx_patch_exclusive(
+        &mut self,
+        tx_id: OpenTxId,
+        table: &str,
+        row_uuid: RowUuid,
+        patch: BTreeMap<String, Value>,
+    ) -> Result<bool, Error> {
+        if !matches!(self.open_tx(tx_id)?.kind, OpenTransactionKind::Exclusive) {
+            return Err(Error::InvalidMergeableCommit(
+                "open transaction is not exclusive",
+            ));
+        }
+        if self.tx_read_raw(tx_id, table, row_uuid)?.is_none() {
+            return Ok(false);
+        }
+        let write_schema_version = self.catalogue.current_write_schema.schema;
+        let table_schema = self.table_in_schema(table, write_schema_version)?;
+        positional_cells_from_map(&table_schema, &patch)?;
+        let cache_key = (table.to_owned(), row_uuid);
+        let snapshot_row = self
+            .open_tx(tx_id)?
+            .base_snapshot_rows
+            .get(&cache_key)
+            .cloned()
+            .ok_or(Error::InvalidStoredValue(
+                "exclusive update did not retain its snapshot row",
+            ))?;
+        let pending = PendingWrite {
+            table: table.to_owned(),
+            row_uuid,
+            schema_version: write_schema_version,
+            cells: PendingCells::Patch(patch),
+            deletion: None,
+            parents: snapshot_row.content_version.into_iter().collect(),
+            now_ms: None,
+            refresh_parents_at_commit: false,
+        };
+        let open_tx = self.open_tx_mut(tx_id)?;
+        open_tx.base_snapshot_rows.remove(&cache_key);
+        if let Some(existing) = open_tx.writes.iter_mut().find(|write| {
+            write.table == pending.table
+                && write.row_uuid == pending.row_uuid
+                && write.deletion.is_none()
+        }) {
+            let cells = match (&existing.cells, &pending.cells) {
+                (PendingCells::Replace(existing), PendingCells::Patch(patch)) => {
+                    let mut cells = existing.clone();
+                    cells.extend(patch.clone());
+                    PendingCells::Replace(cells)
+                }
+                (PendingCells::Patch(existing), PendingCells::Patch(patch)) => {
+                    let mut cells = existing.clone();
+                    cells.extend(patch.clone());
+                    PendingCells::Patch(cells)
+                }
+                _ => unreachable!("exclusive update always stages a patch"),
+            };
+            *existing = PendingWrite { cells, ..pending };
+        } else {
+            open_tx.writes.push(pending);
+        }
+        Ok(true)
     }
 
     pub(crate) fn tx_write_mergeable(
@@ -364,31 +652,66 @@ where
         }
         let made_at = self.mint_tx_time(now_ms);
         let tx_id = TxId::new(made_at, self.node_uuid);
-        let versions = open_tx
-            .writes
-            .into_iter()
-            .map(|write| {
-                let table_schema = self.table_in_schema(&write.table, write.schema_version)?;
-                let PendingCells::Replace(cells) = write.cells else {
-                    return Err(Error::InvalidMergeableCommit(
-                        "exclusive transaction cannot contain update patches",
-                    ));
-                };
-                let cells = positional_cells_from_map(&table_schema, &cells)?;
-                Ok(VersionRecord::encode(
-                    &table_schema,
-                    write.schema_version,
-                    write.row_uuid,
-                    write.parents,
-                    made_by,
-                    made_at,
-                    made_by,
-                    made_at,
-                    &cells,
-                    write.deletion,
-                )?)
-            })
-            .collect::<Result<Vec<_>, Error>>()?;
+        let mut versions = Vec::with_capacity(open_tx.writes.len());
+        for write in open_tx.writes {
+            let table_schema = self
+                .table_in_schema(&write.table, write.schema_version)?
+                .clone();
+            let parent = match write.parents.first().copied() {
+                Some(parent) => Some(
+                    self.query_versions_for_tx(parent)?
+                        .into_iter()
+                        .find(|version| {
+                            version.table() == write.table
+                                && version.row_uuid() == write.row_uuid
+                                && version.layer() == VersionLayer::Content
+                        })
+                        .ok_or(Error::MissingTransaction(parent))?,
+                ),
+                None => None,
+            };
+            let mut cells = match write.cells {
+                PendingCells::Replace(cells) => cells,
+                PendingCells::Patch(patch) => {
+                    let parent = parent.as_ref().ok_or(Error::InvalidMergeableCommit(
+                        "exclusive update patch requires a content parent",
+                    ))?;
+                    let mut cells = BTreeMap::new();
+                    for column in table_schema
+                        .columns
+                        .iter()
+                        .filter(|column| column.large_value.is_none())
+                    {
+                        if let Some(value) = parent.cell(&table_schema, &column.name)? {
+                            cells.insert(column.name.clone(), value);
+                        }
+                    }
+                    cells.extend(patch);
+                    cells
+                }
+            };
+            cells = self.encode_large_value_cells(
+                &table_schema,
+                write.schema_version,
+                write.row_uuid,
+                made_by,
+                cells,
+                parent.as_ref(),
+            )?;
+            let cells = positional_cells_from_map(&table_schema, &cells)?;
+            versions.push(VersionRecord::encode(
+                &table_schema,
+                write.schema_version,
+                write.row_uuid,
+                write.parents,
+                made_by,
+                made_at,
+                made_by,
+                made_at,
+                &cells,
+                write.deletion,
+            )?);
+        }
         let tx = Transaction {
             tx_id,
             kind: TxKind::Exclusive,
@@ -665,6 +988,27 @@ pub(super) enum OpenTransactionKind {
         made_by: AuthorId,
         permission_subject: Option<AuthorId>,
     },
+}
+
+fn authored_large_value_bytes(value: &Value) -> Option<Vec<u8>> {
+    match value {
+        Value::Bytes(bytes) => Some(bytes.clone()),
+        Value::Nullable(Some(value)) => authored_large_value_bytes(value),
+        Value::Nullable(None)
+        | Value::U8(_)
+        | Value::U16(_)
+        | Value::U32(_)
+        | Value::U64(_)
+        | Value::I32(_)
+        | Value::I64(_)
+        | Value::F64(_)
+        | Value::Bool(_)
+        | Value::String(_)
+        | Value::Uuid(_)
+        | Value::Enum(_)
+        | Value::Tuple(_)
+        | Value::Array(_) => None,
+    }
 }
 
 pub(super) struct OpenTransaction {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -868,7 +868,7 @@ where
             }
             let rows = self
                 .node
-                .tx_current_rows(tx_id, &request.source.table)
+                .tx_current_rows_for_query_source(tx_id, &request.source.table)
                 .map_err(|_| source_resolution_error(request, SourceGap::TransactionReadOverlay))?;
             let graph = inline_current_graph(&table, rows)
                 .map_err(|_| source_resolution_error(request, SourceGap::TransactionReadOverlay))?;
@@ -8456,6 +8456,30 @@ where
         binding: &Binding,
         identity: AuthorId,
     ) -> Result<Vec<CurrentRow>, Error> {
+        self.tx_query_for_identity_impl(tx_id, shape, binding, identity, true)
+    }
+
+    /// Evaluate an open-transaction query while leaving large-value cells raw
+    /// for a server adapter that resolves only its returned output columns.
+    #[cfg(feature = "server")]
+    pub(crate) fn tx_query_for_identity_raw(
+        &mut self,
+        tx_id: OpenTxId,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorId,
+    ) -> Result<Vec<CurrentRow>, Error> {
+        self.tx_query_for_identity_impl(tx_id, shape, binding, identity, false)
+    }
+
+    fn tx_query_for_identity_impl(
+        &mut self,
+        tx_id: OpenTxId,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorId,
+        resolve_large_values: bool,
+    ) -> Result<Vec<CurrentRow>, Error> {
         let query = shape.query();
         let predicate_len = self.open_tx(tx_id)?.predicate_reads.len();
         let table = self.table(&query.table)?.clone();
@@ -8482,6 +8506,15 @@ where
         open_tx.predicate_reads.truncate(predicate_len);
         open_tx.predicate_reads.push(predicate_read);
         self.finish_engine_query_rows(query, &mut rows)?;
+        if resolve_large_values && query.aggregate.is_none() {
+            self.resolve_tx_large_value_rows(
+                tx_id,
+                &query.table,
+                query.select.as_deref(),
+                &mut rows,
+            )?;
+        }
+        self.apply_projection(query, &mut rows)?;
         Ok(rows)
     }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -10439,9 +10439,11 @@ fn sort_query_default_rows(rows: &mut [CurrentRow]) {
 
 fn aggregate_row_cell(row: &CurrentRow, column: &str) -> Option<Value> {
     let user_name = user_column_field(column);
-    let idx = row.record.descriptor().fields().iter().position(|field| {
-        field.name.as_deref() == Some(user_name.as_str()) || field.name.as_deref() == Some(column)
-    })?;
+    let idx = row
+        .record
+        .descriptor()
+        .field_index(&user_name)
+        .or_else(|| row.record.descriptor().field_index(column))?;
     nullable_value(row.record.borrowed().get_idx(idx).ok()?).ok()?
 }
 

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -27,9 +27,9 @@ use crate::groove::storage::MemoryStorage;
 #[cfg(feature = "rocksdb")]
 use crate::groove::storage::RocksDbStorage;
 use crate::ids::{AuthorId, RowUuid, SchemaVersionId};
-#[cfg(feature = "server")]
-use crate::node::CurrentRow;
 use crate::node::EdgeCacheBudget;
+#[cfg(feature = "server")]
+use crate::node::{CurrentRow, OpenTxId, OpenTxLargeValueCell};
 use crate::protocol::{
     CatalogueAck, CurrentWriteSchema, MigrationLens, SchemaVersion, SyncMessage,
 };
@@ -339,47 +339,131 @@ impl ShellDb {
     }
 
     #[cfg(feature = "server")]
-    fn insert_settled_as_system(
+    fn begin_exclusive_as_system(&self) -> ShellResult<OpenTxId> {
+        match self {
+            Self::Memory(db) => db.begin_exclusive_as_system().map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db.begin_exclusive_as_system().map_err(Into::into),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn read_exclusive_as_system(
         &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> ShellResult<RowUuid> {
+        open_tx_id: OpenTxId,
+        query: &Query,
+        bindings: BTreeMap<String, Value>,
+    ) -> ShellResult<Vec<CurrentRow>> {
         match self {
             Self::Memory(db) => db
-                .insert_settled_as_system(table, row, cells)
+                .read_exclusive_as_system(open_tx_id, query, bindings)
                 .map_err(Into::into),
             #[cfg(feature = "rocksdb")]
             Self::Rocks(db) => db
-                .insert_settled_as_system(table, row, cells)
+                .read_exclusive_as_system(open_tx_id, query, bindings)
                 .map_err(Into::into),
         }
     }
 
     #[cfg(feature = "server")]
-    fn update_settled_as_system(
+    fn resolve_exclusive_large_value_as_system(
         &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+        column: &str,
+    ) -> ShellResult<Option<OpenTxLargeValueCell>> {
+        match self {
+            Self::Memory(db) => db
+                .resolve_exclusive_large_value_as_system(open_tx_id, table, row, column)
+                .map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db
+                .resolve_exclusive_large_value_as_system(open_tx_id, table, row, column)
+                .map_err(Into::into),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn insert_many_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        rows: Vec<(RowUuid, RowCells)>,
+    ) -> ShellResult<Vec<RowUuid>> {
+        match self {
+            Self::Memory(db) => db
+                .insert_many_exclusive_as_system(open_tx_id, table, rows)
+                .map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db
+                .insert_many_exclusive_as_system(open_tx_id, table, rows)
+                .map_err(Into::into),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn update_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
         table: &str,
         row: RowUuid,
         patch: RowCells,
     ) -> ShellResult<bool> {
         match self {
             Self::Memory(db) => db
-                .update_settled_as_system(table, row, patch)
+                .update_exclusive_as_system(open_tx_id, table, row, patch)
                 .map_err(Into::into),
             #[cfg(feature = "rocksdb")]
             Self::Rocks(db) => db
-                .update_settled_as_system(table, row, patch)
+                .update_exclusive_as_system(open_tx_id, table, row, patch)
                 .map_err(Into::into),
         }
     }
 
     #[cfg(feature = "server")]
-    fn delete_settled_as_system(&self, table: &str, row: RowUuid) -> ShellResult<bool> {
+    fn delete_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+    ) -> ShellResult<bool> {
         match self {
-            Self::Memory(db) => db.delete_settled_as_system(table, row).map_err(Into::into),
+            Self::Memory(db) => db
+                .delete_exclusive_as_system(open_tx_id, table, row)
+                .map_err(Into::into),
             #[cfg(feature = "rocksdb")]
-            Self::Rocks(db) => db.delete_settled_as_system(table, row).map_err(Into::into),
+            Self::Rocks(db) => db
+                .delete_exclusive_as_system(open_tx_id, table, row)
+                .map_err(Into::into),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn commit_exclusive_settled_as_system(&self, open_tx_id: OpenTxId) -> ShellResult<()> {
+        match self {
+            Self::Memory(db) => db
+                .commit_exclusive_settled_as_system(open_tx_id)
+                .map(drop)
+                .map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db
+                .commit_exclusive_settled_as_system(open_tx_id)
+                .map(drop)
+                .map_err(Into::into),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn rollback_exclusive_as_system(&self, open_tx_id: OpenTxId) -> ShellResult<()> {
+        match self {
+            Self::Memory(db) => db
+                .rollback_exclusive_as_system(open_tx_id)
+                .map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db
+                .rollback_exclusive_as_system(open_tx_id)
+                .map_err(Into::into),
         }
     }
 
@@ -669,32 +753,86 @@ impl InMemoryServerShell {
         self.db.hydrate_large_value_handle(handle)
     }
 
-    /// Insert one administrative row and settle it at Global durability.
+    /// Open an exclusive transaction owned by a trusted administrative adapter.
     #[cfg(feature = "server")]
-    pub(crate) fn insert_settled_as_system(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> ShellResult<RowUuid> {
-        self.db.insert_settled_as_system(table, row, cells)
+    pub(crate) fn begin_exclusive_as_system(&self) -> ShellResult<OpenTxId> {
+        self.db.begin_exclusive_as_system()
     }
 
-    /// Update one administrative row and settle it at Global durability.
+    /// Read through the fixed snapshot and write overlay of an open transaction.
     #[cfg(feature = "server")]
-    pub(crate) fn update_settled_as_system(
+    pub(crate) fn read_exclusive_as_system(
         &self,
+        open_tx_id: OpenTxId,
+        query: &Query,
+        bindings: BTreeMap<String, Value>,
+    ) -> ShellResult<Vec<CurrentRow>> {
+        self.db
+            .read_exclusive_as_system(open_tx_id, query, bindings)
+    }
+
+    /// Resolve one returned large-value cell using transaction provenance.
+    #[cfg(feature = "server")]
+    pub(crate) fn resolve_exclusive_large_value_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+        column: &str,
+    ) -> ShellResult<Option<OpenTxLargeValueCell>> {
+        self.db
+            .resolve_exclusive_large_value_as_system(open_tx_id, table, row, column)
+    }
+
+    /// Stage a batch of inserts in an open trusted transaction.
+    #[cfg(feature = "server")]
+    pub(crate) fn insert_many_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        rows: Vec<(RowUuid, RowCells)>,
+    ) -> ShellResult<Vec<RowUuid>> {
+        self.db
+            .insert_many_exclusive_as_system(open_tx_id, table, rows)
+    }
+
+    /// Stage an update in an open trusted transaction.
+    #[cfg(feature = "server")]
+    pub(crate) fn update_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
         table: &str,
         row: RowUuid,
         patch: RowCells,
     ) -> ShellResult<bool> {
-        self.db.update_settled_as_system(table, row, patch)
+        self.db
+            .update_exclusive_as_system(open_tx_id, table, row, patch)
     }
 
-    /// Delete one administrative row and settle it at Global durability.
+    /// Stage a delete in an open trusted transaction.
     #[cfg(feature = "server")]
-    pub(crate) fn delete_settled_as_system(&self, table: &str, row: RowUuid) -> ShellResult<bool> {
-        self.db.delete_settled_as_system(table, row)
+    pub(crate) fn delete_exclusive_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+        table: &str,
+        row: RowUuid,
+    ) -> ShellResult<bool> {
+        self.db.delete_exclusive_as_system(open_tx_id, table, row)
+    }
+
+    /// Settle an open trusted transaction and refresh observers once.
+    #[cfg(feature = "server")]
+    pub(crate) fn commit_exclusive_settled_as_system(
+        &self,
+        open_tx_id: OpenTxId,
+    ) -> ShellResult<()> {
+        self.db.commit_exclusive_settled_as_system(open_tx_id)
+    }
+
+    /// Abandon an open trusted transaction.
+    #[cfg(feature = "server")]
+    pub(crate) fn rollback_exclusive_as_system(&self, open_tx_id: OpenTxId) -> ShellResult<()> {
+        self.db.rollback_exclusive_as_system(open_tx_id)
     }
 
     fn bootstrap_runtime_schema(&mut self, schema: JazzSchema) -> ShellResult<()> {

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -20,16 +20,24 @@ use crate::db::{
     CommitUnitTrust, Db, DbConfig, DbIdentity, Error as DbError, PeerConnection, ResumeCursor,
     RowCells, SeededRowIdSource, Transport, WireTransportAdapter,
 };
+#[cfg(feature = "server")]
+use crate::db::{LocalUpdates, Propagation, ReadOpts};
 use crate::groove::records::Value;
 use crate::groove::storage::MemoryStorage;
 #[cfg(feature = "rocksdb")]
 use crate::groove::storage::RocksDbStorage;
 use crate::ids::{AuthorId, RowUuid, SchemaVersionId};
+#[cfg(feature = "server")]
+use crate::node::CurrentRow;
 use crate::node::EdgeCacheBudget;
 use crate::protocol::{
     CatalogueAck, CurrentWriteSchema, MigrationLens, SchemaVersion, SyncMessage,
 };
+#[cfg(feature = "server")]
+use crate::query::Query;
 use crate::schema::JazzSchema;
+#[cfg(feature = "server")]
+use crate::tx::DurabilityTier;
 use crate::wire::{TransportError, WireTransport};
 
 mod admin_schema_convert;
@@ -293,6 +301,43 @@ impl ShellDb {
         }
     }
 
+    #[cfg(feature = "server")]
+    fn read_as_system(
+        &self,
+        query: &Query,
+        bindings: BTreeMap<String, Value>,
+    ) -> ShellResult<Vec<CurrentRow>> {
+        let opts = ReadOpts {
+            tier: DurabilityTier::Global,
+            local_updates: LocalUpdates::Deferred,
+            propagation: Propagation::LocalOnly,
+            include_deleted: false,
+            read_view: Default::default(),
+        };
+        match self {
+            Self::Memory(db) => {
+                let prepared = db.prepare_query_bound(query, bindings)?;
+                crate::db::block_on(db.all_for_identity(&prepared, opts, AuthorId::SYSTEM))
+                    .map_err(Into::into)
+            }
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => {
+                let prepared = db.prepare_query_bound(query, bindings)?;
+                crate::db::block_on(db.all_for_identity(&prepared, opts, AuthorId::SYSTEM))
+                    .map_err(Into::into)
+            }
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn hydrate_large_value_handle(&self, handle: &[u8]) -> ShellResult<Vec<u8>> {
+        match self {
+            Self::Memory(db) => db.hydrate_large_value_handle(handle).map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db.hydrate_large_value_handle(handle).map_err(Into::into),
+        }
+    }
+
     fn connect_upstream(&self, transport: Box<dyn Transport>) -> ShellPeerConnection {
         match self {
             Self::Memory(db) => ShellPeerConnection::Memory(db.connect_upstream(transport)),
@@ -547,6 +592,37 @@ impl InMemoryServerShell {
     /// Return the current write-schema pointer revision last applied through this shell.
     pub fn runtime_write_schema_revision(&self) -> u64 {
         self.runtime_schema_state.current_write_revision
+    }
+
+    /// Resolve the runtime catalogue schema used by the server's read-only
+    /// administrative interfaces.
+    #[cfg(feature = "server")]
+    pub(crate) fn current_runtime_schema(&self) -> ShellResult<JazzSchema> {
+        let current = self.db.current_write_schema();
+        self.db.catalogue_schema(current.schema).ok_or_else(|| {
+            ShellError::Db(format!(
+                "current runtime schema {:?} is missing from the catalogue",
+                current.schema
+            ))
+        })
+    }
+
+    /// Execute a one-shot query as the system identity against the complete
+    /// core-server store.
+    #[cfg(feature = "server")]
+    pub(crate) fn read_as_system(
+        &self,
+        query: &Query,
+        bindings: BTreeMap<String, Value>,
+    ) -> ShellResult<Vec<CurrentRow>> {
+        self.db.read_as_system(query, bindings)
+    }
+
+    /// Resolve a large-value handle before returning it through an
+    /// administrative interface.
+    #[cfg(feature = "server")]
+    pub(crate) fn hydrate_large_value_handle(&self, handle: &[u8]) -> ShellResult<Vec<u8>> {
+        self.db.hydrate_large_value_handle(handle)
     }
 
     fn bootstrap_runtime_schema(&mut self, schema: JazzSchema) -> ShellResult<()> {

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -338,6 +338,51 @@ impl ShellDb {
         }
     }
 
+    #[cfg(feature = "server")]
+    fn insert_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: RowCells,
+    ) -> ShellResult<RowUuid> {
+        match self {
+            Self::Memory(db) => db
+                .insert_settled_as_system(table, row, cells)
+                .map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db
+                .insert_settled_as_system(table, row, cells)
+                .map_err(Into::into),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn update_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+        patch: RowCells,
+    ) -> ShellResult<bool> {
+        match self {
+            Self::Memory(db) => db
+                .update_settled_as_system(table, row, patch)
+                .map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db
+                .update_settled_as_system(table, row, patch)
+                .map_err(Into::into),
+        }
+    }
+
+    #[cfg(feature = "server")]
+    fn delete_settled_as_system(&self, table: &str, row: RowUuid) -> ShellResult<bool> {
+        match self {
+            Self::Memory(db) => db.delete_settled_as_system(table, row).map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db.delete_settled_as_system(table, row).map_err(Into::into),
+        }
+    }
+
     fn connect_upstream(&self, transport: Box<dyn Transport>) -> ShellPeerConnection {
         match self {
             Self::Memory(db) => ShellPeerConnection::Memory(db.connect_upstream(transport)),
@@ -594,8 +639,7 @@ impl InMemoryServerShell {
         self.runtime_schema_state.current_write_revision
     }
 
-    /// Resolve the runtime catalogue schema used by the server's read-only
-    /// administrative interfaces.
+    /// Resolve the runtime catalogue schema used by the server's administrative interfaces.
     #[cfg(feature = "server")]
     pub(crate) fn current_runtime_schema(&self) -> ShellResult<JazzSchema> {
         let current = self.db.current_write_schema();
@@ -623,6 +667,34 @@ impl InMemoryServerShell {
     #[cfg(feature = "server")]
     pub(crate) fn hydrate_large_value_handle(&self, handle: &[u8]) -> ShellResult<Vec<u8>> {
         self.db.hydrate_large_value_handle(handle)
+    }
+
+    /// Insert one administrative row and settle it at Global durability.
+    #[cfg(feature = "server")]
+    pub(crate) fn insert_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: RowCells,
+    ) -> ShellResult<RowUuid> {
+        self.db.insert_settled_as_system(table, row, cells)
+    }
+
+    /// Update one administrative row and settle it at Global durability.
+    #[cfg(feature = "server")]
+    pub(crate) fn update_settled_as_system(
+        &self,
+        table: &str,
+        row: RowUuid,
+        patch: RowCells,
+    ) -> ShellResult<bool> {
+        self.db.update_settled_as_system(table, row, patch)
+    }
+
+    /// Delete one administrative row and settle it at Global durability.
+    #[cfg(feature = "server")]
+    pub(crate) fn delete_settled_as_system(&self, table: &str, row: RowUuid) -> ShellResult<bool> {
+        self.db.delete_settled_as_system(table, row)
     }
 
     fn bootstrap_runtime_schema(&mut self, schema: JazzSchema) -> ShellResult<()> {

--- a/crates/jazz/src/tools/commands/server.rs
+++ b/crates/jazz/src/tools/commands/server.rs
@@ -23,6 +23,9 @@ pub async fn run(
     upstream_url: Option<String>,
     edge_cache_budget: Option<EdgeCacheBudget>,
     bound_port_file: Option<String>,
+    postgres_port: Option<u16>,
+    postgres_secret: Option<String>,
+    postgres_bound_port_file: Option<String>,
     shutdown_timeout: Duration,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let app_id = AppId::from_string(app_id_str)?;
@@ -76,6 +79,30 @@ pub async fn run(
     }
 
     let state = built.state.clone();
+    let postgres_server = match postgres_port {
+        Some(port) => {
+            let postgres_secret = postgres_secret
+                .ok_or("PostgreSQL interface requires a read-only PostgreSQL secret")?;
+            let postgres = crate::tools::server::postgres::PostgresServerHandle::start(
+                state.clone(),
+                SocketAddr::from(([127, 0, 0, 1], port)),
+                postgres_secret,
+            )
+            .await?;
+            if let Some(path) = postgres_bound_port_file {
+                std::fs::write(&path, postgres.addr().port().to_string()).map_err(|error| {
+                    format!("failed to write PostgreSQL bound port file {path}: {error}")
+                })?;
+            }
+            info!(
+                "PostgreSQL interface listening on postgresql://jazz@{}/{} (password: JAZZ_POSTGRES_SECRET)",
+                postgres.addr(),
+                app_id_string
+            );
+            Some(postgres)
+        }
+        None => None,
+    };
     let shutdown = state.shutdown.clone();
     // Report the current inbound WebSocket count as an OTel gauge. Held for the
     // server's lifetime; dropped when `run` returns. Only active when otel is
@@ -170,6 +197,7 @@ pub async fn run(
         abort_task(&mut shutdown_task).await;
     }
     abort_task(&mut sigterm_task).await;
+    drop(postgres_server);
 
     Ok(())
 }

--- a/crates/jazz/src/tools/commands/server.rs
+++ b/crates/jazz/src/tools/commands/server.rs
@@ -82,7 +82,7 @@ pub async fn run(
     let postgres_server = match postgres_port {
         Some(port) => {
             let postgres_secret = postgres_secret
-                .ok_or("PostgreSQL interface requires a read-only PostgreSQL secret")?;
+                .ok_or("PostgreSQL interface requires a dedicated PostgreSQL secret")?;
             let postgres = crate::tools::server::postgres::PostgresServerHandle::start(
                 state.clone(),
                 SocketAddr::from(([127, 0, 0, 1], port)),

--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -4,7 +4,7 @@ use std::thread;
 
 use crate::db::{CommitUnitTrust, DbIdentity, Transport};
 use crate::groove::records::Value;
-use crate::ids::{AuthorId, NodeUuid, SchemaVersionId};
+use crate::ids::{AuthorId, NodeUuid, RowUuid, SchemaVersionId};
 use crate::node::EdgeCacheBudget;
 use crate::protocol::MigrationLens;
 use crate::query::Query;
@@ -42,6 +42,25 @@ pub(crate) struct PostgresQueryResult {
     pub(crate) table: TableSchema,
     pub(crate) rows: Vec<PostgresRow>,
     pub(crate) response_permit: OwnedSemaphorePermit,
+}
+
+pub(crate) enum PostgresMutation {
+    Insert {
+        row: RowUuid,
+        cells: BTreeMap<String, Value>,
+    },
+    Update {
+        row: RowUuid,
+        patch: BTreeMap<String, Value>,
+    },
+    Delete {
+        row: RowUuid,
+    },
+}
+
+pub(crate) struct PostgresMutationResult {
+    pub(crate) affected_rows: usize,
+    pub(crate) row: Option<RowUuid>,
 }
 
 impl ServerShellHandle {
@@ -300,6 +319,67 @@ impl ServerShellHandle {
             })
         })
         .await
+    }
+
+    pub(crate) async fn postgres_mutate(
+        &self,
+        table_name: String,
+        expected_schema_version: SchemaVersionId,
+        mutation: PostgresMutation,
+        database_job_permit: OwnedSemaphorePermit,
+        query_guard: ActivePostgresQueryGuard,
+    ) -> Result<PostgresMutationResult, String> {
+        let activity_tx = self.activity_tx.clone();
+        let result = self
+            .run_cancelable(move |shell| {
+                let _database_job_permit = database_job_permit;
+                let _query_guard = query_guard;
+                let schema = shell
+                    .current_runtime_schema()
+                    .map_err(|error| error.to_string())?;
+                if schema.version_id() != expected_schema_version {
+                    return Err(
+                        "PostgreSQL schema changed while planning the mutation; retry".to_owned(),
+                    );
+                }
+                if !schema.tables.iter().any(|table| table.name == table_name) {
+                    return Err(format!("unknown table {table_name}"));
+                }
+                match mutation {
+                    PostgresMutation::Insert { row, cells } => {
+                        let row = shell
+                            .insert_settled_as_system(&table_name, row, cells)
+                            .map_err(|error| error.to_string())?;
+                        Ok(PostgresMutationResult {
+                            affected_rows: 1,
+                            row: Some(row),
+                        })
+                    }
+                    PostgresMutation::Update { row, patch } => {
+                        let updated = shell
+                            .update_settled_as_system(&table_name, row, patch)
+                            .map_err(|error| error.to_string())?;
+                        Ok(PostgresMutationResult {
+                            affected_rows: usize::from(updated),
+                            row: updated.then_some(row),
+                        })
+                    }
+                    PostgresMutation::Delete { row } => {
+                        let deleted = shell
+                            .delete_settled_as_system(&table_name, row)
+                            .map_err(|error| error.to_string())?;
+                        Ok(PostgresMutationResult {
+                            affected_rows: usize::from(deleted),
+                            row: deleted.then_some(row),
+                        })
+                    }
+                }
+            })
+            .await;
+        if result.is_ok() {
+            notify_shell_activity(&activity_tx);
+        }
+        result
     }
 
     pub(crate) async fn receive_tick_take(

--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::mpsc;
+use std::sync::{Arc, mpsc};
 use std::thread;
 
 use crate::db::{CommitUnitTrust, DbIdentity, Transport};
@@ -7,12 +7,16 @@ use crate::groove::records::Value;
 use crate::ids::{AuthorId, NodeUuid, SchemaVersionId};
 use crate::node::EdgeCacheBudget;
 use crate::protocol::MigrationLens;
-use crate::schema::JazzSchema;
+use crate::query::Query;
+use crate::schema::{JazzSchema, TableSchema};
 use crate::serving::{
     AbiBytes, InMemoryServerShell, InMemoryServerShellConfig, NodeRole, ServerSession,
     StorageConfig,
 };
-use tokio::sync::{oneshot, watch};
+use crate::tools::server::shutdown::ActivePostgresQueryGuard;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot, watch};
+
+const MAX_ADMITTED_POSTGRES_OWNER_JOBS: usize = 8;
 
 /// Sendable handle for the thread that owns the in-memory server shell.
 ///
@@ -24,9 +28,21 @@ use tokio::sync::{oneshot, watch};
 pub(crate) struct ServerShellHandle {
     jobs: mpsc::Sender<ServerShellJob>,
     activity_tx: watch::Sender<u64>,
+    postgres_job_slots: Arc<Semaphore>,
 }
 
 type ServerShellJob = Box<dyn FnOnce(&mut InMemoryServerShell) + Send + 'static>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PostgresRow {
+    pub(crate) values: Vec<Option<Value>>,
+}
+
+pub(crate) struct PostgresQueryResult {
+    pub(crate) table: TableSchema,
+    pub(crate) rows: Vec<PostgresRow>,
+    pub(crate) response_permit: OwnedSemaphorePermit,
+}
 
 impl ServerShellHandle {
     pub(crate) fn start_with_storage(
@@ -111,7 +127,11 @@ impl ServerShellHandle {
         started_rx
             .recv()
             .map_err(|_| "server shell thread exited before startup".to_owned())??;
-        Ok(Self { jobs, activity_tx })
+        Ok(Self {
+            jobs,
+            activity_tx,
+            postgres_job_slots: Arc::new(Semaphore::new(MAX_ADMITTED_POSTGRES_OWNER_JOBS)),
+        })
     }
 
     pub(crate) fn subscribe_activity(&self) -> watch::Receiver<u64> {
@@ -169,6 +189,117 @@ impl ServerShellHandle {
             notify_shell_activity(&activity_tx);
         }
         result
+    }
+
+    pub(crate) async fn postgres_schema(&self) -> Result<JazzSchema, String> {
+        self.run_cancelable(move |shell| {
+            shell
+                .current_runtime_schema()
+                .map_err(|error| error.to_string())
+        })
+        .await
+    }
+
+    pub(crate) async fn postgres_query(
+        &self,
+        query: Query,
+        expected_schema_version: SchemaVersionId,
+        columns: Vec<String>,
+        bindings: BTreeMap<String, Value>,
+        database_job_permit: OwnedSemaphorePermit,
+        response_permit: OwnedSemaphorePermit,
+        query_guard: ActivePostgresQueryGuard,
+        max_response_bytes: usize,
+    ) -> Result<PostgresQueryResult, String> {
+        self.run_cancelable(move |shell| {
+            let _database_job_permit = database_job_permit;
+            let _query_guard = query_guard;
+            let schema = shell
+                .current_runtime_schema()
+                .map_err(|error| error.to_string())?;
+            if schema.version_id() != expected_schema_version {
+                return Err("PostgreSQL schema changed while planning the query; retry".to_owned());
+            }
+            let table = schema
+                .tables
+                .iter()
+                .find(|table| table.name == query.table)
+                .cloned()
+                .ok_or_else(|| format!("unknown table {}", query.table))?;
+            let current_rows = shell
+                .read_as_system(&query, bindings)
+                .map_err(|error| error.to_string())?;
+            let mut rows = Vec::with_capacity(current_rows.len());
+            let mut response_bytes = 0_usize;
+            for row in current_rows {
+                let row_container_bytes = std::mem::size_of::<PostgresRow>().saturating_add(
+                    columns
+                        .len()
+                        .saturating_mul(std::mem::size_of::<Option<Value>>()),
+                );
+                response_bytes = response_bytes
+                    .checked_add(row_container_bytes)
+                    .ok_or_else(|| {
+                        "PostgreSQL response exceeds configured byte limit".to_owned()
+                    })?;
+                if response_bytes > max_response_bytes {
+                    return Err(format!(
+                        "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
+                    ));
+                }
+                let mut values = Vec::with_capacity(columns.len());
+                for column_name in &columns {
+                    if column_name == "id" {
+                        values.push(Some(Value::Uuid(row.row_uuid().0)));
+                        continue;
+                    }
+
+                    let column = table
+                        .columns
+                        .iter()
+                        .find(|column| column.name == *column_name)
+                        .ok_or_else(|| format!("unknown column {}.{}", table.name, column_name))?;
+                    let mut value = row.cell(&table, column_name);
+                    if column.large_value.is_some()
+                        && let Some(Value::Bytes(handle)) = value.as_ref()
+                    {
+                        let declared_len = crate::node::large_value_handle_len(handle)
+                            .map_err(|error| error.to_string())?;
+                        let declared_len = usize::try_from(declared_len).unwrap_or(usize::MAX);
+                        if response_bytes.saturating_add(declared_len) > max_response_bytes {
+                            return Err(format!(
+                                "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
+                            ));
+                        }
+                        value = Some(Value::Bytes(
+                            shell
+                                .hydrate_large_value_handle(handle)
+                                .map_err(|error| error.to_string())?,
+                        ));
+                    }
+                    if let Some(value) = &value {
+                        response_bytes = response_bytes
+                            .checked_add(postgres_value_size(value))
+                            .ok_or_else(|| {
+                                "PostgreSQL response exceeds configured byte limit".to_owned()
+                            })?;
+                        if response_bytes > max_response_bytes {
+                            return Err(format!(
+                                "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
+                            ));
+                        }
+                    }
+                    values.push(value);
+                }
+                rows.push(PostgresRow { values });
+            }
+            Ok(PostgresQueryResult {
+                table,
+                rows,
+                response_permit,
+            })
+        })
+        .await
     }
 
     pub(crate) async fn receive_tick_take(
@@ -248,15 +379,79 @@ impl ServerShellHandle {
     where
         T: Send + 'static,
     {
+        self.run_inner(run_on_shell, false).await
+    }
+
+    async fn run_cancelable<T>(
+        &self,
+        run_on_shell: impl FnOnce(&mut InMemoryServerShell) -> Result<T, String> + Send + 'static,
+    ) -> Result<T, String>
+    where
+        T: Send + 'static,
+    {
+        // The owner thread uses an unbounded std channel for ordinary server
+        // work. Bound PostgreSQL admission before enqueueing and move the
+        // permit into the queued closure. If the client disconnects or sends
+        // CancelRequest, its future can disappear without freeing a slot for
+        // another closure until the abandoned job is actually skipped.
+        let job_permit = self
+            .postgres_job_slots
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| "PostgreSQL owner-job admission is closed".to_owned())?;
+        self.run_inner(
+            move |shell| {
+                let _job_permit = job_permit;
+                run_on_shell(shell)
+            },
+            true,
+        )
+        .await
+    }
+
+    async fn run_inner<T>(
+        &self,
+        run_on_shell: impl FnOnce(&mut InMemoryServerShell) -> Result<T, String> + Send + 'static,
+        skip_if_response_closed: bool,
+    ) -> Result<T, String>
+    where
+        T: Send + 'static,
+    {
         let (reply, response) = oneshot::channel();
         self.jobs
             .send(Box::new(move |shell| {
+                if skip_if_response_closed && reply.is_closed() {
+                    return;
+                }
                 let _ = reply.send(run_on_shell(shell));
             }))
             .map_err(|_| "server shell thread is not running".to_owned())?;
         response
             .await
             .map_err(|_| "server shell thread dropped response".to_owned())?
+    }
+}
+
+fn postgres_value_size(value: &Value) -> usize {
+    match value {
+        Value::U8(_) | Value::Bool(_) | Value::Enum(_) => 1,
+        Value::U16(_) => 2,
+        Value::U32(_) | Value::I32(_) => 4,
+        Value::U64(_) | Value::I64(_) | Value::F64(_) => 8,
+        Value::Uuid(_) => 16,
+        Value::String(value) => value.len(),
+        Value::Bytes(value) => value.len(),
+        Value::Tuple(values) | Value::Array(values) => values
+            .len()
+            .saturating_mul(std::mem::size_of::<Value>())
+            .saturating_add(values.iter().fold(0_usize, |total, value| {
+                total.saturating_add(postgres_value_size(value))
+            })),
+        Value::Nullable(Some(value)) => {
+            std::mem::size_of::<Value>().saturating_add(postgres_value_size(value))
+        }
+        Value::Nullable(None) => 0,
     }
 }
 

--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -1,11 +1,12 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
 
 use crate::db::{CommitUnitTrust, DbIdentity, Transport};
 use crate::groove::records::Value;
 use crate::ids::{AuthorId, NodeUuid, RowUuid, SchemaVersionId};
-use crate::node::EdgeCacheBudget;
+use crate::node::{EdgeCacheBudget, OpenTxId, OpenTxLargeValueCell};
 use crate::protocol::MigrationLens;
 use crate::query::Query;
 use crate::schema::{JazzSchema, TableSchema};
@@ -17,6 +18,8 @@ use crate::tools::server::shutdown::ActivePostgresQueryGuard;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, oneshot, watch};
 
 const MAX_ADMITTED_POSTGRES_OWNER_JOBS: usize = 8;
+const MAX_POSTGRES_TRANSACTION_ROWS: usize = 1_000;
+const MAX_POSTGRES_TRANSACTION_CELL_BYTES: usize = 1024 * 1024;
 
 /// Sendable handle for the thread that owns the in-memory server shell.
 ///
@@ -29,9 +32,33 @@ pub(crate) struct ServerShellHandle {
     jobs: mpsc::Sender<ServerShellJob>,
     activity_tx: watch::Sender<u64>,
     postgres_job_slots: Arc<Semaphore>,
+    next_postgres_transaction_id: Arc<AtomicU64>,
 }
 
-type ServerShellJob = Box<dyn FnOnce(&mut InMemoryServerShell) + Send + 'static>;
+type ServerShellJob = Box<dyn FnOnce(&mut ServerShellOwner) + Send + 'static>;
+
+struct ServerShellOwner {
+    shell: InMemoryServerShell,
+    postgres_transactions: BTreeMap<u64, PostgresOwnedTransaction>,
+}
+
+struct PostgresOwnedTransaction {
+    open_tx_id: OpenTxId,
+    schema_version: SchemaVersionId,
+    staged_rows: usize,
+    staged_cell_bytes: usize,
+    inserted_rows: BTreeSet<(String, RowUuid)>,
+}
+
+/// RAII lease for a PostgreSQL transaction retained by the shell owner thread.
+/// Dropping the lease queues a rollback, including when an async request is
+/// cancelled after the owner thread opened the Jazz transaction.
+pub(crate) struct PostgresOpenTransaction {
+    shell: ServerShellHandle,
+    owner_id: u64,
+    schema_version: Option<SchemaVersionId>,
+    active: bool,
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct PostgresRow {
@@ -46,11 +73,11 @@ pub(crate) struct PostgresQueryResult {
 
 pub(crate) enum PostgresMutation {
     Insert {
-        row: RowUuid,
-        cells: BTreeMap<String, Value>,
+        rows: Vec<(RowUuid, BTreeMap<String, Value>)>,
     },
     Update {
-        row: RowUuid,
+        query: Query,
+        bindings: BTreeMap<String, Value>,
         patch: BTreeMap<String, Value>,
     },
     Delete {
@@ -60,7 +87,47 @@ pub(crate) enum PostgresMutation {
 
 pub(crate) struct PostgresMutationResult {
     pub(crate) affected_rows: usize,
-    pub(crate) row: Option<RowUuid>,
+    pub(crate) rows: Vec<RowUuid>,
+}
+
+impl PostgresOpenTransaction {
+    pub(crate) fn schema_version(&self) -> SchemaVersionId {
+        self.schema_version
+            .expect("a returned PostgreSQL transaction has a pinned schema")
+    }
+
+    pub(crate) async fn commit(mut self) -> Result<(), String> {
+        let activity_tx = self.shell.activity_tx.clone();
+        let result = self
+            .shell
+            .finish_postgres_transaction(self.owner_id, true)
+            .await;
+        if result.is_ok() {
+            self.active = false;
+            notify_shell_activity(&activity_tx);
+        }
+        result
+    }
+
+    pub(crate) async fn rollback(mut self) -> Result<(), String> {
+        let result = self
+            .shell
+            .finish_postgres_transaction(self.owner_id, false)
+            .await;
+        if result.is_ok() {
+            self.active = false;
+        }
+        result
+    }
+}
+
+impl Drop for PostgresOpenTransaction {
+    fn drop(&mut self) {
+        if self.active {
+            self.shell
+                .queue_postgres_transaction_rollback(self.owner_id);
+        }
+    }
 }
 
 impl ServerShellHandle {
@@ -136,9 +203,12 @@ impl ServerShellHandle {
                     }
                 };
 
-                let mut shell = shell;
+                let mut owner = ServerShellOwner {
+                    shell,
+                    postgres_transactions: BTreeMap::new(),
+                };
                 while let Ok(job) = receiver.recv() {
-                    job(&mut shell);
+                    job(&mut owner);
                 }
             })
             .map_err(|error| format!("failed to spawn server shell thread: {error}"))?;
@@ -150,6 +220,7 @@ impl ServerShellHandle {
             jobs,
             activity_tx,
             postgres_job_slots: Arc::new(Semaphore::new(MAX_ADMITTED_POSTGRES_OWNER_JOBS)),
+            next_postgres_transaction_id: Arc::new(AtomicU64::new(1)),
         })
     }
 
@@ -219,6 +290,45 @@ impl ServerShellHandle {
         .await
     }
 
+    pub(crate) async fn postgres_begin_transaction(
+        &self,
+    ) -> Result<PostgresOpenTransaction, String> {
+        let owner_id = self
+            .next_postgres_transaction_id
+            .fetch_add(1, Ordering::Relaxed);
+        let mut transaction = PostgresOpenTransaction {
+            shell: self.clone(),
+            owner_id,
+            schema_version: None,
+            active: true,
+        };
+        let schema_version = self
+            .run_owner_cancelable(move |owner| {
+                let schema = owner
+                    .shell
+                    .current_runtime_schema()
+                    .map_err(|error| error.to_string())?;
+                let open_tx_id = owner
+                    .shell
+                    .begin_exclusive_as_system()
+                    .map_err(|error| error.to_string())?;
+                owner.postgres_transactions.insert(
+                    owner_id,
+                    PostgresOwnedTransaction {
+                        open_tx_id,
+                        schema_version: schema.version_id(),
+                        staged_rows: 0,
+                        staged_cell_bytes: 0,
+                        inserted_rows: BTreeSet::new(),
+                    },
+                );
+                Ok(schema.version_id())
+            })
+            .await?;
+        transaction.schema_version = Some(schema_version);
+        Ok(transaction)
+    }
+
     pub(crate) async fn postgres_query(
         &self,
         query: Query,
@@ -239,84 +349,67 @@ impl ServerShellHandle {
             if schema.version_id() != expected_schema_version {
                 return Err("PostgreSQL schema changed while planning the query; retry".to_owned());
             }
-            let table = schema
-                .tables
-                .iter()
-                .find(|table| table.name == query.table)
-                .cloned()
-                .ok_or_else(|| format!("unknown table {}", query.table))?;
             let current_rows = shell
                 .read_as_system(&query, bindings)
                 .map_err(|error| error.to_string())?;
-            let mut rows = Vec::with_capacity(current_rows.len());
-            let mut response_bytes = 0_usize;
-            for row in current_rows {
-                let row_container_bytes = std::mem::size_of::<PostgresRow>().saturating_add(
-                    columns
-                        .len()
-                        .saturating_mul(std::mem::size_of::<Option<Value>>()),
-                );
-                response_bytes = response_bytes
-                    .checked_add(row_container_bytes)
-                    .ok_or_else(|| {
-                        "PostgreSQL response exceeds configured byte limit".to_owned()
-                    })?;
-                if response_bytes > max_response_bytes {
-                    return Err(format!(
-                        "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
-                    ));
-                }
-                let mut values = Vec::with_capacity(columns.len());
-                for column_name in &columns {
-                    if column_name == "id" {
-                        values.push(Some(Value::Uuid(row.row_uuid().0)));
-                        continue;
-                    }
-
-                    let column = table
-                        .columns
-                        .iter()
-                        .find(|column| column.name == *column_name)
-                        .ok_or_else(|| format!("unknown column {}.{}", table.name, column_name))?;
-                    let mut value = row.cell(&table, column_name);
-                    if column.large_value.is_some()
-                        && let Some(Value::Bytes(handle)) = value.as_ref()
-                    {
-                        let declared_len = crate::node::large_value_handle_len(handle)
-                            .map_err(|error| error.to_string())?;
-                        let declared_len = usize::try_from(declared_len).unwrap_or(usize::MAX);
-                        if response_bytes.saturating_add(declared_len) > max_response_bytes {
-                            return Err(format!(
-                                "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
-                            ));
-                        }
-                        value = Some(Value::Bytes(
-                            shell
-                                .hydrate_large_value_handle(handle)
-                                .map_err(|error| error.to_string())?,
-                        ));
-                    }
-                    if let Some(value) = &value {
-                        response_bytes = response_bytes
-                            .checked_add(postgres_value_size(value))
-                            .ok_or_else(|| {
-                                "PostgreSQL response exceeds configured byte limit".to_owned()
-                            })?;
-                        if response_bytes > max_response_bytes {
-                            return Err(format!(
-                                "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
-                            ));
-                        }
-                    }
-                    values.push(value);
-                }
-                rows.push(PostgresRow { values });
-            }
-            Ok(PostgresQueryResult {
-                table,
-                rows,
+            build_postgres_query_result(
+                shell,
+                &schema,
+                &query.table,
+                columns,
+                current_rows,
+                None,
                 response_permit,
-            })
+                max_response_bytes,
+            )
+        })
+        .await
+    }
+
+    pub(crate) async fn postgres_query_in_transaction(
+        &self,
+        transaction: &PostgresOpenTransaction,
+        query: Query,
+        expected_schema_version: SchemaVersionId,
+        columns: Vec<String>,
+        bindings: BTreeMap<String, Value>,
+        database_job_permit: OwnedSemaphorePermit,
+        response_permit: OwnedSemaphorePermit,
+        query_guard: ActivePostgresQueryGuard,
+        max_response_bytes: usize,
+    ) -> Result<PostgresQueryResult, String> {
+        let owner_id = transaction.owner_id;
+        self.run_owner_cancelable(move |owner| {
+            let _database_job_permit = database_job_permit;
+            let _query_guard = query_guard;
+            let (open_tx_id, pinned_schema_version) = owner
+                .postgres_transactions
+                .get(&owner_id)
+                .map(|transaction| (transaction.open_tx_id, transaction.schema_version))
+                .ok_or_else(|| "PostgreSQL transaction is no longer open".to_owned())?;
+            let schema = owner
+                .shell
+                .current_runtime_schema()
+                .map_err(|error| error.to_string())?;
+            if schema.version_id() != pinned_schema_version
+                || expected_schema_version != pinned_schema_version
+            {
+                return Err("PostgreSQL schema changed during the transaction; retry".to_owned());
+            }
+            let current_rows = owner
+                .shell
+                .read_exclusive_as_system(open_tx_id, &query, bindings)
+                .map_err(|error| error.to_string())?;
+            build_postgres_query_result(
+                &owner.shell,
+                &schema,
+                &query.table,
+                columns,
+                current_rows,
+                Some(open_tx_id),
+                response_permit,
+                max_response_bytes,
+            )
         })
         .await
     }
@@ -345,41 +438,78 @@ impl ServerShellHandle {
                 if !schema.tables.iter().any(|table| table.name == table_name) {
                     return Err(format!("unknown table {table_name}"));
                 }
-                match mutation {
-                    PostgresMutation::Insert { row, cells } => {
-                        let row = shell
-                            .insert_settled_as_system(&table_name, row, cells)
-                            .map_err(|error| error.to_string())?;
-                        Ok(PostgresMutationResult {
-                            affected_rows: 1,
-                            row: Some(row),
-                        })
+                let open_tx_id = shell
+                    .begin_exclusive_as_system()
+                    .map_err(|error| error.to_string())?;
+                let mut transaction = PostgresOwnedTransaction {
+                    open_tx_id,
+                    schema_version: expected_schema_version,
+                    staged_rows: 0,
+                    staged_cell_bytes: 0,
+                    inserted_rows: BTreeSet::new(),
+                };
+                let result =
+                    stage_postgres_mutation(shell, &mut transaction, &table_name, mutation);
+                let result = match result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        let _ = shell.rollback_exclusive_as_system(open_tx_id);
+                        return Err(error);
                     }
-                    PostgresMutation::Update { row, patch } => {
-                        let updated = shell
-                            .update_settled_as_system(&table_name, row, patch)
-                            .map_err(|error| error.to_string())?;
-                        Ok(PostgresMutationResult {
-                            affected_rows: usize::from(updated),
-                            row: updated.then_some(row),
-                        })
-                    }
-                    PostgresMutation::Delete { row } => {
-                        let deleted = shell
-                            .delete_settled_as_system(&table_name, row)
-                            .map_err(|error| error.to_string())?;
-                        Ok(PostgresMutationResult {
-                            affected_rows: usize::from(deleted),
-                            row: deleted.then_some(row),
-                        })
-                    }
+                };
+                if transaction.staged_rows == 0 {
+                    shell
+                        .rollback_exclusive_as_system(open_tx_id)
+                        .map_err(|error| error.to_string())?;
+                } else {
+                    shell
+                        .commit_exclusive_settled_as_system(open_tx_id)
+                        .map_err(|error| error.to_string())?;
                 }
+                Ok(result)
             })
             .await;
         if result.is_ok() {
             notify_shell_activity(&activity_tx);
         }
         result
+    }
+
+    pub(crate) async fn postgres_mutate_in_transaction(
+        &self,
+        transaction: &PostgresOpenTransaction,
+        table_name: String,
+        expected_schema_version: SchemaVersionId,
+        mutation: PostgresMutation,
+        database_job_permit: OwnedSemaphorePermit,
+        query_guard: ActivePostgresQueryGuard,
+    ) -> Result<PostgresMutationResult, String> {
+        let owner_id = transaction.owner_id;
+        self.run_owner_cancelable(move |owner| {
+            let _database_job_permit = database_job_permit;
+            let _query_guard = query_guard;
+            let schema = owner
+                .shell
+                .current_runtime_schema()
+                .map_err(|error| error.to_string())?;
+            let ServerShellOwner {
+                shell,
+                postgres_transactions,
+            } = owner;
+            let transaction = postgres_transactions
+                .get_mut(&owner_id)
+                .ok_or_else(|| "PostgreSQL transaction is no longer open".to_owned())?;
+            if schema.version_id() != transaction.schema_version
+                || expected_schema_version != transaction.schema_version
+            {
+                return Err("PostgreSQL schema changed during the transaction; retry".to_owned());
+            }
+            if !schema.tables.iter().any(|table| table.name == table_name) {
+                return Err(format!("unknown table {table_name}"));
+            }
+            stage_postgres_mutation(shell, transaction, &table_name, mutation)
+        })
+        .await
     }
 
     pub(crate) async fn receive_tick_take(
@@ -446,9 +576,55 @@ impl ServerShellHandle {
         notify_shell_activity(&self.activity_tx);
     }
 
+    async fn finish_postgres_transaction(&self, owner_id: u64, commit: bool) -> Result<(), String> {
+        self.run_owner_cancelable(move |owner| {
+            let transaction = owner
+                .postgres_transactions
+                .remove(&owner_id)
+                .ok_or_else(|| "PostgreSQL transaction is no longer open".to_owned())?;
+            if !commit || transaction.staged_rows == 0 {
+                return owner
+                    .shell
+                    .rollback_exclusive_as_system(transaction.open_tx_id)
+                    .map_err(|error| error.to_string());
+            }
+            let schema = match owner.shell.current_runtime_schema() {
+                Ok(schema) => schema,
+                Err(error) => {
+                    let _ = owner
+                        .shell
+                        .rollback_exclusive_as_system(transaction.open_tx_id);
+                    return Err(error.to_string());
+                }
+            };
+            if schema.version_id() != transaction.schema_version {
+                let _ = owner
+                    .shell
+                    .rollback_exclusive_as_system(transaction.open_tx_id);
+                return Err("PostgreSQL schema changed during the transaction; retry".to_owned());
+            }
+            owner
+                .shell
+                .commit_exclusive_settled_as_system(transaction.open_tx_id)
+                .map_err(|error| error.to_string())
+        })
+        .await
+    }
+
+    fn queue_postgres_transaction_rollback(&self, owner_id: u64) {
+        let _ = self.jobs.send(Box::new(move |owner| {
+            let Some(transaction) = owner.postgres_transactions.remove(&owner_id) else {
+                return;
+            };
+            let _ = owner
+                .shell
+                .rollback_exclusive_as_system(transaction.open_tx_id);
+        }));
+    }
+
     pub(crate) fn close(&self, session: ServerSession) {
-        let _ = self.jobs.send(Box::new(move |shell| {
-            let _ = shell.close_session(session);
+        let _ = self.jobs.send(Box::new(move |owner| {
+            let _ = owner.shell.close_session(session);
         }));
     }
 
@@ -459,12 +635,24 @@ impl ServerShellHandle {
     where
         T: Send + 'static,
     {
-        self.run_inner(run_on_shell, false).await
+        self.run_owner_inner(move |owner| run_on_shell(&mut owner.shell), false)
+            .await
     }
 
     async fn run_cancelable<T>(
         &self,
         run_on_shell: impl FnOnce(&mut InMemoryServerShell) -> Result<T, String> + Send + 'static,
+    ) -> Result<T, String>
+    where
+        T: Send + 'static,
+    {
+        self.run_owner_cancelable(move |owner| run_on_shell(&mut owner.shell))
+            .await
+    }
+
+    async fn run_owner_cancelable<T>(
+        &self,
+        run_on_owner: impl FnOnce(&mut ServerShellOwner) -> Result<T, String> + Send + 'static,
     ) -> Result<T, String>
     where
         T: Send + 'static,
@@ -480,19 +668,19 @@ impl ServerShellHandle {
             .acquire_owned()
             .await
             .map_err(|_| "PostgreSQL owner-job admission is closed".to_owned())?;
-        self.run_inner(
-            move |shell| {
+        self.run_owner_inner(
+            move |owner| {
                 let _job_permit = job_permit;
-                run_on_shell(shell)
+                run_on_owner(owner)
             },
             true,
         )
         .await
     }
 
-    async fn run_inner<T>(
+    async fn run_owner_inner<T>(
         &self,
-        run_on_shell: impl FnOnce(&mut InMemoryServerShell) -> Result<T, String> + Send + 'static,
+        run_on_owner: impl FnOnce(&mut ServerShellOwner) -> Result<T, String> + Send + 'static,
         skip_if_response_closed: bool,
     ) -> Result<T, String>
     where
@@ -500,17 +688,272 @@ impl ServerShellHandle {
     {
         let (reply, response) = oneshot::channel();
         self.jobs
-            .send(Box::new(move |shell| {
+            .send(Box::new(move |owner| {
                 if skip_if_response_closed && reply.is_closed() {
                     return;
                 }
-                let _ = reply.send(run_on_shell(shell));
+                let _ = reply.send(run_on_owner(owner));
             }))
             .map_err(|_| "server shell thread is not running".to_owned())?;
         response
             .await
             .map_err(|_| "server shell thread dropped response".to_owned())?
     }
+}
+
+fn stage_postgres_mutation(
+    shell: &mut InMemoryServerShell,
+    transaction: &mut PostgresOwnedTransaction,
+    table_name: &str,
+    mutation: PostgresMutation,
+) -> Result<PostgresMutationResult, String> {
+    match mutation {
+        PostgresMutation::Insert { rows } => {
+            for (row, _) in &rows {
+                if transaction
+                    .inserted_rows
+                    .contains(&(table_name.to_owned(), *row))
+                {
+                    return Err(format!(
+                        "encoding error: object already exists in transaction: {}",
+                        row.0
+                    ));
+                }
+            }
+            let cell_bytes = rows.iter().try_fold(0_usize, |total, (_, cells)| {
+                postgres_cells_size(cells).and_then(|bytes| total.checked_add(bytes))
+            });
+            reserve_postgres_transaction_capacity(transaction, rows.len(), cell_bytes)?;
+            let inserted = shell
+                .insert_many_exclusive_as_system(transaction.open_tx_id, table_name, rows)
+                .map_err(|error| error.to_string())?;
+            transaction.staged_rows += inserted.len();
+            transaction.staged_cell_bytes += cell_bytes.expect("capacity check rejected overflow");
+            transaction.inserted_rows.extend(
+                inserted
+                    .iter()
+                    .copied()
+                    .map(|row| (table_name.to_owned(), row)),
+            );
+            Ok(PostgresMutationResult {
+                affected_rows: inserted.len(),
+                rows: inserted,
+            })
+        }
+        PostgresMutation::Update {
+            query,
+            bindings,
+            patch,
+        } => {
+            let current_rows = shell
+                .read_exclusive_as_system(transaction.open_tx_id, &query, bindings)
+                .map_err(|error| error.to_string())?;
+            let rows = current_rows
+                .into_iter()
+                .map(|row| row.row_uuid())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let patch_bytes = postgres_cells_size(&patch);
+            let cell_bytes = patch_bytes.and_then(|bytes| bytes.checked_mul(rows.len()));
+            reserve_postgres_transaction_capacity(transaction, rows.len(), cell_bytes)?;
+            for row in &rows {
+                let updated = shell
+                    .update_exclusive_as_system(
+                        transaction.open_tx_id,
+                        table_name,
+                        *row,
+                        patch.clone(),
+                    )
+                    .map_err(|error| error.to_string())?;
+                if !updated {
+                    return Err(format!(
+                        "row {} disappeared from the PostgreSQL transaction snapshot",
+                        row.0
+                    ));
+                }
+            }
+            transaction.staged_rows += rows.len();
+            transaction.staged_cell_bytes += cell_bytes.expect("capacity check rejected overflow");
+            Ok(PostgresMutationResult {
+                affected_rows: rows.len(),
+                rows,
+            })
+        }
+        PostgresMutation::Delete { row } => {
+            reserve_postgres_transaction_capacity(transaction, 1, Some(0))?;
+            let deleted = shell
+                .delete_exclusive_as_system(transaction.open_tx_id, table_name, row)
+                .map_err(|error| error.to_string())?;
+            if deleted {
+                transaction.staged_rows += 1;
+            }
+            Ok(PostgresMutationResult {
+                affected_rows: usize::from(deleted),
+                rows: deleted.then_some(row).into_iter().collect(),
+            })
+        }
+    }
+}
+
+fn reserve_postgres_transaction_capacity(
+    transaction: &PostgresOwnedTransaction,
+    additional_rows: usize,
+    additional_cell_bytes: Option<usize>,
+) -> Result<(), String> {
+    if transaction
+        .staged_rows
+        .checked_add(additional_rows)
+        .is_none_or(|rows| rows > MAX_POSTGRES_TRANSACTION_ROWS)
+    {
+        return Err(format!(
+            "PostgreSQL transaction cannot affect more than {MAX_POSTGRES_TRANSACTION_ROWS} rows"
+        ));
+    }
+    if additional_cell_bytes
+        .and_then(|bytes| transaction.staged_cell_bytes.checked_add(bytes))
+        .is_none_or(|bytes| bytes > MAX_POSTGRES_TRANSACTION_CELL_BYTES)
+    {
+        return Err(format!(
+            "PostgreSQL transaction cell payload exceeds {MAX_POSTGRES_TRANSACTION_CELL_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
+fn postgres_cells_size(cells: &BTreeMap<String, Value>) -> Option<usize> {
+    cells.values().try_fold(0_usize, |total, value| {
+        total.checked_add(postgres_value_size(value))
+    })
+}
+
+fn build_postgres_query_result(
+    shell: &InMemoryServerShell,
+    schema: &JazzSchema,
+    table_name: &str,
+    columns: Vec<String>,
+    current_rows: Vec<crate::node::CurrentRow>,
+    exclusive_tx_id: Option<OpenTxId>,
+    response_permit: OwnedSemaphorePermit,
+    max_response_bytes: usize,
+) -> Result<PostgresQueryResult, String> {
+    let table = schema
+        .tables
+        .iter()
+        .find(|table| table.name == table_name)
+        .cloned()
+        .ok_or_else(|| format!("unknown table {table_name}"))?;
+    let mut rows = Vec::with_capacity(current_rows.len());
+    let mut response_bytes = 0_usize;
+    for row in current_rows {
+        let row_container_bytes = std::mem::size_of::<PostgresRow>().saturating_add(
+            columns
+                .len()
+                .saturating_mul(std::mem::size_of::<Option<Value>>()),
+        );
+        response_bytes = response_bytes
+            .checked_add(row_container_bytes)
+            .ok_or_else(|| "PostgreSQL response exceeds configured byte limit".to_owned())?;
+        if response_bytes > max_response_bytes {
+            return Err(format!(
+                "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
+            ));
+        }
+        let mut values = Vec::with_capacity(columns.len());
+        for column_name in &columns {
+            if column_name == "id" {
+                values.push(Some(Value::Uuid(row.row_uuid().0)));
+                continue;
+            }
+
+            let column = table
+                .columns
+                .iter()
+                .find(|column| column.name == *column_name)
+                .ok_or_else(|| format!("unknown column {}.{}", table.name, column_name))?;
+            let mut value = row.cell(&table, column_name);
+            if column.large_value.is_some() {
+                let resolved = match exclusive_tx_id {
+                    Some(open_tx_id) => shell
+                        .resolve_exclusive_large_value_as_system(
+                            open_tx_id,
+                            &table.name,
+                            row.row_uuid(),
+                            column_name,
+                        )
+                        .map_err(|error| error.to_string())?,
+                    None => match value.take() {
+                        Some(Value::Bytes(handle)) => {
+                            Some(OpenTxLargeValueCell::SnapshotHandle(handle))
+                        }
+                        None => None,
+                        Some(_) => {
+                            return Err(format!(
+                                "large-value column {}.{} has an invalid value",
+                                table.name, column_name
+                            ));
+                        }
+                    },
+                };
+                let Some(resolved) = resolved else {
+                    values.push(None);
+                    continue;
+                };
+                let handle = match resolved {
+                    OpenTxLargeValueCell::Authored(bytes) => {
+                        value = Some(Value::Bytes(bytes));
+                        if let Some(value) = &value {
+                            response_bytes = response_bytes
+                                .checked_add(postgres_value_size(value))
+                                .ok_or_else(|| {
+                                    "PostgreSQL response exceeds configured byte limit".to_owned()
+                                })?;
+                        }
+                        if response_bytes > max_response_bytes {
+                            return Err(format!(
+                                "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
+                            ));
+                        }
+                        values.push(value);
+                        continue;
+                    }
+                    OpenTxLargeValueCell::SnapshotHandle(handle) => handle,
+                };
+                let declared_len = crate::node::large_value_handle_len(&handle)
+                    .map_err(|error| error.to_string())?;
+                let declared_len = usize::try_from(declared_len).unwrap_or(usize::MAX);
+                if response_bytes.saturating_add(declared_len) > max_response_bytes {
+                    return Err(format!(
+                        "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
+                    ));
+                }
+                value = Some(Value::Bytes(
+                    shell
+                        .hydrate_large_value_handle(&handle)
+                        .map_err(|error| error.to_string())?,
+                ));
+            }
+            if let Some(value) = &value {
+                response_bytes = response_bytes
+                    .checked_add(postgres_value_size(value))
+                    .ok_or_else(|| {
+                        "PostgreSQL response exceeds configured byte limit".to_owned()
+                    })?;
+                if response_bytes > max_response_bytes {
+                    return Err(format!(
+                        "PostgreSQL response exceeds configured {max_response_bytes}-byte limit"
+                    ));
+                }
+            }
+            values.push(value);
+        }
+        rows.push(PostgresRow { values });
+    }
+    Ok(PostgresQueryResult {
+        table,
+        rows,
+        response_permit,
+    })
 }
 
 fn postgres_value_size(value: &Value) -> usize {

--- a/crates/jazz/src/tools/server/mod.rs
+++ b/crates/jazz/src/tools/server/mod.rs
@@ -11,6 +11,7 @@ mod catalogue_entry;
 mod catalogue_storage;
 mod core_server_shell;
 pub mod core_websocket_transport;
+pub(crate) mod postgres;
 pub(crate) mod public_schema_convert;
 pub mod routes;
 pub(crate) mod runtime_catalogue;
@@ -110,7 +111,11 @@ impl ServerState {
 
         self.shutdown.set_phase(ShutdownPhase::DrainingConnections);
         let mut failed = false;
-        let websockets_drained = self.shutdown.wait_for_websocket_drain().await;
+        let (websockets_drained, app_requests_drained, postgres_connections_drained) = tokio::join!(
+            self.shutdown.wait_for_websocket_drain(),
+            self.shutdown.wait_for_app_request_drain(),
+            self.shutdown.wait_for_postgres_connection_drain(),
+        );
         if !websockets_drained {
             tracing::warn!(
                 active_websockets = self.shutdown.active_websockets(),
@@ -119,11 +124,19 @@ impl ServerState {
             failed = true;
         }
 
-        let app_requests_drained = self.shutdown.wait_for_app_request_drain().await;
         if !app_requests_drained {
             tracing::warn!(
                 active_app_requests = self.shutdown.active_app_requests(),
                 "shutdown app request drain timed out"
+            );
+            failed = true;
+        }
+
+        if !postgres_connections_drained {
+            tracing::warn!(
+                active_postgres_connections = self.shutdown.active_postgres_connections(),
+                active_postgres_queries = self.shutdown.active_postgres_queries(),
+                "shutdown PostgreSQL connection drain timed out"
             );
             failed = true;
         }

--- a/crates/jazz/src/tools/server/postgres/mod.rs
+++ b/crates/jazz/src/tools/server/postgres/mod.rs
@@ -34,6 +34,7 @@ use pgwire::messages::extendedquery::{
     TARGET_TYPE_BYTE_PORTAL, TARGET_TYPE_BYTE_STATEMENT,
 };
 use pgwire::messages::response::{ReadyForQuery, TransactionStatus};
+use pgwire::messages::simplequery::Query as SimpleQuery;
 use pgwire::messages::{
     DecodeContext, PgWireBackendMessage, PgWireFrontendMessage, ProtocolVersion,
 };
@@ -53,13 +54,14 @@ use crate::query::{
 };
 use crate::schema::{JazzSchema, LargeValueKind, TableSchema};
 use crate::tools::server::core_server_shell::{
-    PostgresMutation, PostgresQueryResult, ServerShellHandle,
+    PostgresMutation, PostgresOpenTransaction, PostgresQueryResult, ServerShellHandle,
 };
 use crate::tools::server::{ServerState, ServerTopology};
 
 use self::sql::{
-    Command, CompareOp, FilterExpr, InsertPlan, MutationKind, MutationPlan, PageValue,
-    ParsedStatement, ProjectedExpr, SelectPlan, SelectSource, SessionFunction, SqlLiteral,
+    Command, CompareOp, FilterExpr, InsertPlan, MAX_INSERT_ROWS, MutationKind, MutationPlan,
+    PageValue, ParsedStatement, ProjectedExpr, SelectPlan, SelectSource, SessionFunction,
+    SqlLiteral,
 };
 
 const POSTGRES_USER: &str = "jazz";
@@ -620,6 +622,7 @@ struct ConnectionResourceUsage {
     portals: HashMap<String, PortalResourceUsage>,
     portal_bytes: usize,
     response_permits: HashMap<String, Arc<tokio::sync::OwnedSemaphorePermit>>,
+    transaction: Option<Arc<PostgresOpenTransaction>>,
 }
 
 struct PortalResourceUsage {
@@ -628,6 +631,38 @@ struct PortalResourceUsage {
 }
 
 impl ConnectionResources {
+    fn transaction(&self) -> Option<Arc<PostgresOpenTransaction>> {
+        self.usage
+            .lock()
+            .expect("PostgreSQL resource lock")
+            .transaction
+            .clone()
+    }
+
+    fn begin_transaction(&self, transaction: PostgresOpenTransaction) -> bool {
+        let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
+        if usage.transaction.is_some() {
+            return false;
+        }
+        usage.transaction = Some(Arc::new(transaction));
+        true
+    }
+
+    fn take_transaction(&self) -> Option<Arc<PostgresOpenTransaction>> {
+        self.usage
+            .lock()
+            .expect("PostgreSQL resource lock")
+            .transaction
+            .take()
+    }
+
+    fn restore_transaction(&self, transaction: Arc<PostgresOpenTransaction>) {
+        let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
+        if usage.transaction.is_none() {
+            usage.transaction = Some(transaction);
+        }
+    }
+
     fn reserve_statement(&self, name: &str, bytes: usize) -> PgWireResult<()> {
         let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
         let existing = usage.statements.get(name).copied();
@@ -848,6 +883,28 @@ impl QueryParser for ParsedQueryParser {
 
 #[async_trait]
 impl SimpleQueryHandler for PostgresBackend {
+    async fn on_query<C>(&self, client: &mut C, query: SimpleQuery) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let result = self._on_query(client, query).await;
+        if result.is_err()
+            && client.transaction_status() != TransactionStatus::Idle
+            && connection_resources(client).transaction().is_none()
+        {
+            // COMMIT/ROLLBACK consume the Jazz transaction before their final
+            // validation result is known. If that final step fails, the SQL
+            // transaction is still over: make pgwire's outer error handler
+            // preserve Idle instead of turning the now-closed block into E.
+            client.set_transaction_status(TransactionStatus::Idle);
+            clear_connection_portals(client);
+        }
+        result
+    }
+
     async fn do_query<C>(&self, client: &mut C, sql: &str) -> PgWireResult<Vec<Response>>
     where
         C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
@@ -856,6 +913,7 @@ impl SimpleQueryHandler for PostgresBackend {
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         ensure_sql_size(sql)?;
+        let resources = connection_resources(client);
         // PostgreSQL's simple Query message replaces the unnamed statement and
         // every portal derived from it, even when named extended-protocol
         // objects remain on the connection.
@@ -872,7 +930,7 @@ impl SimpleQueryHandler for PostgresBackend {
         if statements.len() > 1 && statements.iter().any(is_mutation) {
             return Err(user_error(
                 "0A000",
-                "PostgreSQL mutations must be sent as individual autocommit statements",
+                "PostgreSQL mutations must be sent as individual statements",
             ));
         }
         if statements.len() > 1
@@ -897,18 +955,11 @@ impl SimpleQueryHandler for PostgresBackend {
                     ))
                 )
             {
+                self.rollback_connection_transaction(&resources).await?;
                 clear_connection_portals(client);
                 return Ok(vec![Response::TransactionEnd(Tag::new("ROLLBACK"))]);
             }
             return Err(failed_transaction_error());
-        }
-        if client.transaction_status() != TransactionStatus::Idle
-            && statements.iter().any(is_mutation)
-        {
-            return Err(user_error(
-                "0A000",
-                "PostgreSQL mutations are currently supported in autocommit mode only",
-            ));
         }
         let application_table_reads = statements
             .iter()
@@ -949,7 +1000,7 @@ impl SimpleQueryHandler for PostgresBackend {
         });
         for statement in statements {
             responses.push(
-                self.execute(statement, &[], &Format::UnifiedText, None)
+                self.execute(&resources, statement, &[], &Format::UnifiedText, None)
                     .await?
                     .response,
             );
@@ -1185,6 +1236,15 @@ impl ExtendedQueryHandler for PostgresBackend {
             .unwrap_or((false, false));
         let result = self._on_execute(client, message).await;
         connection_resources(client).release_response(&portal_name);
+        if result.is_err()
+            && client.transaction_status() != TransactionStatus::Idle
+            && connection_resources(client).transaction().is_none()
+        {
+            // See the simple-query equivalent above. `process_error` maps
+            // Idle to Idle, so the following Sync reports ReadyForQuery(I).
+            client.set_transaction_status(TransactionStatus::Idle);
+            clear_connection_portals(client);
+        }
         if result.is_ok() && completes_mutation {
             connection_resources(client).release_portal(&portal_name);
             client.portal_store().rm_portal(&portal_name);
@@ -1236,20 +1296,15 @@ impl ExtendedQueryHandler for PostgresBackend {
             ));
         }
         let statement = &portal.statement.statement;
+        let resources = connection_resources(client);
         if client.transaction_status() == TransactionStatus::Error {
             return match statement.parsed {
                 ParsedStatement::Command(Command::Rollback | Command::Commit) => {
+                    self.rollback_connection_transaction(&resources).await?;
                     Ok(Response::TransactionEnd(Tag::new("ROLLBACK")))
                 }
                 _ => Err(failed_transaction_error()),
             };
-        }
-        if client.transaction_status() != TransactionStatus::Idle && is_mutation(&statement.parsed)
-        {
-            return Err(user_error(
-                "0A000",
-                "PostgreSQL mutations are currently supported in autocommit mode only",
-            ));
         }
         let current_parameter_kinds = self.parameter_kinds(&statement.parsed).await?;
         let current_result_columns = self
@@ -1266,6 +1321,7 @@ impl ExtendedQueryHandler for PostgresBackend {
         let parameters = decode_parameters(portal, &statement.parameter_kinds)?;
         let executed = self
             .execute(
+                &resources,
                 statement.parsed.clone(),
                 &parameters,
                 &portal.result_column_format,
@@ -1379,6 +1435,7 @@ impl PostgresBackend {
 
     async fn execute(
         &self,
+        resources: &ConnectionResources,
         statement: ParsedStatement,
         parameters: &[ParameterValue],
         format: &Format,
@@ -1387,19 +1444,26 @@ impl PostgresBackend {
         match statement {
             ParsedStatement::Select(plan) => {
                 let output = self
-                    .execute_select(plan, parameters, expected_schema_version)
+                    .execute_select(resources, plan, parameters, expected_schema_version)
                     .await?;
                 output.into_response(format)
             }
             ParsedStatement::Mutation(plan) => {
-                self.execute_mutation(plan, parameters, format, expected_schema_version)
+                self.execute_mutation(resources, plan, parameters, format, expected_schema_version)
                     .await
             }
-            ParsedStatement::Command(command) => self.execute_command(command, format),
+            ParsedStatement::Command(command) => {
+                self.execute_command(resources, command, format).await
+            }
         }
     }
 
-    fn execute_command(&self, command: Command, format: &Format) -> PgWireResult<ExecutedResponse> {
+    async fn execute_command(
+        &self,
+        resources: &ConnectionResources,
+        command: Command,
+        format: &Format,
+    ) -> PgWireResult<ExecutedResponse> {
         match command {
             Command::Show(setting) => {
                 let value = match setting.to_ascii_lowercase().as_str() {
@@ -1424,20 +1488,120 @@ impl PostgresBackend {
                 }
                 .into_response(format)
             }
-            Command::Begin => Ok(ExecutedResponse::without_permit(
-                Response::TransactionStart(Tag::new("BEGIN")),
-            )),
-            Command::Commit => Ok(ExecutedResponse::without_permit(Response::TransactionEnd(
-                Tag::new("COMMIT"),
-            ))),
-            Command::Rollback => Ok(ExecutedResponse::without_permit(Response::TransactionEnd(
-                Tag::new("ROLLBACK"),
-            ))),
+            Command::Begin => {
+                if resources.transaction().is_none() {
+                    let _database_job_permit = self
+                        .database_job
+                        .clone()
+                        .acquire_owned()
+                        .await
+                        .map_err(|_| {
+                            internal_error("PostgreSQL database transaction gate is closed")
+                        })?;
+                    let _query_guard = self
+                        .state
+                        .shutdown
+                        .try_enter_postgres_query()
+                        .ok_or_else(|| user_error("57P01", "Jazz server is shutting down"))?;
+                    let transaction = self
+                        .shell()?
+                        .postgres_begin_transaction()
+                        .await
+                        .map_err(postgres_database_transaction_error)?;
+                    if !resources.begin_transaction(transaction) {
+                        return Err(internal_error(
+                            "PostgreSQL connection transaction state changed during BEGIN",
+                        ));
+                    }
+                }
+                Ok(ExecutedResponse::without_permit(
+                    Response::TransactionStart(Tag::new("BEGIN")),
+                ))
+            }
+            Command::Commit => {
+                self.commit_connection_transaction(resources).await?;
+                Ok(ExecutedResponse::without_permit(Response::TransactionEnd(
+                    Tag::new("COMMIT"),
+                )))
+            }
+            Command::Rollback => {
+                self.rollback_connection_transaction(resources).await?;
+                Ok(ExecutedResponse::without_permit(Response::TransactionEnd(
+                    Tag::new("ROLLBACK"),
+                )))
+            }
         }
+    }
+
+    async fn commit_connection_transaction(
+        &self,
+        resources: &ConnectionResources,
+    ) -> PgWireResult<()> {
+        let Some(transaction) = resources.take_transaction() else {
+            return Ok(());
+        };
+        let transaction = match Arc::try_unwrap(transaction) {
+            Ok(transaction) => transaction,
+            Err(transaction) => {
+                resources.restore_transaction(transaction);
+                return Err(internal_error(
+                    "PostgreSQL transaction is still executing another statement",
+                ));
+            }
+        };
+        let _database_job_permit = self
+            .database_job
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| internal_error("PostgreSQL database transaction gate is closed"))?;
+        let _query_guard = self
+            .state
+            .shutdown
+            .try_enter_postgres_query()
+            .ok_or_else(|| user_error("57P01", "Jazz server is shutting down"))?;
+        transaction
+            .commit()
+            .await
+            .map_err(postgres_database_transaction_error)
+    }
+
+    async fn rollback_connection_transaction(
+        &self,
+        resources: &ConnectionResources,
+    ) -> PgWireResult<()> {
+        let Some(transaction) = resources.take_transaction() else {
+            return Ok(());
+        };
+        let transaction = match Arc::try_unwrap(transaction) {
+            Ok(transaction) => transaction,
+            Err(transaction) => {
+                resources.restore_transaction(transaction);
+                return Err(internal_error(
+                    "PostgreSQL transaction is still executing another statement",
+                ));
+            }
+        };
+        let _database_job_permit = self
+            .database_job
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| internal_error("PostgreSQL database transaction gate is closed"))?;
+        let _query_guard = self
+            .state
+            .shutdown
+            .try_enter_postgres_query()
+            .ok_or_else(|| user_error("57P01", "Jazz server is shutting down"))?;
+        transaction
+            .rollback()
+            .await
+            .map_err(postgres_database_transaction_error)
     }
 
     async fn execute_mutation(
         &self,
+        resources: &ConnectionResources,
         plan: MutationPlan,
         parameters: &[ParameterValue],
         format: &Format,
@@ -1456,55 +1620,68 @@ impl PostgresBackend {
             .ok_or_else(|| user_error("57P01", "Jazz server is shutting down"))?;
         let schema = self.schema().await?;
         let schema_version = schema.version_id();
+        if resources
+            .transaction()
+            .is_some_and(|transaction| transaction.schema_version() != schema_version)
+        {
+            return Err(user_error(
+                "40001",
+                "PostgreSQL schema changed during the transaction; retry",
+            ));
+        }
         if expected_schema_version.is_some_and(|expected| expected != schema_version) {
             return Err(user_error(
                 "0A000",
                 "cached PostgreSQL plan changed after a Jazz schema update; prepare it again",
             ));
         }
-        let table = table_by_name(&schema, &plan.table)?;
+        let table_name = plan.table;
+        let table = table_by_name(&schema, &table_name)?;
+        ensure_postgres_table_supported(table)?;
         let (mutation, command, returning_alias) = match plan.kind {
             MutationKind::Insert(insert) => {
-                let mut cells = BTreeMap::new();
-                let mut row = None;
-                for (column_name, value) in insert.columns.iter().zip(&insert.values) {
-                    if column_name == "id" {
-                        row = Some(resolve_mutation_row_id(value, parameters)?);
-                        continue;
+                let mut rows = Vec::with_capacity(insert.rows.len());
+                for values in &insert.rows {
+                    let mut cells = BTreeMap::new();
+                    let mut row = None;
+                    for (column_name, value) in insert.columns.iter().zip(values) {
+                        if column_name == "id" {
+                            row = Some(resolve_mutation_row_id(value, parameters)?);
+                            continue;
+                        }
+                        let column = ensure_table_column(table, column_name)?
+                            .expect("non-id column has a schema entry");
+                        ensure_mutation_column_supported(column)?;
+                        cells.insert(
+                            column_name.clone(),
+                            resolve_mutation_value(value, column, parameters)?,
+                        );
                     }
-                    let column = ensure_table_column(table, column_name)?
-                        .expect("non-id column has a schema entry");
-                    ensure_mutation_column_supported(column)?;
-                    cells.insert(
-                        column_name.clone(),
-                        resolve_mutation_value(value, column, parameters)?,
-                    );
+                    for column in &table.columns {
+                        if cells.contains_key(&column.name) || column.default.is_some() {
+                            continue;
+                        }
+                        if matches!(column.column_type, ColumnType::Nullable(_)) {
+                            cells.insert(column.name.clone(), Value::Nullable(None));
+                        } else {
+                            return Err(user_error(
+                                "23502",
+                                format!(
+                                    "null value in column {} violates not-null constraint",
+                                    column.name
+                                ),
+                            ));
+                        }
+                    }
+                    rows.push((row.unwrap_or_else(|| RowUuid(uuid::Uuid::now_v7())), cells));
                 }
-                for column in &table.columns {
-                    if cells.contains_key(&column.name) || column.default.is_some() {
-                        continue;
-                    }
-                    if matches!(column.column_type, ColumnType::Nullable(_)) {
-                        cells.insert(column.name.clone(), Value::Nullable(None));
-                    } else {
-                        return Err(user_error(
-                            "23502",
-                            format!(
-                                "null value in column {} violates not-null constraint",
-                                column.name
-                            ),
-                        ));
-                    }
-                }
-                let row = row.unwrap_or_else(|| RowUuid(uuid::Uuid::now_v7()));
                 (
-                    PostgresMutation::Insert { row, cells },
+                    PostgresMutation::Insert { rows },
                     "INSERT",
                     insert.returning.map(|returning| returning.alias),
                 )
             }
             MutationKind::Update(update) => {
-                let row = resolve_mutation_row_id(&update.row_id, parameters)?;
                 let mut patch = BTreeMap::new();
                 for assignment in update.assignments {
                     if assignment.column == "id" {
@@ -1518,7 +1695,20 @@ impl PostgresBackend {
                         resolve_mutation_value(&assignment.value, column, parameters)?,
                     );
                 }
-                (PostgresMutation::Update { row, patch }, "UPDATE", None)
+                let (predicate, bindings) = lower_table_filter(&update.filter, table, parameters)?;
+                let query = Query::from(table_name.clone())
+                    .filter(predicate)
+                    .select(["id"])
+                    .limit(MAX_INSERT_ROWS + 1);
+                (
+                    PostgresMutation::Update {
+                        query,
+                        bindings,
+                        patch,
+                    },
+                    "UPDATE",
+                    None,
+                )
             }
             MutationKind::Delete(delete) => (
                 PostgresMutation::Delete {
@@ -1543,27 +1733,46 @@ impl PostgresBackend {
         } else {
             None
         };
-        let result = self
-            .shell()?
-            .postgres_mutate(
-                plan.table,
-                schema_version,
-                mutation,
-                database_job_permit,
-                query_guard,
-            )
-            .await
-            .map_err(postgres_database_mutation_error)?;
+        let shell = self.shell()?;
+        let result = if let Some(transaction) = resources.transaction() {
+            shell
+                .postgres_mutate_in_transaction(
+                    &transaction,
+                    table_name,
+                    schema_version,
+                    mutation,
+                    database_job_permit,
+                    query_guard,
+                )
+                .await
+        } else {
+            shell
+                .postgres_mutate(
+                    table_name,
+                    schema_version,
+                    mutation,
+                    database_job_permit,
+                    query_guard,
+                )
+                .await
+        }
+        .map_err(postgres_database_mutation_error)?;
         if let Some(alias) = returning_alias {
-            let row = result
-                .row
-                .ok_or_else(|| internal_error("INSERT RETURNING did not produce a row id"))?;
+            if result.rows.len() != result.affected_rows {
+                return Err(internal_error(
+                    "INSERT RETURNING did not produce every affected row id",
+                ));
+            }
             return QueryOutput {
                 columns: vec![OutputColumn::new(
                     alias.unwrap_or_else(|| "id".to_owned()),
                     ColumnKind::Uuid,
                 )],
-                rows: vec![vec![Cell::Uuid(row.0)]],
+                rows: result
+                    .rows
+                    .into_iter()
+                    .map(|row| vec![Cell::Uuid(row.0)])
+                    .collect(),
                 response_permit: returning_permit.map(Arc::new),
                 command_tag: Some("INSERT 0".to_owned()),
             }
@@ -1580,6 +1789,7 @@ impl PostgresBackend {
 
     async fn execute_select(
         &self,
+        resources: &ConnectionResources,
         plan: SelectPlan,
         parameters: &[ParameterValue],
         expected_schema_version: Option<SchemaVersionId>,
@@ -1622,6 +1832,7 @@ impl PostgresBackend {
                     ));
                 }
                 self.execute_table(
+                    resources,
                     plan,
                     table,
                     parameters,
@@ -1649,6 +1860,7 @@ impl PostgresBackend {
 
     async fn execute_table(
         &self,
+        resources: &ConnectionResources,
         plan: SelectPlan,
         table_name: String,
         parameters: &[ParameterValue],
@@ -1670,6 +1882,15 @@ impl PostgresBackend {
             .ok_or_else(|| user_error("57P01", "Jazz server is shutting down"))?;
         let schema = self.schema().await?;
         let schema_version = schema.version_id();
+        if resources
+            .transaction()
+            .is_some_and(|transaction| transaction.schema_version() != schema_version)
+        {
+            return Err(user_error(
+                "40001",
+                "PostgreSQL schema changed during the transaction; retry",
+            ));
+        }
         if expected_schema_version.is_some_and(|expected| expected != schema_version) {
             return Err(user_error(
                 "0A000",
@@ -1677,46 +1898,15 @@ impl PostgresBackend {
             ));
         }
         let table = table_by_name(&schema, &table_name)?;
+        ensure_postgres_table_supported(table)?;
         let columns = projected_table_columns(&plan, table)?;
         let mut query = Query::from(table_name);
+        let mut bindings = BTreeMap::new();
         if let Some(filter) = &plan.filter {
-            let (predicate, bindings) = lower_table_filter(filter, table, parameters)?;
+            let (predicate, lowered_bindings) = lower_table_filter(filter, table, parameters)?;
             query = query.filter(predicate);
-            query = query.select(columns.iter().map(|column| column.source_name.clone()));
-            for order in &plan.order_by {
-                let column = ensure_table_column(table, &order.column)?;
-                ensure_orderable_column(column, &order.column)?;
-                query = query.order_by(
-                    order.column.clone(),
-                    if order.ascending {
-                        OrderDirection::Asc
-                    } else {
-                        OrderDirection::Desc
-                    },
-                );
-            }
-            query = query.limit(limit);
-            query = query.offset(offset);
-            let result = self
-                .shell()?
-                .postgres_query(
-                    query,
-                    schema_version,
-                    columns
-                        .iter()
-                        .map(|column| column.source_name.clone())
-                        .collect(),
-                    bindings,
-                    query_permit,
-                    response_permit,
-                    query_guard,
-                    MAX_RESPONSE_BYTES,
-                )
-                .await
-                .map_err(postgres_database_query_error)?;
-            return table_query_output(result, columns);
+            bindings = lowered_bindings;
         }
-
         query = query.select(columns.iter().map(|column| column.source_name.clone()));
         for order in &plan.order_by {
             let column = ensure_table_column(table, &order.column)?;
@@ -1732,23 +1922,40 @@ impl PostgresBackend {
         }
         query = query.limit(limit);
         query = query.offset(offset);
-        let result = self
-            .shell()?
-            .postgres_query(
-                query,
-                schema_version,
-                columns
-                    .iter()
-                    .map(|column| column.source_name.clone())
-                    .collect(),
-                BTreeMap::new(),
-                query_permit,
-                response_permit,
-                query_guard,
-                MAX_RESPONSE_BYTES,
-            )
-            .await
-            .map_err(postgres_database_query_error)?;
+        let selected_columns = columns
+            .iter()
+            .map(|column| column.source_name.clone())
+            .collect();
+        let shell = self.shell()?;
+        let result = if let Some(transaction) = resources.transaction() {
+            shell
+                .postgres_query_in_transaction(
+                    &transaction,
+                    query,
+                    schema_version,
+                    selected_columns,
+                    bindings,
+                    query_permit,
+                    response_permit,
+                    query_guard,
+                    MAX_RESPONSE_BYTES,
+                )
+                .await
+        } else {
+            shell
+                .postgres_query(
+                    query,
+                    schema_version,
+                    selected_columns,
+                    bindings,
+                    query_permit,
+                    response_permit,
+                    query_guard,
+                    MAX_RESPONSE_BYTES,
+                )
+                .await
+        }
+        .map_err(postgres_database_query_error)?;
         table_query_output(result, columns)
     }
 
@@ -2656,6 +2863,21 @@ fn ensure_mutation_column_supported(column: &crate::schema::ColumnSchema) -> PgW
     Ok(())
 }
 
+fn ensure_postgres_table_supported(table: &crate::schema::TableSchema) -> PgWireResult<()> {
+    if let Some(column) = table.columns.iter().find(|column| {
+        column.large_value.is_some() && matches!(column.column_type, ColumnType::Nullable(_))
+    }) {
+        return Err(user_error(
+            "0A000",
+            format!(
+                "PostgreSQL access does not yet support nullable large-value column {}.{}",
+                table.name, column.name
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn lower_table_filter<'a>(
     filter: &FilterExpr,
     table: &'a TableSchema,
@@ -3126,9 +3348,11 @@ fn infer_mutation_parameter_kinds(
     let mut inferred = BTreeMap::<usize, ColumnKind>::new();
     match &plan.kind {
         MutationKind::Insert(insert) => {
-            for (column, value) in insert.columns.iter().zip(&insert.values) {
-                ensure_table_column(table, column)?;
-                infer_mutation_literal_kind(column, value, &columns, &mut inferred)?;
+            for row in &insert.rows {
+                for (column, value) in insert.columns.iter().zip(row) {
+                    ensure_table_column(table, column)?;
+                    infer_mutation_literal_kind(column, value, &columns, &mut inferred)?;
+                }
             }
         }
         MutationKind::Update(update) => {
@@ -3144,7 +3368,7 @@ fn infer_mutation_parameter_kinds(
                     &mut inferred,
                 )?;
             }
-            infer_mutation_literal_kind("id", &update.row_id, &columns, &mut inferred)?;
+            infer_parameter_kinds_node(&update.filter, &columns, &mut inferred)?;
         }
         MutationKind::Delete(delete) => {
             infer_mutation_literal_kind("id", &delete.row_id, &columns, &mut inferred)?;
@@ -3808,7 +4032,7 @@ fn internal_database_error(error: String) -> PgWireError {
 fn postgres_database_query_error(error: String) -> PgWireError {
     if error.starts_with("PostgreSQL response exceeds configured") {
         user_error("54000", error)
-    } else if error.starts_with("PostgreSQL schema changed while planning") {
+    } else if error.starts_with("PostgreSQL schema changed") {
         user_error("40001", error)
     } else {
         internal_database_error(error)
@@ -3816,13 +4040,18 @@ fn postgres_database_query_error(error: String) -> PgWireError {
 }
 
 fn postgres_database_mutation_error(error: String) -> PgWireError {
-    if error.starts_with("PostgreSQL schema changed while planning") {
+    if error.starts_with("PostgreSQL schema changed") || error.contains("ExclusiveConflict") {
         user_error("40001", error)
     } else if (error.contains("MalformedCommit") && error.contains("exceeds max"))
         || error.contains("server write cell payload exceeds max")
+        || error.starts_with("PostgreSQL transaction cannot affect more than")
+        || error.starts_with("PostgreSQL transaction cell payload exceeds")
     {
         user_error("54000", error)
-    } else if error.contains("object already exists") || error.contains("row already deleted") {
+    } else if error.contains("object already exists")
+        || error.contains("duplicate object id")
+        || error.contains("row already deleted")
+    {
         user_error("23505", error)
     } else if error.contains("policy denied")
         || error.contains("authorization denied")
@@ -3834,6 +4063,10 @@ fn postgres_database_mutation_error(error: String) -> PgWireError {
     } else {
         internal_database_error(error)
     }
+}
+
+fn postgres_database_transaction_error(error: String) -> PgWireError {
+    postgres_database_mutation_error(error)
 }
 
 fn user_error(code: &str, message: impl Into<String>) -> PgWireError {

--- a/crates/jazz/src/tools/server/postgres/mod.rs
+++ b/crates/jazz/src/tools/server/postgres/mod.rs
@@ -16,7 +16,7 @@ use pgwire::api::auth::{
     AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
 };
 use pgwire::api::cancel::DefaultCancelHandler;
-use pgwire::api::portal::{Format, Portal};
+use pgwire::api::portal::{Format, Portal, PortalExecutionState};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{
     DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, FieldFormat, FieldInfo,
@@ -46,18 +46,20 @@ use tokio::sync::Semaphore;
 
 use crate::groove::records::Value;
 use crate::groove::schema::ColumnType;
-use crate::ids::SchemaVersionId;
+use crate::ids::{RowUuid, SchemaVersionId};
 use crate::query::{
     OrderDirection, Predicate, Query, all_of, any_of, col, eq, gt, gte, in_list, is_null, lit, lt,
     lte, ne, not, param,
 };
 use crate::schema::{JazzSchema, LargeValueKind, TableSchema};
-use crate::tools::server::core_server_shell::{PostgresQueryResult, ServerShellHandle};
+use crate::tools::server::core_server_shell::{
+    PostgresMutation, PostgresQueryResult, ServerShellHandle,
+};
 use crate::tools::server::{ServerState, ServerTopology};
 
 use self::sql::{
-    Command, CompareOp, FilterExpr, PageValue, ParsedStatement, ProjectedExpr, SelectPlan,
-    SelectSource, SessionFunction, SqlLiteral,
+    Command, CompareOp, FilterExpr, InsertPlan, MutationKind, MutationPlan, PageValue,
+    ParsedStatement, ProjectedExpr, SelectPlan, SelectSource, SessionFunction, SqlLiteral,
 };
 
 const POSTGRES_USER: &str = "jazz";
@@ -89,6 +91,25 @@ const MAX_STORED_PORTAL_BYTES: usize = 8 * 1024 * 1024;
 const MAX_RESULT_COLUMNS: usize = 1_664;
 const MAX_SIMPLE_BATCH_STATEMENTS: usize = 64;
 const INCOMPLETE_FRAME_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn is_mutation(statement: &ParsedStatement) -> bool {
+    matches!(statement, ParsedStatement::Mutation(_))
+}
+
+fn returns_rows(statement: &ParsedStatement) -> bool {
+    matches!(
+        statement,
+        ParsedStatement::Select(_)
+            | ParsedStatement::Command(Command::Show(_))
+            | ParsedStatement::Mutation(MutationPlan {
+                kind: MutationKind::Insert(InsertPlan {
+                    returning: Some(_),
+                    ..
+                }),
+                ..
+            })
+    )
+}
 
 pub(crate) struct PostgresServerHandle {
     addr: SocketAddr,
@@ -566,7 +587,7 @@ impl PgWireServerHandlers for PostgresHandlerFactory {
     fn startup_handler(&self) -> Arc<impl StartupHandler> {
         let mut parameters = DefaultServerParameterProvider::default();
         parameters.server_version = "16.6".to_owned();
-        parameters.default_transaction_read_only = true;
+        parameters.default_transaction_read_only = false;
         parameters.search_path = "public".to_owned();
         Arc::new(
             CleartextPasswordAuthStartupHandler::new((*self.auth).clone(), parameters)
@@ -848,6 +869,12 @@ impl SimpleQueryHandler for PostgresBackend {
                 ),
             ));
         }
+        if statements.len() > 1 && statements.iter().any(is_mutation) {
+            return Err(user_error(
+                "0A000",
+                "PostgreSQL mutations must be sent as individual autocommit statements",
+            ));
+        }
         if statements.len() > 1
             && statements.iter().any(|statement| {
                 matches!(
@@ -875,6 +902,14 @@ impl SimpleQueryHandler for PostgresBackend {
             }
             return Err(failed_transaction_error());
         }
+        if client.transaction_status() != TransactionStatus::Idle
+            && statements.iter().any(is_mutation)
+        {
+            return Err(user_error(
+                "0A000",
+                "PostgreSQL mutations are currently supported in autocommit mode only",
+            ));
+        }
         let application_table_reads = statements
             .iter()
             .filter(|statement| {
@@ -895,12 +930,7 @@ impl SimpleQueryHandler for PostgresBackend {
         }
         let row_responses = statements
             .iter()
-            .filter(|statement| {
-                matches!(
-                    statement,
-                    ParsedStatement::Select(_) | ParsedStatement::Command(Command::Show(_))
-                )
-            })
+            .filter(|statement| returns_rows(statement))
             .count();
         if row_responses > MAX_BUFFERED_RESPONSES {
             return Err(user_error(
@@ -1139,18 +1169,26 @@ impl ExtendedQueryHandler for PostgresBackend {
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         let portal_name = message.name.as_deref().unwrap_or(DEFAULT_NAME).to_owned();
-        let ends_transaction =
-            client
-                .portal_store()
-                .get_portal(&portal_name)
-                .is_some_and(|portal| {
+        let (ends_transaction, completes_mutation) = client
+            .portal_store()
+            .get_portal(&portal_name)
+            .map(|portal| {
+                let parsed = &portal.statement.statement.parsed;
+                (
                     matches!(
-                        portal.statement.statement.parsed,
+                        parsed,
                         ParsedStatement::Command(Command::Commit | Command::Rollback)
-                    )
-                });
+                    ),
+                    is_mutation(parsed),
+                )
+            })
+            .unwrap_or((false, false));
         let result = self._on_execute(client, message).await;
         connection_resources(client).release_response(&portal_name);
+        if result.is_ok() && completes_mutation {
+            connection_resources(client).release_portal(&portal_name);
+            client.portal_store().rm_portal(&portal_name);
+        }
         if result.is_ok() && ends_transaction {
             clear_connection_portals(client);
         }
@@ -1206,6 +1244,13 @@ impl ExtendedQueryHandler for PostgresBackend {
                 _ => Err(failed_transaction_error()),
             };
         }
+        if client.transaction_status() != TransactionStatus::Idle && is_mutation(&statement.parsed)
+        {
+            return Err(user_error(
+                "0A000",
+                "PostgreSQL mutations are currently supported in autocommit mode only",
+            ));
+        }
         let current_parameter_kinds = self.parameter_kinds(&statement.parsed).await?;
         let current_result_columns = self
             .describe(&statement.parsed, &portal.result_column_format)
@@ -1227,6 +1272,12 @@ impl ExtendedQueryHandler for PostgresBackend {
                 statement.schema_version,
             )
             .await?;
+        if is_mutation(&statement.parsed)
+            && !returns_rows(&statement.parsed)
+            && matches!(&executed.response, Response::Execution(_))
+        {
+            *portal.state().lock().await = PortalExecutionState::Finished;
+        }
         if let Some(response_permit) = executed.response_permit {
             connection_resources(client).retain_response(&portal.name, response_permit);
         }
@@ -1320,7 +1371,8 @@ impl PostgresBackend {
             ParsedStatement::Select(SelectPlan {
                 source: SelectSource::Table(_),
                 ..
-            }) => Ok(Some(self.schema().await?.version_id())),
+            })
+            | ParsedStatement::Mutation(_) => Ok(Some(self.schema().await?.version_id())),
             _ => Ok(None),
         }
     }
@@ -1339,6 +1391,10 @@ impl PostgresBackend {
                     .await?;
                 output.into_response(format)
             }
+            ParsedStatement::Mutation(plan) => {
+                self.execute_mutation(plan, parameters, format, expected_schema_version)
+                    .await
+            }
             ParsedStatement::Command(command) => self.execute_command(command, format),
         }
     }
@@ -1349,7 +1405,7 @@ impl PostgresBackend {
                 let value = match setting.to_ascii_lowercase().as_str() {
                     "server_version" => "16.6",
                     "search_path" => "public",
-                    "transaction_read_only" | "default_transaction_read_only" => "on",
+                    "transaction_read_only" | "default_transaction_read_only" => "off",
                     "standard_conforming_strings" => "on",
                     "client_encoding" | "server_encoding" => "UTF8",
                     "timezone" | "time.zone" => "Etc/UTC",
@@ -1364,6 +1420,7 @@ impl PostgresBackend {
                     columns: vec![OutputColumn::new(setting, ColumnKind::Text)],
                     rows: vec![vec![Cell::Text(value.to_owned())]],
                     response_permit: None,
+                    command_tag: None,
                 }
                 .into_response(format)
             }
@@ -1377,6 +1434,148 @@ impl PostgresBackend {
                 Tag::new("ROLLBACK"),
             ))),
         }
+    }
+
+    async fn execute_mutation(
+        &self,
+        plan: MutationPlan,
+        parameters: &[ParameterValue],
+        format: &Format,
+        expected_schema_version: Option<SchemaVersionId>,
+    ) -> PgWireResult<ExecutedResponse> {
+        let database_job_permit = self
+            .database_job
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| internal_error("PostgreSQL database mutation gate is closed"))?;
+        let query_guard = self
+            .state
+            .shutdown
+            .try_enter_postgres_query()
+            .ok_or_else(|| user_error("57P01", "Jazz server is shutting down"))?;
+        let schema = self.schema().await?;
+        let schema_version = schema.version_id();
+        if expected_schema_version.is_some_and(|expected| expected != schema_version) {
+            return Err(user_error(
+                "0A000",
+                "cached PostgreSQL plan changed after a Jazz schema update; prepare it again",
+            ));
+        }
+        let table = table_by_name(&schema, &plan.table)?;
+        let (mutation, command, returning_alias) = match plan.kind {
+            MutationKind::Insert(insert) => {
+                let mut cells = BTreeMap::new();
+                let mut row = None;
+                for (column_name, value) in insert.columns.iter().zip(&insert.values) {
+                    if column_name == "id" {
+                        row = Some(resolve_mutation_row_id(value, parameters)?);
+                        continue;
+                    }
+                    let column = ensure_table_column(table, column_name)?
+                        .expect("non-id column has a schema entry");
+                    ensure_mutation_column_supported(column)?;
+                    cells.insert(
+                        column_name.clone(),
+                        resolve_mutation_value(value, column, parameters)?,
+                    );
+                }
+                for column in &table.columns {
+                    if cells.contains_key(&column.name) || column.default.is_some() {
+                        continue;
+                    }
+                    if matches!(column.column_type, ColumnType::Nullable(_)) {
+                        cells.insert(column.name.clone(), Value::Nullable(None));
+                    } else {
+                        return Err(user_error(
+                            "23502",
+                            format!(
+                                "null value in column {} violates not-null constraint",
+                                column.name
+                            ),
+                        ));
+                    }
+                }
+                let row = row.unwrap_or_else(|| RowUuid(uuid::Uuid::now_v7()));
+                (
+                    PostgresMutation::Insert { row, cells },
+                    "INSERT",
+                    insert.returning.map(|returning| returning.alias),
+                )
+            }
+            MutationKind::Update(update) => {
+                let row = resolve_mutation_row_id(&update.row_id, parameters)?;
+                let mut patch = BTreeMap::new();
+                for assignment in update.assignments {
+                    if assignment.column == "id" {
+                        return Err(user_error("428C9", "row id cannot be updated"));
+                    }
+                    let column = ensure_table_column(table, &assignment.column)?
+                        .expect("non-id column has a schema entry");
+                    ensure_mutation_column_supported(column)?;
+                    patch.insert(
+                        assignment.column,
+                        resolve_mutation_value(&assignment.value, column, parameters)?,
+                    );
+                }
+                (PostgresMutation::Update { row, patch }, "UPDATE", None)
+            }
+            MutationKind::Delete(delete) => (
+                PostgresMutation::Delete {
+                    row: resolve_mutation_row_id(&delete.row_id, parameters)?,
+                },
+                "DELETE",
+                None,
+            ),
+        };
+        let returning_permit = if returning_alias.is_some() {
+            Some(
+                self.buffered_responses
+                    .clone()
+                    .try_acquire_owned()
+                    .map_err(|_| {
+                        user_error(
+                            "53000",
+                            "too many PostgreSQL responses are still being consumed; finish or close an existing result before retrying",
+                        )
+                    })?,
+            )
+        } else {
+            None
+        };
+        let result = self
+            .shell()?
+            .postgres_mutate(
+                plan.table,
+                schema_version,
+                mutation,
+                database_job_permit,
+                query_guard,
+            )
+            .await
+            .map_err(postgres_database_mutation_error)?;
+        if let Some(alias) = returning_alias {
+            let row = result
+                .row
+                .ok_or_else(|| internal_error("INSERT RETURNING did not produce a row id"))?;
+            return QueryOutput {
+                columns: vec![OutputColumn::new(
+                    alias.unwrap_or_else(|| "id".to_owned()),
+                    ColumnKind::Uuid,
+                )],
+                rows: vec![vec![Cell::Uuid(row.0)]],
+                response_permit: returning_permit.map(Arc::new),
+                command_tag: Some("INSERT 0".to_owned()),
+            }
+            .into_response(format);
+        }
+        let tag = Tag::new(command).with_rows(result.affected_rows);
+        let tag = if command == "INSERT" {
+            tag.with_oid(0)
+        } else {
+            tag
+        };
+        Ok(ExecutedResponse::without_permit(Response::Execution(tag)))
     }
 
     async fn execute_select(
@@ -1595,7 +1794,7 @@ impl PostgresBackend {
                 ProjectedExpr::SessionFunction(SessionFunction::Version) => (
                     "version",
                     ColumnKind::Text,
-                    Cell::Text("PostgreSQL 16.6 compatible Jazz read-only interface".to_owned()),
+                    Cell::Text("PostgreSQL 16.6 compatible Jazz interface".to_owned()),
                 ),
                 ProjectedExpr::SessionFunction(SessionFunction::CurrentDatabase) => (
                     "current_database",
@@ -1641,6 +1840,7 @@ impl PostgresBackend {
             columns,
             rows,
             response_permit: None,
+            command_tag: None,
         })
     }
 
@@ -1654,6 +1854,18 @@ impl PostgresBackend {
                 Ok(vec![OutputColumn::new(setting.clone(), ColumnKind::Text)])
             }
             ParsedStatement::Command(_) => Ok(Vec::new()),
+            ParsedStatement::Mutation(MutationPlan {
+                kind:
+                    MutationKind::Insert(InsertPlan {
+                        returning: Some(returning),
+                        ..
+                    }),
+                ..
+            }) => Ok(vec![OutputColumn::new(
+                returning.alias.clone().unwrap_or_else(|| "id".to_owned()),
+                ColumnKind::Uuid,
+            )]),
+            ParsedStatement::Mutation(_) => Ok(Vec::new()),
             ParsedStatement::Select(plan) => match &plan.source {
                 SelectSource::Table(table_name) => {
                     let schema = self.schema().await?;
@@ -1681,20 +1893,27 @@ impl PostgresBackend {
     }
 
     async fn parameter_kinds(&self, statement: &ParsedStatement) -> PgWireResult<Vec<ColumnKind>> {
-        let ParsedStatement::Select(plan) = statement else {
-            return Ok(Vec::new());
-        };
-        let column_kinds = match &plan.source {
-            SelectSource::Table(table_name) => {
+        match statement {
+            ParsedStatement::Select(plan) => {
+                let column_kinds = match &plan.source {
+                    SelectSource::Table(table_name) => {
+                        let schema = self.schema().await?;
+                        table_column_kinds(table_by_name(&schema, table_name)?)
+                    }
+                    SelectSource::Databases | SelectSource::Tables | SelectSource::Columns => {
+                        catalogue_column_kinds(&plan.source)
+                    }
+                    SelectSource::Session => BTreeMap::new(),
+                };
+                infer_parameter_kinds(plan, &column_kinds)
+            }
+            ParsedStatement::Mutation(plan) => {
                 let schema = self.schema().await?;
-                table_column_kinds(table_by_name(&schema, table_name)?)
+                let table = table_by_name(&schema, &plan.table)?;
+                infer_mutation_parameter_kinds(plan, table)
             }
-            SelectSource::Databases | SelectSource::Tables | SelectSource::Columns => {
-                catalogue_column_kinds(&plan.source)
-            }
-            SelectSource::Session => BTreeMap::new(),
-        };
-        infer_parameter_kinds(plan, &column_kinds)
+            ParsedStatement::Command(_) => Ok(Vec::new()),
+        }
     }
 }
 
@@ -1829,6 +2048,7 @@ struct QueryOutput {
     columns: Vec<OutputColumn>,
     rows: Vec<Vec<Cell>>,
     response_permit: Option<Arc<tokio::sync::OwnedSemaphorePermit>>,
+    command_tag: Option<String>,
 }
 
 struct ExecutedResponse {
@@ -1891,8 +2111,12 @@ impl QueryOutput {
                 rows.next().map(|row| (row, (rows, response_permit)))
             },
         );
+        let mut response = QueryResponse::new(fields, rows);
+        if let Some(command_tag) = self.command_tag {
+            response.set_command_tag(&command_tag);
+        }
         Ok(ExecutedResponse {
-            response: Response::Query(QueryResponse::new(fields, rows)),
+            response: Response::Query(response),
             response_permit,
         })
     }
@@ -2040,6 +2264,7 @@ fn table_query_output(
         columns: output_columns,
         rows,
         response_permit: Some(Arc::new(result.response_permit)),
+        command_tag: None,
     })
 }
 
@@ -2357,6 +2582,80 @@ fn resolve_page_value(value: &PageValue, parameters: &[ParameterValue]) -> PgWir
     }
 }
 
+fn resolve_mutation_row_id(
+    literal: &SqlLiteral,
+    parameters: &[ParameterValue],
+) -> PgWireResult<RowUuid> {
+    let value = match literal {
+        SqlLiteral::Placeholder(position) => {
+            let parameter = parameters
+                .get(position - 1)
+                .ok_or_else(|| user_error("08P01", format!("missing parameter ${position}")))?;
+            if matches!(parameter, ParameterValue::Null) {
+                return Err(user_error("23502", "row id cannot be NULL"));
+            }
+            parameter_to_jazz_value(parameter, None)?
+        }
+        SqlLiteral::Null => return Err(user_error("23502", "row id cannot be NULL")),
+        other => sql_literal_to_jazz_value(other, None)?,
+    };
+    match value {
+        Value::Uuid(value) => Ok(RowUuid(value)),
+        _ => Err(user_error("42804", "row id must have UUID type")),
+    }
+}
+
+fn resolve_mutation_value(
+    literal: &SqlLiteral,
+    column: &crate::schema::ColumnSchema,
+    parameters: &[ParameterValue],
+) -> PgWireResult<Value> {
+    match literal {
+        SqlLiteral::Null => null_mutation_value(column),
+        SqlLiteral::Placeholder(position) => {
+            let parameter = parameters
+                .get(position - 1)
+                .ok_or_else(|| user_error("08P01", format!("missing parameter ${position}")))?;
+            if matches!(parameter, ParameterValue::Null) {
+                return null_mutation_value(column);
+            }
+            parameter_to_jazz_value(parameter, Some(column))
+        }
+        other => sql_literal_to_jazz_value(other, Some(column))
+            .map(|value| wrap_non_null_for_column(value, &column.column_type)),
+    }
+}
+
+fn null_mutation_value(column: &crate::schema::ColumnSchema) -> PgWireResult<Value> {
+    if matches!(column.column_type, ColumnType::Nullable(_)) {
+        Ok(Value::Nullable(None))
+    } else {
+        Err(user_error(
+            "23502",
+            format!(
+                "null value in column {} violates not-null constraint",
+                column.name
+            ),
+        ))
+    }
+}
+
+fn ensure_mutation_column_supported(column: &crate::schema::ColumnSchema) -> PgWireResult<()> {
+    if matches!(
+        unwrap_nullable(&column.column_type),
+        ColumnType::Tuple(_) | ColumnType::Array(_)
+    ) {
+        return Err(user_error(
+            "0A000",
+            format!(
+                "PostgreSQL mutations do not yet support composite column {}",
+                column.name
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn lower_table_filter<'a>(
     filter: &FilterExpr,
     table: &'a TableSchema,
@@ -2558,6 +2857,16 @@ fn sql_literal_to_jazz_value(
             )),
         };
     };
+    if column.large_value == Some(LargeValueKind::Text) {
+        return match literal {
+            SqlLiteral::String(value) => Ok(Value::Bytes(value.as_bytes().to_vec())),
+            SqlLiteral::Placeholder(_) => unreachable!("placeholder handled by caller"),
+            _ => Err(user_error(
+                "42804",
+                format!("literal is incompatible with column {}", column.name),
+            )),
+        };
+    }
     let column_type = unwrap_nullable(&column.column_type);
     match (literal, column_type) {
         (SqlLiteral::String(value), ColumnType::String) => Ok(Value::String(value.clone())),
@@ -2619,6 +2928,18 @@ fn parameter_to_jazz_value(
     let column = column.expect("checked above");
     if matches!(parameter, ParameterValue::Null) {
         return Ok(Value::Nullable(None));
+    }
+    if column.large_value == Some(LargeValueKind::Text) {
+        let value = match parameter {
+            ParameterValue::Text(value) => Value::Bytes(value.as_bytes().to_vec()),
+            _ => {
+                return Err(user_error(
+                    "42804",
+                    format!("parameter is incompatible with column {}", column.name),
+                ));
+            }
+        };
+        return Ok(wrap_non_null_for_column(value, &column.column_type));
     }
     let value = match parameter {
         ParameterValue::Null => unreachable!("handled above"),
@@ -2794,6 +3115,63 @@ fn infer_parameter_kinds(
             "source-less SELECT parameters are not supported",
         ));
     }
+    finish_inferred_parameter_kinds(inferred)
+}
+
+fn infer_mutation_parameter_kinds(
+    plan: &MutationPlan,
+    table: &TableSchema,
+) -> PgWireResult<Vec<ColumnKind>> {
+    let columns = table_column_kinds(table);
+    let mut inferred = BTreeMap::<usize, ColumnKind>::new();
+    match &plan.kind {
+        MutationKind::Insert(insert) => {
+            for (column, value) in insert.columns.iter().zip(&insert.values) {
+                ensure_table_column(table, column)?;
+                infer_mutation_literal_kind(column, value, &columns, &mut inferred)?;
+            }
+        }
+        MutationKind::Update(update) => {
+            for assignment in &update.assignments {
+                if assignment.column == "id" {
+                    return Err(user_error("428C9", "row id cannot be updated"));
+                }
+                ensure_table_column(table, &assignment.column)?;
+                infer_mutation_literal_kind(
+                    &assignment.column,
+                    &assignment.value,
+                    &columns,
+                    &mut inferred,
+                )?;
+            }
+            infer_mutation_literal_kind("id", &update.row_id, &columns, &mut inferred)?;
+        }
+        MutationKind::Delete(delete) => {
+            infer_mutation_literal_kind("id", &delete.row_id, &columns, &mut inferred)?;
+        }
+    }
+    finish_inferred_parameter_kinds(inferred)
+}
+
+fn infer_mutation_literal_kind(
+    column: &str,
+    literal: &SqlLiteral,
+    columns: &BTreeMap<String, ColumnKind>,
+    inferred: &mut BTreeMap<usize, ColumnKind>,
+) -> PgWireResult<()> {
+    let SqlLiteral::Placeholder(position) = literal else {
+        return Ok(());
+    };
+    let kind = columns
+        .get(column)
+        .copied()
+        .ok_or_else(|| user_error("42703", format!("column {column} does not exist")))?;
+    insert_inferred_kind(inferred, *position, kind)
+}
+
+fn finish_inferred_parameter_kinds(
+    inferred: BTreeMap<usize, ColumnKind>,
+) -> PgWireResult<Vec<ColumnKind>> {
     let Some(max) = inferred.keys().next_back().copied() else {
         return Ok(Vec::new());
     };
@@ -3029,6 +3407,7 @@ impl VirtualRelation {
             columns,
             rows,
             response_permit: None,
+            command_tag: None,
         })
     }
 
@@ -3430,6 +3809,27 @@ fn postgres_database_query_error(error: String) -> PgWireError {
     if error.starts_with("PostgreSQL response exceeds configured") {
         user_error("54000", error)
     } else if error.starts_with("PostgreSQL schema changed while planning") {
+        user_error("40001", error)
+    } else {
+        internal_database_error(error)
+    }
+}
+
+fn postgres_database_mutation_error(error: String) -> PgWireError {
+    if error.starts_with("PostgreSQL schema changed while planning") {
+        user_error("40001", error)
+    } else if (error.contains("MalformedCommit") && error.contains("exceeds max"))
+        || error.contains("server write cell payload exceeds max")
+    {
+        user_error("54000", error)
+    } else if error.contains("object already exists") || error.contains("row already deleted") {
+        user_error("23505", error)
+    } else if error.contains("policy denied")
+        || error.contains("authorization denied")
+        || error.contains("AuthorizationDenied")
+    {
+        user_error("42501", error)
+    } else if error.contains("did not reach global durability") {
         user_error("40001", error)
     } else {
         internal_database_error(error)

--- a/crates/jazz/src/tools/server/postgres/mod.rs
+++ b/crates/jazz/src/tools/server/postgres/mod.rs
@@ -1,0 +1,3461 @@
+mod sql;
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Debug;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::Engine;
+use bytes::BytesMut;
+use futures::{Sink, SinkExt, stream};
+use pgwire::api::auth::cleartext::CleartextPasswordAuthStartupHandler;
+use pgwire::api::auth::{
+    AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
+};
+use pgwire::api::cancel::DefaultCancelHandler;
+use pgwire::api::portal::{Format, Portal};
+use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
+use pgwire::api::results::{
+    DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, FieldFormat, FieldInfo,
+    QueryResponse, Response, Tag,
+};
+use pgwire::api::stmt::{QueryParser, StoredStatement};
+use pgwire::api::store::PortalStore;
+use pgwire::api::{
+    ClientInfo, ClientPortalStore, ConnectionManager, DEFAULT_NAME, ErrorHandler,
+    PgWireConnectionState, PgWireServerHandlers, Type,
+};
+use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
+use pgwire::messages::extendedquery::{
+    Bind, BindComplete, Close, CloseComplete, Execute, Parse, ParseComplete, Sync as PgSync,
+    TARGET_TYPE_BYTE_PORTAL, TARGET_TYPE_BYTE_STATEMENT,
+};
+use pgwire::messages::response::{ReadyForQuery, TransactionStatus};
+use pgwire::messages::{
+    DecodeContext, PgWireBackendMessage, PgWireFrontendMessage, ProtocolVersion,
+};
+use pgwire::tokio::server::{negotiate_tls, process_error, process_message};
+use pgwire::types::format::FormatOptions;
+use pgwire::types::{FromSqlText, ToSqlText};
+use postgres_types::{FromSql, IsNull, ToSql};
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::sync::Semaphore;
+
+use crate::groove::records::Value;
+use crate::groove::schema::ColumnType;
+use crate::ids::SchemaVersionId;
+use crate::query::{
+    OrderDirection, Predicate, Query, all_of, any_of, col, eq, gt, gte, in_list, is_null, lit, lt,
+    lte, ne, not, param,
+};
+use crate::schema::{JazzSchema, LargeValueKind, TableSchema};
+use crate::tools::server::core_server_shell::{PostgresQueryResult, ServerShellHandle};
+use crate::tools::server::{ServerState, ServerTopology};
+
+use self::sql::{
+    Command, CompareOp, FilterExpr, PageValue, ParsedStatement, ProjectedExpr, SelectPlan,
+    SelectSource, SessionFunction, SqlLiteral,
+};
+
+const POSTGRES_USER: &str = "jazz";
+const MAX_PAGE_SIZE: usize = 10_000;
+const MAX_OFFSET: usize = 10_000;
+const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+const DATA_ROW_WIRE_OVERHEAD: usize = 1 + 4 + 2;
+const MAX_CONCURRENT_DATABASE_JOBS: usize = 1;
+const MAX_BUFFERED_RESPONSES: usize = 4;
+const MAX_CONNECTIONS: usize = 64;
+const MAX_CANCEL_CONNECTIONS: usize = 4;
+const MAX_SQL_BYTES: usize = 64 * 1024;
+const MAX_PARAMETER_COUNT: usize = 1_024;
+const MAX_PARAMETER_BYTES: usize = 4 * 1024 * 1024;
+const MAX_EXPANDED_BINDING_BYTES: usize = 8 * 1024 * 1024;
+const CANCEL_REQUEST_LENGTH: u32 = 16;
+const CANCEL_REQUEST_CODE: u32 = 80_877_102;
+const STARTUP_FRAME_BYTES: usize = 10_000;
+const QUERY_FRAME_BYTES: usize = 128 * 1024;
+const PARSE_FRAME_BYTES: usize = MAX_SQL_BYTES * 2 + 16 * 1024;
+const BIND_FRAME_BYTES: usize = MAX_PARAMETER_BYTES + 1024 * 1024;
+const OTHER_FRAME_BYTES: usize = 64 * 1024;
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_STORED_STATEMENTS: usize = 64;
+const MAX_STORED_PORTALS: usize = 64;
+const MAX_OBJECT_NAME_BYTES: usize = 256;
+const MAX_STORED_STATEMENT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_STORED_PORTAL_BYTES: usize = 8 * 1024 * 1024;
+const MAX_RESULT_COLUMNS: usize = 1_664;
+const MAX_SIMPLE_BATCH_STATEMENTS: usize = 64;
+const INCOMPLETE_FRAME_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(crate) struct PostgresServerHandle {
+    addr: SocketAddr,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl PostgresServerHandle {
+    pub(crate) async fn start(
+        state: Arc<ServerState>,
+        addr: SocketAddr,
+        postgres_secret: String,
+    ) -> Result<Self, String> {
+        if !addr.ip().is_loopback() {
+            return Err("the PostgreSQL interface must bind to a loopback address".to_owned());
+        }
+        if state.topology != ServerTopology::Core {
+            return Err(
+                "the PostgreSQL interface is only supported on a core server; edge storage is partial"
+                    .to_owned(),
+            );
+        }
+        if postgres_secret.is_empty() {
+            return Err("the PostgreSQL interface requires a non-empty database secret".to_owned());
+        }
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|error| format!("failed to bind PostgreSQL interface on {addr}: {error}"))?;
+        let addr = listener
+            .local_addr()
+            .map_err(|error| format!("failed to resolve PostgreSQL listen address: {error}"))?;
+        let database = state.app_id.to_string();
+        let backend = Arc::new(PostgresBackend {
+            state: state.clone(),
+            database: database.clone(),
+            parser: Arc::new(ParsedQueryParser),
+            database_job: Arc::new(Semaphore::new(MAX_CONCURRENT_DATABASE_JOBS)),
+            buffered_responses: Arc::new(Semaphore::new(MAX_BUFFERED_RESPONSES)),
+        });
+        let connection_manager = Arc::new(ConnectionManager::new());
+        let factory = Arc::new(PostgresHandlerFactory {
+            backend,
+            auth: Arc::new(DatabaseAuth {
+                database,
+                password: postgres_secret,
+            }),
+            connection_manager,
+        });
+        let connection_slots = Arc::new(Semaphore::new(MAX_CONNECTIONS));
+        let cancel_slots = Arc::new(Semaphore::new(MAX_CANCEL_CONNECTIONS));
+        let shutdown = state.shutdown.clone();
+        let task = tokio::spawn(async move {
+            let mut connections = tokio::task::JoinSet::new();
+            loop {
+                tokio::select! {
+                    _ = shutdown.wait_requested() => break,
+                    accepted = listener.accept() => {
+                        let Ok((socket, peer)) = accepted else {
+                            if !shutdown.is_shutting_down() {
+                                tracing::error!("PostgreSQL listener stopped accepting connections");
+                            }
+                            break;
+                        };
+                        let Ok(connection_slot) = connection_slots.clone().try_acquire_owned() else {
+                            let Ok(cancel_slot) = cancel_slots.clone().try_acquire_owned() else {
+                                tracing::warn!(%peer, max_connections = MAX_CONNECTIONS, "PostgreSQL connection limit reached");
+                                drop(socket);
+                                continue;
+                            };
+                            let Some(connection_guard) = shutdown.try_enter_postgres_connection() else {
+                                break;
+                            };
+                            let factory = factory.clone();
+                            connections.spawn(async move {
+                                let _cancel_slot = cancel_slot;
+                                let _connection_guard = connection_guard;
+                                if !looks_like_cancel_request(&socket).await {
+                                    tracing::warn!(%peer, max_connections = MAX_CONNECTIONS, "rejected PostgreSQL connection above the regular limit");
+                                    return;
+                                }
+                                match tokio::time::timeout(
+                                    Duration::from_secs(1),
+                                    process_bounded_socket(socket, factory),
+                                )
+                                .await
+                                {
+                                    Ok(Err(error)) => tracing::debug!(%peer, %error, "PostgreSQL cancel connection closed with an error"),
+                                    Err(_) => tracing::warn!(%peer, "PostgreSQL cancel connection timed out"),
+                                    Ok(Ok(())) => {}
+                                }
+                            });
+                            continue;
+                        };
+                        let Some(connection_guard) = shutdown.try_enter_postgres_connection() else {
+                            break;
+                        };
+                        let factory = factory.clone();
+                        connections.spawn(async move {
+                            let _connection_slot = connection_slot;
+                            let _connection_guard = connection_guard;
+                            if let Err(error) = process_bounded_socket(socket, factory).await {
+                                tracing::debug!(%peer, %error, "PostgreSQL connection closed with an error");
+                            }
+                        });
+                    }
+                    Some(result) = connections.join_next(), if !connections.is_empty() => {
+                        if let Err(error) = result
+                            && !error.is_cancelled()
+                        {
+                            tracing::debug!(%error, "PostgreSQL connection task failed");
+                        }
+                    }
+                }
+            }
+            connections.abort_all();
+            while connections.join_next().await.is_some() {}
+        });
+        Ok(Self { addr, task })
+    }
+
+    pub(crate) fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+async fn looks_like_cancel_request(socket: &tokio::net::TcpStream) -> bool {
+    let mut prefix = [0_u8; 8];
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
+    loop {
+        let read = match tokio::time::timeout_at(deadline, socket.peek(&mut prefix)).await {
+            Ok(Ok(read)) => read,
+            _ => return false,
+        };
+        if read == 0 {
+            return false;
+        }
+        if read >= prefix.len() {
+            return u32::from_be_bytes(prefix[..4].try_into().expect("four-byte length"))
+                == CANCEL_REQUEST_LENGTH
+                && u32::from_be_bytes(prefix[4..].try_into().expect("four-byte code"))
+                    == CANCEL_REQUEST_CODE;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+}
+
+async fn process_bounded_socket(
+    socket: tokio::net::TcpStream,
+    handlers: Arc<PostgresHandlerFactory>,
+) -> Result<(), io::Error> {
+    let startup_deadline = tokio::time::Instant::now() + STARTUP_TIMEOUT;
+    let socket = match tokio::time::timeout_at(
+        startup_deadline,
+        negotiate_tls::<PreparedStatement>(socket, None),
+    )
+    .await
+    {
+        Ok(result) => result?,
+        Err(_) => return Ok(()),
+    };
+    let Some(socket) = socket else {
+        return Ok(());
+    };
+
+    // TLS negotiation may already have read part of the startup frame. Keep
+    // those bytes, then bypass Framed's unbounded frontend decoder so the
+    // declared frame length is checked before any large allocation.
+    let mut parts = socket.into_parts();
+    let mut inbound = std::mem::take(&mut parts.read_buf);
+    let mut socket = tokio_util::codec::Framed::from_parts(parts);
+
+    let startup_handler = handlers.startup_handler();
+    let simple_query_handler = handlers.backend.clone();
+    let extended_query_handler = handlers.backend.clone();
+    let copy_handler = handlers.copy_handler();
+    let cancel_handler = handlers.cancel_handler();
+    let error_handler = handlers.error_handler();
+
+    loop {
+        let state = socket.state();
+        let protocol_version = socket.protocol_version();
+        let read =
+            read_bounded_frontend_message(socket.get_mut(), &mut inbound, state, protocol_version);
+        let message = if matches!(
+            state,
+            PgWireConnectionState::AwaitingStartup
+                | PgWireConnectionState::AuthenticationInProgress
+        ) {
+            match tokio::time::timeout_at(startup_deadline, read).await {
+                Ok(result) => result,
+                Err(_) => return Ok(()),
+            }
+        } else {
+            read.await
+        }
+        .map_err(io::Error::from)?;
+        let Some(message) = message else {
+            break;
+        };
+        if matches!(message, PgWireFrontendMessage::Terminate(_)) {
+            break;
+        }
+        let is_extended_query = match socket.state() {
+            PgWireConnectionState::CopyInProgress(is_extended_query) => is_extended_query,
+            _ => message.is_extended_query(),
+        };
+        if let Err(mut error) = process_message(
+            message,
+            &mut socket,
+            startup_handler.clone(),
+            simple_query_handler.clone(),
+            extended_query_handler.clone(),
+            copy_handler.clone(),
+            cancel_handler.clone(),
+        )
+        .await
+        {
+            error_handler.on_error(&socket, &mut error);
+            process_error(&mut socket, error, is_extended_query).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn read_bounded_frontend_message<S>(
+    io: &mut S,
+    inbound: &mut BytesMut,
+    state: PgWireConnectionState,
+    protocol_version: ProtocolVersion,
+) -> PgWireResult<Option<PgWireFrontendMessage>>
+where
+    S: AsyncRead + Unpin,
+{
+    let startup = matches!(state, PgWireConnectionState::AwaitingStartup);
+    let header_bytes = if startup { 4 } else { 5 };
+    // An entirely idle authenticated connection is allowed to remain open. Once
+    // a client starts a frame, it must finish it promptly so partial frames
+    // cannot pin all connection slots indefinitely.
+    if inbound.is_empty() && !fill_frontend_bytes(io, inbound, 1).await? {
+        return Ok(None);
+    }
+    let frame_deadline = tokio::time::Instant::now() + INCOMPLETE_FRAME_TIMEOUT;
+    let header_complete = tokio::time::timeout_at(
+        frame_deadline,
+        fill_frontend_bytes(io, inbound, header_bytes),
+    )
+    .await
+    .map_err(|_| user_error("57014", "timed out waiting for a complete PostgreSQL frame"))??;
+    if !header_complete {
+        return Err(user_error("08P01", "truncated PostgreSQL frontend header"));
+    }
+
+    let (frame_bytes, frame_limit) = if startup {
+        let frame_bytes = u32::from_be_bytes(
+            inbound[..4]
+                .try_into()
+                .expect("startup frame has a four-byte header"),
+        ) as usize;
+        (frame_bytes, STARTUP_FRAME_BYTES)
+    } else {
+        let message_type = inbound[0];
+        if matches!(state, PgWireConnectionState::AuthenticationInProgress) && message_type != b'p'
+        {
+            return Err(user_error(
+                "08P01",
+                "only a password message is valid during PostgreSQL authentication",
+            ));
+        }
+        let body_bytes = u32::from_be_bytes(
+            inbound[1..5]
+                .try_into()
+                .expect("frontend frame has a four-byte length"),
+        ) as usize;
+        let frame_bytes = body_bytes
+            .checked_add(1)
+            .ok_or_else(|| user_error("54000", "PostgreSQL frame length overflow"))?;
+        let frame_limit = if matches!(state, PgWireConnectionState::AuthenticationInProgress) {
+            STARTUP_FRAME_BYTES
+        } else {
+            frontend_frame_limit(message_type)
+        };
+        (frame_bytes, frame_limit)
+    };
+    if frame_bytes < header_bytes {
+        return Err(user_error("08P01", "invalid PostgreSQL frame length"));
+    }
+    if frame_bytes > frame_limit {
+        return Err(user_error(
+            "54000",
+            format!("PostgreSQL frontend frame cannot exceed {frame_limit} bytes"),
+        ));
+    }
+    let frame_complete = tokio::time::timeout_at(
+        frame_deadline,
+        fill_frontend_bytes(io, inbound, frame_bytes),
+    )
+    .await
+    .map_err(|_| user_error("57014", "timed out waiting for a complete PostgreSQL frame"))??;
+    if !frame_complete {
+        return Err(user_error("08P01", "truncated PostgreSQL frontend frame"));
+    }
+
+    let mut frame = inbound.split_to(frame_bytes);
+    if inbound.is_empty() {
+        *inbound = BytesMut::new();
+    }
+    let mut context = DecodeContext::default();
+    context.protocol_version = protocol_version;
+    context.awaiting_frontend_ssl = false;
+    context.awaiting_frontend_startup = startup;
+    if startup {
+        validate_startup_frame(&frame)?;
+    } else if matches!(state, PgWireConnectionState::AuthenticationInProgress)
+        && (frame.len() < 6 || frame.last() != Some(&0))
+    {
+        return Err(user_error(
+            "08P01",
+            "invalid PostgreSQL cleartext password frame",
+        ));
+    }
+    let decoded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        PgWireFrontendMessage::decode(&mut frame, &context)
+    }))
+    .map_err(|_| user_error("08P01", "malformed PostgreSQL frontend frame"))?;
+    let message = decoded?.ok_or_else(|| {
+        user_error(
+            "08P01",
+            "complete PostgreSQL frontend frame could not be decoded",
+        )
+    })?;
+    if !frame.is_empty() {
+        return Err(user_error(
+            "08P01",
+            "PostgreSQL frontend frame contains trailing bytes",
+        ));
+    }
+    Ok(Some(message))
+}
+
+fn validate_startup_frame(frame: &[u8]) -> PgWireResult<()> {
+    if frame.len() < 8 {
+        return Err(user_error("08P01", "PostgreSQL startup frame is too short"));
+    }
+    let code = u32::from_be_bytes(frame[4..8].try_into().expect("startup code"));
+    if code == CANCEL_REQUEST_CODE {
+        if frame.len() == CANCEL_REQUEST_LENGTH as usize {
+            return Ok(());
+        }
+        return Err(user_error("08P01", "invalid PostgreSQL cancel frame"));
+    }
+    let mut cursor = 8;
+    loop {
+        let Some(key_end) = frame[cursor..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|offset| cursor + offset)
+        else {
+            return Err(user_error(
+                "08P01",
+                "unterminated PostgreSQL startup parameter",
+            ));
+        };
+        if key_end == cursor {
+            if key_end + 1 == frame.len() {
+                return Ok(());
+            }
+            return Err(user_error(
+                "08P01",
+                "trailing bytes after PostgreSQL startup parameters",
+            ));
+        }
+        cursor = key_end + 1;
+        let Some(value_end) = frame[cursor..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|offset| cursor + offset)
+        else {
+            return Err(user_error(
+                "08P01",
+                "unterminated PostgreSQL startup parameter value",
+            ));
+        };
+        cursor = value_end + 1;
+        if cursor >= frame.len() {
+            return Err(user_error(
+                "08P01",
+                "PostgreSQL startup parameters are missing their terminator",
+            ));
+        }
+    }
+}
+
+async fn fill_frontend_bytes<S>(
+    io: &mut S,
+    inbound: &mut BytesMut,
+    required: usize,
+) -> PgWireResult<bool>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut chunk = [0_u8; 8 * 1024];
+    while inbound.len() < required {
+        let missing = required - inbound.len();
+        let read_limit = missing.min(chunk.len());
+        let read = io.read(&mut chunk[..read_limit]).await?;
+        if read == 0 {
+            return Ok(false);
+        }
+        inbound.extend_from_slice(&chunk[..read]);
+    }
+    Ok(true)
+}
+
+fn frontend_frame_limit(message_type: u8) -> usize {
+    match message_type {
+        b'Q' => QUERY_FRAME_BYTES,
+        b'P' => PARSE_FRAME_BYTES,
+        b'B' => BIND_FRAME_BYTES,
+        _ => OTHER_FRAME_BYTES,
+    }
+}
+
+impl Drop for PostgresServerHandle {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Clone)]
+struct DatabaseAuth {
+    database: String,
+    password: String,
+}
+
+impl Debug for DatabaseAuth {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DatabaseAuth")
+            .field("database", &self.database)
+            .field("password", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl AuthSource for DatabaseAuth {
+    async fn get_password(&self, login: &LoginInfo) -> PgWireResult<Password> {
+        if login.user() != Some(POSTGRES_USER) {
+            return Err(fatal_error("28000", "invalid PostgreSQL user"));
+        }
+        if login.database() != Some(self.database.as_str()) {
+            return Err(fatal_error(
+                "3D000",
+                "database does not exist on this Jazz server",
+            ));
+        }
+        Ok(Password::new(None, self.password.as_bytes().to_vec()))
+    }
+}
+
+struct PostgresHandlerFactory {
+    backend: Arc<PostgresBackend>,
+    auth: Arc<DatabaseAuth>,
+    connection_manager: Arc<ConnectionManager>,
+}
+
+impl PgWireServerHandlers for PostgresHandlerFactory {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
+        self.backend.clone()
+    }
+
+    fn extended_query_handler(&self) -> Arc<impl ExtendedQueryHandler> {
+        self.backend.clone()
+    }
+
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
+        let mut parameters = DefaultServerParameterProvider::default();
+        parameters.server_version = "16.6".to_owned();
+        parameters.default_transaction_read_only = true;
+        parameters.search_path = "public".to_owned();
+        Arc::new(
+            CleartextPasswordAuthStartupHandler::new((*self.auth).clone(), parameters)
+                .with_connection_manager(self.connection_manager.clone()),
+        )
+    }
+
+    fn cancel_handler(&self) -> Arc<impl pgwire::api::cancel::CancelHandler> {
+        Arc::new(DefaultCancelHandler::new(self.connection_manager.clone()))
+    }
+}
+
+struct PostgresBackend {
+    state: Arc<ServerState>,
+    database: String,
+    parser: Arc<ParsedQueryParser>,
+    database_job: Arc<Semaphore>,
+    buffered_responses: Arc<Semaphore>,
+}
+
+#[derive(Default)]
+struct ConnectionResources {
+    usage: Mutex<ConnectionResourceUsage>,
+}
+
+#[derive(Default)]
+struct ConnectionResourceUsage {
+    statements: HashMap<String, usize>,
+    statement_bytes: usize,
+    portals: HashMap<String, PortalResourceUsage>,
+    portal_bytes: usize,
+    response_permits: HashMap<String, Arc<tokio::sync::OwnedSemaphorePermit>>,
+}
+
+struct PortalResourceUsage {
+    bytes: usize,
+    statement_name: String,
+}
+
+impl ConnectionResources {
+    fn reserve_statement(&self, name: &str, bytes: usize) -> PgWireResult<()> {
+        let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
+        let existing = usage.statements.get(name).copied();
+        if existing.is_none() && usage.statements.len() >= MAX_STORED_STATEMENTS {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "a PostgreSQL connection cannot retain more than {MAX_STORED_STATEMENTS} prepared statements"
+                ),
+            ));
+        }
+        let without_existing = usage.statement_bytes.saturating_sub(existing.unwrap_or(0));
+        let next_bytes = without_existing
+            .checked_add(bytes)
+            .ok_or_else(|| user_error("54000", "stored PostgreSQL statement size overflow"))?;
+        if next_bytes > MAX_STORED_STATEMENT_BYTES {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "stored PostgreSQL statements cannot exceed {} MiB per connection",
+                    MAX_STORED_STATEMENT_BYTES / (1024 * 1024)
+                ),
+            ));
+        }
+        usage.statements.insert(name.to_owned(), bytes);
+        usage.statement_bytes = next_bytes;
+        Ok(())
+    }
+
+    fn release_statement(&self, name: &str) -> Vec<String> {
+        let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
+        if let Some(bytes) = usage.statements.remove(name) {
+            usage.statement_bytes = usage.statement_bytes.saturating_sub(bytes);
+        }
+        let dependent_portals = usage
+            .portals
+            .iter()
+            .filter(|(_, portal)| portal.statement_name == name)
+            .map(|(portal_name, _)| portal_name.clone())
+            .collect::<Vec<_>>();
+        for portal_name in &dependent_portals {
+            if let Some(portal) = usage.portals.remove(portal_name) {
+                usage.portal_bytes = usage.portal_bytes.saturating_sub(portal.bytes);
+            }
+            usage.response_permits.remove(portal_name);
+        }
+        dependent_portals
+    }
+
+    fn reserve_portal(&self, name: &str, statement_name: &str, bytes: usize) -> PgWireResult<()> {
+        let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
+        let existing = usage.portals.get(name).map(|portal| portal.bytes);
+        if existing.is_none() && usage.portals.len() >= MAX_STORED_PORTALS {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "a PostgreSQL connection cannot retain more than {MAX_STORED_PORTALS} portals"
+                ),
+            ));
+        }
+        let without_existing = usage.portal_bytes.saturating_sub(existing.unwrap_or(0));
+        let next_bytes = without_existing
+            .checked_add(bytes)
+            .ok_or_else(|| user_error("54000", "stored PostgreSQL portal size overflow"))?;
+        if next_bytes > MAX_STORED_PORTAL_BYTES {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "stored PostgreSQL portal parameters cannot exceed {} MiB per connection",
+                    MAX_STORED_PORTAL_BYTES / (1024 * 1024)
+                ),
+            ));
+        }
+        usage.portals.insert(
+            name.to_owned(),
+            PortalResourceUsage {
+                bytes,
+                statement_name: statement_name.to_owned(),
+            },
+        );
+        usage.portal_bytes = next_bytes;
+        Ok(())
+    }
+
+    fn release_portal(&self, name: &str) {
+        let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
+        if let Some(portal) = usage.portals.remove(name) {
+            usage.portal_bytes = usage.portal_bytes.saturating_sub(portal.bytes);
+        }
+        usage.response_permits.remove(name);
+    }
+
+    fn clear_portals(&self) {
+        let mut usage = self.usage.lock().expect("PostgreSQL resource lock");
+        usage.portals.clear();
+        usage.portal_bytes = 0;
+        usage.response_permits.clear();
+    }
+
+    fn retain_response(&self, portal_name: &str, permit: Arc<tokio::sync::OwnedSemaphorePermit>) {
+        self.usage
+            .lock()
+            .expect("PostgreSQL resource lock")
+            .response_permits
+            .insert(portal_name.to_owned(), permit);
+    }
+
+    fn release_response(&self, portal_name: &str) {
+        self.usage
+            .lock()
+            .expect("PostgreSQL resource lock")
+            .response_permits
+            .remove(portal_name);
+    }
+}
+
+fn connection_resources<C: ClientInfo>(client: &C) -> Arc<ConnectionResources> {
+    client
+        .session_extensions()
+        .get_or_insert_with(ConnectionResources::default)
+}
+
+fn remove_statement_and_dependent_portals<C>(client: &mut C, statement_name: &str)
+where
+    C: ClientInfo + ClientPortalStore,
+    C::PortalStore: PortalStore,
+{
+    let dependent_portals = connection_resources(client).release_statement(statement_name);
+    for portal_name in dependent_portals {
+        client.portal_store().rm_portal(&portal_name);
+    }
+    client.portal_store().rm_statement(statement_name);
+}
+
+fn clear_connection_portals<C>(client: &mut C)
+where
+    C: ClientInfo + ClientPortalStore,
+    C::PortalStore: PortalStore,
+{
+    connection_resources(client).clear_portals();
+    client.portal_store().clear_portals();
+}
+
+fn ensure_object_name(name: &str, kind: &str) -> PgWireResult<()> {
+    if name.len() > MAX_OBJECT_NAME_BYTES {
+        return Err(user_error(
+            "42622",
+            format!("PostgreSQL {kind} names cannot exceed {MAX_OBJECT_NAME_BYTES} bytes"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_format_codes(codes: &[i16], expected_columns: usize, kind: &str) -> PgWireResult<()> {
+    if !(codes.is_empty() || codes.len() == 1 || codes.len() == expected_columns) {
+        return Err(user_error(
+            "08P01",
+            format!(
+                "Bind supplied {} {kind} format codes for {expected_columns} values; expected 0, 1, or {expected_columns}",
+                codes.len()
+            ),
+        ));
+    }
+    if codes.iter().any(|code| !matches!(code, 0 | 1)) {
+        return Err(user_error(
+            "08P01",
+            format!("Bind {kind} format codes must be 0 (text) or 1 (binary)"),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug)]
+struct PreparedStatement {
+    parsed: ParsedStatement,
+    parameter_kinds: Vec<ColumnKind>,
+    result_columns: Vec<OutputColumn>,
+    schema_version: Option<SchemaVersionId>,
+}
+
+#[derive(Debug)]
+struct ParsedQueryParser;
+
+#[async_trait]
+impl QueryParser for ParsedQueryParser {
+    type Statement = PreparedStatement;
+
+    async fn parse_sql<C>(
+        &self,
+        _client: &C,
+        sql: &str,
+        _types: &[Option<Type>],
+    ) -> PgWireResult<Self::Statement>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        ensure_sql_size(sql)?;
+        Ok(PreparedStatement {
+            parsed: sql::parse_sql(sql).map_err(sql_error)?,
+            parameter_kinds: Vec::new(),
+            result_columns: Vec::new(),
+            schema_version: None,
+        })
+    }
+
+    fn get_parameter_types(&self, _stmt: &Self::Statement) -> PgWireResult<Vec<Type>> {
+        Ok(Vec::new())
+    }
+
+    fn get_result_schema(
+        &self,
+        _stmt: &Self::Statement,
+        _column_format: Option<&Format>,
+    ) -> PgWireResult<Vec<FieldInfo>> {
+        Ok(Vec::new())
+    }
+}
+
+#[async_trait]
+impl SimpleQueryHandler for PostgresBackend {
+    async fn do_query<C>(&self, client: &mut C, sql: &str) -> PgWireResult<Vec<Response>>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        ensure_sql_size(sql)?;
+        // PostgreSQL's simple Query message replaces the unnamed statement and
+        // every portal derived from it, even when named extended-protocol
+        // objects remain on the connection.
+        remove_statement_and_dependent_portals(client, DEFAULT_NAME);
+        let statements = sql::parse_sql_batch(sql).map_err(sql_error)?;
+        if statements.len() > MAX_SIMPLE_BATCH_STATEMENTS {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "a simple-query batch cannot contain more than {MAX_SIMPLE_BATCH_STATEMENTS} statements"
+                ),
+            ));
+        }
+        if statements.len() > 1
+            && statements.iter().any(|statement| {
+                matches!(
+                    statement,
+                    ParsedStatement::Command(Command::Begin | Command::Commit | Command::Rollback)
+                )
+            })
+        {
+            return Err(user_error(
+                "0A000",
+                "transaction control commands must be sent as individual PostgreSQL statements",
+            ));
+        }
+        if client.transaction_status() == TransactionStatus::Error {
+            if statements.len() == 1
+                && matches!(
+                    statements.first(),
+                    Some(ParsedStatement::Command(
+                        Command::Rollback | Command::Commit
+                    ))
+                )
+            {
+                clear_connection_portals(client);
+                return Ok(vec![Response::TransactionEnd(Tag::new("ROLLBACK"))]);
+            }
+            return Err(failed_transaction_error());
+        }
+        let application_table_reads = statements
+            .iter()
+            .filter(|statement| {
+                matches!(
+                    statement,
+                    ParsedStatement::Select(SelectPlan {
+                        source: SelectSource::Table(_),
+                        ..
+                    })
+                )
+            })
+            .count();
+        if application_table_reads > 1 {
+            return Err(user_error(
+                "0A000",
+                "simple-query batches may contain at most one application-table SELECT; send additional table reads as separate queries",
+            ));
+        }
+        let row_responses = statements
+            .iter()
+            .filter(|statement| {
+                matches!(
+                    statement,
+                    ParsedStatement::Select(_) | ParsedStatement::Command(Command::Show(_))
+                )
+            })
+            .count();
+        if row_responses > MAX_BUFFERED_RESPONSES {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "simple-query batches may contain at most {MAX_BUFFERED_RESPONSES} row-producing statements"
+                ),
+            ));
+        }
+        let mut responses = Vec::with_capacity(statements.len());
+        let ends_transaction = statements.iter().any(|statement| {
+            matches!(
+                statement,
+                ParsedStatement::Command(Command::Commit | Command::Rollback)
+            )
+        });
+        for statement in statements {
+            responses.push(
+                self.execute(statement, &[], &Format::UnifiedText, None)
+                    .await?
+                    .response,
+            );
+        }
+        if ends_transaction {
+            clear_connection_portals(client);
+        }
+        Ok(responses)
+    }
+}
+
+#[async_trait]
+impl ExtendedQueryHandler for PostgresBackend {
+    type Statement = PreparedStatement;
+    type QueryParser = ParsedQueryParser;
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        self.parser.clone()
+    }
+
+    async fn on_parse<C>(&self, client: &mut C, message: Parse) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        ensure_sql_size(&message.query)?;
+        let statement_name = message
+            .name
+            .clone()
+            .unwrap_or_else(|| DEFAULT_NAME.to_owned());
+        ensure_object_name(&statement_name, "prepared statement")?;
+        if statement_name != DEFAULT_NAME
+            && client
+                .portal_store()
+                .get_statement(&statement_name)
+                .is_some()
+        {
+            return Err(user_error(
+                "42P05",
+                format!("prepared statement {statement_name:?} already exists"),
+            ));
+        }
+        let parsed = sql::parse_sql(&message.query).map_err(sql_error)?;
+        let parameter_kinds = self.parameter_kinds(&parsed).await?;
+        validate_declared_parameter_types(&message.type_oids, &parameter_kinds)?;
+        let result_columns = self.describe(&parsed, &Format::UnifiedBinary).await?;
+        let schema_version = self.prepared_schema_version(&parsed).await?;
+        let retained_statement_bytes = message
+            .query
+            .len()
+            .checked_add(statement_name.len())
+            .and_then(|bytes| bytes.checked_add(parameter_kinds.len() * 8))
+            .and_then(|bytes| {
+                result_columns.iter().try_fold(bytes, |total, column| {
+                    total.checked_add(std::mem::size_of::<OutputColumn>() + column.name.len())
+                })
+            })
+            .ok_or_else(|| user_error("54000", "stored PostgreSQL statement size overflow"))?;
+        let statement = StoredStatement::new(
+            statement_name.clone(),
+            PreparedStatement {
+                parsed,
+                parameter_kinds: parameter_kinds.clone(),
+                result_columns,
+                schema_version,
+            },
+            parameter_kinds
+                .into_iter()
+                .map(|kind| Some(kind.pg_type()))
+                .collect(),
+        );
+        if statement_name == DEFAULT_NAME {
+            remove_statement_and_dependent_portals(client, DEFAULT_NAME);
+        }
+        connection_resources(client)
+            .reserve_statement(&statement_name, retained_statement_bytes)?;
+        client.portal_store().put_statement(Arc::new(statement));
+        client
+            .send(PgWireBackendMessage::ParseComplete(ParseComplete::new()))
+            .await?;
+        Ok(())
+    }
+
+    async fn on_bind<C>(&self, client: &mut C, message: Bind) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let statement_name = message.statement_name.as_deref().unwrap_or(DEFAULT_NAME);
+        let portal_name = message
+            .portal_name
+            .clone()
+            .unwrap_or_else(|| DEFAULT_NAME.to_owned());
+        ensure_object_name(statement_name, "prepared statement")?;
+        ensure_object_name(&portal_name, "portal")?;
+        if message.parameters.len() > MAX_PARAMETER_COUNT
+            || message.parameter_format_codes.len() > MAX_PARAMETER_COUNT
+            || message.result_column_format_codes.len() > MAX_PARAMETER_COUNT
+        {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "Bind cannot contain more than {MAX_PARAMETER_COUNT} parameters or format codes"
+                ),
+            ));
+        }
+        let parameter_bytes = message
+            .parameters
+            .iter()
+            .try_fold(0_usize, |total, value| {
+                total
+                    .checked_add(value.as_ref().map_or(0, bytes::Bytes::len))
+                    .ok_or_else(|| user_error("54000", "PostgreSQL parameter size overflow"))
+            })?;
+        if parameter_bytes > MAX_PARAMETER_BYTES {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "encoded PostgreSQL parameters cannot exceed {} MiB",
+                    MAX_PARAMETER_BYTES / (1024 * 1024)
+                ),
+            ));
+        }
+        let retained_portal_bytes = parameter_bytes
+            .checked_add(statement_name.len())
+            .and_then(|bytes| bytes.checked_add(portal_name.len()))
+            .and_then(|bytes| {
+                bytes.checked_add(
+                    message.parameters.len() * std::mem::size_of::<Option<bytes::Bytes>>(),
+                )
+            })
+            .and_then(|bytes| {
+                bytes.checked_add(
+                    (message.parameter_format_codes.len()
+                        + message.result_column_format_codes.len())
+                        * 2,
+                )
+            })
+            .ok_or_else(|| user_error("54000", "stored PostgreSQL portal size overflow"))?;
+        let Some(statement) = client.portal_store().get_statement(statement_name) else {
+            return Err(PgWireError::StatementNotFound(statement_name.to_owned()));
+        };
+        if portal_name != DEFAULT_NAME && client.portal_store().get_portal(&portal_name).is_some() {
+            return Err(user_error(
+                "42P03",
+                format!("portal {portal_name:?} already exists"),
+            ));
+        }
+        if message.parameters.len() != statement.statement.parameter_kinds.len() {
+            return Err(user_error(
+                "08P01",
+                format!(
+                    "prepared statement expects {} parameters, received {}",
+                    statement.statement.parameter_kinds.len(),
+                    message.parameters.len()
+                ),
+            ));
+        }
+        validate_format_codes(
+            &message.parameter_format_codes,
+            statement.statement.parameter_kinds.len(),
+            "parameter",
+        )?;
+        validate_format_codes(
+            &message.result_column_format_codes,
+            statement.statement.result_columns.len(),
+            "result-column",
+        )?;
+        let portal = Portal::try_new(&message, statement)?;
+        if portal_name == DEFAULT_NAME {
+            connection_resources(client).release_portal(DEFAULT_NAME);
+            client.portal_store().rm_portal(DEFAULT_NAME);
+        }
+        connection_resources(client).reserve_portal(
+            &portal_name,
+            statement_name,
+            retained_portal_bytes,
+        )?;
+        client.portal_store().put_portal(Arc::new(portal));
+        client
+            .send(PgWireBackendMessage::BindComplete(BindComplete::new()))
+            .await?;
+        Ok(())
+    }
+
+    async fn on_sync<C>(&self, client: &mut C, _message: PgSync) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        // Sync closes the protocol's implicit transaction. Portals are
+        // transaction-scoped in PostgreSQL, so only an explicit BEGIN keeps
+        // them alive across this boundary; prepared statements remain.
+        if client.transaction_status() == TransactionStatus::Idle {
+            clear_connection_portals(client);
+        }
+        client
+            .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+                client.transaction_status(),
+            )))
+            .await?;
+        client.flush().await?;
+        Ok(())
+    }
+
+    async fn on_execute<C>(&self, client: &mut C, message: Execute) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let portal_name = message.name.as_deref().unwrap_or(DEFAULT_NAME).to_owned();
+        let ends_transaction =
+            client
+                .portal_store()
+                .get_portal(&portal_name)
+                .is_some_and(|portal| {
+                    matches!(
+                        portal.statement.statement.parsed,
+                        ParsedStatement::Command(Command::Commit | Command::Rollback)
+                    )
+                });
+        let result = self._on_execute(client, message).await;
+        connection_resources(client).release_response(&portal_name);
+        if result.is_ok() && ends_transaction {
+            clear_connection_portals(client);
+        }
+        result
+    }
+
+    async fn on_close<C>(&self, client: &mut C, message: Close) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        let name = message.name.as_deref().unwrap_or(DEFAULT_NAME);
+        ensure_object_name(name, "object")?;
+        match message.target_type {
+            TARGET_TYPE_BYTE_STATEMENT => {
+                remove_statement_and_dependent_portals(client, name);
+            }
+            TARGET_TYPE_BYTE_PORTAL => {
+                connection_resources(client).release_portal(name);
+                client.portal_store().rm_portal(name);
+            }
+            target => return Err(PgWireError::InvalidTargetType(target)),
+        }
+        client
+            .send(PgWireBackendMessage::CloseComplete(CloseComplete::new()))
+            .await?;
+        Ok(())
+    }
+
+    async fn do_query<C>(
+        &self,
+        client: &mut C,
+        portal: &Portal<Self::Statement>,
+        max_rows: usize,
+    ) -> PgWireResult<Response>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        if max_rows != 0 {
+            return Err(user_error(
+                "0A000",
+                "incremental portal fetch is not supported; use LIMIT/OFFSET or keyset pagination",
+            ));
+        }
+        let statement = &portal.statement.statement;
+        if client.transaction_status() == TransactionStatus::Error {
+            return match statement.parsed {
+                ParsedStatement::Command(Command::Rollback | Command::Commit) => {
+                    Ok(Response::TransactionEnd(Tag::new("ROLLBACK")))
+                }
+                _ => Err(failed_transaction_error()),
+            };
+        }
+        let current_parameter_kinds = self.parameter_kinds(&statement.parsed).await?;
+        let current_result_columns = self
+            .describe(&statement.parsed, &portal.result_column_format)
+            .await?;
+        if current_parameter_kinds != statement.parameter_kinds
+            || !same_output_schema(&current_result_columns, &statement.result_columns)
+        {
+            return Err(user_error(
+                "0A000",
+                "cached PostgreSQL plan changed after a Jazz schema update; prepare it again",
+            ));
+        }
+        let parameters = decode_parameters(portal, &statement.parameter_kinds)?;
+        let executed = self
+            .execute(
+                statement.parsed.clone(),
+                &parameters,
+                &portal.result_column_format,
+                statement.schema_version,
+            )
+            .await?;
+        if let Some(response_permit) = executed.response_permit {
+            connection_resources(client).retain_response(&portal.name, response_permit);
+        }
+        Ok(executed.response)
+    }
+
+    async fn do_describe_statement<C>(
+        &self,
+        _client: &mut C,
+        statement: &StoredStatement<Self::Statement>,
+    ) -> PgWireResult<DescribeStatementResponse>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        let prepared = &statement.statement;
+        let parameter_types = prepared
+            .parameter_kinds
+            .iter()
+            .copied()
+            .map(|kind| kind.pg_type())
+            .collect();
+        let fields = prepared
+            .result_columns
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(idx, column)| column.field_info(FieldFormat::Binary, idx))
+            .collect();
+        Ok(DescribeStatementResponse::new(parameter_types, fields))
+    }
+
+    async fn do_describe_portal<C>(
+        &self,
+        _client: &mut C,
+        portal: &Portal<Self::Statement>,
+    ) -> PgWireResult<DescribePortalResponse>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        let fields = portal
+            .statement
+            .statement
+            .result_columns
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(idx, column)| {
+                let format = portal.result_column_format.format_for(idx);
+                column.field_info(format, idx)
+            })
+            .collect();
+        Ok(DescribePortalResponse::new(fields))
+    }
+}
+
+impl PostgresBackend {
+    fn shell(&self) -> PgWireResult<ServerShellHandle> {
+        self.state.core_server_shell().ok_or_else(|| {
+            user_error(
+                "55000",
+                "no runtime schema has been published for this Jazz app",
+            )
+        })
+    }
+
+    async fn schema(&self) -> PgWireResult<JazzSchema> {
+        self.schema_optional().await?.ok_or_else(|| {
+            user_error(
+                "55000",
+                "no runtime schema has been published for this Jazz app",
+            )
+        })
+    }
+
+    async fn schema_optional(&self) -> PgWireResult<Option<JazzSchema>> {
+        let Some(shell) = self.state.core_server_shell() else {
+            return Ok(None);
+        };
+        shell
+            .postgres_schema()
+            .await
+            .map(Some)
+            .map_err(internal_database_error)
+    }
+
+    async fn prepared_schema_version(
+        &self,
+        statement: &ParsedStatement,
+    ) -> PgWireResult<Option<SchemaVersionId>> {
+        match statement {
+            ParsedStatement::Select(SelectPlan {
+                source: SelectSource::Table(_),
+                ..
+            }) => Ok(Some(self.schema().await?.version_id())),
+            _ => Ok(None),
+        }
+    }
+
+    async fn execute(
+        &self,
+        statement: ParsedStatement,
+        parameters: &[ParameterValue],
+        format: &Format,
+        expected_schema_version: Option<SchemaVersionId>,
+    ) -> PgWireResult<ExecutedResponse> {
+        match statement {
+            ParsedStatement::Select(plan) => {
+                let output = self
+                    .execute_select(plan, parameters, expected_schema_version)
+                    .await?;
+                output.into_response(format)
+            }
+            ParsedStatement::Command(command) => self.execute_command(command, format),
+        }
+    }
+
+    fn execute_command(&self, command: Command, format: &Format) -> PgWireResult<ExecutedResponse> {
+        match command {
+            Command::Show(setting) => {
+                let value = match setting.to_ascii_lowercase().as_str() {
+                    "server_version" => "16.6",
+                    "search_path" => "public",
+                    "transaction_read_only" | "default_transaction_read_only" => "on",
+                    "standard_conforming_strings" => "on",
+                    "client_encoding" | "server_encoding" => "UTF8",
+                    "timezone" | "time.zone" => "Etc/UTC",
+                    other => {
+                        return Err(user_error(
+                            "42704",
+                            format!("unrecognized configuration parameter {other}"),
+                        ));
+                    }
+                };
+                QueryOutput {
+                    columns: vec![OutputColumn::new(setting, ColumnKind::Text)],
+                    rows: vec![vec![Cell::Text(value.to_owned())]],
+                    response_permit: None,
+                }
+                .into_response(format)
+            }
+            Command::Begin => Ok(ExecutedResponse::without_permit(
+                Response::TransactionStart(Tag::new("BEGIN")),
+            )),
+            Command::Commit => Ok(ExecutedResponse::without_permit(Response::TransactionEnd(
+                Tag::new("COMMIT"),
+            ))),
+            Command::Rollback => Ok(ExecutedResponse::without_permit(Response::TransactionEnd(
+                Tag::new("ROLLBACK"),
+            ))),
+        }
+    }
+
+    async fn execute_select(
+        &self,
+        plan: SelectPlan,
+        parameters: &[ParameterValue],
+        expected_schema_version: Option<SchemaVersionId>,
+    ) -> PgWireResult<QueryOutput> {
+        let limit = plan
+            .limit
+            .as_ref()
+            .map(|value| resolve_page_value(value, parameters))
+            .transpose()?;
+        let offset = resolve_page_value(&plan.offset, parameters)?;
+        if limit.is_some_and(|limit| limit > MAX_PAGE_SIZE) {
+            return Err(user_error(
+                "54000",
+                format!("LIMIT cannot exceed {MAX_PAGE_SIZE} rows"),
+            ));
+        }
+        if offset > MAX_OFFSET {
+            return Err(user_error(
+                "54000",
+                format!("OFFSET cannot exceed {MAX_OFFSET}; use keyset pagination"),
+            ));
+        }
+        let response_permit = self
+            .buffered_responses
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| {
+                user_error(
+                    "53000",
+                    "too many PostgreSQL responses are still being consumed; finish or close an existing result before retrying",
+                )
+            })?;
+        let source = plan.source.clone();
+        match source {
+            SelectSource::Table(table) => {
+                if limit.is_none() {
+                    return Err(user_error(
+                        "54000",
+                        format!("application-table reads require LIMIT (maximum {MAX_PAGE_SIZE})"),
+                    ));
+                }
+                self.execute_table(
+                    plan,
+                    table,
+                    parameters,
+                    limit.expect("checked above"),
+                    offset,
+                    expected_schema_version,
+                    response_permit,
+                )
+                .await
+            }
+            SelectSource::Databases | SelectSource::Tables | SelectSource::Columns => {
+                let mut output = self
+                    .execute_catalogue(plan, parameters, limit, offset)
+                    .await?;
+                output.response_permit = Some(Arc::new(response_permit));
+                Ok(output)
+            }
+            SelectSource::Session => {
+                let mut output = self.execute_session(plan, parameters, limit, offset)?;
+                output.response_permit = Some(Arc::new(response_permit));
+                Ok(output)
+            }
+        }
+    }
+
+    async fn execute_table(
+        &self,
+        plan: SelectPlan,
+        table_name: String,
+        parameters: &[ParameterValue],
+        limit: usize,
+        offset: usize,
+        expected_schema_version: Option<SchemaVersionId>,
+        response_permit: tokio::sync::OwnedSemaphorePermit,
+    ) -> PgWireResult<QueryOutput> {
+        let query_permit = self
+            .database_job
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| internal_error("PostgreSQL database query gate is closed"))?;
+        let query_guard = self
+            .state
+            .shutdown
+            .try_enter_postgres_query()
+            .ok_or_else(|| user_error("57P01", "Jazz server is shutting down"))?;
+        let schema = self.schema().await?;
+        let schema_version = schema.version_id();
+        if expected_schema_version.is_some_and(|expected| expected != schema_version) {
+            return Err(user_error(
+                "0A000",
+                "cached PostgreSQL plan changed after a Jazz schema update; prepare it again",
+            ));
+        }
+        let table = table_by_name(&schema, &table_name)?;
+        let columns = projected_table_columns(&plan, table)?;
+        let mut query = Query::from(table_name);
+        if let Some(filter) = &plan.filter {
+            let (predicate, bindings) = lower_table_filter(filter, table, parameters)?;
+            query = query.filter(predicate);
+            query = query.select(columns.iter().map(|column| column.source_name.clone()));
+            for order in &plan.order_by {
+                let column = ensure_table_column(table, &order.column)?;
+                ensure_orderable_column(column, &order.column)?;
+                query = query.order_by(
+                    order.column.clone(),
+                    if order.ascending {
+                        OrderDirection::Asc
+                    } else {
+                        OrderDirection::Desc
+                    },
+                );
+            }
+            query = query.limit(limit);
+            query = query.offset(offset);
+            let result = self
+                .shell()?
+                .postgres_query(
+                    query,
+                    schema_version,
+                    columns
+                        .iter()
+                        .map(|column| column.source_name.clone())
+                        .collect(),
+                    bindings,
+                    query_permit,
+                    response_permit,
+                    query_guard,
+                    MAX_RESPONSE_BYTES,
+                )
+                .await
+                .map_err(postgres_database_query_error)?;
+            return table_query_output(result, columns);
+        }
+
+        query = query.select(columns.iter().map(|column| column.source_name.clone()));
+        for order in &plan.order_by {
+            let column = ensure_table_column(table, &order.column)?;
+            ensure_orderable_column(column, &order.column)?;
+            query = query.order_by(
+                order.column.clone(),
+                if order.ascending {
+                    OrderDirection::Asc
+                } else {
+                    OrderDirection::Desc
+                },
+            );
+        }
+        query = query.limit(limit);
+        query = query.offset(offset);
+        let result = self
+            .shell()?
+            .postgres_query(
+                query,
+                schema_version,
+                columns
+                    .iter()
+                    .map(|column| column.source_name.clone())
+                    .collect(),
+                BTreeMap::new(),
+                query_permit,
+                response_permit,
+                query_guard,
+                MAX_RESPONSE_BYTES,
+            )
+            .await
+            .map_err(postgres_database_query_error)?;
+        table_query_output(result, columns)
+    }
+
+    async fn execute_catalogue(
+        &self,
+        plan: SelectPlan,
+        parameters: &[ParameterValue],
+        limit: Option<usize>,
+        offset: usize,
+    ) -> PgWireResult<QueryOutput> {
+        let schema = if matches!(&plan.source, SelectSource::Databases) {
+            None
+        } else {
+            self.schema_optional().await?
+        };
+        let relation = catalogue_relation(&plan.source, &self.database, schema.as_ref());
+        relation.apply(plan, parameters, limit, offset)
+    }
+
+    fn execute_session(
+        &self,
+        plan: SelectPlan,
+        parameters: &[ParameterValue],
+        limit: Option<usize>,
+        offset: usize,
+    ) -> PgWireResult<QueryOutput> {
+        if plan.filter.is_some() || !plan.order_by.is_empty() || offset != 0 {
+            return Err(user_error(
+                "0A000",
+                "WHERE, ORDER BY, and OFFSET are not supported without FROM",
+            ));
+        }
+        if !parameters.is_empty() {
+            return Err(user_error(
+                "0A000",
+                "parameters are not supported in session SELECT expressions",
+            ));
+        }
+        let mut columns = Vec::with_capacity(plan.projection.len());
+        let mut row = Vec::with_capacity(plan.projection.len());
+        for projection in &plan.projection {
+            let (default_name, kind, cell) = match &projection.expr {
+                ProjectedExpr::SessionFunction(SessionFunction::Version) => (
+                    "version",
+                    ColumnKind::Text,
+                    Cell::Text("PostgreSQL 16.6 compatible Jazz read-only interface".to_owned()),
+                ),
+                ProjectedExpr::SessionFunction(SessionFunction::CurrentDatabase) => (
+                    "current_database",
+                    ColumnKind::Text,
+                    Cell::Text(self.database.clone()),
+                ),
+                ProjectedExpr::SessionFunction(SessionFunction::CurrentSchema) => (
+                    "current_schema",
+                    ColumnKind::Text,
+                    Cell::Text("public".to_owned()),
+                ),
+                ProjectedExpr::SessionFunction(SessionFunction::CurrentUser) => (
+                    "current_user",
+                    ColumnKind::Text,
+                    Cell::Text(POSTGRES_USER.to_owned()),
+                ),
+                ProjectedExpr::Literal(literal) => {
+                    let (kind, cell) = literal_cell(literal, parameters)?;
+                    ("?column?", kind, cell)
+                }
+                _ => {
+                    return Err(user_error(
+                        "42703",
+                        "a source-less SELECT may only project session functions or literals",
+                    ));
+                }
+            };
+            columns.push(OutputColumn::new(
+                projection
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| default_name.to_owned()),
+                kind,
+            ));
+            row.push(cell);
+        }
+        let rows = if limit == Some(0) {
+            Vec::new()
+        } else {
+            vec![row]
+        };
+        Ok(QueryOutput {
+            columns,
+            rows,
+            response_permit: None,
+        })
+    }
+
+    async fn describe(
+        &self,
+        statement: &ParsedStatement,
+        _format: &Format,
+    ) -> PgWireResult<Vec<OutputColumn>> {
+        match statement {
+            ParsedStatement::Command(Command::Show(setting)) => {
+                Ok(vec![OutputColumn::new(setting.clone(), ColumnKind::Text)])
+            }
+            ParsedStatement::Command(_) => Ok(Vec::new()),
+            ParsedStatement::Select(plan) => match &plan.source {
+                SelectSource::Table(table_name) => {
+                    let schema = self.schema().await?;
+                    let table = table_by_name(&schema, table_name)?;
+                    projected_table_columns(plan, table).map(|columns| {
+                        columns
+                            .into_iter()
+                            .map(|column| OutputColumn::new(column.output_name, column.kind))
+                            .collect()
+                    })
+                }
+                SelectSource::Databases | SelectSource::Tables | SelectSource::Columns => {
+                    let schema = if matches!(&plan.source, SelectSource::Databases) {
+                        None
+                    } else {
+                        self.schema_optional().await?
+                    };
+                    let relation =
+                        catalogue_relation(&plan.source, &self.database, schema.as_ref());
+                    relation.projected_columns(plan)
+                }
+                SelectSource::Session => describe_session(plan),
+            },
+        }
+    }
+
+    async fn parameter_kinds(&self, statement: &ParsedStatement) -> PgWireResult<Vec<ColumnKind>> {
+        let ParsedStatement::Select(plan) = statement else {
+            return Ok(Vec::new());
+        };
+        let column_kinds = match &plan.source {
+            SelectSource::Table(table_name) => {
+                let schema = self.schema().await?;
+                table_column_kinds(table_by_name(&schema, table_name)?)
+            }
+            SelectSource::Databases | SelectSource::Tables | SelectSource::Columns => {
+                catalogue_column_kinds(&plan.source)
+            }
+            SelectSource::Session => BTreeMap::new(),
+        };
+        infer_parameter_kinds(plan, &column_kinds)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ColumnKind {
+    Bool,
+    I32,
+    I64,
+    F64,
+    Text,
+    Bytea,
+    Uuid,
+}
+
+impl ColumnKind {
+    fn pg_type(self) -> Type {
+        match self {
+            Self::Bool => Type::BOOL,
+            Self::I32 => Type::INT4,
+            Self::I64 => Type::INT8,
+            Self::F64 => Type::FLOAT8,
+            Self::Text => Type::TEXT,
+            Self::Bytea => Type::BYTEA,
+            Self::Uuid => Type::UUID,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OutputColumn {
+    name: String,
+    kind: ColumnKind,
+}
+
+impl OutputColumn {
+    fn new(name: impl Into<String>, kind: ColumnKind) -> Self {
+        Self {
+            name: name.into(),
+            kind,
+        }
+    }
+
+    fn field_info(&self, format: FieldFormat, _index: usize) -> FieldInfo {
+        FieldInfo::new(self.name.clone(), None, None, self.kind.pg_type(), format)
+    }
+}
+
+fn same_output_schema(left: &[OutputColumn], right: &[OutputColumn]) -> bool {
+    left == right
+}
+
+#[derive(Clone, Debug)]
+enum Cell {
+    Null,
+    Bool(bool),
+    I32(i32),
+    I64(i64),
+    F64(f64),
+    Text(String),
+    Bytea(Vec<u8>),
+    Uuid(uuid::Uuid),
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PgUuid(uuid::Uuid);
+
+impl ToSql for PgUuid {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        if *ty != Type::UUID {
+            return Err(format!("cannot encode UUID as {ty}").into());
+        }
+        out.extend_from_slice(self.0.as_bytes());
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        *ty == Type::UUID
+    }
+
+    postgres_types::to_sql_checked!();
+}
+
+impl<'a> FromSql<'a> for PgUuid {
+    fn from_sql(
+        ty: &Type,
+        raw: &'a [u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        if *ty != Type::UUID {
+            return Err(format!("cannot decode {ty} as UUID").into());
+        }
+        Ok(Self(uuid::Uuid::from_slice(raw)?))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        *ty == Type::UUID
+    }
+}
+
+impl ToSqlText for PgUuid {
+    fn to_sql_text(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+        _format_options: &FormatOptions,
+    ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        if *ty != Type::UUID {
+            return Err(format!("cannot encode UUID as {ty}").into());
+        }
+        out.extend_from_slice(self.0.to_string().as_bytes());
+        Ok(IsNull::No)
+    }
+}
+
+impl<'a> FromSqlText<'a> for PgUuid {
+    fn from_sql_text(
+        ty: &Type,
+        input: &'a [u8],
+        _format_options: &FormatOptions,
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        if *ty != Type::UUID {
+            return Err(format!("cannot decode {ty} as UUID").into());
+        }
+        Ok(Self(uuid::Uuid::parse_str(std::str::from_utf8(input)?)?))
+    }
+}
+
+struct QueryOutput {
+    columns: Vec<OutputColumn>,
+    rows: Vec<Vec<Cell>>,
+    response_permit: Option<Arc<tokio::sync::OwnedSemaphorePermit>>,
+}
+
+struct ExecutedResponse {
+    response: Response,
+    response_permit: Option<Arc<tokio::sync::OwnedSemaphorePermit>>,
+}
+
+impl ExecutedResponse {
+    fn without_permit(response: Response) -> Self {
+        Self {
+            response,
+            response_permit: None,
+        }
+    }
+}
+
+impl QueryOutput {
+    fn into_response(self, format: &Format) -> PgWireResult<ExecutedResponse> {
+        let response_permit = self.response_permit;
+        let fields = Arc::new(
+            self.columns
+                .iter()
+                .enumerate()
+                .map(|(idx, column)| column.field_info(format.format_for(idx), idx))
+                .collect::<Vec<_>>(),
+        );
+        let mut encoded_rows = Vec::with_capacity(self.rows.len());
+        let mut encoded_response_bytes = 0_usize;
+        for row in self.rows {
+            if row.len() != self.columns.len() {
+                return Err(internal_error("row shape does not match result schema"));
+            }
+            let mut encoder = DataRowEncoder::new(fields.clone());
+            for ((column, cell), _field) in self.columns.iter().zip(row.iter()).zip(fields.iter()) {
+                encode_cell(&mut encoder, column.kind, cell)?;
+            }
+            let encoded_row = encoder.take_row();
+            let encoded_row_bytes = encoded_row
+                .data
+                .len()
+                .checked_add(DATA_ROW_WIRE_OVERHEAD)
+                .ok_or_else(|| user_error("54000", "PostgreSQL response size overflow"))?;
+            encoded_response_bytes = encoded_response_bytes
+                .checked_add(encoded_row_bytes)
+                .ok_or_else(|| user_error("54000", "PostgreSQL response size overflow"))?;
+            if encoded_response_bytes > MAX_RESPONSE_BYTES {
+                return Err(user_error(
+                    "54000",
+                    format!(
+                        "encoded PostgreSQL data rows exceed the {} MiB response limit",
+                        MAX_RESPONSE_BYTES / (1024 * 1024)
+                    ),
+                ));
+            }
+            encoded_rows.push(Ok(encoded_row));
+        }
+        let rows = stream::unfold(
+            (encoded_rows.into_iter(), response_permit.clone()),
+            |(mut rows, response_permit)| async move {
+                rows.next().map(|row| (row, (rows, response_permit)))
+            },
+        );
+        Ok(ExecutedResponse {
+            response: Response::Query(QueryResponse::new(fields, rows)),
+            response_permit,
+        })
+    }
+}
+
+fn encode_cell(encoder: &mut DataRowEncoder, kind: ColumnKind, cell: &Cell) -> PgWireResult<()> {
+    match (kind, cell) {
+        (ColumnKind::Bool, Cell::Bool(value)) => encoder.encode_field(value),
+        (ColumnKind::I32, Cell::I32(value)) => encoder.encode_field(value),
+        (ColumnKind::I64, Cell::I64(value)) => encoder.encode_field(value),
+        (ColumnKind::F64, Cell::F64(value)) => encoder.encode_field(value),
+        (ColumnKind::Text, Cell::Text(value)) => encoder.encode_field(value),
+        (ColumnKind::Bytea, Cell::Bytea(value)) => encoder.encode_field(value),
+        (ColumnKind::Uuid, Cell::Uuid(value)) => encoder.encode_field(&PgUuid(*value)),
+        (ColumnKind::Bool, Cell::Null) => encoder.encode_field(&Option::<bool>::None),
+        (ColumnKind::I32, Cell::Null) => encoder.encode_field(&Option::<i32>::None),
+        (ColumnKind::I64, Cell::Null) => encoder.encode_field(&Option::<i64>::None),
+        (ColumnKind::F64, Cell::Null) => encoder.encode_field(&Option::<f64>::None),
+        (ColumnKind::Text, Cell::Null) => encoder.encode_field(&Option::<String>::None),
+        (ColumnKind::Bytea, Cell::Null) => encoder.encode_field(&Option::<Vec<u8>>::None),
+        (ColumnKind::Uuid, Cell::Null) => encoder.encode_field(&Option::<PgUuid>::None),
+        _ => Err(internal_error("cell type does not match result schema")),
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ProjectedTableColumn {
+    source_name: String,
+    output_name: String,
+    kind: ColumnKind,
+}
+
+fn projected_table_columns(
+    plan: &SelectPlan,
+    table: &TableSchema,
+) -> PgWireResult<Vec<ProjectedTableColumn>> {
+    let mut output = Vec::new();
+    for projection in &plan.projection {
+        match &projection.expr {
+            ProjectedExpr::Wildcard => {
+                if projection.alias.is_some() {
+                    return Err(user_error("42601", "a wildcard cannot have an alias"));
+                }
+                output.push(ProjectedTableColumn {
+                    source_name: "id".to_owned(),
+                    output_name: "id".to_owned(),
+                    kind: ColumnKind::Uuid,
+                });
+                output.extend(
+                    table
+                        .columns
+                        .iter()
+                        .filter(|column| column.name != "id")
+                        .map(|column| ProjectedTableColumn {
+                            source_name: column.name.clone(),
+                            output_name: column.name.clone(),
+                            kind: jazz_column_kind(column),
+                        }),
+                );
+            }
+            ProjectedExpr::Column(name) => {
+                let column = ensure_table_column(table, name)?;
+                output.push(ProjectedTableColumn {
+                    source_name: name.clone(),
+                    output_name: projection.alias.clone().unwrap_or_else(|| name.clone()),
+                    kind: column.map(jazz_column_kind).unwrap_or(ColumnKind::Uuid),
+                });
+            }
+            _ => {
+                return Err(user_error(
+                    "0A000",
+                    "table SELECT projections support columns and * only",
+                ));
+            }
+        }
+        ensure_result_column_count(output.len())?;
+    }
+    Ok(output)
+}
+
+fn ensure_result_column_count(count: usize) -> PgWireResult<()> {
+    if count > MAX_RESULT_COLUMNS {
+        return Err(user_error(
+            "54000",
+            format!("a result cannot contain more than {MAX_RESULT_COLUMNS} columns"),
+        ));
+    }
+    Ok(())
+}
+
+fn table_query_output(
+    result: PostgresQueryResult,
+    columns: Vec<ProjectedTableColumn>,
+) -> PgWireResult<QueryOutput> {
+    let output_columns = columns
+        .iter()
+        .map(|column| OutputColumn::new(column.output_name.clone(), column.kind))
+        .collect();
+    let mut converted_bytes = result
+        .rows
+        .len()
+        .saturating_mul(std::mem::size_of::<Vec<Cell>>());
+    let rows = result
+        .rows
+        .into_iter()
+        .map(|row| {
+            converted_bytes = converted_bytes
+                .saturating_add(columns.len().saturating_mul(std::mem::size_of::<Cell>()));
+            if converted_bytes > MAX_RESPONSE_BYTES {
+                return Err(user_error(
+                    "54000",
+                    "converted PostgreSQL result exceeds the response limit",
+                ));
+            }
+            columns
+                .iter()
+                .zip(row.values)
+                .map(|(projected, value)| {
+                    if projected.source_name == "id" {
+                        return match value {
+                            Some(Value::Uuid(value)) => Ok(Cell::Uuid(value)),
+                            _ => Err(internal_error("row id is missing or invalid")),
+                        };
+                    }
+                    let schema_column = result
+                        .table
+                        .columns
+                        .iter()
+                        .find(|column| column.name == projected.source_name)
+                        .ok_or_else(|| internal_error("projected column disappeared"))?;
+                    converted_bytes = converted_bytes
+                        .saturating_add(jazz_cell_dynamic_size(value.as_ref(), schema_column)?);
+                    if converted_bytes > MAX_RESPONSE_BYTES {
+                        return Err(user_error(
+                            "54000",
+                            "converted PostgreSQL result exceeds the response limit",
+                        ));
+                    }
+                    jazz_value_cell(value, schema_column)
+                })
+                .collect::<PgWireResult<Vec<_>>>()
+        })
+        .collect::<PgWireResult<Vec<_>>>()?;
+    Ok(QueryOutput {
+        columns: output_columns,
+        rows,
+        response_permit: Some(Arc::new(result.response_permit)),
+    })
+}
+
+fn jazz_cell_dynamic_size(
+    value: Option<&Value>,
+    column: &crate::schema::ColumnSchema,
+) -> PgWireResult<usize> {
+    let Some(value) = value else {
+        return Ok(0);
+    };
+    Ok(match value {
+        Value::String(value) => value.len(),
+        Value::Bytes(value) => value.len(),
+        Value::Enum(discriminant) => enum_variant(&column.column_type, *discriminant)?.len(),
+        Value::Tuple(values) | Value::Array(values) => json_array_size_bound(values),
+        Value::Nullable(Some(value)) => jazz_cell_dynamic_size(Some(value), column)?,
+        Value::Nullable(None)
+        | Value::U8(_)
+        | Value::U16(_)
+        | Value::U32(_)
+        | Value::U64(_)
+        | Value::I32(_)
+        | Value::I64(_)
+        | Value::F64(_)
+        | Value::Bool(_)
+        | Value::Uuid(_) => 0,
+    })
+}
+
+fn json_array_size_bound(values: &[Value]) -> usize {
+    values
+        .iter()
+        .fold(2_usize, |total, value| {
+            total.saturating_add(json_value_size_bound(value))
+        })
+        .saturating_add(values.len().saturating_sub(1))
+}
+
+fn json_value_size_bound(value: &Value) -> usize {
+    match value {
+        Value::U8(_) => 3,
+        Value::U16(_) => 5,
+        Value::U32(_) => 10,
+        Value::U64(_) => 20,
+        Value::I32(_) => 11,
+        Value::I64(_) => 20,
+        Value::F64(_) => 32,
+        Value::Bool(_) => 5,
+        Value::String(value) => value.len().saturating_mul(6).saturating_add(2),
+        Value::Bytes(value) => (value.len().saturating_add(2) / 3)
+            .saturating_mul(4)
+            .saturating_add(2),
+        Value::Uuid(_) => 38,
+        Value::Enum(_) => 3,
+        Value::Tuple(values) | Value::Array(values) => json_array_size_bound(values),
+        Value::Nullable(Some(value)) => json_value_size_bound(value),
+        Value::Nullable(None) => 4,
+    }
+}
+
+fn jazz_value_cell(
+    value: Option<Value>,
+    column: &crate::schema::ColumnSchema,
+) -> PgWireResult<Cell> {
+    let Some(value) = value else {
+        return Ok(Cell::Null);
+    };
+    match value {
+        Value::Bool(value) => Ok(Cell::Bool(value)),
+        Value::I32(value) => Ok(Cell::I32(value)),
+        Value::I64(value) => Ok(Cell::I64(value)),
+        Value::U8(value) => Ok(Cell::I32(i32::from(value))),
+        Value::U16(value) => Ok(Cell::I32(i32::from(value))),
+        Value::U32(value) => Ok(Cell::I64(i64::from(value))),
+        Value::U64(value) => Ok(Cell::Text(value.to_string())),
+        Value::F64(value) => Ok(Cell::F64(value)),
+        Value::String(value) => Ok(Cell::Text(value)),
+        Value::Bytes(value) => match column.large_value {
+            Some(LargeValueKind::Text) => String::from_utf8(value)
+                .map(Cell::Text)
+                .map_err(|_| user_error("22021", "text value is not valid UTF-8")),
+            _ => Ok(Cell::Bytea(value)),
+        },
+        Value::Uuid(value) => Ok(Cell::Uuid(value)),
+        Value::Enum(discriminant) => enum_variant(&column.column_type, discriminant)
+            .map(|variant| Cell::Text(variant.to_owned())),
+        Value::Tuple(values) | Value::Array(values) => {
+            format_compound_value(&values).map(Cell::Text)
+        }
+        Value::Nullable(value) => match value {
+            Some(value) => jazz_value_cell(Some(*value), column),
+            None => Ok(Cell::Null),
+        },
+    }
+}
+
+fn format_compound_value(values: &[Value]) -> PgWireResult<String> {
+    serde_json::to_string(
+        &values
+            .iter()
+            .map(groove_value_json)
+            .collect::<PgWireResult<Vec<_>>>()?,
+    )
+    .map_err(|error| internal_error(format!("failed to encode compound value as JSON: {error}")))
+}
+
+fn groove_value_json(value: &Value) -> PgWireResult<serde_json::Value> {
+    Ok(match value {
+        Value::U8(value) => (*value).into(),
+        Value::U16(value) => (*value).into(),
+        Value::U32(value) => (*value).into(),
+        Value::U64(value) => (*value).into(),
+        Value::I32(value) => (*value).into(),
+        Value::I64(value) => (*value).into(),
+        Value::F64(value) => serde_json::Number::from_f64(*value)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| user_error("22003", "non-finite float cannot be encoded as JSON"))?,
+        Value::Bool(value) => (*value).into(),
+        Value::String(value) => value.clone().into(),
+        Value::Bytes(value) => base64::engine::general_purpose::STANDARD
+            .encode(value)
+            .into(),
+        Value::Uuid(value) => value.to_string().into(),
+        Value::Enum(value) => (*value).into(),
+        Value::Tuple(values) | Value::Array(values) => serde_json::Value::Array(
+            values
+                .iter()
+                .map(groove_value_json)
+                .collect::<PgWireResult<Vec<_>>>()?,
+        ),
+        Value::Nullable(Some(value)) => groove_value_json(value)?,
+        Value::Nullable(None) => serde_json::Value::Null,
+    })
+}
+
+fn enum_variant(column_type: &ColumnType, discriminant: u8) -> PgWireResult<&str> {
+    match unwrap_nullable(column_type) {
+        ColumnType::Enum(schema) => schema
+            .variant(discriminant)
+            .map_err(|error| user_error("22000", error.to_string())),
+        _ => Err(internal_error("enum value has a non-enum schema")),
+    }
+}
+
+fn jazz_column_kind(column: &crate::schema::ColumnSchema) -> ColumnKind {
+    if column.large_value == Some(LargeValueKind::Text) {
+        return ColumnKind::Text;
+    }
+    match unwrap_nullable(&column.column_type) {
+        ColumnType::Bool => ColumnKind::Bool,
+        ColumnType::I32 | ColumnType::U8 | ColumnType::U16 => ColumnKind::I32,
+        ColumnType::I64 | ColumnType::U32 => ColumnKind::I64,
+        ColumnType::U64 => ColumnKind::Text,
+        ColumnType::F64 => ColumnKind::F64,
+        ColumnType::String | ColumnType::Enum(_) | ColumnType::Tuple(_) | ColumnType::Array(_) => {
+            ColumnKind::Text
+        }
+        ColumnType::Bytes => ColumnKind::Bytea,
+        ColumnType::Uuid => ColumnKind::Uuid,
+        ColumnType::Nullable(_) => unreachable!("nullable type was unwrapped"),
+    }
+}
+
+fn unwrap_nullable(column_type: &ColumnType) -> &ColumnType {
+    match column_type {
+        ColumnType::Nullable(inner) => unwrap_nullable(inner),
+        other => other,
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ParameterValue {
+    Null,
+    Bool(bool),
+    I32(i32),
+    I64(i64),
+    F64(f64),
+    Text(String),
+    Bytea(Vec<u8>),
+    Uuid(uuid::Uuid),
+}
+
+fn decode_parameters(
+    portal: &Portal<PreparedStatement>,
+    kinds: &[ColumnKind],
+) -> PgWireResult<Vec<ParameterValue>> {
+    if kinds.len() > MAX_PARAMETER_COUNT {
+        return Err(user_error(
+            "54000",
+            format!("a query cannot have more than {MAX_PARAMETER_COUNT} parameters"),
+        ));
+    }
+    if portal.parameter_len() != kinds.len() {
+        return Err(user_error(
+            "08P01",
+            format!(
+                "expected {} query parameters, received {}",
+                kinds.len(),
+                portal.parameter_len()
+            ),
+        ));
+    }
+    let mut parameters = Vec::with_capacity(kinds.len());
+    let mut total_bytes = 0_usize;
+    for (idx, kind) in kinds.iter().enumerate() {
+        let parameter = match kind {
+            ColumnKind::Bool => portal
+                .parameter::<bool>(idx, &Type::BOOL)?
+                .map(ParameterValue::Bool)
+                .unwrap_or(ParameterValue::Null),
+            ColumnKind::I32 => portal
+                .parameter::<i32>(idx, &Type::INT4)?
+                .map(ParameterValue::I32)
+                .unwrap_or(ParameterValue::Null),
+            ColumnKind::I64 => portal
+                .parameter::<i64>(idx, &Type::INT8)?
+                .map(ParameterValue::I64)
+                .unwrap_or(ParameterValue::Null),
+            ColumnKind::F64 => portal
+                .parameter::<f64>(idx, &Type::FLOAT8)?
+                .map(ParameterValue::F64)
+                .unwrap_or(ParameterValue::Null),
+            ColumnKind::Text => portal
+                .parameter::<String>(idx, &Type::TEXT)?
+                .map(ParameterValue::Text)
+                .unwrap_or(ParameterValue::Null),
+            ColumnKind::Bytea => portal
+                .parameter::<Vec<u8>>(idx, &Type::BYTEA)?
+                .map(ParameterValue::Bytea)
+                .unwrap_or(ParameterValue::Null),
+            ColumnKind::Uuid => portal
+                .parameter::<PgUuid>(idx, &Type::UUID)?
+                .map(|value| ParameterValue::Uuid(value.0))
+                .unwrap_or(ParameterValue::Null),
+        };
+        total_bytes = total_bytes
+            .checked_add(parameter_value_size(&parameter))
+            .ok_or_else(|| user_error("54000", "PostgreSQL parameter size overflow"))?;
+        if total_bytes > MAX_PARAMETER_BYTES {
+            return Err(user_error(
+                "54000",
+                format!(
+                    "decoded PostgreSQL parameters cannot exceed {} MiB",
+                    MAX_PARAMETER_BYTES / (1024 * 1024)
+                ),
+            ));
+        }
+        parameters.push(parameter);
+    }
+    Ok(parameters)
+}
+
+fn parameter_value_size(parameter: &ParameterValue) -> usize {
+    match parameter {
+        ParameterValue::Null => 0,
+        ParameterValue::Bool(_) => 1,
+        ParameterValue::I32(_) => 4,
+        ParameterValue::I64(_) | ParameterValue::F64(_) => 8,
+        ParameterValue::Text(value) => value.len(),
+        ParameterValue::Bytea(value) => value.len(),
+        ParameterValue::Uuid(_) => 16,
+    }
+}
+
+fn validate_declared_parameter_types(
+    declared_oids: &[u32],
+    inferred: &[ColumnKind],
+) -> PgWireResult<()> {
+    if declared_oids.len() > inferred.len() {
+        return Err(user_error(
+            "08P01",
+            format!(
+                "prepared statement declares {} parameter types but SQL contains only {} parameters",
+                declared_oids.len(),
+                inferred.len()
+            ),
+        ));
+    }
+    for (idx, (oid, kind)) in declared_oids.iter().zip(inferred).enumerate() {
+        if *oid != 0 && Some(kind.pg_type()) != Type::from_oid(*oid) {
+            return Err(user_error(
+                "42804",
+                format!(
+                    "declared type for parameter ${} does not match inferred type {}",
+                    idx + 1,
+                    kind.pg_type()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_page_value(value: &PageValue, parameters: &[ParameterValue]) -> PgWireResult<usize> {
+    match value {
+        PageValue::Literal(value) => Ok(*value),
+        PageValue::Placeholder(position) => {
+            let parameter = parameters
+                .get(position - 1)
+                .ok_or_else(|| user_error("08P01", format!("missing parameter ${position}")))?;
+            match parameter {
+                ParameterValue::I64(value) => usize::try_from(*value).map_err(|_| {
+                    user_error("22003", "LIMIT and OFFSET must be non-negative integers")
+                }),
+                ParameterValue::Null => Err(user_error(
+                    "22004",
+                    "LIMIT and OFFSET parameters cannot be NULL",
+                )),
+                _ => Err(user_error(
+                    "42804",
+                    "LIMIT and OFFSET parameters must have bigint type",
+                )),
+            }
+        }
+    }
+}
+
+fn lower_table_filter<'a>(
+    filter: &FilterExpr,
+    table: &'a TableSchema,
+    parameters: &[ParameterValue],
+) -> PgWireResult<(Predicate, BTreeMap<String, Value>)> {
+    let mut bindings = BTreeMap::new();
+    let mut binding_names = HashMap::<(usize, Option<&'a ColumnType>), String>::new();
+    let mut expanded_binding_bytes = 0_usize;
+    let predicate = lower_filter_node(
+        filter,
+        table,
+        parameters,
+        &mut bindings,
+        &mut binding_names,
+        &mut expanded_binding_bytes,
+    )?;
+    Ok((predicate, bindings))
+}
+
+fn lower_filter_node<'a>(
+    filter: &FilterExpr,
+    table: &'a TableSchema,
+    parameters: &[ParameterValue],
+    bindings: &mut BTreeMap<String, Value>,
+    binding_names: &mut HashMap<(usize, Option<&'a ColumnType>), String>,
+    expanded_binding_bytes: &mut usize,
+) -> PgWireResult<Predicate> {
+    match filter {
+        FilterExpr::Compare {
+            column,
+            op,
+            literal,
+        } => {
+            let column_schema = ensure_table_column(table, column)?;
+            ensure_filterable_column(column_schema, column)?;
+            let right = lower_literal_operand(
+                literal,
+                column_schema,
+                parameters,
+                bindings,
+                binding_names,
+                expanded_binding_bytes,
+            )?;
+            let left = col(column.clone());
+            Ok(match op {
+                CompareOp::Eq => eq(left, right),
+                CompareOp::NotEq => ne(left, right),
+                CompareOp::Lt => lt(left, right),
+                CompareOp::LtEq => lte(left, right),
+                CompareOp::Gt => gt(left, right),
+                CompareOp::GtEq => gte(left, right),
+            })
+        }
+        FilterExpr::IsNull { column, negated } => {
+            let column_schema = ensure_table_column(table, column)?;
+            if column_schema
+                .is_none_or(|column| !matches!(column.column_type, ColumnType::Nullable(_)))
+            {
+                let predicate = eq(lit(Value::Bool(true)), lit(Value::Bool(false)));
+                return Ok(if *negated { not(predicate) } else { predicate });
+            }
+            let predicate = is_null(col(column.clone()));
+            Ok(if *negated { not(predicate) } else { predicate })
+        }
+        FilterExpr::In {
+            column,
+            values,
+            negated,
+        } => {
+            let column_schema = ensure_table_column(table, column)?;
+            ensure_filterable_column(column_schema, column)?;
+            let values = values
+                .iter()
+                .map(|literal| {
+                    lower_literal_operand(
+                        literal,
+                        column_schema,
+                        parameters,
+                        bindings,
+                        binding_names,
+                        expanded_binding_bytes,
+                    )
+                })
+                .collect::<PgWireResult<Vec<_>>>()?;
+            let predicate = in_list(col(column.clone()), values);
+            Ok(if *negated { not(predicate) } else { predicate })
+        }
+        FilterExpr::And(left, right) => Ok(all_of([
+            lower_filter_node(
+                left,
+                table,
+                parameters,
+                bindings,
+                binding_names,
+                expanded_binding_bytes,
+            )?,
+            lower_filter_node(
+                right,
+                table,
+                parameters,
+                bindings,
+                binding_names,
+                expanded_binding_bytes,
+            )?,
+        ])),
+        FilterExpr::Or(left, right) => Ok(any_of([
+            lower_filter_node(
+                left,
+                table,
+                parameters,
+                bindings,
+                binding_names,
+                expanded_binding_bytes,
+            )?,
+            lower_filter_node(
+                right,
+                table,
+                parameters,
+                bindings,
+                binding_names,
+                expanded_binding_bytes,
+            )?,
+        ])),
+        FilterExpr::Not(inner) => Ok(not(lower_filter_node(
+            inner,
+            table,
+            parameters,
+            bindings,
+            binding_names,
+            expanded_binding_bytes,
+        )?)),
+    }
+}
+
+fn lower_literal_operand<'a>(
+    literal_value: &SqlLiteral,
+    column: Option<&'a crate::schema::ColumnSchema>,
+    parameters: &[ParameterValue],
+    bindings: &mut BTreeMap<String, Value>,
+    binding_names: &mut HashMap<(usize, Option<&'a ColumnType>), String>,
+    expanded_binding_bytes: &mut usize,
+) -> PgWireResult<crate::query::Operand> {
+    match literal_value {
+        SqlLiteral::Placeholder(position) => {
+            let parameter = parameters
+                .get(position - 1)
+                .ok_or_else(|| user_error("08P01", format!("missing parameter ${position}")))?;
+            if matches!(parameter, ParameterValue::Null) {
+                return Err(user_error(
+                    "22004",
+                    "NULL filter parameters are not supported; use IS NULL or IS NOT NULL",
+                ));
+            }
+            let key = (*position, column.map(|column| &column.column_type));
+            if let Some(name) = binding_names.get(&key) {
+                return Ok(param(name.clone()));
+            }
+            let value = parameter_to_jazz_value(parameter, column)?;
+            *expanded_binding_bytes = expanded_binding_bytes
+                .checked_add(parameter_value_size(parameter))
+                .ok_or_else(|| user_error("54000", "PostgreSQL binding size overflow"))?;
+            if *expanded_binding_bytes > MAX_EXPANDED_BINDING_BYTES {
+                return Err(user_error(
+                    "54000",
+                    format!(
+                        "expanded PostgreSQL bindings cannot exceed {} MiB",
+                        MAX_EXPANDED_BINDING_BYTES / (1024 * 1024)
+                    ),
+                ));
+            }
+            // Reuse one converted Jazz value for each PostgreSQL parameter and
+            // exact target type. Different exact Jazz types can share a wire
+            // OID, so those targets intentionally receive separate bindings.
+            let name = format!("pg_{position}_{}", binding_names.len());
+            bindings.insert(name.clone(), value);
+            binding_names.insert(key, name.clone());
+            Ok(param(name))
+        }
+        SqlLiteral::Null => Err(user_error(
+            "42804",
+            "use IS NULL or IS NOT NULL instead of comparing to NULL",
+        )),
+        other => Ok(lit(sql_literal_to_jazz_value(other, column)?)),
+    }
+}
+
+fn sql_literal_to_jazz_value(
+    literal: &SqlLiteral,
+    column: Option<&crate::schema::ColumnSchema>,
+) -> PgWireResult<Value> {
+    let Some(column) = column else {
+        return match literal {
+            SqlLiteral::String(value) => uuid::Uuid::parse_str(value)
+                .map(Value::Uuid)
+                .map_err(|_| user_error("22P02", format!("invalid UUID literal {value}"))),
+            _ => Err(user_error(
+                "42804",
+                "row id comparisons require a UUID literal",
+            )),
+        };
+    };
+    let column_type = unwrap_nullable(&column.column_type);
+    match (literal, column_type) {
+        (SqlLiteral::String(value), ColumnType::String) => Ok(Value::String(value.clone())),
+        (SqlLiteral::String(value), ColumnType::Uuid) => uuid::Uuid::parse_str(value)
+            .map(Value::Uuid)
+            .map_err(|_| user_error("22P02", format!("invalid UUID literal {value}"))),
+        (SqlLiteral::String(value), ColumnType::Enum(schema)) => schema
+            .discriminant(value)
+            .map(Value::Enum)
+            .map_err(|error| user_error("22P02", error.to_string())),
+        (SqlLiteral::Boolean(value), ColumnType::Bool) => Ok(Value::Bool(*value)),
+        (SqlLiteral::Number(value), ColumnType::I32) => value
+            .parse::<i32>()
+            .map(Value::I32)
+            .map_err(|_| user_error("22P02", format!("invalid integer literal {value}"))),
+        (SqlLiteral::Number(value), ColumnType::I64) => value
+            .parse::<i64>()
+            .map(Value::I64)
+            .map_err(|_| user_error("22P02", format!("invalid bigint literal {value}"))),
+        (SqlLiteral::Number(value), ColumnType::U8) => value
+            .parse::<u8>()
+            .map(Value::U8)
+            .map_err(|_| user_error("22P02", format!("invalid unsigned literal {value}"))),
+        (SqlLiteral::Number(value), ColumnType::U16) => value
+            .parse::<u16>()
+            .map(Value::U16)
+            .map_err(|_| user_error("22P02", format!("invalid unsigned literal {value}"))),
+        (SqlLiteral::Number(value), ColumnType::U32) => value
+            .parse::<u32>()
+            .map(Value::U32)
+            .map_err(|_| user_error("22P02", format!("invalid unsigned literal {value}"))),
+        (SqlLiteral::Number(value), ColumnType::U64) => value
+            .parse::<u64>()
+            .map(Value::U64)
+            .map_err(|_| user_error("22P02", format!("invalid unsigned literal {value}"))),
+        (SqlLiteral::Number(value), ColumnType::F64) => value
+            .parse::<f64>()
+            .map(Value::F64)
+            .map_err(|_| user_error("22P02", format!("invalid float literal {value}"))),
+        (SqlLiteral::Placeholder(_), _) => unreachable!("placeholder handled by caller"),
+        _ => Err(user_error(
+            "42804",
+            format!("literal is incompatible with column {}", column.name),
+        )),
+    }
+}
+
+fn parameter_to_jazz_value(
+    parameter: &ParameterValue,
+    column: Option<&crate::schema::ColumnSchema>,
+) -> PgWireResult<Value> {
+    if column.is_none() {
+        return match parameter {
+            ParameterValue::Uuid(value) => Ok(Value::Uuid(*value)),
+            ParameterValue::Null => Ok(Value::Nullable(None)),
+            _ => Err(user_error("42804", "row id parameters must have UUID type")),
+        };
+    }
+    let column = column.expect("checked above");
+    if matches!(parameter, ParameterValue::Null) {
+        return Ok(Value::Nullable(None));
+    }
+    let value = match parameter {
+        ParameterValue::Null => unreachable!("handled above"),
+        ParameterValue::Bool(value) => Ok(Value::Bool(*value)),
+        ParameterValue::I32(value) => match unwrap_nullable(&column.column_type) {
+            ColumnType::I32 => Ok(Value::I32(*value)),
+            ColumnType::U8 => u8::try_from(*value)
+                .map(Value::U8)
+                .map_err(|_| user_error("22003", "parameter is outside u8 range")),
+            ColumnType::U16 => u16::try_from(*value)
+                .map(Value::U16)
+                .map_err(|_| user_error("22003", "parameter is outside u16 range")),
+            _ => Ok(Value::I32(*value)),
+        },
+        ParameterValue::I64(value) => match unwrap_nullable(&column.column_type) {
+            ColumnType::U32 => u32::try_from(*value)
+                .map(Value::U32)
+                .map_err(|_| user_error("22003", "parameter is outside u32 range")),
+            ColumnType::U64 => u64::try_from(*value)
+                .map(Value::U64)
+                .map_err(|_| user_error("22003", "parameter is outside u64 range")),
+            _ => Ok(Value::I64(*value)),
+        },
+        ParameterValue::F64(value) => Ok(Value::F64(*value)),
+        ParameterValue::Text(value) => match unwrap_nullable(&column.column_type) {
+            ColumnType::Enum(schema) => schema
+                .discriminant(value)
+                .map(Value::Enum)
+                .map_err(|error| user_error("22P02", error.to_string())),
+            ColumnType::U64 => value
+                .parse::<u64>()
+                .map(Value::U64)
+                .map_err(|_| user_error("22P02", "invalid unsigned bigint parameter")),
+            _ => Ok(Value::String(value.clone())),
+        },
+        ParameterValue::Bytea(value) => Ok(Value::Bytes(value.clone())),
+        ParameterValue::Uuid(value) => Ok(Value::Uuid(*value)),
+    }?;
+    Ok(wrap_non_null_for_column(value, &column.column_type))
+}
+
+fn wrap_non_null_for_column(value: Value, column_type: &ColumnType) -> Value {
+    match column_type {
+        ColumnType::Nullable(inner) => {
+            Value::Nullable(Some(Box::new(wrap_non_null_for_column(value, inner))))
+        }
+        _ => value,
+    }
+}
+
+fn table_by_name<'a>(schema: &'a JazzSchema, name: &str) -> PgWireResult<&'a TableSchema> {
+    schema
+        .tables
+        .iter()
+        .find(|table| table.name == name)
+        .ok_or_else(|| user_error("42P01", format!("relation public.{name} does not exist")))
+}
+
+fn ensure_table_column<'a>(
+    table: &'a TableSchema,
+    name: &str,
+) -> PgWireResult<Option<&'a crate::schema::ColumnSchema>> {
+    if name == "id" {
+        return Ok(None);
+    }
+    table
+        .columns
+        .iter()
+        .find(|column| column.name == name)
+        .map(Some)
+        .ok_or_else(|| {
+            user_error(
+                "42703",
+                format!("column {}.{name} does not exist", table.name),
+            )
+        })
+}
+
+fn ensure_filterable_column(
+    column: Option<&crate::schema::ColumnSchema>,
+    name: &str,
+) -> PgWireResult<()> {
+    let Some(column) = column else {
+        return Ok(());
+    };
+    if column.large_value.is_some() {
+        return Err(user_error(
+            "0A000",
+            format!("content comparisons are not supported for large-value column {name}"),
+        ));
+    }
+    if is_postgres_text_surrogate(&column.column_type) {
+        return Err(user_error(
+            "0A000",
+            format!(
+                "WHERE comparisons are not supported for column {name} because its PostgreSQL text representation does not preserve Jazz comparison semantics"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_orderable_column(
+    column: Option<&crate::schema::ColumnSchema>,
+    name: &str,
+) -> PgWireResult<()> {
+    let Some(column) = column else {
+        return Ok(());
+    };
+    if column.large_value.is_some() {
+        return Err(user_error(
+            "0A000",
+            format!("ORDER BY is not supported for large-value column {name}"),
+        ));
+    }
+    if is_postgres_text_surrogate(&column.column_type) {
+        return Err(user_error(
+            "0A000",
+            format!(
+                "ORDER BY is not supported for column {name} because its PostgreSQL text representation does not preserve Jazz ordering semantics"
+            ),
+        ));
+    }
+    if matches!(column.column_type, ColumnType::Nullable(_)) {
+        return Err(user_error(
+            "0A000",
+            format!(
+                "ORDER BY nullable column {name} is not supported yet because PostgreSQL NULL ordering cannot be preserved"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn is_postgres_text_surrogate(column_type: &ColumnType) -> bool {
+    matches!(
+        unwrap_nullable(column_type),
+        ColumnType::U64 | ColumnType::Enum(_) | ColumnType::Tuple(_) | ColumnType::Array(_)
+    )
+}
+
+fn table_column_kinds(table: &TableSchema) -> BTreeMap<String, ColumnKind> {
+    let mut columns = table
+        .columns
+        .iter()
+        .map(|column| (column.name.clone(), jazz_column_kind(column)))
+        .collect::<BTreeMap<_, _>>();
+    columns.insert("id".to_owned(), ColumnKind::Uuid);
+    columns
+}
+
+fn infer_parameter_kinds(
+    plan: &SelectPlan,
+    columns: &BTreeMap<String, ColumnKind>,
+) -> PgWireResult<Vec<ColumnKind>> {
+    let mut inferred = BTreeMap::<usize, ColumnKind>::new();
+    if let Some(filter) = &plan.filter {
+        infer_parameter_kinds_node(filter, columns, &mut inferred)?;
+    }
+    for page in plan.limit.iter().chain(std::iter::once(&plan.offset)) {
+        if let PageValue::Placeholder(position) = page {
+            insert_inferred_kind(&mut inferred, *position, ColumnKind::I64)?;
+        }
+    }
+    if plan.projection.iter().any(|projection| {
+        matches!(
+            projection.expr,
+            ProjectedExpr::Literal(SqlLiteral::Placeholder(_))
+        )
+    }) {
+        return Err(user_error(
+            "42P18",
+            "source-less SELECT parameters are not supported",
+        ));
+    }
+    let Some(max) = inferred.keys().next_back().copied() else {
+        return Ok(Vec::new());
+    };
+    (1..=max)
+        .map(|position| {
+            inferred.get(&position).copied().ok_or_else(|| {
+                user_error(
+                    "42P18",
+                    format!("could not determine data type of parameter ${position}"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn infer_parameter_kinds_node(
+    filter: &FilterExpr,
+    columns: &BTreeMap<String, ColumnKind>,
+    inferred: &mut BTreeMap<usize, ColumnKind>,
+) -> PgWireResult<()> {
+    match filter {
+        FilterExpr::Compare {
+            column, literal, ..
+        } => infer_literal_kind(column, literal, columns, inferred),
+        FilterExpr::In { column, values, .. } => {
+            for literal in values {
+                infer_literal_kind(column, literal, columns, inferred)?;
+            }
+            Ok(())
+        }
+        FilterExpr::And(left, right) | FilterExpr::Or(left, right) => {
+            infer_parameter_kinds_node(left, columns, inferred)?;
+            infer_parameter_kinds_node(right, columns, inferred)
+        }
+        FilterExpr::Not(inner) => infer_parameter_kinds_node(inner, columns, inferred),
+        FilterExpr::IsNull { .. } => Ok(()),
+    }
+}
+
+fn infer_literal_kind(
+    column: &str,
+    literal: &SqlLiteral,
+    columns: &BTreeMap<String, ColumnKind>,
+    inferred: &mut BTreeMap<usize, ColumnKind>,
+) -> PgWireResult<()> {
+    let SqlLiteral::Placeholder(position) = literal else {
+        return Ok(());
+    };
+    let kind = columns
+        .get(column)
+        .copied()
+        .ok_or_else(|| user_error("42703", format!("column {column} does not exist")))?;
+    insert_inferred_kind(inferred, *position, kind)
+}
+
+fn insert_inferred_kind(
+    inferred: &mut BTreeMap<usize, ColumnKind>,
+    position: usize,
+    kind: ColumnKind,
+) -> PgWireResult<()> {
+    if let Some(previous) = inferred.insert(position, kind)
+        && previous != kind
+    {
+        return Err(user_error(
+            "42P18",
+            format!("parameter ${position} is used with incompatible column types"),
+        ));
+    }
+    Ok(())
+}
+
+fn literal_cell(
+    literal: &SqlLiteral,
+    parameters: &[ParameterValue],
+) -> PgWireResult<(ColumnKind, Cell)> {
+    match literal {
+        SqlLiteral::String(value) => Ok((ColumnKind::Text, Cell::Text(value.clone()))),
+        SqlLiteral::Number(value) => {
+            if let Ok(value) = value.parse::<i32>() {
+                Ok((ColumnKind::I32, Cell::I32(value)))
+            } else if let Ok(value) = value.parse::<i64>() {
+                Ok((ColumnKind::I64, Cell::I64(value)))
+            } else {
+                value
+                    .parse::<f64>()
+                    .map(|value| (ColumnKind::F64, Cell::F64(value)))
+                    .map_err(|_| user_error("22P02", format!("invalid number {value}")))
+            }
+        }
+        SqlLiteral::Boolean(value) => Ok((ColumnKind::Bool, Cell::Bool(*value))),
+        SqlLiteral::Null => Ok((ColumnKind::Text, Cell::Null)),
+        SqlLiteral::Placeholder(position) => parameter_cell(
+            parameters
+                .get(position - 1)
+                .ok_or_else(|| user_error("08P01", format!("missing parameter ${position}")))?,
+        ),
+    }
+}
+
+fn parameter_cell(parameter: &ParameterValue) -> PgWireResult<(ColumnKind, Cell)> {
+    Ok(match parameter {
+        ParameterValue::Null => (ColumnKind::Text, Cell::Null),
+        ParameterValue::Bool(value) => (ColumnKind::Bool, Cell::Bool(*value)),
+        ParameterValue::I32(value) => (ColumnKind::I32, Cell::I32(*value)),
+        ParameterValue::I64(value) => (ColumnKind::I64, Cell::I64(*value)),
+        ParameterValue::F64(value) => (ColumnKind::F64, Cell::F64(*value)),
+        ParameterValue::Text(value) => (ColumnKind::Text, Cell::Text(value.clone())),
+        ParameterValue::Bytea(value) => (ColumnKind::Bytea, Cell::Bytea(value.clone())),
+        ParameterValue::Uuid(value) => (ColumnKind::Uuid, Cell::Uuid(*value)),
+    })
+}
+
+fn describe_session(plan: &SelectPlan) -> PgWireResult<Vec<OutputColumn>> {
+    plan.projection
+        .iter()
+        .map(|projection| {
+            let (name, kind) = match &projection.expr {
+                ProjectedExpr::SessionFunction(SessionFunction::Version) => {
+                    ("version", ColumnKind::Text)
+                }
+                ProjectedExpr::SessionFunction(SessionFunction::CurrentDatabase) => {
+                    ("current_database", ColumnKind::Text)
+                }
+                ProjectedExpr::SessionFunction(SessionFunction::CurrentSchema) => {
+                    ("current_schema", ColumnKind::Text)
+                }
+                ProjectedExpr::SessionFunction(SessionFunction::CurrentUser) => {
+                    ("current_user", ColumnKind::Text)
+                }
+                ProjectedExpr::Literal(SqlLiteral::Boolean(_)) => ("?column?", ColumnKind::Bool),
+                ProjectedExpr::Literal(SqlLiteral::Number(value)) => {
+                    if value.parse::<i32>().is_ok() {
+                        ("?column?", ColumnKind::I32)
+                    } else if value.parse::<i64>().is_ok() {
+                        ("?column?", ColumnKind::I64)
+                    } else {
+                        ("?column?", ColumnKind::F64)
+                    }
+                }
+                ProjectedExpr::Literal(_) => ("?column?", ColumnKind::Text),
+                _ => {
+                    return Err(user_error(
+                        "42703",
+                        "a source-less SELECT may only project session functions or literals",
+                    ));
+                }
+            };
+            Ok(OutputColumn::new(
+                projection.alias.clone().unwrap_or_else(|| name.to_owned()),
+                kind,
+            ))
+        })
+        .collect()
+}
+
+struct VirtualRelation {
+    columns: Vec<OutputColumn>,
+    rows: Vec<Vec<Cell>>,
+}
+
+impl VirtualRelation {
+    fn projected_columns(&self, plan: &SelectPlan) -> PgWireResult<Vec<OutputColumn>> {
+        let mut projected = Vec::new();
+        for projection in &plan.projection {
+            match &projection.expr {
+                ProjectedExpr::Wildcard => {
+                    if projection.alias.is_some() {
+                        return Err(user_error("42601", "a wildcard cannot have an alias"));
+                    }
+                    projected.extend(self.columns.clone());
+                }
+                ProjectedExpr::Column(name) => {
+                    let column = self.column(name)?;
+                    projected.push(OutputColumn::new(
+                        projection.alias.clone().unwrap_or_else(|| name.clone()),
+                        column.kind,
+                    ));
+                }
+                _ => {
+                    return Err(user_error(
+                        "0A000",
+                        "catalogue SELECT projections support columns and * only",
+                    ));
+                }
+            }
+            ensure_result_column_count(projected.len())?;
+        }
+        Ok(projected)
+    }
+
+    fn apply(
+        mut self,
+        plan: SelectPlan,
+        parameters: &[ParameterValue],
+        limit: Option<usize>,
+        offset: usize,
+    ) -> PgWireResult<QueryOutput> {
+        if let Some(filter) = &plan.filter {
+            let rows = std::mem::take(&mut self.rows);
+            self.rows = rows
+                .into_iter()
+                .map(|row| {
+                    evaluate_virtual_filter(filter, &self.columns, &row, parameters)
+                        .map(|truth| (row, truth == SqlTruth::True))
+                })
+                .collect::<PgWireResult<Vec<_>>>()?
+                .into_iter()
+                .filter_map(|(row, matches)| matches.then_some(row))
+                .collect();
+        }
+        for order in plan.order_by.iter().rev() {
+            let idx = self.column_index(&order.column)?;
+            self.rows.sort_by(|left, right| {
+                compare_cells_for_order(&left[idx], &right[idx], order.ascending)
+            });
+        }
+
+        let projection_indices = virtual_projection_indices(&self, &plan)?;
+        let columns = self.projected_columns(&plan)?;
+        let rows = self
+            .rows
+            .into_iter()
+            .skip(offset)
+            .take(limit.unwrap_or(usize::MAX))
+            .map(|row| {
+                projection_indices
+                    .iter()
+                    .map(|idx| row[*idx].clone())
+                    .collect()
+            })
+            .collect();
+        Ok(QueryOutput {
+            columns,
+            rows,
+            response_permit: None,
+        })
+    }
+
+    fn column(&self, name: &str) -> PgWireResult<&OutputColumn> {
+        self.columns
+            .iter()
+            .find(|column| column.name == name)
+            .ok_or_else(|| user_error("42703", format!("catalogue column {name} does not exist")))
+    }
+
+    fn column_index(&self, name: &str) -> PgWireResult<usize> {
+        self.columns
+            .iter()
+            .position(|column| column.name == name)
+            .ok_or_else(|| user_error("42703", format!("catalogue column {name} does not exist")))
+    }
+}
+
+fn virtual_projection_indices(
+    relation: &VirtualRelation,
+    plan: &SelectPlan,
+) -> PgWireResult<Vec<usize>> {
+    let mut indices = Vec::new();
+    for projection in &plan.projection {
+        match &projection.expr {
+            ProjectedExpr::Wildcard => indices.extend(0..relation.columns.len()),
+            ProjectedExpr::Column(name) => indices.push(relation.column_index(name)?),
+            _ => {
+                return Err(user_error(
+                    "0A000",
+                    "catalogue SELECT projections support columns and * only",
+                ));
+            }
+        }
+        ensure_result_column_count(indices.len())?;
+    }
+    Ok(indices)
+}
+
+fn catalogue_relation(
+    source: &SelectSource,
+    database: &str,
+    schema: Option<&JazzSchema>,
+) -> VirtualRelation {
+    match source {
+        SelectSource::Databases => VirtualRelation {
+            columns: vec![OutputColumn::new("datname", ColumnKind::Text)],
+            rows: vec![vec![Cell::Text(database.to_owned())]],
+        },
+        SelectSource::Tables => {
+            let columns = vec![
+                OutputColumn::new("table_catalog", ColumnKind::Text),
+                OutputColumn::new("table_schema", ColumnKind::Text),
+                OutputColumn::new("table_name", ColumnKind::Text),
+                OutputColumn::new("table_type", ColumnKind::Text),
+            ];
+            let rows = schema
+                .into_iter()
+                .flat_map(|schema| &schema.tables)
+                .map(|table| {
+                    vec![
+                        Cell::Text(database.to_owned()),
+                        Cell::Text("public".to_owned()),
+                        Cell::Text(table.name.clone()),
+                        Cell::Text("BASE TABLE".to_owned()),
+                    ]
+                })
+                .collect();
+            VirtualRelation { columns, rows }
+        }
+        SelectSource::Columns => {
+            let columns = vec![
+                OutputColumn::new("table_catalog", ColumnKind::Text),
+                OutputColumn::new("table_schema", ColumnKind::Text),
+                OutputColumn::new("table_name", ColumnKind::Text),
+                OutputColumn::new("column_name", ColumnKind::Text),
+                OutputColumn::new("ordinal_position", ColumnKind::I32),
+                OutputColumn::new("column_default", ColumnKind::Text),
+                OutputColumn::new("is_nullable", ColumnKind::Text),
+                OutputColumn::new("data_type", ColumnKind::Text),
+                OutputColumn::new("udt_name", ColumnKind::Text),
+            ];
+            let mut rows = Vec::new();
+            for table in schema.into_iter().flat_map(|schema| &schema.tables) {
+                rows.push(vec![
+                    Cell::Text(database.to_owned()),
+                    Cell::Text("public".to_owned()),
+                    Cell::Text(table.name.clone()),
+                    Cell::Text("id".to_owned()),
+                    Cell::I32(1),
+                    Cell::Null,
+                    Cell::Text("NO".to_owned()),
+                    Cell::Text("uuid".to_owned()),
+                    Cell::Text("uuid".to_owned()),
+                ]);
+                for (idx, column) in table
+                    .columns
+                    .iter()
+                    .filter(|column| column.name != "id")
+                    .enumerate()
+                {
+                    let kind = jazz_column_kind(column);
+                    rows.push(vec![
+                        Cell::Text(database.to_owned()),
+                        Cell::Text("public".to_owned()),
+                        Cell::Text(table.name.clone()),
+                        Cell::Text(column.name.clone()),
+                        Cell::I32(i32::try_from(idx + 2).unwrap_or(i32::MAX)),
+                        Cell::Null,
+                        Cell::Text(if matches!(column.column_type, ColumnType::Nullable(_)) {
+                            "YES".to_owned()
+                        } else {
+                            "NO".to_owned()
+                        }),
+                        Cell::Text(information_schema_type(kind).to_owned()),
+                        Cell::Text(postgres_udt_name(kind).to_owned()),
+                    ]);
+                }
+            }
+            VirtualRelation { columns, rows }
+        }
+        SelectSource::Table(_) | SelectSource::Session => unreachable!("not a virtual catalogue"),
+    }
+}
+
+fn catalogue_column_kinds(source: &SelectSource) -> BTreeMap<String, ColumnKind> {
+    let names = match source {
+        SelectSource::Databases => vec![("datname", ColumnKind::Text)],
+        SelectSource::Tables => vec![
+            ("table_catalog", ColumnKind::Text),
+            ("table_schema", ColumnKind::Text),
+            ("table_name", ColumnKind::Text),
+            ("table_type", ColumnKind::Text),
+        ],
+        SelectSource::Columns => vec![
+            ("table_catalog", ColumnKind::Text),
+            ("table_schema", ColumnKind::Text),
+            ("table_name", ColumnKind::Text),
+            ("column_name", ColumnKind::Text),
+            ("ordinal_position", ColumnKind::I32),
+            ("column_default", ColumnKind::Text),
+            ("is_nullable", ColumnKind::Text),
+            ("data_type", ColumnKind::Text),
+            ("udt_name", ColumnKind::Text),
+        ],
+        SelectSource::Table(_) | SelectSource::Session => Vec::new(),
+    };
+    names
+        .into_iter()
+        .map(|(name, kind)| (name.to_owned(), kind))
+        .collect()
+}
+
+fn evaluate_virtual_filter(
+    filter: &FilterExpr,
+    columns: &[OutputColumn],
+    row: &[Cell],
+    parameters: &[ParameterValue],
+) -> PgWireResult<SqlTruth> {
+    match filter {
+        FilterExpr::Compare {
+            column,
+            op,
+            literal,
+        } => {
+            let (idx, kind) = virtual_column(columns, column)?;
+            let right = virtual_literal_cell(literal, kind, parameters)?;
+            if matches!(row[idx], Cell::Null) || matches!(right, Cell::Null) {
+                return Ok(SqlTruth::Unknown);
+            }
+            let ordering = compare_cells(&row[idx], &right);
+            Ok(SqlTruth::from_bool(match op {
+                CompareOp::Eq => ordering.is_eq(),
+                CompareOp::NotEq => !ordering.is_eq(),
+                CompareOp::Lt => ordering.is_lt(),
+                CompareOp::LtEq => ordering.is_le(),
+                CompareOp::Gt => ordering.is_gt(),
+                CompareOp::GtEq => ordering.is_ge(),
+            }))
+        }
+        FilterExpr::IsNull { column, negated } => {
+            let (idx, _) = virtual_column(columns, column)?;
+            Ok(SqlTruth::from_bool(
+                matches!(row[idx], Cell::Null) != *negated,
+            ))
+        }
+        FilterExpr::In {
+            column,
+            values,
+            negated,
+        } => {
+            let (idx, kind) = virtual_column(columns, column)?;
+            if matches!(row[idx], Cell::Null) {
+                return Ok(SqlTruth::Unknown);
+            }
+            let mut truth = SqlTruth::False;
+            for literal in values {
+                let value = virtual_literal_cell(literal, kind, parameters)?;
+                if matches!(value, Cell::Null) {
+                    truth = SqlTruth::Unknown;
+                } else if compare_cells(&row[idx], &value).is_eq() {
+                    truth = SqlTruth::True;
+                    break;
+                }
+            }
+            Ok(if *negated { truth.not() } else { truth })
+        }
+        FilterExpr::And(left, right) => {
+            Ok(evaluate_virtual_filter(left, columns, row, parameters)?
+                .and(evaluate_virtual_filter(right, columns, row, parameters)?))
+        }
+        FilterExpr::Or(left, right) => Ok(evaluate_virtual_filter(left, columns, row, parameters)?
+            .or(evaluate_virtual_filter(right, columns, row, parameters)?)),
+        FilterExpr::Not(inner) => {
+            Ok(evaluate_virtual_filter(inner, columns, row, parameters)?.not())
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SqlTruth {
+    False,
+    True,
+    Unknown,
+}
+
+impl SqlTruth {
+    fn from_bool(value: bool) -> Self {
+        if value { Self::True } else { Self::False }
+    }
+
+    fn not(self) -> Self {
+        match self {
+            Self::False => Self::True,
+            Self::True => Self::False,
+            Self::Unknown => Self::Unknown,
+        }
+    }
+
+    fn and(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::False, _) | (_, Self::False) => Self::False,
+            (Self::True, Self::True) => Self::True,
+            _ => Self::Unknown,
+        }
+    }
+
+    fn or(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::True, _) | (_, Self::True) => Self::True,
+            (Self::False, Self::False) => Self::False,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+fn virtual_column(columns: &[OutputColumn], name: &str) -> PgWireResult<(usize, ColumnKind)> {
+    columns
+        .iter()
+        .enumerate()
+        .find(|(_, column)| column.name == name)
+        .map(|(idx, column)| (idx, column.kind))
+        .ok_or_else(|| user_error("42703", format!("catalogue column {name} does not exist")))
+}
+
+fn virtual_literal_cell(
+    literal: &SqlLiteral,
+    kind: ColumnKind,
+    parameters: &[ParameterValue],
+) -> PgWireResult<Cell> {
+    match literal {
+        SqlLiteral::Placeholder(position) => {
+            let parameter = parameters
+                .get(position - 1)
+                .ok_or_else(|| user_error("08P01", format!("missing parameter ${position}")))?;
+            let (parameter_kind, cell) = parameter_cell(parameter)?;
+            if parameter_kind != kind && !matches!(parameter, ParameterValue::Null) {
+                return Err(user_error(
+                    "42804",
+                    "parameter type does not match catalogue column",
+                ));
+            }
+            Ok(cell)
+        }
+        SqlLiteral::Null => Ok(Cell::Null),
+        SqlLiteral::String(value) if kind == ColumnKind::Text => Ok(Cell::Text(value.clone())),
+        SqlLiteral::Number(value) if kind == ColumnKind::I32 => value
+            .parse::<i32>()
+            .map(Cell::I32)
+            .map_err(|_| user_error("22P02", format!("invalid integer {value}"))),
+        SqlLiteral::Number(value) if kind == ColumnKind::I64 => value
+            .parse::<i64>()
+            .map(Cell::I64)
+            .map_err(|_| user_error("22P02", format!("invalid bigint {value}"))),
+        SqlLiteral::Boolean(value) if kind == ColumnKind::Bool => Ok(Cell::Bool(*value)),
+        _ => Err(user_error(
+            "42804",
+            "literal type does not match catalogue column",
+        )),
+    }
+}
+
+fn compare_cells(left: &Cell, right: &Cell) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (left, right) {
+        (Cell::Null, Cell::Null) => Ordering::Equal,
+        (Cell::Null, _) => Ordering::Less,
+        (_, Cell::Null) => Ordering::Greater,
+        (Cell::Bool(left), Cell::Bool(right)) => left.cmp(right),
+        (Cell::I32(left), Cell::I32(right)) => left.cmp(right),
+        (Cell::I64(left), Cell::I64(right)) => left.cmp(right),
+        (Cell::F64(left), Cell::F64(right)) => left.partial_cmp(right).unwrap_or(Ordering::Equal),
+        (Cell::Text(left), Cell::Text(right)) => left.cmp(right),
+        (Cell::Bytea(left), Cell::Bytea(right)) => left.cmp(right),
+        (Cell::Uuid(left), Cell::Uuid(right)) => left.cmp(right),
+        _ => Ordering::Equal,
+    }
+}
+
+fn compare_cells_for_order(left: &Cell, right: &Cell, ascending: bool) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (left, right) {
+        (Cell::Null, Cell::Null) => Ordering::Equal,
+        (Cell::Null, _) => {
+            if ascending {
+                Ordering::Greater
+            } else {
+                Ordering::Less
+            }
+        }
+        (_, Cell::Null) => {
+            if ascending {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            }
+        }
+        _ => {
+            let ordering = compare_cells(left, right);
+            if ascending {
+                ordering
+            } else {
+                ordering.reverse()
+            }
+        }
+    }
+}
+
+fn information_schema_type(kind: ColumnKind) -> &'static str {
+    match kind {
+        ColumnKind::Bool => "boolean",
+        ColumnKind::I32 => "integer",
+        ColumnKind::I64 => "bigint",
+        ColumnKind::F64 => "double precision",
+        ColumnKind::Text => "text",
+        ColumnKind::Bytea => "bytea",
+        ColumnKind::Uuid => "uuid",
+    }
+}
+
+fn postgres_udt_name(kind: ColumnKind) -> &'static str {
+    match kind {
+        ColumnKind::Bool => "bool",
+        ColumnKind::I32 => "int4",
+        ColumnKind::I64 => "int8",
+        ColumnKind::F64 => "float8",
+        ColumnKind::Text => "text",
+        ColumnKind::Bytea => "bytea",
+        ColumnKind::Uuid => "uuid",
+    }
+}
+
+fn sql_error(error: sql::SqlError) -> PgWireError {
+    user_error("0A000", error.to_string())
+}
+
+fn failed_transaction_error() -> PgWireError {
+    user_error(
+        "25P02",
+        "current transaction is aborted; commands are ignored until ROLLBACK",
+    )
+}
+
+fn ensure_sql_size(sql: &str) -> PgWireResult<()> {
+    if sql.len() > MAX_SQL_BYTES {
+        return Err(user_error(
+            "54000",
+            format!("SQL text cannot exceed {MAX_SQL_BYTES} bytes"),
+        ));
+    }
+    Ok(())
+}
+
+fn internal_database_error(error: String) -> PgWireError {
+    user_error("XX000", format!("Jazz database query failed: {error}"))
+}
+
+fn postgres_database_query_error(error: String) -> PgWireError {
+    if error.starts_with("PostgreSQL response exceeds configured") {
+        user_error("54000", error)
+    } else if error.starts_with("PostgreSQL schema changed while planning") {
+        user_error("40001", error)
+    } else {
+        internal_database_error(error)
+    }
+}
+
+fn user_error(code: &str, message: impl Into<String>) -> PgWireError {
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "ERROR".to_owned(),
+        code.to_owned(),
+        message.into(),
+    )))
+}
+
+fn fatal_error(code: &str, message: impl Into<String>) -> PgWireError {
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "FATAL".to_owned(),
+        code.to_owned(),
+        message.into(),
+    )))
+}
+
+fn internal_error(message: impl Into<String>) -> PgWireError {
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "ERROR".to_owned(),
+        "XX000".to_owned(),
+        message.into(),
+    )))
+}

--- a/crates/jazz/src/tools/server/postgres/sql.rs
+++ b/crates/jazz/src/tools/server/postgres/sql.rs
@@ -1,8 +1,10 @@
+use std::collections::BTreeSet;
 use std::fmt;
 
 use sqlparser::ast::{
-    BinaryOperator, Expr, FunctionArguments, GroupByExpr, Ident, LimitClause, ObjectName,
-    OrderByKind, SelectItem, SetExpr, Statement, TableFactor, UnaryOperator, Value as AstValue,
+    AssignmentTarget, BinaryOperator, Expr, FromTable, FunctionArguments, GroupByExpr, Ident,
+    LimitClause, ObjectName, OrderByKind, SelectItem, SetExpr, Statement, TableFactor, TableObject,
+    TableWithJoins, UnaryOperator, Value as AstValue,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::keywords::Keyword;
@@ -19,7 +21,50 @@ const MAX_FILTER_NODES: usize = 512;
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum ParsedStatement {
     Select(SelectPlan),
+    Mutation(MutationPlan),
     Command(Command),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct MutationPlan {
+    pub(crate) table: String,
+    pub(crate) kind: MutationKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum MutationKind {
+    Insert(InsertPlan),
+    Update(UpdatePlan),
+    Delete(DeletePlan),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct InsertPlan {
+    pub(crate) columns: Vec<String>,
+    pub(crate) values: Vec<SqlLiteral>,
+    pub(crate) returning: Option<ReturningId>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ReturningId {
+    pub(crate) alias: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct UpdatePlan {
+    pub(crate) assignments: Vec<MutationAssignment>,
+    pub(crate) row_id: SqlLiteral,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct MutationAssignment {
+    pub(crate) column: String,
+    pub(crate) value: SqlLiteral,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct DeletePlan {
+    pub(crate) row_id: SqlLiteral,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -199,6 +244,9 @@ pub(crate) fn parse_sql_batch(sql: &str) -> Result<Vec<ParsedStatement>, SqlErro
 fn parse_statement(statement: Statement) -> Result<ParsedStatement, SqlError> {
     match statement {
         Statement::Query(query) => parse_query(*query).map(ParsedStatement::Select),
+        Statement::Insert(insert) => parse_insert(insert).map(ParsedStatement::Mutation),
+        Statement::Update(update) => parse_update(update).map(ParsedStatement::Mutation),
+        Statement::Delete(delete) => parse_delete(delete).map(ParsedStatement::Mutation),
         Statement::ShowVariable { variable } => Ok(ParsedStatement::Command(Command::Show(
             variable
                 .iter()
@@ -207,7 +255,7 @@ fn parse_statement(statement: Statement) -> Result<ParsedStatement, SqlError> {
                 .join("."),
         ))),
         Statement::Set(_) => Err(unsupported(
-            "SET (session settings are not applied by this read-only interface)",
+            "SET (session settings are not applied by this interface)",
         )),
         Statement::StartTransaction {
             modes,
@@ -241,9 +289,328 @@ fn parse_statement(statement: Statement) -> Result<ParsedStatement, SqlError> {
             Err(unsupported("ROLLBACK savepoints, modifiers, and chaining"))
         }
         other => Err(SqlError(format!(
-            "unsupported read-only PostgreSQL statement: {other}"
+            "unsupported PostgreSQL statement: {other}"
         ))),
     }
+}
+
+fn parse_insert(insert: sqlparser::ast::Insert) -> Result<MutationPlan, SqlError> {
+    if !insert.optimizer_hints.is_empty()
+        || insert.or.is_some()
+        || insert.ignore
+        || !insert.into
+        || insert.table_alias.is_some()
+        || insert.overwrite
+        || !insert.assignments.is_empty()
+        || insert.partitioned.is_some()
+        || !insert.after_columns.is_empty()
+        || insert.has_table_keyword
+        || insert.on.is_some()
+        || insert.output.is_some()
+        || insert.replace_into
+        || insert.priority.is_some()
+        || insert.insert_alias.is_some()
+        || insert.settings.is_some()
+        || insert.format_clause.is_some()
+        || insert.multi_table_insert_type.is_some()
+        || !insert.multi_table_into_clauses.is_empty()
+        || !insert.multi_table_when_clauses.is_empty()
+        || insert.multi_table_else_clause.is_some()
+    {
+        return Err(unsupported(
+            "INSERT aliases, conflict handling, assignments, partitions, and extensions",
+        ));
+    }
+
+    let TableObject::TableName(table_name) = &insert.table else {
+        return Err(unsupported("dynamic INSERT targets"));
+    };
+    let table = parse_application_table_name(table_name)?;
+    if insert.columns.is_empty() {
+        return Err(SqlError(
+            "INSERT requires an explicit, non-empty column list".to_owned(),
+        ));
+    }
+    let columns = insert
+        .columns
+        .iter()
+        .map(parse_unqualified_name)
+        .collect::<Result<Vec<_>, _>>()?;
+    reject_duplicate_names(&columns, "INSERT column")?;
+
+    let source = insert
+        .source
+        .ok_or_else(|| SqlError("INSERT requires exactly one explicit VALUES row".to_owned()))?;
+    if source.with.is_some()
+        || source.order_by.is_some()
+        || source.limit_clause.is_some()
+        || source.fetch.is_some()
+        || !source.locks.is_empty()
+        || source.for_clause.is_some()
+        || source.settings.is_some()
+        || source.format_clause.is_some()
+        || !source.pipe_operators.is_empty()
+    {
+        return Err(unsupported("INSERT query extensions"));
+    }
+    let SetExpr::Values(values) = *source.body else {
+        return Err(unsupported("INSERT sources other than VALUES"));
+    };
+    if values.explicit_row || values.value_keyword {
+        return Err(unsupported("INSERT VALUE and explicit ROW syntax"));
+    }
+    if values.rows.len() != 1 {
+        return Err(SqlError(
+            "INSERT requires exactly one VALUES row".to_owned(),
+        ));
+    }
+    let row = values
+        .rows
+        .first()
+        .expect("exactly one INSERT row was checked");
+    if row.len() != columns.len() {
+        return Err(SqlError(format!(
+            "INSERT has {} target columns but {} values",
+            columns.len(),
+            row.len()
+        )));
+    }
+    let values = row.iter().map(parse_literal).collect::<Result<_, _>>()?;
+    let returning = insert
+        .returning
+        .as_deref()
+        .map(parse_returning_id)
+        .transpose()?;
+
+    Ok(MutationPlan {
+        table,
+        kind: MutationKind::Insert(InsertPlan {
+            columns,
+            values,
+            returning,
+        }),
+    })
+}
+
+fn parse_update(update: sqlparser::ast::Update) -> Result<MutationPlan, SqlError> {
+    if !update.optimizer_hints.is_empty()
+        || update.from.is_some()
+        || update.returning.is_some()
+        || update.output.is_some()
+        || update.or.is_some()
+        || !update.order_by.is_empty()
+        || update.limit.is_some()
+    {
+        return Err(unsupported(
+            "UPDATE FROM, RETURNING, conflict handling, ordering, limits, and extensions",
+        ));
+    }
+    let table = parse_mutation_table(&update.table)?;
+    if update.assignments.is_empty() {
+        return Err(SqlError("UPDATE assignments cannot be empty".to_owned()));
+    }
+    let assignments = update
+        .assignments
+        .iter()
+        .map(|assignment| {
+            let AssignmentTarget::ColumnName(column) = &assignment.target else {
+                return Err(unsupported("tuple UPDATE assignments"));
+            };
+            let column = parse_unqualified_name(column)?;
+            if column == "id" {
+                return Err(unsupported("updating the immutable row id"));
+            }
+            Ok(MutationAssignment {
+                column,
+                value: parse_literal(&assignment.value)?,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    reject_duplicate_names(
+        &assignments
+            .iter()
+            .map(|assignment| assignment.column.clone())
+            .collect::<Vec<_>>(),
+        "UPDATE assignment",
+    )?;
+    let row_id = parse_required_row_id_filter(update.selection.as_ref(), "UPDATE", &table)?;
+
+    Ok(MutationPlan {
+        table,
+        kind: MutationKind::Update(UpdatePlan {
+            assignments,
+            row_id,
+        }),
+    })
+}
+
+fn parse_delete(delete: sqlparser::ast::Delete) -> Result<MutationPlan, SqlError> {
+    if !delete.optimizer_hints.is_empty()
+        || !delete.tables.is_empty()
+        || delete.using.is_some()
+        || delete.returning.is_some()
+        || delete.output.is_some()
+        || !delete.order_by.is_empty()
+        || delete.limit.is_some()
+    {
+        return Err(unsupported(
+            "DELETE USING, RETURNING, ordering, limits, multi-table targets, and extensions",
+        ));
+    }
+    let FromTable::WithFromKeyword(from) = &delete.from else {
+        return Err(unsupported("DELETE without FROM"));
+    };
+    if from.len() != 1 {
+        return Err(unsupported("multiple DELETE targets"));
+    }
+    let table = parse_mutation_table(&from[0])?;
+    let row_id = parse_required_row_id_filter(delete.selection.as_ref(), "DELETE", &table)?;
+
+    Ok(MutationPlan {
+        table,
+        kind: MutationKind::Delete(DeletePlan { row_id }),
+    })
+}
+
+fn parse_mutation_table(table: &TableWithJoins) -> Result<String, SqlError> {
+    if !table.joins.is_empty() {
+        return Err(unsupported("joins in mutation targets"));
+    }
+    let TableFactor::Table {
+        name,
+        alias,
+        args,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+    } = &table.relation
+    else {
+        return Err(unsupported("derived mutation targets and table functions"));
+    };
+    if alias.is_some()
+        || args.is_some()
+        || !with_hints.is_empty()
+        || version.is_some()
+        || *with_ordinality
+        || !partitions.is_empty()
+        || json_path.is_some()
+        || sample.is_some()
+        || !index_hints.is_empty()
+    {
+        return Err(unsupported(
+            "mutation target aliases, functions, hints, and versions",
+        ));
+    }
+    parse_application_table_name(name)
+}
+
+fn parse_application_table_name(name: &ObjectName) -> Result<String, SqlError> {
+    let parts = object_name_parts(name)?;
+    match parts.as_slice() {
+        [table] => Ok(table.clone()),
+        [schema, table] if schema == "public" => Ok(table.clone()),
+        _ => Err(SqlError(format!(
+            "mutation target must be an application table in the public schema: {name}"
+        ))),
+    }
+}
+
+fn parse_unqualified_name(name: &ObjectName) -> Result<String, SqlError> {
+    let parts = object_name_parts(name)?;
+    match parts.as_slice() {
+        [name] => Ok(name.clone()),
+        _ => Err(unsupported("qualified mutation column names")),
+    }
+}
+
+fn reject_duplicate_names(names: &[String], kind: &str) -> Result<(), SqlError> {
+    let mut unique = BTreeSet::new();
+    for name in names {
+        if !unique.insert(name) {
+            return Err(SqlError(format!("duplicate {kind} {name}")));
+        }
+    }
+    Ok(())
+}
+
+fn parse_required_row_id_filter(
+    selection: Option<&Expr>,
+    operation: &str,
+    table: &str,
+) -> Result<SqlLiteral, SqlError> {
+    let selection = selection.ok_or_else(|| {
+        SqlError(format!(
+            "{operation} requires WHERE id = <UUID literal or $n placeholder>"
+        ))
+    })?;
+    validate_filter_complexity(selection)?;
+    let selection = strip_nested_expr(selection);
+    let Expr::BinaryOp {
+        left,
+        op: BinaryOperator::Eq,
+        right,
+    } = selection
+    else {
+        return Err(SqlError(format!(
+            "{operation} only supports WHERE id = <UUID literal or $n placeholder>"
+        )));
+    };
+    if is_target_row_id(left, table)? {
+        return parse_literal(right);
+    }
+    if is_target_row_id(right, table)? {
+        return parse_literal(left);
+    }
+    Err(SqlError(format!(
+        "{operation} only supports WHERE id = <UUID literal or $n placeholder>"
+    )))
+}
+
+fn strip_nested_expr(mut expression: &Expr) -> &Expr {
+    while let Expr::Nested(inner) = expression {
+        expression = inner;
+    }
+    expression
+}
+
+fn is_target_row_id(expression: &Expr, table: &str) -> Result<bool, SqlError> {
+    let parts = match strip_nested_expr(expression) {
+        Expr::Identifier(identifier) => vec![normalize_ident(identifier)],
+        Expr::CompoundIdentifier(identifiers) => {
+            identifiers.iter().map(normalize_ident).collect::<Vec<_>>()
+        }
+        _ => return Ok(false),
+    };
+    Ok(match parts.as_slice() {
+        [column] => column == "id",
+        [qualifier, column] => qualifier == table && column == "id",
+        [schema, qualifier, column] => schema == "public" && qualifier == table && column == "id",
+        _ => false,
+    })
+}
+
+fn parse_returning_id(items: &[SelectItem]) -> Result<ReturningId, SqlError> {
+    if items.len() != 1 {
+        return Err(unsupported(
+            "RETURNING projections other than one id column",
+        ));
+    }
+    let (expr, alias) = match &items[0] {
+        SelectItem::UnnamedExpr(expr) => (expr, None),
+        SelectItem::ExprWithAlias { expr, alias } => (expr, Some(normalize_ident(alias))),
+        _ => return Err(unsupported("RETURNING projections other than id")),
+    };
+    let Expr::Identifier(column) = expr else {
+        return Err(unsupported("RETURNING projections other than id"));
+    };
+    if normalize_ident(column) != "id" {
+        return Err(unsupported("RETURNING projections other than id"));
+    }
+    Ok(ReturningId { alias })
 }
 
 fn parse_query(query: sqlparser::ast::Query) -> Result<SelectPlan, SqlError> {
@@ -745,8 +1112,91 @@ mod tests {
     }
 
     #[test]
-    fn rejects_writes_and_joins() {
+    fn parses_basic_single_row_mutations() {
+        let ParsedStatement::Mutation(insert) = parse_sql(
+            "INSERT INTO public.documents (team_id, title, created_at) \
+             VALUES ($1, 'new document', -1) RETURNING id AS document_id",
+        )
+        .expect("parse insert") else {
+            panic!("expected insert mutation");
+        };
+        assert_eq!(insert.table, "documents");
+        let MutationKind::Insert(insert) = insert.kind else {
+            panic!("expected insert plan");
+        };
+        assert_eq!(insert.columns, ["team_id", "title", "created_at"]);
+        assert_eq!(
+            insert.values,
+            [
+                SqlLiteral::Placeholder(1),
+                SqlLiteral::String("new document".to_owned()),
+                SqlLiteral::Number("-1".to_owned()),
+            ]
+        );
+        assert_eq!(
+            insert.returning,
+            Some(ReturningId {
+                alias: Some("document_id".to_owned()),
+            })
+        );
+
+        let ParsedStatement::Mutation(update) = parse_sql(
+            "UPDATE documents SET title = $1, created_at = 42 \
+             WHERE id = '00000000-0000-4000-8000-000000000001'",
+        )
+        .expect("parse update") else {
+            panic!("expected update mutation");
+        };
+        assert_eq!(update.table, "documents");
+        let MutationKind::Update(update) = update.kind else {
+            panic!("expected update plan");
+        };
+        assert_eq!(
+            update.assignments,
+            [
+                MutationAssignment {
+                    column: "title".to_owned(),
+                    value: SqlLiteral::Placeholder(1),
+                },
+                MutationAssignment {
+                    column: "created_at".to_owned(),
+                    value: SqlLiteral::Number("42".to_owned()),
+                },
+            ]
+        );
+        assert_eq!(
+            update.row_id,
+            SqlLiteral::String("00000000-0000-4000-8000-000000000001".to_owned())
+        );
+
+        let ParsedStatement::Mutation(delete) =
+            parse_sql("DELETE FROM public.documents WHERE $1 = id").expect("parse delete")
+        else {
+            panic!("expected delete mutation");
+        };
+        assert_eq!(delete.table, "documents");
+        let MutationKind::Delete(delete) = delete.kind else {
+            panic!("expected delete plan");
+        };
+        assert_eq!(delete.row_id, SqlLiteral::Placeholder(1));
+    }
+
+    #[test]
+    fn rejects_unsupported_mutation_shapes_and_joins() {
         assert!(parse_sql("DELETE FROM documents").is_err());
+        assert!(parse_sql("DELETE FROM documents WHERE team_id = 'team'").is_err());
+        assert!(parse_sql("DELETE FROM documents WHERE users.id = $1").is_err());
+        assert!(parse_sql("DELETE FROM documents WHERE private.documents.id = $1").is_err());
+        assert!(parse_sql("UPDATE documents SET title = 'x' WHERE users.id = $1").is_err());
+        assert!(parse_sql("DELETE FROM documents WHERE documents.id = $1").is_ok());
+        assert!(parse_sql("DELETE FROM documents WHERE public.documents.id = $1").is_ok());
+        assert!(parse_sql("DELETE FROM documents WHERE id = $1 RETURNING id").is_err());
+        assert!(parse_sql("UPDATE documents SET title = 'x'").is_err());
+        assert!(parse_sql("UPDATE documents SET id = $1 WHERE id = $2").is_err());
+        assert!(parse_sql("UPDATE documents SET title = 'x' WHERE id = $1 RETURNING id").is_err());
+        assert!(parse_sql("INSERT INTO documents (title) VALUES ('one'), ('two')").is_err());
+        assert!(parse_sql("INSERT INTO documents (title) VALUES ('x') RETURNING title").is_err());
+        assert!(parse_sql("INSERT INTO private.documents (title) VALUES ('x')").is_err());
         assert!(parse_sql("SELECT * FROM a JOIN b ON a.id = b.id").is_err());
         assert!(parse_sql("SET statement_timeout = '1s'").is_err());
     }
@@ -764,6 +1214,10 @@ mod tests {
         let batch = parse_sql_batch("SELECT 1; SELECT 2").expect("parse safe batch");
         assert_eq!(batch.len(), 2);
         assert!(parse_sql_batch("SELECT 1; DELETE FROM documents").is_err());
+
+        let mutation_batch = parse_sql_batch("SELECT 1; DELETE FROM documents WHERE id = $1")
+            .expect("the SQL parser leaves mutation batch policy to the protocol layer");
+        assert_eq!(mutation_batch.len(), 2);
     }
 
     #[test]

--- a/crates/jazz/src/tools/server/postgres/sql.rs
+++ b/crates/jazz/src/tools/server/postgres/sql.rs
@@ -17,6 +17,7 @@ const MAX_SQL_TOKENS: usize = 2_048;
 const MAX_EXPRESSION_DEPTH: usize = 64;
 const MAX_PREFIX_OPERATOR_DEPTH: usize = 64;
 const MAX_FILTER_NODES: usize = 512;
+pub(crate) const MAX_INSERT_ROWS: usize = 1_000;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum ParsedStatement {
@@ -41,7 +42,7 @@ pub(crate) enum MutationKind {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct InsertPlan {
     pub(crate) columns: Vec<String>,
-    pub(crate) values: Vec<SqlLiteral>,
+    pub(crate) rows: Vec<Vec<SqlLiteral>>,
     pub(crate) returning: Option<ReturningId>,
 }
 
@@ -53,7 +54,7 @@ pub(crate) struct ReturningId {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct UpdatePlan {
     pub(crate) assignments: Vec<MutationAssignment>,
-    pub(crate) row_id: SqlLiteral,
+    pub(crate) filter: FilterExpr,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -340,7 +341,7 @@ fn parse_insert(insert: sqlparser::ast::Insert) -> Result<MutationPlan, SqlError
 
     let source = insert
         .source
-        .ok_or_else(|| SqlError("INSERT requires exactly one explicit VALUES row".to_owned()))?;
+        .ok_or_else(|| SqlError("INSERT requires at least one explicit VALUES row".to_owned()))?;
     if source.with.is_some()
         || source.order_by.is_some()
         || source.limit_clause.is_some()
@@ -359,23 +360,32 @@ fn parse_insert(insert: sqlparser::ast::Insert) -> Result<MutationPlan, SqlError
     if values.explicit_row || values.value_keyword {
         return Err(unsupported("INSERT VALUE and explicit ROW syntax"));
     }
-    if values.rows.len() != 1 {
+    if values.rows.is_empty() {
         return Err(SqlError(
-            "INSERT requires exactly one VALUES row".to_owned(),
+            "INSERT requires at least one VALUES row".to_owned(),
         ));
     }
-    let row = values
-        .rows
-        .first()
-        .expect("exactly one INSERT row was checked");
-    if row.len() != columns.len() {
+    if values.rows.len() > MAX_INSERT_ROWS {
         return Err(SqlError(format!(
-            "INSERT has {} target columns but {} values",
-            columns.len(),
-            row.len()
+            "INSERT cannot contain more than {MAX_INSERT_ROWS} VALUES rows"
         )));
     }
-    let values = row.iter().map(parse_literal).collect::<Result<_, _>>()?;
+    let rows = values
+        .rows
+        .iter()
+        .enumerate()
+        .map(|(row_index, row)| {
+            if row.len() != columns.len() {
+                return Err(SqlError(format!(
+                    "INSERT row {} has {} target columns but {} values",
+                    row_index + 1,
+                    columns.len(),
+                    row.len()
+                )));
+            }
+            row.iter().map(parse_literal).collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     let returning = insert
         .returning
         .as_deref()
@@ -386,7 +396,7 @@ fn parse_insert(insert: sqlparser::ast::Insert) -> Result<MutationPlan, SqlError
         table,
         kind: MutationKind::Insert(InsertPlan {
             columns,
-            values,
+            rows,
             returning,
         }),
     })
@@ -433,13 +443,19 @@ fn parse_update(update: sqlparser::ast::Update) -> Result<MutationPlan, SqlError
             .collect::<Vec<_>>(),
         "UPDATE assignment",
     )?;
-    let row_id = parse_required_row_id_filter(update.selection.as_ref(), "UPDATE", &table)?;
+    let selection = update
+        .selection
+        .as_ref()
+        .ok_or_else(|| SqlError("UPDATE requires a WHERE expression".to_owned()))?;
+    validate_filter_complexity(selection)?;
+    validate_mutation_filter_qualifiers(selection, &table)?;
+    let filter = parse_filter(selection)?;
 
     Ok(MutationPlan {
         table,
         kind: MutationKind::Update(UpdatePlan {
             assignments,
-            row_id,
+            filter,
         }),
     })
 }
@@ -711,6 +727,59 @@ fn validate_filter_complexity(root: &Expr) -> Result<(), SqlError> {
         }
     }
     Ok(())
+}
+
+fn validate_mutation_filter_qualifiers(expr: &Expr, table: &str) -> Result<(), SqlError> {
+    match expr {
+        Expr::BinaryOp { left, right, .. } => {
+            validate_mutation_column_qualifier(left, table)?;
+            validate_mutation_column_qualifier(right, table)?;
+            if matches!(
+                expr,
+                Expr::BinaryOp {
+                    op: BinaryOperator::And | BinaryOperator::Or,
+                    ..
+                }
+            ) {
+                validate_mutation_filter_qualifiers(left, table)?;
+                validate_mutation_filter_qualifiers(right, table)?;
+            }
+        }
+        Expr::UnaryOp {
+            op: UnaryOperator::Not,
+            expr,
+        }
+        | Expr::Nested(expr) => validate_mutation_filter_qualifiers(expr, table)?,
+        Expr::IsNull(expr) | Expr::IsNotNull(expr) => {
+            validate_mutation_column_qualifier(expr, table)?;
+        }
+        Expr::InList { expr, .. } => validate_mutation_column_qualifier(expr, table)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_mutation_column_qualifier(expr: &Expr, table: &str) -> Result<(), SqlError> {
+    let parts = match strip_nested_expr(expr) {
+        Expr::Identifier(identifier) => vec![normalize_ident(identifier)],
+        Expr::CompoundIdentifier(identifiers) => {
+            identifiers.iter().map(normalize_ident).collect::<Vec<_>>()
+        }
+        _ => return Ok(()),
+    };
+    let valid = match parts.as_slice() {
+        [_column] => true,
+        [qualifier, _column] => qualifier == table,
+        [schema, qualifier, _column] => schema == "public" && qualifier == table,
+        _ => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(SqlError(format!(
+            "UPDATE filter column must reference target table public.{table}"
+        )))
+    }
 }
 
 fn parse_source(from: &[sqlparser::ast::TableWithJoins]) -> Result<SelectSource, SqlError> {
@@ -1112,7 +1181,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_basic_single_row_mutations() {
+    fn parses_basic_mutations() {
         let ParsedStatement::Mutation(insert) = parse_sql(
             "INSERT INTO public.documents (team_id, title, created_at) \
              VALUES ($1, 'new document', -1) RETURNING id AS document_id",
@@ -1126,12 +1195,12 @@ mod tests {
         };
         assert_eq!(insert.columns, ["team_id", "title", "created_at"]);
         assert_eq!(
-            insert.values,
-            [
+            insert.rows,
+            [vec![
                 SqlLiteral::Placeholder(1),
                 SqlLiteral::String("new document".to_owned()),
                 SqlLiteral::Number("-1".to_owned()),
-            ]
+            ]]
         );
         assert_eq!(
             insert.returning,
@@ -1165,8 +1234,12 @@ mod tests {
             ]
         );
         assert_eq!(
-            update.row_id,
-            SqlLiteral::String("00000000-0000-4000-8000-000000000001".to_owned())
+            update.filter,
+            FilterExpr::Compare {
+                column: "id".to_owned(),
+                op: CompareOp::Eq,
+                literal: SqlLiteral::String("00000000-0000-4000-8000-000000000001".to_owned()),
+            }
         );
 
         let ParsedStatement::Mutation(delete) =
@@ -1182,19 +1255,87 @@ mod tests {
     }
 
     #[test]
+    fn parses_multi_row_insert_and_predicate_update() {
+        let ParsedStatement::Mutation(insert) = parse_sql(
+            "INSERT INTO documents (team_id, title) VALUES \
+             ($1, 'first'), ($1, $2), ('another-team', 'third') RETURNING id",
+        )
+        .expect("parse insert") else {
+            panic!("expected insert mutation");
+        };
+        let MutationKind::Insert(insert) = insert.kind else {
+            panic!("expected insert plan");
+        };
+        assert_eq!(insert.rows.len(), 3);
+        assert_eq!(
+            insert.rows[1],
+            [SqlLiteral::Placeholder(1), SqlLiteral::Placeholder(2)]
+        );
+
+        let ParsedStatement::Mutation(update) = parse_sql(
+            "UPDATE documents SET title = $1 \
+             WHERE team_id = $2 AND (archived = false OR title IN ('draft', $3))",
+        )
+        .expect("parse update") else {
+            panic!("expected update mutation");
+        };
+        let MutationKind::Update(update) = update.kind else {
+            panic!("expected update plan");
+        };
+        assert_eq!(
+            update.filter,
+            FilterExpr::And(
+                Box::new(FilterExpr::Compare {
+                    column: "team_id".to_owned(),
+                    op: CompareOp::Eq,
+                    literal: SqlLiteral::Placeholder(2),
+                }),
+                Box::new(FilterExpr::Or(
+                    Box::new(FilterExpr::Compare {
+                        column: "archived".to_owned(),
+                        op: CompareOp::Eq,
+                        literal: SqlLiteral::Boolean(false),
+                    }),
+                    Box::new(FilterExpr::In {
+                        column: "title".to_owned(),
+                        values: vec![
+                            SqlLiteral::String("draft".to_owned()),
+                            SqlLiteral::Placeholder(3),
+                        ],
+                        negated: false,
+                    }),
+                )),
+            )
+        );
+    }
+
+    #[test]
     fn rejects_unsupported_mutation_shapes_and_joins() {
         assert!(parse_sql("DELETE FROM documents").is_err());
         assert!(parse_sql("DELETE FROM documents WHERE team_id = 'team'").is_err());
         assert!(parse_sql("DELETE FROM documents WHERE users.id = $1").is_err());
         assert!(parse_sql("DELETE FROM documents WHERE private.documents.id = $1").is_err());
         assert!(parse_sql("UPDATE documents SET title = 'x' WHERE users.id = $1").is_err());
+        assert!(parse_sql("UPDATE documents SET title = 'x' WHERE users.team_id = $1").is_err());
+        assert!(
+            parse_sql("UPDATE documents SET title = 'x' WHERE private.documents.team_id = $1")
+                .is_err()
+        );
+        assert!(parse_sql("UPDATE documents SET title = 'x' WHERE documents.team_id = $1").is_ok());
+        assert!(
+            parse_sql("UPDATE documents SET title = 'x' WHERE public.documents.team_id = $1")
+                .is_ok()
+        );
         assert!(parse_sql("DELETE FROM documents WHERE documents.id = $1").is_ok());
         assert!(parse_sql("DELETE FROM documents WHERE public.documents.id = $1").is_ok());
         assert!(parse_sql("DELETE FROM documents WHERE id = $1 RETURNING id").is_err());
         assert!(parse_sql("UPDATE documents SET title = 'x'").is_err());
         assert!(parse_sql("UPDATE documents SET id = $1 WHERE id = $2").is_err());
         assert!(parse_sql("UPDATE documents SET title = 'x' WHERE id = $1 RETURNING id").is_err());
-        assert!(parse_sql("INSERT INTO documents (title) VALUES ('one'), ('two')").is_err());
+        assert!(parse_sql("INSERT INTO documents (title) VALUES ('one'), ('two')").is_ok());
+        assert!(
+            parse_sql("INSERT INTO documents (title) VALUES ('one'), ('two', 'extra')").is_err()
+        );
         assert!(parse_sql("INSERT INTO documents (title) VALUES ('x') RETURNING title").is_err());
         assert!(parse_sql("INSERT INTO private.documents (title) VALUES ('x')").is_err());
         assert!(parse_sql("SELECT * FROM a JOIN b ON a.id = b.id").is_err());

--- a/crates/jazz/src/tools/server/postgres/sql.rs
+++ b/crates/jazz/src/tools/server/postgres/sql.rs
@@ -1,0 +1,791 @@
+use std::fmt;
+
+use sqlparser::ast::{
+    BinaryOperator, Expr, FunctionArguments, GroupByExpr, Ident, LimitClause, ObjectName,
+    OrderByKind, SelectItem, SetExpr, Statement, TableFactor, UnaryOperator, Value as AstValue,
+};
+use sqlparser::dialect::PostgreSqlDialect;
+use sqlparser::keywords::Keyword;
+use sqlparser::parser::Parser;
+use sqlparser::tokenizer::{Token, Tokenizer};
+
+use super::MAX_RESULT_COLUMNS;
+
+const MAX_SQL_TOKENS: usize = 2_048;
+const MAX_EXPRESSION_DEPTH: usize = 64;
+const MAX_PREFIX_OPERATOR_DEPTH: usize = 64;
+const MAX_FILTER_NODES: usize = 512;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ParsedStatement {
+    Select(SelectPlan),
+    Command(Command),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Command {
+    Show(String),
+    Begin,
+    Commit,
+    Rollback,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct SelectPlan {
+    pub(crate) source: SelectSource,
+    pub(crate) projection: Vec<Projection>,
+    pub(crate) filter: Option<FilterExpr>,
+    pub(crate) order_by: Vec<OrderTerm>,
+    pub(crate) limit: Option<PageValue>,
+    pub(crate) offset: PageValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SelectSource {
+    Table(String),
+    Databases,
+    Tables,
+    Columns,
+    Session,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Projection {
+    pub(crate) expr: ProjectedExpr,
+    pub(crate) alias: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ProjectedExpr {
+    Wildcard,
+    Column(String),
+    SessionFunction(SessionFunction),
+    Literal(SqlLiteral),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SessionFunction {
+    Version,
+    CurrentDatabase,
+    CurrentSchema,
+    CurrentUser,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum FilterExpr {
+    Compare {
+        column: String,
+        op: CompareOp,
+        literal: SqlLiteral,
+    },
+    IsNull {
+        column: String,
+        negated: bool,
+    },
+    In {
+        column: String,
+        values: Vec<SqlLiteral>,
+        negated: bool,
+    },
+    And(Box<Self>, Box<Self>),
+    Or(Box<Self>, Box<Self>),
+    Not(Box<Self>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CompareOp {
+    Eq,
+    NotEq,
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum SqlLiteral {
+    String(String),
+    Number(String),
+    Boolean(bool),
+    Null,
+    Placeholder(usize),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OrderTerm {
+    pub(crate) column: String,
+    pub(crate) ascending: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PageValue {
+    Literal(usize),
+    Placeholder(usize),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SqlError(pub(crate) String);
+
+impl fmt::Display for SqlError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SqlError {}
+
+pub(crate) fn parse_sql(sql: &str) -> Result<ParsedStatement, SqlError> {
+    let mut statements = parse_sql_batch(sql)?;
+    if statements.len() != 1 {
+        return Err(SqlError(
+            "exactly one SQL statement is supported per request".to_owned(),
+        ));
+    }
+    Ok(statements.remove(0))
+}
+
+pub(crate) fn parse_sql_batch(sql: &str) -> Result<Vec<ParsedStatement>, SqlError> {
+    let dialect = PostgreSqlDialect {};
+    let tokens = Tokenizer::new(&dialect, sql)
+        .tokenize()
+        .map_err(|error| SqlError(format!("invalid SQL: {error}")))?;
+    if tokens.len() > MAX_SQL_TOKENS {
+        return Err(SqlError(format!(
+            "SQL cannot contain more than {MAX_SQL_TOKENS} tokens"
+        )));
+    }
+    let mut nesting = 0_usize;
+    let mut prefix_operators = 0_usize;
+    for token in &tokens {
+        match token {
+            Token::LParen => {
+                nesting += 1;
+                if nesting > MAX_EXPRESSION_DEPTH {
+                    return Err(SqlError(format!(
+                        "SQL nesting cannot exceed {MAX_EXPRESSION_DEPTH} levels"
+                    )));
+                }
+            }
+            Token::RParen => nesting = nesting.saturating_sub(1),
+            _ => {}
+        }
+        match token {
+            Token::Whitespace(_) => {}
+            Token::Plus
+            | Token::Minus
+            | Token::Word(sqlparser::tokenizer::Word {
+                keyword: Keyword::NOT,
+                ..
+            }) => {
+                prefix_operators += 1;
+                if prefix_operators > MAX_PREFIX_OPERATOR_DEPTH {
+                    return Err(SqlError(format!(
+                        "SQL prefix operators cannot exceed {MAX_PREFIX_OPERATOR_DEPTH} levels"
+                    )));
+                }
+            }
+            _ => prefix_operators = 0,
+        }
+    }
+    Parser::new(&dialect)
+        .with_tokens(tokens)
+        .parse_statements()
+        .map_err(|error| SqlError(format!("invalid SQL: {error}")))?
+        .into_iter()
+        .map(parse_statement)
+        .collect()
+}
+
+fn parse_statement(statement: Statement) -> Result<ParsedStatement, SqlError> {
+    match statement {
+        Statement::Query(query) => parse_query(*query).map(ParsedStatement::Select),
+        Statement::ShowVariable { variable } => Ok(ParsedStatement::Command(Command::Show(
+            variable
+                .iter()
+                .map(normalize_ident)
+                .collect::<Vec<_>>()
+                .join("."),
+        ))),
+        Statement::Set(_) => Err(unsupported(
+            "SET (session settings are not applied by this read-only interface)",
+        )),
+        Statement::StartTransaction {
+            modes,
+            modifier,
+            statements,
+            exception,
+            has_end_keyword,
+            ..
+        } if modes.is_empty()
+            && modifier.is_none()
+            && statements.is_empty()
+            && exception.is_none()
+            && !has_end_keyword =>
+        {
+            Ok(ParsedStatement::Command(Command::Begin))
+        }
+        Statement::StartTransaction { .. } => Err(unsupported(
+            "transaction modes, modifiers, and procedural BEGIN blocks",
+        )),
+        Statement::Commit {
+            chain: false,
+            end: false,
+            modifier: None,
+        } => Ok(ParsedStatement::Command(Command::Commit)),
+        Statement::Commit { .. } => Err(unsupported("COMMIT modifiers and chaining")),
+        Statement::Rollback {
+            chain: false,
+            savepoint: None,
+        } => Ok(ParsedStatement::Command(Command::Rollback)),
+        Statement::Rollback { .. } => {
+            Err(unsupported("ROLLBACK savepoints, modifiers, and chaining"))
+        }
+        other => Err(SqlError(format!(
+            "unsupported read-only PostgreSQL statement: {other}"
+        ))),
+    }
+}
+
+fn parse_query(query: sqlparser::ast::Query) -> Result<SelectPlan, SqlError> {
+    if query.with.is_some()
+        || query.fetch.is_some()
+        || !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return Err(unsupported("CTEs, locks, fetch, and query extensions"));
+    }
+
+    let SetExpr::Select(select) = *query.body else {
+        return Err(unsupported("set operations and nested queries"));
+    };
+    if select.distinct.is_some()
+        || select.select_modifiers.is_some()
+        || select.top.is_some()
+        || select.into.is_some()
+        || select.prewhere.is_some()
+        || !group_by_is_empty(&select.group_by)
+        || !select.cluster_by.is_empty()
+        || !select.distribute_by.is_empty()
+        || !select.sort_by.is_empty()
+        || select.having.is_some()
+        || !select.named_window.is_empty()
+        || select.qualify.is_some()
+        || !select.connect_by.is_empty()
+        || !select.lateral_views.is_empty()
+    {
+        return Err(unsupported(
+            "DISTINCT, grouping, windows, and SELECT extensions",
+        ));
+    }
+
+    let source = parse_source(&select.from)?;
+    if select.projection.len() > MAX_RESULT_COLUMNS {
+        return Err(SqlError(format!(
+            "SELECT cannot return more than {MAX_RESULT_COLUMNS} columns"
+        )));
+    }
+    let projection = select
+        .projection
+        .iter()
+        .map(|item| parse_projection(item, &source))
+        .collect::<Result<Vec<_>, _>>()?;
+    if projection.is_empty() {
+        return Err(SqlError("SELECT projection cannot be empty".to_owned()));
+    }
+    if let Some(filter) = &select.selection {
+        validate_filter_complexity(filter)?;
+    }
+    let filter = select.selection.as_ref().map(parse_filter).transpose()?;
+    let order_by = parse_order_by(query.order_by.as_ref())?;
+    let (limit, offset) = parse_limit(query.limit_clause.as_ref())?;
+
+    Ok(SelectPlan {
+        source,
+        projection,
+        filter,
+        order_by,
+        limit,
+        offset,
+    })
+}
+
+fn validate_filter_complexity(root: &Expr) -> Result<(), SqlError> {
+    let mut stack = vec![(root, 1_usize)];
+    let mut nodes = 0_usize;
+    while let Some((expr, depth)) = stack.pop() {
+        nodes += 1;
+        if nodes > MAX_FILTER_NODES {
+            return Err(SqlError(format!(
+                "WHERE expressions cannot contain more than {MAX_FILTER_NODES} nodes"
+            )));
+        }
+        if depth > MAX_EXPRESSION_DEPTH {
+            return Err(SqlError(format!(
+                "WHERE expressions cannot exceed {MAX_EXPRESSION_DEPTH} levels"
+            )));
+        }
+        match expr {
+            Expr::BinaryOp { left, right, .. } => {
+                stack.push((right, depth + 1));
+                stack.push((left, depth + 1));
+            }
+            Expr::UnaryOp { expr, .. }
+            | Expr::IsNull(expr)
+            | Expr::IsNotNull(expr)
+            | Expr::Nested(expr) => stack.push((expr, depth + 1)),
+            Expr::InList { expr, list, .. } => {
+                stack.push((expr, depth + 1));
+                stack.extend(list.iter().map(|item| (item, depth + 1)));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn parse_source(from: &[sqlparser::ast::TableWithJoins]) -> Result<SelectSource, SqlError> {
+    if from.is_empty() {
+        return Ok(SelectSource::Session);
+    }
+    if from.len() != 1 || !from[0].joins.is_empty() {
+        return Err(unsupported("joins and multiple FROM relations"));
+    }
+    let TableFactor::Table {
+        name,
+        args,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+        ..
+    } = &from[0].relation
+    else {
+        return Err(unsupported("derived tables and table functions"));
+    };
+    if args.is_some()
+        || !with_hints.is_empty()
+        || version.is_some()
+        || *with_ordinality
+        || !partitions.is_empty()
+        || json_path.is_some()
+        || sample.is_some()
+        || !index_hints.is_empty()
+    {
+        return Err(unsupported("table functions, hints, and table versions"));
+    }
+
+    let parts = object_name_parts(name)?;
+    match parts.as_slice() {
+        [table] if table == "pg_database" => Ok(SelectSource::Databases),
+        [table] => Ok(SelectSource::Table(table.clone())),
+        [schema, table] if schema == "public" => Ok(SelectSource::Table(table.clone())),
+        [schema, table] if schema == "pg_catalog" && table == "pg_database" => {
+            Ok(SelectSource::Databases)
+        }
+        [schema, table] if schema == "information_schema" && table == "tables" => {
+            Ok(SelectSource::Tables)
+        }
+        [schema, table] if schema == "information_schema" && table == "columns" => {
+            Ok(SelectSource::Columns)
+        }
+        _ => Err(SqlError(format!("unsupported schema or relation {}", name))),
+    }
+}
+
+fn parse_projection(item: &SelectItem, source: &SelectSource) -> Result<Projection, SqlError> {
+    let (expr, alias) = match item {
+        SelectItem::Wildcard(options) if options.to_string().is_empty() => {
+            (ProjectedExpr::Wildcard, None)
+        }
+        SelectItem::QualifiedWildcard(kind, options) if options.to_string().is_empty() => {
+            let rendered = kind.to_string();
+            if !rendered.ends_with(".*") {
+                return Err(unsupported("expression wildcards"));
+            }
+            (ProjectedExpr::Wildcard, None)
+        }
+        SelectItem::UnnamedExpr(expr) => (parse_projected_expr(expr, source)?, None),
+        SelectItem::ExprWithAlias { expr, alias } => (
+            parse_projected_expr(expr, source)?,
+            Some(normalize_ident(alias)),
+        ),
+        _ => return Err(unsupported("this SELECT projection")),
+    };
+    Ok(Projection { expr, alias })
+}
+
+fn parse_projected_expr(expr: &Expr, source: &SelectSource) -> Result<ProjectedExpr, SqlError> {
+    match expr {
+        Expr::Identifier(identifier) => {
+            let name = normalize_ident(identifier);
+            if matches!(source, SelectSource::Session) {
+                match name.as_str() {
+                    "current_user" | "session_user" => {
+                        return Ok(ProjectedExpr::SessionFunction(SessionFunction::CurrentUser));
+                    }
+                    _ => {}
+                }
+            }
+            Ok(ProjectedExpr::Column(name))
+        }
+        Expr::CompoundIdentifier(parts) => Ok(ProjectedExpr::Column(normalize_ident(
+            parts
+                .last()
+                .ok_or_else(|| SqlError("empty qualified column".to_owned()))?,
+        ))),
+        Expr::Function(function) if matches!(source, SelectSource::Session) => {
+            if !function_has_no_arguments(function) {
+                return Err(unsupported("arguments to session functions"));
+            }
+            let name = function.name.to_string().to_ascii_lowercase();
+            let function = match name.as_str() {
+                "version" => SessionFunction::Version,
+                "current_database" => SessionFunction::CurrentDatabase,
+                "current_schema" => SessionFunction::CurrentSchema,
+                "current_user" | "session_user" => SessionFunction::CurrentUser,
+                _ => return Err(SqlError(format!("unsupported PostgreSQL function {name}"))),
+            };
+            Ok(ProjectedExpr::SessionFunction(function))
+        }
+        Expr::Value(value) if matches!(source, SelectSource::Session) => {
+            Ok(ProjectedExpr::Literal(parse_literal_value(&value.value)?))
+        }
+        Expr::Nested(inner) => parse_projected_expr(inner, source),
+        _ => Err(unsupported("computed SELECT expressions")),
+    }
+}
+
+fn parse_filter(expr: &Expr) -> Result<FilterExpr, SqlError> {
+    match expr {
+        Expr::BinaryOp { left, op, right } => match op {
+            BinaryOperator::And => Ok(FilterExpr::And(
+                Box::new(parse_filter(left)?),
+                Box::new(parse_filter(right)?),
+            )),
+            BinaryOperator::Or => Ok(FilterExpr::Or(
+                Box::new(parse_filter(left)?),
+                Box::new(parse_filter(right)?),
+            )),
+            _ => parse_comparison(left, op, right),
+        },
+        Expr::UnaryOp {
+            op: UnaryOperator::Not,
+            expr,
+        } => Ok(FilterExpr::Not(Box::new(parse_filter(expr)?))),
+        Expr::IsNull(expr) => Ok(FilterExpr::IsNull {
+            column: parse_column(expr)?,
+            negated: false,
+        }),
+        Expr::IsNotNull(expr) => Ok(FilterExpr::IsNull {
+            column: parse_column(expr)?,
+            negated: true,
+        }),
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } => Ok(FilterExpr::In {
+            column: parse_column(expr)?,
+            values: list.iter().map(parse_literal).collect::<Result<_, _>>()?,
+            negated: *negated,
+        }),
+        Expr::Nested(inner) => parse_filter(inner),
+        _ => Err(unsupported("this WHERE expression")),
+    }
+}
+
+fn parse_comparison(
+    left: &Expr,
+    op: &BinaryOperator,
+    right: &Expr,
+) -> Result<FilterExpr, SqlError> {
+    let parsed_op = compare_op(op)?;
+    if let Ok(column) = parse_column(left) {
+        return Ok(FilterExpr::Compare {
+            column,
+            op: parsed_op,
+            literal: parse_literal(right)?,
+        });
+    }
+    Ok(FilterExpr::Compare {
+        column: parse_column(right)?,
+        op: reverse_compare_op(parsed_op),
+        literal: parse_literal(left)?,
+    })
+}
+
+fn compare_op(op: &BinaryOperator) -> Result<CompareOp, SqlError> {
+    match op {
+        BinaryOperator::Eq => Ok(CompareOp::Eq),
+        BinaryOperator::NotEq => Ok(CompareOp::NotEq),
+        BinaryOperator::Lt => Ok(CompareOp::Lt),
+        BinaryOperator::LtEq => Ok(CompareOp::LtEq),
+        BinaryOperator::Gt => Ok(CompareOp::Gt),
+        BinaryOperator::GtEq => Ok(CompareOp::GtEq),
+        _ => Err(unsupported("this comparison operator")),
+    }
+}
+
+fn reverse_compare_op(op: CompareOp) -> CompareOp {
+    match op {
+        CompareOp::Eq => CompareOp::Eq,
+        CompareOp::NotEq => CompareOp::NotEq,
+        CompareOp::Lt => CompareOp::Gt,
+        CompareOp::LtEq => CompareOp::GtEq,
+        CompareOp::Gt => CompareOp::Lt,
+        CompareOp::GtEq => CompareOp::LtEq,
+    }
+}
+
+fn parse_order_by(order_by: Option<&sqlparser::ast::OrderBy>) -> Result<Vec<OrderTerm>, SqlError> {
+    let Some(order_by) = order_by else {
+        return Ok(Vec::new());
+    };
+    let OrderByKind::Expressions(expressions) = &order_by.kind else {
+        return Err(unsupported("ORDER BY ALL"));
+    };
+    if order_by.interpolate.is_some() {
+        return Err(unsupported("ORDER BY interpolation"));
+    }
+    expressions
+        .iter()
+        .map(|term| {
+            if term.options.nulls_first.is_some() || term.with_fill.is_some() {
+                return Err(unsupported("NULLS FIRST/LAST and WITH FILL"));
+            }
+            Ok(OrderTerm {
+                column: parse_column(&term.expr)?,
+                ascending: term.options.asc.unwrap_or(true),
+            })
+        })
+        .collect()
+}
+
+fn parse_limit(limit: Option<&LimitClause>) -> Result<(Option<PageValue>, PageValue), SqlError> {
+    let Some(limit) = limit else {
+        return Ok((None, PageValue::Literal(0)));
+    };
+    let LimitClause::LimitOffset {
+        limit,
+        offset,
+        limit_by,
+    } = limit
+    else {
+        return Err(unsupported("comma-style LIMIT"));
+    };
+    if !limit_by.is_empty() {
+        return Err(unsupported("LIMIT BY"));
+    }
+    let limit = limit.as_ref().map(parse_page_value).transpose()?;
+    let offset = offset
+        .as_ref()
+        .map(|offset| parse_page_value(&offset.value))
+        .transpose()?
+        .unwrap_or(PageValue::Literal(0));
+    Ok((limit, offset))
+}
+
+fn parse_page_value(expr: &Expr) -> Result<PageValue, SqlError> {
+    match parse_literal(expr)? {
+        SqlLiteral::Number(value) => value
+            .parse::<usize>()
+            .map(PageValue::Literal)
+            .map_err(|_| SqlError("LIMIT and OFFSET must be non-negative integers".to_owned())),
+        SqlLiteral::Placeholder(position) => Ok(PageValue::Placeholder(position)),
+        _ => Err(SqlError(
+            "LIMIT and OFFSET must be integers or PostgreSQL $n placeholders".to_owned(),
+        )),
+    }
+}
+
+fn parse_column(expr: &Expr) -> Result<String, SqlError> {
+    match expr {
+        Expr::Identifier(identifier) => Ok(normalize_ident(identifier)),
+        Expr::CompoundIdentifier(parts) => parts
+            .last()
+            .map(normalize_ident)
+            .ok_or_else(|| SqlError("empty qualified column".to_owned())),
+        Expr::Nested(inner) => parse_column(inner),
+        _ => Err(SqlError("expected a column reference".to_owned())),
+    }
+}
+
+fn parse_literal(expr: &Expr) -> Result<SqlLiteral, SqlError> {
+    match expr {
+        Expr::Value(value) => parse_literal_value(&value.value),
+        Expr::UnaryOp {
+            op: UnaryOperator::Minus,
+            expr,
+        } => match parse_literal(expr)? {
+            SqlLiteral::Number(value) => Ok(SqlLiteral::Number(format!("-{value}"))),
+            _ => Err(SqlError("unary minus requires a number".to_owned())),
+        },
+        Expr::Nested(inner) => parse_literal(inner),
+        _ => Err(SqlError("expected a literal value".to_owned())),
+    }
+}
+
+fn parse_literal_value(value: &AstValue) -> Result<SqlLiteral, SqlError> {
+    match value {
+        AstValue::Number(value, _) => Ok(SqlLiteral::Number(value.clone())),
+        AstValue::SingleQuotedString(value)
+        | AstValue::EscapedStringLiteral(value)
+        | AstValue::UnicodeStringLiteral(value)
+        | AstValue::NationalStringLiteral(value) => Ok(SqlLiteral::String(value.clone())),
+        AstValue::Boolean(value) => Ok(SqlLiteral::Boolean(*value)),
+        AstValue::Null => Ok(SqlLiteral::Null),
+        AstValue::Placeholder(value) => {
+            let position = value
+                .strip_prefix('$')
+                .ok_or_else(|| {
+                    SqlError("only PostgreSQL $n placeholders are supported".to_owned())
+                })?
+                .parse::<usize>()
+                .map_err(|_| SqlError("invalid PostgreSQL placeholder".to_owned()))?;
+            if position == 0 {
+                return Err(SqlError("PostgreSQL placeholders start at $1".to_owned()));
+            }
+            if position > super::MAX_PARAMETER_COUNT {
+                return Err(SqlError(format!(
+                    "PostgreSQL placeholder position cannot exceed ${}",
+                    super::MAX_PARAMETER_COUNT
+                )));
+            }
+            Ok(SqlLiteral::Placeholder(position))
+        }
+        _ => Err(unsupported("this literal type")),
+    }
+}
+
+fn function_has_no_arguments(function: &sqlparser::ast::Function) -> bool {
+    let args_are_empty = match &function.args {
+        FunctionArguments::None => true,
+        FunctionArguments::List(arguments) => {
+            arguments.args.is_empty()
+                && arguments.clauses.is_empty()
+                && arguments.duplicate_treatment.is_none()
+        }
+        FunctionArguments::Subquery(_) => false,
+    };
+    matches!(function.parameters, FunctionArguments::None)
+        && args_are_empty
+        && function.filter.is_none()
+        && function.over.is_none()
+        && function.within_group.is_empty()
+}
+
+fn object_name_parts(name: &ObjectName) -> Result<Vec<String>, SqlError> {
+    name.0
+        .iter()
+        .map(|part| {
+            part.as_ident()
+                .map(normalize_ident)
+                .ok_or_else(|| unsupported("dynamic relation names"))
+        })
+        .collect()
+}
+
+fn normalize_ident(identifier: &Ident) -> String {
+    if identifier.quote_style.is_some() {
+        identifier.value.clone()
+    } else {
+        identifier.value.to_ascii_lowercase()
+    }
+}
+
+fn group_by_is_empty(group_by: &GroupByExpr) -> bool {
+    matches!(group_by, GroupByExpr::Expressions(expressions, modifiers) if expressions.is_empty() && modifiers.is_empty())
+}
+
+fn unsupported(feature: &str) -> SqlError {
+    SqlError(format!("unsupported PostgreSQL feature: {feature}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_table_pagination() {
+        let ParsedStatement::Select(plan) = parse_sql(
+            "SELECT id, title FROM public.documents WHERE team_id = 'team' ORDER BY created_at DESC LIMIT 100 OFFSET 200",
+        )
+        .expect("parse")
+        else {
+            panic!("expected select");
+        };
+        assert_eq!(plan.source, SelectSource::Table("documents".to_owned()));
+        assert_eq!(plan.limit, Some(PageValue::Literal(100)));
+        assert_eq!(plan.offset, PageValue::Literal(200));
+        assert_eq!(plan.order_by[0].column, "created_at");
+        assert!(!plan.order_by[0].ascending);
+    }
+
+    #[test]
+    fn recognizes_catalogues_and_session_functions() {
+        let ParsedStatement::Select(databases) =
+            parse_sql("SELECT datname FROM pg_catalog.pg_database").expect("parse")
+        else {
+            panic!("expected select");
+        };
+        assert_eq!(databases.source, SelectSource::Databases);
+
+        let ParsedStatement::Select(session) =
+            parse_sql("SELECT current_database(), version()").expect("parse")
+        else {
+            panic!("expected select");
+        };
+        assert_eq!(session.source, SelectSource::Session);
+    }
+
+    #[test]
+    fn rejects_writes_and_joins() {
+        assert!(parse_sql("DELETE FROM documents").is_err());
+        assert!(parse_sql("SELECT * FROM a JOIN b ON a.id = b.id").is_err());
+        assert!(parse_sql("SET statement_timeout = '1s'").is_err());
+    }
+
+    #[test]
+    fn parses_parameterized_pagination_and_safe_batches() {
+        let ParsedStatement::Select(plan) =
+            parse_sql("SELECT id FROM documents LIMIT $1 OFFSET $2").expect("parse")
+        else {
+            panic!("expected select");
+        };
+        assert_eq!(plan.limit, Some(PageValue::Placeholder(1)));
+        assert_eq!(plan.offset, PageValue::Placeholder(2));
+
+        let batch = parse_sql_batch("SELECT 1; SELECT 2").expect("parse safe batch");
+        assert_eq!(batch.len(), 2);
+        assert!(parse_sql_batch("SELECT 1; DELETE FROM documents").is_err());
+    }
+
+    #[test]
+    fn rejects_sql_that_would_build_pathologically_deep_parser_state() {
+        let flat_filter = std::iter::repeat_n("title = 'x'", 3_500)
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        assert!(
+            parse_sql(&format!(
+                "SELECT id FROM documents WHERE {flat_filter} LIMIT 1"
+            ))
+            .is_err()
+        );
+
+        let unary_chain = format!("SELECT {}1", "-".repeat(MAX_PREFIX_OPERATOR_DEPTH + 1));
+        assert!(parse_sql(&unary_chain).is_err());
+
+        let nested = format!(
+            "SELECT {}1{}",
+            "(".repeat(MAX_EXPRESSION_DEPTH + 1),
+            ")".repeat(MAX_EXPRESSION_DEPTH + 1)
+        );
+        assert!(parse_sql(&nested).is_err());
+    }
+}

--- a/crates/jazz/src/tools/server/shutdown.rs
+++ b/crates/jazz/src/tools/server/shutdown.rs
@@ -35,6 +35,8 @@ struct ShutdownInner {
     drain_notify: Notify,
     active_app_requests: AtomicUsize,
     active_websockets: AtomicUsize,
+    active_postgres_connections: AtomicUsize,
+    active_postgres_queries: AtomicUsize,
 }
 
 pub struct ActiveAppRequestGuard {
@@ -42,6 +44,14 @@ pub struct ActiveAppRequestGuard {
 }
 
 pub struct ActiveWebSocketGuard {
+    controller: ShutdownController,
+}
+
+pub(crate) struct ActivePostgresConnectionGuard {
+    controller: ShutdownController,
+}
+
+pub(crate) struct ActivePostgresQueryGuard {
     controller: ShutdownController,
 }
 
@@ -57,6 +67,8 @@ impl ShutdownController {
                 drain_notify: Notify::new(),
                 active_app_requests: AtomicUsize::new(0),
                 active_websockets: AtomicUsize::new(0),
+                active_postgres_connections: AtomicUsize::new(0),
+                active_postgres_queries: AtomicUsize::new(0),
             }),
         }
     }
@@ -153,6 +165,58 @@ impl ShutdownController {
         self.inner.active_websockets.load(Ordering::SeqCst)
     }
 
+    pub(crate) fn try_enter_postgres_connection(&self) -> Option<ActivePostgresConnectionGuard> {
+        if self.is_shutting_down() {
+            return None;
+        }
+
+        self.inner
+            .active_postgres_connections
+            .fetch_add(1, Ordering::SeqCst);
+        if self.is_shutting_down() {
+            self.inner
+                .active_postgres_connections
+                .fetch_sub(1, Ordering::SeqCst);
+            self.inner.drain_notify.notify_waiters();
+            return None;
+        }
+
+        Some(ActivePostgresConnectionGuard {
+            controller: self.clone(),
+        })
+    }
+
+    pub(crate) fn active_postgres_connections(&self) -> usize {
+        self.inner
+            .active_postgres_connections
+            .load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn try_enter_postgres_query(&self) -> Option<ActivePostgresQueryGuard> {
+        if self.is_shutting_down() {
+            return None;
+        }
+
+        self.inner
+            .active_postgres_queries
+            .fetch_add(1, Ordering::SeqCst);
+        if self.is_shutting_down() {
+            self.inner
+                .active_postgres_queries
+                .fetch_sub(1, Ordering::SeqCst);
+            self.inner.drain_notify.notify_waiters();
+            return None;
+        }
+
+        Some(ActivePostgresQueryGuard {
+            controller: self.clone(),
+        })
+    }
+
+    pub(crate) fn active_postgres_queries(&self) -> usize {
+        self.inner.active_postgres_queries.load(Ordering::SeqCst)
+    }
+
     pub async fn wait_for_websocket_drain(&self) -> bool {
         let deadline = tokio::time::Instant::now() + self.timeout();
         let notified = self.inner.drain_notify.notified();
@@ -204,6 +268,33 @@ impl ShutdownController {
             }
         }
     }
+
+    pub(crate) async fn wait_for_postgres_connection_drain(&self) -> bool {
+        let deadline = tokio::time::Instant::now() + self.timeout();
+        let notified = self.inner.drain_notify.notified();
+        tokio::pin!(notified);
+
+        loop {
+            notified.as_mut().enable();
+            if self.active_postgres_connections() == 0 && self.active_postgres_queries() == 0 {
+                return true;
+            }
+
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+
+            let sleep = tokio::time::sleep_until(deadline);
+            tokio::select! {
+                _ = notified.as_mut() => {
+                    notified.set(self.inner.drain_notify.notified());
+                }
+                _ = sleep => return self.active_postgres_connections() == 0
+                    && self.active_postgres_queries() == 0,
+            }
+        }
+    }
 }
 
 impl Drop for ActiveAppRequestGuard {
@@ -221,6 +312,26 @@ impl Drop for ActiveWebSocketGuard {
         self.controller
             .inner
             .active_websockets
+            .fetch_sub(1, Ordering::SeqCst);
+        self.controller.inner.drain_notify.notify_waiters();
+    }
+}
+
+impl Drop for ActivePostgresConnectionGuard {
+    fn drop(&mut self) {
+        self.controller
+            .inner
+            .active_postgres_connections
+            .fetch_sub(1, Ordering::SeqCst);
+        self.controller.inner.drain_notify.notify_waiters();
+    }
+}
+
+impl Drop for ActivePostgresQueryGuard {
+    fn drop(&mut self) {
+        self.controller
+            .inner
+            .active_postgres_queries
             .fetch_sub(1, Ordering::SeqCst);
         self.controller.inner.drain_notify.notify_waiters();
     }
@@ -266,8 +377,12 @@ mod tests {
         assert!(controller.is_shutting_down());
         assert!(controller.try_enter_app_request().is_none());
         assert!(controller.try_enter_websocket().is_none());
+        assert!(controller.try_enter_postgres_connection().is_none());
+        assert!(controller.try_enter_postgres_query().is_none());
         assert_eq!(controller.active_app_requests(), 0);
         assert_eq!(controller.active_websockets(), 0);
+        assert_eq!(controller.active_postgres_connections(), 0);
+        assert_eq!(controller.active_postgres_queries(), 0);
     }
 
     #[tokio::test]
@@ -347,5 +462,29 @@ mod tests {
             .expect("running server accepts websocket");
 
         assert!(!controller.wait_for_websocket_drain().await);
+    }
+
+    #[tokio::test]
+    async fn postgres_drain_waits_for_connections_and_owner_thread_queries() {
+        let controller = ShutdownController::new(std::time::Duration::from_secs(30));
+        let connection = controller
+            .try_enter_postgres_connection()
+            .expect("running server accepts PostgreSQL connection");
+        let query = controller
+            .try_enter_postgres_query()
+            .expect("running server accepts PostgreSQL query");
+        let waiter = controller.clone();
+        let task = tokio::spawn(async move { waiter.wait_for_postgres_connection_drain().await });
+
+        tokio::task::yield_now().await;
+        drop(connection);
+        assert!(!task.is_finished());
+        drop(query);
+
+        let drained = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("PostgreSQL drain should complete after both guards drop")
+            .expect("wait task");
+        assert!(drained);
     }
 }

--- a/crates/jazz/src/tools/server/testing.rs
+++ b/crates/jazz/src/tools/server/testing.rs
@@ -63,7 +63,7 @@ impl JazzServerBuilder {
         self
     }
 
-    /// Enable the read-only PostgreSQL interface. Pass `0` to use an
+    /// Enable the administrative PostgreSQL interface. Pass `0` to use an
     /// operating-system-assigned loopback port.
     pub fn with_postgres_port(mut self, port: u16) -> Self {
         self.postgres_port = Some(port);
@@ -420,7 +420,7 @@ impl JazzServer {
         self.postgres.as_ref().map(|server| server.addr().port())
     }
 
-    /// Build a test-only PostgreSQL connection URL containing its read-only
+    /// Build a test-only PostgreSQL connection URL containing its dedicated
     /// database secret.
     pub fn postgres_url(&self) -> Option<String> {
         self.postgres_port().map(|port| {

--- a/crates/jazz/src/tools/server/testing.rs
+++ b/crates/jazz/src/tools/server/testing.rs
@@ -27,6 +27,7 @@ const JWT_SECRET: &str = "test-jwt-secret-for-integration";
 #[derive(Default)]
 pub struct JazzServerBuilder {
     port: Option<u16>,
+    postgres_port: Option<u16>,
     app_id: Option<AppId>,
     data_dir: Option<PathBuf>,
     schema: Option<Schema>,
@@ -44,6 +45,7 @@ impl std::fmt::Debug for JazzServerBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JazzServerBuilder")
             .field("port", &self.port)
+            .field("postgres_port", &self.postgres_port)
             .field("app_id", &self.app_id)
             .field("persistent_storage", &self.persistent_storage)
             .finish()
@@ -58,6 +60,13 @@ impl JazzServerBuilder {
 
     pub fn with_port(mut self, port: u16) -> Self {
         self.port = Some(port);
+        self
+    }
+
+    /// Enable the read-only PostgreSQL interface. Pass `0` to use an
+    /// operating-system-assigned loopback port.
+    pub fn with_postgres_port(mut self, port: u16) -> Self {
+        self.postgres_port = Some(port);
         self
     }
 
@@ -226,6 +235,7 @@ pub struct JazzServer {
     task: Option<JoinHandle<()>>,
     shutdown_task: Option<JoinHandle<()>>,
     port: u16,
+    postgres: Option<super::postgres::PostgresServerHandle>,
     app_id: AppId,
     data_dir: ServerDataDir,
     admin_secret: String,
@@ -238,6 +248,7 @@ pub struct JazzServer {
 impl JazzServer {
     pub const BACKEND_SECRET: &str = "backend-secret-for-integration-tests";
     pub const ADMIN_SECRET: &str = "admin-secret-for-integration-tests";
+    pub const POSTGRES_SECRET: &str = "postgres-secret-for-integration-tests";
 
     /// Creates a builder for configuring a Jazz server before startup.
     pub fn builder() -> JazzServerBuilder {
@@ -255,6 +266,7 @@ impl JazzServer {
     async fn from_builder(builder: JazzServerBuilder) -> Self {
         let JazzServerBuilder {
             port,
+            postgres_port,
             app_id,
             data_dir,
             schema,
@@ -318,6 +330,17 @@ impl JazzServer {
 
         let mut server =
             Self::from_built(built, port, app_id, data_dir, admin_secret, backend_secret).await;
+        if let Some(postgres_port) = postgres_port {
+            server.postgres = Some(
+                super::postgres::PostgresServerHandle::start(
+                    server.state.clone(),
+                    std::net::SocketAddr::from(([127, 0, 0, 1], postgres_port)),
+                    Self::POSTGRES_SECRET.to_owned(),
+                )
+                .await
+                .expect("start test PostgreSQL interface"),
+            );
+        }
         server.embedded_jwks_server = embedded_jwks_server;
         server.auth_clock = auth_clock;
         server
@@ -363,6 +386,7 @@ impl JazzServer {
             task: Some(task),
             shutdown_task: Some(shutdown_task),
             port,
+            postgres: None,
             app_id,
             data_dir,
             admin_secret,
@@ -389,6 +413,24 @@ impl JazzServer {
 
     pub fn base_url(&self) -> String {
         format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// Return the bound PostgreSQL port when the interface is enabled.
+    pub fn postgres_port(&self) -> Option<u16> {
+        self.postgres.as_ref().map(|server| server.addr().port())
+    }
+
+    /// Build a test-only PostgreSQL connection URL containing its read-only
+    /// database secret.
+    pub fn postgres_url(&self) -> Option<String> {
+        self.postgres_port().map(|port| {
+            format!(
+                "postgresql://jazz:{}@127.0.0.1:{}/{}?sslmode=disable",
+                Self::POSTGRES_SECRET,
+                port,
+                self.app_id
+            )
+        })
     }
 
     pub fn admin_secret(&self) -> &str {

--- a/crates/jazz/tests/postgres_interface.rs
+++ b/crates/jazz/tests/postgres_interface.rs
@@ -7,8 +7,10 @@ use std::{path::Path, process::Stdio};
 
 use jazz::row_input;
 use jazz::tools::server::JazzServer;
-use jazz::tools::{ColumnType, DurabilityTier, Schema, SchemaBuilder, TableSchema, Value};
-use support::TestingClient;
+use jazz::tools::{
+    ColumnType, DurabilityTier, ObjectId, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
+};
+use support::{TestingClient, has_added, has_removed, has_updated, wait_for_subscription_update};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_postgres::{NoTls, types::Type};
@@ -48,7 +50,6 @@ async fn postgres_driver_lists_catalogue_and_paginates_jazz_rows() {
                 .ready_on("documents", READY_TIMEOUT)
                 .connect()
                 .await;
-
             for created_at in 0_i64..5 {
                 let (_, _, batch) = writer
                     .insert(
@@ -364,11 +365,14 @@ async fn postgres_driver_lists_catalogue_and_paginates_jazz_rows() {
                 .expect("catalogue filters preserve SQL NULL semantics");
             assert!(null_comparison_rows.is_empty());
 
-            let write_error = client
+            let unsafe_delete_error = client
                 .execute("DELETE FROM documents", &[])
                 .await
-                .expect_err("the PostgreSQL interface is read-only");
-            assert_eq!(write_error.code().map(|code| code.code()), Some("0A000"));
+                .expect_err("DELETE must identify exactly one row by id");
+            assert_eq!(
+                unsafe_delete_error.code().map(|code| code.code()),
+                Some("0A000")
+            );
 
             let unbounded_error = client
                 .query("SELECT * FROM documents", &[])
@@ -463,7 +467,7 @@ async fn postgres_driver_lists_catalogue_and_paginates_jazz_rows() {
             let transaction = client
                 .transaction()
                 .await
-                .expect("start read-only PostgreSQL transaction");
+                .expect("start PostgreSQL read transaction");
             let portal_statement = transaction
                 .prepare("SELECT id FROM documents LIMIT 2")
                 .await
@@ -567,6 +571,421 @@ async fn postgres_driver_lists_catalogue_and_paginates_jazz_rows() {
             .await;
 
             server.shutdown().await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn postgres_driver_mutates_globally_settled_rows_in_autocommit_mode() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = documents_schema();
+            let server = JazzServer::builder()
+                .with_schema(schema.clone())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let observer = TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema)
+                .with_user_id("00000000-0000-4000-8000-000000000077")
+                .as_admin()
+                .ready_on("documents", READY_TIMEOUT)
+                .connect()
+                .await;
+            let mut subscription = observer
+                .subscribe(QueryBuilder::new("documents").build())
+                .await
+                .expect("open an active Jazz subscription before PostgreSQL mutations");
+            let mut subscription_log = Vec::new();
+
+            let url = server.postgres_url().expect("PostgreSQL URL");
+            let (mut client, connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect PostgreSQL mutation client");
+            let connection_task = tokio::spawn(async move {
+                connection
+                    .await
+                    .expect("PostgreSQL mutation connection remains healthy")
+            });
+
+            let read_only = client
+                .query_one("SHOW default_transaction_read_only", &[])
+                .await
+                .expect("inspect advertised transaction mode")
+                .get::<_, String>(0);
+            assert_eq!(read_only, "off");
+
+            let no_note: Option<&str> = None;
+            let inserted = client
+                .query_one(
+                    "INSERT INTO documents \
+                     (team_id, title, optional_note, created_at) \
+                     VALUES ($1, $2, $3, $4) RETURNING id AS document_id",
+                    &[&"team-pg", &"created-through-postgres", &no_note, &7_i64],
+                )
+                .await
+                .expect("insert through PostgreSQL with a generated Jazz id");
+            let document_id = inserted.get::<_, uuid::Uuid>(0);
+            let document_object_id = ObjectId::from_uuid(document_id);
+
+            let visible = client
+                .query_one(
+                    "SELECT title, optional_note, created_at FROM documents \
+                     WHERE id = $1 LIMIT 1",
+                    &[&document_id],
+                )
+                .await
+                .expect("the committed insert is immediately globally readable");
+            assert_eq!(visible.get::<_, String>(0), "created-through-postgres");
+            assert_eq!(visible.get::<_, Option<String>>(1), None);
+            assert_eq!(visible.get::<_, i64>(2), 7);
+
+            wait_for_subscription_update(
+                &mut subscription,
+                &mut subscription_log,
+                Duration::from_secs(5),
+                "PostgreSQL insert to reach an active Jazz observer",
+                |log| has_added(log, document_object_id),
+            )
+            .await;
+
+            let updated = client
+                .execute(
+                    "UPDATE documents SET title = $1, optional_note = $2 WHERE id = $3",
+                    &[
+                        &"updated-through-postgres",
+                        &Some("now-present"),
+                        &document_id,
+                    ],
+                )
+                .await
+                .expect("update through PostgreSQL");
+            assert_eq!(updated, 1);
+            let updated_row = client
+                .query_one(
+                    "SELECT team_id, title, optional_note, created_at FROM documents \
+                     WHERE id = $1 LIMIT 1",
+                    &[&document_id],
+                )
+                .await
+                .expect("read updated row");
+            assert_eq!(updated_row.get::<_, String>(0), "team-pg");
+            assert_eq!(updated_row.get::<_, String>(1), "updated-through-postgres");
+            assert_eq!(
+                updated_row.get::<_, Option<String>>(2).as_deref(),
+                Some("now-present")
+            );
+            assert_eq!(updated_row.get::<_, i64>(3), 7);
+
+            wait_for_subscription_update(
+                &mut subscription,
+                &mut subscription_log,
+                Duration::from_secs(5),
+                "PostgreSQL update to reach an active Jazz observer",
+                |log| has_updated(log, document_object_id),
+            )
+            .await;
+
+            let missing_id = uuid::Uuid::now_v7();
+            assert_eq!(
+                client
+                    .execute(
+                        "UPDATE documents SET title = $1 WHERE id = $2",
+                        &[&"missing", &missing_id],
+                    )
+                    .await
+                    .expect("updating a missing row is a successful no-op"),
+                0
+            );
+            assert_eq!(
+                client
+                    .execute("DELETE FROM documents WHERE id = $1", &[&missing_id])
+                    .await
+                    .expect("deleting a missing row is a successful no-op"),
+                0
+            );
+
+            let missing_required = client
+                .execute("INSERT INTO documents (team_id) VALUES ($1)", &[&"team-pg"])
+                .await
+                .expect_err("missing required columns must be rejected before commit");
+            assert_eq!(
+                missing_required.code().map(|code| code.code()),
+                Some("23502")
+            );
+
+            let duplicate = client
+                .execute(
+                    "INSERT INTO documents \
+                     (id, team_id, title, optional_note, created_at) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                    &[&document_id, &"team-pg", &"duplicate", &no_note, &8_i64],
+                )
+                .await
+                .expect_err("an explicit duplicate Jazz id must not become an update");
+            assert_eq!(duplicate.code().map(|code| code.code()), Some("23505"));
+
+            let oversized_note = "x".repeat(3 * 1024 * 1024);
+            let oversized = client
+                .execute(
+                    "UPDATE documents SET optional_note = $1 WHERE id = $2",
+                    &[&oversized_note, &document_id],
+                )
+                .await
+                .expect_err("an oversized commit must be rejected as a PostgreSQL limit error");
+            assert_eq!(oversized.code().map(|code| code.code()), Some("54000"));
+            let unchanged = client
+                .query_one(
+                    "SELECT optional_note FROM documents WHERE id = $1 LIMIT 1",
+                    &[&document_id],
+                )
+                .await
+                .expect("oversized rejected update leaves the row unchanged");
+            assert_eq!(
+                unchanged.get::<_, Option<String>>(0).as_deref(),
+                Some("now-present")
+            );
+
+            let transaction = client
+                .transaction()
+                .await
+                .expect("begin explicit PostgreSQL transaction");
+            let transaction_id = uuid::Uuid::now_v7();
+            let transaction_error = transaction
+                .execute(
+                    "INSERT INTO documents \
+                     (id, team_id, title, optional_note, created_at) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                    &[
+                        &transaction_id,
+                        &"team-pg",
+                        &"must-not-commit",
+                        &no_note,
+                        &9_i64,
+                    ],
+                )
+                .await
+                .expect_err("DML inside BEGIN is explicitly unsupported");
+            assert_eq!(
+                transaction_error.code().map(|code| code.code()),
+                Some("0A000")
+            );
+            let aborted = transaction
+                .query_one("SELECT 1", &[])
+                .await
+                .expect_err("the failed explicit transaction remains aborted");
+            assert_eq!(aborted.code().map(|code| code.code()), Some("25P02"));
+            transaction
+                .rollback()
+                .await
+                .expect("rollback unsupported DML transaction");
+
+            let mixed_id = uuid::Uuid::now_v7();
+            let mixed_batch = client
+                .simple_query(&format!(
+                    "INSERT INTO documents (id, team_id, title, created_at) \
+                     VALUES ('{mixed_id}', 'team-pg', 'must-not-partially-commit', 10); \
+                     SELECT 1"
+                ))
+                .await
+                .expect_err("mixed DML simple-query batches are rejected before execution");
+            assert_eq!(mixed_batch.code().map(|code| code.code()), Some("0A000"));
+            assert!(
+                client
+                    .query(
+                        "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                        &[&mixed_id],
+                    )
+                    .await
+                    .expect("verify rejected batch did not commit")
+                    .is_empty()
+            );
+
+            assert_eq!(
+                client
+                    .execute("DELETE FROM documents WHERE id = $1", &[&document_id])
+                    .await
+                    .expect("delete through PostgreSQL"),
+                1
+            );
+            assert!(
+                client
+                    .query(
+                        "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                        &[&document_id],
+                    )
+                    .await
+                    .expect("deleted row is no longer visible")
+                    .is_empty()
+            );
+
+            wait_for_subscription_update(
+                &mut subscription,
+                &mut subscription_log,
+                Duration::from_secs(5),
+                "PostgreSQL delete to reach an active Jazz observer",
+                |log| has_removed(log, document_object_id),
+            )
+            .await;
+
+            drop(client);
+            connection_task.await.expect("join mutation connection");
+            observer.shutdown().await.expect("shutdown Jazz observer");
+            server.shutdown().await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn postgres_mutations_survive_persistent_server_restart() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let data_dir = tempfile::tempdir().expect("temporary PostgreSQL server data dir");
+            let app_id = jazz::tools::AppId::random();
+            let schema = documents_schema();
+            let survivor_id = uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000a1")
+                .expect("survivor UUID");
+            let deleted_id = uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000a2")
+                .expect("deleted UUID");
+
+            {
+                let server = JazzServer::builder()
+                    .with_app_id(app_id)
+                    .with_schema(schema.clone())
+                    .with_data_dir(data_dir.path())
+                    .with_postgres_port(0)
+                    .with_persistent_storage()
+                    .start()
+                    .await;
+                let url = server
+                    .postgres_url()
+                    .expect("PostgreSQL URL before restart");
+                let (client, connection) = tokio_postgres::connect(&url, NoTls)
+                    .await
+                    .expect("connect PostgreSQL client before restart");
+                let connection_task = tokio::spawn(async move {
+                    connection
+                        .await
+                        .expect("pre-restart PostgreSQL connection remains healthy")
+                });
+
+                let survivor_note = Some("must-survive-untouched");
+                assert_eq!(
+                    client
+                        .execute(
+                            "INSERT INTO documents \
+                             (id, team_id, title, optional_note, created_at) \
+                             VALUES ($1, $2, $3, $4, $5)",
+                            &[
+                                &survivor_id,
+                                &"team-stable",
+                                &"before-update",
+                                &survivor_note,
+                                &101_i64,
+                            ],
+                        )
+                        .await
+                        .expect("insert survivor before restart"),
+                    1
+                );
+                assert_eq!(
+                    client
+                        .execute(
+                            "INSERT INTO documents \
+                             (id, team_id, title, optional_note, created_at) \
+                             VALUES ($1, $2, $3, $4, $5)",
+                            &[
+                                &deleted_id,
+                                &"team-delete",
+                                &"delete-before-restart",
+                                &Option::<&str>::None,
+                                &202_i64,
+                            ],
+                        )
+                        .await
+                        .expect("insert row to delete before restart"),
+                    1
+                );
+                assert_eq!(
+                    client
+                        .execute(
+                            "UPDATE documents SET title = $1 WHERE id = $2",
+                            &[&"after-update", &survivor_id],
+                        )
+                        .await
+                        .expect("update survivor before restart"),
+                    1
+                );
+                assert_eq!(
+                    client
+                        .execute("DELETE FROM documents WHERE id = $1", &[&deleted_id])
+                        .await
+                        .expect("delete row before restart"),
+                    1
+                );
+
+                drop(client);
+                connection_task
+                    .await
+                    .expect("join pre-restart PostgreSQL connection");
+                server.shutdown().await;
+            }
+
+            let restarted = JazzServer::builder()
+                .with_app_id(app_id)
+                .with_schema(schema)
+                .with_data_dir(data_dir.path())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let url = restarted
+                .postgres_url()
+                .expect("PostgreSQL URL after restart");
+            let (client, connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect PostgreSQL client after restart");
+            let connection_task = tokio::spawn(async move {
+                connection
+                    .await
+                    .expect("post-restart PostgreSQL connection remains healthy")
+            });
+
+            let survivor = client
+                .query_one(
+                    "SELECT team_id, title, optional_note, created_at FROM documents \
+                     WHERE id = $1 LIMIT 1",
+                    &[&survivor_id],
+                )
+                .await
+                .expect("survivor remains readable after restart");
+            assert_eq!(survivor.get::<_, String>(0), "team-stable");
+            assert_eq!(survivor.get::<_, String>(1), "after-update");
+            assert_eq!(
+                survivor.get::<_, Option<String>>(2).as_deref(),
+                Some("must-survive-untouched")
+            );
+            assert_eq!(survivor.get::<_, i64>(3), 101);
+
+            assert!(
+                client
+                    .query(
+                        "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                        &[&deleted_id],
+                    )
+                    .await
+                    .expect("query deleted row after restart")
+                    .is_empty(),
+                "deleted row must not reappear after persistent restart"
+            );
+
+            drop(client);
+            connection_task
+                .await
+                .expect("join post-restart PostgreSQL connection");
+            restarted.shutdown().await;
         })
         .await;
 }
@@ -746,6 +1165,48 @@ async fn raw_extended_protocol_lifecycle(port: u16, database: &str, password: &s
         }
     }
 
+    let returning_sql = "INSERT INTO documents (id, team_id, title, created_at) \
+                         VALUES ('00000000-0000-4000-8000-0000000000b1', \
+                         'team-wire', 'returning-wire', 301) RETURNING id";
+    let mut returning_query = Vec::new();
+    push_c_string(&mut returning_query, returning_sql);
+    write_frontend_frame(&mut socket, b'Q', &returning_query).await;
+    let returning_messages = read_until_ready(&mut socket).await;
+    assert_eq!(
+        command_tags(&returning_messages),
+        ["INSERT 0 1"],
+        "INSERT RETURNING must emit a valid PostgreSQL command tag"
+    );
+
+    let mutation_sql = "INSERT INTO documents (id, team_id, title, created_at) \
+                        VALUES ('00000000-0000-4000-8000-0000000000b2', \
+                        'team-wire', 'execute-once-wire', 302)";
+    let mut mutation_parse = Vec::new();
+    push_c_string(&mut mutation_parse, "mutation_once");
+    push_c_string(&mut mutation_parse, mutation_sql);
+    mutation_parse.extend_from_slice(&0_u16.to_be_bytes());
+    write_frontend_frame(&mut socket, b'P', &mutation_parse).await;
+    let mut mutation_bind = Vec::new();
+    push_c_string(&mut mutation_bind, "mutation_once_portal");
+    push_c_string(&mut mutation_bind, "mutation_once");
+    mutation_bind.extend_from_slice(&0_u16.to_be_bytes());
+    mutation_bind.extend_from_slice(&0_u16.to_be_bytes());
+    mutation_bind.extend_from_slice(&0_u16.to_be_bytes());
+    write_frontend_frame(&mut socket, b'B', &mutation_bind).await;
+    let mut mutation_execute = Vec::new();
+    push_c_string(&mut mutation_execute, "mutation_once_portal");
+    mutation_execute.extend_from_slice(&0_u32.to_be_bytes());
+    write_frontend_frame(&mut socket, b'E', &mutation_execute).await;
+    write_frontend_frame(&mut socket, b'E', &mutation_execute).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    let mutation_messages = read_until_ready(&mut socket).await;
+    assert_eq!(command_tags(&mutation_messages), ["INSERT 0 1"]);
+    assert_eq!(
+        first_error_sqlstate(&mutation_messages).as_deref(),
+        Some("26000"),
+        "a completed mutation portal must not execute its DML twice"
+    );
+
     let mut parse = Vec::new();
     push_c_string(&mut parse, "");
     push_c_string(&mut parse, "SELECT 1");
@@ -922,6 +1383,20 @@ fn first_data_row_text(messages: &[(u8, Vec<u8>)]) -> Option<&str> {
     let length = i32::from_be_bytes(payload.get(2..6)?.try_into().ok()?);
     let length = usize::try_from(length).ok()?;
     std::str::from_utf8(payload.get(6..6 + length)?).ok()
+}
+
+fn command_tags(messages: &[(u8, Vec<u8>)]) -> Vec<&str> {
+    messages
+        .iter()
+        .filter(|(tag, _)| *tag == b'C')
+        .map(|(_, payload)| {
+            let end = payload
+                .iter()
+                .position(|byte| *byte == 0)
+                .expect("PostgreSQL command tag is NUL terminated");
+            std::str::from_utf8(&payload[..end]).expect("PostgreSQL command tag is UTF-8")
+        })
+        .collect()
 }
 
 fn first_error_sqlstate(messages: &[(u8, Vec<u8>)]) -> Option<String> {

--- a/crates/jazz/tests/postgres_interface.rs
+++ b/crates/jazz/tests/postgres_interface.rs
@@ -1,0 +1,942 @@
+#![cfg(feature = "test")]
+
+mod support;
+
+use std::time::Duration;
+use std::{path::Path, process::Stdio};
+
+use jazz::row_input;
+use jazz::tools::server::JazzServer;
+use jazz::tools::{ColumnType, DurabilityTier, Schema, SchemaBuilder, TableSchema, Value};
+use support::TestingClient;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_postgres::{NoTls, types::Type};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(25);
+const PRODUCT_APP_ID: &str = "00000000-0000-0000-0000-000000000123";
+
+fn documents_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("documents")
+                .column("team_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .nullable_column("optional_note", ColumnType::Text)
+                .column("created_at", ColumnType::BigInt)
+                .index_only(["team_id", "title", "optional_note", "created_at"]),
+        )
+        .build()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn postgres_driver_lists_catalogue_and_paginates_jazz_rows() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = documents_schema();
+            let server = JazzServer::builder()
+                .with_schema(schema.clone())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let writer = TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema)
+                .with_user_id("00000000-0000-4000-8000-000000000099")
+                .as_admin()
+                .ready_on("documents", READY_TIMEOUT)
+                .connect()
+                .await;
+
+            for created_at in 0_i64..5 {
+                let (_, _, batch) = writer
+                    .insert(
+                        "documents",
+                        row_input!(
+                            "team_id" => "team-a",
+                            "title" => format!("document-{created_at}"),
+                            "optional_note" => format!("document-{created_at}"),
+                            "created_at" => created_at,
+                        ),
+                    )
+                    .expect("insert document");
+                writer
+                    .wait_for_batch(batch, DurabilityTier::GlobalServer)
+                    .await
+                    .expect("document settles on core server");
+            }
+            let (_, _, batch) = writer
+                .insert(
+                    "documents",
+                    row_input!(
+                        "team_id" => "team-b",
+                        "title" => "other-team-document",
+                        "optional_note" => Value::Null,
+                        "created_at" => 99_i64,
+                    ),
+                )
+                .expect("insert other team document");
+            writer
+                .wait_for_batch(batch, DurabilityTier::GlobalServer)
+                .await
+                .expect("other team document settles on core server");
+
+            let url = server.postgres_url().expect("PostgreSQL URL");
+            let (mut client, connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect with a PostgreSQL driver");
+            let connection_task = tokio::spawn(async move {
+                connection
+                    .await
+                    .expect("PostgreSQL connection remains healthy")
+            });
+
+            let database_rows = client
+                .query("SELECT datname FROM pg_database", &[])
+                .await
+                .expect("list databases through extended query protocol");
+            assert_eq!(database_rows.len(), 1);
+            assert_eq!(
+                database_rows[0].get::<_, String>(0),
+                server.app_id().to_string()
+            );
+
+            let table_rows = client
+                .query(
+                    "SELECT table_name FROM information_schema.tables \
+                     WHERE table_schema = $1 ORDER BY table_name",
+                    &[&"public"],
+                )
+                .await
+                .expect("list tables through a parameterized catalogue query");
+            assert_eq!(table_rows.len(), 1);
+            assert_eq!(table_rows[0].get::<_, String>(0), "documents");
+
+            let column_rows = client
+                .query(
+                    "SELECT column_name, data_type FROM information_schema.columns \
+                     WHERE table_schema = 'public' AND table_name = $1 \
+                     ORDER BY ordinal_position",
+                    &[&"documents"],
+                )
+                .await
+                .expect("list table columns");
+            let column_names = column_rows
+                .iter()
+                .map(|row| row.get::<_, String>(0))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                column_names,
+                vec!["id", "team_id", "title", "optional_note", "created_at"]
+            );
+
+            let rows = client
+                .query(
+                    "SELECT id, title, created_at FROM documents \
+                     WHERE team_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+                    &[&"team-a", &2_i64, &1_i64],
+                )
+                .await
+                .expect("filter and paginate documents");
+            assert_eq!(rows.len(), 2);
+            let titles = rows
+                .iter()
+                .map(|row| row.get::<_, String>(1))
+                .collect::<Vec<_>>();
+            assert_eq!(titles, vec!["document-3", "document-2"]);
+            assert_eq!(rows[0].get::<_, i64>(2), 3);
+            let _: uuid::Uuid = rows[0].get(0);
+
+            let first_keyset_page = client
+                .query(
+                    "SELECT id, title, created_at FROM documents \
+                     WHERE team_id = $1 \
+                     ORDER BY created_at DESC, id DESC LIMIT 2",
+                    &[&"team-a"],
+                )
+                .await
+                .expect("read the first keyset page");
+            let cursor_id = first_keyset_page[1].get::<_, uuid::Uuid>(0);
+            let cursor_created_at = first_keyset_page[1].get::<_, i64>(2);
+            let second_keyset_page = client
+                .query(
+                    "SELECT id, title, created_at FROM documents \
+                     WHERE team_id = $1 AND \
+                       (created_at < $2 OR (created_at = $2 AND id < $3)) \
+                     ORDER BY created_at DESC, id DESC LIMIT 2",
+                    &[&"team-a", &cursor_created_at, &cursor_id],
+                )
+                .await
+                .expect("read the next keyset page");
+            assert_eq!(
+                second_keyset_page
+                    .iter()
+                    .map(|row| row.get::<_, String>(1))
+                    .collect::<Vec<_>>(),
+                vec!["document-2", "document-1"]
+            );
+
+            let reused_parameter_rows = client
+                .query(
+                    "SELECT title FROM documents \
+                     WHERE title = $1 OR optional_note = $1 LIMIT 10",
+                    &[&"document-3"],
+                )
+                .await
+                .expect("one PostgreSQL parameter binds independently to nullable and non-null Jazz columns");
+            assert_eq!(reused_parameter_rows.len(), 1);
+            assert_eq!(reused_parameter_rows[0].get::<_, String>(0), "document-3");
+
+            let non_null_is_null = client
+                .query("SELECT id FROM documents WHERE title IS NULL LIMIT 10", &[])
+                .await
+                .expect("IS NULL on a non-null column is valid PostgreSQL");
+            assert!(non_null_is_null.is_empty());
+            let non_null_is_not_null = client
+                .query(
+                    "SELECT id FROM documents WHERE title IS NOT NULL LIMIT 10",
+                    &[],
+                )
+                .await
+                .expect("IS NOT NULL on a non-null column is valid PostgreSQL");
+            assert_eq!(non_null_is_not_null.len(), 6);
+            let nullable_is_null = client
+                .query(
+                    "SELECT id FROM documents WHERE optional_note IS NULL LIMIT 10",
+                    &[],
+                )
+                .await
+                .expect("IS NULL on a nullable column uses Jazz nullable semantics");
+            assert_eq!(nullable_is_null.len(), 1);
+            let nullable_is_not_null = client
+                .query(
+                    "SELECT id FROM documents WHERE optional_note IS NOT NULL LIMIT 10",
+                    &[],
+                )
+                .await
+                .expect("IS NOT NULL on a nullable column uses Jazz nullable semantics");
+            assert_eq!(nullable_is_not_null.len(), 5);
+
+            let session = client
+                .simple_query("SELECT current_database(), version(); SELECT 2")
+                .await
+                .expect("simple query protocol supports safe statement batches");
+            assert!(session.len() >= 4);
+
+            let table_batch_error = tokio::time::timeout(
+                Duration::from_secs(2),
+                client.simple_query(
+                    "SELECT id FROM documents LIMIT 1; SELECT id FROM documents LIMIT 1",
+                ),
+            )
+            .await
+            .expect("multiple table reads must fail without waiting on the query gate")
+            .expect_err("one simple-query batch cannot retain two table responses");
+            assert_eq!(
+                table_batch_error.code().map(|code| code.code()),
+                Some("0A000")
+            );
+            assert!(
+                table_batch_error
+                    .as_db_error()
+                    .is_some_and(|error| error.message().contains("at most one application-table"))
+            );
+
+            let response_batch_error = client
+                .simple_query("SELECT 1; SELECT 2; SELECT 3; SELECT 4; SELECT 5")
+                .await
+                .expect_err("one simple batch cannot retain more than four row responses");
+            assert_eq!(
+                response_batch_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+
+            let health = client
+                .query_one("SELECT 1", &[])
+                .await
+                .expect("ordinary PostgreSQL health check works");
+            assert_eq!(health.get::<_, i32>(0), 1);
+
+            let oversized_sql = format!("SELECT 1{}", " ".repeat(70_000));
+            let oversized_error = client
+                .simple_query(&oversized_sql)
+                .await
+                .expect_err("oversized SQL must be rejected before parsing");
+            assert_eq!(
+                oversized_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+
+            let huge_placeholder_error = client
+                .prepare("SELECT id FROM documents WHERE title = $1025 LIMIT 1")
+                .await
+                .expect_err("placeholder positions are bounded during parsing");
+            assert_eq!(
+                huge_placeholder_error.code().map(|code| code.code()),
+                Some("0A000")
+            );
+
+            let repeated_wildcards = std::iter::repeat_n("*", 334)
+                .collect::<Vec<_>>()
+                .join(", ");
+            let wide_result_error = client
+                .prepare(&format!(
+                    "SELECT {repeated_wildcards} FROM documents LIMIT 1"
+                ))
+                .await
+                .expect_err("expanded wildcard projections must respect PostgreSQL's column cap");
+            assert_eq!(
+                wide_result_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+
+            let repeated_filter = std::iter::repeat_n("title = $1", 40)
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            let repeated_parameter_sql =
+                format!("SELECT id FROM documents WHERE {repeated_filter} LIMIT 1");
+            let repeated_parameter = "x".repeat(1024 * 1024);
+            let repeated_parameter_rows = client
+                .query(&repeated_parameter_sql, &[&repeated_parameter])
+                .await
+                .expect("repeated references reuse one converted Jazz binding");
+            assert!(repeated_parameter_rows.is_empty());
+
+            let oversized_parameter = "x".repeat(4 * 1024 * 1024 + 1);
+            let oversized_parameter_error = client
+                .query(
+                    "SELECT id FROM documents WHERE title = $1 LIMIT 1",
+                    &[&oversized_parameter],
+                )
+                .await
+                .expect_err("decoded parameter bytes are bounded");
+            assert_eq!(
+                oversized_parameter_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+
+            let null_parameter: Option<&str> = None;
+            let null_parameter_error = client
+                .query(
+                    "SELECT id FROM documents WHERE optional_note = $1 LIMIT 1",
+                    &[&null_parameter],
+                )
+                .await
+                .expect_err("NULL filter parameters require explicit IS NULL syntax");
+            assert_eq!(
+                null_parameter_error.code().map(|code| code.code()),
+                Some("22004")
+            );
+
+            let declared_type_error = client
+                .prepare_typed(
+                    "SELECT title FROM documents WHERE team_id = $1 LIMIT 1",
+                    &[Type::INT4],
+                )
+                .await
+                .expect_err("declared parameter OIDs must match inferred column types");
+            assert_eq!(
+                declared_type_error.code().map(|code| code.code()),
+                Some("42804")
+            );
+
+            let partially_typed = client
+                .prepare_typed(
+                    "SELECT title FROM documents WHERE team_id = $1 LIMIT $2",
+                    &[Type::TEXT],
+                )
+                .await
+                .expect("PostgreSQL permits a typed parameter prefix");
+            let partially_typed_rows = client
+                .query(&partially_typed, &[&"team-a", &1_i64])
+                .await
+                .expect("remaining parameter types are inferred");
+            assert_eq!(partially_typed_rows.len(), 1);
+
+            let null_comparison_rows = client
+                .query(
+                    "SELECT column_name FROM information_schema.columns \
+                     WHERE column_default <> 'x'",
+                    &[],
+                )
+                .await
+                .expect("catalogue filters preserve SQL NULL semantics");
+            assert!(null_comparison_rows.is_empty());
+
+            let write_error = client
+                .execute("DELETE FROM documents", &[])
+                .await
+                .expect_err("the PostgreSQL interface is read-only");
+            assert_eq!(write_error.code().map(|code| code.code()), Some("0A000"));
+
+            let unbounded_error = client
+                .query("SELECT * FROM documents", &[])
+                .await
+                .expect_err("application-table reads must be explicitly bounded");
+            assert_eq!(
+                unbounded_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+
+            let deep_offset_error = client
+                .query(
+                    "SELECT id FROM documents LIMIT $1 OFFSET $2",
+                    &[&1_i64, &10_001_i64],
+                )
+                .await
+                .expect_err("deep offsets must use keyset pagination");
+            assert_eq!(
+                deep_offset_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+
+            let set_error = client
+                .execute("SET statement_timeout = '1s'", &[])
+                .await
+                .expect_err("unsupported session settings must not report success");
+            assert_eq!(set_error.code().map(|code| code.code()), Some("0A000"));
+
+            let transaction_mode_error = client
+                .simple_query("BEGIN READ WRITE")
+                .await
+                .expect_err("unsupported transaction modes must not report success");
+            assert_eq!(
+                transaction_mode_error.code().map(|code| code.code()),
+                Some("0A000")
+            );
+            let transaction_chain_error = client
+                .simple_query("COMMIT AND CHAIN")
+                .await
+                .expect_err("unsupported transaction chaining must not report success");
+            assert_eq!(
+                transaction_chain_error.code().map(|code| code.code()),
+                Some("0A000")
+            );
+            let transaction_batch_error = client
+                .simple_query("COMMIT; SELECT 1")
+                .await
+                .expect_err("transaction control must not be mixed into a simple-query batch");
+            assert_eq!(
+                transaction_batch_error.code().map(|code| code.code()),
+                Some("0A000")
+            );
+            assert_eq!(
+                client
+                    .query_one("SELECT 1", &[])
+                    .await
+                    .expect("a rejected transaction batch leaves the session healthy")
+                    .get::<_, i32>(0),
+                1
+            );
+
+            client
+                .batch_execute("BEGIN")
+                .await
+                .expect("begin explicit failed-transaction regression");
+            let in_transaction_error = client
+                .query("SELECT id FROM documents", &[])
+                .await
+                .expect_err("unbounded table read fails inside a transaction");
+            assert_eq!(
+                in_transaction_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+            let aborted_transaction_error = client
+                .query_one("SELECT 1", &[])
+                .await
+                .expect_err("failed transaction rejects later reads");
+            assert_eq!(
+                aborted_transaction_error.code().map(|code| code.code()),
+                Some("25P02")
+            );
+            client
+                .batch_execute("ROLLBACK")
+                .await
+                .expect("rollback clears failed transaction state");
+            let recovered_health = client
+                .query_one("SELECT 1", &[])
+                .await
+                .expect("reads resume after rollback");
+            assert_eq!(recovered_health.get::<_, i32>(0), 1);
+
+            let transaction = client
+                .transaction()
+                .await
+                .expect("start read-only PostgreSQL transaction");
+            let portal_statement = transaction
+                .prepare("SELECT id FROM documents LIMIT 2")
+                .await
+                .expect("prepare bounded portal query");
+            let portal = transaction
+                .bind(&portal_statement, &[])
+                .await
+                .expect("bind portal query");
+            let portal_error = transaction
+                .query_portal(&portal, 1)
+                .await
+                .expect_err("incremental portal fetch must not silently ignore max_rows");
+            assert_eq!(portal_error.code().map(|code| code.code()), Some("0A000"));
+            transaction
+                .rollback()
+                .await
+                .expect("rollback read-only transaction");
+
+            drop(client);
+            connection_task.await.expect("join PostgreSQL connection");
+
+            let (mut resource_client, resource_connection) =
+                tokio_postgres::connect(&url, NoTls)
+                    .await
+                    .expect("connect for prepared-object resource checks");
+            let resource_connection_task = tokio::spawn(async move {
+                resource_connection
+                    .await
+                    .expect("resource-check connection remains healthy")
+            });
+            let mut retained_statements = Vec::new();
+            for index in 0..64 {
+                retained_statements.push(
+                    resource_client
+                        .prepare(&format!("SELECT {index}"))
+                        .await
+                        .expect("retain a bounded prepared statement"),
+                );
+            }
+            let statement_limit_error = resource_client
+                .prepare("SELECT 64")
+                .await
+                .expect_err("the 65th retained statement must be rejected");
+            assert_eq!(
+                statement_limit_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+
+            let resource_transaction = resource_client
+                .transaction()
+                .await
+                .expect("start portal resource check");
+            let mut retained_portals = Vec::new();
+            for _ in 0..64 {
+                retained_portals.push(
+                    resource_transaction
+                        .bind(&retained_statements[0], &[])
+                        .await
+                        .expect("retain a bounded portal"),
+                );
+            }
+            let portal_limit_error = match resource_transaction
+                .bind(&retained_statements[0], &[])
+                .await
+            {
+                Ok(_) => panic!("the 65th retained portal must be rejected"),
+                Err(error) => error,
+            };
+            assert_eq!(
+                portal_limit_error.code().map(|code| code.code()),
+                Some("54000")
+            );
+            drop(retained_portals);
+            resource_transaction
+                .rollback()
+                .await
+                .expect("rollback resource-check transaction");
+            drop(retained_statements);
+            let health = resource_client
+                .query_one("SELECT 1", &[])
+                .await
+                .expect("connection recovers after releasing prepared objects");
+            assert_eq!(health.get::<_, i32>(0), 1);
+            drop(resource_client);
+            resource_connection_task
+                .await
+                .expect("join resource-check connection");
+
+            let wrong_url = url.replace(JazzServer::POSTGRES_SECRET, "wrong-secret");
+            assert!(tokio_postgres::connect(&wrong_url, NoTls).await.is_err());
+            let admin_url = url.replace(JazzServer::POSTGRES_SECRET, JazzServer::ADMIN_SECRET);
+            assert!(tokio_postgres::connect(&admin_url, NoTls).await.is_err());
+            let backend_url = url.replace(JazzServer::POSTGRES_SECRET, JazzServer::BACKEND_SECRET);
+            assert!(tokio_postgres::connect(&backend_url, NoTls).await.is_err());
+
+            raw_extended_protocol_lifecycle(
+                server.postgres_port().expect("PostgreSQL port"),
+                &server.app_id().to_string(),
+                JazzServer::POSTGRES_SECRET,
+            )
+            .await;
+
+            server.shutdown().await;
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn product_server_cli_exposes_the_postgres_connection_url() {
+    let temp = tempfile::tempdir().expect("temporary product server directory");
+    let http_port_file = temp.path().join("http-port");
+    let postgres_port_file = temp.path().join("postgres-port");
+    let data_dir = temp.path().join("data");
+    let child = std::process::Command::new(env!("CARGO_BIN_EXE_jazz-tools"))
+        .args([
+            "server",
+            PRODUCT_APP_ID,
+            "--port",
+            "0",
+            "--data-dir",
+            data_dir.to_str().expect("UTF-8 data path"),
+            "--admin-secret",
+            "product-test-secret",
+            "--postgres-secret",
+            "product-postgres-secret",
+            "--postgres-port",
+            "0",
+            "--bound-port-file",
+            http_port_file.to_str().expect("UTF-8 HTTP port path"),
+            "--postgres-bound-port-file",
+            postgres_port_file
+                .to_str()
+                .expect("UTF-8 PostgreSQL port path"),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start product jazz-tools server");
+    let mut child = ChildGuard(Some(child));
+
+    let http_port = wait_for_port_file(&http_port_file).await;
+    let postgres_port = wait_for_port_file(&postgres_port_file).await;
+    let url = format!(
+        "postgresql://jazz:product-postgres-secret@127.0.0.1:{postgres_port}/{PRODUCT_APP_ID}?sslmode=disable"
+    );
+    let (client, connection) = tokio_postgres::connect(&url, NoTls)
+        .await
+        .expect("connect to product server PostgreSQL listener");
+    let connection_task = tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    let row = client
+        .query_one("SELECT current_database(), current_user", &[])
+        .await
+        .expect("query product server through extended protocol");
+    assert_eq!(row.get::<_, String>(0), PRODUCT_APP_ID);
+    assert_eq!(row.get::<_, String>(1), "jazz");
+
+    let databases = client
+        .query("SELECT datname FROM pg_catalog.pg_database", &[])
+        .await
+        .expect("list the app before its first schema is published");
+    assert_eq!(databases[0].get::<_, String>(0), PRODUCT_APP_ID);
+    let tables = client
+        .query("SELECT table_name FROM information_schema.tables", &[])
+        .await
+        .expect("a fresh app has an empty table catalogue");
+    assert!(tables.is_empty());
+
+    let deep_filter = std::iter::repeat_n("title = 'x'", 3_500)
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let deep_sql = format!("SELECT id FROM documents WHERE {deep_filter} LIMIT 1");
+    assert!(deep_sql.len() < 64 * 1024);
+    let deep_error = client
+        .simple_query(&deep_sql)
+        .await
+        .expect_err("pathologically complex SQL must be rejected before building a deep AST");
+    assert_eq!(deep_error.code().map(|code| code.code()), Some("0A000"));
+    assert_eq!(
+        client
+            .query_one("SELECT 1", &[])
+            .await
+            .expect("the product server remains healthy after rejecting pathological SQL")
+            .get::<_, i32>(0),
+        1
+    );
+
+    let response = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{http_port}/internal/shutdown"))
+        .header("X-Jazz-Admin-Secret", "product-test-secret")
+        .send()
+        .await
+        .expect("request controlled product shutdown");
+    assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
+    drop(client);
+    connection_task.await.expect("join product connection task");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(status) = child
+            .0
+            .as_mut()
+            .expect("child")
+            .try_wait()
+            .expect("poll child")
+        {
+            assert!(status.success(), "product server exited with {status}");
+            child.0.take();
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "product server did not shut down"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn wait_for_port_file(path: &Path) -> u16 {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Ok(value) = std::fs::read_to_string(path)
+            && let Ok(port) = value.parse::<u16>()
+        {
+            return port;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "server did not write {}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+struct ChildGuard(Option<std::process::Child>);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+async fn raw_extended_protocol_lifecycle(port: u16, database: &str, password: &str) {
+    let mut socket = TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect raw PostgreSQL client");
+    let mut startup = Vec::new();
+    startup.extend_from_slice(&196_608_u32.to_be_bytes());
+    push_c_string(&mut startup, "user");
+    push_c_string(&mut startup, "jazz");
+    push_c_string(&mut startup, "database");
+    push_c_string(&mut startup, database);
+    startup.push(0);
+    socket
+        .write_all(&((startup.len() + 4) as u32).to_be_bytes())
+        .await
+        .expect("write PostgreSQL startup length");
+    socket
+        .write_all(&startup)
+        .await
+        .expect("write PostgreSQL startup body");
+
+    loop {
+        let (tag, payload) = read_backend_frame(&mut socket).await;
+        match tag {
+            b'R' if payload.get(..4) == Some(3_u32.to_be_bytes().as_slice()) => {
+                let mut body = Vec::new();
+                push_c_string(&mut body, password);
+                write_frontend_frame(&mut socket, b'p', &body).await;
+            }
+            b'E' => panic!("raw PostgreSQL authentication failed: {payload:?}"),
+            b'Z' => break,
+            _ => {}
+        }
+    }
+
+    let mut parse = Vec::new();
+    push_c_string(&mut parse, "");
+    push_c_string(&mut parse, "SELECT 1");
+    parse.extend_from_slice(&0_u16.to_be_bytes());
+    write_frontend_frame(&mut socket, b'P', &parse).await;
+    let mut bind = Vec::new();
+    push_c_string(&mut bind, "");
+    push_c_string(&mut bind, "");
+    bind.extend_from_slice(&0_u16.to_be_bytes());
+    bind.extend_from_slice(&0_u16.to_be_bytes());
+    bind.extend_from_slice(&0_u16.to_be_bytes());
+    write_frontend_frame(&mut socket, b'B', &bind).await;
+    let mut execute = Vec::new();
+    push_c_string(&mut execute, "");
+    execute.extend_from_slice(&0_u32.to_be_bytes());
+    write_frontend_frame(&mut socket, b'E', &execute).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    let executed = read_until_ready(&mut socket).await;
+    assert!(executed.iter().any(|(tag, _)| *tag == b'1'));
+    assert!(executed.iter().any(|(tag, _)| *tag == b'2'));
+    assert_eq!(first_data_row_text(&executed), Some("1"));
+
+    write_frontend_frame(&mut socket, b'E', &execute).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert_eq!(
+        first_error_sqlstate(&read_until_ready(&mut socket).await).as_deref(),
+        Some("26000")
+    );
+
+    let mut named_parse = Vec::new();
+    push_c_string(&mut named_parse, "s");
+    push_c_string(&mut named_parse, "SELECT 2");
+    named_parse.extend_from_slice(&0_u16.to_be_bytes());
+    write_frontend_frame(&mut socket, b'P', &named_parse).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert!(
+        read_until_ready(&mut socket)
+            .await
+            .iter()
+            .any(|(tag, _)| *tag == b'1')
+    );
+
+    write_frontend_frame(&mut socket, b'P', &named_parse).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert_eq!(
+        first_error_sqlstate(&read_until_ready(&mut socket).await).as_deref(),
+        Some("42P05")
+    );
+
+    let mut named_bind = Vec::new();
+    push_c_string(&mut named_bind, "p");
+    push_c_string(&mut named_bind, "s");
+    named_bind.extend_from_slice(&0_u16.to_be_bytes());
+    named_bind.extend_from_slice(&0_u16.to_be_bytes());
+    named_bind.extend_from_slice(&0_u16.to_be_bytes());
+    write_frontend_frame(&mut socket, b'B', &named_bind).await;
+    write_frontend_frame(&mut socket, b'B', &named_bind).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert_eq!(
+        first_error_sqlstate(&read_until_ready(&mut socket).await).as_deref(),
+        Some("42P03")
+    );
+
+    let mut begin = Vec::new();
+    push_c_string(&mut begin, "BEGIN");
+    write_frontend_frame(&mut socket, b'Q', &begin).await;
+    assert!(
+        read_until_ready(&mut socket)
+            .await
+            .iter()
+            .any(|(tag, _)| *tag == b'C')
+    );
+
+    write_frontend_frame(&mut socket, b'B', &named_bind).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert!(
+        read_until_ready(&mut socket)
+            .await
+            .iter()
+            .any(|(tag, _)| *tag == b'2')
+    );
+
+    let mut named_execute = Vec::new();
+    push_c_string(&mut named_execute, "p");
+    named_execute.extend_from_slice(&0_u32.to_be_bytes());
+    write_frontend_frame(&mut socket, b'E', &named_execute).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert_eq!(
+        first_data_row_text(&read_until_ready(&mut socket).await),
+        Some("2")
+    );
+
+    let mut close_statement = vec![b'S'];
+    push_c_string(&mut close_statement, "s");
+    write_frontend_frame(&mut socket, b'C', &close_statement).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert!(
+        read_until_ready(&mut socket)
+            .await
+            .iter()
+            .any(|(tag, _)| *tag == b'3')
+    );
+
+    write_frontend_frame(&mut socket, b'E', &named_execute).await;
+    write_frontend_frame(&mut socket, b'S', &[]).await;
+    assert_eq!(
+        first_error_sqlstate(&read_until_ready(&mut socket).await).as_deref(),
+        Some("26000")
+    );
+
+    let mut rollback = Vec::new();
+    push_c_string(&mut rollback, "ROLLBACK");
+    write_frontend_frame(&mut socket, b'Q', &rollback).await;
+    assert!(
+        read_until_ready(&mut socket)
+            .await
+            .iter()
+            .any(|(tag, _)| *tag == b'C')
+    );
+}
+
+fn push_c_string(target: &mut Vec<u8>, value: &str) {
+    target.extend_from_slice(value.as_bytes());
+    target.push(0);
+}
+
+async fn write_frontend_frame(socket: &mut TcpStream, tag: u8, body: &[u8]) {
+    let mut frame = Vec::with_capacity(body.len() + 5);
+    frame.push(tag);
+    frame.extend_from_slice(&((body.len() + 4) as u32).to_be_bytes());
+    frame.extend_from_slice(body);
+    socket
+        .write_all(&frame)
+        .await
+        .expect("write raw PostgreSQL frontend frame");
+}
+
+async fn read_backend_frame(socket: &mut TcpStream) -> (u8, Vec<u8>) {
+    let tag = socket.read_u8().await.expect("read PostgreSQL backend tag");
+    let length = socket
+        .read_u32()
+        .await
+        .expect("read PostgreSQL backend length") as usize;
+    assert!((4..=16 * 1024 * 1024 + 1024).contains(&length));
+    let mut payload = vec![0_u8; length - 4];
+    socket
+        .read_exact(&mut payload)
+        .await
+        .expect("read PostgreSQL backend payload");
+    (tag, payload)
+}
+
+async fn read_until_ready(socket: &mut TcpStream) -> Vec<(u8, Vec<u8>)> {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        let mut messages = Vec::new();
+        loop {
+            let message = read_backend_frame(socket).await;
+            let ready = message.0 == b'Z';
+            messages.push(message);
+            if ready {
+                return messages;
+            }
+        }
+    })
+    .await
+    .expect("PostgreSQL backend reaches ReadyForQuery")
+}
+
+fn first_data_row_text(messages: &[(u8, Vec<u8>)]) -> Option<&str> {
+    let payload = messages.iter().find(|(tag, _)| *tag == b'D')?.1.as_slice();
+    if payload.get(..2)? != 1_u16.to_be_bytes().as_slice() {
+        return None;
+    }
+    let length = i32::from_be_bytes(payload.get(2..6)?.try_into().ok()?);
+    let length = usize::try_from(length).ok()?;
+    std::str::from_utf8(payload.get(6..6 + length)?).ok()
+}
+
+fn first_error_sqlstate(messages: &[(u8, Vec<u8>)]) -> Option<String> {
+    let payload = messages.iter().find(|(tag, _)| *tag == b'E')?.1.as_slice();
+    let mut cursor = 0;
+    while cursor < payload.len() && payload[cursor] != 0 {
+        let field = payload[cursor];
+        cursor += 1;
+        let end = payload[cursor..].iter().position(|byte| *byte == 0)? + cursor;
+        if field == b'C' {
+            return std::str::from_utf8(&payload[cursor..end])
+                .ok()
+                .map(str::to_owned);
+        }
+        cursor = end + 1;
+    }
+    None
+}

--- a/crates/jazz/tests/postgres_interface.rs
+++ b/crates/jazz/tests/postgres_interface.rs
@@ -8,9 +8,13 @@ use std::{path::Path, process::Stdio};
 use jazz::row_input;
 use jazz::tools::server::JazzServer;
 use jazz::tools::{
-    ColumnType, DurabilityTier, ObjectId, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
+    ColumnDescriptor, ColumnType, DurabilityTier, LargeValueKind, ObjectId, QueryBuilder,
+    RowDescriptor, Schema, SchemaBuilder, TableName, TableSchema, Value,
 };
-use support::{TestingClient, has_added, has_removed, has_updated, wait_for_subscription_update};
+use support::{
+    TestingClient, collect_stream_deltas, has_added, has_any_change, has_removed, has_updated,
+    wait_for_subscription_update,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio_postgres::{NoTls, types::Type};
@@ -29,6 +33,54 @@ fn documents_schema() -> Schema {
                 .index_only(["team_id", "title", "optional_note", "created_at"]),
         )
         .build()
+}
+
+fn postgres_large_values_schema() -> Schema {
+    [(
+        TableName::new("assets"),
+        TableSchema::new(RowDescriptor::new(vec![
+            ColumnDescriptor::new("name", ColumnType::Text),
+            ColumnDescriptor::new("body", ColumnType::Bytea).large_value(LargeValueKind::Text),
+            ColumnDescriptor::new("data", ColumnType::Bytea).large_value(LargeValueKind::Blob),
+        ])),
+    )]
+    .into_iter()
+    .collect()
+}
+
+fn postgres_nullable_large_values_schema() -> Schema {
+    [(
+        TableName::new("nullable_assets"),
+        TableSchema::new(RowDescriptor::new(vec![
+            ColumnDescriptor::new("data", ColumnType::Bytea)
+                .nullable()
+                .large_value(LargeValueKind::Blob),
+        ])),
+    )]
+    .into_iter()
+    .collect()
+}
+
+fn handle_shaped_blob_payload(row: uuid::Uuid) -> Vec<u8> {
+    fn push_string(bytes: &mut Vec<u8>, value: &str) {
+        bytes.extend_from_slice(&(value.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(value.as_bytes());
+    }
+
+    let mut bytes = b"JLVH1".to_vec();
+    push_string(&mut bytes, "assets");
+    bytes.extend_from_slice(row.as_bytes());
+    push_string(&mut bytes, "data");
+    bytes.extend_from_slice(&77_u64.to_be_bytes());
+    bytes.extend_from_slice(
+        uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000ff")
+            .expect("handle-shaped payload node UUID")
+            .as_bytes(),
+    );
+    bytes.push(2); // LargeValueKind::Blob
+    bytes.extend_from_slice(&123_u64.to_be_bytes());
+    bytes.extend_from_slice(&0_u64.to_be_bytes());
+    bytes
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -753,34 +805,49 @@ async fn postgres_driver_mutates_globally_settled_rows_in_autocommit_mode() {
                 .await
                 .expect("begin explicit PostgreSQL transaction");
             let transaction_id = uuid::Uuid::now_v7();
-            let transaction_error = transaction
-                .execute(
-                    "INSERT INTO documents \
-                     (id, team_id, title, optional_note, created_at) \
-                     VALUES ($1, $2, $3, $4, $5)",
-                    &[
-                        &transaction_id,
-                        &"team-pg",
-                        &"must-not-commit",
-                        &no_note,
-                        &9_i64,
-                    ],
-                )
-                .await
-                .expect_err("DML inside BEGIN is explicitly unsupported");
             assert_eq!(
-                transaction_error.code().map(|code| code.code()),
-                Some("0A000")
+                transaction
+                    .execute(
+                        "INSERT INTO documents \
+                         (id, team_id, title, optional_note, created_at) \
+                         VALUES ($1, $2, $3, $4, $5)",
+                        &[
+                            &transaction_id,
+                            &"team-pg",
+                            &"must-not-commit",
+                            &no_note,
+                            &9_i64,
+                        ],
+                    )
+                    .await
+                    .expect("stage DML inside BEGIN"),
+                1
             );
-            let aborted = transaction
-                .query_one("SELECT 1", &[])
-                .await
-                .expect_err("the failed explicit transaction remains aborted");
-            assert_eq!(aborted.code().map(|code| code.code()), Some("25P02"));
+            assert_eq!(
+                transaction
+                    .query(
+                        "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                        &[&transaction_id],
+                    )
+                    .await
+                    .expect("the transaction reads its staged insert")
+                    .len(),
+                1
+            );
             transaction
                 .rollback()
                 .await
-                .expect("rollback unsupported DML transaction");
+                .expect("rollback explicit DML transaction");
+            assert!(
+                client
+                    .query(
+                        "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                        &[&transaction_id],
+                    )
+                    .await
+                    .expect("rolled-back staged insert remains absent")
+                    .is_empty()
+            );
 
             let mixed_id = uuid::Uuid::now_v7();
             let mixed_batch = client
@@ -833,6 +900,1143 @@ async fn postgres_driver_mutates_globally_settled_rows_in_autocommit_mode() {
             drop(client);
             connection_task.await.expect("join mutation connection");
             observer.shutdown().await.expect("shutdown Jazz observer");
+            server.shutdown().await;
+        })
+        .await;
+}
+
+/// Contract: PostgreSQL transactions stage multi-row inserts, predicate updates,
+/// and exact-id deletes in one Jazz transaction with snapshot isolation,
+/// read-your-writes, atomic subscription delivery, rollback, and durable commit.
+///
+/// Actors: alice is the PostgreSQL writer, bob is an independent PostgreSQL
+/// reader, carol is an active Jazz subscriber, and dave is a raw PostgreSQL
+/// client that disconnects with an open transaction.
+///
+/// ```text
+/// alice --BEGIN/stage--> server tx overlay --read-own-writes--> alice
+/// bob   ------read-----> committed snapshot (staged rows absent)
+/// alice ----COMMIT-----> RocksDB --one add/update/remove delta--> carol
+/// alice --ROLLBACK/error--> discard --no rows or delta---------> bob/carol
+/// dave  --BEGIN/stage/disconnect--> abandon --no row or delta--> bob/carol
+///                              |
+///                              `--restart--> only committed state survives
+/// ```
+#[tokio::test(flavor = "current_thread")]
+async fn postgres_transactions_are_atomic_and_read_their_own_writes() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let data_dir = tempfile::tempdir().expect("temporary transaction data dir");
+            let app_id = jazz::tools::AppId::random();
+            let schema = documents_schema();
+            let server = JazzServer::builder()
+                .with_app_id(app_id)
+                .with_schema(schema.clone())
+                .with_data_dir(data_dir.path())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let carol = TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema.clone())
+                .with_user_id("00000000-0000-4000-8000-000000000076")
+                .as_admin()
+                .ready_on("documents", READY_TIMEOUT)
+                .connect()
+                .await;
+            let mut carol_subscription = carol
+                .subscribe(QueryBuilder::new("documents").build())
+                .await
+                .expect("open a Jazz subscription before transactional mutations");
+            let mut carol_subscription_log = Vec::new();
+
+            let url = server.postgres_url().expect("PostgreSQL URL");
+            let (mut alice, alice_connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect alice as the transactional PostgreSQL writer");
+            let alice_connection_task = tokio::spawn(async move {
+                alice_connection
+                    .await
+                    .expect("alice's PostgreSQL connection remains healthy")
+            });
+            let (bob, bob_connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect bob as the independent PostgreSQL reader");
+            let bob_connection_task = tokio::spawn(async move {
+                bob_connection
+                    .await
+                    .expect("bob's PostgreSQL connection remains healthy")
+            });
+
+            let seeded = alice
+                .query(
+                    "INSERT INTO documents (team_id, title, optional_note, created_at) VALUES \
+                     ($1, $2, $3, $4), ($1, $5, $6, $7), ($8, $9, $10, $11) \
+                     RETURNING id",
+                    &[
+                        &"team-seed",
+                        &"seed-one",
+                        &Option::<&str>::None,
+                        &11_i64,
+                        &"seed-two",
+                        &Option::<&str>::None,
+                        &12_i64,
+                        &"team-other",
+                        &"other-team",
+                        &Option::<&str>::None,
+                        &13_i64,
+                    ],
+                )
+                .await
+                .expect("autocommit a multi-row INSERT with generated ids");
+            assert_eq!(seeded.len(), 3);
+            let seeded_ids = seeded
+                .iter()
+                .map(|row| row.get::<_, uuid::Uuid>(0))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                seeded_ids
+                    .iter()
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .len(),
+                3,
+                "every VALUES row receives a distinct Jazz id"
+            );
+            wait_for_subscription_update(
+                &mut carol_subscription,
+                &mut carol_subscription_log,
+                Duration::from_secs(5),
+                "alice's seed insert to reach carol's Jazz subscription",
+                |log| {
+                    seeded_ids
+                        .iter()
+                        .all(|id| has_added(log, ObjectId::from_uuid(*id)))
+                },
+            )
+            .await;
+            carol_subscription_log.clear();
+
+            let inserted_ids = [
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000d1")
+                    .expect("first transaction UUID"),
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000d2")
+                    .expect("second transaction UUID"),
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000d3")
+                    .expect("third transaction UUID"),
+            ];
+            let alice_tx = alice
+                .transaction()
+                .await
+                .expect("alice begins a write transaction");
+            let returned = alice_tx
+                .query(
+                    "INSERT INTO documents \
+                     (id, team_id, title, optional_note, created_at) VALUES \
+                     ($1, $2, $3, $4, $5), \
+                     ($6, $2, $7, $8, $9), \
+                     ($10, $2, $11, $12, $13) \
+                     RETURNING id AS document_id",
+                    &[
+                        &inserted_ids[0],
+                        &"team-transaction",
+                        &"transaction-one",
+                        &Option::<&str>::None,
+                        &21_i64,
+                        &inserted_ids[1],
+                        &"transaction-two",
+                        &Some("has-note"),
+                        &22_i64,
+                        &inserted_ids[2],
+                        &"transaction-three",
+                        &Option::<&str>::None,
+                        &23_i64,
+                    ],
+                )
+                .await
+                .expect("stage a multi-row INSERT in the transaction");
+            assert_eq!(
+                returned
+                    .iter()
+                    .map(|row| row.get::<_, uuid::Uuid>(0))
+                    .collect::<Vec<_>>(),
+                inserted_ids,
+                "INSERT RETURNING preserves VALUES order"
+            );
+            assert_eq!(
+                alice_tx
+                    .execute(
+                        "UPDATE documents SET title = $1, optional_note = $2 \
+                         WHERE team_id = $3 AND created_at IN ($4, $5)",
+                        &[
+                            &"predicate-updated",
+                            &Some("updated-note"),
+                            &"team-seed",
+                            &11_i64,
+                            &12_i64,
+                        ],
+                    )
+                    .await
+                    .expect("stage a predicate UPDATE in the transaction"),
+                2
+            );
+            assert_eq!(
+                alice_tx
+                    .execute("DELETE FROM documents WHERE id = $1", &[&seeded_ids[2]],)
+                    .await
+                    .expect("stage an exact-id DELETE in the transaction"),
+                1
+            );
+
+            let own_inserted_rows = alice_tx
+                .query(
+                    "SELECT id FROM documents WHERE team_id = $1 \
+                     ORDER BY created_at LIMIT 10",
+                    &[&"team-transaction"],
+                )
+                .await
+                .expect("transaction reads its staged inserts");
+            assert_eq!(own_inserted_rows.len(), 3);
+            let own_updated_rows = alice_tx
+                .query(
+                    "SELECT title, optional_note FROM documents \
+                     WHERE team_id = $1 ORDER BY created_at LIMIT 10",
+                    &[&"team-seed"],
+                )
+                .await
+                .expect("transaction reads its staged predicate update");
+            assert_eq!(own_updated_rows.len(), 2);
+            assert!(own_updated_rows.iter().all(|row| {
+                row.get::<_, String>(0) == "predicate-updated"
+                    && row.get::<_, Option<String>>(1).as_deref() == Some("updated-note")
+            }));
+            assert!(
+                alice_tx
+                    .query(
+                        "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                        &[&seeded_ids[2]],
+                    )
+                    .await
+                    .expect("transaction reads its staged delete")
+                    .is_empty()
+            );
+
+            assert!(
+                bob.query(
+                    "SELECT id FROM documents WHERE team_id = $1 LIMIT 10",
+                    &[&"team-transaction"],
+                )
+                .await
+                .expect("another session reads the committed snapshot")
+                .is_empty(),
+                "another PostgreSQL session must not see uncommitted inserts"
+            );
+            let external_seed_rows = bob
+                .query(
+                    "SELECT title FROM documents WHERE team_id = $1 \
+                     ORDER BY created_at LIMIT 10",
+                    &[&"team-seed"],
+                )
+                .await
+                .expect("another session does not see the staged update");
+            assert_eq!(
+                external_seed_rows
+                    .iter()
+                    .map(|row| row.get::<_, String>(0))
+                    .collect::<Vec<_>>(),
+                ["seed-one".to_owned(), "seed-two".to_owned()]
+            );
+            assert_eq!(
+                bob.query(
+                    "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                    &[&seeded_ids[2]],
+                )
+                .await
+                .expect("another session does not see the staged delete")
+                .len(),
+                1
+            );
+            collect_stream_deltas(
+                &mut carol_subscription,
+                &mut carol_subscription_log,
+                Duration::from_millis(150),
+            )
+            .await;
+            assert!(
+                inserted_ids.iter().all(|id| {
+                    !has_any_change(&carol_subscription_log, ObjectId::from_uuid(*id))
+                })
+            );
+            assert!(
+                seeded_ids.iter().all(|id| {
+                    !has_any_change(&carol_subscription_log, ObjectId::from_uuid(*id))
+                })
+            );
+
+            alice_tx
+                .commit()
+                .await
+                .expect("atomically commit staged PostgreSQL mutations");
+
+            let committed_rows = bob
+                .query(
+                    "SELECT id FROM documents WHERE team_id = $1 \
+                     ORDER BY created_at LIMIT 10",
+                    &[&"team-transaction"],
+                )
+                .await
+                .expect("another session sees inserts after COMMIT");
+            assert_eq!(committed_rows.len(), 3);
+            let committed_updates = bob
+                .query(
+                    "SELECT title, optional_note FROM documents WHERE team_id = $1 \
+                     ORDER BY created_at LIMIT 10",
+                    &[&"team-seed"],
+                )
+                .await
+                .expect("another session sees predicate updates after COMMIT");
+            assert_eq!(committed_updates.len(), 2);
+            assert!(committed_updates.iter().all(|row| {
+                row.get::<_, String>(0) == "predicate-updated"
+                    && row.get::<_, Option<String>>(1).as_deref() == Some("updated-note")
+            }));
+            assert!(
+                bob.query(
+                    "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                    &[&seeded_ids[2]],
+                )
+                .await
+                .expect("committed exact-id DELETE becomes visible")
+                .is_empty()
+            );
+
+            wait_for_subscription_update(
+                &mut carol_subscription,
+                &mut carol_subscription_log,
+                Duration::from_secs(5),
+                "alice's commit to reach carol atomically",
+                |log| {
+                    log.iter().any(|delta| {
+                        inserted_ids.iter().all(|id| {
+                            delta
+                                .added
+                                .iter()
+                                .any(|change| change.id == ObjectId::from_uuid(*id))
+                        }) && seeded_ids[..2].iter().all(|id| {
+                            delta
+                                .updated
+                                .iter()
+                                .any(|change| change.id == ObjectId::from_uuid(*id))
+                        }) && delta
+                            .removed
+                            .iter()
+                            .any(|change| change.id == ObjectId::from_uuid(seeded_ids[2]))
+                    })
+                },
+            )
+            .await;
+
+            let rollback_ids = [
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000e1")
+                    .expect("first rollback UUID"),
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000e2")
+                    .expect("second rollback UUID"),
+            ];
+            carol_subscription_log.clear();
+            let alice_rollback_tx = alice
+                .transaction()
+                .await
+                .expect("alice begins a transaction to roll back");
+            assert_eq!(
+                alice_rollback_tx
+                    .execute(
+                        "INSERT INTO documents \
+                         (id, team_id, title, optional_note, created_at) VALUES \
+                         ($1, $2, $3, $4, $5), ($6, $2, $7, $4, $8)",
+                        &[
+                            &rollback_ids[0],
+                            &"team-rollback",
+                            &"rollback-one",
+                            &Option::<&str>::None,
+                            &31_i64,
+                            &rollback_ids[1],
+                            &"rollback-two",
+                            &32_i64,
+                        ],
+                    )
+                    .await
+                    .expect("stage rows that will be rolled back"),
+                2
+            );
+            assert_eq!(
+                alice_rollback_tx
+                    .execute(
+                        "UPDATE documents SET title = $1 WHERE team_id = $2",
+                        &[&"must-roll-back", &"team-seed"],
+                    )
+                    .await
+                    .expect("stage predicate update that will be rolled back"),
+                2
+            );
+            assert_eq!(
+                alice_rollback_tx
+                    .query(
+                        "SELECT id FROM documents WHERE team_id = $1 LIMIT 10",
+                        &[&"team-rollback"],
+                    )
+                    .await
+                    .expect("transaction reads rows before rollback")
+                    .len(),
+                2
+            );
+            alice_rollback_tx
+                .rollback()
+                .await
+                .expect("discard all staged mutations");
+            assert!(
+                bob.query(
+                    "SELECT id FROM documents WHERE team_id = $1 LIMIT 10",
+                    &[&"team-rollback"],
+                )
+                .await
+                .expect("rolled-back rows stay invisible")
+                .is_empty()
+            );
+            let after_rollback = bob
+                .query(
+                    "SELECT title FROM documents WHERE team_id = $1 LIMIT 10",
+                    &[&"team-seed"],
+                )
+                .await
+                .expect("rolled-back predicate update stays invisible");
+            assert_eq!(after_rollback.len(), 2);
+            assert!(
+                after_rollback
+                    .iter()
+                    .all(|row| { row.get::<_, String>(0) == "predicate-updated" })
+            );
+
+            let failed_id = uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000f1")
+                .expect("failed transaction UUID");
+            let alice_failed_tx = alice
+                .transaction()
+                .await
+                .expect("alice begins a transaction that will fail");
+            assert_eq!(
+                alice_failed_tx
+                    .execute(
+                        "INSERT INTO documents \
+                         (id, team_id, title, optional_note, created_at) \
+                         VALUES ($1, $2, $3, $4, $5)",
+                        &[
+                            &failed_id,
+                            &"team-failed",
+                            &"must-not-commit",
+                            &Option::<&str>::None,
+                            &41_i64,
+                        ],
+                    )
+                    .await
+                    .expect("stage a row before a later statement fails"),
+                1
+            );
+            let duplicate_error = alice_failed_tx
+                .execute(
+                    "INSERT INTO documents \
+                     (id, team_id, title, optional_note, created_at) \
+                     VALUES ($1, $2, $3, $4, $5)",
+                    &[
+                        &seeded_ids[0],
+                        &"team-failed",
+                        &"duplicate-id",
+                        &Option::<&str>::None,
+                        &42_i64,
+                    ],
+                )
+                .await
+                .expect_err("duplicate id aborts the explicit transaction");
+            assert_eq!(
+                duplicate_error.code().map(|code| code.code()),
+                Some("23505")
+            );
+            let aborted_error = alice_failed_tx
+                .query_one("SELECT 1", &[])
+                .await
+                .expect_err("an aborted transaction rejects later statements");
+            assert_eq!(aborted_error.code().map(|code| code.code()), Some("25P02"));
+            alice_failed_tx
+                .commit()
+                .await
+                .expect("COMMIT on a failed transaction performs PostgreSQL rollback");
+            assert!(
+                bob.query(
+                    "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                    &[&failed_id],
+                )
+                .await
+                .expect("failed transaction has no partial effects")
+                .is_empty()
+            );
+
+            let atomic_ids = [
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-000000000101")
+                    .expect("first atomic-statement UUID"),
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-000000000102")
+                    .expect("second atomic-statement UUID"),
+            ];
+            let null_title: Option<&str> = None;
+            let atomic_error = alice
+                .execute(
+                    "INSERT INTO documents \
+                     (id, team_id, title, optional_note, created_at) VALUES \
+                     ($1, $2, $3, $4, $5), ($6, $2, $7, $4, $8)",
+                    &[
+                        &atomic_ids[0],
+                        &"team-atomic-error",
+                        &Some("valid-row"),
+                        &Option::<&str>::None,
+                        &51_i64,
+                        &atomic_ids[1],
+                        &null_title,
+                        &52_i64,
+                    ],
+                )
+                .await
+                .expect_err("one invalid VALUES row rejects the whole INSERT statement");
+            assert_eq!(atomic_error.code().map(|code| code.code()), Some("23502"));
+            assert!(
+                bob.query(
+                    "SELECT id FROM documents WHERE id IN ($1, $2) LIMIT 10",
+                    &[&atomic_ids[0], &atomic_ids[1]],
+                )
+                .await
+                .expect("failed multi-row INSERT leaves no partial rows")
+                .is_empty()
+            );
+
+            collect_stream_deltas(
+                &mut carol_subscription,
+                &mut carol_subscription_log,
+                Duration::from_millis(150),
+            )
+            .await;
+            for id in rollback_ids
+                .iter()
+                .chain(std::iter::once(&failed_id))
+                .chain(atomic_ids.iter())
+            {
+                assert!(
+                    !has_any_change(&carol_subscription_log, ObjectId::from_uuid(*id)),
+                    "discarded row {id} must not reach an active Jazz subscription"
+                );
+            }
+            assert!(
+                seeded_ids[..2].iter().all(|id| {
+                    !has_any_change(&carol_subscription_log, ObjectId::from_uuid(*id))
+                }),
+                "a rolled-back predicate update must not reach an active Jazz subscription"
+            );
+
+            let disconnected_id = uuid::Uuid::parse_str("00000000-0000-4000-8000-000000000110")
+                .expect("dave's disconnected transaction UUID");
+            carol_subscription_log.clear();
+            let database = server.app_id().to_string();
+            let mut dave = raw_authenticated_postgres_socket(
+                server.postgres_port().expect("PostgreSQL port for dave"),
+                &database,
+                JazzServer::POSTGRES_SECRET,
+            )
+            .await;
+            let dave_begin = raw_simple_query(&mut dave, "BEGIN").await;
+            assert_eq!(command_tags(&dave_begin), ["BEGIN"]);
+            assert_eq!(ready_status(&dave_begin), Some(b'T'));
+            let dave_insert = raw_simple_query(
+                &mut dave,
+                &format!(
+                    "INSERT INTO documents (id, team_id, title, created_at) VALUES \
+                     ('{disconnected_id}', 'team-disconnect', 'dave-staged', 61)"
+                ),
+            )
+            .await;
+            assert_eq!(command_tags(&dave_insert), ["INSERT 0 1"]);
+            assert_eq!(ready_status(&dave_insert), Some(b'T'));
+
+            // Close the transport without a PostgreSQL Terminate, COMMIT, or
+            // ROLLBACK message. EOF confirms the server observed the disconnect.
+            dave.shutdown()
+                .await
+                .expect("dave disconnects with an open transaction");
+            let mut eof = [0_u8; 1];
+            assert_eq!(
+                tokio::time::timeout(Duration::from_secs(3), dave.read(&mut eof))
+                    .await
+                    .expect("server closes dave's disconnected session")
+                    .expect("read dave's disconnected session EOF"),
+                0
+            );
+            assert!(
+                bob.query(
+                    "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                    &[&disconnected_id],
+                )
+                .await
+                .expect("bob cannot observe dave's abandoned insert")
+                .is_empty()
+            );
+            collect_stream_deltas(
+                &mut carol_subscription,
+                &mut carol_subscription_log,
+                Duration::from_millis(150),
+            )
+            .await;
+            assert!(
+                !has_any_change(
+                    &carol_subscription_log,
+                    ObjectId::from_uuid(disconnected_id)
+                ),
+                "carol must not receive dave's abandoned insert"
+            );
+
+            drop(bob);
+            bob_connection_task
+                .await
+                .expect("join bob's PostgreSQL connection");
+            drop(alice);
+            alice_connection_task
+                .await
+                .expect("join alice's PostgreSQL connection");
+            carol
+                .shutdown()
+                .await
+                .expect("shutdown carol's Jazz client");
+            server.shutdown().await;
+
+            let restarted = JazzServer::builder()
+                .with_app_id(app_id)
+                .with_schema(schema)
+                .with_data_dir(data_dir.path())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let restarted_url = restarted
+                .postgres_url()
+                .expect("PostgreSQL URL after transaction restart");
+            let (restarted_client, restarted_connection) =
+                tokio_postgres::connect(&restarted_url, NoTls)
+                    .await
+                    .expect("connect after transaction restart");
+            let restarted_connection_task = tokio::spawn(async move {
+                restarted_connection
+                    .await
+                    .expect("post-restart transaction connection remains healthy")
+            });
+            assert_eq!(
+                restarted_client
+                    .query(
+                        "SELECT id FROM documents WHERE team_id = $1 LIMIT 10",
+                        &[&"team-transaction"],
+                    )
+                    .await
+                    .expect("committed transaction rows survive restart")
+                    .len(),
+                3
+            );
+            let restarted_updates = restarted_client
+                .query(
+                    "SELECT title, optional_note FROM documents WHERE team_id = $1 LIMIT 10",
+                    &[&"team-seed"],
+                )
+                .await
+                .expect("committed predicate update survives restart");
+            assert_eq!(restarted_updates.len(), 2);
+            assert!(restarted_updates.iter().all(|row| {
+                row.get::<_, String>(0) == "predicate-updated"
+                    && row.get::<_, Option<String>>(1).as_deref() == Some("updated-note")
+            }));
+            assert!(
+                restarted_client
+                    .query(
+                        "SELECT id FROM documents WHERE id = $1 LIMIT 1",
+                        &[&seeded_ids[2]],
+                    )
+                    .await
+                    .expect("committed transaction delete survives restart")
+                    .is_empty()
+            );
+            for team in [
+                "team-rollback",
+                "team-failed",
+                "team-atomic-error",
+                "team-disconnect",
+            ] {
+                assert!(
+                    restarted_client
+                        .query(
+                            "SELECT id FROM documents WHERE team_id = $1 LIMIT 10",
+                            &[&team],
+                        )
+                        .await
+                        .expect("discarded transaction rows remain absent after restart")
+                        .is_empty(),
+                    "discarded rows for {team} must not reappear after restart"
+                );
+            }
+            drop(restarted_client);
+            restarted_connection_task
+                .await
+                .expect("join post-restart transaction connection");
+            restarted.shutdown().await;
+        })
+        .await;
+}
+
+/// Contract: PostgreSQL exclusive transactions encode large Text and Blob
+/// inserts as ordinary extent-backed values, expose exact logical bytes to
+/// read-your-writes, let a partial update inherit untouched large columns, and
+/// never mistake authored handle-shaped Blob bytes for a stored handle.
+///
+/// Actor: alice writes and reads the asset through PostgreSQL.
+///
+/// ```text
+/// alice --BEGIN/INSERT--> tx overlay --SELECT exact bytes--> alice
+/// alice ------COMMIT----> RocksDB
+/// alice --BEGIN/UPDATE name only--> parent large values --SELECT--> alice
+/// alice ------COMMIT/new BEGIN/restart----------------------> same bytes
+/// alice --UPDATE handle-shaped Blob/SELECT/ROLLBACK--------> exact authored bytes
+/// ```
+#[tokio::test(flavor = "current_thread")]
+async fn postgres_transactions_preserve_large_values_across_partial_updates_and_restart() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let data_dir = tempfile::tempdir().expect("temporary large-value data dir");
+            let app_id = jazz::tools::AppId::random();
+            let schema = postgres_large_values_schema();
+            let asset_id =
+                uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000b1").expect("asset UUID");
+            let body = "transactional-large-text-".repeat(4_096);
+            let data = (0..128 * 1024)
+                .map(|index| ((index * 31 + 7) % 251) as u8)
+                .collect::<Vec<_>>();
+
+            let server = JazzServer::builder()
+                .with_app_id(app_id)
+                .with_schema(schema.clone())
+                .with_data_dir(data_dir.path())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let url = server.postgres_url().expect("PostgreSQL URL");
+            let (mut alice, alice_connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect alice for large-value writes");
+            let alice_connection_task = tokio::spawn(async move {
+                alice_connection
+                    .await
+                    .expect("alice's large-value connection remains healthy")
+            });
+
+            let insert = alice
+                .transaction()
+                .await
+                .expect("begin large-value insert transaction");
+            assert_eq!(
+                insert
+                    .execute(
+                        "INSERT INTO assets (id, name, body, data) VALUES ($1, $2, $3, $4)",
+                        &[&asset_id, &"original", &body, &data],
+                    )
+                    .await
+                    .expect("stage large Text and Blob values"),
+                1
+            );
+            let staged_insert = insert
+                .query_one(
+                    "SELECT name, body, data FROM assets WHERE id = $1 LIMIT 1",
+                    &[&asset_id],
+                )
+                .await
+                .expect("read staged large values before commit");
+            assert_eq!(staged_insert.get::<_, String>(0), "original");
+            assert_eq!(staged_insert.get::<_, String>(1), body);
+            assert_eq!(staged_insert.get::<_, Vec<u8>>(2), data);
+            insert
+                .commit()
+                .await
+                .expect("commit extent-backed large-value insert");
+
+            let update = alice
+                .transaction()
+                .await
+                .expect("begin partial large-value row update");
+            assert_eq!(
+                update
+                    .execute(
+                        "UPDATE assets SET name = $1 WHERE id = $2",
+                        &[&"renamed", &asset_id],
+                    )
+                    .await
+                    .expect("stage ordinary-column-only update"),
+                1
+            );
+            let staged_update = update
+                .query_one(
+                    "SELECT name, body, data FROM assets WHERE id = $1 LIMIT 1",
+                    &[&asset_id],
+                )
+                .await
+                .expect("read inherited large values before update commit");
+            assert_eq!(staged_update.get::<_, String>(0), "renamed");
+            assert_eq!(staged_update.get::<_, String>(1), body);
+            assert_eq!(staged_update.get::<_, Vec<u8>>(2), data);
+            update
+                .commit()
+                .await
+                .expect("commit partial update without rewriting large values");
+
+            // A fresh transaction sees the large values inherited through the
+            // sparse name-only winner. Read the id first so this also exercises
+            // the projection that must not resolve any large-value history.
+            let inherited = alice
+                .transaction()
+                .await
+                .expect("begin fresh transaction after sparse update");
+            assert_eq!(
+                inherited
+                    .query("SELECT id FROM assets WHERE id = $1 LIMIT 1", &[&asset_id],)
+                    .await
+                    .expect("read only id without resolving large values")
+                    .len(),
+                1
+            );
+            let inherited_row = inherited
+                .query_one(
+                    "SELECT name, body, data FROM assets WHERE id = $1 LIMIT 1",
+                    &[&asset_id],
+                )
+                .await
+                .expect("read large values inherited through sparse winner");
+            assert_eq!(inherited_row.get::<_, String>(0), "renamed");
+            assert_eq!(inherited_row.get::<_, String>(1), body);
+            assert_eq!(inherited_row.get::<_, Vec<u8>>(2), data);
+            inherited
+                .rollback()
+                .await
+                .expect("close inherited-value read transaction");
+
+            let handle_shaped_data = handle_shaped_blob_payload(asset_id);
+            let handle_shaped = alice
+                .transaction()
+                .await
+                .expect("begin handle-shaped Blob transaction");
+            assert_eq!(
+                handle_shaped
+                    .execute(
+                        "UPDATE assets SET data = $1 WHERE id = $2",
+                        &[&handle_shaped_data, &asset_id],
+                    )
+                    .await
+                    .expect("stage a Blob whose bytes encode as a valid Jazz handle"),
+                1
+            );
+            assert_eq!(
+                handle_shaped
+                    .query_one(
+                        "SELECT data FROM assets WHERE id = $1 LIMIT 1",
+                        &[&asset_id],
+                    )
+                    .await
+                    .expect("read handle-shaped authored bytes without hydrating them")
+                    .get::<_, Vec<u8>>(0),
+                handle_shaped_data
+            );
+            handle_shaped
+                .rollback()
+                .await
+                .expect("discard handle-shaped Blob update");
+
+            let committed = alice
+                .query_one(
+                    "SELECT name, body, data FROM assets WHERE id = $1 LIMIT 1",
+                    &[&asset_id],
+                )
+                .await
+                .expect("read committed inherited large values");
+            assert_eq!(committed.get::<_, String>(0), "renamed");
+            assert_eq!(committed.get::<_, String>(1), body);
+            assert_eq!(committed.get::<_, Vec<u8>>(2), data);
+
+            drop(alice);
+            alice_connection_task
+                .await
+                .expect("join alice's large-value connection");
+            server.shutdown().await;
+
+            let restarted = JazzServer::builder()
+                .with_app_id(app_id)
+                .with_schema(schema)
+                .with_data_dir(data_dir.path())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let restarted_url = restarted
+                .postgres_url()
+                .expect("PostgreSQL URL after large-value restart");
+            let (alice, restarted_connection) = tokio_postgres::connect(&restarted_url, NoTls)
+                .await
+                .expect("reconnect alice after large-value restart");
+            let restarted_connection_task = tokio::spawn(async move {
+                restarted_connection
+                    .await
+                    .expect("restarted large-value connection remains healthy")
+            });
+            let durable = alice
+                .query_one(
+                    "SELECT name, body, data FROM assets WHERE id = $1 LIMIT 1",
+                    &[&asset_id],
+                )
+                .await
+                .expect("read durable large values after restart");
+            assert_eq!(durable.get::<_, String>(0), "renamed");
+            assert_eq!(durable.get::<_, String>(1), body);
+            assert_eq!(durable.get::<_, Vec<u8>>(2), data);
+
+            drop(alice);
+            restarted_connection_task
+                .await
+                .expect("join restarted large-value connection");
+            restarted.shutdown().await;
+        })
+        .await;
+}
+
+/// Contract: PostgreSQL rejects a table containing nullable large-value
+/// columns before any read or write can reach Jazz's non-null large-value
+/// storage path.
+///
+/// Actor: alice probes the unsupported table, receives `0A000`, then reuses the
+/// same connection successfully.
+///
+/// ```text
+/// alice --SELECT/INSERT nullable large value--> 0A000
+/// alice ----------------SELECT 1-----------> healthy connection
+/// ```
+#[tokio::test(flavor = "current_thread")]
+async fn postgres_rejects_nullable_large_value_tables_without_writing() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let server = JazzServer::builder()
+                .with_schema(postgres_nullable_large_values_schema())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let url = server.postgres_url().expect("PostgreSQL URL");
+            let (alice, connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect nullable large-value probe");
+            let connection_task = tokio::spawn(async move {
+                connection
+                    .await
+                    .expect("nullable large-value probe connection remains healthy")
+            });
+
+            let read_error = alice
+                .query("SELECT id FROM nullable_assets LIMIT 1", &[])
+                .await
+                .expect_err("nullable large-value table reads are rejected explicitly");
+            assert_eq!(read_error.code().map(|code| code.code()), Some("0A000"));
+            let insert_error = alice
+                .execute(
+                    "INSERT INTO nullable_assets (data) VALUES ($1)",
+                    &[&Some(vec![1_u8, 2, 3])],
+                )
+                .await
+                .expect_err("nullable large-value table writes are rejected explicitly");
+            assert_eq!(insert_error.code().map(|code| code.code()), Some("0A000"));
+            assert_eq!(
+                alice
+                    .query_one("SELECT 1", &[])
+                    .await
+                    .expect("connection remains usable after explicit rejection")
+                    .get::<_, i32>(0),
+                1
+            );
+
+            drop(alice);
+            connection_task
+                .await
+                .expect("join nullable large-value probe connection");
+            server.shutdown().await;
+        })
+        .await;
+}
+
+/// Contract: a serialization failure while committing an exclusive PostgreSQL
+/// transaction closes that transaction and returns ReadyForQuery(I), for both
+/// the simple and extended protocols, so the same connection is immediately
+/// reusable.
+///
+/// Actors: alice and bob conflict through raw simple-query connections; carol
+/// and dave repeat the conflict through prepared/extended execution.
+///
+/// ```text
+/// alice/carol --BEGIN/update----> same snapshot
+/// bob/dave   --BEGIN/update----> same snapshot
+/// alice/carol --COMMIT---------> accepted
+/// bob/dave   --COMMIT---------> 40001 + ReadyForQuery(I) --SELECT 1--> healthy
+/// ```
+#[tokio::test(flavor = "current_thread")]
+async fn postgres_commit_conflicts_return_connections_to_idle() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let data_dir = tempfile::tempdir().expect("temporary conflict data dir");
+            let app_id = jazz::tools::AppId::random();
+            let server = JazzServer::builder()
+                .with_app_id(app_id)
+                .with_schema(documents_schema())
+                .with_data_dir(data_dir.path())
+                .with_postgres_port(0)
+                .with_persistent_storage()
+                .start()
+                .await;
+            let url = server.postgres_url().expect("PostgreSQL URL");
+            let row_id = uuid::Uuid::parse_str("00000000-0000-4000-8000-0000000000c1")
+                .expect("conflict row UUID");
+            let (seed, seed_connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect conflict seed writer");
+            let seed_connection_task = tokio::spawn(async move {
+                seed_connection
+                    .await
+                    .expect("conflict seed connection remains healthy")
+            });
+            seed.execute(
+                "INSERT INTO documents (id, team_id, title, created_at) \
+                 VALUES ($1, $2, $3, $4)",
+                &[&row_id, &"team-conflict", &"base", &1_i64],
+            )
+            .await
+            .expect("seed the row used by both conflict canaries");
+
+            let database = server.app_id().to_string();
+            let port = server.postgres_port().expect("PostgreSQL conflict port");
+            let mut alice =
+                raw_authenticated_postgres_socket(port, &database, JazzServer::POSTGRES_SECRET)
+                    .await;
+            let mut bob =
+                raw_authenticated_postgres_socket(port, &database, JazzServer::POSTGRES_SECRET)
+                    .await;
+            assert_eq!(
+                ready_status(&raw_simple_query(&mut alice, "BEGIN").await),
+                Some(b'T')
+            );
+            assert_eq!(
+                ready_status(&raw_simple_query(&mut bob, "BEGIN").await),
+                Some(b'T')
+            );
+            assert_eq!(
+                command_tags(
+                    &raw_simple_query(
+                        &mut alice,
+                        &format!("UPDATE documents SET title = 'alice' WHERE id = '{row_id}'"),
+                    )
+                    .await,
+                ),
+                ["UPDATE 1"]
+            );
+            assert_eq!(
+                command_tags(
+                    &raw_simple_query(
+                        &mut bob,
+                        &format!("UPDATE documents SET title = 'bob' WHERE id = '{row_id}'"),
+                    )
+                    .await,
+                ),
+                ["UPDATE 1"]
+            );
+            let alice_commit = raw_simple_query(&mut alice, "COMMIT").await;
+            assert_eq!(command_tags(&alice_commit), ["COMMIT"]);
+            assert_eq!(ready_status(&alice_commit), Some(b'I'));
+            let bob_conflict = raw_simple_query(&mut bob, "COMMIT").await;
+            assert_eq!(
+                first_error_sqlstate(&bob_conflict).as_deref(),
+                Some("40001")
+            );
+            assert_eq!(ready_status(&bob_conflict), Some(b'I'));
+            let bob_health = raw_simple_query(&mut bob, "SELECT 1").await;
+            assert_eq!(first_data_row_text(&bob_health), Some("1"));
+            assert_eq!(ready_status(&bob_health), Some(b'I'));
+            drop(alice);
+            drop(bob);
+
+            let (carol, carol_connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect extended-protocol winner");
+            let carol_connection_task = tokio::spawn(async move {
+                carol_connection
+                    .await
+                    .expect("extended-protocol winner remains healthy")
+            });
+            let (dave, dave_connection) = tokio_postgres::connect(&url, NoTls)
+                .await
+                .expect("connect extended-protocol loser");
+            let dave_connection_task = tokio::spawn(async move {
+                dave_connection
+                    .await
+                    .expect("extended-protocol loser remains healthy")
+            });
+            carol
+                .execute("BEGIN", &[])
+                .await
+                .expect("begin extended winner transaction");
+            dave.execute("BEGIN", &[])
+                .await
+                .expect("begin extended loser transaction");
+            carol
+                .execute(
+                    "UPDATE documents SET title = $1 WHERE id = $2",
+                    &[&"carol", &row_id],
+                )
+                .await
+                .expect("stage extended winner update");
+            dave.execute(
+                "UPDATE documents SET title = $1 WHERE id = $2",
+                &[&"dave", &row_id],
+            )
+            .await
+            .expect("stage extended loser update");
+            carol
+                .execute("COMMIT", &[])
+                .await
+                .expect("commit extended winner");
+            let dave_conflict = dave
+                .execute("COMMIT", &[])
+                .await
+                .expect_err("second extended commit conflicts");
+            assert_eq!(dave_conflict.code().map(|code| code.code()), Some("40001"));
+            assert_eq!(
+                dave.query_one("SELECT 1", &[])
+                    .await
+                    .expect("extended loser connection immediately returns to idle")
+                    .get::<_, i32>(0),
+                1
+            );
+
+            drop(dave);
+            dave_connection_task
+                .await
+                .expect("join extended loser connection");
+            drop(carol);
+            carol_connection_task
+                .await
+                .expect("join extended winner connection");
+            drop(seed);
+            seed_connection_task
+                .await
+                .expect("join conflict seed connection");
             server.shutdown().await;
         })
         .await;
@@ -1132,6 +2336,11 @@ impl Drop for ChildGuard {
 }
 
 async fn raw_extended_protocol_lifecycle(port: u16, database: &str, password: &str) {
+    let mut socket = raw_authenticated_postgres_socket(port, database, password).await;
+    raw_extended_protocol_lifecycle_body(&mut socket).await;
+}
+
+async fn raw_authenticated_postgres_socket(port: u16, database: &str, password: &str) -> TcpStream {
     let mut socket = TcpStream::connect(("127.0.0.1", port))
         .await
         .expect("connect raw PostgreSQL client");
@@ -1165,22 +2374,38 @@ async fn raw_extended_protocol_lifecycle(port: u16, database: &str, password: &s
         }
     }
 
+    socket
+}
+
+async fn raw_extended_protocol_lifecycle_body(mut socket: &mut TcpStream) {
     let returning_sql = "INSERT INTO documents (id, team_id, title, created_at) \
                          VALUES ('00000000-0000-4000-8000-0000000000b1', \
-                         'team-wire', 'returning-wire', 301) RETURNING id";
+                         'team-wire', 'returning-wire-one', 301), \
+                         ('00000000-0000-4000-8000-0000000000b2', \
+                         'team-wire', 'returning-wire-two', 302) RETURNING id";
     let mut returning_query = Vec::new();
     push_c_string(&mut returning_query, returning_sql);
     write_frontend_frame(&mut socket, b'Q', &returning_query).await;
     let returning_messages = read_until_ready(&mut socket).await;
     assert_eq!(
         command_tags(&returning_messages),
-        ["INSERT 0 1"],
+        ["INSERT 0 2"],
         "INSERT RETURNING must emit a valid PostgreSQL command tag"
+    );
+    assert_eq!(
+        returning_messages
+            .iter()
+            .filter(|(tag, _)| *tag == b'D')
+            .count(),
+        2,
+        "multi-row INSERT RETURNING emits one DataRow per VALUES row"
     );
 
     let mutation_sql = "INSERT INTO documents (id, team_id, title, created_at) \
-                        VALUES ('00000000-0000-4000-8000-0000000000b2', \
-                        'team-wire', 'execute-once-wire', 302)";
+                        VALUES ('00000000-0000-4000-8000-0000000000b3', \
+                        'team-wire', 'execute-once-wire-one', 303), \
+                        ('00000000-0000-4000-8000-0000000000b4', \
+                        'team-wire', 'execute-once-wire-two', 304)";
     let mut mutation_parse = Vec::new();
     push_c_string(&mut mutation_parse, "mutation_once");
     push_c_string(&mut mutation_parse, mutation_sql);
@@ -1200,11 +2425,49 @@ async fn raw_extended_protocol_lifecycle(port: u16, database: &str, password: &s
     write_frontend_frame(&mut socket, b'E', &mutation_execute).await;
     write_frontend_frame(&mut socket, b'S', &[]).await;
     let mutation_messages = read_until_ready(&mut socket).await;
-    assert_eq!(command_tags(&mutation_messages), ["INSERT 0 1"]);
+    assert_eq!(command_tags(&mutation_messages), ["INSERT 0 2"]);
     assert_eq!(
         first_error_sqlstate(&mutation_messages).as_deref(),
         Some("26000"),
         "a completed mutation portal must not execute its DML twice"
+    );
+
+    let begun = raw_simple_query(&mut socket, "BEGIN").await;
+    assert_eq!(command_tags(&begun), ["BEGIN"]);
+    assert_eq!(ready_status(&begun), Some(b'T'));
+    let staged = raw_simple_query(
+        &mut socket,
+        "INSERT INTO documents (id, team_id, title, created_at) VALUES \
+         ('00000000-0000-4000-8000-0000000000c1', 'team-wire-failed', 'one', 401), \
+         ('00000000-0000-4000-8000-0000000000c2', 'team-wire-failed', 'two', 402)",
+    )
+    .await;
+    assert_eq!(command_tags(&staged), ["INSERT 0 2"]);
+    assert_eq!(ready_status(&staged), Some(b'T'));
+    let failed = raw_simple_query(
+        &mut socket,
+        "INSERT INTO documents (id, team_id, title, created_at) VALUES \
+         ('00000000-0000-4000-8000-0000000000c1', 'team-wire-failed', 'duplicate', 403)",
+    )
+    .await;
+    assert_eq!(first_error_sqlstate(&failed).as_deref(), Some("23505"));
+    assert_eq!(ready_status(&failed), Some(b'E'));
+    let rolled_back = raw_simple_query(&mut socket, "COMMIT").await;
+    assert_eq!(
+        command_tags(&rolled_back),
+        ["ROLLBACK"],
+        "COMMIT in an aborted transaction reports PostgreSQL rollback"
+    );
+    assert_eq!(ready_status(&rolled_back), Some(b'I'));
+    let discarded = raw_simple_query(
+        &mut socket,
+        "SELECT id FROM documents WHERE team_id = 'team-wire-failed' LIMIT 10",
+    )
+    .await;
+    assert_eq!(
+        discarded.iter().filter(|(tag, _)| *tag == b'D').count(),
+        0,
+        "a failed transaction does not partially publish staged rows"
     );
 
     let mut parse = Vec::new();
@@ -1328,6 +2591,13 @@ async fn raw_extended_protocol_lifecycle(port: u16, database: &str, password: &s
     );
 }
 
+async fn raw_simple_query(socket: &mut TcpStream, sql: &str) -> Vec<(u8, Vec<u8>)> {
+    let mut query = Vec::new();
+    push_c_string(&mut query, sql);
+    write_frontend_frame(socket, b'Q', &query).await;
+    read_until_ready(socket).await
+}
+
 fn push_c_string(target: &mut Vec<u8>, value: &str) {
     target.extend_from_slice(value.as_bytes());
     target.push(0);
@@ -1397,6 +2667,13 @@ fn command_tags(messages: &[(u8, Vec<u8>)]) -> Vec<&str> {
             std::str::from_utf8(&payload[..end]).expect("PostgreSQL command tag is UTF-8")
         })
         .collect()
+}
+
+fn ready_status(messages: &[(u8, Vec<u8>)]) -> Option<u8> {
+    messages
+        .iter()
+        .find(|(tag, _)| *tag == b'Z')
+        .and_then(|(_, payload)| payload.first().copied())
 }
 
 fn first_error_sqlstate(messages: &[(u8, Vec<u8>)]) -> Option<String> {


### PR DESCRIPTION
## What changed

- Adds the PostgreSQL wire interface and catalogue-backed reads.
- Adds PostgreSQL INSERT, UPDATE, and DELETE support on the server-default RocksDB path.
- Supports atomic multi-row INSERT statements with ordered RETURNING results.
- Supports UPDATE predicates through the existing query/filter grammar instead of requiring an exact row ID.
- Implements per-connection BEGIN, COMMIT, and ROLLBACK with snapshot reads, read-your-writes, rollback-on-disconnect, and SQLSTATE 40001 conflict reporting.
- Settles each statement or explicit transaction once and refreshes subscriptions once.
- Preserves Text and Blob values through transactions, partial updates, and RocksDB restarts.
- Fixes shared Groove anti/semi-join transition state so multiple consumers all observe threshold crossings.

## Why

The PostgreSQL adapter was read-only and then limited to one-row autocommit mutations. Standard SaaS workloads need atomic imports, filtered updates, ORM-style transactions, and durable read-your-writes behavior without paying one global settle and subscription refresh per row.

The Groove fix addresses a correctness issue exposed by the transaction coverage: shared arrangements consumed old threshold state destructively, so later anti/semi-join consumers could miss the same transition.

## Impact

A multi-row statement or explicit transaction now stages its writes and crosses the global commit/subscription boundary once. Applications can use ordinary PostgreSQL transaction control and non-ID update filters while retaining Jazz conflict detection and RocksDB durability.

Current safety bounds are 1,000 affected operations and 1 MiB of authored payload per transaction.

## Validation

- `cargo test -p jazz`
- `cargo test -p jazz --no-default-features --features test`
- `cargo test -p groove`
- PostgreSQL integration suite: 10/10
- `cargo check -p jazz-sim --benches`
- 300-seed maintained-vs-one-shot differential oracle
- Exact incremental-delivery canary
- All 15 storage/engine smoke benchmark scenarios
- rustfmt, Clippy, and diff hygiene checks

## Known gaps

COPY, ON CONFLICT, update expressions such as `count = count + 1`, and predicate-based DELETE remain unsupported. PostgreSQL access to nullable large-value columns currently returns `0A000` explicitly.