### PR TITLE
fix(jazz-tools): close persistent runtime lifecycle gaps

### DIFF
--- a/packages/jazz-tools/src/runtime/db.transport.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transport.test.ts
@@ -83,7 +83,7 @@ function makeClientStub() {
     shutdown: vi.fn(async () => undefined),
     updateAuthToken: vi.fn(),
     connectTransport: vi.fn(),
-    disconnectTransport: vi.fn(),
+    disconnectTransport: vi.fn(async () => undefined),
     getRuntime: vi.fn(() => ({}) as never),
   } as unknown as JazzClient & {
     connectTransport: ReturnType<typeof vi.fn>;

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1099,6 +1099,11 @@ export class Db {
 
       if (this.config.serverUrl && !this.isTransportDisconnected) {
         client.connectTransport(this.config.serverUrl, this.transportAuthConfig());
+      } else if (this.config.serverUrl) {
+        // A schema-specific client can be created lazily after Db.disconnect().
+        // Put its runtime behind the reconnect barrier immediately too; otherwise
+        // its first edge/global operation could run as if the Db were connected.
+        void client.disconnectTransport().catch(() => undefined);
       }
       this.clients.set(key, client);
       this.clientSchemas.set(key, runtimeSchema);

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -176,6 +176,46 @@ describe("PersistentBrowserOpfsRuntime", () => {
     await runtime.close();
   });
 
+  it("surfaces an unexpected connection failure exactly once through the RPC", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-connect-failure-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app/ws", "{}");
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "connect")).toBe(true);
+    });
+
+    const surfaced: Array<() => void> = [];
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: () => void,
+    ) => {
+      surfaced.push(callback);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    worker.reject(
+      worker.messages.find((message) => message.method === "connect")!.id,
+      "arbitrary websocket failure",
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(surfaced).toHaveLength(1);
+    expect(() => surfaced[0]!()).toThrow("arbitrary websocket failure");
+
+    setTimeoutSpy.mockRestore();
+    await runtime.close();
+  });
+
   it("rejects server-tier work parked behind a reconnect when closed", async () => {
     vi.stubGlobal("Worker", FakeWorker);
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -250,6 +250,70 @@ describe("PersistentBrowserOpfsRuntime", () => {
     await waitRejection;
   });
 
+  it.each(["reconnect", "close"] as const)(
+    "preserves parked server-tier work across repeated disconnects until %s",
+    async (outcome) => {
+      vi.stubGlobal("Worker", FakeWorker);
+
+      const runtime = new PersistentBrowserOpfsRuntime(
+        undefined,
+        schema,
+        `persistent-browser-runtime-repeat-disconnect-${outcome}-test`,
+        new Uint8Array(16),
+        new Uint8Array(16),
+      );
+      const worker = FakeWorker.instances[0];
+
+      const firstDisconnect = runtime.disconnect({ rejectWaiters: false });
+      await vi.waitFor(() => {
+        expect(worker.messages.filter((message) => message.method === "disconnect")).toHaveLength(
+          1,
+        );
+      });
+      worker.respond(
+        worker.messages.find((message) => message.method === "disconnect")!.id,
+        undefined,
+      );
+      await firstDisconnect;
+
+      const query = runtime.query(JSON.stringify({ table: "todos" }), null, "edge", null);
+      const secondDisconnect = runtime.disconnect({ rejectWaiters: false });
+      await vi.waitFor(() => {
+        expect(worker.messages.filter((message) => message.method === "disconnect")).toHaveLength(
+          2,
+        );
+      });
+      worker.respond(
+        worker.messages.filter((message) => message.method === "disconnect")[1]!.id,
+        undefined,
+      );
+      await secondDisconnect;
+
+      if (outcome === "reconnect") {
+        runtime.connect("ws://127.0.0.1:4200/apps/app/ws", "{}");
+        await vi.waitFor(() => {
+          expect(worker.messages.some((message) => message.method === "connect")).toBe(true);
+        });
+        worker.respond(
+          worker.messages.find((message) => message.method === "connect")!.id,
+          undefined,
+        );
+        await vi.waitFor(() => {
+          expect(worker.messages.some((message) => message.method === "query")).toBe(true);
+        });
+        worker.respond(worker.messages.find((message) => message.method === "query")!.id, []);
+        await expect(query).resolves.toEqual([]);
+        await runtime.close();
+      } else {
+        const rejection = expect(query).rejects.toThrow(
+          "Persistent browser native runtime is closed",
+        );
+        await runtime.close();
+        await rejection;
+      }
+    },
+  );
+
   it("returns a pending write handle and waits on the worker transaction id", async () => {
     vi.stubGlobal("Worker", FakeWorker);
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -118,6 +118,98 @@ describe("PersistentBrowserOpfsRuntime", () => {
     FakeWorker.instances = [];
   });
 
+  it("does not require connect before server-tier work in a local-only runtime", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-local-only-ready-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    const wait = runtime.waitForTransaction("local-only-transaction", "edge");
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "waitForTransaction")).toBe(true);
+    });
+    const waitMessage = worker.messages.find((message) => message.method === "waitForTransaction");
+    worker.respond(waitMessage!.id, undefined);
+
+    await expect(wait).resolves.toBeUndefined();
+    await runtime.close();
+  });
+
+  it("handles rejected connection gates that have no server-tier waiters", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-unused-gate-rejection-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app/ws", "{}");
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "connect")).toBe(true);
+    });
+    worker.reject(
+      worker.messages.find((message) => message.method === "connect")!.id,
+      "Persistent browser native runtime connect failed",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    runtime.updateAuth("{}");
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "updateAuth")).toBe(true);
+    });
+    worker.reject(
+      worker.messages.find((message) => message.method === "updateAuth")!.id,
+      "Persistent browser native runtime auth update failed",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await runtime.close();
+  });
+
+  it("rejects server-tier work parked behind a reconnect when closed", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-close-reconnect-waiters-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    const disconnect = runtime.disconnect({ rejectWaiters: false });
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "disconnect")).toBe(true);
+    });
+    const disconnectMessage = worker.messages.find((message) => message.method === "disconnect");
+    worker.respond(disconnectMessage!.id, undefined);
+    await disconnect;
+
+    const query = runtime.query(JSON.stringify({ table: "todos" }), null, "edge", null);
+    const wait = runtime.waitForTransaction("parked-transaction", "global");
+    const queryRejection = expect(query).rejects.toThrow(
+      "Persistent browser native runtime is closed",
+    );
+    const waitRejection = expect(wait).rejects.toThrow(
+      "Persistent browser native runtime is closed",
+    );
+    await runtime.close();
+
+    await queryRejection;
+    await waitRejection;
+  });
+
   it("returns a pending write handle and waits on the worker transaction id", async () => {
     vi.stubGlobal("Worker", FakeWorker);
 
@@ -431,6 +523,64 @@ describe("PersistentBrowserOpfsRuntime", () => {
     expect(edgeQueryMessage?.args[2]).toBe("edge");
     worker.respond(edgeQueryMessage!.id, ["edge"]);
     await expect(edgeRead).resolves.toEqual(["edge"]);
+    await runtime.close();
+  });
+
+  it("does not release disconnected server-tier work when auth changes", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-disconnected-auth-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+
+    const disconnect = runtime.disconnect({ rejectWaiters: false });
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "disconnect")).toBe(true);
+    });
+    worker.respond(
+      worker.messages.find((message) => message.method === "disconnect")!.id,
+      undefined,
+    );
+    await disconnect;
+
+    const query = runtime.query(JSON.stringify({ table: "todos" }), null, "edge", null);
+    const wait = runtime.waitForTransaction("disconnected-auth-transaction", "global");
+    runtime.updateAuth('{"token":"replacement"}');
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "updateAuth")).toBe(true);
+    });
+    worker.respond(
+      worker.messages.find((message) => message.method === "updateAuth")!.id,
+      undefined,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(worker.messages.some((message) => message.method === "query")).toBe(false);
+    expect(worker.messages.some((message) => message.method === "waitForTransaction")).toBe(false);
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app/ws", "{}");
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "connect")).toBe(true);
+    });
+    worker.respond(worker.messages.find((message) => message.method === "connect")!.id, undefined);
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "waitForTransaction")).toBe(true);
+    });
+    worker.respond(
+      worker.messages.find((message) => message.method === "waitForTransaction")!.id,
+      undefined,
+    );
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "query")).toBe(true);
+    });
+    worker.respond(worker.messages.find((message) => message.method === "query")!.id, []);
+
+    await expect(query).resolves.toEqual([]);
+    await expect(wait).resolves.toBeUndefined();
     await runtime.close();
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -314,6 +314,30 @@ describe("PersistentBrowserOpfsRuntime", () => {
     },
   );
 
