### PR TITLE
(new core) Remove the startup current-row validation sweep

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2175,7 +2175,7 @@ where
             .primary_key_get_raw(&global_tables[0].name, &[Value::Uuid(row_uuid.0)])?
         {
             let record = raw.record();
-            let tx = self.current_record_sort_key(record)?;
+            let tx = self.current_record_sort_key(&table.name, row_uuid, record)?;
             candidates.push((decode_current_row(table, record)?, tx));
         }
         let ahead_tables = table.ahead_current_storage_tables();
@@ -2193,7 +2193,7 @@ where
                 ],
             )? {
                 let record = raw.record();
-                let tx = self.current_record_sort_key(record)?;
+                let tx = self.current_record_sort_key(&table.name, row_uuid, record)?;
                 candidates.push((decode_current_row(table, record)?, tx));
             }
         }
@@ -2216,7 +2216,7 @@ where
                 deletion_event_from_value(
                     record.get_idx(RegisterGlobalCurrentRowRecord::FIELD__DELETION_IDX)?,
                 )?,
-                self.current_record_sort_key(record)?,
+                self.current_record_sort_key(&table.name, row_uuid, record)?,
             ));
         }
         let ahead_tables = table.ahead_current_storage_tables();
@@ -2238,7 +2238,7 @@ where
                     deletion_event_from_value(
                         record.get_idx(RegisterGlobalCurrentRowRecord::FIELD__DELETION_IDX)?,
                     )?,
-                    self.current_record_sort_key(record)?,
+                    self.current_record_sort_key(&table.name, row_uuid, record)?,
                 ));
             }
         }
@@ -2247,11 +2247,25 @@ where
 
     fn current_record_sort_key(
         &self,
+        table: &str,
+        row_uuid: RowUuid,
         record: BorrowedRecord<'_>,
     ) -> Result<(TxTime, NodeUuid), Error> {
-        let tx_time = TxTime(record.get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)?);
-        let tx_node_alias =
-            NodeAlias(record.get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)?);
+        let malformed = |source| Error::MalformedCurrentRow {
+            table: table.to_owned(),
+            row_uuid,
+            source,
+        };
+        let tx_time = TxTime(
+            record
+                .get_u64(GlobalCurrentRowRecord::FIELD_TX_TIME_IDX)
+                .map_err(malformed)?,
+        );
+        let tx_node_alias = NodeAlias(
+            record
+                .get_u64(GlobalCurrentRowRecord::FIELD_TX_NODE_ID_IDX)
+                .map_err(malformed)?,
+        );
         let tx_node = self
             .node_aliases
             .iter()
