### PR TITLE
(new core) fix existential authorization before finite windows

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -8787,13 +8787,27 @@ where
             },
             Err(err) => return Err(err),
         };
+        // Authorization is existential per protected row and binding route:
+        // multiple policy branches or multiple qualifying grant rows are
+        // alternative proofs, not additional copies of the application row.
+        // Collapse those proofs before the protected source reaches ordinary
+        // relational operators (especially finite TopBy windows). Route
+        // fields are part of the key because one prepared authorization graph
+        // can serve several independently routed bindings.
+        let mut authorization_keys = vec!["row_uuid".to_owned()];
+        authorization_keys.extend(authorized.route_fields.iter().cloned());
+        let authorized_graph = GraphBuilder::arg_max_by(
+            authorized.graph,
+            authorization_keys.clone(),
+            authorization_keys,
+        );
         if authorized.route_fields.is_empty() {
             let fields = output_fields
                 .iter()
                 .map(|field| ProjectField::renamed(left_field(&field), field.clone()))
                 .collect::<Vec<_>>();
             return Ok(PolicyAuthorizationGraph {
-                graph: GraphBuilder::join(base, authorized.graph, ["row_uuid"], ["row_uuid"])
+                graph: GraphBuilder::join(base, authorized_graph, ["row_uuid"], ["row_uuid"])
                     .project_fields(fields),
                 route_fields: authorized.route_fields,
             });
@@ -8809,7 +8823,7 @@ where
                 .map(|field| ProjectField::renamed(right_field(field), field.clone())),
         );
         Ok(PolicyAuthorizationGraph {
-            graph: GraphBuilder::join(base, authorized.graph, ["row_uuid"], ["row_uuid"])
+            graph: GraphBuilder::join(base, authorized_graph, ["row_uuid"], ["row_uuid"])
                 .project_fields(fields),
             route_fields: authorized.route_fields,
         })

--- a/crates/jazz/src/node/tests/policies_rls.rs
+++ b/crates/jazz/src/node/tests/policies_rls.rs
@@ -5255,3 +5255,135 @@ fn maintained_subscription_view_top_by_partitions_windows_by_policy_claim_bindin
     assert_eq!(adds_a.len(), 100, "owner A should receive its own full window");
     assert_eq!(adds_b.len(), 100, "owner B should receive its own full window");
 }
