### PR TITLE
(new core) Fix permission-filtered resume after authorization churn

### DIFF
--- a/crates/jazz/benches/README.md
+++ b/crates/jazz/benches/README.md
@@ -53,10 +53,10 @@ than old helper behavior:
   byte-wire session/resume path with that recursive read policy: a reader first
   sees direct and inherited docs, disconnects, then resumes after one inherited
   grant is revoked and another is added. It is registered in the Criterion
-  group as a visible failing reproducer: the resumed client still keeps the
-  revoked doc visible. Recursive write-policy settlement is covered in the
-  `jazz` policy tests with global/settled support rows; local-only support rows
-  correctly do not authorize writes.
+  group as a reconnect correctness canary: the resumed subscription must emit
+  exactly the newly granted doc and remove exactly the revoked doc. The `jazz`
+  policy tests cover recursive write-policy settlement with global/settled
+  support rows; local-only support rows correctly do not authorize writes.
 
 `selective_global_hydration` is a custom JSONL receipt over the persisted
 Global query path. It holds one selected team and its result page fixed while

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -960,7 +960,7 @@ fn drain_permission_resume_delta(event: Option<SubscriptionEvent>) -> (usize, us
             assert!(!removed.iter().any(|row| row.row_uuid == RESUME_DOC_NEVER));
             (added.len(), updated.len(), removed.len())
         }
-        None => (0, 0, 0),
+        None => panic!("permission-filtered resume emitted no delta event"),
         other => panic!("expected permission-filtered resume delta event, got {other:?}"),
     }
 }
@@ -1939,14 +1939,12 @@ fn r13_permission_filtered_resume(c: &mut Criterion) {
 
             let (added, updated, removed) =
                 drain_permission_resume_delta(subscription.try_next_event());
-            if added + updated + removed > 0 {
-                assert_eq!(added + updated, 1);
-                assert_eq!(removed, 1);
-            }
-            let rows = client
-                .read(&prepared)
-                .expect("read final permission-filtered docs");
-            assert_permission_resume_docs(&rows, &[RESUME_DOC_DIRECT, RESUME_DOC_GRANTED]);
+            assert_eq!(added + updated, 1);
+            assert_eq!(removed, 1);
+            // `Db::read` is intentionally a local-preview read; it may still
+            // see retained row bodies after upstream membership is revoked.
+            // The authoritative reconnect contract is the subscription delta
+            // asserted above.
 
             black_box((resume_bytes, full_bytes, added, updated, removed))
         });

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -55,6 +55,17 @@ fn member_settle_position(member: &ResultMemberEntry) -> Option<crate::time::Glo
     }
 }
 
