### PR TITLE
(new core) Client initial-sync flush cadence (17.7x faster OPFS initial load)

### DIFF
--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -120,6 +120,17 @@ where
         Ok(self.storage.close()?)
     }
 
+    /// Configure explicit storage durability boundaries for future committed
+    /// write batches.
+    pub fn set_write_flush_cadence(&self, every: usize) -> Result<(), Error> {
+        Ok(self.storage.set_write_flush_cadence(every)?)
+    }
+
+    /// Complete the current storage durability boundary.
+    pub fn flush_write_boundary(&self) -> Result<(), Error> {
+        Ok(self.storage.flush_write_boundary()?)
+    }
+
     pub fn set_auto_direct_family_enabled(&mut self, enabled: bool) {
         self.ivm_runtime.set_auto_direct_family_enabled(enabled);
     }

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -278,6 +278,18 @@ pub trait OrderedKvStorage {
     fn close(&self) -> Result<(), Error> {
         Ok(())
     }
+    /// Configure the number of committed write batches between explicit local
+    /// durability boundaries. Backends that do not require an explicit boundary
+    /// may keep the default no-op implementation.
+    fn set_write_flush_cadence(&self, _every: usize) -> Result<(), Error> {
+        Ok(())
+    }
+    /// Finish any pending write cadence and make all preceding writes locally
+    /// durable. Backends that do not require an explicit boundary may keep the
+    /// default no-op implementation.
+    fn flush_write_boundary(&self) -> Result<(), Error> {
+        Ok(())
+    }
     /// Process-local identity for cache partitioning. Backends may override
     /// this when cheap clones should share cache entries.
     fn cache_token(&self) -> usize
@@ -660,6 +672,14 @@ where
 
     fn close(&self) -> Result<(), Error> {
         self.inner.close()
+    }
+
+    fn set_write_flush_cadence(&self, every: usize) -> Result<(), Error> {
+        self.inner.set_write_flush_cadence(every)
+    }
+
+    fn flush_write_boundary(&self) -> Result<(), Error> {
+        self.inner.flush_write_boundary()
     }
 
     fn scan_range(

--- a/crates/groove/src/storage/opfs.rs
+++ b/crates/groove/src/storage/opfs.rs
@@ -20,6 +20,13 @@ use super::{
 pub struct BtreeStorage<F: SyncFile> {
     tree: Rc<RefCell<OpfsBTree<F>>>,
     column_families: Rc<RefCell<BTreeSet<String>>>,
+    write_flush_cadence: Rc<RefCell<Option<WriteFlushCadence>>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WriteFlushCadence {
+    every: usize,
+    pending: usize,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -58,6 +65,7 @@ where
             column_families: Rc::new(RefCell::new(
                 column_families.iter().map(|cf| (*cf).to_owned()).collect(),
             )),
+            write_flush_cadence: Rc::new(RefCell::new(None)),
         })
     }
 
@@ -157,6 +165,22 @@ where
         Ok(self.tree.borrow_mut().close()?)
     }
 
+    fn set_write_flush_cadence(&self, every: usize) -> Result<(), Error> {
+        assert!(every > 0, "write flush cadence must be non-zero");
+        *self.write_flush_cadence.borrow_mut() = Some(WriteFlushCadence { every, pending: 0 });
+        Ok(())
+    }
+
+    fn flush_write_boundary(&self) -> Result<(), Error> {
+        let mut tree = self.tree.borrow_mut();
+        tree.flush_wal()?;
+        tree.flush_file()?;
+        if let Some(cadence) = self.write_flush_cadence.borrow_mut().as_mut() {
+            cadence.pending = 0;
+        }
+        Ok(())
+    }
+
     fn scan_range(
         &self,
         cf: &ColumnFamilyName,
@@ -254,14 +278,74 @@ where
                 tree.delete(&key)?;
             }
         }
