### PR TITLE
fix(jazz): preserve branch merge-back causality

### DIFF
--- a/crates/jazz/SPEC/11_branches_timetravel.md
+++ b/crates/jazz/SPEC/11_branches_timetravel.md
@@ -181,8 +181,30 @@ merge-back and discard have graduated:
   partition table names.
 - ✅ **Merge-back / discard** (`INV-BRANCH-17`, `INV-BRANCH-18`). Merge-back emits
   one atomic mergeable squash of the branch's net effects into the parent,
-  records typed `Transaction.source_branch` provenance, then flips state to
-  `Merged` with overlay history retained. Content and deletion-register overlay
+  records typed `Transaction.source_branch` provenance, and returns a typed
+  `Accepted`, `Pending`, or `Rejected` outcome. A pending squash has one durable,
+  node-local reservation of its exact `(Transaction, VersionRecord[])` commit
+  unit which is reused across retries and reopen; branch writes and discard are
+  blocked until it settles. Recovery reconciles a durably accepted or rejected
+  reserved transaction before allowing retry. Accepted recovery requires the
+  exact durable transaction and full normal-version payload to equal the frozen
+  reservation before closing the branch. Rejected recovery requires the exact
+  transaction envelope only: rejection contributes no normal versions, may
+  precede history insertion, and leaves the branch open after reservation clear.
+  Only that exact locally reserved
+  transaction—not peer-supplied `source_branch` provenance—may
+  transition the branch to `Merged`, and only after `Accepted`; `Rejected` clears
+  the reservation and leaves the branch open. Overlay history is retained.
+  When authority admission translates the reserved versions through a newer
+  current schema/lens path, it durably rewrites the trusted reservation to that
+  exact canonical admitted payload before transaction/history persistence. The
+  TxId and branch association do not change; foreign `source_branch` provenance
+  cannot trigger this rewrite. While a locally reserved unit is parked or being
+  retried, trust is bound to its exact pre-translation transaction and sorted
+  version payload, not merely its TxId; a same-TxId mismatch conflicts before
+  translation or staging. A successful canonical rewrite deliberately advances
+  that exact trusted binding to the translated payload.
+  Content and deletion-register overlay
   winners are emitted independently, so a restored deletion-register winner can
   be squashed alongside the row's content winner. Discard is a metadata state
   flip to `Discarded`; both paths make the branch read-only. The correctness rule

--- a/crates/jazz/src/node/branches.rs
+++ b/crates/jazz/src/node/branches.rs
@@ -24,6 +24,28 @@ pub struct BranchRecord {
     pub state: codec::BranchState,
 }
 
+/// Authority settlement state of one branch merge-back attempt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BranchMergeOutcome {
+    /// The squash was accepted and the branch is now merged.
+    Accepted {
+        /// Accepted public squash transaction.
+        tx_id: TxId,
+    },
+    /// The squash is durably reserved and awaits missing prerequisites.
+    Pending {
+        /// Reserved squash transaction awaiting admission prerequisites.
+        tx_id: TxId,
+    },
+    /// Authority rejected the squash; the branch remains open for a new attempt.
+    Rejected {
+        /// Rejected public squash transaction.
+        tx_id: TxId,
+        /// Exact authority rejection.
+        reason: RejectionReason,
+    },
+}
+
 impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
@@ -78,7 +100,9 @@ where
             .get(&branch_id)
             .cloned()
             .ok_or(Error::BranchNotFound(branch_id))?;
-        if record.state != codec::BranchState::Open {
+        if record.state != codec::BranchState::Open
+            || self.branches.pending_merge_backs.contains_key(&branch_id)
+        {
             return Err(Error::BranchClosed(branch_id));
         }
         record.state = codec::BranchState::Discarded;
@@ -88,7 +112,7 @@ where
     }
 
     /// Merge an open branch overlay back into its parent as one mergeable squash.
-    pub fn merge_back_branch(&mut self, branch_id: BranchId) -> Result<TxId, Error>
+    pub fn merge_back_branch(&mut self, branch_id: BranchId) -> Result<BranchMergeOutcome, Error>
     where
         S: ReopenableStorage,
     {
@@ -100,6 +124,10 @@ where
             .ok_or(Error::BranchNotFound(branch_id))?;
         if branch.state != codec::BranchState::Open {
             return Err(Error::BranchClosed(branch_id));
+        }
+
+        if let Some(reservation) = self.branches.pending_merge_backs.get(&branch_id).cloned() {
+            return self.ingest_reserved_merge_back(branch_id, reservation);
         }
 
         let mut versions = Vec::new();
@@ -152,12 +180,7 @@ where
                 "merge-back requires at least one branch overlay write",
             ));
         }
-        let tx_id = self.commit_merge_back_squash(branch_id, versions)?;
-        let mut record = branch;
-        record.state = codec::BranchState::Merged;
-        self.persist_branch_record(&record)?;
-        self.branches.branches.insert(branch_id, record);
-        Ok(tx_id)
+        self.commit_merge_back_squash(branch_id, versions)
     }
 
     /// Branch-scoped exclusives are intentionally not implemented in v1.
