### PR TITLE
(new core) Retain current-core route/subscription scaling receipt

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -220,6 +220,11 @@ harness = false
 name = "subscription_benchmark"
 harness = false
 
+[[bench]]
+name = "route_subscription_curve"
+harness = false
+required-features = ["testing"]
+
 [[test]]
 name = "large_blob_permissions"
 required-features = ["test"]

--- a/crates/jazz/benches/route_subscription_curve.rs
+++ b/crates/jazz/benches/route_subscription_curve.rs
@@ -1,0 +1,500 @@
+//! Current-core same-shape, distinct-binding subscription scaling receipt.
+//!
+//! Run each scale in a fresh process so RSS and allocator retention remain
+//! attributable:
+//!
+//! ```text
+//! JAZZ_ROUTE_CURVE_ROUTES=100 cargo bench --profile perf -p jazz \
+//!   --features testing --bench route_subscription_curve --quiet
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::time::{Duration, Instant};
+
+use jazz::db::{
+    Db, DbConfig, DbIdentity, LocalUpdates, Propagation, ReadOpts, SeededRowIdSource,
+    SubscriptionEvent, SubscriptionStream, block_on,
+};
+use jazz::groove::records::Value;
+use jazz::groove::schema::{ColumnSchema, ColumnType};
+use jazz::groove::storage::MemoryStorage;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, col, eq, param};
+use jazz::schema::{JazzSchema, Policy, TableSchema};
+use jazz::tx::DurabilityTier;
+use serde::Serialize;
+
+const DOCUMENTS: &str = "route_curve_documents";
+const TEAMS: usize = 1_001;
+const HOT_TEAM_DOCUMENTS: usize = 1_000;
+const PAGE_SIZE: usize = 100;
+const MAX_ROUTES: usize = 1_000;
+const WRITER: AuthorId = AuthorId::SYSTEM;
+
+type BenchDb = Db<MemoryStorage>;
+
+#[derive(Serialize)]
+struct Receipt {
+    scenario: &'static str,
+    routes: usize,
+    teams: usize,
+    documents: usize,
+    page_size: usize,
+    seed_us: u64,
+    hydration_total_us: u64,
+    prepare: LatencyStats,
+    subscribe: LatencyStats,
+    initial_rows: usize,
+    runtime: RuntimeReceipt,
+    retained: RetainedReceipt,
+    rss_kib_after_seed: Option<u64>,
+    rss_kib_after_hydration: Option<u64>,
+    peak_rss_kib: Option<u64>,
+    matching_write_us: u64,
+    unrelated_write_us: u64,
+    below_boundary_write_us: u64,
+    exact_initial: bool,
+    exact_matching_delta: bool,
+    unrelated_quiet: bool,
+    below_boundary_quiet: bool,
+    ok: bool,
+    tooling_friction: &'static str,
+}
+
+#[derive(Serialize)]
+struct LatencyStats {
+    samples: usize,
+    total_us: u64,
+    min_us: u64,
+    p50_us: u64,
+    p95_us: u64,
+    max_us: u64,
+}
+
+#[derive(Serialize)]
+struct RuntimeReceipt {
+    graph_nodes: usize,
+    active_subscriptions: usize,
+    active_prepared_shapes: usize,
+    active_shape_params: usize,
+    arrangement_count: usize,
+    arrangement_rows: usize,
+    arrangement_encoded_bytes: usize,
+    logical_nodes_requested: u64,
+    deduped_graph_nodes: usize,
+}
+
+#[derive(Serialize)]
+struct RetainedReceipt {
+    subscriptions: usize,
+    root_rows: usize,
+    result_rows: usize,
+    version_identities: usize,
+    replacement_entries: usize,
+    maintained_heap_bytes: usize,
+    result_weights_bytes: usize,
+    result_payloads_bytes: usize,
+    versions_bytes: usize,
+    replacements_bytes: usize,
+    terminal_schemas_bytes: usize,
+    control_state_bytes: usize,
+    maintained_and_control_heap_bytes: usize,
+    snapshot_bytes: usize,
+    reset_frame_bytes: usize,
+}
+
+fn main() {
+    let routes = env_usize("JAZZ_ROUTE_CURVE_ROUTES", 100);
+    assert!(
+        (1..=MAX_ROUTES).contains(&routes),
+        "JAZZ_ROUTE_CURVE_ROUTES must be between 1 and {MAX_ROUTES}"
+    );
+    let receipt = run(routes);
+    println!(
+        "{}",
+        serde_json::to_string(&receipt).expect("serialize route curve receipt")
+    );
+    assert!(receipt.ok, "route curve correctness gate failed");
+}
+
+fn run(routes: usize) -> Receipt {
+    let db = open_db(routes as u64);
+    let seed_started = Instant::now();
+    seed_fixture(&db);
+    let seed_us = micros(seed_started.elapsed());
+    let rss_kib_after_seed = proc_status_kib("VmRSS:");
+
+    let query = Query::from(DOCUMENTS)
+        .filter(eq(col("team"), param("team")))
+        .order_by("updated_at", OrderDirection::Desc)
+        .limit(PAGE_SIZE);
+    let mut streams = Vec::with_capacity(routes);
+    let mut prepare_samples = Vec::with_capacity(routes);
+    let mut subscribe_samples = Vec::with_capacity(routes);
+    let mut initial_rows = 0;
+    let mut exact_initial = true;
+    let mut shape_id = None;
+    let hydration_started = Instant::now();
+
+    for team in 0..routes {
+        let prepare_started = Instant::now();
+        let prepared = db
+            .prepare_query_bound(
+                &query,
+                BTreeMap::from([("team".to_owned(), Value::Uuid(team_row(team).0))]),
+            )
+            .expect("prepare route binding");
+        prepare_samples.push(prepare_started.elapsed());
+        if let Some(expected_shape) = shape_id {
+            assert_eq!(prepared.shape().shape_id(), expected_shape);
+        } else {
+            shape_id = Some(prepared.shape().shape_id());
+        }
+
+        let subscribe_started = Instant::now();
+        let mut stream = block_on(db.subscribe(&prepared, local_opts())).expect("subscribe route");
+        subscribe_samples.push(subscribe_started.elapsed());
+        let actual = take_initial_reset(&mut stream);
+        let expected = expected_initial_rows(team);
+        initial_rows += actual.len();
+        exact_initial &= actual == expected;
+        streams.push(stream);
+    }
+
+    let hydration_total_us = micros(hydration_started.elapsed());
+    let runtime = runtime_receipt(&db);
+    let retained = retained_receipt(&db);
+    let rss_kib_after_hydration = proc_status_kib("VmRSS:");
+
+    let matching_row = document_row(0, HOT_TEAM_DOCUMENTS + 1);
+    let matching_started = Instant::now();
+    insert_document(&db, matching_row, 0, HOT_TEAM_DOCUMENTS as u64 + 1);
+    let matching_write_us = micros(matching_started.elapsed());
+    let matching_events = drain_events(&mut streams);
+    let exact_matching_delta = matching_events.first().is_some_and(|delta| {
+        delta.events == 1
+            && delta.added == BTreeSet::from([matching_row])
+            && delta.removed == BTreeSet::from([document_row(0, HOT_TEAM_DOCUMENTS - PAGE_SIZE)])
+            && delta.updated.is_empty()
+            && !delta.reset
+    }) && matching_events.iter().skip(1).all(Delta::is_quiet);
+
+    let unrelated_started = Instant::now();
+    insert_document(&db, document_row(MAX_ROUTES, 1), MAX_ROUTES, 1);
+    let unrelated_write_us = micros(unrelated_started.elapsed());
+    let unrelated_quiet = drain_events(&mut streams).iter().all(Delta::is_quiet);
+
+    let below_boundary_started = Instant::now();
+    insert_document(&db, document_row(0, HOT_TEAM_DOCUMENTS + 2), 0, 0);
+    let below_boundary_write_us = micros(below_boundary_started.elapsed());
+    let below_boundary_quiet = drain_events(&mut streams).iter().all(Delta::is_quiet);
+
+    let ok = exact_initial
+        && exact_matching_delta
+        && unrelated_quiet
+        && below_boundary_quiet
+        && runtime.active_subscriptions == routes
+        && retained.subscriptions == routes;
+
+    Receipt {
+        scenario: "current_core_route_subscription_curve",
+        routes,
+        teams: TEAMS,
+        documents: HOT_TEAM_DOCUMENTS + TEAMS - 1,
+        page_size: PAGE_SIZE,
+        seed_us,
+        hydration_total_us,
+        prepare: latency_stats(prepare_samples),
+        subscribe: latency_stats(subscribe_samples),
+        initial_rows,
+        runtime,
+        retained,
+        rss_kib_after_seed,
+        rss_kib_after_hydration,
+        peak_rss_kib: proc_status_kib("VmHWM:"),
+        matching_write_us,
+        unrelated_write_us,
+        below_boundary_write_us,
+        exact_initial,
+        exact_matching_delta,
+        unrelated_quiet,
+        below_boundary_quiet,
+        ok,
+        tooling_friction: "run each route count in a fresh process on a quiet host",
+    }
+}
+
+#[derive(Default)]
+struct Delta {
+    events: usize,
+    reset: bool,
+    added: BTreeSet<RowUuid>,
+    updated: BTreeSet<RowUuid>,
+    removed: BTreeSet<RowUuid>,
+}
+
+impl Delta {
+    fn is_quiet(&self) -> bool {
+        self.events == 0
+    }
+}
+
+fn drain_events(streams: &mut [SubscriptionStream]) -> Vec<Delta> {
+    streams
+        .iter_mut()
+        .map(|stream| {
+            let mut delta = Delta::default();
+            while let Some(event) = stream.try_next_event() {
+                delta.events += 1;
+                match event {
+                    SubscriptionEvent::Delta {
+                        reset,
+                        added,
+                        updated,
+                        removed,
+                        ..
+                    } => {
+                        delta.reset |= reset;
+                        delta
+                            .added
+                            .extend(added.into_iter().map(|row| row.row_uuid()));
+                        delta
+                            .updated
+                            .extend(updated.into_iter().map(|row| row.row_uuid()));
+                        delta
+                            .removed
+                            .extend(removed.into_iter().map(|row| row.row_uuid));
+                    }
+                    SubscriptionEvent::Rejected { reason } => {
+                        panic!("route subscription rejected: {reason:?}")
+                    }
+                    SubscriptionEvent::Closed => panic!("route subscription closed"),
+                }
+            }
+            delta
+        })
+        .collect()
+}
+
+fn take_initial_reset(stream: &mut SubscriptionStream) -> BTreeSet<RowUuid> {
+    match stream
+        .try_next_event()
+        .expect("route subscription did not emit an initial reset")
+    {
+        SubscriptionEvent::Delta {
+            reset: true,
+            added,
+            updated,
+            removed,
+            ..
+        } => {
+            assert!(updated.is_empty());
+            assert!(removed.is_empty());
+            added.into_iter().map(|row| row.row_uuid()).collect()
+        }
+        other => panic!("expected initial reset, got {other:?}"),
+    }
+}
+
+fn expected_initial_rows(team: usize) -> BTreeSet<RowUuid> {
+    if team == 0 {
+        (HOT_TEAM_DOCUMENTS - PAGE_SIZE..HOT_TEAM_DOCUMENTS)
+            .map(|ordinal| document_row(team, ordinal))
+            .collect()
+    } else {
+        BTreeSet::from([document_row(team, 0)])
+    }
+}
+
+fn open_db(seed: u64) -> BenchDb {
+    let schema = JazzSchema::new([TableSchema::new(
+        DOCUMENTS,
+        [
+            ColumnSchema::new("team", ColumnType::Uuid),
+            ColumnSchema::new("updated_at", ColumnType::U64),
+            ColumnSchema::new("title", ColumnType::String),
+        ],
+    )
+    .with_read_policy(Policy::public())
+    .with_write_policy(Policy::public())]);
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    block_on(Db::open(
+        DbConfig::new(
+            schema,
+            MemoryStorage::new(&family_refs),
+            DbIdentity {
+                node: NodeUuid::from_bytes((0x7600_u128 + seed as u128).to_be_bytes()),
+                author: WRITER,
+            },
+        )
+        .with_id_source(SeededRowIdSource::new(0x7600 + seed)),
+    ))
+    .expect("open route curve db")
+}
+
+fn seed_fixture(db: &BenchDb) {
+    for ordinal in 0..HOT_TEAM_DOCUMENTS {
+        insert_document(db, document_row(0, ordinal), 0, ordinal as u64);
+    }
+    for team in 1..TEAMS {
+        insert_document(db, document_row(team, 0), team, team as u64);
+    }
+}
+
+fn insert_document(db: &BenchDb, row: RowUuid, team: usize, updated_at: u64) {
+    db.insert_with_id(
+        DOCUMENTS,
+        row,
+        BTreeMap::from([
+            ("team".to_owned(), Value::Uuid(team_row(team).0)),
+            ("updated_at".to_owned(), Value::U64(updated_at)),
+            (
+                "title".to_owned(),
+                Value::String(format!("route {team} document {updated_at}")),
+            ),
+        ]),
+    )
+    .expect("insert route curve document");
+}
+
+fn team_row(team: usize) -> RowUuid {
+    tagged_row(0x7601, team as u64)
+}
+
+fn document_row(team: usize, ordinal: usize) -> RowUuid {
+    tagged_row(0x7602 + team as u64, ordinal as u64)
+}
+
+fn tagged_row(namespace: u64, value: u64) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[..8].copy_from_slice(&namespace.to_be_bytes());
+    bytes[8..].copy_from_slice(&value.to_be_bytes());
+    RowUuid::from_bytes(bytes)
+}
+
+fn local_opts() -> ReadOpts {
+    ReadOpts {
+        tier: DurabilityTier::Local,
+        local_updates: LocalUpdates::Immediate,
+        propagation: Propagation::LocalOnly,
+        include_deleted: false,
+        ..ReadOpts::default()
+    }
+}
+
+fn runtime_receipt(db: &BenchDb) -> RuntimeReceipt {
+    let stats = db.runtime_stats_for_test();
+    RuntimeReceipt {
+        graph_nodes: stats.graph_nodes,
+        active_subscriptions: stats.active_subscriptions,
+        active_prepared_shapes: stats.active_prepared_shapes,
+        active_shape_params: stats.active_shape_params,
+        arrangement_count: stats.arrangement_count,
+        arrangement_rows: stats.arrangement_rows,
+        arrangement_encoded_bytes: stats.arrangement_encoded_bytes,
+        logical_nodes_requested: stats.logical_nodes_requested,
+        deduped_graph_nodes: stats.deduped_graph_nodes,
+    }
+}
+
+fn retained_receipt(db: &BenchDb) -> RetainedReceipt {
+    let receipts = db.maintained_subscription_size_receipts_for_test();
+    RetainedReceipt {
+        subscriptions: receipts.len(),
+        root_rows: receipts.iter().map(|receipt| receipt.root_rows).sum(),
+        result_rows: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.result_rows)
+            .sum(),
+        version_identities: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.version_identities)
+            .sum(),
+        replacement_entries: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.replacement_entries)
+            .sum(),
+        maintained_heap_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.maintained_heap_bytes)
+            .sum(),
+        result_weights_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.result_weights_bytes)
+            .sum(),
+        result_payloads_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.result_payloads_bytes)
+            .sum(),
+        versions_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.versions_bytes)
+            .sum(),
+        replacements_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.replacements_bytes)
+            .sum(),
+        terminal_schemas_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.terminal_schemas_bytes)
+            .sum(),
+        control_state_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.control_state_bytes)
+            .sum(),
+        maintained_and_control_heap_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.footprint.total_heap_bytes)
+            .sum(),
+        snapshot_bytes: receipts.iter().map(|receipt| receipt.snapshot_bytes).sum(),
+        reset_frame_bytes: receipts
+            .iter()
+            .map(|receipt| receipt.reset_frame_bytes)
+            .sum(),
+    }
+}
+
+fn latency_stats(samples: Vec<Duration>) -> LatencyStats {
+    let mut samples = samples.into_iter().map(micros).collect::<Vec<_>>();
+    samples.sort_unstable();
+    let percentile = |numerator: usize, denominator: usize| {
+        let index = ((samples.len() - 1) * numerator).div_ceil(denominator);
+        samples[index]
+    };
+    LatencyStats {
+        samples: samples.len(),
+        total_us: samples.iter().sum(),
+        min_us: samples[0],
+        p50_us: percentile(50, 100),
+        p95_us: percentile(95, 100),
+        max_us: *samples.last().expect("non-empty latency samples"),
+    }
+}
+
+fn micros(duration: Duration) -> u64 {
+    duration.as_micros().try_into().unwrap_or(u64::MAX)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{name} must be an unsigned integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn proc_status_kib(label: &str) -> Option<u64> {
+    fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find(|line| line.starts_with(label))?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()
+}

--- a/dev/benchmarks/OVERVIEW.md
+++ b/dev/benchmarks/OVERVIEW.md
@@ -137,6 +137,9 @@ Ranked by their ability to change an engineering decision:
 1. **Policy and selective-hydration cost receipts.** Extract the stable lanes
    from #1170: authorized write-to-reader visibility, route/subscription scale,
    policy churn/reconnect, and selective Global hydration.
+   `ROUTE_SUBSCRIPTION_CURVE.md` now extracts the current-core
+   route/subscription lane and attributes its remaining slope to binding-private
+   full-source version/replacement witness state.
 2. **PERF-5 maintained versus rehydrate.** Compare work, bytes, and retained
    state over increasing view sizes while asserting identical results.
 3. **S4 fixed-delta/varying-view gate.** S4 already separates settlement and

--- a/dev/benchmarks/ROUTE_SUBSCRIPTION_CURVE.md
+++ b/dev/benchmarks/ROUTE_SUBSCRIPTION_CURVE.md
@@ -1,0 +1,105 @@
+# Current-core route/subscription scaling receipt
+
+Date: 2026-08-05
+
+Status: quiet developer-machine result, not a performance promise.
+
+## Question
+
+After the refresh batching and selective-hydration work, what still grows when
+one current-core query shape is retained across many distinct application
+bindings: shared graph state, write refresh, or binding-private maintained
+state?
+
+The retained harness is
+`crates/jazz/benches/route_subscription_curve.rs`. It uses public Jazz schema,
+query, subscription, and write APIs plus existing test-only sizing diagnostics.
+Every initial result and later mutation is checked exactly.
+
+## Workload
+
+- `MemoryStorage`, local reads, immediate local updates;
+- one public `documents` table with `team`, `updated_at`, and `title`;
+- 2,000 documents across 1,001 teams;
+- team 0 has 1,000 documents and every other team has one;
+- one parameterized `team = $team` query, ordered by `updated_at DESC`, limited
+  to 100 rows;
+- 1 / 10 / 100 / 1,000 retained bindings of the same validated shape;
+- one matching above-boundary insert, one unrelated-team insert, and one
+  matching below-boundary insert;
+- a fresh process per route count so RSS and allocator retention remain
+  attributable.
+
+The measurements ran from `d4ebc2a74` with only the benchmark and receipt
+changes present. The one-minute host load was 0.82 before the release matrix.
+
+Example command:
+
+```sh
+JAZZ_ROUTE_CURVE_ROUTES=100 \
+  cargo bench --profile perf -p jazz --features testing \
+  --bench route_subscription_curve --quiet
+```
+
+The smoke ledger retains the 10-route correctness lane.
+
+## Results
+
+| Routes | Total attach | Median subscribe | Matching write | Unrelated write | Below-boundary write | Private maintained/control estimate | Process RSS after attach |
+| -----: | -----------: | ---------------: | -------------: | --------------: | -------------------: | ----------------------------------: | -----------------------: |
+|      1 |     38.28 ms |         38.24 ms |        0.93 ms |         0.13 ms |              0.71 ms |                            5.30 MiB |                49.46 MiB |
+|     10 |    151.16 ms |         12.58 ms |        1.22 ms |         0.23 ms |              0.80 ms |                           52.12 MiB |               141.98 MiB |
+|    100 |      1.292 s |         12.54 ms |        3.41 ms |         1.37 ms |              1.78 ms |                          520.36 MiB |                 1.04 GiB |
+|  1,000 |     14.285 s |         14.23 ms |       25.17 ms |        20.45 ms |             19.94 ms |                            5.08 GiB |                10.16 GiB |
+
+All initial resets, the matching add/evict delta, and both quiet-write oracles
+were exact at every scale.
+
+## Attribution
+
+The shared Groove structures are not the dominant slope:
+
+| Routes | Graph nodes | Arrangements | Arrangement rows | Arrangement encoded bytes |
+| -----: | ----------: | -----------: | ---------------: | ------------------------: |
+|      1 |          81 |           15 |           19,001 |               3,331,365 B |
+|     10 |          99 |           15 |           19,019 |               3,334,020 B |
+|    100 |         279 |           15 |           19,199 |               3,360,750 B |
+|  1,000 |       2,079 |           15 |           20,999 |               3,629,850 B |
+
+The private maintained view is the slope. Every binding retains witnesses for
+the complete 2,000-row source even when its result contains one row:
+
+| Routes | Result rows | Version identities | Replacement entries | Version-index bytes | Replacement-index bytes |
+| -----: | ----------: | -----------------: | ------------------: | ------------------: | ----------------------: |
+|      1 |         100 |              2,000 |               2,000 |         3,304,380 B |             2,143,028 B |
+|     10 |         109 |             20,000 |              20,000 |        33,043,800 B |            21,430,280 B |
+|    100 |         199 |            200,000 |             200,000 |       330,438,000 B |           214,302,800 B |
+|  1,000 |       1,099 |          2,000,000 |           2,000,000 |     3,304,380,000 B |         2,143,028,000 B |
+
+Source inspection agrees with the receipt. Maintained version and replacement
+witness terminals are built from each complete resolved source without routing
+fields. Each bound `LocalMaintainedViewSubscription` then owns independent
+`WeightedVersionIndex` and `ReplacementIndex` instances so it can materialize
+row versions and replacement winners when result membership changes.
+
+## Conclusion
+
+The old repeated-flush write pathology is no longer the dominant route-scale
+cost. Current writes remain tens of milliseconds at 1,000 routes, including
+quiet writes. The remaining clear problem is full-source witness retention and
+attach work repeated once per binding.
+
+This receipt does **not** propose routing or sharing witness state. Witnesses
+support version materialization, transaction lookup, replacement-winner
+selection, deletions, and rows entering a finite window later. Narrowing them
+requires an explicit correctness design and adversarial transition coverage.
+The next investigation should compare two designs:
+
+1. share route-independent version/replacement witness indexes across bindings
+   while retaining binding-private result membership; or
+2. route witness facts to bindings and prove that every row entering a result
+   has the required content, deletion, and replacement witnesses in the same
+   transition cycle.
+
+Tooling friction: fresh worktrees need enough disk for a Rust target; old
+recoverable build outputs had filled the filesystem before this run.

--- a/dev/benchmarks/smoke.sh
+++ b/dev/benchmarks/smoke.sh
@@ -428,6 +428,11 @@ run_scenario \
   env JAZZ_INC_DELIVERY_SCALES=1000,2500,5000,10000,20000 JAZZ_INC_DELIVERY_SAMPLES=1 cargo bench -p jazz --no-default-features --bench relation_include_delivery
 
 run_scenario \
+  "jazz/route_subscription_curve" \
+  "JAZZ_ROUTE_CURVE_ROUTES=10 cargo bench -p jazz --features testing --bench route_subscription_curve" \
+  env JAZZ_ROUTE_CURVE_ROUTES=10 cargo bench -p jazz --features testing --bench route_subscription_curve
+
+run_scenario \
   "jazz-sim/micro" \
   "JAZZ_MICRO_ITERS=1 cargo bench -p jazz-sim --bench micro # no JAZZ_SMOKE; fixed size ladders remain" \
   env JAZZ_MICRO_ITERS=1 cargo bench -p jazz-sim --bench micro


### PR DESCRIPTION
## What

- add a deterministic public-API benchmark for current-core route/subscription scaling
- measure attach, matching and non-matching writes, retained state, and resident memory
- retain release-profile results for 1, 10, 100, and 1,000 routes
- add the benchmark to the local smoke suite and benchmark overview

## Why

The receipt isolates the cost of maintaining many routed subscriptions over the same source data. It shows that shared arrangements remain flat, while each route currently retains its own complete version and replacement indexes. At 1,000 routes this produces roughly 5.08 GiB of retained state and 10.16 GiB RSS, alongside a 14.3 second total attach phase.

This is a measurement and attribution PR, not a behavior change. It gives the next design investigation a reproducible baseline for comparing shared route-independent witness state with routed witness facts.

## Validation

- release-profile runs at 1, 10, 100, and 1,000 routes, with exact result oracles
- `cargo fmt --all -- --check`
- `cargo check -p jazz --features testing --bench route_subscription_curve`
- `cargo clippy -p jazz --features testing --bench route_subscription_curve -- -D warnings`
- `bash -n dev/benchmarks/smoke.sh`
- pre-commit Jazz clippy, sensitive-data, oxfmt, and rustfmt checks

