### PR TITLE
fix: preserve gathered subscription rows

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -5384,17 +5384,15 @@ where
         projection: Option<&[String]>,
     ) -> Result<Option<CurrentRow>, Error> {
         let table = self.table(table_name)?.clone();
-        let content_descriptor = table.history_storage_table().record_schema();
         let Some(tx_node_alias) = self.node_aliases.get(&tx_id.node).copied() else {
             return Err(Error::MissingTransaction(tx_id));
         };
-        let Some(version) = self.query_version_by_alias_with_descriptor(
+        let Some(version) = self.query_version_by_alias(
             table_name,
             row_uuid,
             VersionLayer::Content,
             tx_id.time,
             tx_node_alias,
-            &content_descriptor,
         )?
         else {
             if self.query_transaction(tx_id)?.is_some() {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1676,7 +1676,8 @@ export class NativeRuntimeAdapter implements Runtime {
       }
       if (
         chunk.relationDelta &&
-        (subscription.query === null || subscription.relationMaterialization.arraySubqueries.length > 0)
+        (subscription.query === null ||
+          subscription.relationMaterialization.arraySubqueries.length > 0)
       ) {
         const previousRows = subscription.rows;
         applyRelationSubscriptionDelta(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1674,7 +1674,10 @@ export class NativeRuntimeAdapter implements Runtime {
         subscription.packedResetBatches = null;
         subscription.packedResetRows = null;
       }
-      if (chunk.relationDelta && subscription.relationMaterialization.arraySubqueries.length > 0) {
+      if (
+        chunk.relationDelta &&
+        (subscription.query === null || subscription.relationMaterialization.arraySubqueries.length > 0)
+      ) {
         const previousRows = subscription.rows;
         applyRelationSubscriptionDelta(
           subscription,

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -3387,6 +3387,79 @@ describe("NativeRuntimeAdapter server transport", () => {
     runtime.close();
   });
 
+  it("reconciles native relation subscription lifecycles without leaking projection records", () => {
+    const first = uuidBytes("00000000-0000-0000-0000-000000000401");
+    const second = uuidBytes("00000000-0000-0000-0000-000000000402");
+    const chunks = [
+      relationSubscriptionChunk({
+        reset: true,
+        rootAdded: [{ table: "todos", rowId: first, title: "first" }],
+        relationAdded: [{ table: "todos", rowId: first, title: "first" }],
+      }),
+      relationSubscriptionChunk({
+        // Relation snapshots carry the authoritative rendered row. The root
+        // delta can be stale/partial while that snapshot advances.
+        rootUpdated: [{ table: "todos", rowId: first, title: "stale root" }],
+        relationUpdated: [{ table: "todos", rowId: first, title: "first updated" }],
+      }),
+      relationSubscriptionChunk({
+        rootRemoved: [{ table: "todos", rowId: first }],
+        relationRemoved: [{ table: "todos", rowId: first }],
+      }),
+      relationSubscriptionChunk({
+        reset: true,
+        rootAdded: [{ table: "todos", rowId: second, title: "second" }],
+        relationAdded: [{ table: "todos", rowId: second, title: "second" }],
+      }),
+    ];
+    const runtime = runtimeWithNativeRelationSubscriptionChunks(chunks);
+    const deltas: NativeRowDelta[] = [];
+    const handle = runtime.createSubscription(
+      JSON.stringify({ table: "todos", relation_ir: { Gather: {} } }),
+      null,
+      null,
+      null,
+    );
+
+    runtime.executeSubscription(handle, (delta: NativeRowDelta) => deltas.push(delta));
+
+    expect(deltas).toHaveLength(4);
+    expect(decodeTestDeltas([deltas[0]!])[0]).toMatchObject([
+      { kind: 0, id: formatUuid(first), index: 0, row: { values: [{ value: "first" }] } },
+    ]);
+    expect(decodeTestDeltas([deltas[1]!])[0]).toMatchObject([
+      {
+        kind: 2,
+        id: formatUuid(first),
+        index: 0,
+        row: { values: [{ value: "first updated" }] },
+      },
+    ]);
+    expect(decodeTestDeltas([deltas[2]!])[0]).toEqual([
+      { kind: 1, id: formatUuid(first), index: 0 },
+    ]);
+    expect(decodeTestDeltas([deltas[3]!])[0]).toMatchObject([
+      { kind: 0, id: formatUuid(second), index: 0, row: { values: [{ value: "second" }] } },
+    ]);
+    expect(deltas[0]!.reset).toBe(true);
+    expect(deltas[3]!.reset).toBe(true);
+    runtime.close();
+
+    const ordinary = runtimeWithNativeSubscriptionChunk(
+      relationSubscriptionChunk({
+        reset: true,
+        rootAdded: [{ table: "todos", rowId: first, title: "ordinary" }],
+      }),
+    );
+    const ordinaryDeltas: NativeRowDelta[] = [];
+    const ordinaryHandle = ordinary.createSubscription(JSON.stringify({ table: "todos" }));
+    ordinary.executeSubscription(ordinaryHandle, (delta: NativeRowDelta) => ordinaryDeltas.push(delta));
+    expect(decodeTestDeltas(ordinaryDeltas)[0]).toMatchObject([
+      { kind: 0, id: formatUuid(first), row: { values: [{ value: "ordinary" }] } },
+    ]);
+    ordinary.close();
+  });
+
   it("rewraps user field option bytes when packed reset frames filter engine records", () => {
     const schema = {
       notes: {
@@ -4755,6 +4828,67 @@ function runtimeWithNativeSubscriptionChunk(
     1,
     true,
   );
+}
+
+function runtimeWithNativeRelationSubscriptionChunks(chunks: unknown[]): NativeRuntimeAdapter {
+  return new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          subscribeRelationQuery: () => ({
+            readAll: () => chunks,
+            close: () => true,
+          }),
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    new Uint8Array(16),
+    1,
+    true,
+  );
+}
+
+function relationSubscriptionChunk({
+  reset = false,
+  rootAdded = [],
+  rootUpdated = [],
+  rootRemoved = [],
+  relationAdded = [],
+  relationUpdated = [],
+  relationRemoved = [],
+}: {
+  reset?: boolean;
+  rootAdded?: EncodedTestRow[];
+  rootUpdated?: EncodedTestRow[];
+  rootRemoved?: Array<{ table: string; rowId: Uint8Array }>;
+  relationAdded?: EncodedTestRow[];
+  relationUpdated?: EncodedTestRow[];
+  relationRemoved?: Array<{ table: string; rowId: Uint8Array }>;
+}): unknown {
+  return {
+    type: "delta",
+    reset,
+    settled: true,
+    delta: encodeSubscriptionDelta({
+      added: rootAdded,
+      updated: rootUpdated,
+      removed: rootRemoved,
+    }),
+    relation_delta: encodeRelationSubscriptionDelta({
+      baseCursor: 0,
+      cursor: 1,
+      added: relationAdded,
+      updated: relationUpdated,
+      removed: relationRemoved,
+      addedEdges: [],
+      removedEdges: [],
+    }),
+  };
 }
 
 function indexedUuidBytes(index: number): Uint8Array {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -3453,7 +3453,9 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
     const ordinaryDeltas: NativeRowDelta[] = [];
     const ordinaryHandle = ordinary.createSubscription(JSON.stringify({ table: "todos" }));
-    ordinary.executeSubscription(ordinaryHandle, (delta: NativeRowDelta) => ordinaryDeltas.push(delta));
+    ordinary.executeSubscription(ordinaryHandle, (delta: NativeRowDelta) =>
+      ordinaryDeltas.push(delta),
+    );
     expect(decodeTestDeltas(ordinaryDeltas)[0]).toMatchObject([
       { kind: 0, id: formatUuid(first), row: { values: [{ value: "ordinary" }] } },
     ]);

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -949,7 +949,15 @@ describe("db.subscribeAll browser integration", () => {
       () => {
         const latestAll = deltas[deltas.length - 1]?.all ?? [];
         const ids = latestAll.map((row) => row.id);
-        return ids.includes(rootId) && ids.includes(midId) && ids.includes(leafId);
+        const names = latestAll.map((row) => row.name);
+        return (
+          ids.includes(rootId) &&
+          ids.includes(midId) &&
+          ids.includes(leafId) &&
+          names.includes("root") &&
+          names.includes("mid") &&
+          names.includes("leaf")
+        );
       },
       4000,
       "expected gather query subscription result",


### PR DESCRIPTION
🤖 Fixes gathered/native-relation subscription rows in both direct `subscribeAll` and React `useAll`.

## Root cause

Native relation subscriptions are represented by `subscription.query === null` and deliver both root and relation deltas. The adapter only entered relation reconciliation when array includes existed, so a gather without arrays fell through to the plain root-delta decoder. Projection record bytes were then decoded with the table schema, producing binary-garbled field values.

## Changes

- route query-null native relation subscriptions through `applyRelationSubscriptionDelta`, even without array includes
- retain the existing plain-delta path for ordinary prepared subscriptions
- resolve authoritative reset rows with their schema-partition descriptor rather than the base descriptor
- strengthen browser gather coverage to assert actual `root/mid/leaf` values, not only IDs
- add lifecycle coverage for add, relation-authoritative update, removal, reset, and order

## Validation

- independent adversarial review: safe to land
- native-runtime lifecycle unit passes and directly distinguishes relation delta from a deliberately stale root delta
- direct `db.subscribeAll` gather and React `useAll` gather Chromium tests pass
- planted restoration of the old condition fails the unit and both browser regressions
- ordinary query-non-null/no-array control retains its prior path
- formatting and diff checks pass

## Stack

This draft is based on #1323.
