### PR TITLE
(new core) Spec: the multi-source query result contract

### DIFF
--- a/crates/groove/SPEC/3_queries_operators.md
+++ b/crates/groove/SPEC/3_queries_operators.md
@@ -157,6 +157,27 @@ logical-time delta at most once per arrangement key/scope (ch. 4).
 `INV-QUERY-13` — anti-join changes only when the right count crosses zero.
 `INV-QUERY-14` — same-tick arrivals suppress/emit a left row exactly once.
 
+#### Multi-source terminal records
+
+When a consumer exposes a joined record as a multi-source output rather than
+using the join only for root membership, its terminal `RecordDescriptor` MUST
+retain ordered source-slot identity/version/provenance fields in addition to
+the projected application fields. The descriptor records each slot's canonical
+role, source relation/read-view selection, projection mapping, and ordering
+tie fields; source roles distinguish repeated uses of one table. It also
+contains the per-source policy/lens inputs or their canonical graph references.
+This is required by `INV-QUERY-1A`: a node producing one source tuple must not
+be deduplicated with one whose source provenance, policy, read view, or output
+slot mapping differs.
+
+The physical join remains the ordinary weighted join defined above. Hydration
+and incremental ticks consume the same source records and terminal descriptor,
+so they produce the same weighted composite records. A source delta may update
+only composites reachable through its join arrangements; the terminal contract
+does not permit recomputing a consumer's full output relation on each tick.
+Jazz defines the protocol-visible composite membership and source-wise
+authorization semantics in jazz SPEC 6 §6.4.
+
 ### 3.5 `ArgMaxBy` / `ArgMinBy` (maintained per-group winners)
 
 Per-group winner selection maintains the current winning row for each group and

--- a/crates/jazz/SPEC/6_queries.md
+++ b/crates/jazz/SPEC/6_queries.md
@@ -227,6 +227,73 @@ identity. Result members MUST retain the typed membership, source, and version
 information needed to deliver the result correctly; synthetic and path-tuple
 members follow that same result-set contract (`INV-QUERY-8`).
 
+#### Multi-source output rows
+
+An ordinary join is allowed to be a root-membership predicate: it may decide
+whether one root `RealRow` is in a result without making its witness an output
+column. A query whose output selects columns from more than one table is a
+different terminal contract, called a **multi-source output row**. It is not a
+root row with borrowed cells and it is not a client-side post-processing step.
+
+A multi-source output row has a stable composite identity and an ordered list
+of **source slots**. A source slot contains the logical source role (root or a
+canonical join/path role), the source table, and the complete `RealRow` member
+identity for that source: row UUID, visible content/deletion version as
+applicable, source/read-view, schema projection, branch/prefix, and all other
+dimensions of `RealRowMemberEntry`. The composite identity is the ordered tuple
+of those slot identities. Roles, rather than table names alone, distinguish two
+uses of the same table. A source slot also carries the source row's provenance
+(`created_by`, `created_at`, `updated_by`, `updated_at`) resolved for that
+source's visible version. The output payload is a projection over these slots;
+the default flattened projection is each slot's ordinary application columns in
+slot order. Qualified projection references select an individual source slot.
+
+The root row UUID remains a convenience/public API identifier for a result that
+has a root slot, but it is not the membership identity of the flattened result:
+two joined tuples with the same root are distinct results. A wire/result-set
+entry for a multi-source output MUST therefore carry the composite identity and
+its per-slot provenance, and the accompanying row/version payload MUST be
+attributable to the matching slot. Replacing this with one synthetic row or one
+root `RealRowMemberEntry` is incorrect because it loses the version and
+provenance of the other sources.
+
+Permission evaluation is per source slot, against that source's visible row
+after its applicable lens/schema transform and under the caller's current
+policy/claims. A flattened inner result is emitted only when every projected
+source slot is readable. In particular, visibility of a root row does not make
+an unreadable joined row visible, nor may its cells or provenance be carried as
+a witness. A policy change, lens transform, or source-version change affecting
+one slot retracts/replaces precisely the composite rows containing that slot.
+This source-wise rule also applies to one-shot reads and to reset hydration.
+
+Source slots have a canonical order: root first, followed by the canonical
+output-role order derived from the validated join/path graph. This order is
+encoded in the shape; source declaration order that validation treats as
+commutative cannot change output columns. A multi-source `order_by` names
+qualified slot columns. It compares the declared terms lexicographically and
+then breaks ties by the lexicographic tuple of source-slot identities (role,
+table, row UUID); this is a total, replay-stable order. With no explicit order,
+that same tuple order is the default. The order contract applies to snapshots,
+one-shot reads, reset result sets, and incremental additions/removals.
+
+The maintained and one-shot paths MUST evaluate the same validated output
+program and emit the same ordered composite identities, projections, source
+versions, and per-source provenance at the same read frontier. One-shot is the
+first-delta observation of that maintained program, not a separately assembled
+join. A maintained source delta is joined through the relevant arrangements and
+emits only the affected composite-row transitions; it MUST NOT re-materialize
+or diff the accumulated output state (`INV-INC-1`).
+
+Every descriptor participating in the program MUST encode every
+output-affecting input (`INV-QUERY-1A`): the ordered source-role/output schema;
+all source table and read-view selections; projection mapping; join/path keys,
+filters, and null/inner semantics; per-source policy programs and their
+canonical claim/binding declarations; lens/schema projections; ordering and
+window configuration; and the provenance/version fields needed at the terminal.
+Subject-specific claim values remain execution bindings, not baked constants.
+Descriptors that differ in any such input MUST NOT share a groove node or a
+maintained result set.
+
 Membership includes more than the projected output rows. Each result set carries
 the matched include-reference targets and join/junction rows that contributed to
 the output. Include payload material is not a separate public or internal mode:


