### PR TITLE
(new core) Round-trip the whole ValueType space through the native row codec

### DIFF
--- a/crates/jazz/fixtures/native_row_codec.json
+++ b/crates/jazz/fixtures/native_row_codec.json
@@ -1,4 +1,90 @@
 {
-  "descriptor_hex": "060108726f775f7575696408010a757365725f7469746c650c060109757365725f646f6e650c05010d757365725f7072696f726974790c0f010774785f74696d650e0110757365725f6465736372697074696f6e0c06",
-  "record_hex": "11111111111111111111111111111111010001070000002a000000000000002c00000001427579206d696c6b00"
+  "cases": [
+    {
+      "name": "all_value_types_depth_three",
+      "descriptor_hex": [
+        "15010875385f76616c75650001097531365f76616c75650101097533325f76616c75650201097536345f76616c756503",
+        "01096636345f76616c756504010a626f6f6c5f76616c756505010c737472696e675f76616c756506010b62797465735f",
+        "76616c756507010a757569645f76616c756508010a656e756d5f76616c756509046d6f646502036c6f770468696768",
+        "010b6d697865645f7475706c650a04000e0c050f010b66697865645f61727261790b0f010e7661726961626c655f6172",
+        "7261790b06011a6e756c6c61626c655f61727261795f64657074685f74687265650c0b0c0f010d696e6c696e655f726563",
+        "6f72640d02010b6368696c645f636f756e740f010b6368696c645f6c6162656c0c06010c7265636f72645f61727261790b",
+        "0d02010b6368696c645f636f756e740f010b6368696c645f6c6162656c0c060111656d7074795f66697865645f61727261790b010114656d7074795f7661726961626c655f61727261",
+        "790b06010e6e756c6c5f66697865645f6933320c0f01096936345f76616c75650e01096933325f76616c75650f"
+      ],
+      "record_hex": [
+        "a1c3b207f6e5d4807060504030201000000000000029400011111111111111111111111111111111",
+        "01097ffffffffffffffd00007fffffef0000000000d6fffffffffffffff3ffffff72000000740000007c00000087000000",
+        "920000009a000000af000000af00000073796e746865746963deadfdffffff05000000020000000900000078797a0100",
+        "0000000001f9ffffff04000000016f6e650200000010000000050000000174776f060000000000000000"
+      ],
+      "fields": [
+        { "name": "u8_value", "encoded_hex": "a1", "decoded_hex": "a1" },
+        { "name": "u16_value", "encoded_hex": "c3b2", "decoded_hex": "c3b2" },
+        { "name": "u32_value", "encoded_hex": "07f6e5d4", "decoded_hex": "07f6e5d4" },
+        {
+          "name": "u64_value",
+          "encoded_hex": "8070605040302010",
+          "decoded_hex": "8070605040302010"
+        },
+        {
+          "name": "f64_value",
+          "encoded_hex": "0000000000002940",
+          "decoded_hex": "0000000000002940"
+        },
+        { "name": "bool_value", "encoded_hex": "00", "decoded_hex": "00" },
+        {
+          "name": "string_value",
+          "encoded_hex": "73796e746865746963",
+          "decoded_hex": "73796e746865746963"
+        },
+        { "name": "bytes_value", "encoded_hex": "dead", "decoded_hex": "dead" },
+        {
+          "name": "uuid_value",
+          "encoded_hex": "11111111111111111111111111111111",
+          "decoded_hex": "11111111111111111111111111111111"
+        },
+        { "name": "enum_value", "encoded_hex": "01", "decoded_hex": "01" },
+        {
+          "name": "mixed_tuple",
+          "encoded_hex": "097ffffffffffffffd00007fffffef",
+          "decoded_hex": "097ffffffffffffffd00007fffffef"
+        },
+        {
+          "name": "fixed_array",
+          "encoded_hex": "fdffffff05000000",
+          "decoded_hex": "fdffffff05000000"
+        },
+        {
+          "name": "variable_array",
+          "encoded_hex": "020000000900000078797a",
+          "decoded_hex": "020000000900000078797a"
+        },
+        {
+          "name": "nullable_array_depth_three",
+          "encoded_hex": "01000000000001f9ffffff",
+          "decoded_hex": "000000000001f9ffffff"
+        },
+        {
+          "name": "inline_record",
+          "encoded_hex": "04000000016f6e65",
+          "decoded_hex": "04000000016f6e65"
+        },
+        {
+          "name": "record_array",
+          "encoded_hex": "0200000010000000050000000174776f0600000000",
+          "decoded_hex": "0200000010000000050000000174776f0600000000"
+        },
+        { "name": "empty_fixed_array", "encoded_hex": "", "decoded_hex": "" },
+        { "name": "empty_variable_array", "encoded_hex": "00000000", "decoded_hex": "00000000" },
+        { "name": "null_fixed_i32", "encoded_hex": "0000000000", "decoded_hex": null },
+        {
+          "name": "i64_value",
+          "encoded_hex": "d6ffffffffffffff",
+          "decoded_hex": "d6ffffffffffffff"
+        },
+        { "name": "i32_value", "encoded_hex": "f3ffffff", "decoded_hex": "f3ffffff" }
+      ]
+    }
+  ]
 }

