### PR TITLE
(new core) Output occurrence identity — shared foundation for structured results and flat joins

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1952,11 +1952,21 @@ fn core_subscription_event_to_json(event: &SubscriptionEvent) -> napi::Result<se
             tier,
             ..
         } => {
-            let delta = encode_core_subscription_delta(added, updated, removed)
+            // Keep the current native wire source-row addressed until a later
+            // revision carries occurrence identity explicitly.
+            let added = added
+                .iter()
+                .map(|output| output.row.clone())
+                .collect::<Vec<_>>();
+            let updated = updated
+                .iter()
+                .map(|output| output.row.clone())
+                .collect::<Vec<_>>();
+            let delta = encode_core_subscription_delta(&added, &updated, removed)
                 .map_err(|error| napi::Error::from_reason(error.to_string()))?;
             let relation_delta = encode_core_relation_subscription_delta(
-                added,
-                updated,
+                &added,
+                &updated,
                 removed,
                 added_related,
                 added_edges,

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -1830,7 +1830,7 @@ fn apply_event(rows: &mut BTreeSet<RowUuid>, event: SubscriptionEvent) {
                 rows.remove(&row.row_uuid);
             }
             for row in added.into_iter().chain(updated) {
-                rows.insert(row.row_uuid());
+                rows.insert(row.row.row_uuid());
             }
         }
         SubscriptionEvent::Rejected { reason } => {

--- a/crates/jazz-sim/benches/policy_graph_concurrent.rs
+++ b/crates/jazz-sim/benches/policy_graph_concurrent.rs
@@ -1172,7 +1172,7 @@ fn apply_event(rows: &mut BTreeSet<RowUuid>, event: SubscriptionEvent) -> bool {
                 rows.remove(&row.row_uuid);
             }
             for row in added.into_iter().chain(updated) {
-                rows.insert(row.row_uuid());
+                rows.insert(row.row.row_uuid());
             }
             settled
         }

--- a/crates/jazz-sim/benches/s1_saas.rs
+++ b/crates/jazz-sim/benches/s1_saas.rs
@@ -1597,8 +1597,11 @@ fn subscription_snapshot_row_set(
             updated,
             ..
         } => {
-            let mut rows = added;
-            rows.extend(updated);
+            let mut rows = added
+                .into_iter()
+                .map(|output| output.row)
+                .collect::<Vec<_>>();
+            rows.extend(updated.into_iter().map(|output| output.row));
             row_set(rows)
         }
         event => panic!("expected subscription snapshot, got {event:?}"),
@@ -1635,7 +1638,7 @@ fn apply_subscription_event(rows: &mut BTreeSet<(String, RowUuid)>, event: Subsc
                 rows.remove(&(row.table, row.row_uuid));
             }
             for row in added.into_iter().chain(updated) {
-                rows.insert((row.table().to_owned(), row.row_uuid()));
+                rows.insert((row.row.table().to_owned(), row.row.row_uuid()));
             }
         }
         SubscriptionEvent::Rejected { reason } => {

--- a/crates/jazz-sim/benches/s2_canvas.rs
+++ b/crates/jazz-sim/benches/s2_canvas.rs
@@ -2399,7 +2399,7 @@ fn apply_db_subscription_event(
             for row in removed {
                 current.remove(&row.row_uuid);
             }
-            for row in added.into_iter().chain(updated) {
+            for row in added.into_iter().chain(updated).map(|output| output.row) {
                 current.insert(row.row_uuid(), row);
             }
         }

--- a/crates/jazz-sim/benches/s3_permissions.rs
+++ b/crates/jazz-sim/benches/s3_permissions.rs
@@ -1889,7 +1889,7 @@ fn apply_db_subscription_event(visible_rows: &mut BTreeSet<RowUuid>, event: Subs
                 visible_rows.remove(&row.row_uuid);
             }
             for row in added.into_iter().chain(updated) {
-                visible_rows.insert(row.row_uuid());
+                visible_rows.insert(row.row.row_uuid());
             }
         }
         SubscriptionEvent::Rejected { reason } => {

--- a/crates/jazz-sim/benches/s5_durable_stream.rs
+++ b/crates/jazz-sim/benches/s5_durable_stream.rs
@@ -1186,8 +1186,11 @@ fn subscription_opened_rows(event: SubscriptionEvent) -> Vec<jazz::node::Current
             updated,
             ..
         } => {
-            let mut rows = added;
-            rows.extend(updated);
+            let mut rows = added
+                .into_iter()
+                .map(|output| output.row)
+                .collect::<Vec<_>>();
+            rows.extend(updated.into_iter().map(|output| output.row));
             rows
         }
         other => panic!("expected subscription snapshot, got {other:?}"),
@@ -1220,7 +1223,7 @@ fn apply_subscription_event(rows: &mut Vec<jazz::node::CurrentRow>, event: Subsc
                 .map(|row| row.row_uuid)
                 .collect::<BTreeSet<_>>();
             rows.retain(|row| !removed.contains(&row.row_uuid()));
-            for row in added.into_iter().chain(updated) {
+            for row in added.into_iter().chain(updated).map(|output| output.row) {
                 if let Some(slot) = rows
                     .iter_mut()
                     .find(|existing| existing.row_uuid() == row.row_uuid())

--- a/crates/jazz-sim/tests/customer_child_policy_minimal.rs
+++ b/crates/jazz-sim/tests/customer_child_policy_minimal.rs
@@ -217,7 +217,7 @@ fn apply_event(rows: &mut BTreeSet<RowUuid>, event: SubscriptionEvent) {
                 rows.remove(&row.row_uuid);
             }
             for row in added.into_iter().chain(updated) {
-                rows.insert(row.row_uuid());
+                rows.insert(row.row.row_uuid());
             }
         }
         SubscriptionEvent::Rejected { reason } => {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -2443,6 +2443,17 @@ fn subscription_chunk_to_js(event: SubscriptionEvent) -> Result<JsValue, JsValue
             settled,
             tier,
         } => {
+            // The current native wire remains source-row addressed. Occurrence
+            // identity is maintained in the Rust subscription boundary until a
+            // later wire-format revision carries it explicitly.
+            let added = added
+                .into_iter()
+                .map(|output| output.row)
+                .collect::<Vec<_>>();
+            let updated = updated
+                .into_iter()
+                .map(|output| output.row)
+                .collect::<Vec<_>>();
             let delta =
                 encode_subscription_delta(&added, &updated, &removed).map_err(to_js_error)?;
             let relation_delta = encode_relation_subscription_delta(

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -1787,8 +1787,11 @@ fn r12_recursive_permissions(c: &mut Criterion) {
                     updated,
                     ..
                 }) => {
-                    let mut rows = added;
-                    rows.extend(updated);
+                    let mut rows = added
+                        .into_iter()
+                        .map(|output| output.row)
+                        .collect::<Vec<_>>();
+                    rows.extend(updated.into_iter().map(|output| output.row));
                     assert_recursive_docs_visible(&rows);
                 }
                 other => panic!("expected recursive docs reset event, got {other:?}"),

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -65,6 +65,7 @@ use crate::query::{
 };
 use crate::schema::{JazzSchema, TableSchema};
 use crate::time::GlobalSeq;
+use crate::tools::{ObjectId, OutputOccurrenceId};
 use crate::tx::{DeletionEvent, DurabilityTier, Fate, RejectionReason, TxId, TxKind};
 use crate::wire::{
     FEATURE_STRUCTURED_ERRORS, FEATURE_SYNC_MESSAGE_PAYLOAD, TransportError, WIRE_PROTOCOL_VERSION,
@@ -7800,7 +7801,7 @@ struct SubscriptionState {
 
 #[derive(Clone, Default)]
 struct RelationSnapshotIndex {
-    roots: BTreeMap<(String, RowUuid), usize>,
+    roots: BTreeMap<OutputOccurrenceId, usize>,
     related: BTreeMap<(String, RowUuid), usize>,
     edges: BTreeSet<RelationEdge>,
 }
@@ -7811,7 +7812,7 @@ impl RelationSnapshotIndex {
         for (position, row) in snapshot.rows.iter().take(snapshot.root_count).enumerate() {
             index
                 .roots
-                .insert((row.table().to_owned(), row.row_uuid()), position);
+                .insert(single_source_occurrence_id(row), position);
         }
         for (offset, row) in snapshot.rows.iter().skip(snapshot.root_count).enumerate() {
             index.related.insert(
@@ -7845,6 +7846,25 @@ pub struct RemovedRow {
     pub table: String,
     /// Stable row identity.
     pub row_uuid: RowUuid,
+    /// Stable identity of the removed output occurrence.
+    pub occurrence_id: OutputOccurrenceId,
+}
+
+/// One row addressed by its maintained output occurrence identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubscriptionOutputRow {
+    /// Stable output occurrence identity.
+    pub occurrence_id: OutputOccurrenceId,
+    /// Materialized row body for this output occurrence.
+    pub row: CurrentRow,
+}
+
+impl std::ops::Deref for SubscriptionOutputRow {
+    type Target = CurrentRow;
+
+    fn deref(&self) -> &Self::Target {
+        &self.row
+    }
 }
 
 /// Materialized relation edge removed from a subscription result.
@@ -7860,9 +7880,9 @@ pub enum SubscriptionEvent {
         /// Fresh subscriptions start with a reset delta from the empty result.
         reset: bool,
         /// Rows newly visible to the subscription.
-        added: Vec<CurrentRow>,
+        added: Vec<SubscriptionOutputRow>,
         /// Rows still visible with changed projected cells.
-        updated: Vec<CurrentRow>,
+        updated: Vec<SubscriptionOutputRow>,
         /// Rows no longer visible to the subscription.
         removed: Vec<RemovedRow>,
         /// Related rows newly referenced by relation edges.
@@ -7980,7 +8000,11 @@ fn subscription_reset_event(
 ) -> SubscriptionEvent {
     SubscriptionEvent::Delta {
         reset: true,
-        added: current.rows,
+        added: current
+            .rows
+            .into_iter()
+            .map(subscription_output_row)
+            .collect(),
         updated: Vec::new(),
         removed: Vec::new(),
         added_related: Vec::new(),
@@ -8024,8 +8048,10 @@ fn subscription_delta_event_with_reset(
 
     for (key, row) in &current_by_id {
         match previous_by_id.get(key) {
-            None => added.push((*row).clone()),
-            Some(previous_row) if *previous_row != *row => updated.push((*row).clone()),
+            None => added.push(subscription_output_row((*row).clone())),
+            Some(previous_row) if *previous_row != *row => {
+                updated.push(subscription_output_row((*row).clone()))
+            }
             Some(_) => {}
         }
     }
@@ -8035,6 +8061,7 @@ fn subscription_delta_event_with_reset(
             removed.push(RemovedRow {
                 table: key.0.clone(),
                 row_uuid: key.1,
+                occurrence_id: OutputOccurrenceId::single_source(ObjectId::from_uuid(key.1.0)),
             });
         }
     }
@@ -8079,7 +8106,10 @@ fn apply_maintained_update_to_snapshot(
             *snapshot_index = RelationSnapshotIndex::from_snapshot(snapshot);
             return SubscriptionEvent::Delta {
                 reset: false,
-                added: update_added,
+                added: update_added
+                    .into_iter()
+                    .map(subscription_output_row)
+                    .collect(),
                 updated: Vec::new(),
                 removed: Vec::new(),
                 added_related: Vec::new(),
@@ -8121,7 +8151,11 @@ fn apply_maintained_update_to_snapshot(
 
         return SubscriptionEvent::Delta {
             reset: false,
-            added: event_added,
+            added: event_added
+                .iter()
+                .cloned()
+                .map(subscription_output_row)
+                .collect(),
             updated: Vec::new(),
             removed: Vec::new(),
             added_related,
@@ -8141,23 +8175,22 @@ fn apply_maintained_update_to_snapshot(
     let mut added_related = Vec::new();
 
     for row in &update_added {
-        let key = (row.table().to_owned(), row.row_uuid());
+        let key = single_source_occurrence_id(row);
         if let Some(position) = snapshot_index.roots.get(&key).copied() {
             if snapshot.rows[position] != *row {
                 snapshot.rows[position] = row.clone();
-                updated.push(row.clone());
+                updated.push(subscription_output_row(row.clone()));
             }
         } else {
             snapshot.rows.insert(snapshot.root_count, row.clone());
             for position in snapshot_index.related.values_mut() {
                 *position += 1;
             }
-            snapshot_index.roots.insert(
-                (row.table().to_owned(), row.row_uuid()),
-                snapshot.root_count,
-            );
+            snapshot_index
+                .roots
+                .insert(single_source_occurrence_id(row), snapshot.root_count);
             snapshot.root_count += 1;
-            added.push(row.clone());
+            added.push(subscription_output_row(row.clone()));
         }
     }
 
@@ -8173,10 +8206,13 @@ fn apply_maintained_update_to_snapshot(
         {
             let row = snapshot.rows.remove(index);
             snapshot.root_count -= 1;
-            snapshot_index.roots.remove(&row_key);
+            snapshot_index
+                .roots
+                .remove(&single_source_occurrence_id(&row));
             removed.push(RemovedRow {
                 table: row.table().to_owned(),
                 row_uuid: row.row_uuid(),
+                occurrence_id: single_source_occurrence_id(&row),
             });
         } else {
             index += 1;
@@ -8203,10 +8239,11 @@ fn apply_maintained_update_to_snapshot(
         let Some(row) = row else {
             continue;
         };
-        let key = (row.table().to_owned(), row.row_uuid());
-        if snapshot_index.roots.contains_key(&key) {
+        let root_key = single_source_occurrence_id(row);
+        if snapshot_index.roots.contains_key(&root_key) {
             continue;
         }
+        let key = (row.table().to_owned(), row.row_uuid());
         if let Some(position) = snapshot_index.related.get(&key).copied() {
             snapshot.rows[position] = row.clone();
         } else {
@@ -8222,7 +8259,11 @@ fn apply_maintained_update_to_snapshot(
                 && edge.target_row == removed_edge.target_row
         });
         let target_key = (removed_edge.target_table.clone(), removed_edge.target_row);
-        let is_root = snapshot_index.roots.contains_key(&target_key);
+        let is_root = snapshot_index
+            .roots
+            .contains_key(&OutputOccurrenceId::single_source(ObjectId::from_uuid(
+                target_key.1.0,
+            )));
         if !still_referenced && !is_root {
             if let Some(position) = snapshot_index.related.remove(&target_key) {
                 snapshot.rows.remove(position);
@@ -8284,6 +8325,17 @@ where
         binding_id: binding.binding_id(),
         read_view: RegisterShapeOptions { tier, read_view }.read_view_key(),
     })
+}
+
+fn single_source_occurrence_id(row: &CurrentRow) -> OutputOccurrenceId {
+    OutputOccurrenceId::single_source(ObjectId::from_uuid(row.row_uuid().0))
+}
+
+fn subscription_output_row(row: CurrentRow) -> SubscriptionOutputRow {
+    SubscriptionOutputRow {
+        occurrence_id: single_source_occurrence_id(&row),
+        row,
+    }
 }
 
 fn subscription_row_key(row: &CurrentRow) -> (String, RowUuid) {

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -76,6 +76,7 @@ fn apply_subscription_event(snapshot: &mut RelationSnapshot, event: Subscription
             }
 
             for row in updated {
+                let row = row.row;
                 if let Some(position) = snapshot.rows.iter().position(|current| {
                     current.table() == row.table() && current.row_uuid() == row.row_uuid()
                 }) {
@@ -84,6 +85,7 @@ fn apply_subscription_event(snapshot: &mut RelationSnapshot, event: Subscription
             }
 
             for row in added {
+                let row = row.row;
                 if let Some(position) =
                     snapshot
                         .rows
@@ -200,7 +202,11 @@ fn delta_rows(event: SubscriptionEvent) -> (Vec<CurrentRow>, Vec<CurrentRow>, Ve
             updated,
             removed,
             ..
-        } => (added, updated, removed),
+        } => (
+            added.into_iter().map(|output| output.row).collect(),
+            updated.into_iter().map(|output| output.row).collect(),
+            removed,
+        ),
         other => panic!("expected subscription delta event, got {other:?}"),
     }
 }

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -8703,6 +8703,12 @@ where
         identity: AuthorId,
         read_view: &ReadViewSpec,
     ) -> Result<(), Error> {
+        if !shape.query().joins.is_empty() {
+            return Err(Error::QueryCapability(
+                "maintained flat joined output requires complete OutputOccurrenceId source tuples; a root row id alone is unsafe"
+                    .to_owned(),
+            ));
+        }
         self.compile_current_query_program_for_read_view(
             shape,
             binding,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -8703,12 +8703,11 @@ where
         identity: AuthorId,
         read_view: &ReadViewSpec,
     ) -> Result<(), Error> {
-        if !shape.query().joins.is_empty() {
-            return Err(Error::QueryCapability(
-                "maintained flat joined output requires complete OutputOccurrenceId source tuples; a root row id alone is unsafe"
-                    .to_owned(),
-            ));
-        }
+        // `JoinVia` is an existential constraint on this query's root-row
+        // result, not flat joined output: maintained membership and delivery
+        // remain addressed by the selected root row. Flat public join output,
+        // which can contain several occurrences for one root, remains rejected
+        // at the public-client boundary until it supplies source tuples.
         self.compile_current_query_program_for_read_view(
             shape,
             binding,

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -12,8 +12,9 @@ use crate::db::{
     Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, Error as CoreDbError,
     ExclusiveTxOps, LocalUpdates as CoreLocalUpdates, PeerConnection as CorePeerConnection,
     Propagation as CorePropagation, ReadOpts as CoreReadOpts,
-    SubscriptionEvent as CoreSubscriptionEvent, TextEdit as CoreTextEdit, TickScheduler,
-    TickUrgency, Transport as CoreTransport, WireTransportAdapter,
+    SubscriptionEvent as CoreSubscriptionEvent, SubscriptionOutputRow as CoreSubscriptionOutputRow,
+    TextEdit as CoreTextEdit, TickScheduler, TickUrgency, Transport as CoreTransport,
+    WireTransportAdapter,
 };
 use crate::groove::records::Value as CoreValue;
 use crate::groove::storage::MemoryStorage as CoreMemoryStorage;
@@ -50,8 +51,9 @@ use uuid::Uuid;
 #[cfg(feature = "rocksdb")]
 use crate::tools::ClientStorage;
 use crate::tools::{
-    AppContext, JazzError, ObjectId, Result, SubscriptionHandle, SubscriptionRejectReason,
-    SubscriptionServerFailureCode, SubscriptionStream, SubscriptionStreamItem,
+    AppContext, JazzError, ObjectId, OutputOccurrenceId, Result, SubscriptionHandle,
+    SubscriptionRejectReason, SubscriptionServerFailureCode, SubscriptionStream,
+    SubscriptionStreamItem,
 };
 
 type CoreMemoryDb = CoreDb<CoreMemoryStorage>;
@@ -1231,7 +1233,7 @@ impl ClientDbInner {
         let inner = Rc::clone(inner);
         tokio::task::spawn_local(async move {
             let mut stream = stream;
-            let mut current_rows: Vec<crate::node::CurrentRow> = Vec::new();
+            let mut current_rows: Vec<CoreSubscriptionOutputRow> = Vec::new();
             while let Some(event) = stream.next_event().await {
                 match event {
                     CoreSubscriptionEvent::Delta {
@@ -1241,9 +1243,9 @@ impl ClientDbInner {
                         removed,
                         ..
                     } => {
-                        let previous_rows: Vec<ObjectId> = current_rows
+                        let previous_rows: Vec<OutputOccurrenceId> = current_rows
                             .iter()
-                            .map(|row| ObjectId::from_uuid(row.row_uuid().0))
+                            .map(|row| row.occurrence_id.clone())
                             .collect();
                         JazzClient::apply_core_subscription_rows(
                             &mut current_rows,
@@ -1252,7 +1254,11 @@ impl ClientDbInner {
                             &updated,
                             &removed,
                         );
-                        inner.borrow_mut().remember_rows(&table, &current_rows);
+                        let rows_for_cache = current_rows
+                            .iter()
+                            .map(|row| row.row.clone())
+                            .collect::<Vec<_>>();
+                        inner.borrow_mut().remember_rows(&table, &rows_for_cache);
                         let delta = if reset {
                             JazzClient::core_subscription_reset_delta(
                                 &db,
@@ -1954,8 +1960,13 @@ impl JazzClient {
         }
     }
     fn core_query(&self, query: &Query) -> Result<crate::query::Query> {
+        if !query.joins.is_empty() {
+            return Err(JazzError::Query(
+                "flat joined output requires complete OutputOccurrenceId source tuples; a root row id alone is unsafe"
+                    .to_string(),
+            ));
+        }
         if query.disjuncts.len() != 1
-            || !query.joins.is_empty()
             || !query.array_subqueries.is_empty()
             || query.recursive.is_some()
             || query.include_deleted
@@ -2102,17 +2113,20 @@ impl JazzClient {
         Ok(rows)
     }
 
-    fn core_subscription_row_to_public(db: &Backend, row: &crate::node::CurrentRow) -> Result<Row> {
-        let (_, encoded) = row.encoded_record();
+    fn core_subscription_row_to_public(
+        db: &Backend,
+        row: &CoreSubscriptionOutputRow,
+    ) -> Result<Row> {
+        let (_, encoded) = row.row.encoded_record();
         let provenance = db
-            .row_provenance(row)
+            .row_provenance(&row.row)
             .map_err(|error| JazzError::Query(error.to_string()))?
             .map(core_row_provenance_to_public)
             .unwrap_or_else(|| {
                 crate::tools::metadata::RowProvenance::for_insert("jazz:unknown", 0)
             });
         Ok(Row::new(
-            ObjectId::from_uuid(row.row_uuid().0),
+            row.occurrence_id.clone(),
             encoded.to_vec(),
             BatchId([0; 16]),
             provenance,
@@ -2121,7 +2135,7 @@ impl JazzClient {
 
     fn core_subscription_snapshot_delta(
         db: &Backend,
-        rows: &[crate::node::CurrentRow],
+        rows: &[CoreSubscriptionOutputRow],
     ) -> Result<OrderedRowDelta> {
         let added = rows
             .iter()
@@ -2129,7 +2143,7 @@ impl JazzClient {
             .map(|(index, row)| {
                 let public = Self::core_subscription_row_to_public(db, row)?;
                 Ok(OrderedAdded {
-                    id: public.id,
+                    id: public.id.clone(),
                     index,
                     row: public,
                 })
@@ -2143,12 +2157,12 @@ impl JazzClient {
 
     fn core_subscription_reset_delta(
         db: &Backend,
-        previous_rows: &[ObjectId],
-        rows: &[crate::node::CurrentRow],
+        previous_rows: &[OutputOccurrenceId],
+        rows: &[CoreSubscriptionOutputRow],
     ) -> Result<OrderedRowDelta> {
         let removed = previous_rows
             .iter()
-            .copied()
+            .cloned()
             .enumerate()
             .map(|(index, id)| OrderedRemoved { id, index })
             .collect();
@@ -2158,10 +2172,10 @@ impl JazzClient {
     }
 
     fn apply_core_subscription_rows(
-        current_rows: &mut Vec<crate::node::CurrentRow>,
+        current_rows: &mut Vec<CoreSubscriptionOutputRow>,
         reset: bool,
-        added_rows: &[crate::node::CurrentRow],
-        updated_rows: &[crate::node::CurrentRow],
+        added_rows: &[CoreSubscriptionOutputRow],
+        updated_rows: &[CoreSubscriptionOutputRow],
         removed_rows: &[crate::db::RemovedRow],
     ) {
         if reset {
@@ -2170,12 +2184,12 @@ impl JazzClient {
         current_rows.retain(|row| {
             !removed_rows
                 .iter()
-                .any(|removed| row.row_uuid() == removed.row_uuid)
+                .any(|removed| row.occurrence_id == removed.occurrence_id)
         });
         for row in updated_rows {
             if let Some(position) = current_rows
                 .iter()
-                .position(|current| current.row_uuid() == row.row_uuid())
+                .position(|current| current.occurrence_id == row.occurrence_id)
             {
                 current_rows[position] = row.clone();
             }
@@ -2183,7 +2197,7 @@ impl JazzClient {
         for row in added_rows {
             if let Some(position) = current_rows
                 .iter()
-                .position(|current| current.row_uuid() == row.row_uuid())
+                .position(|current| current.occurrence_id == row.occurrence_id)
             {
                 current_rows[position] = row.clone();
             } else {
@@ -2194,24 +2208,25 @@ impl JazzClient {
 
     fn core_subscription_change_delta(
         db: &Backend,
-        current_rows: &[crate::node::CurrentRow],
-        added_rows: &[crate::node::CurrentRow],
-        updated_rows: &[crate::node::CurrentRow],
+        current_rows: &[CoreSubscriptionOutputRow],
+        added_rows: &[CoreSubscriptionOutputRow],
+        updated_rows: &[CoreSubscriptionOutputRow],
         removed_rows: &[crate::db::RemovedRow],
     ) -> Result<OrderedRowDelta> {
-        let index_of = |id: ObjectId| {
+        let index_of = |id: &OutputOccurrenceId| {
             current_rows
                 .iter()
-                .position(|row| ObjectId::from_uuid(row.row_uuid().0) == id)
+                .position(|row| &row.occurrence_id == id)
                 .unwrap_or(0)
         };
         let added = added_rows
             .iter()
             .map(|row| {
                 let public = Self::core_subscription_row_to_public(db, row)?;
+                let index = index_of(&public.id);
                 Ok(OrderedAdded {
-                    id: public.id,
-                    index: index_of(public.id),
+                    id: public.id.clone(),
+                    index,
                     row: public,
                 })
             })
@@ -2220,9 +2235,9 @@ impl JazzClient {
             .iter()
             .map(|row| {
                 let public = Self::core_subscription_row_to_public(db, row)?;
-                let index = index_of(public.id);
+                let index = index_of(&public.id);
                 Ok(OrderedUpdated {
-                    id: public.id,
+                    id: public.id.clone(),
                     old_index: index,
                     new_index: index,
                     row: Some(public),
@@ -2233,7 +2248,7 @@ impl JazzClient {
             .iter()
             .enumerate()
             .map(|(index, row)| OrderedRemoved {
-                id: ObjectId::from_uuid(row.row_uuid.0),
+                id: row.occurrence_id.clone(),
                 index,
             })
             .collect();

--- a/crates/jazz/src/tools/mod.rs
+++ b/crates/jazz/src/tools/mod.rs
@@ -48,7 +48,7 @@ pub use crate::db::TextEdit;
 #[cfg(feature = "client")]
 pub use client::{JazzClient, JazzTransaction};
 
-pub use object::ObjectId;
+pub use object::{ObjectId, OutputOccurrenceId};
 #[cfg(feature = "client")]
 pub use sync::ClientId;
 #[cfg(feature = "client")]

--- a/crates/jazz/src/tools/object.rs
+++ b/crates/jazz/src/tools/object.rs
@@ -1,5 +1,6 @@
 use internment::Intern;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use smallvec::SmallVec;
 use uuid::Uuid;
 
 /// Interned UUID identifying an object.
@@ -64,6 +65,89 @@ impl PartialOrd for ObjectId {
 impl Ord for ObjectId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.uuid().cmp(other.uuid())
+    }
+}
+
+/// Stable identity of one rendered query-output occurrence.
+///
+/// The root source row is always first. `joined` contains contributing source
+/// rows in the query's declared join order. This is deliberately distinct from
+/// a source [`ObjectId`]: one source row can contribute to more than one output
+/// occurrence.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct OutputOccurrenceId {
+    root: ObjectId,
+    joined: SmallVec<[ObjectId; 2]>,
+}
+
+impl OutputOccurrenceId {
+    /// Construct an occurrence from its root and joined source rows.
+    ///
+    /// `joined` must be in declared join order. The ordinary one- and two-hop
+    /// cases stay inline.
+    pub fn new(root: ObjectId, joined: impl IntoIterator<Item = ObjectId>) -> Self {
+        Self {
+            root,
+            joined: joined.into_iter().collect(),
+        }
+    }
+
+    /// Construct the single-source occurrence used by plain-table output.
+    pub fn single_source(root: ObjectId) -> Self {
+        Self {
+            root,
+            joined: SmallVec::new(),
+        }
+    }
+
+    /// Root source-row identity.
+    pub fn root(&self) -> ObjectId {
+        self.root
+    }
+
+    /// Joined source-row identities in declared join order.
+    pub fn joined(&self) -> &[ObjectId] {
+        &self.joined
+    }
+
+    /// All contributing source-row identities, root first.
+    pub fn contributing_rows(&self) -> impl Iterator<Item = ObjectId> + '_ {
+        std::iter::once(self.root).chain(self.joined.iter().copied())
+    }
+
+    /// Canonical positional bytes for terminal-state keys and consolidation.
+    ///
+    /// Each component is a fixed-width UUID, so concatenating root followed by
+    /// joined rows is unambiguous; byte length records the number of joined
+    /// sources and component position records declared join position.
+    pub fn canonical_bytes(&self) -> SmallVec<[u8; 48]> {
+        let mut bytes = SmallVec::with_capacity((self.joined.len() + 1) * 16);
+        bytes.extend_from_slice(self.root.uuid().as_bytes());
+        for id in &self.joined {
+            bytes.extend_from_slice(id.uuid().as_bytes());
+        }
+        bytes
+    }
+}
+
+impl From<ObjectId> for OutputOccurrenceId {
+    fn from(root: ObjectId) -> Self {
+        Self::single_source(root)
+    }
+}
+
+/// Single-source occurrences compare equal to their compatibility root id.
+/// Multi-source occurrences intentionally do not: treating either as a plain
+/// row id would recreate the flat-join collapse this type prevents.
+impl PartialEq<ObjectId> for OutputOccurrenceId {
+    fn eq(&self, other: &ObjectId) -> bool {
+        self.joined.is_empty() && self.root == *other
+    }
+}
+
+impl PartialEq<OutputOccurrenceId> for ObjectId {
+    fn eq(&self, other: &OutputOccurrenceId) -> bool {
+        other == self
     }
 }
 

--- a/crates/jazz/src/tools/public_api/types/row.rs
+++ b/crates/jazz/src/tools/public_api/types/row.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 
 use crate::tools::metadata::RowProvenance;
-use crate::tools::object::ObjectId;
+use crate::tools::object::OutputOccurrenceId;
 use crate::tools::transaction::BatchId;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -67,10 +67,10 @@ impl<'de> Deserialize<'de> for RowBytes {
     }
 }
 
-/// A row with its object ID, binary data, and batch identity.
+/// A maintained output row with its occurrence identity, binary data, and batch identity.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Row {
-    pub id: ObjectId,
+    pub id: OutputOccurrenceId,
     /// Binary encoded row data.
     pub data: RowBytes,
     pub batch_id: BatchId,
@@ -79,7 +79,7 @@ pub struct Row {
 
 impl Row {
     pub fn new(
-        id: ObjectId,
+        id: OutputOccurrenceId,
         data: impl Into<RowBytes>,
         batch_id: BatchId,
         provenance: RowProvenance,
@@ -101,7 +101,7 @@ pub struct RowDelta {
     pub removed: Vec<Row>,
     /// Rows that stayed in-window but changed position.
     /// Semantics: detach these IDs from current order, then append in listed order.
-    pub moved: Vec<ObjectId>,
+    pub moved: Vec<OutputOccurrenceId>,
     /// Updated rows as (old, new) pairs.
     pub updated: Vec<(Row, Row)>,
 }
@@ -121,20 +121,20 @@ impl RowDelta {
 
 #[derive(Debug, Clone)]
 pub struct OrderedAdded {
-    pub id: ObjectId,
+    pub id: OutputOccurrenceId,
     pub index: usize,
     pub row: Row,
 }
 
 #[derive(Debug, Clone)]
 pub struct OrderedRemoved {
-    pub id: ObjectId,
+    pub id: OutputOccurrenceId,
     pub index: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct OrderedUpdated {
-    pub id: ObjectId,
+    pub id: OutputOccurrenceId,
     pub old_index: usize,
     pub new_index: usize,
     pub row: Option<Row>,

--- a/crates/jazz/tests/cli_dry_run.rs
+++ b/crates/jazz/tests/cli_dry_run.rs
@@ -229,8 +229,8 @@ fn subscription_fields(
                 for removed in removed {
                     rows.remove(&removed.row_uuid);
                 }
-                ingest_current_rows(&mut rows, table, &added);
-                ingest_current_rows(&mut rows, table, &updated);
+                ingest_current_rows(&mut rows, table, added.iter().map(|output| &output.row));
+                ingest_current_rows(&mut rows, table, updated.iter().map(|output| &output.row));
             }
             SubscriptionEvent::Rejected { reason } => {
                 panic!("subscription rejected unexpectedly: {reason:?}")
@@ -243,10 +243,10 @@ fn subscription_fields(
     fields
 }
 
-fn ingest_current_rows(
+fn ingest_current_rows<'a>(
     rows: &mut BTreeMap<RowUuid, (String, bool)>,
     table: &TableSchema,
-    current: &[jazz::node::CurrentRow],
+    current: impl IntoIterator<Item = &'a jazz::node::CurrentRow>,
 ) {
     for row in current {
         let Some(Value::String(title)) = row.cell(table, "title") else {

--- a/crates/jazz/tests/edge_server_mode.rs
+++ b/crates/jazz/tests/edge_server_mode.rs
@@ -85,7 +85,11 @@ async fn subscription_orders_by_unprojected_field() {
             };
 
             assert_eq!(
-                delta.added.iter().map(|added| added.id).collect::<Vec<_>>(),
+                delta
+                    .added
+                    .iter()
+                    .map(|added| added.id.clone())
+                    .collect::<Vec<_>>(),
                 vec![ids[1], ids[2], ids[0]],
                 "subscription reset must follow rank even when rank is not projected"
             );

--- a/crates/jazz/tests/output_occurrence_id.rs
+++ b/crates/jazz/tests/output_occurrence_id.rs
@@ -1,0 +1,146 @@
+#![cfg(feature = "test")]
+
+mod support;
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use jazz::row_input;
+use jazz::tools::server::JazzServer;
+use jazz::tools::{
+    ColumnType, DurabilityTier, ObjectId, OutputOccurrenceId, QueryBuilder, Schema, SchemaBuilder,
+    SubscriptionStreamItem, TableSchema,
+};
+use support::TestingClient;
+use uuid::Uuid;
+
+fn todos_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean),
+        )
+        .build()
+}
+
+async fn next_delta(stream: &mut jazz::tools::SubscriptionStream) -> jazz::tools::OrderedRowDelta {
+    let item = tokio::time::timeout(Duration::from_secs(10), stream.next())
+        .await
+        .expect("subscription delta arrives")
+        .expect("subscription remains open");
+    let SubscriptionStreamItem::Delta(delta) = item else {
+        panic!("subscription was rejected")
+    };
+    delta
+}
+
+async fn next_delta_with_added(
+    stream: &mut jazz::tools::SubscriptionStream,
+) -> jazz::tools::OrderedRowDelta {
+    for _ in 0..8 {
+        let delta = next_delta(stream).await;
+        if !delta.added.is_empty() {
+            return delta;
+        }
+    }
+    panic!("subscription did not emit an added output occurrence")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn plain_table_output_occurrence_is_root_stable_across_reset_and_join_order_is_positional() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = todos_schema();
+            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let client = TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema)
+                .with_user_id("00000000-0000-4000-8000-000000000023")
+                .ready_on("todos", Duration::from_secs(30))
+                .connect()
+                .await;
+            let query = QueryBuilder::new("todos").build();
+            let mut initial_stream = client.subscribe(query.clone()).await.expect("subscribe");
+            let empty_reset = next_delta(&mut initial_stream).await;
+            assert!(
+                empty_reset.added.is_empty(),
+                "new subscription begins with a reset"
+            );
+
+            let (root, _, batch) = client
+                .insert("todos", row_input!("title" => "draft", "done" => false))
+                .expect("insert todo");
+            client
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
+                .await
+                .expect("todo settles locally");
+
+            let one_shot = client
+                .query(query.clone(), None)
+                .await
+                .expect("one-shot query");
+            let one_shot_root: ObjectId = one_shot[0].0;
+            assert_eq!(
+                one_shot_root, root,
+                "one-shot results retain their root id field"
+            );
+            let initial = next_delta_with_added(&mut initial_stream).await;
+            let initial_id = initial.added[0].id.clone();
+
+            assert_eq!(
+                initial_id, root,
+                "plain-table output remains root-compatible"
+            );
+            assert_eq!(initial_id.root(), root);
+            assert!(initial_id.joined().is_empty());
+            assert_eq!(
+                initial_id.canonical_bytes().as_slice(),
+                root.uuid().as_bytes()
+            );
+
+            drop(initial_stream);
+            let mut reset_stream = client.subscribe(query).await.expect("resubscribe");
+            let reset = next_delta_with_added(&mut reset_stream).await;
+            assert_eq!(
+                reset.added[0].id, initial_id,
+                "reset preserves occurrence identity"
+            );
+
+            let first_join = ObjectId::from_uuid(Uuid::from_bytes([0x11; 16]));
+            let second_join = ObjectId::from_uuid(Uuid::from_bytes([0x22; 16]));
+            let ordered = OutputOccurrenceId::new(root, [first_join, second_join]);
+            let reversed = OutputOccurrenceId::new(root, [second_join, first_join]);
+            assert_ne!(
+                ordered, reversed,
+                "declared join order is part of the identity"
+            );
+            assert_eq!(
+                ordered.contributing_rows().collect::<Vec<_>>(),
+                vec![root, first_join, second_join]
+            );
+            assert_ne!(ordered.canonical_bytes(), reversed.canonical_bytes());
+            let by_occurrence =
+                BTreeMap::from([(ordered.clone(), "ordered"), (reversed, "reversed")]);
+            assert_eq!(by_occurrence.get(&ordered), Some(&"ordered"));
+
+            let joined_query = QueryBuilder::new("todos")
+                .join("todos")
+                .on("todos.id", "todos.id")
+                .build();
+            let error = match client.subscribe(joined_query).await {
+                Ok(_) => panic!("joined maintained output cannot default to root identity"),
+                Err(error) => error,
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("OutputOccurrenceId source tuples"),
+                "joined subscription must fail loudly: {error}"
+            );
+
+            client.shutdown().await.expect("shutdown test client");
+            server.shutdown().await;
+        })
+        .await;
+}

--- a/crates/jazz/tests/warm_reopen_differential.rs
+++ b/crates/jazz/tests/warm_reopen_differential.rs
@@ -278,6 +278,7 @@ fn apply_subscription_event(snapshot: &mut RelationSnapshot, event: Subscription
                 let mut roots = Vec::new();
                 let mut related = Vec::new();
                 for row in added {
+                    let row = row.row;
                     if related_keys.contains(&(row.table(), row.row_uuid())) {
                         related.push(row);
                     } else {
@@ -307,6 +308,7 @@ fn apply_subscription_event(snapshot: &mut RelationSnapshot, event: Subscription
             }
 
             for row in updated {
+                let row = row.row;
                 if let Some(position) = snapshot.rows.iter().position(|current| {
                     current.table() == row.table() && current.row_uuid() == row.row_uuid()
                 }) {
@@ -315,6 +317,7 @@ fn apply_subscription_event(snapshot: &mut RelationSnapshot, event: Subscription
             }
 
             for row in added {
+                let row = row.row;
                 if let Some(position) =
                     snapshot
                         .rows


### PR DESCRIPTION
Adds `OutputOccurrenceId`: the identity by which a query result row is
addressed. First implementation step for both #1245 (structured results) and
#1246 (flat joins), which deliberately share one identity concept rather than
inventing two.

## What it is

A root row id plus the ordered contributing source row ids, in declared join
order.

Today every output occurrence has exactly one contributing source row, so the
composite collapses to the root id. **This change is therefore a behavioural
no-op** — that is the point of doing it first. It puts the identity in place
while there is still only one shape it can take, so the paths that will need it
are already threaded before anything depends on the distinction.

## Why the identity has to exist before joins do

`Vec<(ObjectId, Vec<Value>)>` addresses a result row by its *root* row id. That
is sufficient while one output row corresponds to one source row. It stops being
sufficient the moment a query returns a user joined to three posts: three output
rows, one id, and maintained deltas that address each other.

The consequence is not a visible error. It is a silent overwrite in the public
maintained adapter — rows quietly replacing one another with no failure anywhere.

So where an occurrence id is required and only a root id is available, this
fails loudly, in both the public adapter and core maintained-query validation.
A default-to-root-id fallback would reproduce precisely the collapse the design
exists to prevent.

## Scope

The guard sits at the public flat-join boundary. Core `JoinVia` maintained
subscriptions are unaffected: relation facade queries normalize to one selected
output table with joins as existential constraints, includes carry unique root
rows plus separately keyed related rows and edges, and prepared non-simple plans
share the same root-row terminal. All of them collapse to one root row per
output, so root identity remains correct there. The distinction is documented at
`query_eval.rs:8706`.

## Where it fits

```
→ occurrence identity  (this PR)
  ├── flat joins           → #1246, needs composite addressing
  └── CollectBy            → #1245, addresses a nested parent by the same notion
      └── terminal emission → wire v4 → delete client-side reassembly
```

## Review notes

`INV-QUERY-23` (#1246) and `INV-QUERY-22` (#1245) describe this one concept.
Tests cover the single-source collapse, stability across a reset, ordering
determinism for a multi-source id, use as a map key, and the loud rejection.

Gates green including the INV-INC-1 delivery canary. The three
`catalogue_sync_integration` failures behind the `core_query` guard are
pre-existing and unrelated.
