### PR TITLE
(new core) Correct the canonical gate list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,15 +23,21 @@ For ordinary Rust/core work, the full gate set is:
 - `cargo test -p jazz`
 - `cargo test -p groove`
 - `cargo test -p jazz --no-default-features --features test` (matches `crates/jazz/TESTING_GUIDELINES.md`).
-  This replaces the former `cargo test -p jazz-tools --features test`: `jazz-tools`
-  and `jazz-server` are now part of `jazz`, so their suites run here. Note it also
-  runs `jazz-tools`' library unit and doc tests, which its old `[lib] test = false`
-  had suppressed.
-- `cargo test -p jazz-server`
-
+  This replaces the former `cargo test -p jazz-tools --features test` **and
+  `cargo test -p jazz-server`**: `jazz-tools` and `jazz-server` are now part of
+  `jazz`, so their suites run here. Neither is a workspace member any more —
+  `cargo test -p jazz-server` fails with `package ID specification did not match
+any packages`, so do not add it back. Note this also runs `jazz-tools`' library
+  unit and doc tests, which its old `[lib] test = false` had suppressed.
 - `cargo check -p jazz-sim --benches` (always; it is cheap enough and catches bench API rot)
 - `dev/gates/ts-wire-codec.sh` for TypeScript/native-runtime wire-codec coverage
   (Anselm-approved 2026-07-07)
+- `dev/gates/invariant-registry.sh` parses both invariant registries and fails on
+  a malformed row, a duplicate id within one registry, a cited test that does not
+  exist, or a `✓`-covered invariant citing no test. `now` + `untested` is reported
+  but does not fail — that is documented debt the registry deliberately keeps
+  visible. Both registries escape literal `|` inside table cells as `\|`; an
+  unescaped pipe silently shreds a row.
 - `JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle`
   for maintained-vs-one-shot equivalence coverage (Anselm-approved 2026-07-08)
 - `cargo test -p jazz --test incremental_delivery_canary maintained_relation_include_single_row_changes_are_scale_independent -- --exact`


### PR DESCRIPTION
Two corrections to the canonical gate list in `AGENTS.md` (which `.claude/CLAUDE.md` symlinks to).

## `cargo test -p jazz-server` cannot pass

```
$ cargo test -p jazz-server --no-run
error: package ID specification `jazz-server` did not match any packages
```

There is no such workspace member, and the same section already said `jazz-tools` and `jazz-server` "are now part of `jazz`" — so the list contradicted itself two lines apart.

This matters beyond tidiness: **a canonical gate that can never pass trains people to ignore gate failures.** That habit is expensive here. Lane reports have repeatedly misstated exit codes — claiming `0` where the truth was `101` — and a gate list containing a guaranteed failure makes "some of these are always red" a reasonable-sounding excuse.

Removed, with a note saying why so it does not get added back.

## `dev/gates/invariant-registry.sh` was unlisted

It exists on the branch but was not in the gate list. Added, with what it fails on — malformed row, duplicate id within one registry, cited test that does not exist, `✓`-covered invariant citing no test — and what it deliberately only **reports**: `now` + `untested`, which is documented debt the registry keeps visible on purpose.

Also records that both registries escape literal `|` in table cells as `\|`. An unescaped pipe silently shreds a row; that happened to `INV-INC-2` and made `lint` red repo-wide until #1286.

## Verification

Every gate still named in the file was run or checked for existence: `cargo test -p jazz` ok · `cargo test -p groove` ok · `cargo check -p jazz-sim --benches` **0** · `dev/gates/ts-wire-codec.sh` present · `dev/gates/invariant-registry.sh` present, exits 1 on the known 30 broken citations · `dev/benchmarks/smoke.sh` present.

`pnpm exec oxfmt --check` → **0**. The formatter reflowed the file, so I compared word sequences to confirm nothing was lost: **847 words before and after, identical order**.

The one remaining `jazz-server` mention is the historical note about its `cli_dry_run` target rotting, which is accurate and worth keeping as the reason the gate discipline exists.
