### PR TITLE
(new core) Enforce global-sequence durability, and bound replay without a new index

### DIFF
--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -157,6 +157,7 @@ where
                 global_seq,
                 durability,
             } => {
+                validate_received_fate_update_global_seq_durability(global_seq, durability)?;
                 self.apply_fate_update(tx_id, fate, global_seq, durability)?;
                 self.drain_parked_commit_units()
             }
@@ -1298,6 +1299,10 @@ where
         global_seq: Option<GlobalSeq>,
         durability: DurabilityTier,
     ) -> Result<(), Error> {
+        debug_assert!(
+            global_seq.is_none() || durability == DurabilityTier::Global,
+            "a global sequence requires Global durability"
+        );
         self.merge_tx_time(tx.tx_id.time);
         let versions = canonical_versions(versions);
         if let Some(existing) = self.query_transaction(tx.tx_id)? {
@@ -1347,6 +1352,10 @@ where
         durability: DurabilityTier,
         staged_global_seqs: &mut Vec<GlobalSeq>,
     ) -> Result<(), Error> {
+        debug_assert!(
+            global_seq.is_none() || durability == DurabilityTier::Global,
+            "a global sequence requires Global durability"
+        );
         self.merge_tx_time(tx.tx_id.time);
         let versions = canonical_versions(versions);
         if self.query_transaction(tx.tx_id)?.is_some() {
@@ -1376,6 +1385,10 @@ where
     ) -> Result<BTreeSet<TxId>, Error> {
         let mut bundles_by_tx = BTreeMap::<TxId, Vec<VersionBundleRef<'_>>>::new();
         for bundle in bundles {
+            validate_received_view_bundle_global_seq_durability(
+                bundle.global_seq,
+                bundle.durability,
+            )?;
             bundles_by_tx
                 .entry(bundle.tx.tx_id)
                 .or_default()
@@ -1644,6 +1657,10 @@ where
         global_seq: Option<GlobalSeq>,
         durability: Option<DurabilityTier>,
     ) -> Result<(), Error> {
+        debug_assert!(
+            global_seq.is_none() || durability == Some(DurabilityTier::Global),
+            "a global sequence requires Global durability"
+        );
         let mut terminal_fate_persisted = false;
         let result = self.apply_fate_update_once(
             tx_id,
@@ -4637,6 +4654,34 @@ where
         self.database.commit_batch(batch)?;
         Ok(())
     }
+}
+
+/// A sequence is the global-authority receipt. Peer payloads which pair it
+/// with a weaker durability must be rejected before they can reach storage.
+pub(super) fn validate_received_fate_update_global_seq_durability(
+    global_seq: Option<GlobalSeq>,
+    durability: Option<DurabilityTier>,
+) -> Result<(), Error> {
+    if global_seq.is_some() && durability != Some(DurabilityTier::Global) {
+        return Err(Error::UnsupportedSyncMessage(
+            "global sequence requires Global durability",
+        ));
+    }
+    Ok(())
+}
+
+/// View bundles are peer payloads too, including reset bundles eligible for
+/// bulk persistence.
+pub(super) fn validate_received_view_bundle_global_seq_durability(
+    global_seq: Option<GlobalSeq>,
+    durability: DurabilityTier,
+) -> Result<(), Error> {
+    if global_seq.is_some() && durability != DurabilityTier::Global {
+        return Err(Error::MalformedViewUpdate(
+            "global sequence requires Global durability",
+        ));
+    }
+    Ok(())
 }
 
 fn merge_large_value_head_ops(

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2594,20 +2594,52 @@ where
         node: NodeUuid,
         author: AuthorId,
     ) -> Result<Vec<TxId>, Error> {
-        let mut pending = Vec::new();
-        for tx_id in self.transaction_ids()? {
-            let Some(transaction) = self.query_transaction(tx_id)? else {
-                continue;
-            };
-            if transaction.tx.tx_id.node == node
-                && transaction.tx.made_by == author
-                && matches!(transaction.fate, Fate::Pending | Fate::Accepted)
-                && transaction.durability < DurabilityTier::Global
+        Ok(self.pending_transaction_scan_for(node, author)?.tx_ids)
+    }
+
+    /// Find replayable local transactions in the null slice of
+    /// `by_global_seq`. The sequence/durability invariant makes every
+    /// below-Global transaction sequence-null, so settled history is outside
+    /// this scan without a second index or an upgrade backfill.
+    fn pending_transaction_scan_for(
+        &mut self,
+        node: NodeUuid,
+        author: AuthorId,
+    ) -> Result<PendingTransactionScan, Error> {
+        let Some(node_alias) = self.node_aliases.get(&node).copied() else {
+            return Ok(PendingTransactionScan::default());
+        };
+
+        let mut scan = PendingTransactionScan::default();
+        for raw in self.database.index_scan_raw(
+            "jazz_transactions",
+            "by_global_seq",
+            &[Value::Nullable(None)],
+        )? {
+            scan.records_visited += 1;
+            let record = raw.record();
+            if NodeAlias(record.get_u64(TransactionRowRecord::FIELD_NODE_ID_IDX)?) != node_alias
+                || AuthorId(record.get_uuid(TransactionRowRecord::FIELD_MADE_BY_IDX)?) != author
             {
-                pending.push(tx_id);
+                continue;
             }
+            if !matches!(
+                record.get_enum(TransactionRowRecord::FIELD_FATE_IDX)?,
+                0 | 1
+            ) || durability_from_discriminant(
+                record.get_enum(TransactionRowRecord::FIELD_DURABILITY_IDX)?,
+            )? >= DurabilityTier::Global
+            {
+                continue;
+            }
+            scan.tx_ids.push(TxId::new(
+                TxTime(record.get_u64(TransactionRowRecord::FIELD_TIME_IDX)?),
+                node,
+            ));
         }
-        Ok(pending)
+        scan.tx_ids.sort();
+        scan.tx_ids.dedup();
+        Ok(scan)
     }
 
     /// Resolve creator/updater provenance for a projected current row.
@@ -3797,6 +3829,10 @@ where
     ) -> Result<(), Error> {
         let request_set = requests.iter().cloned().collect::<BTreeSet<_>>();
         for bundle in version_bundles {
+            ingest::validate_received_view_bundle_global_seq_durability(
+                bundle.global_seq,
+                bundle.durability,
+            )?;
             let versions = bundle
                 .versions
                 .into_iter()
@@ -4148,6 +4184,17 @@ pub struct CurrentRow {
     table: groove::Intern<String>,
     record: std::sync::Arc<OwnedRecord>,
     deleted: bool,
+}
+
+/// Work performed by the durable local-write replay lookup.
+///
+/// Kept separate from storage metrics so scale tests can assert candidate
+/// records independently of storage-window and cache details.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct PendingTransactionScan {
+    tx_ids: Vec<TxId>,
+    records_visited: usize,
+    full_transactions_decoded: usize,
 }
 
 /// User-visible row provenance resolved from commit authorship.

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -122,12 +122,20 @@ where
             .index_scan_raw("jazz_transactions", "by_global_seq", &[])?
         {
             let record = raw.record();
+            let global_seq = record.get_nullable_u64(TransactionRowRecord::FIELD_GLOBAL_SEQ_IDX)?;
+            if global_seq.is_some()
+                && durability_from_discriminant(
+                    record.get_enum(TransactionRowRecord::FIELD_DURABILITY_IDX)?,
+                )? != DurabilityTier::Global
+            {
+                return Err(Error::InvalidStoredValue(
+                    "global sequence requires Global durability",
+                ));
+            }
             if !matches!(fate_from_encoded_fields(record)?, Fate::Accepted) {
                 continue;
             }
-            if let Some(global_seq) =
-                record.get_nullable_u64(TransactionRowRecord::FIELD_GLOBAL_SEQ_IDX)?
-            {
+            if let Some(global_seq) = global_seq {
                 accepted_global_seqs.push(GlobalSeq(global_seq));
             }
         }

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -402,6 +402,262 @@ fn recovery_rebuilds_global_clock_from_accepted_transactions() {
 }
 
 #[test]
+fn reopen_refuses_preexisting_sequenced_non_global_transaction() {
+    // This is necessarily an internal recovery test: old receivers could
+    // persist this malformed peer state before admission validation existed.
+    // Opening must surface it, never rewrite the durable audit history.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        let tx_id = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(3), 10).cells(title_cells("persisted")),
+            )
+            .unwrap();
+        let stored = node.query_transaction(tx_id).unwrap().unwrap();
+        let mut batch = node.database.open_batch();
+        batch.update(
+            "jazz_transactions",
+            transaction_values(
+                stored.node_alias,
+                &stored.tx,
+                Fate::Accepted,
+                Some(GlobalSeq(7)),
+                DurabilityTier::Edge,
+            ),
+        );
+        node.database.commit_batch(batch).unwrap();
+    }
+
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).unwrap();
+    let error = match NodeState::new(node(1), schema, storage) {
+        Ok(_) => panic!("reopen must refuse impossible persisted durability"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        Error::InvalidStoredValue("global sequence requires Global durability")
+    ));
+}
+
+// This is necessarily an internal mechanism regression test: the public API
+// exposes the restored upload queue but not candidate-record work. It seeds
+// transaction states through node ingest APIs, then compares the null-slice
+// lookup against the former full-decode predicate.
+fn pending_replay_fixture_transaction(tx_id: TxId, made_by: AuthorId) -> Transaction {
+    Transaction {
+        tx_id,
+        kind: TxKind::Mergeable,
+        n_total_writes: 0,
+        made_by,
+        permission_subject: None,
+        base_snapshot: None,
+        row_read_set: None,
+        absent_read_set: None,
+        predicate_read_set: None,
+        user_metadata_json: None,
+        source_branch: None,
+        merge_strategy: None,
+    }
+}
+
+fn seed_pending_replay_state(
+    node: &mut NodeState<RocksDbStorage>,
+    tx_id: TxId,
+    made_by: AuthorId,
+    fate: Fate,
+    global_seq: Option<GlobalSeq>,
+    durability: DurabilityTier,
+) {
+    node.ingest_relay_commit_unit(pending_replay_fixture_transaction(tx_id, made_by), Vec::new())
+        .unwrap();
+    if !matches!(fate, Fate::Pending) || global_seq.is_some() || durability != DurabilityTier::Local
+    {
+        node.apply_fate_update(tx_id, fate, global_seq, Some(durability))
+            .unwrap();
+    }
+}
+
+fn legacy_pending_transaction_ids_for(
+    node: &mut NodeState<RocksDbStorage>,
+    local_node: NodeUuid,
+    author: AuthorId,
+) -> PendingTransactionScan {
+    let mut scan = PendingTransactionScan::default();
+    for tx_id in node.transaction_ids().unwrap() {
+        scan.records_visited += 1;
+        let transaction = node.query_transaction(tx_id).unwrap().unwrap();
+        scan.full_transactions_decoded += 1;
+        if transaction.tx.tx_id.node == local_node
+            && transaction.tx.made_by == author
+            && matches!(transaction.fate, Fate::Pending | Fate::Accepted)
+            && transaction.durability < DurabilityTier::Global
+        {
+            scan.tx_ids.push(tx_id);
+        }
+    }
+    scan.tx_ids.sort();
+    scan
+}
+
+#[test]
+fn pending_replay_null_slice_is_a_superset_then_filters_fate_and_identity() {
+    let (_dir, mut node_under_test) = open_node();
+    let local_node = node(1);
+    let local_author = AuthorId::from_bytes([0xa1; 16]);
+    let other_author = AuthorId::from_bytes([0xb2; 16]);
+    let other_node = node(2);
+    let states = [
+        (local_node, local_author, Fate::Pending, None, DurabilityTier::Local),
+        (local_node, local_author, Fate::Accepted, None, DurabilityTier::Edge),
+        (
+            local_node,
+            local_author,
+            Fate::Accepted,
+            Some(GlobalSeq(7)),
+            DurabilityTier::Global,
+        ),
+        (
+            local_node,
+            local_author,
+            Fate::Rejected(RejectionReason::AuthorizationDenied),
+            None,
+            DurabilityTier::Local,
+        ),
+        (local_node, other_author, Fate::Pending, None, DurabilityTier::Local),
+        (other_node, local_author, Fate::Pending, None, DurabilityTier::Local),
+    ];
+    for (offset, (tx_node, author, fate, global_seq, durability)) in states.into_iter().enumerate()
+    {
+        seed_pending_replay_state(
+            &mut node_under_test,
+            TxId::new(TxTime::from((offset + 1) as u64), tx_node),
+            author,
+            fate,
+            global_seq,
+            durability,
+        );
+    }
+
+    let legacy = legacy_pending_transaction_ids_for(&mut node_under_test, local_node, local_author);
+    let null_slice = node_under_test
+        .pending_transaction_scan_for(local_node, local_author)
+        .unwrap();
+    assert_eq!(null_slice.tx_ids, legacy.tx_ids);
+    assert_eq!(null_slice.tx_ids.len(), 2);
+    assert_eq!(null_slice.records_visited, 5);
+    assert_eq!(null_slice.full_transactions_decoded, 0);
+}
+
+const SERVER_UNSETTLED_OTHER_IDENTITIES: usize = 256;
+const SERVER_REJECTED_NULL_SEQUENCE: usize = 16;
+
+fn pending_replay_lookup_work(settled_history: usize) -> (PendingTransactionScan, PendingTransactionScan) {
+    let (_dir, mut node_under_test) = open_node();
+    let local_node = node(1);
+    let local_author = AuthorId::from_bytes([0xa1; 16]);
+    for offset in 0..settled_history {
+        seed_pending_replay_state(
+            &mut node_under_test,
+            TxId::new(TxTime::from((offset + 1) as u64), local_node),
+            local_author,
+            Fate::Accepted,
+            Some(GlobalSeq((offset + 1) as u64)),
+            DurabilityTier::Global,
+        );
+    }
+    for offset in 0..SERVER_UNSETTLED_OTHER_IDENTITIES {
+        seed_pending_replay_state(
+            &mut node_under_test,
+            TxId::new(TxTime::from(10_000 + offset as u64), node(0x40 + (offset / 4) as u8)),
+            AuthorId::from_bytes([offset as u8; 16]),
+            Fate::Pending,
+            None,
+            DurabilityTier::Local,
+        );
+    }
+    for offset in 0..SERVER_REJECTED_NULL_SEQUENCE {
+        seed_pending_replay_state(
+            &mut node_under_test,
+            TxId::new(TxTime::from(20_000 + offset as u64), node(0xe0)),
+            AuthorId::from_bytes([0xf0; 16]),
+            Fate::Rejected(RejectionReason::AuthorizationDenied),
+            None,
+            DurabilityTier::Local,
+        );
+    }
+    for (offset, fate, durability) in [
+        (0, Fate::Pending, DurabilityTier::Local),
+        (1, Fate::Accepted, DurabilityTier::Edge),
+    ] {
+        seed_pending_replay_state(
+            &mut node_under_test,
+            TxId::new(TxTime::from(30_000 + offset), local_node),
+            local_author,
+            fate,
+            None,
+            durability,
+        );
+    }
+    let legacy = legacy_pending_transaction_ids_for(&mut node_under_test, local_node, local_author);
+    let null_slice = node_under_test
+        .pending_transaction_scan_for(local_node, local_author)
+        .unwrap();
+    (legacy, null_slice)
+}
+
+#[test]
+fn pending_replay_null_slice_work_is_independent_of_settled_history() {
+    let (legacy_empty, null_empty) = pending_replay_lookup_work(0);
+    let (legacy_small, null_small) = pending_replay_lookup_work(8);
+    let (legacy_large, null_large) = pending_replay_lookup_work(128);
+    let server_null_slice = SERVER_UNSETTLED_OTHER_IDENTITIES + SERVER_REJECTED_NULL_SEQUENCE + 2;
+
+    assert_eq!(null_empty.records_visited, server_null_slice);
+    assert_eq!(null_small.records_visited, server_null_slice);
+    assert_eq!(null_large.records_visited, server_null_slice);
+    assert_eq!(null_empty.full_transactions_decoded, 0);
+    assert_eq!(null_small.full_transactions_decoded, 0);
+    assert_eq!(null_large.full_transactions_decoded, 0);
+    assert_eq!(null_large.tx_ids.len(), 2);
+    // The #1295 replay-state index would visit these two local candidates.
+    // The existing full scan visits and reconstructs every retained record.
+    assert_eq!(legacy_empty.records_visited, server_null_slice);
+    assert_eq!(legacy_small.records_visited, server_null_slice + 8);
+    assert_eq!(legacy_large.records_visited, server_null_slice + 128);
+    assert_eq!(legacy_large.full_transactions_decoded, legacy_large.records_visited);
+    assert!(legacy_large.records_visited > legacy_small.records_visited);
+}
+
+#[test]
+fn reopen_replay_lookup_keeps_local_pending_write() {
+    let schema = schema();
+    let (node_dir, mut writer) = open_node_with_schema(node(1), schema.clone());
+    let tx_id = writer
+        .commit_mergeable(MergeableCommit::new("todos", row(4), 10).cells(title_cells("keep me")))
+        .unwrap();
+    drop(writer);
+
+    let mut reopened = reopen_node_at(&node_dir, node(1), schema);
+    assert_eq!(
+        reopened.pending_transaction_ids_for(node(1), AuthorId::SYSTEM).unwrap(),
+        vec![tx_id]
+    );
+    assert_eq!(
+        reopened
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row(4), title_cells("keep me"))])
+    );
+}
+
+#[test]
 fn reopen_in_place_recovers_history_watermarks_pending_edges_and_rehydrates_peer() {
     let (_dir, mut core) = open_node_with_uuid(node(0x3a));
     let mut peer = PeerState::new();

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -1467,7 +1467,7 @@ fn fate_update_rejects_backward_global_seq_and_keeps_durability_monotone() {
             tx_id,
             Fate::Accepted,
             Some(GlobalSeq(4)),
-            Some(DurabilityTier::Local),
+            Some(DurabilityTier::Global),
         ),
         Err(Error::NonMonotoneState("global seq cannot move backwards"))
     ));
