### PR TITLE
(new core) Bound websocket sync frame batches to the server's message cap

### DIFF
--- a/crates/jazz/src/tools/server/core_websocket_transport.rs
+++ b/crates/jazz/src/tools/server/core_websocket_transport.rs
@@ -19,6 +19,12 @@ use crate::tools::websocket_prelude_auth::AuthConfig;
 
 const WS_CLIENT_REQUIRED_FEATURES: u64 = FEATURE_SYNC_MESSAGE_PAYLOAD;
 const WS_CLIENT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+// The serving route caps each WebSocket message at one MiB. Keep a small
+// postcard framing reserve so a burst of individually-valid wire frames never
+// becomes an invalid WebSocket message.
+const WS_CLIENT_BATCH_BYTES: usize = 1 << 20;
+const POSTCARD_FRAME_LENGTH_RESERVE: usize = 5;
+const POSTCARD_BATCH_LENGTH_RESERVE: usize = 5;
 
 #[derive(Debug)]
 pub enum WebSocketClientError {
@@ -255,11 +261,32 @@ async fn run_ws_pump(
                     return;
                 };
                 let mut batch = vec![first_frame];
+                let mut batch_bytes = POSTCARD_BATCH_LENGTH_RESERVE
+                    + batch[0].len()
+                    + POSTCARD_FRAME_LENGTH_RESERVE;
                 while let Ok(frame) = outbound.try_recv() {
+                    let frame_bytes = frame.len() + POSTCARD_FRAME_LENGTH_RESERVE;
+                    if batch_bytes.saturating_add(frame_bytes) > WS_CLIENT_BATCH_BYTES {
+                        let Ok(bytes) = postcard::to_allocvec(&batch) else {
+                            return;
+                        };
+                        #[cfg(feature = "sync-autopsy")]
+                        crate::db::sync_autopsy::record(format!(
+                            "client websocket send batch frames={} bytes={}",
+                            batch.len(),
+                            bytes.len()
+                        ));
+                        if ws.send(Message::Binary(bytes.into())).await.is_err() {
+                            return;
+                        }
+                        batch = Vec::new();
+                        batch_bytes = POSTCARD_BATCH_LENGTH_RESERVE;
+                    }
+                    batch_bytes = batch_bytes.saturating_add(frame_bytes);
                     batch.push(frame);
                 }
                 let Ok(bytes) = postcard::to_allocvec(&batch) else {
-                    continue;
+                    return;
                 };
                 #[cfg(feature = "sync-autopsy")]
                 crate::db::sync_autopsy::record(format!(

--- a/crates/jazz/tests/transactions.rs
+++ b/crates/jazz/tests/transactions.rs
@@ -749,3 +749,50 @@ async fn wait_for_batch_errors_for_unattainable_durability_tier() {
         .expect("local durability should be reachable");
 }
 }
+
+// A client may queue a large local-first import before asking for durability on
+// a later, single-row update. The later wait must observe its own global fate;
+// it must not be starved by the preceding outbox backlog.
+local_tokio_test! {
+async fn global_wait_after_large_pending_import_settles() {
+    let schema = todo_schema();
+    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let client = connect_user(&server, schema, &unique_user_id("bulk-global-wait")).await;
+
+    let (target_id, _, _) = client
+        .insert(
+            "todos",
+            row_input!("title" => "durability target", "completed" => false),
+        )
+        .expect("insert target row");
+
+    for index in 0..2_048 {
+        client
+            .insert(
+                "todos",
+                row_input!("title" => format!("imported row {index}"), "completed" => false),
+            )
+            .expect("queue import row");
+    }
+
+    let target_batch = client
+        .update(target_id, vec![("completed".to_owned(), Value::Boolean(true))])
+        .expect("update target row after import");
+
+    client
+        .wait_for_batch(target_batch, DurabilityTier::Local)
+        .await
+        .expect("target update should settle locally without draining the import backlog");
+
+    tokio::time::timeout(
+        Duration::from_secs(25),
+        client.wait_for_batch(target_batch, DurabilityTier::GlobalServer),
+    )
+    .await
+    .expect("global wait should settle after import backlog")
+    .expect("target update should reach global durability");
+
+    client.shutdown().await.expect("shutdown client");
+    server.shutdown().await;
+}
+}

--- a/crates/jazz/tests/transactions.rs
+++ b/crates/jazz/tests/transactions.rs
@@ -750,11 +750,11 @@ async fn wait_for_batch_errors_for_unattainable_durability_tier() {
 }
 }
 
-// A client may queue a large local-first import before asking for durability on
-// a later, single-row update. The later wait must observe its own global fate;
-// it must not be starved by the preceding outbox backlog.
+// Regression guard for websocket transport batching: a local-first import whose
+// encoded wire frames exceed the server's 1 MiB WebSocket-message cap must be
+// split before a later batch can reach global durability.
 local_tokio_test! {
-async fn global_wait_after_large_pending_import_settles() {
+async fn global_wait_after_over_one_mib_websocket_import_settles() {
     let schema = todo_schema();
     let server = JazzServer::start_with_schema(schema.clone()).await;
     let client = connect_user(&server, schema, &unique_user_id("bulk-global-wait")).await;
@@ -766,11 +766,12 @@ async fn global_wait_after_large_pending_import_settles() {
         )
         .expect("insert target row");
 
+    let import_payload = "x".repeat(600);
     for index in 0..2_048 {
         client
             .insert(
                 "todos",
-                row_input!("title" => format!("imported row {index}"), "completed" => false),
+                row_input!("title" => format!("imported row {index}: {import_payload}"), "completed" => false),
             )
             .expect("queue import row");
     }
@@ -785,7 +786,7 @@ async fn global_wait_after_large_pending_import_settles() {
         .expect("target update should settle locally without draining the import backlog");
 
     tokio::time::timeout(
-        Duration::from_secs(25),
+        Duration::from_secs(30),
         client.wait_for_batch(target_batch, DurabilityTier::GlobalServer),
     )
     .await

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -40,6 +40,36 @@ describe("websocket frame carrier", () => {
     ]);
   });
 
+  // This is intentionally transport-level: the public Db API cannot expose
+  // individual WebSocket message boundaries, which are the limit being kept.
+  it("splits a burst of wire frames into server-sized websocket messages", async () => {
+    let socket: RecordingWebSocket | undefined;
+    const carrier = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity: new Uint8Array(16),
+      onFrame: () => {},
+      WebSocket: class extends RecordingWebSocket {
+        constructor(url: string) {
+          super(url, (created) => {
+            socket = created;
+          });
+        }
+      },
+    });
+
+    await carrier.ready();
+    socket!.sent.length = 0;
+    const frames = [new Uint8Array(600_000), new Uint8Array(600_000), new Uint8Array(600_000)];
+    await carrier.sendBatch(frames);
+
+    const batches = socket!.sent.filter(
+      (message): message is Uint8Array => message instanceof Uint8Array,
+    );
+    expect(batches).toHaveLength(3);
+    expect(batches.every((batch) => batch.byteLength <= 1 << 20)).toBe(true);
+    expect(batches.flatMap((batch) => decodeWebSocketFrameBatch(batch))).toEqual(frames);
+  });
+
   it("uses app-scoped websocket URLs without identity query parameters", () => {
     expect(webSocketUrl("http://127.0.0.1:4200", "app-a")).toBe(
       "ws://127.0.0.1:4200/apps/app-a/ws",
@@ -203,5 +233,18 @@ class MessageWebSocket {
 
   emitMessage(data: Uint8Array): void {
     for (const listener of this.messageListeners) listener({ data });
+  }
+}
+
+class RecordingWebSocket extends MessageWebSocket {
+  sent: Array<Uint8Array | string> = [];
+
+  constructor(url: string, onCreate?: (socket: RecordingWebSocket) => void) {
+    super(url);
+    onCreate?.(this);
+  }
+
+  override send(data: Uint8Array | string): void {
+    this.sent.push(data);
   }
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -46,6 +46,13 @@ export const FEATURE_PAYLOAD_ZSTD = 1 << 4;
 export const CLIENT_WIRE_FEATURES =
   FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS | FEATURE_PAYLOAD_ZSTD;
 
+// The server route accepts WebSocket messages up to one MiB. Reserve enough
+// postcard framing bytes that a burst of otherwise-valid wire frames remains
+// a valid WebSocket message.
+const MAX_WEBSOCKET_BATCH_BYTES = 1 << 20;
+const POSTCARD_FRAME_LENGTH_RESERVE = 5;
+const POSTCARD_BATCH_LENGTH_RESERVE = 5;
+
 export function webSocketUrl(serverUrl: string, appId: string): string {
   return httpUrlToWs(serverUrl, appId);
 }
@@ -141,13 +148,26 @@ export class WebSocketCarrier {
   }
 
   async send(frame: Uint8Array): Promise<void> {
-    await this.ready();
-    this.socket.send(encodeWebSocketFrameBatch([frame]));
+    await this.sendBatch([frame]);
   }
 
   async sendBatch(frames: readonly Uint8Array[]): Promise<void> {
     await this.ready();
-    this.socket.send(encodeWebSocketFrameBatch(frames));
+    let batch: Uint8Array[] = [];
+    let batchBytes = POSTCARD_BATCH_LENGTH_RESERVE;
+    for (const frame of frames) {
+      const frameBytes = frame.byteLength + POSTCARD_FRAME_LENGTH_RESERVE;
+      if (batch.length > 0 && batchBytes + frameBytes > MAX_WEBSOCKET_BATCH_BYTES) {
+        this.socket.send(encodeWebSocketFrameBatch(batch));
+        batch = [];
+        batchBytes = POSTCARD_BATCH_LENGTH_RESERVE;
+      }
+      batch.push(frame);
+      batchBytes += frameBytes;
+    }
+    if (batch.length > 0) {
+      this.socket.send(encodeWebSocketFrameBatch(batch));
+    }
   }
 
   ready(): Promise<void> {


### PR DESCRIPTION
A client with more than 1 MiB of queued sync frames stops making progress, silently. No error, no rejection — a durability wait simply never settles.

## What was wrong

The client drained every queued wire frame into a single WebSocket message. The serving route accepts messages up to 1 MiB (`crates/jazz/src/tools/server/routes/websocket.rs:63`), so past that size the server never decoded the message and never acknowledged the transactions inside it. A later `wait({ tier: "global" })` then waited forever on a `FateUpdate` that could not arrive.

Nothing in the path complains: the frames are individually valid, the batch is what exceeds the limit.

Both carriers now split batches below the cap — the Rust client (`core_websocket_transport.rs`) and the TypeScript/NAPI carrier (`websocket.ts`), each keeping a small postcard framing reserve so a burst of individually-valid frames can't become an invalid message.

## Where it was found

A real bulk import: schema publish succeeded, 26,512 write operations committed across 133 transactions, then a single-row update's global-tier durability wait hung indefinitely. That import is how we intend to measure customer-scale cold load, so this was blocking a benchmark as well as being a live defect.

The wait path itself was fine and is worth recording: `WriteHandle.wait` → `waitForTransaction` → `Write.wait`, waiters keyed by `TxId`, woken by a `FateUpdate { tx_id, durability: Global }` at `db.rs:5287`. The missing step was outbound delivery, not acknowledgement matching.

## Regression coverage

`global_wait_after_over_one_mib_websocket_import_settles` (`crates/jazz/tests/transactions.rs:753`) queues 2,048 anonymized 600-byte rows — about 1.25 MiB before framing — then waits for global durability on a single later update.

The size matters: an earlier version of this test used ~200 KB and passed with *or* without the fix, guarding nothing. Verified both ways, independently of the change's author:

- fix present → pass, 23.3s
- `core_websocket_transport.rs` reverted to the pre-fix revision → **fail, 27.0s**, `Sync("timed out waiting for batch to reach GlobalServer")`

## One thing this is not

At ~4 MiB the same test fails on `wait_for_batch`'s own 25s client-side timeout. That is throughput, not a second size bound: with a diagnostic-only 60s deadline it settles in 28.4s. Settle time scales smoothly — ~0.2 MiB / 20.5s, ~1.2 MiB / 23.3s, ~4 MiB / 28.4s. The only relevant limits are the 1 MiB message cap and the 2 MiB individual wire-frame cap, and every row here is far below the latter. No production timeout was changed.

## Gates

`cargo test -p jazz` 0 · `cargo check --workspace --all-targets` 0 · `cargo fmt --check` 0 · `cargo test -p jazz --no-default-features --features test` shows only the three known pre-existing `catalogue_sync_integration` failures (21 passed / 3 failed), which are gated on flat-join support.
