### PR TITLE
(new core) CollectBy Expand mode

### DIFF
--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -263,6 +263,23 @@ fn history_collect_by(limit: u64) -> GraphBuilder {
     )
 }
 
+fn history_collect_by_expand(offset: u64, limit: u64) -> GraphBuilder {
+    GraphBuilder::collect_by_expand(
+        GraphBuilder::table("history"),
+        ["row"],
+        [
+            CollectByField::named("row"),
+            CollectByField::renamed("node", "source_node"),
+            CollectByField::renamed("title", "child_title"),
+        ],
+        ["row", "node"],
+        [TopByOrder::asc("stamp")],
+        ["node"],
+        offset,
+        TopByLimit::Finite(limit),
+    )
+}
+
 fn collect_parent(row: u64, children: &[(u64, &str)]) -> Vec<Value> {
     let child_descriptor = RecordDescriptor::new([
         ("child_id", ValueType::U64),
@@ -4783,6 +4800,171 @@ fn collect_by_round_trips_ordered_explicit_child_ids() {
             1,
         )]
     );
+}
+
+#[test]
+fn collect_by_expand_renders_selected_tuples_in_source_order() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).unwrap();
+    let subscription = database
+        .subscribe_one_sink(history_collect_by_expand(0, 3))
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    // Deliberately not in declared stamp order. The first two columns are the
+    // ordered root/child occurrence-source vector carried by the tuple.
+    batch.insert("history", history_values(1, 30, 30, "third"));
+    batch.insert("history", history_values(1, 10, 10, "first"));
+    batch.insert("history", history_values(1, 20, 20, "second"));
+    database.commit_batch(batch).unwrap();
+
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (
+                vec![
+                    Value::U64(1),
+                    Value::U64(10),
+                    Value::String("first".to_owned()),
+                ],
+                1,
+            ),
+            (
+                vec![
+                    Value::U64(1),
+                    Value::U64(20),
+                    Value::String("second".to_owned()),
+                ],
+                1,
+            ),
+            (
+                vec![
+                    Value::U64(1),
+                    Value::U64(30),
+                    Value::String("third".to_owned()),
+                ],
+                1,
+            ),
+        ]
+    );
+}
+
+#[test]
+fn collect_by_expand_diffs_only_selected_tuple_occurrences() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).unwrap();
+    let subscription = database
+        .subscribe_one_sink(history_collect_by_expand(0, 2))
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 10, 10, "first"));
+    batch.insert("history", history_values(1, 20, 20, "second"));
+    database.commit_batch(batch).unwrap();
+    let _initial = subscription.recv().unwrap();
+
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 5, 5, "front"));
+    database.commit_batch(batch).unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (
+                vec![
+                    Value::U64(1),
+                    Value::U64(5),
+                    Value::String("front".to_owned()),
+                ],
+                1,
+            ),
+            (
+                vec![
+                    Value::U64(1),
+                    Value::U64(20),
+                    Value::String("second".to_owned()),
+                ],
+                -1,
+            ),
+        ]
+    );
+}
+
+#[test]
+fn collect_by_expand_suppresses_byte_equal_selected_tuples() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).unwrap();
+    let subscription = database
+        .subscribe_one_sink(history_collect_by_expand(0, 2))
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 10, 10, "first"));
+    batch.insert("history", history_values(1, 20, 20, "second"));
+    database.commit_batch(batch).unwrap();
+    let _initial = subscription.recv().unwrap();
+
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 30, 30, "outside"));
+    database.commit_batch(batch).unwrap();
+    assert!(matches!(subscription.try_recv(), Err(TryRecvError::Empty)));
+}
+
+#[test]
+fn collect_by_expand_honors_order_tie_offset_and_limit() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).unwrap();
+    let subscription = database
+        .subscribe_one_sink(history_collect_by_expand(1, 2))
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 10, 10, "first"));
+    batch.insert("history", history_values(1, 10, 20, "tied-second"));
+    batch.insert("history", history_values(1, 20, 30, "third"));
+    batch.insert("history", history_values(1, 30, 40, "outside"));
+    database.commit_batch(batch).unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (
+                vec![
+                    Value::U64(1),
+                    Value::U64(20),
+                    Value::String("tied-second".to_owned()),
+                ],
+                1,
+            ),
+            (
+                vec![
+                    Value::U64(1),
+                    Value::U64(30),
+                    Value::String("third".to_owned()),
+                ],
+                1,
+            ),
+        ]
+    );
+}
+
+#[test]
+fn collect_by_expand_rejects_duplicate_occurrence_source_ids() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 10, 7, "first"));
+    batch.insert("history", history_values(1, 20, 7, "ambiguous"));
+    database.commit_batch(batch).unwrap();
+
+    assert!(matches!(
+        database.subscribe_one_sink(history_collect_by_expand(0, 3)),
+        Err(Error::IvmRuntime(
+            IvmRuntimeError::DuplicateCollectByOccurrenceId
+        ))
+    ));
 }
 
 #[test]

