### PR TITLE
(new core) Reuse relation snapshots across equivalent terminals

### DIFF
--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -1685,7 +1685,9 @@ fn assert_direct_record_store_round_trips_array_of_record_values() {
     let results = Value::Array(vec![Value::Record(first), Value::Record(second)]);
     let store = database.direct_record_store("rendered_results").unwrap();
 
-    store.set(&[Value::U64(7)], &[results.clone()]).unwrap();
+    store
+        .set(&[Value::U64(7)], std::slice::from_ref(&results))
+        .unwrap();
 
     assert_eq!(
         store

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -2174,6 +2174,7 @@ struct ScanCountingStorage {
     inner: MemoryStorage,
     scan_range_count: Rc<Cell<usize>>,
     scan_prefix_count: Rc<Cell<usize>>,
+    visited_records: Rc<Cell<usize>>,
 }
 
 impl ScanCountingStorage {
@@ -2182,6 +2183,7 @@ impl ScanCountingStorage {
             inner: MemoryStorage::new(column_families),
             scan_range_count: Rc::new(Cell::new(0)),
             scan_prefix_count: Rc::new(Cell::new(0)),
+            visited_records: Rc::new(Cell::new(0)),
         }
     }
 
@@ -2191,6 +2193,10 @@ impl ScanCountingStorage {
 
     fn scan_prefix_count(&self) -> usize {
         self.scan_prefix_count.get()
+    }
+
+    fn visited_records(&self) -> usize {
+        self.visited_records.get()
     }
 }
 
@@ -2235,7 +2241,12 @@ impl OrderedKvStorage for ScanCountingStorage {
     ) -> Result<(), StorageError> {
         self.scan_prefix_count
             .set(self.scan_prefix_count.get().saturating_add(1));
-        self.inner.scan_prefix(cf, prefix, visit)
+        let mut counting_visit = |key: &[u8], value: &[u8]| {
+            self.visited_records
+                .set(self.visited_records.get().saturating_add(1));
+            visit(key, value)
+        };
+        self.inner.scan_prefix(cf, prefix, &mut counting_visit)
     }
 
     fn scan_prefix_reverse(
@@ -4368,6 +4379,7 @@ fn equivalent_query_graph_terminals_share_snapshot_materialization() {
     database.commit_batch(batch).unwrap();
 
     let scans_before = counter.scan_prefix_count();
+    let visits_before = counter.visited_records();
     let snapshots = database
         .query_graphs([
             ("first", GraphBuilder::table("albums").project(["id"])),
@@ -4389,6 +4401,142 @@ fn equivalent_query_graph_terminals_share_snapshot_materialization() {
         1,
         "equivalent output terminals should construct their shared table snapshot once"
     );
+    assert_eq!(counter.visited_records() - visits_before, 2);
+}
+
+#[test]
+fn equivalent_query_graph_snapshot_work_is_constant_in_terminal_count() {
+    for terminal_count in [1_usize, 2, 4, 8] {
+        let storage = ScanCountingStorage::new(&["albums"]);
+        let counter = storage.clone();
+        let mut database = Database::new(albums_schema(), storage).unwrap();
+        let mut batch = database.open_batch();
+        for id in 0..32 {
+            batch.insert(
+                "albums",
+                vec![Value::U64(id), Value::String(format!("album-{id}"))],
+            );
+        }
+        database.commit_batch(batch).unwrap();
+
+        let sinks = (0..terminal_count).map(|terminal| {
+            (
+                format!("terminal-{terminal}"),
+                GraphBuilder::table("albums").project(["id"]),
+            )
+        });
+        let scans_before = counter.scan_prefix_count();
+        let visits_before = counter.visited_records();
+        let snapshots = database.query_graphs(sinks).unwrap();
+
+        assert_eq!(snapshots.sinks.len(), terminal_count);
+        assert!(snapshots.sinks.values().all(|rows| rows.deltas.len() == 32));
+        assert_eq!(counter.scan_prefix_count() - scans_before, 1);
+        assert_eq!(counter.visited_records() - visits_before, 32);
+    }
+}
+
+#[test]
+fn distinct_snapshot_scan_shapes_do_not_share_materialization() {
+    let storage = ScanCountingStorage::new(&["docs", "indices"]);
+    let counter = storage.clone();
+    let mut database = Database::new(scan_spec_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    insert_scan_doc(&mut batch, "a", 1, "/one", b"one");
+    insert_scan_doc(&mut batch, "b", 2, "/two", b"two");
+    database.commit_batch(batch).unwrap();
+
+    let scans_before = counter.scan_prefix_count();
+    let snapshots = database
+        .query_graphs([
+            (
+                "a",
+                GraphBuilder::table_scan(
+                    "docs",
+                    StaticScanSpec::Prefix(vec![LiteralValue::String("a".to_owned())]),
+                ),
+            ),
+            (
+                "b",
+                GraphBuilder::table_scan(
+                    "docs",
+                    StaticScanSpec::Prefix(vec![LiteralValue::String("b".to_owned())]),
+                ),
+            ),
+        ])
+        .unwrap();
+
+    assert_eq!(snapshots.get("a").unwrap().deltas.len(), 1);
+    assert_eq!(snapshots.get("b").unwrap().deltas.len(), 1);
+    assert_eq!(counter.scan_prefix_count() - scans_before, 2);
+}
+
+#[test]
+fn shared_snapshot_materialization_advances_after_data_change() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let counter = storage.clone();
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+
+    let graph = || GraphBuilder::table("albums").project(["id"]);
+    let initial = database
+        .query_graphs([("first", graph()), ("second", graph())])
+        .unwrap();
+    assert!(initial.get("first").unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    database.commit_batch(batch).unwrap();
+
+    let scans_before = counter.scan_prefix_count();
+    let advanced = database
+        .query_graphs([("first", graph()), ("second", graph())])
+        .unwrap();
+    let expected = [(vec![Value::U64(7)], 1)];
+    assert_eq!(
+        advanced.get("first").unwrap().to_values().unwrap(),
+        expected
+    );
+    assert_eq!(
+        advanced.get("second").unwrap().to_values().unwrap(),
+        expected
+    );
+    assert_eq!(counter.scan_prefix_count() - scans_before, 1);
+}
+
+#[test]
+fn shared_snapshot_materialization_preserves_multiset_weights() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let counter = storage.clone();
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    database.commit_batch(batch).unwrap();
+
+    let graph = || {
+        let rows = GraphBuilder::table("albums").project(["id"]);
+        GraphBuilder::union([rows.clone(), rows])
+    };
+    let scans_before = counter.scan_prefix_count();
+    let snapshots = database
+        .query_graphs([("first", graph()), ("second", graph())])
+        .unwrap();
+    let expected = [(vec![Value::U64(7)], 1), (vec![Value::U64(7)], 1)];
+
+    assert_eq!(
+        snapshots.get("first").unwrap().to_values().unwrap(),
+        expected
+    );
+    assert_eq!(
+        snapshots.get("second").unwrap().to_values().unwrap(),
+        expected
+    );
+    assert_eq!(counter.scan_prefix_count() - scans_before, 1);
 }
 
 #[test]

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4450,6 +4450,41 @@ fn equivalent_query_graph_snapshot_work_is_constant_in_terminal_count() {
 }
 
 #[test]
+fn distinct_snapshot_groups_retain_at_most_one_materialized_source_set() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    for id in 0..32 {
+        batch.insert(
+            "albums",
+            vec![Value::U64(id), Value::String(format!("album-{id}"))],
+        );
+    }
+    database.commit_batch(batch).unwrap();
+
+    let sinks = (0..64).map(|terminal| {
+        (
+            format!("terminal-{terminal}"),
+            GraphBuilder::table_scan(
+                "albums",
+                StaticScanSpec::Prefix(vec![LiteralValue::U64(terminal % 32)]),
+            )
+            .project(["id"]),
+        )
+    });
+    let snapshots = database.query_graphs(sinks).unwrap();
+
+    assert_eq!(snapshots.sinks.len(), 64);
+    assert_eq!(
+        database
+            .runtime_stats()
+            .hydration_snapshot_peak_cached_source_sets,
+        1,
+        "distinct source sets must be materialized and released one group at a time"
+    );
+}
+
+#[test]
 #[ignore = "receipt-only timing for equivalent-terminal snapshot hydration"]
 fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
     const SAMPLES: usize = 7;

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4643,6 +4643,96 @@ fn equivalent_subscription_terminals_share_join_hydration_and_advance() {
         full.get("second").unwrap().to_values().unwrap(),
         expected_full
     );
+
+    let mut batch = database.open_batch();
+    batch.delete("albums", PrimaryKeyValue::U64(8));
+    database.commit_batch(batch).unwrap();
+    let retraction = subscription.recv().unwrap();
+    let expected_retraction = [
+        (
+            vec![Value::U64(8), Value::String("Giant Steps".to_owned())],
+            -1,
+        ),
+        (
+            vec![Value::U64(8), Value::String("Giant Steps".to_owned())],
+            -1,
+        ),
+    ];
+    assert_eq!(
+        retraction.get("first").unwrap().to_values().unwrap(),
+        expected_retraction
+    );
+    assert_eq!(
+        retraction.get("second").unwrap().to_values().unwrap(),
+        expected_retraction
+    );
+}
+
+#[test]
+fn different_prepared_bindings_do_not_share_hydrated_results() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let counter = storage.clone();
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("Blue Train".to_owned())],
+    );
+    batch.insert(
+        "albums",
+        vec![Value::U64(2), Value::String("Giant Steps".to_owned())],
+    );
+    database.commit_batch(batch).unwrap();
+
+    let binding = RecordDescriptor::new([("id", ValueType::U64)]);
+    let graph = GraphBuilder::join(
+        GraphBuilder::binding_source("album_route", binding),
+        GraphBuilder::table("albums"),
+        ["id"],
+        ["id"],
+    )
+    .project_fields([
+        ProjectField::renamed("right.title", "title"),
+        ProjectField::renamed("left.id", "__route_id"),
+    ]);
+    let shape = database
+        .prepare(
+            [RoutedMultisinkTerminal::new(
+                "album",
+                graph,
+                ["__route_id"],
+                ["title"],
+            )],
+            "album_route",
+            binding,
+        )
+        .unwrap();
+
+    let scans_before = counter.scan_prefix_count();
+    let first = database
+        .bind_shape(shape.id(), &[Value::U64(1)])
+        .unwrap()
+        .recv()
+        .unwrap();
+    let second = database
+        .bind_shape(shape.id(), &[Value::U64(2)])
+        .unwrap()
+        .recv()
+        .unwrap();
+
+    assert_eq!(
+        first.get("album").unwrap().to_values().unwrap(),
+        [(vec![Value::String("Blue Train".to_owned())], 1)]
+    );
+    assert_eq!(
+        second.get("album").unwrap().to_values().unwrap(),
+        [(vec![Value::String("Giant Steps".to_owned())], 1)]
+    );
+    assert_eq!(
+        counter.scan_prefix_count() - scans_before,
+        2,
+        "request-local hydration snapshots must not cross binding requests"
+    );
 }
 
 #[test]

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4489,14 +4489,17 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
             let snapshots = database.query_graphs(sinks).unwrap();
             elapsed_us.push(started.elapsed().as_micros() as u64);
 
