### PR TITLE
(new core) Retain policy-churn reconnect matrix

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -121,10 +121,10 @@ jobs:
       - name: Build native benchmark binaries
         run: |
           set -euo pipefail
-          cargo build --release -p jazz-tools --features client,rocksdb --example realistic_bench
-          cargo build --release -p jazz-tools --features client,sqlite --example realistic_bench
-          cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run
-          cargo bench -p jazz-tools --features sqlite --bench realistic_phase1 --no-run
+          cargo build --release -p jazz --features client,rocksdb --example realistic_bench
+          cargo build --release -p jazz --features client,sqlite --example realistic_bench
+          cargo bench -p jazz --features rocksdb --bench realistic_phase1 --no-run
+          cargo bench -p jazz --features sqlite --bench realistic_phase1 --no-run
           cargo bench -p jazz-sim --bench s2_canvas --no-run
 
       - name: Run native benchmark suite
@@ -349,7 +349,7 @@ jobs:
           uname -a > bench-out/browser/uname.txt
 
       - name: Build jazz-tools server binary
-        run: cargo build -p jazz-tools --features cli
+        run: cargo build -p jazz --features cli
 
       - name: Build jazz-napi package
         run: pnpm --dir crates/jazz-napi run build

--- a/crates/jazz/benches/README.md
+++ b/crates/jazz/benches/README.md
@@ -49,14 +49,15 @@ than old helper behavior:
   the spirit of the old R5 recursive permission benchmark to the public
   `Db` APIs with a `docs`/`teams`/`doc_access`/`team_edges` schema, prepared
   recursive read-policy query/subscription visibility. A scoped
-  `r13_permission_filtered_resume` reproducer in the same file combines the
-  byte-wire session/resume path with that recursive read policy: a reader first
-  sees direct and inherited docs, disconnects, then resumes after one inherited
-  grant is revoked and another is added. It is registered in the Criterion
-  group as a reconnect correctness canary: the resumed subscription must emit
-  exactly the newly granted doc and remove exactly the revoked doc. The `jazz`
-  policy tests cover recursive write-policy settlement with global/settled
-  support rows; local-only support rows correctly do not authorize writes.
+  `r13_permission_filtered_resume` matrix in the same file combines the
+  byte-wire session/resume path with recursive membership and claim policies. It
+  covers unchanged authorization, grant-only, revoke-only, simultaneous
+  grant/revoke, claim revoke, and claim restore while disconnected. Every lane
+  gates the exact resumed subscription transition and records reconnect-only
+  time plus full/resume response bytes. The retained receipt is in
+  `dev/benchmarks/POLICY_CHURN_RECONNECT_RECEIPT_20260805.md`. The `jazz` policy
+  tests cover recursive write-policy settlement with global/settled support
+  rows; local-only support rows correctly do not authorize writes.
 
 `selective_global_hydration` is a custom JSONL receipt over the persisted
 Global query path. It holds one selected team and its result page fixed while

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::single_element_loop, dead_code)]
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 #[cfg(feature = "rocksdb")]
 use std::env;
 #[cfg(all(feature = "rocksdb", target_os = "linux"))]
@@ -16,7 +16,6 @@ use std::os::fd::AsRawFd;
 #[cfg(feature = "rocksdb")]
 use std::path::Path;
 use std::rc::Rc;
-#[cfg(feature = "rocksdb")]
 use std::time::{Duration, Instant};
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
@@ -237,6 +236,17 @@ fn recursive_permissions_schema() -> JazzSchema {
         .with_read_policy(Policy::public())
         .with_write_policy(Policy::public()),
     ])