-        Ok(tree.flush_wal()?)
+        let should_flush = match self.write_flush_cadence.borrow_mut().as_mut() {
+            Some(cadence) => {
+                cadence.pending += 1;
+                if cadence.pending == cadence.every {
+                    cadence.pending = 0;
+                    true
+                } else {
+                    false
+                }
+            }
+            None => true,
+        };
+        if should_flush {
+            tree.flush_wal()?;
+            if self.write_flush_cadence.borrow().is_some() {
+                tree.flush_file()?;
+            }
+        }
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opfs_btree::{BTreeOptions, MemoryFile};
+    use opfs_btree::{BTreeError, BTreeOptions, MemoryFile, SyncFile};
+
+    #[derive(Clone)]
+    struct FlushCountingFile {
+        inner: MemoryFile,
+        flushes: Rc<RefCell<usize>>,
+    }
+
+    impl FlushCountingFile {
+        fn new() -> Self {
+            Self {
+                inner: MemoryFile::new(),
+                flushes: Rc::new(RefCell::new(0)),
+            }
+        }
+
+        fn flushes(&self) -> usize {
+            *self.flushes.borrow()
+        }
+    }
+
+    impl SyncFile for FlushCountingFile {
+        fn len(&self) -> Result<u64, BTreeError> {
+            self.inner.len()
+        }
+
+        fn read_exact_at(&self, offset: u64, buf: &mut [u8]) -> Result<(), BTreeError> {
+            self.inner.read_exact_at(offset, buf)
+        }
+
+        fn write_all_at(&self, offset: u64, buf: &[u8]) -> Result<(), BTreeError> {
+            self.inner.write_all_at(offset, buf)
+        }
+
+        fn truncate(&self, len: u64) -> Result<(), BTreeError> {
+            self.inner.truncate(len)
+        }
+
+        fn flush(&self) -> Result<(), BTreeError> {
+            *self.flushes.borrow_mut() += 1;
+            self.inner.flush()
+        }
+    }
 
     fn memory_storage(column_families: &[&str]) -> BtreeStorage<MemoryFile> {
         BtreeStorage::from_file(MemoryFile::new(), column_families).unwrap()
@@ -325,6 +409,42 @@ mod tests {
         let checkpoint_len = storage.tree.borrow().checkpoint_state().total_pages
             * BTreeOptions::default().page_size as u64;
         assert_eq!(file.len().unwrap(), checkpoint_len);
+    }
+
+    #[test]
+    fn configured_cadence_flushes_at_the_boundary_and_final_partial_batch() {
+        // This is intentionally a storage-level test: the public Db API cannot
+        // observe OPFS SyncAccessHandle flush calls, which are the physical
+        // durability boundary exercised by this setting.
+        let file = FlushCountingFile::new();
+        let tree = OpfsBTree::open(
+            file.clone(),
+            browser_fidelity_options_with_sync_policy(BtreeSyncPolicy::OnClose),
+        )
+        .unwrap();
+        let storage = BtreeStorage::from_tree(tree, &["records"]).unwrap();
+        let baseline = file.flushes();
+        storage.set_write_flush_cadence(2).unwrap();
+
+        storage
+            .write_many(&[WriteOperation::set("records", b"1", b"first")])
+            .unwrap();
+        assert_eq!(file.flushes(), baseline, "first write is below cadence");
+
+        storage
+            .write_many(&[WriteOperation::set("records", b"2", b"second")])
+            .unwrap();
+        assert_eq!(file.flushes(), baseline + 1, "second write crosses cadence");
+
+        storage
+            .write_many(&[WriteOperation::set("records", b"3", b"third")])
+            .unwrap();
+        storage.flush_write_boundary().unwrap();
+        assert_eq!(
+            file.flushes(),
+            baseline + 2,
+            "final partial batch is flushed"
+        );
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/groove/src/storage/rocksdb.rs
+++ b/crates/groove/src/storage/rocksdb.rs
@@ -7,6 +7,7 @@
 //! storage for tests lives in [`super`], and all schema-aware behavior lives
 //! above this adapter.
 
+use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -54,6 +55,13 @@ pub struct RocksDbStorage {
     column_families: BTreeSet<String>,
     db: DB,
     write_options: WriteOptions,
+    write_flush_cadence: RefCell<Option<WriteFlushCadence>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WriteFlushCadence {
+    every: usize,
+    pending: usize,
 }
 
 impl RocksDbStorage {
@@ -121,6 +129,7 @@ impl RocksDbStorage {
             column_families: opened_column_families,
             db,
             write_options,
+            write_flush_cadence: RefCell::new(None),
         })
     }
 
@@ -284,6 +293,20 @@ impl OrderedKvStorage for RocksDbStorage {
             .delete_cf_opt(self.cf_handle(cf)?, key, &self.write_options)?)
     }
 
+    fn set_write_flush_cadence(&self, every: usize) -> Result<(), Error> {
+        assert!(every > 0, "write flush cadence must be non-zero");
+        *self.write_flush_cadence.borrow_mut() = Some(WriteFlushCadence { every, pending: 0 });
+        Ok(())
+    }
+
+    fn flush_write_boundary(&self) -> Result<(), Error> {
+        self.db.flush_wal(true)?;
+        if let Some(cadence) = self.write_flush_cadence.borrow_mut().as_mut() {
+            cadence.pending = 0;
+        }
+        Ok(())
+    }
+
     fn scan_range(
         &self,
         cf: &ColumnFamilyName,
@@ -437,7 +460,25 @@ impl OrderedKvStorage for RocksDbStorage {
             }
         }
 
-        Ok(self.db.write_opt(&batch, &self.write_options)?)
+        let should_flush = match self.write_flush_cadence.borrow_mut().as_mut() {
+            Some(cadence) => {
+                cadence.pending += 1;
+                if cadence.pending == cadence.every {
+                    cadence.pending = 0;
+                    true
+                } else {
+                    false
+                }
+            }
+            None => return Ok(self.db.write_opt(&batch, &self.write_options)?),
+        };
+        let mut write_options = WriteOptions::default();
+        write_options.disable_wal(false);
+        self.db.write_opt(&batch, &write_options)?;
+        if should_flush {
+            self.db.flush_wal(true)?;
+        }
+        Ok(())
     }
 
     fn column_family_names(&self) -> Option<Vec<String>> {
@@ -497,7 +538,7 @@ mod tests {
     use super::{
         CLASS_AHEAD_CURRENT_CF, CLASS_CHANGES_CF, CLASS_CONTENT_CF, CLASS_GLOBAL_CURRENT_CF,
         CLASS_HISTORY_CF, CLASS_INDICES_CF, CLASS_META_CF, CLASS_REGISTER_CF, RocksDbClassProfile,
-        rocksdb_class_profile,
+        RocksDbStorage, rocksdb_class_profile,
     };
 
     #[test]
@@ -536,5 +577,14 @@ mod tests {
             rocksdb_class_profile("ordinary"),
             RocksDbClassProfile::Default
         );
+    }
+
+    #[test]
+    fn ordinary_rocksdb_open_does_not_enable_client_flush_cadence() {
+        // Server storage follows this ordinary open path. The client-only
+        // cadence must stay opt-in so its durability behavior is unchanged.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RocksDbStorage::open(dir.path(), &["records"]).unwrap();
+        assert!(storage.write_flush_cadence.borrow().is_none());
     }
 }

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -43,12 +43,13 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jazz::db::{
     Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity,
-    LocalUpdates as CoreLocalUpdates, MergeableTxOps, PeerConnection as CorePeerConnection,
-    PreparedQuery as PreparedQueryInner, Propagation as CorePropagation,
-    QueryAttachment as CoreQueryAttachment, ReadOpts as CoreReadOpts, RowCells as CoreRowCells,
-    SeededRowIdSource as CoreSeededRowIdSource, SubscriptionEvent, SubscriptionStream,
-    TickScheduler as CoreTickScheduler, TickUrgency as CoreTickUrgency,
-    WireTransportAdapter as CoreWireTransportAdapter, WriteHandle, block_on as core_block_on,
+    InitialSyncFlushCadence as CoreInitialSyncFlushCadence, LocalUpdates as CoreLocalUpdates,
+    MergeableTxOps, PeerConnection as CorePeerConnection, PreparedQuery as PreparedQueryInner,
+    Propagation as CorePropagation, QueryAttachment as CoreQueryAttachment,
+    ReadOpts as CoreReadOpts, RowCells as CoreRowCells, SeededRowIdSource as CoreSeededRowIdSource,
+    SubscriptionEvent, SubscriptionStream, TickScheduler as CoreTickScheduler,
+    TickUrgency as CoreTickUrgency, WireTransportAdapter as CoreWireTransportAdapter, WriteHandle,
+    block_on as core_block_on,
 };
 use jazz::groove::records::{
     BorrowedRecord as CoreBorrowedRecord, RecordDescriptor, Value as CoreValue,
@@ -78,6 +79,7 @@ struct CoreOpenDbConfig {
     identity: CoreOpenDbIdentity,
     row_id_seed: Option<u64>,
     history_complete: bool,
+    initial_sync_flush_every: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -1521,11 +1523,32 @@ where
     if let Some(seed) = config.row_id_seed {
         db_config = db_config.with_id_source(CoreSeededRowIdSource::new(seed));
     }
+    let initial_sync_flush_every = config.initial_sync_flush_every;
     if config.history_complete {
-        core_block_on(CoreDb::open_history_complete(db_config))
+        let db = core_block_on(CoreDb::open_history_complete(db_config))?;
+        configure_initial_sync_flush_cadence(&db, initial_sync_flush_every)?;
+        Ok(db)
     } else {
-        core_block_on(CoreDb::open(db_config))
+        let db = core_block_on(CoreDb::open(db_config))?;
+        configure_initial_sync_flush_cadence(&db, initial_sync_flush_every)?;
+        Ok(db)
     }
+}
+
+fn configure_initial_sync_flush_cadence<S>(
+    db: &CoreDb<S>,
+    every: Option<u32>,
+) -> std::result::Result<(), jazz::db::Error>
+where
+    S: CoreOrderedKvStorage + CoreReopenableStorage + 'static,
+{
+    let Some(every) = every else {
+        return Ok(());
+    };
+    let Some(every) = std::num::NonZeroUsize::new(every as usize) else {
+        return Ok(());
+    };
+    db.set_initial_sync_flush_cadence(CoreInitialSyncFlushCadence::every(every))
 }
 
 fn decode_core_cells(bytes: &[u8]) -> napi::Result<CoreRowCells> {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -7,10 +7,10 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use futures_util::{Stream, StreamExt};
 use jazz::db::{
-    block_on, Db, DbConfig, DbIdentity, ExclusiveTxOps, LocalUpdates, MergeableTxOps,
-    PeerConnection, PreparedQuery, Propagation, QueryAttachment, ReadOpts, RowCells,
-    SeededRowIdSource, SubscriptionEvent, TickScheduler, TickUrgency, WireTransportAdapter,
-    WriteHandle,
+    block_on, Db, DbConfig, DbIdentity, ExclusiveTxOps, InitialSyncFlushCadence, LocalUpdates,
+    MergeableTxOps, PeerConnection, PreparedQuery, Propagation, QueryAttachment, ReadOpts,
+    RowCells, SeededRowIdSource, SubscriptionEvent, TickScheduler, TickUrgency,
+    WireTransportAdapter, WriteHandle,
 };
 use jazz::groove::records::{BorrowedRecord, RecordDescriptor, Value};
 #[cfg(target_arch = "wasm32")]
@@ -152,6 +152,7 @@ struct WasmOpenDbConfig {
     identity: WasmDbIdentity,
     row_id_seed: Option<u64>,
     history_complete: bool,
+    initial_sync_flush_every: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -2098,11 +2099,32 @@ where
     if let Some(seed) = config.row_id_seed {
         db_config = db_config.with_id_source(SeededRowIdSource::new(seed));
     }
+    let initial_sync_flush_every = config.initial_sync_flush_every;
     if config.history_complete {
-        block_on(Db::open_history_complete(db_config))
+        let db = block_on(Db::open_history_complete(db_config))?;
+        configure_initial_sync_flush_cadence(&db, initial_sync_flush_every)?;
+        Ok(db)
     } else {
-        block_on(Db::open(db_config))
+        let db = block_on(Db::open(db_config))?;
+        configure_initial_sync_flush_cadence(&db, initial_sync_flush_every)?;
+        Ok(db)
     }
+}
+
+fn configure_initial_sync_flush_cadence<S>(
+    db: &Db<S>,
+    every: Option<u32>,
+) -> Result<(), jazz::db::Error>
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    let Some(every) = every else {
+        return Ok(());
+    };
+    let Some(every) = std::num::NonZeroUsize::new(every as usize) else {
+        return Ok(());
+    };
+    db.set_initial_sync_flush_cadence(InitialSyncFlushCadence::every(every))
 }
 
 fn tick_connection<S>(connection: &Option<Rc<RefCell<PeerConnection<S>>>>) -> Result<u32, JsValue>

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -7,6 +7,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::pin::{Pin, pin};
 use std::rc::{Rc, Weak};
 #[cfg(feature = "sync-autopsy")]
@@ -289,6 +290,32 @@ pub struct WriteState {
     pub durability: DurabilityTier,
 }
 
+/// Explicit client durability cadence while the first server snapshot is
+/// loading.
+///
+/// A crash can lose up to `M - 1` writes since the last completed boundary,
+/// where `M` is this value. Older completed boundaries recover from the
+/// storage WAL. The final partial initial-sync batch is always flushed before
+/// the client returns to per-write durability.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InitialSyncFlushCadence(NonZeroUsize);
+
+impl InitialSyncFlushCadence {
+    /// The client default: a durability boundary every 512 initial-sync writes.
+    pub const DEFAULT: Self = Self(NonZeroUsize::new(512).expect("non-zero"));
+
+    /// Create a cadence with one durability boundary per `writes` initial-sync
+    /// writes.
+    pub const fn every(writes: NonZeroUsize) -> Self {
+        Self(writes)
+    }
+
+    /// Number of writes between completed durability boundaries.
+    pub const fn writes(self) -> usize {
+        self.0.get()
+    }
+}
+
 /// Usage-site query coverage attachment.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct QueryAttachment {
@@ -421,6 +448,21 @@ where
     /// close the underlying storage.
     pub fn close(&self) -> Result<(), Error> {
         Ok(self.node.node.borrow_mut().close()?)
+    }
+
+    /// Configure this client database's first-snapshot durability cadence.
+    ///
+    /// Servers do not call this client-only setting and retain their existing
+    /// storage durability behavior.
+    pub fn set_initial_sync_flush_cadence(
+        &self,
+        cadence: InitialSyncFlushCadence,
+    ) -> Result<(), Error> {
+        Ok(self
+            .node
+            .node
+            .borrow_mut()
+            .set_initial_sync_flush_cadence(cadence.writes())?)
     }
 
     /// Seed a settled mergeable row for server bootstrap/import flows.

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
@@ -3633,6 +3634,53 @@ fn array_subquery_remote_subscription_hydrates_edge_referenced_child_rows() {
         delivered.is_some(),
         "remote maintained array subscription must hydrate the child row referenced by relation-edge facts"
     );
+}
+
+#[test]
+fn client_initial_sync_flush_cadence_preserves_public_snapshot_delivery() {
+    let schema = schema();
+    let server = open_core(0xd4, AuthorId::SYSTEM, &schema);
+    for ordinal in 0..3_u8 {
+        server
+            .insert_with_id(
+                "todos",
+                row(0xd0 + ordinal),
+                BTreeMap::from([
+                    (
+                        "title".to_owned(),
+                        Value::String(format!("server {ordinal}")),
+                    ),
+                    ("done".to_owned(), Value::Bool(false)),
+                ]),
+            )
+            .unwrap();
+    }
+
+    let client_author = AuthorId::from_bytes([0xd5; 16]);
+    let client = open_db(0xd5, client_author, &schema);
+    client
+        .set_initial_sync_flush_cadence(InitialSyncFlushCadence::every(
+            NonZeroUsize::new(2).unwrap(),
+        ))
+        .unwrap();
+    let (client_transport, server_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let query = client.table("todos");
+    let mut subscription = prepared_subscribe(&client, &query, global_subscribe_opts()).unwrap();
+    let _ = block_on(subscription.next_event()).unwrap();
+
+    for _ in 0..20 {
+        client.tick().unwrap();
+        server.server.tick().unwrap();
+        client.tick().unwrap();
+        if let Some(event) = subscription.try_next_event()
+            && opened_rows(event).len() == 3
+        {
+            return;
+        }
+    }
+    panic!("client configured with a cadence must receive the initial snapshot");
 }
 
 #[test]

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -231,6 +231,13 @@ pub struct NodeState<S> {
     /// Whether this authority has installed the permissions head that governs
     /// session-scoped reads and writes.
     permissions_ready: bool,
+    /// Client-only write cadence selected for the first snapshot hydration.
+    initial_sync_flush_cadence: Option<usize>,
+    /// Whether the first snapshot is currently using the configured cadence.
+    initial_sync_flush_active: bool,
+    /// Once the initial snapshot has completed, ordinary writes return to their
+    /// existing per-write durability boundaries.
+    initial_sync_flush_completed: bool,
 }
 
 /// Schema catalogue and schema-version storage layout known by the node.
@@ -630,6 +637,9 @@ where
             session_claims: BTreeMap::new(),
             session_claim_revisions: BTreeMap::new(),
             permissions_ready: true,
+            initial_sync_flush_cadence: None,
+            initial_sync_flush_active: false,
+            initial_sync_flush_completed: false,
         };
         node.recover_from_storage()?;
         node.recover_known_state_facts()?;
