### PR TITLE
(new core) Remove a durable-key test obsoleted by #1260

### DIFF
--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -1765,28 +1765,6 @@ fn direct_record_store_rejects_record_containing_durable_keys_at_schema_admissio
 }
 
 #[test]
-fn direct_record_store_rejects_record_valued_durable_keys() {
-    let child = RecordDescriptor::new([("id", ValueType::U64)]);
-    let schema = DatabaseSchema::new([]).with_direct_record_store(DirectRecordStoreSchema::new(
-        "rendered_results",
-        RecordDescriptor::new([("result", ValueType::Record(Box::new(child)))]),
-        RecordDescriptor::new([("payload", ValueType::Bytes)]),
-    ));
-    let storage = MemoryStorage::new(&schema.column_families());
-    let database = Database::new(schema, storage).unwrap();
-    let store = database.direct_record_store("rendered_results").unwrap();
-    let child = crate::records::OwnedRecord::new(child.create(&[Value::U64(1)]).unwrap(), child);
-
-    assert!(matches!(
-        store.set(
-            &[Value::Record(child)],
-            &[Value::Bytes(b"not-a-key".to_vec())],
-        ),
-        Err(Error::InvalidDirectRecordStoreKey(_))
-    ));
-}
-
-#[test]
 fn commit_metrics_split_storage_and_tick_work() {
     let temp_dir = tempfile::tempdir().unwrap();
     let storage = RocksDbStorage::open(temp_dir.path(), &["albums"]).unwrap();


### PR DESCRIPTION
**`cargo test -p groove` is red on the integration base**, and it is my #1260's doing.

`db::tests::direct_record_store_rejects_record_valued_durable_keys` encodes the **pre-#1260** contract: `Database::new` accepts a record-valued direct-store key, and the codec rejects it later at encode time. #1260 deliberately moved that rejection to **schema admission** — so the test's own `Database::new(...).unwrap()` now panics at `tests.rs:1776`, before reaching the assertion it was written for.

The test is not wrong about anything; it is asserting a contract we intentionally replaced. #1260 added the new admission test and did not retire the old one.

## Why removal rather than rewrite

The property is now covered at a strictly stronger point by `direct_record_store_rejects_record_containing_durable_keys_at_schema_admission`, which `INV-STORAGE-27` already cites. Rewriting the old test would mean constructing a store whose key contains a record — which admission now makes unreachable through the public schema path, and making it reachable again would defeat the change.

The codec rejection itself stays as defense in depth. It is simply no longer reachable via a schema, which is exactly what #1260 intended.

## Verification

`cargo test -p groove` → **0** · `cargo fmt --check` → **0**

## Context

This was found while re-gating other work after the base was restored to compiling. The base currently carries several red gates — the three `catalogue_sync_integration` failures, `ts-wire-codec` byte-stability, four `known_state` rehydrate tests introduced by #1266, and this one. Each red gate makes the next one harder to notice; a hard compile failure hid in that noise for hours this morning.