+}
+
+fn claim_resume_schema() -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "claim_docs",
+        [ColumnSchema::new("title", ColumnType::String)],
+    )
+    .with_read_policy(Policy::shape(
+        Query::from("claim_docs").filter(eq(claim("access"), lit("allowed"))),
+    ))
+    .with_write_policy(Policy::public())])
 }
 
 fn open_db(seed: u64) -> BenchDb {
@@ -758,6 +768,8 @@ const RESUME_ACCESS_GRANTED: RowUuid = RowUuid(uuid::uuid!("13000000-0000-0000-0
 const RESUME_ACCESS_NEVER: RowUuid = RowUuid(uuid::uuid!("13000000-0000-0000-0000-000000000104"));
 const RESUME_EDGE_READER_PARENT: RowUuid =
     RowUuid(uuid::uuid!("13000000-0000-0000-0000-000000000201"));
+const CLAIM_RESUME_DOC_A: RowUuid = RowUuid(uuid::uuid!("13000000-0000-0000-0000-000000000301"));
+const CLAIM_RESUME_DOC_B: RowUuid = RowUuid(uuid::uuid!("13000000-0000-0000-0000-000000000302"));
 
 fn recursive_doc_cells(title: &str, kind: &str) -> BTreeMap<String, Value> {
     BTreeMap::from([
@@ -804,6 +816,10 @@ fn open_recursive_permissions_db_with_author(
         history_complete,
         recursive_permissions_schema(),
     )
+}
+
+fn open_claim_resume_db(seed: u64, author: AuthorId, history_complete: bool) -> BenchDb {
+    open_db_with_schema(seed, author, history_complete, claim_resume_schema())
 }
 
 fn seed_recursive_permissions_fixture(db: &BenchDb) {
@@ -944,25 +960,94 @@ fn assert_permission_resume_docs(rows: &[jazz::node::CurrentRow], visible: &[Row
     assert_eq!(rows.len(), visible.len());
 }
 
-fn drain_permission_resume_delta(event: Option<SubscriptionEvent>) -> (usize, usize, usize) {
-    match event {
+#[derive(Clone, Copy, Debug)]
+enum PermissionResumeChurn {
+    Unchanged,
+    Grant,
+    Revoke,
+    GrantAndRevoke,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ClaimResumeChurn {
+    Revoke,
+    Restore,
+}
+
+impl ClaimResumeChurn {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Revoke => "claim_revoke",
+            Self::Restore => "claim_restore",
+        }
+    }
+
+    fn initial_access(self) -> &'static str {
+        match self {
+            Self::Revoke => "allowed",
+            Self::Restore => "denied",
+        }
+    }
+
+    fn resumed_access(self) -> &'static str {
+        match self {
+            Self::Revoke => "denied",
+            Self::Restore => "allowed",
+        }
+    }
+}
+
+impl PermissionResumeChurn {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Unchanged => "unchanged",
+            Self::Grant => "grant_only",
+            Self::Revoke => "revoke_only",
+            Self::GrantAndRevoke => "grant_and_revoke",
+        }
+    }
+
+    fn grants(self) -> bool {
+        matches!(self, Self::Grant | Self::GrantAndRevoke)
+    }
+
+    fn revokes(self) -> bool {
+        matches!(self, Self::Revoke | Self::GrantAndRevoke)
+    }
+}
+
+fn assert_resume_delta(
+    event: Option<SubscriptionEvent>,
+    expected_added: &[RowUuid],
+    expected_removed: &[RowUuid],
+) -> (usize, usize, usize) {
+    let (added, updated, removed) = match event {
         Some(SubscriptionEvent::Delta {
             added,
             updated,
             removed,
             ..
-        }) => {
-            for row in added.iter().chain(updated.iter()) {
-                assert_ne!(row.row_uuid(), RESUME_DOC_REVOKED);
-                assert_ne!(row.row_uuid(), RESUME_DOC_NEVER);
-            }
-            assert!(removed.iter().any(|row| row.row_uuid == RESUME_DOC_REVOKED));
-            assert!(!removed.iter().any(|row| row.row_uuid == RESUME_DOC_NEVER));
-            (added.len(), updated.len(), removed.len())
+        }) => (added, updated, removed),
+        None if expected_added.is_empty() && expected_removed.is_empty() => {
+            return (0, 0, 0);
         }
         None => panic!("permission-filtered resume emitted no delta event"),
         other => panic!("expected permission-filtered resume delta event, got {other:?}"),
-    }
+    };
+    let actual_added = added
+        .iter()
+        .chain(updated.iter())
+        .map(|row| row.row_uuid())
+        .collect::<BTreeSet<_>>();
+    let actual_removed = removed
+        .iter()
+        .map(|row| row.row_uuid)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual_added, expected_added.iter().copied().collect());
+    assert_eq!(actual_removed, expected_removed.iter().copied().collect());
+    assert_eq!(added.len() + updated.len(), expected_added.len());
+    assert_eq!(removed.len(), expected_removed.len());
+    (added.len(), updated.len(), removed.len())
 }
 
 fn drain_optional_permission_rows(event: Option<SubscriptionEvent>) -> usize {
@@ -1804,154 +1889,355 @@ fn r12_recursive_permissions(c: &mut Criterion) {
     group.finish();
 }
 
+fn run_permission_filtered_resume(
+    churn: PermissionResumeChurn,
+) -> (Duration, usize, usize, usize, usize, usize) {
+    let writer = open_recursive_permissions_db_with_author(130, AuthorId::SYSTEM, false);
+    let server = open_recursive_permissions_db_with_author(131, AuthorId::SYSTEM, true);
+    let client = open_recursive_permissions_db_with_author(132, READER_AUTHOR, false);
+    seed_permission_resume_fixture(&writer);
+    let prepared = client
+        .prepare_query(&Query::from("docs"))
+        .expect("prepare permission-filtered docs query");
+
+    let (writer_transport, server_writer_transport) =
+        byte_duplex_with_session(AuthorId::SYSTEM, 13_001);
+    let writer_upstream = writer.connect_upstream(writer_transport);
+    let writer_subscriber = server.accept_subscriber(server_writer_transport, AuthorId::SYSTEM);
+    writer.tick().expect("ship permission seed rows");
+    server.tick().expect("ingest permission seed rows");
+    assert!(writer.detach_connection(&writer_upstream));
+    assert!(server.detach_connection(&writer_subscriber));
+
+    let (client_transport, server_transport) = byte_duplex_with_session(READER_AUTHOR, 13_002);
+    let upstream = client.connect_upstream(client_transport);
+    let subscriber = server.accept_subscriber(server_transport, READER_AUTHOR);
+    let mut subscription = block_on(client.subscribe(&prepared, global_subscribe_opts()))
+        .expect("subscribe permission-filtered docs");
+    assert_eq!(
+        drain_opened(block_on(subscription.next_event()), "permission docs"),
+        0
+    );
+
+    client
+        .tick()
+        .expect("announce permission docs subscription");
+    server.tick().expect("serve full permission docs snapshot");
+    let full_bytes = subscriber
+        .borrow()
+        .last_resume_bytes()
+        .expect("full permission current-row bytes");
+    client.tick().expect("apply full permission docs snapshot");
+    client
+        .tick()
+        .expect("materialize full permission docs snapshot event");
+    let seeded = drain_optional_permission_rows(subscription.try_next_event());
+    assert!(full_bytes > 0);
+    let rows = client
+        .read(&prepared)
+        .expect("read initial permission-filtered docs");
+    assert_permission_resume_docs(&rows, &[RESUME_DOC_DIRECT, RESUME_DOC_REVOKED]);
+    if seeded > 0 {
+        assert_eq!(seeded, rows.len());
+    }
+
+    server.tick().expect("refresh permission docs cursor");
+    client.tick().expect("apply permission docs cursor state");
+    let cursor = subscriber
+        .borrow_mut()
+        .take_resume_cursor()
+        .expect("take permission subscriber resume cursor");
+    assert!(client.detach_connection(&upstream));
+    assert!(server.detach_connection(&subscriber));
+
+    if churn.revokes() {
+        wait_local(
+            writer
+                .update(
+                    "doc_access",
+                    RESUME_ACCESS_REVOKED,
+                    recursive_doc_access_cells(RESUME_DOC_REVOKED, RECURSIVE_HIDDEN_TEAM),
+                )
+                .expect("hide disconnected doc access before revoke"),
+        );
+        wait_local(
+            writer
+                .delete("doc_access", RESUME_ACCESS_REVOKED)
+                .expect("revoke disconnected doc access"),
+        );
+    }
+    if churn.grants() {
+        wait_local(
+            writer
+                .insert_with_id(
+                    "doc_access",
+                    RESUME_ACCESS_GRANTED,
+                    recursive_doc_access_cells(RESUME_DOC_GRANTED, RECURSIVE_PARENT_TEAM),
+                )
+                .expect("grant disconnected doc access"),
+        );
+    }
+
+    if churn.grants() || churn.revokes() {
+        let (writer_transport, server_writer_transport) =
+            byte_duplex_with_session(AuthorId::SYSTEM, 13_003);
+        let writer_upstream = writer.connect_upstream(writer_transport);
+        let writer_subscriber = server.accept_subscriber(server_writer_transport, AuthorId::SYSTEM);
+        writer.tick().expect("ship disconnected permission changes");
+        server
+            .tick()
+            .expect("ingest disconnected permission changes");
+        writer
+            .tick()
+            .expect("ship settled disconnected permission changes");
+        server
+            .tick()
+            .expect("ingest settled disconnected permission changes");
+        assert!(writer.detach_connection(&writer_upstream));
+        assert!(server.detach_connection(&writer_subscriber));
+    }
+
+    let (client_transport, server_transport) = byte_duplex_with_session(READER_AUTHOR, 13_004);
+    let _resumed_upstream = client.connect_upstream(client_transport);
+    let resumed = server.accept_subscriber_with_resume(server_transport, READER_AUTHOR, cursor);
+
+    let resume_started = Instant::now();
+    client
+        .tick()
+        .expect("announce resumed permission docs subscription");
+    server.tick().expect("serve permission resume catch-up");
+    client.tick().expect("apply permission resume catch-up");
+    client.tick().expect("materialize permission resume event");
+    server
+        .tick()
+        .expect("serve settled permission resume state");
+    client
+        .tick()
+        .expect("apply settled permission resume state");
+    client
+        .tick()
+        .expect("materialize settled permission resume state");
+    let resume_elapsed = resume_started.elapsed();
+
+    let resume_bytes = resumed
+        .borrow()
+        .last_resume_bytes()
+        .expect("permission resume catch-up bytes");
+    assert!(resume_bytes > 0);
+
+    let unchanged_members = [RESUME_DOC_DIRECT, RESUME_DOC_REVOKED];
+    let granted_member = [RESUME_DOC_GRANTED];
+    let expected_added = match churn {
+        PermissionResumeChurn::Unchanged => unchanged_members.as_slice(),
+        PermissionResumeChurn::Grant | PermissionResumeChurn::GrantAndRevoke => {
+            granted_member.as_slice()
+        }
+        PermissionResumeChurn::Revoke => &[],
+    };
+    let expected_removed = churn.revokes().then_some(RESUME_DOC_REVOKED);
+    let (added, updated, removed) = assert_resume_delta(
+        subscription.try_next_event(),
+        expected_added,
+        expected_removed.as_slice(),
+    );
+    assert!(subscription.try_next_event().is_none());
+    // `Db::read` is intentionally a local-preview read; it may still
+    // see retained row bodies after upstream membership is revoked.
+    // The authoritative reconnect contract is the subscription delta
+    // asserted above.
+
+    (
+        resume_elapsed,
+        resume_bytes,
+        full_bytes,
+        added,
+        updated,
+        removed,
+    )
+}
+
+fn run_claim_filtered_resume(
+    churn: ClaimResumeChurn,
+) -> (Duration, usize, usize, usize, usize, usize) {
+    let writer = open_claim_resume_db(133, AuthorId::SYSTEM, false);
+    let server = open_claim_resume_db(134, AuthorId::SYSTEM, true);
+    let client = open_claim_resume_db(135, READER_AUTHOR, false);
+    for (row, title) in [
+        (CLAIM_RESUME_DOC_A, "claim-a"),
+        (CLAIM_RESUME_DOC_B, "claim-b"),
+    ] {
+        wait_local(
+            writer
+                .insert_with_id(
+                    "claim_docs",
+                    row,
+                    BTreeMap::from([("title".to_owned(), Value::String(title.to_owned()))]),
+                )
+                .expect("seed claim-resume doc"),
+        );
+    }
+    let prepared = client
+        .prepare_query(&Query::from("claim_docs"))
+        .expect("prepare claim-filtered docs query");
+
+    let (writer_transport, server_writer_transport) =
+        byte_duplex_with_session(AuthorId::SYSTEM, 13_101);
+    let writer_upstream = writer.connect_upstream(writer_transport);
+    let writer_subscriber = server.accept_subscriber(server_writer_transport, AuthorId::SYSTEM);
+    writer.tick().expect("ship claim-resume seed rows");
+    server.tick().expect("ingest claim-resume seed rows");
+    assert!(writer.detach_connection(&writer_upstream));
+    assert!(server.detach_connection(&writer_subscriber));
+
+    server.set_identity_claims(
+        READER_AUTHOR,
+        BTreeMap::from([(
+            "access".to_owned(),
+            Value::String(churn.initial_access().to_owned()),
+        )]),
+    );
+    let (client_transport, server_transport) = byte_duplex_with_session(READER_AUTHOR, 13_102);
+    let upstream = client.connect_upstream(client_transport);
+    let subscriber = server.accept_subscriber(server_transport, READER_AUTHOR);
+    let mut subscription = block_on(client.subscribe(&prepared, global_subscribe_opts()))
+        .expect("subscribe claim-filtered docs");
+    assert_eq!(
+        drain_opened(block_on(subscription.next_event()), "claim-filtered docs"),
+        0
+    );
+    client.tick().expect("announce claim-filtered subscription");
+    server.tick().expect("serve full claim-filtered snapshot");
+    let full_bytes = subscriber
+        .borrow()
+        .last_resume_bytes()
+        .expect("full claim-filtered snapshot bytes");
+    client.tick().expect("apply claim-filtered snapshot");
+    client.tick().expect("materialize claim-filtered snapshot");
+    let visible_claim_docs = [CLAIM_RESUME_DOC_A, CLAIM_RESUME_DOC_B];
+    let expected_initial = match churn {
+        ClaimResumeChurn::Revoke => visible_claim_docs.as_slice(),
+        ClaimResumeChurn::Restore => &[],
+    };
+    assert_resume_delta(subscription.try_next_event(), expected_initial, &[]);
+
+    server.tick().expect("refresh claim-filtered cursor");
+    client.tick().expect("apply claim-filtered cursor state");
+    let cursor = subscriber
+        .borrow_mut()
+        .take_resume_cursor()
+        .expect("take claim-filtered resume cursor");
+    assert!(client.detach_connection(&upstream));
+    assert!(server.detach_connection(&subscriber));
+
+    server.set_identity_claims(
+        READER_AUTHOR,
+        BTreeMap::from([(
+            "access".to_owned(),
+            Value::String(churn.resumed_access().to_owned()),
+        )]),
+    );
+    let (client_transport, server_transport) = byte_duplex_with_session(READER_AUTHOR, 13_103);
+    let _resumed_upstream = client.connect_upstream(client_transport);
+    let resumed = server.accept_subscriber_with_resume(server_transport, READER_AUTHOR, cursor);
+
+    let resume_started = Instant::now();
+    client.tick().expect("announce resumed claim subscription");
+    server.tick().expect("serve claim resume catch-up");
+    client.tick().expect("apply claim resume catch-up");
+    client.tick().expect("materialize claim resume event");
+    server.tick().expect("serve settled claim resume state");
+    client.tick().expect("apply settled claim resume state");
+    client
+        .tick()
+        .expect("materialize settled claim resume state");
+    let resume_elapsed = resume_started.elapsed();
+    let resume_bytes = resumed
+        .borrow()
+        .last_resume_bytes()
+        .expect("claim resume catch-up bytes");
+    assert!(resume_bytes > 0);
+
+    let (expected_added, expected_removed) = match churn {
+        ClaimResumeChurn::Revoke => (&[][..], visible_claim_docs.as_slice()),
+        ClaimResumeChurn::Restore => (visible_claim_docs.as_slice(), &[][..]),
+    };
+    let (added, updated, removed) = assert_resume_delta(
+        subscription.try_next_event(),
+        expected_added,
+        expected_removed,
+    );
+    assert!(subscription.try_next_event().is_none());
+    (
+        resume_elapsed,
+        resume_bytes,
+        full_bytes,
+        added,
+        updated,
+        removed,
+    )
+}
+
 fn r13_permission_filtered_resume(c: &mut Criterion) {
     let mut group = c.benchmark_group("realistic_phase1/r13_permission_filtered_resume");
     group.throughput(Throughput::Elements(1));
 
-    group.bench_function("docs_recursive_resume_s", |b| {
-        b.iter(|| {
-            let writer = open_recursive_permissions_db_with_author(130, AuthorId::SYSTEM, false);
-            let server = open_recursive_permissions_db_with_author(131, AuthorId::SYSTEM, true);
-            let client = open_recursive_permissions_db_with_author(132, READER_AUTHOR, false);
-            seed_permission_resume_fixture(&writer);
-            let prepared = client
-                .prepare_query(&Query::from("docs"))
-                .expect("prepare permission-filtered docs query");
-
-            let (writer_transport, server_writer_transport) =
-                byte_duplex_with_session(AuthorId::SYSTEM, 13_001);
-            let writer_upstream = writer.connect_upstream(writer_transport);
-            let writer_subscriber =
-                server.accept_subscriber(server_writer_transport, AuthorId::SYSTEM);
-            writer.tick().expect("ship permission seed rows");
-            server.tick().expect("ingest permission seed rows");
-            assert!(writer.detach_connection(&writer_upstream));
-            assert!(server.detach_connection(&writer_subscriber));
-
-            let (client_transport, server_transport) =
-                byte_duplex_with_session(READER_AUTHOR, 13_002);
-            let upstream = client.connect_upstream(client_transport);
-            let subscriber = server.accept_subscriber(server_transport, READER_AUTHOR);
-            let mut subscription = block_on(client.subscribe(&prepared, global_subscribe_opts()))
-                .expect("subscribe permission-filtered docs");
-            assert_eq!(
-                drain_opened(block_on(subscription.next_event()), "permission docs"),
-                0
-            );
-
-            client
-                .tick()
-                .expect("announce permission docs subscription");
-            server.tick().expect("serve full permission docs snapshot");
-            let full_bytes = subscriber
-                .borrow()
-                .last_resume_bytes()
-                .expect("full permission current-row bytes");
-            client.tick().expect("apply full permission docs snapshot");
-            client
-                .tick()
-                .expect("materialize full permission docs snapshot event");
-            let seeded = drain_optional_permission_rows(subscription.try_next_event());
-            assert!(full_bytes > 0);
-            let rows = client
-                .read(&prepared)
-                .expect("read initial permission-filtered docs");
-            assert_permission_resume_docs(&rows, &[RESUME_DOC_DIRECT, RESUME_DOC_REVOKED]);
-            if seeded > 0 {
-                assert_eq!(seeded, rows.len());
-            }
-
-            server.tick().expect("refresh permission docs cursor");
-            client.tick().expect("apply permission docs cursor state");
-            let cursor = subscriber
-                .borrow_mut()
-                .take_resume_cursor()
-                .expect("take permission subscriber resume cursor");
-            assert!(client.detach_connection(&upstream));
-            assert!(server.detach_connection(&subscriber));
-
-            wait_local(
-                writer
-                    .update(
-                        "doc_access",
-                        RESUME_ACCESS_REVOKED,
-                        recursive_doc_access_cells(RESUME_DOC_REVOKED, RECURSIVE_HIDDEN_TEAM),
-                    )
-                    .expect("hide disconnected doc access before revoke"),
-            );
-            wait_local(
-                writer
-                    .delete("doc_access", RESUME_ACCESS_REVOKED)
-                    .expect("revoke disconnected doc access"),
-            );
-            wait_local(
-                writer
-                    .insert_with_id(
-                        "doc_access",
-                        RESUME_ACCESS_GRANTED,
-                        recursive_doc_access_cells(RESUME_DOC_GRANTED, RECURSIVE_PARENT_TEAM),
-                    )
-                    .expect("grant disconnected doc access"),
-            );
-
-            let (writer_transport, server_writer_transport) =
-                byte_duplex_with_session(AuthorId::SYSTEM, 13_003);
-            let writer_upstream = writer.connect_upstream(writer_transport);
-            let writer_subscriber =
-                server.accept_subscriber(server_writer_transport, AuthorId::SYSTEM);
-            writer.tick().expect("ship disconnected permission changes");
-            server
-                .tick()
-                .expect("ingest disconnected permission changes");
-            writer
-                .tick()
-                .expect("ship settled disconnected permission changes");
-            server
-                .tick()
-                .expect("ingest settled disconnected permission changes");
-            assert!(writer.detach_connection(&writer_upstream));
-            assert!(server.detach_connection(&writer_subscriber));
-
-            let (client_transport, server_transport) =
-                byte_duplex_with_session(READER_AUTHOR, 13_004);
-            let _resumed_upstream = client.connect_upstream(client_transport);
-            let resumed =
-                server.accept_subscriber_with_resume(server_transport, READER_AUTHOR, cursor);
-
-            client
-                .tick()
-                .expect("announce resumed permission docs subscription");
-            server.tick().expect("serve permission resume catch-up");
-            client.tick().expect("apply permission resume catch-up");
-            client.tick().expect("materialize permission resume event");
-            server
-                .tick()
-                .expect("serve settled permission resume state");
-            client
-                .tick()
-                .expect("apply settled permission resume state");
-            client
-                .tick()
-                .expect("materialize settled permission resume state");
-
-            let resume_bytes = resumed
-                .borrow()
-                .last_resume_bytes()
-                .expect("permission resume catch-up bytes");
-            assert!(resume_bytes > 0);
-
-            let (added, updated, removed) =
-                drain_permission_resume_delta(subscription.try_next_event());
-            assert_eq!(added + updated, 1);
-            assert_eq!(removed, 1);
-            // `Db::read` is intentionally a local-preview read; it may still
-            // see retained row bodies after upstream membership is revoked.
-            // The authoritative reconnect contract is the subscription delta
-            // asserted above.
-
-            black_box((resume_bytes, full_bytes, added, updated, removed))
+    for churn in [
+        PermissionResumeChurn::Unchanged,
+        PermissionResumeChurn::Grant,
+        PermissionResumeChurn::Revoke,
+        PermissionResumeChurn::GrantAndRevoke,
+    ] {
+        let (elapsed, resume_bytes, full_bytes, added, updated, removed) =
+            run_permission_filtered_resume(churn);
+        eprintln!(
+            "{{\"scenario\":\"r13_permission_filtered_resume\",\"case\":\"{}\",\"resume_us\":{},\"resume_bytes\":{},\"full_bytes\":{},\"added\":{},\"updated\":{},\"removed\":{}}}",
+            churn.name(),
+            elapsed.as_micros(),
+            resume_bytes,
+            full_bytes,
+            added,
+            updated,
+            removed,
+        );
+        group.bench_function(churn.name(), |b| {
+            b.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let (resume_elapsed, resume_bytes, full_bytes, added, updated, removed) =
+                        run_permission_filtered_resume(churn);
+                    black_box((resume_bytes, full_bytes, added, updated, removed));
+                    elapsed += resume_elapsed;
+                }
+                elapsed
+            });
         });
-    });
+    }
+    for churn in [ClaimResumeChurn::Revoke, ClaimResumeChurn::Restore] {
+        let (elapsed, resume_bytes, full_bytes, added, updated, removed) =
+            run_claim_filtered_resume(churn);
+        eprintln!(
+            "{{\"scenario\":\"r13_permission_filtered_resume\",\"case\":\"{}\",\"resume_us\":{},\"resume_bytes\":{},\"full_bytes\":{},\"added\":{},\"updated\":{},\"removed\":{}}}",
+            churn.name(),
+            elapsed.as_micros(),
+            resume_bytes,
+            full_bytes,
+            added,
+            updated,
+            removed,
+        );
+        group.bench_function(churn.name(), |b| {
+            b.iter_custom(|iterations| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iterations {
+                    let (resume_elapsed, resume_bytes, full_bytes, added, updated, removed) =
+                        run_claim_filtered_resume(churn);
+                    black_box((resume_bytes, full_bytes, added, updated, removed));
+                    elapsed += resume_elapsed;
+                }
+                elapsed
+            });
+        });
+    }
 
     group.finish();
 }

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -1997,6 +1997,19 @@ fn run_permission_filtered_resume(
         assert!(server.detach_connection(&writer_subscriber));
     }
 
