### PR TITLE
fix: fail when global sequence is exhausted

### DIFF
--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -1606,8 +1606,7 @@ where
             self.ingest_rejected_transaction(stored.tx, fate)?;
             return Ok(());
         }
-        let global_seq = self.clock.next_global_seq;
-        self.clock.next_global_seq = self.clock.next_global_seq.next();
+        let global_seq = self.clock.allocate_global_seq()?;
         self.apply_fate_update(
             tx_id,
             Fate::Accepted,
@@ -1654,8 +1653,7 @@ where
             self.ingest_rejected_transaction(tx, fate.clone())?;
             return Ok(fate);
         }
-        let global_seq = self.clock.next_global_seq;
-        self.clock.next_global_seq = self.clock.next_global_seq.next();
+        let global_seq = self.clock.allocate_global_seq()?;
         self.apply_fate_update(
             tx_id,
             Fate::Accepted,
@@ -1822,8 +1820,7 @@ where
                 durability: None,
             }]);
         }
-        let global_seq = self.clock.next_global_seq;
-        self.clock.next_global_seq = self.clock.next_global_seq.next();
+        let global_seq = self.clock.allocate_global_seq()?;
         let fate = Fate::Accepted;
         let durability = DurabilityTier::Global;
         let root_target = tx.target_lineage == crate::tx::BranchLineage::Root;
@@ -2127,8 +2124,7 @@ where
         if tx.kind != TxKind::Mergeable && tx.kind != TxKind::Exclusive {
             return Err(Error::UnsupportedCommitUnit("unsupported commit unit kind"));
         }
-        let global_seq = self.clock.next_global_seq;
-        self.clock.next_global_seq = self.clock.next_global_seq.next();
+        let global_seq = self.clock.allocate_global_seq()?;
         let fate = Fate::Accepted;
         let durability = DurabilityTier::Global;
         let root_target = tx.target_lineage == crate::tx::BranchLineage::Root;
@@ -3793,8 +3789,7 @@ where
             merge_commit = merge_commit.merge_strategy(strategy);
         }
         let merge_tx = self.commit_mergeable_at(merge_commit, made_at)?;
