### PR TITLE
(new core) [WIP] Numeric aggregate differential oracle, and the maintenance defects it found

### DIFF
--- a/crates/jazz/src/node/tests/m3_differential.rs
+++ b/crates/jazz/src/node/tests/m3_differential.rs
@@ -17,7 +17,10 @@
 // | projection with includes                     | `docs_projected_with_doc_access`            |
 // | relation traversal facade, forward hop       | `docs_relation_facade_direct_access`        |
 // | recursive membership                         | both reachable shapes include transitive hops |
-// | aggregate                                    | `docs_count`                                |
+// | aggregate: count, min, max, sum, avg          | `docs_*_by_bucket`                          |
+// | aggregate numeric value types                 | `F64`, `I64`, `U64`                         |
+// | aggregate nullable / empty inputs              | `m3_aggregate_null_semantics`                |
+// | aggregate cancellation and sustained churn     | `m3_aggregate_churn_curve`                   |
 
 #[derive(Clone)]
 struct DifferentialShape {
@@ -32,7 +35,7 @@ struct DifferentialOracle {
     peers: Vec<PeerState>,
     shapes: Vec<DifferentialShape>,
     rows: Vec<BTreeSet<(String, RowUuid)>>,
-    aggregate: AggregateDifferential,
+    aggregates: Vec<AggregateDifferential>,
 }
 
 struct AggregateDifferential {
@@ -42,14 +45,44 @@ struct AggregateDifferential {
     identity: AuthorId,
     subscription: SubscriptionKey,
     peer: PeerState,
-    value: Value,
+    output: &'static str,
+    agreement: AggregateAgreement,
+    values: BTreeMap<u64, Value>,
+    maintenance_updates: u64,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AggregateAgreement {
+    Exact,
+    /// Floating-point addition/subtraction is order-sensitive.  The oracle
+    /// uses a forward-error budget relative to Σ|x|, with one rounding budget
+    /// for each input and each subsequent maintained update.
+    F64Approx,
+}
+
+const F64_AGGREGATE_ERROR_FACTOR: f64 = 64.0;
+type AggregateSpec = (
+    &'static str,
+    crate::query::Aggregate,
+    &'static str,
+    AggregateAgreement,
+);
+
 impl DifferentialOracle {
-    fn open(
-        core: &mut NodeState<RocksDbStorage>,
+    fn open<S: OrderedKvStorage>(
+        core: &mut NodeState<S>,
         schema: &JazzSchema,
         shapes: Vec<DifferentialShape>,
+        seed: u64,
+    ) -> Self {
+        Self::open_with_aggregate_specs(core, schema, shapes, aggregate_differential_specs(), seed)
+    }
+
+    fn open_with_aggregate_specs<S: OrderedKvStorage>(
+        core: &mut NodeState<S>,
+        schema: &JazzSchema,
+        shapes: Vec<DifferentialShape>,
+        aggregate_specs: Vec<AggregateSpec>,
         seed: u64,
     ) -> Self {
         let mut peers = Vec::new();
@@ -69,41 +102,67 @@ impl DifferentialOracle {
             rows.push(shape_rows);
             peers.push(peer);
         }
-        let aggregate_shape = Query::from("docs").count().validate(schema).unwrap();
-        let aggregate_binding = aggregate_shape.bind(BTreeMap::new()).unwrap();
-        let aggregate_subscription = SubscriptionKey {
-            shape_id: aggregate_shape.shape_id(),
-            binding_id: aggregate_binding.binding_id(),
-            read_view: Default::default(),
-        };
-        let mut aggregate_peer = PeerState::client_link(user(0xa1));
-        let aggregate_initial = aggregate_peer
-            .rehydrate_query(core, &aggregate_shape, &aggregate_binding)
-            .unwrap_or_else(|err| {
-                panic!("seed {seed}: initial maintained open failed for docs_count: {err:?}")
+        let mut aggregates = Vec::new();
+        for (name, aggregate, output, agreement) in aggregate_specs {
+            let shape = Query::from("docs")
+                .aggregate([aggregate])
+                .group_by("bucket")
+                .validate(schema)
+                .unwrap();
+            let binding = shape.bind(BTreeMap::new()).unwrap();
+            let subscription = SubscriptionKey {
+                shape_id: shape.shape_id(),
+                binding_id: binding.binding_id(),
+                read_view: Default::default(),
+            };
+            let mut peer = PeerState::client_link(user(0xa1));
+            let initial = peer
+                .rehydrate_query(core, &shape, &binding)
+                .unwrap_or_else(|err| {
+                    panic!("seed {seed}: initial maintained open failed for {name}: {err:?}")
+                });
+            let mut values = BTreeMap::new();
+            apply_aggregate_payload(&mut values, &initial, output);
+            aggregates.push(AggregateDifferential {
+                name,
+                shape,
+                binding,
+                identity: user(0xa1),
+                subscription,
+                peer,
+                output,
+                agreement,
+                values,
+                maintenance_updates: 0,
             });
-        let mut aggregate_value = Value::U64(0);
-        apply_aggregate_payload(&mut aggregate_value, &aggregate_initial);
+        }
 
         let mut oracle = Self {
             peers,
             shapes,
             rows,
-            aggregate: AggregateDifferential {
-                name: "docs_count",
-                shape: aggregate_shape,
-                binding: aggregate_binding,
-                identity: user(0xa1),
-                subscription: aggregate_subscription,
-                peer: aggregate_peer,
-                value: aggregate_value,
-            },
+            aggregates,
         };
         oracle.assert_checkpoint(core, seed, "t0");
         oracle
     }
 
-    fn tick_and_assert(&mut self, core: &mut NodeState<RocksDbStorage>, seed: u64, checkpoint: &str) {
+    fn tick_and_assert<S: OrderedKvStorage>(
+        &mut self,
+        core: &mut NodeState<S>,
+        seed: u64,
+        checkpoint: &str,
+    ) {
+        self.tick(core, seed, checkpoint);
+        self.assert_checkpoint(core, seed, checkpoint);
+    }
+
+    fn tick<S: OrderedKvStorage>(
+        &mut self,
+        core: &mut NodeState<S>,
+        seed: u64,
+        checkpoint: &str,
+    ) {
         for ((peer, shape), rows) in self
             .peers
             .iter_mut()
@@ -111,7 +170,12 @@ impl DifferentialOracle {
             .zip(self.rows.iter_mut())
         {
             let update = peer
-                .query_update_for_subscription(core, shape.subscription, &shape.shape, &shape.binding)
+                .query_update_for_subscription(
+                    core,
+                    shape.subscription,
+                    &shape.shape,
+                    &shape.binding,
+                )
                 .unwrap_or_else(|err| {
                     panic!(
                         "seed {seed}: maintained update failed for {} at {checkpoint}: {err:?}",
@@ -120,26 +184,38 @@ impl DifferentialOracle {
                 });
             apply_result_members(rows, &update, &shape.shape.query().table);
         }
-        let aggregate_update = self
-            .aggregate
-            .peer
-            .query_update_for_subscription(
-                core,
-                self.aggregate.subscription,
-                &self.aggregate.shape,
-                &self.aggregate.binding,
-            )
-            .unwrap_or_else(|err| {
-                panic!(
-                    "seed {seed}: maintained update failed for {} at {checkpoint}: {err:?}",
-                    self.aggregate.name
+        for aggregate in &mut self.aggregates {
+            let aggregate_update = aggregate
+                .peer
+                .query_update_for_subscription(
+                    core,
+                    aggregate.subscription,
+                    &aggregate.shape,
+                    &aggregate.binding,
                 )
-            });
-        apply_aggregate_payload(&mut self.aggregate.value, &aggregate_update);
-        self.assert_checkpoint(core, seed, checkpoint);
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "seed {seed}: maintained update failed for {} at {checkpoint}: {err:?}",
+                        aggregate.name
+                    )
+                });
+            apply_aggregate_payload(&mut aggregate.values, &aggregate_update, aggregate.output);
+            aggregate.maintenance_updates += 1;
+        }
     }
 
-    fn assert_checkpoint(&mut self, core: &mut NodeState<RocksDbStorage>, seed: u64, checkpoint: &str) {
+    fn charge_aggregate_updates(&mut self, updates: u64) {
+        for aggregate in &mut self.aggregates {
+            aggregate.maintenance_updates += updates;
+        }
+    }
+
+    fn assert_checkpoint<S: OrderedKvStorage>(
+        &mut self,
+        core: &mut NodeState<S>,
+        seed: u64,
+        checkpoint: &str,
+    ) {
         for (maintained, shape) in self.rows.iter().zip(self.shapes.iter()) {
             let one_shot = one_shot_rows(core, &shape.shape, &shape.binding, shape.identity);
             assert_eq!(
@@ -148,17 +224,29 @@ impl DifferentialOracle {
                 shape.name
             );
         }
-        let one_shot = one_shot_aggregate_value(
-            core,
-            &self.aggregate.shape,
-            &self.aggregate.binding,
-            self.aggregate.identity,
-        );
-        assert_eq!(
-            self.aggregate.value, one_shot,
-            "seed {seed}: maintained/one-shot aggregate divergence for {} at {checkpoint}",
-            self.aggregate.name
-        );
+        for agreement in [AggregateAgreement::Exact, AggregateAgreement::F64Approx] {
+            for aggregate in self
+                .aggregates
+                .iter()
+                .filter(|aggregate| aggregate.agreement == agreement)
+            {
+                let one_shot = one_shot_aggregate_values(
+                    core,
+                    &aggregate.shape,
+                    &aggregate.binding,
+                    aggregate.identity,
+                    aggregate.output,
+                );
+                assert_aggregate_agreement(
+                    &aggregate.values,
+                    &one_shot,
+                    aggregate,
+                    core,
+                    seed,
+                    checkpoint,
+                );
+            }
+        }
     }
 }
 
@@ -180,6 +268,7 @@ fn m3_differential_seeds() -> Vec<u64> {
 
 #[test]
 fn m3_maintained_one_shot_differential_oracle() {
+    run_m3_aggregate_churn_curve();
     for seed in m3_differential_seeds() {
         if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             run_m3_differential_seed(seed)
@@ -194,7 +283,8 @@ fn run_m3_differential_seed(seed: u64) {
     let schema = m3_differential_schema();
     let (_core_dir, mut core) = open_node_with_schema(node(0x71), schema.clone());
     seed_m3_differential_base(&mut core, seed);
-    let mut differential = DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), seed);
+    let mut differential =
+        DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), seed);
 
     let mut rng = Lcg::new(seed ^ 0x9e37_79b9);
     let mut parents = m3_differential_parent_map(&mut core);
@@ -209,6 +299,414 @@ fn run_m3_differential_seed(seed: u64) {
             _ => update_created_at_match(&mut core, &mut parents, step),
         }
         differential.tick_and_assert(&mut core, seed, &format!("fuzz-step-{step}"));
+    }
+}
+
+fn run_m3_aggregate_churn_curve() {
+    let schema = m3_differential_schema();
+    let column_families = schema.column_families();
+    let column_family_refs = column_families.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut core = NodeState::new(
+        node(0x76),
+        schema.clone(),
+        MemoryStorage::new(&column_family_refs),
+    )
+    .unwrap();
+    let mut parents = BTreeMap::new();
+
+    // This group deliberately cancels large opposite-sign values.  A bound
+    // relative to the result would collapse around zero; Σ|x| remains about
+    // 2e16 throughout the churn arm.
+    for (doc, f64_value, nullable_f64_value, i64_value, u64_value) in [
+        (row(0x11), 1.0e16, Some(1.0e16), -11, 11),
+        (row(0x12), -1.0e16, Some(-1.0e16), 7, 19),
+        (row(0x14), 0.1, None, 13, 23),
+    ] {
+        accept_churn_with_parent(
+            &mut core,
+            &mut parents,
+            doc,
+            400,
+            differential_doc_cells(
+                "churn-cancellation",
+                "match",
+                user(0xa1),
+                7,
+                1,
+                f64_value,
+                nullable_f64_value,
+                i64_value,
+                u64_value,
+            ),
+        );
+    }
+    let mut differential = DifferentialOracle::open_with_aggregate_specs(
+        &mut core,
+        &schema,
+        Vec::new(),
+        vec![
+            (
+                "docs_f64_sum_by_bucket",
+                crate::query::Aggregate::sum("f64_value"),
+                "sum_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+            (
+                "docs_f64_avg_by_bucket",
+                crate::query::Aggregate::avg("f64_value"),
+                "avg_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+        ],
+        0,
+    );
+    let mut previous_depth = 0;
+    for depth in m3_aggregate_churn_depths() {
+        for operation in previous_depth + 1..=depth {
+            match operation % 3 {
+                0 => {
+                    delete_churn_with_parent(
+                        &mut core,
+                        &mut parents,
+                        churn_row(operation / 3),
+                        1_000 + operation,
+                    );
+                }
+                1 => {
+                    accept_churn_with_parent(
+                        &mut core,
+                        &mut parents,
+                        churn_row(operation / 3 + 1),
+                        1_000 + operation,
+                        differential_doc_cells(
+                            "churn-transient",
+                            "match",
+                            user(0xa1),
+                            7,
+                            1,
+                            0.3,
+                            Some(0.3),
+                            1,
+                            1,
+                        ),
+                    );
+                }
+                _ => {
+                    accept_churn_with_parent(
+                        &mut core,
+                        &mut parents,
+                        churn_row(operation / 3),
+                        1_000 + operation,
+                        differential_doc_cells(
+                            "churn-transient-updated",
+                            "match",
+                            user(0xa1),
+                            7,
+                            1,
+                            0.4,
+                            Some(0.4),
+                            1,
+                            1,
+                        ),
+                    );
+                }
+            }
+        }
+        differential.charge_aggregate_updates(depth - previous_depth - 1);
+        differential.tick(&mut core, 0, &format!("churn-{depth}"));
+        report_f64_churn_divergence(&differential, &mut core, depth);
+        previous_depth = depth;
+    }
+}
+
+fn m3_aggregate_churn_depths() -> Vec<u64> {
+    std::env::var("JAZZ_DIFFERENTIAL_CHURN_DEPTHS")
+        .ok()
+        .map(|depths| {
+            depths
+                .split(',')
+                .map(|depth| depth.parse::<u64>().expect("churn depths must be u64"))
+                .collect()
+        })
+        .unwrap_or_else(|| vec![10, 1_000, 100_000])
+}
+
+fn churn_row(index: u64) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[..8].copy_from_slice(&index.to_be_bytes());
+    bytes[15] = 0xfe;
+    RowUuid::from_bytes(bytes)
+}
+
+fn accept_churn_with_parent<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
+    parents: &mut BTreeMap<RowUuid, TxId>,
+    row_uuid: RowUuid,
+    made_at: u64,
+    cells: BTreeMap<String, Value>,
+) {
+    let mut commit = MergeableCommit::new("docs", row_uuid, made_at).cells(cells);
+    if let Some(parent) = parents.get(&row_uuid).copied() {
+        commit = commit.parents(vec![parent]);
+    }
+    let tx_id = core.commit_mergeable(commit).unwrap();
+    core.apply_fate_update(
+        tx_id,
+        Fate::Accepted,
+        Some(core.clock.next_global_seq),
+        Some(DurabilityTier::Global),
+    )
+    .unwrap();
+    parents.insert(row_uuid, tx_id);
+}
+
+fn delete_churn_with_parent<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
+    parents: &mut BTreeMap<RowUuid, TxId>,
+    row_uuid: RowUuid,
+    made_at: u64,
+) {
+    let parent = parents[&row_uuid];
+    let tx_id = core
+        .commit_mergeable(
+            MergeableCommit::new("docs", row_uuid, made_at)
+                .parents(vec![parent])
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    core.apply_fate_update(
+        tx_id,
+        Fate::Accepted,
+        Some(core.clock.next_global_seq),
+        Some(DurabilityTier::Global),
+    )
+    .unwrap();
+    parents.insert(row_uuid, tx_id);
+}
+
+#[test]
+fn m3_maintained_one_shot_differential_oracle_f64_approximate_control() {
+    let schema = m3_differential_schema();
+    let column_families = schema.column_families();
+    let column_family_refs = column_families.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut core = NodeState::new(
+        node(0x78),
+        schema.clone(),
+        MemoryStorage::new(&column_family_refs),
+    )
+    .unwrap();
+    let mut parents = BTreeMap::new();
+    for (row_uuid, f64_value) in [(row(0x21), 1.5), (row(0x22), -0.25)] {
+        accept_churn_with_parent(
+            &mut core,
+            &mut parents,
+            row_uuid,
+            600,
+            differential_doc_cells(
+                "f64-control",
+                "match",
+                user(0xa1),
+                7,
+                1,
+                f64_value,
+                Some(f64_value),
+                1,
+                1,
+            ),
+        );
+    }
+    let mut differential = DifferentialOracle::open_with_aggregate_specs(
+        &mut core,
+        &schema,
+        Vec::new(),
+        vec![
+            (
+                "docs_count_by_bucket",
+                crate::query::Aggregate::count(),
+                "count",
+                AggregateAgreement::Exact,
+            ),
+            (
+                "docs_f64_min_by_bucket",
+                crate::query::Aggregate::min("f64_value"),
+                "min_f64_value",
+                AggregateAgreement::Exact,
+            ),
+            (
+                "docs_f64_max_by_bucket",
+                crate::query::Aggregate::max("f64_value"),
+                "max_f64_value",
+                AggregateAgreement::Exact,
+            ),
+            (
+                "docs_f64_sum_by_bucket",
+                crate::query::Aggregate::sum("f64_value"),
+                "sum_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+            (
+                "docs_f64_avg_by_bucket",
+                crate::query::Aggregate::avg("f64_value"),
+                "avg_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+        ],
+        0,
+    );
+    accept_churn_with_parent(
+        &mut core,
+        &mut parents,
+        row(0x23),
+        601,
+        differential_doc_cells(
+            "f64-control-insert",
+            "match",
+            user(0xa1),
+            7,
+            1,
+            0.5,
+            Some(0.5),
+            1,
+            1,
+        ),
+    );
+    differential.tick_and_assert(&mut core, 0, "normal-scale-insert");
+}
+
+#[test]
+fn m3_maintained_one_shot_differential_oracle_null_semantics() {
+    let schema = m3_differential_schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(0x77), schema.clone());
+    seed_m3_differential_base(&mut core, 0);
+    let mut parents = m3_differential_parent_map(&mut core);
+    accept_with_parent(
+        &mut core,
+        &mut parents,
+        "docs",
+        row(0x15),
+        500,
+        differential_doc_cells(
+            "all-null",
+            "match",
+            user(0xa1),
+            7,
+            3,
+            4.0,
+            None,
+            4,
+            4,
+        ),
+    );
+
+    let shape = Query::from("docs")
+        .sum("nullable_f64_value")
+        .group_by("bucket")
+        .validate(&schema)
+        .unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let subscription = SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: binding.binding_id(),
+        read_view: Default::default(),
+    };
+    let mut peer = PeerState::client_link(user(0xa1));
+    let initial = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
+    let mut maintained = BTreeMap::new();
+    apply_aggregate_payload(&mut maintained, &initial, "sum_nullable_f64_value");
+    assert_eq!(
+        maintained,
+        one_shot_aggregate_values(
+            &mut core,
+            &shape,
+            &binding,
+            user(0xa1),
+            "sum_nullable_f64_value",
+        ),
+        "nullable aggregates must agree at initial hydration"
+    );
+    assert!(
+        !maintained.contains_key(&3),
+        "all-NULL groups must not materialize a numeric aggregate value"
+    );
+
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x11), 501);
+    let update = peer
+        .query_update_for_subscription(&mut core, subscription, &shape, &binding)
+        .unwrap();
+    apply_aggregate_payload(&mut maintained, &update, "sum_nullable_f64_value");
+    assert_eq!(
+        maintained,
+        one_shot_aggregate_values(
+            &mut core,
+            &shape,
+            &binding,
+            user(0xa1),
+            "sum_nullable_f64_value",
+        ),
+        "nullable aggregates must agree after a group becomes all-NULL"
+    );
+    assert!(
+        !maintained.contains_key(&1),
+        "groups that become all-NULL must be removed from the synthetic result"
+    );
+
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x12), 502);
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x13), 503);
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x14), 504);
+    let update = peer
+        .query_update_for_subscription(&mut core, subscription, &shape, &binding)
+        .unwrap();
+    apply_aggregate_payload(&mut maintained, &update, "sum_nullable_f64_value");
+    assert_eq!(
+        maintained,
+        one_shot_aggregate_values(
+            &mut core,
+            &shape,
+            &binding,
+            user(0xa1),
+            "sum_nullable_f64_value",
+        ),
+        "nullable aggregates must agree after a group becomes empty"
+    );
+    assert!(
+        !maintained.contains_key(&2),
+        "empty groups must not remain in the synthetic result"
+    );
+}
+
+fn report_f64_churn_divergence<S: OrderedKvStorage>(
+    differential: &DifferentialOracle,
+    core: &mut NodeState<S>,
+    depth: u64,
+) {
+    let absolute_sums = f64_absolute_sums_by_bucket(core);
+    for aggregate in &differential.aggregates {
+        if !matches!(aggregate.agreement, AggregateAgreement::F64Approx) {
+            continue;
+        }
+        let one_shot = one_shot_aggregate_values(
+            core,
+            &aggregate.shape,
+            &aggregate.binding,
+            aggregate.identity,
+            aggregate.output,
+        );
+        let Value::F64(maintained) = aggregate.values[&1] else {
+            panic!("{} must produce F64 output", aggregate.name);
+        };
+        let Value::F64(one_shot) = one_shot[&1] else {
+            panic!("{} must produce F64 output", aggregate.name);
+        };
+        let error = (maintained - one_shot).abs();
+        let tolerance = F64_AGGREGATE_ERROR_FACTOR
+            * f64::EPSILON
+            * (depth as f64 + 4.0)
+            * absolute_sums[&1];
+        eprintln!(
+            "M3 F64 CHURN depth={depth} aggregate={} error={error:e} tolerance={tolerance:e} sum_abs={:e} maintained={maintained:e} one_shot={one_shot:e}",
+            aggregate.name,
+            absolute_sums[&1],
+        );
     }
 }
 
