### PR TITLE
(new core) fix: preserve app rows for implicit routed paths

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -4861,13 +4861,20 @@ fn lowered_terminals(
     // domain rather than only `root_route_fields` to keep routed maintained
     // array queries on their existing fact-terminal path; the tree collector
     // cannot retain any routed binding fields yet.
-    let has_routed_tree_app_projection = matches!(
-        &request.output.app_rows,
-        Some(AppRowOutputRequest {
-            projection: PayloadProjection::Tree(tree),
-            ..
-        }) if !tree.paths.is_empty() && !routing_param_fields.is_empty()
-    );
+    let has_correlated_path_projection = request
+        .input
+        .shape
+        .nodes
+        .values()
+        .any(|node| matches!(node, RowSetExpr::CorrelatedPathProjection { .. }));
+    let has_routed_tree_app_projection = has_correlated_path_projection
+        && matches!(
+            &request.output.app_rows,
+            Some(AppRowOutputRequest {
+                projection: PayloadProjection::Tree(tree),
+                ..
+            }) if !tree.paths.is_empty() && !routing_param_fields.is_empty()
+        );
     if let Some(app_rows) = &request.output.app_rows
         && !has_routed_tree_app_projection
     {


### PR DESCRIPTION
## What changed

- Restrict the routed tree fallback introduced in #1297 to requests that actually contain a correlated-path projection.
- Preserve the ordinary app-row terminal for routed queries whose tree paths come only from implicit reference closure.

## Root cause

The #1297 fallback used the presence of any projected tree path plus any routing parameter as a proxy for a routed maintained array. Ordinary policy reads can also have both: claim-based policy routing supplies a parameter, while schema references supply implicit tree paths. Those reads incorrectly skipped their app-row terminal and returned an empty result for otherwise public rows.

## Impact

Mixed policies such as `public OR member` return their public rows again, while parameter-routed maintained array subscriptions retain the fact-terminal fallback added by #1297.

## Validation

- `cargo test -p jazz read_policy_branch_or_join_allows_public_or_membership_reads -- --nocapture`
- `cargo test -p jazz --test structured_result_tree maintained_array_subscription_with_root_parameter_lowers_and_delivers -- --nocapture`
- `cargo clippy -p jazz --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