+fn fast_cursor_membership_mismatch(
+    position: crate::time::GlobalSeq,
+    previous: &BTreeSet<ResultMemberEntry>,
+    current: &BTreeSet<ResultMemberEntry>,
+) -> bool {
+    previous.difference(current).next().is_some()
+        || current
+            .difference(previous)
+            .any(|member| member_settle_position(member).is_none_or(|settled| settled <= position))
+}
+
 /// Tracks what one downstream peer has already received.
 #[derive(Debug)]
 pub struct PeerState {
@@ -999,7 +1010,19 @@ impl PeerState {
             .difference(&current_member_result_set)
             .cloned()
             .collect::<Vec<_>>();
+        // The downstream cursor tracks data progress, not authorization. A
+        // removed prior member or newly visible pre-cursor member cannot be
+        // reconstructed from that cursor, so it cannot safely suppress the
+        // authoritative membership diff or the payload needed to apply it.
+        let cursor_membership_mismatch = known_membership_position.is_some_and(|position| {
+            fast_cursor_membership_mismatch(
+                position,
+                previous_member_result_set,
+                &current_member_result_set,
+            )
+        });
         let (program_fact_adds, program_fact_removes, reset_result_set) = if reset_result_set
+            && !cursor_membership_mismatch
             && let Some(position) = known_membership_position
             && watermark.0 > 0
             && position >= watermark
@@ -1008,6 +1031,7 @@ impl PeerState {
             result_member_removes.clear();
             (Vec::new(), Vec::new(), false)
         } else if reset_result_set
+            && !cursor_membership_mismatch
             && simple_membership_delta
             && let Some(position) = known_membership_position
             && result_member_adds
@@ -1025,6 +1049,11 @@ impl PeerState {
                 transitions.program_fact_removes,
                 reset_result_set,
             )
+        };
+        let bundle_known_state = if cursor_membership_mismatch {
+            None
+        } else {
+            known_state.clone()
         };
         let filter_elapsed = filter_start.elapsed();
         let peer_complete_tx_payloads = self.acknowledged_complete_tx_payloads();
@@ -1045,7 +1074,7 @@ impl PeerState {
             crate::node::MaintainedViewBundleInputs {
                 subscription,
                 peer_complete_tx_payloads,
-                known_state,
+                known_state: bundle_known_state,
                 complete_exclusive_payloads: self.ship_complete_exclusive_payloads,
                 previous_result_set: BTreeSet::new(),
                 result_member_adds,
@@ -2269,7 +2298,7 @@ mod tests {
         Aggregate, OrderDirection, Query, claim, col, eq, gt, is_null, lit, ne, not, param,
     };
     use crate::schema::{JazzSchema, Policy, TableSchema};
-    use crate::time::GlobalSeq;
+    use crate::time::{GlobalSeq, TxTime};
     use crate::tx::DeletionEvent;
     use crate::tx::{DurabilityTier, Fate, TxKind};
     use groove::records::{BorrowedRecord, RecordDescriptor, Value, ValueType};
@@ -2288,6 +2317,43 @@ mod tests {
         let mut bytes = [0; 16];
         bytes[..8].copy_from_slice(&value.to_be_bytes());
         RowUuid::from_bytes(bytes)
+    }
+
+    fn settled_member(row_uuid: RowUuid, position: u64) -> ResultMemberEntry {
+        ResultMemberEntry::Row(
+            crate::protocol::RealRowMemberEntry::current_content((
+                String::from("docs").into(),
+                row_uuid,
+                TxId::new(TxTime(position), node(0x44)),
+            ))
+            .with_settle_position(Some(GlobalSeq(position))),
+        )
+    }
+
+    #[test]
+    fn fast_cursor_membership_mismatch_detects_pre_cursor_changes() {
+        let direct = settled_member(row(1), 5);
+        let revoked = settled_member(row(2), 6);
+        let newly_granted_old_row = settled_member(row(3), 7);
+        let new_post_cursor_row = settled_member(row(4), 12);
+        let cursor = GlobalSeq(10);
+
+        let previous = BTreeSet::from([direct.clone(), revoked.clone()]);
+        assert!(fast_cursor_membership_mismatch(
+            cursor,
+            &previous,
+            &BTreeSet::from([direct.clone()]),
+        ));
+        assert!(fast_cursor_membership_mismatch(
+            cursor,
+            &previous,
+            &BTreeSet::from([direct.clone(), revoked.clone(), newly_granted_old_row]),
+        ));
+        assert!(!fast_cursor_membership_mismatch(
+            cursor,
+            &previous,
+            &BTreeSet::from([direct, revoked, new_post_cursor_row]),
+        ));
     }
 
     fn current_row_pair(row: crate::node::CurrentRow) -> (RowUuid, BTreeMap<String, Value>) {


### PR DESCRIPTION
## What changed

- detect when freshly evaluated subscription membership cannot be reconstructed from a fast downstream data cursor
- retain the compact cursor path for ordinary rows settled after the cursor
- fall back to an authoritative membership response, including required payloads, for removals and newly visible pre-cursor rows
- turn the existing permission-filtered reconnect reproducer into a strict correctness canary

## Root cause

Fast known-state declarations track data progress, not authorization progress. After authorization changed while a reader was disconnected, reconnect re-evaluated the correct membership but still used the old data cursor to suppress the membership delta and the payload of a newly authorized row whose sequence predated that cursor.

The resumed subscriber could therefore retain a revoked row and fail to receive a newly granted row.

## Behavior and tradeoff

The fallback is conservative. A removed prior member or a newly visible member settled at or before the cursor invalidates the fast membership assumption and sends the authoritative response. Pure post-cursor additions keep the bounded fast path.

`Db::read` is intentionally a local-preview API and may retain row bodies after upstream membership changes, so the benchmark now validates the authoritative subscription delta directly: exactly one newly granted row and exactly one revoked row.

## Validation

- adversarial review, including a missing-event false-positive found and fixed
- focused grant/revoke/post-cursor classification regression
- strict byte-wire `r13_permission_filtered_resume` Criterion run: approximately 12.24 ms on the local development box
- existing in-process and byte-wire ordinary resume regressions
- focused Clippy with warnings denied
- rustfmt, oxfmt, sensitive-data, and pre-commit checks
- cherry-pick and focused validation directly on `codex/jazz-core-engine-swap`, independent of #1261

Tracks the policy-churn/reconnect item in #1170.
