### PR TITLE
fix(jazz): harden authored column semantics

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -3132,6 +3132,12 @@ where
         patch: RowCells,
         identity: AuthorId,
     ) -> Result<(RowCells, Option<TxId>, BTreeSet<String>), Error> {
+        if patch.is_empty() {
+            return Err(crate::node::Error::InvalidMergeableCommit(
+                "partial UPDATE requires at least one cell",
+            )
+            .into());
+        }
         let table_schema = self.table_schema(table)?;
         self.ensure_row_not_deleted(table, row)?;
         if table_schema

--- a/crates/jazz/src/node/tests/branching.rs
+++ b/crates/jazz/src/node/tests/branching.rs
@@ -880,6 +880,74 @@ fn merge_back_parents_every_concurrent_target_head() {
     assert_eq!(parents, vec![left, right]);
 }
 
+/// Successive partial branch writes accumulate authored presence across their
+/// private ancestry. A later patch must not make an earlier explicit branch
+/// edit look inherited merely because the tip's own authored set names only
+/// the later patch.
+///
+/// Planted positive: calculate the merge from only the final branch winner's
+/// authored set. The merged transaction would then lose `title=branch`.
+#[test]
+fn merge_back_accumulates_authored_columns_across_successive_branch_patches() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "todos",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("completed", ColumnType::Bool),
+        ],
+    )]);
+    let (_writer_dir, mut writer) = open_node_with_schema(node(0x83), schema.clone());
+    let (_core_dir, mut core) = open_history_complete_node_with_schema(node(0x84), schema.clone());
+    let mut oracle = Oracle::new();
+    let row_uuid = row(0x83);
+    let (base, _) = commit_global_and_oracle(
+        &mut writer,
+        &mut core,
+        &mut oracle,
+        MergeableCommit::new("todos", row_uuid, 10).cells(BTreeMap::from([
+            ("title".to_owned(), Value::String("base".to_owned())),
+            ("completed".to_owned(), Value::Bool(false)),
+        ])),
+    );
+
+    let branch_id = branch(0x83);
+    core.create_branch(branch_id).unwrap();
+    let title_patch = core
+        .commit_mergeable_on_branch(
+            branch_id,
+            MergeableCommit::new("todos", row_uuid, 20)
+                .parents(vec![base])
+                .cells(BTreeMap::from([
+                    ("title".to_owned(), Value::String("branch".to_owned())),
+                    ("completed".to_owned(), Value::Bool(false)),
+                ]))
+                .authored_columns(BTreeSet::from(["title".to_owned()])),
+        )
+        .unwrap();
+    core.commit_mergeable_on_branch(
+        branch_id,
+        MergeableCommit::new("todos", row_uuid, 30)
+            .parents(vec![title_patch])
+            .cells(BTreeMap::from([
+                ("title".to_owned(), Value::String("branch".to_owned())),
+                ("completed".to_owned(), Value::Bool(true)),
+            ]))
+            .authored_columns(BTreeSet::from(["completed".to_owned()])),
+    )
+    .unwrap();
+
+    core.merge_back_branch(branch_id).unwrap();
+    let rows = core.current_rows("todos", DurabilityTier::Local).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].test_cells_by_descriptor(),
+        BTreeMap::from([
+            ("title".to_owned(), Value::String("branch".to_owned())),
+            ("completed".to_owned(), Value::Bool(true)),
+        ])
+    );
+}
+
 #[test]
 fn branch_target_is_canonical_atomic_transaction_state_across_reopen() {
     let (core_dir, mut core) = open_history_complete_node_with_schema(node(2), schema());

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -3690,3 +3690,80 @@ fn duplicate_commit_units_compare_versions_without_wire_order() {
             .is_ok()
     );
 }