@@ -3082,6 +3092,38 @@ where
 
     pub(crate) fn flush_query_runtime(&mut self) -> Result<(), Error> {
         self.database.flush().map_err(Error::Groove)
+    }
+
+    pub(crate) fn set_initial_sync_flush_cadence(&mut self, every: usize) -> Result<(), Error> {
+        debug_assert!(every > 0);
+        self.initial_sync_flush_cadence = Some(every);
+        // The cadence only relaxes durability while the first snapshot is
+        // active. Normal client writes retain a boundary per committed batch.
+        self.database.set_write_flush_cadence(1)?;
+        Ok(())
+    }
+
+    pub(super) fn begin_initial_sync_flush_cadence(&mut self) -> Result<(), Error> {
+        let Some(every) = self.initial_sync_flush_cadence else {
+            return Ok(());
+        };
+        if self.initial_sync_flush_active || self.initial_sync_flush_completed {
+            return Ok(());
+        }
+        self.database.set_write_flush_cadence(every)?;
+        self.initial_sync_flush_active = true;
+        Ok(())
+    }
+
+    pub(super) fn finish_initial_sync_flush_cadence(&mut self) -> Result<(), Error> {
+        if !self.initial_sync_flush_active {
+            return Ok(());
+        }
+        self.database.flush_write_boundary()?;
+        self.database.set_write_flush_cadence(1)?;
+        self.initial_sync_flush_active = false;
+        self.initial_sync_flush_completed = true;
+        Ok(())
     }
 
     pub(crate) fn post_tick_consolidate_history_windows(

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -631,6 +631,9 @@ where
         if updates.is_empty() {
             return Ok(());
         }
+        if updates.iter().any(|update| update.reset_result_set) {
+            self.begin_initial_sync_flush_cadence()?;
+        }
         let mut bulk_candidates = Vec::new();
         let mut initial_hydration_binding_views =
             self.query.initial_hydration_binding_views.clone();
@@ -709,6 +712,9 @@ where
         // arrival order below.
         for update in updates {
             self.apply_view_update_inner(update, Some(&preloaded_tx_ids))?;
+        }
+        if self.initial_sync_flush_active && self.query.initial_hydration_binding_views.is_empty() {
+            self.finish_initial_sync_flush_cadence()?;
         }
         Ok(())
     }

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -593,6 +593,15 @@ impl<F: SyncFile> OpfsBTree<F> {
         Ok(())
     }
 
