### PR TITLE
fix: repair integration API drift

### DIFF
--- a/crates/jazz-sim/benches/micro.rs
+++ b/crates/jazz-sim/benches/micro.rs
@@ -11,6 +11,7 @@ use jazz::node::{MergeableCommit, NodeState, SKEW_TOLERANCE_MS};
 use jazz::protocol::{SyncMessage, VersionRecord};
 use jazz::schema::{JazzSchema, TableSchema};
 use jazz::time::TxTime;
+use jazz::tools::OpenBatchId;
 use jazz::tx::{BranchLineage, DeletionEvent, DurabilityTier, Fate, Transaction};
 use jazz_sim::{emit_json_line, metadata_fields};
 use serde_json::{Map, Value as JsonValue, json};
@@ -286,7 +287,8 @@ fn run_read_set_capture(config: &Config) {
     seed_local_rows(&mut node_, 64);
 
     let mut row_hist = NsHist::new();
-    let tx = node_.open_exclusive().expect("open tx");
+    let tx = OpenBatchId::new();
+    node_.open_exclusive(tx).expect("open tx");
     for idx in 0..config.iterations {
         let start = Instant::now();
         let _ = node_
@@ -299,7 +301,8 @@ fn run_read_set_capture(config: &Config) {
 
     let mut predicate_hist = NsHist::new();
     for _ in 0..config.iterations {
-        let tx = node_.open_exclusive().expect("open tx");
+        let tx = OpenBatchId::new();
+        node_.open_exclusive(tx).expect("open tx");
         let start = Instant::now();
         let rows = node_
             .tx_current_rows(tx, TABLE)
@@ -330,7 +333,8 @@ fn run_validation_entries(config: &Config) {
 
     let mut row_hist = NsHist::new();
     for idx in 0..config.iterations {
-        let tx = client.open_exclusive().expect("open tx");
+        let tx = OpenBatchId::new();
+        client.open_exclusive(tx).expect("open tx");
         let _ = client.tx_read(tx, TABLE, row(idx % 64)).expect("tx read");
         client
             .tx_write(
@@ -364,7 +368,8 @@ fn run_validation_entries(config: &Config) {
 
     let mut predicate_hist = NsHist::new();
     for idx in 0..config.iterations {
-        let tx = client.open_exclusive().expect("open tx");
+        let tx = OpenBatchId::new();
+        client.open_exclusive(tx).expect("open tx");
         let _ = client.tx_current_rows(tx, TABLE).expect("tx current rows");
         client
             .tx_write(

--- a/crates/jazz/SPEC/E_structured_results_implementation_plan.md
+++ b/crates/jazz/SPEC/E_structured_results_implementation_plan.md
@@ -33,20 +33,20 @@ variant.
 
 ## Status (2026-08-06)
 
-| stage | state |
-|---|---|
-| PR 1 — durable-key rejection | **merged** (#1260); `INV-STORAGE-27` now/✓ |
-| PR 2 — Groove `CollectBy` terminal | **merged** (#1263); `INV-QUERY-27`, `INV-QUERY-28`, `G-INV-REC-16` now/✓ |
-| PR 3 — canonical `ResultTree`, explicit boundedness | **merged** (#1282); `INV-QUERY-29` now/✓ |
-| PR 3.5 — terminal integration | **blocked**, see _Terminal integration blocker_ below |
-| PR 4 — atomic structured delivery on v4 | **blocked** on the same question |
-| PR 5 — structured differential oracle | not started; `INV-TEST-5` target |
+| stage                                               | state                                                                    |
+| --------------------------------------------------- | ------------------------------------------------------------------------ |
+| PR 1 — durable-key rejection                        | **merged** (#1260); `INV-STORAGE-27` now/✓                               |
+| PR 2 — Groove `CollectBy` terminal                  | **merged** (#1263); `INV-QUERY-27`, `INV-QUERY-28`, `G-INV-REC-16` now/✓ |
+| PR 3 — canonical `ResultTree`, explicit boundedness | **merged** (#1282); `INV-QUERY-29` now/✓                                 |
+| PR 3.5 — terminal integration                       | **blocked**, see _Terminal integration blocker_ below                    |
+| PR 4 — atomic structured delivery on v4             | **blocked** on the same question                                         |
+| PR 5 — structured differential oracle               | not started; `INV-TEST-5` target                                         |
 
 Two decisions taken after this plan was written, and not part of its original
 five stages:
 
-- **Explicit boundedness.** `INV-QUERY-29` means *boundedness must be declared*,
-  not *a finite limit must be present*. An array subquery declares `limit(n)`
+- **Explicit boundedness.** `INV-QUERY-29` means _boundedness must be declared_,
+  not _a finite limit must be present_. An array subquery declares `limit(n)`
   (zero valid, rendering `[]`) or `unbounded()`; declaring neither is a
   validation error. `unbounded()` is a first-class supported mode — three
   correctness gates use it deliberately, so a literal ban would have forced them
@@ -63,10 +63,10 @@ stopped before mutating anything. The reasons compose into one question.
 
 **`CollectBy` renders one collection slot.** `CollectByOp` carries a single
 `collection_field` and produces one parent with one `Array<Record>`.
-`ResultTree` requires *named ordered child arrays* — sibling relations — and
+`ResultTree` requires _named ordered child arrays_ — sibling relations — and
 recursion through parent → child → grandchild. The obvious bridge is composing
 collectors, but `INV-QUERY-27` forbids precisely that: a collector may not be
-an input to any graph node, *including another collector*. The rule that makes
+an input to any graph node, _including another collector_. The rule that makes
 the terminal clean is the rule that prevents composing one into a tree.
 
 **The carrier forces flattening.** The only public maintained carrier is
@@ -75,7 +75,7 @@ deltas (`crates/jazz/src/db.rs:8128`); the remote carrier encodes
 `RelationEdgeEntry` (`crates/jazz/src/protocol.rs:1890`). A structured terminal
 result cannot traverse either without flattening back into rows and edges —
 which is the facade-side reconstruction the design forbids. So over the
-retained v3 path a changed child *cannot* be delivered as a whole-parent
+retained v3 path a changed child _cannot_ be delivered as a whole-parent
 replacement.
 
 Together these mean terminal integration and the wire cut cannot be separated

--- a/crates/jazz/tests/catalogue_sync_integration.rs
+++ b/crates/jazz/tests/catalogue_sync_integration.rs
@@ -2648,7 +2648,10 @@ async fn local_join_query_uses_current_permissions_for_joined_provenance_after_l
         )
         .expect("admin creates current-schema post");
     current_admin
-        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .wait_for_batch(
+            batch_id.expect("ordinary mutation commits immediately"),
+            DurabilityTier::EdgeServer,
+        )
         .await
         .expect("current-schema post reaches edge");
 
@@ -2712,9 +2715,12 @@ async fn local_join_query_uses_current_permissions_for_joined_provenance_after_l
             vec![("viewer_name".to_owned(), Value::Text(test_user_id("alice")))],
         )
         .expect("move one joined occurrence to Alice's policy scope");
-    bob.wait_for_batch(batch_id, DurabilityTier::EdgeServer)
-        .await
-        .expect("selective policy update reaches edge");
+    bob.wait_for_batch(
+        batch_id.expect("ordinary mutation commits immediately"),
+        DurabilityTier::EdgeServer,
+    )
+    .await
+    .expect("selective policy update reaches edge");
 
     let retained_bob_rows = wait_for_query_results(
         &bob,

--- a/crates/jazz/tests/output_occurrence_id.rs
+++ b/crates/jazz/tests/output_occurrence_id.rs
@@ -170,7 +170,10 @@ async fn flat_join_output_occurrence_identity_addresses_additions_removals_and_r
                 )
                 .expect("insert first matching joined row");
             client
-                .wait_for_batch(batch, DurabilityTier::Local)
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::Local,
+                )
                 .await
                 .expect("first joined row settles locally");
             let first_added = next_delta_with_added(&mut joined_stream).await;
@@ -196,7 +199,10 @@ async fn flat_join_output_occurrence_identity_addresses_additions_removals_and_r
                 )
                 .expect("insert second matching join row");
             client
-                .wait_for_batch(batch, DurabilityTier::EdgeServer)
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::EdgeServer,
+                )
                 .await
                 .expect("second todo settles");
             let fan_out = next_delta_with_added(&mut joined_stream).await;
@@ -277,7 +283,10 @@ async fn flat_join_output_occurrence_identity_addresses_additions_removals_and_r
                 )
                 .expect("replace root source content");
             client
-                .wait_for_batch(batch, DurabilityTier::EdgeServer)
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::EdgeServer,
+                )
                 .await
                 .expect("replacement settles");
             let replacement = next_delta_with_updated(&mut joined_stream).await;
@@ -304,7 +313,10 @@ async fn flat_join_output_occurrence_identity_addresses_additions_removals_and_r
                 )
                 .expect("replace joined source content");
             client
-                .wait_for_batch(batch, DurabilityTier::EdgeServer)
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::EdgeServer,
+                )
                 .await
                 .expect("joined-side replacement settles");
             let joined_replacement = next_delta_with_updated(&mut joined_stream).await;
@@ -336,7 +348,10 @@ async fn flat_join_output_occurrence_identity_addresses_additions_removals_and_r
 
             let batch = client.delete(first).expect("remove first joined row");
             client
-                .wait_for_batch(batch, DurabilityTier::EdgeServer)
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::EdgeServer,
+                )
                 .await
                 .expect("joined-row removal settles");
             let removal = next_delta_with_removed(&mut joined_stream).await;
@@ -419,7 +434,10 @@ async fn flat_join_payload_netting_drops_add_then_remove_in_one_transaction_batc
                 )
                 .expect("insert root");
             client
-                .wait_for_batch(batch, DurabilityTier::EdgeServer)
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::EdgeServer,
+                )
                 .await
                 .expect("root settles");
 
@@ -458,7 +476,10 @@ async fn flat_join_payload_netting_drops_add_then_remove_in_one_transaction_batc
                 )
                 .expect("insert durable matching joined row");
             client
-                .wait_for_batch(batch, DurabilityTier::EdgeServer)
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::EdgeServer,
+                )
                 .await
                 .expect("durable joined row settles");
             let delta = next_delta_with_added(&mut stream).await;

--- a/crates/jazz/tests/sync_telemetry_otel.rs
+++ b/crates/jazz/tests/sync_telemetry_otel.rs
@@ -69,7 +69,10 @@ async fn sync_layers_emit_otel_spans() {
         .insert("todos", todo_values("trace sync telemetry", false))
         .expect("alice creates persisted todo");
     alice
-        .wait_for_batch(batch_id, DurabilityTier::EdgeServer)
+        .wait_for_batch(
+            batch_id.expect("ordinary mutation commits immediately"),
+            DurabilityTier::EdgeServer,
+        )
         .await
         .expect("alice persisted todo reaches edge");
 


### PR DESCRIPTION
Repairs stale integration call sites after the explicit open-batch and optional committed-batch API changes.

- supply generated `OpenBatchId` values to jazz-sim micro benchmark transaction APIs
- assert committed batch IDs before waiting for edge durability in affected Rust integration tests

Validation: `cargo fmt --all -- --check`; `cargo check --workspace --all-targets`; `cargo test -p jazz --test sync_telemetry_otel --features "test otel-core"`.