### PR TITLE
(new core) Deliver maintained aggregate subscriptions to clients

### DIFF
--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -438,6 +438,32 @@ impl AntiJoinState {
 }
 
 impl ArrangementState {
+    pub(super) fn clone_keys<'a>(&self, keys: impl IntoIterator<Item = &'a Vec<u8>>) -> Self {
+        let mut index = HashMap::default();
+        for key in keys {
+            let key = JoinKey::from_slice(key);
+            if let Some(bucket) = self.index.get(&key) {
+                index.insert(key, bucket.clone());
+            }
+        }
+        Self { index }
+    }
+
+    pub(super) fn replace_keys<'a>(
+        &mut self,
+        keys: impl IntoIterator<Item = &'a Vec<u8>>,
+        mut replacement: Self,
+    ) {
+        for key in keys {
+            let key = JoinKey::from_slice(key);
+            if let Some(bucket) = replacement.index.remove(&key) {
+                self.index.insert(key, bucket);
+            } else {
+                self.index.remove(&key);
+            }
+        }
+    }
+
     pub(super) fn row_count(&self) -> usize {
         self.index
             .values()

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -6467,22 +6467,24 @@ where
                 next: format!("{sub_tick:?}"),
             });
         }
-        let before_groups =
-            if self.context.arrangement_update_mode == ArrangementUpdateMode::Replace {
-                BTreeMap::new()
-            } else {
-                touched_groups
-                    .keys()
-                    .map(|group| {
-                        (
-                            group.clone(),
-                            current_arrangement
-                                .map(|arrangement| arrangement.value().records_for_key(group))
-                                .unwrap_or_default(),
-                        )
-                    })
-                    .collect::<BTreeMap<_, _>>()
-            };
+        let before_groups = if self.context.arrangement_update_mode
+            == ArrangementUpdateMode::Replace
+            || !should_apply_arrangement
+        {
+            BTreeMap::new()
+        } else {
+            touched_groups
+                .keys()
+                .map(|group| {
+                    (
+                        group.clone(),
+                        current_arrangement
+                            .map(|arrangement| arrangement.value().records_for_key(group))
+                            .unwrap_or_default(),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>()
+        };
         let mut staged_arrangement =
             if self.context.arrangement_update_mode == ArrangementUpdateMode::Replace {
                 ArrangementState::default()

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -6444,10 +6444,6 @@ where
             ValueComparison::Exact,
         )?;
         let sub_tick = self.arrangement_sub_tick(&arrangement_key);
-        let mut arrangement = self
-            .arrangement_states
-            .remove(&arrangement_key)
-            .unwrap_or_default();
         let mut touched_groups = BTreeMap::<Vec<u8>, Vec<RecordDelta>>::new();
         for delta in &input.deltas {
             let group_key =
@@ -6457,50 +6453,56 @@ where
                 .or_default()
                 .push(delta.clone());
         }
+        let current_arrangement = self.arrangement_states.get(&arrangement_key);
+        let current_as_of = current_arrangement.and_then(AsOf::as_of);
+        let should_apply_arrangement = self.context.arrangement_update_mode
+            == ArrangementUpdateMode::Replace
+            || current_as_of != Some(sub_tick);
+        let replace_within_same_tick = self.context.arrangement_update_mode
+            == ArrangementUpdateMode::Replace
+            && current_as_of.is_some_and(|current| current.tick == sub_tick.tick);
+        if !replace_within_same_tick && current_as_of.is_some_and(|current| current > sub_tick) {
+            return Err(IvmRuntimeError::OutOfOrderRuntimeState {
+                current: format!("{:?}", current_as_of.expect("checked above")),
+                next: format!("{sub_tick:?}"),
+            });
+        }
         let before_groups =
             if self.context.arrangement_update_mode == ArrangementUpdateMode::Replace {
                 BTreeMap::new()
             } else {
                 touched_groups
                     .keys()
-                    .map(|group| (group.clone(), arrangement.value().records_for_key(group)))
+                    .map(|group| {
+                        (
+                            group.clone(),
+                            current_arrangement
+                                .map(|arrangement| arrangement.value().records_for_key(group))
+                                .unwrap_or_default(),
+                        )
+                    })
                     .collect::<BTreeMap<_, _>>()
             };
-        let should_apply_arrangement = self.context.arrangement_update_mode
-            == ArrangementUpdateMode::Replace
-            || arrangement.as_of() != Some(sub_tick);
+        let mut staged_arrangement =
+            if self.context.arrangement_update_mode == ArrangementUpdateMode::Replace {
+                ArrangementState::default()
+            } else {
+                current_arrangement
+                    .map(|arrangement| arrangement.value().clone_keys(touched_groups.keys()))
+                    .unwrap_or_default()
+            };
         if should_apply_arrangement {
-            let replace_within_same_tick = self.context.arrangement_update_mode
-                == ArrangementUpdateMode::Replace
-                && arrangement
-                    .as_of()
-                    .is_some_and(|current| current.tick == sub_tick.tick);
-            if !replace_within_same_tick
-                && arrangement
-                    .as_of()
-                    .is_some_and(|current| current > sub_tick)
-            {
-                return Err(IvmRuntimeError::OutOfOrderRuntimeState {
-                    current: format!("{:?}", arrangement.as_of().expect("checked above")),
-                    next: format!("{sub_tick:?}"),
-                });
-            }
-            arrangement.value_mut().apply_record_deltas(
+            staged_arrangement.apply_record_deltas(
                 input_desc,
                 group_fields.as_ref(),
                 &input.deltas,
                 self.context.arrangement_update_mode,
             )?;
-            if replace_within_same_tick {
-                arrangement.replace_as_of_at_least(sub_tick);
-            } else {
-                arrangement.mark_forward_as_of(sub_tick)?;
-            }
         }
 
         let mut output = Vec::new();
         for group_prefix in touched_groups.keys() {
-            let after_records = arrangement.value().records_for_key(group_prefix);
+            let after_records = staged_arrangement.records_for_key(group_prefix);
             let after =
                 aggregate_row_from_records(input_desc, output_desc, aggregate, &after_records)?;
             let before_records = if let Some(records) = before_groups
@@ -6529,7 +6531,29 @@ where
                 output.push(RecordDelta { record, weight: 1 });
             }
         }
-        self.arrangement_states.insert(arrangement_key, arrangement);
+        if should_apply_arrangement {
+            match self.context.arrangement_update_mode {
+                ArrangementUpdateMode::Accumulate => {
+                    let arrangement = self.arrangement_states.entry(arrangement_key).or_default();
+                    arrangement.mark_forward_as_of(sub_tick)?;
+                    arrangement
+                        .value_mut()
+                        .replace_keys(touched_groups.keys(), staged_arrangement);
+                }
+                ArrangementUpdateMode::Replace => {
+                    let mut arrangement = AsOf {
+                        value: staged_arrangement,
+                        as_of: current_as_of,
+                    };
+                    if replace_within_same_tick {
+                        arrangement.replace_as_of_at_least(sub_tick);
+                    } else {
+                        arrangement.mark_forward_as_of(sub_tick)?;
+                    }
+                    self.arrangement_states.insert(arrangement_key, arrangement);
+                }
+            }
+        }
 
         Ok(RecordDeltas {
             descriptor: output_desc,

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -470,6 +470,35 @@ impl MaintainedSubscriptionView {
         }
     }
 
+    /// Rebase aggregate terminal state after an authoritative remote reset.
+    /// The local IVM may still emit the matching before/after pair while its
+    /// source catches up; retaining an obsolete synthetic revision here would
+    /// otherwise turn that harmless pair into a later public removal.
+    pub(crate) fn replace_aggregate_result_state(
+        &mut self,
+        members: &BTreeSet<ResultMemberEntry>,
+        facts: &BTreeSet<ProgramFactEntry>,
+    ) {
+        self.result_weights
+            .retain(|member, _| !matches!(member, ResultMemberEntry::Synthetic { .. }));
+        self.result_payloads
+            .retain(|member, _| !matches!(member, ResultMemberEntry::Synthetic { .. }));
+        for member in members {
+            if matches!(member, ResultMemberEntry::Synthetic { .. }) {
+                self.result_weights.insert(member.clone(), 1);
+            }
+        }
+        for fact in facts {
+            let ProgramFactEntry::ResultPayload(payload) = fact else {
+                continue;
+            };
+            if matches!(payload.member, ResultMemberEntry::Synthetic { .. }) {
+                self.result_payloads
+                    .insert(payload.member.clone(), payload.clone());
+            }
+        }
+    }
+
     fn apply_result_delta(
         &mut self,
         entry: ResultMemberEntry,
@@ -527,7 +556,7 @@ impl MaintainedSubscriptionView {
         {
             transitions.removes.push(old_member.clone());
             self.result_weights.remove(&old_member);
-            if let Some(existing) = old_payload {
+            if let Some(existing) = self.result_payloads.remove(&old_member).or(old_payload) {
                 transitions
                     .program_fact_removes
                     .push(ProgramFactEntry::ResultPayload(existing));

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -500,24 +500,20 @@ impl MaintainedSubscriptionView {
         &mut self,
         member: ResultMemberEntry,
         payload: ResultMemberPayloadEntry,
-        synthetic: &super::query_engine::SyntheticResultMembershipSchema,
-        value_fields: &[String],
+        _synthetic: &super::query_engine::SyntheticResultMembershipSchema,
+        _value_fields: &[String],
         weight: i64,
         transitions: &mut ResultTransitions,
     ) -> Result<(), super::Error> {
         let (old_member, old_payload) = self.aggregate_payload_for_stable_member(&member);
-        let materialized = materialize_aggregate_payload_delta(
-            old_payload.as_ref(),
-            payload,
-            synthetic,
-            value_fields,
-            weight,
-        )?;
-        if aggregate_payload_is_empty(&materialized, value_fields)? {
-            if let Some(old_member) = old_member {
-                transitions.removes.push(old_member.clone());
-                self.result_weights.remove(&old_member);
-                if let Some(existing) = self.result_payloads.remove(&old_member) {
+        if weight < 0 {
+            // Groove's aggregate operator emits complete before/after group
+            // rows. A retraction therefore removes only the payload it names;
+            // if its replacement is already current, it is stale.
+            if old_member.as_ref() == Some(&member) {
+                transitions.removes.push(member.clone());
+                self.result_weights.remove(&member);
+                if let Some(existing) = self.result_payloads.remove(&member) {
                     transitions
                         .program_fact_removes
                         .push(ProgramFactEntry::ResultPayload(existing));
@@ -525,31 +521,26 @@ impl MaintainedSubscriptionView {
             }
             return Ok(());
         }
+
         if let Some(old_member) = old_member
-            && old_member != materialized.member
+            && old_member != member
         {
             transitions.removes.push(old_member.clone());
             self.result_weights.remove(&old_member);
-            if let Some(existing) = self.result_payloads.remove(&old_member) {
+            if let Some(existing) = old_payload {
                 transitions
                     .program_fact_removes
                     .push(ProgramFactEntry::ResultPayload(existing));
             }
         }
-        let old = self
-            .result_weights
-            .get(&materialized.member)
-            .copied()
-            .unwrap_or(0);
-        if old <= 0 {
-            transitions.adds.push(materialized.member.clone());
+        if self.result_weights.get(&member).copied().unwrap_or(0) <= 0 {
+            transitions.adds.push(member.clone());
         }
         transitions
             .program_fact_adds
-            .push(ProgramFactEntry::ResultPayload(materialized.clone()));
-        self.result_payloads
-            .insert(materialized.member.clone(), materialized.clone());
-        self.result_weights.insert(materialized.member, 1);
+            .push(ProgramFactEntry::ResultPayload(payload.clone()));
+        self.result_payloads.insert(member.clone(), payload);
+        self.result_weights.insert(member, 1);
         Ok(())
     }
 
@@ -1490,143 +1481,6 @@ impl NetEvent {
             }
         }
     }
-}
-
-fn materialize_aggregate_payload_delta(
-    previous: Option<&ResultMemberPayloadEntry>,
-    delta: ResultMemberPayloadEntry,
-    synthetic: &super::query_engine::SyntheticResultMembershipSchema,
-    value_fields: &[String],
-    weight: i64,
-) -> Result<ResultMemberPayloadEntry, super::Error> {
-    let delta_descriptor = decode_payload_descriptor(&delta.descriptor)?;
-    let delta_record = BorrowedRecord::new(&delta.record, &delta_descriptor);
-    let mut values = if let Some(previous) = previous {
-        let previous_descriptor = decode_payload_descriptor(&previous.descriptor)?;
-        BorrowedRecord::new(&previous.record, &previous_descriptor)
-            .to_values()
-            .map_err(|_| super::Error::InvalidStoredValue("aggregate payload decode failed"))?
-    } else {
-        delta_record
-            .to_values()
-            .map_err(|_| super::Error::InvalidStoredValue("aggregate payload decode failed"))?
-    };
-    if previous.is_none() {
-        for field in value_fields {
-            let idx = field_idx(delta_record, field)?;
-            values[idx] = zero_aggregate_value(values[idx].clone());
-        }
-    }
-    for field in value_fields {
-        let idx = field_idx(delta_record, field)?;
-        let delta_value = delta_record.get_idx(idx)?;
-        values[idx] = apply_aggregate_value_delta(values[idx].clone(), delta_value, weight)?;
-    }
-    if let Some(first_value_field) = value_fields.first() {
-        let value_idx = field_idx(delta_record, first_value_field)?;
-        let revision_idx = field_idx(delta_record, &synthetic.revision_field)?;
-        values[revision_idx] = values[value_idx].clone();
-    }
-    let raw = delta_descriptor
-        .create(&values)
-        .map_err(|_| super::Error::InvalidStoredValue("aggregate payload encoding failed"))?;
-    let revision_value = values[field_idx(delta_record, &synthetic.revision_field)?].clone();
-    let revision = postcard::to_allocvec(&revision_value).map_err(|_| {
-        super::Error::InvalidStoredValue("aggregate result revision encoding failed")
-    })?;
-    let member = match delta.member {
-        ResultMemberEntry::Synthetic { table, row, .. } => ResultMemberEntry::Synthetic {
-            table,
-            row,
-            revision,
-        },
-        _ => delta.member,
-    };
-    Ok(ResultMemberPayloadEntry {
-        member,
-        descriptor: delta.descriptor,
-        record: raw,
-    })
-}
-
-fn decode_payload_descriptor(bytes: &[u8]) -> Result<RecordDescriptor, super::Error> {
-    let fields: Vec<(Option<String>, groove::records::ValueType)> = postcard::from_bytes(bytes)
-        .map_err(|_| super::Error::InvalidStoredValue("aggregate descriptor decoding failed"))?;
-    Ok(RecordDescriptor::new(fields.into_iter().map(
-        |(name, value_type)| (name.unwrap_or_default(), value_type),
-    )))
-}
-
-fn apply_aggregate_value_delta(
-    current: Value,
-    delta: Value,
-    weight: i64,
-) -> Result<Value, super::Error> {
-    macro_rules! signed_int {
-        ($value:expr, $variant:ident, $ty:ty) => {{
-            let next = ($value as i128)
-                .checked_add(
-                    (weight as i128)
-                        * (match delta {
-                            Value::$variant(value) => value as i128,
-                            _ => return Ok(delta),
-                        }),
-                )
-                .ok_or(super::Error::InvalidStoredValue("aggregate value overflow"))?;
-            Value::$variant(
-                <$ty>::try_from(next)
-                    .map_err(|_| super::Error::InvalidStoredValue("aggregate value overflow"))?,
-            )
-        }};
-    }
-    Ok(match current {
-        Value::U8(value) => signed_int!(value, U8, u8),
-        Value::U16(value) => signed_int!(value, U16, u16),
-        Value::U32(value) => signed_int!(value, U32, u32),
-        Value::U64(value) => signed_int!(value, U64, u64),
-        Value::I32(value) => signed_int!(value, I32, i32),
-        Value::I64(value) => signed_int!(value, I64, i64),
-        Value::F64(value) => match delta {
-            Value::F64(delta) => Value::F64(value + (weight as f64) * delta),
-            _ => delta,
-        },
-        _ => delta,
-    })
-}
-
-fn zero_aggregate_value(value: Value) -> Value {
-    match value {
-        Value::U8(_) => Value::U8(0),
-        Value::U16(_) => Value::U16(0),
-        Value::U32(_) => Value::U32(0),
-        Value::U64(_) => Value::U64(0),
-        Value::I32(_) => Value::I32(0),
-        Value::I64(_) => Value::I64(0),
-        Value::F64(_) => Value::F64(0.0),
-        other => other,
-    }
-}
-
-fn aggregate_payload_is_empty(
-    payload: &ResultMemberPayloadEntry,
-    value_fields: &[String],
-) -> Result<bool, super::Error> {
-    if value_fields.is_empty() {
-        return Ok(false);
-    }
-    let descriptor = decode_payload_descriptor(&payload.descriptor)?;
-    let record = BorrowedRecord::new(&payload.record, &descriptor);
-    for field in value_fields {
-        let value = record.get_idx(field_idx(record, field)?)?;
-        match value {
-            Value::U8(0) | Value::U16(0) | Value::U32(0) | Value::U64(0) => {}
-            Value::I32(0) => {}
-            Value::I64(0) => {}
-            Value::F64(0.0) => {}
-            _ => return Ok(false),
-        }
-    }
-    Ok(true)
 }
 
 fn encode_record_descriptor(descriptor: &RecordDescriptor) -> Result<Vec<u8>, super::Error> {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -47,8 +47,9 @@ use super::query_engine::{
 };
 use crate::protocol::{
     BindingViewKey, KnownStateCompleteness, KnownStateDeclaration, ProgramFactEntry, ReadViewKey,
-    ReadViewSourceSpec, ReadViewSpec, ResultMemberEntry, ResultMemberPayloadEntry, RowVersionRef,
-    ShapeAst, ShapeBody, Subscribe, SubscriptionKey, SyncMessage,
+    ReadViewSourceSpec, ReadViewSpec, RegisterShapeOptions, ResultMemberEntry,
+    ResultMemberPayloadEntry, RowVersionRef, ShapeAst, ShapeBody, Subscribe, SubscriptionKey,
+    SyncMessage,
 };
 use crate::protocol_limits::{MAX_KNOWN_STATE_EXACT_REFS, MAX_SYNC_MESSAGE_BYTES};
 use crate::query::{
@@ -60,6 +61,49 @@ use crate::schema::{ColumnSchema, branch_metadata_table_schema, global_current_i
 
 pub(crate) const JAZZ_APP_ROWS_SINK: &str = "app_rows";
 const PENDING_BINDING_SOURCE_SHAPE: &str = "__jazz_pending_binding_source";
+
+/// The maintained aggregate terminal deliberately names its synthetic relation
+/// after the source table.  Admit only that exact terminal as a public root:
+/// other synthetic members have protocol meanings that cannot be rendered as
+/// application rows.
+fn is_public_aggregate_result_member(
+    member: &ResultMemberEntry,
+    result_table: &str,
+    aggregate_query: bool,
+) -> bool {
+    aggregate_query
+        && matches!(
+            member,
+            ResultMemberEntry::Synthetic { table, .. }
+                if table == &format!("{result_table}_aggregate")
+        )
+}
+
+fn is_public_result_member(
+    member: &ResultMemberEntry,
+    result_table: &str,
+    aggregate_query: bool,
+) -> bool {
+    member.table_name() == Some(result_table)
+        || is_public_aggregate_result_member(member, result_table, aggregate_query)
+}
+
+fn aggregate_result_member_row_uuid(member: &ResultMemberEntry) -> Result<RowUuid, Error> {
+    let ResultMemberEntry::Synthetic { table, row, .. } = member else {
+        return Err(Error::InvalidStoredValue(
+            "aggregate result member must be synthetic",
+        ));
+    };
+    let mut identity = b"jazz:aggregate-result:v1".to_vec();
+    identity.extend_from_slice(&(table.len() as u64).to_be_bytes());
+    identity.extend_from_slice(table.as_bytes());
+    identity.extend_from_slice(&(row.len() as u64).to_be_bytes());
+    identity.extend_from_slice(row);
+    Ok(RowUuid(uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_OID,
+        &identity,
+    )))
+}
 
 #[derive(Clone, Copy)]
 struct RelationSnapshotWindow {
@@ -75,6 +119,7 @@ pub(crate) struct LocalMaintainedViewSubscription {
     tables: BTreeMap<String, TableSchema>,
     result_query: JazzQuery,
     result_table: String,
+    binding_view_key: BindingViewKey,
     result_select: Option<Vec<String>>,
     result_set: BTreeSet<ResultMemberEntry>,
     result_payloads: BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
@@ -2578,7 +2623,14 @@ fn query_read_set_for_read_view(
     tier: DurabilityTier,
     read_view: &ReadViewSpec,
     settled_binding_view: Option<BindingViewKey>,
+    aggregate_query: bool,
 ) -> Result<RequestedReadSet, Error> {
+    // A settled binding view stores aggregate output as synthetic result
+    // members, not source-table rows. Re-feeding it through the source graph
+    // would turn an aggregate replacement into an empty source and retract
+    // the public row. Its authoritative result is materialized directly by
+    // the subscription facade instead.
+    let settled_binding_view = (!aggregate_query).then_some(settled_binding_view).flatten();
     if settled_binding_view.is_some() {
         if !read_view.is_default() {
             return Err(Error::QueryCapability(
@@ -5008,6 +5060,17 @@ where
         output_tables: &BTreeMap<String, TableSchema>,
     ) -> Result<Option<super::maintained_subscription_view::ResultTransitions>, Error> {
         let binding_view_key = self.binding_view_key_for_subscription(subscription)?;
+        // Settled binding views are shared by canonical query binding, while a
+        // table read policy is identity-scoped. Never relay a synthetic
+        // aggregate from that shared cache across an identity boundary; the
+        // per-peer maintained program remains the authority for policy-shaped
+        // aggregate output.
+        let shared_view_has_read_policy = self
+            .query
+            .registered_shapes
+            .get(&subscription.shape_id)
+            .and_then(|shape| self.table(shape.query().table.as_str()).ok())
+            .is_some_and(|table| table.read_policy.is_some());
         let Some(settled_members) = self.query.settled_result_sets.get(&binding_view_key) else {
             return Ok(None);
         };
@@ -5023,7 +5086,8 @@ where
             };
             result_table_filter.is_none_or(|table| table_name == table)
                 && (output_tables.contains_key(table_name)
-                    || matches!(member, ResultMemberEntry::Synthetic { .. }))
+                    || (matches!(member, ResultMemberEntry::Synthetic { .. })
+                        && !shared_view_has_read_policy))
         };
         let current = settled_members
             .iter()
@@ -5096,12 +5160,14 @@ where
         let result_table = shape.query().table.as_str();
         let mut rows = Vec::new();
         let mut row_keys = BTreeSet::new();
-        for member in result_members
-            .iter()
-            .filter(|member| member.table_name() == Some(result_table))
-        {
-            let Some(row) =
-                self.materialize_authoritative_reset_member(member, &result_payloads)?
+        for member in result_members.iter().filter(|member| {
+            is_public_result_member(member, result_table, shape.query().aggregate.is_some())
+        }) {
+            let Some(row) = self.materialize_authoritative_reset_member(
+                shape.query(),
+                member,
+                &result_payloads,
+            )?
             else {
                 continue;
             };
@@ -5147,9 +5213,20 @@ where
 
     fn materialize_authoritative_reset_member(
         &mut self,
+        query: &crate::query::Query,
         member: &ResultMemberEntry,
         result_payloads: &BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
     ) -> Result<Option<CurrentRow>, Error> {
+        if is_public_aggregate_result_member(
+            member,
+            query.table.as_str(),
+            query.aggregate.is_some(),
+        ) && let Some(payload) = result_payloads.get(member)
+        {
+            return self
+                .current_row_from_aggregate_result_payload(query, member, payload)
+                .map(Some);
+        }
         if member.as_row().is_none()
             && let Some(payload) = result_payloads.get(member)
         {
@@ -6043,6 +6120,7 @@ where
                 tier,
                 read_view,
                 settled_binding_view,
+                shape.query().aggregate.is_some(),
             )?,
             policy,
             input,
@@ -7317,6 +7395,15 @@ where
             tables,
             result_query: shape.query().clone(),
             result_table: shape.query().table.clone(),
+            binding_view_key: BindingViewKey::new(
+                shape.shape_id(),
+                binding.binding_id(),
+                RegisterShapeOptions {
+                    tier,
+                    read_view: read_view.clone(),
+                }
+                .read_view_key(),
+            ),
             result_select: shape.query().select.clone(),
             result_set: BTreeSet::new(),
             result_payloads: BTreeMap::new(),
@@ -7369,12 +7456,21 @@ where
             .get(&binding_view_key)
             .cloned()
             .unwrap_or_default();
+        if local.result_query.aggregate.is_some() {
+            local
+                .maintained
+                .replace_aggregate_result_state(&local.result_set, &local.program_facts);
+        }
         local.result_payloads = local
             .program_facts
             .iter()
             .filter_map(|fact| match fact {
                 ProgramFactEntry::ResultPayload(payload)
-                    if payload.member.table_name() == Some(local.result_table.as_str()) =>
+                    if is_public_result_member(
+                        &payload.member,
+                        local.result_table.as_str(),
+                        local.result_query.aggregate.is_some(),
+                    ) =>
                 {
                     Some((payload.member.clone(), payload.clone()))
                 }
@@ -7387,6 +7483,80 @@ where
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
     ) -> Result<Option<super::maintained_subscription_view::ResultTransitions>, Error> {
+        if local.result_query.aggregate.is_some()
+            && let Some(remote_members) =
+                self.query.settled_result_sets.get(&local.binding_view_key)
+            && let Some(remote_facts) = self
+                .query
+                .settled_program_facts
+                .get(&local.binding_view_key)
+        {
+            let visible_members = remote_members
+                .iter()
+                .filter(|member| {
+                    is_public_result_member(
+                        member,
+                        local.result_table.as_str(),
+                        local.result_query.aggregate.is_some(),
+                    )
+                })
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let visible_facts = remote_facts
+                .iter()
+                .filter(|fact| match fact {
+                    ProgramFactEntry::ResultPayload(payload) => is_public_result_member(
+                        &payload.member,
+                        local.result_table.as_str(),
+                        local.result_query.aggregate.is_some(),
+                    ),
+                    _ => false,
+                })
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            if visible_members != local.result_set || visible_facts != local.program_facts {
+                let mut transitions = super::maintained_subscription_view::ResultTransitions {
+                    adds: visible_members
+                        .difference(&local.result_set)
+                        .cloned()
+                        .collect(),
+                    removes: local
+                        .result_set
+                        .difference(&visible_members)
+                        .cloned()
+                        .collect(),
+                    program_fact_adds: visible_facts
+                        .difference(&local.program_facts)
+                        .cloned()
+                        .collect(),
+                    program_fact_removes: local
+                        .program_facts
+                        .difference(&visible_facts)
+                        .cloned()
+                        .collect(),
+                    ..Default::default()
+                };
+                transitions.result_payload_adds = transitions
+                    .program_fact_adds
+                    .iter()
+                    .filter_map(|fact| match fact {
+                        ProgramFactEntry::ResultPayload(payload) => {
+                            Some((payload.member.clone(), payload.clone()))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                transitions.result_payload_removes = transitions
+                    .program_fact_removes
+                    .iter()
+                    .filter_map(|fact| match fact {
+                        ProgramFactEntry::ResultPayload(payload) => Some(payload.member.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                return Ok(Some(transitions));
+            }
+        }
         let mut states = BTreeMap::<ResultMemberEntry, (bool, bool)>::new();
         let mut fact_states = BTreeMap::<ProgramFactEntry, (bool, bool)>::new();
         loop {
@@ -7468,6 +7638,18 @@ where
         transitions: super::maintained_subscription_view::ResultTransitions,
         materialize_update: bool,
     ) -> Result<LocalMaintainedViewSubscriptionUpdate, Error> {
+        let aggregate_replacements = transitions
+            .adds
+            .iter()
+            .filter(|member| {
+                is_public_aggregate_result_member(
+                    member,
+                    local.result_table.as_str(),
+                    local.result_query.aggregate.is_some(),
+                )
+            })
+            .map(aggregate_result_member_row_uuid)
+            .collect::<Result<BTreeSet<_>, _>>()?;
         let mut added = Vec::new();
         let mut removed = Vec::new();
         let mut added_edges = Vec::new();
@@ -7476,12 +7658,20 @@ where
             local.result_payloads.remove(&member);
         }
         for (member, payload) in transitions.result_payload_adds {
-            if member.table_name() == Some(local.result_table.as_str()) {
+            if is_public_result_member(
+                &member,
+                local.result_table.as_str(),
+                local.result_query.aggregate.is_some(),
+            ) {
                 local.result_payloads.insert(member, payload);
             }
         }
         for member in transitions.adds {
-            if member.table_name() != Some(local.result_table.as_str()) {
+            if !is_public_result_member(
+                &member,
+                local.result_table.as_str(),
+                local.result_query.aggregate.is_some(),
+            ) {
                 continue;
             }
             if local.result_set.insert(member.clone()) && materialize_update {
@@ -7493,12 +7683,35 @@ where
             }
         }
         for member in transitions.removes {
-            if member.table_name() != Some(local.result_table.as_str()) {
+            if !is_public_result_member(
+                &member,
+                local.result_table.as_str(),
+                local.result_query.aggregate.is_some(),
+            ) {
                 continue;
             }
             if local.result_set.remove(&member) {
-                if materialize_update && let Some((table, row_uuid, _)) = member.as_row() {
-                    removed.push((table.to_string(), row_uuid));
+                if materialize_update {
+                    if let Some((table, row_uuid, _)) = member.as_row() {
+                        removed.push((table.to_string(), row_uuid));
+                    } else if is_public_aggregate_result_member(
+                        &member,
+                        local.result_table.as_str(),
+                        local.result_query.aggregate.is_some(),
+                    ) {
+                        let row_uuid = aggregate_result_member_row_uuid(&member)?;
+                        let replacement_is_current = local.result_set.iter().any(|candidate| {
+                            is_public_aggregate_result_member(
+                                candidate,
+                                local.result_table.as_str(),
+                                local.result_query.aggregate.is_some(),
+                            ) && aggregate_result_member_row_uuid(candidate)
+                                .is_ok_and(|candidate_uuid| candidate_uuid == row_uuid)
+                        });
+                        if !aggregate_replacements.contains(&row_uuid) && !replacement_is_current {
+                            removed.push((local.result_table.clone(), row_uuid));
+                        }
+                    }
                 }
             }
         }
@@ -7686,6 +7899,21 @@ where
         local: &LocalMaintainedViewSubscription,
         member: &ResultMemberEntry,
     ) -> Result<Option<CurrentRow>, Error> {
+        if is_public_aggregate_result_member(
+            member,
+            local.result_table.as_str(),
+            local.result_query.aggregate.is_some(),
+        ) {
+            let payload = local
+                .result_payloads
+                .get(member)
+                .ok_or(Error::InvalidStoredValue(
+                    "aggregate result member is missing its payload",
+                ))?;
+            return self
+                .current_row_from_aggregate_result_payload(&local.result_query, member, payload)
+                .map(Some);
+        }
         let Some(entry) = member.as_row() else {
             return Err(Error::InvalidStoredValue(
                 "local maintained subscription cannot materialize non-row result member yet",
@@ -7733,6 +7961,21 @@ where
         member: &ResultMemberEntry,
         cache: &mut LocalMaintainedMaterializationCache,
     ) -> Result<Option<CurrentRow>, Error> {
+        if is_public_aggregate_result_member(
+            member,
+            local.result_table.as_str(),
+            local.result_query.aggregate.is_some(),
+        ) {
+            let payload = local
+                .result_payloads
+                .get(member)
+                .ok_or(Error::InvalidStoredValue(
+                    "aggregate result member is missing its payload",
+                ))?;
+            return self
+                .current_row_from_aggregate_result_payload(&local.result_query, member, payload)
+                .map(Some);
+        }
         let Some(entry) = member.as_row() else {
             return Err(Error::InvalidStoredValue(
                 "local maintained subscription cannot materialize non-row result member yet",
@@ -8063,6 +8306,42 @@ where
         refs.sort();
         refs.dedup();
         Ok(refs)
+    }
+
+    fn current_row_from_aggregate_result_payload(
+        &mut self,
+        query: &crate::query::Query,
+        member: &ResultMemberEntry,
+        payload: &ResultMemberPayloadEntry,
+    ) -> Result<CurrentRow, Error> {
+        let source_table = self.table(query.table.as_str())?.clone();
+        let table = aggregate_result_table(query, &source_table)?;
+        let fields: Vec<(Option<String>, ValueType)> = postcard::from_bytes(&payload.descriptor)
+            .map_err(|_| Error::InvalidStoredValue("result payload descriptor is invalid"))?;
+        let payload_descriptor = RecordDescriptor::new(
+            fields
+                .into_iter()
+                .map(|(name, value_type)| {
+                    name.map(|name| (name, value_type))
+                        .ok_or(Error::InvalidStoredValue(
+                            "result payload descriptor field must be named",
+                        ))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+        let payload_record = BorrowedRecord::new(&payload.record, &payload_descriptor);
+        let mut cells = BTreeMap::new();
+        for column in &table.columns {
+            let field = user_column_field(&column.name);
+            let index = payload_descriptor
+                .field_index(&field)
+                .or_else(|| payload_descriptor.field_index(&column.name))
+                .ok_or(Error::InvalidStoredValue(
+                    "aggregate result payload is missing an output column",
+                ))?;
+            cells.insert(column.name.clone(), payload_record.get_idx(index)?);
+        }
+        current_row_from_cells(&table, aggregate_result_member_row_uuid(member)?, &cells)
     }
 
     fn current_row_from_result_payload(

--- a/crates/jazz/src/node/tests/m3_differential.rs
+++ b/crates/jazz/src/node/tests/m3_differential.rs
@@ -17,7 +17,10 @@
 // | projection with includes                     | `docs_projected_with_doc_access`            |
 // | relation traversal facade, forward hop       | `docs_relation_facade_direct_access`        |
 // | recursive membership                         | both reachable shapes include transitive hops |
-// | aggregate                                    | `docs_count`                                |
+// | aggregate: count, min, max, sum, avg          | `docs_*_by_bucket`                          |
+// | aggregate numeric value types                 | `F64`, `I64`, `U64`                         |
+// | aggregate nullable / empty inputs              | `m3_aggregate_null_semantics`                |
+// | aggregate cancellation and sustained churn     | `m3_aggregate_churn_curve`                   |
 
 #[derive(Clone)]
 struct DifferentialShape {
@@ -32,7 +35,7 @@ struct DifferentialOracle {
     peers: Vec<PeerState>,
     shapes: Vec<DifferentialShape>,
     rows: Vec<BTreeSet<(String, RowUuid)>>,
-    aggregate: AggregateDifferential,
+    aggregates: Vec<AggregateDifferential>,
 }
 
 struct AggregateDifferential {
@@ -42,14 +45,44 @@ struct AggregateDifferential {
     identity: AuthorId,
     subscription: SubscriptionKey,
     peer: PeerState,
-    value: Value,
+    output: &'static str,
+    agreement: AggregateAgreement,
+    values: BTreeMap<u64, Value>,
+    maintenance_updates: u64,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AggregateAgreement {
+    Exact,
+    /// Floating-point addition/subtraction is order-sensitive.  The oracle
+    /// uses a forward-error budget relative to Σ|x|, with one rounding budget
+    /// for each input and each subsequent maintained update.
+    F64Approx,
+}
+
+const F64_AGGREGATE_ERROR_FACTOR: f64 = 64.0;
+type AggregateSpec = (
+    &'static str,
+    crate::query::Aggregate,
+    &'static str,
+    AggregateAgreement,
+);
+
 impl DifferentialOracle {
-    fn open(
-        core: &mut NodeState<RocksDbStorage>,
+    fn open<S: OrderedKvStorage>(
+        core: &mut NodeState<S>,
         schema: &JazzSchema,
         shapes: Vec<DifferentialShape>,
+        seed: u64,
+    ) -> Self {
+        Self::open_with_aggregate_specs(core, schema, shapes, aggregate_differential_specs(), seed)
+    }
+
+    fn open_with_aggregate_specs<S: OrderedKvStorage>(
+        core: &mut NodeState<S>,
+        schema: &JazzSchema,
+        shapes: Vec<DifferentialShape>,
+        aggregate_specs: Vec<AggregateSpec>,
         seed: u64,
     ) -> Self {
         let mut peers = Vec::new();
@@ -69,41 +102,67 @@ impl DifferentialOracle {
             rows.push(shape_rows);
             peers.push(peer);
         }
-        let aggregate_shape = Query::from("docs").count().validate(schema).unwrap();
-        let aggregate_binding = aggregate_shape.bind(BTreeMap::new()).unwrap();
-        let aggregate_subscription = SubscriptionKey {
-            shape_id: aggregate_shape.shape_id(),
-            binding_id: aggregate_binding.binding_id(),
-            read_view: Default::default(),
-        };
-        let mut aggregate_peer = PeerState::client_link(user(0xa1));
-        let aggregate_initial = aggregate_peer
-            .rehydrate_query(core, &aggregate_shape, &aggregate_binding)
-            .unwrap_or_else(|err| {
-                panic!("seed {seed}: initial maintained open failed for docs_count: {err:?}")
+        let mut aggregates = Vec::new();
+        for (name, aggregate, output, agreement) in aggregate_specs {
+            let shape = Query::from("docs")
+                .aggregate([aggregate])
+                .group_by("bucket")
+                .validate(schema)
+                .unwrap();
+            let binding = shape.bind(BTreeMap::new()).unwrap();
+            let subscription = SubscriptionKey {
+                shape_id: shape.shape_id(),
+                binding_id: binding.binding_id(),
+                read_view: Default::default(),
+            };
+            let mut peer = PeerState::client_link(user(0xa1));
+            let initial = peer
+                .rehydrate_query(core, &shape, &binding)
+                .unwrap_or_else(|err| {
+                    panic!("seed {seed}: initial maintained open failed for {name}: {err:?}")
+                });
+            let mut values = BTreeMap::new();
+            apply_aggregate_payload(&mut values, &initial, output);
+            aggregates.push(AggregateDifferential {
+                name,
+                shape,
+                binding,
+                identity: user(0xa1),
+                subscription,
+                peer,
+                output,
+                agreement,
+                values,
+                maintenance_updates: 0,
             });
-        let mut aggregate_value = Value::U64(0);
-        apply_aggregate_payload(&mut aggregate_value, &aggregate_initial);
+        }
 
         let mut oracle = Self {
             peers,
             shapes,
             rows,
-            aggregate: AggregateDifferential {
-                name: "docs_count",
-                shape: aggregate_shape,
-                binding: aggregate_binding,
-                identity: user(0xa1),
-                subscription: aggregate_subscription,
-                peer: aggregate_peer,
-                value: aggregate_value,
-            },
+            aggregates,
         };
         oracle.assert_checkpoint(core, seed, "t0");
         oracle
     }
 
-    fn tick_and_assert(&mut self, core: &mut NodeState<RocksDbStorage>, seed: u64, checkpoint: &str) {
+    fn tick_and_assert<S: OrderedKvStorage>(
+        &mut self,
+        core: &mut NodeState<S>,
+        seed: u64,
+        checkpoint: &str,
+    ) {
+        self.tick(core, seed, checkpoint);
+        self.assert_checkpoint(core, seed, checkpoint);
+    }
+
+    fn tick<S: OrderedKvStorage>(
+        &mut self,
+        core: &mut NodeState<S>,
+        seed: u64,
+        checkpoint: &str,
+    ) {
         for ((peer, shape), rows) in self
             .peers
             .iter_mut()
@@ -111,7 +170,12 @@ impl DifferentialOracle {
             .zip(self.rows.iter_mut())
         {
             let update = peer
-                .query_update_for_subscription(core, shape.subscription, &shape.shape, &shape.binding)
+                .query_update_for_subscription(
+                    core,
+                    shape.subscription,
+                    &shape.shape,
+                    &shape.binding,
+                )
                 .unwrap_or_else(|err| {
                     panic!(
                         "seed {seed}: maintained update failed for {} at {checkpoint}: {err:?}",
@@ -120,26 +184,38 @@ impl DifferentialOracle {
                 });
             apply_result_members(rows, &update, &shape.shape.query().table);
         }
-        let aggregate_update = self
-            .aggregate
-            .peer
-            .query_update_for_subscription(
-                core,
-                self.aggregate.subscription,
-                &self.aggregate.shape,
-                &self.aggregate.binding,
-            )
-            .unwrap_or_else(|err| {
-                panic!(
-                    "seed {seed}: maintained update failed for {} at {checkpoint}: {err:?}",
-                    self.aggregate.name
+        for aggregate in &mut self.aggregates {
+            let aggregate_update = aggregate
+                .peer
+                .query_update_for_subscription(
+                    core,
+                    aggregate.subscription,
+                    &aggregate.shape,
+                    &aggregate.binding,
                 )
-            });
-        apply_aggregate_payload(&mut self.aggregate.value, &aggregate_update);
-        self.assert_checkpoint(core, seed, checkpoint);
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "seed {seed}: maintained update failed for {} at {checkpoint}: {err:?}",
+                        aggregate.name
+                    )
+                });
+            apply_aggregate_payload(&mut aggregate.values, &aggregate_update, aggregate.output);
+            aggregate.maintenance_updates += 1;
+        }
     }
 
-    fn assert_checkpoint(&mut self, core: &mut NodeState<RocksDbStorage>, seed: u64, checkpoint: &str) {
+    fn charge_aggregate_updates(&mut self, updates: u64) {
+        for aggregate in &mut self.aggregates {
+            aggregate.maintenance_updates += updates;
+        }
+    }
+
+    fn assert_checkpoint<S: OrderedKvStorage>(
+        &mut self,
+        core: &mut NodeState<S>,
+        seed: u64,
+        checkpoint: &str,
+    ) {
         for (maintained, shape) in self.rows.iter().zip(self.shapes.iter()) {
             let one_shot = one_shot_rows(core, &shape.shape, &shape.binding, shape.identity);
             assert_eq!(
@@ -148,17 +224,29 @@ impl DifferentialOracle {
                 shape.name
             );
         }
-        let one_shot = one_shot_aggregate_value(
-            core,
-            &self.aggregate.shape,
-            &self.aggregate.binding,
-            self.aggregate.identity,
-        );
-        assert_eq!(
-            self.aggregate.value, one_shot,
-            "seed {seed}: maintained/one-shot aggregate divergence for {} at {checkpoint}",
-            self.aggregate.name
-        );
+        for agreement in [AggregateAgreement::Exact, AggregateAgreement::F64Approx] {
+            for aggregate in self
+                .aggregates
+                .iter()
+                .filter(|aggregate| aggregate.agreement == agreement)
+            {
+                let one_shot = one_shot_aggregate_values(
+                    core,
+                    &aggregate.shape,
+                    &aggregate.binding,
+                    aggregate.identity,
+                    aggregate.output,
+                );
+                assert_aggregate_agreement(
+                    &aggregate.values,
+                    &one_shot,
+                    aggregate,
+                    core,
+                    seed,
+                    checkpoint,
+                );
+            }
+        }
     }
 }
 
@@ -180,6 +268,7 @@ fn m3_differential_seeds() -> Vec<u64> {
 
 #[test]
 fn m3_maintained_one_shot_differential_oracle() {
+    run_m3_aggregate_churn_curve();
     for seed in m3_differential_seeds() {
         if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             run_m3_differential_seed(seed)
@@ -194,7 +283,8 @@ fn run_m3_differential_seed(seed: u64) {
     let schema = m3_differential_schema();
     let (_core_dir, mut core) = open_node_with_schema(node(0x71), schema.clone());
     seed_m3_differential_base(&mut core, seed);
-    let mut differential = DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), seed);
+    let mut differential =
+        DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), seed);
 
     let mut rng = Lcg::new(seed ^ 0x9e37_79b9);
     let mut parents = m3_differential_parent_map(&mut core);
@@ -209,6 +299,414 @@ fn run_m3_differential_seed(seed: u64) {
             _ => update_created_at_match(&mut core, &mut parents, step),
         }
         differential.tick_and_assert(&mut core, seed, &format!("fuzz-step-{step}"));
+    }
+}
+
+fn run_m3_aggregate_churn_curve() {
+    let schema = m3_differential_schema();
+    let column_families = schema.column_families();
+    let column_family_refs = column_families.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut core = NodeState::new(
+        node(0x76),
+        schema.clone(),
+        MemoryStorage::new(&column_family_refs),
+    )
+    .unwrap();
+    let mut parents = BTreeMap::new();
+
+    // This group deliberately cancels large opposite-sign values.  A bound
+    // relative to the result would collapse around zero; Σ|x| remains about
+    // 2e16 throughout the churn arm.
+    for (doc, f64_value, nullable_f64_value, i64_value, u64_value) in [
+        (row(0x11), 1.0e16, Some(1.0e16), -11, 11),
+        (row(0x12), -1.0e16, Some(-1.0e16), 7, 19),
+        (row(0x14), 0.1, None, 13, 23),
+    ] {
+        accept_churn_with_parent(
+            &mut core,
+            &mut parents,
+            doc,
+            400,
+            differential_doc_cells(
+                "churn-cancellation",
+                "match",
+                user(0xa1),
+                7,
+                1,
+                f64_value,
+                nullable_f64_value,
+                i64_value,
+                u64_value,
+            ),
+        );
+    }
+    let mut differential = DifferentialOracle::open_with_aggregate_specs(
+        &mut core,
+        &schema,
+        Vec::new(),
+        vec![
+            (
+                "docs_f64_sum_by_bucket",
+                crate::query::Aggregate::sum("f64_value"),
+                "sum_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+            (
+                "docs_f64_avg_by_bucket",
+                crate::query::Aggregate::avg("f64_value"),
+                "avg_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+        ],
+        0,
+    );
+    let mut previous_depth = 0;
+    for depth in m3_aggregate_churn_depths() {
+        for operation in previous_depth + 1..=depth {
+            match operation % 3 {
+                0 => {
+                    delete_churn_with_parent(
+                        &mut core,
+                        &mut parents,
+                        churn_row(operation / 3),
+                        1_000 + operation,
+                    );
+                }
+                1 => {
+                    accept_churn_with_parent(
+                        &mut core,
+                        &mut parents,
+                        churn_row(operation / 3 + 1),
+                        1_000 + operation,
+                        differential_doc_cells(
+                            "churn-transient",
+                            "match",
+                            user(0xa1),
+                            7,
+                            1,
+                            0.3,
+                            Some(0.3),
+                            1,
+                            1,
+                        ),
+                    );
+                }
+                _ => {
+                    accept_churn_with_parent(
+                        &mut core,
+                        &mut parents,
+                        churn_row(operation / 3),
+                        1_000 + operation,
+                        differential_doc_cells(
+                            "churn-transient-updated",
+                            "match",
+                            user(0xa1),
+                            7,
+                            1,
+                            0.4,
+                            Some(0.4),
+                            1,
+                            1,
+                        ),
+                    );
+                }
+            }
+        }
+        differential.charge_aggregate_updates(depth - previous_depth - 1);
+        differential.tick(&mut core, 0, &format!("churn-{depth}"));
+        report_f64_churn_divergence(&differential, &mut core, depth);
+        previous_depth = depth;
+    }
+}
+
+fn m3_aggregate_churn_depths() -> Vec<u64> {
+    std::env::var("JAZZ_DIFFERENTIAL_CHURN_DEPTHS")
+        .ok()
+        .map(|depths| {
+            depths
+                .split(',')
+                .map(|depth| depth.parse::<u64>().expect("churn depths must be u64"))
+                .collect()
+        })
+        .unwrap_or_else(|| vec![10, 1_000, 100_000])
+}
+
+fn churn_row(index: u64) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[..8].copy_from_slice(&index.to_be_bytes());
+    bytes[15] = 0xfe;
+    RowUuid::from_bytes(bytes)
+}
+
+fn accept_churn_with_parent<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
+    parents: &mut BTreeMap<RowUuid, TxId>,
+    row_uuid: RowUuid,
+    made_at: u64,
+    cells: BTreeMap<String, Value>,
+) {
+    let mut commit = MergeableCommit::new("docs", row_uuid, made_at).cells(cells);
+    if let Some(parent) = parents.get(&row_uuid).copied() {
+        commit = commit.parents(vec![parent]);
+    }
+    let tx_id = core.commit_mergeable(commit).unwrap();
+    core.apply_fate_update(
+        tx_id,
+        Fate::Accepted,
+        Some(core.clock.next_global_seq),
+        Some(DurabilityTier::Global),
+    )
+    .unwrap();
+    parents.insert(row_uuid, tx_id);
+}
+
+fn delete_churn_with_parent<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
+    parents: &mut BTreeMap<RowUuid, TxId>,
+    row_uuid: RowUuid,
+    made_at: u64,
+) {
+    let parent = parents[&row_uuid];
+    let tx_id = core
+        .commit_mergeable(
+            MergeableCommit::new("docs", row_uuid, made_at)
+                .parents(vec![parent])
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    core.apply_fate_update(
+        tx_id,
+        Fate::Accepted,
+        Some(core.clock.next_global_seq),
+        Some(DurabilityTier::Global),
+    )
+    .unwrap();
+    parents.insert(row_uuid, tx_id);
+}
+
+#[test]
+fn m3_maintained_one_shot_differential_oracle_f64_approximate_control() {
+    let schema = m3_differential_schema();
+    let column_families = schema.column_families();
+    let column_family_refs = column_families.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut core = NodeState::new(
+        node(0x78),
+        schema.clone(),
+        MemoryStorage::new(&column_family_refs),
+    )
+    .unwrap();
+    let mut parents = BTreeMap::new();
+    for (row_uuid, f64_value) in [(row(0x21), 1.5), (row(0x22), -0.25)] {
+        accept_churn_with_parent(
+            &mut core,
+            &mut parents,
+            row_uuid,
+            600,
+            differential_doc_cells(
+                "f64-control",
+                "match",
+                user(0xa1),
+                7,
+                1,
+                f64_value,
+                Some(f64_value),
+                1,
+                1,
+            ),
+        );
+    }
+    let mut differential = DifferentialOracle::open_with_aggregate_specs(
+        &mut core,
+        &schema,
+        Vec::new(),
+        vec![
+            (
+                "docs_count_by_bucket",
+                crate::query::Aggregate::count(),
+                "count",
+                AggregateAgreement::Exact,
+            ),
+            (
+                "docs_f64_min_by_bucket",
+                crate::query::Aggregate::min("f64_value"),
+                "min_f64_value",
+                AggregateAgreement::Exact,
+            ),
+            (
+                "docs_f64_max_by_bucket",
+                crate::query::Aggregate::max("f64_value"),
+                "max_f64_value",
+                AggregateAgreement::Exact,
+            ),
+            (
+                "docs_f64_sum_by_bucket",
+                crate::query::Aggregate::sum("f64_value"),
+                "sum_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+            (
+                "docs_f64_avg_by_bucket",
+                crate::query::Aggregate::avg("f64_value"),
+                "avg_f64_value",
+                AggregateAgreement::F64Approx,
+            ),
+        ],
+        0,
+    );
+    accept_churn_with_parent(
+        &mut core,
+        &mut parents,
+        row(0x23),
+        601,
+        differential_doc_cells(
+            "f64-control-insert",
+            "match",
+            user(0xa1),
+            7,
+            1,
+            0.5,
+            Some(0.5),
+            1,
+            1,
+        ),
+    );
+    differential.tick_and_assert(&mut core, 0, "normal-scale-insert");
+}
+
+#[test]
+fn m3_maintained_one_shot_differential_oracle_null_semantics() {
+    let schema = m3_differential_schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(0x77), schema.clone());
+    seed_m3_differential_base(&mut core, 0);
+    let mut parents = m3_differential_parent_map(&mut core);
+    accept_with_parent(
+        &mut core,
+        &mut parents,
+        "docs",
+        row(0x15),
+        500,
+        differential_doc_cells(
+            "all-null",
+            "match",
+            user(0xa1),
+            7,
+            3,
+            4.0,
+            None,
+            4,
+            4,
+        ),
+    );
+
+    let shape = Query::from("docs")
+        .sum("nullable_f64_value")
+        .group_by("bucket")
+        .validate(&schema)
+        .unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let subscription = SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: binding.binding_id(),
+        read_view: Default::default(),
+    };
+    let mut peer = PeerState::client_link(user(0xa1));
+    let initial = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
+    let mut maintained = BTreeMap::new();
+    apply_aggregate_payload(&mut maintained, &initial, "sum_nullable_f64_value");
+    assert_eq!(
+        maintained,
+        one_shot_aggregate_values(
+            &mut core,
+            &shape,
+            &binding,
+            user(0xa1),
+            "sum_nullable_f64_value",
+        ),
+        "nullable aggregates must agree at initial hydration"
+    );
+    assert!(
+        !maintained.contains_key(&3),
+        "all-NULL groups must not materialize a numeric aggregate value"
+    );
+
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x11), 501);
+    let update = peer
+        .query_update_for_subscription(&mut core, subscription, &shape, &binding)
+        .unwrap();
+    apply_aggregate_payload(&mut maintained, &update, "sum_nullable_f64_value");
+    assert_eq!(
+        maintained,
+        one_shot_aggregate_values(
+            &mut core,
+            &shape,
+            &binding,
+            user(0xa1),
+            "sum_nullable_f64_value",
+        ),
+        "nullable aggregates must agree after a group becomes all-NULL"
+    );
+    assert!(
+        !maintained.contains_key(&1),
+        "groups that become all-NULL must be removed from the synthetic result"
+    );
+
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x12), 502);
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x13), 503);
+    delete_with_parent(&mut core, &mut parents, "docs", row(0x14), 504);
+    let update = peer
+        .query_update_for_subscription(&mut core, subscription, &shape, &binding)
+        .unwrap();
+    apply_aggregate_payload(&mut maintained, &update, "sum_nullable_f64_value");
+    assert_eq!(
+        maintained,
+        one_shot_aggregate_values(
+            &mut core,
+            &shape,
+            &binding,
+            user(0xa1),
+            "sum_nullable_f64_value",
+        ),
+        "nullable aggregates must agree after a group becomes empty"
+    );
+    assert!(
+        !maintained.contains_key(&2),
+        "empty groups must not remain in the synthetic result"
+    );
+}
+
+fn report_f64_churn_divergence<S: OrderedKvStorage>(
+    differential: &DifferentialOracle,
+    core: &mut NodeState<S>,
+    depth: u64,
+) {
+    let absolute_sums = f64_absolute_sums_by_bucket(core);
+    for aggregate in &differential.aggregates {
+        if !matches!(aggregate.agreement, AggregateAgreement::F64Approx) {
+            continue;
+        }
+        let one_shot = one_shot_aggregate_values(
+            core,
+            &aggregate.shape,
+            &aggregate.binding,
+            aggregate.identity,
+            aggregate.output,
+        );
+        let Value::F64(maintained) = aggregate.values[&1] else {
+            panic!("{} must produce F64 output", aggregate.name);
+        };
+        let Value::F64(one_shot) = one_shot[&1] else {
+            panic!("{} must produce F64 output", aggregate.name);
+        };
+        let error = (maintained - one_shot).abs();
+        let tolerance = F64_AGGREGATE_ERROR_FACTOR
+            * f64::EPSILON
+            * (depth as f64 + 4.0)
+            * absolute_sums[&1];
+        eprintln!(
+            "M3 F64 CHURN depth={depth} aggregate={} error={error:e} tolerance={tolerance:e} sum_abs={:e} maintained={maintained:e} one_shot={one_shot:e}",
+            aggregate.name,
+            absolute_sums[&1],
+        );
     }
 }
 
@@ -251,6 +749,11 @@ fn m3_differential_empty_seed_then_insert_created_by() {
             "match",
             identity,
             7,
+            1,
+            2.5,
+            Some(2.5),
+            17,
+            17,
         )),
     );
     oracle.tick_and_assert(&mut core, 0, "after-created-by-insert");
@@ -301,7 +804,8 @@ fn m3_differential_revoke_mid_stream_and_reconnect_mid_stream() {
     let schema = m3_differential_schema();
     let (core_dir, mut core) = open_node_with_schema(node(0x75), schema.clone());
     seed_m3_differential_base(&mut core, 0);
-    let mut oracle = DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), 0);
+    let mut oracle =
+        DifferentialOracle::open(&mut core, &schema, m3_differential_shapes(&schema), 0);
     let mut parents = m3_differential_parent_map(&mut core);
 
     revoke_edge_access(&mut core, &mut parents, 0);
@@ -349,6 +853,11 @@ fn m3_differential_schema() -> JazzSchema {
                 ColumnSchema::new("kind", ColumnType::String),
                 ColumnSchema::new("createdBy", ColumnType::Uuid),
                 ColumnSchema::new("createdAt", ColumnType::U64),
+                ColumnSchema::new("bucket", ColumnType::U64),
+                ColumnSchema::new("f64_value", ColumnType::F64),
+                ColumnSchema::new("nullable_f64_value", ColumnType::F64.nullable()),
+                ColumnSchema::new("i64_value", ColumnType::I64),
+                ColumnSchema::new("u64_value", ColumnType::U64),
             ],
         )
         .with_read_policy(Policy::public())
@@ -363,10 +872,13 @@ fn m3_differential_schema() -> JazzSchema {
         .with_reference("doc", "docs")
         .with_read_policy(Policy::public())
         .with_write_policy(Policy::public()),
-        TableSchema::new("grandchildren", [ColumnSchema::new("child", ColumnType::Uuid)])
-            .with_reference("child", "children")
-            .with_read_policy(Policy::public())
-            .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "grandchildren",
+            [ColumnSchema::new("child", ColumnType::Uuid)],
+        )
+        .with_reference("child", "children")
+        .with_read_policy(Policy::public())
+        .with_write_policy(Policy::public()),
         TableSchema::new(
             "teams",
             [
@@ -411,9 +923,12 @@ fn m3_differential_schema() -> JazzSchema {
         .with_reference("team", "teams")
         .with_read_policy(Policy::public())
         .with_write_policy(Policy::public()),
-        TableSchema::new("resources", [ColumnSchema::new("label", ColumnType::String)])
-            .with_read_policy(Policy::shape(same_table_policy))
-            .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "resources",
+            [ColumnSchema::new("label", ColumnType::String)],
+        )
+        .with_read_policy(Policy::shape(same_table_policy))
+        .with_write_policy(Policy::public()),
         TableSchema::new(
             "string_resources",
             [ColumnSchema::new("label", ColumnType::String)],
@@ -508,7 +1023,10 @@ fn m3_differential_shapes(schema: &JazzSchema) -> Vec<DifferentialShape> {
     );
     push(
         "children_inherit_doc",
-        Query::from("children").inherits("doc").validate(schema).unwrap(),
+        Query::from("children")
+            .inherits("doc")
+            .validate(schema)
+            .unwrap(),
     );
     push(
         "grandchildren_inherit_child",
@@ -534,6 +1052,91 @@ fn m3_differential_shapes(schema: &JazzSchema) -> Vec<DifferentialShape> {
         relation_doc_access_shape().validate(schema).unwrap(),
     );
     specs
+}
+
+fn aggregate_differential_specs() -> Vec<AggregateSpec> {
+    use crate::query::Aggregate;
+
+    vec![
+        (
+            "docs_count_by_bucket",
+            Aggregate::count(),
+            "count",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_f64_sum_by_bucket",
+            Aggregate::sum("f64_value"),
+            "sum_f64_value",
+            AggregateAgreement::F64Approx,
+        ),
+        (
+            "docs_f64_avg_by_bucket",
+            Aggregate::avg("f64_value"),
+            "avg_f64_value",
+            AggregateAgreement::F64Approx,
+        ),
+        (
+            "docs_f64_min_by_bucket",
+            Aggregate::min("f64_value"),
+            "min_f64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_f64_max_by_bucket",
+            Aggregate::max("f64_value"),
+            "max_f64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_sum_by_bucket",
+            Aggregate::sum("i64_value"),
+            "sum_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_avg_by_bucket",
+            Aggregate::avg("i64_value"),
+            "avg_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_min_by_bucket",
+            Aggregate::min("i64_value"),
+            "min_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_i64_max_by_bucket",
+            Aggregate::max("i64_value"),
+            "max_i64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_sum_by_bucket",
+            Aggregate::sum("u64_value"),
+            "sum_u64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_avg_by_bucket",
+            Aggregate::avg("u64_value"),
+            "avg_u64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_min_by_bucket",
+            Aggregate::min("u64_value"),
+            "min_u64_value",
+            AggregateAgreement::Exact,
+        ),
+        (
+            "docs_u64_max_by_bucket",
+            Aggregate::max("u64_value"),
+            "max_u64_value",
+            AggregateAgreement::Exact,
+        ),
+    ]
 }
 
 fn created_by_shape(schema: &JazzSchema) -> ValidatedQuery {
@@ -609,7 +1212,10 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
             ])),
         );
     }
-    accept_global(core, team_edge_commit(row(0x41), row(0x31), row(0x32), false, 2));
+    accept_global(
+        core,
+        team_edge_commit(row(0x41), row(0x31), row(0x32), false, 2),
+    );
     accept_global(
         core,
         MergeableCommit::new("group_access_edges", row(0x42), 3).cells(BTreeMap::from([
@@ -618,16 +1224,79 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
         ])),
     );
 
-    for (doc, title, kind, author, created_at) in [
-        (row(0x11), "visible-direct", "match", alice, 7),
-        (row(0x12), "visible-transitive", "match", alice, 7),
-        (row(0x13), "hidden", "match", bob, 8),
-        (row(0x14), "filtered-out", "other", alice, 9),
+    for (
+        doc,
+        title,
+        kind,
+        author,
+        created_at,
+        bucket,
+        f64_value,
+        nullable_f64_value,
+        i64_value,
+        u64_value,
+    ) in [
+        (
+            row(0x11),
+            "visible-direct",
+            "match",
+            alice,
+            7,
+            1,
+            1.5,
+            Some(1.5),
+            -11,
+            11,
+        ),
+        (
+            row(0x12),
+            "visible-transitive",
+            "match",
+            alice,
+            7,
+            1,
+            -0.25,
+            None,
+            7,
+            19,
+        ),
+        (
+            row(0x13),
+            "hidden",
+            "match",
+            bob,
+            8,
+            2,
+            3.0,
+            Some(3.0),
+            -5,
+            5,
+        ),
+        (
+            row(0x14),
+            "filtered-out",
+            "other",
+            alice,
+            9,
+            2,
+            0.75,
+            None,
+            13,
+            23,
+        ),
     ] {
         accept_global(
             core,
             MergeableCommit::new("docs", doc, 10 + seed % 3).cells(differential_doc_cells(
-                title, kind, author, created_at,
+                title,
+                kind,
+                author,
+                created_at,
+                bucket,
+                f64_value,
+                nullable_f64_value,
+                i64_value,
+                u64_value,
             )),
         );
     }
@@ -644,11 +1313,17 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
             ])),
         );
     }
-    for (resource, label) in [(row(0x61), "direct"), (row(0x62), "transitive"), (row(0x63), "hidden")] {
+    for (resource, label) in [
+        (row(0x61), "direct"),
+        (row(0x62), "transitive"),
+        (row(0x63), "hidden"),
+    ] {
         accept_global(
             core,
-            MergeableCommit::new("resources", resource, 30)
-                .cells(BTreeMap::from([("label".to_owned(), Value::String(label.to_owned()))])),
+            MergeableCommit::new("resources", resource, 30).cells(BTreeMap::from([(
+                "label".to_owned(),
+                Value::String(label.to_owned()),
+            )])),
         );
     }
     for (edge, resource, team) in [
@@ -672,8 +1347,10 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
     ] {
         accept_global(
             core,
-            MergeableCommit::new("string_resources", resource, 32)
-                .cells(BTreeMap::from([("label".to_owned(), Value::String(label.to_owned()))])),
+            MergeableCommit::new("string_resources", resource, 32).cells(BTreeMap::from([(
+                "label".to_owned(),
+                Value::String(label.to_owned()),
+            )])),
         );
     }
     for (edge, resource, team) in [
@@ -699,12 +1376,16 @@ fn seed_m3_differential_base(core: &mut NodeState<RocksDbStorage>, seed: u64) {
     );
     accept_global(
         core,
-        MergeableCommit::new("grandchildren", row(0x81), 41)
-            .cells(BTreeMap::from([("child".to_owned(), Value::Uuid(row(0x71).0))])),
+        MergeableCommit::new("grandchildren", row(0x81), 41).cells(BTreeMap::from([(
+            "child".to_owned(),
+            Value::Uuid(row(0x71).0),
+        )])),
     );
 }
 
-fn m3_differential_parent_map(core: &mut NodeState<RocksDbStorage>) -> BTreeMap<(&'static str, RowUuid), TxId> {
+fn m3_differential_parent_map(
+    core: &mut NodeState<RocksDbStorage>,
+) -> BTreeMap<(&'static str, RowUuid), TxId> {
     let mut parents = BTreeMap::new();
     for table in [
         "docs",
@@ -723,12 +1404,30 @@ fn m3_differential_parent_map(core: &mut NodeState<RocksDbStorage>) -> BTreeMap<
     parents
 }
 
-fn differential_doc_cells(title: &str, kind: &str, author: AuthorId, created_at: u64) -> BTreeMap<String, Value> {
+fn differential_doc_cells(
+    title: &str,
+    kind: &str,
+    author: AuthorId,
+    created_at: u64,
+    bucket: u64,
+    f64_value: f64,
+    nullable_f64_value: Option<f64>,
+    i64_value: i64,
+    u64_value: u64,
+) -> BTreeMap<String, Value> {
     BTreeMap::from([
         ("title".to_owned(), Value::String(title.to_owned())),
         ("kind".to_owned(), Value::String(kind.to_owned())),
         ("createdBy".to_owned(), Value::Uuid(author.0)),
         ("createdAt".to_owned(), Value::U64(created_at)),
+        ("bucket".to_owned(), Value::U64(bucket)),
+        ("f64_value".to_owned(), Value::F64(f64_value)),
+        (
+            "nullable_f64_value".to_owned(),
+            Value::Nullable(nullable_f64_value.map(|value| Box::new(Value::F64(value)))),
+        ),
+        ("i64_value".to_owned(), Value::I64(i64_value)),
+        ("u64_value".to_owned(), Value::U64(u64_value)),
     ])
 }
 
@@ -793,7 +1492,7 @@ fn add_visible_doc(
         "docs",
         row_uuid,
         100 + step,
-        differential_doc_cells("added", "match", user(0xa1), 7),
+        differential_doc_cells("added", "match", user(0xa1), 7, 1, 0.5, Some(0.5), 3, 3),
     );
     accept_with_parent(
         core,
@@ -819,7 +1518,7 @@ fn add_hidden_doc(
         "docs",
         row(0xb0 + step as u8),
         140 + step,
-        differential_doc_cells("hidden-added", "match", user(0xb2), 8),
+        differential_doc_cells("hidden-added", "match", user(0xb2), 8, 2, -0.5, None, -3, 5),
     );
 }
 
@@ -886,19 +1585,33 @@ fn update_created_at_match(
         "docs",
         row(0x14),
         240 + step,
-        differential_doc_cells("filtered-now-created-at", "match", user(0xa1), 7),
+        differential_doc_cells(
+            "filtered-now-created-at",
+            "match",
+            user(0xa1),
+            7,
+            2,
+            0.75,
+            None,
+            13,
+            23,
+        ),
     );
 }
 
-fn latest_tx_for_row(core: &mut NodeState<RocksDbStorage>, table: &str, row_uuid: RowUuid) -> Option<TxId> {
+fn latest_tx_for_row(
+    core: &mut NodeState<RocksDbStorage>,
+    table: &str,
+    row_uuid: RowUuid,
+) -> Option<TxId> {
     core.row_history(table, row_uuid)
         .unwrap()
         .last()
         .map(|row| row.tx_id())
 }
 
-fn one_shot_rows(
-    core: &mut NodeState<RocksDbStorage>,
+fn one_shot_rows<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
     shape: &ValidatedQuery,
     binding: &Binding,
     identity: AuthorId,
@@ -910,7 +1623,11 @@ fn one_shot_rows(
         .collect()
 }
 
-fn apply_result_members(rows: &mut BTreeSet<(String, RowUuid)>, update: &SyncMessage, root_table: &str) {
+fn apply_result_members(
+    rows: &mut BTreeSet<(String, RowUuid)>,
+    update: &SyncMessage,
+    root_table: &str,
+) {
     let SyncMessage::ViewUpdate {
         reset_result_set,
         result_member_adds,
@@ -939,26 +1656,35 @@ fn apply_result_members(rows: &mut BTreeSet<(String, RowUuid)>, update: &SyncMes
     }
 }
 
-fn apply_aggregate_payload(value: &mut Value, update: &SyncMessage) {
+fn apply_aggregate_payload(values: &mut BTreeMap<u64, Value>, update: &SyncMessage, output: &str) {
     let SyncMessage::ViewUpdate {
         reset_result_set,
         program_fact_adds,
+        program_fact_removes,
         ..
     } = update
     else {
         panic!("expected view update");
     };
     if *reset_result_set {
-        *value = Value::U64(0);
+        values.clear();
+    }
+    for fact in program_fact_removes {
+        if let Some((bucket, _)) = aggregate_payload_value(fact, output) {
+            values.remove(&bucket);
+        }
     }
     for fact in program_fact_adds {
-        if let Some(next) = aggregate_payload_count(fact) {
-            *value = next;
+        if let Some((bucket, value)) = aggregate_payload_value(fact, output) {
+            values.insert(bucket, value);
         }
     }
 }
 
-fn aggregate_payload_count(fact: &crate::protocol::ProgramFactEntry) -> Option<Value> {
+fn aggregate_payload_value(
+    fact: &crate::protocol::ProgramFactEntry,
+    output: &str,
+) -> Option<(u64, Value)> {
     let crate::protocol::ProgramFactEntry::ResultPayload(payload) = fact else {
         return None;
     };
@@ -974,21 +1700,91 @@ fn aggregate_payload_count(fact: &crate::protocol::ProgramFactEntry) -> Option<V
             .map(|(name, value_type)| (name.unwrap(), value_type)),
     );
     let record = groove::records::BorrowedRecord::new(&payload.record, &descriptor);
-    Some(record.get("count").unwrap().clone())
+    let Value::U64(bucket) = record.get("user_bucket").unwrap() else {
+        panic!("aggregate bucket must be U64");
+    };
+    Some((bucket, record.get(output).unwrap().clone()))
 }
 
-fn one_shot_aggregate_value(
-    core: &mut NodeState<RocksDbStorage>,
+fn one_shot_aggregate_values<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
     shape: &ValidatedQuery,
     binding: &Binding,
     identity: AuthorId,
-) -> Value {
-    let rows = core
-        .query_rows_for_link(shape, binding, DurabilityTier::Global, identity)
-        .unwrap();
-    if rows.is_empty() {
-        return Value::U64(0);
+    output: &str,
+) -> BTreeMap<u64, Value> {
+    core.query_rows_for_link(shape, binding, DurabilityTier::Global, identity)
+        .unwrap()
+        .into_iter()
+        .map(|row| {
+            let cells = row.test_cells_by_descriptor();
+            let Value::U64(bucket) = &cells["bucket"] else {
+                panic!("aggregate bucket must be U64");
+            };
+            (*bucket, cells[output].clone())
+        })
+        .collect()
+}
+
+fn assert_aggregate_agreement<S: OrderedKvStorage>(
+    maintained: &BTreeMap<u64, Value>,
+    one_shot: &BTreeMap<u64, Value>,
+    aggregate: &AggregateDifferential,
+    core: &mut NodeState<S>,
+    seed: u64,
+    checkpoint: &str,
+) {
+    match aggregate.agreement {
+        AggregateAgreement::Exact => assert_eq!(
+            maintained, one_shot,
+            "seed {seed}: maintained/one-shot aggregate divergence for {} at {checkpoint}",
+            aggregate.name
+        ),
+        AggregateAgreement::F64Approx => {
+            assert_eq!(
+                maintained.keys().collect::<Vec<_>>(),
+                one_shot.keys().collect::<Vec<_>>(),
+                "seed {seed}: maintained/one-shot aggregate group divergence for {} at {checkpoint}",
+                aggregate.name
+            );
+            let absolute_sums = f64_absolute_sums_by_bucket(core);
+            for (bucket, maintained) in maintained {
+                let Value::F64(maintained) = maintained else {
+                    panic!("{} must produce F64 output", aggregate.name);
+                };
+                let Value::F64(one_shot) = one_shot[bucket] else {
+                    panic!("{} must produce F64 output", aggregate.name);
+                };
+                let error = (maintained - one_shot).abs();
+                let tolerance = F64_AGGREGATE_ERROR_FACTOR
+                    * f64::EPSILON
+                    * (f64::from(aggregate.maintenance_updates as u32) + 4.0)
+                    * absolute_sums[bucket];
+                assert!(
+                    error <= tolerance,
+                    "seed {seed}: maintained/one-shot F64 aggregate divergence for {} bucket {bucket} at {checkpoint}: error={error:e}, tolerance={tolerance:e}, Σ|x|={:e}, maintenance_updates={}",
+                    aggregate.name,
+                    absolute_sums[bucket],
+                    aggregate.maintenance_updates,
+                );
+            }
+        }
     }
-    assert_eq!(rows.len(), 1, "aggregate one-shot should produce at most one synthetic row");
-    rows[0].test_cells_by_descriptor()["count"].clone()
+}
+
+fn f64_absolute_sums_by_bucket<S: OrderedKvStorage>(
+    core: &mut NodeState<S>,
+) -> BTreeMap<u64, f64> {
+    let mut sums = BTreeMap::new();
+    for row in core.current_rows("docs", DurabilityTier::Global).unwrap() {
+        let cells = row.test_cells_by_descriptor();
+        let Value::U64(bucket) = &cells["bucket"] else {
+            panic!("docs bucket must be U64");
+        };
+        let Value::F64(value) = &cells["f64_value"] else {
+            panic!("docs f64_value must be F64");
+        };
+        *sums.entry(*bucket).or_insert(0.0) += value.abs();
+    }
+    sums
 }

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -832,7 +832,7 @@ impl PeerState {
     fn drain_maintained_subscription_view_changes<S>(
         &mut self,
         node: &mut NodeState<S>,
-        _shape: &ValidatedQuery,
+        shape: &ValidatedQuery,
         subscription: SubscriptionKey,
         result_table_filter: Option<&str>,
         flush_query_runtime: bool,
@@ -859,6 +859,11 @@ impl PeerState {
             .and_then(|state| state.maintained_subscription_view.as_ref())
             .map(|maintained| maintained.tables.clone())
             .unwrap_or_default();
+        let aggregate_is_policy_scoped = shape.query().aggregate.is_some()
+            && node
+                .table(shape.query().table.as_str())?
+                .read_policy
+                .is_some();
         let mut states = BTreeMap::<ResultMemberEntry, (bool, bool)>::new();
         let mut program_fact_adds = Vec::new();
         let mut program_fact_removes = Vec::new();
@@ -955,7 +960,8 @@ impl PeerState {
                 continue;
             }
             if !output_tables.contains_key(table_name)
-                && !matches!(member, ResultMemberEntry::Synthetic { .. })
+                && (!matches!(member, ResultMemberEntry::Synthetic { .. })
+                    || aggregate_is_policy_scoped)
             {
                 continue;
             }
@@ -1017,6 +1023,11 @@ impl PeerState {
         let raw_fact_add_count = transitions.program_fact_adds.len();
         let filter_start = Instant::now();
         let output_tables = tables.clone();
+        let aggregate_is_policy_scoped = shape.query().aggregate.is_some()
+            && node
+                .table(shape.query().table.as_str())?
+                .read_policy
+                .is_some();
         let known_state = self
             .subscriptions
             .get(&subscription)
@@ -1040,7 +1051,8 @@ impl PeerState {
                 };
                 result_table_filter.is_none_or(|table| table_name == table)
                     && (output_tables.contains_key(table_name)
-                        || matches!(member, ResultMemberEntry::Synthetic { .. }))
+                        || (matches!(member, ResultMemberEntry::Synthetic { .. })
+                            && !aggregate_is_policy_scoped))
             })
             .collect::<Vec<_>>();
         let current_member_result_set = result_member_adds.iter().cloned().collect::<BTreeSet<_>>();

--- a/crates/jazz/tests/aggregate_subscriptions.rs
+++ b/crates/jazz/tests/aggregate_subscriptions.rs
@@ -4,12 +4,14 @@ mod support;
 
 use std::time::{Duration, Instant};
 
+use jazz::groove::records::{BorrowedRecord, RecordDescriptor, Value as GrooveValue, ValueType};
 use jazz::row_input;
 use jazz::tools::public_schema::AggregateFunction;
 use jazz::tools::server::JazzServer;
 use jazz::tools::{
-    ColumnMergeStrategy, ColumnType, DurabilityTier, JazzClient, PolicyExpr, QueryBuilder,
-    RowDescriptor, Schema, SchemaBuilder, TableName, TablePolicies, TableSchema, Value,
+    ColumnMergeStrategy, ColumnType, DurabilityTier, JazzClient, PolicyExpr, QueryBuilder, Row,
+    RowDescriptor, Schema, SchemaBuilder, SubscriptionStream, SubscriptionStreamItem, TableName,
+    TablePolicies, TableSchema, Value,
 };
 use support::{TestingClient, wait_for_query};
 use uuid::Uuid;
@@ -123,6 +125,158 @@ async fn wait_for_values(
     assert_eq!(last_actual, expected, "{label}");
 }
 
+/// A materialized view of values delivered by the public subscription stream.
+///
+/// This deliberately decodes only `SubscriptionStreamItem::Delta` rows. It
+/// never asks `JazzClient` to re-run the query, so it observes maintained
+/// delivery rather than one-shot evaluation.
+struct ObservedSubscription {
+    stream: SubscriptionStream,
+    descriptor: RecordDescriptor,
+    rows: Vec<Row>,
+    observed_initial_delta: bool,
+    delivered_deltas: usize,
+}
+
+impl ObservedSubscription {
+    fn new(stream: SubscriptionStream, descriptor: RecordDescriptor) -> Self {
+        Self {
+            stream,
+            descriptor,
+            rows: Vec::new(),
+            observed_initial_delta: false,
+            delivered_deltas: 0,
+        }
+    }
+
+    fn apply_delta(&mut self, delta: jazz::tools::OrderedRowDelta) {
+        for removed in delta.removed {
+            self.rows.retain(|row| row.id != removed.id);
+        }
+        for updated in delta.updated {
+            let Some(row) = updated.row else {
+                continue;
+            };
+            let position = self
+                .rows
+                .iter()
+                .position(|current| current.id == updated.id)
+                .unwrap_or_else(|| panic!("subscription updated unknown row {:?}", updated.id));
+            self.rows[position] = row;
+        }
+        for added in delta.added {
+            if let Some(position) = self.rows.iter().position(|current| current.id == added.id) {
+                self.rows[position] = added.row;
+            } else {
+                self.rows.push(added.row);
+            }
+        }
+    }
+
+    fn values(&self) -> Vec<Vec<Value>> {
+        let mut values = self
+            .rows
+            .iter()
+            .map(|row| {
+                BorrowedRecord::new(row.data.as_ref(), &self.descriptor)
+                    .to_values()
+                    .unwrap_or_else(|err| panic!("decode delivered subscription row: {err}"))
+                    .into_iter()
+                    .map(|value| match value {
+                        GrooveValue::String(value) => Value::Text(value),
+                        GrooveValue::I32(value) => Value::Integer(value),
+                        GrooveValue::I64(value) => Value::BigInt(value),
+                        GrooveValue::U64(value) => Value::Timestamp(value),
+                        GrooveValue::F64(value) => Value::Double(value),
+                        other => panic!("unsupported delivered aggregate value: {other:?}"),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        values.sort_by(|left, right| format!("{left:?}").cmp(&format!("{right:?}")));
+        values
+    }
+
+    async fn wait_for_values(&mut self, expected: Vec<Vec<Value>>, label: &str) {
+        self.wait_for_values_since(self.delivered_deltas, expected, label)
+            .await;
+    }
+
+    async fn wait_for_values_since(
+        &mut self,
+        minimum_deliveries: usize,
+        expected: Vec<Vec<Value>>,
+        label: &str,
+    ) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if self.delivered_deltas >= minimum_deliveries
+                && self.observed_initial_delta
+                && self.values() == expected
+            {
+                return;
+            }
+            let now = Instant::now();
+            let item =
+                tokio::time::timeout(deadline.saturating_duration_since(now), self.stream.next())
+                    .await
+                    .unwrap_or_else(|_| {
+                        panic!(
+                            "{label}: timed out; delivered values were {:?}",
+                            self.values()
+                        )
+                    })
+                    .unwrap_or_else(|| panic!("{label}: subscription stream closed"));
+            match item {
+                SubscriptionStreamItem::Delta(delta) => {
+                    self.apply_delta(delta);
+                    self.observed_initial_delta = true;
+                    self.delivered_deltas += 1;
+                }
+                SubscriptionStreamItem::Rejected { reason } => {
+                    panic!("{label}: subscription rejected: {reason:?}")
+                }
+            }
+        }
+    }
+
+    async fn assert_values_remain(
+        &mut self,
+        expected: Vec<Vec<Value>>,
+        duration: Duration,
+        label: &str,
+    ) {
+        let deadline = Instant::now() + duration;
+        loop {
+            if self.values() != expected {
+                panic!("{label}: delivered values were {:?}", self.values());
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return;
+            }
+            match tokio::time::timeout(deadline - now, self.stream.next()).await {
+                Err(_) => return,
+                Ok(None) => panic!("{label}: subscription stream closed"),
+                Ok(Some(SubscriptionStreamItem::Rejected { reason })) => {
+                    panic!("{label}: subscription rejected: {reason:?}")
+                }
+                Ok(Some(SubscriptionStreamItem::Delta(delta))) => {
+                    self.apply_delta(delta);
+                    self.observed_initial_delta = true;
+                    self.delivered_deltas += 1;
+                }
+            }
+        }
+    }
+}
+
+fn aggregate_descriptor(
+    fields: impl IntoIterator<Item = (&'static str, ValueType)>,
+) -> RecordDescriptor {
+    RecordDescriptor::new(fields)
+}
+
 async fn insert_metric(client: &JazzClient, bucket: &str, score: i32) {
     let (_, _, batch) = client
         .insert("metrics", row_input!("bucket" => bucket, "score" => score))
@@ -149,6 +303,15 @@ async fn insert_metric_at_tier(
 }
 
 async fn insert_bigint_metric(client: &JazzClient, bucket: &str, score: i64) {
+    insert_bigint_metric_at_tier(client, bucket, score, DurabilityTier::Local).await;
+}
+
+async fn insert_bigint_metric_at_tier(
+    client: &JazzClient,
+    bucket: &str,
+    score: i64,
+    tier: DurabilityTier,
+) {
     let (_, _, batch) = client
         .insert(
             "metrics",
@@ -156,12 +319,17 @@ async fn insert_bigint_metric(client: &JazzClient, bucket: &str, score: i64) {
         )
         .expect("insert bigint metric");
     client
-        .wait_for_batch(batch, DurabilityTier::Local)
+        .wait_for_batch(batch, tier)
         .await
         .expect("bigint metric settles");
 }
 
-async fn insert_double_metric(client: &JazzClient, bucket: &str, score: f64) {
+async fn insert_double_metric_at_tier(
+    client: &JazzClient,
+    bucket: &str,
+    score: f64,
+    tier: DurabilityTier,
+) {
     let (_, _, batch) = client
         .insert(
             "metrics",
@@ -169,7 +337,7 @@ async fn insert_double_metric(client: &JazzClient, bucket: &str, score: f64) {
         )
         .expect("insert double metric");
     client
-        .wait_for_batch(batch, DurabilityTier::Local)
+        .wait_for_batch(batch, tier)
         .await
         .expect("double metric settles");
 }
@@ -196,8 +364,14 @@ async fn aggregate_subscription_count_and_grouped_sum_track_full_state() {
         .run_until(async {
             let schema = metrics_schema();
             let server = JazzServer::start_with_schema(schema.clone()).await;
+            let writer = JazzClient::connect(server.make_client_context_for_user(
+                schema.clone(),
+                "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa1",
+            ))
+            .await
+            .expect("connect writer");
             let client = JazzClient::connect(
-                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa1"),
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa11"),
             )
             .await
             .expect("connect client");
@@ -206,112 +380,101 @@ async fn aggregate_subscription_count_and_grouped_sum_track_full_state() {
                 .sum("score")
                 .group_by("bucket")
                 .build();
-            let _count_stream = client
-                .subscribe(count_query.clone())
-                .await
-                .expect("subscribe count aggregate");
-            let _sum_stream = client
-                .subscribe(grouped_sum_query.clone())
-                .await
-                .expect("subscribe grouped sum aggregate");
+            let mut count_stream = ObservedSubscription::new(
+                client
+                    .subscribe(count_query.clone())
+                    .await
+                    .expect("subscribe count aggregate"),
+                aggregate_descriptor([("count", ValueType::U64)]),
+            );
+            let mut sum_stream = ObservedSubscription::new(
+                client
+                    .subscribe(grouped_sum_query.clone())
+                    .await
+                    .expect("subscribe grouped sum aggregate"),
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("sum_score", ValueType::I32),
+                ]),
+            );
 
-            wait_for_values(
-                &client,
-                count_query.clone(),
-                Vec::new(),
-                "initial empty count",
-            )
-            .await;
+            count_stream
+                .wait_for_values(Vec::new(), "initial empty count")
+                .await;
 
-            let (a1, _, batch) = client
+            let (a1, _, batch) = writer
                 .insert("metrics", row_input!("bucket" => "a", "score" => 10))
                 .expect("insert a1");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("a1 settles");
-            wait_for_values(
-                &client,
-                count_query.clone(),
-                vec![vec![Value::Timestamp(1)]],
-                "count after a1",
-            )
-            .await;
-            wait_for_values(
-                &client,
-                grouped_sum_query.clone(),
-                vec![vec![Value::Text("a".to_owned()), Value::Integer(10)]],
-                "sum after a1",
-            )
-            .await;
+            count_stream
+                .wait_for_values(vec![vec![Value::Timestamp(1)]], "count after a1")
+                .await;
+            sum_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("a".to_owned()), Value::Integer(10)]],
+                    "sum after a1",
+                )
+                .await;
 
-            let (b1, _, batch) = client
+            let (b1, _, batch) = writer
                 .insert("metrics", row_input!("bucket" => "b", "score" => 7))
                 .expect("insert b1");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("b1 settles");
-            wait_for_values(
-                &client,
-                count_query.clone(),
-                vec![vec![Value::Timestamp(2)]],
-                "count after b1",
-            )
-            .await;
-            wait_for_values(
-                &client,
-                grouped_sum_query.clone(),
-                vec![
-                    vec![Value::Text("a".to_owned()), Value::Integer(10)],
-                    vec![Value::Text("b".to_owned()), Value::Integer(7)],
-                ],
-                "sum after b1",
-            )
-            .await;
+            count_stream
+                .wait_for_values(vec![vec![Value::Timestamp(2)]], "count after b1")
+                .await;
+            sum_stream
+                .wait_for_values(
+                    vec![
+                        vec![Value::Text("a".to_owned()), Value::Integer(10)],
+                        vec![Value::Text("b".to_owned()), Value::Integer(7)],
+                    ],
+                    "sum after b1",
+                )
+                .await;
 
-            let batch = client.delete(b1).expect("delete b1 and empty b");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            let batch = writer.delete(b1).expect("delete b1 and empty b");
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("delete b1 settles");
-            let (_b2, _, batch) = client
+            let (_b2, _, batch) = writer
                 .insert("metrics", row_input!("bucket" => "b", "score" => 5))
                 .expect("repopulate b");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("repopulate b settles");
-            wait_for_values(
-                &client,
-                grouped_sum_query.clone(),
-                vec![
-                    vec![Value::Text("a".to_owned()), Value::Integer(10)],
-                    vec![Value::Text("b".to_owned()), Value::Integer(5)],
-                ],
-                "sum after repopulating b",
-            )
-            .await;
+            sum_stream
+                .wait_for_values(
+                    vec![
+                        vec![Value::Text("a".to_owned()), Value::Integer(10)],
+                        vec![Value::Text("b".to_owned()), Value::Integer(5)],
+                    ],
+                    "sum after repopulating b",
+                )
+                .await;
 
-            let batch = client.delete(a1).expect("delete a1");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            let batch = writer.delete(a1).expect("delete a1");
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("delete settles");
-            wait_for_values(
-                &client,
-                count_query.clone(),
-                vec![vec![Value::Timestamp(1)]],
-                "count after delete a1",
-            )
-            .await;
-            wait_for_values(
-                &client,
-                grouped_sum_query.clone(),
-                vec![vec![Value::Text("b".to_owned()), Value::Integer(5)]],
-                "sum after delete a1",
-            )
-            .await;
+            count_stream
+                .wait_for_values(vec![vec![Value::Timestamp(1)]], "count after delete a1")
+                .await;
+            sum_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("b".to_owned()), Value::Integer(5)]],
+                    "sum after delete a1",
+                )
+                .await;
         })
         .await;
 }
@@ -322,8 +485,14 @@ async fn maintained_integer_sum_accumulates_multiple_deltas_and_retracts_empty_g
         .run_until(async {
             let schema = metrics_schema();
             let server = JazzServer::start_with_schema(schema.clone()).await;
+            let writer = JazzClient::connect(server.make_client_context_for_user(
+                schema.clone(),
+                "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa6",
+            ))
+            .await
+            .expect("connect writer");
             let client = JazzClient::connect(
-                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa6"),
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa12"),
             )
             .await
             .expect("connect client");
@@ -331,66 +500,65 @@ async fn maintained_integer_sum_accumulates_multiple_deltas_and_retracts_empty_g
                 .sum("score")
                 .group_by("bucket")
                 .build();
-            let _sum_stream = client
-                .subscribe(grouped_sum_query.clone())
-                .await
-                .expect("subscribe grouped sum aggregate");
+            let mut sum_stream = ObservedSubscription::new(
+                client
+                    .subscribe(grouped_sum_query.clone())
+                    .await
+                    .expect("subscribe grouped sum aggregate"),
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("sum_score", ValueType::I32),
+                ]),
+            );
 
-            let (first, _, batch) = client
+            let (first, _, batch) = writer
                 .insert("metrics", row_input!("bucket" => "same", "score" => 10))
                 .expect("insert first metric");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("first metric settles");
-            wait_for_values(
-                &client,
-                grouped_sum_query.clone(),
-                vec![vec![Value::Text("same".to_owned()), Value::Integer(10)]],
-                "sum after first same-group delta",
-            )
-            .await;
+            sum_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Integer(10)]],
+                    "sum after first same-group delta",
+                )
+                .await;
 
-            let (second, _, batch) = client
+            let (second, _, batch) = writer
                 .insert("metrics", row_input!("bucket" => "same", "score" => 7))
                 .expect("insert second metric");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("second metric settles");
-            wait_for_values(
-                &client,
-                grouped_sum_query.clone(),
-                vec![vec![Value::Text("same".to_owned()), Value::Integer(17)]],
-                "sum accumulates a second same-group delta",
-            )
-            .await;
+            sum_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Integer(17)]],
+                    "sum accumulates a second same-group delta",
+                )
+                .await;
 
-            let batch = client.delete(first).expect("delete first metric");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            let batch = writer.delete(first).expect("delete first metric");
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("first delete settles");
-            wait_for_values(
-                &client,
-                grouped_sum_query.clone(),
-                vec![vec![Value::Text("same".to_owned()), Value::Integer(7)]],
-                "sum subtracts a signed deletion delta",
-            )
-            .await;
+            sum_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Integer(7)]],
+                    "sum subtracts a signed deletion delta",
+                )
+                .await;
 
-            let batch = client.delete(second).expect("delete second metric");
-            client
-                .wait_for_batch(batch, DurabilityTier::Local)
+            let batch = writer.delete(second).expect("delete second metric");
+            writer
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("second delete settles");
-            wait_for_values(
-                &client,
-                grouped_sum_query,
-                Vec::new(),
-                "empty signed aggregate group is retracted",
-            )
-            .await;
+            sum_stream
+                .wait_for_values(Vec::new(), "empty signed aggregate group is retracted")
+                .await;
         })
         .await;
 }
@@ -401,8 +569,14 @@ async fn maintained_bigint_sum_replaces_a_multi_row_group_after_insert() {
         .run_until(async {
             let schema = bigint_metrics_schema();
             let server = JazzServer::start_with_schema(schema.clone()).await;
+            let writer = JazzClient::connect(server.make_client_context_for_user(
+                schema.clone(),
+                "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa9",
+            ))
+            .await
+            .expect("connect writer");
             let client = JazzClient::connect(
-                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa9"),
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa13"),
             )
             .await
             .expect("connect client");
@@ -411,28 +585,32 @@ async fn maintained_bigint_sum_replaces_a_multi_row_group_after_insert() {
                 .group_by("bucket")
                 .build();
 
-            insert_bigint_metric(&client, "same", -11).await;
-            insert_bigint_metric(&client, "same", 7).await;
-            let _stream = client
-                .subscribe(query.clone())
-                .await
-                .expect("subscribe grouped bigint sum");
-            wait_for_values(
-                &client,
-                query.clone(),
-                vec![vec![Value::Text("same".to_owned()), Value::BigInt(-4)]],
-                "initial multi-row bigint sum",
-            )
-            .await;
+            insert_bigint_metric_at_tier(&writer, "same", -11, DurabilityTier::EdgeServer).await;
+            insert_bigint_metric_at_tier(&writer, "same", 7, DurabilityTier::EdgeServer).await;
+            let mut stream = ObservedSubscription::new(
+                client
+                    .subscribe(query.clone())
+                    .await
+                    .expect("subscribe grouped bigint sum"),
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("sum_score", ValueType::I64),
+                ]),
+            );
+            stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::BigInt(-4)]],
+                    "initial multi-row bigint sum",
+                )
+                .await;
 
-            insert_bigint_metric(&client, "same", 3).await;
-            wait_for_values(
-                &client,
-                query,
-                vec![vec![Value::Text("same".to_owned()), Value::BigInt(-1)]],
-                "bigint sum replaces the prior group result after insert",
-            )
-            .await;
+            insert_bigint_metric_at_tier(&writer, "same", 3, DurabilityTier::EdgeServer).await;
+            stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::BigInt(-1)]],
+                    "bigint sum replaces the prior group result after insert",
+                )
+                .await;
         })
         .await;
 }
@@ -443,8 +621,14 @@ async fn maintained_double_sum_and_avg_replace_a_multi_row_group_after_insert() 
         .run_until(async {
             let schema = double_metrics_schema();
             let server = JazzServer::start_with_schema(schema.clone()).await;
+            let writer = JazzClient::connect(server.make_client_context_for_user(
+                schema.clone(),
+                "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa10",
+            ))
+            .await
+            .expect("connect writer");
             let client = JazzClient::connect(
-                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa10"),
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa14"),
             )
             .await
             .expect("connect client");
@@ -457,35 +641,58 @@ async fn maintained_double_sum_and_avg_replace_a_multi_row_group_after_insert() 
                 .group_by("bucket")
                 .build();
 
-            insert_double_metric(&client, "same", 1.5).await;
-            insert_double_metric(&client, "same", -0.25).await;
-            let _sum_stream = client
-                .subscribe(sum_query.clone())
-                .await
-                .expect("subscribe grouped double sum");
-            let _avg_stream = client
-                .subscribe(avg_query.clone())
-                .await
-                .expect("subscribe grouped double avg");
+            insert_double_metric_at_tier(&writer, "same", 1.5, DurabilityTier::EdgeServer).await;
+            insert_double_metric_at_tier(&writer, "same", -0.25, DurabilityTier::EdgeServer).await;
+            let mut sum_stream = ObservedSubscription::new(
+                client
+                    .subscribe(sum_query.clone())
+                    .await
+                    .expect("subscribe grouped double sum"),
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("sum_score", ValueType::F64),
+                ]),
+            );
+            let mut avg_stream = ObservedSubscription::new(
+                client
+                    .subscribe(avg_query.clone())
+                    .await
+                    .expect("subscribe grouped double avg"),
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("avg_score", ValueType::F64),
+                ]),
+            );
 
-            insert_double_metric(&client, "same", 0.5).await;
-            wait_for_values(
-                &client,
-                sum_query,
-                vec![vec![Value::Text("same".to_owned()), Value::Double(1.75)]],
-                "double sum replaces the prior group result after insert",
-            )
-            .await;
-            wait_for_values(
-                &client,
-                avg_query,
-                vec![vec![
-                    Value::Text("same".to_owned()),
-                    Value::Double(1.75 / 3.0),
-                ]],
-                "double avg replaces the prior group result after insert",
-            )
-            .await;
+            sum_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Double(1.25)]],
+                    "initial multi-row double sum",
+                )
+                .await;
+            avg_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Double(0.625)]],
+                    "initial multi-row double avg",
+                )
+                .await;
+
+            insert_double_metric_at_tier(&writer, "same", 0.5, DurabilityTier::EdgeServer).await;
+            sum_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Double(1.75)]],
+                    "double sum replaces the prior group result after insert",
+                )
+                .await;
+            avg_stream
+                .wait_for_values(
+                    vec![vec![
+                        Value::Text("same".to_owned()),
+                        Value::Double(1.75 / 3.0),
+                    ]],
+                    "double avg replaces the prior group result after insert",
+                )
+                .await;
         })
         .await;
 }
@@ -797,12 +1004,16 @@ async fn aggregate_subscription_spy_stays_at_policy_visible_truth() {
             .await
             .expect("connect spy");
             let count_query = QueryBuilder::new("metrics").count().build();
-            let _spy_stream = spy
-                .subscribe(count_query.clone())
-                .await
-                .expect("subscribe spy aggregate");
+            let mut spy_stream = ObservedSubscription::new(
+                spy.subscribe(count_query.clone())
+                    .await
+                    .expect("subscribe spy aggregate"),
+                aggregate_descriptor([("count", ValueType::U64)]),
+            );
 
-            wait_for_values(&spy, count_query.clone(), Vec::new(), "spy initial count").await;
+            spy_stream
+                .wait_for_values(Vec::new(), "spy initial count")
+                .await;
 
             let (admin_row, _, batch) = admin
                 .insert(
@@ -811,29 +1022,29 @@ async fn aggregate_subscription_spy_stays_at_policy_visible_truth() {
                 )
                 .expect("insert admin row");
             admin
-                .wait_for_batch(batch, DurabilityTier::Local)
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("admin row settles");
-            wait_for_values(
-                &spy,
-                count_query.clone(),
-                Vec::new(),
-                "spy count ignores admin row",
-            )
-            .await;
+            spy_stream
+                .assert_values_remain(
+                    Vec::new(),
+                    Duration::from_millis(250),
+                    "spy count ignores admin row",
+                )
+                .await;
 
             let batch = admin.delete(admin_row).expect("delete admin row");
             admin
-                .wait_for_batch(batch, DurabilityTier::Local)
+                .wait_for_batch(batch, DurabilityTier::EdgeServer)
                 .await
                 .expect("admin delete settles");
-            wait_for_values(
-                &spy,
-                count_query,
-                Vec::new(),
-                "spy count remains empty after invisible delete",
-            )
-            .await;
+            spy_stream
+                .assert_values_remain(
+                    Vec::new(),
+                    Duration::from_millis(250),
+                    "spy count remains empty after invisible delete",
+                )
+                .await;
         })
         .await;
 }

--- a/crates/jazz/tests/aggregate_subscriptions.rs
+++ b/crates/jazz/tests/aggregate_subscriptions.rs
@@ -36,6 +36,16 @@ fn bigint_metrics_schema() -> Schema {
         .build()
 }
 
+fn double_metrics_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("metrics")
+                .column("bucket", ColumnType::Text)
+                .column("score", ColumnType::Double),
+        )
+        .build()
+}
+
 fn counter_schema() -> Schema {
     let mut schema = SchemaBuilder::new()
         .table(
@@ -149,6 +159,19 @@ async fn insert_bigint_metric(client: &JazzClient, bucket: &str, score: i64) {
         .wait_for_batch(batch, DurabilityTier::Local)
         .await
         .expect("bigint metric settles");
+}
+
+async fn insert_double_metric(client: &JazzClient, bucket: &str, score: f64) {
+    let (_, _, batch) = client
+        .insert(
+            "metrics",
+            row_input!("bucket" => bucket, "score" => Value::Double(score)),
+        )
+        .expect("insert double metric");
+    client
+        .wait_for_batch(batch, DurabilityTier::Local)
+        .await
+        .expect("double metric settles");
 }
 
 fn aggregate_query(
@@ -366,6 +389,101 @@ async fn maintained_integer_sum_accumulates_multiple_deltas_and_retracts_empty_g
                 grouped_sum_query,
                 Vec::new(),
                 "empty signed aggregate group is retracted",
+            )
+            .await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn maintained_bigint_sum_replaces_a_multi_row_group_after_insert() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = bigint_metrics_schema();
+            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let client = JazzClient::connect(
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa9"),
+            )
+            .await
+            .expect("connect client");
+            let query = QueryBuilder::new("metrics")
+                .sum("score")
+                .group_by("bucket")
+                .build();
+
+            insert_bigint_metric(&client, "same", -11).await;
+            insert_bigint_metric(&client, "same", 7).await;
+            let _stream = client
+                .subscribe(query.clone())
+                .await
+                .expect("subscribe grouped bigint sum");
+            wait_for_values(
+                &client,
+                query.clone(),
+                vec![vec![Value::Text("same".to_owned()), Value::BigInt(-4)]],
+                "initial multi-row bigint sum",
+            )
+            .await;
+
+            insert_bigint_metric(&client, "same", 3).await;
+            wait_for_values(
+                &client,
+                query,
+                vec![vec![Value::Text("same".to_owned()), Value::BigInt(-1)]],
+                "bigint sum replaces the prior group result after insert",
+            )
+            .await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn maintained_double_sum_and_avg_replace_a_multi_row_group_after_insert() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = double_metrics_schema();
+            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let client = JazzClient::connect(
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa10"),
+            )
+            .await
+            .expect("connect client");
+            let sum_query = QueryBuilder::new("metrics")
+                .sum("score")
+                .group_by("bucket")
+                .build();
+            let avg_query = QueryBuilder::new("metrics")
+                .avg("score")
+                .group_by("bucket")
+                .build();
+
+            insert_double_metric(&client, "same", 1.5).await;
+            insert_double_metric(&client, "same", -0.25).await;
+            let _sum_stream = client
+                .subscribe(sum_query.clone())
+                .await
+                .expect("subscribe grouped double sum");
+            let _avg_stream = client
+                .subscribe(avg_query.clone())
+                .await
+                .expect("subscribe grouped double avg");
+
+            insert_double_metric(&client, "same", 0.5).await;
+            wait_for_values(
+                &client,
+                sum_query,
+                vec![vec![Value::Text("same".to_owned()), Value::Double(1.75)]],
+                "double sum replaces the prior group result after insert",
+            )
+            .await;
+            wait_for_values(
+                &client,
+                avg_query,
+                vec![vec![
+                    Value::Text("same".to_owned()),
+                    Value::Double(1.75 / 3.0),
+                ]],
+                "double avg replaces the prior group result after insert",
             )
             .await;
         })

--- a/crates/jazz/tests/aggregate_subscriptions.rs
+++ b/crates/jazz/tests/aggregate_subscriptions.rs
@@ -174,15 +174,38 @@ impl ObservedSubscription {
     }
 
     fn values(&self) -> Vec<Vec<Value>> {
+        // Public aggregate subscription rows use a synthetic row id plus the
+        // query columns. The observer removes only that id envelope, then
+        // decodes the user-visible aggregate columns from delivered bytes.
+        let descriptor = RecordDescriptor::new(
+            std::iter::once(("row_uuid".to_owned(), ValueType::Uuid)).chain(
+                self.descriptor.fields().iter().map(|field| {
+                    (
+                        field.name.clone().expect("named aggregate field"),
+                        ValueType::Nullable(Box::new(field.value_type.clone())),
+                    )
+                }),
+            ),
+        );
         let mut values = self
             .rows
             .iter()
             .map(|row| {
-                BorrowedRecord::new(row.data.as_ref(), &self.descriptor)
+                BorrowedRecord::new(row.data.as_ref(), &descriptor)
                     .to_values()
                     .unwrap_or_else(|err| panic!("decode delivered subscription row: {err}"))
                     .into_iter()
+                    .skip(1)
+                    .take(self.descriptor.fields().len())
                     .map(|value| match value {
+                        GrooveValue::Nullable(Some(value)) => match *value {
+                            GrooveValue::String(value) => Value::Text(value),
+                            GrooveValue::I32(value) => Value::Integer(value),
+                            GrooveValue::I64(value) => Value::BigInt(value),
+                            GrooveValue::U64(value) => Value::Timestamp(value),
+                            GrooveValue::F64(value) => Value::Double(value),
+                            other => panic!("unsupported delivered aggregate value: {other:?}"),
+                        },
                         GrooveValue::String(value) => Value::Text(value),
                         GrooveValue::I32(value) => Value::Integer(value),
                         GrooveValue::I64(value) => Value::BigInt(value),
@@ -691,6 +714,84 @@ async fn maintained_double_sum_and_avg_replace_a_multi_row_group_after_insert() 
                         Value::Double(1.75 / 3.0),
                     ]],
                     "double avg replaces the prior group result after insert",
+                )
+                .await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn maintained_min_and_max_replace_multi_row_groups() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = metrics_schema();
+            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let writer = JazzClient::connect(server.make_client_context_for_user(
+                schema.clone(),
+                "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa15",
+            ))
+            .await
+            .expect("connect writer");
+            let client = JazzClient::connect(
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa16"),
+            )
+            .await
+            .expect("connect client");
+            insert_metric_at_tier(&writer, "same", 10, DurabilityTier::EdgeServer).await;
+            insert_metric_at_tier(&writer, "same", 4, DurabilityTier::EdgeServer).await;
+            let mut min_stream = ObservedSubscription::new(
+                client
+                    .subscribe(
+                        QueryBuilder::new("metrics")
+                            .min("score")
+                            .group_by("bucket")
+                            .build(),
+                    )
+                    .await
+                    .expect("subscribe grouped min"),
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("min_score", ValueType::I32),
+                ]),
+            );
+            let mut max_stream = ObservedSubscription::new(
+                client
+                    .subscribe(
+                        QueryBuilder::new("metrics")
+                            .max("score")
+                            .group_by("bucket")
+                            .build(),
+                    )
+                    .await
+                    .expect("subscribe grouped max"),
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("max_score", ValueType::I32),
+                ]),
+            );
+            min_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Integer(4)]],
+                    "initial multi-row min",
+                )
+                .await;
+            max_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Integer(10)]],
+                    "initial multi-row max",
+                )
+                .await;
+            insert_metric_at_tier(&writer, "same", 1, DurabilityTier::EdgeServer).await;
+            min_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Integer(1)]],
+                    "min replacement",
+                )
+                .await;
+            max_stream
+                .wait_for_values(
+                    vec![vec![Value::Text("same".to_owned()), Value::Integer(10)]],
+                    "max remains stable",
                 )
                 .await;
         })


