### PR TITLE
Fix maintained join allocation scaling

### DIFF
--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -26,6 +26,18 @@ pub(super) type JoinKey = SmallVec<[u8; 64]>;
 type JoinBucket = HashMap<Bytes, i64>;
 type JoinIndex = HashMap<JoinKey, JoinBucket>;
 
+pub(super) fn touched_join_keys(
+    descriptor: &RecordDescriptor,
+    fields: &[String],
+    deltas: &[RecordDelta],
+    comparison: ValueComparison,
+) -> Result<Vec<Vec<u8>>, IvmRuntimeError> {
+    Ok(keyed_join_deltas(descriptor, fields, deltas, comparison)?
+        .into_iter()
+        .map(|delta| delta.key.into_vec())
+        .collect())
+}
+
 #[derive(Clone, Debug, Default)]
 pub(super) struct JoinState;
 

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -46,7 +46,7 @@ mod join;
 mod persist;
 mod recursion;
 
-use join::{AntiJoinState, ArrangementState, JoinState};
+use join::{AntiJoinState, ArrangementState, JoinState, touched_join_keys};
 use persist::apply_persist_delta;
 use recursion::{
     RecursiveState, hydrate_recursive_arrangements, recompute_recursive, recursive_delta,
@@ -7087,8 +7087,32 @@ where
             .unwrap_or_default();
         // Pull arrangements out while applying so both sides can be mutated
         // without aliasing the arrangement map.
-        let mut right_arrangement = if left_key == right_key {
-            left_arrangement.clone()
+        let shared_arrangement_keys = if left_key == right_key {
+            let mut keys = touched_join_keys(
+                &join.left_descriptor,
+                &left_key.fields,
+                left_delta,
+                join.comparison,
+            )?;
+            keys.extend(touched_join_keys(
+                &join.right_descriptor,
+                &right_key.fields,
+                right_delta,
+                join.comparison,
+            )?);
+            // `replace_keys` consumes each replacement bucket. A key can be
+            // present in both sides' deltas, so pass every touched key once.
+            keys.sort_unstable();
+            keys.dedup();
+            Some(keys)
+        } else {
+            None
+        };
+        let mut right_arrangement = if let Some(keys) = &shared_arrangement_keys {
+            AsOf {
+                value: left_arrangement.value().clone_keys(keys.iter()),
+                as_of: left_arrangement.as_of(),
+            }
         } else {
             self.arrangement_states
                 .remove(&right_key)
@@ -7110,8 +7134,10 @@ where
             self.arrangement_sub_tick(&right_key),
             self.context.arrangement_update_mode,
         )?;
-        if left_key == right_key {
-            left_arrangement = right_arrangement;
+        if let Some(keys) = shared_arrangement_keys {
+            left_arrangement
+                .value_mut()
+                .replace_keys(keys.iter(), right_arrangement.value().clone());
         } else {
             self.arrangement_states.insert(right_key, right_arrangement);
         }


### PR DESCRIPTION
🤖

## What changed

When both sides of a maintained join share the same arrangement, update only the buckets for join keys touched by the incoming deltas. The previous implementation cloned the entire accumulated arrangement for every child change.

Touched keys are sorted and deduplicated before buckets are moved and replaced. Deduplication is required because moving a bucket consumes it; processing the same left/right key twice would drop the replacement.

## Why

A single relation/include child write performed O(total accumulated relation state) allocation inside `db.insert`, even though the maintained query emitted one terminal operation. At 20,000 accumulated rows, allocated bytes grew by roughly 10x.

## Result

Exact 20k canary after the fix:

- small: 5,100 allocations / 653,606 bytes
- large: 5,101 allocations / 654,256 bytes

The allocation and byte cost are effectively constant with accumulated state.

## Validation

- independent adversarial review: no P0/P1/P2 findings
- all incremental-delivery canaries: 3/3
- Groove: 389 passed, 1 ignored; doc tests passed
- structured result tree: 4/4
- authorization scope re-entry: 3/3
- prepared claim routing: 9 passed, 1 ignored
- parameterized subscription routing and reconnect coverage passed
- planted old full-clone, missing-dedup, and wrong-replacement variants exercised the intended failure boundaries
- strict Groove Clippy, formatting, sensitive-data and clean-tree checks passed
