### PR TITLE
(new core) Fix silent subscription cancellation on transient shape rejection

### DIFF
--- a/examples/docs/todo-client-localfirst-ts/package.json
+++ b/examples/docs/todo-client-localfirst-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "check": "tsc --noEmit",
+    "check": "tsc --noEmit && tsc --noEmit --project tsconfig.browser-test.json",
     "build": "node ../../../packages/jazz-tools/dist/cli.js validate && pnpm run check && vite build",
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.browser.ts"

--- a/examples/docs/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
+++ b/examples/docs/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
@@ -7,9 +7,8 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { startApp } from "../../src/main.js";
-import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
-import { app } from "../../schema.js";
-import { createDb, DbConfig } from "jazz-tools";
+import { TEST_PORT, APP_ID } from "./test-constants.js";
+import { type Db, type DbConfig } from "jazz-tools";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -56,16 +55,24 @@ describe("Vanilla TS Todo App E2E", () => {
 
   /** Mount the app into a fresh container. */
   async function mount(config?: Partial<DbConfig>): Promise<HTMLDivElement> {
+    const { container } = await mountWithDb(config);
+    return container;
+  }
+
+  /** Mount the app into a fresh container and expose its public Db API. */
+  async function mountWithDb(
+    config?: Partial<DbConfig>,
+  ): Promise<{ container: HTMLDivElement; db: Db }> {
     const el = document.createElement("div");
     document.body.appendChild(el);
 
-    const { destroy } = await startApp(el, config);
+    const { db, destroy } = await startApp(el, config);
     instances.push({ container: el, destroy });
 
     // Wait for the app to render
     await waitFor(() => el.querySelector("#todo-list") !== null, 5000, "App should render");
 
-    return el;
+    return { container: el, db };
   }
 
   /** Destroy a specific instance. */
@@ -264,20 +271,31 @@ describe("Vanilla TS Todo App E2E", () => {
   it("syncs a todo between two app instances through the server", async () => {
     const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
 
-    const el1 = await mount({
+    const { container: el1, db: db1 } = await mountWithDb({
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-a") },
       serverUrl,
-      auth: { localFirstSecret: "IsHiz7lWH1KJEuM5J8Hn_oleBb6SBcuGSE9Ro3H0G68" },
-      adminSecret: ADMIN_SECRET,
+      secret: "IsHiz7lWH1KJEuM5J8Hn_oleBb6SBcuGSE9Ro3H0G68",
     });
-    const el2 = await mount({
+    const { container: el2, db: db2 } = await mountWithDb({
       appId: APP_ID,
       driver: { type: "persistent", dbName: uniqueDbName("sync-b") },
       serverUrl,
-      auth: { localFirstSecret: "C5-etNr9-YLchXK15XLhDVIn-An8mgb35sc5lfJpAQE" },
-      adminSecret: ADMIN_SECRET,
+      secret: "C5-etNr9-YLchXK15XLhDVIn-An8mgb35sc5lfJpAQE",
     });
+
+    await waitFor(
+      () => db1.getAuthState().authMode === "local-first",
+      5000,
+      "App 1 should reach local-first auth",
+    );
+    await waitFor(
+      () => db2.getAuthState().authMode === "local-first",
+      5000,
+      "App 2 should reach local-first auth",
+    );
+    expect(db1.getAuthState().session?.authMode).toBe("local-first");
+    expect(db2.getAuthState().session?.authMode).toBe("local-first");
 
     // Let both app instances finish server/event-stream setup before mutating.
     await new Promise((r) => setTimeout(r, 750));

--- a/examples/docs/todo-client-localfirst-ts/tsconfig.browser-test.json
+++ b/examples/docs/todo-client-localfirst-ts/tsconfig.browser-test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["tests/browser/todo-app.test.ts"]
+}

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1568,8 +1568,10 @@ export class NativeRuntimeAdapter implements Runtime {
         const next = await source.source.read();
         if (next.done || subscription.cancelled) return;
         void this.applySubscriptionChunk(subscription, next.value).catch((error: unknown) => {
-          subscription.cancelled = true;
-          console.error("Core subscription failed", error);
+          this.failSubscription(
+            subscription,
+            error instanceof Error ? error : new Error(String(error)),
+          );
         });
       }
     } finally {
@@ -1586,8 +1588,10 @@ export class NativeRuntimeAdapter implements Runtime {
     for (const event of source.source.readAll()) {
       if (subscription.cancelled || this.subscriptions.get(handle) !== subscription) return;
       void this.applySubscriptionChunk(subscription, event).catch((error: unknown) => {
-        subscription.cancelled = true;
-        console.error("Core subscription failed", error);
+        this.failSubscription(
+          subscription,
+          error instanceof Error ? error : new Error(String(error)),
+        );
       });
     }
   }
@@ -1602,6 +1606,9 @@ export class NativeRuntimeAdapter implements Runtime {
       return;
     }
     if (chunk.type === "rejected") {
+      if (chunk.reason.type === "ShapeRegistrationPendingCatalogueAdmission") {
+        return;
+      }
       this.failSubscription(subscription, subscriptionRejectionError(chunk.reason));
       return;
     }
@@ -4104,7 +4111,8 @@ function normalizeSubscriptionChunk(chunk: unknown):
       type: "rejected";
       reason:
         | { type: "UnsupportedShapeCapability"; detail: string }
-        | { type: "ServerFailure"; code: string };
+        | { type: "ServerFailure"; code: string }
+        | { type: "ShapeRegistrationPendingCatalogueAdmission" };
     }
   | { type: "closed" } {
   if (!chunk || typeof chunk !== "object") throw new Error("expected subscription chunk");
@@ -4163,13 +4171,17 @@ function normalizeSubscriptionRejectionReason(
   reason: unknown,
 ):
   | { type: "UnsupportedShapeCapability"; detail: string }
-  | { type: "ServerFailure"; code: string } {
+  | { type: "ServerFailure"; code: string }
+  | { type: "ShapeRegistrationPendingCatalogueAdmission" } {
   if (!reason || typeof reason !== "object") {
     throw new Error("expected subscription rejection reason");
   }
   const record = reason as { type?: unknown; detail?: unknown; code?: unknown };
   if (record.type === "UnsupportedShapeCapability" && typeof record.detail === "string") {
     return { type: "UnsupportedShapeCapability", detail: record.detail };
+  }
+  if (record.type === "ShapeRegistrationPendingCatalogueAdmission") {
+    return { type: "ShapeRegistrationPendingCatalogueAdmission" };
   }
   if (record.type === "ServerFailure" && typeof record.code === "string") {
     return { type: "ServerFailure", code: record.code };
@@ -4180,9 +4192,15 @@ function normalizeSubscriptionRejectionReason(
 function subscriptionRejectionError(
   reason:
     | { type: "UnsupportedShapeCapability"; detail: string }
-    | { type: "ServerFailure"; code: string },
+    | { type: "ServerFailure"; code: string }
+    | { type: "ShapeRegistrationPendingCatalogueAdmission" },
 ): Error {
-  const detail = reason.type === "UnsupportedShapeCapability" ? reason.detail : reason.code;
+  const detail =
+    reason.type === "UnsupportedShapeCapability"
+      ? reason.detail
+      : reason.type === "ServerFailure"
+        ? reason.code
+        : "catalogue admission pending";
   return new Error(`Subscription rejected: ${reason.type}: ${detail}`);
 }
 


### PR DESCRIPTION
A local-first client could not see its own writes in the browser. It can now: the example's browser suite goes from a failing delivery assertion to **13 passed / 1 failed**, with the remaining failure a separate, specified gap (below).

## What was wrong

The core returns `ShapeRegistrationPendingCatalogueAdmission` when a shape is registered before its catalogue schema is present. The browser adapter did not recognise that variant, treated it as an unknown error, set `subscription.cancelled = true` and wrote to `console.error`. The subscription was gone, silently, and a client stopped seeing even its own local writes.

Two changes:

- **The transient rejection is recognised and tolerated**, so the local subscription survives while admission is pending.
- **Two silent-cancel sites now route through `failSubscription`**, so an unexpected async subscription error reaches the callback instead of vanishing into the console. This is the more important half — the silence is what hid the bug, and it would have hidden the next one too.

## Test harness fix, included

`todo-app.test.ts` passed `auth: { localFirstSecret }` where `DbConfig` expects a top-level `secret`, so the nested object was ignored and neither client ever had a local-first session — the test was asserting against unauthenticated clients. Both clients now use `secret`, the unused `adminSecret` is gone, and `Db.getAuthState()` asserts both reach `local-first` **before** any delivery is tested, so the suite cannot silently go back to testing nothing.

## The remaining failure is a specification gap, not a loose end

`syncs a todo between two app instances through the server` still times out. Tolerating the pending rejection keeps the local subscription alive, but **nothing re-drives admission**: the serving peer parks the shape, admits it later, and drops the original `Subscribe`; only a new `Subscribe` re-registers, and the client does not retry.

That is not fixable here without deciding a protocol question, because `SubscribeRejected` is specified for a *permanent* capability gap and states the subscription is not active afterwards — a transient condition is riding a contract written for a permanent one. Recorded as an open question in #1255. The agreed direction is that the serving peer should park the subscription alongside the shape and activate it on admission, so this case stops being a rejection at all.

## Verification

`pnpm test` in `examples/docs/todo-client-localfirst-ts`: 14 tests genuinely ran, 13 passed. I confirmed this independently of the change's author.
