### PR TITLE
(new core) Deliver session claims per upstream link

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -245,10 +245,6 @@ enum PendingUpstreamCommand {
         owner: LargeValueOwnerRef,
         extent: crate::node::content_store::Extent,
     },
-    SessionClaims {
-        identity: AuthorId,
-        claims: BTreeMap<String, Value>,
-    },
 }
 
 #[derive(Clone)]
@@ -2041,15 +2037,15 @@ where
 
     /// Attach process-local auth claims for `identity`.
     pub fn set_identity_claims(&self, identity: AuthorId, claims: BTreeMap<String, Value>) {
-        self.node
-            .node
-            .borrow_mut()
-            .set_session_claims(identity, claims.clone());
-        self.node
-            .upstream_subscriptions
-            .borrow_mut()
-            .push(PendingUpstreamCommand::SessionClaims { identity, claims });
-        self.node.schedule_tick(TickUrgency::Deferred);
+        let changed = {
+            let mut node = self.node.node.borrow_mut();
+            let previous_revision = node.session_claim_revision(identity);
+            node.set_session_claims(identity, claims);
+            node.session_claim_revision(identity) != previous_revision
+        };
+        if changed {
+            self.node.schedule_tick(TickUrgency::Deferred);
+        }
     }
 
     /// Return whether this Db's author can delete the current local row.
@@ -3776,6 +3772,7 @@ where
                 pending,
                 upstream_subscriptions: Rc::clone(&self.upstream_subscriptions),
                 announced_shapes: BTreeSet::new(),
+                sent_session_claim_revisions: BTreeMap::new(),
                 outbox: Rc::clone(&self.outbox),
                 uploaded: BTreeSet::new(),
                 pending_row_version_repairs: VecDeque::new(),
