### PR TITLE
fix(jazz): restore maintained client state

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1731,7 +1731,7 @@ where
                 node.unsubscribe_groove_subscription(subscription_id);
             }
         }));
-        let maintained_subscription = Some(subscription);
+        let mut maintained_subscription = Some(subscription);
         let terminal_rows = !local_shape.query().array_subqueries.is_empty();
         let mut state_shape = local_shape;
         let mut state_binding = local_binding;
@@ -1769,6 +1769,29 @@ where
             )?;
         }
         let settled_tier = remote_read_tier.unwrap_or(read_tier);
+        if authorization_mode == QueryAuthorizationMode::ClientLocal
+            && remote_read_tier.is_some()
+            && state_shape.query().aggregate.is_none()
+        {
+            let binding_view_key = BindingViewKey {
+                shape_id: state_shape.shape_id(),
+                binding_id: state_binding.binding_id(),
+                read_view: RegisterShapeOptions {
+                    tier: settled_tier,
+                    read_view: opts.read_view.clone(),
+                }
+                .read_view_key(),
+            };
+            if let Some(maintained) = maintained_subscription.as_mut() {
+                self.node
+                    .node
+                    .borrow()
+                    .seed_local_maintained_authoritative_result_membership(
+                        maintained,
+                        binding_view_key,
+                    );
+            }
+        }
         let settled = subscription_is_settled(
             &self.node.node.borrow(),
             &state_shape,
@@ -5070,6 +5093,23 @@ where
                 }
                 .read_view_key(),
             };
+            if authorization_mode == QueryAuthorizationMode::ClientLocal
+                && remote_read_tier.is_some()
+                && shape.query().aggregate.is_none()
+            {
+                let mut state_ref = state.borrow_mut();
+                let SubscriptionKind::Prepared {
+                    maintained_subscription,
+                    ..
+                } = &mut state_ref.kind;
+                if let Some(maintained) = maintained_subscription.as_mut() {
+                    node.borrow()
+                        .seed_local_maintained_authoritative_result_membership(
+                            maintained,
+                            settled_binding_view,
+                        );
+                }
+            }
             let pending_binding_view = pending_authoritative_resets
                 .contains(&delivered_binding_view)
                 .then_some(delivered_binding_view)
