### PR TITLE
(new core) Record-valued ValueType, with canonical-bytes enforcement

### DIFF
--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -926,7 +926,7 @@ where
         let mut encoded_key = Vec::new();
         for (value, column) in key.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut encoded_key, value);
+            encode_primary_key_part(&mut encoded_key, value)?;
         }
         let staged_contains_key = batch
             .txn_operations
@@ -978,7 +978,7 @@ where
         let mut encoded_key = Vec::new();
         for (value, column) in key.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut encoded_key, value);
+            encode_primary_key_part(&mut encoded_key, value)?;
         }
         let key_descriptor = primary_key_descriptor(primary_key);
         let store = record_store_for_table(storage, table, Some(key_descriptor), descriptor);
@@ -1015,7 +1015,7 @@ where
         let mut key_prefix = Vec::new();
         for (value, column) in prefix.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut key_prefix, value);
+            encode_primary_key_part(&mut key_prefix, value)?;
         }
         let key_descriptor = primary_key_descriptor(primary_key);
         let store = record_store_for_table(storage, table, Some(key_descriptor), descriptor);
@@ -1054,7 +1054,7 @@ where
         let mut key_prefix = Vec::new();
         for (value, column) in prefix.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut key_prefix, value);
+            encode_primary_key_part(&mut key_prefix, value)?;
         }
         let key_descriptor = primary_key_descriptor(primary_key);
         let store = record_store_for_table(storage, table, Some(key_descriptor), descriptor);
@@ -1099,12 +1099,12 @@ where
         let mut start_key = Vec::new();
         for (value, column) in start.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut start_key, value);
+            encode_primary_key_part(&mut start_key, value)?;
         }
         let mut end_key = Vec::new();
         for (value, column) in end.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut end_key, value);
+            encode_primary_key_part(&mut end_key, value)?;
         }
         let storage = MeteredStorage::new(&self.storage, &self.storage_read_metrics);
         let key_descriptor = primary_key_descriptor(primary_key);
@@ -1182,12 +1182,12 @@ where
         let mut key_prefix = Vec::new();
         for (value, column) in prefix.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut key_prefix, value);
+            encode_primary_key_part(&mut key_prefix, value)?;
         }
         let mut upper_key = Vec::new();
         for (value, column) in upper.iter().zip(&primary_key.columns) {
             ensure_primary_key_value_type(table_schema, column, value)?;
-            encode_primary_key_part(&mut upper_key, value);
+            encode_primary_key_part(&mut upper_key, value)?;
         }
         if !upper_key.starts_with(&key_prefix) {
             return Ok(None);
@@ -2098,7 +2098,7 @@ where
         let _ = prefix_descriptor.create(values)?;
         let mut bytes = Vec::new();
         for value in values {
-            encode_primary_key_part(&mut bytes, value);
+            encode_primary_key_part(&mut bytes, value)?;
         }
         Ok(bytes)
     }
