### PR TITLE
(new core) Fix base: PeerState::for_author was renamed to client_link

### DIFF
--- a/crates/jazz/src/node/tests/policies_rls.rs
+++ b/crates/jazz/src/node/tests/policies_rls.rs
@@ -5325,7 +5325,7 @@ fn authorization_proofs_are_existential_before_top_by_windows() {
     assert_eq!(initial_one_shot, expected_initial);
     assert_eq!(initial_one_shot.iter().copied().collect::<BTreeSet<_>>().len(), 100);
 
-    let mut peer = PeerState::for_author(reader);
+    let mut peer = PeerState::client_link(reader);
     let initial = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
     let (initial_adds, initial_removes) =
         canonical_view_update_rows_for_table(&initial, "documents");


### PR DESCRIPTION
🤖 **Base does not compile.** One line.

```
error[E0599]: no function or associated item named `for_author` found for
struct `peer::PeerState`
  --> crates/jazz/src/node/tests/policies_rls.rs:5328
```

## How it happened

Two merged PRs collided semantically:

- **#1108** (via #1156) renamed `PeerState::for_author` → `PeerState::client_link`,
  because the old name implied a fate authority edge servers should not have.
- **#1238** added a test *calling* `for_author`.

They touched different files, so git merged both without a conflict and cargo
rejected the result. Neither branch was wrong; neither could see the other.

## The gap this exposes

`cargo check --workspace --all-targets` passes. The failure is in the **lib test**
target, so a PR gating only its own branch would not see it — and both branches
did compile alone. Only the merge commit is broken.

That is what CI's `test-rust` job is for, and it would have caught this on the
merge commit. Worth noting #1234 restored `lint` but `test-ts` is still red, so
CI is not yet being read as a gate.

## The fix

`PeerState::for_author(reader)` → `PeerState::client_link(reader)`. Signature
matches (`peer.rs:265`). A sweep for other stale peer-vocabulary references
found none — only historical mentions in documentation.

Gates at `dbad0f9d4`, clean tree: `cargo metadata`, no-default-features test
compile, `cargo test -p jazz`, workspace all-targets, `cargo fmt --check` all
exit 0. The no-default-features run is nonzero for the three known
`catalogue_sync_integration` reds behind the `core_query` guard — pre-existing
since #1217 and unrelated.