### PR DESCRIPTION
Maintained aggregate subscriptions delivered **nothing** to public clients. Every value in the file's tests came from a one-shot re-query, so nothing noticed.

## The defect

The aggregate reaches the wire correctly — created as `AggregateResult` terminal output (`lowering.rs:6196`), decoded to `ResultMemberEntry::Synthetic` plus a `ResultPayload` (`maintained_subscription_view.rs:674`), placed into `ViewUpdate` (`views.rs:361`, `:613`), persisted by the receiver (`views.rs:898`). With `JAZZ_REHYDRATE_TRACE=1` the server reports `raw_adds=1 raw_fact_adds=1`.

It died at the **client facade**. Aggregate members are deliberately named `<source>_aggregate` (`lowering.rs:6779`), but row materialization filtered members against the plain **source table name**, so `metrics_aggregate` was discarded where `metrics` was expected — at `query_eval.rs:5044` (remote/reset) and `:7427` (local maintained-update).

This affected `count`, `sum`, `avg`, `min` and `max` identically, and was independent of topology: `JazzClient::subscribe` opens an edge-tier subscription, and the local maintained path used the same filter, so neither settlement tier could deliver.

## Why it went unseen

`crates/jazz/tests/aggregate_subscriptions.rs` asserted through a helper that issued a fresh `client.query(...)` — a **one-shot read** — rather than reading what the subscription delivered. That helper was used 24 times across 22 test functions. Anything named `aggregate_subscription_*` or `maintained_*` in that file was a one-shot assertion wearing a subscription's name.

