### PR TITLE
(new core) fix completed exclusive view fragment indexing

### DIFF
--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -690,6 +690,137 @@ fn receiver_batch_coalesces_partial_bundles_for_same_tx() {
     assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);
 }
 
+// This stays internal because it directly exercises the protocol receiver's
+// single-message fragment assembly boundary.
+#[test]
+fn sequential_partial_exclusive_bundles_index_the_complete_transaction() {
+    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let tx_id = TxId::new(TxTime::from(10), node(1));
+    let tx = Transaction {
+        tx_id,
+        kind: TxKind::Exclusive,
+        n_total_writes: 2,
+        made_by: AuthorId::SYSTEM,
+        permission_subject: None,
+        base_snapshot: None,
+        row_read_set: None,
+        absent_read_set: None,
+        predicate_read_set: None,
+        user_metadata_json: None,
+        source_branch: None,
+        merge_strategy: None,
+    };
+    let updates = [
+        (row(1), version_record(row(1), Vec::new(), title_cells("one"), None)),
+        (row(2), version_record(row(2), Vec::new(), title_cells("two"), None)),
+    ];
+
+    for (row_uuid, version) in updates {
+        reader
+            .apply_view_update(partial_exclusive_view_update(
+                subscription,
+                tx.clone(),
+                row_uuid,
+                version,
+            ))
+            .unwrap();
+    }
+
+    assert_eq!(
+        reader
+            .current_rows("todos", DurabilityTier::Global)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row(1), title_cells("one")), (row(2), title_cells("two"))])
+    );
+}
+
+#[test]
+fn completing_partial_exclusive_transaction_rejects_conflicting_metadata() {
+    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let tx_id = TxId::new(TxTime::from(10), node(1));
+    let tx = Transaction {
+        tx_id,
+        kind: TxKind::Exclusive,
+        n_total_writes: 2,
+        made_by: AuthorId::SYSTEM,
+        permission_subject: None,
+        base_snapshot: None,
+        row_read_set: None,
+        absent_read_set: None,
+        predicate_read_set: None,
+        user_metadata_json: None,
+        source_branch: None,
+        merge_strategy: None,
+    };
+    reader
+        .apply_view_update(partial_exclusive_view_update(
+            subscription,
+            tx.clone(),
+            row(1),
+            version_record(row(1), Vec::new(), title_cells("one"), None),
+        ))
+        .unwrap();
+
+    let mut conflicting_tx = tx;
+    conflicting_tx.made_by = AuthorId::from_bytes([0xa1; 16]);
+    assert!(matches!(
+        reader.apply_view_update(partial_exclusive_view_update(
+            subscription,
+            conflicting_tx,
+            row(2),
+            version_record(row(2), Vec::new(), title_cells("two"), None),
+        )),
+        Err(Error::ConflictingCommitUnit(conflicting)) if conflicting == tx_id
+    ));
+    assert_eq!(
+        reader.query_versions_for_tx(tx_id).unwrap().len(),
+        1,
+        "the conflicting completing fragment must not be stored"
+    );
+    assert_eq!(
+        reader.query_transaction(tx_id).unwrap().unwrap().tx.made_by,
+        AuthorId::SYSTEM,
+        "the original transaction metadata must remain authoritative"
+    );
+}
+
+fn partial_exclusive_view_update(
+    subscription: SubscriptionKey,
+    tx: Transaction,
+    row_uuid: RowUuid,
+    version: VersionRecord,
+) -> ViewUpdateParts {
+    let tx_id = tx.tx_id;
+    ViewUpdateParts {
+        subscription,
+        settled_through: GlobalSeq(1),
+        defer_settlement: false,
+        reset_result_set: false,
+        version_carriers: Vec::new(),
+        version_bundles: vec![VersionBundle {
+            tx,
+            versions: vec![version],
+            fate: Fate::Accepted,
+            global_seq: Some(GlobalSeq(1)),
+            durability: DurabilityTier::Global,
+        }],
+        peer_complete_tx_payload_refs: Vec::new(),
+        result_member_adds: vec![ResultMemberEntry::row((
+            "todos".to_owned().into(),
+            row_uuid,
+            tx_id,
+        ))],
+        result_member_removes: Vec::new(),
+        program_fact_adds: Vec::new(),
+        program_fact_removes: Vec::new(),
+    }
+}
+
 #[test]
 fn receiver_batch_resolves_current_winner_across_bundles() {
     let (_writer_dir, mut writer) = open_node_with_uuid(node(1));

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1062,6 +1062,11 @@ where
                 bundle.durability,
             )?;
             if matches!(bundle.fate, Fate::Accepted) {
+                // Ingesting only the previously missing versions replaces the
+                // transaction-version cache with that subset. Reload the full
+                // assembled transaction before applying its fate so every
+                // earlier fragment receives a current index.
+                self.invalidate_tx_version_tables_cache(tx_id);
                 self.apply_fate_update(
                     tx_id,
                     bundle.fate,


### PR DESCRIPTION
## What changed

- invalidate the partial transaction-version cache when the final fragment of an exclusive transaction arrives
- reload the complete stored transaction before building its current indexes
- add a regression test for an exclusive transaction delivered across sequential view-update messages
- preserve rejection of conflicting transaction metadata on the completing fragment

## Why

Earlier fragments of an incomplete exclusive transaction are deliberately stored without current indexes. When the final fragment arrived, ingesting only the missing versions replaced the transaction-version cache with that subset. The subsequent fate update therefore rebuilt current indexes from only the final fragment, so an observer could retain stale current rows. The fix invalidates that subset cache after the normal known-transaction validation path, forcing the fate update to reload every stored version.

## Impact

Clients receiving a multi-row exclusive transaction across separate messages now expose the complete accepted transaction in current state rather than only the final fragment.

## Validation

- `cargo test -p jazz partial_exclusive`
- repository pre-commit checks: Clippy, sensitive-data scan, and rustfmt