@@ -251,6 +749,11 @@ fn m3_differential_empty_seed_then_insert_created_by() {
             "match",
             identity,
             7,
+            1,
+            2.5,
+            Some(2.5),
+            17,
+            17,
         )),
     );
     oracle.tick_and_assert(&mut core, 0, "after-created-by-insert");
@@ -301,7 +804,8 @@ fn m3_differential_revoke_mid_stream_and_reconnect_mid_stream() {
     let schema = m3_differential_schema();
     let (core_dir, mut core) = open_node_with_schema(node(0x75), schema.clone());
     seed_m3_differential_base(&mut core, 0);
-    let mut oracle = DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), 0);
+    let mut oracle =
+        DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), 0);
     let mut parents = m3_differential_parent_map(&mut core);
 
     revoke_edge_access(&mut core, &mut parents, 0);
@@ -349,6 +853,11 @@ fn m3_differential_schema() -> JazzSchema {
                 ColumnSchema::new("kind", ColumnType::String),
                 ColumnSchema::new("createdBy", ColumnType::Uuid),
                 ColumnSchema::new("createdAt", ColumnType::U64),
+                ColumnSchema::new("bucket", ColumnType::U64),
+                ColumnSchema::new("f64_value", ColumnType::F64),
+                ColumnSchema::new("nullable_f64_value", ColumnType::F64.nullable()),
+                ColumnSchema::new("i64_value", ColumnType::I64),
+                ColumnSchema::new("u64_value", ColumnType::U64),
             ],
         )
         .with_read_policy(Policy::public())
