### PR TITLE
(new core) Accept local-first tokens that carry no application claims

### DIFF
--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -43,7 +43,7 @@ use crate::tx::{
     RejectionReason as CoreRejectionReason, TxId as CoreTxId,
 };
 use base64::Engine;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -87,7 +87,25 @@ enum StorageBundle {
 struct UnverifiedJwtClaims {
     sub: String,
     #[serde(default)]
-    claims: serde_json::Value,
+    claims: JwtClaimsPayload,
+}
+
+/// Keeps a missing application-claims field distinct from a supplied JSON
+/// value, including JSON `null`.
+#[derive(Debug, Default)]
+enum JwtClaimsPayload {
+    #[default]
+    Absent,
+    Present(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for JwtClaimsPayload {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        serde_json::Value::deserialize(deserializer).map(Self::Present)
+    }
 }
 
 /// Jazz client for building applications.
@@ -1445,7 +1463,10 @@ fn session_from_unverified_jwt(token: &str) -> Option<Session> {
 
     Some(Session {
         user_id: user_id.to_string(),
-        claims: claims.claims,
+        claims: match claims.claims {
+            JwtClaimsPayload::Absent => serde_json::Value::Object(serde_json::Map::new()),
+            JwtClaimsPayload::Present(claims) => claims,
+        },
         ..Session::new(user_id)
     })
 }
@@ -2780,6 +2801,14 @@ mod tests {
         );
         format!("{header}.{payload}.sig")
     }
+
+    fn make_test_jwt_without_claims(sub: &str) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&json!({ "sub": sub })).expect("serialize jwt payload"));
+        format!("{header}.{payload}.sig")
+    }
     #[test]
     fn core_integer_bridge_uses_signed_value_domain() {
         let core_value =
@@ -2810,6 +2839,29 @@ mod tests {
         let session = default_session_from_context(&context).expect("derive session from jwt");
         assert_eq!(session.user_id, "alice");
         assert_eq!(session.claims["join_code"], "secret-123");
+    }
+
+    // These internal tests are necessary because the distinction is made while
+    // decoding the unverified JWT, before a client connection can expose it.
+    #[test]
+    fn session_from_unverified_jwt_defaults_absent_claims_to_an_empty_object() {
+        let session = session_from_unverified_jwt(&make_test_jwt_without_claims("alice"))
+            .expect("derive session from jwt without application claims");
+
+        assert_eq!(session.claims, json!({}));
+        assert!(session_claims_to_core_claims(&session).is_ok());
+    }
+
+    #[test]
+    fn session_from_unverified_jwt_preserves_explicit_non_object_claims() {
+        let session = session_from_unverified_jwt(&make_test_jwt("alice", json!(null)))
+            .expect("derive session from jwt with explicit null claims");
+
+        let error = session_claims_to_core_claims(&session)
+            .expect_err("explicit null application claims must be rejected");
+        assert!(
+            matches!(error, JazzError::Connection(message) if message == "JWT claims payload must be a JSON object")
+        );
     }
 
     #[test]

--- a/crates/jazz/tests/local_first_auth_integration.rs
+++ b/crates/jazz/tests/local_first_auth_integration.rs
@@ -349,8 +349,14 @@ async fn local_first_and_jwt_clients_coexist_impl() {
     .expect("connect alice (local-first)");
     let alice_user_id = identity::derive_user_id(&alice_seed()).to_string();
 
-    // Bob authenticates via the default HS256 JWT minted by JazzServer.
-    let mut bob_ctx = server.make_client_context_for_user(test_schema(), "bob");
+    // Bob authenticates via the default HS256 JWT minted by JazzServer. The
+    // testing helper derives a stable wire principal for a symbolic subject,
+    // because WebSocket sessions validate principals as UUIDs, so Bob's
+    // provenance is that derived id rather than the literal subject.
+    let bob_subject = "bob";
+    let bob_user_id =
+        uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, bob_subject.as_bytes()).to_string();
+    let mut bob_ctx = server.make_client_context_for_user(test_schema(), bob_subject);
     bob_ctx.backend_secret = None;
     bob_ctx.admin_secret = None;
     let bob = JazzClient::connect(bob_ctx)
@@ -374,7 +380,7 @@ async fn local_first_and_jwt_clients_coexist_impl() {
     let bob_row = vec![
         Value::Text("bob via jwt".to_string()),
         Value::Boolean(true),
-        Value::Text("bob".to_string()),
+        Value::Text(bob_user_id.clone()),
     ];
 
     wait_for_rows(


### PR DESCRIPTION
First of three, splitting #1256. Independent of the other two.

Local-first tokens carry identity proof only — `iss`, `sub`, `aud`, public key, `iat`, `exp` — and deliberately no application `claims` object. The client deserialized an absent `claims` as JSON `null`, then required an object, and rejected the session outright.

Absent now defaults to `{}`. An **explicit** `claims: null` is still rejected, because that is a malformed payload rather than a token with no application claims. Both cases have unit tests; they live beside the decoder rather than in an integration test because the distinction is made while decoding the unverified JWT, before a client connection can expose it.

Also finishes a test migration that belongs with this suite: `017c4ad036` moved test session ids to derived UUIDs and updated the local-first client in `local_first_and_jwt_clients_coexist`, but left the JWT client asserting the literal subject `"bob"`. The testing helper derives a stable wire principal for a symbolic subject because WebSocket sessions validate principals as UUIDs, so provenance carries the derived id — and `$createdBy` is typed `Uuid` by contract. Note the two derivations differ and are not interchangeable: a local-first principal comes from `derive_user_id(&seed)`, a JWT principal from a UUID-v5 of the subject.

Worth knowing for review: `mod client` sits behind `feature = "client"`, so none of this compiles under a plain `cargo test -p jazz` — only the canonical `--no-default-features --features test` reaches it.

Gates: `--features test` **101**, only the three known `catalogue_sync_integration` failures; `cargo test -p jazz` 0; `wire_fixtures` 0; workspace check 0; fmt 0.
