### PR TITLE
(new core) fix maintained authorization scope re-entry

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -298,6 +298,10 @@ required-features = ["test"]
 name = "parameterized_subscription_routing"
 required-features = ["test"]
 
+[[test]]
+name = "authorization_scope_reentry"
+required-features = ["test"]
+
 [[example]]
 name = "realistic_bench"
 required-features = ["client"]

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2899,13 +2899,19 @@ where
         table: &str,
         row: RowUuid,
         patch: RowCells,
-        identity: AuthorId,
+        _identity: AuthorId,
     ) -> Result<(RowCells, Option<TxId>), Error> {
         let table_schema = self.table_schema(table)?;
         self.ensure_row_not_deleted(table, row)?;
         let mut cells = BTreeMap::new();
         let mut parent = None;
-        if let Some(existing) = self.local_row_for_identity(table, row, identity)? {
+        // A partial update preserves omitted cells from the storage-visible
+        // current row. That merge is implementation bookkeeping, not a read
+        // granted to the writer: using the writer's read policy here would
+        // turn every omitted cell into `NULL` when write permission does not
+        // also imply read permission, and a later authorization re-entry would
+        // surface a corrupted row to maintained queries.
+        if let Some(existing) = self.local_row_for_identity(table, row, AuthorId::SYSTEM)? {
             for column in &table_schema.columns {
                 if column.large_value.is_some() {
                     continue;

--- a/crates/jazz/tests/authorization_scope_reentry.rs
+++ b/crates/jazz/tests/authorization_scope_reentry.rs
@@ -1,0 +1,224 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use jazz::block_on;
+use jazz::db::{
+    Db, DbConfig, DbIdentity, LocalUpdates, Propagation, ReadOpts, SeededRowIdSource,
+    SubscriptionEvent, SubscriptionStream,
+};
+use jazz::groove::records::Value;
+use jazz::groove::schema::{ColumnSchema, ColumnType};
+use jazz::groove::storage::MemoryStorage;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, claim, col, eq};
+use jazz::schema::{JazzSchema, Policy, TableSchema};
+use jazz::tx::DurabilityTier;
+
+const TEAMS: &str = "teams";
+const MEMBERSHIPS: &str = "team_memberships";
+const DOCUMENTS: &str = "documents";
+const WRITER: AuthorId = AuthorId(uuid::uuid!("81000000-0000-0000-0000-000000000001"));
+const READER: AuthorId = AuthorId(uuid::uuid!("81000000-0000-0000-0000-000000000002"));
+
+fn row(seed: u8) -> RowUuid {
+    RowUuid::from_bytes([seed; 16])
+}
+
+fn schema() -> JazzSchema {
+    let document_policy = Query::from(DOCUMENTS).join_via_column(
+        MEMBERSHIPS,
+        "team",
+        "team",
+        [eq(col("user"), claim("sub"))],
+    );
+    JazzSchema::new([
+        TableSchema::new(TEAMS, [ColumnSchema::new("name", ColumnType::String)])
+            .with_read_policy(Policy::public())
+            .with_write_policy(Policy::public()),
+        TableSchema::new(
+            MEMBERSHIPS,
+            [
+                ColumnSchema::new("team", ColumnType::Uuid),
+                ColumnSchema::new("user", ColumnType::Uuid),
+            ],
+        )
+        .with_reference("team", TEAMS)
+        .with_read_policy(Policy::owner_only(MEMBERSHIPS, "user"))
+        .with_write_policy(Policy::public()),
+        TableSchema::new(
+            DOCUMENTS,
+            [
+                ColumnSchema::new("team", ColumnType::Uuid),
+                ColumnSchema::new("rank", ColumnType::U64),
+            ],
+        )
+        .with_reference("team", TEAMS)
+        .with_indexed_columns(["team", "rank"])
+        .with_read_policy(Policy::shape(document_policy))
+        .with_write_policy(Policy::public()),
+    ])
+}
+
+fn open_db() -> Db<MemoryStorage> {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    block_on(Db::open(
+        DbConfig::new(
+            schema,
+            MemoryStorage::new(&family_refs),
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x81; 16]),
+                author: WRITER,
+            },
+        )
+        .with_id_source(SeededRowIdSource::new(0x8100)),
+    ))
+    .expect("open authorization scope re-entry db")
+}
+
+fn opts() -> ReadOpts {
+    ReadOpts {
+        tier: DurabilityTier::Local,
+        local_updates: LocalUpdates::Immediate,
+        propagation: Propagation::LocalOnly,
+        include_deleted: false,
+        ..ReadOpts::default()
+    }
+}
+
+fn insert_document(db: &Db<MemoryStorage>, id: RowUuid, team: RowUuid, rank: u64) {
+    db.insert_with_id(
+        DOCUMENTS,
+        id,
+        BTreeMap::from([
+            ("team".to_owned(), Value::Uuid(team.0)),
+            ("rank".to_owned(), Value::U64(rank)),
+        ]),
+    )
+    .expect("insert document");
+}
+
+fn initial_rows(stream: &mut SubscriptionStream) -> BTreeSet<RowUuid> {
+    match stream.try_next_event().expect("initial subscription reset") {
+        SubscriptionEvent::Delta {
+            reset: true,
+            added,
+            updated,
+            removed,
+            ..
+        } => {
+            assert!(updated.is_empty());
+            assert!(removed.is_empty());
+            added.into_iter().map(|row| row.row_uuid()).collect()
+        }
+        event => panic!("expected initial reset, got {event:?}"),
+    }
+}
+
+fn exact_delta(stream: &mut SubscriptionStream) -> (BTreeSet<RowUuid>, BTreeSet<RowUuid>) {
+    let event = stream.try_next_event().expect("incremental scope delta");
+    let SubscriptionEvent::Delta {
+        reset,
+        added,
+        updated,
+        removed,
+        ..
+    } = event
+    else {
+        panic!("expected subscription delta, got {event:?}");
+    };
+    assert!(!reset);
+    assert!(updated.is_empty());
+    assert!(stream.try_next_event().is_none());
+    (
+        added.into_iter().map(|row| row.row_uuid()).collect(),
+        removed.into_iter().map(|row| row.row_uuid).collect(),
+    )
+}
+
+#[test]
+fn maintained_authorization_restores_an_ordered_page_after_scope_reentry() {
+    let db = open_db();
+    let authorized_team = row(0x11);
+    let unauthorized_team = row(0x12);
+    let winner = row(0x21);
+    let second = row(0x22);
+    let refill = row(0x23);
+
+    for (team, name) in [
+        (authorized_team, "authorized"),
+        (unauthorized_team, "unauthorized"),
+    ] {
+        db.insert_with_id(
+            TEAMS,
+            team,
+            BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+        )
+        .expect("insert team");
+    }
+    db.insert_with_id(
+        MEMBERSHIPS,
+        row(0x31),
+        BTreeMap::from([
+            ("team".to_owned(), Value::Uuid(authorized_team.0)),
+            ("user".to_owned(), Value::Uuid(READER.0)),
+        ]),
+    )
+    .expect("insert reader membership");
+    insert_document(&db, winner, authorized_team, 30);
+    insert_document(&db, second, authorized_team, 20);
+    insert_document(&db, refill, authorized_team, 10);
+
+    let prepared = db
+        .prepare_query(
+            &Query::from(DOCUMENTS)
+                .order_by("rank", OrderDirection::Desc)
+                .limit(2),
+        )
+        .expect("prepare exact ordered page");
+    let one_shot = || {
+        block_on(db.all_for_identity(&prepared, opts(), READER))
+            .expect("one-shot reader page")
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>()
+    };
+    let mut stream = block_on(db.subscribe_for_identity(&prepared, opts(), READER))
+        .expect("subscribe reader page");
+
+    let mut maintained = initial_rows(&mut stream);
+    assert_eq!(maintained, BTreeSet::from([winner, second]));
+    assert_eq!(one_shot(), vec![winner, second]);
+
+    db.update(
+        DOCUMENTS,
+        winner,
+        BTreeMap::from([("team".to_owned(), Value::Uuid(unauthorized_team.0))]),
+    )
+    .expect("move winning document out of scope");
+    let move_out_delta = exact_delta(&mut stream);
+    assert_eq!(
+        move_out_delta,
+        (BTreeSet::from([refill]), BTreeSet::from([winner]))
+    );
+    maintained.remove(&winner);
+    maintained.insert(refill);
+    assert_eq!(maintained, BTreeSet::from([second, refill]));
+    assert_eq!(one_shot(), vec![second, refill]);
+
+    db.update(
+        DOCUMENTS,
+        winner,
+        BTreeMap::from([("team".to_owned(), Value::Uuid(authorized_team.0))]),
+    )
+    .expect("move winning document back into scope");
+    assert_eq!(one_shot(), vec![winner, second]);
+    let move_back_delta = exact_delta(&mut stream);
+    assert_eq!(
+        move_back_delta,
+        (BTreeSet::from([winner]), BTreeSet::from([refill]))
+    );
+    maintained.remove(&refill);
+    maintained.insert(winner);
+    assert_eq!(maintained, BTreeSet::from([winner, second]));
+}


### PR DESCRIPTION
## What changed

- add an anonymized public-API regression for a reader authorized through team membership
- exercise an exact ordered/limited page across both directions of an authorization-scope move
- preserve omitted cells from the storage-visible row when composing a partial update

## Root cause

Partial updates merged omitted cells through the writer's read-policy view. When write permission did not imply read permission, moving a row changed only its team while silently dropping its rank from the composed row. The move out of scope therefore removed/refilled correctly, but the move back re-entered with a null ordering value and produced no maintained-page delta.

The merge now uses the storage-visible current row strictly for internal patch composition; it does not expose those cells or grant a read to the writer.

## Validation

- `cargo test -p jazz --no-default-features --features test --test authorization_scope_reentry`
- `cargo test -p jazz --no-default-features --features test --test parameterized_subscription_routing`
- `cargo test -p jazz --no-default-features --features test --test incremental_delivery_canary`
- `cargo test -p jazz --no-default-features --features test`
- `cargo test -p jazz`
- `cargo test -p groove`
- `cargo check -p jazz-sim --benches`
- `JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle`
- sensitive-data guard
- pre-commit clippy and rustfmt

## Existing gate caveats

- `cargo test -p jazz-server` cannot run because this base no longer contains a separate `jazz-server` package; its tests run under `cargo test -p jazz` and passed.
- `dev/benchmarks/smoke.sh` passes all scenarios except `jazz/relation_include_delivery`, whose base command builds `jazz-server` without the required server feature.
- `dev/gates/ts-wire-codec.sh` compiles TypeScript but its existing policy-graph byte-stability fixture differs in ordering/encoding; this PR does not touch TypeScript or wire code.

Tooling friction: making the smoke relation/include command feature-complete and making the TS perf fixture deterministic would avoid unrelated landing-gate triage.