+/// A locally pending partial update is rebuilt from durable history after
+/// `bob` reopens, then uploaded as a real commit unit. Its explicitly authored
+/// `title` wins while `alice`'s concurrent `completed` edit survives.
+///
+/// ```text
+/// base(base,false) ─┬─ alice(completed=true) ──┐
+///                   └─ bob(title=base) ─ reopen ─ upload ─┴─► base,true
+/// ```
+///
+/// Planted positive: force `VersionRecord::from_stored` to attach
+/// `authored_columns=None`. Bob's materialized `completed=false` then appears
+/// authored on the rebuilt wire unit and this test fails.
+#[test]
+fn reopened_pending_partial_update_upload_preserves_authored_columns() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "todos",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("completed", ColumnType::Bool),
+        ],
+    )]);
+    let (bob_dir, mut bob) = open_node_with_schema(node(0x91), schema.clone());
+    let (_alice_dir, mut alice) = open_node_with_schema(node(0x92), schema.clone());
+    let (_core_dir, mut core) =
+        open_history_complete_node_with_schema(node(0x93), schema.clone());
+    let row_uuid = row(0x91);
+
+    let (base, base_unit) = bob
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", row_uuid, 10).cells(BTreeMap::from([
+                ("title".to_owned(), Value::String("base".to_owned())),
+                ("completed".to_owned(), Value::Bool(false)),
+            ])),
+        )
+        .unwrap();
+    let [base_fate] = core.apply_sync_message(base_unit).unwrap().try_into().unwrap();
+    bob.apply_sync_message(base_fate).unwrap();
+
+    let (_alice_tx, alice_unit) = alice
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", row_uuid, 20)
+                .parents(vec![base])
+                .cells(BTreeMap::from([(
+                    "completed".to_owned(),
+                    Value::Bool(true),
+                )])),
+        )
+        .unwrap();
+    core.apply_sync_message(alice_unit).unwrap();
+
+    let bob_tx = bob
+        .commit_mergeable(
+            MergeableCommit::new("todos", row_uuid, 30)
+                .parents(vec![base])
+                .cells(BTreeMap::from([
+                    ("title".to_owned(), Value::String("base".to_owned())),
+                    ("completed".to_owned(), Value::Bool(false)),
+                ]))
+                .authored_columns(BTreeSet::from(["title".to_owned()])),
+        )
+        .unwrap();
+    drop(bob);
+
+    let mut reopened = reopen_node_at(&bob_dir, node(0x91), schema);
+    let rebuilt = reopened.commit_unit_for(bob_tx).unwrap();
+    core.apply_sync_message(rebuilt).unwrap();
+
+    let rows = core.current_rows("todos", DurabilityTier::Local).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].test_cells_by_descriptor(),
+        BTreeMap::from([
+            ("title".to_owned(), Value::String("base".to_owned())),
+            ("completed".to_owned(), Value::Bool(true)),
+        ])
+    );
+}

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -547,6 +547,7 @@ impl Ord for VersionRecord {
             .cmp(other.table())
             .then_with(|| self.schema_version.cmp(&other.schema_version))
             .then_with(|| self.record.raw().cmp(other.record.raw()))
+            .then_with(|| self.authored_columns.cmp(&other.authored_columns))
     }
 }
 
