### PR TITLE
(new core) Developer evidence tooling: artifact freshness, zero-match test guard, canonical gate report

### DIFF
--- a/dev/gates/artifacts-fresh.sh
+++ b/dev/gates/artifacts-fresh.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Verify that the artifacts consumed by local tooling are newer than their inputs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+for required in find; do
+  command -v "$required" >/dev/null 2>&1 || {
+    echo "artifacts-fresh: required command not found: $required" >&2
+    exit 127
+  }
+done
+
+failed=0
+
+newest_artifact() {
+  local path candidate newest=""
+  for path in "$@"; do
+    if [[ -f "$path" ]]; then
+      if [[ -z "$newest" || "$path" -nt "$newest" ]]; then
+        newest="$path"
+      fi
+    elif [[ -d "$path" ]]; then
+      while IFS= read -r candidate; do
+        if [[ -z "$newest" || "$candidate" -nt "$newest" ]]; then
+          newest="$candidate"
+        fi
+      done < <(find "$path" -type f -print 2>/dev/null)
+    fi
+  done
+  [[ -n "$newest" ]] || return 1
+  printf '%s\n' "$newest"
+}
+
+check_layer() {
+  local layer="$1"
+  local fix="$2"
+  shift 2
+  local artifact newest_source
+
+  for source_root in "${source_roots[@]}"; do
+    [[ -e "$source_root" ]] || {
+      echo "STALE $layer: cannot inspect source input $source_root. Fix: $fix" >&2
+      failed=1
+      return
+    }
+  done
+
+  artifact="$(newest_artifact "$@")" || {
+    echo "STALE $layer: artifact is missing. Fix: $fix" >&2
+    failed=1
+    return
+  }
+  [[ -n "$artifact" ]] || {
+    echo "STALE $layer: artifact is empty. Fix: $fix" >&2
+    failed=1
+    return
+  }
+
+  newest_source="$(find "${source_roots[@]}" -type f -newer "$artifact" -print -quit 2>/dev/null || true)"
+  if [[ -n "$newest_source" ]]; then
+    echo "STALE $layer: $newest_source is newer than $artifact. Fix: $fix" >&2
+    failed=1
+  else
+    echo "FRESH $layer: $artifact"
+  fi
+}
+
+# Cargo packages have local path dependencies. Listing them explicitly keeps this
+# check useful without declaring unrelated workspace changes stale.
+source_roots=(packages/jazz-tools/src packages/jazz-tools/scripts packages/jazz-tools/package.json packages/jazz-tools/svelte.config.js packages/jazz-tools/tsconfig.json packages/jazz-tools/tsconfig.react-native-tests.json packages/jazz-tools/tsconfig.solid.json packages/jazz-tools/tsconfig.svelte.json packages/jazz-tools/tsconfig.tests.json packages/jazz-tools/vite.config.solid.ts packages/jazz-tools/vitest.config.browser.ts packages/jazz-tools/vitest.config.react.ts packages/jazz-tools/vitest.config.solid.ts packages/jazz-tools/vitest.config.svelte.ts packages/jazz-tools/vitest.config.ts pnpm-lock.yaml package.json)
+check_layer \
+  "packages/jazz-tools/dist" \
+  "pnpm --filter jazz-tools build" \
+  packages/jazz-tools/dist
+
+source_roots=(crates/jazz/src crates/groove/src crates/jazz/Cargo.toml crates/groove/Cargo.toml Cargo.toml Cargo.lock)
+check_layer \
+  "target/debug/jazz-tools" \
+  "cargo build -p jazz --bin jazz-tools --features cli" \
+  target/debug/jazz-tools
+
+# index.js and index.d.ts are outputs of napi build, not inputs.
+source_roots=(crates/jazz-napi/src crates/jazz-napi/build.rs crates/jazz-napi/Cargo.toml crates/jazz-napi/package.json crates/jazz-napi/scripts crates/jazz/src crates/groove/src crates/jazz/Cargo.toml crates/groove/Cargo.toml Cargo.toml Cargo.lock)
+shopt -s nullglob
+napi_artifacts=(crates/jazz-napi/*.node)
+shopt -u nullglob
+check_layer \
+  "crates/jazz-napi/*.node" \
+  "pnpm --filter jazz-napi build:debug" \
+  "${napi_artifacts[@]}"
+
+source_roots=(crates/jazz-wasm/src crates/jazz-wasm/Cargo.toml crates/jazz-wasm/package.json crates/jazz/src crates/groove/src crates/opfs-btree/src crates/jazz/Cargo.toml crates/groove/Cargo.toml crates/opfs-btree/Cargo.toml Cargo.toml Cargo.lock)
+check_layer \
+  "crates/jazz-wasm/pkg" \
+  "pnpm --filter jazz-wasm build" \
+  crates/jazz-wasm/pkg
+
+exit "$failed"

--- a/dev/gates/run-canonical.sh
+++ b/dev/gates/run-canonical.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run the canonical core gates and preserve their direct statuses in TSV output.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+usage() {
+  echo "Usage: dev/gates/run-canonical.sh [--only gate-id] [--output-dir directory]" >&2
+}
+
+only=""
+output_dir=""
+while (($# > 0)); do
+  case "$1" in
+    --only)
+      (($# >= 2)) || { usage; exit 2; }
+      only="$2"
+      shift 2
+      ;;
+    --output-dir)
+      (($# >= 2)) || { usage; exit 2; }
+      output_dir="$2"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+for required in git cargo pnpm mktemp date env; do
+  command -v "$required" >/dev/null 2>&1 || {
+    echo "run-canonical: required command not found: $required" >&2
+    exit 127
+  }
+done
+
+sha="$(git rev-parse HEAD)"
+if [[ -n "$(git status --porcelain)" ]]; then
+  tree_clean=false
+else
+  tree_clean=true
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ -z "$output_dir" ]]; then
+  output_dir="target/gate-reports"
+fi
+mkdir -p "$output_dir"
+tsv="$output_dir/canonical-$timestamp-$sha.tsv"
+
+printf 'sha\t%s\n' "$sha" >"$tsv"
+printf 'tree_clean\t%s\n' "$tree_clean" >>"$tsv"
+printf 'gate\texit_code\tsummary\n' >>"$tsv"
+
+printf 'Canonical gates for %s (tree_clean=%s)\n' "$sha" "$tree_clean"
+printf '%-48s %9s  %s\n' 'gate' 'exit code' 'summary'
+
+overall=0
+ran_count=0
+run_gate() {
+  local id="$1"
+  shift
+  local log status summary
+
+  if [[ -n "$only" && "$only" != "$id" ]]; then
+    return
+  fi
+  ((ran_count += 1))
+
+  log="$(mktemp "${TMPDIR:-/tmp}/jazz-gate-${id}.XXXXXX")"
+  printf '\n==> %s\n    ' "$id"
+  printf '%q ' "$@"
+  printf '\n'
+
+  # This deliberately avoids a conditional or pipeline around the gate. The
+  # status captured here is the command's direct status, including 127.
+  set +e
+  "$@" >"$log" 2>&1
+  status=$?
+  set -e
+  cat "$log"
+  summary=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ -n "${line//[[:space:]]/}" ]]; then
+      summary="${line//$'\t'/ }"
+    fi
+  done <"$log"
+  [[ -n "$summary" ]] || summary="no output"
+  printf '%-48s %9d  %s\n' "$id" "$status" "$summary"
+  printf '%s\t%d\t%s\n' "$id" "$status" "$summary" >>"$tsv"
+  rm -f "$log"
+
+  if ((status != 0)); then
+    overall=1
+  fi
+}
+
+run_gate cargo-test-jazz cargo test -p jazz
+run_gate cargo-test-groove cargo test -p groove
+run_gate cargo-test-jazz-no-default-features cargo test -p jazz --no-default-features --features test
+run_gate cargo-test-jazz-server cargo test -p jazz-server
+run_gate cargo-check-jazz-sim-benches cargo check -p jazz-sim --benches
+run_gate ts-wire-codec dev/gates/ts-wire-codec.sh
+run_gate m3-maintained-one-shot env JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle
+run_gate incremental-delivery-canary cargo test -p jazz --test incremental_delivery_canary maintained_relation_include_single_row_changes_are_scale_independent -- --exact
+
+if [[ -n "$only" ]] && ((ran_count == 0)); then
+  echo "run-canonical: unknown gate id: $only" >&2
+  exit 2
+fi
+
+echo "TSV report: $tsv"
+exit "$overall"

--- a/dev/rebuild-artifacts.sh
+++ b/dev/rebuild-artifacts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Rebuild the independently cached artifacts used by local Jazz tooling.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+usage() {
+  cat <<'EOF'
+Usage: dev/rebuild-artifacts.sh [tools] [server] [napi] [wasm]
+
+With no arguments, rebuild every layer. Specify one or more layers to skip
+expensive layers such as wasm.
+EOF
+}
+
+if (($# == 0)); then
+  layers=(tools server napi wasm)
+else
+  layers=("$@")
+fi
+
+for layer in "${layers[@]}"; do
+  case "$layer" in
+    tools|server|napi|wasm) ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "unknown artifact layer: $layer" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+overall=0
+run_layer() {
+  local layer="$1"
+  shift
+  local status
+
+  printf '\n==> %s\n' "$layer"
+  printf '    '
+  printf '%q ' "$@"
+  printf '\n'
+
+  # Do not use this command as an if-condition: capture its status directly so
+  # command-not-found (127) and every build failure are reported truthfully.
+  set +e
+  "$@"
+  status=$?
+  set -e
+
+  printf '<== %s: exit %d\n' "$layer" "$status"
+  if ((status != 0)); then
+    overall=1
+  fi
+}
+
+for layer in "${layers[@]}"; do
+  case "$layer" in
+    tools)
+      run_layer tools pnpm --filter jazz-tools build
+      ;;
+    server)
+      run_layer server cargo build -p jazz --bin jazz-tools --features cli
+      ;;
+    napi)
+      run_layer napi pnpm --filter jazz-napi build:debug
+      ;;
+    wasm)
+      run_layer wasm pnpm --filter jazz-wasm build
+      ;;
+  esac
+done
+
+exit "$overall"

--- a/dev/t
+++ b/dev/t
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run a cargo-test filter, refusing Cargo's successful "running 0 tests" result.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+usage() {
+  echo "Usage: dev/t <filter> [cargo test arguments...]" >&2
+}
+
+(($# >= 1)) || {
+  usage
+  exit 2
+}
+
+for required in cargo rg mktemp cat grep; do
+  command -v "$required" >/dev/null 2>&1 || {
+    echo "dev/t: required command not found: $required" >&2
+    exit 127
+  }
+done
+
+filter="$1"
+shift
+output="$(mktemp "${TMPDIR:-/tmp}/jazz-dev-t.XXXXXX")"
+trap 'rm -f "$output"' EXIT
+
+# Redirect to a file instead of teeing through a pipe so the captured status is
+# Cargo's actual status, not a pipeline's status.
+set +e
+cargo test "$filter" "$@" >"$output" 2>&1
+status=$?
+set -e
+cat "$output"
+
+if ((status != 0)); then
+  exit "$status"
+fi
+
+# Cargo may also print zero-test doctest targets after a real match. It only
+# matched nothing when no result line reports one or more passed tests.
+if grep -q 'running 0 tests' "$output" && ! grep -Eq 'test result: ok\. [1-9][0-9]* passed;' "$output"; then
+  test_name="${filter##*::}"
+  echo "dev/t: filter matched nothing: $filter" >&2
+  echo "Likely location(s) for $test_name:" >&2
+  matches="$(rg -l -F "$test_name" --glob '*.rs' crates 2>/dev/null || true)"
+  if [[ -n "$matches" ]]; then
+    while IFS= read -r file; do
+      echo "  $file" >&2
+      base="$(basename "$file")"
+      includers="$(rg -l -F "include!(\"$base\")" --glob '*.rs' crates 2>/dev/null || true)"
+      if [[ -n "$includers" ]]; then
+        while IFS= read -r includer; do
+          module="${includer#crates/*/src/}"
+          module="${module%.rs}"
+          module="${module%/mod}"
+          module="${module//\//::}"
+          echo "    likely module path: $module::$test_name (included by $includer)" >&2
+        done <<<"$includers"
+      fi
+    done <<<"$matches"
+  else
+    echo "  no Rust source mention found" >&2
+  fi
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Four small tools, each addressing a friction that produced a **wrong conclusion** in real work this week — not a hypothetical annoyance.

