### PR TITLE
(new core) Fix corrupted integer schema defaults

### DIFF
--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WebSocket } from "undici";
 import { afterEach, describe, expect, it } from "vitest";
-import type { WasmSchema } from "../drivers/types.js";
+import type { ColumnType, Value, WasmSchema } from "../drivers/types.js";
 import { startLocalJazzServer, type LocalJazzServerHandle } from "../testing/index.js";
 import { webSocketUrl } from "./native-runtime/websocket.js";
 import { openConfig } from "./native-runtime/native-codec.js";
@@ -35,6 +35,47 @@ const DEFAULTS_SCHEMA: WasmSchema = {
     ],
   },
 };
+
+const SIGNED_DEFAULT_CASES: Array<{
+  name: string;
+  columnType: ColumnType;
+  value: Value;
+}> = [
+  {
+    name: "i32 minimum",
+    columnType: { type: "Integer" },
+    value: { type: "Integer", value: -2_147_483_648 },
+  },
+  {
+    name: "i32 negative one",
+    columnType: { type: "Integer" },
+    value: { type: "Integer", value: -1 },
+  },
+  { name: "i32 zero", columnType: { type: "Integer" }, value: { type: "Integer", value: 0 } },
+  { name: "i32 one", columnType: { type: "Integer" }, value: { type: "Integer", value: 1 } },
+  {
+    name: "i32 maximum",
+    columnType: { type: "Integer" },
+    value: { type: "Integer", value: 2_147_483_647 },
+  },
+  {
+    name: "i64 minimum",
+    columnType: { type: "BigInt" },
+    value: { type: "BigInt", value: -(1n << 63n) },
+  },
+  {
+    name: "i64 negative one",
+    columnType: { type: "BigInt" },
+    value: { type: "BigInt", value: -1n },
+  },
+  { name: "i64 zero", columnType: { type: "BigInt" }, value: { type: "BigInt", value: 0n } },
+  { name: "i64 one", columnType: { type: "BigInt" }, value: { type: "BigInt", value: 1n } },
+  {
+    name: "i64 maximum",
+    columnType: { type: "BigInt" },
+    value: { type: "BigInt", value: (1n << 63n) - 1n },
+  },
+];
 
 const ALICE_ID = "00000000-0000-4000-8000-0000000000a1";
 const BOB_ID = "00000000-0000-4000-8000-0000000000b2";
@@ -373,6 +414,42 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
     runtime.close();
   });