--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -237,10 +237,15 @@ pub enum GraphBuilder {
 /// recursive graph-builder value carried by unrelated query paths.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CollectByBuilder {
+    pub mode: CollectByMode,
     pub group_cols: Vec<FieldRef>,
     pub parent_fields: Vec<CollectByField>,
     pub child_fields: Vec<CollectByField>,
     pub collection_field: String,
+    /// Flat output projection used by [`CollectByMode::Expand`].
+    pub tuple_fields: Vec<CollectByField>,
+    /// Ordered source-row identity fields used by [`CollectByMode::Expand`].
+    pub occurrence_id_cols: Vec<FieldRef>,
     pub order_cols: Vec<TopByOrder>,
     pub tie_cols: Vec<FieldRef>,
     pub offset: u64,
@@ -482,16 +487,78 @@ impl GraphBuilder {
         Self::CollectBy {
             input: Box::new(input),
             collect: Box::new(CollectByBuilder {
+                mode: CollectByMode::Collect,
                 group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
                 parent_fields: parent_fields.into_iter().collect(),
                 child_fields: child_fields.into_iter().collect(),
                 collection_field: collection_field.into(),
+                tuple_fields: Vec::new(),
+                occurrence_id_cols: Vec::new(),
                 order_cols: order_cols.into_iter().collect(),
                 tie_cols: tie_cols.into_iter().map(FieldRef::name).collect(),
                 offset,
                 limit,
             }),
         }
+    }
+
+    /// Render the selected rows of a grouped ordered stream as flat tuples.
+    ///
+    /// `occurrence_id_cols` are source-row ids in root-then-join order. They
+    /// address the rendered tuple independently of its bytes, so equal tuples
+    /// from different joins remain distinct while ambiguous duplicate ids are
+    /// rejected by the terminal.
+    #[allow(clippy::too_many_arguments)]
+    pub fn collect_by_expand(
+        input: GraphBuilder,
+        group_cols: impl IntoIterator<Item = impl Into<String>>,
+        tuple_fields: impl IntoIterator<Item = CollectByField>,
+        occurrence_id_cols: impl IntoIterator<Item = impl Into<String>>,
+        order_cols: impl IntoIterator<Item = TopByOrder>,
+        tie_cols: impl IntoIterator<Item = impl Into<String>>,
+        offset: u64,
+        limit: TopByLimit,
+    ) -> Self {
+        Self::CollectBy {
+            input: Box::new(input),
+            collect: Box::new(CollectByBuilder {
+                mode: CollectByMode::Expand,
+                group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
+                parent_fields: Vec::new(),
+                child_fields: Vec::new(),
+                collection_field: String::new(),
+                tuple_fields: tuple_fields.into_iter().collect(),
+                occurrence_id_cols: occurrence_id_cols.into_iter().map(FieldRef::name).collect(),
+                order_cols: order_cols.into_iter().collect(),
+                tie_cols: tie_cols.into_iter().map(FieldRef::name).collect(),
+                offset,
+                limit,
+            }),
+        }
+    }
+
+    /// Alias for callers that prefer the terminal mode before its name.
+    #[allow(clippy::too_many_arguments)]
+    pub fn expand_by(
+        input: GraphBuilder,
+        group_cols: impl IntoIterator<Item = impl Into<String>>,
+        tuple_fields: impl IntoIterator<Item = CollectByField>,
+        occurrence_id_cols: impl IntoIterator<Item = impl Into<String>>,
+        order_cols: impl IntoIterator<Item = TopByOrder>,
+        tie_cols: impl IntoIterator<Item = impl Into<String>>,
+        offset: u64,
+        limit: TopByLimit,
+    ) -> Self {
+        Self::collect_by_expand(
+            input,
+            group_cols,
+            tuple_fields,
+            occurrence_id_cols,
+            order_cols,
+            tie_cols,
+            offset,
+            limit,
+        )
     }
 
     pub fn aggregate(
@@ -940,6 +1007,70 @@ impl NodeDescriptor {
             }
             OpType::CollectBy(collect_by) => {
                 expect_arity(&self.inputs, 1)?;
+                if collect_by.mode == CollectByMode::Expand {
+                    if collect_by.tuple_fields.is_empty()
+                        || collect_by.occurrence_id_field_indices.is_empty()
+                        || collect_by.sort_field_indices.len() != collect_by.sort_directions.len()
+                        || collect_by.sort_field_indices.len()
+                            != collect_by.order_fields.len() + collect_by.tie_fields.len()
+                        || collect_by.order_fields.is_empty()
+                        || collect_by.tie_fields.is_empty()
+                        || self.output.fields().len() != collect_by.tuple_fields.len()
+                    {
+                        return Err(GraphValidationError::CollectByOutputDescriptorMismatch);
+                    }
+                    for field in collect_by
+                        .group_field_indices
+                        .iter()
+                        .chain(&collect_by.sort_field_indices)
+                        .chain(&collect_by.occurrence_id_field_indices)
+                        .chain(collect_by.tuple_fields.iter().map(|field| &field.field_idx))
+                    {
+                        if *field >= input_outputs[0].fields().len() {
+                            return Err(GraphValidationError::FieldIndexOutOfBounds {
+                                index: *field,
+                                len: input_outputs[0].fields().len(),
+                            });
+                        }
+                    }
+                    for (output_field, projection) in
+                        self.output.fields().iter().zip(&collect_by.tuple_fields)
+                    {
+                        let input_field = &input_outputs[0].fields()[projection.field_idx];
+                        if output_field.name.as_deref() != Some(projection.output_name.as_str())
+                            || output_field.value_type != input_field.value_type
+                        {
+                            return Err(GraphValidationError::CollectByOutputDescriptorMismatch);
+                        }
+                    }
+                    for &field_idx in collect_by
+                        .group_field_indices
+                        .iter()
+                        .chain(&collect_by.sort_field_indices)
+                        .chain(&collect_by.occurrence_id_field_indices)
+                    {
+                        let value_type = &input_outputs[0].fields()[field_idx].value_type;
+                        let scalar = matches!(
+                            value_type,
+                            ValueType::U8
+                                | ValueType::U16
+                                | ValueType::U32
+                                | ValueType::U64
+                                | ValueType::I32
+                                | ValueType::I64
+                                | ValueType::F64
+                                | ValueType::Bool
+                                | ValueType::String
+                                | ValueType::Bytes
+                                | ValueType::Uuid
+                                | ValueType::Enum(_)
+                        );
+                        if !scalar || value_type.contains_record() {
+                            return Err(GraphValidationError::CollectByKeyFieldMustBeScalar);
+                        }
+                    }
+                    return Ok(());
+                }
                 if collect_by.collection_field_index >= self.output.fields().len() {
                     return Err(GraphValidationError::FieldIndexOutOfBounds {
                         index: collect_by.collection_field_index,
@@ -1559,6 +1690,7 @@ mod tests {
         let collector = graph.dedup_node(
             NodeDescriptor::new(
                 OpType::CollectBy(Box::new(CollectByOp {
+                    mode: CollectByMode::Collect,
                     group_fields: vec!["f0".to_owned()],
                     group_field_indices: vec![0],
                     parent_fields: vec![CollectByProjection {
@@ -1574,6 +1706,9 @@ mod tests {
                     child_descriptor: child,
                     collection_field: "children".to_owned(),
                     collection_field_index: 1,
+                    tuple_fields: Vec::new(),
+                    occurrence_id_fields: Vec::new(),
+                    occurrence_id_field_indices: Vec::new(),
                     order_fields: vec![TopByOrderField {
                         field: "f0".to_owned(),
                         direction: TopByDirection::Asc,

--- a/crates/groove/src/ivm/op_types.rs
+++ b/crates/groove/src/ivm/op_types.rs
@@ -282,6 +282,7 @@ pub struct CollectByProjection {
 /// allowed to affect a shared collector node.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CollectByOp {
+    pub mode: CollectByMode,
     pub group_fields: Vec<String>,
     pub group_field_indices: Vec<usize>,
     pub parent_fields: Vec<CollectByProjection>,
@@ -289,12 +290,28 @@ pub struct CollectByOp {
     pub child_descriptor: RecordDescriptor,
     pub collection_field: String,
     pub collection_field_index: usize,
+    /// Flat output projection used only in [`CollectByMode::Expand`].
+    pub tuple_fields: Vec<CollectByProjection>,
+    /// Ordered contributing source-row ids used to address expanded tuples.
+    pub occurrence_id_fields: Vec<String>,
+    pub occurrence_id_field_indices: Vec<usize>,
     pub order_fields: Vec<TopByOrderField>,
     pub tie_fields: Vec<String>,
     pub sort_field_indices: Vec<usize>,
     pub sort_directions: Vec<TopByDirection>,
     pub offset: u64,
     pub limit: TopByLimit,
+}
+
+/// The rendered shape selected by the terminal [`CollectByOp`].
+///
+/// Both variants consume the same grouped, ordered input and window.  Collect
+/// owns a single parent record, while Expand owns one output occurrence per
+/// selected flat tuple.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CollectByMode {
+    Collect,
+    Expand,
 }
 
 /// Placeholder aggregate descriptor for future lowering/execution.

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -23,12 +23,13 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::ivm::{
     AggregateExpr, AggregateFunction, AggregateOp, ArgMaxByOp, ArgMinByOp, BindingSourceOp,
-    CollectByBuilder, CollectByField, CollectByOp, CollectByProjection, DurableStorage, FieldRef,
-    FilterOp, FrontierName, FrontierSourceOp, GraphBuilder, IndexByOp, IndexSourceOp,
-    InlineRecordsOp, IvmGraph, JoinOp, JoinOpKind, LiteralValue, MapProjectOp, NodeDescriptor,
-    NodeDurability, NodeId, OpType, PersistOp, PlanExpr, PredicateExpr, ProjectExpr, ProjectField,
-    ProjectionExpr, RecursiveOp, Retainer, StaticScanSpec, TableSourceOp, TopByDirection,
-    TopByLimit, TopByOp, TopByOrderField, UnnestOp, UnwrapNullableOp, ValueComparison,
+    CollectByBuilder, CollectByField, CollectByMode, CollectByOp, CollectByProjection,
+    DurableStorage, FieldRef, FilterOp, FrontierName, FrontierSourceOp, GraphBuilder, IndexByOp,
+    IndexSourceOp, InlineRecordsOp, IvmGraph, JoinOp, JoinOpKind, LiteralValue, MapProjectOp,
+    NodeDescriptor, NodeDurability, NodeId, OpType, PersistOp, PlanExpr, PredicateExpr,
+    ProjectExpr, ProjectField, ProjectionExpr, RecursiveOp, Retainer, StaticScanSpec,
+    TableSourceOp, TopByDirection, TopByLimit, TopByOp, TopByOrderField, UnnestOp,
+    UnwrapNullableOp, ValueComparison,
 };
 use crate::records::{
     self, BorrowedRecord, OwnedRecord, RawProjectionField, RawProjectionScratch, RecordDescriptor,
@@ -1304,12 +1305,17 @@ impl IvmRuntime {
             }
             GraphBuilder::CollectBy { input, collect, .. } => {
                 let input = self.infer_builder_output_cached(input, output_memo)?;
-                collect_by_descriptor(
-                    &input,
-                    &collect.parent_fields,
-                    &collect.child_fields,
-                    &collect.collection_field,
-                )
+                match collect.mode {
+                    CollectByMode::Collect => collect_by_descriptor(
+                        &input,
+                        &collect.parent_fields,
+                        &collect.child_fields,
+                        &collect.collection_field,
+                    ),
+                    CollectByMode::Expand => {
+                        collect_by_expand_descriptor(&input, &collect.tuple_fields)
+                    }
+                }
             }
             GraphBuilder::Aggregate {
                 input,
@@ -2455,17 +2461,25 @@ impl IvmRuntime {
             .collect::<Result<Vec<_>, _>>()?;
         let parent_fields = collect_by_projections(&input_output, &collect.parent_fields)?;
         let child_fields = collect_by_projections(&input_output, &collect.child_fields)?;
+        let tuple_fields = collect_by_projections(&input_output, &collect.tuple_fields)?;
+        let occurrence_id_field_indices = collect
+            .occurrence_id_cols
+            .iter()
+            .map(|field| resolve_field_ref(&input_output, field))
+            .collect::<Result<Vec<_>, _>>()?;
         // Parent values must be determined by the group, rather than by
         // whichever child happens to be selected.
-        if parent_fields
-            .iter()
-            .any(|field| !group_field_indices.contains(&field.field_idx))
+        if collect.mode == CollectByMode::Collect
+            && parent_fields
+                .iter()
+                .any(|field| !group_field_indices.contains(&field.field_idx))
         {
             return Err(IvmRuntimeError::InvalidCollectBy(
                 "parent projection fields must be grouping fields".into(),
             ));
         }
         validate_collect_by_key_types(&input_output, &group_field_indices)?;
+        validate_collect_by_key_types(&input_output, &occurrence_id_field_indices)?;
         let order_field_indices = collect
             .order_cols
             .iter()
@@ -2520,10 +2534,18 @@ impl IvmRuntime {
             let value_type = input_output.fields()[field.field_idx].value_type.clone();
             (field.output_name.clone(), value_type)
         }));
+        if collect.mode == CollectByMode::Expand
+            && (tuple_fields.is_empty() || occurrence_id_field_indices.is_empty())
+        {
+            return Err(IvmRuntimeError::InvalidCollectBy(
+                "expand mode requires a tuple projection and ordered occurrence-id fields".into(),
+            ));
+        }
         let collection_field_index = parent_fields.len();
         let node = self.graph.dedup_node(
             NodeDescriptor::new(
                 OpType::CollectBy(Box::new(CollectByOp {
+                    mode: collect.mode,
                     group_fields,
                     group_field_indices,
                     parent_fields,
@@ -2531,6 +2553,12 @@ impl IvmRuntime {
                     child_descriptor,
                     collection_field: collect.collection_field.clone(),
                     collection_field_index,
+                    tuple_fields,
+                    occurrence_id_fields: occurrence_id_field_indices
+                        .iter()
+                        .map(|field| field_name_at(&input_output, *field))
+                        .collect::<Result<Vec<_>, _>>()?,
+                    occurrence_id_field_indices,
                     order_fields,
                     tie_fields,
                     sort_field_indices,
@@ -6214,26 +6242,71 @@ where
         for (group_prefix, group_deltas) in touched_groups {
             let after_records = arrangement.value().records_for_key(&group_prefix);
             let before_records = records_before_deltas(after_records.clone(), &group_deltas);
-            let before = collect_by_parent_from_records(
-                input_desc,
-                output_desc,
-                collect_by,
-                &before_records,
-            )?;
-            let after = collect_by_parent_from_records(
-                input_desc,
-                output_desc,
-                collect_by,
-                &after_records,
-            )?;
-            if before == after {
-                continue;
-            }
-            if let Some(record) = before {
-                output.push(RecordDelta { record, weight: -1 });
-            }
-            if let Some(record) = after {
-                output.push(RecordDelta { record, weight: 1 });
+            match collect_by.mode {
+                CollectByMode::Collect => {
+                    let before = collect_by_parent_from_records(
+                        input_desc,
+                        output_desc,
+                        collect_by,
+                        &before_records,
+                    )?;
+                    let after = collect_by_parent_from_records(
+                        input_desc,
+                        output_desc,
+                        collect_by,
+                        &after_records,
+                    )?;
+                    if before == after {
+                        continue;
+                    }
+                    if let Some(record) = before {
+                        output.push(RecordDelta { record, weight: -1 });
+                    }
+                    if let Some(record) = after {
+                        output.push(RecordDelta { record, weight: 1 });
+                    }
+                }
+                CollectByMode::Expand => {
+                    let before = collect_by_expanded_window(
+                        input_desc,
+                        output_desc,
+                        collect_by,
+                        &before_records,
+                    )?;
+                    let after = collect_by_expanded_window(
+                        input_desc,
+                        output_desc,
+                        collect_by,
+                        &after_records,
+                    )?;
+                    let mut occurrences = BTreeSet::new();
+                    occurrences.extend(before.keys().cloned());
+                    occurrences.extend(after.keys().cloned());
+                    for occurrence in occurrences {
+                        match (before.get(&occurrence), after.get(&occurrence)) {
+                            (Some(before), Some(after)) if before == after => {}
+                            (Some(before), Some(after)) => {
+                                output.push(RecordDelta {
+                                    record: before.clone(),
+                                    weight: -1,
+                                });
+                                output.push(RecordDelta {
+                                    record: after.clone(),
+                                    weight: 1,
+                                });
+                            }
+                            (Some(before), None) => output.push(RecordDelta {
+                                record: before.clone(),
+                                weight: -1,
+                            }),
+                            (None, Some(after)) => output.push(RecordDelta {
+                                record: after.clone(),
+                                weight: 1,
+                            }),
+                            (None, None) => unreachable!("occurrence came from a selected window"),
+                        }
+                    }
+                }
             }
         }
         self.arrangement_states.insert(arrangement_key, arrangement);
@@ -6722,6 +6795,34 @@ fn collect_by_descriptor(
         )))),
     ));
     Ok(RecordDescriptor::new(output))
+}
+
+fn collect_by_expand_descriptor(
+    input: &RecordDescriptor,
+    tuple_fields: &[CollectByField],
+) -> Result<RecordDescriptor, IvmRuntimeError> {
+    if tuple_fields.is_empty() {
+        return Err(IvmRuntimeError::InvalidCollectBy(
+            "expand mode requires a non-empty tuple projection".into(),
+        ));
+    }
+    let mut names = HashSet::new();
+    tuple_fields
+        .iter()
+        .map(|field| {
+            if !names.insert(field.output_name.clone()) {
+                return Err(IvmRuntimeError::InvalidCollectBy(
+                    "expand tuple output field names must be unique".into(),
+                ));
+            }
+            let index = resolve_field_ref(input, &field.field)?;
+            Ok((
+                field.output_name.clone(),
+                input.fields()[index].value_type.clone(),
+            ))
+        })
+        .collect::<Result<Vec<_>, IvmRuntimeError>>()
+        .map(RecordDescriptor::new)
 }
 
 fn collect_by_projections(
@@ -8635,6 +8736,45 @@ fn collect_by_parent_from_records(
     Ok(Some(output_desc.create(&values)?.into()))
 }
 
+/// Render the selected expand window keyed by its ordered contributing source
+/// ids. Keeping the key separate from the rendered bytes is what lets expand
+/// suppress only a byte-equal occurrence without collapsing equal tuples from
+/// different joins.
+fn collect_by_expanded_window(
+    input_desc: RecordDescriptor,
+    output_desc: RecordDescriptor,
+    collect_by: &CollectByOp,
+    records: &[(Bytes, i64)],
+) -> Result<BTreeMap<Vec<u8>, Bytes>, IvmRuntimeError> {
+    let window = collect_by_window_from_records(input_desc, records, collect_by)?;
+    let mut expanded = BTreeMap::new();
+    for (record, copies) in window {
+        let occurrence =
+            encoded_record_key_part(input_desc, &record, &collect_by.occurrence_id_field_indices)?;
+        // A weighted duplicate or two different source rows that map to the
+        // same vector cannot be addressed by OutputOccurrenceId yet. Do not
+        // silently turn that ambiguity into one row.
+        if copies != 1 || expanded.contains_key(&occurrence) {
+            return Err(IvmRuntimeError::DuplicateCollectByOccurrenceId);
+        }
+        let values = BorrowedRecord::new(&record, &input_desc)
+            .to_values()
+            .map_err(IvmRuntimeError::RecordEncoding)?;
+        let tuple = collect_by
+            .tuple_fields
+            .iter()
+            .map(|field| {
+                values
+                    .get(field.field_idx)
+                    .cloned()
+                    .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(field.field_idx))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        expanded.insert(occurrence, output_desc.create(&tuple)?.into());
+    }
+    Ok(expanded)
+}
+
 fn collect_by_window_from_records(
     descriptor: RecordDescriptor,
     records: &[(Bytes, i64)],
@@ -8924,6 +9064,8 @@ pub enum IvmRuntimeError {
     CollectByMustBeTerminal,
     #[error("invalid collect_by descriptor: {0}")]
     InvalidCollectBy(String),
+    #[error("collect_by expand encountered duplicate output occurrence source ids")]
+    DuplicateCollectByOccurrenceId,
     #[error("unsupported operator")]
     UnsupportedOperator,
 }


### PR DESCRIPTION
Implements **Expand mode** on Groove's `CollectBy`, per the design merged as #1279.

> Joins produce flat wide rows in the graph. The terminal decides output shape — nest or expand. Nothing else renders.

`CollectBy` now has two modes over shared machinery — ordering with tie-break, offset/limit windows, byte-equal suppression, no child deltas:

- **Collect** — unchanged: group N children into one parent row containing an array.
- **Expand** — new: render one row per (parent, child) tuple, in declared source order, addressed by ordered contributing source-row ids.

## The work bound is the point

Expand projects selected flat tuples and diffs the old and new selected windows **by occurrence**, suppressing byte-equal tuples. It never emits a group-wide replacement.

That distinction is the whole of `INV-INC-2` for this mode: an expansion that re-emits the touched group satisfies the formula's letter and loses the property. Collect emits one parent replacement; Expand emits the actual tuple-occurrence diff, bounded by the selected window and never by accumulated state.

**Planted positive, run independently of the author:** disabling byte-equal suppression so the whole selected window re-emits makes both `collect_by_expand_diffs_only_selected_tuple_occurrences` and `collect_by_expand_suppresses_byte_equal_selected_tuples` fail, while the other three tests still pass. The property is guarded, not merely asserted.

Worth recording why that check mattered — the branch's own born-red evidence was a *compile* failure from the missing `GraphBuilder::collect_by_expand`, which proves the API is new but says nothing about the behaviour being protected.

## Multiplicity, rejected loudly

Groove joins are weighted, so a bag or multi-path source can produce two copies sharing an identical source-id vector — which `OutputOccurrenceId` cannot distinguish. Per the spec, duplicate selected occurrence-source vectors fail with `IvmRuntimeError::DuplicateCollectByOccurrenceId` rather than being silently deduplicated or emitted ambiguously. That stands until a stable derivation discriminator exists and is folded into the identity.

## Scope

**Groove only.** Jazz-side lowering that produces wide association rows, and delivery, come later. No Jazz-side renderer — a facade-side fan-in was reverted once and a Jazz maintained-terminal renderer was rejected on review; the terminal belongs here.

`INV-QUERY-22` is untouched and stays `target` — it is not proven until delivery demonstrates it. No registry rows changed.

## Tests

Public-API through `Database::subscribe_one_sink` and `GraphBuilder`, as PR 2 did for Collect:

- `collect_by_expand_renders_selected_tuples_in_source_order`
- `collect_by_expand_diffs_only_selected_tuple_occurrences`
- `collect_by_expand_suppresses_byte_equal_selected_tuples`
- `collect_by_expand_honors_order_tie_offset_and_limit`
- `collect_by_expand_rejects_duplicate_occurrence_source_ids`

Collect's existing tests are untouched and pass.

## Gates

`cargo test -p groove` **0** · `cargo check -p jazz-sim --benches` **0** · `cargo check --workspace --all-targets` **0** · `cargo fmt --check` **0** · `INV-INC-1` incremental-delivery canary **0**.

`cargo test -p jazz` and `--features test` show the four `node::tests::harness::*known_state*` rehydrate failures inherited from #1266 — fixed separately by the authorization-epoch work in **#1280**, which is still open. They are not from this change.

`cargo clippy --package jazz --all-targets` reports the pre-existing `type_complexity` in `warm_reopen_differential.rs:477`, with no Groove diagnostic — so nothing widened here. `CollectByOp` already needed boxing once when a large variant on a widely-used enum blew the stack, so that was worth confirming.