@@ -1480,13 +1480,128 @@ fn fate_update_rejects_backward_global_seq_and_keeps_durability_monotone() {
         tx_id,
         Fate::Accepted,
         Some(GlobalSeq(6)),
-        Some(DurabilityTier::Local),
+        Some(DurabilityTier::Global),
     )
     .unwrap();
     assert_eq!(
         node.transaction_state(tx_id).unwrap(),
         (Fate::Accepted, Some(GlobalSeq(6)), DurabilityTier::Global)
     );
+}
+
+#[test]
+fn peer_rejects_sequenced_non_global_fate_without_crashing_the_node() {
+    let (_temp_dir, mut node) = open_node();
+    let tx_id = node
+        .commit_mergeable(MergeableCommit::new("todos", row(8), 10).cells(title_cells("base")))
+        .unwrap();
+
+    let received = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        node.apply_sync_message(SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Accepted,
+            global_seq: Some(GlobalSeq(7)),
+            durability: Some(DurabilityTier::Edge),
+        })
+    }));
+    assert!(received.is_ok(), "a peer message must not panic the receiver");
+    assert!(matches!(
+        received.unwrap(),
+        Err(Error::UnsupportedSyncMessage(
+            "global sequence requires Global durability"
+        ))
+    ));
+    assert_eq!(
+        node.transaction_state(tx_id),
+        Some((Fate::Pending, None, DurabilityTier::Local))
+    );
+
+    node.apply_sync_message(SyncMessage::FateUpdate {
+        tx_id,
+        fate: Fate::Accepted,
+        global_seq: Some(GlobalSeq(7)),
+        durability: Some(DurabilityTier::Global),
+    })
+    .unwrap();
+    assert_eq!(
+        node.transaction_state(tx_id),
+        Some((Fate::Accepted, Some(GlobalSeq(7)), DurabilityTier::Global))
+    );
+}
+
+#[test]
+fn peer_rejects_sequenced_non_global_view_bundle_before_persisting_it() {
+    let (_temp_dir, mut receiver) = open_node();
+    let bad_tx = TxId::new(TxTime::from(10), node(8));
+    let received = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        receiver.apply_sync_message(SyncMessage::ViewUpdate {
+            subscription: SubscriptionKey {
+                shape_id: ShapeId(uuid::Uuid::from_u128(1)),
+                binding_id: BindingId(uuid::Uuid::from_u128(2)),
+                read_view: Default::default(),
+            },
+            settled_through: GlobalSeq(0),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: vec![VersionBundle {
+                tx: Transaction {
+                    tx_id: bad_tx,
+                    kind: TxKind::Mergeable,
+                    n_total_writes: 0,
+                    made_by: AuthorId::SYSTEM,
+                    permission_subject: None,
+                    base_snapshot: None,
+                    row_read_set: None,
+                    absent_read_set: None,
+                    predicate_read_set: None,
+                    user_metadata_json: None,
+                    source_branch: None,
+                    merge_strategy: None,
+                },
+                versions: Vec::new(),
+                fate: Fate::Accepted,
+                global_seq: Some(GlobalSeq(7)),
+                durability: DurabilityTier::Edge,
+            }],
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+    }));
+    assert!(received.is_ok(), "a peer view must not panic the receiver");
+    assert!(matches!(
+        received.unwrap(),
+        Err(Error::MalformedViewUpdate(
+            "global sequence requires Global durability"
+        ))
+    ));
+    assert!(receiver.transaction_state(bad_tx).is_none());
+    assert!(receiver
+        .commit_mergeable(MergeableCommit::new("todos", row(9), 11).cells(title_cells("alive")))
+        .is_ok());
+}
+
+// This is necessarily an internal mechanism test: the public sync boundary
+// returns a protocol error instead. The assertion protects locally constructed
+// state without turning malformed peer input into a remote panic vector.
+#[cfg(debug_assertions)]
+#[test]
+fn internal_sequenced_non_global_fate_trips_the_debug_assertion() {
+    let (_temp_dir, mut node) = open_node();
+    let tx_id = node
+        .commit_mergeable(MergeableCommit::new("todos", row(10), 10).cells(title_cells("base")))
+        .unwrap();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        node.apply_fate_update(
+            tx_id,
+            Fate::Accepted,
+            Some(GlobalSeq(7)),
+            Some(DurabilityTier::Edge),
+        )
+    }));
+    assert!(result.is_err());
 }
 
 #[test]

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -6,6 +6,7 @@
 //! [`super::query_eval`]. It sits on the node side of the protocol boundary and
 //! emits [`crate::protocol::SyncMessage`] values.
 
