### PR TITLE
refactor(groove): split graph compiler stack frames

### DIFF
--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -1821,6 +1821,44 @@ impl IvmRuntime {
     ) -> Result<CompiledNode, IvmRuntimeError> {
         let inferred_output = self.infer_builder_output_cached(graph, output_memo)?;
         match graph {
+            GraphBuilder::Table { .. }
+            | GraphBuilder::InlineRecords { .. }
+            | GraphBuilder::Index { .. }
+            | GraphBuilder::FrontierSource { .. }
+            | GraphBuilder::BindingSource { .. }
+            | GraphBuilder::Recursive { .. }
+            | GraphBuilder::CollectBy { .. } => {
+                self.add_dedup_source_graph(graph, inferred_output, output_memo)
+            }
+            GraphBuilder::ArgMaxBy { .. }
+            | GraphBuilder::ArgMinBy { .. }
+            | GraphBuilder::TopBy { .. } => {
+                self.add_dedup_ordering_graph(graph, inferred_output, output_memo)
+            }
+            GraphBuilder::Aggregate { .. }
+            | GraphBuilder::Filter { .. }
+            | GraphBuilder::Project { .. }
+            | GraphBuilder::UnwrapNullable { .. }
+            | GraphBuilder::Unnest { .. }
+            | GraphBuilder::Union { .. } => {
+                self.add_dedup_unary_graph(graph, inferred_output, output_memo)
+            }
+            GraphBuilder::Join { .. }
+            | GraphBuilder::SemiJoin { .. }
+            | GraphBuilder::AntiJoin { .. } => {
+                self.add_dedup_join_graph(graph, inferred_output, output_memo)
+            }
+        }
+    }
+
+    #[inline(never)]
+    fn add_dedup_source_graph(
+        &mut self,
+        graph: &GraphBuilder,
+        inferred_output: RecordDescriptor,
+        output_memo: &mut HashMap<usize, RecordDescriptor>,
+    ) -> Result<CompiledNode, IvmRuntimeError> {
+        match graph {
             GraphBuilder::Table { table, scan } => {
                 let output = inferred_output;
                 let node = self.graph.dedup_node(
@@ -1948,6 +1986,21 @@ impl IvmRuntime {
                 self.initialize_node_runtime(node);
                 Ok(CompiledNode { output, node })
             }
+            GraphBuilder::CollectBy { input, collect } => {
+                self.add_collect_by_graph(input, collect, inferred_output, output_memo)
+            }
+            _ => unreachable!("dispatcher routes only source graph builders here"),
+        }
+    }
+
+    #[inline(never)]
+    fn add_dedup_ordering_graph(
+        &mut self,
+        graph: &GraphBuilder,
+        inferred_output: RecordDescriptor,
+        output_memo: &mut HashMap<usize, RecordDescriptor>,
+    ) -> Result<CompiledNode, IvmRuntimeError> {
+        match graph {
             GraphBuilder::ArgMaxBy {
                 input,
                 group_cols,
@@ -2169,9 +2222,18 @@ impl IvmRuntime {
                 self.initialize_node_runtime(node);
                 Ok(CompiledNode { output, node })
             }
-            GraphBuilder::CollectBy { input, collect } => {
-                self.add_collect_by_graph(input, collect, inferred_output, output_memo)
-            }
+            _ => unreachable!("dispatcher routes only ordering graph builders here"),
+        }
+    }
+
+    #[inline(never)]
+    fn add_dedup_unary_graph(
+        &mut self,
+        graph: &GraphBuilder,
+        inferred_output: RecordDescriptor,
+        output_memo: &mut HashMap<usize, RecordDescriptor>,
+    ) -> Result<CompiledNode, IvmRuntimeError> {
+        match graph {
             GraphBuilder::Aggregate {
                 input,
                 group_cols,
@@ -2331,6 +2393,18 @@ impl IvmRuntime {
                 self.initialize_node_runtime(node);
                 Ok(CompiledNode { output, node })
             }
+            _ => unreachable!("dispatcher routes only unary graph builders here"),
+        }
+    }
+
+    #[inline(never)]
+    fn add_dedup_join_graph(
+        &mut self,
+        graph: &GraphBuilder,
+        inferred_output: RecordDescriptor,
+        output_memo: &mut HashMap<usize, RecordDescriptor>,
+    ) -> Result<CompiledNode, IvmRuntimeError> {
+        match graph {
             GraphBuilder::Join {
                 left,
                 right,
@@ -2448,6 +2522,7 @@ impl IvmRuntime {
                 self.initialize_node_runtime(node);
                 Ok(CompiledNode { output, node })
             }
+            _ => unreachable!("dispatcher routes only join graph builders here"),
         }
     }
 


### PR DESCRIPTION
🤖 Splits `IvmRuntime::add_dedup_graph_cached` into a small dispatcher and non-inlined source, ordering, unary, and join helpers. Operator arm bodies and error propagation are unchanged.

## Why

The monolithic match reserved 48,328 bytes per native debug frame. A normal two-hop prepared-policy graph recursively compiled through 46 such frames and exceeded the default 2 MiB native stack. Raising `RUST_MIN_STACK` is not a product fix because WASM is a first-class target with a roughly 1 MiB, non-configurable stack.

This is a general graph-compilation ceiling, not a PolicyProof-specific workaround.

## Measurement

- Before: dispatcher/monolith 48,328 bytes per debug frame.
- After: dispatcher 536 bytes; largest debug helper 17,704 bytes.
- Conservative inherited 46-level estimate: about 839 KiB plus the transient inference frame.
- Independent release-WASM disassembly retained separate functions and measured a 64-byte dispatcher plus 560/400/480-byte join, unary, and ordering helper frames.

All 20 current `GraphBuilder` variants are routed exactly once. `#[inline(never)]` keeps the frame boundary explicit in optimized builds.

## Validation

- `cargo test -p groove --lib --no-fail-fast` — 406 passed, 1 ignored (pre-rebase implementation and independent review runs).
- `cargo build -p jazz-wasm --target wasm32-unknown-unknown --release` — passed during independent review.
- Post-rebase `cargo test -p groove --lib --no-fail-fast` — 406 passed, 1 ignored.

Independent review found no correctness or stack-accounting issues.
