### PR TITLE
(new core) Gate the invariant registries, and classify 30 broken citations

### DIFF
--- a/dev/gates/invariant-registry.sh
+++ b/dev/gates/invariant-registry.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Keep the Jazz and Groove invariant registries mechanically honest.
+# `now` + `untested` is intentionally visible documented debt, not a failure.
+
+# Do not inherit errexit: expected missing citations are accumulated below and
+# every external command's status is read explicitly.
+set +e
+set -u -o pipefail
+
+readonly JAZZ_REGISTRY="${JAZZ_INVARIANT_REGISTRY:-crates/jazz/SPEC/INVARIANTS.md}"
+readonly GROOVE_REGISTRY="${GROOVE_INVARIANT_REGISTRY:-crates/groove/SPEC/INVARIANTS.md}"
+
+failures=0
+rows=0
+missing_tests=0
+uncited_covered=0
+now_untested=0
+declare -A known_functions=()
+
+fail() {
+    printf 'invariant-registry: ERROR: %s\n' "$*" >&2
+    failures=$((failures + 1))
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        fail "required command not found: $1"
+        return 1
+    fi
+    return 0
+}
+
+# Emits six unit-separator-delimited fields for each structurally valid registry
+# row. A literal Markdown pipe must be written as \|; the parser retains it in
+# the field rather than treating it as a table boundary.
+parse_registry() {
+    local registry=$1 parsed_status
+    PARSED_ROWS="$(perl - "$registry" <<'PERL'
+use strict;
+use warnings;
+
+my ($path) = @ARGV;
+open my $fh, '<', $path or die "cannot read $path: $!\n";
+my ($line_no, $state, $bad) = (0, 'before-header', 0);
+
+sub trim {
+    my ($value) = @_;
+    $value =~ s/^\s+|\s+$//g;
+    return $value;
+}
+
+sub split_row {
+    my ($line) = @_;
+    return unless $line =~ /^\|.*\|$/;
+    my ($cell, @fields) = ('');
+    my $inside = substr($line, 1, -1);
+    for (my $i = 0; $i < length $inside; $i++) {
+        my $char = substr($inside, $i, 1);
+        if ($char eq '\\' && $i + 1 < length($inside) && substr($inside, $i + 1, 1) eq '|') {
+            $cell .= '\\|';
+            $i++;
+        } elsif ($char eq '|') {
+            push @fields, trim($cell);
+            $cell = '';
+        } else {
+            $cell .= $char;
+        }
+    }
+    push @fields, trim($cell);
+    return @fields;
+}
+
+while (my $line = <$fh>) {
+    chomp $line;
+    $line_no++;
+    if ($state eq 'before-header') {
+        if ($line =~ /^\|\s*id\s*\|/) {
+            my @fields = split_row($line);
+            if (@fields != 6 || $fields[0] ne 'id' || $fields[1] ne 'invariant' || $fields[2] ne 'enforced by (test)' || $fields[3] ne 'impl' || $fields[4] ne 'status' || $fields[5] ne 'coverage') {
+                warn "$path:$line_no: malformed invariant-registry header\n";
+                $bad++;
+                last;
+            }
+            $state = 'separator';
+        } elsif ($line =~ /^\|/) {
+            warn "$path:$line_no: table row before invariant-registry header\n";
+            $bad++;
+        }
+    } elsif ($state eq 'separator') {
+        my @fields = split_row($line);
+        if (@fields != 6 || grep { !/^:?-{3,}:?$/ } @fields) {
+            warn "$path:$line_no: malformed table separator\n";
+            $bad++;
+        }
+        $state = 'rows';
+    } elsif ($state eq 'rows') {
+        if ($line !~ /^\|/) {
+            $state = 'after-table';
+            next;
+        }
+        my @fields = split_row($line);
+        if (@fields != 6) {
+            warn "$path:$line_no: malformed row (expected six columns; escape literal pipes as \\|)\n";
+            $bad++;
+            next;
+        }
+        print join("\x1f", @fields), "\n";
+    } elsif ($state eq 'after-table' && $line =~ /^\|/) {
+        warn "$path:$line_no: unexpected table row after invariant registry\n";
+        $bad++;
+    }
+}
+
+if ($state eq 'before-header' || $state eq 'separator') {
+    warn "$path: invariant registry table is missing or incomplete\n";
+    $bad++;
+}
+exit($bad ? 1 : 0);
+PERL
+)"
+    parsed_status=$?
+    if (( parsed_status != 0 )); then
+        fail "$registry: parser failed (exit $parsed_status)"
+    fi
+}
+
+index_test_functions() {
+    local output status source_line function
+    output="$(git grep -h -E 'fn[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(' -- crates)"
+    status=$?
+    if (( status != 0 )); then
+        fail "git grep could not build the Rust test-function index (exit $status)"
+        return
+    fi
+    while IFS= read -r source_line; do
+        if [[ $source_line =~ fn[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\( ]]; then
+            function=${BASH_REMATCH[1]}
+            known_functions[$function]=1
+        fi
+    done <<< "$output"
+}
+
+check_test_citations() {
+    local registry=$1 id=$2 text=$3 remaining citation function prefix brace_names brace_name
+    remaining=$text
+    while [[ $remaining =~ ([a-z][a-z0-9_]*(::[A-Za-z0-9_]+)+)::\{([^}]*)\} ]]; do
+        citation=${BASH_REMATCH[0]}
+        prefix=${BASH_REMATCH[1]}
+        brace_names=${BASH_REMATCH[3]}
+        remaining=${remaining#*"$citation"}
+        while IFS= read -r brace_name; do
+            brace_name=${brace_name//[[:space:]]/}
+            [[ -n $brace_name ]] || continue
+            check_test_citations "$registry" "$id" "$prefix::$brace_name"
+        done <<< "${brace_names//,/$'\n'}"
+    done
+    while [[ $remaining =~ [a-z][a-z0-9_]*(::[A-Za-z0-9_*]+)+ ]]; do
+        citation=${BASH_REMATCH[0]}
+        remaining=${remaining#*"$citation"}
+        function=${citation##*::}
+        if [[ ! $function =~ ^[A-Za-z_][A-Za-z0-9_]*$ || -z ${known_functions[$function]+present} ]]; then
+            printf 'invariant-registry: missing test: %s:%s: %s\n' "$registry" "$id" "$citation" >&2
+            missing_tests=$((missing_tests + 1))
+            failures=$((failures + 1))
+        fi
+    done
+}
+
+check_registry() {
+    local registry=$1 record id invariant tests impl status coverage registry_rows=0
+    local -A seen_ids=()
+    parse_registry "$registry"
+    while IFS=$'\x1f' read -r id invariant tests impl status coverage; do
+        [[ -n $id ]] || continue
+        if [[ ! $id =~ ^(G-)?INV-[A-Za-z0-9-]+$ ]]; then
+            fail "$registry: invalid invariant id '$id'"
+            continue
+        fi
+        if [[ -n ${seen_ids[$id]+present} ]]; then
+            fail "$registry: duplicate invariant id '$id'"
+        else
+            seen_ids[$id]=1
+        fi
+        if [[ -z $status || -z $coverage ]]; then
+            fail "$registry:$id: status and coverage must not be empty"
+        fi
+        if [[ $coverage == '✓' && ! $tests =~ [a-z][a-z0-9_]*(::[A-Za-z0-9_*]+)+ ]]; then
+            printf 'invariant-registry: covered without test: %s:%s\n' "$registry" "$id" >&2
+            uncited_covered=$((uncited_covered + 1))
+            failures=$((failures + 1))
+        fi
+        if [[ $status == 'now' && $coverage == 'untested' ]]; then
+            now_untested=$((now_untested + 1))
+            printf 'invariant-registry: documented debt (not failing): %s:%s is now + untested\n' "$registry" "$id" >&2
+        fi
+        check_test_citations "$registry" "$id" "$tests"
+        registry_rows=$((registry_rows + 1))
+        rows=$((rows + 1))
+    done <<< "$PARSED_ROWS"
+    printf 'invariant-registry: checked %s (%d rows)\n' "$registry" "$registry_rows"
+}
+
+require_command git || exit 1
+require_command perl || exit 1
+index_test_functions
+check_registry "$JAZZ_REGISTRY"
+check_registry "$GROOVE_REGISTRY"
+printf 'invariant-registry: summary: %d rows, %d missing test citations, %d covered rows without a test, %d now + untested (not failing)\n' \
+    "$rows" "$missing_tests" "$uncited_covered" "$now_untested"
+
+(( failures == 0 ))


### PR DESCRIPTION
Both invariant registries cite tests that do not exist. Nothing checked, so the rot accumulated silently. This adds the check and classifies every broken row — **without repairing any of them**, because the repairs split into three groups that need different decisions.

## The gate

`dev/gates/invariant-registry.sh`. It fails on a malformed row, a duplicate id **within** one registry, a cited test that does not exist, and an invariant marked covered (`✓`) that cites no test. It **reports without failing** on `now` + `untested` — that is documented debt the registry's own text says should stay visible, and turning it red would just invite deletion.

Not wired into CI or lefthook, so merging it cannot turn anything red.

Verified independently:

- current tree → **exit 1**, `432 rows, 30 missing test citations, 1 covered row without a test, 12 now + untested (not failing)`
- `PATH` stripped → **exit 127**, non-zero. It fails closed; `if cmd` swallowing 127 is exactly how a gate silently passes forever.
- escaped pipes parse as literal text: against the pre-#1286 registry it reads **120** Groove rows, against the #1286 registry **121**, and `INV-INC-2` parses cleanly rather than shredding. That row is the one that mangled the table before.

## The 30 broken citations

| classification | count | what it means |
| --- | --- | --- |
| **incorrect citation** | 11 | wrong name/path; the test exists |
| **never existed** | 11 | the citation was aspirational — a real coverage gap |
| **renamed** | 4 | one-line fix, new name identified |
| **deleted** | 4 | test was removed deliberately; needs a decision |

The 15 renamed-or-incorrect rows are mechanical. The **11 that never existed** are the finding: those invariants have never been tested, and the registry has been asserting otherwise. Nearly all trace to a single commit (`85a3ce4`) that added rows with citations to tests that were never written.

Examples, with evidence:

- `INV-LOWER-13` → **renamed**: `3d03fa3` renamed it to `…default_order_limited_variants_are_supported`.
- `INV-LVAL-4`/`-5`/`-12` → **renamed**: `78f41d3` renamed to `…blob_column_round_trips_opaque_bytes`.
- `INV-LOWER-8` → **deleted** in `eab8a67` ("Use table change watermark for whole-table validation").
- `INV-QUERY-16` and `INV-SYNC-20` → **deleted** in `8e0a073` ("Remove legacy peer delta oracle").
- `INV-QUERY-4` → **incorrect**: cites `…catalogue_lenses::*`, a module wildcard, not a test.
- `INV-READ-12` → **incorrect**: cites `assert_currency_tables_match_storage`, a generic helper in `tests/support.rs`.
- `INV-SYNC-8`, `INV-SYNC-9`, `INV-QUERY-9`, `INV-READ-6`, `INV-LOWER-16`, Groove `INV-SHAPE-6`/`-8`/`-17`, Groove `INV-STORAGE-26` → **never existed**, registry-only history at `85a3ce4`.

Full classification with per-row evidence is in the lane report; happy to paste it inline if useful.

## Why no repairs here

The 15 mechanical rows are safe to fix and I can follow up immediately. The other 15 are not mine to decide: a citation pointing at a test that never existed is a coverage gap, and "fix" could mean writing the test, downgrading the row to `target`/`untested`, or deleting the row. Deleting a failing citation would make the gate green while making the registry *less* honest, which is the opposite of the point.

Recommend merging the gate and the classification first, then taking the three groups separately.