-            let mut canonical = snapshots
+            let canonical = snapshots
                 .sinks
                 .values()
                 .map(|rows| format!("{:?}", rows.to_values().unwrap()))
                 .collect::<Vec<_>>();
-            canonical.sort_unstable();
+            assert!(
+                canonical.windows(2).all(|pair| pair[0] == pair[1]),
+                "equivalent terminals must materialize byte-identical logical rows"
+            );
             let mut hasher = DefaultHasher::new();
-            canonical.hash(&mut hasher);
+            canonical[0].hash(&mut hasher);
             let digest = hasher.finish();
             let memo_after = database.runtime_stats();
             receipt = Some((
@@ -4516,7 +4519,8 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
         let (snapshot_queries, child_visits, memo_computes, memo_hits, result_rows, digest) =
             receipt.unwrap();
         println!(
-            "{{\"scenario\":\"equivalent_terminal_snapshot_hydration\",\"terminals\":{terminal_count},\"input_rows\":{ROWS},\"samples\":{SAMPLES},\"snapshot_query_executions\":{snapshot_queries},\"storage_snapshots_constructed\":{snapshot_queries},\"child_visits\":{child_visits},\"hydration_memo_computes\":{memo_computes},\"hydration_memo_hits\":{memo_hits},\"result_rows\":{result_rows},\"result_digest\":\"{digest:016x}\",\"first_read_p50_us\":{}}}",
+            "{{\"scenario\":\"equivalent_terminal_snapshot_hydration\",\"terminals\":{terminal_count},\"input_rows\":{ROWS},\"samples\":{SAMPLES},\"storage_prefix_scans\":{snapshot_queries},\"storage_records_visited\":{child_visits},\"hydration_memo_computes\":{memo_computes},\"hydration_memo_hits\":{memo_hits},\"total_result_rows\":{result_rows},\"per_terminal_rows\":{},\"per_terminal_digest\":\"{digest:016x}\",\"first_read_p50_us\":{}}}",
+            result_rows / terminal_count,
             elapsed_us[SAMPLES / 2]
         );
     }

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4540,6 +4540,112 @@ fn shared_snapshot_materialization_preserves_multiset_weights() {
 }
 
 #[test]
+fn equivalent_subscription_terminals_share_join_hydration_and_advance() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let counter = storage.clone();
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    database.commit_batch(batch).unwrap();
+
+    let graph = || {
+        let joined = GraphBuilder::join(
+            GraphBuilder::table("albums"),
+            GraphBuilder::table("albums"),
+            ["id"],
+            ["id"],
+        )
+        .project(["left.id", "right.title"]);
+        GraphBuilder::union([joined.clone(), joined])
+    };
+    let scans_before = counter.scan_prefix_count();
+    let subscription = database
+        .subscribe([("first", graph()), ("second", graph())])
+        .unwrap();
+    let initial = subscription.recv().unwrap();
+    let expected_initial = [
+        (
+            vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+            1,
+        ),
+        (
+            vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+            1,
+        ),
+    ];
+    assert_eq!(
+        initial.get("first").unwrap().to_values().unwrap(),
+        expected_initial
+    );
+    assert_eq!(
+        initial.get("second").unwrap().to_values().unwrap(),
+        expected_initial
+    );
+    assert_eq!(counter.scan_prefix_count() - scans_before, 1);
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(8), Value::String("Giant Steps".to_owned())],
+    );
+    database.commit_batch(batch).unwrap();
+    let incremental = subscription.recv().unwrap();
+    let expected_incremental = [
+        (
+            vec![Value::U64(8), Value::String("Giant Steps".to_owned())],
+            1,
+        ),
+        (
+            vec![Value::U64(8), Value::String("Giant Steps".to_owned())],
+            1,
+        ),
+    ];
+    assert_eq!(
+        incremental.get("first").unwrap().to_values().unwrap(),
+        expected_incremental
+    );
+    assert_eq!(
+        incremental.get("second").unwrap().to_values().unwrap(),
+        expected_incremental
+    );
+
+    let mut fresh = Database::new(albums_schema(), counter.clone()).unwrap();
+    let full = fresh
+        .subscribe([("first", graph()), ("second", graph())])
+        .unwrap();
+    let full = full.recv().unwrap();
+    let expected_full = [
+        (
+            vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+            1,
+        ),
+        (
+            vec![Value::U64(8), Value::String("Giant Steps".to_owned())],
+            1,
+        ),
+        (
+            vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+            1,
+        ),
+        (
+            vec![Value::U64(8), Value::String("Giant Steps".to_owned())],
+            1,
+        ),
+    ];
+    assert_eq!(
+        full.get("first").unwrap().to_values().unwrap(),
+        expected_full
+    );
+    assert_eq!(
+        full.get("second").unwrap().to_values().unwrap(),
+        expected_full
+    );
+}
+
+#[test]
 fn unwrap_nullable_retractions_flow_symmetrically() {
     let temp_dir = tempfile::tempdir().unwrap();
     let storage = RocksDbStorage::open(temp_dir.path(), &["tracks", "indices"]).unwrap();

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4380,6 +4380,7 @@ fn equivalent_query_graph_terminals_share_snapshot_materialization() {
 
     let scans_before = counter.scan_prefix_count();
     let visits_before = counter.visited_records();
+    let memo_before = database.runtime_stats();
     let snapshots = database
         .query_graphs([
             ("first", GraphBuilder::table("albums").project(["id"])),
@@ -4402,10 +4403,16 @@ fn equivalent_query_graph_terminals_share_snapshot_materialization() {
         "equivalent output terminals should construct their shared table snapshot once"
     );
     assert_eq!(counter.visited_records() - visits_before, 2);
+    let memo_after = database.runtime_stats();
+    assert!(
+        memo_after.hydration_memo_hits > memo_before.hydration_memo_hits,
+        "the second equivalent terminal must reuse evaluated relation nodes"
+    );
 }
 
 #[test]
 fn equivalent_query_graph_snapshot_work_is_constant_in_terminal_count() {
+    let mut computed_nodes = Vec::new();
     for terminal_count in [1_usize, 2, 4, 8] {
         let storage = ScanCountingStorage::new(&["albums"]);
         let counter = storage.clone();
@@ -4433,7 +4440,59 @@ fn equivalent_query_graph_snapshot_work_is_constant_in_terminal_count() {
         assert!(snapshots.sinks.values().all(|rows| rows.deltas.len() == 32));
         assert_eq!(counter.scan_prefix_count() - scans_before, 1);
         assert_eq!(counter.visited_records() - visits_before, 32);
+        computed_nodes.push(database.runtime_stats().hydration_memo_computes);
     }
+    assert!(
+        computed_nodes.windows(2).all(|pair| pair[0] == pair[1]),
+        "evaluated relation work must remain constant as equivalent terminals are added: {computed_nodes:?}"
+    );
+}
+
+#[test]
+fn different_downstream_shapes_share_only_raw_snapshot_materialization() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let counter = storage.clone();
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("Blue Train".to_owned())],
+    );
+    batch.insert(
+        "albums",
+        vec![Value::U64(2), Value::String("Giant Steps".to_owned())],
+    );
+    database.commit_batch(batch).unwrap();
+
+    let scans_before = counter.scan_prefix_count();
+    let snapshots = database
+        .query_graphs([
+            (
+                "ids",
+                GraphBuilder::table("albums")
+                    .filter(PredicateExpr::eq("id", Value::U64(1)))
+                    .project(["id"]),
+            ),
+            ("titles", GraphBuilder::table("albums").project(["title"])),
+        ])
+        .unwrap();
+
+    assert_eq!(
+        snapshots.get("ids").unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1)], 1)]
+    );
+    assert_eq!(
+        snapshots.get("titles").unwrap().to_values().unwrap(),
+        [
+            (vec![Value::String("Blue Train".to_owned())], 1),
+            (vec![Value::String("Giant Steps".to_owned())], 1),
+        ]
+    );
+    assert_eq!(
+        counter.scan_prefix_count() - scans_before,
+        1,
+        "different evaluated query shapes may share raw rows but not evaluated outputs"
+    );
 }
 
 #[test]

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -8,6 +8,7 @@
 
 use super::*;
 use std::cell::Cell;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::rc::Rc;
 use std::sync::mpsc::TryRecvError;
 use std::time::Instant;
