### PR TITLE
test: await server authorization rejections

### DIFF
--- a/packages/jazz-tools/src/backend/create-jazz-context.test.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.test.ts
@@ -217,7 +217,10 @@ describe("backend/create-jazz-context", () => {
       expect.any(Uint8Array),
       1,
       true,
-      { persistentPath: "/tmp/jazz.db" },
+      {
+        persistentPath: "/tmp/jazz.db",
+        readAuthorizationHost: "trusted-serving",
+      },
     );
   });
 
@@ -546,7 +549,7 @@ describe("backend/create-jazz-context", () => {
       expect.any(Uint8Array),
       1,
       true,
-      undefined,
+      { readAuthorizationHost: "trusted-serving" },
     );
   });
 

--- a/packages/jazz-tools/src/runtime/napi.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.for-request.test.ts
@@ -220,15 +220,17 @@ describe("forRequest auth and policy", () => {
       { timeout: 10_000 },
     );
 
-    // Insert with a foreign owner_id is rejected by the policy.
-    expect(() =>
-      aliceDb.insert(todoApp.todos, {
-        title: "imposter",
-        done: false,
-        description: scopeTag,
-        owner_id: "someone-else",
-      }),
-    ).toThrow('Insert failed: WriteError("policy denied INSERT on table todos")');
+    // The client stages this optimistically; the serving authority rejects it.
+    await expect(
+      aliceDb
+        .insert(todoApp.todos, {
+          title: "imposter",
+          done: false,
+          description: scopeTag,
+          owner_id: "someone-else",
+        })
+        .wait({ tier: "edge" }),
+    ).rejects.toThrow(/AuthorizationDenied|Write rejected by server authorization/);
 
     // Backend can see the row regardless of ownership.
     await vi.waitFor(
@@ -486,24 +488,27 @@ describe("forRequest concurrent session isolation", () => {
       { timeout: 10_000 },
     );
 
-    // Cross-user write rejection: alice and bob must not be able to insert
-    // rows owned by each other, even when their requests are in flight concurrently.
-    expect(() =>
-      aliceDb.insert(todoApp.todos, {
-        title: "alice-as-bob",
-        done: false,
-        description: scopeTag,
-        owner_id: bob.userId,
-      }),
-    ).toThrow('Insert failed: WriteError("policy denied INSERT on table todos")');
-    expect(() =>
-      bobDb.insert(todoApp.todos, {
-        title: "bob-as-alice",
-        done: false,
-        description: scopeTag,
-        owner_id: alice.userId,
-      }),
-    ).toThrow('Insert failed: WriteError("policy denied INSERT on table todos")');
+    // Cross-user writes stage locally but are rejected by the serving authority.
+    await expect(
+      aliceDb
+        .insert(todoApp.todos, {
+          title: "alice-as-bob",
+          done: false,
+          description: scopeTag,
+          owner_id: bob.userId,
+        })
+        .wait({ tier: "edge" }),
+    ).rejects.toThrow(/AuthorizationDenied|Write rejected by server authorization/);
+    await expect(
+      bobDb
+        .insert(todoApp.todos, {
+          title: "bob-as-alice",
+          done: false,
+          description: scopeTag,
+          owner_id: alice.userId,
+        })
+        .wait({ tier: "edge" }),
+    ).rejects.toThrow(/AuthorizationDenied|Write rejected by server authorization/);
 
     // A new Db handle for alice (same identity, new forRequest call — simulating
     // a subsequent HTTP request from the same user) must stay isolated from bob's data.
@@ -619,12 +624,12 @@ describe("forRequest concurrent session isolation", () => {
         .wait({ tier: "edge" }),
     ]);
 
-    // Cross-user delete must be rejected while rows still exist.
-    expect(() => aliceDb.delete(todoApp.todos, bobRow.id)).toThrow(
-      'Delete failed: WriteError("policy denied DELETE on table todos")',
+    // Cross-user deletes stage locally but are rejected by the serving authority.
+    await expect(aliceDb.delete(todoApp.todos, bobRow.id).wait({ tier: "edge" })).rejects.toThrow(
+      /AuthorizationDenied|Write rejected by server authorization/,
     );
-    expect(() => bobDb.delete(todoApp.todos, aliceRow.id)).toThrow(
-      'Delete failed: WriteError("policy denied DELETE on table todos")',
+    await expect(bobDb.delete(todoApp.todos, aliceRow.id).wait({ tier: "edge" })).rejects.toThrow(
+      /AuthorizationDenied|Write rejected by server authorization/,
     );
 
     // Each user can delete their own row concurrently.

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -601,14 +601,16 @@ describe("NAPI integration", () => {
         { timeout: 20_000 },
       );
 
-      expect(() =>
-        aliceDb.insert(policyTodosTable, {
-          title: "session-policy-denied",
-          done: false,
-          description: "",
-          owner_id: "bob",
-        }),
-      ).toThrow('Insert failed: WriteError("policy denied INSERT on table todos")');
+      await expect(
+        aliceDb
+          .insert(policyTodosTable, {
+            title: "session-policy-denied",
+            done: false,
+            description: "",
+            owner_id: "bob",
+          })
+          .wait({ tier: "edge" }),
+      ).rejects.toThrow(/AuthorizationDenied|Write rejected by server authorization/);
 
       await withTimeout(
         aliceDb.update(policyTodosTable, createdTodo.id, { done: true }).wait({ tier: "edge" }),

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -377,8 +377,8 @@ describe("createPolicyTestApp", () => {
         });
       });
 
-      bob.expectDenied((db) => {
-        db.insert(testApp.todos, {
+      await bob.expectDenied((db) => {
+        return db.insert(testApp.todos, {
           title: "Bob cannot insert Alice's todo",
           done: false,
           ownerId: "alice",

--- a/packages/jazz-tools/src/testing/policy-test-app.ts
+++ b/packages/jazz-tools/src/testing/policy-test-app.ts
@@ -14,8 +14,14 @@ type ExpectLike = (value: unknown) => {
     toThrow(expected?: unknown): void;
   };
   toThrow(expected?: unknown): void;
+  rejects: {
+    toThrow(expected?: unknown): Promise<void>;
+  };
 };
 type TestDbMethodCallback = (db: Db) => unknown;
+type PendingWrite = {
+  wait(options: { tier: "edge" }): Promise<unknown>;
+};
 type SeedWrite<T> = {
   readonly value: T;
   wait(options: { tier: "local" }): Promise<T>;
@@ -28,21 +34,24 @@ export async function settlePolicySeed<T>(write: SeedWrite<T>): Promise<T> {
 
 /**
  * Db used for testing permissions.
- * Supports all {@link Db} operations plus the {@link TestDb.expectAllowed} and {@link TestDb.expectDenied}
- * helpers to test write operations without producing side effects on the test database.
+ * Supports all {@link Db} operations plus helpers for client-local write
+ * staging and serving-authority rejection. A rejected write briefly exists as
+ * an optimistic local batch, but is not persisted by the server.
  */
 export type TestDb = Db & {
   /**
-   * Assert that the callback does not throw a policy error.
+   * Assert that the callback does not throw while staging its write locally.
    * Write operations performed inside the callback are not persisted.
    */
   expectAllowed(callback: TestDbMethodCallback): void;
 
   /**
-   * Assert that the callback throws a policy error.
-   * Write operations performed inside the callback are not persisted.
+   * Assert that a write is rejected by the serving authority.
+   *
+   * Client writes are admitted optimistically, so this checks the write's edge
+   * receipt rather than expecting synchronous local permission enforcement.
    */
-  expectDenied(callback: TestDbMethodCallback): void;
+  expectDenied(callback: (db: Db) => PendingWrite): Promise<void>;
 };
 
 function asTestDb(db: Db, expect: ExpectLike): TestDb {
@@ -60,8 +69,11 @@ function asTestDb(db: Db, expect: ExpectLike): TestDb {
       },
     },
     expectDenied: {
-      value: (callback: TestDbMethodCallback) => {
-        expect(() => callback(db)).toThrow('WriteError("policy denied');
+      value: async (callback: (db: Db) => PendingWrite) => {
+        const write = callback(db);
+        await expect(write.wait({ tier: "edge" })).rejects.toThrow(
+          /AuthorizationDenied|Write rejected by server authorization/,
+        );
       },
     },
   });

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -190,7 +190,7 @@ describe("TS Insert API", () => {
     expect(() => db.insert(app.projects, {})).toThrow("missing required column name");
   });
 
-  it("fails synchronously if a permission rejects the insert", () => {
+  it("stages locally even when the serving policy will reject the insert", () => {
     const project = insertProject(db);
     const owner = insertUser(db);
     expect(() =>
@@ -198,10 +198,10 @@ describe("TS Insert API", () => {
         title: "Test Todo",
         projectId: project.id,
         ownerId: owner.id,
-        // Rows can only be inserted with `done: false`
+        // Client-local runtimes do not evaluate serving permissions.
         done: true,
       }),
-    ).toThrow('Insert failed: WriteError("policy denied INSERT on table todos")');
+    ).not.toThrow();
   });
 
   it("stores explicit values for defaulted columns instead of replacing them", async () => {


### PR DESCRIPTION
🤖 Updates stale authorization test expectations after the client/server permission-boundary changes.

Client mutations now stage optimistically and authoritative server rejection arrives asynchronously through the edge receipt. The affected tests still expected the old synchronous client-side denial. This updates them to await the authoritative result, documents that behavior in the policy helper, and records the explicit trusted-serving host mode in backend construction tests.

This changes tests and test helpers only; production authorization behavior is unchanged.

Validation:

- focused authorization/runtime tests: 149 passed, 1 skipped
- jazz-tools test TypeScript typecheck
- independent adversarial review
- public sensitive-data guard

The broader Node suite remains red in separately owned merged-baseline clusters, so this PR is intentionally draft.
