### PR TITLE
(new core) perf(opfs-btree): direct-write large overflow extents (~85% faster large RMW)

### DIFF
--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -1,6 +1,6 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
-use std::collections::BinaryHeap;
+use std::collections::{BTreeMap, BinaryHeap};
 
 use crate::BTreeError;
 use crate::file::SyncFile;
@@ -20,6 +20,10 @@ const DEFAULT_CACHE_BYTES: usize = 32 * 1024 * 1024;
 const DEFAULT_OVERFLOW_THRESHOLD: usize = 4 * 1024;
 const OVERFLOW_REUSE_MIN_BYTES: usize = 128 * 1024;
 const OVERFLOW_DIRECT_READ_MIN_BYTES: usize = 128 * 1024;
+// Keep the write threshold aligned with the read threshold.  At 128 KiB this
+// avoids replacing a handful of cheap page writes with an allocation-sized
+// staging buffer, while a default-page extent has already reached eight pages.
+const OVERFLOW_DIRECT_WRITE_MIN_BYTES: usize = OVERFLOW_DIRECT_READ_MIN_BYTES;
 const BOOTSTRAP_GENERATION: u64 = 1;
 const ALLOC_NEAR_WINDOW: u64 = 32;
 // Larger WAL tails reduce checkpoint frequency, but make browser files larger
@@ -30,6 +34,14 @@ const WAL_CHECKPOINT_THRESHOLD_PAGES: u64 = 1024;
 
 type OpfsMap<K, V> = FxHashMap<K, V>;
 type OpfsSet<T> = FxHashSet<T>;
+
+/// A contiguous overflow run staged outside the page cache.  It becomes one
+/// extent WAL record, rather than one dirty cache entry and WAL frame per page.
+#[derive(Debug)]
+struct DirtyBlobExtent {
+    page_count: usize,
+    raw: Vec<u8>,
+}
 
 struct PageWrite<'a> {
     page_id: PageId,