@@ -363,10 +872,13 @@ fn m3_differential_schema() -> JazzSchema {
         .with_reference("doc", "docs")
         .with_read_policy(Policy::public())
         .with_write_policy(Policy::public()),
-        TableSchema::new("grandchildren", [ColumnSchema::new("child", ColumnType::Uuid)])
-            .with_reference("child", "children")
-            .with_read_policy(Policy::public())
-            .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "grandchildren",
+            [ColumnSchema::new("child", ColumnType::Uuid)],
+        )
+        .with_reference("child", "children")
+        .with_read_policy(Policy::public())
+        .with_write_policy(Policy::public()),
         TableSchema::new(
             "teams",
             [
@@ -411,9 +923,12 @@ fn m3_differential_schema() -> JazzSchema {
         .with_reference("team", "teams")
         .with_read_policy(Policy::public())
         .with_write_policy(Policy::public()),
-        TableSchema::new("resources", [ColumnSchema::new("label", ColumnType::String)])
-            .with_read_policy(Policy::shape(same_table_policy))
-            .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "resources",
+            [ColumnSchema::new("label", ColumnType::String)],
+        )
+        .with_read_policy(Policy::shape(same_table_policy))
+        .with_write_policy(Policy::public()),
         TableSchema::new(
             "string_resources",
             [ColumnSchema::new("label", ColumnType::String)],
@@ -508,7 +1023,10 @@ fn m3_differential_shapes(schema: &JazzSchema) -> Vec<DifferentialShape> {
     );
     push(
         "children_inherit_doc",
-        Query::from("children").inherits("doc").validate(schema).unwrap(),
+        Query::from("children")
+            .inherits("doc")
+            .validate(schema)
+            .unwrap(),
     );
     push(
         "grandchildren_inherit_child",
@@ -534,6 +1052,91 @@ fn m3_differential_shapes(schema: &JazzSchema) -> Vec<DifferentialShape> {
         relation_doc_access_shape().validate(schema).unwrap(),
     );
     specs
+}
+
+fn aggregate_differential_specs() -> Vec<AggregateSpec> {
+    use crate::query::Aggregate;
+
+    vec![
+        (
+            "docs_count_by_bucket",
+            Aggregate::count(),
+            "count",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_f64_sum_by_bucket",
+            Aggregate::sum("f64_value"),
+            "sum_f64_value",
+            AggregateAgreement::F64Approx,
+        ),
+        (
+            "docs_f64_avg_by_bucket",
+            Aggregate::avg("f64_value"),
+            "avg_f64_value",
+            AggregateAgreement::F64Approx,
+        ),
+        (
+            "docs_f64_min_by_bucket",
+            Aggregate::min("f64_value"),
+            "min_f64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_f64_max_by_bucket",
+            Aggregate::max("f64_value"),
+            "max_f64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_sum_by_bucket",
+            Aggregate::sum("i64_value"),
+            "sum_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_avg_by_bucket",
+            Aggregate::avg("i64_value"),
+            "avg_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_min_by_bucket",
+            Aggregate::min("i64_value"),
+            "min_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_max_by_bucket",
+            Aggregate::max("i64_value"),
+            "max_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_sum_by_bucket",
+            Aggregate::sum("u64_value"),
+            "sum_u64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_avg_by_bucket",
+            Aggregate::avg("u64_value"),
+            "avg_u64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_min_by_bucket",
+            Aggregate::min("u64_value"),
+            "min_u64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_max_by_bucket",
+            Aggregate::max("u64_value"),
+            "max_u64_value",
+            AggregateAgreement::Exact,
+        ),
+    ]
 }
 
 fn created_by_shape(schema: &JazzSchema) -> ValidatedQuery {
@@ -609,7 +1212,10 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
             ])),
         );
     }