## What they do

**`dev/rebuild-artifacts.sh`** — rebuilds the four independently stale-able artifact layers: `packages/jazz-tools/dist`, `target/debug/jazz-tools` (needs `--features cli`, which is easy to omit), `crates/jazz-napi/*.node` (what the TS runtime actually calls into), and `crates/jazz-wasm/pkg` (what browser suites use). Supports subsets, since wasm alone is ~3 minutes and an all-or-nothing script gets skipped. Reports each layer's true exit code separately.

**`dev/gates/artifacts-fresh.sh`** — fails when any artifact is older than the sources feeding it, naming the stale artifact and the one command that fixes it.

**`dev/t`** — runs a test filter and **fails when it matched nothing**. `cargo test --exact` with a wrong module path runs zero tests and exits **0**, which produced false greens repeatedly.

**`dev/gates/run-canonical.sh`** — runs the canonical set and emits a TSV alongside human output, recording the gated SHA and whether the tree was clean.

## Why these specifically

Stale artifacts do not fail — they **faithfully reproduce bugs that are already fixed**. That caused two misdiagnoses: a bulk-import "hang" that was a `dist` built an hour before the fix it needed, and a `decode cells` error reported as a live codec defect that was a stale NAPI module.

`dev/t` earns its place immediately. Tests in `crates/jazz/src/node/tests/queries.rs` resolve under `node::tests::harness::` because `harness.rs` contains `include!("queries.rs")` — unguessable without knowing. Verified independently:

