### PR TITLE
(new core) Box MalformedCurrentRow — it took clippy from 2 errors to 641

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2270,10 +2270,12 @@ where
         row_uuid: RowUuid,
         record: BorrowedRecord<'_>,
     ) -> Result<(TxTime, NodeUuid), Error> {
-        let malformed = |source| Error::MalformedCurrentRow {
-            table: table.to_owned(),
-            row_uuid,
-            source,
+        let malformed = |source| {
+            Error::MalformedCurrentRow(Box::new(MalformedCurrentRow {
+                table: table.to_owned(),
+                row_uuid,
+                source,
+            }))
         };
         let tx_time = TxTime(
             record
@@ -5142,6 +5144,19 @@ fn storage_consistency_marker_key() -> [Value; 1] {
     [Value::String(STORAGE_CONSISTENCY_MARKER_NAME.to_owned())]
 }
 
+/// Details of a persisted current row that could not be decoded at the point of use.
+#[derive(Debug, thiserror::Error)]
+#[error("malformed current row in table {table} for {row_uuid:?}: {source}")]
+pub struct MalformedCurrentRow {
+    /// Logical table containing the row.
+    pub table: String,
+    /// Primary-key row identity of the malformed record.
+    pub row_uuid: RowUuid,
+    /// The record decoding failure.
+    #[source]
+    pub source: records::Error,
+}
+
 /// Error type returned by the storage-backed node API.
 #[derive(Debug, Error)]
 pub enum Error {
@@ -5152,16 +5167,8 @@ pub enum Error {
     #[error(transparent)]
     Record(#[from] records::Error),
     /// A persisted current row could not be decoded at the point of use.
-    #[error("malformed current row in table {table} for {row_uuid:?}: {source}")]
-    MalformedCurrentRow {
-        /// Logical table containing the row.
-        table: String,
-        /// Primary-key row identity of the malformed record.
-        row_uuid: RowUuid,
-        /// The record decoding failure.
-        #[source]
-        source: records::Error,
-    },
+    #[error(transparent)]
+    MalformedCurrentRow(#[from] Box<MalformedCurrentRow>),
     /// Error returned by storage.
     #[error(transparent)]
     Storage(#[from] storage::Error),

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -96,11 +96,8 @@ fn opening_defers_malformed_current_row_to_read() {
     assert!(
         matches!(
             error,
-            Error::MalformedCurrentRow {
-                ref table,
-                row_uuid,
-                ..
-            } if table == "todos" && row_uuid == row(0xff)
+            Error::MalformedCurrentRow(ref details)
+                if details.table == "todos" && details.row_uuid == row(0xff)
         ),
         "unexpected current-row read error: {error}"
     );


### PR DESCRIPTION
**The pre-commit hook is currently blocking every commit**, and it's my #1274's doing.

#1274 added `MalformedCurrentRow` as a struct variant carrying a `String`, a `RowUuid` and a `records::Error`. That pushed `jazz::node::Error` past clippy's `result_large_err` threshold — and because the lint fires on **every function returning `Result<_, Error>`**, one variant produced 639 new errors across the crate.

`cargo clippy --package jazz --all-targets -- -D warnings`: **2 before #1274, 641 after.** That is the groove pre-commit hook, so lanes have been committing with `--no-verify` to get anything done.

## The fix

Move the payload into a boxed `MalformedCurrentRow` struct. `Error` shrinks back under the threshold and the count returns to its pre-#1274 value of **2**.

`Display` and the `source` chain are unchanged — the error reads exactly the same. Only the destructuring pattern changes, which one test uses.

## Verification

- `cargo clippy --package jazz --all-targets -- -D warnings` → **2** (was 641; the remaining 2 pre-date #1274)
- `cargo test -p jazz --lib recovery` → 6 passed
- `cargo fmt --check` → 0

## Worth noting

The blast radius here is the interesting part. A single variant on a widely-returned `Result` silently made a lint fire in ~640 unrelated places, and the only symptom anyone saw was "the pre-commit hook fails, use `--no-verify`". That is how a hook stops being a hook.

Same family as the `CollectBy` stack overflow in #1263: a large payload on a widely-used type, where the cost shows up somewhere that looks unrelated to the change. Worth remembering when adding to `Error` or `OpType`.