### PR TITLE
(new core) bench: gate S4 propagation by fixed delta

### DIFF
--- a/crates/jazz-sim/benches/s4_order_processing.rs
+++ b/crates/jazz-sim/benches/s4_order_processing.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::future::Future;
 use std::pin::pin;
 use std::rc::Rc;
@@ -12,7 +12,7 @@ use jazz::groove::records::Value;
 use jazz::groove::schema::{ColumnSchema, ColumnType};
 use jazz::groove::storage::{Durability, RocksDbStorage};
 use jazz::ids::{AuthorId, NodeUuid, RowUuid};
-use jazz::node::{MergeableCommit, NodeState};
+use jazz::node::{CurrentRow, MergeableCommit, NodeState};
 use jazz::peer::PeerState;
 use jazz::protocol::{SyncMessage, expand_version_carriers};
 use jazz::schema::{JazzSchema, TableSchema};
@@ -1173,6 +1173,8 @@ struct PropagationWork {
     program_fact_removes: usize,
     version_bundles: usize,
     version_records: usize,
+    result_add_rows: BTreeSet<(String, RowUuid)>,
+    result_remove_rows: BTreeSet<(String, RowUuid)>,
 }
 
 impl PropagationWork {
@@ -1194,6 +1196,16 @@ impl PropagationWork {
         };
         self.result_adds += result_member_adds.len();
         self.result_removes += result_member_removes.len();
+        self.result_add_rows
+            .extend(result_member_adds.iter().map(|member| {
+                let (table, row, _) = member.as_row().expect("S4 result add is a real row");
+                (table.as_str().to_owned(), row)
+            }));
+        self.result_remove_rows
+            .extend(result_member_removes.iter().map(|member| {
+                let (table, row, _) = member.as_row().expect("S4 result removal is a real row");
+                (table.as_str().to_owned(), row)
+            }));
         self.program_fact_adds += program_fact_adds.len();
         self.program_fact_removes += program_fact_removes.len();
         let expanded_carriers =
@@ -1228,12 +1240,41 @@ impl PropagationWork {
             self.version_records, expected.version_records,
             "{hop} version records"
         );
+        assert_eq!(
+            self.result_add_rows, expected.result_add_rows,
+            "{hop} added row identities"
+        );
+        assert_eq!(
+            self.result_remove_rows, expected.result_remove_rows,
+            "{hop} removed row identities"
+        );
         assert!(
             self.wire_bytes.abs_diff(expected.wire_bytes)
                 <= MAX_SETTLED_THROUGH_FRAMING_DELTA_PER_HOP,
             "{hop} wire bytes exceeded the fixed settled-through framing allowance: actual={}, expected={}",
             self.wire_bytes,
             expected.wire_bytes
+        );
+    }
+
+    fn assert_payment_delta(&self, hop: &str) {
+        let replaced_rows = BTreeSet::from([
+            (WAREHOUSES.to_owned(), warehouse_row(0)),
+            (DISTRICTS.to_owned(), district_row(0, 0)),
+            (CUSTOMERS.to_owned(), customer_row(0, 0, 0)),
+        ]);
+        let mut added_rows = replaced_rows.clone();
+        added_rows.insert((PAYMENTS.to_owned(), payment_row(0, 0, 0, 10_000)));
+        assert_eq!(self.result_adds, 4, "{hop} Payment result adds");
+        assert_eq!(self.result_removes, 3, "{hop} Payment result removes");
+        assert_eq!(self.program_fact_adds, 0, "{hop} Payment fact adds");
+        assert_eq!(self.program_fact_removes, 0, "{hop} Payment fact removes");
+        assert_eq!(self.version_bundles, 4, "{hop} Payment version bundles");
+        assert_eq!(self.version_records, 10, "{hop} Payment version records");
+        assert_eq!(self.result_add_rows, added_rows, "{hop} Payment added rows");
+        assert_eq!(
+            self.result_remove_rows, replaced_rows,
+            "{hop} Payment removed rows"
         );
     }
 }