Converting the assertions to read only `SubscriptionStreamItem::Delta` rows is what exposed it. `SubscriptionStreamItem` has exactly two variants, `Delta` and `Rejected` (`crates/jazz/src/tools/mod.rs:194`), so there was no third channel the observer could have been missing.

## The contract

`SPEC/16_maintained_subscription_views.md`:

- **§16.1.1**: applying the delta reducer in stream order must produce the same result as a one-shot read at the corresponding frontier — **including the reset delta that forms the initial view**. So the initial snapshot must carry the aggregate, not only later updates.
- **§16.4**: an unsupported shape must be **rejected**, not accepted as a silently-empty stream.
- Operational target: **O(touched groups plus boundary output)**, not O(result set).

## The fix

Synthetic `<table>_aggregate` members now materialize as stable public rows on both the reset and incremental paths. Incremental reconciliation is **member-delta based** — touched groups only — preserving a changed summary as an update rather than rematerializing results.

## Verification

Run by me, exit codes read unpiped.

- `cargo test -p jazz --features test-utils --test aggregate_subscriptions` → **0**, `13 passed`, including the four acceptance tests and new `min`/`max` coverage.
- **Reverting only the production files** (keeping the tests) reproduces the original symptom exactly:
  ```
  sum after first same-group delta: timed out; delivered values were []
  count after a1: timed out; delivered values were []
  initial multi-row bigint sum: timed out; delivered values were []
  ```
  So these tests are load-bearing — unlike the ones they replace.
- `cargo test -p groove` → **0**
- incremental-delivery canary → **0**
- `cargo test -p jazz` → 101, `1110 passed; 1 failed`: only `m3_maintained_one_shot_differential_oracle_null_semantics`, which is red by design on this branch's oracle commits because nullable numeric aggregates are rejected at validation with `OperandTypeMismatch` (#1125's territory).

## Note on the branch

This builds on the diagnostic commit and the two aggregate **value-correctness** fixes found by the same oracle work — the maintained-view adapter treating Groove's complete before/after aggregate rows as arithmetic deltas, and aggregate siblings sharing an input arrangement skipping prior-state reconstruction. Those are separate defects from this one: they made delivered values *wrong*, this made them *absent*.
