### PR TITLE
(new core) Enable 11 jazz-tools binary tests hidden by test = false

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -153,7 +153,6 @@ rcgen = { version = "0.13", default-features = false, features = ["ring"] }
 name = "jazz-tools"
 path = "src/bin/jazz-tools.rs"
 required-features = ["cli"]
-test = false
 
 [[bin]]
 name = "jazz-server"


### PR DESCRIPTION
A `jazz-tools` Rust binary target carried `test = false`, so its **11 tests never built or ran**. Removing the suppression makes all 11 run and pass.

No product code changed. These tests were already correct; they were simply switched off.

## Why this was worth hunting

An audit of tests-that-exist-but-do-not-run was prompted by a pattern that kept recurring this week:

- `jazz-tools#test` — the package with the real TypeScript suite — **never executed in CI at all**, because Turbo halts once a task fails and an earlier task was failing on a codec bug. When it finally ran it exposed **78 genuine defects**.
- Aggregate subscription tests asserted via a one-shot re-query, so they could not observe a maintained-path defect. Underneath them, maintained aggregate subscriptions were delivering nothing at all.
- Three `deep-include-reactivity` tests failed during subscription creation, before their assertions ever ran.

A test that does not run is a good place to look. This one is the cheapest instance: free coverage for a one-line manifest change.

## Verification

`cargo test -p jazz --no-default-features --features test` — the binary now runs and reports **`11 passed`**, then the suite continues to the three documented `catalogue_sync_integration` known-reds.

`cargo test -p jazz` → only the two documented websocket parallel-load flakes, both passing on isolated rerun. `cargo check --workspace --all-targets` **0** · `cargo fmt --check` **0**.

Deliberately independent of #1307, which addresses a different masking mechanism in the same package.
