### PR TITLE
(new core) Remove the autotests = false trap

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 autobins = false
 autobenches = false
-autotests = false
+autotests = true
 
 [features]
 default = ["rocksdb", "server", "transport-compression-zstd"]
@@ -221,42 +221,6 @@ name = "subscription_benchmark"
 harness = false
 
 [[test]]
-name = "column_defaults"
-
-[[test]]
-name = "fate_regressions"
-
-[[test]]
-name = "four_tier"
-
-[[test]]
-name = "incremental_delivery_canary"
-
-[[test]]
-name = "row_provenance"
-
-[[test]]
-name = "shared_coverage_differential"
-
-[[test]]
-name = "threaded_four_tier"
-
-[[test]]
-name = "warm_reopen_differential"
-
-[[test]]
-name = "wire_fixtures"
-
-[[test]]
-name = "admin_schema_api"
-
-[[test]]
-name = "auth_admission"
-
-[[test]]
-name = "cli_dry_run"
-
-[[test]]
 name = "large_blob_permissions"
 required-features = ["test"]
 
@@ -307,12 +271,6 @@ required-features = ["test"]
 [[test]]
 name = "flush_once_per_refresh"
 required-features = ["test"]
-
-[[test]]
-name = "coverage_group_flush_once"
-
-[[test]]
-name = "edge_fate_authority"
 
 [[test]]
 name = "rename_write_authorization"


### PR DESCRIPTION
Removes the `autotests = false` trap. Pure refactor of how test targets are
declared — **no test starts or stops running**, verified below.

## The trap

`crates/jazz/Cargo.toml` set `autotests = false`, so every test target had to be
hand-declared. That cost us, repeatedly:

- **eight test files went dark** — present in `tests/`, never compiled, never
  run, nothing red. Found only when someone went looking.
- **five separate branches** produced a duplicate `[[test]]` block on merge.
  Cargo then rejects the *entire* manifest, which takes the whole crate dark
  rather than failing one target.
- a duplicate `libc` key in `[dev-dependencies]` did the same thing, from two
  branches independently moving one dependency out of the deleted
  `crates/jazz-tools` manifest.

The shape is always the same: git text-merges hand-maintained declarations
without any conflict, and the failure is either silent or crate-wide.

## The fix

`autotests = true`, keeping explicit `[[test]]` blocks **only** for the 23
targets that need `required-features` (`["test"]` ×18, `["test-utils"]` ×4,
`["test","otel-core"]` ×1). Explicit declarations take precedence; the other 14
are auto-discovered.

**The failure mode becomes correct.** A new plain test file is discovered and
runs. A new test file needing a feature is auto-discovered, compiled *without*
it, and fails loudly at compile time — so the author adds the declaration.
Neither can be silently dark. And 14 fewer hand-maintained blocks is 14 fewer
things for a merge to duplicate.

## Proof it changed nothing

- **Target set before vs after is byte-identical** — 37 names both sides.
- **37 `tests/*.rs` files, 37 metadata test targets**, exact match with no
  target lacking a file and no file lacking a target.
- An undeclared probe file was added, confirmed discovered by `cargo metadata`,
  run via `cargo test --test autotest_autodiscovery_probe`, then deleted.

## What is deliberately left alone

**Benches** keep `autobenches = false`: all 15 use `harness = false`, and
auto-discovery has no way to express a per-target manifest setting. **Bins**
keep `autobins = false`: both use `required-features`. No other workspace crate
sets any of these opt-outs, so there is no matching exposure elsewhere.

## Gates

All exit 0 on a clean tree: `cargo metadata --no-deps`, `cargo test -p jazz`,
`cargo test -p groove`, `cargo test -p jazz --no-default-features --features
test`, `cargo check --workspace --all-targets`, `cargo fmt --check`,
`oxfmt --check`.