@@ -4853,6 +4850,10 @@ enum ConnectionLink {
         upstream_subscriptions: PendingUpstreamCommands,
         /// Shapes already registered on this connection.
         announced_shapes: BTreeSet<ShapeRegistrationKey>,
+        /// Latest session-claim revision shipped for each identity on this
+        /// connection. A fresh link starts empty and therefore receives every
+        /// current claim map, even if another link has already received it.
+        sent_session_claim_revisions: BTreeMap<AuthorId, u64>,
         /// Locally-authored transactions to upload (shared with the `Db`).
         outbox: Outbox,
         /// Transactions already shipped on this connection (dedup across ticks).
@@ -5098,12 +5099,32 @@ where
                 pending,
                 upstream_subscriptions,
                 announced_shapes,
+                sent_session_claim_revisions,
                 outbox,
                 uploaded,
                 pending_row_version_repairs,
                 pending_view_update_chunks,
             } => {
                 pending.extend(upstream_subscriptions.borrow_mut().drain(..));
+                let claims = self.node.borrow().session_claims_with_revisions();
+                for (identity, claims, revision) in claims {
+                    if sent_session_claim_revisions
+                        .get(&identity)
+                        .is_some_and(|sent| *sent >= revision)
+                    {
+                        continue;
+                    }
+                    if let Err(error) = self
+                        .transport
+                        .send(SyncMessage::SessionClaims { identity, claims })
+                    {
+                        if handle_transport_backpressure(&self.node, &self.scheduler, &error) {
+                            return Ok(stats);
+                        }
+                        return Err(transport_error(error));
+                    }
+                    sent_session_claim_revisions.insert(identity, revision);
+                }
                 let pending_index = 0;
                 while pending_index < pending.len() {
                     match &pending[pending_index] {
@@ -5198,21 +5219,6 @@ where
                                     extent: extent.clone(),
                                 })
                             {
-                                if handle_transport_backpressure(
-                                    &self.node,
-                                    &self.scheduler,
-                                    &error,
-                                ) {
-                                    return Ok(stats);
-                                }
-                                return Err(transport_error(error));
-                            }
-                        }
-                        PendingUpstreamCommand::SessionClaims { identity, claims } => {
-                            if let Err(error) = self.transport.send(SyncMessage::SessionClaims {
-                                identity: *identity,
-                                claims: claims.clone(),
-                            }) {
                                 if handle_transport_backpressure(
                                     &self.node,
                                     &self.scheduler,

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -8482,6 +8482,99 @@ fn connect_upstream_announces_existing_subscriptions_on_first_tick() {
     assert_eq!(subscribe.subscription.shape_id, shape_id);
 }
 
+// SessionClaims has no distinct public state once the receiving NodeState has
+// ignored an identical map, so wire-count coverage must inspect the transport.
+// The policy-visible integration coverage lives above this facade; this test
+// protects the otherwise unobservable wire-chatter contract.
+#[test]
+fn repeated_identical_session_claims_emit_once_on_a_live_connection() {
+    let schema = schema();
+    let client_author = AuthorId::from_bytes([0xc1; 16]);
+    let client = open_db(0xc1, client_author, &schema);
+    let (client_transport, mut upstream_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let claims = BTreeMap::from([("role".to_owned(), Value::String("reader".to_owned()))]);
+
+    client.set_identity_claims(client_author, claims.clone());
+    client.set_identity_claims(client_author, claims);
+    client.tick().unwrap();
+
+    assert!(matches!(
+        upstream_transport.try_recv(),
+        Some(SyncMessage::SessionClaims { .. })
+    ));
+    assert!(
+        upstream_transport.try_recv().is_none(),
+        "an unchanged claim map must not produce another wire message"
+    );
+}
+
+// This is lower-level for the same reason as the wire-count test above. In
+// particular, it is the regression that a global deduplication would miss:
+// each newly attached transport must receive the current map independently.
+#[test]
+fn current_session_claims_reach_late_and_reconnected_upstreams() {
+    let schema = schema();
+    let client_author = AuthorId::from_bytes([0xc1; 16]);
+    let client = open_db(0xc1, client_author, &schema);
+    let claims = BTreeMap::from([("role".to_owned(), Value::String("reader".to_owned()))]);
+
+    client.set_identity_claims(client_author, claims.clone());
+    let (first_transport, mut first_upstream_transport) = duplex();
+    let first_upstream = client.connect_upstream(first_transport);
+    client.tick().unwrap();
+    assert!(matches!(
+        first_upstream_transport.try_recv(),
+        Some(SyncMessage::SessionClaims { identity, claims: received })
+            if identity == client_author && received == claims
+    ));
+    assert!(first_upstream_transport.try_recv().is_none());
+
+    client.set_identity_claims(client_author, claims.clone());
+    assert!(client.detach_connection(&first_upstream));
+
+    let (reconnected_transport, mut reconnected_upstream_transport) = duplex();
+    let _reconnected_upstream = client.connect_upstream(reconnected_transport);
+    client.tick().unwrap();
+    assert!(matches!(
+        reconnected_upstream_transport.try_recv(),
+        Some(SyncMessage::SessionClaims { identity, claims: received })
+            if identity == client_author && received == claims
+    ));
+    assert!(reconnected_upstream_transport.try_recv().is_none());
+}
+
+#[test]
+fn changed_session_claims_advance_delivery_after_an_identical_call() {
+    let schema = schema();
+    let client_author = AuthorId::from_bytes([0xc1; 16]);
+    let client = open_db(0xc1, client_author, &schema);
+    let (client_transport, mut upstream_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let reader = BTreeMap::from([("role".to_owned(), Value::String("reader".to_owned()))]);
+    let writer = BTreeMap::from([("role".to_owned(), Value::String("writer".to_owned()))]);
+
+    client.set_identity_claims(client_author, reader.clone());
+    client.tick().unwrap();
+    assert!(matches!(
+        upstream_transport.try_recv(),
+        Some(SyncMessage::SessionClaims { claims, .. }) if claims == reader
+    ));
+
+    client.set_identity_claims(client_author, reader);
+    client.tick().unwrap();
+    assert!(upstream_transport.try_recv().is_none());
+
+    client.set_identity_claims(client_author, writer.clone());
+    client.tick().unwrap();
+    assert!(matches!(
+        upstream_transport.try_recv(),
+        Some(SyncMessage::SessionClaims { identity, claims })
+            if identity == client_author && claims == writer
+    ));
+    assert!(upstream_transport.try_recv().is_none());
+}
+
 #[test]
 fn global_subscription_registers_array_subquery_upstream_coverage() {
     let schema = relation_schema();

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -724,6 +724,25 @@ where
             .unwrap_or_default()
     }
 
+    /// Return the current process-local claims together with their revisions.
+    ///
+    /// Upstream links use this snapshot to decide which claims have not yet
+    /// reached that particular connection.
+    pub(crate) fn session_claims_with_revisions(
+        &self,
+    ) -> Vec<(AuthorId, BTreeMap<String, Value>, u64)> {
+        self.session_claims
+            .iter()
+            .map(|(identity, claims)| {
+                (
+                    *identity,
+                    claims.clone(),
+                    self.session_claim_revision(*identity),
+                )
+            })
+            .collect()
+    }
+
     /// Gate session-scoped serving until an authority has installed its
     /// permissions head. Local/offline nodes stay ready by default.
     pub(crate) fn set_permissions_ready(&mut self, ready: bool) {


### PR DESCRIPTION
Stops `SessionClaims` chatter without breaking claim delivery. **Supersedes #1110**, whose approach is unsafe.

## The chatter is real

`Db::set_identity_claims` queues a `SessionClaims` wire message on **every** call, even when the claim map is unchanged. `NodeState` already ignores an unchanged map internally, so the repeat is pure wire waste.

## Why #1110's approach could not land

#1110 deduplicates **globally**: `NodeState` reports whether the local map changed, and `Db` skips queueing when it did not.

A newly created or reconnected upstream connection receives commands only from its pending queue, and #1110 keeps no per-link record of what was sent. So suppressing a repeated `set_identity_claims` can suppress the claims a **fresh link still needs** — trading harmless chatter for a connection that never learns the identity's claims.

Demonstrated, not argued: in an isolated worktree at #1110's own commit I added the attach/reconnect regression and ran it. **Exit 101 — the reconnected transport received no `SessionClaims`.**

Its only test covered two identical calls *before* the first connection, which is precisely the case that cannot expose this.

## What this does instead

Per-upstream-link claim revision:

- `NodeState` stays the authoritative per-identity claim revision source.
- Each upstream `PeerConnection` records the revisions it has successfully sent.
- On every upstream tick a link sends only claim maps whose revision exceeds its own sent revision. A fresh or reconnected link starts empty and therefore receives all current maps.
- An unchanged call schedules nothing and produces no wire traffic.
- **Backpressure does not advance the sent revision**, so a dropped send is retried rather than silently skipped.

Correct delivery is the requirement; suppressing equivalent repeated sends is the optimisation. Never the other way round.

## Tests

- repeated identical calls on a live link emit one `SessionClaims`;
- **claims reach both a late-attached and a reconnected link after a suppressed duplicate** — the case #1110 fails;
- a real claim change after suppression is delivered.

The wire-count and delivery tests inspect the transport, because duplicate `SessionClaims` are deliberately unobservable through public state once the receiver ignores them. That exception to the black-box preference is documented inline, per the testing guidelines.

## Gates

`cargo check --workspace --all-targets` 0 · `cargo fmt --check` 0 · focused suite **5 passed, 0 failed**.

`cargo test -p jazz` and `--no-default-features --features test` are **101**, from four `node::tests::harness::*known_state*` rehydrate failures that **reproduce identically on the merged base** `43a8d4739` (introduced by #1266, reported separately). One websocket test also failed once under parallel load; its exact rerun passed.