@@ -135,6 +147,7 @@ pub struct OpfsBTree<F: SyncFile> {
     access_epoch: u64,
     dirty_pages: OpfsSet<PageId>,
     wal_pages: OpfsSet<PageId>,
+    dirty_blob_extents: BTreeMap<PageId, DirtyBlobExtent>,
     freelist_dirty: bool,
     free_pages: Vec<PageId>,
     free_set: OpfsSet<PageId>,
@@ -196,6 +209,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             access_epoch: 0,
             dirty_pages: OpfsSet::default(),
             wal_pages: OpfsSet::default(),
+            dirty_blob_extents: BTreeMap::new(),
             freelist_dirty: false,
             free_pages: Vec::new(),
             free_set: OpfsSet::default(),
@@ -518,6 +532,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         self.truncate_wal_tail()?;
         self.dirty_pages.clear();
         self.wal_pages.clear();
+        self.dirty_blob_extents.clear();
         self.freelist_dirty = false;
         self.evict_pages_if_needed(None);
         Ok(())
@@ -533,6 +548,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         let root_page_id = self.root_page_id.unwrap_or(0);
         if self.dirty_pages.is_empty()
             && !self.freelist_dirty
+            && self.dirty_blob_extents.is_empty()
             && root_page_id == self.active.root_page_id
             && self.total_pages == self.active.total_pages
         {
@@ -550,15 +566,24 @@ impl<F: SyncFile> OpfsBTree<F> {
                 return Ok(());
             }
 
-            let wal_frames: Vec<WalFrameRef<'_>> = frames
+            let mut wal_frames: Vec<WalFrameRef<'_>> = frames
                 .iter()
-                .map(|frame| WalFrameRef {
+                .map(|frame| WalFrameRef::Page {
                     page_id: frame.page_id,
                     is_blob: frame.is_blob,
                     is_freelist: frame.is_freelist,
                     raw: frame.raw.as_ref(),
                 })
                 .collect();
+            wal_frames.extend(
+                self.dirty_blob_extents
+                    .iter()
+                    .map(|(&head_page_id, extent)| WalFrameRef::BlobExtent {
+                        head_page_id,
+                        page_count: extent.page_count,
+                        raw: &extent.raw,
+                    }),
+            );
             let start_page_id = self.persisted_pages.max(2);
             let pages_written = wal::append_commit(
                 &self.file,
@@ -580,6 +605,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         self.flush_for_write()?;
 
         self.wal_pages.extend(dirty_page_ids);
+        self.materialize_dirty_blob_extents_into_wal()?;
         self.dirty_pages.clear();
         self.active = Superblock::new(
             self.options.page_size as u32,
@@ -830,6 +856,10 @@ impl<F: SyncFile> OpfsBTree<F> {
         let max_chunk = self.options.page_size;
         let page_count = overflow_pages_for_len(expected_len, max_chunk);
 
+        if let Some(raw) = self.dirty_blob_extent_raw(head_page_id, page_count) {
+            return overflow_payload_from_raw(raw, expected_len, self.options.page_size);
+        }
+
         if expected_len >= OVERFLOW_DIRECT_READ_MIN_BYTES
             && !self.overflow_extent_has_dirty_pages(head_page_id, page_count)?
         {
@@ -933,6 +963,9 @@ impl<F: SyncFile> OpfsBTree<F> {
         head_page_id: PageId,
         page_count: usize,
     ) -> Result<bool, BTreeError> {
+        if self.dirty_blob_extent_overlaps(head_page_id, page_count)? {
+            return Ok(true);
+        }
         for idx in 0..page_count {
             let page_id = head_page_id.checked_add(idx as u64).ok_or_else(|| {
                 BTreeError::Corrupt("overflow extent page id overflow".to_string())
@@ -942,6 +975,32 @@ impl<F: SyncFile> OpfsBTree<F> {
             }
         }
         Ok(false)
+    }
+
+    fn dirty_blob_extent_raw(&self, head_page_id: PageId, page_count: usize) -> Option<&[u8]> {
+        self.dirty_blob_extents
+            .get(&head_page_id)
+            .filter(|extent| extent.page_count >= page_count)
+            .map(|extent| extent.raw.as_slice())
+    }
+
+    fn dirty_blob_extent_overlaps(
+        &self,
+        head_page_id: PageId,
+        page_count: usize,
+    ) -> Result<bool, BTreeError> {
+        let end_page_id = head_page_id
+            .checked_add(page_count as u64)
+            .ok_or_else(|| BTreeError::Corrupt("overflow extent page id overflow".to_string()))?;
+        Ok(self
+            .dirty_blob_extents
+            .iter()
+            .any(|(&extent_head, extent)| {
+                let Some(extent_end) = extent_head.checked_add(extent.page_count as u64) else {
+                    return true;
+                };
+                extent_head < end_page_id && head_page_id < extent_end
+            }))
     }
 
     fn free_value_cell(&mut self, value: ValueCell) -> Result<(), BTreeError> {
@@ -1103,16 +1162,22 @@ impl<F: SyncFile> OpfsBTree<F> {
             ));
         }
 
-        let mut remaining = value;
-        for idx in 0..needed_pages {
-            let consume = remaining.len().min(max_chunk);
-            let chunk = &remaining[..consume];
-            remaining = &remaining[consume..];
-            let page_id = head_page_id.checked_add(idx as u64).ok_or_else(|| {
-                BTreeError::Corrupt("overflow extent page id overflow".to_string())
-            })?;
-            let raw = build_blob_page(chunk, self.options.page_size)?;
-            self.set_dirty_blob_page(page_id, raw);
+        if value.len() >= OVERFLOW_DIRECT_WRITE_MIN_BYTES
+            && !self.overflow_extent_has_dirty_pages(head_page_id, needed_pages)?
+        {
+            self.validate_overflow_extent(head_page_id, needed_pages)?;
+            self.dirty_blob_extents.insert(
+                head_page_id,
+                DirtyBlobExtent {
+                    page_count: needed_pages,
+                    raw: build_blob_extent(value, self.options.page_size, needed_pages)?,
+                },
+            );
+        } else {
+            // A preceding direct rewrite is still unflushed.  Materialize it
+            // before taking the page path so the later write wins page by page.
+            self.materialize_dirty_blob_extents_overlapping(head_page_id, existing_pages)?;
+            self.rewrite_overflow_extent_by_page(head_page_id, needed_pages, value)?;
         }
 
         for idx in needed_pages..existing_pages {
@@ -1127,6 +1192,27 @@ impl<F: SyncFile> OpfsBTree<F> {
             head_page_id,
             total_len,
         })
+    }
+
+    fn rewrite_overflow_extent_by_page(
+        &mut self,
+        head_page_id: PageId,
+        needed_pages: usize,
+        value: &[u8],
+    ) -> Result<(), BTreeError> {
+        let max_chunk = self.options.page_size;
+        let mut remaining = value;
+        for idx in 0..needed_pages {
+            let consume = remaining.len().min(max_chunk);
+            let chunk = &remaining[..consume];
+            remaining = &remaining[consume..];
+            let page_id = head_page_id.checked_add(idx as u64).ok_or_else(|| {
+                BTreeError::Corrupt("overflow extent page id overflow".to_string())
+            })?;
+            let raw = build_blob_page(chunk, self.options.page_size)?;
+            self.set_dirty_blob_page(page_id, raw);
+        }
+        Ok(())
     }
 
     fn find_leaf_page_id(&mut self, key: &[u8]) -> Result<Option<PageId>, BTreeError> {
@@ -1443,6 +1529,17 @@ impl<F: SyncFile> OpfsBTree<F> {
             idx = end;
         }
 
+        // Direct overflow rewrites intentionally bypass the page cache.  They
+        // still reach their home extent only during a checkpoint, after the
+        // WAL commit is durable and before the superblock advances.
+        for (&head_page_id, extent) in &self.dirty_blob_extents {
+            self.validate_overflow_extent(head_page_id, extent.page_count)?;
+            let offset = head_page_id.checked_mul(page_size as u64).ok_or_else(|| {
+                BTreeError::Io("checkpoint overflow extent write offset overflow".to_string())
+            })?;
+            self.file.write_all_at(offset, &extent.raw)?;
+        }
+
         Ok(())
     }
 
@@ -1589,28 +1686,40 @@ impl<F: SyncFile> OpfsBTree<F> {
         self.freelist_meta_pages.clear();
 
         for frame in frames {
-            self.validate_writable_page_id(frame.page_id)?;
-            if frame.raw.len() != self.options.page_size {
-                return Err(BTreeError::Corrupt(format!(
-                    "WAL frame page {} has invalid length {}",
-                    frame.page_id,
-                    frame.raw.len()
-                )));
+            match frame {
+                WalFrame::Page {
+                    page_id,
+                    is_blob,
+                    is_freelist,
+                    raw,
+                } => self.apply_wal_page(page_id, is_blob, is_freelist, raw)?,
+                WalFrame::BlobExtent {
+                    head_page_id,
+                    page_count,
+                    raw,
+                } => {
+                    self.validate_overflow_extent(head_page_id, page_count)?;
+                    if raw.len()
+                        != page_count
+                            .checked_mul(self.options.page_size)
+                            .ok_or_else(|| {
+                                BTreeError::Corrupt("WAL blob extent size overflow".to_string())
+                            })?
+                    {
+                        return Err(BTreeError::Corrupt(
+                            "WAL blob extent length does not match page count".to_string(),
+                        ));
+                    }
+                    for idx in 0..page_count {
+                        let page_id = head_page_id.checked_add(idx as u64).ok_or_else(|| {
+                            BTreeError::Corrupt("overflow extent page id overflow".to_string())
+                        })?;
+                        let start = idx * self.options.page_size;
+                        let end = start + self.options.page_size;
+                        self.apply_wal_page(page_id, true, false, raw[start..end].to_vec())?;
+                    }
+                }
             }
-            if frame.is_blob {
-                self.blob_pages.insert(frame.page_id);
-            } else {
-                let _ = validate_page(&frame.raw, self.options.page_size)?;
-                self.blob_pages.remove(&frame.page_id);
-            }
-            self.pages.insert(frame.page_id, frame.raw);
-            if frame.is_freelist {
-                self.dirty_pages.remove(&frame.page_id);
-                self.wal_pages.remove(&frame.page_id);
-            } else {
-                self.wal_pages.insert(frame.page_id);
-            }
-            self.touch_page(frame.page_id);
         }
 
         if header.freelist_head_page_id != 0 {
@@ -1630,6 +1739,38 @@ impl<F: SyncFile> OpfsBTree<F> {
         // after the freelist load because freelist frames are clean and
         // evictable the moment they are applied.
         self.evict_pages_if_needed(None);
+        Ok(())
+    }
+
+    fn apply_wal_page(
+        &mut self,
+        page_id: PageId,
+        is_blob: bool,
+        is_freelist: bool,
+        raw: Vec<u8>,
+    ) -> Result<(), BTreeError> {
+        self.validate_writable_page_id(page_id)?;
+        if raw.len() != self.options.page_size {
+            return Err(BTreeError::Corrupt(format!(
+                "WAL frame page {} has invalid length {}",
+                page_id,
+                raw.len()
+            )));
+        }
+        if is_blob {
+            self.blob_pages.insert(page_id);
+        } else {
+            let _ = validate_page(&raw, self.options.page_size)?;
+            self.blob_pages.remove(&page_id);
+        }
+        self.pages.insert(page_id, raw);
+        if is_freelist {
+            self.dirty_pages.remove(&page_id);
+            self.wal_pages.remove(&page_id);
+        } else {
+            self.wal_pages.insert(page_id);
+        }
+        self.touch_page(page_id);
         Ok(())
     }
 
@@ -1689,6 +1830,84 @@ impl<F: SyncFile> OpfsBTree<F> {
         self.evict_pages_if_needed(Some(page_id));
     }
 
+    fn validate_overflow_extent(
+        &self,
+        head_page_id: PageId,
+        page_count: usize,
+    ) -> Result<(), BTreeError> {
+        if page_count == 0 || head_page_id < 2 {
+            return Err(BTreeError::Corrupt(
+                "overflow extent page id out of bounds".to_string(),
+            ));
+        }
+        let last_page_id = head_page_id
+            .checked_add((page_count - 1) as u64)
+            .ok_or_else(|| BTreeError::Corrupt("overflow extent page id overflow".to_string()))?;
+        if last_page_id >= self.total_pages {
+            return Err(BTreeError::Corrupt(format!(
+                "overflow extent [{}..={}] exceeds total_pages {}",
+                head_page_id, last_page_id, self.total_pages
+            )));
+        }
+        Ok(())
+    }
+
+    fn materialize_dirty_blob_extents_overlapping(
+        &mut self,
+        head_page_id: PageId,
+        page_count: usize,
+    ) -> Result<(), BTreeError> {
+        if !self.dirty_blob_extent_overlaps(head_page_id, page_count)? {
+            return Ok(());
+        }
+        let end_page_id = head_page_id
+            .checked_add(page_count as u64)
+            .ok_or_else(|| BTreeError::Corrupt("overflow extent page id overflow".to_string()))?;
+        let matching_heads: Vec<PageId> = self
+            .dirty_blob_extents
+            .iter()
+            .filter_map(|(&extent_head, extent)| {
+                let extent_end = extent_head.checked_add(extent.page_count as u64)?;
+                (extent_head < end_page_id && head_page_id < extent_end).then_some(extent_head)
+            })
+            .collect();
+        for extent_head in matching_heads {
+            let extent = self
+                .dirty_blob_extents
+                .remove(&extent_head)
+                .expect("matching dirty overflow extent exists");
+            for idx in 0..extent.page_count {
+                let page_id = extent_head.checked_add(idx as u64).ok_or_else(|| {
+                    BTreeError::Corrupt("overflow extent page id overflow".to_string())
+                })?;
+                let start = idx * self.options.page_size;
+                let end = start + self.options.page_size;
+                self.set_dirty_blob_page(page_id, extent.raw[start..end].to_vec());
+            }
+        }
+        Ok(())
+    }
+
+    fn materialize_dirty_blob_extents_into_wal(&mut self) -> Result<(), BTreeError> {
+        let extents = std::mem::take(&mut self.dirty_blob_extents);
+        for (head_page_id, extent) in extents {
+            self.validate_overflow_extent(head_page_id, extent.page_count)?;
+            for idx in 0..extent.page_count {
+                let page_id = head_page_id.checked_add(idx as u64).ok_or_else(|| {
+                    BTreeError::Corrupt("overflow extent page id overflow".to_string())
+                })?;
+                let start = idx * self.options.page_size;
+                let end = start + self.options.page_size;
+                self.pages.insert(page_id, extent.raw[start..end].to_vec());
+                self.blob_pages.insert(page_id);
+                self.wal_pages.insert(page_id);
+                self.touch_page(page_id);
+            }
+        }
+        self.evict_pages_if_needed(None);
+        Ok(())
+    }
+
     // Marking an already-cached page dirty cannot grow the cache, so it must
     // not trigger an eviction scan; only the insertion paths do that.
     fn mark_dirty_loaded_page(&mut self, page_id: PageId) {
@@ -1697,6 +1916,12 @@ impl<F: SyncFile> OpfsBTree<F> {
     }
 
     fn remove_page(&mut self, page_id: PageId) -> Option<Vec<u8>> {
+        self.dirty_blob_extents.retain(|&head_page_id, extent| {
+            let Some(end_page_id) = head_page_id.checked_add(extent.page_count as u64) else {
+                return false;
+            };
+            !(head_page_id <= page_id && page_id < end_page_id)
+        });
         if self.last_leaf_hint == Some(page_id) {
             self.last_leaf_hint = None;
         }
@@ -2052,6 +2277,45 @@ fn build_blob_page(chunk: &[u8], page_size: usize) -> Result<Vec<u8>, BTreeError
     let mut raw = vec![0u8; page_size];
     raw[..chunk.len()].copy_from_slice(chunk);
     Ok(raw)
+}
+
+fn build_blob_extent(
+    value: &[u8],
+    page_size: usize,
+    page_count: usize,
+) -> Result<Vec<u8>, BTreeError> {
+    let raw_len = page_count
+        .checked_mul(page_size)
+        .ok_or_else(|| BTreeError::Io("overflow extent write size overflow".to_string()))?;
+    if value.len() > raw_len {
+        return Err(BTreeError::Corrupt(format!(
+            "overflow payload {} exceeds extent {}",
+            value.len(),
+            raw_len
+        )));
+    }
+    let mut raw = vec![0u8; raw_len];
+    raw[..value.len()].copy_from_slice(value);
+    Ok(raw)
+}
+
+fn overflow_payload_from_raw(
+    raw: &[u8],
+    expected_len: usize,
+    page_size: usize,
+) -> Result<Vec<u8>, BTreeError> {
+    let page_count = overflow_pages_for_len(expected_len, page_size);
+    let required_len = page_count
+        .checked_mul(page_size)
+        .ok_or_else(|| BTreeError::Io("overflow extent read size overflow".to_string()))?;
+    if raw.len() < required_len || expected_len > raw.len() {
+        return Err(BTreeError::Corrupt(format!(
+            "overflow payload truncated: expected {}, found {}",
+            expected_len,
+            raw.len()
+        )));
+    }
+    Ok(raw[..expected_len].to_vec())
 }
 
 fn ensure_page_fits(page: &Page, page_size: usize, context: &str) -> Result<(), BTreeError> {
@@ -2759,6 +3023,111 @@ mod tests {
         assert!(
             !tree.free_set.is_empty(),
             "shrinking overflow value should return tail pages to free list"
+        );
+    }
+
+    // This is an internal test because whether a large overflow rewrite is
+    // represented by one staged extent or individual dirty pages is a storage
+    // implementation detail; public API tests below cover the visible values.
+    #[test]
+    fn direct_overflow_rewrite_stages_one_contiguous_extent() {
+        let file = MemoryFile::new();
+        let mut tree = OpfsBTree::open(file, small_options()).expect("open tree");
+        let first = deterministic_bytes(1, 256 * 1024);
+        let replacement = deterministic_bytes(2, 256 * 1024);
+
+        tree.put(b"large", &first).expect("seed large value");
+        tree.checkpoint().expect("checkpoint seed");
+        tree.put(b"large", &replacement).expect("direct rewrite");
+
+        assert_eq!(tree.dirty_blob_extents.len(), 1);
+        let extent = tree
+            .dirty_blob_extents
+            .values()
+            .next()
+            .expect("staged extent");
+        assert_eq!(extent.raw.len(), replacement.len());
+        assert_eq!(
+            tree.get(b"large").expect("read staged rewrite"),
+            Some(replacement)
+        );
+    }
+
+    // Internal for the same reason as the direct-staging assertion above: the
+    // public contract is the resulting value, while dirty-page fallback is an
+    // implementation guard that prevents an unflushed extent being replaced.
+    #[test]
+    fn dirty_overflow_extent_uses_page_by_page_fallback() {
+        let file = MemoryFile::new();
+        let mut tree = OpfsBTree::open(file, small_options()).expect("open tree");
+        let first = deterministic_bytes(3, 256 * 1024);
+        let second = deterministic_bytes(4, 256 * 1024);
+        let third = deterministic_bytes(5, 256 * 1024);
+
+        tree.put(b"large", &first).expect("seed large value");
+        tree.checkpoint().expect("checkpoint seed");
+        tree.put(b"large", &second).expect("direct rewrite");
+        assert_eq!(tree.dirty_blob_extents.len(), 1);
+
+        tree.put(b"large", &third).expect("dirty fallback rewrite");
+        assert!(tree.dirty_blob_extents.is_empty());
+        assert!(
+            tree.dirty_pages.len() >= overflow_pages_for_len(third.len(), tree.options.page_size),
+            "fallback must materialize page-level dirty state"
+        );
+        assert_eq!(
+            tree.get(b"large").expect("read fallback rewrite"),
+            Some(third)
+        );
+    }
+
+    #[test]
+    fn overflow_rewrite_below_direct_threshold_keeps_page_path() {
+        let file = MemoryFile::new();
+        let mut tree = OpfsBTree::open(file, small_options()).expect("open tree");
+        let first = deterministic_bytes(6, 256 * 1024);
+        let replacement = deterministic_bytes(7, OVERFLOW_DIRECT_WRITE_MIN_BYTES - 1);
+
+        tree.put(b"large", &first).expect("seed large value");
+        tree.checkpoint().expect("checkpoint seed");
+        tree.put(b"large", &replacement)
+            .expect("below-threshold rewrite");
+
+        assert!(tree.dirty_blob_extents.is_empty());
+        assert_eq!(
+            tree.get(b"large").expect("read below-threshold rewrite"),
+            Some(replacement)
+        );
+    }
+
+    #[test]
+    fn direct_overflow_rewrite_boundary_recovers_only_after_wal_commit() {
+        let file = MemoryFile::new();
+        let old = deterministic_bytes(8, OVERFLOW_DIRECT_WRITE_MIN_BYTES);
+        let new = deterministic_bytes(9, OVERFLOW_DIRECT_WRITE_MIN_BYTES);
+
+        {
+            let mut tree = OpfsBTree::open(file.clone(), small_options()).expect("open tree");
+            tree.put(b"large", &old).expect("seed value");
+            tree.checkpoint().expect("checkpoint seed");
+            tree.put(b"large", &new).expect("stage direct rewrite");
+            assert_eq!(tree.dirty_blob_extents.len(), 1);
+        }
+        let mut uncommitted = OpfsBTree::open(file.clone(), small_options()).expect("reopen crash");
+        assert_eq!(
+            uncommitted.get(b"large").expect("read old value"),
+            Some(old.clone())
+        );
+
+        {
+            let mut tree = OpfsBTree::open(file.clone(), small_options()).expect("reopen tree");
+            tree.put(b"large", &new).expect("stage direct rewrite");
+            tree.flush_wal().expect("commit direct rewrite to WAL");
+        }
+        let mut recovered = OpfsBTree::open(file, small_options()).expect("reopen committed WAL");
+        assert_eq!(
+            recovered.get(b"large").expect("read recovered value"),
+            Some(new)
         );
     }
 

--- a/crates/opfs-btree/src/wal.rs
+++ b/crates/opfs-btree/src/wal.rs
@@ -10,10 +10,14 @@ const WAL_COMMIT_MAGIC: [u8; 8] = *b"OPFSWC01";
 const WAL_FORMAT_VERSION: u32 = 1;
 const WAL_FRAME_FLAG_BLOB: u32 = 1;
 const WAL_FRAME_FLAG_FREELIST: u32 = 1 << 1;
+const WAL_FRAME_FLAG_BLOB_EXTENT: u32 = 1 << 2;
+const WAL_FRAME_FLAG_PAGE_COUNT_SHIFT: u32 = 3;
 
 const WAL_HEADER_CHECKSUM_OFFSET: usize = 56;
 const WAL_FRAME_CHECKSUM_OFFSET: usize = 32;
 const WAL_COMMIT_CHECKSUM_OFFSET: usize = 28;
+
+type WalFrameMeta = (PageId, bool, bool, Option<usize>, u32);
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct WalHeader {
@@ -49,19 +53,33 @@ impl WalHeader {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct WalFrame {
-    pub(crate) page_id: PageId,
-    pub(crate) is_blob: bool,
-    pub(crate) is_freelist: bool,
-    pub(crate) raw: Vec<u8>,
+pub(crate) enum WalFrame {
+    Page {
+        page_id: PageId,
+        is_blob: bool,
+        is_freelist: bool,
+        raw: Vec<u8>,
+    },
+    BlobExtent {
+        head_page_id: PageId,
+        page_count: usize,
+        raw: Vec<u8>,
+    },
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct WalFrameRef<'a> {
-    pub(crate) page_id: PageId,
-    pub(crate) is_blob: bool,
-    pub(crate) is_freelist: bool,
-    pub(crate) raw: &'a [u8],
+pub(crate) enum WalFrameRef<'a> {
+    Page {
+        page_id: PageId,
+        is_blob: bool,
+        is_freelist: bool,
+        raw: &'a [u8],
+    },
+    BlobExtent {
+        head_page_id: PageId,
+        page_count: usize,
+        raw: &'a [u8],
+    },
 }
 
 pub(crate) fn append_commit<F: SyncFile>(
@@ -73,7 +91,8 @@ pub(crate) fn append_commit<F: SyncFile>(
 ) -> Result<u64, BTreeError> {
     let frame_count = u64::try_from(frames.len())
         .map_err(|_| BTreeError::Io("WAL frame count overflow".to_string()))?;
-    let wal_pages = commit_page_count(frame_count, "WAL page count overflow", BTreeError::Io)?;
+    let wal_pages =
+        commit_page_count(frames, page_size, "WAL page count overflow", BTreeError::Io)?;
     let required_pages = start_page_id
         .checked_add(wal_pages)
         .ok_or_else(|| BTreeError::Io("WAL file length overflow".to_string()))?;
@@ -83,29 +102,75 @@ pub(crate) fn append_commit<F: SyncFile>(
     file.truncate(required_len)?;
 
     let header = header.with_frame_count(frame_count);
-    write_page(
-        file,
-        page_size,
-        start_page_id,
-        &encode_wal_header_page(page_size, header)?,
-    )?;
-
-    let mut cursor = start_page_id + 1;
+    // One contiguous append is safe: the commit page remains last, and every
+    // frame payload is checksummed during replay. A torn append therefore
+    // cannot make an incomplete extent visible as a committed transaction.
+    let byte_len = usize::try_from(wal_pages)
+        .ok()
+        .and_then(|pages| pages.checked_mul(page_size))
+        .ok_or_else(|| BTreeError::Io("WAL commit buffer size overflow".to_string()))?;
+    let mut encoded = Vec::with_capacity(byte_len);
+    encoded.extend_from_slice(&encode_wal_header_page(page_size, header)?);
     for frame in frames {
-        let meta = encode_wal_frame_meta_page(
-            page_size,
-            frame.page_id,
-            frame.is_blob,
-            frame.is_freelist,
-            frame.raw,
-        )?;
-        write_page(file, page_size, cursor, &meta)?;
-        write_page(file, page_size, cursor + 1, frame.raw)?;
-        cursor += 2;
+        match frame {
+            WalFrameRef::Page {
+                page_id,
+                is_blob,
+                is_freelist,
+                raw,
+            } => {
+                if raw.len() != page_size {
+                    return Err(BTreeError::Corrupt(format!(
+                        "WAL page raw length {} does not match page size {}",
+                        raw.len(),
+                        page_size
+                    )));
+                }
+                encoded.extend_from_slice(&encode_wal_frame_meta_page(
+                    page_size,
+                    *page_id,
+                    *is_blob,
+                    *is_freelist,
+                    None,
+                    raw,
+                )?);
+                encoded.extend_from_slice(raw);
+            }
+            WalFrameRef::BlobExtent {
+                head_page_id,
+                page_count,
+                raw,
+            } => {
+                if *page_count == 0
+                    || raw.len()
+                        != page_count
+                            .checked_mul(page_size)
+                            .ok_or_else(|| BTreeError::Io("WAL extent size overflow".to_string()))?
+                {
+                    return Err(BTreeError::Corrupt(
+                        "WAL blob extent length does not match page count".to_string(),
+                    ));
+                }
+                encoded.extend_from_slice(&encode_wal_frame_meta_page(
+                    page_size,
+                    *head_page_id,
+                    true,
+                    false,
+                    Some(*page_count),
+                    raw,
+                )?);
+                encoded.extend_from_slice(raw);
+            }
+        }
     }
-
-    let commit = encode_wal_commit_page(page_size, header.generation, frame_count)?;
-    write_page(file, page_size, cursor, &commit)?;
+    encoded.extend_from_slice(&encode_wal_commit_page(
+        page_size,
+        header.generation,
+        frame_count,
+    )?);
+    debug_assert_eq!(encoded.len(), byte_len);
+    let offset = page_offset(start_page_id, page_size, "WAL write offset overflow")?;
+    file.write_all_at(offset, &encoded)?;
     Ok(wal_pages)
 }
 
@@ -145,42 +210,72 @@ fn read_commit_with_mode<F: SyncFile>(
     };
     let frame_count = usize::try_from(header.frame_count)
         .map_err(|_| BTreeError::Corrupt("WAL frame count too large".to_string()))?;
-    let wal_pages = commit_page_count(
-        header.frame_count,
-        "WAL page count overflow",
-        BTreeError::Corrupt,
-    )?;
-    let next_cursor = start_page_id
-        .checked_add(wal_pages)
+    let mut frames = Vec::with_capacity(frame_count);
+    let mut cursor = start_page_id + 1;
+    for _ in 0..frame_count {
+        let meta_end = cursor
+            .checked_add(1)
+            .ok_or_else(|| BTreeError::Corrupt("WAL cursor overflow".to_string()))?;
+        if meta_end > persisted_pages {
+            truncate_tail(file, page_size, start_page_id)?;
+            return Ok(None);
+        }
+        reader.limit_to(meta_end);
+        let Some((page_id, is_blob, is_freelist, page_count, expected_checksum)) =
+            decode_wal_frame_meta_page(&reader.page(cursor)?, page_size)?
+        else {
+            truncate_tail(file, page_size, start_page_id)?;
+            return Ok(None);
+        };
+        let raw_page_count = page_count.unwrap_or(1);
+        let data_start = cursor
+            .checked_add(1)
+            .ok_or_else(|| BTreeError::Corrupt("WAL cursor overflow".to_string()))?;
+        let data_end = data_start
+            .checked_add(raw_page_count as u64)
+            .ok_or_else(|| BTreeError::Corrupt("WAL cursor overflow".to_string()))?;
+        if data_end > persisted_pages {
+            truncate_tail(file, page_size, start_page_id)?;
+            return Ok(None);
+        }
+        reader.limit_to(data_end);
+        let mut raw = Vec::with_capacity(
+            raw_page_count
+                .checked_mul(page_size)
+                .ok_or_else(|| BTreeError::Corrupt("WAL extent size overflow".to_string()))?,
+        );
+        for page_idx in 0..raw_page_count {
+            raw.extend_from_slice(&reader.page(data_start + page_idx as u64)?);
+        }
+        if checksum::hash(&raw) != expected_checksum {
+            truncate_tail(file, page_size, start_page_id)?;
+            return Ok(None);
+        }
+        if page_count.is_some() {
+            frames.push(WalFrame::BlobExtent {
+                head_page_id: page_id,
+                page_count: raw_page_count,
+                raw,
+            });
+        } else {
+            frames.push(WalFrame::Page {
+                page_id,
+                is_blob,
+                is_freelist,
+                raw,
+            });
+        }
+        cursor = data_end;
+    }
+
+    let next_cursor = cursor
+        .checked_add(1)
         .ok_or_else(|| BTreeError::Corrupt("WAL cursor overflow".to_string()))?;
     if next_cursor > persisted_pages {
         truncate_tail(file, page_size, start_page_id)?;
         return Ok(None);
     }
     reader.limit_to(next_cursor);
-
-    let mut frames = Vec::with_capacity(frame_count);
-    let mut cursor = start_page_id + 1;
-    for _ in 0..frame_count {
-        let Some((page_id, is_blob, is_freelist, expected_checksum)) =
-            decode_wal_frame_meta_page(&reader.page(cursor)?, page_size)?
-        else {
-            truncate_tail(file, page_size, start_page_id)?;
-            return Ok(None);
-        };
-        let raw = reader.page(cursor + 1)?.into_owned();
-        if checksum::hash(&raw) != expected_checksum {
-            truncate_tail(file, page_size, start_page_id)?;
-            return Ok(None);
-        }
-        frames.push(WalFrame {
-            page_id,
-            is_blob,
-            is_freelist,
-            raw,
-        });
-        cursor += 2;
-    }
 
     if !decode_wal_commit_page(&reader.page(cursor)?, header.generation, header.frame_count)? {
         truncate_tail(file, page_size, start_page_id)?;
@@ -190,14 +285,30 @@ fn read_commit_with_mode<F: SyncFile>(
 }
 
 fn commit_page_count(
-    frame_count: u64,
+    frames: &[WalFrameRef<'_>],
+    page_size: usize,
     overflow_message: &'static str,
     err: fn(String) -> BTreeError,
 ) -> Result<u64, BTreeError> {
-    frame_count
-        .checked_mul(2)
-        .and_then(|pages| pages.checked_add(2))
-        .ok_or_else(|| err(overflow_message.to_string()))
+    frames.iter().try_fold(2u64, |pages, frame| {
+        let payload_pages = match frame {
+            WalFrameRef::Page { .. } => 1,
+            WalFrameRef::BlobExtent {
+                page_count, raw, ..
+            } => {
+                if *page_count == 0
+                    || raw.len() != page_count.checked_mul(page_size).unwrap_or(usize::MAX)
+                {
+                    return Err(err(overflow_message.to_string()));
+                }
+                u64::try_from(*page_count).map_err(|_| err(overflow_message.to_string()))?
+            }
+        };
+        pages
+            .checked_add(1)
+            .and_then(|n| n.checked_add(payload_pages))
+            .ok_or_else(|| err(overflow_message.to_string()))
+    })
 }
 
 /// Page source for `read_commit_with_mode`: either the run-buffered reader or
@@ -319,23 +430,6 @@ impl<'a, F: SyncFile> PageRunReader<'a, F> {
     }
 }
 
-fn write_page<F: SyncFile>(
-    file: &F,
-    page_size: usize,
-    page_id: PageId,
-    raw: &[u8],
-) -> Result<(), BTreeError> {
-    if raw.len() != page_size {
-        return Err(BTreeError::Corrupt(format!(
-            "WAL page raw length {} does not match page size {}",
-            raw.len(),
-            page_size
-        )));
-    }
-    let offset = page_offset(page_id, page_size, "WAL write offset overflow")?;
-    file.write_all_at(offset, raw)
-}
-
 fn truncate_tail<F: SyncFile>(
     file: &F,
     page_size: usize,
@@ -402,6 +496,7 @@ fn encode_wal_frame_meta_page(
     page_id: PageId,
     is_blob: bool,
     is_freelist: bool,
+    blob_extent_page_count: Option<usize>,
     raw_page: &[u8],
 ) -> Result<Vec<u8>, BTreeError> {
     let mut page = vec![0u8; page_size];
@@ -417,6 +512,16 @@ fn encode_wal_frame_meta_page(
     if is_freelist {
         flags |= WAL_FRAME_FLAG_FREELIST;
     }
+    if let Some(page_count) = blob_extent_page_count {
+        let page_count = u32::try_from(page_count)
+            .map_err(|_| BTreeError::Io("WAL extent page count overflow".to_string()))?;
+        if page_count == 0 || page_count > (u32::MAX >> WAL_FRAME_FLAG_PAGE_COUNT_SHIFT) {
+            return Err(BTreeError::Io(
+                "WAL extent page count out of range".to_string(),
+            ));
+        }
+        flags |= WAL_FRAME_FLAG_BLOB_EXTENT | (page_count << WAL_FRAME_FLAG_PAGE_COUNT_SHIFT);
+    }
     write_u32_at(&mut page, 24, flags)?;
     write_u32_at(&mut page, 28, checksum::hash(raw_page))?;
     let checksum = checksum::hash(&page[..WAL_FRAME_CHECKSUM_OFFSET]);
@@ -427,7 +532,7 @@ fn encode_wal_frame_meta_page(
 fn decode_wal_frame_meta_page(
     raw: &[u8],
     page_size: usize,
-) -> Result<Option<(PageId, bool, bool, u32)>, BTreeError> {
+) -> Result<Option<WalFrameMeta>, BTreeError> {
     ensure_wal_page_capacity(raw, WAL_FRAME_CHECKSUM_OFFSET + 4)?;
     if raw[0..8] != WAL_FRAME_MAGIC {
         return Ok(None);
@@ -443,13 +548,27 @@ fn decode_wal_frame_meta_page(
         return Ok(None);
     }
     let flags = read_u32_at(raw, 24)?;
-    if flags & !(WAL_FRAME_FLAG_BLOB | WAL_FRAME_FLAG_FREELIST) != 0 {
+    let is_blob_extent = flags & WAL_FRAME_FLAG_BLOB_EXTENT != 0;
+    if !is_blob_extent && flags & !(WAL_FRAME_FLAG_BLOB | WAL_FRAME_FLAG_FREELIST) != 0 {
+        return Ok(None);
+    }
+    if is_blob_extent
+        && (flags & (WAL_FRAME_FLAG_BLOB | WAL_FRAME_FLAG_FREELIST) != WAL_FRAME_FLAG_BLOB)
+    {
+        return Ok(None);
+    }
+    let page_count = is_blob_extent.then(|| {
+        usize::try_from(flags >> WAL_FRAME_FLAG_PAGE_COUNT_SHIFT)
+            .expect("u32 fits in usize on supported targets")
+    });
+    if page_count == Some(0) {
         return Ok(None);
     }
     Ok(Some((
         read_u64_at(raw, 16)?,
         flags & WAL_FRAME_FLAG_BLOB != 0,
         flags & WAL_FRAME_FLAG_FREELIST != 0,
+        page_count,
         read_u32_at(raw, 28)?,
     )))
 }
@@ -553,13 +672,13 @@ mod tests {
         let page_a = vec![1u8; PAGE_SIZE];
         let page_b = vec![2u8; PAGE_SIZE];
         let frames = [
-            WalFrameRef {
+            WalFrameRef::Page {
                 page_id: 3,
                 is_blob: false,
                 is_freelist: false,
                 raw: &page_a,
             },
-            WalFrameRef {
+            WalFrameRef::Page {
                 page_id: 4,
                 is_blob: true,
                 is_freelist: false,
@@ -582,8 +701,14 @@ mod tests {
         assert_eq!(read_header.freelist_head_page_id, 4);
         assert_eq!(read_header.total_pages, 9);
         assert_eq!(read_frames.len(), 2);
-        assert_eq!(read_frames[0].raw, page_a);
-        assert_eq!(read_frames[1].raw, page_b);
+        assert!(matches!(
+            &read_frames[0],
+            WalFrame::Page { raw, .. } if raw == &page_a
+        ));
+        assert!(matches!(
+            &read_frames[1],
+            WalFrame::Page { raw, .. } if raw == &page_b
+        ));
         assert_eq!(next_cursor, persisted_pages);
     }
 
@@ -597,7 +722,7 @@ mod tests {
         let frames: Vec<WalFrameRef<'_>> = frame_pages
             .iter()
             .enumerate()
-            .map(|(i, raw)| WalFrameRef {
+            .map(|(i, raw)| WalFrameRef::Page {
                 page_id: 100 + i as PageId,
                 is_blob: i % 3 == 0,
                 is_freelist: i % 5 == 0,
@@ -619,19 +744,73 @@ mod tests {
             assert_eq!(next_cursor, persisted_pages);
             assert_eq!(read_frames.len(), 40);
             for (i, frame) in read_frames.iter().enumerate() {
-                assert_eq!(frame.page_id, 100 + i as PageId);
-                assert_eq!(frame.is_blob, i % 3 == 0);
-                assert_eq!(frame.is_freelist, i % 5 == 0);
-                assert_eq!(frame.raw, frame_pages[i]);
+                let WalFrame::Page {
+                    page_id,
+                    is_blob,
+                    is_freelist,
+                    raw,
+                } = frame
+                else {
+                    panic!("expected ordinary WAL page frame");
+                };
+                assert_eq!(*page_id, 100 + i as PageId);
+                assert_eq!(*is_blob, i % 3 == 0);
+                assert_eq!(*is_freelist, i % 5 == 0);
+                assert_eq!(*raw, frame_pages[i]);
             }
         }
+    }
+
+    #[test]
+    fn blob_extent_frame_round_trips_and_rejects_a_torn_payload() {
+        let file = MemoryFile::new();
+        let page_count = 32;
+        let payload = (0..page_count * PAGE_SIZE)
+            .map(|i| (i % 251) as u8)
+            .collect::<Vec<_>>();
+        let frames = [WalFrameRef::BlobExtent {
+            head_page_id: 40,
+            page_count,
+            raw: &payload,
+        }];
+
+        let pages_written =
+            append_commit(&file, PAGE_SIZE, START_PAGE_ID, header(), &frames).expect("append WAL");
+        assert_eq!(pages_written, 2 + 1 + page_count as u64);
+        let persisted_pages = START_PAGE_ID + pages_written;
+        let (_, frames, _) = read_commit(&file, PAGE_SIZE, START_PAGE_ID, persisted_pages)
+            .expect("read WAL")
+            .expect("commit present");
+        assert!(matches!(
+            &frames[0],
+            WalFrame::BlobExtent {
+                head_page_id: 40,
+                page_count: 32,
+                raw,
+            } if raw == &payload
+        ));
+
+        // Simulate a crash that left a payload byte torn while the commit page
+        // was already present. The extent checksum must reject the whole WAL
+        // transaction rather than exposing a partly rewritten value.
+        file.write_all_at((START_PAGE_ID + 2) * PAGE_SIZE as u64, &[0xff])
+            .expect("tear extent payload");
+        assert!(
+            read_commit(&file, PAGE_SIZE, START_PAGE_ID, persisted_pages)
+                .expect("read torn WAL")
+                .is_none()
+        );
+        assert_eq!(
+            file.len().expect("file len"),
+            START_PAGE_ID * PAGE_SIZE as u64
+        );
     }
 
     #[test]
     fn read_commit_returns_none_and_truncates_truncated_tail() {
         let file = MemoryFile::new();
         let page = vec![1u8; PAGE_SIZE];
-        let frames = [WalFrameRef {
+        let frames = [WalFrameRef::Page {
             page_id: 3,
             is_blob: false,
             is_freelist: false,
@@ -657,7 +836,7 @@ mod tests {
     fn read_commit_returns_none_and_truncates_corrupt_frame() {
         let file = MemoryFile::new();
         let page = vec![1u8; PAGE_SIZE];
-        let frames = [WalFrameRef {
+        let frames = [WalFrameRef::Page {
             page_id: 3,
             is_blob: false,
             is_freelist: false,


### PR DESCRIPTION
`opfs-btree` had a fast path for reading large overflow extents and none for
writing them. This adds the symmetric write path.

## The asymmetry

Values too large to inline go to an overflow page chain at
`DEFAULT_PAGE_SIZE = 16 KiB`. `rewrite_overflow_extent` looped `needed_pages`,
built a blob page per 16 KiB slice, and called `set_dirty_blob_page` for each —
so **a 4 MiB value was 256 page builds, 256 dirty-page entries and 256 WAL
frames, not one write.**

Reads already avoided this: `OVERFLOW_DIRECT_READ_MIN_BYTES = 128 KiB` and
`read_overflow_extent_direct` read a clean multi-page extent as one contiguous
read. Overflow pages are allocated contiguously (`head_page_id + idx`), which is
what makes that possible — and means nothing structural prevented the write
equivalent.

## What changed

Large **clean** overflow rewrites now stage one contiguous payload and emit one
checksummed WAL extent record. Threshold is 128 KiB, matching the read side.
Dirty extents, below-threshold values and the page-level fallback keep their
existing behaviour: this is an optimisation, not a semantic change.

## Measured, real Chromium OPFS worker

4 MiB read-modify-write, p50 µs:

| shape | before row / chunk | after row / chunk |
|---|---:|---:|
| 1 col, warm | 800 / **92,200** | 500 / **18,100** |
| 1 col, cold | 800 / **91,600** | 700 / **18,700** |
| 8 col, warm | 800 / **90,900** | 300 / **12,800** |
| 8 col, cold | 800 / **90,800** | 300 / **11,700** |

**~80–87% reduction in chunk-RMW p50.** Machine load was 1.3–2.9, lower than
the 4–12 of the original measurement.

Coalescing break-evens for columnar chunk updates also moved:

- `k=512`: first win `m=512` → **`m=256`**
- `k=4096`: `m=2048` is now clear (4.9 ms vs 7.9 ms) rather than marginal
- `k=1`, `8`, `64`: still no coalesced win in the tested sweep

## Crash safety

Preserved, not traded. Home pages are written only at checkpoint after the WAL
is durable; a torn extent payload rejects the whole commit; a crash before the
WAL write retains the old value.

Coverage added for multi-page round-trip, dirty-extent fallback, below-threshold
behaviour, committed/uncommitted boundary recovery, and torn extent WAL
payloads.

## Gates

`cargo metadata`, `opfs-btree` (61 tests), `jazz`, `groove`, workspace
all-targets, formatting, and the pre-commit clippy/sensitive-data hooks — all
pass on a clean tree.