@@ -4446,6 +4447,79 @@ fn equivalent_query_graph_snapshot_work_is_constant_in_terminal_count() {
         computed_nodes.windows(2).all(|pair| pair[0] == pair[1]),
         "evaluated relation work must remain constant as equivalent terminals are added: {computed_nodes:?}"
     );
+}
+
+#[test]
+#[ignore = "receipt-only timing for equivalent-terminal snapshot hydration"]
+fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
+    const ROWS: usize = 4_096;
+    const SAMPLES: usize = 7;
+
+    for terminal_count in [1_usize, 2, 4, 8] {
+        let mut elapsed_us = Vec::with_capacity(SAMPLES);
+        let mut receipt = None;
+        for _ in 0..SAMPLES {
+            let storage = ScanCountingStorage::new(&["albums"]);
+            let counter = storage.clone();
+            let mut database = Database::new(albums_schema(), storage).unwrap();
+            let mut batch = database.open_batch();
+            for id in 0..ROWS as u64 {
+                batch.insert(
+                    "albums",
+                    vec![Value::U64(id), Value::String(format!("album-{id}"))],
+                );
+            }
+            database.commit_batch(batch).unwrap();
+
+            let graph = || {
+                GraphBuilder::join(
+                    GraphBuilder::table("albums"),
+                    GraphBuilder::table("albums"),
+                    ["id"],
+                    ["id"],
+                )
+                .project(["left.id", "right.title"])
+            };
+            let sinks =
+                (0..terminal_count).map(|terminal| (format!("terminal-{terminal}"), graph()));
+            let scans_before = counter.scan_prefix_count();
+            let visits_before = counter.visited_records();
+            let memo_before = database.runtime_stats();
+            let started = Instant::now();
+            let snapshots = database.query_graphs(sinks).unwrap();
+            elapsed_us.push(started.elapsed().as_micros() as u64);
+
+            let mut canonical = snapshots
+                .sinks
+                .values()
+                .map(|rows| format!("{:?}", rows.to_values().unwrap()))
+                .collect::<Vec<_>>();
+            canonical.sort_unstable();
+            let mut hasher = DefaultHasher::new();
+            canonical.hash(&mut hasher);
+            let digest = hasher.finish();
+            let memo_after = database.runtime_stats();
+            receipt = Some((
+                counter.scan_prefix_count() - scans_before,
+                counter.visited_records() - visits_before,
+                memo_after.hydration_memo_computes - memo_before.hydration_memo_computes,
+                memo_after.hydration_memo_hits - memo_before.hydration_memo_hits,
+                snapshots
+                    .sinks
+                    .values()
+                    .map(|rows| rows.deltas.len())
+                    .sum::<usize>(),
+                digest,
+            ));
+        }
+        elapsed_us.sort_unstable();
+        let (snapshot_queries, child_visits, memo_computes, memo_hits, result_rows, digest) =
+            receipt.unwrap();
+        println!(
+            "{{\"scenario\":\"equivalent_terminal_snapshot_hydration\",\"terminals\":{terminal_count},\"input_rows\":{ROWS},\"samples\":{SAMPLES},\"snapshot_query_executions\":{snapshot_queries},\"storage_snapshots_constructed\":{snapshot_queries},\"child_visits\":{child_visits},\"hydration_memo_computes\":{memo_computes},\"hydration_memo_hits\":{memo_hits},\"result_rows\":{result_rows},\"result_digest\":\"{digest:016x}\",\"first_read_p50_us\":{}}}",
+            elapsed_us[SAMPLES / 2]
+        );
+    }
 }
 
 #[test]

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -2173,6 +2173,7 @@ fn jazz_docs_history_database() -> Database<MemoryStorage> {
 struct ScanCountingStorage {
     inner: MemoryStorage,
     scan_range_count: Rc<Cell<usize>>,
+    scan_prefix_count: Rc<Cell<usize>>,
 }
 
 impl ScanCountingStorage {
@@ -2180,11 +2181,16 @@ impl ScanCountingStorage {
         Self {
             inner: MemoryStorage::new(column_families),
             scan_range_count: Rc::new(Cell::new(0)),
+            scan_prefix_count: Rc::new(Cell::new(0)),
         }
     }
 
     fn scan_range_count(&self) -> usize {
         self.scan_range_count.get()
+    }
+
+    fn scan_prefix_count(&self) -> usize {
+        self.scan_prefix_count.get()
     }
 }
 
@@ -2227,6 +2233,8 @@ impl OrderedKvStorage for ScanCountingStorage {
         prefix: &Key,
         visit: &mut ScanVisitor<'_>,
     ) -> Result<(), StorageError> {
+        self.scan_prefix_count
+            .set(self.scan_prefix_count.get().saturating_add(1));
         self.inner.scan_prefix(cf, prefix, visit)
     }
 
@@ -4339,6 +4347,47 @@ fn query_graphs_returns_named_one_shot_snapshots() {
             (vec![Value::String("Blue Train".to_owned())], 1),
             (vec![Value::String("Giant Steps".to_owned())], 1)
         ]
+    );
+}
+
+#[test]
+fn equivalent_query_graph_terminals_share_snapshot_materialization() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let counter = storage.clone();
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("Blue Train".to_owned())],
+    );
+    batch.insert(
+        "albums",
+        vec![Value::U64(2), Value::String("Giant Steps".to_owned())],
+    );
+    database.commit_batch(batch).unwrap();
+
+    let scans_before = counter.scan_prefix_count();
+    let snapshots = database
+        .query_graphs([
+            ("first", GraphBuilder::table("albums").project(["id"])),
+            ("second", GraphBuilder::table("albums").project(["id"])),
+        ])
+        .unwrap();
+
+    let expected = [(vec![Value::U64(1)], 1), (vec![Value::U64(2)], 1)];
+    assert_eq!(
+        snapshots.get("first").unwrap().to_values().unwrap(),
+        expected
+    );
+    assert_eq!(
+        snapshots.get("second").unwrap().to_values().unwrap(),
+        expected
+    );
+    assert_eq!(
+        counter.scan_prefix_count() - scans_before,
+        1,
+        "equivalent output terminals should construct their shared table snapshot once"
     );
 }
 

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4499,6 +4499,10 @@ fn distinct_snapshot_groups_retain_at_most_one_materialized_source_set() {
 #[ignore = "receipt-only timing for equivalent-terminal snapshot hydration"]
 fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
     const SAMPLES: usize = 7;
+    assert!(
+        std::env::var_os("GROOVE_PROFILE_HYDRATION_OPERATORS").is_some(),
+        "join attribution is unavailable; rerun with GROOVE_PROFILE_HYDRATION_OPERATORS=1"
+    );
     let rows = std::env::var("GROOVE_HYDRATION_RECEIPT_ROWS")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
@@ -4668,6 +4672,35 @@ fn distinct_snapshot_scan_shapes_do_not_share_materialization() {
 }
 
 #[test]
+fn different_validated_schema_descriptors_do_not_share_snapshot_materialization() {
+    let storage = ScanCountingStorage::new(&["albums"]);
+    let counter = storage.clone();
+    let bytes_schema = DatabaseSchema::new([TableSchema::new(
+        "albums",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("title", ColumnType::Bytes),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+
+    let mut strings = Database::new(albums_schema(), storage.clone()).unwrap();
+    let mut bytes = Database::new(bytes_schema, storage).unwrap();
+    strings
+        .query_graph(GraphBuilder::table("albums").project(["id"]))
+        .unwrap();
+    bytes
+        .query_graph(GraphBuilder::table("albums").project(["id"]))
+        .unwrap();
+
+    assert_eq!(
+        counter.scan_prefix_count(),
+        2,
+        "validated source descriptors from different schema runtimes remain request-local"
+    );
+}
+
+#[test]
 fn shared_snapshot_materialization_advances_after_data_change() {
     let storage = ScanCountingStorage::new(&["albums"]);
     let counter = storage.clone();
@@ -4733,6 +4766,14 @@ fn shared_snapshot_materialization_preserves_multiset_weights() {
         expected
     );
     assert_eq!(counter.scan_prefix_count() - scans_before, 1);
+
+    let mut fresh = Database::new(albums_schema(), counter.clone()).unwrap();
+    let rehydrated = fresh.query_graph(graph()).unwrap();
+    assert_eq!(
+        snapshots.get("first").unwrap().to_values().unwrap(),
+        rehydrated.to_values().unwrap(),
+        "shared multiset output must equal a fresh full hydration"
+    );
 }
 
 #[test]

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4452,8 +4452,11 @@ fn equivalent_query_graph_snapshot_work_is_constant_in_terminal_count() {
 #[test]
 #[ignore = "receipt-only timing for equivalent-terminal snapshot hydration"]
 fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
-    const ROWS: usize = 4_096;
     const SAMPLES: usize = 7;
+    let rows = std::env::var("GROOVE_HYDRATION_RECEIPT_ROWS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(4_096);
 
     for terminal_count in [1_usize, 2, 4, 8] {
         let mut elapsed_us = Vec::with_capacity(SAMPLES);
@@ -4463,7 +4466,7 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
             let counter = storage.clone();
             let mut database = Database::new(albums_schema(), storage).unwrap();
             let mut batch = database.open_batch();
-            for id in 0..ROWS as u64 {
+            for id in 0..rows as u64 {
                 batch.insert(
                     "albums",
                     vec![Value::U64(id), Value::String(format!("album-{id}"))],
@@ -4519,7 +4522,7 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
         let (snapshot_queries, child_visits, memo_computes, memo_hits, result_rows, digest) =
             receipt.unwrap();
         println!(
-            "{{\"scenario\":\"equivalent_terminal_snapshot_hydration\",\"terminals\":{terminal_count},\"input_rows\":{ROWS},\"samples\":{SAMPLES},\"storage_prefix_scans\":{snapshot_queries},\"storage_records_visited\":{child_visits},\"hydration_memo_computes\":{memo_computes},\"hydration_memo_hits\":{memo_hits},\"total_result_rows\":{result_rows},\"per_terminal_rows\":{},\"per_terminal_digest\":\"{digest:016x}\",\"first_read_p50_us\":{}}}",
+            "{{\"scenario\":\"equivalent_terminal_snapshot_hydration\",\"terminals\":{terminal_count},\"input_rows\":{rows},\"samples\":{SAMPLES},\"storage_prefix_scans\":{snapshot_queries},\"storage_records_visited\":{child_visits},\"hydration_memo_computes\":{memo_computes},\"hydration_memo_hits\":{memo_hits},\"total_result_rows\":{result_rows},\"per_terminal_rows\":{},\"per_terminal_digest\":\"{digest:016x}\",\"first_read_p50_us\":{}}}",
             result_rows / terminal_count,
             elapsed_us[SAMPLES / 2]
         );

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4482,6 +4482,17 @@ fn distinct_snapshot_groups_retain_at_most_one_materialized_source_set() {
         1,
         "distinct source sets must be materialized and released one group at a time"
     );
+
+    database
+        .query_graph(GraphBuilder::table("albums").project(["id"]))
+        .unwrap();
+    assert_eq!(
+        database
+            .runtime_stats()
+            .hydration_snapshot_peak_cached_source_sets,
+        0,
+        "a single terminal must not retain a reusable source-set snapshot"
+    );
 }
 
 #[test]
@@ -4494,8 +4505,7 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
         .unwrap_or(4_096);
 
     for terminal_count in [1_usize, 2, 4, 8] {
-        let mut elapsed_us = Vec::with_capacity(SAMPLES);
-        let mut receipt = None;
+        let mut samples = Vec::with_capacity(SAMPLES);
         for _ in 0..SAMPLES {
             let storage = ScanCountingStorage::new(&["albums"]);
             let counter = storage.clone();
@@ -4525,7 +4535,7 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
             let memo_before = database.runtime_stats();
             let started = Instant::now();
             let snapshots = database.query_graphs(sinks).unwrap();
-            elapsed_us.push(started.elapsed().as_micros() as u64);
+            let elapsed_us = started.elapsed().as_micros() as u64;
 
             let canonical = snapshots
                 .sinks
@@ -4540,11 +4550,14 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
             canonical[0].hash(&mut hasher);
             let digest = hasher.finish();
             let memo_after = database.runtime_stats();
-            receipt = Some((
+            samples.push((
+                elapsed_us,
                 counter.scan_prefix_count() - scans_before,
                 counter.visited_records() - visits_before,
                 memo_after.hydration_memo_computes - memo_before.hydration_memo_computes,
                 memo_after.hydration_memo_hits - memo_before.hydration_memo_hits,
+                memo_after.hydration_join_evaluation_nanos
+                    - memo_before.hydration_join_evaluation_nanos,
                 snapshots
                     .sinks
                     .values()
@@ -4553,13 +4566,21 @@ fn equivalent_terminal_snapshot_hydration_scaling_receipt() {
                 digest,
             ));
         }
-        elapsed_us.sort_unstable();
-        let (snapshot_queries, child_visits, memo_computes, memo_hits, result_rows, digest) =
-            receipt.unwrap();
+        samples.sort_unstable_by_key(|sample| sample.0);
+        let (
+            first_read_us,
+            snapshot_queries,
+            child_visits,
+            memo_computes,
+            memo_hits,
+            join_evaluation_nanos,
+            result_rows,
+            digest,
+        ) = samples[SAMPLES / 2];
         println!(
-            "{{\"scenario\":\"equivalent_terminal_snapshot_hydration\",\"terminals\":{terminal_count},\"input_rows\":{rows},\"samples\":{SAMPLES},\"storage_prefix_scans\":{snapshot_queries},\"storage_records_visited\":{child_visits},\"hydration_memo_computes\":{memo_computes},\"hydration_memo_hits\":{memo_hits},\"total_result_rows\":{result_rows},\"per_terminal_rows\":{},\"per_terminal_digest\":\"{digest:016x}\",\"first_read_p50_us\":{}}}",
+            "{{\"scenario\":\"equivalent_terminal_snapshot_hydration\",\"terminals\":{terminal_count},\"input_rows\":{rows},\"samples\":{SAMPLES},\"storage_prefix_scans\":{snapshot_queries},\"storage_records_visited\":{child_visits},\"hydration_memo_computes\":{memo_computes},\"hydration_memo_hits\":{memo_hits},\"join_evaluation_us\":{},\"total_result_rows\":{result_rows},\"per_terminal_rows\":{},\"per_terminal_digest\":\"{digest:016x}\",\"first_read_p50_us\":{first_read_us}}}",
+            join_evaluation_nanos / 1_000,
             result_rows / terminal_count,
-            elapsed_us[SAMPLES / 2]
         );
     }
 }

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -49,14 +49,34 @@ mod recursion;
 use join::{AntiJoinState, ArrangementState, JoinState};
 use persist::apply_persist_delta;
 use recursion::{
-    RecursiveState, hydrate_recursive_arrangements, materialize_snapshot_table_deltas,
-    recompute_recursive, recursive_delta, recursive_read_tables, snapshot_table_deltas,
-    snapshot_table_sources,
+    RecursiveState, TableSnapshotSource, hydrate_recursive_arrangements,
+    materialize_snapshot_table_deltas, recompute_recursive, recursive_delta, recursive_read_tables,
+    snapshot_table_deltas, snapshot_table_sources,
 };
 
 const DEFAULT_SINK: &str = "__default";
 const EVAL_MEMO_MAX_ENTRIES: usize = 8192;
 const EVAL_MEMO_MAX_BYTES: usize = 128 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SnapshotSourceSet(HashMap<TableSnapshotSource, RecordDescriptor>);
+type SnapshotSourceGroup = (SnapshotSourceSet, Vec<(String, CompiledNode)>);
+
+impl Hash for SnapshotSourceSet {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let mut entry_hashes = self
+            .0
+            .iter()
+            .map(|entry| {
+                let mut hasher = DefaultHasher::new();
+                entry.hash(&mut hasher);
+                hasher.finish()
+            })
+            .collect::<Vec<_>>();
+        entry_hashes.sort_unstable();
+        entry_hashes.hash(state);
+    }
+}
 
 // These maps are keyed by local runtime/schema/graph metadata produced after
 // validation. Wire-facing or otherwise adversarial-input maps must keep the
@@ -93,6 +113,8 @@ pub struct IvmRuntime {
     hydration_memo_hits: u64,
     hydration_memo_computes: u64,
     hydration_memo_computed_nodes: HashSet<NodeId>,
+    hydration_snapshot_peak_cached_source_sets: usize,
+    hydration_join_evaluation_nanos: u64,
     /// Retainers and GC age live outside operator state so stateless leaf nodes
     /// can be retained without allocating fake operator state.
     node_meta: HashMap<NodeId, NodeRuntimeMeta>,
@@ -126,6 +148,8 @@ impl IvmRuntime {
             hydration_memo_hits: 0,
             hydration_memo_computes: 0,
             hydration_memo_computed_nodes: HashSet::default(),
+            hydration_snapshot_peak_cached_source_sets: 0,
+            hydration_join_evaluation_nanos: 0,
             node_meta: HashMap::default(),
             current_tick: 0,
             next_subscription_id: 1,
@@ -189,6 +213,7 @@ impl IvmRuntime {
         S: OrderedKvStorage,
     {
         self.flush_pending_binding_retractions(storage)?;
+        self.hydration_snapshot_peak_cached_source_sets = 0;
         if builder_contains_binding_source(&graph) {
             return Err(IvmRuntimeError::BindingSourceRequiresPrepare);
         }
@@ -579,6 +604,7 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage,
     {
+        self.hydration_snapshot_peak_cached_source_sets = 0;
         if let Some((sink, output)) = outputs.first_key_value().filter(|_| outputs.len() == 1) {
             let records = self.hydration_snapshot(output.node, storage)?;
             if records.descriptor != output.output {
@@ -589,29 +615,18 @@ impl IvmRuntime {
             });
         }
         let mut sinks = BTreeMap::new();
-        let mut table_snapshot_cache = Vec::new();
-        for (sink, output) in outputs {
-            let sources = snapshot_table_sources(&self.graph, output.node)?;
-            let cache_index = if let Some(index) = table_snapshot_cache
-                .iter()
-                .position(|(cached_sources, _)| cached_sources == &sources)
-            {
-                index
-            } else {
-                let table_deltas =
-                    materialize_snapshot_table_deltas(&self.schema, storage, sources.clone())?;
-                table_snapshot_cache.push((sources, table_deltas));
-                table_snapshot_cache.len() - 1
-            };
-            let records = self.hydration_snapshot_from_table_deltas(
-                output.node,
-                storage,
-                &table_snapshot_cache[cache_index].1,
-            )?;
-            if records.descriptor != output.output {
-                return Err(IvmRuntimeError::GraphOutputMismatch);
+        let groups = group_outputs_by_snapshot_sources(&self.graph, outputs)?;
+        self.hydration_snapshot_peak_cached_source_sets = usize::from(!groups.is_empty());
+        for (sources, outputs) in groups {
+            let table_deltas = materialize_snapshot_table_deltas(&self.schema, storage, sources.0)?;
+            for (sink, output) in outputs {
+                let records =
+                    self.hydration_snapshot_from_table_deltas(output.node, storage, &table_deltas)?;
+                if records.descriptor != output.output {
+                    return Err(IvmRuntimeError::GraphOutputMismatch);
+                }
+                sinks.insert(sink, records);
             }
-            sinks.insert(sink.clone(), records);
         }
         Ok(MultisinkDeltas { sinks })
     }
@@ -679,6 +694,7 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage,
     {
+        self.hydration_snapshot_peak_cached_source_sets = 0;
         if let Some((sink, output)) = outputs.first_key_value().filter(|_| outputs.len() == 1) {
             let records = self.subscription_hydration_snapshot(output.node, storage)?;
             if records.descriptor != output.output {
@@ -689,29 +705,21 @@ impl IvmRuntime {
             });
         }
         let mut sinks = BTreeMap::new();
-        let mut table_snapshot_cache = Vec::new();
-        for (sink, output) in outputs {
-            let sources = snapshot_table_sources(&self.graph, output.node)?;
-            let cache_index = if let Some(index) = table_snapshot_cache
-                .iter()
-                .position(|(cached_sources, _)| cached_sources == &sources)
-            {
-                index
-            } else {
-                let table_deltas =
-                    materialize_snapshot_table_deltas(&self.schema, storage, sources.clone())?;
-                table_snapshot_cache.push((sources, table_deltas));
-                table_snapshot_cache.len() - 1
-            };
-            let records = self.subscription_hydration_snapshot_from_table_deltas(
-                output.node,
-                storage,
-                &table_snapshot_cache[cache_index].1,
-            )?;
-            if records.descriptor != output.output {
-                return Err(IvmRuntimeError::GraphOutputMismatch);
+        let groups = group_outputs_by_snapshot_sources(&self.graph, outputs)?;
+        self.hydration_snapshot_peak_cached_source_sets = usize::from(!groups.is_empty());
+        for (sources, outputs) in groups {
+            let table_deltas = materialize_snapshot_table_deltas(&self.schema, storage, sources.0)?;
+            for (sink, output) in outputs {
+                let records = self.subscription_hydration_snapshot_from_table_deltas(
+                    output.node,
+                    storage,
+                    &table_deltas,
+                )?;
+                if records.descriptor != output.output {
+                    return Err(IvmRuntimeError::GraphOutputMismatch);
+                }
+                sinks.insert(sink, records);
             }
-            sinks.insert(sink.clone(), records);
         }
         Ok(MultisinkDeltas { sinks })
     }
@@ -1679,6 +1687,9 @@ impl IvmRuntime {
             hydration_memo_hits: self.hydration_memo_hits,
             hydration_memo_computes: self.hydration_memo_computes,
             hydration_memo_distinct_computed_nodes: self.hydration_memo_computed_nodes.len(),
+            hydration_snapshot_peak_cached_source_sets: self
+                .hydration_snapshot_peak_cached_source_sets,
+            hydration_join_evaluation_nanos: self.hydration_join_evaluation_nanos,
             logical_nodes_requested: self.logical_nodes_requested,
             deduped_graph_nodes: self.graph.nodes().len(),
             ..RuntimeStats::default()
@@ -1690,6 +1701,9 @@ impl IvmRuntime {
         self.hydration_memo_computes += metrics.hydration_memo_computes;
         self.hydration_memo_computed_nodes
             .extend(metrics.hydration_memo_computed_nodes.iter().copied());
+        self.hydration_join_evaluation_nanos = self
+            .hydration_join_evaluation_nanos
+            .saturating_add(metrics.join_evaluation_nanos);
     }
 
     fn add_retainer(&mut self, id: NodeId, retainer: Retainer) -> bool {
@@ -2819,6 +2833,23 @@ impl IvmRuntime {
     }
 }
 
+fn group_outputs_by_snapshot_sources(
+    graph: &IvmGraph,
+    outputs: &BTreeMap<String, CompiledNode>,
+) -> Result<Vec<SnapshotSourceGroup>, IvmRuntimeError> {
+    let mut groups = HashMap::<SnapshotSourceSet, Vec<(String, CompiledNode)>>::default();
+    for (sink, output) in outputs {
+        let sources = SnapshotSourceSet(snapshot_table_sources(graph, output.node)?);
+        groups
+            .entry(sources)
+            .or_default()
+            .push((sink.clone(), output.clone()));
+    }
+    let mut groups = groups.into_iter().collect::<Vec<_>>();
+    groups.sort_by(|(_, left), (_, right)| left[0].0.cmp(&right[0].0));
+    Ok(groups)
+}
+
 /// Point-in-time runtime counters for benchmark and diagnostics reporting.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RuntimeStats {
@@ -2833,6 +2864,13 @@ pub struct RuntimeStats {
     pub hydration_memo_hits: u64,
     pub hydration_memo_computes: u64,
     pub hydration_memo_distinct_computed_nodes: usize,
+    /// Maximum number of complete source-set snapshots retained concurrently
+    /// by the most recent multisink hydration. Equivalent outputs are grouped,
+    /// so this is bounded to one; single-output hydration does not cache a set.
+    pub hydration_snapshot_peak_cached_source_sets: usize,
+    /// Join operator time collected during hydration when
+    /// `GROOVE_PROFILE_HYDRATION_OPERATORS` is set. Zero otherwise.
+    pub hydration_join_evaluation_nanos: u64,
     pub arrangement_rows: usize,
     pub arrangement_encoded_bytes: usize,
     pub recursive_state_count: usize,
@@ -2861,6 +2899,7 @@ pub struct TickMetrics {
     pub hydration_memo_hits: u64,
     pub hydration_memo_computes: u64,
     pub hydration_memo_computed_nodes: HashSet<NodeId>,
+    join_evaluation_nanos: u64,
     pub notifications_sent: usize,
     pub notification_records: usize,
     pub notification_encoded_bytes: usize,
@@ -5510,7 +5549,10 @@ where
                 };
                 let left = self.update_node(*left_input)?;
                 let right = self.update_node(*right_input)?;
-                self.update_join(
+                let profile = std::env::var_os("GROOVE_PROFILE_HYDRATION_OPERATORS").is_some()
+                    && self.context.eval_mode == EvalMode::Hydrate;
+                let started = profile.then(std::time::Instant::now);
+                let result = self.update_join(
                     node,
                     join,
                     output_desc,
@@ -5518,7 +5560,14 @@ where
                     *right_input,
                     &left.deltas,
                     &right.deltas,
-                )
+                );
+                if let Some(started) = started {
+                    self.metrics.join_evaluation_nanos = self
+                        .metrics
+                        .join_evaluation_nanos
+                        .saturating_add(started.elapsed().as_nanos().min(u64::MAX as u128) as u64);
+                }
+                result
             }
             OpType::SemiJoin(join) => {
                 let [left_input, right_input] = graph_node.descriptor.inputs.as_slice() else {

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -579,6 +579,15 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage,
     {
+        if let Some((sink, output)) = outputs.first_key_value().filter(|_| outputs.len() == 1) {
+            let records = self.hydration_snapshot(output.node, storage)?;
+            if records.descriptor != output.output {
+                return Err(IvmRuntimeError::GraphOutputMismatch);
+            }
+            return Ok(MultisinkDeltas {
+                sinks: BTreeMap::from([(sink.clone(), records)]),
+            });
+        }
         let mut sinks = BTreeMap::new();
         let mut table_snapshot_cache = Vec::new();
         for (sink, output) in outputs {
@@ -650,6 +659,18 @@ impl IvmRuntime {
         records
     }
 
+    fn subscription_hydration_snapshot<S>(
+        &mut self,
+        output_node: NodeId,
+        storage: &S,
+    ) -> Result<RecordDeltas, IvmRuntimeError>
+    where
+        S: OrderedKvStorage,
+    {
+        let table_deltas = snapshot_table_deltas(&self.schema, &self.graph, storage, output_node)?;
+        self.subscription_hydration_snapshot_from_table_deltas(output_node, storage, &table_deltas)
+    }
+
     fn subscription_hydration_snapshots<S>(
         &mut self,
         outputs: &BTreeMap<String, CompiledNode>,
@@ -658,6 +679,15 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage,
     {
+        if let Some((sink, output)) = outputs.first_key_value().filter(|_| outputs.len() == 1) {
+            let records = self.subscription_hydration_snapshot(output.node, storage)?;
+            if records.descriptor != output.output {
+                return Err(IvmRuntimeError::GraphOutputMismatch);
+            }
+            return Ok(MultisinkDeltas {
+                sinks: BTreeMap::from([(sink.clone(), records)]),
+            });
+        }
         let mut sinks = BTreeMap::new();
         let mut table_snapshot_cache = Vec::new();
         for (sink, output) in outputs {

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -49,8 +49,9 @@ mod recursion;
 use join::{AntiJoinState, ArrangementState, JoinState};
 use persist::apply_persist_delta;
 use recursion::{
-    RecursiveState, hydrate_recursive_arrangements, recompute_recursive, recursive_delta,
-    recursive_read_tables, snapshot_table_deltas,
+    RecursiveState, hydrate_recursive_arrangements, materialize_snapshot_table_deltas,
+    recompute_recursive, recursive_delta, recursive_read_tables, snapshot_table_deltas,
+    snapshot_table_sources,
 };
 
 const DEFAULT_SINK: &str = "__default";
@@ -523,12 +524,24 @@ impl IvmRuntime {
         S: OrderedKvStorage,
     {
         let table_deltas = snapshot_table_deltas(&self.schema, &self.graph, storage, output_node)?;
+        self.hydration_snapshot_from_table_deltas(output_node, storage, &table_deltas)
+    }
+
+    fn hydration_snapshot_from_table_deltas<S>(
+        &mut self,
+        output_node: NodeId,
+        storage: &S,
+        table_deltas: &[TableDelta],
+    ) -> Result<RecordDeltas, IvmRuntimeError>
+    where
+        S: OrderedKvStorage,
+    {
         let binding_snapshots = self.binding_snapshot_deltas();
         let mut metrics = TickMetrics::default();
         let mut evaluator = TickEvaluator {
             schema: &self.schema,
             graph: &self.graph,
-            table_deltas: &table_deltas,
+            table_deltas,
             binding_deltas: &[],
             binding_snapshots: &binding_snapshots,
             current_tick: self.current_tick,
@@ -567,8 +580,25 @@ impl IvmRuntime {
         S: OrderedKvStorage,
     {
         let mut sinks = BTreeMap::new();
+        let mut table_snapshot_cache = Vec::new();
         for (sink, output) in outputs {
-            let records = self.hydration_snapshot(output.node, storage)?;
+            let sources = snapshot_table_sources(&self.graph, output.node)?;
+            let cache_index = if let Some(index) = table_snapshot_cache
+                .iter()
+                .position(|(cached_sources, _)| cached_sources == &sources)
+            {
+                index
+            } else {
+                let table_deltas =
+                    materialize_snapshot_table_deltas(&self.schema, storage, sources.clone())?;
+                table_snapshot_cache.push((sources, table_deltas));
+                table_snapshot_cache.len() - 1
+            };
+            let records = self.hydration_snapshot_from_table_deltas(
+                output.node,
+                storage,
+                &table_snapshot_cache[cache_index].1,
+            )?;
             if records.descriptor != output.output {
                 return Err(IvmRuntimeError::GraphOutputMismatch);
             }
@@ -577,22 +607,22 @@ impl IvmRuntime {
         Ok(MultisinkDeltas { sinks })
     }
 
-    fn subscription_hydration_snapshot<S>(
+    fn subscription_hydration_snapshot_from_table_deltas<S>(
         &mut self,
         output_node: NodeId,
         storage: &S,
+        table_deltas: &[TableDelta],
     ) -> Result<RecordDeltas, IvmRuntimeError>
     where
         S: OrderedKvStorage,
     {
-        let table_deltas = snapshot_table_deltas(&self.schema, &self.graph, storage, output_node)?;
         let binding_snapshots = self.binding_snapshot_deltas();
         let hydrate_arrangements = self.output_depends_on_aggregate(output_node)?;
         let mut metrics = TickMetrics::default();
         let mut evaluator = TickEvaluator {
             schema: &self.schema,
             graph: &self.graph,
-            table_deltas: &table_deltas,
+            table_deltas,
             binding_deltas: &[],
             binding_snapshots: &binding_snapshots,
             current_tick: self.current_tick,
@@ -629,8 +659,25 @@ impl IvmRuntime {
         S: OrderedKvStorage,
     {
         let mut sinks = BTreeMap::new();
+        let mut table_snapshot_cache = Vec::new();
         for (sink, output) in outputs {
-            let records = self.subscription_hydration_snapshot(output.node, storage)?;
+            let sources = snapshot_table_sources(&self.graph, output.node)?;
+            let cache_index = if let Some(index) = table_snapshot_cache
+                .iter()
+                .position(|(cached_sources, _)| cached_sources == &sources)
+            {
+                index
+            } else {
+                let table_deltas =
+                    materialize_snapshot_table_deltas(&self.schema, storage, sources.clone())?;
+                table_snapshot_cache.push((sources, table_deltas));
+                table_snapshot_cache.len() - 1
+            };
+            let records = self.subscription_hydration_snapshot_from_table_deltas(
+                output.node,
+                storage,
+                &table_snapshot_cache[cache_index].1,
+            )?;
             if records.descriptor != output.output {
                 return Err(IvmRuntimeError::GraphOutputMismatch);
             }

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -10,7 +10,7 @@
 //! [`crate::ivm::graph`], and storage mechanics in [`crate::storage`].
 
 use bytes::{Bytes, BytesMut};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::hash::{Hash, Hasher};
@@ -75,6 +75,45 @@ impl Hash for SnapshotSourceSet {
             .collect::<Vec<_>>();
         entry_hashes.sort_unstable();
         entry_hashes.hash(state);
+    }
+}
+
+#[derive(Debug, Default)]
+struct SnapshotSourceSetRetention {
+    live: Cell<usize>,
+    peak: Cell<usize>,
+}
+
+impl SnapshotSourceSetRetention {
+    fn track(&self, table_deltas: Vec<TableDelta>) -> MaterializedSnapshotSourceSet<'_> {
+        let live = self.live.get() + 1;
+        self.live.set(live);
+        self.peak.set(self.peak.get().max(live));
+        MaterializedSnapshotSourceSet {
+            table_deltas,
+            retention: self,
+        }
+    }
+
+    fn peak(&self) -> usize {
+        self.peak.get()
+    }
+}
+
+struct MaterializedSnapshotSourceSet<'a> {
+    table_deltas: Vec<TableDelta>,
+    retention: &'a SnapshotSourceSetRetention,
+}
+
+impl MaterializedSnapshotSourceSet<'_> {
+    fn table_deltas(&self) -> &[TableDelta] {
+        &self.table_deltas
+    }
+}
+
+impl Drop for MaterializedSnapshotSourceSet<'_> {
+    fn drop(&mut self) {
+        self.retention.live.set(self.retention.live.get() - 1);
     }
 }
 
@@ -616,18 +655,26 @@ impl IvmRuntime {
         }
         let mut sinks = BTreeMap::new();
         let groups = group_outputs_by_snapshot_sources(&self.graph, outputs)?;
-        self.hydration_snapshot_peak_cached_source_sets = usize::from(!groups.is_empty());
+        let retention = SnapshotSourceSetRetention::default();
         for (sources, outputs) in groups {
-            let table_deltas = materialize_snapshot_table_deltas(&self.schema, storage, sources.0)?;
+            let table_deltas = retention.track(materialize_snapshot_table_deltas(
+                &self.schema,
+                storage,
+                sources.0,
+            )?);
             for (sink, output) in outputs {
-                let records =
-                    self.hydration_snapshot_from_table_deltas(output.node, storage, &table_deltas)?;
+                let records = self.hydration_snapshot_from_table_deltas(
+                    output.node,
+                    storage,
+                    table_deltas.table_deltas(),
+                )?;
                 if records.descriptor != output.output {
                     return Err(IvmRuntimeError::GraphOutputMismatch);
                 }
                 sinks.insert(sink, records);
             }
         }
+        self.hydration_snapshot_peak_cached_source_sets = retention.peak();
         Ok(MultisinkDeltas { sinks })
     }
 
@@ -706,14 +753,18 @@ impl IvmRuntime {
         }
         let mut sinks = BTreeMap::new();
         let groups = group_outputs_by_snapshot_sources(&self.graph, outputs)?;
-        self.hydration_snapshot_peak_cached_source_sets = usize::from(!groups.is_empty());
+        let retention = SnapshotSourceSetRetention::default();
         for (sources, outputs) in groups {
-            let table_deltas = materialize_snapshot_table_deltas(&self.schema, storage, sources.0)?;
+            let table_deltas = retention.track(materialize_snapshot_table_deltas(
+                &self.schema,
+                storage,
+                sources.0,
+            )?);
             for (sink, output) in outputs {
                 let records = self.subscription_hydration_snapshot_from_table_deltas(
                     output.node,
                     storage,
-                    &table_deltas,
+                    table_deltas.table_deltas(),
                 )?;
                 if records.descriptor != output.output {
                     return Err(IvmRuntimeError::GraphOutputMismatch);
@@ -721,6 +772,7 @@ impl IvmRuntime {
                 sinks.insert(sink, records);
             }
         }
+        self.hydration_snapshot_peak_cached_source_sets = retention.peak();
         Ok(MultisinkDeltas { sinks })
     }
 

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -374,8 +374,24 @@ pub(super) fn snapshot_table_deltas(
     storage: &impl OrderedKvStorage,
     root: NodeId,
 ) -> Result<Vec<TableDelta>, IvmRuntimeError> {
+    let tables = snapshot_table_sources(graph, root)?;
+    materialize_snapshot_table_deltas(schema, storage, tables)
+}
+
+pub(super) fn snapshot_table_sources(
+    graph: &IvmGraph,
+    root: NodeId,
+) -> Result<HashMap<TableSnapshotSource, RecordDescriptor>, IvmRuntimeError> {
     let mut tables = HashMap::<TableSnapshotSource, RecordDescriptor>::default();
     collect_table_sources(graph, root, &mut tables)?;
+    Ok(tables)
+}
+
+pub(super) fn materialize_snapshot_table_deltas(
+    schema: &crate::schema::DatabaseSchema,
+    storage: &impl OrderedKvStorage,
+    tables: HashMap<TableSnapshotSource, RecordDescriptor>,
+) -> Result<Vec<TableDelta>, IvmRuntimeError> {
     tables
         .into_iter()
         .map(|(source, descriptor)| {
@@ -412,7 +428,7 @@ pub(super) fn snapshot_table_deltas(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct TableSnapshotSource {
+pub(super) struct TableSnapshotSource {
     table: String,
     scan: Option<StaticScanSpec>,
 }

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -38,6 +38,8 @@ use jazz::wire::{
     WIRE_PROTOCOL_VERSION, WireSession, WireTransport,
 };
 #[cfg(feature = "rocksdb")]
+use sha2::{Digest, Sha256};
+#[cfg(feature = "rocksdb")]
 use tempfile::TempDir;
 
 type BenchDb = Db<MemoryStorage>;
@@ -1123,6 +1125,11 @@ struct R3PhaseSample {
     first_read_apply_projection: Duration,
     first_read_unattributed: Duration,
     rows: usize,
+    result_digest: String,
+    storage_reads: usize,
+    storage_ranges: usize,
+    hydration_memo_computes: u64,
+    hydration_memo_hits: u64,
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1259,6 +1266,10 @@ fn measure_r3_phase_sample(
     let query = project_board_query(&db, project);
     let prepare = prepare_started.elapsed();
 
+    #[cfg(feature = "testing")]
+    db.reset_storage_read_metrics_for_test();
+    #[cfg(feature = "testing")]
+    let runtime_before = db.runtime_stats_for_test();
     let read_started = Instant::now();
     let (rows, read_profile) = db
         .read_profiled(&query)
@@ -1269,6 +1280,17 @@ fn measure_r3_phase_sample(
         expected_rows,
         "R3 project-board result count changed"
     );
+    #[cfg(feature = "testing")]
+    let storage_reads = db.take_storage_read_metrics_for_test();
+    #[cfg(feature = "testing")]
+    let runtime_after = db.runtime_stats_for_test();
+    let mut row_ids = rows.iter().map(|row| row.row_uuid()).collect::<Vec<_>>();
+    row_ids.sort_unstable();
+    let mut digest = Sha256::new();
+    for row_id in row_ids {
+        digest.update(row_id.0.as_bytes());
+    }
+    let result_digest = format!("{:x}", digest.finalize());
 
     R3PhaseSample {
         storage_open,
@@ -1284,6 +1306,27 @@ fn measure_r3_phase_sample(
         first_read_apply_projection: read_profile.apply_projection,
         first_read_unattributed: first_read.saturating_sub(read_profile.total),
         rows: rows.len(),
+        result_digest,
+        #[cfg(feature = "testing")]
+        storage_reads: storage_reads.total.reads,
+        #[cfg(not(feature = "testing"))]
+        storage_reads: 0,
+        #[cfg(feature = "testing")]
+        storage_ranges: storage_reads.total.ranges,
+        #[cfg(not(feature = "testing"))]
+        storage_ranges: 0,
+        #[cfg(feature = "testing")]
+        hydration_memo_computes: runtime_after
+            .hydration_memo_computes
+            .saturating_sub(runtime_before.hydration_memo_computes),
+        #[cfg(not(feature = "testing"))]
+        hydration_memo_computes: 0,
+        #[cfg(feature = "testing")]
+        hydration_memo_hits: runtime_after
+            .hydration_memo_hits
+            .saturating_sub(runtime_before.hydration_memo_hits),
+        #[cfg(not(feature = "testing"))]
+        hydration_memo_hits: 0,
     }
 }
 
@@ -1309,6 +1352,17 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
         let samples = (0..sample_count)
             .map(|sample| measure_r3_phase_sample(path, project, expected_rows, sample, cache_mode))
             .collect::<Vec<_>>();
+        assert!(
+            samples.iter().all(|sample| {
+                sample.rows == samples[0].rows
+                    && sample.result_digest == samples[0].result_digest
+                    && sample.storage_reads == samples[0].storage_reads
+                    && sample.storage_ranges == samples[0].storage_ranges
+                    && sample.hydration_memo_computes == samples[0].hydration_memo_computes
+                    && sample.hydration_memo_hits == samples[0].hydration_memo_hits
+            }),
+            "R3 result and attributed work must be deterministic across samples: {samples:?}"
+        );
 
         println!(
             "{}",
@@ -1325,6 +1379,11 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
                 "watchers_per_task": selected.profile.watchers_per_task,
                 "activity_events": selected.profile.activity_events,
                 "result_rows": samples[0].rows,
+                "result_digest": samples[0].result_digest,
+                "storage_reads": samples[0].storage_reads,
+                "storage_ranges": samples[0].storage_ranges,
+                "hydration_memo_computes": samples[0].hydration_memo_computes,
+                "hydration_memo_hits": samples[0].hydration_memo_hits,
                 "samples": sample_count,
                 "durability": "wal_no_sync",
                 "total_p50_us": median_us(&samples, |sample| {

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -1130,6 +1130,7 @@ struct R3PhaseSample {
     storage_ranges: usize,
     hydration_memo_computes: u64,
     hydration_memo_hits: u64,
+    instrumentation_available: bool,
 }
 
 #[cfg(feature = "rocksdb")]
@@ -1284,11 +1285,15 @@ fn measure_r3_phase_sample(
     let storage_reads = db.take_storage_read_metrics_for_test();
     #[cfg(feature = "testing")]
     let runtime_after = db.runtime_stats_for_test();
-    let mut row_ids = rows.iter().map(|row| row.row_uuid()).collect::<Vec<_>>();
-    row_ids.sort_unstable();
+    let mut canonical_rows = rows
+        .iter()
+        .map(|row| format!("{row:?}"))
+        .collect::<Vec<_>>();
+    canonical_rows.sort_unstable();
     let mut digest = Sha256::new();
-    for row_id in row_ids {
-        digest.update(row_id.0.as_bytes());
+    for row in canonical_rows {
+        digest.update((row.len() as u64).to_be_bytes());
+        digest.update(row.as_bytes());
     }
     let result_digest = format!("{:x}", digest.finalize());
 
@@ -1327,6 +1332,7 @@ fn measure_r3_phase_sample(
             .saturating_sub(runtime_before.hydration_memo_hits),
         #[cfg(not(feature = "testing"))]
         hydration_memo_hits: 0,
+        instrumentation_available: cfg!(feature = "testing"),
     }
 }
 
@@ -1384,6 +1390,7 @@ fn emit_r3_phase_receipts(path: &Path, project: RowUuid, selected: R3Profile) {
                 "storage_ranges": samples[0].storage_ranges,
                 "hydration_memo_computes": samples[0].hydration_memo_computes,
                 "hydration_memo_hits": samples[0].hydration_memo_hits,
+                "instrumentation_available": samples[0].instrumentation_available,
                 "samples": sample_count,
                 "durability": "wal_no_sync",
                 "total_p50_us": median_us(&samples, |sample| {

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -3382,12 +3382,14 @@ fn array_subquery_policy_oracle_filters_child_array_contents_per_identity() {
         .array_subquery(ArraySubquery::new("comments", "comments", "todo_id", "id").unbounded());
     let prepared_query = prepared(&db, &query);
 
+    db.node.node.borrow().reset_storage_read_metrics();
     let admin = block_on(db.all_relation_snapshot_for_identity(
         &prepared_query,
         ReadOpts::default(),
         AuthorId::SYSTEM,
     ))
     .unwrap();
+    let admin_reads = db.node.node.borrow().take_storage_read_metrics();
     assert_eq!(
         sorted_related_text_values(
             &admin,
@@ -3401,12 +3403,14 @@ fn array_subquery_policy_oracle_filters_child_array_contents_per_identity() {
         vec!["member-visible".to_owned(), "other-visible".to_owned()]
     );
 
+    db.node.node.borrow().reset_storage_read_metrics();
     let member_snapshot = block_on(db.all_relation_snapshot_for_identity(
         &prepared_query,
         ReadOpts::default(),
         member,
     ))
     .unwrap();
+    let member_reads = db.node.node.borrow().take_storage_read_metrics();
     assert_eq!(
         sorted_related_text_values(
             &member_snapshot,
@@ -3420,9 +3424,11 @@ fn array_subquery_policy_oracle_filters_child_array_contents_per_identity() {
         vec!["member-visible".to_owned()]
     );
 
+    db.node.node.borrow().reset_storage_read_metrics();
     let spy_snapshot =
         block_on(db.all_relation_snapshot_for_identity(&prepared_query, ReadOpts::default(), spy))
             .unwrap();
+    let spy_reads = db.node.node.borrow().take_storage_read_metrics();
     assert_eq!(
         sorted_related_text_values(
             &spy_snapshot,
@@ -3434,6 +3440,10 @@ fn array_subquery_policy_oracle_filters_child_array_contents_per_identity() {
             "body"
         ),
         Vec::<String>::new()
+    );
+    assert!(
+        admin_reads.total.reads > 0 && member_reads.total.reads > 0 && spy_reads.total.reads > 0,
+        "relation snapshot storage inputs must remain request-local across permission identities: admin={admin_reads:?}, member={member_reads:?}, spy={spy_reads:?}"
     );
 }
 


### PR DESCRIPTION
## What changed

Follow-up to #1219. Equivalent output terminals in one relation-hydration request now share storage snapshot materialisation before terminal-specific hydration begins.

- groups terminals by the complete validated table-source set (table, scan/query shape, and record descriptor)
- materialises one source group at a time, so retained full-snapshot state is bounded
- reuses the existing hydration evaluation memo for shared relation nodes
- preserves each terminal's independent output materialisation
- preserves #1219's one-probe `ArrangementUpdateMode::Replace` join path
- adds opt-in join-time attribution and snapshot/query counters for receipts

The reuse lifetime is one validated runtime hydration call. It cannot cross identities, permission contexts, prepared bindings, or schema runtimes. Different source scans and validated descriptors do not group.

## Why

#1219 removes redundant arrangement probes during replacement, but equivalent output terminals could still independently scan and materialise the same complete relation inputs before the hydration memo had a chance to reuse evaluated nodes. That made first-read work scale with equivalent terminal count.

This moves the reuse boundary ahead of storage snapshot construction without adding a persistent cache or retained incremental arrangements.

## Correctness coverage

Integration/black-box coverage verifies:

- equivalent terminals scan/materialise their shared snapshot once and receive identical correct results
- work remains constant from 1 to 8 equivalent terminals
- different prepared bindings, scan shapes, downstream query shapes, validated schema descriptors, and permission identities do not leak/share incompatible results
- data changes advance the reused state
- weighted duplicates, incremental inserts, negative retractions, and fresh full-rehydration results remain equivalent
- distinct source groups retain at most one complete source-set snapshot concurrently

## Performance receipts

Synthetic inner-join fixture, 4,096 input rows, seven release samples:

| terminals | scans | visited rows | join evaluation | first-read p50 |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1 | 4,096 | 2,216 µs | 3,285 µs |
| 2 | 1 | 4,096 | 2,235 µs | 3,202 µs |
| 4 | 1 | 4,096 | 2,088 µs | 3,190 µs |
| 8 | 1 | 4,096 | 2,195 µs | 3,316 µs |

The per-terminal digest and 4,096-row result are unchanged. Storage scans, visited records, join evaluation, and total time no longer grow linearly with equivalent terminal count. A single terminal retains its direct path.

Runs against the anonymised real-world relation-heavy fixture returned the same 65 root rows and 43,013 child rows with an unchanged digest and showed an approximately 2.5% first-read improvement. That is a useful positive result, but modest enough to be cautious about generalising the gain: the targeted synthetic fixture shows that the mechanism removes terminal-count scaling, while the end-to-end benefit depends on how many equivalent output terminals a real hydration request contains and how much of its first read is dominated by other work.

Residual cost remains proportional to accumulated source state for each distinct source group. Persisted/incremental arrangement hydration remains a separate possible optimization.

## Validation

- full Groove suite: 394 passed; 2 receipt-only tests ignored
- focused Jazz permission-identity regression
- incremental-delivery canaries
- shared-coverage and warm-reopen differential gates
- maintained-vs-one-shot oracle, 50 seeds
- Clippy, rustfmt, sensitive-data guard
- complete benchmark smoke suite
- independent adversarial review after remediation: no blocker/high/medium findings

The branch was rebased patch-identically onto the live `codex/jazz-core-engine-swap` stack tip before publication.