+    /// Force a durability boundary for data already written to the WAL.
+    ///
+    /// This intentionally bypasses [`SyncPolicy`]: callers use it for an
+    /// explicit bounded cadence while the ordinary write path remains free to
+    /// defer syncs between boundaries.
+    pub fn flush_file(&self) -> Result<(), BTreeError> {
+        self.file.flush()
+    }
+
     pub fn checkpoint_state(&self) -> CheckpointState {
         // Reports the latest durable logical state: checkpoint metadata plus
         // any replayed or newly flushed WAL commits. `active_slot` still names

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -94,6 +94,12 @@ export interface DbConfig {
   backendSecret?: string;
   /** Database name for OPFS persistence (browser only, default: appId) */
   dbName?: string;
+  /**
+   * Initial-sync durability boundary, in writes (default: 512 for clients).
+   * A crash can lose up to M - 1 writes since the previous boundary; older
+   * boundaries recover from the storage WAL.
+   */
+  initialSyncFlushEvery?: number;
   /** Optional WASM tracing level for benchmark/debug scenarios (default: "warn"). */
   logLevel?: WasmLogLevel;
   /** Optional OTLP/HTTP collector URL for WASM trace telemetry. */

--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -71,6 +71,14 @@ function authorBytesForSubject(subject: string, fallbackSeed: string): Uint8Arra
   return uuidBytes(subject) ?? deterministicBytes(`${fallbackSeed}:author`);
 }
 
+function initialSyncFlushEvery(config: DbConfig): number {
+  const value = config.initialSyncFlushEvery ?? 512;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("initialSyncFlushEvery must be a positive integer");
+  }
+  return value;
+}
+
 export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
   private module: WasmModule | null = null;
 