+
+  it.each(SIGNED_DEFAULT_CASES)(
+    "round-trips the $name schema default through a direct napi insert",
+    async ({ columnType, value }) => {
+      const { NapiDb } = await loadNapiModule();
+      const runtime = new NativeRuntimeAdapter(
+        { openMemory: (schema, config) => NapiDb.openMemory(schema, config) as never },
+        {
+          signed_defaults: {
+            columns: [
+              { name: "title", column_type: { type: "Text" }, nullable: false },
+              { name: "value", column_type: columnType, nullable: false, default: value },
+            ],
+          },
+        },
+        deterministicBytes("jazz-napi-native-runtime-signed-defaults:node"),
+        deterministicBytes("jazz-napi-native-runtime-signed-defaults:author"),
+        1,
+        true,
+      );
+
+      const inserted = runtime.insert("signed_defaults", {
+        title: { type: "Text", value: "direct napi signed default row" },
+      });
+
+      await expect(runtime.query(JSON.stringify({ table: "signed_defaults" }))).resolves.toEqual([
+        {
+          id: inserted.id,
+          table: "signed_defaults",
+          values: [{ type: "Text", value: "direct napi signed default row" }, value],
+        },
+      ]);
+
+      runtime.close();
+    },
+  );
 
   it("delivers native NAPI subscription updates through the native handle", async () => {
     const { NapiDb } = await loadNapiModule();

--- a/packages/jazz-tools/src/runtime/native-runtime/schema-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/schema-codec.ts
@@ -7,7 +7,7 @@ import type {
   Value,
   WasmSchema,
 } from "../../drivers/types.js";
-import { PostcardWriter, writeValueType, type ValueType } from "./native-codec.js";
+import { PostcardWriter, type ValueType } from "./native-codec.js";
 
 const OUTER_ROW_SESSION_PREFIX = "__jazz_outer_row";
 
@@ -84,7 +84,7 @@ export function encodeSchema(schema: WasmSchema): Uint8Array {
     table.vec((column, columnIndex) => {
       const columnSpec = definition.columns[columnIndex]!;
       column.string(columnSpec.name);
-      writeValueType(column, columnValueType(columnSpec));
+      writeColumnType(column, columnValueType(columnSpec));
       writeLargeValueKind(column, columnSpec);
       column.none();
       writeColumnDefault(column, columnSpec);
@@ -112,6 +112,33 @@ export function encodeSchema(schema: WasmSchema): Uint8Array {
 export function columnValueType(column: ColumnDescriptor): ValueType {
   const valueType = columnTypeToValueType(column.column_type);
   return column.nullable ? { tag: 12, inner: valueType } : valueType;
+}
+
+// JazzSchema columns use groove::schema::ColumnType's postcard layout, which
+// differs from groove::records::ValueType at tag 13: it is I64, not Record.
+function writeColumnType(writer: PostcardWriter, columnType: ValueType): void {
+  writer.enumUnit(columnType.tag);
+  if (columnType.tag === 9) {
+    if (!columnType.enumSchema) throw new Error("missing enum schema for Groove ColumnType::Enum");
+    writer.string(columnType.enumSchema.name);
+    writer.vec(
+      (variantWriter, index) => variantWriter.string(columnType.enumSchema!.variants[index]!),
+      columnType.enumSchema.variants.length,
+    );
+    return;
+  }
+  if (columnType.tag === 10) {
+    const members = columnType.members ?? (columnType.inner ? [columnType.inner] : []);
+    writer.vec(
+      (memberWriter, index) => writeColumnType(memberWriter, members[index]!),
+      members.length,
+    );
+    return;
+  }
+  if (columnType.tag === 11 || columnType.tag === 12) {
+    if (!columnType.inner) throw new Error(`missing inner column type for tag ${columnType.tag}`);
+    writeColumnType(writer, columnType.inner);
+  }
 }
 
 function writeLargeValueKind(writer: PostcardWriter, column: ColumnDescriptor) {
@@ -159,14 +186,14 @@ function writeDefaultValue(writer: PostcardWriter, columnType: ColumnType, value
       return;
     case "Integer":
       writer.u64(14); // groove::records::Value::I32
-      writer.i64(expectI32(value, "Integer"));
+      writer.i64(encodeSignedI32DefaultForStorage(expectI32(value, "Integer")));
       return;
     case "BigInt":
       if (value.type !== "BigInt" && value.type !== "Integer") {
         throw new Error("expected BigInt default");
       }
       writer.u64(13); // groove::records::Value::I64
-      writer.i64(value.value);
+      writer.i64(encodeSignedI64DefaultForStorage(BigInt(value.value)));
       return;
     case "Timestamp":
       if (value.type !== "Timestamp") throw new Error("expected Timestamp default");
@@ -208,6 +235,14 @@ function writeDefaultValue(writer: PostcardWriter, columnType: ColumnType, value
     case "Row":
       throw new Error("Core runtime schema defaults do not support Row values yet");
   }
+}
+
+function encodeSignedI32DefaultForStorage(value: number): number {
+  return (value ^ 0x8000_0000) | 0;
+}
+
+function encodeSignedI64DefaultForStorage(value: bigint): bigint {
+  return BigInt.asIntN(64, BigInt.asUintN(64, value) ^ (1n << 63n));
 }
 
 function writeIndexedColumns(writer: PostcardWriter, indexedColumns: string[] | undefined): void {


### PR DESCRIPTION
Schema defaults were persisting corrupted. An integer default of `1` came back as **`-2147483647`**, and `i64` defaults threw `missing inline record descriptor for tag 13`.

**Two independent causes**, which is worth stating because a single "codec" story would have hidden one.

## Cause 1 — defaults written in logical form, not storage form

`1` as `i32` with the order-preserving sign bit flipped is `1 XOR 0x80000000` = `0x80000001`, read back as two's complement = `-2147483647`. Defaults were serialized logically while the reader expected signed **storage** form.

Fixed at `packages/jazz-tools/src/runtime/native-runtime/schema-codec.ts:187` (`i32`) and `:191` (`i64`).

Same family as the row-codec signed-storage bug fixed earlier (`-42` reading back as `2147483606`), surviving on the defaults path.

## Cause 2 — a tag-namespace mix-up

**Schema columns use `ColumnType` tags, where tag 13 is `I64`. The codec used the `ValueType` writer, where tag 13 is `Record`.** Hence `missing inline record descriptor for tag 13` — it was trying to read a record descriptor for what is actually an `i64` column.

Fixed at `schema-codec.ts:87` by using the correct column-type encoder. No `Record`-default handling was involved, so no `Record` test was added — this was purely a namespace confusion.

**This is the third parallel-tag collision found this week.** Jazz schema tag 15 is JSON while Groove `ValueType` tag 15 is `I32`; `ColumnType` tag 13 is `I64` while `ValueType` tag 13 is `Record`; and inserting `Record` mid-enum once shifted `I64`/`I32` to 14/15 and silently broke an in-flight PR. Three overlapping numeric tag spaces distinguished only by which writer you happen to call is a recurring hazard, and worth a spec note independently of this fix.

## Coverage

Full signed-boundary round-trips through direct NAPI at `packages/jazz-tools/src/runtime/napi.core.test.ts:39` — `i32::MIN`, `-1`, `0`, `1`, `i32::MAX` and the `i64` equivalents.

**Before the fix**: all five `i32` cases returned the sign-flipped value, and all five `i64` cases independently threw the tag-13 error. **After**: `10 passed`. The two causes were separable in the evidence, not just in the narrative.

The existing coverage missed this because it never exercised values whose storage form differs from their logical form.

## Verification

The three originally-failing tests pass: insert defaults `2 passed`, direct NAPI defaults `1 passed`, signed-boundary guard `10 passed`.

`cargo test -p jazz` → `1114 passed; 3 failed`; all three are `ws_*` websocket tests, and I re-ran **each** in isolation → `1 passed` apiece. Known parallel-load flakes.

`cargo test -p groove` **0** · `cargo test -p jazz --test wire_fixtures` **0** · `cargo check --workspace --all-targets` **0** · `cargo fmt --check` **0** · `dev/gates/ts-wire-codec.sh` 1 (known policy-graph byte-stability failure only).

## Scope

Deliberately narrow. The row codec is untouched, native query encoding is a separate PR, and the integer **query-literal** `U32`-versus-`I32` coercion gap belongs to #1168 — those rows correctly did **not** move.