```
$ ./dev/t node::tests::queries::maintained_array_collector_retains_authorized_parent_trees_incrementally -p jazz --lib -- --exact
exit=1
Likely location(s): crates/jazz/src/node/tests/queries.rs
  likely module path: node::tests::harness::maintained_array_collector_… (included by harness.rs)
```

An adversarial review lane fell into exactly this trap earlier today and reported a test as "orphaned and cannot run" when it ran fine under the other path.

## The scripts are held to their own standard

Each was demonstrated with a **planted positive** and a **bare-`PATH`** run:

- `artifacts-fresh` — `touch crates/jazz-wasm/src/lib.rs` → `STALE crates/jazz-wasm/pkg`, exit 1; clean tree → exit 0
- `rebuild-artifacts` — faked-PATH tools layer → `exit 23`, overall exit 1
- `dev/t` — zero-match filter → exit 1 with the suggested path
- `run-canonical` — faked-PATH gate → `cargo-test-jazz 101`, exit 1

They capture status with `set +e; command; status=$?; set -e` — never by piping a gate or putting it in an `if` condition, because `if cmd` swallows exit 127 and turns a missing tool into a silent pass. A freshness checker that succeeds when broken is worse than none, since it converts an unchecked risk into a false assurance.

`shellcheck` is not installed in this environment, so it was not run.

