### PR TITLE
test(jazz): repair policy graph timing receipt fixture

### DIFF
--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -1905,12 +1905,38 @@ fn policy_graph_dropdown_entry_cells(dropdown: RowUuid, idx: usize) -> BTreeMap<
             nullable(Some(Value::Bool(false))),
         ),
         ("c729".to_owned(), Value::Bool(true)),
-        ("c488".to_owned(), nullable(Some(Value::U32(idx as u32)))),
+        ("c488".to_owned(), nullable(Some(Value::I32(idx as i32)))),
         ("c730".to_owned(), Value::Bool(idx.is_multiple_of(3))),
         ("c731".to_owned(), nullable(None)),
         ("c732".to_owned(), nullable(None)),
-        ("c733".to_owned(), nullable(Some(Value::U32(0)))),
+        ("c733".to_owned(), nullable(Some(Value::I32(0)))),
     ])
+}
+
+fn assert_policy_graph_perf_fixture_matches_schema(schema: &JazzSchema) {
+    for (table_name, column_name, expected_type) in [
+        ("t50", "c632", ColumnType::I32),
+        ("t67", "c488", ColumnType::I32.nullable()),
+        ("t67", "c733", ColumnType::I32.nullable()),
+    ] {
+        let table = schema
+            .tables
+            .iter()
+            .find(|candidate| candidate.name == table_name)
+            .unwrap_or_else(|| panic!("policy-graph performance fixture is missing {table_name}"));
+        let column = table
+            .columns
+            .iter()
+            .find(|candidate| candidate.name == column_name)
+            .unwrap_or_else(|| {
+                panic!("policy-graph performance fixture is missing {table_name}.{column_name}")
+            });
+        assert_eq!(
+            column.column_type,
+            expected_type,
+            "policy-graph performance fixture writes {table_name}.{column_name} as Value::I32"
+        );
+    }
 }
 
 fn policy_graph_version(
@@ -1936,7 +1962,11 @@ fn policy_graph_version(
         cells,
         None,
     )
-    .unwrap()
+    .unwrap_or_else(|error| {
+        panic!(
+            "policy-graph performance fixture has invalid cells for table={table} row={row_uuid:?}: {error:?}; cells={cells:?}"
+        )
+    })
 }
 
 fn seed_policy_graph_known_global(
@@ -2036,6 +2066,7 @@ where
 fn policy_graph_perf_dropdown_entry_reset_ingest_timing_receipt() {
     jazz_benchmark_guard::refuse_contaminated_measurement();
     let schema = policy_graph_perf_schema_fixture();
+    assert_policy_graph_perf_fixture_matches_schema(&schema);
     let (_core_dir, mut core) = open_node_with_schema(node(0x22), schema.clone());
 
     let member = policy_graph_author(0x31, 1);
@@ -2068,7 +2099,7 @@ fn policy_graph_perf_dropdown_entry_reset_ingest_timing_receipt() {
         corp,
         BTreeMap::from([
             ("c457".to_owned(), Value::Uuid(member_team.0)),
-            ("c632".to_owned(), Value::U32(0)),
+            ("c632".to_owned(), Value::I32(0)),
         ]),
     ));
     seed_rows.push((


### PR DESCRIPTION
🤖 Repairs the ignored policy-graph reset-ingest timing receipt so its handwritten rows match the current schema.

## Why

The receipt had rotted before measurement: three fields declared as I32 were still populated with U32 values. Fixture construction therefore failed before the 19,894-row workload began.

## Changes

- write `t50.c632`, `t67.c488`, and `t67.c733` using I32 values
- preflight those three schema column types before expensive setup, so future drift fails early and identifies the field
- add table, row, validation error, and cell context when receipt row construction fails

The test remains ignored and manual. This changes only the receipt fixture and its diagnostics; it does not change runtime behavior or the measured workload.

## Validation

- Clean full-scale receipt: 19,894 rows; passed
- Timing: seed 828236 ms; serve 2962 ms; memory apply 5620 ms; RocksDB apply 6282 ms; native B-tree on-close apply 11212 ms
- Formatting, clippy, whitespace checks, and commit hooks passed
- Independent review: no P0, P1, or P2 findings; confirmed exact schema parity, safe fixed-size I32 conversion, retained ignore status, and unchanged timing behavior
- `git diff --check`: clean
- Worktree clean at `f2007f4b3`
