### PR TITLE
(new core) Spec: pending catalogue admission should park, not reject

### DIFF
--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -478,28 +478,34 @@ network wire-frame batches.
 
 ### Open questions
 
-- 🔶 **Temporary subscribe rejection: who re-drives admission?** `SubscribeRejected`
-  is specified only for a **permanent** capability gap, and states that after it
-  the subscription is not active and the requester must not expect `ViewUpdate`s.
+- 🔶 **Pending catalogue admission should park, not reject.** `SubscribeRejected`
+  is specified for a **permanent** capability gap, and states that after it the
+  subscription is not active and the requester must not expect `ViewUpdate`s.
   The implementation also emits `ShapeRegistrationPendingCatalogueAdmission`,
   which is **transient**: the serving peer parks the shape when its catalogue
-  schema is absent, admits it later, and drops the original `Subscribe`. Only a
-  new `Subscribe` re-registers. The client sends its registration once and
-  routes the rejection onward without retrying, so nothing re-drives admission
-  and delivery never begins.
+  schema is absent and admits it later, but it drops the accompanying
+  `Subscribe`. Only a new `Subscribe` re-registers, and the requester does not
+  retry, so nothing re-drives admission and delivery never begins.
 
-  No side owns re-drive under the current contract, and both candidate answers
-  change it. Either the serving peer follows up once admission completes —
-  which contradicts "not active, expect no `ViewUpdate`s" for this reason — or
-  a client retry/re-subscribe obligation is specified, which adds a duty the
-  protocol does not currently place on requesters. A third option is to split
-  the vocabulary so permanent and transient rejections are distinct message
-  semantics rather than two reasons sharing one contract.
+  The parking machinery already exists — the serving peer parks the *shape*. The
+  proposed direction is to park the *subscription* alongside it and activate it
+  when admission completes, so this case stops being a rejection at all and
+  `SubscribeRejected` keeps its permanent-only meaning untouched. Two riders
+  the design must answer:
 
-  Decide before implementing either: an unspecified retry loop against a
-  rejection defined as permanent would be a protocol behaviour no peer is
-  required to honour. Observed against a two-client browser scenario where the
-  local client recovers but cross-client delivery never starts.
+  - **Restart.** Parking is in-memory (see _Parked-unit persistence_ below), so
+    a serving-peer restart drops parked subscriptions. Requester retry is then
+    still needed as a recovery path, even though it is no longer the normal
+    path. Decide whether that is stated as an implementation limitation or
+    resolved by persisting parked units.
+  - **Bound.** A subscription parked for a shape that is never admitted must not
+    accumulate indefinitely. Decide the bound and what the requester observes
+    when it is reached — that outcome may legitimately be a rejection, at which
+    point the permanent/transient distinction in the reason vocabulary becomes
+    meaningful again.
+
+  Observed against a two-client browser scenario where the local client
+  recovers but cross-client delivery never starts.
 
 - 🔶 **Transport state.** The current binding-facing send/poll surface can
   express "send" and "no message staged"; it cannot express closed/error/

--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -478,6 +478,29 @@ network wire-frame batches.
 
 ### Open questions
 
+- 🔶 **Temporary subscribe rejection: who re-drives admission?** `SubscribeRejected`
+  is specified only for a **permanent** capability gap, and states that after it
+  the subscription is not active and the requester must not expect `ViewUpdate`s.
+  The implementation also emits `ShapeRegistrationPendingCatalogueAdmission`,
+  which is **transient**: the serving peer parks the shape when its catalogue
+  schema is absent, admits it later, and drops the original `Subscribe`. Only a
+  new `Subscribe` re-registers. The client sends its registration once and
+  routes the rejection onward without retrying, so nothing re-drives admission
+  and delivery never begins.
+
+  No side owns re-drive under the current contract, and both candidate answers
+  change it. Either the serving peer follows up once admission completes —
+  which contradicts "not active, expect no `ViewUpdate`s" for this reason — or
+  a client retry/re-subscribe obligation is specified, which adds a duty the
+  protocol does not currently place on requesters. A third option is to split
+  the vocabulary so permanent and transient rejections are distinct message
+  semantics rather than two reasons sharing one contract.
+
+  Decide before implementing either: an unspecified retry loop against a
+  rejection defined as permanent would be a protocol behaviour no peer is
+  required to honour. Observed against a two-client browser scenario where the
+  local client recovers but cross-client delivery never starts.
+
 - 🔶 **Transport state.** The current binding-facing send/poll surface can
   express "send" and "no message staged"; it cannot express closed/error/
   backpressure, auth expiry, protocol-version mismatch, or resume-cursor


### PR DESCRIPTION
Records a protocol gap found while chasing local-first browser delivery, and the direction agreed for closing it. Spec only — no code, no invariant, no behaviour change.

## The gap

`SubscribeRejected` is specified for a **permanent** maintained-subscription capability gap, and says that afterwards the subscription is not active and the requester must not expect `ViewUpdate`s.

The implementation also emits `ShapeRegistrationPendingCatalogueAdmission`, which is **transient**: the serving peer parks a shape when its catalogue schema is absent and admits it later — but drops the accompanying `Subscribe`. Only a new `Subscribe` re-registers, and the requester does not retry. So nothing re-drives admission and delivery never begins.

A transient condition is riding a message contract written for a permanent one.

## The direction

Don't reject at all. The parking machinery already exists — the serving peer parks the *shape*; the gap is that it drops the *subscription*. Park the subscription alongside it and activate it on admission. This case then stops being a rejection, and `SubscribeRejected` keeps its permanent-only meaning untouched, so no existing contract changes.

That's better than the alternatives considered: having the peer follow up after admission contradicts "not active, expect no `ViewUpdate`s" for this reason, and specifying a requester retry adds a duty the protocol doesn't place on requesters — a retry loop against a rejection *defined* as permanent is behaviour no peer is required to honour.

## Two riders the design still owes

- **Restart.** Parking is in-memory (see the adjacent _Parked-unit persistence_ question), so a serving-peer restart drops parked subscriptions. Requester retry remains necessary as a *recovery* path, even though it's no longer the normal path. Either state that as an implementation limitation or persist parked units.
- **Bound.** A subscription parked for a shape that is never admitted must not accumulate indefinitely. The bound, and what the requester observes on reaching it, need deciding — and that outcome may legitimately be a rejection, at which point a permanent/transient distinction in the reason vocabulary becomes meaningful again.

## Where it was observed

A two-client browser scenario: the local client recovers and sees its own writes (#1257), but cross-client delivery never starts. 13 of 14 tests pass; the one failure is the cross-client case.
