### PR TITLE
Draft: columnar base chunks with a durable row delta (Groove SPEC §2.10)

### DIFF
--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -438,26 +438,25 @@ framing. Those are CPU-only figures, not backend measurements.
   supports the structural choice of grouping attributes within a bounded page:
   it improves cache-line behavior for scans while keeping a row's parts local.
   It does not establish this delta, compaction, or write protocol.
-- [DBSP — Budiu et al., VLDB 2023](https://www.vldb.org/pvldb/vol16/p1601-budiu.pdf)
-  supports independently recomputing a touched grouping for aggregates that
-  need it. The proposed one-range/chunk compaction work bound is nevertheless
-  a custom storage-operator contract, not a theorem proved by DBSP or a claim
-  that all work is bounded by the cited model.
-- [Koch, Lupei, and Tannen, PODS 2016](https://arxiv.org/abs/1412.4320)
-  identifies inner-bag update as the difficult case and uses shredding for a
-  correlated child collection. This design is **not IncNRC+**: it does not
-  claim the paper's syntactic fragment or its results for member-addressed
-  updates to nested collections.
-- SAP HANA's delta merge is supporting precedent for a write-optimised row
-  delta before columnar merge; the [HTAP survey (arXiv:2404.15670)](https://arxiv.org/abs/2404.15670)
-  likewise distinguishes random-write-friendly rows from scan-friendly columns.
-  Modern-SSD work is supporting context for avoiding a “read bigger units”
-  conclusion and for treating decompression as a possible bottleneck. Neither
-  establishes the present thresholds or visibility semantics.
+- SAP HANA's delta merge is the closest shipping precedent for the shape
+  proposed here: a write-optimised delta in front of a read-optimised column
+  store, merged in the background. Notably its L1 delta holds updates in **row**
+  format. No production system appears to ship columnar-only for
+  transactional workloads.
+- The [HTAP survey (arXiv:2404.15670)](https://arxiv.org/abs/2404.15670)
+  likewise distinguishes random-write-friendly row layouts from scan-friendly
+  column layouts, and describes hybrids rather than a single format.
+- Modern-SSD work is supporting context in two directions: it undermines the
+  spinning-disk assumptions behind point-lookup-optimised layouts, but it also
+  cautions against concluding "read bigger units" — small random reads became
+  cheap, and decompression, not I/O, became the bottleneck.
 
-Ordered nested collections are not covered by those citations. A stable
-row-id tie-breaker can define a total order, but dense numeric positions make
-front insertion renumber successors; this draft does not solve that problem.
+None of these establish the thresholds, the compaction work bound, or the
+delta visibility semantics proposed above. Those are contracts this draft is
+asserting, to be pinned by measurement.
+
+The work bound in particular is a **custom storage-operator contract**, not a
+result carried over from any cited system.
 
 #### Deferred choices
 

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -352,9 +352,21 @@ included in a range scan. Compaction later reads a base-plus-delta view for a
 range, writes new immutable chunk(s), makes them current, and reclaims
 superseded material.
 
-How a reader locates the current base for a range, and how compaction makes new
-chunks current, is deliberately left open below. That mechanism is not chosen
-here, and this section should not be read as having chosen one.
+**Compaction of a range does not overlap a scan of that range.** The proposal
+is to exclude the two rather than to isolate a reader from a publish it is
+concurrent with. This is the smallest of the available options and the reason
+the rest of the section needs no multi-version machinery: because no reader is
+mid-scan across a publish, superseded chunks need not stay addressable
+afterwards, and nothing has to track which readers still hold an older base.
+Whether the exclusion is worth relaxing later is a performance question, not a
+correctness one, and it is recorded as future work below.
+
+That decision does not settle how a reader locates the current base for a
+range, or what makes a newly compacted chunk current. Chunk boundaries are
+data-dependent and change when compaction splits or merges ranges, so the
+mapping is itself mutable state whatever form it takes. That mechanism is
+deliberately left open below, and this section should not be read as having
+chosen one.
 
 In particular, inserts whose keys fall into an existing chunk range use the
 same durable delta path. Whether their later compaction cost and scheduling
@@ -491,28 +503,32 @@ record descriptors, and reopen/migration diagnostics.
 
 ### Open questions
 
-- 🔶 **How a base is located, made current, and reclaimed.** The draft above
-  fixes the representation (immutable chunks + durable delta) but deliberately
-  does not choose the mechanism that connects them. Four coupled decisions are
-  open, and this is a correctness and recovery question rather than a
-  performance-tuning one:
+- 🔶 **How a base is located and made current.** The draft above fixes the
+  representation (immutable chunks + durable delta) and excludes compaction
+  from overlapping a scan of the same range, but deliberately does not choose
+  the mechanism that connects base to delta. Two coupled decisions are open,
+  and they are correctness and recovery questions rather than
+  performance-tuning ones:
   - How a reader finds the current base for a primary-key range, given that
     chunk boundaries are data-dependent and change when compaction splits or
-    merges ranges.
-  - What makes a newly compacted chunk current, and at what point that becomes
-    observable to a reader.
-  - Whether a reader must be isolated from a compaction that publishes while
-    the reader is mid-scan. Note as input, not as a conclusion: today
-    `OrderedKvStorage` offers `get`/`scan_range`/`scan_prefix`/`write_many`
-    with no snapshot or read-version, so a scan observes whatever is committed
-    as it runs. Whichever way this is settled — by constraining when
-    compaction may run, by keeping superseded material addressable, by
-    changing the storage contract, or otherwise — should follow from the
-    decision, not drive it.
-  - When superseded chunks and folded-in delta entries may be reclaimed. One
-    concrete hazard to preserve in any answer: compaction must retire exactly
-    the delta entries it consumed, not a key range, or rows written during the
-    compaction window are lost.
+    merges ranges. Encoding the mapping in the key space and deriving it by
+    ordered seek, or holding it in separate metadata, are both open; each
+    trades a consistency obligation against a lookup.
+  - What makes a newly compacted chunk current, and how superseded chunks and
+    folded-in delta entries are retired. Because no reader is mid-scan across
+    that point, retirement may be immediate. One concrete hazard to preserve
+    in any answer: compaction must retire exactly the delta entries it
+    consumed, not a key range, or rows written during the compaction window
+    are lost.
+- 🔶 **Future: allow compaction concurrent with a scan of the same range.**
+  The draft avoids the problem by excluding the two, which costs compaction
+  scheduling freedom under sustained read load. Relaxing it needs a source of
+  reader isolation, and today there is none to draw on: `OrderedKvStorage`
+  offers `get`/`scan_range`/`scan_prefix`/`write_many` with no snapshot or
+  read-version, so a scan observes whatever is committed while it runs.
+  Keeping superseded material addressable and changing the storage contract
+  are both possible answers. Neither should be pursued before the exclusion is
+  measured and shown to bind.
 - 🔶 **Compaction rule: per backend or one portable rule?** RocksDB's observed
   coalescing points are `m=32`/`128`/`2048` at `k=64`/`512`/`4096`; OPFS is
   later or absent in the matched sweep (`none through 64`, `m=512`, and only a

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -339,22 +339,22 @@ explicitly not a columnar-only design.
 
 For a table selected for this representation, a base chunk covers a bounded
 primary-key range and contains a primary-key stream plus one encoded stream per
-record field. The chunk directory chooses a generation for each range. The row
-delta is a separate durable, primary-keyed store of complete current rows or
-tombstones. It is the authoritative current state, not a cache, a best-effort
-write buffer, or an optional optimisation.
+record field. The row delta is a separate durable, primary-keyed store of
+complete current rows or tombstones. It is the authoritative current state, not
+a cache, a best-effort write buffer, or an optional optimisation.
 
 The proposed interactive write path appends/replaces the affected row's delta
 entry under the ordinary storage atomicity and durability boundary. It does not
 read, decode, modify, and rewrite a base chunk. Reads reconstruct a logical
-table by combining the selected base generation with the delta: a delta row
-replaces a base row of the same primary key, a tombstone hides it, and a
-delta-only key is included in a range scan. Compaction later reads a stable
-base-plus-delta view for a range, writes new immutable chunk generation(s), and
-publishes the directory change atomically before reclaiming superseded material.
-The exact delta visibility and reclamation rules are intentionally open below;
-the preceding paragraph is the proposed representation, not a claim that those
-rules already exist.
+table by combining the base for a range with the delta: a delta row replaces a
+base row of the same primary key, a tombstone hides it, and a delta-only key is
+included in a range scan. Compaction later reads a base-plus-delta view for a
+range, writes new immutable chunk(s), makes them current, and reclaims
+superseded material.
+
+How a reader locates the current base for a range, and how compaction makes new
+chunks current, is deliberately left open below. That mechanism is not chosen
+here, and this section should not be read as having chosen one.
 
 In particular, inserts whose keys fall into an existing chunk range use the
 same durable delta path. Whether their later compaction cost and scheduling
@@ -491,11 +491,28 @@ record descriptors, and reopen/migration diagnostics.
 
 ### Open questions
 
-- 🔶 **Columnar-delta visibility semantics.** Before this draft can become a
-  contract, decide the snapshot point at which a durable delta is visible, how
-  a reader selects a base generation and its overlay, and when old deltas and
-  chunk generations may be reclaimed. This is a correctness and recovery
-  design question, not a performance-tuning choice.
+- 🔶 **How a base is located, made current, and reclaimed.** The draft above
+  fixes the representation (immutable chunks + durable delta) but deliberately
+  does not choose the mechanism that connects them. Four coupled decisions are
+  open, and this is a correctness and recovery question rather than a
+  performance-tuning one:
+  - How a reader finds the current base for a primary-key range, given that
+    chunk boundaries are data-dependent and change when compaction splits or
+    merges ranges.
+  - What makes a newly compacted chunk current, and at what point that becomes
+    observable to a reader.
+  - Whether a reader must be isolated from a compaction that publishes while
+    the reader is mid-scan. Note as input, not as a conclusion: today
+    `OrderedKvStorage` offers `get`/`scan_range`/`scan_prefix`/`write_many`
+    with no snapshot or read-version, so a scan observes whatever is committed
+    as it runs. Whichever way this is settled — by constraining when
+    compaction may run, by keeping superseded material addressable, by
+    changing the storage contract, or otherwise — should follow from the
+    decision, not drive it.
+  - When superseded chunks and folded-in delta entries may be reclaimed. One
+    concrete hazard to preserve in any answer: compaction must retire exactly
+    the delta entries it consumed, not a key range, or rows written during the
+    compaction window are lost.
 - 🔶 **Compaction rule: per backend or one portable rule?** RocksDB's observed
   coalescing points are `m=32`/`128`/`2048` at `k=64`/`512`/`4096`; OPFS is
   later or absent in the matched sweep (`none through 64`, `m=512`, and only a

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -328,6 +328,150 @@ history consolidation. `history_windows_are_transparent_to_subscription_hydratio
 and `history_consolidation_visits_direct_record_stores` verify that the
 representation remains invisible to record-store consumers.
 
+### 2.10 Draft — columnar base chunks with a durable row delta
+
+**Draft decision note (evidence reports dated 2026-08-04/05; not accepted or
+implemented).** This section records a proposed table representation and the
+measurements behind it. It creates no new invariant and does not describe the
+current implementation. The proposed representation is **immutable columnar
+base chunks + a durable per-row delta + background compaction**. It is
+explicitly not a columnar-only design.
+
+For a table selected for this representation, a base chunk covers a bounded
+primary-key range and contains a primary-key stream plus one encoded stream per
+record field. The chunk directory chooses a generation for each range. The row
+delta is a separate durable, primary-keyed store of complete current rows or
+tombstones. It is the authoritative current state, not a cache, a best-effort
+write buffer, or an optional optimisation.
+
+The proposed interactive write path appends/replaces the affected row's delta
+entry under the ordinary storage atomicity and durability boundary. It does not
+read, decode, modify, and rewrite a base chunk. Reads reconstruct a logical
+table by combining the selected base generation with the delta: a delta row
+replaces a base row of the same primary key, a tombstone hides it, and a
+delta-only key is included in a range scan. Compaction later reads a stable
+base-plus-delta view for a range, writes new immutable chunk generation(s), and
+publishes the directory change atomically before reclaiming superseded material.
+The exact delta visibility and reclamation rules are intentionally open below;
+the preceding paragraph is the proposed representation, not a claim that those
+rules already exist.
+
+In particular, inserts whose keys fall into an existing chunk range use the
+same durable delta path. Whether their later compaction cost and scheduling
+behave like updates is an inference, not a measurement.
+
+#### Evidence and limits
+
+The numbers below are cited from the staged write-shape, RocksDB-update,
+OPFS-update, flush-cadence, row-reconstruction, and compression reports. They
+were taken on one shared AMD EPYC 4564P development box. Several runs had load
+averages around 7–12; the flush report deliberately ran at lower,
+non-overlapped load, and the compression run started at lower load. They are
+therefore directional crossovers and ratios, not service objectives, device
+guarantees, or a substitute for measurements on a target workload. Cache modes
+also differ by backend: “cold” is a RocksDB block-cache miss in the native
+report and a fresh B-tree cache in the OPFS report, not physical-media-cold
+latency.
+
+**Write shape.** For 10,000 individual logical puts, operation count dominates
+through roughly `k=64` on both RocksDB and Chromium OPFS. With 0.91 KiB mean
+records, the per-batch curve has effectively plateaued by `k=512`: RocksDB was
+76.6 ms at 64, 42.9 ms at 512, and 41.7 ms at one 10,000-row commit; OPFS was
+567.7 ms, 442.0 ms, and 428.7 ms respectively. With 9.54 KiB mean / 4.80 KiB
+median records, byte/page work dominates after 64: RocksDB remained 497–668 ms
+and OPFS 2.97–3.19 s while reducing 157 commits to one. The OPFS runs still
+issued 447–462 MiB at `k>=64`. A whole chunk is consequently not “as cheap as
+one row” once a batch carries multi-KiB records.
+
+**Update RMW and coalescing.** A blind row delta avoids a chunk read and rewrite
+on every interactive update. The conservative, at-least-2x single-update
+crossovers differ materially by backend:
+
+| record shape          | RocksDB, first material chunk-RMW loss | OPFS, first material chunk-RMW loss |
+| --------------------- | -------------------------------------- | ----------------------------------- |
+| 64 B, 1 or 8 columns  | warm `k=64`; cold `k=1`                | warm and cold `k=4096`              |
+| 1 KiB, 1 or 8 columns | warm and cold `k=1`                    | warm and cold `k=64`                |
+
+For 8-column, 256-byte rows, the first clear RocksDB coalescing wins for one
+chunk rewrite over blind row writes were `m=32` distinct rows at `k=64`,
+`m=128` at `k=512`, and `m=2048` at `k=4096`; `k=1` never won. The apparent
+`k=8, m=4` win had overlapping distributions and is not material. On real
+Chromium OPFS, thresholds are later, not earlier: no win through `m=64` at
+`k=64`; `m=512` at `k=512`; and `m=2048` was marginal at `k=4096`, with the
+first clear win at `m=4096`. Separate, uncoalesced chunk RMW never beat row
+writes in either report. This is the direct evidence for the durable delta and
+for making compaction a background, coalescing operation rather than an
+interactive write strategy.
+
+**CPU reconstruction.** The resident-memory, uncompressed measurement found
+that complete-row reconstruction was not materially worse through `k=512` and
+was often faster for variable-width records. The clear counterexample was
+`k=4096` with 64 columns: columnar/row time was 1.07x for all-fixed, 1.47x for
+mixed, and 2.21x for mostly-variable rows (2,012 ns / 1,889 ns; 3,902 ns /
+2,653 ns; and 6,813 ns / 3,079 ns). A one-column read remained roughly flat
+in chunk length. The adverse result is therefore principally width — touching
+64 separate columns for a full row — rather than length alone. This excludes
+storage I/O and compression.
+
+**Flush cadence, at the storage boundary only.** The initial-load flush cadence
+is a client-layer setting outside this Groove specification; it is already
+implemented there. Its storage relevance is that batching durability boundaries
+changes both wall time and OPFS write amplification. For a 10,000-row load,
+flush-once versus flush-every was 42.0x faster for about-1-KiB rows and 6.6x
+for about-10-KiB rows in RocksDB, and 17.7x / 3.3x in OPFS. At every 512 rows,
+the run was within 6–16% of flush-once; every 4,096 was within 4%. For 1-KiB
+OPFS input, every-write issued 749.4 MB and every-512 55.5 MB. This section
+does not choose the client cadence or its crash-loss policy.
+
+**Compression.** Compression is a space trade-off, not evidence that a
+compressed chunk belongs on the synchronous read path. In the 64-column,
+mixed, `k=64` CPU measurement, per-column LZ4 made a complete row
+16.27+/-0.04 us rather than 1.76+/-0.03 us uncompressed, for 1.62x reduction;
+per-column Zstd-1 was 128.30+/-0.59 us for 2.12x. Projection requires
+per-column framing: at mixed `k=4096`, a projected value took
+19.08+/-0.05 us with per-column LZ4 but 1,600.74+/-2.89 us with whole-chunk
+framing. Those are CPU-only figures, not backend measurements.
+
+#### Literature backing and boundary
+
+- [PAX — Ailamaki et al., VLDB 2001](https://www.vldb.org/conf/2001/P169.pdf)
+  supports the structural choice of grouping attributes within a bounded page:
+  it improves cache-line behavior for scans while keeping a row's parts local.
+  It does not establish this delta, compaction, or write protocol.
+- [DBSP — Budiu et al., VLDB 2023](https://www.vldb.org/pvldb/vol16/p1601-budiu.pdf)
+  supports independently recomputing a touched grouping for aggregates that
+  need it. The proposed one-range/chunk compaction work bound is nevertheless
+  a custom storage-operator contract, not a theorem proved by DBSP or a claim
+  that all work is bounded by the cited model.
+- [Koch, Lupei, and Tannen, PODS 2016](https://arxiv.org/abs/1412.4320)
+  identifies inner-bag update as the difficult case and uses shredding for a
+  correlated child collection. This design is **not IncNRC+**: it does not
+  claim the paper's syntactic fragment or its results for member-addressed
+  updates to nested collections.
+- SAP HANA's delta merge is supporting precedent for a write-optimised row
+  delta before columnar merge; the [HTAP survey (arXiv:2404.15670)](https://arxiv.org/abs/2404.15670)
+  likewise distinguishes random-write-friendly rows from scan-friendly columns.
+  Modern-SSD work is supporting context for avoiding a “read bigger units”
+  conclusion and for treating decompression as a possible bottleneck. Neither
+  establishes the present thresholds or visibility semantics.
+
+Ordered nested collections are not covered by those citations. A stable
+row-id tie-breaker can define a total order, but dense numeric positions make
+front insertion renumber successors; this draft does not solve that problem.
+
+#### Deferred choices
+
+**Merge operators.** The owner decision is to defer them “to keep things simple
+and see how fast stuff is without it.” They may later reduce chunk-update cost,
+but this draft specifies neither their semantics nor a backend abstraction for
+them.
+
+**Read-path compression.** Compression on the synchronous read path is deferred.
+The measurement above shows that it changes CPU cost decisively, and any future
+compressed projection format must preserve independently readable columns. No
+compaction-quality result is used as evidence here: current quality is known
+poor and its measurements were deliberately excluded from this design.
+
 ### 2.12 Subsumed storage backlog
 
 The former top-level storage notes are now represented by this chapter's
@@ -348,6 +492,27 @@ record descriptors, and reopen/migration diagnostics.
 
 ### Open questions
 
+- 🔶 **Columnar-delta visibility semantics.** Before this draft can become a
+  contract, decide the snapshot point at which a durable delta is visible, how
+  a reader selects a base generation and its overlay, and when old deltas and
+  chunk generations may be reclaimed. This is a correctness and recovery
+  design question, not a performance-tuning choice.
+- 🔶 **Compaction rule: per backend or one portable rule?** RocksDB's observed
+  coalescing points are `m=32`/`128`/`2048` at `k=64`/`512`/`4096`; OPFS is
+  later or absent in the matched sweep (`none through 64`, `m=512`, and only a
+  marginal `m=2048` / clear `m=4096`). Decide whether the eventual scheduler
+  uses backend-specific rules or one conservative portable rule, after target
+  workload measurements rather than treating either report as a service goal.
+- 🔶 **Inserts into an existing chunk range.** The draft sends them to the row
+  delta, but their compaction behavior is inferred from updates and was never
+  measured separately. Measure them before using update coalescing thresholds
+  to schedule insert-heavy ranges.
+- 🔶 **Chunk eligibility and compaction quality.** The `k=64`/`512` evidence
+  does not measure wide production schemas, insert-heavy ranges, backlog/space
+  limits, or compaction quality. Current compaction quality is known poor; its
+  measurements were intentionally not used as supporting evidence. Establish
+  receipts for range size, delta depth, bytes, foreground interference, and
+  output quality before selecting a broader policy.
 - 🔶 **Portable backend contract.** Before exposing storage through WASM/NAPI or
   a server package, pin which guarantees every backend must provide beyond the
   current reference surface: ordered key/value operations, atomic batches,


### PR DESCRIPTION
Records the columnar storage design we arrived at over the last week of spikes, as a draft decision note in the Groove storage chapter (§2.10). It is explicitly **not accepted and not implemented** — it creates no invariant and describes no current behaviour. The point is that the shape, the numbers and the literature don't evaporate now that the spikes are done.

## The design

**Immutable columnar base chunks + a durable per-row delta + background compaction.**

A base chunk covers a bounded primary-key range and holds a primary-key stream plus one encoded stream per field. The delta is a separate durable, primary-keyed store of complete current rows or tombstones — authoritative current state, not a cache or a best-effort buffer.

Interactive writes append or replace the row's delta entry. They never read-decode-modify-rewrite a chunk. Reads overlay the delta on the base for a range. Compaction runs in the background: read a base-plus-delta view for a range, write new immutable chunks, make them current, reclaim what they supersede.

**Compaction of a range does not overlap a scan of that range.** That is the one mechanism decision the draft does make, and it's deliberately the smallest available: exclude the two rather than isolate a reader from a publish it's concurrent with. Everything else follows from it — no multi-version machinery, superseded chunks need not stay addressable, nothing tracks which readers hold an older base. Relaxing it later is a performance question, not a correctness one.

Deliberately **not** decided: how a reader locates the current base for a range, and what makes a newly compacted chunk current. Chunk boundaries are data-dependent and shift when compaction splits or merges ranges, so that mapping is mutable state whatever form it takes — key-encoded and derived by ordered seek, or held as separate metadata. The measurements support the representation, not either mechanism, so it stays an open question rather than getting written down as a choice.

The key claim is negative and it's what the measurements bought us: **a columnar-only design does not survive an interactive write path.** The delta isn't a concession, it's the load-bearing part.

## Why the numbers say that

Everything is cited inline with its report. Directional crossovers from one shared dev box, not service objectives — the section says so up front.

- **Write shape** — operation count dominates through about `k=64`; by `k=512` the per-batch curve has plateaued. With multi-KiB records, byte work dominates and a whole chunk is *not* "as cheap as one row."
- **Update RMW** — this is the one that decides the design. Chunk-rewrite-per-update loses to blind row writes almost immediately: RocksDB at `k=1` for 1 KiB rows, OPFS at `k=64`. Uncoalesced chunk RMW never beat row writes on either backend.
- **Coalescing** — rewriting a chunk only pays once enough distinct rows accumulate: RocksDB `m=32` at `k=64`, `m=128` at `k=512`, `m=2048` at `k=4096`. OPFS thresholds land later, not earlier. That is the argument for compaction being a background coalescing operation rather than a write strategy.
- **CPU reconstruction** — row reassembly is fine through `k=512`, and often faster than row layout for variable-width records. It degrades on *width*, not length: 64 columns at `k=4096` costs 2.21x for mostly-variable rows.
- **Flush cadence** — included only for its storage-boundary effect on write amplification; the client-layer setting itself is out of scope here and already landed.
- **Compression** — a space trade-off, not something that belongs on the synchronous read path. Per-column LZ4 turns a 1.76 us row read into 16.27 us for 1.62x. Whichever format wins later must keep columns independently readable: whole-chunk framing made a projected value 1,600 us against 19 us per-column.

## Literature

PAX for grouping attributes inside a bounded page; SAP HANA's delta merge as the closest shipping precedent — and worth noting its L1 delta is row-format; the HTAP survey for the row-writes/column-scans split; modern-SSD work as context in both directions, including the caution against concluding "read bigger units."

None of it establishes our thresholds or visibility semantics. Those are contracts we're asserting and still owe measurements for.

## What is deliberately left open

Five 🔶 open questions in the chapter. The first is the one above — how a base is located and made current. The second is future work: allowing compaction concurrent with a scan of the same range, which would need a source of reader isolation, and there is none to draw on today — `OrderedKvStorage` offers `get`/`scan_range`/`scan_prefix`/`write_many` with no snapshot or read-version. Not worth pursuing before the exclusion is measured and shown to bind. Then: whether compaction gets one portable rule or per-backend rules; inserts into an existing chunk range, whose compaction behaviour is inferred from updates and never measured; and chunk eligibility, where current compaction quality is known poor and was intentionally excluded from the evidence.

Merge operators are deferred by owner decision — see how fast this is without them first.

Docs only. No code, no invariants, no gates affected.