+  it.each(["during close", "after close"] as const)(
+    "does not install a new reconnect gate when disconnecting %s",
+    async (timing) => {
+      vi.stubGlobal("Worker", FakeWorker);
+
+      const runtime = new PersistentBrowserOpfsRuntime(
+        undefined,
+        schema,
+        `persistent-browser-runtime-disconnect-${timing.replace(" ", "-")}-test`,
+        new Uint8Array(16),
+        new Uint8Array(16),
+      );
+
+      const close = runtime.close();
+      if (timing === "after close") await close;
+      await runtime.disconnect({ rejectWaiters: false });
+
+      await expect(
+        runtime.query(JSON.stringify({ table: "todos" }), null, "edge", null),
+      ).rejects.toThrow("Persistent browser native runtime is closed");
+      await close;
+    },
+  );
+
   it("returns a pending write handle and waits on the worker transaction id", async () => {
     vi.stubGlobal("Worker", FakeWorker);
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -338,6 +338,36 @@ describe("PersistentBrowserOpfsRuntime", () => {
     },
   );
 
+  it.each([
+    ["connect", "during close"],
+    ["connect", "after close"],
+    ["updateAuth", "during close"],
+    ["updateAuth", "after close"],
+  ] as const)("does not replace the terminal gate via %s %s", async (operation, timing) => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      `persistent-browser-runtime-${operation}-${timing.replace(" ", "-")}-test`,
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+
+    const close = runtime.close();
+    if (timing === "after close") await close;
+    if (operation === "connect") {
+      runtime.connect("ws://127.0.0.1:4200/apps/app/ws", "{}");
+    } else {
+      runtime.updateAuth("{}");
+    }
+
+    await expect(
+      runtime.query(JSON.stringify({ table: "todos" }), null, "edge", null),
+    ).rejects.toThrow("Persistent browser native runtime is closed");
+    await close;
+  });
+
   it("returns a pending write handle and waits on the worker transaction id", async () => {
     vi.stubGlobal("Worker", FakeWorker);
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -400,7 +400,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   }
 
   disconnect(options?: { rejectWaiters?: boolean }): Promise<void> {
-    this.connectionReady = connectionGate();
+    if (!this.waitingForReconnect) this.connectionReady = connectionGate();
     this.waitingForReconnect = true;
     if (this.closed) return Promise.resolve();
     return this.opened

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -62,7 +62,11 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   // Server-tier operations capture this gate while intentionally disconnected.
   // Reconnect resolves that same gate, so outstanding operations survive instead
   // of observing a replacement promise that can never settle.
-  private connectionReady = connectionGate();
+  // Before an explicit disconnect there is no reconnect barrier. This preserves
+  // local-only runtimes, which never call connect(), while disconnect() below
+  // installs the unresolved gate that server-tier work must await.
+  private connectionReady = connectionGate(true);
+  private waitingForReconnect = false;
   private pagehideAbort: AbortController | null = null;
   private nextCallId = 1;
   private nextSubscriptionId = 1;
@@ -374,17 +378,28 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   }
 
   connect(url: string, authJson: string): void {
-    const gate = this.connectionReady;
+    const gate = this.waitingForReconnect ? this.connectionReady : connectionGate();
+    this.connectionReady = gate;
     const connected = this.opened.then(() => {
       if (this.closed) return undefined;
       return this.send("connect", [url, authJson]);
     });
-    void connected.then(gate.resolve, gate.reject);
+    void connected.then(
+      () => {
+        if (this.connectionReady === gate) this.waitingForReconnect = false;
+        gate.resolve();
+      },
+      (error) => {
+        if (this.connectionReady === gate) this.waitingForReconnect = false;
+        gate.reject(error);
+      },
+    );
     void connected.catch(ignoreExpectedShutdown);
   }
 
   disconnect(options?: { rejectWaiters?: boolean }): Promise<void> {
     this.connectionReady = connectionGate();
+    this.waitingForReconnect = true;
     if (this.closed) return Promise.resolve();
     return this.opened
       .then(() => {
@@ -395,12 +410,22 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   }
 
   updateAuth(authJson: string): void {
-    const gate = this.connectionReady;
+    const gate = this.waitingForReconnect ? this.connectionReady : connectionGate();
+    this.connectionReady = gate;
     const updated = this.opened.then(() => {
       if (this.closed) return undefined;
       return this.send("updateAuth", [authJson]);
     });
-    void updated.then(gate.resolve, gate.reject);
+    void updated.then(
+      () => {
+        if (this.connectionReady === gate) this.waitingForReconnect = false;
+        gate.resolve();
+      },
+      (error) => {
+        if (this.connectionReady === gate) this.waitingForReconnect = false;
+        gate.reject(error);
+      },
+    );
     void updated.catch(ignoreExpectedShutdown);
   }
 
@@ -715,13 +740,14 @@ function destroyBrowserStorage(
   });
 }
 
-function connectionGate(): ConnectionGate {
+function connectionGate(resolved = false): ConnectionGate {
   let resolve!: () => void;
   let reject!: (error: unknown) => void;
   const promise = new Promise<void>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
     reject = rejectPromise;
   });
+  if (resolved) resolve();
   return { promise, resolve, reject };
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -400,9 +400,9 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   }
 
   disconnect(options?: { rejectWaiters?: boolean }): Promise<void> {
+    if (this.closing || this.closed) return Promise.resolve();
     if (!this.waitingForReconnect) this.connectionReady = connectionGate();
     this.waitingForReconnect = true;
-    if (this.closed) return Promise.resolve();
     return this.opened
       .then(() => {
         if (this.closed) return undefined;

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -380,6 +380,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   }
 
   connect(url: string, authJson: string): void {
+    if (this.closing || this.closed) return;
     const gate = this.waitingForReconnect ? this.connectionReady : connectionGate();
     this.connectionReady = gate;
     const connected = this.opened.then(() => {
@@ -412,6 +413,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   }
 
   updateAuth(authJson: string): void {
+    if (this.closing || this.closed) return;
     // Updating credentials cannot reconnect an explicitly disconnected worker:
     // without a server endpoint the worker treats updateAuth as a no-op. Keep the
     // reconnect gate parked until connect() supplies an endpoint.

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -761,7 +761,7 @@ function connectionGate(resolved = false): ConnectionGate {
   });
   // A gate may have no current consumers (for example, connect/updateAuth). Mark
   // its rejection handled without changing the promise observed by later waiters.
-  void promise.catch(ignoreExpectedShutdown);
+  void promise.catch(() => undefined);
   if (resolved) resolve();
   return { promise, resolve, reject };
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -342,6 +342,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   async close(): Promise<void> {
     if (this.closed) return;
     this.closing = true;
+    this.rejectConnectionWaiters();
     try {
       await this.opened;
       await Promise.allSettled(this.writes.values());
@@ -359,6 +360,7 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   async clearClientStorage(): Promise<void> {
     if (this.closed) return;
     this.closing = true;
+    this.rejectConnectionWaiters();
     let namespace = this.dbName;
     try {
       await this.opened;
@@ -410,27 +412,37 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   }
 
   updateAuth(authJson: string): void {
-    const gate = this.waitingForReconnect ? this.connectionReady : connectionGate();
-    this.connectionReady = gate;
+    // Updating credentials cannot reconnect an explicitly disconnected worker:
+    // without a server endpoint the worker treats updateAuth as a no-op. Keep the
+    // reconnect gate parked until connect() supplies an endpoint.
+    const gate = this.waitingForReconnect ? undefined : connectionGate();
+    if (gate) this.connectionReady = gate;
     const updated = this.opened.then(() => {
       if (this.closed) return undefined;
       return this.send("updateAuth", [authJson]);
     });
-    void updated.then(
-      () => {
-        if (this.connectionReady === gate) this.waitingForReconnect = false;
-        gate.resolve();
-      },
-      (error) => {
-        if (this.connectionReady === gate) this.waitingForReconnect = false;
-        gate.reject(error);
-      },
-    );
+    if (gate) {
+      void updated.then(
+        () => {
+          if (this.connectionReady === gate) this.waitingForReconnect = false;
+          gate.resolve();
+        },
+        (error) => {
+          if (this.connectionReady === gate) this.waitingForReconnect = false;
+          gate.reject(error);
+        },
+      );
+    }
     void updated.catch(ignoreExpectedShutdown);
   }
 
   onAuthFailure(callback: (reason: string) => void): void {
     this.authFailureCallback = callback;
+  }
+
+  private rejectConnectionWaiters(): void {
+    this.waitingForReconnect = false;
+    this.connectionReady.reject(new Error("Persistent browser native runtime is closed"));
   }
 
   private writeId(): string {
@@ -747,6 +759,9 @@ function connectionGate(resolved = false): ConnectionGate {
     resolve = resolvePromise;
     reject = rejectPromise;
   });
+  // A gate may have no current consumers (for example, connect/updateAuth). Mark
+  // its rejection handled without changing the promise observed by later waiters.
+  void promise.catch(ignoreExpectedShutdown);
   if (resolved) resolve();
   return { promise, resolve, reject };
 }

--- a/packages/jazz-tools/tests/browser/db.disconnect.test.ts
+++ b/packages/jazz-tools/tests/browser/db.disconnect.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { CompiledPermissions, schema as s } from "../../src/";
 import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
+import { PersistentBrowserOpfsRuntime } from "../../src/runtime/native-runtime/persistent-browser-runtime.js";
 import {
   fetchPermissionsHead,
   publishStoredPermissions,
@@ -130,6 +131,35 @@ describe("Db disconnect/reconnect", () => {
   });
 
   describe("worker mode", () => {
+    it.each(["close", "clearClientStorage"] as const)(
+      "rejects server-tier work parked behind reconnect on %s",
+      async (terminalMethod) => {
+        const runtime = new PersistentBrowserOpfsRuntime(
+          undefined,
+          app.wasmSchema,
+          uniqueDbName(`db-disconnect-${terminalMethod}`),
+          new Uint8Array(16),
+          new Uint8Array(16),
+        );
+
+        await runtime.disconnect({ rejectWaiters: false });
+        const query = runtime.query(JSON.stringify({ table: "todos" }), null, "edge", null);
+        const wait = runtime.waitForTransaction("parked-browser-transaction", "global");
+        const queryRejection = expect(query).rejects.toThrow(
+          "Persistent browser native runtime is closed",
+        );
+        const waitRejection = expect(wait).rejects.toThrow(
+          "Persistent browser native runtime is closed",
+        );
+
+        await runtime[terminalMethod]();
+
+        await queryRejection;
+        await waitRejection;
+      },
+      60_000,
+    );
+
     it("syncs writes made while disconnected after reconnect", async () => {
       const { db, peer } = await createDbPair(ctx, createWorkerDb);
 


### PR DESCRIPTION
🤖 Follow-up to #1301 that closes the connection-gate lifecycle gaps found after merge.

## What changed

- local-only persistent runtimes start ready instead of waiting for a connection that may never be created
- explicit disconnect creates one stable reconnect barrier, including for lazily created schema clients
- only a real reconnect releases work parked by explicit disconnect; offline authentication refresh does not
- close and storage clearing reject operations parked behind the reconnect barrier
- terminal connection commands cannot resurrect or replace a rejected barrier
- connection failures are surfaced exactly once while gate promises remain safely handled

## Why

#1301 introduced a proxy-side connection barrier for edge/global reads and durability waits. The initial barrier also blocked local-only runtimes, and several disconnect, reconnect, authentication, and shutdown races could either release work without a transport or leave it pending forever.

## Validation

- persistent runtime and transport tests: 41 passed
- Chromium disconnect lifecycle suite: 8 passed
- local-only async transaction regression passed
- full jazz-tools build passed
- formatting, lint, and sensitive-data checks passed
- independent adversarial review found no remaining P0/P1/P2