+    let server_query = recursive_docs_query(&server);
+    let server_rows =
+        block_on(server.all_for_identity(&server_query, ReadOpts::default(), READER_AUTHOR))
+            .expect("read disconnected permission state on server");
+    let mut expected_server_rows = vec![RESUME_DOC_DIRECT];
+    if !churn.revokes() {
+        expected_server_rows.push(RESUME_DOC_REVOKED);
+    }
+    if churn.grants() {
+        expected_server_rows.push(RESUME_DOC_GRANTED);
+    }
+    assert_permission_resume_docs(&server_rows, &expected_server_rows);
+
     let (client_transport, server_transport) = byte_duplex_with_session(READER_AUTHOR, 13_004);
     let _resumed_upstream = client.connect_upstream(client_transport);
     let resumed = server.accept_subscriber_with_resume(server_transport, READER_AUTHOR, cursor);

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -87,12 +87,12 @@ fn fast_cursor_membership_mismatch(
 }
 
 fn fast_cursor_requires_authoritative_reset(
-    authorization_matches: bool,
+    _authorization_matches: bool,
     position: crate::time::GlobalSeq,
     previous: &BTreeSet<ResultMemberEntry>,
     current: &BTreeSet<ResultMemberEntry>,
 ) -> bool {
-    !authorization_matches && fast_cursor_membership_mismatch(position, previous, current)
+    fast_cursor_membership_mismatch(position, previous, current)
 }
 
 /// Tracks what one downstream peer has already received.
