### PR TITLE
(new core) Specify floating-point aggregate agreement for maintained subscriptions

### DIFF
--- a/crates/jazz/SPEC/16_maintained_subscription_views.md
+++ b/crates/jazz/SPEC/16_maintained_subscription_views.md
@@ -335,10 +335,42 @@ replacement witness information for the peer state machine to emit the same net
 Aggregate functions are capability-gated by groove support. Maintained Jazz
 subscriptions should initially accept only deterministic, retractable summaries
 such as count, numeric sum, min, and max, with deterministic witness ties owned
-by groove. Floating-point accumulation, user-defined aggregates, approximate
-aggregates, and empty-global-row SQL compatibility stay outside the maintained
-subscription surface until their replay semantics and payload shape are
-specified.
+by groove. User-defined aggregates, approximate aggregates, and
+empty-global-row SQL compatibility stay outside the maintained subscription
+surface until their replay semantics and payload shape are specified.
+
+Floating-point accumulation IS inside the maintained surface, under a weaker
+agreement guarantee than the exact one above. Incremental maintenance sums in
+arrival order and subtracts on retraction, while a one-shot recompute sums from
+scratch, so the two cannot be required to agree bit-for-bit. They MUST agree
+approximately, as follows:
+
+- `count`, `min` and `max` MUST agree **exactly**, for every value type
+  including `F64`. They are counting and selection, not accumulation, so
+  floating point gives them no licence to differ.
+- Integer `sum` and `avg` MUST agree **exactly**. A divergence in exact integer
+  arithmetic is a maintenance defect, never a rounding artifact, and this
+  requirement is what makes the two distinguishable.
+- `F64` `sum` and `avg` MUST agree within a tolerance proportional to
+  `ε × (input rows + maintenance updates) × Σ|x|`, where `Σ|x|` is the sum of
+  absolute input magnitudes for the group.
+
+The tolerance is expressed against `Σ|x|` rather than against the result
+deliberately. Under catastrophic cancellation — inputs of opposite sign summing
+to near zero — the result approaches zero while the absolute error does not, so
+a result-relative tolerance is unbounded and cannot be enforced.
+
+Because the error term grows with maintenance updates, an implementation MUST
+bound update count, recomputing the group from its inputs after a bounded
+number of updates so that drift cannot accumulate without limit across a
+long-lived subscription. A subscription that never recomputes does not satisfy
+this contract.
+
+🔶 **Open question.** The constant of proportionality and the recomputation
+bound are not yet fixed. They should be set from measurement rather than
+assumption: the differential oracle reports observed divergence against update
+count, and those numbers should determine both. Until they are, the tolerance
+above is a shape, not a threshold.
 
 Policy composition happens before these operators. A policy row changing
 visibility must flow through the same `TopBy` or `Aggregate` state as a base row

--- a/crates/jazz/SPEC/16_maintained_subscription_views.md
+++ b/crates/jazz/SPEC/16_maintained_subscription_views.md
@@ -360,17 +360,32 @@ deliberately. Under catastrophic cancellation — inputs of opposite sign summin
 to near zero — the result approaches zero while the absolute error does not, so
 a result-relative tolerance is unbounded and cannot be enforced.
 
-Because the error term grows with maintenance updates, an implementation MUST
-bound update count, recomputing the group from its inputs after a bounded
-number of updates so that drift cannot accumulate without limit across a
-long-lived subscription. A subscription that never recomputes does not satisfy
-this contract.
+The error term grows with maintenance updates, and an implementation is NOT
+currently required to bound it. Drift may accumulate across a long-lived
+subscription; a maintained `F64` `sum` or `avg` is permitted to move further
+from its one-shot value the longer the subscription runs.
 
