### PR TITLE
Fix terminal subscription identity and record decoding

### DIFF
--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -10519,6 +10519,14 @@ fn collect_by_projection_value_type(
     })
 }
 
+fn collect_by_output_value(output_type: &ValueType, value: Value) -> Value {
+    match (output_type, value) {
+        (ValueType::Nullable(_), value @ Value::Nullable(_)) => value,
+        (ValueType::Nullable(_), value) => Value::Nullable(Some(Box::new(value))),
+        (_, value) => value,
+    }
+}
+
 fn collect_by_projected_value(
     values: &[Value],
     field: &CollectByProjection,
@@ -10672,7 +10680,13 @@ fn update_unbounded_collect_by_terminal_state(
             .unwrap_or(collect_by.collection_field.as_str());
         let child_values = child_fields
             .iter()
-            .map(|field| collect_by_projected_value(&source_values, field))
+            .enumerate()
+            .map(|(index, field)| {
+                Ok::<Value, IvmRuntimeError>(collect_by_output_value(
+                    &child_descriptor.fields()[index].value_type,
+                    collect_by_projected_value(&source_values, field)?,
+                ))
+            })
             .collect::<Result<Vec<_>, _>>()?;
         let child_record: Vec<u8> = child_descriptor.create(&child_values)?;
         let child_key = encoded_record_key_part(child_descriptor, &child_record, &[0])?;
@@ -10849,11 +10863,7 @@ fn collect_by_root_from_records(
         .map(|(index, field)| {
             let value = collect_by_projected_value(&parent_values, field)?;
             let output_type = &output_desc.fields()[index].value_type;
-            Ok::<Value, IvmRuntimeError>(match (output_type, value) {
-                (ValueType::Nullable(_), value @ Value::Nullable(_)) => value,
-                (ValueType::Nullable(_), value) => Value::Nullable(Some(Box::new(value))),
-                (_, value) => value,
-            })
+            Ok::<Value, IvmRuntimeError>(collect_by_output_value(output_type, value))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let record = output_desc.create(&values).map_err(|error| {
@@ -10881,11 +10891,7 @@ fn collect_by_parent_from_records(
         .map(|(index, field)| {
             let value = collect_by_projected_value(&parent_values, field)?;
             let output_type = &output_desc.fields()[index].value_type;
-            Ok::<Value, IvmRuntimeError>(match (output_type, value) {
-                (ValueType::Nullable(_), value @ Value::Nullable(_)) => value,
-                (ValueType::Nullable(_), value) => Value::Nullable(Some(Box::new(value))),
-                (_, value) => value,
-            })
+            Ok::<Value, IvmRuntimeError>(collect_by_output_value(output_type, value))
         })
         .collect::<Result<Vec<_>, _>>()?;
     let window = collect_by_window_from_records(input_desc, records, collect_by)?;
@@ -10897,7 +10903,13 @@ fn collect_by_parent_from_records(
         let child_values = collect_by
             .child_fields
             .iter()
-            .map(|field| collect_by_projected_value(&source_values, field))
+            .enumerate()
+            .map(|(index, field)| {
+                Ok::<Value, IvmRuntimeError>(collect_by_output_value(
+                    &collect_by.child_descriptor.fields()[index].value_type,
+                    collect_by_projected_value(&source_values, field)?,
+                ))
+            })
             .collect::<Result<Vec<_>, _>>()?;
         let child = OwnedRecord::new(
             collect_by.child_descriptor.create(&child_values)?,
@@ -10926,7 +10938,13 @@ fn collect_by_tree_parent_from_records(
     let mut values = collect_by
         .parent_fields
         .iter()
-        .map(|field| collect_by_projected_value(&parent_values, field))
+        .enumerate()
+        .map(|(index, field)| {
+            Ok::<Value, IvmRuntimeError>(collect_by_output_value(
+                &output_desc.fields()[index].value_type,
+                collect_by_projected_value(&parent_values, field)?,
+            ))
+        })
         .collect::<Result<Vec<_>, _>>()?;
     values.extend(render_collect_by_slots(
         input_desc,
@@ -11003,7 +11021,13 @@ fn render_collect_by_slots(
                 let mut child_values = slot
                     .child_fields
                     .iter()
-                    .map(|field| collect_by_projected_value(&source_values, field))
+                    .enumerate()
+                    .map(|(index, field)| {
+                        Ok::<Value, IvmRuntimeError>(collect_by_output_value(
+                            &slot.child_descriptor.fields()[index].value_type,
+                            collect_by_projected_value(&source_values, field)?,
+                        ))
+                    })
                     .collect::<Result<Vec<_>, _>>()?;
                 child_values.extend(render_collect_by_slots(
                     input_desc,
@@ -11446,6 +11470,33 @@ mod tests {
         ColumnSchema, ColumnType, DatabaseSchema, IndexSchema, IntegerKeyType, PrimaryKey,
     };
     use crate::storage::{RecordStore, RocksDbStorage};
+
+    #[test]
+    fn collect_by_terminal_records_preserve_nullable_descriptor_wrappers() {
+        let uuid = uuid::Uuid::from_bytes([7; 16]);
+
+        assert_eq!(
+            collect_by_output_value(
+                &ValueType::Nullable(Box::new(ValueType::I32)),
+                Value::I32(3),
+            ),
+            Value::Nullable(Some(Box::new(Value::I32(3))))
+        );
+        assert_eq!(
+            collect_by_output_value(
+                &ValueType::Nullable(Box::new(ValueType::Uuid)),
+                Value::Uuid(uuid),
+            ),
+            Value::Nullable(Some(Box::new(Value::Uuid(uuid))))
+        );
+        assert_eq!(
+            collect_by_output_value(
+                &ValueType::Nullable(Box::new(ValueType::I32)),
+                Value::Nullable(None),
+            ),
+            Value::Nullable(None)
+        );
+    }
 
     #[test]
     fn root_ordering_rewrites_insert_indices_and_emits_moves_after_payload_edits() {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -4853,7 +4853,7 @@ where
                         .reset_local_maintained_view_subscription_from_binding_view(
                             maintained,
                             binding_view,
-                        );
+                        )?;
                     snapshot = authoritative;
                     consumed_authoritative_resets.insert(binding_view);
                 }
@@ -5057,7 +5057,7 @@ where
                                             .reset_local_maintained_view_subscription_from_binding_view(
                                                 maintained,
                                                 authoritative_reset_binding_view,
-                                            );
+                                            )?;
                                         None
                                     }
                                     Err(error) => return Err(error.into()),

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -9272,6 +9272,126 @@ fn server_reset_subscription_materializes_without_local_snapshot_eval() {
 }
 
 #[test]
+fn authoritative_reset_rebuilds_occurrence_sidecar_after_order_and_count_change() {
+    let schema = schema();
+    let client_author = AuthorId::from_bytes([0xc1; 16]);
+    let client = open_db(0xc1, client_author, &schema);
+
+    let first = row(0x71);
+    let middle = row(0x72);
+    let last = row(0x73);
+    let first_write = client
+        .insert_with_id("todos", first, cells("alpha", false, client_author))
+        .unwrap();
+    let _middle_write = client
+        .insert_with_id("todos", middle, cells("middle", false, client_author))
+        .unwrap();
+    let last_write = client
+        .insert_with_id("todos", last, cells("omega", false, client_author))
+        .unwrap();
+    client.tick().unwrap();
+
+    let query = Query::from("todos").order_by("title", OrderDirection::Asc);
+    let prepared = prepared(&client, &query);
+    let opts = ReadOpts::default();
+    let mut subscription = block_on(client.subscribe(&prepared, opts.clone())).unwrap();
+    let SubscriptionEvent::Delta { added, .. } = block_on(subscription.next_event()).unwrap()
+    else {
+        panic!("expected opening subscription delta");
+    };
+    assert_eq!(
+        added.iter().map(|row| row.row_uuid()).collect::<Vec<_>>(),
+        vec![first, middle, last]
+    );
+
+    let first_updated = client
+        .update(
+            "todos",
+            first,
+            BTreeMap::from([("title".to_owned(), Value::String("zulu".to_owned()))]),
+        )
+        .unwrap();
+    let binding_view_key = BindingViewKey::new(
+        prepared.shape().shape_id(),
+        prepared.binding().binding_id(),
+        RegisterShapeOptions {
+            tier: opts.tier,
+            read_view: opts.read_view,
+        }
+        .read_view_key(),
+    );
+    client
+        .node
+        .node
+        .borrow_mut()
+        .inject_pending_authoritative_reset_for_test(
+            binding_view_key,
+            [
+                ResultMemberEntry::row((
+                    "todos".to_owned().into(),
+                    first,
+                    first_updated.mergeable_tx_id(),
+                )),
+                ResultMemberEntry::row((
+                    "todos".to_owned().into(),
+                    last,
+                    last_write.mergeable_tx_id(),
+                )),
+            ],
+            GlobalSeq(42),
+        );
+
+    assert_eq!(client.refresh_subscriptions().unwrap(), 1);
+    let event = block_on(subscription.next_event()).unwrap();
+    let reset = if matches!(event, SubscriptionEvent::Delta { reset: true, .. }) {
+        event
+    } else {
+        block_on(subscription.next_event()).unwrap()
+    };
+    assert!(matches!(
+        reset,
+        SubscriptionEvent::Delta { reset: true, .. }
+    ));
+
+    let state = subscription._state.borrow();
+    let SubscriptionKind::Prepared {
+        maintained_subscription: Some(maintained),
+        ..
+    } = &state.kind
+    else {
+        panic!("expected maintained subscription state");
+    };
+    let paired = subscription_outputs_with_occurrence_sidecar(
+        &state.snapshot,
+        maintained.root_occurrence_ids(),
+    )
+    .expect("authoritative reset must atomically replace the root occurrence sidecar");
+    assert_eq!(
+        paired
+            .iter()
+            .map(|output| output.row_uuid())
+            .collect::<Vec<_>>(),
+        vec![last, first],
+        "reset rows reordered after the title update and removed the middle row"
+    );
+    assert_eq!(
+        paired
+            .iter()
+            .map(|output| output.occurrence_id.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            OutputOccurrenceId::single_source(ObjectId::from_uuid(last.0)),
+            OutputOccurrenceId::single_source(ObjectId::from_uuid(first.0)),
+        ],
+        "each reset row remains paired with its current occurrence root"
+    );
+    assert_ne!(
+        first_write.mergeable_tx_id(),
+        first_updated.mergeable_tx_id()
+    );
+}
+
+#[test]
 fn authoritative_reset_with_missing_payload_falls_back_to_refresh() {
     let schema = schema();
     let client_author = AuthorId::from_bytes([0xc1; 16]);

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -6522,7 +6522,7 @@ fn collect_slot_builder(
     CollectBySlotBuilder::new(
         std::iter::once(parent_row_id.to_owned()).chain(route_fields.iter().cloned()),
         slot.fields.iter().map(|field| {
-            if field.is_row_id {
+            if field.is_row_id || field.value_type == field.output_value_type {
                 CollectByField::renamed(&field.input, &field.output)
             } else {
                 CollectByField::renamed_unwrap_nullable(&field.input, &field.output)

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -7901,7 +7901,7 @@ where
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
         binding_view_key: BindingViewKey,
-    ) {
+    ) -> Result<(), Error> {
         local.result_set = self
             .query
             .settled_result_sets
@@ -7935,6 +7935,15 @@ where
                 _ => None,
             })
             .collect();
+        // An authoritative reset replaces membership without flowing through
+        // the ordinary local transition reducer. Rebuild the occurrence
+        // sidecar from exactly that new state before the caller pairs it with
+        // the reset snapshot; retaining the opening vector makes a later
+        // reset fail its root-count invariant (or, worse, pair wrong roots).
+        local.root_occurrence_ids = self
+            .materialize_local_maintained_relation_snapshot_with_occurrences(local)?
+            .root_occurrence_ids;
+        Ok(())
     }
 
     fn drain_local_maintained_view_subscription_transitions(

--- a/crates/jazz/src/tools/object.rs
+++ b/crates/jazz/src/tools/object.rs
@@ -531,6 +531,14 @@ mod tests {
             "typed discriminator records must use strictly ascending positions"
         );
 
+        let mut invalid_utf8 = vec![TYPED_RESULT_KEY_WIRE_VERSION];
+        invalid_utf8.extend_from_slice(&valid.typed_canonical_bytes());
+        *invalid_utf8.last_mut().expect("typed key has arm label") = 0xff;
+        assert!(
+            serde_json::from_value::<ResultKey>(serde_json::json!(invalid_utf8)).is_err(),
+            "typed discriminator labels must be valid UTF-8"
+        );
+
         let typed = ResultKey(valid);
         let mut oversized: Vec<u8> =
             serde_json::from_slice(&serde_json::to_vec(&typed).expect("encode typed key fixture"))

--- a/crates/jazz/src/tools/object.rs
+++ b/crates/jazz/src/tools/object.rs
@@ -274,10 +274,14 @@ fn decode_typed_result_key(identity: &[u8]) -> Option<ResultKey> {
     }
     let discriminator_count =
         u32::from_be_bytes(take(identity, &mut cursor, 4)?.try_into().ok()?) as usize;
-    if discriminator_count > joined_count {
+    // v2 is reserved for union-discriminated occurrences. A zero-arm v2
+    // representation would deserialize to a plain occurrence that serializes
+    // as v1, so reject it rather than accepting a noncanonical alias.
+    if discriminator_count == 0 || discriminator_count > joined_count {
         return None;
     }
     let mut union_arms = Vec::with_capacity(discriminator_count);
+    let mut previous_position = None;
     for _ in 0..discriminator_count {
         let position =
             u32::from_be_bytes(take(identity, &mut cursor, 4)?.try_into().ok()?) as usize;
@@ -286,9 +290,15 @@ fn decode_typed_result_key(identity: &[u8]) -> Option<ResultKey> {
         {
             return None;
         }
+        if position >= joined_count
+            || previous_position.is_some_and(|previous| position <= previous)
+        {
+            return None;
+        }
         let label = std::str::from_utf8(take(identity, &mut cursor, len)?)
             .ok()?
             .to_owned();
+        previous_position = Some(position);
         union_arms.push((position, label));
     }
     if cursor != identity.len() {
@@ -494,6 +504,32 @@ mod tests {
         malformed.extend_from_slice(&valid.typed_canonical_bytes());
         malformed.push(0);
         assert!(serde_json::from_value::<ResultKey>(serde_json::json!(malformed)).is_err());
+
+        let mut zero_arm = vec![TYPED_RESULT_KEY_WIRE_VERSION];
+        zero_arm.extend_from_slice(&valid.typed_canonical_bytes());
+        zero_arm[37..41].copy_from_slice(&0_u32.to_be_bytes());
+        assert!(
+            serde_json::from_value::<ResultKey>(serde_json::json!(zero_arm)).is_err(),
+            "zero-arm v2 aliases the v1 occurrence representation"
+        );
+
+        let second_joined = ObjectId::from_uuid(Uuid::from_u128(3));
+        let mut reordered = vec![TYPED_RESULT_KEY_WIRE_VERSION];
+        reordered.extend_from_slice(root.uuid().as_bytes());
+        reordered.extend_from_slice(&2_u32.to_be_bytes());
+        reordered.extend_from_slice(joined.uuid().as_bytes());
+        reordered.extend_from_slice(second_joined.uuid().as_bytes());
+        reordered.extend_from_slice(&2_u32.to_be_bytes());
+        reordered.extend_from_slice(&1_u32.to_be_bytes());
+        reordered.extend_from_slice(&1_u32.to_be_bytes());
+        reordered.push(b"b"[0]);
+        reordered.extend_from_slice(&0_u32.to_be_bytes());
+        reordered.extend_from_slice(&1_u32.to_be_bytes());
+        reordered.push(b"a"[0]);
+        assert!(
+            serde_json::from_value::<ResultKey>(serde_json::json!(reordered)).is_err(),
+            "typed discriminator records must use strictly ascending positions"
+        );
 
         let typed = ResultKey(valid);
         let mut oversized: Vec<u8> =

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { PostcardReader, PostcardWriter } from "./native-codec.js";
 import {
   createRecord,
+  decodeNativeTerminalRow,
   decodeNativeRowValues,
   decodeRecordValue,
   encodeNativeRowValues,
@@ -187,6 +188,65 @@ describe("native row codec", () => {
     expect(decodeNativeRowValues(columns, explicitNull)).toEqual([{ type: "Null" }]);
     expect(decodeNativeRowValues(columns, sparseAbsence)).toEqual([{ type: "Null" }]);
   });
+
+  it("decodes terminal arrays as physical nested records rather than packed row envelopes", () => {
+    const rootId = "00000000-0000-4000-8000-000000000001";
+    const firstChildId = "00000000-0000-4000-8000-000000000002";
+    const secondChildId = "00000000-0000-4000-8000-000000000003";
+    const children = [
+      { name: "children", column_type: { type: "Text" as const }, nullable: false },
+    ];
+    const columns = [
+      {
+        name: "children",
+        column_type: {
+          type: "Array" as const,
+          element: { type: "Row" as const, columns: children },
+        },
+        nullable: false,
+      },
+    ];
+    const childRecord = (id: string, name: string) =>
+      Uint8Array.from([...uuidBytes(id), ...new TextEncoder().encode(name)]);
+    const first = childRecord(firstChildId, "first");
+    const second = childRecord(secondChildId, "second");
+    const childArray = Uint8Array.from([
+      2,
+      0,
+      0,
+      0,
+      4 + 4 + first.length,
+      0,
+      0,
+      0,
+      ...first,
+      ...second,
+    ]);
+    const descriptor = [
+      { name: "__jazz_terminal_row_key", valueType: { tag: 10 } },
+      { name: "children", valueType: { tag: 13, inner: { tag: 15, record: [] } } },
+    ];
+    const raw = createRecord(descriptor, [uuidBytes(rootId), childArray]);
+
+    expect(decodeNativeTerminalRow(rootId, columns, raw)).toMatchObject({
+      id: rootId,
+      values: [
+        {
+          type: "Array",
+          value: [
+            {
+              type: "Row",
+              value: { id: firstChildId, values: [{ type: "Text", value: "first" }] },
+            },
+            {
+              type: "Row",
+              value: { id: secondChildId, values: [{ type: "Text", value: "second" }] },
+            },
+          ],
+        },
+      ],
+    });
+  });
 });
 
 function nativeRowCodecFixture(): NativeRowCodecFixture {
@@ -208,4 +268,13 @@ function hexToBytes(hex: string): Uint8Array {
 
 function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function uuidBytes(id: string): Uint8Array {
+  return Uint8Array.from(
+    id
+      .replaceAll("-", "")
+      .match(/../g)!
+      .map((hex) => Number.parseInt(hex, 16)),
+  );
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -107,8 +107,10 @@ function validTypedResultKey(bytes: Uint8Array): boolean {
   cursor += joined * 16;
   const discriminators = readU32(cursor);
   cursor += 4;
-  if (discriminators > joined) return false;
-  const positions = new Set<number>();
+  // v2 is reserved for typed union occurrences. A zero-arm v2 value would
+  // normalize to the same ordered UUID key as a v1 occurrence.
+  if (discriminators === 0 || discriminators > joined) return false;
+  let previousPosition = -1;
   for (let index = 0; index < discriminators; index++) {
     if (cursor + 8 > bytes.length) return false;
     const position = readU32(cursor);
@@ -116,14 +118,14 @@ function validTypedResultKey(bytes: Uint8Array): boolean {
     cursor += 8;
     if (
       position >= joined ||
-      positions.has(position) ||
+      position <= previousPosition ||
       length === 0 ||
       length > 4096 ||
       cursor + length > bytes.length
     ) {
       return false;
     }
-    positions.add(position);
+    previousPosition = position;
     cursor += length;
   }
   return cursor === bytes.length;

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -2,6 +2,7 @@ import type { ColumnDescriptor, ColumnType, Value, WasmRow } from "../../drivers
 import { isProvenanceMagicTimestampColumn } from "../../magic-columns.js";
 
 const textDecoder = new TextDecoder();
+const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 export type ValueType = {
   tag: number;
@@ -121,7 +122,8 @@ function validTypedResultKey(bytes: Uint8Array): boolean {
       position <= previousPosition ||
       length === 0 ||
       length > 4096 ||
-      cursor + length > bytes.length
+      cursor + length > bytes.length ||
+      !isValidUtf8(bytes.subarray(cursor, cursor + length))
     ) {
       return false;
     }
@@ -129,6 +131,15 @@ function validTypedResultKey(bytes: Uint8Array): boolean {
     cursor += length;
   }
   return cursor === bytes.length;
+}
+
+function isValidUtf8(bytes: Uint8Array): boolean {
+  try {
+    fatalUtf8Decoder.decode(bytes);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function readNativeRelationSubscriptionSnapshot(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -340,7 +340,7 @@ export function decodeNativeTerminalRow(
   raw: Uint8Array,
 ): WasmRow {
   const terminalColumns = [terminalRowKeyColumn, ...columns];
-  const decoded = decodeNativeRowValues(terminalColumns, raw);
+  const decoded = decodeNativeTerminalRowValues(terminalColumns, raw);
   const embeddedKey = decoded[0];
   if (embeddedKey?.type !== "Uuid" || embeddedKey.value !== id) {
     throw new Error(
@@ -356,6 +356,45 @@ export function decodeNativeTerminalRow(
     configurable: true,
   });
   return row;
+}
+
+/**
+ * Groove terminal payloads retain `Record` values for nested relation rows.
+ * Ordinary packed transport deliberately represents those rows as byte arrays
+ * with an id/length envelope instead. Both outer records have the same layout,
+ * but decoding a terminal tree through the ordinary path makes the first UUID
+ * of a child look like that envelope's flag and length.
+ */
+function decodeNativeTerminalRowValues(
+  columns: readonly ColumnDescriptor[],
+  raw: Uint8Array,
+): Value[] {
+  const descriptor = descriptorFromColumns(columns);
+  return columns.map((column, index) => {
+    const bytes = decodeRecordValue(descriptor, raw, index);
+    if (bytes == null) return { type: "Null" };
+    return decodeTerminalBytes(column.column_type, bytes);
+  });
+}
+
+function decodeTerminalBytes(type: ColumnType, bytes: Uint8Array): Value {
+  switch (type.type) {
+    case "Array":
+      return { type: "Array", value: decodeTerminalArray(type.element, bytes) };
+    case "Row": {
+      if (bytes.byteLength < 16) throw new Error("terminal nested row is missing its physical key");
+      const id = formatUuid(bytes.subarray(0, 16));
+      return { type: "Row", value: decodeNativeTerminalRow(id, type.columns, bytes) };
+    }
+    default:
+      return decodeBytes(type, bytes);
+  }
+}
+
+function decodeTerminalArray(elementType: ColumnType, bytes: Uint8Array): Value[] {
+  return decodeArrayElements(elementType, bytes, (element) =>
+    decodeTerminalBytes(elementType, element),
+  );
 }
 
 export function encodeNativeRowValues(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -3745,7 +3745,13 @@ export function decodeNestedRowBytes(
         name,
         valueBytes == null
           ? { type: "Null" }
-          : decodeBytes(column.column_type, valueBytes, name, payloadDescriptor[index]?.valueType),
+          : decodeBytes(
+              column.column_type,
+              valueBytes,
+              name,
+              payloadDescriptor[index]?.valueType,
+              carrier,
+            ),
       );
     }
     const row: { id?: string; values: Value[]; valuesByColumn?: Map<string, Value> } = {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -6285,6 +6285,25 @@ it("rejects malformed or misaligned subscription occurrence sidecars", () => {
   expect(() => readNativeSubscriptionDelta(new PostcardReader(aliasedV1))).toThrow(
     "malformed v2 ResultKey",
   );
+
+  const invalidUtf8 = new Uint8Array(50);
+  invalidUtf8[0] = 2;
+  invalidUtf8.fill(1, 1, 17);
+  new DataView(invalidUtf8.buffer).setUint32(17, 1);
+  invalidUtf8.fill(2, 21, 37);
+  new DataView(invalidUtf8.buffer).setUint32(37, 1);
+  new DataView(invalidUtf8.buffer).setUint32(41, 0);
+  new DataView(invalidUtf8.buffer).setUint32(45, 1);
+  invalidUtf8[49] = 0xff;
+  const malformedLabel = encodeSubscriptionDelta({
+    added: [],
+    updated: [],
+    removed: [{ table: "todos", rowId: new Uint8Array(16) }],
+    removedOccurrenceKeys: [invalidUtf8],
+  });
+  expect(() => readNativeSubscriptionDelta(new PostcardReader(malformedLabel))).toThrow(
+    "malformed v2 ResultKey",
+  );
 });
 
 it("keeps same-row union occurrences distinct through apply, removal, and reopen", () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -93,6 +93,43 @@ describe("nested row physical carriers", () => {
     expect(row.id).toBe(id);
     expect(row.values).toEqual([{ type: "Text", value: "terminal" }]);
   });
+
+  it("decodes the complete raw Record element carried by a terminal array", () => {
+    const todoColumns: ColumnDescriptor[] = [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "done", column_type: { type: "Boolean" }, nullable: false },
+      { name: "priority", column_type: { type: "Integer" }, nullable: true },
+      { name: "owner_id", column_type: { type: "Uuid" }, nullable: true },
+      { name: "tags", column_type: { type: "Array", element: { type: "Text" } }, nullable: false },
+    ];
+    const todoDescriptor = [
+      { name: "row_uuid", valueType: { tag: 10 } as const },
+      { name: "title", valueType: { tag: 8 } as const },
+      { name: "done", valueType: { tag: 7 } as const },
+      { name: "priority", valueType: { tag: 14, inner: { tag: 4 } } as const },
+      { name: "owner_id", valueType: { tag: 14, inner: { tag: 10 } } as const },
+      { name: "tags", valueType: { tag: 13, inner: { tag: 8 } } as const },
+    ];
+    const bytes = createRecord(todoDescriptor, [
+      uuidBytes("e20942bf-8789-e652-23fd-c86c3a105743"),
+      new TextEncoder().encode("owned-todo"),
+      Uint8Array.of(0),
+      presentBytes(Uint8Array.of(1, 0, 0, 0)),
+      presentBytes(uuidBytes("06839e1b-9b29-732c-1b39-8ee592bd2a68")),
+      concatBytes([Uint8Array.of(1, 0, 0, 0), new TextEncoder().encode("x")]),
+    ]);
+
+    expect(decodeNestedRowBytes(todoColumns, bytes, todoDescriptor, "full-record")).toMatchObject({
+      id: "e20942bf-8789-e652-23fd-c86c3a105743",
+      values: [
+        { type: "Text", value: "owned-todo" },
+        { type: "Boolean", value: false },
+        { type: "Integer", value: 1 },
+        { type: "Uuid", value: "06839e1b-9b29-732c-1b39-8ee592bd2a68" },
+        { type: "Array", value: [{ type: "Text", value: "x" }] },
+      ],
+    });
+  });
 });
 
 function decodeTestDeltas(

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -6270,6 +6270,21 @@ it("rejects malformed or misaligned subscription occurrence sidecars", () => {
   expect(() => readNativeSubscriptionDelta(new PostcardReader(malformed))).toThrow(
     "malformed v2 ResultKey",
   );
+
+  const zeroArm = new Uint8Array(41);
+  zeroArm[0] = 2;
+  zeroArm.fill(1, 1, 17);
+  new DataView(zeroArm.buffer).setUint32(17, 1);
+  zeroArm.fill(2, 21, 37);
+  const aliasedV1 = encodeSubscriptionDelta({
+    added: [],
+    updated: [],
+    removed: [{ table: "todos", rowId: new Uint8Array(16) }],
+    removedOccurrenceKeys: [zeroArm],
+  });
+  expect(() => readNativeSubscriptionDelta(new PostcardReader(aliasedV1))).toThrow(
+    "malformed v2 ResultKey",
+  );
 });
 
 it("keeps same-row union occurrences distinct through apply, removal, and reopen", () => {

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -214,6 +214,241 @@ describe("SubscriptionManager", () => {
     expect(result.all).toEqual([{ id, name: "after", count: 2 }]);
   });
 
+  it("matches a compound terminal key to the seeded full occurrence identity", () => {
+    const manager = new SubscriptionManager<TestItem>();
+    const id = "00000000-0000-4000-8000-000000000001";
+    const joinedId = "00000000-0000-4000-8000-000000000002";
+    const key = [10, ...uuidBytes(id), 10, ...uuidBytes(joinedId)];
+
+    manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: nativeAddedRecord(id, 0, "before", 6),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 1,
+        removedCount: 0,
+        updatedCount: 0,
+        addedOccurrenceKeys: [Uint8Array.from([1, ...uuidBytes(id), ...uuidBytes(joinedId)])],
+      },
+      transform,
+      nativeColumns,
+    );
+
+    const result = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: key,
+            path: [],
+            edit: { Update: { key, value: [...terminalRowData(id, "joined", 7)] } },
+          },
+        ],
+      },
+      transform,
+      nativeColumns,
+    );
+
+    expect(result.all).toEqual([{ id, name: "joined", count: 7 }]);
+    expect(result.delta[0]?.id).toBe(
+      `result:01${Array.from(uuidBytes(id), (byte) => byte.toString(16).padStart(2, "0")).join("")}${Array.from(uuidBytes(joinedId), (byte) => byte.toString(16).padStart(2, "0")).join("")}`,
+    );
+  });
+
+  it("does not collapse malformed or typed terminal root keys to their leading UUID", () => {
+    const id = "00000000-0000-4000-8000-000000000001";
+    const joinedId = "00000000-0000-4000-8000-000000000002";
+    const fullOccurrence = Uint8Array.from([1, ...uuidBytes(id), ...uuidBytes(joinedId)]);
+    const malformed = [10, ...uuidBytes(id), 10];
+    const typedComponent = [10, ...uuidBytes(id), 8, 0x61];
+
+    for (const key of [malformed, typedComponent]) {
+      const manager = new SubscriptionManager<TestItem>();
+      manager.handleDelta(
+        {
+          __jazzNativeRowDelta: true,
+          added: nativeAddedRecord(id, 0, "before", 6),
+          removed: new Uint8Array(),
+          updated: new Uint8Array(),
+          addedCount: 1,
+          removedCount: 0,
+          updatedCount: 0,
+          addedOccurrenceKeys: [fullOccurrence],
+        },
+        transform,
+        nativeColumns,
+      );
+
+      expect(() =>
+        manager.handleDelta(
+          {
+            __jazzNativeRowDelta: true,
+            added: new Uint8Array(),
+            removed: new Uint8Array(),
+            updated: new Uint8Array(),
+            addedCount: 0,
+            removedCount: 0,
+            updatedCount: 0,
+            terminalOperations: [
+              {
+                root_key: key,
+                path: [],
+                edit: { Update: { key, value: [...terminalRowData(id, "after", 7)] } },
+              },
+            ],
+          },
+          transform,
+          nativeColumns,
+        ),
+      ).toThrow(/addressed missing root/);
+      expect(manager.all()).toEqual([{ id, name: "before", count: 6 }]);
+    }
+
+    const typedV2Occurrence = Uint8Array.from([
+      2,
+      ...uuidBytes(id),
+      0,
+      0,
+      0,
+      1,
+      ...uuidBytes(joinedId),
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      3,
+      0x61,
+      0x72,
+      0x6d,
+    ]);
+    const manager = new SubscriptionManager<TestItem>();
+    manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: nativeAddedRecord(id, 0, "typed", 8),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 1,
+        removedCount: 0,
+        updatedCount: 0,
+        addedOccurrenceKeys: [typedV2Occurrence],
+      },
+      transform,
+      nativeColumns,
+    );
+    const legacyComposite = [10, ...uuidBytes(id), 10, ...uuidBytes(joinedId)];
+    expect(
+      manager.handleDelta(
+        {
+          __jazzNativeRowDelta: true,
+          added: new Uint8Array(),
+          removed: new Uint8Array(),
+          updated: new Uint8Array(),
+          addedCount: 0,
+          removedCount: 0,
+          updatedCount: 0,
+          terminalOperations: [
+            {
+              root_key: legacyComposite,
+              path: [],
+              edit: { Update: { key: legacyComposite, value: [...terminalRowData(id, "bad", 9)] } },
+            },
+          ],
+        },
+        transform,
+        nativeColumns,
+      ),
+    ).toEqual({ delta: [], all: [{ id, name: "typed", count: 8 }] });
+    expect(manager.all()).toEqual([{ id, name: "typed", count: 8 }]);
+  });
+
+  it("bridges a unique legacy snapshot root to its composite terminal address", () => {
+    const manager = new SubscriptionManager<TestItem>();
+    const id = "00000000-0000-4000-8000-000000000001";
+    const joinedId = "00000000-0000-4000-8000-000000000002";
+    const key = [10, ...uuidBytes(id), 10, ...uuidBytes(joinedId)];
+    manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: nativeAddedRecord(id, 0, "snapshot", 1),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 1,
+        removedCount: 0,
+        updatedCount: 0,
+      },
+      transform,
+      nativeColumns,
+    );
+
+    const result = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: key,
+            path: [],
+            edit: { Update: { key, value: [...terminalRowData(id, "patched", 2)] } },
+          },
+        ],
+      },
+      transform,
+      nativeColumns,
+    );
+
+    expect(result.all).toEqual([{ id, name: "patched", count: 2 }]);
+    expect(result.delta).toMatchObject([{ kind: 2, id }]);
+  });
+
+  it("treats a missing UUID-only terminal root update as an idempotent stale patch", () => {
+    const manager = new SubscriptionManager<TestItem>();
+    const id = "00000000-0000-4000-8000-000000000001";
+    const key = [10, ...uuidBytes(id)];
+
+    const result = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: key,
+            path: [],
+            edit: { Update: { key, value: [...terminalRowData(id, "stale", 1)] } },
+          },
+        ],
+      },
+      transform,
+      nativeColumns,
+    );
+
+    expect(result).toEqual({ delta: [], all: [] });
+  });
+
   it("rejects mismatched terminal identities without mutating subscription state", () => {
     const manager = new SubscriptionManager<TestItem>();
     const id = "00000000-0000-4000-8000-000000000001";

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -452,6 +452,9 @@ describe("SubscriptionManager", () => {
         ],
       ),
     );
+    const invalidUtf8 = typedResultKey(root, [joined], [[0, "valid"]]);
+    invalidUtf8[invalidUtf8.length - 1] = 0xff;
+    rejectSidecar(invalidUtf8);
 
     const manager = new SubscriptionManager<TestItem>();
     const registry = manager as unknown as {

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -376,6 +376,101 @@ describe("SubscriptionManager", () => {
     expect(manager.all()).toEqual([{ id, name: "typed", count: 8 }]);
   });
 
+  it("applies typed-v2 terminal update, removal, and reopen through its exact ordered key", () => {
+    const manager = new SubscriptionManager<TestItem>();
+    const id = "00000000-0000-4000-8000-000000000001";
+    const joinedId = "00000000-0000-4000-8000-000000000002";
+    const sidecar = Uint8Array.from([
+      2,
+      ...uuidBytes(id),
+      0,
+      0,
+      0,
+      1,
+      ...uuidBytes(joinedId),
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      3,
+      0x61,
+      0x72,
+      0x6d,
+    ]);
+    // Groove's ordered Record key: root UUID, union-arm String, joined UUID.
+    const key = [10, ...uuidBytes(id), 6, 0x61, 0x72, 0x6d, 0, 0, 10, ...uuidBytes(joinedId)];
+    const emptyNative = {
+      __jazzNativeRowDelta: true as const,
+      added: new Uint8Array(),
+      removed: new Uint8Array(),
+      updated: new Uint8Array(),
+      addedCount: 0,
+      removedCount: 0,
+      updatedCount: 0,
+    };
+
+    manager.handleDelta(
+      {
+        ...emptyNative,
+        added: nativeAddedRecord(id, 0, "opened", 1),
+        addedCount: 1,
+        addedOccurrenceKeys: [sidecar],
+      },
+      transform,
+      nativeColumns,
+    );
+    const updated = manager.handleDelta(
+      {
+        ...emptyNative,
+        terminalOperations: [
+          {
+            root_key: key,
+            path: [],
+            edit: { Update: { key, value: [...terminalRowData(id, "updated", 2)] } },
+          },
+        ],
+      },
+      transform,
+      nativeColumns,
+    );
+    expect(updated.all).toEqual([{ id, name: "updated", count: 2 }]);
+    expect(updated.delta[0]?.id).toMatch(/^result:02/);
+
+    const removed = manager.handleDelta(
+      {
+        ...emptyNative,
+        terminalOperations: [{ root_key: key, path: [], edit: { Remove: { key } } }],
+      },
+      transform,
+      nativeColumns,
+    );
+    expect(removed).toEqual({ delta: [{ kind: 1, id: updated.delta[0]?.id, index: 0 }], all: [] });
+
+    const reopened = manager.handleDelta(
+      {
+        ...emptyNative,
+        terminalOperations: [
+          {
+            root_key: key,
+            path: [],
+            edit: { Insert: { key, index: 0, value: [...terminalRowData(id, "reopened", 3)] } },
+          },
+        ],
+      },
+      transform,
+      nativeColumns,
+    );
+    expect(reopened.all).toEqual([{ id, name: "reopened", count: 3 }]);
+    expect(reopened.delta[0]?.id).toBe(updated.delta[0]?.id);
+  });
+
   it("bridges a unique legacy snapshot root to its composite terminal address", () => {
     const manager = new SubscriptionManager<TestItem>();
     const id = "00000000-0000-4000-8000-000000000001";

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -63,6 +63,28 @@ function uuidBytes(id: string): Uint8Array {
   );
 }
 
+function pushU32Be(target: number[], value: number): void {
+  target.push((value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff);
+}
+
+function typedResultKey(
+  root: Uint8Array,
+  joined: readonly Uint8Array[],
+  discriminators: ReadonlyArray<readonly [number, string]>,
+): Uint8Array {
+  const bytes = [2, ...root];
+  pushU32Be(bytes, joined.length);
+  for (const value of joined) bytes.push(...value);
+  pushU32Be(bytes, discriminators.length);
+  for (const [position, label] of discriminators) {
+    const encoded = new TextEncoder().encode(label);
+    pushU32Be(bytes, position);
+    pushU32Be(bytes, encoded.byteLength);
+    bytes.push(...encoded);
+  }
+  return Uint8Array.from(bytes);
+}
+
 function pushU32(target: number[], value: number): void {
   target.push(value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff);
 }
@@ -374,6 +396,72 @@ describe("SubscriptionManager", () => {
       ),
     ).toEqual({ delta: [], all: [{ id, name: "typed", count: 8 }] });
     expect(manager.all()).toEqual([{ id, name: "typed", count: 8 }]);
+  });
+
+  it("rejects noncanonical typed terminal occurrence sidecars and ordered-key collisions", () => {
+    const id = "00000000-0000-4000-8000-000000000001";
+    const joinedId = "00000000-0000-4000-8000-000000000002";
+    const joinedSecondId = "00000000-0000-4000-8000-000000000003";
+    const root = uuidBytes(id);
+    const joined = uuidBytes(joinedId);
+    const secondJoined = uuidBytes(joinedSecondId);
+    const emptyNative = {
+      __jazzNativeRowDelta: true as const,
+      added: new Uint8Array(),
+      removed: new Uint8Array(),
+      updated: new Uint8Array(),
+      addedCount: 0,
+      removedCount: 0,
+      updatedCount: 0,
+    };
+    const rejectSidecar = (sidecar: Uint8Array) => {
+      const manager = new SubscriptionManager<TestItem>();
+      expect(() =>
+        manager.handleDelta(
+          {
+            ...emptyNative,
+            added: nativeAddedRecord(id, 0, "typed", 1),
+            addedCount: 1,
+            addedOccurrenceKeys: [sidecar],
+          },
+          transform,
+          nativeColumns,
+        ),
+      ).toThrow(/malformed or noncanonical typed terminal occurrence key/);
+      expect(manager.all()).toEqual([]);
+    };
+
+    rejectSidecar(typedResultKey(root, [joined], []));
+    rejectSidecar(
+      typedResultKey(
+        root,
+        [joined, secondJoined],
+        [
+          [1, "second"],
+          [0, "first"],
+        ],
+      ),
+    );
+    rejectSidecar(
+      typedResultKey(
+        root,
+        [joined, secondJoined],
+        [
+          [0, "first"],
+          [0, "duplicate"],
+        ],
+      ),
+    );
+
+    const manager = new SubscriptionManager<TestItem>();
+    const registry = manager as unknown as {
+      registerTerminalOccurrenceAddress(ordered: Uint8Array, occurrence: string): void;
+    };
+    const ordered = Uint8Array.from([10, ...root, 6, 0x61, 0x00, 0x00, 10, ...joined]);
+    registry.registerTerminalOccurrenceAddress(ordered, "result:02first");
+    expect(() => registry.registerTerminalOccurrenceAddress(ordered, "result:02second")).toThrow(
+      /conflicting typed terminal occurrence keys share an ordered root key/,
+    );
   });
 
   it("applies typed-v2 terminal update, removal, and reopen through its exact ordered key", () => {

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -346,17 +346,18 @@ export class SubscriptionManager<T extends { id: string }> {
     // on operation-key ordering.
     for (const operation of rootInserts) {
       const rootId = terminalKeyId(operation.root_key);
+      const rootRowId = terminalPayloadRowId(operation.root_key);
       const edit = operation.edit;
       assertTerminalRootEditKey(operation.root_key, edit);
       if (!("Insert" in edit)) throw new Error("terminal root insert partition is invalid");
       this.terminalRows.set(
         rootId,
-        decodeNativeTerminalRow(rootId, rootColumns, Uint8Array.from(edit.Insert.value)),
+        decodeNativeTerminalRow(rootRowId, rootColumns, Uint8Array.from(edit.Insert.value)),
       );
     }
 
     for (const operation of operations) {
-      const rootId = terminalKeyId(operation.root_key);
+      const rootId = this.terminalRootId(operation.root_key);
       const edit = operation.edit;
       if (operation.path.length === 0) {
         assertTerminalRootEditKey(operation.root_key, edit);
@@ -368,14 +369,20 @@ export class SubscriptionManager<T extends { id: string }> {
           this.insertIdAt(rootId, edit.Insert.index);
         } else if ("Update" in edit) {
           if (!this.terminalRows.has(rootId)) {
+            if (isUuidOnlyTerminalKey(operation.root_key)) continue;
             throw new Error(`terminal root update addressed missing root ${rootId}`);
           }
           this.terminalRows.set(
             rootId,
-            decodeNativeTerminalRow(rootId, rootColumns, Uint8Array.from(edit.Update.value)),
+            decodeNativeTerminalRow(
+              terminalPayloadRowId(operation.root_key),
+              rootColumns,
+              Uint8Array.from(edit.Update.value),
+            ),
           );
         } else if ("Remove" in edit) {
           if (!this.terminalRows.delete(rootId)) {
+            if (isUuidOnlyTerminalKey(operation.root_key)) continue;
             throw new Error(`terminal root removal addressed missing root ${rootId}`);
           }
           this.currentResults.delete(rootId);
@@ -398,24 +405,24 @@ export class SubscriptionManager<T extends { id: string }> {
       if (!target) throw new Error(`terminal child edit addressed an unresolved path on ${rootId}`);
       const { values, columns } = target;
       if ("Insert" in edit) {
-        const id = terminalKeyId(edit.Insert.key);
+        const id = terminalPayloadRowId(edit.Insert.key);
         const row = decodeNativeTerminalRow(id, columns, Uint8Array.from(edit.Insert.value));
         const value: Value = { type: "Row", value: { id, values: row.values } };
         removeTerminalValue(values, id);
         values.splice(Math.max(0, Math.min(edit.Insert.index, values.length)), 0, value);
       } else if ("Update" in edit) {
-        const id = terminalKeyId(edit.Update.key);
+        const id = terminalPayloadRowId(edit.Update.key);
         const index = terminalValueIndex(values, id);
         if (index === -1) throw new Error(`terminal child update addressed missing key ${id}`);
         const row = decodeNativeTerminalRow(id, columns, Uint8Array.from(edit.Update.value));
         values[index] = { type: "Row", value: { id, values: row.values } };
       } else if ("Remove" in edit) {
-        const id = terminalKeyId(edit.Remove.key);
+        const id = terminalPayloadRowId(edit.Remove.key);
         if (!removeTerminalValue(values, id)) {
           throw new Error(`terminal child removal addressed missing key ${id}`);
         }
       } else if ("Move" in edit) {
-        const id = terminalKeyId(edit.Move.key);
+        const id = terminalPayloadRowId(edit.Move.key);
         const index = terminalValueIndex(values, id);
         if (index === -1) throw new Error(`terminal child move addressed missing key ${id}`);
         const [value] = values.splice(index, 1);
@@ -433,7 +440,7 @@ export class SubscriptionManager<T extends { id: string }> {
       }
       if (index === undefined || row === undefined) return [];
       const item = transform(row);
-      this.currentResults.set(id, item);
+      this.currentResults.set(id, withResultIdentity(item, id));
       return [
         beforeIndex === undefined
           ? { kind: RowChangeKind.Added, id, index, item }
@@ -441,6 +448,25 @@ export class SubscriptionManager<T extends { id: string }> {
       ];
     });
     return { delta, all: this.all() } as SubscriptionDelta<T>;
+  }
+
+  /**
+   * Snapshots predating occurrence sidecars seed terminal state by physical
+   * row UUID. Prefer the full ResultKey address, but bridge that legacy
+   * snapshot only when exactly one retained root has the addressed UUID.
+   */
+  private terminalRootId(encoded: readonly number[]): string {
+    const address = terminalKeyId(encoded);
+    if (this.terminalRows.has(address)) return address;
+    // Only UUID-only legacy composite keys have a lossless correspondence to
+    // an occurrence sidecar. Typed values and v2 identities must remain
+    // opaque: matching either by physical UUID would erase a discriminator.
+    if (!address.startsWith("result:01")) return address;
+    const physicalId = terminalPayloadRowId(encoded);
+    const matches = Array.from(this.terminalRows, ([id, row]) =>
+      row.id === physicalId && !id.startsWith("result:") ? id : null,
+    ).filter((id): id is string => id !== null);
+    return matches.length === 1 ? matches[0]! : address;
   }
 
   seed(rows: T[]): SubscriptionDelta<T> {
@@ -625,7 +651,40 @@ function terminalKeyId(encoded: readonly number[]): string {
   if (bytes.length === 17 && bytes[0] === 10) {
     return readUuid(bytes, 1);
   }
+  // Groove terminal operations address roots by an ordered Record key. A
+  // multi-source row is therefore `Uuid, Uuid, …`, while the packed stream's
+  // occurrence sidecar uses the equivalent v1 ResultKey (`1, uuid, uuid,
+  // …`). Normalize only this exact physical form so terminal patches meet the
+  // same full occurrence identity that seeded the subscription state.
+  if (bytes.length > 17 && isUuidOnlyTerminalKey(bytes)) {
+    const occurrence = [1];
+    for (let offset = 0; offset < bytes.length; offset += 17) {
+      if (bytes[offset] !== 10) {
+        return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+      }
+      occurrence.push(...bytes.subarray(offset + 1, offset + 17));
+    }
+    return publicResultKey(Uint8Array.from(occurrence));
+  }
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function isUuidOnlyTerminalKey(encoded: ArrayLike<number>): boolean {
+  const bytes = Uint8Array.from(encoded);
+  return (
+    bytes.length >= 17 &&
+    bytes.length % 17 === 0 &&
+    Array.from({ length: bytes.length / 17 }, (_, index) => bytes[index * 17] === 10).every(Boolean)
+  );
+}
+
+/** Decode the leading UUID key field from Groove's ordered record-key carrier. */
+function terminalPayloadRowId(encoded: readonly number[]): string {
+  const bytes = Uint8Array.from(encoded);
+  if (bytes.length < 17 || bytes[0] !== 10) {
+    throw new Error("terminal key must begin with a UUID row key");
+  }
+  return readUuid(bytes, 1);
 }
 
 function assertTerminalRootEditKey(
@@ -714,7 +773,7 @@ function terminalCollection(
     if (index === path.length - 1) return { values, columns: childColumns };
     const keySegment = path[++index];
     if (!keySegment || !("Key" in keySegment)) return undefined;
-    const childId = terminalKeyId(keySegment.Key);
+    const childId = terminalPayloadRowId(keySegment.Key);
     if (index === path.length - 1) return { values, columns: childColumns };
     const child = values.find((value) => value.type === "Row" && value.value.id === childId);
     if (child?.type !== "Row") return undefined;

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -285,7 +285,9 @@ export class SubscriptionManager<T extends { id: string }> {
         ]) {
           const orderedKey = orderedTerminalKeyForTypedOccurrence(key);
           if (orderedKey) {
-            this.terminalOccurrenceAddresses.set(bytesKey(orderedKey), publicResultKey(key));
+            this.registerTerminalOccurrenceAddress(orderedKey, publicResultKey(key));
+          } else if (key[0] === 2) {
+            throw new Error("malformed or noncanonical typed terminal occurrence key");
           }
         }
         // Packed row deltas have already been normalized to the public logical
@@ -488,6 +490,18 @@ export class SubscriptionManager<T extends { id: string }> {
     return this.terminalOccurrenceAddresses.get(bytesKey(encoded)) ?? terminalKeyId(encoded);
   }
 
+  private registerTerminalOccurrenceAddress(
+    orderedKey: Uint8Array,
+    occurrenceAddress: string,
+  ): void {
+    const address = bytesKey(orderedKey);
+    const existing = this.terminalOccurrenceAddresses.get(address);
+    if (existing !== undefined && existing !== occurrenceAddress) {
+      throw new Error("conflicting typed terminal occurrence keys share an ordered root key");
+    }
+    this.terminalOccurrenceAddresses.set(address, occurrenceAddress);
+  }
+
   seed(rows: T[]): SubscriptionDelta<T> {
     return this.handleTypedDelta(
       rows.map((item, index) => ({
@@ -686,8 +700,11 @@ function orderedTerminalKeyForTypedOccurrence(sidecar: Uint8Array): Uint8Array |
   });
   const discriminatorCount = readU32Be(sidecar, cursor);
   cursor += 4;
-  if (discriminatorCount > joinedCount) return undefined;
+  // ResultKey v2 exists only for union-discriminated output. Allowing no arms
+  // aliases the UUID-only v1 ordered key, so it is deliberately noncanonical.
+  if (discriminatorCount === 0 || discriminatorCount > joinedCount) return undefined;
   const arms = new Map<number, Uint8Array>();
+  let previousPosition = -1;
   for (let index = 0; index < discriminatorCount; index += 1) {
     if (cursor + 8 > sidecar.byteLength) return undefined;
     const position = readU32Be(sidecar, cursor);
@@ -695,12 +712,15 @@ function orderedTerminalKeyForTypedOccurrence(sidecar: Uint8Array): Uint8Array |
     cursor += 8;
     if (
       position >= joinedCount ||
+      position <= previousPosition ||
       length === 0 ||
+      length > 4096 ||
       cursor + length > sidecar.byteLength ||
       arms.has(position)
     ) {
       return undefined;
     }
+    previousPosition = position;
     arms.set(position, sidecar.subarray(cursor, (cursor += length)));
   }
   if (cursor !== sidecar.byteLength) return undefined;

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -21,6 +21,8 @@ import {
   logicalStorageColumns,
 } from "./native-runtime/native-row-codec.js";
 
+const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
 export const RowChangeKind = {
   Added: 0 as const,
   Removed: 1 as const,
@@ -716,6 +718,7 @@ function orderedTerminalKeyForTypedOccurrence(sidecar: Uint8Array): Uint8Array |
       length === 0 ||
       length > 4096 ||
       cursor + length > sidecar.byteLength ||
+      !isValidUtf8(sidecar.subarray(cursor, cursor + length)) ||
       arms.has(position)
     ) {
       return undefined;
@@ -754,6 +757,15 @@ function orderedBytes(value: Uint8Array): number[] {
   }
   encoded.push(0, 0);
   return encoded;
+}
+
+function isValidUtf8(bytes: Uint8Array): boolean {
+  try {
+    fatalUtf8Decoder.decode(bytes);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function bytesKey(bytes: ArrayLike<number>): string {

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -54,6 +54,7 @@ export type SubscriptionDelta<T> =
 type SubscriptionManagerSnapshot<T> = {
   currentResults: Map<string, T>;
   terminalRows: Map<string, WasmRow>;
+  terminalOccurrenceAddresses: Map<string, string>;
   orderedIds: string[];
   orderedIdIndex: Map<string, number>;
 };
@@ -230,6 +231,8 @@ function resultIdentity(item: { id: string }): string {
 export class SubscriptionManager<T extends { id: string }> {
   private currentResults = new Map<string, T>();
   private terminalRows = new Map<string, WasmRow>();
+  /** Exact ordered Groove root key -> opaque v2 occurrence sidecar address. */
+  private terminalOccurrenceAddresses = new Map<string, string>();
   private orderedIds: string[] = [];
   private orderedIdIndex = new Map<string, number>();
 
@@ -275,6 +278,16 @@ export class SubscriptionManager<T extends { id: string }> {
         if (reset) {
           this.clear();
         }
+        for (const key of [
+          ...(delta.addedOccurrenceKeys ?? []),
+          ...(delta.updatedOccurrenceKeys ?? []),
+          ...(delta.removedOccurrenceKeys ?? []),
+        ]) {
+          const orderedKey = orderedTerminalKeyForTypedOccurrence(key);
+          if (orderedKey) {
+            this.terminalOccurrenceAddresses.set(bytesKey(orderedKey), publicResultKey(key));
+          }
+        }
         // Packed row deltas have already been normalized to the public logical
         // record layout. Only Groove terminal edit payloads retain the outer
         // sparse current-row carrier described by `sparse`.
@@ -317,6 +330,7 @@ export class SubscriptionManager<T extends { id: string }> {
       terminalRows: new Map(
         Array.from(this.terminalRows, ([id, row]) => [id, cloneTerminalRow(row, columns)]),
       ),
+      terminalOccurrenceAddresses: new Map(this.terminalOccurrenceAddresses),
       orderedIds: [...this.orderedIds],
       orderedIdIndex: new Map(this.orderedIdIndex),
     };
@@ -325,6 +339,7 @@ export class SubscriptionManager<T extends { id: string }> {
   private restore(snapshot: SubscriptionManagerSnapshot<T>): void {
     this.currentResults = snapshot.currentResults;
     this.terminalRows = snapshot.terminalRows;
+    this.terminalOccurrenceAddresses = snapshot.terminalOccurrenceAddresses;
     this.orderedIds = snapshot.orderedIds;
     this.orderedIdIndex = snapshot.orderedIdIndex;
   }
@@ -345,7 +360,7 @@ export class SubscriptionManager<T extends { id: string }> {
     // applying its index before an earlier root Remove makes the outcome depend
     // on operation-key ordering.
     for (const operation of rootInserts) {
-      const rootId = terminalKeyId(operation.root_key);
+      const rootId = this.terminalAddress(operation.root_key);
       const rootRowId = terminalPayloadRowId(operation.root_key);
       const edit = operation.edit;
       assertTerminalRootEditKey(operation.root_key, edit);
@@ -456,7 +471,7 @@ export class SubscriptionManager<T extends { id: string }> {
    * snapshot only when exactly one retained root has the addressed UUID.
    */
   private terminalRootId(encoded: readonly number[]): string {
-    const address = terminalKeyId(encoded);
+    const address = this.terminalAddress(encoded);
     if (this.terminalRows.has(address)) return address;
     // Only UUID-only legacy composite keys have a lossless correspondence to
     // an occurrence sidecar. Typed values and v2 identities must remain
@@ -467,6 +482,10 @@ export class SubscriptionManager<T extends { id: string }> {
       row.id === physicalId && !id.startsWith("result:") ? id : null,
     ).filter((id): id is string => id !== null);
     return matches.length === 1 ? matches[0]! : address;
+  }
+
+  private terminalAddress(encoded: readonly number[]): string {
+    return this.terminalOccurrenceAddresses.get(bytesKey(encoded)) ?? terminalKeyId(encoded);
   }
 
   seed(rows: T[]): SubscriptionDelta<T> {
@@ -624,6 +643,7 @@ export class SubscriptionManager<T extends { id: string }> {
   clear(): void {
     this.currentResults.clear();
     this.terminalRows.clear();
+    this.terminalOccurrenceAddresses.clear();
     this.orderedIds = [];
     this.orderedIdIndex.clear();
   }
@@ -644,6 +664,80 @@ export class SubscriptionManager<T extends { id: string }> {
 
 export function isNativeRowDelta(delta: SubscriptionWireDelta): delta is NativeRowDelta {
   return !Array.isArray(delta) && delta.__jazzNativeRowDelta === true;
+}
+
+/**
+ * Reconstruct the exact Groove ordered root key from a typed ResultKey v2.
+ * This is metadata-driven: a terminal key is accepted as typed only when it
+ * byte-for-byte matches the sidecar's root, joined UUIDs, and union-arm
+ * discriminators. It intentionally does not infer meaning from a string in an
+ * arbitrary ordered key.
+ */
+function orderedTerminalKeyForTypedOccurrence(sidecar: Uint8Array): Uint8Array | undefined {
+  if (sidecar[0] !== 2 || sidecar.byteLength < 25) return undefined;
+  let cursor = 1;
+  const root = sidecar.subarray(cursor, (cursor += 16));
+  const joinedCount = readU32Be(sidecar, cursor);
+  cursor += 4;
+  if (joinedCount > 256 || cursor + joinedCount * 16 + 4 > sidecar.byteLength) return undefined;
+  const joined = Array.from({ length: joinedCount }, () => {
+    const value = sidecar.subarray(cursor, (cursor += 16));
+    return value;
+  });
+  const discriminatorCount = readU32Be(sidecar, cursor);
+  cursor += 4;
+  if (discriminatorCount > joinedCount) return undefined;
+  const arms = new Map<number, Uint8Array>();
+  for (let index = 0; index < discriminatorCount; index += 1) {
+    if (cursor + 8 > sidecar.byteLength) return undefined;
+    const position = readU32Be(sidecar, cursor);
+    const length = readU32Be(sidecar, cursor + 4);
+    cursor += 8;
+    if (
+      position >= joinedCount ||
+      length === 0 ||
+      cursor + length > sidecar.byteLength ||
+      arms.has(position)
+    ) {
+      return undefined;
+    }
+    arms.set(position, sidecar.subarray(cursor, (cursor += length)));
+  }
+  if (cursor !== sidecar.byteLength) return undefined;
+
+  const ordered: number[] = [10, ...root];
+  for (const [index, uuid] of joined.entries()) {
+    const arm = arms.get(index);
+    if (arm) {
+      ordered.push(6, ...orderedBytes(arm));
+    }
+    ordered.push(10, ...uuid);
+  }
+  return Uint8Array.from(ordered);
+}
+
+function readU32Be(bytes: Uint8Array, offset: number): number {
+  return (
+    (((bytes[offset] ?? 0) << 24) |
+      ((bytes[offset + 1] ?? 0) << 16) |
+      ((bytes[offset + 2] ?? 0) << 8) |
+      (bytes[offset + 3] ?? 0)) >>>
+    0
+  );
+}
+
+function orderedBytes(value: Uint8Array): number[] {
+  const encoded: number[] = [];
+  for (const byte of value) {
+    if (byte === 0) encoded.push(0, 0xff);
+    else encoded.push(byte);
+  }
+  encoded.push(0, 0);
+  return encoded;
+}
+
+function bytesKey(bytes: ArrayLike<number>): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function terminalKeyId(encoded: readonly number[]): string {

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -789,6 +789,69 @@ describe("db.subscribeAll browser integration", () => {
     unsubscribe();
   });
 
+  it("decodes nullable child records delivered through an include terminal", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-subscribe-test",
+        driver: { type: "persistent", dbName: uniqueDbName("include-nullable-child") },
+      }),
+    );
+
+    const {
+      value: { id: userId },
+    } = db.insert(users, { name: "Owner", team_id: undefined });
+    const deltas: Array<SubscriptionDelta<User & { todosViaOwner?: Todo[] }>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<User & { todosViaOwner?: Todo[] }>("users", {
+          conditions: [{ column: "id", op: "eq", value: userId }],
+          includes: { todosViaOwner: true },
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    const {
+      value: { id: todoId },
+    } = db.insert(todos, {
+      title: "nullable terminal child",
+      done: false,
+      priority: 3,
+      owner_id: userId,
+      tags: ["x"],
+      payload: Uint8Array.of(7, 0, 8),
+    });
+
+    await waitForCondition(
+      () => {
+        const child = deltas[deltas.length - 1]?.all[0]?.todosViaOwner?.find(
+          (todo) => todo.id === todoId,
+        );
+        return child?.id === todoId;
+      },
+      4000,
+      "expected nullable child record through include terminal",
+    );
+    const child = deltas[deltas.length - 1]?.all[0]?.todosViaOwner?.find(
+      (todo) => todo.id === todoId,
+    );
+    expect(child?.priority).toBe(3);
+    expect(child?.owner_id).toBe(userId);
+    expect(child?.payload).toEqual(Uint8Array.of(7, 0, 8));
+
+    await db.update(todos, todoId, { priority: 7 });
+    await waitForCondition(
+      () =>
+        deltas[deltas.length - 1]?.all[0]?.todosViaOwner?.some(
+          (todo) => todo.id === todoId && todo.priority === 7,
+        ) === true,
+      4000,
+      "expected nullable child terminal update to decode",
+    );
+
+    unsubscribe();
+  });
+
   it("supports hop queries", async () => {
     const db = track(
       await createDb({


### PR DESCRIPTION
🤖 This fixes the inherited terminal-subscription failures exposed after the terminal assembly merge.

## What changed

- Preserve composite occurrence identity while decoding terminal row payloads by physical row UUID.
- Decode nested terminal records using their raw record layout, and keep nullable child layouts aligned with published descriptors.
- Rebuild occurrence sidecars atomically during authoritative resets.
- Translate typed `UNION ALL` occurrence keys between Groove's ordered representation and `ResultKey` v2 for add, update, remove, reset, and reopen.
- Reject ambiguous, non-canonical, colliding, oversized, zero-arm, duplicate-position, and invalid-UTF-8 typed keys consistently in Rust and TypeScript.

## Why

Snapshots already carried full typed occurrence identities, but incremental terminal patches only normalized UUID-only keys. Union-derived rows could therefore open correctly and later fail to update or remove. Related terminal paths also mixed logical descriptors with sparse/raw carrier bytes, which caused malformed nested records and stale reset sidecars.

## Validation

- Independent adversarial review: P0 none, P1 none, P2 none.
- Browser terminal matrix: 197 passed, 1 skipped; the remaining two private-read failures belong to the separate client-authorization stack. No terminal/codec unhandled errors.
- Focused browser terminal matrix: 83/83.
- Native codec/runtime/subscription manager: 124 passed, 1 skipped.
- Structured result tree: 4/4.
- Groove collect-by: 16/16.
- Authoritative reset, typed ResultKey, nullable-child, add/update/remove/reopen, legacy-wire, malformed-key, collision, and UTF-8 sensitivity tests pass.
- `cargo clippy -p groove -p jazz -- -D warnings`, formatting, TypeScript compilation, and sensitive-data checks pass.

The existing stale wire-fixture assertion is unchanged by this PR.