@@ -3022,14 +3022,22 @@ impl PrimaryKeyValue {
     fn into_bytes(self) -> Vec<u8> {
         let mut bytes = Vec::new();
         match self {
-            Self::U8(value) => encode_primary_key_part(&mut bytes, &Value::U8(value)),
-            Self::U16(value) => encode_primary_key_part(&mut bytes, &Value::U16(value)),
-            Self::U32(value) => encode_primary_key_part(&mut bytes, &Value::U32(value)),
-            Self::U64(value) => encode_primary_key_part(&mut bytes, &Value::U64(value)),
-            Self::Bool(value) => encode_primary_key_part(&mut bytes, &Value::Bool(value)),
-            Self::String(value) => encode_primary_key_part(&mut bytes, &Value::String(value)),
-            Self::Bytes(value) => encode_primary_key_part(&mut bytes, &Value::Bytes(value)),
-            Self::Uuid(value) => encode_primary_key_part(&mut bytes, &Value::Uuid(value)),
+            Self::U8(value) => encode_primary_key_part(&mut bytes, &Value::U8(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
+            Self::U16(value) => encode_primary_key_part(&mut bytes, &Value::U16(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
+            Self::U32(value) => encode_primary_key_part(&mut bytes, &Value::U32(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
+            Self::U64(value) => encode_primary_key_part(&mut bytes, &Value::U64(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
+            Self::Bool(value) => encode_primary_key_part(&mut bytes, &Value::Bool(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
+            Self::String(value) => encode_primary_key_part(&mut bytes, &Value::String(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
+            Self::Bytes(value) => encode_primary_key_part(&mut bytes, &Value::Bytes(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
+            Self::Uuid(value) => encode_primary_key_part(&mut bytes, &Value::Uuid(value))
+                .expect("PrimaryKeyValue only contains encodable primary-key values"),
             Self::Composite(values) => {
                 for value in values {
                     bytes.extend(value.into_bytes());
@@ -3093,7 +3101,7 @@ fn primary_key_bytes(
     for column in &primary_key.columns {
         let value = record_schema.get(record, &column.column)?;
         ensure_primary_key_value_type(table, column, &value)?;
-        encode_primary_key_part(&mut bytes, &value);
+        encode_primary_key_part(&mut bytes, &value)?;
     }
     Ok(bytes)
 }
@@ -3188,7 +3196,7 @@ fn primary_key_from_index_columns(
             .get(index_position)
             .ok_or_else(|| Error::InvalidPersistedIndex(index_name.to_owned()))?;
         ensure_primary_key_value_type(table, primary_key_column, value)?;
-        encode_primary_key_part(&mut bytes, value);
+        encode_primary_key_part(&mut bytes, value)?;
     }
     Ok(bytes)
 }
@@ -3257,7 +3265,7 @@ fn ensure_primary_key_value_type(
     }
 }
 
-fn encode_primary_key_part(key: &mut Vec<u8>, value: &Value) {
+fn encode_primary_key_part(key: &mut Vec<u8>, value: &Value) -> Result<(), Error> {
     match value {
         Value::U8(value) => {
             key.push(0);
@@ -3306,13 +3314,16 @@ fn encode_primary_key_part(key: &mut Vec<u8>, value: &Value) {
         Value::Tuple(values) => {
             key.push(11);
             for value in values {
-                encode_primary_key_part(key, value);
+                encode_primary_key_part(key, value)?;
             }
         }
-        Value::F64(_) | Value::Array(_) | Value::Nullable(_) => {
-            unreachable!("unsupported primary-key value type was validated before encoding")
+        Value::F64(_) | Value::Array(_) | Value::Nullable(_) | Value::Record(_) => {
+            return Err(Error::InvalidDirectRecordStoreKey(
+                "unsupported direct record store key type".to_owned(),
+            ));
         }
     }
+    Ok(())
 }
 
 fn encode_ordered_bytes(key: &mut Vec<u8>, value: &[u8]) {
@@ -3425,7 +3436,8 @@ fn decode_primary_key_part(
         records::ValueType::F64
         | records::ValueType::Array(_)
         | records::ValueType::Nullable(_)
-        | records::ValueType::Tuple(_) => Err(Error::InvalidDirectRecordStoreKey(
+        | records::ValueType::Tuple(_)
+        | records::ValueType::Record(_) => Err(Error::InvalidDirectRecordStoreKey(
             "unsupported direct record store key type".to_owned(),
         )),
     }

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -1046,7 +1046,7 @@ fn vec_derived_primary_key_scan_raw(
 ) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut key_prefix = Vec::new();
     for value in prefix {
-        encode_primary_key_part(&mut key_prefix, value);
+        encode_primary_key_part(&mut key_prefix, value).unwrap();
     }
     let mut rows = database
         .primary_key_scan_raw(table, prefix)
@@ -1584,6 +1584,28 @@ fn direct_record_store_stores_ordered_records_independent_of_tables() {
             .collect::<Vec<_>>(),
         vec![Value::String("Blue Train".to_owned())]
     );
+}
+
+#[test]
+fn direct_record_store_rejects_record_valued_durable_keys() {
+    let child = RecordDescriptor::new([("id", ValueType::U64)]);
+    let schema = DatabaseSchema::new([]).with_direct_record_store(DirectRecordStoreSchema::new(
+        "rendered_results",
+        RecordDescriptor::new([("result", ValueType::Record(Box::new(child)))]),
+        RecordDescriptor::new([("payload", ValueType::Bytes)]),
+    ));
+    let storage = MemoryStorage::new(&schema.column_families());
+    let database = Database::new(schema, storage).unwrap();
+    let store = database.direct_record_store("rendered_results").unwrap();
+    let child = crate::records::OwnedRecord::new(child.create(&[Value::U64(1)]).unwrap(), child);
+
+    assert!(matches!(
+        store.set(
+            &[Value::Record(child)],
+            &[Value::Bytes(b"not-a-key".to_vec())],
+        ),
+        Err(Error::InvalidDirectRecordStoreKey(_))
+    ));
 }
 
 #[test]

--- a/crates/groove/src/ivm/op_types.rs
+++ b/crates/groove/src/ivm/op_types.rs
@@ -337,6 +337,8 @@ pub enum LiteralValue {
     Tuple(Vec<LiteralValue>),
     Array(Vec<LiteralValue>),
     Nullable(Option<Box<LiteralValue>>),
+    /// Record-valued predicates are intentionally unsupported in this stage.
+    Record,
 }
 
 impl From<Value> for LiteralValue {
@@ -357,6 +359,7 @@ impl From<Value> for LiteralValue {
             Value::Tuple(values) => Self::Tuple(values.into_iter().map(Into::into).collect()),
             Value::Array(values) => Self::Array(values.into_iter().map(Into::into).collect()),
             Value::Nullable(value) => Self::Nullable(value.map(|value| Box::new((*value).into()))),
+            Value::Record(_) => Self::Record,
         }
     }
 }
@@ -389,6 +392,7 @@ impl LiteralValue {
                 .value_type()
                 .map(|value_type| ValueType::Nullable(Box::new(value_type))),
             Self::Nullable(None) => None,
+            Self::Record => None,
         }
     }
 
@@ -411,6 +415,7 @@ impl LiteralValue {
             Self::Nullable(value) => {
                 Value::Nullable(value.as_ref().map(|value| Box::new(value.to_value())))
             }
+            Self::Record => unreachable!("record literals are rejected during type validation"),
         }
     }
 }

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -7560,7 +7560,7 @@ pub(crate) fn encode_key_part(key: &mut Vec<u8>, value: &Value) -> Result<(), Iv
             key.push(9);
             encode_key_part(key, value)?;
         }
-        Value::Array(_) => return Err(IvmRuntimeError::UnsupportedJoinKey),
+        Value::Array(_) | Value::Record(_) => return Err(IvmRuntimeError::UnsupportedJoinKey),
     }
     Ok(())
 }
@@ -8193,12 +8193,15 @@ pub(super) fn encoded_record_key_part(
     let mut key = Vec::new();
     for field_idx in field_indices {
         let value = descriptor.get_idx(record, *field_idx)?;
-        encode_runtime_primary_key_part(&mut key, &value);
+        encode_runtime_primary_key_part(&mut key, &value)?;
     }
     Ok(key)
 }
 
-fn encode_runtime_primary_key_part(key: &mut Vec<u8>, value: &Value) {
+fn encode_runtime_primary_key_part(
+    key: &mut Vec<u8>,
+    value: &Value,
+) -> Result<(), IvmRuntimeError> {
     match value {
         Value::U8(value) => {
             key.push(0);
@@ -8251,7 +8254,7 @@ fn encode_runtime_primary_key_part(key: &mut Vec<u8>, value: &Value) {
         Value::Tuple(values) => {
             key.push(11);
             for value in values {
-                encode_runtime_primary_key_part(key, value);
+                encode_runtime_primary_key_part(key, value)?;
             }
         }
         Value::Nullable(None) => {
@@ -8261,12 +8264,11 @@ fn encode_runtime_primary_key_part(key: &mut Vec<u8>, value: &Value) {
         Value::Nullable(Some(value)) => {
             key.push(12);
             key.push(1);
-            encode_runtime_primary_key_part(key, value);
+            encode_runtime_primary_key_part(key, value)?;
         }
-        Value::Array(_) => {
-            unreachable!("unsupported primary-key value type was validated before encoding")
-        }
+        Value::Array(_) | Value::Record(_) => return Err(IvmRuntimeError::UnsupportedJoinKey),
     }
+    Ok(())
 }
 
 fn ordered_f64_key(value: f64) -> u64 {
@@ -9818,6 +9820,46 @@ mod tests {
             Err(IvmRuntimeError::RecordEncoding(
                 records::Error::InvalidF64NaN
             ))
+        ));
+    }
+
+    #[test]
+    fn record_values_canonicalize_delta_identity_and_are_rejected_as_arrangement_keys() {
+        // This is deliberately a runtime-level test: consolidation identifies
+        // records by their encoded bytes, so the relevant observable is the
+        // delta batch produced by the maintained runtime rather than a record
+        // field accessor alone.
+        let child = RecordDescriptor::new([("id", ValueType::U64)]);
+        let first = records::OwnedRecord::new(child.create(&[Value::U64(7)]).unwrap(), child);
+        let second = records::OwnedRecord::new(child.create(&[Value::U64(7)]).unwrap(), child);
+        let descriptor = RecordDescriptor::new([("child", ValueType::Record(Box::new(child)))]);
+        let first_parent = descriptor.create(&[Value::Record(first)]).unwrap();
+        let second_parent = descriptor.create(&[Value::Record(second)]).unwrap();
+
+        assert_eq!(first_parent, second_parent);
+        assert!(
+            consolidate_deltas(vec![
+                RecordDelta {
+                    record: first_parent.into(),
+                    weight: 1,
+                },
+                RecordDelta {
+                    record: second_parent.into(),
+                    weight: -1,
+                },
+            ])
+            .is_empty()
+        );
+
+        let record = descriptor
+            .create(&[Value::Record(records::OwnedRecord::new(
+                child.create(&[Value::U64(7)]).unwrap(),
+                child,
+            ))])
+            .unwrap();
+        assert!(matches!(
+            encoded_record_key_part(descriptor, &record, &[0]),
+            Err(IvmRuntimeError::UnsupportedJoinKey)
         ));
     }
 }

--- a/crates/groove/src/records/macros.rs
+++ b/crates/groove/src/records/macros.rs
@@ -28,6 +28,7 @@ pub enum FieldKind {
     Tuple,
     Array,
     Nullable,
+    Record,
 }
 
 impl FieldKind {
@@ -48,6 +49,7 @@ impl FieldKind {
                 | (Self::Tuple, ValueType::Tuple(_))
                 | (Self::Array, ValueType::Array(_))
                 | (Self::Nullable, ValueType::Nullable(_))
+                | (Self::Record, ValueType::Record(_))
         )
     }
 }

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -1725,6 +1725,8 @@ pub enum Error {
     UnknownEnumVariant { enum_name: String, variant: String },
     #[error("invalid offset")]
     InvalidOffset,
+    #[error("nested record bytes are not canonical")]
+    NonCanonicalRecord,
     #[error("tuple members must be fixed-width, got {member_type:?}")]
     InvalidTupleMember { member_type: ValueType },
     #[error("invalid utf-8 string")]

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -198,6 +198,73 @@ fn creates_and_reads_mixed_records() {
 }
 
 #[test]
+fn record_values_and_arrays_of_records_round_trip() {
+    let child = RecordDescriptor::new([("id", ValueType::U64), ("title", ValueType::String)]);
+    let first = OwnedRecord::new(
+        child
+            .create(&[Value::U64(1), Value::String("Kind of Blue".to_owned())])
+            .unwrap(),
+        child,
+    );
+    let second = OwnedRecord::new(
+        child
+            .create(&[Value::U64(2), Value::String("A Love Supreme".to_owned())])
+            .unwrap(),
+        child,
+    );
+    let descriptor = RecordDescriptor::new([
+        ("featured", ValueType::Record(Box::new(child))),
+        (
+            "albums",
+            ValueType::Array(Box::new(ValueType::Record(Box::new(child)))),
+        ),
+    ]);
+    let values = vec![
+        Value::Record(first.clone()),
+        Value::Array(vec![Value::Record(first), Value::Record(second)]),
+    ];
+
+    let raw = descriptor.create(&values).unwrap();
+
+    assert_eq!(descriptor.bind(&raw).to_values().unwrap(), values);
+}
+
+#[test]
+fn nested_record_values_round_trip_at_multiple_depths() {
+    let leaf = RecordDescriptor::new([("name", ValueType::String)]);
+    let leaf_record = OwnedRecord::new(
+        leaf.create(&[Value::String("leaf".to_owned())]).unwrap(),
+        leaf,
+    );
+    let middle = RecordDescriptor::new([("leaf", ValueType::Record(Box::new(leaf)))]);
+    let middle_record = OwnedRecord::new(
+        middle.create(&[Value::Record(leaf_record)]).unwrap(),
+        middle,
+    );
+    let root = RecordDescriptor::new([("middle", ValueType::Record(Box::new(middle)))]);
+    let values = vec![Value::Record(middle_record)];
+
+    let raw = root.create(&values).unwrap();
+
+    assert_eq!(root.bind(&raw).to_values().unwrap(), values);
+}
+
+#[test]
+fn record_values_reject_non_canonical_child_bytes() {
+    let child = RecordDescriptor::new([("maybe_id", ValueType::Nullable(Box::new(ValueType::U8)))]);
+    // A fixed-width null reserves one zero payload byte. `OwnedRecord::new`
+    // permits these arbitrary bytes, so validation at the embedding boundary is
+    // what prevents this malformed child from entering byte-based deltas.
+    let non_canonical = OwnedRecord::new(vec![0, 7], child);
+    let parent = RecordDescriptor::new([("child", ValueType::Record(Box::new(child)))]);
+
+    assert_eq!(
+        parent.create(&[Value::Record(non_canonical)]).unwrap_err(),
+        Error::InvalidOffset
+    );
+}
+
+#[test]
 fn pure_fixed_schema_bytes_are_unchanged() {
     let schema = RecordDescriptor::new([
         ("a", ValueType::U8),

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -24,9 +24,9 @@ pub enum Value {
     Tuple(Vec<Value>),
     Array(Vec<Value>),
     Nullable(Option<Box<Value>>),
-    Record(OwnedRecord),
     I64(i64),
     I32(i32),
+    Record(OwnedRecord),
 }
 
 impl From<u8> for Value {

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -7,7 +7,7 @@
 //! borrowed/owned record access. Query expressions and schemas refer to these
 //! value types but do not perform byte-level encoding themselves.
 
-use super::Error;
+use super::{Error, OwnedRecord, RecordDescriptor};
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum Value {
@@ -24,6 +24,7 @@ pub enum Value {
     Tuple(Vec<Value>),
     Array(Vec<Value>),
     Nullable(Option<Box<Value>>),
+    Record(OwnedRecord),
     I64(i64),
     I32(i32),
 }
@@ -183,6 +184,8 @@ pub enum ValueType {
     Tuple(Vec<ValueType>),
     Array(Box<ValueType>),
     Nullable(Box<ValueType>),
+    /// A variable-width nested record interpreted by this inline descriptor.
+    Record(Box<RecordDescriptor>),
     I64,
     I32,
 }
@@ -201,7 +204,7 @@ impl ValueType {
                 .iter()
                 .try_fold(0usize, |total, member| Some(total + member.fixed_size()?)),
             Self::Nullable(value_type) => value_type.fixed_size().map(|size| size + 1),
-            Self::String | Self::Bytes | Self::Array(_) => None,
+            Self::String | Self::Bytes | Self::Array(_) | Self::Record(_) => None,
         }
     }
 
@@ -226,6 +229,10 @@ pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<
         }
         (Value::Nullable(value), ValueType::Nullable(inner_type)) => {
             encode_nullable(&mut bytes, value.as_deref(), inner_type)?;
+        }
+        (Value::Record(record), ValueType::Record(_)) => {
+            ensure_value_type(value, value_type)?;
+            bytes.extend_from_slice(record.raw());
         }
         _ if value_type.is_fixed_size() => encode_fixed_value(&mut bytes, value, value_type)?,
         _ => {
@@ -264,6 +271,11 @@ pub(super) fn encode_fixed_value(
         }
         (Value::Nullable(value), ValueType::Nullable(inner_type)) => {
             encode_nullable(bytes, value.as_deref(), inner_type)?;
+        }
+        (_, ValueType::Record(_)) => {
+            return Err(Error::TypeMismatch {
+                expected: value_type.clone(),
+            });
         }
         _ => {
             return Err(Error::TypeMismatch {
@@ -304,6 +316,17 @@ pub(super) fn decode_value(bytes: &[u8], value_type: &ValueType) -> Result<Value
         ValueType::Tuple(members) => decode_tuple(bytes, members),
         ValueType::Array(element_type) => decode_array(bytes, element_type),
         ValueType::Nullable(inner_type) => decode_nullable(bytes, inner_type),
+        ValueType::Record(descriptor) => {
+            let values = descriptor.bind(bytes).to_values()?;
+            let canonical = descriptor.create(&values)?;
+            if canonical != bytes {
+                return Err(Error::NonCanonicalRecord);
+            }
+            Ok(Value::Record(OwnedRecord::new(
+                bytes.to_vec(),
+                **descriptor,
+            )))
+        }
     }
 }
 
@@ -469,6 +492,18 @@ pub(super) fn ensure_value_type(value: &Value, value_type: &ValueType) -> Result
         (Value::Nullable(Some(value)), ValueType::Nullable(inner_type)) => {
             ensure_value_type(value, inner_type)
         }
+        (Value::Record(record), ValueType::Record(descriptor)) => {
+            if record.descriptor() != descriptor.as_ref() {
+                return Err(Error::TypeMismatch {
+                    expected: value_type.clone(),
+                });
+            }
+            let values = record.to_values()?;
+            if descriptor.create(&values)? != record.raw() {
+                return Err(Error::NonCanonicalRecord);
+            }
+            Ok(())
+        }
         _ => Err(Error::TypeMismatch {
             expected: value_type.clone(),
         }),
@@ -489,6 +524,12 @@ pub(super) fn validate_schema_value_type(value_type: &ValueType) -> Result<(), E
             Ok(())
         }
         ValueType::Array(inner) | ValueType::Nullable(inner) => validate_schema_value_type(inner),
+        ValueType::Record(descriptor) => {
+            for field in descriptor.fields() {
+                validate_schema_value_type(&field.value_type)?;
+            }
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -592,11 +633,13 @@ fn decode_tuple_member(bytes: &[u8], value_type: &ValueType) -> Result<Value, Er
         }
         ValueType::Tuple(members) => decode_tuple(bytes, members),
         ValueType::Nullable(inner_type) => decode_nullable(bytes, inner_type),
-        ValueType::F64 | ValueType::String | ValueType::Bytes | ValueType::Array(_) => {
-            Err(Error::InvalidTupleMember {
-                member_type: value_type.clone(),
-            })
-        }
+        ValueType::F64
+        | ValueType::String
+        | ValueType::Bytes
+        | ValueType::Array(_)
+        | ValueType::Record(_) => Err(Error::InvalidTupleMember {
+            member_type: value_type.clone(),
+        }),
     }
 }
 

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -1733,7 +1733,8 @@ fn encode_key_part(key: &mut Vec<u8>, value: &RecordValue) -> Result<(), Error> 
         RecordValue::F64(_)
         | RecordValue::Tuple(_)
         | RecordValue::Array(_)
-        | RecordValue::Nullable(_) => {
+        | RecordValue::Nullable(_)
+        | RecordValue::Record(_) => {
             return Err(Error::InvalidStorageKey(
                 "unsupported window key value type".to_owned(),
             ));
@@ -1825,9 +1826,13 @@ fn decode_key_part(bytes: &mut &[u8], value_type: &ValueType) -> Result<RecordVa
             expect_key_tag(bytes, 0)?;
             Ok(RecordValue::Enum(take_key_bytes(bytes, 1)?[0]))
         }
-        ValueType::F64 | ValueType::Tuple(_) | ValueType::Array(_) | ValueType::Nullable(_) => Err(
-            Error::InvalidStorageKey("unsupported window key type".to_owned()),
-        ),
+        ValueType::F64
+        | ValueType::Tuple(_)
+        | ValueType::Array(_)
+        | ValueType::Nullable(_)
+        | ValueType::Record(_) => Err(Error::InvalidStorageKey(
+            "unsupported window key type".to_owned(),
+        )),
     }
 }
 

--- a/crates/groove/src/window_codec.rs
+++ b/crates/groove/src/window_codec.rs
@@ -941,15 +941,24 @@ fn order_preserving_i32_bits(value: i32) -> u32 {
 }
 
 fn is_integer_type(value_type: &ValueType) -> bool {
-    matches!(
-        value_type,
+    match value_type {
         ValueType::U8
-            | ValueType::U16
-            | ValueType::U32
-            | ValueType::U64
-            | ValueType::I32
-            | ValueType::I64
-    )
+        | ValueType::U16
+        | ValueType::U32
+        | ValueType::U64
+        | ValueType::I32
+        | ValueType::I64 => true,
+        ValueType::F64
+        | ValueType::Bool
+        | ValueType::String
+        | ValueType::Bytes
+        | ValueType::Uuid
+        | ValueType::Enum(_)
+        | ValueType::Tuple(_)
+        | ValueType::Array(_)
+        | ValueType::Nullable(_)
+        | ValueType::Record(_) => false,
+    }
 }
 
 fn integer_value(value: &Value, value_type: &ValueType) -> Option<u128> {
@@ -984,7 +993,16 @@ fn integer_to_value(value: u128, value_type: &ValueType) -> Result<Value, Window
         ValueType::I64 => u64::try_from(value)
             .map(|value| Value::I64((value ^ (1_u64 << 63)) as i64))
             .map_err(|_| WindowCodecError::Invalid("i64 delta value out of range")),
-        _ => Err(WindowCodecError::Invalid("non-integer delta column")),
+        ValueType::F64
+        | ValueType::Bool
+        | ValueType::String
+        | ValueType::Bytes
+        | ValueType::Uuid
+        | ValueType::Enum(_)
+        | ValueType::Tuple(_)
+        | ValueType::Array(_)
+        | ValueType::Nullable(_)
+        | ValueType::Record(_) => Err(WindowCodecError::Invalid("non-integer delta column")),
     }
 }
 

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -576,6 +576,11 @@ fn column_type_from_value_type(value_type: &ValueType) -> ColumnType {
         ValueType::Nullable(inner) => {
             ColumnType::Nullable(Box::new(column_type_from_value_type(inner)))
         }
+        ValueType::Record(_) => {
+            panic!(
+                "record-valued Groove outputs are not part of the Jazz query schema in this stage"
+            )
+        }
     }
 }
 

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -2348,6 +2348,9 @@ fn put_value(bytes: &mut Vec<u8>, value: &Value) {
                 None => bytes.push(0),
             }
         }
+        Value::Record(_) => {
+            panic!("record-valued values have no v3 protocol encoding")
+        }
     }
 }
 

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -4010,6 +4010,9 @@ fn value_type(value: &Value) -> ColumnType {
             .unwrap_or_else(|| ColumnType::Array(Box::new(ColumnType::Bytes))),
         Value::Nullable(Some(value)) => ColumnType::Nullable(Box::new(value_type(value))),
         Value::Nullable(None) => ColumnType::Nullable(Box::new(ColumnType::Bytes)),
+        Value::Record(_) => {
+            panic!("record-valued query bindings are not part of the current Jazz query surface")
+        }
     }
 }
 
@@ -4041,6 +4044,9 @@ fn value_matches_type(value: &Value, column_type: &ColumnType) -> bool {
         (Value::Nullable(Some(value)), ColumnType::Nullable(inner)) => {
             value_matches_type(value, inner)
         }
+        // Jazz has no public record column type in this step, so records are
+        // never accepted as query-bound values.
+        (Value::Record(_), _) => false,
         _ => false,
     }
 }
@@ -4117,6 +4123,9 @@ fn put_value(bytes: &mut Vec<u8>, value: &Value) {
             bytes.push(13);
             bytes.push(1);
             put_value(bytes, value);
+        }
+        Value::Record(_) => {
+            panic!("record-valued query bindings have no current canonical encoding")
         }
     }
 }

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -2492,6 +2492,20 @@ mod tests {
             crate::groove::records::ValueType::Nullable(inner) => {
                 GrooveValue::Nullable(Some(Box::new(sample_groove_value(inner))))
             }
+            crate::groove::records::ValueType::Record(descriptor) => {
+                GrooveValue::Record(crate::groove::records::OwnedRecord::new(
+                    descriptor
+                        .create(
+                            &descriptor
+                                .fields()
+                                .iter()
+                                .map(|field| sample_groove_value(&field.value_type))
+                                .collect::<Vec<_>>(),
+                        )
+                        .unwrap(),
+                    **descriptor,
+                ))
+            }
         }
     }
 

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -2405,6 +2405,47 @@ mod tests {
             GrooveColumnType::I32.array_of()
         );
 
+        let numeric_default_schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("numeric_defaults")
+                    .column_with_default("integer", ColumnType::Integer, Value::Integer(-7))
+                    .column_with_default("bigint", ColumnType::BigInt, Value::Integer(-7))
+                    .column_with_default("bigint_literal", ColumnType::BigInt, Value::BigInt(-7))
+                    .column_with_default(
+                        "integers",
+                        ColumnType::Array {
+                            element: Box::new(ColumnType::Integer),
+                        },
+                        Value::Array(vec![Value::Integer(-7), Value::BigInt(8)]),
+                    ),
+            )
+            .build();
+        let numeric_default_table = convert_public_schema(&numeric_default_schema)
+            .unwrap()
+            .tables
+            .into_iter()
+            .find(|table| table.name == "numeric_defaults")
+            .unwrap();
+        assert_eq!(
+            numeric_default_table
+                .columns
+                .iter()
+                .map(|column| (column.name.as_str(), &column.default))
+                .collect::<Vec<_>>(),
+            vec![
+                ("integer", &Some(GrooveValue::I32(-7))),
+                ("bigint", &Some(GrooveValue::I64(-7))),
+                ("bigint_literal", &Some(GrooveValue::I64(-7))),
+                (
+                    "integers",
+                    &Some(GrooveValue::Array(vec![
+                        GrooveValue::I32(-7),
+                        GrooveValue::I32(8),
+                    ])),
+                ),
+            ]
+        );
+
         let default_schema = [(
             TableName::new("todos"),
             TableSchema::new(RowDescriptor::new(vec![

--- a/packages/jazz-tools/src/runtime/native-runtime/schema-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/schema-codec.ts
@@ -158,8 +158,8 @@ function writeDefaultValue(writer: PostcardWriter, columnType: ColumnType, value
       writer.bool(value.value);
       return;
     case "Integer":
-      writer.u64(2); // groove::records::Value::U32
-      writer.u64(encodeSignedI32ForCore(expectI32(value, "Integer")));
+      writer.u64(14); // groove::records::Value::I32
+      writer.i64(expectI32(value, "Integer"));
       return;
     case "BigInt":
       if (value.type !== "BigInt" && value.type !== "Integer") {
@@ -242,7 +242,7 @@ export function columnTypeToValueType(type: ColumnType): ValueType {
     case "Boolean":
       return { tag: 5 };
     case "Integer":
-      return { tag: 2 };
+      return { tag: 14 };
     case "BigInt":
       return { tag: 13 };
     case "Timestamp":
@@ -1470,10 +1470,6 @@ function expectI32(value: Value, type: string): number {
     throw new Error(`${type} default must be a signed 32-bit integer`);
   }
   return number;
-}
-
-function encodeSignedI32ForCore(value: number): number {
-  return (value ^ 0x80000000) >>> 0;
 }
 
 function f64Bytes(value: number): Uint8Array {


### PR DESCRIPTION
Adds `ValueType::Record`, so a groove value can be a record — and, through the
existing array machinery, a list of records. Implements `INV-STORAGE-27` from
#1245.

## Why

#1245 moves structured query results out of the client and into core: instead of
emitting flat rows plus edges for consumers to reassemble, the output terminal
emits a parent with its children already nested. That needs a value type capable
of holding a record. Groove has not had one — arrays are recursive, but their
element schema is only a `ValueType`, and no variant carries a
`RecordDescriptor`.

This PR adds that variant and nothing else. No operator, no terminal emission,
no wire change — those are later steps.

## The design

`ValueType::Record(Box<RecordDescriptor>)`, inline. A registry keyed by
descriptor id would share metadata better, but needs wire format and version
machinery for no benefit at this stage; inline is lifetime-free and reuses the
existing offset-framed layout, so no new outer-record encoding is required.

**Two properties the type has to guarantee, both enforced here.**

*Canonical bytes.* `OwnedRecord::new` accepts arbitrary raw bytes, so two
logically equal nested records could differ byte-wise. Consolidation cancels
deltas by record equality, so non-canonical encodings would mean deltas silently
failing to cancel — accumulating state with no error anywhere. Validation
requires descriptor equality *and* canonical bytes: decode every child field,
recreate through the descriptor, require byte equality.
`record_values_reject_non_canonical_child_bytes` proves arbitrary bytes are
refused.

*Not a key.* A nested value must not appear, directly or recursively, in an
arrangement key or durable primary key. Every such site gets an explicit reject
arm rather than falling through a catch-all — runtime arrangement and primary
keys, durable and direct-store keys, storage window keys, numeric window
classification, and the wildcard-adjacent consumers the compiler would not have
forced a visit to: predicate literals, and jazz's query-binding, canonical
encoder and lowering paths.

## Where it fits

```
occurrence identity (#1250)
  ├── flat joins        → #1246
  └── record-valued type  (this PR)
      └── CollectBy       → the operator that emits an array per group
          └── terminal emission → wire v4 → delete client-side reassembly
```

## Review notes

**Variant ordering is load-bearing.** `Record` sits after the existing integer
variants deliberately: these are postcard-serialized, so inserting a variant
earlier shifts discriminants and changes how already-written bytes decode.
Anything added later belongs at the end for the same reason.

This also aligns the TypeScript schema encoder to emit `I32` for public
`Integer` columns and defaults, matching core — public `Integer` maps to core
`I32`, values are width-strict in encoding and type checks, and insert defaults
are forwarded directly into row cells.

Coverage: record and array-of-record round trips, recursive depth, delta
consolidation cancellation, arrangement-key and durable-key rejection, the
non-canonical rejection, and `Integer`/`BigInt`/integer-array defaults.

All gates green. The three `catalogue_sync_integration` failures behind the
`core_query` guard are pre-existing and unrelated — verified directly on this
branch.