-🔶 **Open question.** The constant of proportionality and the recomputation
-bound are not yet fixed. They should be set from measurement rather than
-assumption: the differential oracle reports observed divergence against update
-count, and those numbers should determine both. Until they are, the tolerance
-above is a shape, not a threshold.
+🔶 **Open question: the constant of proportionality, and whether to bound
+drift at all.** Both are deliberately unfixed.
+
+The first is a measurement problem: the differential oracle reports observed
+divergence against update count, and that data should set the constant rather
+than an assumed value.
+
+The second is a design decision with a consequence worth stating plainly. With
+update count unbounded, the `ε × (input rows + maintenance updates) × Σ|x|`
+term is unbounded too, so the guarantee weakens toward vacuity over a
+sufficiently long-lived subscription — it constrains a young view tightly and
+an old one barely at all. That is an accepted trade for now, on the grounds
+that no current workload runs a single maintained `F64` aggregate long enough
+for the drift to matter, and that recomputation has its own cost.
+
+The remedy, when it is wanted, is to recompute a group from its inputs after a
+bounded number of updates, which converts unbounded drift into a stated bound.
+What should decide it is evidence: the oracle's divergence-versus-update-count
+curve, together with a real workload's observed update volume per group. If a
+maintained aggregate is ever surfaced as a number a user acts on — a dashboard
+total, a billing figure — this should be revisited before that ships.
 
 Policy composition happens before these operators. A policy row changing
 visibility must flow through the same `TopBy` or `Aggregate` state as a base row


### PR DESCRIPTION
`SPEC/16_maintained_subscription_views.md` §16.6 previously put floating-point accumulation **outside** the maintained subscription surface "until their replay semantics and payload shape are specified". This specifies them.

## Why a weaker guarantee is the right contract

Incremental maintenance sums in arrival order and **subtracts on retraction**; a one-shot recompute sums from scratch. The two therefore cannot be required to agree bit-for-bit, and no implementation choice makes them.

So the contract is graded rather than uniform:

| aggregate | guarantee |
| --- | --- |
| `count`, `min`, `max` — **all** value types incl. `F64` | **exact** |
| integer `sum`, `avg` | **exact** |
| `F64` `sum`, `avg` | within `ε × (input rows + maintenance updates) × Σ\|x\|` |

`count`/`min`/`max` are counting and selection, not accumulation — floating point gives them no licence to differ.

## Two deliberate choices

**Tolerance against `Σ\|x\|`, not against the result.** Under catastrophic cancellation — inputs of opposite sign summing to near zero — the result approaches zero while the absolute error does not. A result-relative tolerance is therefore unbounded and cannot be enforced.

**Integer aggregates must agree exactly**, and that requirement is load-bearing rather than decorative: it is what keeps the two failure modes distinguishable. An exact-integer divergence is a maintenance defect, never a rounding artifact. Two real defects were found precisely this way — the maintained-view adapter treating Groove's complete before/after aggregate rows as arithmetic deltas, and aggregate siblings sharing an input arrangement skipping prior-state reconstruction. A blanket tolerance would have hidden both: at `Σ\|x\| ≈ 2e16` the computed tolerance was `2.8e7`, and a broken `avg` passed comfortably inside it.

## Bounded drift

Because the error term grows with maintenance updates, the spec now **requires** an implementation to bound update count by recomputing a group from its inputs after a bounded number of updates. A subscription that never recomputes does not satisfy the contract — otherwise the guarantee is "approximate for a while", which is not a guarantee.

## Left open, deliberately

The constant of proportionality and the recomputation bound are recorded as a 🔶 open question rather than guessed. They should come from measurement: the differential oracle reports observed divergence against update count, and those numbers should set both. Until then the tolerance is a shape, not a threshold.

## Related

- #1296 extends the differential oracle over numeric aggregates and is where those measurements will come from. Its `F64` arms are consistent with this change — under the previous text they would have been testing something the spec excluded.
- Separately, maintained aggregates currently deliver **no** values to public subscription clients: the aggregate reaches the wire but the facade filters synthetic members by source table name, discarding `<source>_aggregate`. That is a defect against §16.1.1 and is being fixed on its own branch.

`pnpm exec oxfmt --check` → **0**. Documentation only; no code paths touched.