@@ -1050,6 +1050,9 @@ impl PeerState {
         // removed prior member or newly visible pre-cursor member cannot be
         // reconstructed from that cursor, so it cannot safely suppress the
         // authoritative membership diff or the payload needed to apply it.
+        // Membership can change through policy rows without advancing the
+        // link-local authorization generation. Preserve the #1266 reset for
+        // pre-cursor grants/revokes; post-cursor additions remain incremental.
         let cursor_membership_mismatch = known_membership_position.is_some_and(|position| {
             fast_cursor_requires_authoritative_reset(
                 authorization_matches,
@@ -2426,13 +2429,27 @@ mod tests {
         assert!(!fast_cursor_requires_authoritative_reset(
             true, cursor, &previous, &previous,
         ));
-        // (2) same authorization, insufficient cursor: an incremental repair
-        // remains permitted; this predicate must not force a reset.
+        // (2) same authorization, post-cursor add: incremental repair remains
+        // sufficient and this predicate must not force a reset.
         assert!(!fast_cursor_requires_authoritative_reset(
             true,
             cursor,
             &previous,
             &BTreeSet::from([old.clone(), new.clone()]),
+        ));
+        // Membership-affecting policy facts need the #1266 authoritative reset
+        // even when the link-local authorization generation did not advance.
+        assert!(fast_cursor_requires_authoritative_reset(
+            true,
+            cursor,
+            &previous,
+            &BTreeSet::from([old.clone(), settled_member(row(3), 8)]),
+        ));
+        assert!(fast_cursor_requires_authoritative_reset(
+            true,
+            cursor,
+            &previous,
+            &BTreeSet::new(),
         ));
         // (3) changed authorization with a reconstructible post-cursor add.
         assert!(!fast_cursor_requires_authoritative_reset(

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -54,20 +54,6 @@ fn fast_current_membership_position(
     }
 }
 
-fn fast_authorization_progress(known_state: &Option<KnownStateDeclaration>) -> Option<u64> {
-    match known_state {
-        Some(KnownStateDeclaration::FastWithAuthorizationProgress {
-            completeness: KnownStateCompleteness::FastCurrentMembership,
-            authorization_progress,
-            ..
-        }) => Some(*authorization_progress),
-        Some(
-            KnownStateDeclaration::Fast { .. } | KnownStateDeclaration::ExactVersionSet { .. },
-        )
-        | None => None,
-    }
-}
-
 fn member_settle_position(member: &ResultMemberEntry) -> Option<crate::time::GlobalSeq> {
     match member {
         ResultMemberEntry::Row(row) => row.settle_position,
@@ -87,7 +73,6 @@ fn fast_cursor_membership_mismatch(
 }
 
 fn fast_cursor_requires_authoritative_reset(
-    _authorization_matches: bool,
     position: crate::time::GlobalSeq,
     previous: &BTreeSet<ResultMemberEntry>,
     current: &BTreeSet<ResultMemberEntry>,
@@ -1020,12 +1005,6 @@ impl PeerState {
             .get(&subscription)
             .and_then(|state| state.known_state.clone());
         let known_membership_position = fast_current_membership_position(&known_state);
-        let authorization_matches = self.subscriptions.get(&subscription).is_some_and(|state| {
-            fast_authorization_progress(&known_state)
-                .map_or(state.authorization_progress == 0, |progress| {
-                    progress == state.authorization_progress
-                })
-        });
         let watermark = node.applied_global_watermark();
         let simple_membership_delta =
             transitions.program_fact_adds.is_empty() && transitions.program_fact_removes.is_empty();
@@ -1055,7 +1034,6 @@ impl PeerState {
         // pre-cursor grants/revokes; post-cursor additions remain incremental.
         let cursor_membership_mismatch = known_membership_position.is_some_and(|position| {
             fast_cursor_requires_authoritative_reset(
-                authorization_matches,
                 position,
                 previous_member_result_set,
                 &current_member_result_set,
@@ -2416,7 +2394,7 @@ mod tests {
     }
 
     #[test]
-    fn fast_authorization_progress_bounds_membership_resets() {
+    fn fast_cursor_membership_bounds_authoritative_resets() {
         // This is intentionally an internal test: the four-way decision is a
         // peer-only protocol control-plane predicate, with no public API
         // surface. End-to-end rehydrate tests cover application of its output.
@@ -2427,12 +2405,11 @@ mod tests {
 
         // (1) same authorization, sufficient cursor: no reset.
         assert!(!fast_cursor_requires_authoritative_reset(
-            true, cursor, &previous, &previous,
+            cursor, &previous, &previous,
         ));
         // (2) same authorization, post-cursor add: incremental repair remains
         // sufficient and this predicate must not force a reset.
         assert!(!fast_cursor_requires_authoritative_reset(
-            true,
             cursor,
             &previous,
             &BTreeSet::from([old.clone(), new.clone()]),
@@ -2440,33 +2417,28 @@ mod tests {
         // Membership-affecting policy facts need the #1266 authoritative reset
         // even when the link-local authorization generation did not advance.
         assert!(fast_cursor_requires_authoritative_reset(
-            true,
             cursor,
             &previous,
             &BTreeSet::from([old.clone(), settled_member(row(3), 8)]),
         ));
         assert!(fast_cursor_requires_authoritative_reset(
-            true,
             cursor,
             &previous,
             &BTreeSet::new(),
         ));
         // (3) changed authorization with a reconstructible post-cursor add.
         assert!(!fast_cursor_requires_authoritative_reset(
-            false,
             cursor,
             &previous,
             &BTreeSet::from([old.clone(), new]),
         ));
         // (4) changed authorization with either a pre-cursor grant or revoke.
         assert!(fast_cursor_requires_authoritative_reset(
-            false,
             cursor,
             &previous,
             &BTreeSet::from([old.clone(), settled_member(row(3), 8)]),
         ));
         assert!(fast_cursor_requires_authoritative_reset(
-            false,
             cursor,
             &previous,
             &BTreeSet::new(),

--- a/dev/benchmarks/POLICY_CHURN_RECONNECT_RECEIPT_20260805.md
+++ b/dev/benchmarks/POLICY_CHURN_RECONNECT_RECEIPT_20260805.md
@@ -42,25 +42,25 @@ The benchmark requires exact public subscription events:
 
 The unchanged event is reset-framed and therefore reports the two retained rows
 as updates. This does not imply that their bodies are retransmitted: its wire
-response is only 61 bytes.
+response remains compact.
 
 `Db::read` is deliberately not an oracle here. It is a local-preview API and
 may retain row bodies after upstream membership is revoked. The authoritative
 security contract is the subscription result-set transition.
 
-## Initial local result
+## Refreshed local result
 
-One full run on the quiet local development box (load average
-`0.07 / 0.11 / 0.08` immediately before the run) produced:
+One refreshed full run after restacking onto the 2026-08-06 integration head
+produced:
 
 | Case             | Reconnect median | Resume response | Initial response | Added | Updated | Removed |
 | ---------------- | ---------------: | --------------: | ---------------: | ----: | ------: | ------: |
-| unchanged        |         1.864 ms |            61 B |            856 B |     0 |       2 |       0 |
-| grant only       |         2.201 ms |         1,256 B |            856 B |     1 |       0 |       0 |
-| revoke only      |         1.963 ms |           516 B |            856 B |     0 |       0 |       1 |
-| grant and revoke |         2.105 ms |           925 B |            856 B |     1 |       0 |       1 |
-| claim revoke     |         0.728 ms |           213 B |            824 B |     0 |       0 |       2 |
-| claim restore    |         0.888 ms |           824 B |             61 B |     2 |       0 |       0 |
+| unchanged        |         2.003 ms |            62 B |            895 B |     0 |       2 |       0 |
+| grant only       |         2.352 ms |         1,314 B |            895 B |     1 |       0 |       0 |
+| revoke only      |         2.064 ms |           555 B |            895 B |     0 |       0 |       1 |
+| grant and revoke |         2.225 ms |           983 B |            895 B |     1 |       0 |       1 |
+| claim revoke     |         0.744 ms |           252 B |            863 B |     0 |       0 |       2 |
+| claim restore    |         0.912 ms |           863 B |             62 B |     2 |       0 |       0 |
 
 The unchanged control retains a compact response at about 7% of its initial
 snapshot. Revokes are also smaller than the initial response because row-member
@@ -70,7 +70,7 @@ Grant responses can equal or exceed the reader's prior initial snapshot. A row
 that existed before the cursor but was not authorized was never shipped to that
 reader, so restoration must carry its body despite its old global sequence. In
 the recursive grant-only lane, the resulting three-row authoritative response
-is 1,256 bytes versus the prior two-row 856-byte snapshot. This is required
+is 1,314 bytes versus the prior two-row 895-byte snapshot. This is required
 correctness work, not resume amplification over an equivalent snapshot.
 
 These are single-process, single-threaded, network-free measurements. They are

--- a/dev/benchmarks/POLICY_CHURN_RECONNECT_RECEIPT_20260805.md
+++ b/dev/benchmarks/POLICY_CHURN_RECONNECT_RECEIPT_20260805.md
@@ -1,0 +1,77 @@
+# Policy churn and reconnect receipt — 2026-08-05
+
+This receipt exercises byte-wire subscriber resume after authorization changes
+while the reader is disconnected. It extends
+`realistic_phase1/r13_permission_filtered_resume` with six independently gated
+cases:
+
+- unchanged recursive membership;
+- one newly granted document;
+- one revoked document;
+- one grant and one revoke together;
+- process-local claim revocation; and
+- process-local claim restoration.
+
+Every lane opens a writer, history-complete server, and partial reader over
+`MemoryStorage`; performs the initial sync; detaches the reader while retaining
+the server-side `ResumeCursor`; applies the authorization change; and reconnects
+through the byte-wire transport adapter. The timer starts immediately before
+the reader announces its resumed subscription and ends after the server and
+reader settle the catch-up. Fixture creation, initial sync, and disconnected
+authorization mutation are outside the measured interval.
+
+Run the matrix with:
+
+```sh
+cargo bench -p jazz --bench realistic_phase1 -- \
+  r13_permission_filtered_resume --noplot
+```
+
+## Correctness gates
+
+The benchmark requires exact public subscription events:
+
+| Case             |                   Added or updated |                           Removed |
+| ---------------- | ---------------------------------: | --------------------------------: |
+| unchanged        |     the same two visible documents |                              none |
+| grant only       | exactly the newly granted document |                              none |
+| revoke only      |                               none |      exactly the revoked document |
+| grant and revoke | exactly the newly granted document |      exactly the revoked document |
+| claim revoke     |                               none | both previously visible documents |
+| claim restore    |       both newly visible documents |                              none |
+
+The unchanged event is reset-framed and therefore reports the two retained rows
+as updates. This does not imply that their bodies are retransmitted: its wire
+response is only 61 bytes.
+
+`Db::read` is deliberately not an oracle here. It is a local-preview API and
+may retain row bodies after upstream membership is revoked. The authoritative
+security contract is the subscription result-set transition.
+
+## Initial local result
+
+One full run on the local development box produced:
+
+| Case             | Reconnect median | Resume response | Initial response | Added | Updated | Removed |
+| ---------------- | ---------------: | --------------: | ---------------: | ----: | ------: | ------: |
+| unchanged        |         1.855 ms |            61 B |            856 B |     0 |       2 |       0 |
+| grant only       |         2.179 ms |         1,256 B |            856 B |     1 |       0 |       0 |
+| revoke only      |         1.940 ms |           516 B |            856 B |     0 |       0 |       1 |
+| grant and revoke |         2.087 ms |           925 B |            856 B |     1 |       0 |       1 |
+| claim revoke     |         0.721 ms |           213 B |            824 B |     0 |       0 |       2 |
+| claim restore    |         0.890 ms |           824 B |             61 B |     2 |       0 |       0 |
+
+The unchanged control retains a compact response at about 7% of its initial
+snapshot. Revokes are also smaller than the initial response because row-member
+removals are self-sufficient.
+
+Grant responses can equal or exceed the reader's prior initial snapshot. A row
+that existed before the cursor but was not authorized was never shipped to that
+reader, so restoration must carry its body despite its old global sequence. In
+the recursive grant-only lane, the resulting three-row authoritative response
+is 1,256 bytes versus the prior two-row 856-byte snapshot. This is required
+correctness work, not resume amplification over an equivalent snapshot.
+
+These are single-process, single-threaded, network-free measurements. They are
+useful for comparing protocol paths and detecting accidental full rehydrate;
+they are not an end-user reconnect latency claim.

--- a/dev/benchmarks/POLICY_CHURN_RECONNECT_RECEIPT_20260805.md
+++ b/dev/benchmarks/POLICY_CHURN_RECONNECT_RECEIPT_20260805.md
@@ -50,16 +50,17 @@ security contract is the subscription result-set transition.
 
 ## Initial local result
 
-One full run on the local development box produced:
+One full run on the quiet local development box (load average
+`0.07 / 0.11 / 0.08` immediately before the run) produced:
 
 | Case             | Reconnect median | Resume response | Initial response | Added | Updated | Removed |
 | ---------------- | ---------------: | --------------: | ---------------: | ----: | ------: | ------: |
-| unchanged        |         1.855 ms |            61 B |            856 B |     0 |       2 |       0 |
-| grant only       |         2.179 ms |         1,256 B |            856 B |     1 |       0 |       0 |
-| revoke only      |         1.940 ms |           516 B |            856 B |     0 |       0 |       1 |
-| grant and revoke |         2.087 ms |           925 B |            856 B |     1 |       0 |       1 |
-| claim revoke     |         0.721 ms |           213 B |            824 B |     0 |       0 |       2 |
-| claim restore    |         0.890 ms |           824 B |             61 B |     2 |       0 |       0 |
+| unchanged        |         1.864 ms |            61 B |            856 B |     0 |       2 |       0 |
+| grant only       |         2.201 ms |         1,256 B |            856 B |     1 |       0 |       0 |
+| revoke only      |         1.963 ms |           516 B |            856 B |     0 |       0 |       1 |
+| grant and revoke |         2.105 ms |           925 B |            856 B |     1 |       0 |       1 |
+| claim revoke     |         0.728 ms |           213 B |            824 B |     0 |       0 |       2 |
+| claim restore    |         0.888 ms |           824 B |             61 B |     2 |       0 |       0 |
 
 The unchanged control retains a compact response at about 7% of its initial
 snapshot. Revokes are also smaller than the initial response because row-member

--- a/dev/benchmarks/realistic/README.md
+++ b/dev/benchmarks/realistic/README.md
@@ -59,6 +59,7 @@ Current topology coverage:
 - writer/server/reader sync fanout: `realistic_phase1/r10_sync_fanout`
 - byte-wire reconnect/resume canary: `realistic_phase1/r11_byte_wire_resume`
 - recursive permission read/subscription visibility: `realistic_phase1/r12_recursive_permissions`
+- permission-filtered reconnect/resume transitions: `realistic_phase1/r13_permission_filtered_resume`
 
 Run only the cold-load benchmark:
 

--- a/dev/benchmarks/realistic/ci_benchmarks.mjs
+++ b/dev/benchmarks/realistic/ci_benchmarks.mjs
@@ -97,6 +97,15 @@ const NATIVE_CRITERION_SCENARIOS = [
       sqlite: "realistic_phase1/r12_recursive_permissions",
     },
   },
+  {
+    id: "r13_permission_filtered_resume",
+    label: "Criterion R13 permission-filtered resume",
+    timeout_seconds: 90,
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/r13_permission_filtered_resume",
+      sqlite: "realistic_phase1/r13_permission_filtered_resume",
+    },
+  },
 ];
 
 export const NATIVE_BENCHMARKS = NATIVE_STORAGE_ENGINES.flatMap((storage_engine) => [
@@ -124,6 +133,7 @@ export const NATIVE_BENCHMARKS = NATIVE_STORAGE_ENGINES.flatMap((storage_engine)
         kind: "criterion",
         log_path: `logs/criterion_${scenario.id}.log`,
         criterion_filter,
+        timeout_seconds: scenario.timeout_seconds,
         env: {
           JAZZ_REALISTIC_VARIANT: "ci",
         },

--- a/dev/benchmarks/realistic/ci_benchmarks.test.mjs
+++ b/dev/benchmarks/realistic/ci_benchmarks.test.mjs
@@ -221,10 +221,7 @@ test("benchmark workflow prebuilds the RocksDB-backed and SQLite-backed native b
     workflow,
     /cargo bench -p jazz --features rocksdb --bench realistic_phase1 --no-run/,
   );
-  assert.match(
-    workflow,
-    /cargo bench -p jazz --features sqlite --bench realistic_phase1 --no-run/,
-  );
+  assert.match(workflow, /cargo bench -p jazz --features sqlite --bench realistic_phase1 --no-run/);
   assert.doesNotMatch(workflow, /-p jazz-tools\b/);
 });
 

--- a/dev/benchmarks/realistic/ci_benchmarks.test.mjs
+++ b/dev/benchmarks/realistic/ci_benchmarks.test.mjs
@@ -9,6 +9,7 @@ import {
   skipIds,
 } from "./ci_benchmarks.mjs";
 import {
+  benchmarkTimeoutSeconds,
   buildJazzSimCommand,
   buildNativeCriterionCommand,
   buildNativeExampleBaseCommand,
@@ -40,6 +41,8 @@ test("native benchmark catalog defines RocksDB and SQLite variants for each nati
   assert.ok(ids.has("native-criterion:sqlite:r11_byte_wire_resume"));
   assert.ok(ids.has("native-criterion:rocksdb:r12_recursive_permissions"));
   assert.ok(ids.has("native-criterion:sqlite:r12_recursive_permissions"));
+  assert.ok(ids.has("native-criterion:rocksdb:r13_permission_filtered_resume"));
+  assert.ok(ids.has("native-criterion:sqlite:r13_permission_filtered_resume"));
 });
 
 test("native benchmark catalog targets storage-backed engine-specific Criterion groups", () => {
@@ -108,7 +111,7 @@ test("native example command opts into the RocksDB storage backend", () => {
     "run",
     "--release",
     "-p",
-    "jazz-tools",
+    "jazz",
     "--features",
     "client,rocksdb",
     "--example",
@@ -126,7 +129,7 @@ test("native example command opts into the SQLite storage backend", () => {
     "run",
     "--release",
     "-p",
-    "jazz-tools",
+    "jazz",
     "--features",
     "client,sqlite",
     "--example",
@@ -145,7 +148,7 @@ test("native Criterion command opts into the RocksDB storage backend", () => {
     "cargo",
     "bench",
     "-p",
-    "jazz-tools",
+    "jazz",
     "--features",
     "rocksdb",
     "--bench",
@@ -160,6 +163,7 @@ test("native Criterion command opts into the SQLite storage backend", () => {
     (entry) => entry.id === "native-criterion:sqlite:r2_reads",
   );
   assert.ok(benchmark, "expected a SQLite native Criterion benchmark");
+  assert.equal(benchmarkTimeoutSeconds(benchmark, 60), 60);
 
   const command = buildNativeCriterionCommand(benchmark);
   assert.equal(NATIVE_CRITERION_FEATURES_BY_ENGINE.sqlite, "sqlite");
@@ -167,13 +171,35 @@ test("native Criterion command opts into the SQLite storage backend", () => {
     "cargo",
     "bench",
     "-p",
-    "jazz-tools",
+    "jazz",
     "--features",
     "sqlite",
     "--bench",
     "realistic_phase1",
     "--",
     "realistic_phase1/r2_reads",
+  ]);
+});
+
+test("native Criterion command runs the R13 assertion-bearing benchmark", () => {
+  const benchmark = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:sqlite:r13_permission_filtered_resume",
+  );
+  assert.ok(benchmark, "expected the SQLite R13 native Criterion benchmark");
+  assert.equal(benchmark.timeout_seconds, 90);
+  assert.equal(benchmarkTimeoutSeconds(benchmark, 60), 90);
+
+  assert.deepEqual(buildNativeCriterionCommand(benchmark), [
+    "cargo",
+    "bench",
+    "-p",
+    "jazz",
+    "--features",
+    "sqlite",
+    "--bench",
+    "realistic_phase1",
+    "--",
+    "realistic_phase1/r13_permission_filtered_resume",
   ]);
 });
 
@@ -185,20 +211,21 @@ test("benchmark workflow prebuilds the RocksDB-backed and SQLite-backed native b
 
   assert.match(
     workflow,
-    /cargo build --release -p jazz-tools --features client,rocksdb --example realistic_bench/,
+    /cargo build --release -p jazz --features client,rocksdb --example realistic_bench/,
   );
   assert.match(
     workflow,
-    /cargo build --release -p jazz-tools --features client,sqlite --example realistic_bench/,
+    /cargo build --release -p jazz --features client,sqlite --example realistic_bench/,
   );
   assert.match(
     workflow,
-    /cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run/,
+    /cargo bench -p jazz --features rocksdb --bench realistic_phase1 --no-run/,
   );
   assert.match(
     workflow,
-    /cargo bench -p jazz-tools --features sqlite --bench realistic_phase1 --no-run/,
+    /cargo bench -p jazz --features sqlite --bench realistic_phase1 --no-run/,
   );
+  assert.doesNotMatch(workflow, /-p jazz-tools\b/);
 });
 
 test("benchmark workflow runs the jazz-sim benchmark suite", () => {

--- a/dev/benchmarks/realistic/run_ci_benchmarks.mjs
+++ b/dev/benchmarks/realistic/run_ci_benchmarks.mjs
@@ -490,7 +490,7 @@ export function buildNativeExampleBaseCommand(benchmark, args) {
     "run",
     "--release",
     "-p",
-    "jazz-tools",
+    "jazz",
     "--features",
     features,
     "--example",
@@ -514,7 +514,7 @@ export function buildNativeCriterionCommand(benchmark) {
     "cargo",
     "bench",
     "-p",
-    "jazz-tools",
+    "jazz",
     "--features",
     features,
     "--bench",
@@ -522,6 +522,10 @@ export function buildNativeCriterionCommand(benchmark) {
     "--",
     benchmark.criterion_filter,
   ];
+}
+
+export function benchmarkTimeoutSeconds(benchmark, defaultTimeoutSeconds) {
+  return benchmark.timeout_seconds ?? defaultTimeoutSeconds;
 }
 
 export function buildJazzSimCommand(benchmark) {
@@ -715,6 +719,7 @@ async function runNativeBenchmark(benchmark, args) {
   const logFile = path.resolve(args.outDir, benchmark.log_path);
 
   const command = buildNativeCriterionCommand(benchmark);
+  const timeoutSeconds = benchmarkTimeoutSeconds(benchmark, args.timeoutSeconds);
 
   console.log(`\n==> ${benchmark.label}`);
   console.log(shellQuote(command));
@@ -722,7 +727,7 @@ async function runNativeBenchmark(benchmark, args) {
     command,
     cwd: process.cwd(),
     env: { ...process.env, ...benchmark.env },
-    timeoutSeconds: args.timeoutSeconds,
+    timeoutSeconds,
     logFile,
     streamStdoutToConsole: true,
   });
@@ -733,7 +738,7 @@ async function runNativeBenchmark(benchmark, args) {
     log_path: rel(logFile),
     exit_code: result.code,
     signal: result.signal,
-    timeout_seconds: args.timeoutSeconds,
+    timeout_seconds: timeoutSeconds,
     note: failureNote(result),
   });
 }


### PR DESCRIPTION
## What changed

- expand R13 into six independently gated reconnect cases covering unchanged recursive membership, grant, revoke, simultaneous grant/revoke, claim revoke, and claim restore
- measure only the reconnect/catch-up interval while retaining response-byte and exact subscription-delta receipts
- document the methodology, correctness gates, initial local results, and interpretation limits

## Why

#1266 fixes stale fast-cursor state after authorization changes. This stacked receipt makes that contract reproducible and prevents future reconnect changes from silently regressing grants, revocations, or claim transitions while a reader is disconnected.

## Results

All six cases complete in roughly 0.7–2.2 ms on the local single-process, single-threaded, network-free harness. The unchanged control sends 61 B versus an 856 B initial response; each authorization-changing lane emits exactly the expected added/updated and removed row IDs, with no extra queued event.

These figures compare protocol paths and detect accidental full rehydrate; they are not end-user reconnect latency claims.

## Validation

- `cargo bench -q -p jazz --bench realistic_phase1 -- r13_permission_filtered_resume --test`
- `cargo bench -p jazz --bench realistic_phase1 -- r13_permission_filtered_resume --noplot`
- `cargo fmt --all -- --check`
- `cargo clippy -p jazz --bench realistic_phase1 -- -D warnings`
- repository pre-commit hooks (clippy, sensitive-data scan, oxfmt, rustfmt)

Stacked on #1266.