@@ -108,6 +116,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     const author = subject
       ? authorBytesForSubject(subject, identitySeed)
       : deterministicBytes(`${identitySeed}:author`);
+    const flushEvery = initialSyncFlushEvery(config);
     const mainThreadPeerRuntime = persistentBrowserDbName
       ? new PersistentBrowserOpfsRuntime(
           config.runtimeSources,
@@ -115,8 +124,11 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
           persistentBrowserDbName,
           node,
           author,
+          flushEvery,
         )
-      : new NativeRuntimeAdapter(this.wasmModule.WasmDb, schema, node, author, 1, true);
+      : new NativeRuntimeAdapter(this.wasmModule.WasmDb, schema, node, author, 1, true, {
+          initialSyncFlushEvery: flushEvery,
+        });
 
     return JazzClient.connectWithRuntime(
       mainThreadPeerRuntime,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
@@ -125,6 +125,7 @@ export function openConfig(
   author: Uint8Array,
   sourceId?: number,
   historyComplete = false,
+  initialSyncFlushEvery?: number,
 ): Uint8Array {
   const writer = new PostcardWriter();
   writer.bytes(node);
@@ -135,6 +136,11 @@ export function openConfig(
     writer.some((value) => value.u64(sourceId));
   }
   writer.bool(historyComplete);
+  if (initialSyncFlushEvery == null) {
+    writer.none();
+  } else {
+    writer.some((value) => value.u64(initialSyncFlushEvery));
+  }
   return writer.finish();
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -389,10 +389,16 @@ export class NativeRuntimeAdapter implements Runtime {
     author: Uint8Array,
     sourceId: number,
     historyComplete: boolean,
-    opts?: { persistentPath?: string; db?: NativeDb },
+    opts?: { persistentPath?: string; db?: NativeDb; initialSyncFlushEvery?: number },
   ) {
     this.schemaBytes = encodeSchema(schema);
-    this.configBytes = openConfig(node, author, sourceId, historyComplete);
+    this.configBytes = openConfig(
+      node,
+      author,
+      sourceId,
+      historyComplete,
+      opts?.initialSyncFlushEvery,
+    );
     this.peerIdentity = author;
     this.schemaHash = serializeRuntimeSchema(schema);
     if (opts?.db) {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
@@ -11,6 +11,7 @@ type OpenRequest = {
     schema: WasmSchema,
     node: Uint8Array,
     author: Uint8Array,
+    initialSyncFlushEvery: number | undefined,
   ];
 };
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -647,4 +647,47 @@ describe("PersistentBrowserOpfsRuntime", () => {
     expect(worker.terminated).toBe(true);
     expect(worker.messages.some((message) => message.method === "close")).toBe(true);
   });
+
+  it("forwards the configured initial-sync flush cadence to the OPFS owner", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-flush-cadence-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+      17,
+    );
+    const worker = FakeWorker.instances[0];
+
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "open")).toBe(true);
+    });
+    const openMessage = worker.messages.find((message) => message.method === "open");
+    expect(openMessage?.args[5]).toBe(17);
+
+    await runtime.close();
+  });
+
+  it("defaults the OPFS owner initial-sync flush cadence to 512 writes", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-default-flush-cadence-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "open")).toBe(true);
+    });
+    const openMessage = worker.messages.find((message) => message.method === "open");
+    expect(openMessage?.args[5]).toBe(512);
+
+    await runtime.close();
+  });
 });

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -61,6 +61,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     private readonly dbName: string,
     private readonly node: Uint8Array,
     private readonly author: Uint8Array,
