### PR TITLE
(new core) Refuse contaminated benchmark measurements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "bytes",
  "hdrhistogram",
  "internment",
+ "jazz-benchmark-guard",
  "opfs-btree",
  "paste",
  "postcard",
@@ -1950,6 +1951,7 @@ dependencies = [
  "hex",
  "insta",
  "internment",
+ "jazz-benchmark-guard",
  "jsonschema",
  "jsonwebtoken",
  "libc",
@@ -1988,6 +1990,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "jazz-benchmark-guard"
+version = "0.1.0"
+
+[[package]]
 name = "jazz-napi"
 version = "0.1.0"
 dependencies = [
@@ -2016,6 +2022,7 @@ dependencies = [
  "diamond-types",
  "hdrhistogram",
  "jazz",
+ "jazz-benchmark-guard",
  "libc",
  "postcard",
  "pprof",
@@ -2778,6 +2785,7 @@ name = "opfs-btree"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "jazz-benchmark-guard",
  "js-sys",
  "rustc-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "crates/benchmark-guard",
   "crates/groove",
   "crates/jazz",
   "crates/jazz-sim",

--- a/crates/benchmark-guard/Cargo.toml
+++ b/crates/benchmark-guard/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "jazz-benchmark-guard"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Shared precondition for trustworthy Jazz benchmark and receipt measurements."
+
+[lib]
+path = "src/lib.rs"

--- a/crates/benchmark-guard/src/lib.rs
+++ b/crates/benchmark-guard/src/lib.rs
@@ -1,0 +1,133 @@
+//! Refuse benchmark and receipt runs whose instrumentation changes the numbers.
+
+/// An environment switch that changes the work performed by a measurement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContaminatingInstrumentation {
+    /// The environment variable that enables the instrumentation.
+    pub name: &'static str,
+    /// Why numbers collected while it is set are not trustworthy.
+    pub reason: &'static str,
+}
+
+/// The complete, single-source list of instrumentation that contaminates ordinary
+/// wall-clock or storage-counter benchmark and receipt measurements.
+pub const CONTAMINATING_INSTRUMENTATION: &[ContaminatingInstrumentation] = &[
+    ContaminatingInstrumentation {
+        name: "JAZZ_REHYDRATE_TRACE",
+        reason: "it resets storage-read metrics and adds timing plus formatted stderr output inside rehydration",
+    },
+    ContaminatingInstrumentation {
+        name: "GROOVE_PROFILE_HYDRATION_OPERATORS",
+        reason: "it times every hydration join, inflating wall-clock measurements",
+    },
+    ContaminatingInstrumentation {
+        name: "GROOVE_TRACE_INDEX_BY",
+        reason: "it times and formats IndexBy and Persist work inside the measured runtime path",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_CLOSURE_TRACE",
+        reason: "it formats and writes recursive-runtime trace records during measured work",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_CAPABILITY_TRACE",
+        reason: "it enables capability trace formatting during query compilation",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_CAPABILITY_TRACE_FILE",
+        reason: "it writes capability traces and captures backtraces during query compilation",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_PROFILE_OUT",
+        reason: "it enables CPU profiling around benchmark phases",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_CUSTOMER_TRACE_TICKS",
+        reason: "it formats and writes per-tick customer cold-start trace output during settling",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_ALLOC_SITE_SAMPLE_RATE",
+        reason: "it configures allocation stack sampling during the customer cold-start receipt",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_ALLOC_SITE_MAX_SAMPLES",
+        reason: "it configures allocation stack sampling during the customer cold-start receipt",
+    },
+];
+
+/// Return the first configured contaminating switch, if any.
+pub fn contaminating_instrumentation() -> Option<&'static ContaminatingInstrumentation> {
+    first_contaminating_instrumentation(|name| std::env::var_os(name).is_some())
+}
+
+/// Refuse to produce an ordinary benchmark or receipt measurement under
+/// instrumentation that would corrupt its wall-clock or counter results.
+///
+/// Attribution-only profiling paths deliberately do not call this function.
+pub fn refuse_contaminated_measurement() {
+    if let Some(instrumentation) = contaminating_instrumentation() {
+        eprintln!(
+            "refusing to run: {} is set; {}. Wall-clock and storage-counter numbers would be wrong. Unset it and re-run.",
+            instrumentation.name, instrumentation.reason,
+        );
+        std::process::exit(2);
+    }
+}
+
+fn first_contaminating_instrumentation(
+    is_set: impl Fn(&str) -> bool,
+) -> Option<&'static ContaminatingInstrumentation> {
+    CONTAMINATING_INSTRUMENTATION
+        .iter()
+        .find(|instrumentation| is_set(instrumentation.name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn process_refuses_contamination_and_permits_a_clean_environment() {
+        const PROBE_ENV: &str = "JAZZ_BENCHMARK_GUARD_TEST_PROBE";
+
+        if std::env::var_os(PROBE_ENV).is_some() {
+            refuse_contaminated_measurement();
+            return;
+        }
+
+        let clean = run_probe(PROBE_ENV, None);
+        assert!(clean.status.success(), "clean probe failed: {clean:?}");
+
+        let contaminated = run_probe(PROBE_ENV, Some(("JAZZ_REHYDRATE_TRACE", "1")));
+        assert_eq!(contaminated.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&contaminated.stderr).contains("JAZZ_REHYDRATE_TRACE"),
+            "refusal should name the contaminating variable"
+        );
+    }
+
+    fn run_probe(probe_env: &str, contamination: Option<(&str, &str)>) -> std::process::Output {
+        let mut command = Command::new(std::env::current_exe().expect("current test executable"));
+        command
+            .arg("--exact")
+            .arg("tests::process_refuses_contamination_and_permits_a_clean_environment")
+            .arg("--nocapture")
+            .env(probe_env, "1");
+        for instrumentation in CONTAMINATING_INSTRUMENTATION {
+            command.env_remove(instrumentation.name);
+        }
+        if let Some((name, value)) = contamination {
+            command.env(name, value);
+        }
+        command.output().expect("run guard probe")
+    }
+
+    #[test]
+    fn finds_the_first_configured_contaminating_variable() {
+        let refusal = first_contaminating_instrumentation(|name| name == "JAZZ_REHYDRATE_TRACE")
+            .expect("JAZZ_REHYDRATE_TRACE should be refused");
+
+        assert_eq!(refusal.name, "JAZZ_REHYDRATE_TRACE");
+        assert!(first_contaminating_instrumentation(|_| false).is_none());
+    }
+}

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -26,6 +26,7 @@ rustc-hash.workspace = true
 opfs-btree = { path = "../opfs-btree" }
 
 [dev-dependencies]
+jazz-benchmark-guard = { path = "../benchmark-guard" }
 hdrhistogram = "7.5.4"
 rusqlite = { version = "0.34", features = ["bundled"] }
 tempfile = "3.27.0"

--- a/crates/groove/benches/micro.rs
+++ b/crates/groove/benches/micro.rs
@@ -11,6 +11,7 @@ use groove::storage::{Durability, RocksDbStorage};
 use hdrhistogram::Histogram;
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let iterations = env_usize("GROOVE_MICRO_ITERS", 1_000);
     let report = [
         run_record_encode_decode(iterations),

--- a/crates/groove/benches/scenario.rs
+++ b/crates/groove/benches/scenario.rs
@@ -17,6 +17,7 @@ use hdrhistogram::Histogram;
 use rusqlite::{Connection, params};
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let scenario = env::var("GROOVE_SCENARIO").unwrap_or_else(|_| "social_feed".to_owned());
     let engine = env::var("GROOVE_ENGINE").unwrap_or_else(|_| "groove".to_owned());
     match (scenario.as_str(), engine.as_str()) {

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -4238,6 +4238,7 @@ fn unwrap_nullable_graph_drops_none_and_unwraps_present_values() {
 #[test]
 #[ignore = "receipt-only timing for batch-general schema index maintenance"]
 fn indexed_batch_commit_timing_receipt_20k_and_single_row() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     const ROWS: u64 = 20_000;
     let temp_dir = tempfile::tempdir().unwrap();
     let storage = RocksDbStorage::open(temp_dir.path(), &["tracks", "indices"]).unwrap();

--- a/crates/jazz-sim/Cargo.toml
+++ b/crates/jazz-sim/Cargo.toml
@@ -27,6 +27,9 @@ tempfile = "3.27.0"
 uuid = "1.18.1"
 zstd = "0.13.3"
 
+[dev-dependencies]
+jazz-benchmark-guard = { path = "../benchmark-guard" }
+
 [[bench]]
 name = "echo"
 harness = false

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -298,6 +298,7 @@ const RESOURCE_SPECS: [ResourceSpec; 14] = [
 ];
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let config = Config::from_env();
     let schema = schema();
     let seeded = seed_core(&schema, &config);

--- a/crates/jazz-sim/benches/echo.rs
+++ b/crates/jazz-sim/benches/echo.rs
@@ -1,6 +1,7 @@
 use jazz_sim::{PeerProfile, run_echo_deterministic, run_echo_threaded};
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let seed = env_u64("JAZZ_SEED", 1);
     let rounds = env_u64("JAZZ_ECHO_ROUNDS", 100);
     let one_way_ms = env_u64("JAZZ_LINK_ONE_WAY_MS", 1);

--- a/crates/jazz-sim/benches/fixture_smoke.rs
+++ b/crates/jazz-sim/benches/fixture_smoke.rs
@@ -23,6 +23,7 @@ const ISSUES: &str = "issues";
 const ISSUE_MEMBERS: &str = "issue_members";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let seed = env_u64("JAZZ_SEED", 0x000f_17c7_51e5);
     let profile_name = std::env::var("JAZZ_PROFILE").unwrap_or_else(|_| "fixture-local".into());
     let profile = PeerProfile::new(profile_name.clone(), 0, 0, 0);

--- a/crates/jazz-sim/benches/micro.rs
+++ b/crates/jazz-sim/benches/micro.rs
@@ -18,6 +18,7 @@ use serde_json::{Map, Value as JsonValue, json};
 const TABLE: &str = "items";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let config = Config::from_env();
     run_node_open(&config);
     run_hlc(&config);

--- a/crates/jazz-sim/benches/policy_graph_concurrent.rs
+++ b/crates/jazz-sim/benches/policy_graph_concurrent.rs
@@ -33,6 +33,7 @@ const SEED_CACHE_VERSION: &str = "policy-graph-concurrent-seed-v14-env-fixture";
 const SEED_CACHE_READY: &str = ".jazz_policy_graph_seed_ready";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let session_id = std::env::var("CODEX_SESSION_ID")
         .or_else(|_| std::env::var("JAZZ_CODEX_SESSION_ID"))
         .unwrap_or_else(|_| format!("pid-{}", std::process::id()));

--- a/crates/jazz-sim/benches/s1_saas.rs
+++ b/crates/jazz-sim/benches/s1_saas.rs
@@ -51,6 +51,7 @@ const STATE_IN_PROGRESS: u8 = 2;
 const STATE_DONE: u8 = 3;
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;

--- a/crates/jazz-sim/benches/s2_canvas.rs
+++ b/crates/jazz-sim/benches/s2_canvas.rs
@@ -35,6 +35,7 @@ const SHAPES: &str = "shapes";
 type SharedMetrics = Arc<Mutex<Metrics>>;
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;

--- a/crates/jazz-sim/benches/s3_permissions.rs
+++ b/crates/jazz-sim/benches/s3_permissions.rs
@@ -50,6 +50,7 @@ const PROFILE_REVOKE_SIZES: &[usize] = &[1, 10, 50];
 const FAST_REVOKE_SIZES: &[usize] = &[1, 3];
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;

--- a/crates/jazz-sim/benches/s4_order_processing.rs
+++ b/crates/jazz-sim/benches/s4_order_processing.rs
@@ -43,6 +43,7 @@ const TABLES: [&str; 8] = [
 ];
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;

--- a/crates/jazz-sim/benches/s5_durable_stream.rs
+++ b/crates/jazz-sim/benches/s5_durable_stream.rs
@@ -34,6 +34,7 @@ const STREAMS: &str = "streams";
 const STREAM_DOCS: &str = "streamDocs";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;

--- a/crates/jazz-sim/benches/s6_text_traces.rs
+++ b/crates/jazz-sim/benches/s6_text_traces.rs
@@ -38,6 +38,7 @@ const EDITING_TRACES_COMMIT: &str = "762fa6c51605c88a05ebe5c4b9d4540caca30b97";
 const EGWALKER_ARTIFACT_COMMIT: &str = "4fb0970ce3fab729aac31e8e622b530fd17938cb";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;

--- a/crates/jazz-sim/benches/s7_migrations.rs
+++ b/crates/jazz-sim/benches/s7_migrations.rs
@@ -24,6 +24,7 @@ use jazz_sim::{emit_json_line, metadata_fields};
 use serde_json::{Value as JsonValue, json};
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     smoke();
 }
 

--- a/crates/jazz-sim/benches/s9_durable_execution.rs
+++ b/crates/jazz-sim/benches/s9_durable_execution.rs
@@ -60,6 +60,7 @@ impl Transport for QueueTransport {
 }
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     if std::env::var("JAZZ_SMOKE").is_ok() {
         smoke();
         return;

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -125,6 +125,7 @@ opentelemetry-appender-tracing = { version = "0.31", optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
 
 [dev-dependencies]
+jazz-benchmark-guard = { path = "../benchmark-guard" }
 hdrhistogram = "7.5.4"
 tempfile = "3.27.0"
 opentelemetry_sdk = { version = "0.31", features = ["testing"] }

--- a/crates/jazz/benches/authorization_scope_benchmark.rs
+++ b/crates/jazz/benches/authorization_scope_benchmark.rs
@@ -198,9 +198,16 @@ fn many_initial_authorized_scopes_share_schema_context(c: &mut Criterion) {
     group.finish();
 }
 
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    initial_authorized_scope(c);
+    initial_authorized_scope_with_wide_schema(c);
+    many_initial_authorized_scopes_share_schema_context(c);
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = initial_authorized_scope, initial_authorized_scope_with_wide_schema, many_initial_authorized_scopes_share_schema_context
+    targets = guarded_benches
 }
 criterion_main!(benches);

--- a/crates/jazz/benches/cold_subscription.rs
+++ b/crates/jazz/benches/cold_subscription.rs
@@ -20,6 +20,7 @@ use support::{
 const TABLE: &str = "todos";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     for depth in depths() {
         for ahead in pending_sizes() {
             let mut bench = ColdSubscriptionBench::new();

--- a/crates/jazz/benches/db_benchmark.rs
+++ b/crates/jazz/benches/db_benchmark.rs
@@ -431,9 +431,19 @@ fn core_owner_policy_insert(c: &mut Criterion) {
     group.finish();
 }
 
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    core_insert(c);
+    core_update_and_read(c);
+    core_filtered_prepared_read(c);
+    core_subscribed_write(c);
+    core_owner_policy_insert(c);
+    core_reachable_policy_read(c);
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = core_insert, core_update_and_read, core_filtered_prepared_read, core_subscribed_write, core_owner_policy_insert, core_reachable_policy_read
+    targets = guarded_benches
 }
 criterion_main!(benches);

--- a/crates/jazz/benches/insert_benchmark.rs
+++ b/crates/jazz/benches/insert_benchmark.rs
@@ -332,5 +332,12 @@ fn insert_batch(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, insert_own_folder, insert_team_folder, insert_batch);
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    insert_own_folder(c);
+    insert_team_folder(c);
+    insert_batch(c);
+}
+
+criterion_group!(benches, guarded_benches);
 criterion_main!(benches);

--- a/crates/jazz/benches/known_state_scaling.rs
+++ b/crates/jazz/benches/known_state_scaling.rs
@@ -22,6 +22,7 @@ use support::{csv_usizes, emit_json_line, env_usize, phase_fields};
 const TABLE: &str = "documents";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let rows = env_usize("JAZZ_KNOWN_STATE_ROWS", 1_000).max(1);
     let coverage_percentages = csv_usizes("JAZZ_KNOWN_STATE_COVERAGE", "0,25,50,75,100");
     assert!(

--- a/crates/jazz/benches/large_value_checkpointing.rs
+++ b/crates/jazz/benches/large_value_checkpointing.rs
@@ -13,6 +13,7 @@ use support::{
 };
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let depth = support::env_usize("JAZZ_LV_DEPTH", 300);
     for interval in csv_usizes("JAZZ_LV_INTERVALS", "64")
         .into_iter()

--- a/crates/jazz/benches/maintained_rehydrate_scaling.rs
+++ b/crates/jazz/benches/maintained_rehydrate_scaling.rs
@@ -23,18 +23,7 @@ const ACTIVE: &str = "active";
 const INACTIVE: &str = "inactive";
 
 fn main() {
-    // JAZZ_REHYDRATE_TRACE makes the traced path call reset_storage_read_metrics()
-    // and add timing plus formatting inside the measured region (peer.rs:644).
-    // Storage-read counters and timings reported here would be wrong, so refuse
-    // to produce a receipt that silently understates its own instrumentation.
-    if std::env::var_os("JAZZ_REHYDRATE_TRACE").is_some() {
-        eprintln!(
-            "refusing to run: JAZZ_REHYDRATE_TRACE is set. It resets storage read \
-             metrics and adds timing inside the measured path, so the reported \
-             reads and durations would be contaminated. Unset it and re-run."
-        );
-        std::process::exit(2);
-    }
+    jazz_benchmark_guard::refuse_contaminated_measurement();
 
     for source_rows in csv_usizes("JAZZ_PERF5_ROWS", "100,1000,10000") {
         assert!(source_rows >= 2, "PERF-5 rungs require at least two rows");

--- a/crates/jazz/benches/merge_back_cost.rs
+++ b/crates/jazz/benches/merge_back_cost.rs
@@ -16,6 +16,7 @@ use support::{emit_json_line, env_usize, insert_node_metrics, phase_fields, rese
 const TABLE: &str = "todos";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let writes = env_usize("JAZZ_MERGE_BACK_WRITES", 1_000).max(1);
     let (dir, mut node) = open_node(node_uuid(1), schema());
     let branch_id = branch(0x51);

--- a/crates/jazz/benches/observer_write_path.rs
+++ b/crates/jazz/benches/observer_write_path.rs
@@ -163,9 +163,14 @@ fn update_write_path_with_and_without_observer(c: &mut Criterion) {
     group.finish();
 }
 
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    update_write_path_with_and_without_observer(c);
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = update_write_path_with_and_without_observer
+    targets = guarded_benches
 }
 criterion_main!(benches);

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -1956,9 +1956,22 @@ fn r13_permission_filtered_resume(c: &mut Criterion) {
     group.finish();
 }
 
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    r1_crud(c);
+    r2_reads(c);
+    r3_rocksdb_cold_load(c);
+    r4_hot_task_history(c);
+    r9_subscribed_write(c);
+    r10_sync_fanout(c);
+    r11_byte_wire_resume(c);
+    r12_recursive_permissions(c);
+    r13_permission_filtered_resume(c);
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = r1_crud, r2_reads, r3_rocksdb_cold_load, r4_hot_task_history, r9_subscribed_write, r10_sync_fanout, r11_byte_wire_resume, r12_recursive_permissions, r13_permission_filtered_resume
+    targets = guarded_benches
 }
 criterion_main!(benches);

--- a/crates/jazz/benches/relation_include_delivery.rs
+++ b/crates/jazz/benches/relation_include_delivery.rs
@@ -54,6 +54,7 @@ const DEFAULT_SAMPLES: usize = 3;
 const DEFAULT_MAX_RATIO: f64 = 1.025;
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let scales = csv_usizes("JAZZ_INC_DELIVERY_SCALES", DEFAULT_SCALES);
     assert!(
         scales.len() >= 3,

--- a/crates/jazz/benches/route_subscription_curve.rs
+++ b/crates/jazz/benches/route_subscription_curve.rs
@@ -105,6 +105,7 @@ struct RetainedReceipt {
 }
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let routes = env_usize("JAZZ_ROUTE_CURVE_ROUTES", 100);
     assert!(
         (1..=MAX_ROUTES).contains(&routes),

--- a/crates/jazz/benches/selective_global_hydration.rs
+++ b/crates/jazz/benches/selective_global_hydration.rs
@@ -38,6 +38,7 @@ use sha2::{Digest, Sha256};
 const TABLE: &str = "documents";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let config = Config::from_env();
     config.validate();
 

--- a/crates/jazz/benches/subscription_benchmark.rs
+++ b/crates/jazz/benches/subscription_benchmark.rs
@@ -332,12 +332,14 @@ fn batch_insert_subscription_latency(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    single_subscription_latency,
-    fanout_latency,
-    cold_start_latency,
-    filtered_subscription_latency,
-    batch_insert_subscription_latency
-);
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    single_subscription_latency(c);
+    fanout_latency(c);
+    cold_start_latency(c);
+    filtered_subscription_latency(c);
+    batch_insert_subscription_latency(c);
+}
+
+criterion_group!(benches, guarded_benches);
 criterion_main!(benches);

--- a/crates/jazz/benches/sync.rs
+++ b/crates/jazz/benches/sync.rs
@@ -19,6 +19,7 @@ use support::{emit_json_line, insert_node_metrics, phase_fields, reset_phase_cou
 const TABLE: &str = "todos";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let config = Config::from_env();
     let mut bench = SyncBench::new(config);
     let elapsed = bench.run();

--- a/crates/jazz/benches/update_benchmark.rs
+++ b/crates/jazz/benches/update_benchmark.rs
@@ -221,9 +221,15 @@ fn update_batch(c: &mut Criterion) {
     group.finish();
 }
 
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    update_own_documents(c);
+    update_batch(c);
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = update_own_documents, update_batch
+    targets = guarded_benches
 }
 criterion_main!(benches);

--- a/crates/jazz/benches/validation.rs
+++ b/crates/jazz/benches/validation.rs
@@ -20,6 +20,7 @@ use support::{emit_json_line, insert_node_metrics, phase_fields, reset_phase_cou
 const TABLE: &str = "items";
 
 fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let config = Config::from_env();
     let mut bench = ValidationBench::new(config);
     bench.seed();

--- a/crates/jazz/examples/commit_superlinearity_native.rs
+++ b/crates/jazz/examples/commit_superlinearity_native.rs
@@ -108,6 +108,7 @@ fn run_case(max_rows: usize, subscribed: bool) -> Result<(), Box<dyn std::error:
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let max_rows = std::env::args()
         .nth(1)
         .map(|arg| arg.parse::<usize>())

--- a/crates/jazz/examples/realistic_bench.rs
+++ b/crates/jazz/examples/realistic_bench.rs
@@ -942,6 +942,7 @@ fn maybe_write_seed_state(path: Option<&Path>, seed: &SeedState) -> Result<(), D
 
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let args = parse_args()?;
     let scenario: ScenarioConfig = load_json(&args.scenario_path)?;
     let profile: DatasetProfile = load_json(&args.profile_path)?;

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -1919,6 +1919,7 @@ where
 #[ignore]
 #[test]
 fn policy_graph_perf_dropdown_entry_reset_ingest_timing_receipt() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
     let schema = policy_graph_perf_schema_fixture();
     let (_core_dir, mut core) = open_node_with_schema(node(0x22), schema.clone());
 

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -1156,6 +1156,7 @@ mod tests {
     ))]
     #[test]
     fn synthetic_small_delta_streaming_compression_receipt() {
+        jazz_benchmark_guard::refuse_contaminated_measurement();
         let shape_id = ShapeId(uuid::Uuid::from_bytes([0x22; 16]));
         let binding_id = BindingId(uuid::Uuid::from_bytes([0x33; 16]));
         let subscription = crate::protocol::SubscriptionKey {

--- a/crates/opfs-btree/Cargo.toml
+++ b/crates/opfs-btree/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+jazz-benchmark-guard = { path = "../benchmark-guard" }
 criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3"
 

--- a/crates/opfs-btree/benches/hot_paths.rs
+++ b/crates/opfs-btree/benches/hot_paths.rs
@@ -120,12 +120,14 @@ fn bench_open_replay(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    bench_get,
-    bench_range,
-    bench_put,
-    bench_put_churn,
-    bench_open_replay
-);
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    bench_get(c);
+    bench_range(c);
+    bench_put(c);
+    bench_put_churn(c);
+    bench_open_replay(c);
+}
+
+criterion_group!(benches, guarded_benches);
 criterion_main!(benches);

--- a/dev/benchmarks/storage/native/Cargo.toml
+++ b/dev/benchmarks/storage/native/Cargo.toml
@@ -10,6 +10,7 @@ name = "native_storage_engines"
 harness = false
 
 [dev-dependencies]
+jazz-benchmark-guard = { path = "../../../../crates/benchmark-guard" }
 bench-core = { package = "jazz-storage-bench-core", path = "../bench-core" }
 criterion = "0.5"
 redb = "4.1"

--- a/dev/benchmarks/storage/native/benches/native_storage_engines.rs
+++ b/dev/benchmarks/storage/native/benches/native_storage_engines.rs
@@ -210,12 +210,17 @@ fn block_on<F: Future>(future: F) -> F::Output {
     }
 }
 
+fn guarded_benches(c: &mut Criterion) {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    bench_native_storage(c);
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
         .sample_size(10)
         .warm_up_time(Duration::from_millis(500))
         .measurement_time(Duration::from_secs(3));
-    targets = bench_native_storage
+    targets = guarded_benches
 }
 criterion_main!(benches);


### PR DESCRIPTION
Benchmarks silently accepted instrumentation flags that change the very timings they measure. A run with `JAZZ_REHYDRATE_TRACE` set produced a number that looked ordinary and was not.

This makes the refusal shared and total: a contaminated benchmark **exits 2** instead of reporting a figure.

## Mechanism

New crate `jazz-benchmark-guard` owns the single flag list and exits 2 naming the flag and why it contaminates. Wired into **all 17 Jazz benchmark targets, all 13 Jazz Sim targets, both Groove benchmarks**, the Groove/Jazz receipt tests, the in-tree OPFS and native-storage Criterion targets, and the Jazz receipt/benchmark examples.

Criterion targets carry an outer guard only — measurement functions are untouched, so the guard cannot itself perturb a timing.

## Which flags contaminate

Refused: `JAZZ_REHYDRATE_TRACE`, `GROOVE_PROFILE_HYDRATION_OPERATORS`, `GROOVE_TRACE_INDEX_BY`, `JAZZ_CLOSURE_TRACE`, `JAZZ_CAPABILITY_TRACE`, `JAZZ_CAPABILITY_TRACE_FILE`, `JAZZ_PROFILE_OUT`, `JAZZ_CUSTOMER_TRACE_TICKS`, `JAZZ_ALLOC_SITE_SAMPLE_RATE`, `JAZZ_ALLOC_SITE_MAX_SAMPLES`.

Deliberately **not** refused, with reasons: `JAZZ_PROFILE_FREQUENCY` (only configures an already-enabled profiler; the enabling flag `JAZZ_PROFILE_OUT` is guarded), `JAZZ_S3_HEADLINE_PROGRESS` (post-phase output), `JAZZ_PROFILE`/`JAZZ_BENCH_PROFILE` and workload-size flags (select labels and workloads), `JAZZ_BENCH_IGNORE_RESULT_DIRTY`/`JAZZ_RETAIN` (receipt retention metadata), and the OTel/test-server flags (server telemetry, off the benchmark path).

## Verification

Re-run independently of the implementing lane:

- `JAZZ_REHYDRATE_TRACE=1 cargo bench -p jazz --bench maintained_rehydrate_scaling` → **exit 2** with the named refusal
- the same bench with the flag unset → **exit 0**, completing normally — the guard does not false-positive
- `cargo test -p jazz-benchmark-guard` → **0** (2 passed), covering both the clean and contaminated environments

Exit codes read unpiped.

## Gates

`cargo check -p jazz-sim --benches` **0** · `cargo check --workspace --all-targets` **0** · `cargo test -p jazz` **0** · `cargo test -p groove` **0** · `cargo fmt --check` **0**

`cargo clippy --package jazz --all-targets -- -D warnings` → 101, from the pre-existing `clippy::type_complexity` in `crates/jazz/tests/warm_reopen_differential.rs:478`, unrelated to this change.

## Follow-ups for unmerged branches

Three benchmark entrypoints live only on their own branches and will need the guard when they land: `policy_cost_receipt.rs` (#1240), #1262's attributed hydration receipt (which should keep its attribution-only run separate and guard the uninstrumented timing run), and the unmerged scenarios behind #1237's S4 and #1267's `realistic_phase1` entrypoints — those two entrypoints exist on base and are already wired here.
