### PR TITLE
fix(jazz-tools): order worker subscriptions before writes

### DIFF
--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -2245,22 +2245,9 @@ fn users_to_orgs_relation_query() -> RelationQuery {
         rel: RelationExpr::Project {
             input: Box::new(RelationExpr::Join {
                 left: Box::new(RelationExpr::Join {
-                    left: Box::new(RelationExpr::Filter {
-                        input: Box::new(RelationExpr::TableScan {
-                            table: "users".to_owned(),
-                            alias: None,
-                        }),
-                        predicate: RelationPredicate::Cmp {
-                            left: RelationColumnRef {
-                                scope: Some("users".to_owned()),
-                                column: "id".to_owned(),
-                            },
-                            op: RelationCmpOp::Eq,
-                            right: RelationValueRef::Literal(serde_json::json!({
-                                "type": "Uuid",
-                                "value": row(0x21).0.to_string(),
-                            })),
-                        },
+                    left: Box::new(RelationExpr::TableScan {
+                        table: "users".to_owned(),
+                        alias: None,
                     }),
                     right: Box::new(RelationExpr::TableScan {
                         table: "teams".to_owned(),

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -158,6 +158,91 @@ describe("PersistentBrowserOpfsRuntime", () => {
     await runtime.close();
   });
 
+  it("registers a subscription before a subsequent fire-and-forget write", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-subscribe-before-write-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    const subscription = runtime.createSubscription(JSON.stringify({ table: "todos" }));
+    runtime.executeSubscription(subscription, () => undefined);
+    runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "must follow subscription registration" } },
+      undefined,
+      "00000000-0000-0000-0000-000000000001",
+    );
+
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "createExecutedSubscription")).toBe(
+        true,
+      );
+    });
+    expect(worker.messages.some((message) => message.method === "insert")).toBe(false);
+
+    const create = worker.messages.find(
+      (message) => message.method === "createExecutedSubscription",
+    );
+    worker.respond(create!.id, 7);
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "insert")).toBe(true);
+    });
+    const insert = worker.messages.find((message) => message.method === "insert");
+    worker.respond(insert!.id, { transactionId: "native-runtime-transaction" });
+
+    await runtime.close();
+  });
+
+  it("does not delay a write behind a subscription created later", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-write-before-subscribe-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "must be in the subscription snapshot" } },
+      undefined,
+      "00000000-0000-0000-0000-000000000001",
+    );
+    const subscription = runtime.createSubscription(JSON.stringify({ table: "todos" }));
+    runtime.executeSubscription(subscription, () => undefined);
+
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "insert")).toBe(true);
+    });
+    expect(worker.messages.some((message) => message.method === "createExecutedSubscription")).toBe(
+      false,
+    );
+
+    const insert = worker.messages.find((message) => message.method === "insert")!;
+    worker.respond(insert.id, { transactionId: "native-runtime-transaction" });
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "createExecutedSubscription")).toBe(
+        true,
+      );
+    });
+    const create = worker.messages.find(
+      (message) => message.method === "createExecutedSubscription",
+    )!;
+    expect(worker.messages.indexOf(insert)).toBeLessThan(worker.messages.indexOf(create));
+    worker.respond(create.id, 7);
+
+    await runtime.close();
+  });
+
   it("rejects waits when the worker write fails before core returns a transaction id", async () => {
     vi.stubGlobal("Worker", FakeWorker);
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -180,9 +180,9 @@ describe("PersistentBrowserOpfsRuntime", () => {
     );
 
     await vi.waitFor(() => {
-      expect(worker.messages.some((message) => message.method === "createExecutedSubscription")).toBe(
-        true,
-      );
+      expect(
+        worker.messages.some((message) => message.method === "createExecutedSubscription"),
+      ).toBe(true);
     });
     expect(worker.messages.some((message) => message.method === "insert")).toBe(false);
 
@@ -230,9 +230,9 @@ describe("PersistentBrowserOpfsRuntime", () => {
     const insert = worker.messages.find((message) => message.method === "insert")!;
     worker.respond(insert.id, { transactionId: "native-runtime-transaction" });
     await vi.waitFor(() => {
-      expect(worker.messages.some((message) => message.method === "createExecutedSubscription")).toBe(
-        true,
-      );
+      expect(
+        worker.messages.some((message) => message.method === "createExecutedSubscription"),
+      ).toBe(true);
     });
     const create = worker.messages.find(
       (message) => message.method === "createExecutedSubscription",

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -47,6 +47,11 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   private readonly commitErrors = new Map<string, Error>();
   private readonly subscriptions = new Map<number, Function>();
   private readonly remoteSubscriptions = new Map<number, Promise<number>>();
+  // A public subscription is synchronous at this boundary, while the worker
+  // registration is asynchronous. Preserve the caller's program order: a
+  // write issued immediately after subscribe must not overtake registration
+  // and become invisible to its maintained view.
+  private subscriptionRegistration: Promise<void> = Promise.resolve();
   private authFailureCallback: ((reason: string) => void) | undefined;
   private connectionReady: Promise<unknown> | null = null;
   private pagehideAbort: AbortController | null = null;
@@ -300,6 +305,9 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     });
     void remoteHandle.catch(ignoreExpectedShutdown);
     this.remoteSubscriptions.set(localHandle, remoteHandle);
+    this.subscriptionRegistration = this.subscriptionRegistration
+      .catch(() => undefined)
+      .then(() => remoteHandle.then(() => undefined).catch(() => undefined));
     return localHandle;
   }
 
@@ -422,6 +430,9 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     method: Method,
     ...args: PersistentBrowserRequestArgs<Method>
   ): void {
+    // Capture the registration frontier at the public call boundary. A
+    // subscription created after this write must not retroactively delay it.
+    const registrationBeforeWrite = this.subscriptionRegistration;
     const batchId = this.batchIdFromWriteArgs(method, args);
     if (batchId && this.completedTxs.has(batchId)) {
       throw new Error(
@@ -432,6 +443,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     // worker's transaction id. The public Runtime API is synchronous, so the
     // result returned from insert/update/etc. is only a pending handle.
     const write = this.opened.then(async () => {
+      await registrationBeforeWrite;
       if (batchId && this.completedTxs.get(batchId) === "rolled_back") {
         return batchId;
       }


### PR DESCRIPTION
🤖 Preserves public call order between persistent-worker subscription registration and writes.

## Root cause

`createSubscription` crosses an asynchronous `prepareReadOptions` boundary, while the worker message handler processes requests concurrently. An immediate write could therefore reach the runtime before the preceding subscription was registered. The browser saw only its synchronous empty seed and never received the post-insert hop delta.

## Changes

- maintain a failure-tolerant subscription-registration frontier in the persistent browser runtime
- capture that frontier synchronously when a write is queued, then wait for only the subscriptions that precede that write in public program order
- preserve the opposite ordering too: a write issued before a subscription is not delayed behind that later subscription
- strengthen the Rust multi-hop maintained-delivery regression to use the browser's unfiltered source shape

## Validation

- independent adversarial review: safe
- deterministic worker tests cover both `subscription → write` and `write → subscription` orderings
- removing the barrier fails the first ordering test; reading the barrier late fails the reverse-order test
- unfiltered Rust multi-hop maintained subscription passes
- exact Chromium `subscribeAll` hop test passes (1 passed, 24 skipped)
- formatting and diff checks pass

## Stack

This draft is based on #1323.