@@ -2631,9 +2632,34 @@ pub enum OutboxMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use groove::schema::{ColumnSchema, ColumnType};
 
     fn schema_id(byte: u8) -> SchemaVersionId {
         SchemaVersionId::from_bytes([byte; 16])
+    }
+
+    #[test]
+    fn version_record_ordering_distinguishes_authored_presence() {
+        let table = TableSchema::new("todos", [ColumnSchema::new("title", ColumnType::String)]);
+        let base = VersionRecord::from_cells(
+            &table,
+            schema_id(1),
+            RowUuid::from_bytes([1; 16]),
+            Vec::new(),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            &BTreeMap::from([("title".to_owned(), Value::String("x".to_owned()))]),
+            None,
+        )
+        .unwrap();
+        let authored = base
+            .clone()
+            .with_authored_columns(Some(BTreeSet::from(["title".to_owned()])));
+
+        assert_ne!(base, authored);
+        assert_ne!(base.cmp(&authored), Ordering::Equal);
     }
 
     fn sample_lens() -> MigrationLens {

--- a/crates/jazz/tests/edge_fate_authority.rs
+++ b/crates/jazz/tests/edge_fate_authority.rs
@@ -229,11 +229,12 @@ fn core_shell_client_upload_still_reports_global_immediately() {
 /// Black-box regression for authored-column carriage across the public Db and
 /// sync/wire path. Bob explicitly writes the unchanged base title at the newer
 /// timestamp; that authored write must participate in per-column LWW and beat
-/// Alice's older concurrent title change after both commits cross the wire.
+/// Alice's older concurrent title change after both commits cross the wire,
+/// without claiming Alice's independent `completed` edit.
 ///
 /// Planted positive: removing `MergeableCommit::authored_columns` from the
-/// partial-update lowering makes Bob's materialized title look inherited, so
-/// this test resolves to `alice-change` instead of `base`.
+/// partial-update lowering makes Bob's entire materialized row look authored;
+/// Bob still wins `title`, but incorrectly reverts `completed` to false.
 #[test]
 fn explicit_unchanged_partial_write_survives_sync_and_wins_lww() {
     let schema = schema();
@@ -273,13 +274,25 @@ fn explicit_unchanged_partial_write_survives_sync_and_wins_lww() {
     pump_client_edge(&bob, &bob_wire, &mut core, bob_session);
     pump_client_edge(&alice, &alice_wire, &mut core, alice_session);
 
+    // An empty partial update has no authored cells and is rejected rather
+    // than becoming a legacy "all materialized cells authored" write. Planted
+    // positive: remove the empty-patch guard in `merge_existing_cells`; this
+    // assertion succeeds and such a concurrent no-op can clobber Alice.
+    assert!(
+        bob.update_at_ms("todos", row, BTreeMap::new(), 250)
+            .is_err()
+    );
+
     // Neither client is pumped after these writes until both heads exist, so
     // they remain concurrent children of the shared t=100 base.
     alice
         .update_at_ms(
             "todos",
             row,
-            BTreeMap::from([("title".to_owned(), Value::String("alice-change".to_owned()))]),
+            BTreeMap::from([
+                ("title".to_owned(), Value::String("alice-change".to_owned())),
+                ("completed".to_owned(), Value::Bool(true)),
+            ]),
             200,
         )
         .unwrap();
@@ -295,4 +308,20 @@ fn explicit_unchanged_partial_write_survives_sync_and_wins_lww() {
     pump_client_edge(&bob, &bob_wire, &mut core, bob_session);
     pump_client_edge(&alice, &alice_wire, &mut core, alice_session);
     assert_eq!(visible_titles(&alice, DurabilityTier::Global), ["base"]);
+    let prepared = alice.prepare_query(&Query::from("todos")).unwrap();
+    let rows = block_on(alice.all(
+        &prepared,
+        ReadOpts {
+            tier: DurabilityTier::Global,
+            local_updates: LocalUpdates::Deferred,
+            propagation: Propagation::Full,
+            ..ReadOpts::default()
+        },
+    ))
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].cell(&schema.tables[0], "completed"),
+        Some(Value::Bool(true))
+    );
 }


### PR DESCRIPTION
🤖 Hardens authored-column presence on top of the ordinary lineage-targeted branch merge design in #1324.

## Why

Per-column LWW must distinguish an explicitly authored value from a materialized inherited value, including explicit no-op writes. The #1324 stack already carries authored presence through history and uses contribution dots for ordinary merge commits; this follow-up adds the remaining API guards and end-to-end seams without restoring the superseded branch-overlay squash algorithm.

## Changes

- reject empty public partial updates before row materialization, preventing the legacy `None = all present cells authored` fallback from turning a no-op into a whole-row write
- include authored presence in `VersionRecord` ordering so `Ord` remains consistent with derived equality and canonical unit comparison
- strengthen the public sync regression: an explicitly unchanged field wins while a concurrent inherited field survives
- add a durable storage → reopen → commit-unit → authority regression for authored metadata
- prove successive branch patches contribute cumulatively through #1324's ordinary merge calculator

## Correctness boundary

Cross-schema authored-presence translation remains the documented open limitation. Legacy or lens-translated `None` conservatively treats all present cells as authored; this PR does not guess rename/transform presence semantics.

## Validation

- independent adversarial review: safe to stack on #1324
- focused public edge explicit-unchanged/concurrent-field regression
- focused ordinary branch successive-patch regression
- focused durable reopen-to-wire regression
- `VersionRecord` ordering contract regression
- no-default offline reconnect history-conflict regression
- planted removal of earlier branch contributions loses the prior authored field and fails the cumulative regression
- commit hooks and diff checks pass

## Stack

This draft is based on #1324. The next small child will activate the browser different-field convergence scenario.