@@ -1249,6 +1290,11 @@ struct PropagationSignature {
 }
 
 impl PropagationSignature {
+    fn assert_payment_delta(&self) {
+        self.core_to_edge.assert_payment_delta("core-to-edge");
+        self.edge_to_client.assert_payment_delta("edge-to-client");
+    }
+
     fn assert_delta_bounded(&self, expected: &Self) {
         self.core_to_edge
             .assert_delta_bounded(&expected.core_to_edge, "core-to-edge");
@@ -1325,7 +1371,7 @@ fn run_fixed_delta_scaling(customer_rungs: &[usize]) {
         let schema = schema();
         let (_core_dir, mut core) = open_node(node(250), schema.clone());
         seed_jazz_fixture(&config, &mut core);
-        let mut clients = open_clients(1, 20, &schema, &mut core);
+        let mut clients = open_clients(2, 20, &schema, &mut core);
         let mut edge_acceptance = Histogram::new(3).unwrap();
         let op = Op::Payment {
             warehouse: 0,
@@ -1345,8 +1391,10 @@ fn run_fixed_delta_scaling(customer_rungs: &[usize]) {
         );
 
         let started = Instant::now();
-        let signature = propagate_client(&mut core, &mut clients[0]);
+        let signature = propagate_client(&mut core, &mut clients[1]);
         let wall_us = started.elapsed().as_micros();
+        assert_observer_payment(&clients[1].db, &schema);
+        signature.assert_payment_delta();
         let view_rows = customers + 5;
         assert_eq!(
             TABLES
@@ -1405,6 +1453,44 @@ fn run_fixed_delta_scaling(customer_rungs: &[usize]) {
             &JsonValue::Object(fields).to_string(),
         );
     }
+}
+
+fn assert_observer_payment(db: &Db<RocksDbStorage>, schema: &JazzSchema) {
+    let warehouse = observer_row(db, WAREHOUSES, warehouse_row(0));
+    assert_eq!(
+        warehouse.cell(table_schema(schema, WAREHOUSES), "ytd"),
+        Some(Value::F64(1.0))
+    );
+    let district = observer_row(db, DISTRICTS, district_row(0, 0));
+    assert_eq!(
+        district.cell(table_schema(schema, DISTRICTS), "ytd"),
+        Some(Value::F64(1.0))
+    );
+    let customer = observer_row(db, CUSTOMERS, customer_row(0, 0, 0));
+    assert_eq!(
+        customer.cell(table_schema(schema, CUSTOMERS), "balance"),
+        Some(Value::F64(-1.0))
+    );
+    assert_eq!(
+        customer.cell(table_schema(schema, CUSTOMERS), "paymentCount"),
+        Some(Value::U64(1))
+    );
+    let payment = observer_row(db, PAYMENTS, payment_row(0, 0, 0, 10_000));
+    assert_eq!(
+        payment.cell(table_schema(schema, PAYMENTS), "amount"),
+        Some(Value::F64(1.0))
+    );
+}
+
+fn observer_row(db: &Db<RocksDbStorage>, table: &str, row: RowUuid) -> CurrentRow {
+    let prepared = db
+        .prepare_query(&db.table(table))
+        .unwrap_or_else(|error| panic!("prepare observer {table} query failed: {error}"));
+    db.read(&prepared)
+        .unwrap_or_else(|error| panic!("read observer {table} query failed: {error}"))
+        .into_iter()
+        .find(|candidate| candidate.row_uuid() == row)
+        .unwrap_or_else(|| panic!("observer is missing {table} row {row:?}"))
 }
 
 fn insert_propagation_work(

--- a/crates/jazz-sim/benches/s4_order_processing.rs
+++ b/crates/jazz-sim/benches/s4_order_processing.rs
@@ -14,11 +14,11 @@ use jazz::groove::storage::{Durability, RocksDbStorage};
 use jazz::ids::{AuthorId, NodeUuid, RowUuid};
 use jazz::node::{MergeableCommit, NodeState};
 use jazz::peer::PeerState;
-use jazz::protocol::SyncMessage;
+use jazz::protocol::{SyncMessage, expand_version_carriers};
 use jazz::schema::{JazzSchema, TableSchema};
 use jazz::time::GlobalSeq;
 use jazz::tx::{DurabilityTier, Fate};
-use jazz::wire::TransportError;
+use jazz::wire::{TransportError, encode_sync_message};
 use jazz_sim::{PeerProfile, bench_profile, emit_json_line, metadata_fields, profiling};
 use rusqlite::{Connection, params};
 use serde_json::{Value as JsonValue, json};
@@ -41,8 +41,14 @@ const TABLES: [&str; 8] = [
     ORDER_LINES,
     PAYMENTS,
 ];
+// A postcard u64 can grow from one to ten bytes in each view-update envelope.
+const MAX_SETTLED_THROUGH_FRAMING_DELTA_PER_HOP: u64 = TABLES.len() as u64 * 9;
 
 fn main() {
+    if std::env::var("JAZZ_S4_PROPAGATION_SCALE_ONLY").is_ok() {
+        run_fixed_delta_scaling(&fixed_delta_rungs());
+        return;
+    }
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;
@@ -311,6 +317,21 @@ pub fn smoke() {
         &hot_items.accepted_schedule,
         &hot_items.final_totals,
     );
+    run_fixed_delta_scaling(&[2, 20, 200]);
+}
+
+fn fixed_delta_rungs() -> Vec<usize> {
+    std::env::var("JAZZ_S4_PROPAGATION_CUSTOMERS")
+        .unwrap_or_else(|_| "10,1000,10000".to_owned())
+        .split(',')
+        .map(|value| {
+            value
+                .trim()
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("invalid JAZZ_S4_PROPAGATION_CUSTOMERS: {value}"))
+                .max(1)
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug)]
@@ -1141,6 +1162,278 @@ fn refresh_client(core: &mut NodeState<RocksDbStorage>, client: &mut ClientHarne
         client.inbound.borrow_mut().push_back(update);
     }
     client.db.tick().unwrap();
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct PropagationWork {
+    wire_bytes: u64,
+    result_adds: usize,
+    result_removes: usize,
+    program_fact_adds: usize,
+    program_fact_removes: usize,
+    version_bundles: usize,
+    version_records: usize,
+}
+
+impl PropagationWork {
+    fn record(&mut self, update: &SyncMessage) {
+        self.wire_bytes += encode_sync_message(update)
+            .expect("encode S4 view update")
+            .len() as u64;
+        let SyncMessage::ViewUpdate {
+            version_carriers,
+            version_bundles,
+            result_member_adds,
+            result_member_removes,
+            program_fact_adds,
+            program_fact_removes,
+            ..
+        } = update
+        else {
+            panic!("S4 propagation must emit a view update");
+        };
+        self.result_adds += result_member_adds.len();
+        self.result_removes += result_member_removes.len();
+        self.program_fact_adds += program_fact_adds.len();
+        self.program_fact_removes += program_fact_removes.len();
+        let expanded_carriers =
+            expand_version_carriers(version_carriers).expect("expand S4 version carriers");
+        self.version_bundles += version_bundles.len() + expanded_carriers.len();
+        self.version_records += version_bundles
+            .iter()
+            .chain(expanded_carriers.iter())
+            .map(|bundle| bundle.versions.len())
+            .sum::<usize>();
+    }
+
+    fn assert_delta_bounded(&self, expected: &Self, hop: &str) {
+        assert_eq!(self.result_adds, expected.result_adds, "{hop} result adds");
+        assert_eq!(
+            self.result_removes, expected.result_removes,
+            "{hop} result removes"
+        );
+        assert_eq!(
+            self.program_fact_adds, expected.program_fact_adds,
+            "{hop} program fact adds"
+        );
+        assert_eq!(
+            self.program_fact_removes, expected.program_fact_removes,
+            "{hop} program fact removes"
+        );
+        assert_eq!(
+            self.version_bundles, expected.version_bundles,
+            "{hop} version bundles"
+        );
+        assert_eq!(
+            self.version_records, expected.version_records,
+            "{hop} version records"
+        );
+        assert!(
+            self.wire_bytes.abs_diff(expected.wire_bytes)
+                <= MAX_SETTLED_THROUGH_FRAMING_DELTA_PER_HOP,
+            "{hop} wire bytes exceeded the fixed settled-through framing allowance: actual={}, expected={}",
+            self.wire_bytes,
+            expected.wire_bytes
+        );
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct PropagationSignature {
+    core_to_edge: PropagationWork,
+    edge_to_client: PropagationWork,
+    core_reads: usize,
+    core_ranges: usize,
+    edge_reads: usize,
+    edge_ranges: usize,
+}
+
+impl PropagationSignature {
+    fn assert_delta_bounded(&self, expected: &Self) {
+        self.core_to_edge
+            .assert_delta_bounded(&expected.core_to_edge, "core-to-edge");
+        self.edge_to_client
+            .assert_delta_bounded(&expected.edge_to_client, "edge-to-client");
+        assert_eq!(self.core_reads, expected.core_reads, "core storage reads");
+        assert_eq!(
+            self.core_ranges, expected.core_ranges,
+            "core storage ranges"
+        );
+        assert_eq!(self.edge_reads, expected.edge_reads, "edge storage reads");
+        assert_eq!(
+            self.edge_ranges, expected.edge_ranges,
+            "edge storage ranges"
+        );
+    }
+}
+
+fn propagate_client(
+    core: &mut NodeState<RocksDbStorage>,
+    client: &mut ClientHarness,
+) -> PropagationSignature {
+    let mut signature = PropagationSignature::default();
+    core.reset_storage_read_metrics();
+    client.edge.reset_storage_read_metrics();
+    for table in TABLES {
+        let update = client.edge_peer.current_rows_update(core, table).unwrap();
+        client.hydration_bytes += view_update_bytes(&update);
+        client.hydration_rows += result_row_count(&update);
+        signature.core_to_edge.record(&update);
+        client.edge.apply_sync_message(update).unwrap();
+    }
+    for table in TABLES {
+        let update = client
+            .client_peer
+            .current_rows_update(&mut client.edge, table)
+            .unwrap();
+        signature.edge_to_client.record(&update);
+        client.inbound.borrow_mut().push_back(update);
+    }
+    client.db.tick().unwrap();
+    let core_reads = core.storage_read_metrics();
+    let edge_reads = client.edge.storage_read_metrics();
+    signature.core_reads = core_reads.total.reads;
+    signature.core_ranges = core_reads.total.ranges;
+    signature.edge_reads = edge_reads.total.reads;
+    signature.edge_ranges = edge_reads.total.ranges;
+    signature
+}
+
+fn run_fixed_delta_scaling(customer_rungs: &[usize]) {
+    assert!(
+        !customer_rungs.is_empty(),
+        "S4 propagation ladder is non-empty"
+    );
+    let mut expected_signature = None;
+    for &customers in customer_rungs {
+        let config = Config {
+            seed: 0x5400_0001,
+            profile: "s4-fixed-delta".to_owned(),
+            warehouses: 1,
+            districts_per_warehouse: 1,
+            customers_per_district: customers,
+            items: 1,
+            clients: 1,
+            throughput_commits: 1,
+            slo_commits: 1,
+            order_lines: 1,
+            new_order_pct: 0,
+            delivery_pct: 0,
+            stock_level_pct: 0,
+            per_warehouse_rate: 1,
+        };
+        let schema = schema();
+        let (_core_dir, mut core) = open_node(node(250), schema.clone());
+        seed_jazz_fixture(&config, &mut core);
+        let mut clients = open_clients(1, 20, &schema, &mut core);
+        let mut edge_acceptance = Histogram::new(3).unwrap();
+        let op = Op::Payment {
+            warehouse: 0,
+            district: 0,
+            customer: 0,
+            amount: 1.0,
+        };
+        assert!(
+            apply_jazz_op(
+                &mut clients[0],
+                &mut core,
+                &op,
+                10_000,
+                &mut edge_acceptance,
+            )
+            .expect("apply fixed S4 payment")
+        );
+
+        let started = Instant::now();
+        let signature = propagate_client(&mut core, &mut clients[0]);
+        let wall_us = started.elapsed().as_micros();
+        let view_rows = customers + 5;
+        assert_eq!(
+            TABLES
+                .iter()
+                .map(|table| {
+                    core.current_rows(table, DurabilityTier::Global)
+                        .expect("read S4 gate current rows")
+                        .len()
+                })
+                .sum::<usize>(),
+            view_rows
+        );
+        assert_sqlite_replay_matches(
+            &config,
+            std::slice::from_ref(&op),
+            &jazz_totals(&config, &schema, &mut core),
+        );
+        if let Some(expected) = &expected_signature {
+            signature.assert_delta_bounded(expected);
+        } else {
+            expected_signature = Some(signature.clone());
+        }
+
+        let mut fields = metadata_fields(
+            "s4_order_processing",
+            "synchronous",
+            config.seed,
+            &config.profile,
+        );
+        fields.insert("phase".to_owned(), json!("fixed_delta_propagation_scaling"));
+        fields.insert("customers".to_owned(), json!(customers));
+        fields.insert("view_rows".to_owned(), json!(view_rows));
+        fields.insert("changed_rows".to_owned(), json!(4));
+        fields.insert("fixed_delta_op".to_owned(), json!("payment"));
+        fields.insert(
+            "wire_byte_allowance_per_hop".to_owned(),
+            json!(MAX_SETTLED_THROUGH_FRAMING_DELTA_PER_HOP),
+        );
+        fields.insert("wall_us".to_owned(), json!(wall_us));
+        insert_propagation_work(&mut fields, "core_to_edge", &signature.core_to_edge);
+        insert_propagation_work(&mut fields, "edge_to_client", &signature.edge_to_client);
+        fields.insert("core_storage_reads".to_owned(), json!(signature.core_reads));
+        fields.insert(
+            "core_storage_ranges".to_owned(),
+            json!(signature.core_ranges),
+        );
+        fields.insert("edge_storage_reads".to_owned(), json!(signature.edge_reads));
+        fields.insert(
+            "edge_storage_ranges".to_owned(),
+            json!(signature.edge_ranges),
+        );
+        fields.insert("same_schedule_replay".to_owned(), json!("matched"));
+        fields.insert("structural_gate".to_owned(), json!("delta_bounded"));
+        emit_json_line(
+            "s4_order_processing",
+            &JsonValue::Object(fields).to_string(),
+        );
+    }
+}
+
+fn insert_propagation_work(
+    fields: &mut serde_json::Map<String, JsonValue>,
+    prefix: &str,
+    work: &PropagationWork,
+) {
+    fields.insert(format!("{prefix}_wire_bytes"), json!(work.wire_bytes));
+    fields.insert(format!("{prefix}_result_adds"), json!(work.result_adds));
+    fields.insert(
+        format!("{prefix}_result_removes"),
+        json!(work.result_removes),
+    );
+    fields.insert(
+        format!("{prefix}_program_fact_adds"),
+        json!(work.program_fact_adds),
+    );
+    fields.insert(
+        format!("{prefix}_program_fact_removes"),
+        json!(work.program_fact_removes),
+    );
+    fields.insert(
+        format!("{prefix}_version_bundles"),
+        json!(work.version_bundles),
+    );
+    fields.insert(
+        format!("{prefix}_version_records"),
+        json!(work.version_records),
+    );
 }
 
 fn seed_jazz_fixture(config: &Config, core: &mut NodeState<RocksDbStorage>) {

--- a/dev/benchmarks/OVERVIEW.md
+++ b/dev/benchmarks/OVERVIEW.md
@@ -123,6 +123,11 @@ latency numbers. #1224 adds B7 for public relation-result hydration coverage.
    Exact result equality is hard-gated; maintained output and storage work stay
    flat while full-rehydrate bytes and reads grow linearly. The lane also
    exposes a separate O(view) metrics-footprint refresh on the maintained path.
+8. **S4 fixed-delta propagation:** `s4_order_processing` now holds one accepted
+   four-row Payment delta fixed across increasing unrelated retained views. A
+   smoke-enforced gate requires identical reads, ranges, results, facts, and
+   bundles across both propagation hops, with only a fixed cursor-framing byte
+   allowance.
 
 ### Important negative results retained
 
@@ -147,12 +152,9 @@ Ranked by their ability to change an engineering decision:
    full-source version/replacement witness state.
 2. **PERF-5 maintained versus rehydrate.** Compare work, bytes, and retained
    state over increasing view sizes while asserting identical results.
-3. **S4 fixed-delta/varying-view gate.** S4 already separates settlement and
-   propagation; add a deterministic structural bound proving propagation stays
-   proportional to the affected delta.
-4. **S8 branch/merge/offline lifecycle.** Cover accumulated offline edits,
+3. **S8 branch/merge/offline lifecycle.** Cover accumulated offline edits,
    reconnect, merge-back, conflicts, and payload reuse end to end.
-5. **S5–S7 promised dimensions.** Add remote resume and evicted-prefix coverage
+4. **S5–S7 promised dimensions.** Add remote resume and evicted-prefix coverage
    for S5, full-history memory for S6, and native-versus-lens plus migration-wave
    costs for S7.
 
@@ -164,7 +166,7 @@ Ranked by their ability to change an engineering decision:
 | PERF-4 known-state payload dedup           | retained exact-coverage sweep with bytes, bundles, reads, and correctness digest | profile the coverage-invariant serving work only if a user-facing cost justifies it            |
 | PERF-5 maintained converges to rehydrate   | exact-result, cost, bytes, reads, and retained-state scale receipt               | optimize the O(view) metrics-footprint refresh if its measured latency warrants it             |
 | PERF-7/8 current reads are O(current rows) | R3 persisted receipts, current-row and checkpoint benches                        | retained filtered/indexed-read slope where selection is held fixed                             |
-| S4 post-acceptance propagation is O(delta) | separate settlement/propagation phases                                           | fixed-delta/varying-view structural gate                                                       |
+| S4 post-acceptance propagation is O(delta) | smoke-enforced fixed-delta/varying-view gate over both propagation hops          | profile the residual view-sized CPU bookkeeping only if its measured latency warrants it       |
 
 Targets should come from specification properties and measured deterministic
 spread, not from an arbitrary percentage around today’s laptop timing.
@@ -176,8 +178,7 @@ spread, not from an arbitrary percentage around today’s laptop timing.
    its durable-format decision has team agreement.
 2. Extract focused policy/selective-hydration receipts from #1170 rather than
    merging one omnibus benchmark investigation.
-3. Add the S4 structural gate.
-4. Build S8, then fill the remaining S5–S7 dimensions.
+3. Build S8, then fill the remaining S5–S7 dimensions.
 
 Add retention alongside each lane. A broad receipt-unification project is no
 longer a prerequisite for useful performance work.

--- a/dev/benchmarks/S4_FIXED_DELTA_SCALING.md
+++ b/dev/benchmarks/S4_FIXED_DELTA_SCALING.md
@@ -6,18 +6,22 @@ view with unrelated customer rows. The transaction changes four current rows:
 one warehouse, district, customer, and newly inserted payment.
 
 The gate primes all eight S4 table subscriptions across both core-to-edge and
-edge-to-client hops before the change. Every rung must then preserve:
+edge-to-client hops before the change. One client writes the transaction and a
+separate client observes it, so the second hop cannot pass by relying on the
+writer's local state. Every rung must then preserve:
 
 - the SQLite-reference final state;
-- exactly four result additions, three replaced-result removals, and fixed
-  version bundle and record counts on each hop;
+- exactly the four expected result additions (warehouse, district, customer,
+  and payment), the three expected replacement removals, and fixed version
+  bundle and record counts on each hop;
 - identical program-fact additions and removals; and
-- identical storage reads and ranges on each node.
+- identical storage reads and ranges on each node; and
+- the expected post-Payment values in the observer's local database.
 
-Encoded wire bytes may differ from the first rung by at most 72 bytes per hop:
-the maximum nine-byte growth of a postcard-encoded `u64` `settled_through`
-cursor across eight view-update envelopes. This is a fixed framing allowance,
-not a view-size ratio.
+Encoded wire bytes may differ from the first rung by at most 72 bytes per hop,
+covering the maximum nine-byte growth of sequence/cursor framing across eight
+view-update envelopes. This is a fixed framing allowance, not a view-size
+ratio.
 
 Run the default ladder with:
 
@@ -35,13 +39,14 @@ One 10/1,000/10,000-customer run on the local development box produced:
 
 | View rows | Changed rows | Core → edge bytes | Edge → client bytes | Adds/removes per hop | Bundles/records per hop | Core reads/ranges | Edge reads/ranges | Wall time |
 | --------: | -----------: | ----------------: | ------------------: | -------------------: | ----------------------: | ----------------: | ----------------: | --------: |
-|        15 |            4 |           4,570 B |             4,570 B |                  4/3 |                    4/10 |               4/4 |           184/192 |  5,949 us |
-|     1,005 |            4 |           4,594 B |             4,594 B |                  4/3 |                    4/10 |               4/4 |           184/192 |  7,469 us |
-|    10,005 |            4 |           4,602 B |             4,602 B |                  4/3 |                    4/10 |               4/4 |           184/192 | 27,542 us |
+|        15 |            4 |           4,570 B |             4,570 B |                  4/3 |                    4/10 |               4/4 |           104/119 |  5,926 us |
+|     1,005 |            4 |           4,594 B |             4,594 B |                  4/3 |                    4/10 |               4/4 |           104/119 |  8,707 us |
+|    10,005 |            4 |           4,602 B |             4,602 B |                  4/3 |                    4/10 |               4/4 |           104/119 | 28,857 us |
 
-Propagation I/O, result deltas, facts, and version payload work remain fixed as
-the unrelated retained view grows. The 32-byte wire difference is cursor
-framing across eight messages on each hop.
+Propagation I/O, exact result identities, facts, version payload work, and the
+observer's final values remain fixed as the unrelated retained view grows. The
+32-byte wire difference is sequence/cursor framing across eight messages on
+each hop.
 
 Wall time is directional and is not the acceptance claim. It still grows with
 the retained view despite flat I/O and output, consistent with retained-view

--- a/dev/benchmarks/S4_FIXED_DELTA_SCALING.md
+++ b/dev/benchmarks/S4_FIXED_DELTA_SCALING.md
@@ -1,0 +1,53 @@
+# S4 fixed-delta propagation scaling
+
+The `fixed_delta_propagation_scaling` phase in `s4_order_processing` holds one
+accepted Payment transaction fixed while increasing the retained whole-table
+view with unrelated customer rows. The transaction changes four current rows:
+one warehouse, district, customer, and newly inserted payment.
+
+The gate primes all eight S4 table subscriptions across both core-to-edge and
+edge-to-client hops before the change. Every rung must then preserve:
+
+- the SQLite-reference final state;
+- exactly four result additions, three replaced-result removals, and fixed
+  version bundle and record counts on each hop;
+- identical program-fact additions and removals; and
+- identical storage reads and ranges on each node.
+
+Encoded wire bytes may differ from the first rung by at most 72 bytes per hop:
+the maximum nine-byte growth of a postcard-encoded `u64` `settled_through`
+cursor across eight view-update envelopes. This is a fixed framing allowance,
+not a view-size ratio.
+
+Run the default ladder with:
+
+```sh
+JAZZ_S4_PROPAGATION_SCALE_ONLY=1 cargo bench -p jazz-sim --bench s4_order_processing
+```
+
+Override customer counts with the comma-separated
+`JAZZ_S4_PROPAGATION_CUSTOMERS`. The smoke scenario runs a smaller 2/20/200
+ladder with the same hard gate.
+
+## Initial result
+
+One 10/1,000/10,000-customer run on the local development box produced:
+
+| View rows | Changed rows | Core → edge bytes | Edge → client bytes | Adds/removes per hop | Bundles/records per hop | Core reads/ranges | Edge reads/ranges | Wall time |
+| --------: | -----------: | ----------------: | ------------------: | -------------------: | ----------------------: | ----------------: | ----------------: | --------: |
+|        15 |            4 |           4,570 B |             4,570 B |                  4/3 |                    4/10 |               4/4 |           184/192 |  5,949 us |
+|     1,005 |            4 |           4,594 B |             4,594 B |                  4/3 |                    4/10 |               4/4 |           184/192 |  7,469 us |
+|    10,005 |            4 |           4,602 B |             4,602 B |                  4/3 |                    4/10 |               4/4 |           184/192 | 27,542 us |
+
+Propagation I/O, result deltas, facts, and version payload work remain fixed as
+the unrelated retained view grows. The 32-byte wire difference is cursor
+framing across eight messages on each hop.
+
+Wall time is directional and is not the acceptance claim. It still grows with
+the retained view despite flat I/O and output, consistent with retained-view
+bookkeeping such as the metrics-footprint refresh identified by PERF-5. This
+receipt establishes structurally delta-bounded propagation, not constant CPU
+time.
+
+Tooling friction: a shared release target would have avoided rebuilding the
+RocksDB dependency graph in the clean benchmark worktree.


### PR DESCRIPTION
## Base

This PR is based directly on `codex/jazz-core-engine-swap`. The fix from #1236 is merged and inherited from that integration base; the two commits unique to this PR are benchmark changes. It is no longer stacked on #1232 and can be reviewed independently.

## What changed

- add an S4 fixed-delta/varying-view benchmark phase using the Payment operation
- propagate from a writer through core and edge to a separate observer client
- hard-gate the exact added and removed row identities, program facts, version bundles and records, wire bytes, storage reads and ranges, and final observer values
- add an attributable receipt and update the benchmark roadmap

## What it demonstrates

For a fixed four-row Payment transaction, propagation work on both hops remains structurally bounded by the delta as the retained whole-table view grows from 15 to 10,005 rows:

- result changes remain 4 additions / 3 removals per hop
- version payload remains 4 bundles / 10 records per hop
- core storage work remains 4 reads / 4 ranges
- edge storage work remains 104 reads / 119 ranges
- encoded bytes grow only from 4,570 B to 4,602 B due to fixed sequence/cursor framing

Wall time grows from approximately 5.9 ms to 28.9 ms because retained-view bookkeeping remains view-sized. Constant CPU time is deliberately not the acceptance claim.

## Validation

- `cargo test -p jazz partial_exclusive`
- `cargo check -p jazz-sim --benches`
- `JAZZ_S4_PROPAGATION_SCALE_ONLY=1 JAZZ_S4_PROPAGATION_CUSTOMERS=2,20 cargo bench -p jazz-sim --bench s4_order_processing`
- `JAZZ_S4_PROPAGATION_SCALE_ONLY=1 JAZZ_S4_PROPAGATION_CUSTOMERS=10,1000,10000 cargo bench -p jazz-sim --bench s4_order_processing`
- repository pre-commit checks: Clippy, sensitive-data scan, oxfmt, and rustfmt