+use super::ingest::validate_received_view_bundle_global_seq_durability;
 use super::policy::ViewEvaluationContext;
 use super::*;
 use crate::ids::SchemaVersionId;
@@ -629,6 +630,7 @@ where
 
     /// Apply a downstream current-row view update.
     pub(super) fn apply_view_update(&mut self, update: ViewUpdateParts) -> Result<(), Error> {
+        self.validate_received_view_update_global_seq_durability(&update)?;
         self.apply_view_update_inner(update, None)
     }
 
@@ -638,6 +640,9 @@ where
     ) -> Result<(), Error> {
         if updates.is_empty() {
             return Ok(());
+        }
+        for update in &updates {
+            self.validate_received_view_update_global_seq_durability(update)?;
         }
         if updates.iter().any(|update| update.reset_result_set) {
             self.begin_initial_sync_flush_cadence()?;
@@ -1026,6 +1031,7 @@ where
     }
 
     fn ingest_view_bundle(&mut self, bundle: VersionBundle) -> Result<(), Error> {
+        validate_received_view_bundle_global_seq_durability(bundle.global_seq, bundle.durability)?;
         if bundle.tx.kind != TxKind::Exclusive {
             return self.ingest_known_transaction(
                 bundle.tx,
@@ -1109,6 +1115,7 @@ where
         staged_tx_ids: &mut BTreeSet<TxId>,
         staged_global_seqs: &mut Vec<GlobalSeq>,
     ) -> Result<bool, Error> {
+        validate_received_view_bundle_global_seq_durability(bundle.global_seq, bundle.durability)?;
         if bundle.tx.kind == TxKind::Exclusive {
             let complete_len = usize::try_from(bundle.tx.n_total_writes).map_err(|_| {
                 Error::InvalidStoredValue("exclusive transaction write count does not fit usize")
@@ -1133,6 +1140,21 @@ where
             staged_global_seqs,
         )?;
         Ok(true)
+    }
+
+    fn validate_received_view_update_global_seq_durability(
+        &self,
+        update: &ViewUpdateParts,
+    ) -> Result<(), Error> {
+        for bundle in
+            version_bundle_refs_for_carriers(&update.version_bundles, &update.version_carriers)?
+        {
+            validate_received_view_bundle_global_seq_durability(
+                bundle.global_seq,
+                bundle.durability,
+            )?;
+        }
+        Ok(())
     }
 
     pub(crate) fn whole_table_subscription_key(

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -1057,11 +1057,9 @@ mod tests {
                     ],
                     fate: Fate::Accepted,
                     global_seq: Some(GlobalSeq(10_000 + index as u64)),
-                    durability: if index % 3 == 0 {
-                        DurabilityTier::Edge
-                    } else {
-                        DurabilityTier::Global
-                    },
+                    // A sequence is the global-authority receipt, and so its
+                    // companion durability is Global in every valid fixture.
+                    durability: DurabilityTier::Global,
                 }
             })
             .collect()


### PR DESCRIPTION
**Supersedes the unmerged branch `perf/bounded-pending-transaction-scan`**, which was pushed but never opened as a PR. Same goal — stop local write replay from scanning all retained history — reached without a new index or a migration, by enforcing the invariant that made the simple approach unsound.

## The invariant

A transaction may carry a `global_seq` only if it is globally durable. A sequence *is* the global-authority receipt.

All four authority producers already honoured this, assigning `Accepted` + `Global` together. The **receiver** did not: `apply_fate_update_once` checked only monotonicity, with `global_seq.or(...)` and `durability.max(...)` advancing independently, and `ViewUpdate` bundle ingestion persisted a sequence with whatever durability arrived. So an inbound `FateUpdate { fate: Accepted, global_seq: Some(7), durability: Edge }` persisted exactly that.

## Did anything real violate it?

**No.** A full-suite survey with the check in force found exactly two violations, both fixture bugs:

- `crates/jazz/src/wire.rs:1058` built globally-sequenced `Accepted` bundles at `Edge` durability. Wrong data, not a legitimate scenario — corrected to `Global`.
- `fate_update_rejects_backward_global_seq_and_keeps_durability_monotone` injected sequences at `Local` durability. Corrected; its monotonicity intent remains covered.

No production path required a sequence before global durability.

## Where the check lives

- **Untrusted receive boundary** — fate updates rejected before mutation; view updates, chunks, batch ingestion and bulk-reset bundles prevalidated before persistence. These **reject as protocol errors rather than panic**: an `assert!` reachable from a peer message is a remote crash vector.
- **Internal construction paths** use `debug_assert!` — free in release, loud in development.
- **Reopen rejects** pre-existing violating rows with `InvalidStoredValue`. No migration, no silent rewrite. Such rows can only come from the old permissive receiver accepting a malformed peer; failing loudly rather than continuing from contradictory durable history is the intended behaviour and is explicitly approved.

## The payoff

With the invariant enforced, `durability < Global` implies `global_seq IS NULL`, so replay selects from the **null slice of the existing `by_global_seq` index** — filtering fate so null-sequenced Rejected rows are not replayed, then node/author. **No new index, no backfill.**

Head-to-head on a server-shaped fixture (256 unsettled remote records, 16 rejected null-sequenced, 2 local replay candidates):

| Settled history | Null slice visited / decoded | `by_replay_state` index visited / decoded |
|---:|---:|---:|
| 0 | 274 / **0** | 2 / **0** |
| 8 | 274 / **0** | 2 / **0** |
| 128 | 274 / **0** | 2 / **0** |

Both are constant in settled history, which was the actual defect — previously this was a full scan *and* full decode of every retained transaction. The null slice touches more raw index records but performs **zero** transaction decodes, and avoids a permanent second index plus an upgrade backfill. Worth revisiting only if servers come to retain a very large unsettled tail.

## Verification

Re-run independently of the implementing lane; exit codes read unpiped.

**Planted positive**: stubbing `validate_received_fate_update_global_seq_durability` to return `Ok(())` immediately fails `peer_rejects_sequenced_non_global_fate_without_crashing_the_node`. Restored; tree clean. The view-bundle guard passed under that plant because it validates on a separate path, which matches the design.

- `cargo test -p jazz` → **0**
- `cargo test -p jazz --no-default-features --features test` → **101**, only the three known `catalogue_sync_integration` failures
- both `peer_rejects_sequenced_*` tests → **2 passed**

Lane-reported: `--features test-utils --test transactions` **0** · `wire_fixtures` **0** · `cargo test -p groove` **0** · `ts-wire-codec.sh` **1** (known policy-graph failure) · `cargo check --workspace --all-targets` **0** · `cargo fmt --check` **0** · `clippy` **101** (known `warm_reopen_differential` lint).

## Unrelated flake found while gating

`global_wait_after_over_one_mib_websocket_import_settles` is **wall-clock marginal**: 23.3–27.4s against a 25s internal budget. It failed once during this work and I initially suspected a regression, but the only intervening commits were a markdown-only change, and the same commit then passed 3/3 on repeat. Not caused by this PR, and worth re-keying on work done rather than elapsed time before it erodes trust in the suite.