-    accept_global(core, team_edge_commit(row(0x41), row(0x31), row(0x32), false, 2));
+    accept_global(
+        core,
+        team_edge_commit(row(0x41), row(0x31), row(0x32), false, 2),
+    );
     accept_global(
         core,
         MergeableCommit::new("group_access_edges", row(0x42), 3).cells(BTreeMap::from([
@@ -618,16 +1224,79 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
         ])),
     );
 
-    for (doc, title, kind, author, created_at) in [
-        (row(0x11), "visible-direct", "match", alice, 7),
-        (row(0x12), "visible-transitive", "match", alice, 7),
-        (row(0x13), "hidden", "match", bob, 8),
-        (row(0x14), "filtered-out", "other", alice, 9),
+    for (
+        doc,
+        title,
+        kind,
+        author,
+        created_at,
+        bucket,
+        f64_value,
+        nullable_f64_value,
+        i64_value,
+        u64_value,
+    ) in [
+        (
+            row(0x11),
+            "visible-direct",
+            "match",
+            alice,
+            7,
+            1,
+            1.5,
+            Some(1.5),
+            -11,
+            11,
+        ),
+        (
+            row(0x12),
+            "visible-transitive",
+            "match",
+            alice,
+            7,
+            1,
+            -0.25,
+            None,
+            7,
+            19,
+        ),
+        (
+            row(0x13),
+            "hidden",
+            "match",
+            bob,
+            8,
+            2,
+            3.0,
+            Some(3.0),
+            -5,
+            5,
+        ),
+        (
+            row(0x14),
+            "filtered-out",
+            "other",
+            alice,
+            9,
+            2,
+            0.75,
+            None,
+            13,
+            23,
+        ),
     ] {
         accept_global(
             core,
             MergeableCommit::new("docs", doc, 10 + seed % 3).cells(differential_doc_cells(
-                title, kind, author, created_at,
+                title,
+                kind,
+                author,
+                created_at,
+                bucket,
+                f64_value,
+                nullable_f64_value,
+                i64_value,
+                u64_value,
             )),
         );
     }
@@ -644,11 +1313,17 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
             ])),
         );
     }
