### PR TITLE
Fix: restore a brace lost resolving the #1259 conflict — the base does not compile

### DIFF
--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -2354,6 +2354,7 @@ mod tests {
             &previous,
             &BTreeSet::from([direct, revoked, new_post_cursor_row]),
         ));
+    }
 
     fn output_member(root: RowUuid, joined: RowUuid, time: u64) -> ResultMemberEntry {
         RealRowMemberEntry::current_content((


### PR DESCRIPTION
**The integration branch currently does not compile.** `crates/jazz/src/peer.rs:6061`, unclosed delimiter — the whole `jazz` lib fails, so every downstream target fails with it.

My fault, and worth recording how.

#1259 and #1266 both added tests to the same module in `peer.rs`, which git surfaced as a conflict. It was a false conflict — two independent additions — so I resolved it by keeping both blocks. I stitched them with a text splice and dropped the closing brace of `fast_cursor_membership_mismatch_detects_pre_cursor_changes`. #1259 then merged.

I verified the *resolution* (no conflict markers, both test functions present) but never compiled it. Checking for markers is not checking for correctness, and a brace is exactly what that check cannot see.

## The fix

One brace. Both tests are intact and neither was altered.

- `cargo check -p jazz` → 0
- `cargo test -p jazz --lib peer::` → **59 passed, 0 failed**
- `cargo fmt --check` → 0

## Worth noting

Nothing caught this between merge and now. CI on the integration branch has been red for other reasons long enough that a hard compile failure did not stand out against the noise — the three `catalogue_sync_integration` failures and the `ts-wire-codec` byte-stability failure were already there, so "red" carried no new information.

That is the real cost of a persistently red base: it stops being a signal. Both of those are tracked, and the catalogue three clear when flat joins land.