+    private readonly initialSyncFlushEvery: number | undefined = 512,
   ) {
     this.worker = new Worker(new URL("./persistent-browser-worker.js", import.meta.url), {
       type: "module",
@@ -88,9 +89,14 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
         ),
       );
     };
-    this.opened = this.send("open", [runtimeSources, dbName, schema, node, author]).then(
-      () => undefined,
-    );
+    this.opened = this.send("open", [
+      runtimeSources,
+      dbName,
+      schema,
+      node,
+      author,
+      initialSyncFlushEvery,
+    ]).then(() => undefined);
     if (typeof window !== "undefined") {
       this.pagehideAbort = new AbortController();
       window.addEventListener(

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -174,13 +174,13 @@ function dispatchWrite(message: WriteMessage): { transactionId: string } {
 }
 
 async function openRuntime(message: OpenMessage): Promise<void> {
-  const [runtimeSources, dbName, schema, node, author] = message.args;
+  const [runtimeSources, dbName, schema, node, author, initialSyncFlushEvery] = message.args;
   const wasmModule = await loadWasmModule(runtimeSources);
   runtimeNamespace = dbName;
   const db = await wasmModule.WasmDb.openBrowser(
     dbName,
     encodeSchema(schema as never),
-    openConfig(node, author, 1, true),
+    openConfig(node, author, 1, true, initialSyncFlushEvery),
   );
 
   runtime = NativeRuntimeAdapter.fromDb(db as never, schema as never, node, author, 1, true);


### PR DESCRIPTION
Client-only durability cadence for initial sync. Independent of the columnar
storage work — no format change, no chunking, no compaction.

## Measured opportunity

A benchmark of the 10,000-record initial-load write path on this machine:

| policy | RocksDB ~1 KiB | OPFS ~1 KiB |
|---|---|---|
| flush every write | baseline | baseline |
| flush once at end | 42.0× faster | 17.7× faster |
| **flush every 512** | within **16%** of once | within **6%** of once |
| flush every 4,096 | within 4% | within 4% |

OPFS bytes written for the same load: **749 MB at flush-every, 55.5 MB at
every-512**; flush calls drop from 10,129 to 26.

The curve saturating early is what makes this safe. **Flushing once at the end
of sync was deliberately not implemented** — it needs new semantics and risks
losing an entire in-progress load for a few percent more. A bounded cadence
gets nearly all of it.

## What this adds

`InitialSyncFlushCadence` (Rust) and `DbConfig.initialSyncFlushEvery`
(TypeScript), defaulting to **512** in the standard client runtime.

It activates only for first snapshot hydration, forces a final partial
boundary, then returns the client to per-write boundaries.

**Servers are untouched.** The justification is client-specific — a client that
crashes mid-initial-load can simply re-fetch — and that is not true of a
server. Direct core use is explicitly opt-in; server code never enables it.

No suitable setting already existed: `DurabilityTier` is read/write visibility
semantics, and storage carried only static backend durability options, not a
client-scoped bounded cadence.

## Durability bound

**Up to `M - 1` writes since the prior completed boundary may be lost on a
crash; older boundaries recover from WAL.** Documented where the setting lives.

At the default of 512 that is at most 511 records of an in-progress initial
load — data which is by definition re-fetchable, since it is being fetched.

## Backend behaviour differs, deliberately

- **OPFS/B-tree** defers WAL commits and flushes the `SyncFile` directly at
  cadence boundaries.
- **RocksDB** uses WAL-enabled unsynced writes during the cadence, then
  `flush_wal(true)` at boundaries.
- With no client setting, RocksDB retains its previous write path exactly.

## Gates

All exit 0 on a clean tree at `daa2ce5b6`: `cargo metadata`,
`cargo test -p jazz`, `cargo test -p groove`, `cargo check --workspace
--all-targets`, `cargo fmt --check`, `oxfmt --check`. The
no-default-features run is nonzero for exactly the three pre-existing
`catalogue_sync_integration` failures behind the `core_query` guard — no others
introduced.

Tests cover the OPFS boundary and final flush, runtime default and override
propagation, public sync delivery, and that ordinary RocksDB/server storage
does not enable the cadence.