-    for (resource, label) in [(row(0x61), "direct"), (row(0x62), "transitive"), (row(0x63), "hidden")] {
+    for (resource, label) in [
+        (row(0x61), "direct"),
+        (row(0x62), "transitive"),
+        (row(0x63), "hidden"),
+    ] {
         accept_global(
             core,
-            MergeableCommit::new("resources", resource, 30)
-                .cells(BTreeMap::from([("label".to_owned(), Value::String(label.to_owned()))])),
+            MergeableCommit::new("resources", resource, 30).cells(BTreeMap::from([(
+                "label".to_owned(),
+                Value::String(label.to_owned()),
+            )])),
         );
     }
     for (edge, resource, team) in [
@@ -672,8 +1347,10 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
     ] {
         accept_global(
             core,
-            MergeableCommit::new("string_resources", resource, 32)
-                .cells(BTreeMap::from([("label".to_owned(), Value::String(label.to_owned()))])),
+            MergeableCommit::new("string_resources", resource, 32).cells(BTreeMap::from([(
+                "label".to_owned(),
+                Value::String(label.to_owned()),
+            )])),
         );
     }
     for (edge, resource, team) in [
@@ -699,12 +1376,16 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
     );
     accept_global(
         core,
-        MergeableCommit::new("grandchildren", row(0x81), 41)
-            .cells(BTreeMap::from([("child".to_owned(), Value::Uuid(row(0x71).0))])),
+        MergeableCommit::new("grandchildren", row(0x81), 41).cells(BTreeMap::from([(
+            "child".to_owned(),
+            Value::Uuid(row(0x71).0),
+        )])),
     );
 }
 
