### PR TITLE
(new core) Flush durability fates during ingest, not after the batch

### DIFF
--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -12,7 +12,7 @@ use crate::serving::{
     AbiBytes, InMemoryServerShell, InMemoryServerShellConfig, NodeRole, ServerSession,
     StorageConfig,
 };
-use tokio::sync::{oneshot, watch};
+use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 
 /// Sendable handle for the thread that owns the in-memory server shell.
 ///
@@ -171,24 +171,39 @@ impl ServerShellHandle {
         result
     }
 
-    pub(crate) async fn receive_tick_take(
+    /// Service one WebSocket message as ordered frame-sized shell ticks.
+    ///
+    /// Results become available as each frame has completed its tick while the
+    /// shell thread keeps ingesting later frames. This is intentionally a
+    /// streaming operation rather than one large `run` job so a route can
+    /// publish a durability fate as soon as it is true.
+    pub(crate) fn receive_tick_stream(
         &self,
         session: ServerSession,
         frames: Vec<AbiBytes>,
-    ) -> Result<Vec<AbiBytes>, String> {
+    ) -> Result<tokio_mpsc::UnboundedReceiver<Result<Vec<AbiBytes>, String>>, String> {
         let activity_tx = self.activity_tx.clone();
-        self.run(move |shell| {
-            let result = shell
-                .receive_frames(session, frames)
-                .and_then(|()| shell.tick())
-                .and_then(|()| shell.take_frames(session))
-                .map_err(|error| error.to_string());
-            if result.is_ok() {
-                notify_shell_activity(&activity_tx);
-            }
-            result
-        })
-        .await
+        let (outbound_tx, outbound_rx) = tokio_mpsc::unbounded_channel();
+        self.jobs
+            .send(Box::new(move |shell| {
+                for frame in frames {
+                    let result = shell
+                        .receive_frames(session, [frame])
+                        .and_then(|()| shell.tick())
+                        .and_then(|()| shell.take_frames(session))
+                        .map_err(|error| error.to_string());
+                    let keep_streaming = result.is_ok();
+                    if outbound_tx.send(result).is_err() {
+                        return;
+                    }
+                    if !keep_streaming {
+                        return;
+                    }
+                    notify_shell_activity(&activity_tx);
+                }
+            }))
+            .map_err(|_| "server shell thread is not running".to_owned())?;
+        Ok(outbound_rx)
     }
 
     pub(crate) async fn tick_take(&self, session: ServerSession) -> Result<Vec<AbiBytes>, String> {

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -615,7 +615,7 @@ async fn handle_ws_connection(
         return;
     }
 
-    loop {
+    'connection: loop {
         tokio::select! {
             eviction = admission_registration.evict_rx.recv() => {
                 if eviction.is_some() {
@@ -655,19 +655,38 @@ async fn handle_ws_connection(
                             break;
                         }
                     };
-                    let outbound = match core_server_shell.receive_tick_take(session, frames).await {
-                        Ok(frames) => frames,
+                    // The shell owns a synchronous database, so one tick is the
+                    // smallest ordering-preserving unit at which its newly
+                    // durable responses can be observed. Do not hold those
+                    // responses behind the rest of this WebSocket message: a
+                    // large import can otherwise delay an already-global
+                    // FateUpdate until every later commit has been ingested.
+                    let mut outbound = match core_server_shell.receive_tick_stream(session, frames) {
+                        Ok(outbound) => outbound,
                         Err(error) => {
                             send_ws_error(
                                 &mut socket,
                                 WireError::new(WireErrorCode::Internal, WireRetry::Later, error),
                             )
                             .await;
-                            break;
+                            break 'connection;
                         }
                     };
-                    if !outbound.is_empty()
-                        && let Err(error) = send_ws_encoded_frames(&mut socket, &outbound).await {
+                    while let Some(outbound) = outbound.recv().await {
+                        let outbound = match outbound {
+                            Ok(frames) => frames,
+                            Err(error) => {
+                                send_ws_error(
+                                    &mut socket,
+                                    WireError::new(WireErrorCode::Internal, WireRetry::Later, error),
+                                )
+                                .await;
+                                break 'connection;
+                            }
+                        };
+                        if !outbound.is_empty()
+                            && let Err(error) = send_ws_encoded_frames(&mut socket, &outbound).await
+                        {
                             send_ws_error(
                                 &mut socket,
                                 WireError::new(
@@ -677,8 +696,9 @@ async fn handle_ws_connection(
                                 ),
                             )
                             .await;
-                            break;
+                            break 'connection;
                         }
+                    }
                 }
                 Some(Ok(Message::Close(_))) | None => break,
                 Some(Ok(Message::Ping(payload))) => {
@@ -840,12 +860,13 @@ mod tests {
     use crate::groove::schema::ColumnType as CoreColumnType;
     use crate::groove::storage::MemoryStorage as CoreMemoryStorage;
     use crate::ids::NodeUuid;
+    use crate::protocol::SyncMessage;
     use crate::query::{Query, claim, col, eq};
     use crate::schema::{ColumnSchema, JazzSchema, Policy, TableSchema};
-    use crate::tx::DurabilityTier;
+    use crate::tx::{DurabilityTier, TxId};
     use crate::wire::FEATURE_STRUCTURED_ERRORS;
-    use crate::wire::decode_frame;
     use crate::wire::{TransportError, WireTransport};
+    use crate::wire::{WireStreamDecoder, decode_frame, decode_sync_message};
     use futures::StreamExt as _;
     use futures::stream::FuturesUnordered;
     use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
@@ -1322,6 +1343,23 @@ mod tests {
             .collect()
     }
 
+    fn fate_tx_ids(decoder: &mut WireStreamDecoder, message: &WsMessage) -> Vec<TxId> {
+        decode_ws_message(message)
+            .into_iter()
+            .filter_map(|frame| match frame {
+                WireFrame::Message(envelope) => decoder
+                    .decode_message(&envelope.payload, envelope.features)
+                    .ok()
+                    .and_then(|payload| decode_sync_message(&payload).ok())
+                    .and_then(|message| match message {
+                        SyncMessage::FateUpdate { tx_id, .. } => Some(tx_id),
+                        _ => None,
+                    }),
+                WireFrame::Hello(_) | WireFrame::Error(_) => None,
+            })
+            .collect()
+    }
+
     #[derive(Clone, Default)]
     struct TestWireTransport {
         queues: Rc<RefCell<TestWireQueues>>,
@@ -1400,6 +1438,19 @@ mod tests {
                 )
                 .expect("insert client row")
                 .row_uuid()
+        }
+
+        fn write_todo_tx_id(&self, title: &str) -> TxId {
+            self.db
+                .insert(
+                    "todos",
+                    RowCells::from([
+                        ("title".to_owned(), CoreValue::String(title.to_owned())),
+                        ("done".to_owned(), CoreValue::Bool(false)),
+                    ]),
+                )
+                .expect("insert client row")
+                .mergeable_tx_id()
         }
 
         fn insert_private_doc(&self, title: &str, owner: AuthorId) -> crate::ids::RowUuid {
@@ -1638,6 +1689,57 @@ mod tests {
             vec!["route sync".to_owned()],
             "the receiving client must materialize the row through the websocket route"
         );
+    }
+
+    // Internal route-boundary guard: WebSocket message boundaries are not
+    // observable through the public JazzClient facade. Two real Db clients and
+    // the public websocket route are therefore required to prove that a fate
+    // already made Global is emitted before a later input frame is ingested.
+    #[tokio::test(flavor = "current_thread")]
+    async fn ws_flushes_early_global_fate_before_later_batch_frames() {
+        let state = make_ws_convergence_test_state().await;
+        let addr = start_ws_test_server(state.clone()).await;
+        let client = TestClient::new(ws_public_schema_convert(), 0xa1, 0xa100).await;
+        let mut ws = open_negotiated_ws(addr, &state, AuthorId::from_bytes([0xa1; 16])).await;
+
+        let early_tx = client.write_todo_tx_id("early fate");
+        let mut final_tx = early_tx;
+        for index in 0..32 {
+            final_tx = client.write_todo_tx_id(&format!("later fate {index}"));
+        }
+        let outbound = client.tick_take();
+        assert!(outbound.len() > 1, "import must contain later input frames");
+        ws.send(WsMessage::Binary(ws_frame_batch(&outbound).into()))
+            .await
+            .expect("send one batched import message");
+
+        let first_response = ws
+            .next()
+            .await
+            .expect("server response while later frames remain")
+            .expect("valid websocket response");
+        let mut decoder = WireStreamDecoder::new(current_wire_features())
+            .expect("current wire compression must be available");
+        let first_fates = fate_tx_ids(&mut decoder, &first_response);
+        assert!(
+            first_fates.contains(&early_tx),
+            "the first server response must include the already-global early transaction; frames={:?}",
+            decode_ws_message(&first_response)
+        );
+        assert!(
+            !first_fates.contains(&final_tx),
+            "the final transaction must not be ingested before the early fate is flushed"
+        );
+
+        let mut observed_final = false;
+        while !observed_final {
+            let response = ws
+                .next()
+                .await
+                .expect("server continues ingesting the batch")
+                .expect("valid websocket response");
+            observed_final = fate_tx_ids(&mut decoder, &response).contains(&final_tx);
+        }
     }
 
     // Internal route-boundary test: this exercises the public websocket


### PR DESCRIPTION
A bulk import of 133 transactions × ~200 operations never completed: the final global-tier durability wait hung indefinitely. This fixes it, and the diagnosis overturned two plausible-but-wrong theories along the way.

## What it was not

- **Not a lost wakeup or a circular wait.** `NativeRuntimeAdapter.waitForTransaction` (`packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts:695`) registers `nextWriteStateChange()` *before* awaiting and then rechecks `Write.wait()`, which forecloses the ack-before-registration race. Core waiters are keyed by `TxId` (`crates/jazz/src/db.rs:3707`), woken by `FateUpdate` after apply.
- **Not the 1 MiB WebSocket message cap.** `c37645a94` fixed that and is a real fix; this is a second, independent bound behind it.
- **Not transaction count**, which was my first reading of the curve.

## What it is

Holding total writes constant while repartitioning isolates the driver:

| Shape | Total writes | Early-fate delay (pre-fix) |
| --- | ---: | ---: |
| 32 × 30 | 960 | 3.81 s |
| 64 × 15 | 960 | 3.91 s |
| 32 × 60 | 1,920 | 13.64 s |
| 64 × 30 | 1,920 | 13.79 s |

Same total writes, same delay, regardless of how they are split. The delay tracks **total writes, roughly `total_writes^1.8`** in this regime — not transaction count, not `transactions × writes`, not `transactions²`.

The barrier was the full-vector `receive_frames → tick → take_frames` closure in `core_server_shell.rs`: it withheld **every already-produced fate** until the tail of the batch had been ingested. An early transaction's fate could be globally durable and still sit unsent behind thousands of later writes.

## The fix

Stream frame-sized shell ticks (`crates/jazz/src/tools/server/core_server_shell.rs:174`) and send each resulting outbound batch immediately (`crates/jazz/src/tools/server/routes/websocket.rs:658`). Input and output order are preserved.

**The durability contract is unchanged.** A fate is emitted only after its frame's `shell.tick()` has completed, which is after authority ingestion has committed global durability. A tail transaction still waits for its own ingest and its own real durability. No timeout was added, raised, or bypassed.

| Shape | Early transaction's global wait, post-fix |
| --- | --- |
| 133 × 1 | 7 ms |
| 1 × 3,990 | 2.74 s |
| 64 × 30 | 55 ms |
| 96 × 30 | 76 ms |
| 133 × 30 | 93 ms |

96 × 30 and 133 × 30 previously **timed out**. The 1 × 3,990 case stays at 2.74 s, correctly — a single transaction must wait for its own ingest.

## The guard

`ws_flushes_early_global_fate_before_later_batch_frames` (`crates/jazz/src/tools/server/routes/websocket.rs:1694`) keys on **work done, not elapsed time**, so it cannot flake by wall-clock. It sends one batch and requires the first response to contain the early global fate and *not* the final transaction's fate. It uses real databases and the public WebSocket route because message boundaries are not observable through `JazzClient`.

An earlier attempt at this problem deliberately reverted its timeout-based reproduction rather than leave a test that fails by stopwatch; this replaces it with a deterministic one.

**Planted positive, verified independently.** Restoring aggregate-after-ingest in `receive_tick_stream` fails it immediately:

```
panicked at crates/jazz/src/tools/server/routes/websocket.rs:1729:
the final transaction must not be ingested before the early fate is flushed
test result: FAILED. 0 passed; 1 failed
```

Reverted; tree clean.

## Gates

Verified by me: the guard test → **0**, `1 passed`; `cargo test -p jazz` → **0**, zero failing targets.

Lane-reported: `--features test-utils --test transactions` **0** · `cargo test -p groove` **0** · `cargo check -p jazz-sim --benches` **0** · `cargo check --workspace --all-targets` **0** · `cargo fmt --check` **0** · incremental-delivery canary **0** · `--no-default-features --features test` **101** (the three known `catalogue_sync_integration` reds) · `clippy` **101** (the documented `warm_reopen_differential` type-complexity lint).
