### PR TITLE
(new core) Drop redundant RecordDescriptor clones in wire fixtures

### DIFF
--- a/crates/jazz/tests/wire_fixtures.rs
+++ b/crates/jazz/tests/wire_fixtures.rs
@@ -545,7 +545,7 @@ fn exhaustive_native_row_codec_case() -> (
                     Value::Nullable(label.map(|label| Box::new(Value::String(label.to_owned())))),
                 ])
                 .expect("child record encodes"),
-            child.clone(),
+            child,
         )
     };
     let descriptor = RecordDescriptor::new([
@@ -579,10 +579,10 @@ fn exhaustive_native_row_codec_case() -> (
                 Box::new(ValueType::I32),
             ))))),
         ),
-        ("inline_record", ValueType::Record(Box::new(child.clone()))),
+        ("inline_record", ValueType::Record(Box::new(child))),
         (
             "record_array",
-            ValueType::Array(Box::new(ValueType::Record(Box::new(child.clone())))),
+            ValueType::Array(Box::new(ValueType::Record(Box::new(child)))),
         ),
         (
             "empty_fixed_array",


### PR DESCRIPTION
`cargo clippy --package jazz --all-targets -- -D warnings` is red on `codex/jazz-core-engine-swap` with three instances of:

```
error: using `clone` on type `RecordDescriptor` which implements the `Copy` trait
  --> crates/jazz/tests/wire_fixtures.rs:548:13
```

`RecordDescriptor` is `Copy`. The three `child.clone()` calls came in with the `ValueType` round-trip fixtures (#1291); dropping them is a no-op at runtime.

Verified on this branch, exit codes read unpiped:

- `cargo clippy --package jazz --test wire_fixtures -- -D warnings` → **0** (was 101, three errors)
- `cargo test -p jazz --test wire_fixtures` → **0**, 3 passed

The pre-existing `warm_reopen_differential` `type_complexity` lint is untouched and still the only remaining clippy red in the crate.
