### PR TITLE
(new core) Fix local-first auth: absent claims, storage release, and queued-write replay

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -3514,13 +3514,12 @@ where
     /// Restore durable local writes into the process-local upload queue after
     /// reopening client storage.
     fn restore_pending_uploads(&self, author: AuthorId) -> Result<(), Error> {
-        let pending = self
-            .node
-            .borrow_mut()
-            .pending_transaction_ids_for(author)?;
-        self.outbox
-            .borrow_mut()
-            .extend(pending.into_iter().map(|tx_id| PendingUpload { tx_id, unit: None }));
+        let pending = self.node.borrow_mut().pending_transaction_ids_for(author)?;
+        self.outbox.borrow_mut().extend(
+            pending
+                .into_iter()
+                .map(|tx_id| PendingUpload { tx_id, unit: None }),
+        );
         Ok(())
     }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -405,11 +405,13 @@ where
             false,
             config.large_value_checkpoint_op_interval,
         )?;
+        let node = Node::new(node);
+        node.restore_pending_uploads(config.identity.author)?;
         Ok(Self {
             schema: config.schema,
             schema_version_id,
             identity: config.identity,
-            node: Node::new(node),
+            node,
             row_id_source: RefCell::new(
                 config
                     .id_source
@@ -3507,6 +3509,19 @@ where
             subscriber_dirty_epoch: Rc::new(Cell::new(0)),
             edge_cache_budget: Cell::new(None),
         }
+    }
+
+    /// Restore durable local writes into the process-local upload queue after
+    /// reopening client storage.
+    fn restore_pending_uploads(&self, author: AuthorId) -> Result<(), Error> {
+        let pending = self
+            .node
+            .borrow_mut()
+            .pending_transaction_ids_for(author)?;
+        self.outbox
+            .borrow_mut()
+            .extend(pending.into_iter().map(|tx_id| PendingUpload { tx_id, unit: None }));
+        Ok(())
     }
 
     /// Borrow the served node.

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -2501,7 +2501,7 @@ where
         Ok(refs)
     }
 