-        let global_seq = self.clock.next_global_seq;
-        self.clock.next_global_seq = self.clock.next_global_seq.next();
+        let global_seq = self.clock.allocate_global_seq()?;
         self.apply_fate_update(
             merge_tx,
             Fate::Accepted,

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -654,10 +654,27 @@ struct Clock {
     tx_time: TxTime,
     /// Next global sequence number to allocate when accepting local work globally.
     next_global_seq: GlobalSeq,
+    /// Whether the maximum global sequence has already been allocated or recovered.
+    global_seq_exhausted: bool,
     /// Contiguous global sequence watermark already applied to local storage.
     applied_global_watermark: GlobalSeq,
     /// Applied global sequence numbers above the contiguous watermark.
     applied_global_above_watermark: BTreeSet<GlobalSeq>,
+}
+
+impl Clock {
+    fn allocate_global_seq(&mut self) -> Result<GlobalSeq, Error> {
+        if self.global_seq_exhausted {
+            return Err(Error::InvalidStoredValue("global sequence exhausted"));
+        }
+        let global_seq = self.next_global_seq;
+        if global_seq == GlobalSeq(u64::MAX) {
+            self.global_seq_exhausted = true;
+        } else {
+            self.next_global_seq = global_seq.next();
+        }
+        Ok(global_seq)
+    }
 }
 
 /// Payloads parked until missing schema or catalogue context arrives.
@@ -1075,6 +1092,7 @@ where
             clock: Clock {
                 tx_time: TxTime::default(),
                 next_global_seq: GlobalSeq(1),
+                global_seq_exhausted: false,
                 applied_global_watermark: GlobalSeq(0),
                 applied_global_above_watermark: BTreeSet::new(),
             },

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -866,7 +866,12 @@ where
     }
 
     pub(super) fn record_applied_global_seq(&mut self, global_seq: GlobalSeq) -> Vec<GlobalSeq> {
-        self.clock.next_global_seq = self.clock.next_global_seq.max(global_seq.next());
+        if global_seq == GlobalSeq(u64::MAX) {
+            self.clock.next_global_seq = global_seq;
+            self.clock.global_seq_exhausted = true;
+        } else if !self.clock.global_seq_exhausted {
+            self.clock.next_global_seq = self.clock.next_global_seq.max(global_seq.next());
+        }
         if global_seq <= self.clock.applied_global_watermark {
             return Vec::new();
         }

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -472,6 +472,82 @@ fn recovery_rebuilds_global_clock_from_accepted_transactions() {
     assert_eq!(reopened.clock.next_global_seq, GlobalSeq(3));
 }
 
+// This must remain an internal regression: reaching the last sequence requires
+// planting the authority clock at u64::MAX, which ordinary public writes cannot
+// feasibly do. It proves the boundary itself, while the recovery test below
+// proves that a persisted last sequence retains the exhausted state on reopen.
+#[test]
+fn global_sequence_allocates_max_once_then_stays_exhausted() {
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut node = open_node_at(&temp_dir, schema);
+    node.clock.next_global_seq = GlobalSeq(u64::MAX);
+
+    let last_tx = node
+        .commit_mergeable(
+            MergeableCommit::new("todos", row(22), 22).cells(title_cells("last sequence")),
+        )
+        .unwrap();
+    node.finalize_local_mergeable_commit(last_tx).unwrap();
+    assert_eq!(
+        node.transaction_state(last_tx).unwrap(),
+        (
+            Fate::Accepted,
+            Some(GlobalSeq(u64::MAX)),
+            DurabilityTier::Global,
+        )
+    );
+    assert!(node.clock.global_seq_exhausted);
+
+    let after_exhaustion = node
+        .commit_mergeable(
+            MergeableCommit::new("todos", row(23), 23).cells(title_cells("after exhaustion")),
+        )
+        .unwrap();
+    assert!(matches!(
+        node.finalize_local_mergeable_commit(after_exhaustion),
+        Err(Error::InvalidStoredValue("global sequence exhausted"))
+    ));
+    assert_eq!(
+        node.transaction_state(after_exhaustion).unwrap(),
+        (Fate::Pending, None, DurabilityTier::Local)
+    );
+}
+
+// This must remain an internal recovery regression: planting a persisted
+// u64::MAX sequence is not reachable through the public allocation API.
+#[test]
+fn recovery_rejects_global_sequence_allocation_after_max() {
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    {
+        let mut node = open_node_at(&temp_dir, schema.clone());
+        let tx_id = node
+            .commit_mergeable(
+                MergeableCommit::new("todos", row(24), 24).cells(title_cells("last sequence")),
+            )
+            .unwrap();
+        mark_accepted_without_ahead_cleanup(&mut node, tx_id, GlobalSeq(u64::MAX));
+    }
+
+    let mut reopened = reopen_node_at(&temp_dir, node(1), schema);
+    assert_eq!(
+        reopened.clock.applied_global_above_watermark,
+        BTreeSet::from([GlobalSeq(u64::MAX)])
+    );
+    assert_eq!(reopened.clock.next_global_seq, GlobalSeq(u64::MAX));
+
+    let next_tx = reopened
+        .commit_mergeable(
+            MergeableCommit::new("todos", row(25), 25).cells(title_cells("after exhaustion")),
+        )
+        .unwrap();
+    assert!(matches!(
+        reopened.finalize_local_mergeable_commit(next_tx),
+        Err(Error::InvalidStoredValue("global sequence exhausted"))
+    ));
+}
+
 #[test]
 fn reopen_refuses_preexisting_sequenced_non_global_transaction() {
     // This is necessarily an internal recovery test: old receivers could

--- a/crates/jazz/src/time.rs
+++ b/crates/jazz/src/time.rs
@@ -26,7 +26,7 @@ pub struct GlobalSeq(pub u64);
 impl GlobalSeq {
     /// Return the next global sequence value.
     pub fn next(self) -> Self {
-        Self(self.0 + 1)
+        Self(self.0.checked_add(1).expect("global sequence exhausted"))
     }
 }
 


### PR DESCRIPTION
🤖

## What changed

- centralizes GlobalSeq allocation behind a fallible clock helper
- allows `u64::MAX` to be allocated or recovered exactly once, then returns a loud `global sequence exhausted` error instead of wrapping or reusing it
- applies the guard to all five current authority allocation sites
- makes direct `GlobalSeq::next()` overflow loud in release builds with `checked_add`
- adds a recovery regression that plants a persisted `u64::MAX` sequence and verifies the next allocation is rejected

## Why

#1176 originally carried this correctness guard on head `86542d5d`, but its merged result only retained the bounded recovery scan and explicit maximum-endpoint lookup. That left current integration able to wrap in release builds after recovering or allocating `u64::MAX`.

This is a standalone follow-up on the current integration branch. It does not restore any downstream R3 recovery-stack work.

## Validation

- exact post-maximum regression passed with default features
- exact post-maximum regression passed with `--no-default-features --features test`
- exact post-maximum regression passed in `--release`
- recovery filter: 6 passed
- `cargo clippy -p jazz --lib --tests -- -D warnings`
- `cargo test -p groove`: 391 passed, 1 ignored, plus integration/doc tests passed
- `cargo check -p jazz-sim --benches`
- incremental-delivery canary passed
- formatting, diff, and sensitive-data checks passed

The broader `cargo test -p jazz` run reached unrelated existing database/websocket failures and long-running tests and was stopped; the invariant registry is also red on existing missing citations. The TypeScript wire gate could not start because `pnpm` is unavailable on this machine. No performance benchmark or benchmark smoke run was executed.