+
+#[test]
+fn authorization_proofs_are_existential_before_top_by_windows() {
+    let reader = user(0xa1);
+    let documents_policy = Query::from("documents")
+        .join_via(
+            "documentAccess",
+            "document",
+            [eq(col("reader"), claim("sub"))],
+        )
+        .policy_branch(PolicyBranch::single_alternative_from_query(
+            Query::from("documents").filter(eq(col("published"), lit(true))),
+        ));
+    let schema = JazzSchema::new([
+        TableSchema::new(
+            "documents",
+            [
+                ColumnSchema::new("updated_at", ColumnType::U64),
+                ColumnSchema::new("published", ColumnType::Bool),
+            ],
+        )
+        .with_read_policy(Policy::shape(documents_policy)),
+        TableSchema::new(
+            "documentAccess",
+            [
+                ColumnSchema::new("document", ColumnType::Uuid),
+                ColumnSchema::new("reader", ColumnType::Uuid),
+            ],
+        )
+        .with_reference("document", "documents"),
+    ]);
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let mut document_txs = Vec::new();
+    let mut grant_txs = Vec::new();
+    for index in 0..100_u64 {
+        let document = row(index as u8);
+        document_txs.push(accept_global(
+            &mut core,
+            MergeableCommit::new("documents", document, index * 3 + 1).cells(BTreeMap::from([
+                ("updated_at".to_owned(), Value::U64(index)),
+                ("published".to_owned(), Value::Bool(index >= 95)),
+            ])),
+        ));
+        let grant = row((index + 100) as u8);
+        grant_txs.push(accept_global(
+            &mut core,
+            MergeableCommit::new("documentAccess", grant, index * 3 + 2).cells(BTreeMap::from([
+                ("document".to_owned(), Value::Uuid(document.0)),
+                ("reader".to_owned(), Value::Uuid(reader.0)),
+            ])),
+        ));
+    }
+    let shape = Query::from("documents")
+        .order_by("updated_at", OrderDirection::Desc)
+        .limit(100)
+        .validate(&core.catalogue.schema)
+        .unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let query_rows = |core: &mut NodeState<RocksDbStorage>| {
+        core.query_rows_for_link(&shape, &binding, DurabilityTier::Global, reader)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(query_rows(&mut core).len(), 100);
+
+    let mut peer = PeerState::for_author(reader);
+    let initial = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
+    assert_eq!(canonical_view_update_rows_for_table(&initial, "documents").0.len(), 100);
+
+    let duplicate_grant = row(0xfe);
+    let duplicate_grant_tx = accept_global(
+        &mut core,
+        MergeableCommit::new("documentAccess", duplicate_grant, 302).cells(BTreeMap::from([
+            ("document".to_owned(), Value::Uuid(row(99).0)),
+            ("reader".to_owned(), Value::Uuid(reader.0)),
+        ])),
+    );
+    let duplicate = peer.query_update(&mut core, &shape, &binding).unwrap();
+    assert_eq!(
+        canonical_view_update_rows_for_table(&duplicate, "documents"),
+        (Vec::new(), Vec::new())
+    );
+    assert_eq!(query_rows(&mut core).len(), 100);
+
+    accept_global(
+        &mut core,
+        MergeableCommit::new("documentAccess", row(199), 303)
+            .parents(vec![grant_txs[99]])
+            .deletion(DeletionEvent::Deleted),
+    );
+    let partial_revoke = peer.query_update(&mut core, &shape, &binding).unwrap();
+    assert_eq!(
+        canonical_view_update_rows_for_table(&partial_revoke, "documents"),
+        (Vec::new(), Vec::new())
+    );
+    assert_eq!(query_rows(&mut core).len(), 100);
+
+    accept_global(
+        &mut core,
+        MergeableCommit::new("documentAccess", duplicate_grant, 304)
+            .parents(vec![duplicate_grant_tx])
+            .deletion(DeletionEvent::Deleted),
+    );
+    let overlapping_branch = peer.query_update(&mut core, &shape, &binding).unwrap();
+    assert_eq!(
+        canonical_view_update_rows_for_table(&overlapping_branch, "documents"),
+        (Vec::new(), Vec::new())
+    );
+    assert_eq!(query_rows(&mut core).len(), 100);
+
+    accept_global(
+        &mut core,
+        MergeableCommit::new("documents", row(99), 305)
+            .parents(vec![document_txs[99]])
+            .cells(BTreeMap::from([
+                ("updated_at".to_owned(), Value::U64(99)),
+                ("published".to_owned(), Value::Bool(false)),
+            ])),
+    );
+    let final_revoke = peer.query_update(&mut core, &shape, &binding).unwrap();
+    assert_eq!(
+        canonical_view_update_rows_for_table(&final_revoke, "documents")
+            .1
+            .iter()
+            .map(|(_, row, _)| *row)
+            .collect::<Vec<_>>(),
+        vec![row(99)]
+    );
+    assert_eq!(query_rows(&mut core).len(), 99);
+}

--- a/crates/jazz/src/node/tests/policies_rls.rs
+++ b/crates/jazz/src/node/tests/policies_rls.rs
@@ -5320,11 +5320,23 @@ fn authorization_proofs_are_existential_before_top_by_windows() {
             .map(|row| row.row_uuid())
             .collect::<Vec<_>>()
     };
-    assert_eq!(query_rows(&mut core).len(), 100);
+    let expected_initial = (0..100_u8).rev().map(row).collect::<Vec<_>>();
+    let initial_one_shot = query_rows(&mut core);
+    assert_eq!(initial_one_shot, expected_initial);
+    assert_eq!(initial_one_shot.iter().copied().collect::<BTreeSet<_>>().len(), 100);
 
     let mut peer = PeerState::for_author(reader);
     let initial = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
-    assert_eq!(canonical_view_update_rows_for_table(&initial, "documents").0.len(), 100);
+    let (initial_adds, initial_removes) =
+        canonical_view_update_rows_for_table(&initial, "documents");
+    assert!(initial_removes.is_empty());
+    assert_eq!(
+        initial_adds
+            .iter()
+            .map(|(_, row, _)| *row)
+            .collect::<BTreeSet<_>>(),
+        expected_initial.iter().copied().collect()
+    );
 
     let duplicate_grant = row(0xfe);
     let duplicate_grant_tx = accept_global(
@@ -5378,12 +5390,14 @@ fn authorization_proofs_are_existential_before_top_by_windows() {
     );
     let final_revoke = peer.query_update(&mut core, &shape, &binding).unwrap();
     assert_eq!(
-        canonical_view_update_rows_for_table(&final_revoke, "documents")
-            .1
-            .iter()
-            .map(|(_, row, _)| *row)
-            .collect::<Vec<_>>(),
-        vec![row(99)]
+        canonical_view_update_rows_for_table(&final_revoke, "documents"),
+        (
+            Vec::new(),
+            vec![("documents".to_owned().into(), row(99), document_txs[99])]
+        )
     );
-    assert_eq!(query_rows(&mut core).len(), 99);
+    assert_eq!(
+        query_rows(&mut core),
+        (0..99_u8).rev().map(row).collect::<Vec<_>>()
+    );
 }


### PR DESCRIPTION
## Diagnosis

Authorization proof rows were joined back to protected application rows with an ordinary multiplicity-preserving join. Overlapping policy branches and duplicate grants therefore produced multiple copies before ORDER BY / LIMIT, letting proofs consume TopBy slots; the deterministic regression returned 95 unique rows instead of 100.

## Fix

Collapse the authorization terminal to one maintained proof per protected row plus binding route before joining it to the protected source. The reduction is route-aware so prepared multi-binding subscriptions remain isolated, while ordinary application joins and UnionAll retain bag semantics.

## Regression coverage

- 100 ACL-authorized documents with ORDER BY updated_at DESC LIMIT 100
- five highest-ranked documents also authorized by the published branch (base reproduces 95 unique rows)
- one-shot and maintained subscription results
- duplicate grant insertion
- partial grant revocation
- remaining overlapping policy branch
- final revocation
- existing Groove bag-semantics TopBy multiplicity test

## Passing validation

- cargo test -p jazz
- cargo test -p groove
- cargo test -p jazz --no-default-features --features test
- cargo check -p jazz-sim --benches
- JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle
- all three incremental_delivery_canary tests, including the exact INV-INC-1 canary
- focused existential authorization regression
- inherited duplicate-derivation authorization regression
- ordinary Groove TopBy bag-multiplicity regression
- pre-commit clippy, rustfmt, and sensitive-data guard

## Confirmed base-gate caveats

These are unrelated to the two-file authorization change and were approved for push with caveats:

- cargo test -p jazz-server: package ID does not exist on this base; server tests run under jazz and passed.
- dev/gates/ts-wire-codec.sh: existing policy graph perf fixture byte-stability mismatch; no codec/schema files changed.
- dev/benchmarks/smoke.sh: jazz/relation_include_delivery cannot compile the jazz-server binary under --no-default-features because server-gated modules are unavailable; all other smoke lanes passed.

Tooling friction: a base-gate health manifest identifying retired packages and known fixture/feature failures would have avoided substantial validation time.