## A canonical gate that cannot pass

Running the full set surfaced this: **`cargo test -p jazz-server` fails with `package ID specification 'jazz-server' did not match any packages`.** There is no such workspace member — `.claude/CLAUDE.md` itself says at lines 26–27 that `jazz-tools` and `jazz-server` "are now part of `jazz`", while line 30 still lists `cargo test -p jazz-server` as a canonical gate.

I have **not** edited `CLAUDE.md`, since it is the project's instruction file. But a canonical gate that can never pass trains people to ignore gate failures, which is the opposite of what the gate list is for. Recommend deleting that line.

## Honest assessment

From the implementing lane, and I agree: the rebuild/freshness pair and `dev/t` will get used daily; the canonical TSV report is **landing ceremony** — valuable when writing up a batch, not in the inner loop.

Canonical run at the gated SHA: `jazz` 0 · `groove` 0 · `--no-default-features --features test` 101 (the known `catalogue_sync_integration` reds) · `jazz-sim --benches` 0 · TS wire codec 1 (known byte-stability fixture) · M3 oracle 0 · incremental canary 0 · `jazz-server` 101 (the non-existent package above).

Final gates on a clean tree: `artifacts-fresh` **0**, `cargo fmt --check` **0**, `pnpm exec oxfmt --check` **0**.