-fn m3_differential_parent_map(core: &mut NodeState<RocksDbStorage>) -> BTreeMap<(&'static str, RowUuid), TxId> {
+fn m3_differential_parent_map(
+    core: &mut NodeState<RocksDbStorage>,
+) -> BTreeMap<(&'static str, RowUuid), TxId> {
     let mut parents = BTreeMap::new();
     for table in [
         "docs",
@@ -723,12 +1404,30 @@ fn m3_differential_parent_map(core: &mut NodeState<RocksDbStorage>) -> BTreeMap<
     parents
 }
 
-fn differential_doc_cells(title: &str, kind: &str, author: AuthorId, created_at: u64) -> BTreeMap<String, Value> {
+fn differential_doc_cells(
+    title: &str,
+    kind: &str,
+    author: AuthorId,
+    created_at: u64,
+    bucket: u64,
+    f64_value: f64,
+    nullable_f64_value: Option<f64>,
+    i64_value: i64,
+    u64_value: u64,
+) -> BTreeMap<String, Value> {
     BTreeMap::from([
         ("title".to_owned(), Value::String(title.to_owned())),
         ("kind".to_owned(), Value::String(kind.to_owned())),
         ("createdBy".to_owned(), Value::Uuid(author.0)),
         ("createdAt".to_owned(), Value::U64(created_at)),
+        ("bucket".to_owned(), Value::U64(bucket)),
+        ("f64_value".to_owned(), Value::F64(f64_value)),
+        (
+            "nullable_f64_value".to_owned(),
+            Value::Nullable(nullable_f64_value.map(|value| Box::new(Value::F64(value)))),
+        ),
+        ("i64_value".to_owned(), Value::I64(i64_value)),
+        ("u64_value".to_owned(), Value::U64(u64_value)),
     ])
 }
 
@@ -793,7 +1492,7 @@ fn add_visible_doc(
         "docs",
         row_uuid,
         100 + step,
-        differential_doc_cells("added", "match", user(0xa1), 7),
+        differential_doc_cells("added", "match", user(0xa1), 7, 1, 0.5, Some(0.5), 3, 3),
     );
     accept_with_parent(
         core,
@@ -819,7 +1518,7 @@ fn add_hidden_doc(
         "docs",
         row(0xb0 + step as u8),
         140 + step,
-        differential_doc_cells("hidden-added", "match", user(0xb2), 8),
+        differential_doc_cells("hidden-added", "match", user(0xb2), 8, 2, -0.5, None, -3, 5),
     );
 }
 
@@ -886,19 +1585,33 @@ fn update_created_at_match(
         "docs",
         row(0x14),
         240 + step,
-        differential_doc_cells("filtered-now-created-at", "match", user(0xa1), 7),
+        differential_doc_cells(
+            "filtered-now-created-at",
+            "match",
+            user(0xa1),
+            7,
+            2,
+            0.75,
+            None,
+            13,
+            23,
+        ),
     );
 }
 
-fn latest_tx_for_row(core: &mut NodeState<RocksDbStorage>, table: &str, row_uuid: RowUuid) -> Option<TxId> {
+fn latest_tx_for_row(
+    core: &mut NodeState<RocksDbStorage>,
+    table: &str,
+    row_uuid: RowUuid,
+) -> Option<TxId> {
     core.row_history(table, row_uuid)
         .unwrap()
         .last()
         .map(|row| row.tx_id())
 }
 
-fn one_shot_rows(
-    core: &mut NodeState<RocksDbStorage>,
+fn one_shot_rows<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
     shape: &ValidatedQuery,
     binding: &Binding,
     identity: AuthorId,
@@ -910,7 +1623,11 @@ fn one_shot_rows(
         .collect()
 }
 
-fn apply_result_members(rows: &mut BTreeSet<(String, RowUuid)>, update: &SyncMessage, root_table: &str) {
+fn apply_result_members(
+    rows: &mut BTreeSet<(String, RowUuid)>,
+    update: &SyncMessage,
+    root_table: &str,
+) {
     let SyncMessage::ViewUpdate {
         reset_result_set,
         result_member_adds,
@@ -939,26 +1656,35 @@ fn apply_result_members(rows: &mut BTreeSet<(String, RowUuid)>, update: &SyncMes
     }
 }
 
-fn apply_aggregate_payload(value: &mut Value, update: &SyncMessage) {
+fn apply_aggregate_payload(values: &mut BTreeMap<u64, Value>, update: &SyncMessage, output: &str) {
     let SyncMessage::ViewUpdate {
         reset_result_set,
         program_fact_adds,
+        program_fact_removes,
         ..
     } = update
     else {
         panic!("expected view update");
     };
     if *reset_result_set {
-        *value = Value::U64(0);
+        values.clear();
+    }
+    for fact in program_fact_removes {
+        if let Some((bucket, _)) = aggregate_payload_value(fact, output) {
+            values.remove(&bucket);
+        }
     }
     for fact in program_fact_adds {
-        if let Some(next) = aggregate_payload_count(fact) {
-            *value = next;
+        if let Some((bucket, value)) = aggregate_payload_value(fact, output) {
+            values.insert(bucket, value);
         }
     }
 }
 
-fn aggregate_payload_count(fact: &crate::protocol::ProgramFactEntry) -> Option<Value> {
+fn aggregate_payload_value(
+    fact: &crate::protocol::ProgramFactEntry,
+    output: &str,
+) -> Option<(u64, Value)> {
     let crate::protocol::ProgramFactEntry::ResultPayload(payload) = fact else {
         return None;
     };
@@ -974,21 +1700,91 @@ fn aggregate_payload_count(fact: &crate::protocol::ProgramFactEntry) -> Option<V
             .map(|(name, value_type)| (name.unwrap(), value_type)),
     );
     let record = groove::records::BorrowedRecord::new(&payload.record, &descriptor);
-    Some(record.get("count").unwrap().clone())
+    let Value::U64(bucket) = record.get("user_bucket").unwrap() else {
+        panic!("aggregate bucket must be U64");
+    };
+    Some((bucket, record.get(output).unwrap().clone()))
 }
 
-fn one_shot_aggregate_value(
-    core: &mut NodeState<RocksDbStorage>,
+fn one_shot_aggregate_values<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
     shape: &ValidatedQuery,
     binding: &Binding,
     identity: AuthorId,
-) -> Value {
-    let rows = core
-        .query_rows_for_link(shape, binding, DurabilityTier::Global, identity)
-        .unwrap();
-    if rows.is_empty() {
-        return Value::U64(0);
+    output: &str,
+) -> BTreeMap<u64, Value> {
+    core.query_rows_for_link(shape, binding, DurabilityTier::Global, identity)
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            let cells = row.test_cells_by_descriptor();
+            let Value::U64(bucket) = &cells["bucket"] else {
+                panic!("aggregate bucket must be U64");
+            };
+            (*bucket, cells[output].clone())
+        })
+        .collect()
+}
+
+fn assert_aggregate_agreement<S: OrderedKvStorage>(
+    maintained: &BTreeMap<u64, Value>,
+    one_shot: &BTreeMap<u64, Value>,
+    aggregate: &AggregateDifferential,
+    core: &mut NodeState<S>,
+    seed: u64,
+    checkpoint: &str,
+) {
+    match aggregate.agreement {
+        AggregateAgreement::Exact => assert_eq!(
+            maintained, one_shot,
+            "seed {seed}: maintained/one-shot aggregate divergence for {} at {checkpoint}",
+            aggregate.name
+        ),
+        AggregateAgreement::F64Approx => {
+            assert_eq!(
+                maintained.keys().collect::<Vec<_>>(),
+                one_shot.keys().collect::<Vec<_>>(),
+                "seed {seed}: maintained/one-shot aggregate group divergence for {} at {checkpoint}",
+                aggregate.name
+            );
+            let absolute_sums = f64_absolute_sums_by_bucket(core);
+            for (bucket, maintained) in maintained {
+                let Value::F64(maintained) = maintained else {
+                    panic!("{} must produce F64 output", aggregate.name);
+                };
+                let Value::F64(one_shot) = one_shot[bucket] else {
+                    panic!("{} must produce F64 output", aggregate.name);
+                };
+                let error = (maintained - one_shot).abs();
+                let tolerance = F64_AGGREGATE_ERROR_FACTOR
+                    * f64::EPSILON
+                    * (f64::from(aggregate.maintenance_updates as u32) + 4.0)
+                    * absolute_sums[bucket];
+                assert!(
+                    error <= tolerance,
+                    "seed {seed}: maintained/one-shot F64 aggregate divergence for {} bucket {bucket} at {checkpoint}: error={error:e}, tolerance={tolerance:e}, Σ|x|={:e}, maintenance_updates={}",
+                    aggregate.name,
+                    absolute_sums[bucket],
+                    aggregate.maintenance_updates,
+                );
+            }
+        }
     }
-    assert_eq!(rows.len(), 1, "aggregate one-shot should produce at most one synthetic row");
-    rows[0].test_cells_by_descriptor()["count"].clone()
+}
+
+fn f64_absolute_sums_by_bucket<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
+) -> BTreeMap<u64, f64> {
+    let mut sums = BTreeMap::new();
+    for row in core.current_rows("docs", DurabilityTier::Global).unwrap() {
+        let cells = row.test_cells_by_descriptor();
+        let Value::U64(bucket) = &cells["bucket"] else {
+            panic!("docs bucket must be U64");
+        };
+        let Value::F64(value) = &cells["f64_value"] else {
+            panic!("docs f64_value must be F64");
+        };
+        *sums.entry(*bucket).or_insert(0.0) += value.abs();
+    }
+    sums
 }


### PR DESCRIPTION
> **Currently red by design.** The oracle is in; the fixes for what it found are in progress and will land on this same branch. Do not merge until the arms below are green.

The maintained-vs-one-shot differential oracle mentioned aggregates ~39 times but exercised only **`count`**, over a value space of `Uuid`/`String`/`U64`/`Bool` — no numeric aggregation and no `F64` at all. So nothing checked that a maintained numeric aggregate agrees with a one-shot recompute.

That matters because aggregate output **travels over the wire** as a synthetic result row (`crates/jazz/src/protocol.rs:1555`) rather than being recomputed per replica. The exposure is a client receiving a maintained value, then a later rehydrate recomputing it differently and contradicting what it was already shown.

## What the oracle now covers

Grouped, **multi-row** `F64`/`I64`/`U64` across `count`/`sum`/`avg`/`min`/`max`, a normal-scale F64 control, nullable inputs, and insert→update→retract churn at depths of 10 / 1,000 / 100,000.

Two deliberate design choices:

- **An integer control arm.** `I64`/`U64` aggregates must agree **exactly**. This is what separates "floating point is hard" from "our aggregation is wrong".
- **Tolerance relative to Σ|x|**, not to the result. Under catastrophic cancellation the result approaches zero while absolute error does not, so a result-relative tolerance is unbounded and fails on adversarial input.

`min`/`max`/`count` are asserted **exactly** — they are selection or counting, not accumulation.

## What it found — none of it floating-point

**1. Exact integer sums diverge.** `docs_i64_sum_by_bucket`, seed 11, `fuzz-step-0`: maintained `-5`, one-shot `-1`. `I64 sum` is exact arithmetic; this is a plain correctness bug in incremental maintenance.

**2. `avg` is wrong by a constant, independent of churn depth.**

| depth | avg maintained | avg one-shot | avg error | sum error |
|---:|---:|---:|---:|---:|
| 10 | 0.29333333 | 0.02 | 2.733e-1 | **0** |
| 1,000 | 0.19333333 | 0.02 | 1.733e-1 | **0** |
| 100,000 | 0.19333333 | 0.02 | 1.733e-1 | **0** |

Identical error at 1,000 and 100,000 updates means a **wrong formula**, not accumulated drift — and `sum` being exact in the same runs points at how `avg` is derived from `sum`/`count`.

**3. Normal-scale F64 sum is wrong after one update.** `error=5e-1`, `tolerance=1.599e-13`, `Σ|x|=2.25`, `maintenance_updates=1`. A 0.5 absolute error on a total absolute magnitude of 2.25 after a single update is semantic, not round-off.

**4. Nullable numeric aggregates are rejected** at validation with `OperandTypeMismatch`, so NULL-skipping, all-NULL and empty-group semantics are unsupported on the maintained path — a gap against what #1125 specifies.

## Why "approximate agreement" cannot be the contract yet

A tolerance would have hidden all of this. In the churn arm, Σ|x| ≈ 2e16 gives a computed tolerance of 2.8e7 — the broken `avg` passes comfortably. Specifying a tolerance for values that are wrong for non-numeric reasons would convert real defects into documented noise.

Once the defects are fixed, the supportable statement is a bound proportional to `ε × (input rows + maintenance updates) × Σ|x|`, with update count bounded by recomputation or rehydration after N updates.

## Verification

Reproduced independently of the implementing lane at `JAZZ_SEED_COUNT=20`: three arms fail — `..._oracle`, `..._oracle_f64_approximate_control`, `..._oracle_null_semantics` — with the figures quoted above. `cargo test -p groove` **0** (405 passed), `cargo check --workspace --all-targets` **0**, `cargo fmt --check` **0**, `clippy` **101** (only the known `warm_reopen_differential` lint).

## Relationship to the aggregate PRs

#1125 (SQL semantics) and #1126 (transactional maintenance) both touch this path and neither is merged. The in-progress fix work is checking whether either already addresses any of these defects; if so that changes the plan for both. Worth knowing for #1126 in particular: maintenance is not only non-transactional, it computes wrong values.