### PR DESCRIPTION
Specification only — no implementation, no behaviour change.

## Why

#1217 enabled every dormant test target. Three of the tests it surfaced are red
on the integration branch, all on the same guard at
`crates/jazz/src/tools/client.rs:1933`:

- `local_join_query_uses_current_permissions_for_joined_provenance_after_lens_transform`
- `table_rename_join_query_translates_join_target_on_old_branch`
- `table_rename_fk_array_lookup_finds_related_rows_on_old_branch`

Two need joins, one needs array subqueries. Core does lower `Query::joins`, but
only as a **root-row membership join** whose normalized result is a single
`RealRow` from the root table. These tests need a flattened cross-table result,
which neither `crate::query::Query` nor the relation facade can represent — the
facade explicitly normalizes to one output table.

Building this in the client instead would be the semantic duplication catalogued
in `dev/TS_SEMANTIC_DUPLICATION_AUDIT.md`, and would drift from core's
permission, provenance and ordering semantics — which is precisely what these
three tests assert.

## What this defines

`crates/jazz/SPEC/6_queries.md` and `crates/groove/SPEC/3_queries_operators.md`
now specify:

- **composite source-slot identity** for a result carrying columns from more
  than one source table;
- **per-source provenance and permissions after lens transforms** — a row must
  not become visible merely by being joined to a visible row;
- **stable cross-source ordering**;
- **identical one-shot and maintained semantics.** One-shot is the first-delta
  observation of the maintained program, not a separately assembled join, so
  the differential oracle stays meaningful. A maintained source delta emits only
  affected composite-row transitions and MUST NOT re-materialize or diff
  accumulated output state (`INV-INC-1`);
- **descriptor inputs required by `INV-QUERY-1A`** — ordered source-role/output
  schema, source table and read-view selections, projection mapping, join keys
  and null/inner semantics, per-source policy programs with canonical claim
  declarations, lens projections, ordering and window config, and the
  provenance/version fields needed at the terminal. Subject-specific claim
  values stay execution bindings, not baked constants, so node sharing remains
  sound.

## Feasibility: this is not a small change

Estimated **10–15 engineer-days plus soak and gate time**, touching the query
AST and lowering, terminal record descriptors, `CurrentRow` and the read APIs,
protocol and wire result members, maintained-view transition state, peer result
indexing and delivery, per-source provenance resolution, and core-owned array
result shaping.

So this is posted as a decision aid, not a plan of record. The three tests stay
red behind the guard until it is scheduled; `result_element_index` shares the
same blocker.

Landing the contract now means the eventual implementation has something to be
measured against, and that the reason those tests are red is written down rather
than remembered.
