### PR TITLE
Honor backend default durability tier

### DIFF
--- a/.changeset/backend-default-durability-tier.md
+++ b/.changeset/backend-default-durability-tier.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Honor `defaultDurabilityTier` independently from the backend node's durability tier.

--- a/packages/jazz-tools/src/backend/create-jazz-context.test.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.test.ts
@@ -230,6 +230,35 @@ describe("backend/create-jazz-context", () => {
     );
   });
 
+  it("BC-U01a: keeps query durability independent from the node tier", () => {
+    const context = createJazzContext({
+      appId: "server-app",
+      app: { wasmSchema: SCHEMA_A },
+      permissions: {},
+      driver: { type: "persistent", dataPath: "/tmp/jazz.db" },
+      tier: "local",
+      defaultDurabilityTier: "edge",
+    });
+
+    context.db();
+
+    expect(mocks.runtimeCtor).toHaveBeenCalledWith(
+      expect.any(String),
+      "server-app",
+      "dev",
+      "main",
+      "/tmp/jazz.db",
+      "local",
+    );
+    expect(mocks.connectWithRuntime).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        tier: "local",
+        defaultDurabilityTier: "edge",
+      }),
+    );
+  });
+
   it("BC-U01b: rejects configuring both jwksUrl and jwtPublicKey", () => {
     expect(() =>
       createJazzContext({

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -144,7 +144,7 @@ export class JazzContext {
       backendSecret: this.config.backendSecret,
       adminSecret: this.config.adminSecret,
       tier: nodeTier,
-      defaultDurabilityTier: nodeTier,
+      defaultDurabilityTier: this.config.defaultDurabilityTier ?? nodeTier,
     };
 
     this.clientInstance = JazzClient.connectWithRuntime(this.runtime, context);


### PR DESCRIPTION
## What changed

- honor `defaultDurabilityTier` when creating a backend Jazz client
- retain the backend node tier as the fallback when no query default is configured
- add regression coverage for a local-tier backend whose queries default to edge
- add a patch changeset for `jazz-tools`

## Why

`BackendContextConfig` exposes `defaultDurabilityTier`, but `createJazzContext` replaced it with the
node's durability tier. This prevented backend clients from using a local node identity while making
unannotated queries wait for edge durability.

Closes #1353.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/backend/create-jazz-context.test.ts`
- `pnpm --filter jazz-tools check`
- `pnpm exec oxfmt --check packages/jazz-tools/src/backend/create-jazz-context.ts packages/jazz-tools/src/backend/create-jazz-context.test.ts .changeset/backend-default-durability-tier.md`
- `pnpm exec oxlint packages/jazz-tools/src/backend/create-jazz-context.ts packages/jazz-tools/src/backend/create-jazz-context.test.ts`