--- a/crates/jazz/tests/wire_fixtures.rs
+++ b/crates/jazz/tests/wire_fixtures.rs
@@ -47,8 +47,21 @@ struct Fixture {
 
 #[derive(Deserialize)]
 struct NativeRowCodecFixture {
-    descriptor_hex: String,
-    record_hex: String,
+    cases: Vec<NativeRowCodecCase>,
+}
+
+#[derive(Deserialize)]
+struct NativeRowCodecCase {
+    name: String,
+    descriptor_hex: Vec<String>,
+    record_hex: Vec<String>,
+    fields: Vec<NativeRowCodecField>,
+}
+
+#[derive(Deserialize)]
+struct NativeRowCodecField {
+    name: String,
+    encoded_hex: String,
 }
 
 fn wire_fixture_messages() -> Vec<(&'static str, &'static str, SyncMessage)> {
@@ -451,55 +464,179 @@ fn wire_message_frame_fixtures_decode_to_expected_messages() {
     }
 }
 
-// This is intentionally a codec-level integration fixture: a TypeScript row
-// decoder consumes these exact bytes, while this Rust test pins the Groove
-// descriptor discriminants and record layout that produced them.
+// This is intentionally a codec-level integration fixture: TypeScript creates
+// and reads these exact records, while this Rust test independently creates and
+// decodes them. That is the narrowest useful cross-language test for a raw
+// record-layout contract, which is not observable through the public API.
 #[test]
-fn native_row_codec_fixture_matches_groove_descriptor_and_record_layout() {
+fn native_row_codec_fixture_round_trips_every_groove_value_type() {
     let fixture: NativeRowCodecFixture =
         serde_json::from_str(include_str!("../fixtures/native_row_codec.json"))
             .expect("native row codec fixture parses");
-    let descriptor = groove::records::RecordDescriptor::new([
-        ("row_uuid", groove::records::ValueType::Uuid),
-        (
-            "user_title",
-            groove::records::ValueType::Nullable(Box::new(groove::records::ValueType::String)),
-        ),
-        (
-            "user_done",
-            groove::records::ValueType::Nullable(Box::new(groove::records::ValueType::Bool)),
-        ),
-        (
-            "user_priority",
-            groove::records::ValueType::Nullable(Box::new(groove::records::ValueType::I32)),
-        ),
-        ("tx_time", groove::records::ValueType::I64),
-        (
-            "user_description",
-            groove::records::ValueType::Nullable(Box::new(groove::records::ValueType::String)),
-        ),
-    ]);
+    let (descriptor, values) = exhaustive_native_row_codec_case();
+    let case = fixture
+        .cases
+        .iter()
+        .find(|case| case.name == "all_value_types_depth_three")
+        .expect("all ValueType fixture is present");
     let descriptor_fields = descriptor
         .fields()
         .iter()
         .map(|field| (field.name.clone(), field.value_type.clone()))
         .collect::<Vec<_>>();
     let descriptor_bytes = postcard::to_allocvec(&descriptor_fields).expect("descriptor encodes");
-    let record = descriptor
-        .create(&[
-            groove::records::Value::Uuid(uuid::Uuid::from_bytes([0x11; 16])),
-            groove::records::Value::Nullable(Some(Box::new(groove::records::Value::String(
-                "Buy milk".to_owned(),
-            )))),
-            groove::records::Value::Nullable(Some(Box::new(groove::records::Value::Bool(false)))),
-            groove::records::Value::Nullable(Some(Box::new(groove::records::Value::I32(7)))),
-            groove::records::Value::I64(42),
-            groove::records::Value::Nullable(None),
-        ])
-        .expect("record encodes");
+    let record = descriptor.create(&values).expect("record encodes");
 
-    assert_eq!(hex(&descriptor_bytes), fixture.descriptor_hex);
-    assert_eq!(hex(&record), fixture.record_hex);
+    assert_eq!(hex(&descriptor_bytes), case.descriptor_hex.concat());
+    assert_eq!(hex(&record), case.record_hex.concat());
+    assert_eq!(
+        descriptor
+            .bind(&record)
+            .to_values()
+            .expect("record decodes"),
+        values
+    );
+
+    for (index, field) in case.fields.iter().enumerate() {
+        assert_eq!(
+            descriptor.fields()[index].name.as_deref(),
+            Some(field.name.as_str())
+        );
+        let span = descriptor
+            .field_span(&record, index)
+            .expect("field span resolves");
+        assert_eq!(
+            hex(&record[span]),
+            field.encoded_hex,
+            "{} encoded",
+            field.name
+        );
+        assert_eq!(
+            descriptor
+                .bind(&record)
+                .get_idx(index)
+                .expect("field decodes"),
+            values[index],
+            "{} decoded",
+            field.name
+        );
+    }
+}
+
+fn exhaustive_native_row_codec_case() -> (
+    groove::records::RecordDescriptor,
+    Vec<groove::records::Value>,
+) {
+    use groove::records::{EnumSchema, OwnedRecord, RecordDescriptor, Value, ValueType};
+
+    let mode = EnumSchema::new("mode", ["low", "high"]).expect("enum schema is valid");
+    let child = RecordDescriptor::new([
+        ("child_count", ValueType::I32),
+        (
+            "child_label",
+            ValueType::Nullable(Box::new(ValueType::String)),
+        ),
+    ]);
+    let child_record = |count, label: Option<&str>| {
+        OwnedRecord::new(
+            child
+                .create(&[
+                    Value::I32(count),
+                    Value::Nullable(label.map(|label| Box::new(Value::String(label.to_owned())))),
+                ])
+                .expect("child record encodes"),
+            child.clone(),
+        )
+    };
+    let descriptor = RecordDescriptor::new([
+        ("u8_value", ValueType::U8),
+        ("u16_value", ValueType::U16),
+        ("u32_value", ValueType::U32),
+        ("u64_value", ValueType::U64),
+        ("f64_value", ValueType::F64),
+        ("bool_value", ValueType::Bool),
+        ("string_value", ValueType::String),
+        ("bytes_value", ValueType::Bytes),
+        ("uuid_value", ValueType::Uuid),
+        ("enum_value", ValueType::Enum(mode)),
+        (
+            "mixed_tuple",
+            ValueType::Tuple(vec![
+                ValueType::U8,
+                ValueType::I64,
+                ValueType::Nullable(Box::new(ValueType::Bool)),
+                ValueType::I32,
+            ]),
+        ),
+        ("fixed_array", ValueType::Array(Box::new(ValueType::I32))),
+        (
+            "variable_array",
+            ValueType::Array(Box::new(ValueType::String)),
+        ),
+        (
+            "nullable_array_depth_three",
+            ValueType::Nullable(Box::new(ValueType::Array(Box::new(ValueType::Nullable(
+                Box::new(ValueType::I32),
+            ))))),
+        ),
+        ("inline_record", ValueType::Record(Box::new(child.clone()))),
+        (
+            "record_array",
+            ValueType::Array(Box::new(ValueType::Record(Box::new(child.clone())))),
+        ),
+        (
+            "empty_fixed_array",
+            ValueType::Array(Box::new(ValueType::U16)),
+        ),
+        (
+            "empty_variable_array",
+            ValueType::Array(Box::new(ValueType::String)),
+        ),
+        (
+            "null_fixed_i32",
+            ValueType::Nullable(Box::new(ValueType::I32)),
+        ),
+        ("i64_value", ValueType::I64),
+        ("i32_value", ValueType::I32),
+    ]);
+    let values = vec![
+        Value::U8(0xa1),
+        Value::U16(0xb2c3),
+        Value::U32(0xd4e5_f607),
+        Value::U64(0x1020_3040_5060_7080),
+        Value::F64(12.5),
+        Value::Bool(false),
+        Value::String("synthetic".to_owned()),
+        Value::Bytes(vec![0xde, 0xad]),
+        Value::Uuid(uuid::Uuid::from_bytes([0x11; 16])),
+        Value::Enum(1),
+        Value::Tuple(vec![
+            Value::U8(9),
+            Value::I64(-3),
+            Value::Nullable(None),
+            Value::I32(-17),
+        ]),
+        Value::Array(vec![Value::I32(-3), Value::I32(5)]),
+        Value::Array(vec![
+            Value::String("x".to_owned()),
+            Value::String("yz".to_owned()),
+        ]),
+        Value::Nullable(Some(Box::new(Value::Array(vec![
+            Value::Nullable(None),
+            Value::Nullable(Some(Box::new(Value::I32(-7)))),
+        ])))),
+        Value::Record(child_record(4, Some("one"))),
+        Value::Array(vec![
+            Value::Record(child_record(5, Some("two"))),
+            Value::Record(child_record(6, None)),
+        ]),
+        Value::Array(Vec::new()),
+        Value::Array(Vec::new()),
+        Value::Nullable(None),
+        Value::I64(-42),
+        Value::I32(-13),
+    ];
+    (descriptor, values)
 }
 
 fn hex(bytes: &[u8]) -> String {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -5,17 +5,19 @@ import { describe, expect, it } from "vitest";
 import { PostcardReader, PostcardWriter } from "./native-codec.js";
 import {
   createRecord,
-  decodeRecordBool,
-  decodeRecordBytes,
-  decodeRecordString,
   decodeRecordValue,
   readDescriptor,
   writeDescriptor,
 } from "./native-row-codec.js";
 
 type NativeRowCodecFixture = {
-  descriptor_hex: string;
-  record_hex: string;
+  cases: NativeRowCodecCase[];
+};
+type NativeRowCodecCase = {
+  name: string;
+  descriptor_hex: string[];
+  record_hex: string[];
+  fields: { name: string; encoded_hex: string; decoded_hex: string | null }[];
 };
 
 describe("native row codec", () => {
@@ -41,41 +43,45 @@ describe("native row codec", () => {
     expect(reader.u64()).toBe(42);
   });
 
-  it("decodes the Rust I32/I64 descriptor fixture without treating fixed fields as offsets", () => {
+  it("round-trips every Groove ValueType fixture, including depth-three nesting", () => {
     const fixture = nativeRowCodecFixture();
-    const descriptorBytes = hexToBytes(fixture.descriptor_hex);
-    const raw = hexToBytes(fixture.record_hex);
+    const testCase = fixture.cases.find(
+      (candidate) => candidate.name === "all_value_types_depth_three",
+    );
+    expect(testCase).toBeDefined();
+    const descriptorBytes = hexToBytes(testCase!.descriptor_hex.join(""));
+    const raw = hexToBytes(testCase!.record_hex.join(""));
     const descriptor = readDescriptor(new PostcardReader(descriptorBytes));
 
-    expect(descriptor.map((field) => [field.name, field.valueType.tag])).toEqual([
-      ["row_uuid", 8],
-      ["user_title", 12],
-      ["user_done", 12],
-      ["user_priority", 12],
-      ["tx_time", 14],
-      ["user_description", 12],
-    ]);
-    expect(descriptor[3]?.valueType.inner?.tag).toBe(15);
-
-    expect(decodeRecordString(descriptor, raw, 1)).toBe("Buy milk");
-    expect(decodeRecordBool(descriptor, raw, 2)).toBe(false);
-    expect(decodeRecordBytes(descriptor, raw, 3)).toEqual(Uint8Array.of(7, 0, 0, 0));
-    expect(decodeRecordBytes(descriptor, raw, 4)).toEqual(Uint8Array.of(42, 0, 0, 0, 0, 0, 0, 0));
-    expect(decodeRecordValue(descriptor, raw, 5)).toBeNull();
+    expect(new Set(descriptor.map((field) => field.valueType.tag))).toEqual(
+      new Set(Array.from({ length: 16 }, (_, tag) => tag)),
+    );
+    expect(descriptor[9]?.valueType).toMatchObject({
+      tag: 9,
+      enumSchema: { name: "mode", variants: ["low", "high"] },
+    });
+    expect(descriptor[10]?.valueType.members?.map((member) => member.tag)).toEqual([0, 14, 12, 15]);
+    expect(descriptor[13]?.valueType).toMatchObject({
+      tag: 12,
+      inner: { tag: 11, inner: { tag: 12 } },
+    });
+    expect(descriptor[15]?.valueType).toMatchObject({ tag: 11, inner: { tag: 13 } });
 
     const descriptorWriter = new PostcardWriter();
     writeDescriptor(descriptorWriter, descriptor);
     expect(descriptorWriter.finish()).toEqual(descriptorBytes);
     expect(
-      createRecord(descriptor, [
-        raw.subarray(0, 16),
-        Uint8Array.of(1, ...new TextEncoder().encode("Buy milk")),
-        Uint8Array.of(1, 0),
-        Uint8Array.of(1, 7, 0, 0, 0),
-        Uint8Array.of(42, 0, 0, 0, 0, 0, 0, 0),
-        Uint8Array.of(0),
-      ]),
+      createRecord(
+        descriptor,
+        testCase!.fields.map((field) => hexToBytes(field.encoded_hex)),
+      ),
     ).toEqual(raw);
+
+    for (const [index, field] of testCase!.fields.entries()) {
+      expect(descriptor[index]?.name).toBe(field.name);
+      const decoded = decodeRecordValue(descriptor, raw, index);
+      expect(decoded == null ? null : bytesToHex(decoded)).toBe(field.decoded_hex);
+    }
   });
 });
 
@@ -94,4 +100,8 @@ function hexToBytes(hex: string): Uint8Array {
     bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
   }
   return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -8,8 +8,10 @@ export type ValueType = {
   inner?: ValueType;
   members?: ValueType[];
   record?: DescriptorField[];
+  enumSchema?: EnumSchema;
 };
 export type DescriptorField = { name?: string; valueType: ValueType };
+export type EnumSchema = { name: string; variants: string[] };
 export type NativeRow = { rowId: Uint8Array; deleted: boolean; raw: Uint8Array };
 export type NativeRowBatch = { table: string; descriptor: DescriptorField[]; rows: NativeRow[] };
 export type NativeRemovedRow = { table: string; rowId: Uint8Array };
@@ -127,14 +129,14 @@ export function readNativeRelationSubscriptionEdge(
 export function writeDescriptor(writer: PostcardWriterLike, descriptor: DescriptorField[]): void {
   writer.vec((field, index) => {
     field.some((nameWriter) => nameWriter.string(descriptor[index].name ?? ""));
-    writeValueType(field, descriptor[index].valueType);
+    writeGrooveValueType(field, descriptor[index].valueType);
   }, descriptor.length);
 }
 
 export function readDescriptor(reader: PostcardReaderLike): DescriptorField[] {
   return reader.readVec((fieldReader) => ({
     name: fieldReader.option((nameReader) => nameReader.string()),
-    valueType: readValueType(fieldReader),
+    valueType: readGrooveValueType(fieldReader),
   }));
 }
 
@@ -166,6 +168,61 @@ export function readValueType(reader: PostcardReaderLike): ValueType {
   }
   if (tag === 10) {
     const members = reader.readVec(readValueType);
+    return { tag, members, inner: members[0] };
+  }
+  if (tag === 13) {
+    return { tag, record: readDescriptor(reader) };
+  }
+  return { tag };
+}
+
+function writeGrooveValueType(writer: PostcardWriterLike, valueType: ValueType): void {
+  writer.enumUnit(valueType.tag);
+  if (valueType.tag === 9) {
+    if (!valueType.enumSchema) throw new Error("missing enum schema for Groove ValueType::Enum");
+    writer.string(valueType.enumSchema.name);
+    writer.vec(
+      (variantWriter, index) => variantWriter.string(valueType.enumSchema!.variants[index]!),
+      valueType.enumSchema.variants.length,
+    );
+    return;
+  }
+  if (valueType.tag === 10) {
+    const members = valueType.members ?? (valueType.inner ? [valueType.inner] : []);
+    writer.vec(
+      (memberWriter, index) => writeGrooveValueType(memberWriter, members[index]!),
+      members.length,
+    );
+    return;
+  }
+  if (valueType.tag === 11 || valueType.tag === 12) {
+    if (!valueType.inner) throw new Error(`missing inner value type for tag ${valueType.tag}`);
+    writeGrooveValueType(writer, valueType.inner);
+    return;
+  }
+  if (valueType.tag === 13) {
+    if (!valueType.record)
+      throw new Error("missing inline record descriptor for Groove ValueType::Record");
+    writeDescriptor(writer, valueType.record);
+  }
+}
+
+function readGrooveValueType(reader: PostcardReaderLike): ValueType {
+  const tag = reader.u64();
+  if (tag === 9) {
+    return {
+      tag,
+      enumSchema: {
+        name: reader.string(),
+        variants: reader.readVec((variantReader) => variantReader.string()),
+      },
+    };
+  }
+  if (tag === 11 || tag === 12) {
+    return { tag, inner: readGrooveValueType(reader) };
+  }
+  if (tag === 10) {
+    const members = reader.readVec(readGrooveValueType);
     return { tag, members, inner: members[0] };
   }
   if (tag === 13) {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -20,7 +20,6 @@ import {
   readNativeRelationSubscriptionDelta,
   readNativeRelationSubscriptionSnapshot,
   readNativeSubscriptionDelta,
-  writeValueType,
   type NativeSubscriptionDelta,
   type NativeRelationSubscriptionSnapshot,
   type NativeRelationSubscriptionDelta,
@@ -43,6 +42,7 @@ import {
   createRecordValueDecoder,
   storageColumnTypeToValueType,
   storageColumnValueType,
+  writeDescriptor,
 } from "./native-row-codec.js";
 import { HIDDEN_INCLUDE_COLUMN_PREFIX, hiddenIncludeColumnName } from "../select-projection.js";
 import {
@@ -3379,10 +3379,7 @@ function encodeCells(
     encodeValue(column, valueFor(column), requireMissingDefaults),
   );
   const writer = new PostcardWriter();
-  writer.vec((field, index) => {
-    field.some((name) => name.string(descriptor[index]!.name));
-    writeValueType(field, descriptor[index]!.valueType);
-  }, descriptor.length);
+  writeDescriptor(writer, descriptor);
   writer.bytes(createRecord(descriptor, values));
   return writer.finish();
 }


### PR DESCRIPTION
Stacked on #1288 — merge that first.

#1288 fixed `I64`/`I32` being read as variable-width. A real bulk import proved that was not the whole story, so this closes the remaining divergence and pins the **entire `ValueType` space** so the class cannot recur silently.

## The remaining defect

TypeScript's descriptor codec wrote and read **only the tag byte** for Groove `Enum` (tag 9). Rust's `ValueType::Enum` carries a serialized `EnumSchema` payload after the tag (`crates/groove/src/records/values.rs:127,171`).

So every field *after* an enum in a descriptor was read from the wrong offset. Rust was correct; TypeScript was wrong. Fixed in `native-row-codec.ts:129` and the Groove-specific type codec at `:179`, with staged-cell encoding now explicitly using the Groove descriptor path (`native-runtime-adapter.ts:3382`) so the **separate Jazz schema-tag namespace is preserved** — Jazz tag 15 is JSON, not Groove `I32`.

## Full round-trip coverage, both directions

| Tag | ValueType | TS → Rust | Rust → TS |
|---:|---|---|---|
| 0–2 | U8, U16, U32 | pass | pass |
| 3–5 | U64, F64, Bool | pass | pass |
| 6–8 | String, Bytes, Uuid | pass | pass |
| 9 | Enum | **pass after fix** | **pass after fix** |
| 10–12 | Tuple, Array, Nullable | pass | pass |
| 13 | Record | pass | pass |
| 14–15 | I64, I32 | pass | pass |

Nesting to depth three: `Nullable<Array<Nullable<I32>>>`, `Array<Record<…>>`, mixed-width tuples with a null member, fixed nullable nulls, and both fixed and variable empty arrays. The enum assertions are **born-red without this fix**.

Fixture and tests extend #1288's: `crates/jazz/fixtures/native_row_codec.json`, `crates/jazz/tests/wire_fixtures.rs:467`, `packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts:46`, all gated by `dev/gates/ts-wire-codec.sh`.

## What I verified, and what I could not attribute

Re-run independently, exit codes unpiped:

- `dev/gates/ts-wire-codec.sh` → **1**, `91 passed`, single failure `encodes the policy graph perf fixture byte-stably` — the pre-existing policy-graph failure documented in `CLAUDE.md`.
- `cargo test -p jazz --test wire_fixtures` → **0**, `3 passed`.

Lane-reported: `cargo test -p jazz` **0** · `cargo test -p groove` **0** (402 passed) · `cargo check --workspace --all-targets` **0** · `cargo fmt --check` **0** · `--no-default-features --features test` **101**, the three known `catalogue_sync_integration` failures only.

**Honest limit on attribution.** With this fix the bulk import gets past cell staging entirely — 133 transactions, 26,512 operations, zero errors, where it previously died on the first batch. But that run *also* required rebuilding the NAPI native module, which had been stale since before #1288. I cannot separate this fix's contribution from #1288's in the real-world run. The enum defect is nevertheless real and independently proven by the born-red round-trip assertions above.