-    fn transaction_ids(&self) -> Result<Vec<TxId>, Error> {
+    pub(crate) fn transaction_ids(&self) -> Result<Vec<TxId>, Error> {
         let mut tx_ids = Vec::new();
         for raw in self
             .database

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2548,6 +2548,27 @@ where
             .map(|stored| stored.to_record())
     }
 
+    /// Return locally-authored transactions that still need an upstream fate.
+    ///
+    /// Client reconnect restores these durable transactions into its in-memory
+    /// upload queue. Transactions from other authors are never replayed by this
+    /// client, even when they were recovered from the same local history.
+    pub fn pending_transaction_ids_for(&mut self, author: AuthorId) -> Result<Vec<TxId>, Error> {
+        let mut pending = Vec::new();
+        for tx_id in self.transaction_ids()? {
+            let Some(transaction) = self.query_transaction(tx_id)? else {
+                continue;
+            };
+            if transaction.tx.made_by == author
+                && matches!(transaction.fate, Fate::Pending | Fate::Accepted)
+                && transaction.durability < DurabilityTier::Global
+            {
+                pending.push(tx_id);
+            }
+        }
+        Ok(pending)
+    }
+
     /// Resolve creator/updater provenance for a projected current row.
     pub fn row_provenance(&mut self, row: &CurrentRow) -> Result<Option<RowProvenance>, Error> {
         row.provenance()

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -647,7 +647,7 @@ impl ClientDb {
         .await?;
         let inner = Rc::new(RefCell::new(inner));
         if has_upstream {
-            Self::spawn_local_tick_driver(Rc::clone(&inner), Rc::clone(&scheduler));
+            Self::spawn_local_tick_driver(Rc::downgrade(&inner), Rc::clone(&scheduler));
         }
         Ok(Rc::new(Self { inner }))
     }
@@ -1016,7 +1016,7 @@ impl ClientDb {
     }
 
     fn spawn_local_tick_driver(
-        inner: Rc<RefCell<ClientDbInner>>,
+        inner: Weak<RefCell<ClientDbInner>>,
         scheduler: Rc<TickSchedulerImpl>,
     ) {
         let state = scheduler.wake_handle();
@@ -1024,6 +1024,9 @@ impl ClientDb {
             loop {
                 state.notify.notified().await;
                 while let Some(urgency) = scheduler.take() {
+                    let Some(inner) = inner.upgrade() else {
+                        return;
+                    };
                     if urgency == TickUrgency::Deferred {
                         tokio::time::sleep(Duration::from_millis(1)).await;
                     }

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -43,7 +43,7 @@ use crate::tx::{
     RejectionReason as CoreRejectionReason, TxId as CoreTxId,
 };
 use base64::Engine;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -87,7 +87,25 @@ enum StorageBundle {
 struct UnverifiedJwtClaims {
     sub: String,
     #[serde(default)]
-    claims: serde_json::Value,
+    claims: JwtClaimsPayload,
+}
+
+/// Keeps a missing application-claims field distinct from a supplied JSON
+/// value, including JSON `null`.
+#[derive(Debug, Default)]
+enum JwtClaimsPayload {
+    #[default]
+    Absent,
+    Present(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for JwtClaimsPayload {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        serde_json::Value::deserialize(deserializer).map(Self::Present)
+    }
 }
 
 /// Jazz client for building applications.
@@ -1445,7 +1463,10 @@ fn session_from_unverified_jwt(token: &str) -> Option<Session> {
 
     Some(Session {
         user_id: user_id.to_string(),
-        claims: claims.claims,
+        claims: match claims.claims {
+            JwtClaimsPayload::Absent => serde_json::Value::Object(serde_json::Map::new()),
+            JwtClaimsPayload::Present(claims) => claims,
+        },
         ..Session::new(user_id)
     })
 }
@@ -2780,6 +2801,14 @@ mod tests {
         );
         format!("{header}.{payload}.sig")
     }
+
+    fn make_test_jwt_without_claims(sub: &str) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&json!({ "sub": sub })).expect("serialize jwt payload"));
+        format!("{header}.{payload}.sig")
+    }
     #[test]
     fn core_integer_bridge_uses_signed_value_domain() {
         let core_value =
@@ -2810,6 +2839,29 @@ mod tests {
         let session = default_session_from_context(&context).expect("derive session from jwt");
         assert_eq!(session.user_id, "alice");
         assert_eq!(session.claims["join_code"], "secret-123");
+    }
+
+    // These internal tests are necessary because the distinction is made while
+    // decoding the unverified JWT, before a client connection can expose it.
+    #[test]
+    fn session_from_unverified_jwt_defaults_absent_claims_to_an_empty_object() {
+        let session = session_from_unverified_jwt(&make_test_jwt_without_claims("alice"))
+            .expect("derive session from jwt without application claims");
+
+        assert_eq!(session.claims, json!({}));
+        assert!(session_claims_to_core_claims(&session).is_ok());
+    }
+
+    #[test]
+    fn session_from_unverified_jwt_preserves_explicit_non_object_claims() {
+        let session = session_from_unverified_jwt(&make_test_jwt("alice", json!(null)))
+            .expect("derive session from jwt with explicit null claims");
+
+        let error = session_claims_to_core_claims(&session)
+            .expect_err("explicit null application claims must be rejected");
+        assert!(
+            matches!(error, JazzError::Connection(message) if message == "JWT claims payload must be a JSON object")
+        );
     }
 
     #[test]

--- a/crates/jazz/tests/local_first_auth_integration.rs
+++ b/crates/jazz/tests/local_first_auth_integration.rs
@@ -349,8 +349,14 @@ async fn local_first_and_jwt_clients_coexist_impl() {
     .expect("connect alice (local-first)");
     let alice_user_id = identity::derive_user_id(&alice_seed()).to_string();
 
-    // Bob authenticates via the default HS256 JWT minted by JazzServer.
-    let mut bob_ctx = server.make_client_context_for_user(test_schema(), "bob");
+    // Bob authenticates via the default HS256 JWT minted by JazzServer. The
+    // testing helper derives a stable wire principal for a symbolic subject,
+    // because WebSocket sessions validate principals as UUIDs, so Bob's
+    // provenance is that derived id rather than the literal subject.
+    let bob_subject = "bob";
+    let bob_user_id =
+        uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, bob_subject.as_bytes()).to_string();
+    let mut bob_ctx = server.make_client_context_for_user(test_schema(), bob_subject);
     bob_ctx.backend_secret = None;
     bob_ctx.admin_secret = None;
     let bob = JazzClient::connect(bob_ctx)
@@ -374,7 +380,7 @@ async fn local_first_and_jwt_clients_coexist_impl() {
     let bob_row = vec![
         Value::Text("bob via jwt".to_string()),
         Value::Boolean(true),
-        Value::Text("bob".to_string()),
+        Value::Text(bob_user_id.clone()),
     ];
 
     wait_for_rows(

--- a/examples/docs/todo-client-localfirst-ts/package.json
+++ b/examples/docs/todo-client-localfirst-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "check": "tsc --noEmit",
+    "check": "tsc --noEmit && tsc --noEmit --project tsconfig.browser-test.json",
     "build": "node ../../../packages/jazz-tools/dist/cli.js validate && pnpm run check && vite build",
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.browser.ts"

--- a/examples/docs/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
+++ b/examples/docs/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
@@ -7,9 +7,8 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { startApp } from "../../src/main.js";
-import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
-import { app } from "../../schema.js";
-import { createDb, DbConfig } from "jazz-tools";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
+import { type Db, type DbConfig } from "jazz-tools";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -56,16 +55,24 @@ describe("Vanilla TS Todo App E2E", () => {
 
   /** Mount the app into a fresh container. */
   async function mount(config?: Partial<DbConfig>): Promise<HTMLDivElement> {
+    const { container } = await mountWithDb(config);
+    return container;
+  }
+
+  /** Mount the app into a fresh container and expose its public Db API. */
+  async function mountWithDb(
+    config?: Partial<DbConfig>,
+  ): Promise<{ container: HTMLDivElement; db: Db }> {
     const el = document.createElement("div");
     document.body.appendChild(el);
 
-    const { destroy } = await startApp(el, config);
+    const { db, destroy } = await startApp(el, config);
     instances.push({ container: el, destroy });
 
     // Wait for the app to render
     await waitFor(() => el.querySelector("#todo-list") !== null, 5000, "App should render");
 
-    return el;
+    return { container: el, db };
   }
 
   /** Destroy a specific instance. */
@@ -264,20 +271,31 @@ describe("Vanilla TS Todo App E2E", () => {
   it("syncs a todo between two app instances through the server", async () => {
     const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
 
-    const el1 = await mount({
+    const { container: el1, db: db1 } = await mountWithDb({
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-a") },
       serverUrl,
-      auth: { localFirstSecret: "IsHiz7lWH1KJEuM5J8Hn_oleBb6SBcuGSE9Ro3H0G68" },
-      adminSecret: ADMIN_SECRET,
+      secret: "IsHiz7lWH1KJEuM5J8Hn_oleBb6SBcuGSE9Ro3H0G68",
     });
-    const el2 = await mount({
+    const { container: el2, db: db2 } = await mountWithDb({
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-b") },
       serverUrl,
-      auth: { localFirstSecret: "C5-etNr9-YLchXK15XLhDVIn-An8mgb35sc5lfJpAQE" },
-      adminSecret: ADMIN_SECRET,
+      secret: "C5-etNr9-YLchXK15XLhDVIn-An8mgb35sc5lfJpAQE",
     });
+
+    await waitFor(
+      () => db1.getAuthState().authMode === "local-first",
+      5000,
+      "App 1 should reach local-first auth",
+    );
+    await waitFor(
+      () => db2.getAuthState().authMode === "local-first",
+      5000,
+      "App 2 should reach local-first auth",
+    );
+    expect(db1.getAuthState().session?.authMode).toBe("local-first");
+    expect(db2.getAuthState().session?.authMode).toBe("local-first");
 
     // Let both app instances finish server/event-stream setup before mutating.
     await new Promise((r) => setTimeout(r, 750));

--- a/examples/docs/todo-client-localfirst-ts/tsconfig.browser-test.json
+++ b/examples/docs/todo-client-localfirst-ts/tsconfig.browser-test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["tests/browser/todo-app.test.ts"]
+}


### PR DESCRIPTION
Takes `local_first_auth_integration` from **2 passed / 6 failed** to **8 passed / 0 failed**. Three independent defects plus one unfinished test migration.

## Absent JWT claims were rejected

Local-first tokens carry identity proof only — `iss`, `sub`, `aud`, public key, `iat`, `exp` — and deliberately no application `claims` object. The client deserialized an absent `claims` as JSON `null` and then required an object, rejecting the session outright.

Absent now defaults to `{}`. An **explicit** `claims: null` is still rejected, because that is a malformed payload rather than a token with no application claims. Both cases are covered by unit tests, which live here rather than in an integration test because the distinction is made while decoding the unverified JWT, before a client connection can expose it.

## Storage was never released after shutdown

The client tick task held a strong `Rc` for its lifetime, so persistent storage stayed open after shutdown and a reconnect could not reopen RocksDB. It now holds a `Weak`.

## Writes queued before a token expired were never replayed

Reopen initialised the process-local outbox empty, so a durable transaction authored before expiry was lost to the upload path — the reconnect admitted the fresh token and applied server views, but replayed nothing. Reopen now rehydrates pending locally-authored transactions.

## Finishing a test migration

`017c4ad036` moved test session ids to derived UUIDs and updated the local-first client in `local_first_and_jwt_clients_coexist`, but left the JWT client asserting the literal subject `"bob"`. The testing helper derives a stable wire principal for a symbolic subject, because WebSocket sessions validate principals as UUIDs — so provenance carries the derived id, not the subject string, and `$createdBy` is typed `Uuid` by contract. The assertion now uses the derived id. Anselm approved finishing the migration rather than changing the contract.

Note the two derivations differ and are not interchangeable: a local-first principal comes from `derive_user_id(&seed)`, a JWT principal from a UUID-v5 of the subject.

## Verification

`cargo test -p jazz --no-default-features --features test --test local_first_auth_integration` → 8 passed, 0 failed. `cargo fmt --check` clean.

Worth knowing for review: `mod client` sits behind `feature = "client"`, so none of this compiles under a plain `cargo test -p jazz` — only the canonical `--no-default-features --features test` reaches it.