@@ -638,7 +661,12 @@ where
 
     fn ensure_branch_open(&self, branch_id: BranchId) -> Result<(), Error> {
         match self.branches.branches.get(&branch_id) {
-            Some(record) if record.state == codec::BranchState::Open => Ok(()),
+            Some(record)
+                if record.state == codec::BranchState::Open
+                    && !self.branches.pending_merge_backs.contains_key(&branch_id) =>
+            {
+                Ok(())
+            }
             Some(_) => Err(Error::BranchClosed(branch_id)),
             None => Err(Error::BranchNotFound(branch_id)),
         }
@@ -648,10 +676,18 @@ where
         &mut self,
         branch_id: BranchId,
         versions: Vec<VersionRecord>,
-    ) -> Result<TxId, Error>
+    ) -> Result<BranchMergeOutcome, Error>
     where
         S: ReopenableStorage,
     {
+        // The overlay tip is private to the branch, so it may not have passed
+        // through the ordinary public ingest path that advances this node's
+        // HLC. The squash nevertheless names every derived frontier member as
+        // a causal parent, so observe the complete frontier before minting a
+        // child transaction (INV-TX-6).
+        for parent in versions.iter().flat_map(|version| version.parents()) {
+            self.merge_tx_time(parent.time);
+        }
         let made_at = self.mint_tx_time(0);
         let tx_id = TxId::new(made_at, self.node_uuid);
         let tx = Transaction {
@@ -670,8 +706,197 @@ where
             source_branch: Some(branch_id),
             merge_strategy: None,
         };
-        self.ingest_edge_authority_mergeable_commit_unit(tx, versions, made_at.physical_ms())?;
-        Ok(tx_id)
+        let reservation = PendingBranchMerge { tx, versions };
+        self.persist_merge_back_reservation(branch_id, &reservation)?;
+        self.ingest_reserved_merge_back(branch_id, reservation)
+    }
+
+    fn ingest_reserved_merge_back(
+        &mut self,
+        branch_id: BranchId,
+        reservation: PendingBranchMerge,
+    ) -> Result<BranchMergeOutcome, Error>
+    where
+        S: ReopenableStorage,
+    {
+        let tx_id = reservation.tx.tx_id;
+        self.merge_tx_time(tx_id.time);
+        let mut trusted = reservation.clone();
+        trusted.versions.sort();
+        self.parking
+            .trusted_branch_merge_backs
+            .insert(tx_id, trusted);
+        let updates = self.ingest_edge_authority_mergeable_commit_unit(
+            reservation.tx,
+            reservation.versions,
+            tx_id.time.physical_ms(),
+        )?;
+        let fate = updates.into_iter().find_map(|update| match update {
+            SyncMessage::FateUpdate {
+                tx_id: updated_tx_id,
+                fate,
+                ..
+            } if updated_tx_id == tx_id => Some(fate),
+            _ => None,
+        });
+        match fate {
+            Some(Fate::Accepted) => {
+                self.settle_reserved_branch_merge(branch_id, tx_id, &Fate::Accepted)?;
+                Ok(BranchMergeOutcome::Accepted { tx_id })
+            }
+            Some(Fate::Rejected(reason)) => {
+                self.settle_reserved_branch_merge(
+                    branch_id,
+                    tx_id,
+                    &Fate::Rejected(reason.clone()),
+                )?;
+                Ok(BranchMergeOutcome::Rejected { tx_id, reason })
+            }
+            Some(Fate::Pending) | None => Ok(BranchMergeOutcome::Pending { tx_id }),
+        }
+    }
+
+    pub(super) fn settle_reserved_branch_merge(
+        &mut self,
+        branch_id: BranchId,
+        tx_id: TxId,
+        fate: &Fate,
+    ) -> Result<(), Error> {
+        if self
+            .branches
+            .pending_merge_backs
+            .get(&branch_id)
+            .map(|reservation| reservation.tx.tx_id)
+            != Some(tx_id)
+        {
+            return Ok(());
+        }
+        if !matches!(fate, Fate::Accepted | Fate::Rejected(_)) {
+            return Ok(());
+        }
+        let Some(mut record) = self.branches.branches.get(&branch_id).cloned() else {
+            return Ok(());
+        };
+        if matches!(fate, Fate::Accepted) && record.state == codec::BranchState::Open {
+            record.state = codec::BranchState::Merged;
+            self.persist_branch_record(&record)?;
+            self.branches.branches.insert(branch_id, record);
+        }
+        self.parking.trusted_branch_merge_backs.remove(&tx_id);
+        self.clear_merge_back_reservation(branch_id)?;
+        Ok(())
+    }
+
+    pub(super) fn durable_reserved_commit_unit_matches(
+        &mut self,
+        reservation: &PendingBranchMerge,
+        fate: &Fate,
+    ) -> Result<bool, Error> {
+        let tx_id = reservation.tx.tx_id;
+        let Some(stored) = self.query_transaction(tx_id)? else {
+            return Ok(false);
+        };
+        if stored.tx != reservation.tx {
+            return Ok(false);
+        }
+        if matches!(fate, Fate::Rejected(_)) {
+            // Rejection contributes no normal versions and may happen before
+            // versions enter history. Rejected-version retry storage is
+            // intentionally lossy, so the exact durable Transaction envelope
+            // is the available proof; unlike Accepted, this path never closes
+            // the branch or makes the reserved row effects visible.
+            return Ok(true);
+        }
+        let mut stored_versions = self
+            .query_versions_for_tx(tx_id)?
+            .into_iter()
+            .map(|stored| self.version_record_from_row(&stored))
+            .collect::<Result<Vec<_>, Error>>()?;
+        let mut reserved_versions = reservation.versions.clone();
+        stored_versions.sort();
+        reserved_versions.sort();
+        Ok(stored_versions == reserved_versions)
+    }
+
+    pub(super) fn rewrite_trusted_merge_reservation(
+        &mut self,
+        tx: &Transaction,
+        versions: Vec<VersionRecord>,
+    ) -> Result<(), Error> {
+        let Some(branch_id) = tx.source_branch else {
+            return Ok(());
+        };
+        if !self
+            .parking
+            .trusted_branch_merge_backs
+            .contains_key(&tx.tx_id)
+            || self
+                .branches
+                .pending_merge_backs
+                .get(&branch_id)
+                .map(|reservation| reservation.tx.tx_id)
+                != Some(tx.tx_id)
+        {
+            return Ok(());
+        }
+        let mut canonical = PendingBranchMerge {
+            tx: tx.clone(),
+            versions,
+        };
+        canonical.versions.sort();
+        self.persist_merge_back_reservation(branch_id, &canonical)?;
+        self.parking
+            .trusted_branch_merge_backs
+            .insert(tx.tx_id, canonical);
+        Ok(())
+    }
+
+    pub(super) fn validate_trusted_merge_input(
+        &self,
+        tx: &Transaction,
+        versions: &[VersionRecord],
+    ) -> Result<(), Error> {
+        let Some(trusted) = self.parking.trusted_branch_merge_backs.get(&tx.tx_id) else {
+            return Ok(());
+        };
+        if trusted.tx != *tx || trusted.versions != versions {
+            return Err(Error::ConflictingCommitUnit(tx.tx_id));
+        }
+        Ok(())
+    }
+
+    pub(super) fn persist_merge_back_reservation(
+        &mut self,
+        branch_id: BranchId,
+        reservation: &PendingBranchMerge,
+    ) -> Result<(), Error> {
+        if commit_unit_limit_violation(&reservation.tx, &reservation.versions, None).is_some() {
+            return Err(Error::UnsupportedCommitUnit(
+                "branch merge-back exceeds commit-unit limits",
+            ));
+        }
+        let encoded = postcard::to_allocvec(reservation)
+            .map_err(|_| Error::InvalidStoredValue("branch merge reservation must encode"))?;
+        if encoded.len() > MAX_COMMIT_UNIT_BYTES {
+            return Err(Error::UnsupportedCommitUnit(
+                "branch merge-back reservation exceeds encoded-size limit",
+            ));
+        }
+        self.database
+            .direct_record_store(BRANCH_MERGE_RESERVATIONS_STORE)?
+            .set(&[Value::Uuid(branch_id.0)], &[Value::Bytes(encoded)])?;
+        self.branches
+            .pending_merge_backs
+            .insert(branch_id, reservation.clone());
+        Ok(())
+    }
+
+    fn clear_merge_back_reservation(&mut self, branch_id: BranchId) -> Result<(), Error> {
+        self.database
+            .direct_record_store(BRANCH_MERGE_RESERVATIONS_STORE)?
+            .delete(&[Value::Uuid(branch_id.0)])?;
+        self.branches.pending_merge_backs.remove(&branch_id);
+        Ok(())
     }
 
     fn persist_branch_record(&mut self, record: &BranchRecord) -> Result<(), Error> {

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -529,6 +529,8 @@ where
         ingest_context: Option<CommitUnitIngestContext>,
         encoded_len: Option<usize>,
     ) -> Result<Vec<SyncMessage>, Error> {
+        let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         if let Some(reason) = commit_unit_limit_violation(&tx, &versions, encoded_len) {
             let fate = Fate::Rejected(RejectionReason::MalformedCommit(reason));
             self.ingest_rejected_transaction(tx.clone(), fate.clone())?;
@@ -692,6 +694,7 @@ where
         now_ms: u64,
     ) -> Result<Vec<SyncMessage>, Error> {
         let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         let mut memo = IngestMemo::default();
         if tx.kind != TxKind::Mergeable {
             return Err(Error::UnsupportedCommitUnit(
@@ -880,6 +883,7 @@ where
             return Err(Error::UnsupportedCommitUnit("unsupported commit unit kind"));
         }
         let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         if let Some(existing) = self.query_transaction(tx.tx_id)? {
             let mut existing_versions = self
                 .query_versions_for_tx(tx.tx_id)?
@@ -938,6 +942,7 @@ where
         ingest_context: Option<CommitUnitIngestContext>,
     ) -> Result<Vec<SyncMessage>, Error> {
         let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         let mut memo = IngestMemo::default();
         if !commit_unit_write_count_matches(&tx, versions.len()) {
             let fate = Fate::Rejected(RejectionReason::MalformedCommit(
@@ -1131,6 +1136,7 @@ where
         ingest_context: Option<CommitUnitIngestContext>,
     ) -> Result<Vec<SyncMessage>, Error> {
         let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         let mut memo = IngestMemo::default();
         if tx.kind != TxKind::Mergeable {
             return Err(Error::UnsupportedCommitUnit(
@@ -1306,6 +1312,7 @@ where
         );
         self.merge_tx_time(tx.tx_id.time);
         let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         if let Some(existing) = self.query_transaction(tx.tx_id)? {
             let mut existing_versions = self
                 .query_versions_for_tx(tx.tx_id)?
@@ -1359,6 +1366,7 @@ where
         );
         self.merge_tx_time(tx.tx_id.time);
         let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         if self.query_transaction(tx.tx_id)?.is_some() {
             return self.ingest_known_transaction(tx, versions, fate, global_seq, durability);
         }
@@ -2263,10 +2271,14 @@ where
                 let Some(unit) = self.parking.parked_commit_units.remove(&tx_id) else {
                     continue;
                 };
+                let source_branch = unit.tx.source_branch;
+                let trusted_branch_merge =
+                    self.parking.trusted_branch_merge_backs.contains_key(&tx_id);
                 self.sync_metrics.parked_orphans_resolved += 1;
                 if self.parking.parked_catalogue_commit_units.remove(&tx_id) {
                     self.sync_metrics.parked_catalogue_orphans_resolved += 1;
                 }
+                let first_update = updates.len();
                 if unit.edge_accepted_mergeable {
                     updates.extend(self.finalize_edge_accepted_mergeable_commit_unit_once(
                         unit.tx,
@@ -2287,6 +2299,23 @@ where
                         unit.now_ms,
                         unit.ingest_context,
                     )?);
+                }
+                self.parking.trusted_branch_merge_backs.remove(&tx_id);
+                if trusted_branch_merge
+                    && let Some(branch_id) = source_branch
+                    && let Some(fate) =
+                        updates[first_update..]
+                            .iter()
+                            .find_map(|update| match update {
+                                SyncMessage::FateUpdate {
+                                    tx_id: updated_tx_id,
+                                    fate,
+                                    ..
+                                } if *updated_tx_id == tx_id => Some(fate),
+                                _ => None,
+                            })
+                {
+                    self.settle_reserved_branch_merge(branch_id, tx_id, fate)?;
                 }
             }
         }
@@ -4380,6 +4409,8 @@ where
         durability: DurabilityTier,
         update_current_indexes: bool,
     ) -> Result<(), Error> {
+        let versions = canonical_versions(versions);
+        self.validate_trusted_merge_input(&tx, &versions)?;
         self.merge_tx_time(tx.tx_id.time);
         let tx_node_alias = self.ensure_node_alias(tx.tx_id.node)?;
         let tx_already_known = self.query_transaction(tx.tx_id)?.is_some();
@@ -4575,6 +4606,11 @@ where
         } else if matches!(fate, Fate::Pending) {
             self.record_child_edges(tx.tx_id, parent_edges);
         }
+        let canonical_versions = stored_versions
+            .iter()
+            .map(|stored| self.version_record_from_row(stored))
+            .collect::<Result<Vec<_>, Error>>()?;
+        self.rewrite_trusted_merge_reservation(&tx, canonical_versions)?;
         self.cache_tx_versions(tx.tx_id, stored_versions);
         Ok(())
     }

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -36,12 +36,15 @@ use crate::protocol::{
     SubscriptionKey, SyncMessage, VersionBundle, VersionCarrier, VersionRecord, ViewFactEntry,
     expand_version_carriers,
 };
-use crate::protocol_limits::MAX_CONTENT_EXTENT_BYTES;
+use crate::protocol_limits::{
+    MAX_COMMIT_UNIT_BYTES, MAX_CONTENT_EXTENT_BYTES, commit_unit_limit_violation,
+};
 use crate::query::{Binding, BindingId, QueryError, ShapeId, ValidatedQuery};
 use crate::schema::{
-    CLEAN_CLOSE_MARKERS_STORE, ColumnSchema, JazzSchema, KNOWN_STATE_FACTS_STORE, LargeValueKind,
-    MergeStrategy, SETTLED_PROGRAM_FACTS_STORE, SETTLED_RESULT_MEMBERS_STORE,
-    STORAGE_CONSISTENCY_MARKERS_STORE, TableSchema, registered_column_transform,
+    BRANCH_MERGE_RESERVATIONS_STORE, CLEAN_CLOSE_MARKERS_STORE, ColumnSchema, JazzSchema,
+    KNOWN_STATE_FACTS_STORE, LargeValueKind, MergeStrategy, SETTLED_PROGRAM_FACTS_STORE,
+    SETTLED_RESULT_MEMBERS_STORE, STORAGE_CONSISTENCY_MARKERS_STORE, TableSchema,
+    registered_column_transform,
 };
 use crate::text_merge::{Run as PlainTextRun, TextOp as PlainTextOp};
 use crate::time::{GlobalSeq, TxTime};
@@ -83,7 +86,7 @@ pub(crate) use views::MaintainedViewBundleInputs;
 
 type ResultRowMembershipKey = crate::tools::OutputOccurrenceId;
 
-use branches::BranchRecord;
+pub use branches::{BranchMergeOutcome, BranchRecord};
 use codec::*;
 use content_store::ContentStore;
 use open_tx::*;
@@ -272,6 +275,14 @@ struct Branches {
     branches: BTreeMap<BranchId, BranchRecord>,
     /// Storage partitions materialized for table/schema-version/branch triples.
     branch_partitions: BTreeSet<(String, SchemaVersionId, BranchId)>,
+    /// Locally minted merge-back identity reserved per open branch.
+    pending_merge_backs: BTreeMap<BranchId, PendingBranchMerge>,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+struct PendingBranchMerge {
+    tx: Transaction,
+    versions: Vec<VersionRecord>,
 }
 
 /// Local transaction clock and settled-global application progress.
@@ -296,6 +307,8 @@ struct Parking {
     parked_binding_deltas: BTreeMap<ShapeId, Vec<Subscribe>>,
     /// Commit units waiting for parent transactions or schema context.
     parked_commit_units: BTreeMap<TxId, ParkedCommitUnit>,
+    /// Parked units created by the local reserved branch merge-back path.
+    trusted_branch_merge_backs: BTreeMap<TxId, PendingBranchMerge>,
     /// Catalogue commit units waiting to be applied in dependency order.
     parked_catalogue_commit_units: BTreeSet<TxId>,
 }
@@ -590,6 +603,7 @@ where
             branches: Branches {
                 branches: BTreeMap::new(),
                 branch_partitions,
+                pending_merge_backs: BTreeMap::new(),
             },
             clock: Clock {
                 tx_time: TxTime::default(),

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -83,7 +83,6 @@ where
         for raw in branch_records {
             self.recover_branch_record(BorrowedRecord::new(&raw, &branch_descriptor))?;
         }
-
         let alias_to_node = self
             .node_aliases
             .iter()
@@ -219,8 +218,81 @@ where
                 .rejected_transactions
                 .insert(tx_id, RejectedTransaction::new(tx_id, record, versions));
         }
+        self.recover_branch_merge_reservations()?;
         if !cleanly_closed {
             self.cleanup_settled_ahead_current_leftovers(storage_consistent_through)?;
+        }
+        Ok(())
+    }
+
+    fn recover_branch_merge_reservations(&mut self) -> Result<(), Error> {
+        let reservations = self
+            .database
+            .direct_record_store(BRANCH_MERGE_RESERVATIONS_STORE)?
+            .prefix_entries(&[])?
+            .into_iter()
+            .map(|entry| {
+                let branch_id = match entry.key.as_slice() {
+                    [Value::Uuid(id)] => BranchId(*id),
+                    _ => {
+                        return Err(Error::InvalidStoredValue(
+                            "branch merge reservation key must be branch uuid",
+                        ));
+                    }
+                };
+                let encoded = match entry.value.get_idx(0)? {
+                    Value::Bytes(encoded) => encoded,
+                    _ => {
+                        return Err(Error::InvalidStoredValue(
+                            "branch merge reservation must contain commit-unit bytes",
+                        ));
+                    }
+                };
+                if encoded.len() > MAX_COMMIT_UNIT_BYTES {
+                    return Err(Error::InvalidStoredValue(
+                        "branch merge reservation exceeds encoded-size limit",
+                    ));
+                }
+                let reservation =
+                    postcard::from_bytes::<PendingBranchMerge>(&encoded).map_err(|_| {
+                        Error::InvalidStoredValue("branch merge reservation must decode")
+                    })?;
+                if commit_unit_limit_violation(&reservation.tx, &reservation.versions, None)
+                    .is_some()
+                {
+                    return Err(Error::InvalidStoredValue(
+                        "branch merge reservation exceeds commit-unit limits",
+                    ));
+                }
+                Ok((branch_id, reservation))
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+        for (branch_id, reservation) in reservations {
+            if !self
+                .branches
+                .branches
+                .get(&branch_id)
+                .is_some_and(|branch| branch.state == codec::BranchState::Open)
+            {
+                self.database
+                    .direct_record_store(BRANCH_MERGE_RESERVATIONS_STORE)?
+                    .delete(&[Value::Uuid(branch_id.0)])?;
+                continue;
+            }
+            let tx_id = reservation.tx.tx_id;
+            self.merge_tx_time(tx_id.time);
+            self.branches
+                .pending_merge_backs
+                .insert(branch_id, reservation.clone());
+            let Some(fate) = self.query_transaction(tx_id)?.map(|stored| stored.fate) else {
+                continue;
+            };
+            if matches!(fate, Fate::Accepted | Fate::Rejected(_)) {
+                if !self.durable_reserved_commit_unit_matches(&reservation, &fate)? {
+                    return Err(Error::ConflictingCommitUnit(tx_id));
+                }
+                self.settle_reserved_branch_merge(branch_id, tx_id, &fate)?;
+            }
         }
         Ok(())
     }

--- a/crates/jazz/src/node/tests/branching.rs
+++ b/crates/jazz/src/node/tests/branching.rs
@@ -715,7 +715,11 @@ fn merge_back_branch_squashes_net_overlay_into_parent_and_closes_branch() {
         )
         .unwrap();
 
-    let squash = core.merge_back_branch(branch_id).unwrap();
+    let BranchMergeOutcome::Accepted { tx_id: squash } =
+        core.merge_back_branch(branch_id).unwrap()
+    else {
+        panic!("merge-back must be accepted");
+    };
     assert_eq!(
         core.branch_record(branch_id).unwrap().state,
         codec::BranchState::Merged
@@ -765,6 +769,715 @@ fn merge_back_branch_squashes_net_overlay_into_parent_and_closes_branch() {
         reopened.transaction_record(squash).unwrap().source_branch,
         Some(branch_id)
     );
+}
+
+/// A merge-back squash observes its private branch frontier before minting its
+/// public child transaction, so authority admission accepts it and persists its
+/// versions even if the local HLC register is stale.
+///
+/// Actors: `alice` owns the branch and performs the merge-back; the authority
+/// is the same node in this v1 node-layer test.
+///
+/// ```text
+/// alice branch tip (t=100) ──private parent──► squash (must be > t=100)
+///                     │
+///                  stale local HLC (t=0)
+/// ```
+///
+/// This is intentionally a node-layer regression rather than a `Db` test:
+/// the public facade has no branch mutation API or HLC fault injector yet
+/// (SPEC/11 open question, binding-facing branch facade). All branch writes
+/// and merge-back use the public `NodeState` branch API; only the stale-clock
+/// fault is injected directly.
+#[test]
+fn merge_back_observes_private_frontier_before_minting_squash() {
+    let (_dir, mut core) = open_history_complete_node_with_schema(node(0x71), schema());
+    let branch_id = branch(0x71);
+    core.create_branch(branch_id).unwrap();
+    let branch_tip = core
+        .commit_mergeable_on_branch(
+            branch_id,
+            MergeableCommit::new("todos", row(0x71), 100).cells(title_cells("branch value")),
+        )
+        .unwrap();
+
+    // Simulate a stale HLC register after the private overlay was recovered by
+    // a path that did not observe its frontier. The regression is the public
+    // merge-back behavior, not a claim that normal recovery should do this.
+    core.clock.tx_time = TxTime::default();
+
+    let BranchMergeOutcome::Accepted { tx_id: squash } =
+        core.merge_back_branch(branch_id).unwrap()
+    else {
+        panic!("merge-back must be accepted");
+    };
+    let stored = core.transaction_record(squash).unwrap();
+    assert_eq!(stored.fate, Fate::Accepted);
+    assert!(
+        squash.time > branch_tip.time,
+        "INV-TX-6: squash must be strictly newer than its private parent"
+    );
+    assert_eq!(core.query_versions_for_tx(squash).unwrap().len(), 1);
+    assert_eq!(
+        core.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Merged
+    );
+
+    // Planted positive: remove the `merge_tx_time(parent.time)` loop in
+    // `commit_merge_back_squash`. The mint below then uses t=0 and admission
+    // rejects the squash as a CausalityViolation before storing any versions.
+}
+
+/// A rejected merge-back fate keeps the branch open, so `alice` can repair its
+/// branch inputs and retry instead of losing the overlay to a false `Merged`
+/// lifecycle transition.
+///
+/// Actors: `alice` owns the private branch tip; the authority has already
+/// rejected that tip, so its public squash must cascade-reject.
+///
+/// ```text
+/// rejected private tip ──parent──► squash ──cascade reject──► branch stays Open
+/// ```
+///
+/// This stays at the node layer because no stable public branch facade exists;
+/// `apply_fate_update` is the public authority-fate API used to inject the
+/// otherwise unreachable rejected-private-parent condition.
+#[test]
+fn rejected_merge_back_fate_does_not_close_the_branch() {
+    let (_dir, mut core) = open_history_complete_node_with_schema(node(0x72), schema());
+    let branch_id = branch(0x72);
+    core.create_branch(branch_id).unwrap();
+    let branch_tip = core
+        .commit_mergeable_on_branch(
+            branch_id,
+            MergeableCommit::new("todos", row(0x72), 100).cells(title_cells("branch value")),
+        )
+        .unwrap();
+    core.apply_fate_update(
+        branch_tip,
+        Fate::Rejected(RejectionReason::CausalityViolation),
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert!(matches!(
+        core.merge_back_branch(branch_id),
+        Ok(BranchMergeOutcome::Rejected {
+            reason: RejectionReason::Cascade { root },
+            ..
+        }) if root == branch_tip
+    ));
+    assert_eq!(
+        core.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Open,
+        "a rejected squash must leave the overlay retryable"
+    );
+    assert!(!core.branches.pending_merge_backs.contains_key(&branch_id));
+
+    // Planted positive: restore the old unconditional `Ok(tx_id)` return from
+    // `commit_merge_back_squash`. This merge call then succeeds and the outer
+    // lifecycle transition incorrectly marks the branch Merged.
+}
+
+/// A merge-back parked for a missing private prerequisite remains one logical
+/// squash across retries and closes the branch only when canonical ingest later
+/// accepts that same squash.
+///
+/// Actors: `alice` owns the branch; the local edge authority temporarily lacks
+/// the branch-tip transaction metadata.
+///
+/// ```text
+/// missing branch tip ──► parked squash ──retry──► same parked squash
+/// restored branch tip ──► drain/accept ──► exactly one public squash + Merged
+/// ```
+///
+/// There is no public fault injector for selectively losing transaction
+/// metadata, so the test removes and restores only that durable prerequisite;
+/// merge-back and retry themselves use the public branch API.
+#[test]
+fn parked_merge_back_retry_does_not_mint_a_second_squash() {
+    let (dir, mut core) = open_history_complete_node_with_schema(node(0x73), schema());
+    let branch_id = branch(0x73);
+    core.create_branch(branch_id).unwrap();
+    let branch_tip = core
+        .commit_mergeable_on_branch(
+            branch_id,
+            MergeableCommit::new("todos", row(0x73), 100).cells(title_cells("branch value")),
+        )
+        .unwrap();
+    let stored_tip = core.query_transaction(branch_tip).unwrap().unwrap();
+    let mut batch = core.database.open_batch();
+    batch.delete(
+        "jazz_transactions",
+        groove::db::PrimaryKeyValue::Composite(vec![
+            groove::db::PrimaryKeyValue::U64(branch_tip.time.0),
+            groove::db::PrimaryKeyValue::U64(stored_tip.node_alias.0),
+        ]),
+    );
+    core.database.commit_batch(batch).unwrap();
+
+    let pending_tx = match core.merge_back_branch(branch_id).unwrap() {
+        BranchMergeOutcome::Pending { tx_id } => tx_id,
+        outcome => panic!("expected pending merge-back, got {outcome:?}"),
+    };
+    let parked = core
+        .parking
+        .parked_commit_units
+        .values()
+        .filter(|unit| unit.tx.source_branch == Some(branch_id))
+        .map(|unit| unit.tx.tx_id)
+        .collect::<Vec<_>>();
+    assert_eq!(parked.len(), 1);
+    assert_eq!(parked[0], pending_tx);
+    let trusted_before = core
+        .branches
+        .pending_merge_backs
+        .get(&branch_id)
+        .cloned()
+        .unwrap();
+    let forged_tx = trusted_before.tx.clone();
+    let forged_versions = vec![version_record(
+        row(0x7e),
+        Vec::new(),
+        title_cells("forged satisfiable squash"),
+        None,
+    )];
+    assert!(matches!(
+        core.ingest_edge_authority_mergeable_commit_unit(
+            forged_tx.clone(),
+            forged_versions.clone(),
+            pending_tx.time.physical_ms(),
+        ),
+        Err(Error::ConflictingCommitUnit(tx_id)) if tx_id == pending_tx
+    ));
+    assert!(matches!(
+        core.ingest_commit_unit(
+            forged_tx.clone(),
+            forged_versions.clone(),
+            pending_tx.time.physical_ms(),
+        ),
+        Err(Error::ConflictingCommitUnit(tx_id)) if tx_id == pending_tx
+    ));
+    assert!(matches!(
+        core.ingest_relay_commit_unit(forged_tx, forged_versions),
+        Err(Error::ConflictingCommitUnit(tx_id)) if tx_id == pending_tx
+    ));
+    assert_eq!(
+        core.branches.pending_merge_backs.get(&branch_id),
+        Some(&trusted_before),
+        "forged same-TxId input must not rewrite the durable reservation"
+    );
+    assert_eq!(
+        core.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Open
+    );
+    assert_eq!(core.parking.parked_commit_units.len(), 1);
+    assert!(matches!(
+        core.commit_mergeable_on_branch(
+            branch_id,
+            MergeableCommit::new("todos", row(0x77), 101).cells(title_cells("late write")),
+        ),
+        Err(Error::BranchClosed(id)) if id == branch_id
+    ));
+    assert!(matches!(
+        core.discard_branch(branch_id),
+        Err(Error::BranchClosed(id)) if id == branch_id
+    ));
+    assert_eq!(
+        core.merge_back_branch(branch_id).unwrap(),
+        BranchMergeOutcome::Pending { tx_id: pending_tx }
+    );
+    assert_eq!(
+        core.parking
+            .parked_commit_units
+            .values()
+            .filter(|unit| unit.tx.source_branch == Some(branch_id))
+            .count(),
+        1,
+        "retry must reuse the one parked merge-back rather than minting another"
+    );
+
+    drop(core);
+    let mut core = reopen_node_at(&dir, node(0x73), schema());
+    assert_eq!(
+        core.branches
+            .pending_merge_backs
+            .get(&branch_id)
+            .map(|reservation| reservation.tx.tx_id),
+        Some(pending_tx),
+        "the trusted squash reservation must survive reopen"
+    );
+    assert!(core.parking.parked_commit_units.is_empty());
+    assert_eq!(
+        core.merge_back_branch(branch_id).unwrap(),
+        BranchMergeOutcome::Pending { tx_id: pending_tx },
+        "reopen must reconstruct and park the exact reserved squash"
+    );
+
+    let mut batch = core.database.open_batch();
+    batch.update(
+        "jazz_transactions",
+        transaction_values(
+            stored_tip.node_alias,
+            &stored_tip.tx,
+            stored_tip.fate,
+            stored_tip.global_seq,
+            stored_tip.durability,
+        ),
+    );
+    core.database.commit_batch(batch).unwrap();
+    let updates = core.drain_parked_commit_units().unwrap();
+    assert!(updates.iter().any(|update| matches!(
+        update,
+        SyncMessage::FateUpdate { tx_id, fate: Fate::Accepted, .. } if *tx_id == parked[0]
+    )));
+    assert_eq!(
+        core.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Merged
+    );
+    assert_eq!(core.query_versions_for_tx(parked[0]).unwrap().len(), 1);
+    assert_eq!(
+        core.parking
+            .parked_commit_units
+            .values()
+            .filter(|unit| unit.tx.source_branch == Some(branch_id))
+            .count(),
+        0
+    );
+
+    // Planted positives: remove the parked-unit guard to observe two squashes;
+    // remove drain-time lifecycle settlement to leave the branch falsely Open.
+}
+
+#[test]
+fn reopen_reconciles_accepted_reserved_merge_before_branch_settlement() {
+    let (dir, mut core) = open_history_complete_node_with_schema(node(0x78), schema());
+    let branch_id = branch(0x78);
+    let (branch_tip, stored_tip, pending_tx) =
+        park_merge_back_with_missing_tip(&mut core, branch_id, row(0x78));
+    restore_transaction(&mut core, &stored_tip);
+
+    let reservation = core
+        .branches
+        .pending_merge_backs
+        .get(&branch_id)
+        .cloned()
+        .unwrap();
+    core.parking.parked_commit_units.remove(&pending_tx);
+    core.parking.trusted_branch_merge_backs.remove(&pending_tx);
+    let updates = core
+        .ingest_edge_authority_mergeable_commit_unit(
+            reservation.tx,
+            reservation.versions,
+            pending_tx.time.physical_ms(),
+        )
+        .unwrap();
+    assert!(updates.iter().any(|update| matches!(
+        update,
+        SyncMessage::FateUpdate { tx_id, fate: Fate::Accepted, .. } if *tx_id == pending_tx
+    )));
+    assert_eq!(
+        core.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Open,
+        "fixture must stop in the accepted-before-lifecycle crash window"
+    );
+    assert!(core.branches.pending_merge_backs.contains_key(&branch_id));
+    assert_eq!(core.transaction_record(branch_tip).unwrap().tx_id, branch_tip);
+
+    drop(core);
+    let reopened = reopen_node_at(&dir, node(0x78), schema());
+    assert_eq!(
+        reopened.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Merged
+    );
+    assert!(!reopened.branches.pending_merge_backs.contains_key(&branch_id));
+
+    // Planted positive: skip durable fate reconciliation during recovery; the
+    // branch incorrectly reopens as Open with an accepted reserved squash.
+}
+
+#[test]
+fn translated_reserved_merge_reopens_against_canonical_admitted_payload() {
+    let (dir, mut core) = open_history_complete_node_with_schema(node(0x7d), schema());
+    let branch_id = branch(0x7d);
+    let (_branch_tip, stored_tip, pending_tx) =
+        park_merge_back_with_missing_tip(&mut core, branch_id, row(0x7d));
+    let original_schema = schema();
+    let evolved = catalogue_evolved_schema();
+    let evolved_payload = SchemaVersion::new(evolved.clone());
+    core.apply_sync_message(SyncMessage::PublishSchema {
+        author: AuthorId::SYSTEM,
+        schema: Box::new(evolved_payload.clone()),
+    })
+    .unwrap();
+    core.apply_sync_message(SyncMessage::PublishLens {
+        author: AuthorId::SYSTEM,
+        lens: MigrationLens::new(
+            original_schema.version_id(),
+            evolved_payload.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "body".to_owned(),
+                    default: Value::String(String::new()),
+                }],
+            }],
+        ),
+    })
+    .unwrap();
+    core.apply_sync_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved_payload.id,
+        },
+    })
+    .unwrap();
+    restore_transaction(&mut core, &stored_tip);
+
+    let reserved_a = core
+        .branches
+        .pending_merge_backs
+        .get(&branch_id)
+        .cloned()
+        .unwrap();
+    assert!(reserved_a
+        .versions
+        .iter()
+        .all(|version| version.schema_version() == original_schema.version_id()));
+    core.parking.parked_commit_units.remove(&pending_tx);
+    core.parking
+        .trusted_branch_merge_backs
+        .insert(pending_tx, reserved_a.clone());
+    let updates = core
+        .ingest_edge_authority_mergeable_commit_unit(
+            reserved_a.tx,
+            reserved_a.versions,
+            pending_tx.time.physical_ms(),
+        )
+        .unwrap();
+    assert!(updates.iter().any(|update| matches!(
+        update,
+        SyncMessage::FateUpdate { tx_id, fate: Fate::Accepted, .. } if *tx_id == pending_tx
+    )));
+    let reserved_b = core
+        .branches
+        .pending_merge_backs
+        .get(&branch_id)
+        .unwrap();
+    assert!(reserved_b
+        .versions
+        .iter()
+        .all(|version| version.schema_version() == evolved_payload.id));
+    assert_eq!(
+        core.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Open,
+        "fixture stops after canonical acceptance but before lifecycle settlement"
+    );
+
+    drop(core);
+    let reopened = reopen_node_at(&dir, node(0x7d), original_schema);
+    assert_eq!(
+        reopened.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Merged
+    );
+    assert!(!reopened.branches.pending_merge_backs.contains_key(&branch_id));
+
+    // Planted positive: skip `rewrite_trusted_merge_reservation`; recovery then
+    // compares the admitted B history to stale reserved A and fails conflict.
+}
+
+#[test]
+fn reopen_reconciles_rejected_reserved_merge_before_reservation_clear() {
+    let (dir, mut core) = open_history_complete_node_with_schema(node(0x79), schema());
+    let branch_id = branch(0x79);
+    let (branch_tip, stored_tip, pending_tx) =
+        park_merge_back_with_missing_tip(&mut core, branch_id, row(0x79));
+    restore_transaction(&mut core, &stored_tip);
+    core.apply_fate_update(
+        branch_tip,
+        Fate::Rejected(RejectionReason::CausalityViolation),
+        None,
+        None,
+    )
+    .unwrap();
+
+    let reservation = core
+        .branches
+        .pending_merge_backs
+        .get(&branch_id)
+        .cloned()
+        .unwrap();
+    core.parking.parked_commit_units.remove(&pending_tx);
+    core.parking.trusted_branch_merge_backs.remove(&pending_tx);
+    let updates = core
+        .ingest_edge_authority_mergeable_commit_unit(
+            reservation.tx,
+            reservation.versions,
+            pending_tx.time.physical_ms(),
+        )
+        .unwrap();
+    assert!(updates.iter().any(|update| matches!(
+        update,
+        SyncMessage::FateUpdate { tx_id, fate: Fate::Rejected(_), .. } if *tx_id == pending_tx
+    )));
+    assert!(core.branches.pending_merge_backs.contains_key(&branch_id));
+
+    drop(core);
+    let mut reopened = reopen_node_at(&dir, node(0x79), schema());
+    assert_eq!(
+        reopened.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Open
+    );
+    assert!(!reopened.branches.pending_merge_backs.contains_key(&branch_id));
+    let BranchMergeOutcome::Rejected { tx_id: retry, .. } =
+        reopened.merge_back_branch(branch_id).unwrap()
+    else {
+        panic!("the reopened branch must permit a new terminal attempt");
+    };
+    assert_ne!(retry, pending_tx);
+    assert!(!reopened.branches.pending_merge_backs.contains_key(&branch_id));
+}
+
+#[test]
+fn reopen_rejects_terminal_commit_unit_mismatching_reserved_payload() {
+    let (dir, mut core) = open_history_complete_node_with_schema(node(0x7a), schema());
+    let branch_id = branch(0x7a);
+    let (_branch_tip, stored_tip, pending_tx) =
+        park_merge_back_with_missing_tip(&mut core, branch_id, row(0x7a));
+    restore_transaction(&mut core, &stored_tip);
+    let reservation = core
+        .branches
+        .pending_merge_backs
+        .get(&branch_id)
+        .cloned()
+        .unwrap();
+    core.parking.parked_commit_units.remove(&pending_tx);
+    core.parking.trusted_branch_merge_backs.remove(&pending_tx);
+    let foreign_tx = reservation.tx.clone();
+    let mut foreign_versions = reservation.versions;
+    let original = &foreign_versions[0];
+    foreign_versions[0] = version_record(
+        original.row_uuid(),
+        original.parents(),
+        title_cells("foreign collision"),
+        original.deletion(),
+    );
+    core.ingest_edge_authority_mergeable_commit_unit(
+        foreign_tx,
+        foreign_versions,
+        pending_tx.time.physical_ms(),
+    )
+    .unwrap();
+    drop(core);
+
+    let schema = schema();
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    assert!(matches!(
+        NodeState::new_history_complete(node(0x7a), schema, storage),
+        Err(Error::ConflictingCommitUnit(tx_id)) if tx_id == pending_tx
+    ));
+
+    // The deterministic open error occurs before settlement/clear; the
+    // reservation remains durable for diagnosis rather than closing the branch.
+}
+
+#[test]
+fn merge_reservation_rejects_oversized_commit_unit_before_persisting() {
+    let (_dir, mut core) = open_history_complete_node_with_schema(node(0x7b), schema());
+    let branch_id = branch(0x7b);
+    core.create_branch(branch_id).unwrap();
+    let table = core.catalogue.current_write_schema.schema;
+    let table_schema = core.table_in_schema("todos", table).unwrap();
+    let version = VersionRecord::encode(
+        &table_schema,
+        table,
+        row(0x7b),
+        Vec::new(),
+        AuthorId::SYSTEM,
+        TxTime(1),
+        AuthorId::SYSTEM,
+        TxTime(1),
+        &table_schema.columns.iter().map(|_| None).collect::<Vec<_>>(),
+        None,
+    )
+    .unwrap();
+    let tx_id = TxId::new(TxTime(2), node(0x7b));
+    let reservation = PendingBranchMerge {
+        tx: Transaction {
+            tx_id,
+            kind: TxKind::Mergeable,
+            n_total_writes: (crate::protocol_limits::MAX_COMMIT_UNIT_VERSIONS + 1) as u32,
+            made_by: AuthorId::SYSTEM,
+            permission_subject: None,
+            base_snapshot: None,
+            row_read_set: None,
+            absent_read_set: None,
+            predicate_read_set: None,
+            user_metadata_json: None,
+            source_branch: Some(branch_id),
+            merge_strategy: None,
+        },
+        versions: vec![version; crate::protocol_limits::MAX_COMMIT_UNIT_VERSIONS + 1],
+    };
+    assert!(matches!(
+        core.persist_merge_back_reservation(branch_id, &reservation),
+        Err(Error::UnsupportedCommitUnit(
+            "branch merge-back exceeds commit-unit limits"
+        ))
+    ));
+    assert!(!core.branches.pending_merge_backs.contains_key(&branch_id));
+}
+
+#[test]
+fn reopen_rejects_oversized_reservation_before_postcard_decode() {
+    let (dir, mut core) = open_history_complete_node_with_schema(node(0x7c), schema());
+    let branch_id = branch(0x7c);
+    core.create_branch(branch_id).unwrap();
+    core.database
+        .direct_record_store(BRANCH_MERGE_RESERVATIONS_STORE)
+        .unwrap()
+        .set(
+            &[Value::Uuid(branch_id.0)],
+            &[Value::Bytes(vec![0; MAX_COMMIT_UNIT_BYTES + 1])],
+        )
+        .unwrap();
+    drop(core);
+
+    let schema = schema();
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    assert!(matches!(
+        NodeState::new_history_complete(node(0x7c), schema, storage),
+        Err(Error::InvalidStoredValue(
+            "branch merge reservation exceeds encoded-size limit"
+        ))
+    ));
+}
+
+fn park_merge_back_with_missing_tip(
+    core: &mut NodeState<RocksDbStorage>,
+    branch_id: BranchId,
+    row_uuid: RowUuid,
+) -> (TxId, StoredTransaction, TxId) {
+    core.create_branch(branch_id).unwrap();
+    let branch_tip = core
+        .commit_mergeable_on_branch(
+            branch_id,
+            MergeableCommit::new("todos", row_uuid, 100).cells(title_cells("branch value")),
+        )
+        .unwrap();
+    let stored_tip = core.query_transaction(branch_tip).unwrap().unwrap();
+    let mut batch = core.database.open_batch();
+    batch.delete(
+        "jazz_transactions",
+        groove::db::PrimaryKeyValue::Composite(vec![
+            groove::db::PrimaryKeyValue::U64(branch_tip.time.0),
+            groove::db::PrimaryKeyValue::U64(stored_tip.node_alias.0),
+        ]),
+    );
+    core.database.commit_batch(batch).unwrap();
+    let BranchMergeOutcome::Pending { tx_id } = core.merge_back_branch(branch_id).unwrap() else {
+        panic!("missing tip must park merge-back");
+    };
+    (branch_tip, stored_tip, tx_id)
+}
+
+fn restore_transaction(core: &mut NodeState<RocksDbStorage>, stored: &StoredTransaction) {
+    let mut batch = core.database.open_batch();
+    batch.update(
+        "jazz_transactions",
+        transaction_values(
+            stored.node_alias,
+            &stored.tx,
+            stored.fate.clone(),
+            stored.global_seq,
+            stored.durability,
+        ),
+    );
+    core.database.commit_batch(batch).unwrap();
+}
+
+/// Peer-provided `source_branch` provenance cannot impersonate the locally
+/// reserved merge-back identity or mutate local branch lifecycle.
+///
+/// Actors: `mallory` uploads a child transaction carrying `alice`'s branch id;
+/// `alice` then performs her real local merge-back.
+///
+/// ```text
+/// mallory child(source_branch=alice) ──park/drain/accept──► branch stays Open
+/// alice locally reserved squash ─────────────────────────► branch becomes Merged
+/// ```
+#[test]
+fn foreign_source_branch_cannot_block_or_settle_local_branch() {
+    let (_core_dir, mut core) = open_history_complete_node_with_schema(node(0x74), schema());
+    let (_peer_dir, mut peer) = open_history_complete_node_with_schema(node(0x75), schema());
+    let branch_id = branch(0x74);
+    core.create_branch(branch_id).unwrap();
+    core.commit_mergeable_on_branch(
+        branch_id,
+        MergeableCommit::new("todos", row(0x74), 100).cells(title_cells("local branch")),
+    )
+    .unwrap();
+
+    let parent = peer
+        .commit_mergeable(
+            MergeableCommit::new("todos", row(0x75), 10).cells(title_cells("peer parent")),
+        )
+        .unwrap();
+    let child = peer
+        .commit_mergeable(
+            MergeableCommit::new("todos", row(0x76), 11)
+                .parents(vec![parent])
+                .cells(title_cells("peer child")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit {
+        tx: mut child_tx,
+        versions: child_versions,
+    } = peer.commit_unit_for(child).unwrap()
+    else {
+        panic!("expected child commit unit");
+    };
+    child_tx.source_branch = Some(branch_id);
+    let child_updates = core
+        .ingest_edge_authority_mergeable_commit_unit(child_tx, child_versions, 11)
+        .unwrap();
+    assert!(child_updates.is_empty());
+    assert_eq!(core.parking.parked_commit_units.len(), 1);
+
+    let SyncMessage::CommitUnit {
+        tx: parent_tx,
+        versions: parent_versions,
+    } = peer.commit_unit_for(parent).unwrap()
+    else {
+        panic!("expected parent commit unit");
+    };
+    let updates = core
+        .ingest_edge_authority_mergeable_commit_unit(parent_tx, parent_versions, 12)
+        .unwrap();
+    assert!(updates.iter().any(|update| matches!(
+        update,
+        SyncMessage::FateUpdate { tx_id, fate: Fate::Accepted, .. } if *tx_id == child
+    )));
+    assert_eq!(
+        core.branch_record(branch_id).unwrap().state,
+        codec::BranchState::Open
+    );
+    assert!(!core.branches.pending_merge_backs.contains_key(&branch_id));
+
+    assert!(matches!(
+        core.merge_back_branch(branch_id).unwrap(),
+        BranchMergeOutcome::Accepted { .. }
+    ));
+
+    // Planted positive: settle by `source_branch` without requiring the exact
+    // durable reservation; the foreign child then closes Alice's branch.
 }
 
 #[derive(Clone, Copy)]
@@ -895,7 +1608,12 @@ fn run_merge_back_oracle_seed(seed: u64, include_restore: bool) -> MergeBackOrac
         }
     }
 
-    let merge_back_tx = merged.merge_back_branch(branch_id).unwrap();
+    let BranchMergeOutcome::Accepted {
+        tx_id: merge_back_tx,
+    } = merged.merge_back_branch(branch_id).unwrap()
+    else {
+        panic!("merge-back must be accepted");
+    };
     let direct_txs = apply_direct_net_effects(&mut direct, seed, include_restore, branch_parents);
     MergeBackOracleRun {
         merged,

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -36,6 +36,8 @@ pub const KNOWN_STATE_FACTS_STORE: &str = "jazz_known_state_facts";
 pub const SETTLED_RESULT_MEMBERS_STORE: &str = "jazz_settled_result_members";
 /// Direct groove record store used for persisted settled program facts.
 pub const SETTLED_PROGRAM_FACTS_STORE: &str = "jazz_settled_program_facts";
+/// Direct groove record store for node-local branch merge-back reservations.
+pub const BRANCH_MERGE_RESERVATIONS_STORE: &str = "jazz_branch_merge_reservations";
 /// Direct groove record store used to distinguish clean shutdown from crash
 /// recovery windows for bounded startup repair.
 pub const CLEAN_CLOSE_MARKERS_STORE: &str = "jazz_clean_close_markers";
@@ -383,6 +385,11 @@ impl JazzSchema {
                     ("fact", ValueType::Bytes),
                 ]),
                 RecordDescriptor::new([("present", ValueType::U64)]),
+            ))
+            .with_direct_record_store(DirectRecordStoreSchema::new(
+                BRANCH_MERGE_RESERVATIONS_STORE,
+                RecordDescriptor::new([("branch_id", ValueType::Uuid)]),
+                RecordDescriptor::new([("commit_unit", ValueType::Bytes)]),
             ))
             .with_direct_record_store(DirectRecordStoreSchema::new(
                 CLEAN_CLOSE_MARKERS_STORE,


### PR DESCRIPTION
🤖

## Summary

- make branch merge-back return a typed `Accepted`, `Pending`, or `Rejected` outcome instead of closing the branch optimistically
- reserve the exact merge-back transaction and version payload durably, reuse it across retries and reopen, and block further branch writes/discard while it is pending
- bind settlement to the locally reserved commit unit rather than trusting peer-supplied `source_branch` provenance
- reconcile accepted and rejected reservations safely during recovery, including canonical payload rewrites after schema/lens translation
- observe the complete private/public parent frontier before minting the squash transaction and reject oversized or malformed reservations before recovery allocation

## Correctness boundary

An accepted reservation closes the branch only when the durable transaction and complete admitted version payload match the frozen local unit. A rejected reservation checks the exact durable transaction envelope, clears the reservation, and leaves the branch open. Same-TxId substitutions conflict across normal authority, relay, edge-authority, accepted-finalization, known/staged-known, and shared-staging ingress paths.

The branch spec now records these settlement, retry, recovery, translation, and provenance rules.

## Tests

Coverage includes:

- private-frontier clock observation before squash minting
- accepted, pending, rejected, retry, and reopen behavior
- accepted/rejected durable recovery asymmetry
- canonical reservation recovery after schema/lens translation
- exact commit-unit mismatch and foreign-provenance rejection across ingress routes
- reservation arity, encoded-size, and recovery decode bounds
- seeded merge-back row/deletion and strict-version oracles

An independent adversarial review exercised the provenance, translated-recovery, reopen, and bounds paths and found the final commit safe to publish.

## Out of scope

Ordinary peer sync still does not transport private branch-partition ancestors. A squash received by a peer that lacks its private branch-tip parent therefore remains parked; transport of those ancestors is separate follow-up work.
