### PR TITLE
(new core) Release persistent storage when the client shuts down

### DIFF
--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -629,7 +629,7 @@ impl ClientDb {
         .await?;
         let inner = Rc::new(RefCell::new(inner));
         if has_upstream {
-            Self::spawn_local_tick_driver(Rc::clone(&inner), Rc::clone(&scheduler));
+            Self::spawn_local_tick_driver(Rc::downgrade(&inner), Rc::clone(&scheduler));
         }
         Ok(Rc::new(Self { inner }))
     }
@@ -998,7 +998,7 @@ impl ClientDb {
     }
 
     fn spawn_local_tick_driver(
-        inner: Rc<RefCell<ClientDbInner>>,
+        inner: Weak<RefCell<ClientDbInner>>,
         scheduler: Rc<TickSchedulerImpl>,
     ) {
         let state = scheduler.wake_handle();
@@ -1006,6 +1006,9 @@ impl ClientDb {
             loop {
                 state.notify.notified().await;
                 while let Some(urgency) = scheduler.take() {
+                    let Some(inner) = inner.upgrade() else {
+                        return;
+                    };
                     if urgency == TickUrgency::Deferred {
                         tokio::time::sleep(Duration::from_millis(1)).await;
                     }

--- a/crates/jazz/tests/client_storage_shutdown_integration.rs
+++ b/crates/jazz/tests/client_storage_shutdown_integration.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "test")]
+
+//! Public-API coverage that a connected persistent client releases its local
+//! storage when it shuts down.
+
+use jazz::tools::server::JazzServer;
+use jazz::tools::{ClientStorage, ColumnType, JazzClient, SchemaBuilder, TableSchema};
+use tempfile::TempDir;
+
+fn test_schema() -> jazz::tools::Schema {
+    SchemaBuilder::new()
+        .table(TableSchema::builder("todos").column("title", ColumnType::Text))
+        .build()
+}
+
+#[tokio::test]
+async fn shutdown_releases_persistent_storage_for_reopen() {
+    tokio::task::LocalSet::new()
+        .run_until(shutdown_releases_persistent_storage_for_reopen_impl())
+        .await
+}
+
+async fn shutdown_releases_persistent_storage_for_reopen_impl() {
+    let server = JazzServer::start_with_schema(test_schema()).await;
+    let data_dir = TempDir::new().expect("create persistent client directory");
+    let mut context = server.make_client_context_for_user(test_schema(), "storage-release-user");
+    context.storage = ClientStorage::Persistent;
+    context.data_dir = data_dir.path().to_path_buf();
+
+    JazzClient::connect(context.clone())
+        .await
+        .expect("connect persistent client")
+        .shutdown()
+        .await
+        .expect("shutdown persistent client");
+
+    JazzClient::connect(context)
+        .await
+        .expect("reopen the same persistent client directory")
+        .shutdown()
+        .await
+        .expect("shutdown reopened persistent client");
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
Second of three, splitting #1256. Independent of #1270; **#1272 stacks on this one.**

The client tick task held a strong `Rc` for its lifetime, so persistent storage was never released after `shutdown()`. Reopening the same `data_dir` then failed because RocksDB's lock was still held by the dead client's retained handle. It now holds a `Weak`.

This looks small and is not: it makes "close the client, open it again" work at all, which is the ordinary lifecycle for any persistent local-first app — every restart, every hot reload. It surfaced through an expired-token reconnect test, but nothing about it is auth-specific.

## Coverage

A dedicated test: after `shutdown()`, reopening the same persistent `data_dir` succeeds. Previously the property was only covered incidentally by an auth scenario, which is why the defect read as an auth bug.

Planted positive: restoring the strong `Rc` fails that test with exit 101, RocksDB reporting the lock still held.

## Gates

`--features test` **101**, only the three known `catalogue_sync_integration` failures · `cargo test -p jazz` 0 · `wire_fixtures` 0 · `cargo check --workspace --all-targets` 0 · `cargo fmt --check` 0.
