### PR TITLE
chore(groove): add plain-row storage instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,7 @@ dependencies = [
  "rust-rocksdb",
  "rustc-hash",
  "serde",
+ "serde_json",
  "smallvec",
  "tempfile",
  "thiserror",

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -30,6 +30,7 @@ jazz-benchmark-guard = { path = "../benchmark-guard" }
 hdrhistogram = "7.5.4"
 rusqlite = { version = "0.34", features = ["bundled"] }
 tempfile = "3.27.0"
+serde_json = "1"
 
 [[bench]]
 name = "scenario"

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -33,7 +33,7 @@ pub use opfs::OpfsStorage;
 #[cfg(not(target_arch = "wasm32"))]
 pub use opfs::{BtreeSyncPolicy, NativeBtreeStorage};
 #[cfg(feature = "rocksdb")]
-pub use rocksdb_storage::{Durability, RocksDbStorage};
+pub use rocksdb_storage::{Durability, RocksDbMetrics, RocksDbStorage};
 
 pub type ColumnFamilyName = str;
 pub type Key = [u8];

--- a/crates/groove/src/storage/rocksdb.rs
+++ b/crates/groove/src/storage/rocksdb.rs
@@ -174,6 +174,8 @@ impl RocksDbStorage {
         let mut live_data = Vec::new();
         let mut memtables = Vec::new();
         let mut pending_compaction = Vec::new();
+        let mut flush_pending = Vec::new();
+        let mut compaction_pending = Vec::new();
         for name in &self.column_families {
             let Some(handle) = self.db.cf_handle(name) else {
                 continue;
@@ -184,6 +186,8 @@ impl RocksDbStorage {
             live_data.push(property(properties::ESTIMATE_LIVE_DATA_SIZE)?);
             memtables.push(property(properties::SIZE_ALL_MEM_TABLES)?);
             pending_compaction.push(property(properties::ESTIMATE_PENDING_COMPACTION_BYTES)?);
+            flush_pending.push(property(properties::MEM_TABLE_FLUSH_PENDING)?);
+            compaction_pending.push(property(properties::COMPACTION_PENDING)?);
         }
         let global = |property| self.db.property_int_value(property);
         Ok(RocksDbMetrics {
@@ -194,8 +198,8 @@ impl RocksDbStorage {
             pending_compaction_bytes: sum_available(&pending_compaction),
             running_flushes: global(properties::NUM_RUNNING_FLUSHES)?,
             running_compactions: global(properties::NUM_RUNNING_COMPACTIONS)?,
-            flush_pending: global(properties::MEM_TABLE_FLUSH_PENDING)?.map(|v| v != 0),
-            compaction_pending: global(properties::COMPACTION_PENDING)?.map(|v| v != 0),
+            flush_pending: any_available(&flush_pending),
+            compaction_pending: any_available(&compaction_pending),
         })
     }
 }
@@ -204,6 +208,12 @@ fn sum_available(values: &[Option<u64>]) -> Option<u64> {
     values.iter().try_fold(0u64, |sum, value| {
         value.map(|value| sum.saturating_add(value))
     })
+}
+
+fn any_available(values: &[Option<u64>]) -> Option<bool> {
+    values
+        .iter()
+        .try_fold(false, |any, value| value.map(|value| any || value != 0))
 }
 
 fn rocksdb_options(block_cache: &Cache, write_buffer_manager: &WriteBufferManager) -> Options {
@@ -604,7 +614,7 @@ mod tests {
     use super::{
         CLASS_AHEAD_CURRENT_CF, CLASS_CHANGES_CF, CLASS_CONTENT_CF, CLASS_GLOBAL_CURRENT_CF,
         CLASS_HISTORY_CF, CLASS_INDICES_CF, CLASS_META_CF, CLASS_REGISTER_CF, RocksDbClassProfile,
-        RocksDbStorage, rocksdb_class_profile, sum_available,
+        RocksDbStorage, any_available, rocksdb_class_profile, sum_available,
     };
 
     #[test]
@@ -675,6 +685,8 @@ mod tests {
     fn metrics_include_default_cf_and_keep_unavailable_aggregates_unknown() {
         assert_eq!(sum_available(&[Some(2), Some(3)]), Some(5));
         assert_eq!(sum_available(&[Some(2), None, Some(3)]), None);
+        assert_eq!(any_available(&[Some(0), Some(1)]), Some(true));
+        assert_eq!(any_available(&[Some(0), None]), None);
 
         let dir = tempfile::tempdir().unwrap();
         let storage = RocksDbStorage::open(dir.path(), &["left", "right"]).unwrap();

--- a/crates/groove/src/storage/rocksdb.rs
+++ b/crates/groove/src/storage/rocksdb.rs
@@ -16,6 +16,7 @@ use rocksdb::{
     Direction, IteratorMode, MergeOperands, Options, ReadOptions, UniversalCompactOptions,
     WriteBatch, WriteBufferManager, WriteOptions, properties,
 };
+use serde::Serialize;
 
 use super::{
     ColumnFamilyName, Error, Key, OrderedKvStorage, ScanVisitor, Value, WriteOperation,
@@ -62,22 +63,22 @@ pub struct RocksDbStorage {
 /// useful when attributing a storage receipt.  These are backend counters, not
 /// process memory measurements: in particular `memtable_bytes` excludes the
 /// shared block cache and Rust allocations.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
 pub struct RocksDbMetrics {
     /// Total bytes in all SST files, including files no longer live.
-    pub total_sst_bytes: u64,
+    pub total_sst_bytes: Option<u64>,
     /// Bytes in SST files reachable from the latest LSM version.
-    pub live_sst_bytes: u64,
+    pub live_sst_bytes: Option<u64>,
     /// Estimated bytes of live key/value data.
-    pub estimated_live_data_bytes: u64,
+    pub estimated_live_data_bytes: Option<u64>,
     /// Bytes in mutable and immutable memtables; not the block cache.
-    pub memtable_bytes: u64,
+    pub memtable_bytes: Option<u64>,
     /// Estimated bytes awaiting compaction (where supported by the profile).
-    pub pending_compaction_bytes: u64,
-    pub running_flushes: u64,
-    pub running_compactions: u64,
-    pub flush_pending: bool,
-    pub compaction_pending: bool,
+    pub pending_compaction_bytes: Option<u64>,
+    pub running_flushes: Option<u64>,
+    pub running_compactions: Option<u64>,
+    pub flush_pending: Option<bool>,
+    pub compaction_pending: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -123,6 +124,7 @@ impl RocksDbStorage {
             .iter()
             .map(|name| (*name).to_owned())
             .collect::<BTreeSet<_>>();
+        opened_column_families.insert("default".to_owned());
         if path.exists()
             && let Ok(existing) = DB::list_cf(&options, &path)
         {
@@ -167,40 +169,41 @@ impl RocksDbStorage {
     /// record these snapshots before and after a workload alongside recursive
     /// on-disk directory bytes and machine metadata.
     pub fn metrics(&self) -> Result<RocksDbMetrics, Error> {
-        let mut metrics = RocksDbMetrics::default();
+        let mut total_sst = Vec::new();
+        let mut live_sst = Vec::new();
+        let mut live_data = Vec::new();
+        let mut memtables = Vec::new();
+        let mut pending_compaction = Vec::new();
         for name in &self.column_families {
             let Some(handle) = self.db.cf_handle(name) else {
                 continue;
             };
             let property = |property| self.db.property_int_value_cf(handle, property);
-            metrics.total_sst_bytes = metrics
-                .total_sst_bytes
-                .saturating_add(property(properties::TOTAL_SST_FILES_SIZE)?.unwrap_or(0));
-            metrics.live_sst_bytes = metrics
-                .live_sst_bytes
-                .saturating_add(property(properties::LIVE_SST_FILES_SIZE)?.unwrap_or(0));
-            metrics.estimated_live_data_bytes = metrics
-                .estimated_live_data_bytes
-                .saturating_add(property(properties::ESTIMATE_LIVE_DATA_SIZE)?.unwrap_or(0));
-            metrics.memtable_bytes = metrics
-                .memtable_bytes
-                .saturating_add(property(properties::SIZE_ALL_MEM_TABLES)?.unwrap_or(0));
-            metrics.pending_compaction_bytes = metrics.pending_compaction_bytes.saturating_add(
-                property(properties::ESTIMATE_PENDING_COMPACTION_BYTES)?.unwrap_or(0),
-            );
-            metrics.running_flushes = metrics
-                .running_flushes
-                .saturating_add(property(properties::NUM_RUNNING_FLUSHES)?.unwrap_or(0));
-            metrics.running_compactions = metrics
-                .running_compactions
-                .saturating_add(property(properties::NUM_RUNNING_COMPACTIONS)?.unwrap_or(0));
-            metrics.flush_pending |=
-                property(properties::MEM_TABLE_FLUSH_PENDING)?.unwrap_or(0) != 0;
-            metrics.compaction_pending |=
-                property(properties::COMPACTION_PENDING)?.unwrap_or(0) != 0;
+            total_sst.push(property(properties::TOTAL_SST_FILES_SIZE)?);
+            live_sst.push(property(properties::LIVE_SST_FILES_SIZE)?);
+            live_data.push(property(properties::ESTIMATE_LIVE_DATA_SIZE)?);
+            memtables.push(property(properties::SIZE_ALL_MEM_TABLES)?);
+            pending_compaction.push(property(properties::ESTIMATE_PENDING_COMPACTION_BYTES)?);
         }
-        Ok(metrics)
+        let global = |property| self.db.property_int_value(property);
+        Ok(RocksDbMetrics {
+            total_sst_bytes: sum_available(&total_sst),
+            live_sst_bytes: sum_available(&live_sst),
+            estimated_live_data_bytes: sum_available(&live_data),
+            memtable_bytes: sum_available(&memtables),
+            pending_compaction_bytes: sum_available(&pending_compaction),
+            running_flushes: global(properties::NUM_RUNNING_FLUSHES)?,
+            running_compactions: global(properties::NUM_RUNNING_COMPACTIONS)?,
+            flush_pending: global(properties::MEM_TABLE_FLUSH_PENDING)?.map(|v| v != 0),
+            compaction_pending: global(properties::COMPACTION_PENDING)?.map(|v| v != 0),
+        })
     }
+}
+
+fn sum_available(values: &[Option<u64>]) -> Option<u64> {
+    values.iter().try_fold(0u64, |sum, value| {
+        value.map(|value| sum.saturating_add(value))
+    })
 }
 
 fn rocksdb_options(block_cache: &Cache, write_buffer_manager: &WriteBufferManager) -> Options {
@@ -601,7 +604,7 @@ mod tests {
     use super::{
         CLASS_AHEAD_CURRENT_CF, CLASS_CHANGES_CF, CLASS_CONTENT_CF, CLASS_GLOBAL_CURRENT_CF,
         CLASS_HISTORY_CF, CLASS_INDICES_CF, CLASS_META_CF, CLASS_REGISTER_CF, RocksDbClassProfile,
-        RocksDbStorage, rocksdb_class_profile,
+        RocksDbStorage, rocksdb_class_profile, sum_available,
     };
 
     #[test]
@@ -663,8 +666,25 @@ mod tests {
         let after = storage.metrics().unwrap();
 
         assert!(
-            after.memtable_bytes > before.memtable_bytes,
+            after.memtable_bytes.unwrap() > before.memtable_bytes.unwrap(),
             "two writes must be visible to the per-CF metric aggregation: before={before:?}, after={after:?}"
+        );
+    }
+
+    #[test]
+    fn metrics_include_default_cf_and_keep_unavailable_aggregates_unknown() {
+        assert_eq!(sum_available(&[Some(2), Some(3)]), Some(5));
+        assert_eq!(sum_available(&[Some(2), None, Some(3)]), None);
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RocksDbStorage::open(dir.path(), &["left", "right"]).unwrap();
+        assert!(storage.column_families.contains("default"));
+        assert_eq!(
+            storage.metrics().unwrap().running_flushes,
+            storage
+                .db
+                .property_int_value(rocksdb::properties::NUM_RUNNING_FLUSHES)
+                .unwrap()
         );
     }
 }

--- a/crates/groove/src/storage/rocksdb.rs
+++ b/crates/groove/src/storage/rocksdb.rs
@@ -58,6 +58,28 @@ pub struct RocksDbStorage {
     write_flush_cadence: RefCell<Option<WriteFlushCadence>>,
 }
 
+/// A best-effort, allocation-free snapshot of the RocksDB counters that are
+/// useful when attributing a storage receipt.  These are backend counters, not
+/// process memory measurements: in particular `memtable_bytes` excludes the
+/// shared block cache and Rust allocations.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RocksDbMetrics {
+    /// Total bytes in all SST files, including files no longer live.
+    pub total_sst_bytes: u64,
+    /// Bytes in SST files reachable from the latest LSM version.
+    pub live_sst_bytes: u64,
+    /// Estimated bytes of live key/value data.
+    pub estimated_live_data_bytes: u64,
+    /// Bytes in mutable and immutable memtables; not the block cache.
+    pub memtable_bytes: u64,
+    /// Estimated bytes awaiting compaction (where supported by the profile).
+    pub pending_compaction_bytes: u64,
+    pub running_flushes: u64,
+    pub running_compactions: u64,
+    pub flush_pending: bool,
+    pub compaction_pending: bool,
+}
+
 #[derive(Clone, Copy, Debug)]
 struct WriteFlushCadence {
     every: usize,
@@ -137,6 +159,47 @@ impl RocksDbStorage {
         self.db
             .cf_handle(cf)
             .ok_or_else(|| Error::ColumnFamilyNotFound(cf.to_owned()))
+    }
+
+    /// Snapshot RocksDB's per-column-family size and background-work
+    /// properties.  This intentionally does not enable RocksDB statistics:
+    /// enabling counters changes the workload being measured.  Receipts should
+    /// record these snapshots before and after a workload alongside recursive
+    /// on-disk directory bytes and machine metadata.
+    pub fn metrics(&self) -> Result<RocksDbMetrics, Error> {
+        let mut metrics = RocksDbMetrics::default();
+        for name in &self.column_families {
+            let Some(handle) = self.db.cf_handle(name) else {
+                continue;
+            };
+            let property = |property| self.db.property_int_value_cf(handle, property);
+            metrics.total_sst_bytes = metrics
+                .total_sst_bytes
+                .saturating_add(property(properties::TOTAL_SST_FILES_SIZE)?.unwrap_or(0));
+            metrics.live_sst_bytes = metrics
+                .live_sst_bytes
+                .saturating_add(property(properties::LIVE_SST_FILES_SIZE)?.unwrap_or(0));
+            metrics.estimated_live_data_bytes = metrics
+                .estimated_live_data_bytes
+                .saturating_add(property(properties::ESTIMATE_LIVE_DATA_SIZE)?.unwrap_or(0));
+            metrics.memtable_bytes = metrics
+                .memtable_bytes
+                .saturating_add(property(properties::SIZE_ALL_MEM_TABLES)?.unwrap_or(0));
+            metrics.pending_compaction_bytes = metrics.pending_compaction_bytes.saturating_add(
+                property(properties::ESTIMATE_PENDING_COMPACTION_BYTES)?.unwrap_or(0),
+            );
+            metrics.running_flushes = metrics
+                .running_flushes
+                .saturating_add(property(properties::NUM_RUNNING_FLUSHES)?.unwrap_or(0));
+            metrics.running_compactions = metrics
+                .running_compactions
+                .saturating_add(property(properties::NUM_RUNNING_COMPACTIONS)?.unwrap_or(0));
+            metrics.flush_pending |=
+                property(properties::MEM_TABLE_FLUSH_PENDING)?.unwrap_or(0) != 0;
+            metrics.compaction_pending |=
+                property(properties::COMPACTION_PENDING)?.unwrap_or(0) != 0;
+        }
+        Ok(metrics)
     }
 }
 
@@ -586,5 +649,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let storage = RocksDbStorage::open(dir.path(), &["records"]).unwrap();
         assert!(storage.write_flush_cadence.borrow().is_none());
+    }
+
+    #[test]
+    fn metrics_include_memtable_bytes_written_to_each_column_family() {
+        use crate::storage::OrderedKvStorage;
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RocksDbStorage::open(dir.path(), &["left", "right"]).unwrap();
+        let before = storage.metrics().unwrap();
+        storage.set("left", b"a", &vec![7; 32 * 1024]).unwrap();
+        storage.set("right", b"b", &vec![9; 32 * 1024]).unwrap();
+        let after = storage.metrics().unwrap();
+
+        assert!(
+            after.memtable_bytes > before.memtable_bytes,
+            "two writes must be visible to the per-CF metric aggregation: before={before:?}, after={after:?}"
+        );
     }
 }

--- a/crates/groove/tests/plain_row_receipt.rs
+++ b/crates/groove/tests/plain_row_receipt.rs
@@ -1,6 +1,7 @@
 //! Manual plain-row RocksDB receipt. Its JSON line is intended to be captured
 //! by `dev/benchmarks/run-receipt.mjs`.
 
+use std::cell::Cell;
 use std::fs;
 use std::path::Path;
 use std::time::Instant;
@@ -74,13 +75,43 @@ fn recursive_disk_bytes(path: &Path) -> std::io::Result<u64> {
     })
 }
 
+fn fresh_open_after_exclusive_drop(
+    storage: RocksDbStorage,
+    path: &Path,
+    column_families: &[&str],
+) -> Result<(RocksDbStorage, usize), Box<dyn std::error::Error>> {
+    let fresh_open_attempts = Cell::new(0usize);
+    let reopened = fresh_open_after_exclusive_drop_with(storage, path, column_families, || {
+        fresh_open_attempts.set(fresh_open_attempts.get() + 1);
+        RocksDbStorage::open(path, column_families)
+    })?;
+    Ok((reopened, fresh_open_attempts.get()))
+}
+
+fn fresh_open_after_exclusive_drop_with(
+    storage: RocksDbStorage,
+    path: &Path,
+    column_families: &[&str],
+    mut fresh_open: impl FnMut() -> Result<RocksDbStorage, groove::storage::Error>,
+) -> Result<RocksDbStorage, Box<dyn std::error::Error>> {
+    assert!(
+        RocksDbStorage::open(path, column_families).is_err(),
+        "RocksDB must reject a competing open while the original handle is alive"
+    );
+    storage.close()?;
+    drop(storage);
+
+    Ok(fresh_open()?)
+}
+
 #[test]
 #[ignore = "manual storage receipt; noisy and host-specific"]
 fn plain_row_write_point_scan_and_reopen_receipt() -> Result<(), Box<dyn std::error::Error>> {
     jazz_benchmark_guard::refuse_contaminated_measurement();
     let dir = tempfile::tempdir()?;
     let schema = schema();
-    let storage = RocksDbStorage::open(dir.path(), &schema.column_families())?;
+    let column_families = schema.column_families();
+    let storage = RocksDbStorage::open(dir.path(), &column_families)?;
     let mut db = Database::new(schema.clone(), storage)?;
 
     let write_started = Instant::now();
@@ -127,14 +158,14 @@ fn plain_row_write_point_scan_and_reopen_receipt() -> Result<(), Box<dyn std::er
 
     let storage = db.into_storage();
     let before = storage.metrics()?;
-    storage.close()?;
-    drop(storage);
-    let disk_bytes = recursive_disk_bytes(dir.path())?;
 
     let reopen_started = Instant::now();
-    let storage = RocksDbStorage::open(dir.path(), &schema.column_families())?;
+    let (storage, fresh_open_attempts) =
+        fresh_open_after_exclusive_drop(storage, dir.path(), &column_families)?;
+    assert_eq!(fresh_open_attempts, 1);
     let reopened = Database::new(schema, storage)?;
     let reopen = reopen_started.elapsed();
+    let disk_bytes = recursive_disk_bytes(dir.path())?;
     let mut checksum_after = 0u64;
     for id in 0..ROWS {
         let record = reopened
@@ -161,6 +192,7 @@ fn plain_row_write_point_scan_and_reopen_receipt() -> Result<(), Box<dyn std::er
             "point_read_us": point.as_micros(),
             "scan_us": scan.as_micros(),
             "reopen_and_database_init_us": reopen.as_micros(),
+            "fresh_open_attempts": fresh_open_attempts,
             "disk_bytes_recursive": disk_bytes,
             "logical_point_reads": format!("{point_reads:?}"),
             "logical_scan_reads": format!("{scan_reads:?}"),
@@ -186,5 +218,30 @@ fn checksum_is_sensitive_to_returned_row_content() {
     assert_ne!(
         checksum_record(&row(7, 0)).unwrap(),
         checksum_record(&row(7, 1)).unwrap()
+    );
+}
+
+#[test]
+fn fresh_open_requires_dropping_the_original_exclusive_handle() {
+    let dir = tempfile::tempdir().unwrap();
+    let column_families = vec!["records"];
+    let storage = RocksDbStorage::open(dir.path(), &["records"]).unwrap();
+    storage.set("records", b"key", b"persisted").unwrap();
+
+    let attempts = Cell::new(0usize);
+    let reopened =
+        fresh_open_after_exclusive_drop_with(storage, dir.path(), &column_families, || {
+            attempts.set(attempts.get() + 1);
+            RocksDbStorage::open(dir.path(), &column_families)
+        })
+        .unwrap();
+    assert_eq!(
+        attempts.get(),
+        1,
+        "fresh open callback must run exactly once"
+    );
+    assert_eq!(
+        reopened.get("records", b"key").unwrap().as_deref(),
+        Some(b"persisted".as_slice())
     );
 }

--- a/crates/groove/tests/plain_row_receipt.rs
+++ b/crates/groove/tests/plain_row_receipt.rs
@@ -1,43 +1,89 @@
-//! Manual plain-row RocksDB receipt. Run with:
-//! `cargo test -p groove --test plain_row_receipt -- --ignored --nocapture`.
-//!
-//! The output is intentionally raw: retain it with the command, git revision,
-//! and host metadata (`uname -a`, CPU governor, and available memory).  The
-//! RocksDB snapshot is backend attribution, not process allocation accounting;
-//! its memtable number excludes Groove/Rust allocations and the shared cache.
+//! Manual plain-row RocksDB receipt. Its JSON line is intended to be captured
+//! by `dev/benchmarks/run-receipt.mjs`.
 
+use std::fs;
+use std::path::Path;
 use std::time::Instant;
 
 use groove::db::Database;
 use groove::records::{Value, VersionedRecord};
-use groove::schema::{ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema};
-use groove::storage::{ReopenableStorage, RocksDbStorage};
+use groove::schema::{
+    ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema,
+};
+use groove::storage::{OrderedKvStorage, RocksDbStorage};
+use serde_json::json;
 
 const ROWS: u64 = 1_000;
 const UPDATES: u64 = 1_000;
 
 fn schema() -> DatabaseSchema {
-    DatabaseSchema::new([TableSchema::new("rows", [
-        ColumnSchema::new("id", ColumnType::U64),
-        ColumnSchema::new("body", ColumnType::String),
-    ]).with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
+    DatabaseSchema::new([TableSchema::new(
+        "rows",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("body", ColumnType::String),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
 }
 
 fn row(id: u64, revision: u64) -> VersionedRecord {
-    let descriptor = schema().table("rows").unwrap().record_schema_for_version(0).unwrap();
-    VersionedRecord::create(0, descriptor, &[Value::U64(id), Value::String(format!("row-{id}-revision-{revision}"))]).unwrap()
+    let schema = schema();
+    let descriptor = schema
+        .table("rows")
+        .unwrap()
+        .record_schema_for_version(0)
+        .unwrap();
+    VersionedRecord::create(
+        0,
+        descriptor,
+        &[
+            Value::U64(id),
+            Value::String(format!("row-{id}-revision-{revision}")),
+        ],
+    )
+    .unwrap()
+}
+
+fn checksum_record(record: &VersionedRecord) -> Result<u64, groove::records::Error> {
+    let mut hash = 0xcbf29ce484222325u64;
+    for value in record.to_values()? {
+        let bytes = match value {
+            Value::U64(value) => value.to_le_bytes().to_vec(),
+            Value::String(value) => value.into_bytes(),
+            other => format!("{other:?}").into_bytes(),
+        };
+        for byte in bytes {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+    }
+    Ok(hash)
+}
+
+fn recursive_disk_bytes(path: &Path) -> std::io::Result<u64> {
+    fs::read_dir(path)?.try_fold(0u64, |total, entry| {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        let bytes = if metadata.is_dir() {
+            recursive_disk_bytes(&entry.path())?
+        } else {
+            metadata.len()
+        };
+        Ok(total.saturating_add(bytes))
+    })
 }
 
 #[test]
 #[ignore = "manual storage receipt; noisy and host-specific"]
-fn plain_row_write_point_history_scan_and_reopen_receipt() -> Result<(), Box<dyn std::error::Error>> {
+fn plain_row_write_point_scan_and_reopen_receipt() -> Result<(), Box<dyn std::error::Error>> {
     jazz_benchmark_guard::refuse_contaminated_measurement();
     let dir = tempfile::tempdir()?;
     let schema = schema();
     let storage = RocksDbStorage::open(dir.path(), &schema.column_families())?;
     let mut db = Database::new(schema.clone(), storage)?;
+
     let write_started = Instant::now();
-    let mut checksum = 0u64;
     for revision in 0..2 {
         let count = if revision == 0 { ROWS } else { UPDATES };
         for id in 0..count {
@@ -48,28 +94,97 @@ fn plain_row_write_point_history_scan_and_reopen_receipt() -> Result<(), Box<dyn
                 batch.update("rows", row(id, revision));
             }
             db.commit_batch(batch)?;
-            checksum = checksum.wrapping_add(id ^ revision);
         }
     }
     let write = write_started.elapsed();
+
     db.reset_storage_read_metrics();
     let point_started = Instant::now();
-    for id in 0..ROWS { assert!(db.primary_key_get("rows", &[Value::U64(id)])?.is_some()); checksum = checksum.wrapping_add(id); }
+    let mut checksum_before = 0u64;
+    for id in 0..ROWS {
+        let record = db
+            .primary_key_get("rows", &[Value::U64(id)])?
+            .expect("updated row exists");
+        assert_eq!(
+            record.to_values()?[1],
+            Value::String(format!("row-{id}-revision-1"))
+        );
+        checksum_before = checksum_before.wrapping_add(checksum_record(&record)?);
+    }
     let point = point_started.elapsed();
     let point_reads = db.take_storage_read_metrics();
+
     db.reset_storage_read_metrics();
     let scan_started = Instant::now();
-    let scanned = db.primary_key_scan("rows", &[])?.len();
+    let scanned = db.primary_key_scan("rows", &[])?;
     let scan = scan_started.elapsed();
     let scan_reads = db.take_storage_read_metrics();
-    assert_eq!(scanned as u64, ROWS, "plain-row scan must see every final row");
+    assert_eq!(scanned.len() as u64, ROWS);
+    let scan_checksum = scanned.iter().try_fold(0u64, |sum, record| {
+        checksum_record(record).map(|hash| sum.wrapping_add(hash))
+    })?;
+    assert_eq!(scan_checksum, checksum_before);
+
     let storage = db.into_storage();
     let before = storage.metrics()?;
+    storage.close()?;
+    drop(storage);
+    let disk_bytes = recursive_disk_bytes(dir.path())?;
+
     let reopen_started = Instant::now();
-    let storage = storage.reopen(&schema.column_families())?;
+    let storage = RocksDbStorage::open(dir.path(), &schema.column_families())?;
+    let reopened = Database::new(schema, storage)?;
     let reopen = reopen_started.elapsed();
-    let after = storage.metrics()?;
-    let disk_bytes = std::fs::read_dir(dir.path())?.filter_map(Result::ok).filter_map(|e| e.metadata().ok()).map(|m| m.len()).sum::<u64>();
-    println!("plain_row_receipt rows={ROWS} updates={UPDATES} writes={} checksum={checksum} write_ms={} point_ms={} point_reads={:?} scan_ms={} scan_rows={scanned} scan_reads={:?} reopen_ms={} disk_bytes={} metrics_before={before:?} metrics_after={after:?}", ROWS + UPDATES, write.as_secs_f64()*1e3, point.as_secs_f64()*1e3, point_reads, scan.as_secs_f64()*1e3, scan_reads, reopen.as_secs_f64()*1e3, disk_bytes);
+    let mut checksum_after = 0u64;
+    for id in 0..ROWS {
+        let record = reopened
+            .primary_key_get("rows", &[Value::U64(id)])?
+            .expect("row survives fresh open");
+        assert_eq!(
+            record.to_values()?[1],
+            Value::String(format!("row-{id}-revision-1"))
+        );
+        checksum_after = checksum_after.wrapping_add(checksum_record(&record)?);
+    }
+    assert_eq!(checksum_after, checksum_before);
+    let after = reopened.into_storage().metrics()?;
+
+    println!(
+        "{}",
+        json!({
+            "scenario": "groove_plain_row",
+            "phase": "plain_row_receipt",
+            "config": {"rows": ROWS, "updates": UPDATES, "durability": "wal_no_sync", "timing_includes_metered_storage": true},
+            "operation_counts": {"inserts": ROWS, "updates": UPDATES, "point_reads_before": ROWS, "scan_rows": scanned.len(), "point_reads_after": ROWS},
+            "checksum_hex": format!("{checksum_after:016x}"),
+            "write_us": write.as_micros(),
+            "point_read_us": point.as_micros(),
+            "scan_us": scan.as_micros(),
+            "reopen_and_database_init_us": reopen.as_micros(),
+            "disk_bytes_recursive": disk_bytes,
+            "logical_point_reads": format!("{point_reads:?}"),
+            "logical_scan_reads": format!("{scan_reads:?}"),
+            "rocksdb_before_close": before,
+            "rocksdb_after_fresh_open": after,
+            "memory_caveat": "memtable excludes shared block cache and Rust/process allocations"
+        })
+    );
     Ok(())
+}
+
+#[test]
+fn recursive_disk_bytes_counts_nested_files() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir(dir.path().join("nested")).unwrap();
+    fs::write(dir.path().join("root"), [0; 3]).unwrap();
+    fs::write(dir.path().join("nested/child"), [0; 5]).unwrap();
+    assert_eq!(recursive_disk_bytes(dir.path()).unwrap(), 8);
+}
+
+#[test]
+fn checksum_is_sensitive_to_returned_row_content() {
+    assert_ne!(
+        checksum_record(&row(7, 0)).unwrap(),
+        checksum_record(&row(7, 1)).unwrap()
+    );
 }

--- a/crates/groove/tests/plain_row_receipt.rs
+++ b/crates/groove/tests/plain_row_receipt.rs
@@ -1,0 +1,75 @@
+//! Manual plain-row RocksDB receipt. Run with:
+//! `cargo test -p groove --test plain_row_receipt -- --ignored --nocapture`.
+//!
+//! The output is intentionally raw: retain it with the command, git revision,
+//! and host metadata (`uname -a`, CPU governor, and available memory).  The
+//! RocksDB snapshot is backend attribution, not process allocation accounting;
+//! its memtable number excludes Groove/Rust allocations and the shared cache.
+
+use std::time::Instant;
+
+use groove::db::Database;
+use groove::records::{Value, VersionedRecord};
+use groove::schema::{ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema};
+use groove::storage::{ReopenableStorage, RocksDbStorage};
+
+const ROWS: u64 = 1_000;
+const UPDATES: u64 = 1_000;
+
+fn schema() -> DatabaseSchema {
+    DatabaseSchema::new([TableSchema::new("rows", [
+        ColumnSchema::new("id", ColumnType::U64),
+        ColumnSchema::new("body", ColumnType::String),
+    ]).with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
+}
+
+fn row(id: u64, revision: u64) -> VersionedRecord {
+    let descriptor = schema().table("rows").unwrap().record_schema_for_version(0).unwrap();
+    VersionedRecord::create(0, descriptor, &[Value::U64(id), Value::String(format!("row-{id}-revision-{revision}"))]).unwrap()
+}
+
+#[test]
+#[ignore = "manual storage receipt; noisy and host-specific"]
+fn plain_row_write_point_history_scan_and_reopen_receipt() -> Result<(), Box<dyn std::error::Error>> {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    let dir = tempfile::tempdir()?;
+    let schema = schema();
+    let storage = RocksDbStorage::open(dir.path(), &schema.column_families())?;
+    let mut db = Database::new(schema.clone(), storage)?;
+    let write_started = Instant::now();
+    let mut checksum = 0u64;
+    for revision in 0..2 {
+        let count = if revision == 0 { ROWS } else { UPDATES };
+        for id in 0..count {
+            let mut batch = db.open_batch();
+            if revision == 0 {
+                batch.insert("rows", row(id, revision));
+            } else {
+                batch.update("rows", row(id, revision));
+            }
+            db.commit_batch(batch)?;
+            checksum = checksum.wrapping_add(id ^ revision);
+        }
+    }
+    let write = write_started.elapsed();
+    db.reset_storage_read_metrics();
+    let point_started = Instant::now();
+    for id in 0..ROWS { assert!(db.primary_key_get("rows", &[Value::U64(id)])?.is_some()); checksum = checksum.wrapping_add(id); }
+    let point = point_started.elapsed();
+    let point_reads = db.take_storage_read_metrics();
+    db.reset_storage_read_metrics();
+    let scan_started = Instant::now();
+    let scanned = db.primary_key_scan("rows", &[])?.len();
+    let scan = scan_started.elapsed();
+    let scan_reads = db.take_storage_read_metrics();
+    assert_eq!(scanned as u64, ROWS, "plain-row scan must see every final row");
+    let storage = db.into_storage();
+    let before = storage.metrics()?;
+    let reopen_started = Instant::now();
+    let storage = storage.reopen(&schema.column_families())?;
+    let reopen = reopen_started.elapsed();
+    let after = storage.metrics()?;
+    let disk_bytes = std::fs::read_dir(dir.path())?.filter_map(Result::ok).filter_map(|e| e.metadata().ok()).map(|m| m.len()).sum::<u64>();
+    println!("plain_row_receipt rows={ROWS} updates={UPDATES} writes={} checksum={checksum} write_ms={} point_ms={} point_reads={:?} scan_ms={} scan_rows={scanned} scan_reads={:?} reopen_ms={} disk_bytes={} metrics_before={before:?} metrics_after={after:?}", ROWS + UPDATES, write.as_secs_f64()*1e3, point.as_secs_f64()*1e3, point_reads, scan.as_secs_f64()*1e3, scan_reads, reopen.as_secs_f64()*1e3, disk_bytes);
+    Ok(())
+}

--- a/dev/benchmarks/run-receipt.mjs
+++ b/dev/benchmarks/run-receipt.mjs
@@ -8,6 +8,7 @@
  * smoke.sh.
  */
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -74,6 +75,10 @@ function gitDirty() {
     spawnSync("git", ["-C", root, "diff", "--quiet"]).status !== 0 ||
     spawnSync("git", ["-C", root, "diff", "--cached", "--quiet"]).status !== 0
   );
+}
+function commandVersion(command, args = ["--version"]) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "unavailable";
 }
 function rowsFromJson(value) {
   if (Array.isArray(value)) return value.flatMap(rowsFromJson);
@@ -332,6 +337,23 @@ async function main() {
     emitted_json_lines: rows.length,
     invocation: args.invocation,
     log: path.relative(root, log),
+    git_revision: git(["rev-parse", "HEAD"]),
+    git_branch: git(["branch", "--show-current"]),
+    git_dirty: gitDirty(),
+    machine: {
+      platform: os.platform(),
+      release: os.release(),
+      arch: os.arch(),
+      cpu_model: os.cpus()[0]?.model ?? "unknown",
+      logical_cpus: os.cpus().length,
+      total_memory_bytes: os.totalmem(),
+      free_memory_bytes_at_receipt: os.freemem(),
+    },
+    compiler: {
+      rustc: commandVersion("rustc"),
+      cargo: commandVersion("cargo"),
+      node: process.version,
+    },
   });
   fs.writeFileSync(jsonl, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
   appendLedger({


### PR DESCRIPTION
🤖 Add a trustworthy measurement baseline for the plain-row Groove storage model.

## What changes

- Exposes a non-perturbing RocksDB metrics snapshot for live/total SST data, estimated live bytes, memtables, pending work and active background work.
- Preserves the distinction between DB-global counters, per-column-family flags and unavailable properties.
- Adds a manual plain-row receipt using real Groove inserts and updates, point reads, full scans, recursive disk sizing and a genuine close/fresh-open cycle.
- Verifies returned revision content and checksums before and after reopen.
- Emits operation counts, RocksDB attribution, git/compiler/machine/configuration metadata and measurement caveats through the existing receipt wrapper.

This does not change the storage format or row-storage behavior. It gives subsequent row-layout, batching, compression and history experiments a reproducible baseline instead of relying on the older generic KV or retired window/column harnesses.

## Validation

- full `cargo test -p groove`: 393 tests plus 27 doctests passed; one manual receipt intentionally ignored by default
- manual ignored receipt and receipt-wrapper capture
- `cargo fmt --check`
- independent Terra-high review, no P0/P1/P2 findings
- planted mutations for content checksum, unavailable metrics, per-CF/global aggregation, recursive disk accounting and no-op reopen lifecycle
- public sensitive-data guard

The receipt currently measures history write behavior through real row updates. Groove does not yet expose a public history-query surface suitable for a history-scan phase, so it does not claim to benchmark that operation.