@@ -5118,6 +5132,17 @@ pub enum Error {
     /// Error returned by groove records.
     #[error(transparent)]
     Record(#[from] records::Error),
+    /// A persisted current row could not be decoded at the point of use.
+    #[error("malformed current row in table {table} for {row_uuid:?}: {source}")]
+    MalformedCurrentRow {
+        /// Logical table containing the row.
+        table: String,
+        /// Primary-key row identity of the malformed record.
+        row_uuid: RowUuid,
+        /// The record decoding failure.
+        #[source]
+        source: records::Error,
+    },
     /// Error returned by storage.
     #[error(transparent)]
     Storage(#[from] storage::Error),

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -5124,13 +5124,14 @@ where
             return Ok(None);
         };
         let content_record = content_raw.record();
-        let content_tx = self.current_record_sort_key(content_record)?;
+        let content_tx = self.current_record_sort_key(table_name, row_uuid, content_record)?;
         if let Some(deletion_raw) = self
             .database
             .primary_key_get_raw(&global_tables[1].name, &[Value::Uuid(row_uuid.0)])?
         {
             let deletion_record = deletion_raw.record();
-            let deletion_tx = self.current_record_sort_key(deletion_record)?;
+            let deletion_tx =
+                self.current_record_sort_key(table_name, row_uuid, deletion_record)?;
             let deletion = deletion_event_from_value(
                 deletion_record.get_idx(RegisterGlobalCurrentRowRecord::FIELD__DELETION_IDX)?,
             )?;

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -99,7 +99,6 @@ where
             ));
         }
         for table in self.catalogue.schema.tables.clone() {
-            self.validate_current_row_storage_layout(&table)?;
             if let Some(raw) =
                 self.database
                     .index_last_raw(&history_table_name(&table.name), "by_tx", &[])?
@@ -214,51 +213,6 @@ where
         }
         if !cleanly_closed {
             self.cleanup_settled_ahead_current_leftovers(storage_consistent_through)?;
-        }
-        Ok(())
-    }
-
-    fn validate_current_row_storage_layout(&self, table: &TableSchema) -> Result<(), Error> {
-        let storage_tables = table.global_current_storage_tables();
-        self.validate_content_current_rows(&storage_tables[0])?;
-        self.validate_register_current_rows(&storage_tables[1])?;
-
-        let storage_tables = table.ahead_current_storage_tables();
-        self.validate_content_current_rows(&storage_tables[0])?;
-        self.validate_register_current_rows(&storage_tables[1])?;
-        Ok(())
-    }
-
-    fn validate_content_current_rows(
-        &self,
-        storage_table: &groove::schema::TableSchema,
-    ) -> Result<(), Error> {
-        let descriptor = storage_table.record_schema();
-        for raw in self
-            .database
-            .primary_key_scan_raw(&storage_table.name, &[])?
-        {
-            let record = BorrowedRecord::new(raw.raw(), &descriptor);
-            record.get_u64(GlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
-            record.get_idx(GlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
-            record.get_nullable_u64(GlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
-        }
-        Ok(())
-    }
-
-    fn validate_register_current_rows(
-        &self,
-        storage_table: &groove::schema::TableSchema,
-    ) -> Result<(), Error> {
-        let descriptor = storage_table.record_schema();
-        for raw in self
-            .database
-            .primary_key_scan_raw(&storage_table.name, &[])?
-        {
-            let record = BorrowedRecord::new(raw.raw(), &descriptor);
-            record.get_u64(RegisterGlobalCurrentRowRecord::FIELD_SCHEMA_VERSION_IDX)?;
-            record.get_idx(RegisterGlobalCurrentRowRecord::FIELD_PARENTS_IDX)?;
-            record.get_nullable_u64(RegisterGlobalCurrentRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
         }
         Ok(())
     }

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -45,6 +45,68 @@ fn opening_existing_storage_recovers_mirrors_and_high_water_marks() {
 }
 
 #[test]
+fn opening_defers_malformed_current_row_to_read() {
+    // This is necessarily an internal regression test: planting malformed
+    // persisted bytes requires direct storage access, and the core point-read
+    // path is where the persisted row key is available for error context.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        let tx_id = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(0xff), 10).cells(title_cells("persisted")),
+            )
+            .unwrap();
+        node.apply_fate_update(
+            tx_id,
+            Fate::Accepted,
+            Some(GlobalSeq(1)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+        let table = schema.tables[0].global_current_storage_tables()[0]
+            .name
+            .clone();
+        let (key, raw) = node
+            .database
+            .primary_key_get_raw(&table, &[Value::Uuid(row(0xff).0)])
+            .unwrap()
+            .unwrap()
+            .into_parts();
+        node.database.close().unwrap();
+        drop(node);
+
+        let cfs = schema.column_families();
+        let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+        let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+        let storage =
+            groove::storage::LayoutStorage::new(storage, StorageLayout::jazz_class_v1()).unwrap();
+        storage.set(&table, &key, &raw[..1]).unwrap();
+        storage.close().unwrap();
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    let mut reopened = NodeState::new(node(1), schema, storage).unwrap();
+    let error = reopened
+        .local_current_row("todos", row(0xff))
+        .expect_err("malformed current row must fail when read");
+    assert!(
+        matches!(
+            error,
+            Error::MalformedCurrentRow {
+                ref table,
+                row_uuid,
+                ..
+            } if table == "todos" && row_uuid == row(0xff)
+        ),
+        "unexpected current-row read error: {error}"
+    );
+}
+
+#[test]
 fn recovery_sweeps_ahead_rows_for_globally_fated_transactions() {
     let schema = schema();
     let temp_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Removes the startup current-row validation sweep. **Supersedes #1202**, which bounded the same scan by sampling one representative row per table.

## Why remove rather than bound

The sweep decoded every global/ahead content and register-current row at open, reading schema-version, parents and global-sequence fields solely to validate layout. #1202 proposed sampling instead. The objection to that — Anselm's — is that the check does not belong at this layer at all:

- **It cannot be complete, so its value is largely illusory.** It sees only rows present at open, and says nothing about rows written afterwards or corruption occurring between opens. That *sampling* was considered an acceptable weakening is itself the argument: if the property mattered, sampling would not do; if sampling does, the scan was not buying much.
- **It taxes the operation we care about most.** Cold open is under active benchmarking, and this made part of it proportional to store size for a property no caller consumes.
- **It duplicates a boundary that already exists.** Decoding a persisted record is an interior operation, and the codec must already handle malformed bytes. Two layers checking the same thing means neither owns it.

If we want corruption detection later, it belongs in storage as an explicit, opt-in verification pass run deliberately — not on every application start.

## What changed

Removed the sweep from `crates/jazz/src/node/recovery.rs:101`. No R3 validation counters or receipts existed on this base, so none needed removing.

**Nothing depended on it.** Point reads and authoritative-reset reads decode their own current-row metadata and now report the affected table and row UUID via `MalformedCurrentRow` (`crates/jazz/src/node/mod.rs:5135`). No existing test asserted the startup scan happened.

## The test that justifies the removal

`opening_defers_malformed_current_row_to_read` (`crates/jazz/src/node/tests/recovery.rs:48`) truncates a persisted global-current row, confirms reopen succeeds, then proves the point read fails **naming the affected table and row**. Corrupt data still surfaces — later, in context, with the key that failed, rather than as an eager whole-store sweep. Planting corruption necessarily uses internal storage mutation.

## Gates

Re-run on a compiling base — this branch was first gated while the integration branch had an unclosed delimiter in `peer.rs`, so every earlier number was noise.

`cargo test -p jazz --no-default-features --features test` → **1100 passed, 4 failed**. Those four are `node::tests::harness::*known_state*` and are **not from this change**: they fail identically on the merged base, and pass on the commit before #1266 merged (16 passed, 0 failed there). Reported separately.