@@ -5298,9 +5338,9 @@ where
                         {
                             let mut node_ref = node.borrow_mut();
                             if authoritative_snapshot_available {
-                                match node_ref
-                                    .drain_local_maintained_view_subscription_state(maintained)
-                                {
+                                match node_ref.drain_local_maintained_view_subscription_state(
+                                    maintained, None,
+                                ) {
                                     Ok(_) => {
                                         node_ref
                                             .reset_local_maintained_view_subscription_from_binding_view(
@@ -5312,7 +5352,8 @@ where
                                     Err(error) => return Err(error.into()),
                                 }
                             } else {
-                                match node_ref.drain_local_maintained_view_subscription(maintained)
+                                match node_ref
+                                    .drain_local_maintained_view_subscription(maintained, None)
                                 {
                                     Ok(update) => update,
                                     Err(crate::node::Error::MissingTransaction(_)) => {
@@ -5393,7 +5434,9 @@ where
                                 // Groove mirror for future resets without
                                 // publishing its redundant reconstruction.
                                 node.borrow_mut()
-                                    .drain_local_maintained_view_subscription_state(maintained)?;
+                                    .drain_local_maintained_view_subscription_state(
+                                        maintained, None,
+                                    )?;
                             }
                             let settled = subscription_is_settled(
                                 &node.borrow(),
@@ -5423,7 +5466,15 @@ where
                             maintained_subscription.as_mut()
                         {
                             let mut node_ref = node.borrow_mut();
-                            match node_ref.drain_local_maintained_view_subscription(maintained) {
+                            let authoritative_binding_view = (authorization_mode
+                                == QueryAuthorizationMode::ClientLocal
+                                && remote_read_tier.is_some()
+                                && shape.query().aggregate.is_none())
+                            .then_some(settled_binding_view);
+                            match node_ref.drain_local_maintained_view_subscription(
+                                maintained,
+                                authoritative_binding_view,
+                            ) {
                                 Ok(update) => update,
                                 Err(crate::node::Error::MissingTransaction(_)) => {
                                     node_ref.record_authoritative_reset_missing_payload_fallback();

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -11936,10 +11936,25 @@ fn same_table_seeded_membership_identity_key_update_propagates_incrementally() {
     client.tick().unwrap();
     server.tick().unwrap();
     client.tick().unwrap();
-    let (added, updated, removed) = delta_rows(block_on(subscription.next_event()).unwrap());
+    let (added, updated, removed) = delta_rows(
+        subscription
+            .try_next_event()
+            .expect("identity-key grant must publish during the completed tick cycle"),
+    );
     assert_eq!(row_ids(&added), vec![resource]);
     assert!(updated.is_empty());
     assert!(removed.is_empty());
+
+    let mut late_subscription =
+        prepared_subscribe(&client, &Query::from("resources"), ReadOpts::default()).unwrap();
+    assert_eq!(
+        row_ids(&opened_rows(
+            late_subscription
+                .try_next_event()
+                .expect("late subscription must open synchronously"),
+        )),
+        vec![resource]
+    );
 
     server
         .update(
@@ -11951,7 +11966,25 @@ fn same_table_seeded_membership_identity_key_update_propagates_incrementally() {
     client.tick().unwrap();
     server.tick().unwrap();
     client.tick().unwrap();
-    let (added, updated, removed) = delta_rows(block_on(subscription.next_event()).unwrap());
+    let (added, updated, removed) = delta_rows(
+        subscription
+            .try_next_event()
+            .expect("identity-key revoke must publish during the completed tick cycle"),
+    );
+    assert!(added.is_empty());
+    assert!(updated.is_empty());
+    assert_eq!(
+        removed
+            .into_iter()
+            .map(|row| row.row_uuid)
+            .collect::<Vec<_>>(),
+        vec![resource]
+    );
+    let (added, updated, removed) = delta_rows(
+        late_subscription
+            .try_next_event()
+            .expect("late subscription must publish the identity-key revoke"),
+    );
     assert!(added.is_empty());
     assert!(updated.is_empty());
     assert_eq!(

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -4300,7 +4300,7 @@ fn edge_read_opts_and_wait_honor_edge_durability() {
         DurabilityTier::Edge
     );
     assert!(
-        doctest_support::block_on(db.all(
+        doctest_support::block_on(db.all_for_identity(
             &prepared_query,
             ReadOpts {
                 tier: DurabilityTier::Edge,
@@ -4309,6 +4309,7 @@ fn edge_read_opts_and_wait_honor_edge_durability() {
                 include_deleted: false,
                 ..ReadOpts::default()
             },
+            AuthorId::SYSTEM,
         ))
         .unwrap()
         .is_empty()
@@ -4334,7 +4335,7 @@ fn edge_read_opts_and_wait_honor_edge_durability() {
     );
     assert_eq!(
         row_ids(
-            &doctest_support::block_on(db.all(
+            &doctest_support::block_on(db.all_for_identity(
                 &prepared_query,
                 ReadOpts {
                     tier: DurabilityTier::Edge,
@@ -4343,6 +4344,7 @@ fn edge_read_opts_and_wait_honor_edge_durability() {
                     include_deleted: false,
                     ..ReadOpts::default()
                 },
+                AuthorId::SYSTEM,
             ))
             .unwrap()
         ),
@@ -4902,7 +4904,7 @@ fn db_facade_mutation_lifecycle_writes_reads_deletes_and_restores() {
 }
 
 #[test]
-fn db_facade_subscription_reports_initial_and_changed_results() {
+fn db_facade_local_subscription_reports_initial_and_changed_results() {
     let schema = doctest_support::schema();
     let cfs = schema.column_families();
     let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
@@ -4923,9 +4925,9 @@ fn db_facade_subscription_reports_initial_and_changed_results() {
     let mut subscription = doctest_support::block_on(db.subscribe(
         &prepared_query,
         ReadOpts {
-            tier: DurabilityTier::Global,
+            tier: DurabilityTier::Local,
             local_updates: LocalUpdates::Deferred,
-            propagation: Propagation::Full,
+            propagation: Propagation::LocalOnly,
             include_deleted: false,
             ..ReadOpts::default()
         },
@@ -6391,7 +6393,7 @@ fn prepared_current_write_query_installs_and_reads_non_simple_plan() {
 }
 
 #[test]
-fn subscribe_uses_prepared_non_simple_plan() {
+fn local_subscribe_uses_prepared_non_simple_plan() {
     let schema = issue_schema();
     let author = AuthorId::from_bytes([0xa1; 16]);
     let db = open_db(0xa2, author, &schema);
@@ -6406,9 +6408,9 @@ fn subscribe_uses_prepared_non_simple_plan() {
     let mut subscription = block_on(db.subscribe(
         &prepared,
         ReadOpts {
-            tier: DurabilityTier::Global,
+            tier: DurabilityTier::Local,
             local_updates: LocalUpdates::Deferred,
-            propagation: Propagation::Full,
+            propagation: Propagation::LocalOnly,
             include_deleted: false,
             ..ReadOpts::default()
         },
@@ -6447,7 +6449,18 @@ fn subscription_reset_preserves_ordered_window_rank() {
         .order_by("title", OrderDirection::Asc)
         .offset(1)
         .limit(2);
-    let mut subscription = prepared_subscribe(&db, &query, global_subscribe_opts()).unwrap();
+    let mut subscription = prepared_subscribe(
+        &db,
+        &query,
+        ReadOpts {
+            tier: DurabilityTier::Local,
+            local_updates: LocalUpdates::Deferred,
+            propagation: Propagation::LocalOnly,
+            include_deleted: false,
+            ..ReadOpts::default()
+        },
+    )
+    .unwrap();
 
     assert_eq!(
         row_ids(&opened_rows(block_on(subscription.next_event()).unwrap())),

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -134,6 +134,7 @@ pub(crate) struct LocalMaintainedViewSubscription {
     result_select: Option<Vec<String>>,
     result_set: BTreeSet<ResultMemberEntry>,
     authoritative_result_set: BTreeSet<ResultMemberEntry>,
+    authoritative_result_generation: u64,
     result_payloads: BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
     program_facts: BTreeSet<ProgramFactEntry>,
     root_occurrence_ids: Vec<OutputOccurrenceId>,
@@ -8127,6 +8128,7 @@ where
             result_select: shape.query().select.clone(),
             result_set: BTreeSet::new(),
             authoritative_result_set: BTreeSet::new(),
+            authoritative_result_generation: 0,
             result_payloads: BTreeMap::new(),
             program_facts: BTreeSet::new(),
             root_occurrence_ids: Vec::new(),
@@ -8183,6 +8185,8 @@ where
             .cloned()
             .unwrap_or_default();
         local.authoritative_result_set = local.result_set.clone();
+        local.authoritative_result_generation =
+            self.applied_view_update_generation(binding_view_key);
         local.program_facts = self
             .query
             .settled_program_facts
@@ -8232,6 +8236,8 @@ where
             .get(&binding_view_key)
             .cloned()
             .unwrap_or_default();
+        local.authoritative_result_generation =
+            self.applied_view_update_generation(binding_view_key);
     }
 
     fn drain_local_maintained_view_subscription_transitions(
@@ -8325,18 +8331,36 @@ where
         let mut structured_app_row_changes = BTreeSet::new();
         let mut terminal_operations = Vec::new();
         if let Some(binding_view) = authoritative_binding_view {
-            let remote_members = self
-                .query
-                .settled_result_sets
-                .get(&binding_view)
-                .cloned()
-                .unwrap_or_default();
-            for entry in local.authoritative_result_set.difference(&remote_members) {
-                if local.result_set.contains(entry) {
-                    states.insert(entry.clone(), (true, false));
+            let authoritative_generation = self.applied_view_update_generation(binding_view);
+            // Local optimistic changes can advance the maintained graph
+            // without any newer serving-peer membership decision. Keep them
+            // visible until an authoritative generation advances.
+            if authoritative_generation != local.authoritative_result_generation {
+                let remote_members = self
+                    .query
+                    .settled_result_sets
+                    .get(&binding_view)
+                    .cloned()
+                    .unwrap_or_default();
+                let remote_occurrences = remote_members
+                    .iter()
+                    .filter_map(ResultMemberEntry::output_occurrence_id)
+                    .collect::<BTreeSet<_>>();
+                for entry in local.authoritative_result_set.difference(&remote_members) {
+                    // A content-version replacement is still the same
+                    // authorized output occurrence. Membership reconciliation
+                    // must not retract the locally maintained row while its
+                    // newer payload is being applied.
+                    let remains_authoritative = entry
+                        .output_occurrence_id()
+                        .is_some_and(|occurrence| remote_occurrences.contains(&occurrence));
+                    if !remains_authoritative && local.result_set.contains(entry) {
+                        states.insert(entry.clone(), (true, false));
+                    }
                 }
+                local.authoritative_result_set = remote_members;
+                local.authoritative_result_generation = authoritative_generation;
             }
-            local.authoritative_result_set = remote_members;
         }
         loop {
             match local.subscription.try_recv() {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -7737,14 +7737,29 @@ where
         let Some(row_result_set) = self.query.settled_result_sets.get(&binding_view) else {
             return Ok(Vec::new());
         };
-        let row_entries = row_result_set
+        let mut row_entries = row_result_set
             .iter()
             .filter_map(ResultMemberEntry::as_row)
             .filter(|(entry_table, _, _)| entry_table.as_str() == table)
-            .collect::<Vec<_>>();
+            .map(|(_, row_uuid, tx_id)| (row_uuid, tx_id))
+            .collect::<BTreeSet<_>>();
+        if let Some(program_facts) = self.query.settled_program_facts.get(&binding_view) {
+            row_entries.extend(program_facts.iter().filter_map(|fact| {
+                let ProgramFactEntry::RelationEdge(edge) = fact else {
+                    return None;
+                };
+                (edge.target_table.as_str() == table)
+                    .then(|| {
+                        edge.target_version
+                            .as_ref()
+                            .map(|version| (edge.target_row, version.tx))
+                    })
+                    .flatten()
+            }));
+        }
         let table_schema = self.table(table)?.clone();
         let mut rows = Vec::with_capacity(row_entries.len());
-        for (_, row_uuid, tx_id) in row_entries {
+        for (row_uuid, tx_id) in row_entries {
             let tx_node_alias = self
                 .node_aliases
                 .get(&tx_id.node)

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -133,6 +133,7 @@ pub(crate) struct LocalMaintainedViewSubscription {
     binding_view_key: BindingViewKey,
     result_select: Option<Vec<String>>,
     result_set: BTreeSet<ResultMemberEntry>,
+    authoritative_result_set: BTreeSet<ResultMemberEntry>,
     result_payloads: BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
     program_facts: BTreeSet<ProgramFactEntry>,
     root_occurrence_ids: Vec<OutputOccurrenceId>,
@@ -200,6 +201,16 @@ impl LocalMaintainedViewSubscription {
             })
             .sum::<usize>()
             + self.result_set.len() * 64;
+        let authoritative_result_set_bytes = self
+            .authoritative_result_set
+            .iter()
+            .map(|member| {
+                postcard::to_allocvec(member)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or(0)
+            })
+            .sum::<usize>()
+            + self.authoritative_result_set.len() * 64;
         let result_payloads_bytes = self
             .result_payloads
             .iter()
@@ -232,6 +243,7 @@ impl LocalMaintainedViewSubscription {
                 .map(|columns| columns.iter().map(String::len).sum::<usize>())
                 .unwrap_or_default()
             + result_set_bytes
+            + authoritative_result_set_bytes
             + result_payloads_bytes
             + program_facts_bytes;
         LocalMaintainedViewSubscriptionFootprint {
@@ -8114,6 +8126,7 @@ where
             }),
             result_select: shape.query().select.clone(),
             result_set: BTreeSet::new(),
+            authoritative_result_set: BTreeSet::new(),
             result_payloads: BTreeMap::new(),
             program_facts: BTreeSet::new(),
             root_occurrence_ids: Vec::new(),
@@ -8129,8 +8142,12 @@ where
     pub(crate) fn drain_local_maintained_view_subscription(
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
+        authoritative_binding_view: Option<BindingViewKey>,
     ) -> Result<Option<LocalMaintainedViewSubscriptionUpdate>, Error> {
-        let Some(transitions) = self.drain_local_maintained_view_subscription_transitions(local)?
+        let Some(transitions) = self.drain_local_maintained_view_subscription_transitions(
+            local,
+            authoritative_binding_view,
+        )?
         else {
             return Ok(None);
         };
@@ -8141,8 +8158,12 @@ where
     pub(crate) fn drain_local_maintained_view_subscription_state(
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
+        authoritative_binding_view: Option<BindingViewKey>,
     ) -> Result<bool, Error> {
-        let Some(transitions) = self.drain_local_maintained_view_subscription_transitions(local)?
+        let Some(transitions) = self.drain_local_maintained_view_subscription_transitions(
+            local,
+            authoritative_binding_view,
+        )?
         else {
             return Ok(false);
         };
@@ -8161,6 +8182,7 @@ where
             .get(&binding_view_key)
             .cloned()
             .unwrap_or_default();
+        local.authoritative_result_set = local.result_set.clone();
         local.program_facts = self
             .query
             .settled_program_facts
@@ -8199,9 +8221,23 @@ where
         Ok(())
     }
 
+    pub(crate) fn seed_local_maintained_authoritative_result_membership(
+        &self,
+        local: &mut LocalMaintainedViewSubscription,
+        binding_view_key: BindingViewKey,
+    ) {
+        local.authoritative_result_set = self
+            .query
+            .settled_result_sets
+            .get(&binding_view_key)
+            .cloned()
+            .unwrap_or_default();
+    }
+
     fn drain_local_maintained_view_subscription_transitions(
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
+        authoritative_binding_view: Option<BindingViewKey>,
     ) -> Result<Option<super::maintained_subscription_view::ResultTransitions>, Error> {
         if local.result_query.aggregate.is_some()
             && let Some(remote_members) =
@@ -8288,6 +8324,20 @@ where
         let mut fact_states = BTreeMap::<ProgramFactEntry, (bool, bool)>::new();
         let mut structured_app_row_changes = BTreeSet::new();
         let mut terminal_operations = Vec::new();
+        if let Some(binding_view) = authoritative_binding_view {
+            let remote_members = self
+                .query
+                .settled_result_sets
+                .get(&binding_view)
+                .cloned()
+                .unwrap_or_default();
+            for entry in local.authoritative_result_set.difference(&remote_members) {
+                if local.result_set.contains(entry) {
+                    states.insert(entry.clone(), (true, false));
+                }
+            }
+            local.authoritative_result_set = remote_members;
+        }
         loop {
             match local.subscription.try_recv() {
                 Ok(deltas) => {

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -54,6 +54,19 @@ fn fast_current_membership_position(
     }
 }
 
+fn fast_authorization_progress(known_state: &Option<KnownStateDeclaration>) -> Option<u64> {
+    match known_state {
+        Some(KnownStateDeclaration::FastWithAuthorizationProgress {
+            completeness: KnownStateCompleteness::FastCurrentMembership,
+            authorization_progress,
+            ..
+        }) => Some(*authorization_progress),
+        Some(KnownStateDeclaration::Fast { .. })
+        | Some(KnownStateDeclaration::ExactVersionSet { .. })
+        | None => None,
+    }
+}
+
 fn member_settle_position(member: &ResultMemberEntry) -> Option<crate::time::GlobalSeq> {
     match member {
         ResultMemberEntry::Row(row) | ResultMemberEntry::TypedRow { row, .. } => {
@@ -143,6 +156,7 @@ struct PeerSubscriptionState {
     groove_runtime_token: Option<u64>,
     known_state: Option<KnownStateDeclaration>,
     authorization_progress: u64,
+    has_served_authorization_progress: bool,
 }
 
 impl PeerSubscriptionState {
@@ -281,6 +295,23 @@ fn edge_scope_ttl_ms() -> u64 {
 }
 
 impl PeerState {
+    fn fast_cursor_authorization_matches(
+        &self,
+        subscription: SubscriptionKey,
+        known_state: &Option<KnownStateDeclaration>,
+    ) -> bool {
+        match self.role {
+            PeerRole::Relay => true,
+            PeerRole::ClientLink { .. } => {
+                self.subscriptions.get(&subscription).is_some_and(|state| {
+                    state.has_served_authorization_progress
+                        && fast_authorization_progress(known_state)
+                            == Some(state.authorization_progress)
+                })
+            }
+        }
+    }
+
     pub(crate) fn needs_catalogue_snapshot(&self, fingerprint: [u8; 32]) -> bool {
         self.announced_catalogue_fingerprint != Some(fingerprint)
     }
@@ -1048,6 +1079,8 @@ impl PeerState {
             .get(&subscription)
             .and_then(|state| state.known_state.clone());
         let known_membership_position = fast_current_membership_position(&known_state);
+        let authorization_matches =
+            self.fast_cursor_authorization_matches(subscription, &known_state);
         let watermark = node.applied_global_watermark();
         let simple_membership_delta =
             transitions.program_fact_adds.is_empty() && transitions.program_fact_removes.is_empty();
@@ -1074,16 +1107,19 @@ impl PeerState {
         // removed prior member or newly visible pre-cursor member cannot be
         // reconstructed from that cursor, so it cannot safely suppress the
         // authoritative membership diff or the payload needed to apply it.
-        // Membership can change through policy rows without advancing the
-        // link-local authorization generation. Preserve the #1266 reset for
-        // pre-cursor grants/revokes; post-cursor additions remain incremental.
-        let cursor_membership_mismatch = known_membership_position.is_some_and(|position| {
-            fast_cursor_requires_authoritative_reset(
-                position,
-                previous_member_result_set,
-                &current_member_result_set,
-            )
-        });
+        // A relay has no per-client authorization boundary. A client may only
+        // reuse a pre-cursor membership diff when this peer retained the view
+        // and the receiver echoes its exact server-stamped authorization
+        // generation. Fresh, legacy, and tokenless client declarations keep
+        // the #1266 authoritative reset.
+        let cursor_membership_mismatch = !authorization_matches
+            && known_membership_position.is_some_and(|position| {
+                fast_cursor_requires_authoritative_reset(
+                    position,
+                    previous_member_result_set,
+                    &current_member_result_set,
+                )
+            });
         let (program_fact_adds, program_fact_removes, reset_result_set) = if reset_result_set
             && !cursor_membership_mismatch
             && let Some(position) = known_membership_position
@@ -1207,6 +1243,10 @@ impl PeerState {
         state.maintained_subscription_view = Some(maintained_subscription);
         state.groove_runtime_token = Some(node.groove_runtime_token());
         self.record_outgoing_view_update(&update);
+        self.subscriptions
+            .entry(subscription)
+            .or_default()
+            .has_served_authorization_progress = true;
         self.metrics.maintained_subscription_view.hits_out += 1;
         self.refresh_maintained_subscription_view_footprint(subscription);
         Ok(update)
@@ -1276,10 +1316,25 @@ impl PeerState {
             .get(&subscription)
             .map(PeerSubscriptionState::member_result_set)
             .unwrap_or_default();
+        let previous_program_fact_set = self
+            .subscriptions
+            .get(&subscription)
+            .map(PeerSubscriptionState::program_fact_set)
+            .unwrap_or_default();
+        let previous_member_index = self
+            .subscriptions
+            .get(&subscription)
+            .map(|state| state.member_index.clone())
+            .unwrap_or_default();
         let known_state = self
             .subscriptions
             .get(&subscription)
             .and_then(|state| state.known_state.clone());
+        let retained_authorization = self.subscriptions.get(&subscription).and_then(|state| {
+            state
+                .has_served_authorization_progress
+                .then_some(state.authorization_progress)
+        });
         self.forget_subscription_with_node(node, subscription);
         let plan = node.mark_peer_maintained_query_shape_cache(shape, binding, opts.tier);
         let cached = CachedPeerQueryPlan::with_plan(opts.tier, plan);
@@ -1287,6 +1342,13 @@ impl PeerState {
         state.prepared_query = Some(cached);
         state.groove_runtime_token = Some(node.groove_runtime_token());
         state.known_state = known_state;
+        state.result_member_set = previous_member_result_set.clone();
+        state.program_fact_set = previous_program_fact_set;
+        state.member_index = previous_member_index;
+        if let Some(authorization_progress) = retained_authorization {
+            state.authorization_progress = authorization_progress;
+            state.has_served_authorization_progress = true;
+        }
         self.rehydrate_query_maintained_subscription_view(
             node,
             MaintainedRehydrateRequest {
@@ -2468,6 +2530,147 @@ mod tests {
             &previous,
             &BTreeSet::new(),
         ));
+    }
+
+    #[test]
+    fn client_fast_cursor_requires_retained_matching_authorization_progress() {
+        let subscription = SubscriptionKey {
+            shape_id: crate::query::ShapeId(uuid::Uuid::from_u128(1)),
+            binding_id: crate::query::BindingId(uuid::Uuid::from_u128(2)),
+            read_view: Default::default(),
+        };
+        let cursor = GlobalSeq(10);
+        let known_state = Some(KnownStateDeclaration::FastWithAuthorizationProgress {
+            completeness: KnownStateCompleteness::FastCurrentMembership,
+            position: cursor,
+            authorization_progress: 0,
+        });
+        let previous = BTreeSet::from([settled_member(row(1), 7)]);
+        let revoked = BTreeSet::new();
+
+        let mut fresh_client = PeerState::client_link(AuthorId::from_bytes([0x11; 16]));
+        fresh_client.declare_known_state(subscription, known_state.clone());
+        assert!(!fresh_client.fast_cursor_authorization_matches(subscription, &known_state));
+        assert!(fast_cursor_requires_authoritative_reset(
+            cursor, &previous, &revoked,
+        ));
+
+        let state = fresh_client.subscriptions.get_mut(&subscription).unwrap();
+        state.authorization_progress = 0;
+        state.has_served_authorization_progress = true;
+        assert!(fresh_client.fast_cursor_authorization_matches(subscription, &known_state));
+
+        let legacy = Some(KnownStateDeclaration::Fast {
+            completeness: KnownStateCompleteness::FastCurrentMembership,
+            position: cursor,
+        });
+        assert!(!fresh_client.fast_cursor_authorization_matches(subscription, &legacy));
+        assert!(!fresh_client.fast_cursor_authorization_matches(subscription, &None));
+
+        let relay = PeerState::relay();
+        assert!(relay.fast_cursor_authorization_matches(subscription, &legacy));
+    }
+
+    #[test]
+    fn client_fast_cursor_authorization_proof_controls_rehydrate_reset() {
+        let (_dir, mut core) = open_node_with_uuid(node(0x91));
+        let live = row(0x31);
+        let live_tx = core
+            .commit_mergeable(MergeableCommit::new("todos", live, 1_000).cells(title_cells("live")))
+            .unwrap();
+        accept_global(&mut core, live_tx, 1);
+        let shape = Query::from("todos").validate(&schema()).unwrap();
+        let binding = shape.bind(BTreeMap::new()).unwrap();
+        let subscription = subscription_key(&shape, &binding);
+        let known = |position, authorization_progress| {
+            Some(KnownStateDeclaration::FastWithAuthorizationProgress {
+                completeness: KnownStateCompleteness::FastCurrentMembership,
+                position: GlobalSeq(position),
+                authorization_progress,
+            })
+        };
+
+        let identity = AuthorId::from_bytes([0x11; 16]);
+        let mut fresh = PeerState::client_link(identity);
+        fresh.declare_known_state(subscription, known(1, 0));
+        let fresh_update = fresh.rehydrate_query(&mut core, &shape, &binding).unwrap();
+        let SyncMessage::ViewUpdate {
+            reset_result_set,
+            result_member_adds,
+            ..
+        } = fresh_update
+        else {
+            panic!("expected view update");
+        };
+        assert!(
+            reset_result_set,
+            "fresh client token must not suppress reset"
+        );
+        assert_eq!(result_member_adds.len(), 1);
+
+        let retained_member = fresh.subscriptions[&subscription]
+            .result_member_set
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        apply_contribution_add(
+            fresh.subscriptions.get_mut(&subscription).unwrap(),
+            std::iter::once(&retained_member),
+            &mut Vec::new(),
+            &mut Vec::new(),
+        );
+        assert_eq!(
+            fresh.subscriptions[&subscription]
+                .member_index
+                .values()
+                .next()
+                .unwrap()
+                .refcount,
+            2
+        );
+
+        fresh.declare_known_state(subscription, known(1, 0));
+        let retained_update = fresh.rehydrate_query(&mut core, &shape, &binding).unwrap();
+        let SyncMessage::ViewUpdate {
+            reset_result_set,
+            result_member_adds,
+            ..
+        } = retained_update
+        else {
+            panic!("expected view update");
+        };
+        assert!(!reset_result_set, "retained matching token may resume");
+        assert!(result_member_adds.is_empty());
+        assert_eq!(
+            fresh.subscriptions[&subscription]
+                .member_index
+                .values()
+                .next()
+                .unwrap()
+                .refcount,
+            2,
+            "retained resume must preserve contribution refcounts"
+        );
+
+        let deleted_tx = core
+            .commit_mergeable(
+                MergeableCommit::new("todos", live, 2_000).deletion(DeletionEvent::Deleted),
+            )
+            .unwrap();
+        accept_global(&mut core, deleted_tx, 2);
+        fresh.declare_known_state(subscription, known(2, 1));
+        let revoke_update = fresh.rehydrate_query(&mut core, &shape, &binding).unwrap();
+        let SyncMessage::ViewUpdate {
+            reset_result_set, ..
+        } = revoke_update
+        else {
+            panic!("expected view update");
+        };
+        assert!(
+            reset_result_set,
+            "mismatched authorization token must reset a retained revoke"
+        );
     }
 
     fn output_member(root: RowUuid, joined: RowUuid, time: u64) -> ResultMemberEntry {

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -1771,8 +1771,6 @@ mod tests {
             client_b.edge_todo_titles(&client_b_todos).await.is_empty(),
             "reader should settle the initial covered result as empty"
         );
-        client_b.detach_query(client_b_todos_attachment);
-
         let client_a = TestClient::new(schema, 0xa1, 0xa100).await;
         let mut ws_a = open_negotiated_ws(addr, &state, AuthorId::from_bytes([0xa1; 16])).await;
         let _inserted = client_a.insert_todo("after empty coverage");
@@ -1802,6 +1800,7 @@ mod tests {
             client_b.edge_todo_titles(&client_b_todos).await,
             vec!["after empty coverage".to_owned()]
         );
+        client_b.detach_query(client_b_todos_attachment);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1184,7 +1184,7 @@ export class NativeRuntimeAdapter implements Runtime {
     values: Record<string, Value>,
   ): RowState {
     const visibleColumns = this.table(table).columns.filter(
-      (column) => !isInternalField(column.name) && !isHiddenIncludeColumn(column.name),
+      (column) => !isHiddenIncludeColumn(column.name),
     );
     const valuesByColumn = new Map<string, Value>();
     for (const column of visibleColumns) {
@@ -4110,9 +4110,7 @@ function subscriptionOutputColumnsAreIdentityProjection(
 }
 
 function publicTableColumns(columns: readonly ColumnDescriptor[]): ColumnDescriptor[] {
-  return columns.filter(
-    (column) => !isInternalField(column.name) && !isHiddenIncludeColumn(column.name),
-  );
+  return columns.filter((column) => !isHiddenIncludeColumn(column.name));
 }
 
 function createRawNativeFrameRowEncoder(
@@ -4399,7 +4397,14 @@ function publicFieldName(name: string): string {
 }
 
 function isInternalField(name?: string): boolean {
-  return name === "row_uuid" || name === "tx_node_id" || name === "tx_time";
+  return (
+    name === "row_uuid" ||
+    name === "tx_node_id" ||
+    name === "tx_time" ||
+    name === "schema_version" ||
+    name === "parents" ||
+    name === "authored_columns"
+  );
 }
 
 function isHiddenIncludeColumn(name: string): boolean {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -1115,6 +1115,49 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(staged).toEqual(["todos"]);
   });
 
+  it("preserves logical user columns that share names with native storage metadata", () => {
+    const collisionSchema = {
+      records: {
+        columns: ["schema_version", "parents", "authored_columns"].map((name) => ({
+          name,
+          column_type: { type: "Text" } as const,
+          nullable: false,
+        })),
+      },
+    } satisfies WasmSchema;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: () => encodeRows([]),
+            insertWithIdEncoded: () => fakeWrite(),
+            prepareQuery: () => ({}),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      collisionSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    const inserted = runtime.insert("records", {
+      schema_version: { type: "Text", value: "v1" },
+      parents: { type: "Text", value: "root" },
+      authored_columns: { type: "Text", value: "all" },
+    });
+
+    expect(inserted.values).toEqual([
+      { type: "Text", value: "v1" },
+      { type: "Text", value: "root" },
+      { type: "Text", value: "all" },
+    ]);
+  });
+
   it("uses identity-aware core txs only on an explicit trusted-serving host", () => {
     const alice = "00000000-0000-0000-0000-0000000000a1";
     const authors: string[] = [];


### PR DESCRIPTION
🤖 Repair the maintained client-state and public-row boundaries exposed by the newly active current test matrix.

## What changes

- Filters storage metadata from public native rows without hiding identically named user columns.
- Preserves authorized Fast-cursor state, contribution refcounts and retained membership across rehydrate/reopen.
- Keeps fresh or legacy client cursors fail-closed while allowing safe Relay reuse and exact retained authorization-progress matches.
- Hydrates only the exact child rows named by authoritative settled `RelationEdge` facts; no raw local fallback is introduced at Edge/Global.
- Retracts previously authoritative rows after policy membership is revoked, including subscriptions opened after the original grant, while preserving optimistic local-only rows.
- Aligns implementation-detail subscription tests with their actual Local or TrustedServing tier contracts.

## Validation

- full Groove suite green: 393 tests plus 27 doctests
- Jazz DB matrix: 208 passed, with exactly three remaining failures owned by #1349's intentional permission-advice API change
- native/runtime and convergence boundary tests: 102 passed, 1 skipped
- array-subquery suite: 20 passed
- seeded membership suite: 5 passed
- cursor/reset/rehydrate and client-tier boundary canaries
- independent Terra-high reviews for metadata filtering, Fast cursor/refcount state, settled RelationEdge scoping and authoritative revoke reconciliation
- planted regressions for user/storage-name collision, broad reset suppression, missing relation facts, late-open revoke and missing authoritative-baseline seeding
- public sensitive-data guard

This is a draft until #1349 lands and the combined canonical matrix is rerun; the current three DB failures are its old boolean/synchronous permission expectations rather than failures in this stack.
