### PR TITLE
feat(schema): expose enum and payload-enum columns

### DIFF
--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -19,7 +19,9 @@ use crate::queries::{
     BinaryOp, ColumnRef, Cte, Expr, JoinConstraint, JoinKind, Query, Select, SelectItem, TableRef,
     UnaryOp, WithQuery,
 };
-use crate::records::{EnumCase, EnumSchema, RecordDescriptor, ScalarEnumSchema, ValueType};
+use crate::records::{
+    EnumCase, EnumSchema, EnumValue, RecordDescriptor, ScalarEnumSchema, ValueType,
+};
 use crate::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, DirectRecordStoreSchema, IndexSchema, IntegerKeyType,
     PrimaryKey, PrimaryKeyColumn, PrimaryKeyType, TableVariant, TableVariantField,
@@ -748,6 +750,58 @@ fn live_table_rejects_non_additive_enum_registry_mutations() {
             .column_type,
         old_payload
     );
+}
+
+fn open_task_payload_descriptor() -> RecordDescriptor {
+    RecordDescriptor::new([("priority", ValueType::U64), ("title", ValueType::String)])
+}
+
+fn closed_task_payload_descriptor() -> RecordDescriptor {
+    RecordDescriptor::new([("reason", ValueType::String)])
+}
+
+fn payload_enum_tasks_schema() -> DatabaseSchema {
+    let task_state = ColumnType::Enum(Box::new(
+        EnumSchema::new(
+            "task_state",
+            [
+                EnumCase::new("open", open_task_payload_descriptor()),
+                EnumCase::new("closed", closed_task_payload_descriptor()),
+            ],
+        )
+        .unwrap(),
+    ))
+    .nullable();
+    DatabaseSchema::new([TableSchema::new(
+        "payload_tasks",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("state", task_state),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
+}
+
+fn open_task(priority: u64, title: &str) -> Value {
+    Value::Enum(
+        EnumValue::create(
+            0,
+            open_task_payload_descriptor(),
+            &[Value::U64(priority), Value::String(title.to_owned())],
+        )
+        .unwrap(),
+    )
+}
+
+fn closed_task(reason: &str) -> Value {
+    Value::Enum(
+        EnumValue::create(
+            1,
+            closed_task_payload_descriptor(),
+            &[Value::String(reason.to_owned())],
+        )
+        .unwrap(),
+    )
 }
 
 #[test]
@@ -3137,6 +3191,105 @@ fn subscription_reports_incremental_contains_filter_deltas() {
             (vec![11_u64.into(), "Blue Train".into()], -1),
             (vec![7_u64.into(), "Night Train".into()], 1),
         ]
+    );
+}
+
+// This is intentionally an IVM-level test: Jazz lowers payload-enum matching
+// to this internal predicate, and the regression is the filter's weighted
+// incremental behavior rather than a client-facing API concern.
+#[test]
+fn payload_enum_filter_matches_selected_case_and_emits_cross_case_deltas() {
+    let storage = MemoryStorage::new(&["payload_tasks"]);
+    let mut database = Database::new(payload_enum_tasks_schema(), storage).unwrap();
+    let graph = GraphBuilder::table("payload_tasks")
+        .filter(PredicateExpr::EnumMatch {
+            field: "state".to_owned(),
+            case_tag: 0,
+            payload: Box::new(PredicateExpr::eq("priority", Value::U64(1))),
+        })
+        .project_fields([ProjectField::named("id")]);
+    let subscription = database.subscribe_one_sink(graph.clone()).unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "payload_tasks",
+        vec![
+            Value::U64(1),
+            Value::Nullable(Some(Box::new(open_task(1, "matching")))),
+        ],
+    );
+    batch.insert(
+        "payload_tasks",
+        vec![
+            Value::U64(2),
+            Value::Nullable(Some(Box::new(open_task(2, "wrong payload")))),
+        ],
+    );
+    batch.insert(
+        "payload_tasks",
+        vec![
+            Value::U64(3),
+            Value::Nullable(Some(Box::new(closed_task("wrong case")))),
+        ],
+    );
+    batch.insert("payload_tasks", vec![Value::U64(4), Value::Nullable(None)]);
+    database.commit_batch(batch).unwrap();
+    assert_eq!(expect_recv_vals(&subscription), [(vec![1_u64.into()], 1)]);
+    assert_eq!(
+        database
+            .query_graph(graph.clone())
+            .unwrap()
+            .to_values()
+            .unwrap(),
+        [(vec![1_u64.into()], 1)]
+    );
+
+    let mut batch = database.open_batch();
+    batch.update(
+        "payload_tasks",
+        vec![
+            Value::U64(1),
+            Value::Nullable(Some(Box::new(closed_task("moved arm")))),
+        ],
+    );
+    batch.update(
+        "payload_tasks",
+        vec![
+            Value::U64(2),
+            Value::Nullable(Some(Box::new(open_task(1, "now matching")))),
+        ],
+    );
+    batch.update(
+        "payload_tasks",
+        vec![
+            Value::U64(3),
+            Value::Nullable(Some(Box::new(open_task(1, "changed arm")))),
+        ],
+    );
+    database.commit_batch(batch).unwrap();
+    assert_eq!(
+        expect_recv_vals(&subscription),
+        [
+            (vec![1_u64.into()], -1),
+            (vec![2_u64.into()], 1),
+            (vec![3_u64.into()], 1),
+        ]
+    );
+
+    let mut batch = database.open_batch();
+    batch.update(
+        "payload_tasks",
+        vec![
+            Value::U64(2),
+            Value::Nullable(Some(Box::new(open_task(2, "no longer matching")))),
+        ],
+    );
+    database.commit_batch(batch).unwrap();
+    assert_eq!(expect_recv_vals(&subscription), [(vec![2_u64.into()], -1)]);
+    assert_eq!(
+        database.query_graph(graph).unwrap().to_values().unwrap(),
+        [(vec![3_u64.into()], 1)]
     );
 }
 

--- a/crates/groove/src/ivm/op_types.rs
+++ b/crates/groove/src/ivm/op_types.rs
@@ -449,18 +449,60 @@ pub enum PlanExpr {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum PredicateExpr {
-    Eq { field: String, value: LiteralValue },
-    Neq { field: String, value: LiteralValue },
-    Contains { field: String, value: LiteralValue },
-    EqField { field: String, value_field: String },
-    ContainsField { field: String, needle_field: String },
-    NeqField { field: String, value_field: String },
-    Gt { field: String, value: LiteralValue },
-    GtEq { field: String, value: LiteralValue },
-    Lt { field: String, value: LiteralValue },
-    LtEq { field: String, value: LiteralValue },
-    IsNull { field: String },
-    IsNotNull { field: String },
+    Eq {
+        field: String,
+        value: LiteralValue,
+    },
+    Neq {
+        field: String,
+        value: LiteralValue,
+    },
+    Contains {
+        field: String,
+        value: LiteralValue,
+    },
+    EqField {
+        field: String,
+        value_field: String,
+    },
+    ContainsField {
+        field: String,
+        needle_field: String,
+    },
+    NeqField {
+        field: String,
+        value_field: String,
+    },
+    Gt {
+        field: String,
+        value: LiteralValue,
+    },
+    GtEq {
+        field: String,
+        value: LiteralValue,
+    },
+    Lt {
+        field: String,
+        value: LiteralValue,
+    },
+    LtEq {
+        field: String,
+        value: LiteralValue,
+    },
+    IsNull {
+        field: String,
+    },
+    IsNotNull {
+        field: String,
+    },
+    /// Match one tagged enum case and evaluate a predicate against that
+    /// case's payload record. The payload predicate field names are relative
+    /// to the selected case descriptor.
+    EnumMatch {
+        field: String,
+        case_tag: u32,
+        payload: Box<PredicateExpr>,
+    },
     And(Vec<PredicateExpr>),
     Or(Vec<PredicateExpr>),
 }

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -4741,6 +4741,28 @@ impl PredicateExpr {
             }
             Self::IsNull { field } => Ok(is_sql_null_value(&record.get(field)?)),
             Self::IsNotNull { field } => Ok(!is_sql_null_value(&record.get(field)?)),
+            Self::EnumMatch {
+                field,
+                case_tag,
+                payload,
+            } => {
+                let value = record.get(field)?;
+                let value = match value {
+                    Value::Nullable(Some(value)) => *value,
+                    value => value,
+                };
+                match value {
+                    Value::Enum(value) if value.tag() == *case_tag => {
+                        payload.matches(value.record().borrowed(), comparison)
+                    }
+                    // Wrong arms and NULL never match. This is intentionally
+                    // fail-closed so cross-case updates produce ordinary
+                    // removal/insertion deltas through the existing filter
+                    // operator.
+                    Value::Enum(_) | Value::Nullable(None) => Ok(false),
+                    _ => Ok(false),
+                }
+            }
             Self::And(predicates) => predicates
                 .iter()
                 .map(|predicate| predicate.matches(record, comparison))

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -12784,14 +12784,14 @@ mod tests {
         let ValueType::Enum(payload_schema) = physical_payload else {
             panic!("payload expected")
         };
-        let payload = payload_schema.case(0).unwrap().payload.clone();
+        let payload = payload_schema.case(0).unwrap().payload;
         let nested = Value::Enum(EnumValue::create(0, payload, &[Value::EnumTag(2)]).unwrap());
         let ValueType::Record(source_record) = &source else {
             panic!("record expected")
         };
         let value = Value::Record(OwnedRecord::new(
             source_record.create(&[nested]).unwrap(),
-            (**source_record).clone(),
+            **source_record,
         ));
         let projected =
             remap_recursive_enum_value(value, &source, &target, &remaps, "root").unwrap();
@@ -12819,7 +12819,7 @@ mod tests {
         );
         let value = Value::Record(OwnedRecord::new(
             source_record.create(&[unknown]).unwrap(),
-            (**source_record).clone(),
+            **source_record,
         ));
         assert!(matches!(
             remap_recursive_enum_value(value, &source, &target, &remaps, "root"),

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -1397,6 +1397,143 @@ fn rebound_registry_projector_allows_identical_layout_but_not_added_tags() {
 }
 
 #[test]
+fn rebound_variant_projector_rejects_changed_payload_field_type_or_layout() {
+    let source = || {
+        RecordDescriptor::new([(
+            "event",
+            ValueType::Enum(Box::new(
+                EnumSchema::new(
+                    "event",
+                    [
+                        EnumCase::new(
+                            "message",
+                            RecordDescriptor::new([("level", ValueType::I32)]),
+                        ),
+                        EnumCase::new("closed", RecordDescriptor::new([("code", ValueType::I32)])),
+                    ],
+                )
+                .unwrap()
+                .with_registry_id(101),
+            )),
+        )])
+    };
+    let rejects = |target: RecordDescriptor| {
+        assert!(matches!(
+            RecordProjector::new_registry_rebound(source(), target, [(0, 0)]),
+            Err(Error::ProjectTypeMismatch { .. })
+        ));
+    };
+
+    rejects(RecordDescriptor::new([(
+        "event",
+        ValueType::Enum(Box::new(
+            EnumSchema::new(
+                "event",
+                [
+                    EnumCase::new(
+                        "message",
+                        RecordDescriptor::new([("level", ValueType::I64)]),
+                    ),
+                    EnumCase::new("closed", RecordDescriptor::new([("code", ValueType::I32)])),
+                ],
+            )
+            .unwrap()
+            .with_registry_id(202),
+        )),
+    )]));
+    rejects(RecordDescriptor::new([(
+        "event",
+        ValueType::Enum(Box::new(
+            EnumSchema::new(
+                "event",
+                [
+                    EnumCase::new(
+                        "message",
+                        RecordDescriptor::new([
+                            ("level", ValueType::I32),
+                            ("extra", ValueType::Bool),
+                        ]),
+                    ),
+                    EnumCase::new("closed", RecordDescriptor::new([("code", ValueType::I32)])),
+                ],
+            )
+            .unwrap()
+            .with_registry_id(202),
+        )),
+    )]));
+}
+
+#[test]
+fn rebound_variant_projector_rejects_changed_case_name() {
+    let enum_descriptor = |registry_id, message_case_name| {
+        RecordDescriptor::new([(
+            "event",
+            ValueType::Enum(Box::new(
+                EnumSchema::new(
+                    "event",
+                    [
+                        EnumCase::new(
+                            message_case_name,
+                            RecordDescriptor::new([("value", ValueType::I32)]),
+                        ),
+                        EnumCase::new("closed", RecordDescriptor::new([("value", ValueType::I32)])),
+                    ],
+                )
+                .unwrap()
+                .with_registry_id(registry_id),
+            )),
+        )])
+    };
+
+    assert!(matches!(
+        RecordProjector::new_registry_rebound(
+            enum_descriptor(101, "message"),
+            enum_descriptor(202, "renamed_message"),
+            [(0, 0)],
+        ),
+        Err(Error::ProjectTypeMismatch { .. })
+    ));
+}
+
+#[test]
+fn rebound_variant_projector_rejects_reordered_same_layout_cases() {
+    let enum_descriptor = |registry_id, cases: [EnumCase; 2]| {
+        RecordDescriptor::new([(
+            "event",
+            ValueType::Enum(Box::new(
+                EnumSchema::new("event", cases)
+                    .unwrap()
+                    .with_registry_id(registry_id),
+            )),
+        )])
+    };
+    let source = enum_descriptor(
+        101,
+        [
+            EnumCase::new(
+                "message",
+                RecordDescriptor::new([("value", ValueType::I32)]),
+            ),
+            EnumCase::new("closed", RecordDescriptor::new([("value", ValueType::I32)])),
+        ],
+    );
+    let target = enum_descriptor(
+        202,
+        [
+            EnumCase::new("closed", RecordDescriptor::new([("value", ValueType::I32)])),
+            EnumCase::new(
+                "message",
+                RecordDescriptor::new([("value", ValueType::I32)]),
+            ),
+        ],
+    );
+    assert!(matches!(
+        RecordProjector::new_registry_rebound(source, target, [(0, 0)]),
+        Err(Error::ProjectTypeMismatch { .. })
+    ));
+}
+
+#[test]
 fn patch_field_overwrites_fixed_width_values_without_shifting_layout() {
     let schema = RecordDescriptor::new([
         ("id", ValueType::U64),

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -9466,6 +9466,9 @@ fn predicate_references_id(predicate: &Predicate) -> bool {
             operand_is_id(operand) || values.iter().any(operand_is_id)
         }
         Predicate::IsNull(operand) => operand_is_id(operand),
+        Predicate::EnumMatch {
+            column, payload, ..
+        } => column == "id" || predicate_references_id(payload),
     }
 }
 

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroUsize;
 use std::pin::pin;
 use std::task::{Context, Poll, Waker};
 
+use groove::records::{EnumCase, EnumSchema, EnumValue, RecordDescriptor, ValueType};
 use groove::schema::{ColumnSchema, ColumnType};
 use groove::storage::{OrderedKvStorage, ReopenableStorage, RocksDbStorage};
 
@@ -461,6 +462,49 @@ fn schema() -> JazzSchema {
     .with_write_policy(Policy::public())])
 }
 
+fn payload_enum_query_schema() -> JazzSchema {
+    let event = ColumnType::Enum(Box::new(
+        EnumSchema::new(
+            "event",
+            [
+                EnumCase::new(
+                    "message",
+                    RecordDescriptor::new([("level", ValueType::I32)]),
+                ),
+                EnumCase::new("closed", RecordDescriptor::new([("code", ValueType::I32)])),
+            ],
+        )
+        .unwrap(),
+    ));
+    JazzSchema::new([
+        TableSchema::new("events", [ColumnSchema::new("event", event)])
+            .with_read_policy(Policy::public())
+            .with_write_policy(Policy::public()),
+    ])
+}
+
+fn payload_message(level: i32) -> Value {
+    Value::Enum(
+        EnumValue::create(
+            0,
+            RecordDescriptor::new([("level", ValueType::I32)]),
+            &[Value::I32(level)],
+        )
+        .unwrap(),
+    )
+}
+
+fn payload_closed(code: i32) -> Value {
+    Value::Enum(
+        EnumValue::create(
+            1,
+            RecordDescriptor::new([("code", ValueType::I32)]),
+            &[Value::I32(code)],
+        )
+        .unwrap(),
+    )
+}
+
 fn owner_read_schema() -> JazzSchema {
     JazzSchema::new([TableSchema::new(
         "todos",
@@ -490,6 +534,74 @@ fn created_by_read_schema_for_claim(claim_name: &str) -> JazzSchema {
         Query::from("todos").filter(eq(col("$createdBy"), claim(claim_name))),
     ))
     .with_write_policy(Policy::public())])
+}
+
+#[test]
+fn payload_enum_match_filters_one_shot_and_maintained_case_transitions() {
+    let schema = payload_enum_query_schema();
+    let db = open_db(0xe7, AuthorId::from_bytes([0xe7; 16]), &schema);
+    let matching = row(0xe1);
+    let other_case = row(0xe2);
+    db.insert_with_id(
+        "events",
+        matching,
+        BTreeMap::from([("event".to_owned(), payload_message(2))]),
+    )
+    .unwrap();
+    db.insert_with_id(
+        "events",
+        other_case,
+        BTreeMap::from([("event".to_owned(), payload_closed(2))]),
+    )
+    .unwrap();
+
+    let query = Query::from("events").filter(Predicate::EnumMatch {
+        column: "event".to_owned(),
+        case: "message".to_owned(),
+        payload: Box::new(Predicate::Eq(
+            Operand::Column("level".to_owned()),
+            Operand::Literal(Value::I32(2)),
+        )),
+    });
+    assert_eq!(row_ids(&prepared_read(&db, &query)), vec![matching]);
+
+    let prepared_query = prepared(&db, &query);
+    let mut subscription = prepared_subscribe(&db, &query, ReadOpts::default()).unwrap();
+    let initial = snapshot_from_event(block_on(subscription.next_event()).unwrap());
+    assert_eq!(row_ids(&initial.rows), vec![matching]);
+
+    db.update(
+        "events",
+        matching,
+        BTreeMap::from([("event".to_owned(), payload_closed(2))]),
+    )
+    .unwrap();
+    let (added, updated, removed) = delta_rows(block_on(subscription.next_event()).unwrap());
+    assert!(added.is_empty());
+    assert!(updated.is_empty());
+    assert_eq!(
+        removed
+            .into_iter()
+            .map(|row| row.row_uuid)
+            .collect::<Vec<_>>(),
+        vec![matching]
+    );
+    assert!(db.read(&prepared_query).unwrap().is_empty());
+
+    db.update(
+        "events",
+        other_case,
+        BTreeMap::from([("event".to_owned(), payload_message(2))]),
+    )
+    .unwrap();
+    let (added, updated, removed) = delta_rows(block_on(subscription.next_event()).unwrap());
+    assert_eq!(row_ids(&added), vec![other_case]);
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
+    assert_eq!(
+        row_ids(&db.read(&prepared_query).unwrap()),
+        vec![other_case]
+    );
 }
 
 fn owner_write_schema() -> JazzSchema {

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -257,7 +257,7 @@ impl MaintainedSubscriptionView {
         for (sink, terminal) in &deltas.terminal_sinks {
             if let MaintainedTerminalKind::StructuredAppRows { layout, .. } = schemas.get(sink)? {
                 for operation in &terminal.operations {
-                    if operation.root_descriptor != layout.root_descriptor {
+                    if !terminal_operation_descriptor_matches_layout(operation, layout) {
                         return Err(super::Error::InvalidStoredValue(
                             "structured terminal operation descriptor disagrees with prepared root layout",
                         ));
@@ -265,7 +265,14 @@ impl MaintainedSubscriptionView {
                 }
                 transitions
                     .terminal_operations
-                    .extend(terminal.operations.iter().cloned());
+                    .extend(terminal.operations.iter().cloned().map(|mut operation| {
+                        // Enum registry identities are physical-occurrence metadata, not
+                        // a byte-layout change. Publish the prepared descriptor after the
+                        // rebound check above so every operation obeys the early-bound
+                        // terminal layout contract.
+                        operation.root_descriptor = layout.root_descriptor;
+                        operation
+                    }));
             }
         }
         for (sink, deltas) in deltas.sinks {
@@ -642,6 +649,20 @@ impl MaintainedSubscriptionView {
             .map(|(member, payload)| (Some(member), Some(payload)))
             .unwrap_or((None, None))
     }
+}
+
+fn terminal_operation_descriptor_matches_layout(
+    operation: &TerminalOperation,
+    layout: &TerminalRootLayout,
+) -> bool {
+    operation.root_descriptor == layout.root_descriptor
+        || (operation.root_descriptor.fields().len() == layout.root_descriptor.fields().len()
+            && RecordProjector::new_registry_rebound(
+                operation.root_descriptor,
+                layout.root_descriptor,
+                (0..operation.root_descriptor.fields().len()).map(|index| (index, index)),
+            )
+            .is_ok())
 }
 
 impl MaintainedTerminalSchemas {

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -1001,9 +1001,10 @@ where
     }
 
     /// Construct the physical-to-authored side of the enum interning boundary
-    /// for one user cell.  Every entry is keyed by a structural occurrence;
-    /// absent target cases deliberately stay `None` so projection fails rather
-    /// than fabricating an older client's value.
+    /// for one user cell. Entries are keyed by structural occurrence; absent
+    /// target cases stay `None`, so older schema views fail rather than
+    /// fabricating a value. Payload values also receive a `root/nullable`
+    /// alias for the current-table's synthetic nullable cell carrier.
     fn physical_to_authored_enum_remaps(
         &self,
         target_mapping: &TablePhysicalMapping,
@@ -1018,52 +1019,52 @@ where
             let physical_cases = self
                 .physical_scalar_enum_cases(target_mapping.table_id, column_id)
                 .unwrap_or_else(|_| target_cases.clone());
-            remaps.scalar.insert(
-                "root".to_owned(),
-                physical_cases
-                    .iter()
-                    .map(|identity| {
-                        target_cases
-                            .iter()
-                            .position(|candidate| candidate == identity)
-                            .map(|tag| {
-                                u8::try_from(tag).map_err(|_| {
-                                    Error::InvalidStoredValue("target scalar enum tag exhausted")
-                                })
+            let tags = physical_cases
+                .iter()
+                .map(|identity| {
+                    target_cases
+                        .iter()
+                        .position(|candidate| candidate == identity)
+                        .map(|tag| {
+                            u8::try_from(tag).map_err(|_| {
+                                Error::InvalidStoredValue("target scalar enum tag exhausted")
                             })
-                            .transpose()
-                    })
-                    .collect::<Result<_, _>>()?,
-            );
+                        })
+                        .transpose()
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            remaps.scalar.insert("root".to_owned(), tags);
         }
         if let Some(target_cases) = target_mapping.payload_enum_cases.get(&column_id) {
             let physical_cases = self
                 .physical_payload_enum_cases(target_mapping.table_id, column_id)
                 .unwrap_or_else(|_| target_cases.clone());
-            remaps.payload.insert(
-                "root".to_owned(),
-                physical_cases
-                    .iter()
-                    .map(|identity| {
-                        target_cases
-                            .iter()
-                            .position(|candidate| candidate == identity)
-                            .map(|tag| {
-                                u32::try_from(tag).map_err(|_| {
-                                    Error::InvalidStoredValue("target payload enum tag exhausted")
-                                })
+            let tags = physical_cases
+                .iter()
+                .map(|identity| {
+                    target_cases
+                        .iter()
+                        .position(|candidate| candidate == identity)
+                        .map(|tag| {
+                            u32::try_from(tag).map_err(|_| {
+                                Error::InvalidStoredValue("target payload enum tag exhausted")
                             })
-                            .transpose()
-                    })
-                    .collect::<Result<_, _>>()?,
-            );
-            remaps.payload_children.insert(
-                "root".to_owned(),
-                physical_cases
-                    .iter()
-                    .map(|identity| Some(global_case_path("root", identity)))
-                    .collect(),
-            );
+                        })
+                        .transpose()
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let children = physical_cases
+                .iter()
+                .map(|identity| Some(global_case_path("root", identity)))
+                .collect::<Vec<_>>();
+            remaps.payload.insert("root".to_owned(), tags.clone());
+            remaps
+                .payload_children
+                .insert("root".to_owned(), children.clone());
+            remaps.payload.insert("root/nullable".to_owned(), tags);
+            remaps
+                .payload_children
+                .insert("root/nullable".to_owned(), children);
         }
         if let Some(paths) = target_mapping.nested_scalar_enum_cases.get(&column_id) {
             for (path, target_cases) in paths {

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -4693,7 +4693,7 @@ mod variant_case_tests {
         let base = schema(1);
         let archived = schema(2);
         let snoozed = schema(3);
-        let base_cases = vec![
+        let base_cases = [
             GlobalScalarEnumCaseId {
                 introducing_schema: base,
                 introducing_ordinal: 0,

--- a/crates/jazz/src/node/query_engine/input.rs
+++ b/crates/jazz/src/node/query_engine/input.rs
@@ -501,6 +501,13 @@ pub(crate) enum PredicateExpr {
     IsNull(NormalizedValueRef),
     /// Non-null test.
     IsNotNull(NormalizedValueRef),
+    /// Case-tag test and payload-record predicate for a tagged enum source
+    /// field. Payload source fields are relative to the selected case.
+    EnumMatch {
+        value: NormalizedValueRef,
+        case_tag: u32,
+        payload: Box<PredicateExpr>,
+    },
     /// Boolean conjunction.
     And(Vec<PredicateExpr>),
     /// Boolean disjunction.

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -516,6 +516,7 @@ fn collect_equality_filter_route_params(predicate: &PredicateExpr, routing: &mut
         | PredicateExpr::TextContains { .. }
         | PredicateExpr::IsNull(_)
         | PredicateExpr::IsNotNull(_)
+        | PredicateExpr::EnumMatch { .. }
         | PredicateExpr::Or(_)
         | PredicateExpr::Not(_) => {}
     }
@@ -1777,6 +1778,9 @@ fn predicate_contains_param(predicate: &PredicateExpr) -> bool {
             predicates.iter().any(predicate_contains_param)
         }
         PredicateExpr::Not(predicate) => predicate_contains_param(predicate),
+        PredicateExpr::EnumMatch { value, payload, .. } => {
+            value_contains_param(value) || predicate_contains_param(payload)
+        }
     }
 }
 
@@ -2259,6 +2263,9 @@ fn collect_predicate_requirements(
         }
         PredicateExpr::Not(predicate) => {
             collect_predicate_requirements(predicate, source, requirements)
+        }
+        PredicateExpr::EnumMatch { value, .. } => {
+            collect_value_requirements(value, source, requirements)
         }
     }
 }
@@ -4859,6 +4866,23 @@ fn lower_predicate_inner(
         PredicateExpr::IsNotNull(value) => {
             lower_null_test(value, false, source_id, source, request)?
         }
+        PredicateExpr::EnumMatch {
+            value,
+            case_tag,
+            payload,
+        } => {
+            let LoweredValueRef::Field(field) = lower_value_ref(value, source_id, source, request)?
+            else {
+                return Err(UnsupportedReason::Operator(
+                    "enum match requires a source field".to_owned(),
+                ));
+            };
+            GroovePredicateExpr::EnumMatch {
+                field,
+                case_tag: *case_tag,
+                payload: Box::new(lower_enum_payload_predicate(payload)?),
+            }
+        }
         PredicateExpr::And(predicates) => GroovePredicateExpr::And(
             predicates
                 .iter()
@@ -4873,6 +4897,83 @@ fn lower_predicate_inner(
         ),
         PredicateExpr::Not(predicate) => {
             lower_not_predicate(predicate, source_id, source, request)?
+        }
+    })
+}
+
+fn lower_enum_payload_predicate(
+    predicate: &PredicateExpr,
+) -> Result<GroovePredicateExpr, UnsupportedReason> {
+    Ok(match predicate {
+        PredicateExpr::True => GroovePredicateExpr::And(Vec::new()),
+        PredicateExpr::False => GroovePredicateExpr::Or(Vec::new()),
+        PredicateExpr::Compare { left, op, right } => {
+            let (field, value, op) = match (left, right) {
+                (
+                    NormalizedValueRef::SourceField { field, .. },
+                    NormalizedValueRef::Literal(bytes),
+                ) => {
+                    let value = postcard::from_bytes::<Value>(bytes).map_err(|err| {
+                        UnsupportedReason::Operator(format!(
+                            "payload enum literal could not be decoded: {err}"
+                        ))
+                    })?;
+                    (field.clone(), LiteralValue::from(value), *op)
+                }
+                (
+                    NormalizedValueRef::Literal(bytes),
+                    NormalizedValueRef::SourceField { field, .. },
+                ) => {
+                    let value = postcard::from_bytes::<Value>(bytes).map_err(|err| {
+                        UnsupportedReason::Operator(format!(
+                            "payload enum literal could not be decoded: {err}"
+                        ))
+                    })?;
+                    (
+                        field.clone(),
+                        LiteralValue::from(value),
+                        invert_comparison(*op),
+                    )
+                }
+                _ => {
+                    return Err(UnsupportedReason::Operator(
+                        "payload enum predicates require field/literal comparisons".to_owned(),
+                    ));
+                }
+            };
+            GroovePredicateExpr::from_field_literal(predicate_kind(op), field, value)
+        }
+        PredicateExpr::IsNull(NormalizedValueRef::SourceField { field, .. }) => {
+            GroovePredicateExpr::IsNull {
+                field: field.clone(),
+            }
+        }
+        PredicateExpr::IsNotNull(NormalizedValueRef::SourceField { field, .. }) => {
+            GroovePredicateExpr::IsNotNull {
+                field: field.clone(),
+            }
+        }
+        PredicateExpr::And(children) => GroovePredicateExpr::And(
+            children
+                .iter()
+                .map(lower_enum_payload_predicate)
+                .collect::<Result<_, _>>()?,
+        ),
+        PredicateExpr::Or(children) => GroovePredicateExpr::Or(
+            children
+                .iter()
+                .map(lower_enum_payload_predicate)
+                .collect::<Result<_, _>>()?,
+        ),
+        PredicateExpr::Not(_child) => {
+            return Err(UnsupportedReason::Operator(
+                "negated payload enum predicates are not lowered yet".to_owned(),
+            ));
+        }
+        _ => {
+            return Err(UnsupportedReason::Operator(
+                "unsupported payload enum predicate".to_owned(),
+            ));
         }
     })
 }
@@ -4937,6 +5038,11 @@ fn lower_not_predicate_inner(
                 .collect::<Result<Vec<_>, _>>()?,
         ),
         PredicateExpr::Not(predicate) => lower_predicate(predicate, source_id, source, request)?,
+        PredicateExpr::EnumMatch { .. } => {
+            return Err(UnsupportedReason::Operator(
+                "negated enum match predicates are not lowered yet".to_owned(),
+            ));
+        }
     })
 }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -3019,6 +3019,7 @@ fn collect_root_literal_equalities(
         | Predicate::Lt(_, _)
         | Predicate::Lte(_, _)
         | Predicate::Contains(_, _)
+        | Predicate::EnumMatch { .. }
         | Predicate::IsNull(_) => {}
     }
     Ok(())
@@ -3136,6 +3137,33 @@ fn normalize_predicate(
         },
         Predicate::IsNull(value) => {
             NormalizedPredicateExpr::IsNull(normalize_operand(source, value)?)
+        }
+        Predicate::EnumMatch {
+            column,
+            case,
+            payload,
+        } => {
+            let column_type =
+                operand_column_type(schema, source, &Operand::Column(column.clone()))?.ok_or_else(
+                    || Error::QueryLowering("enum match column has no type".to_owned()),
+                )?;
+            let column_type = match column_type {
+                ColumnType::Nullable(inner) => *inner,
+                other => other,
+            };
+            let ColumnType::Enum(enum_schema) = column_type else {
+                return Err(Error::QueryLowering(
+                    "enum match requires a payload enum column".to_owned(),
+                ));
+            };
+            let case_tag = enum_schema
+                .tag(case)
+                .map_err(|_| Error::QueryLowering(format!("unknown payload enum case {case}")))?;
+            NormalizedPredicateExpr::EnumMatch {
+                value: normalize_operand(source, &Operand::Column(column.clone()))?,
+                case_tag,
+                payload: Box::new(normalize_predicate(schema, source, payload)?),
+            }
         }
     })
 }
@@ -12274,6 +12302,15 @@ fn rewrite_claim_predicate_for_binding(
             false_predicate()
         }
         Predicate::Contains(left, right) => Predicate::Contains(left, right),
+        Predicate::EnumMatch {
+            column,
+            case,
+            payload,
+        } => Predicate::EnumMatch {
+            column,
+            case,
+            payload: Box::new(rewrite_claim_predicate_for_binding(*payload, claims)),
+        },
         Predicate::IsNull(_) => false_predicate(),
     }
 }
@@ -12397,6 +12434,9 @@ fn bind_scope_claim_predicate(
         }
         Predicate::IsNull(operand) => {
             bind_scope_claim_operand(operand, claim_values, binding_values);
+        }
+        Predicate::EnumMatch { payload, .. } => {
+            bind_scope_claim_predicate(payload, claim_values, binding_values);
         }
     }
 }
@@ -12552,6 +12592,7 @@ fn rename_predicate_params(predicate: &mut Predicate, aliases: &BTreeMap<String,
             }
         }
         Predicate::IsNull(operand) => rename_operand_param(operand, aliases),
+        Predicate::EnumMatch { payload, .. } => rename_predicate_params(payload, aliases),
     }
 }
 
@@ -12594,6 +12635,7 @@ fn predicate_contains_unbound_claim(
                     .any(|operand| operand_contains_unbound_claim(operand, claims))
         }
         Predicate::IsNull(operand) => operand_contains_unbound_claim(operand, claims),
+        Predicate::EnumMatch { payload, .. } => predicate_contains_unbound_claim(payload, claims),
     }
 }
 
@@ -12999,6 +13041,13 @@ fn collect_claim_field_params_from_predicate(
         NormalizedPredicateExpr::Not(child) => {
             collect_claim_field_params_from_predicate(child, param_types, params);
         }
+        // Payload fields belong to the enum value rather than the containing
+        // record. They can still contain claim parameters, so walk the nested
+        // predicate while only collecting the enclosing record value here.
+        NormalizedPredicateExpr::EnumMatch { value, payload, .. } => {
+            collect_claim_field_param(value, ColumnType::Uuid, params);
+            collect_claim_field_params_from_predicate(payload, params);
+        }
     }
 }
 
@@ -13128,6 +13177,15 @@ fn bind_query_predicate(
         Predicate::IsNull(operand) => {
             Predicate::IsNull(bind_query_operand(operand, binding, mode)?)
         }
+        Predicate::EnumMatch {
+            column,
+            case,
+            payload,
+        } => Predicate::EnumMatch {
+            column,
+            case,
+            payload,
+        },
     })
 }
 
@@ -13779,6 +13837,9 @@ fn predicate_params(predicates: &[Predicate]) -> BTreeSet<String> {
                 }
             }
             Predicate::IsNull(operand) => collect_operand_param(operand, &mut params),
+            Predicate::EnumMatch { payload, .. } => {
+                params.extend(predicate_params(std::slice::from_ref(payload)));
+            }
         }
     }
     params

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -3159,12 +3159,216 @@ fn normalize_predicate(
             let case_tag = enum_schema
                 .tag(case)
                 .map_err(|_| Error::QueryLowering(format!("unknown payload enum case {case}")))?;
+            let enum_case = enum_schema
+                .case(case_tag)
+                .map_err(|_| Error::QueryLowering(format!("unknown payload enum case {case}")))?;
             NormalizedPredicateExpr::EnumMatch {
                 value: normalize_operand(source, &Operand::Column(column.clone()))?,
                 case_tag,
-                payload: Box::new(normalize_predicate(schema, source, payload)?),
+                payload: Box::new(normalize_enum_payload_predicate(
+                    &enum_case.payload,
+                    source,
+                    payload,
+                )?),
             }
         }
+    })
+}
+
+/// Normalize a predicate evaluated inside one selected payload-enum case.
+///
+/// Payload fields are case-local. They must never be resolved against the
+/// outer table, even when that table happens to have the same field name.
+fn normalize_enum_payload_predicate(
+    descriptor: &crate::groove::records::RecordDescriptor,
+    source: &SourceId,
+    predicate: &Predicate,
+) -> Result<NormalizedPredicateExpr, Error> {
+    Ok(match predicate {
+        Predicate::All(predicates) => NormalizedPredicateExpr::And(
+            predicates
+                .iter()
+                .map(|predicate| normalize_enum_payload_predicate(descriptor, source, predicate))
+                .collect::<Result<Vec<_>, Error>>()?,
+        ),
+        Predicate::Any(predicates) => NormalizedPredicateExpr::Or(
+            predicates
+                .iter()
+                .map(|predicate| normalize_enum_payload_predicate(descriptor, source, predicate))
+                .collect::<Result<Vec<_>, Error>>()?,
+        ),
+        Predicate::Not(predicate) => NormalizedPredicateExpr::Not(Box::new(
+            normalize_enum_payload_predicate(descriptor, source, predicate)?,
+        )),
+        Predicate::Eq(left, right) => normalize_enum_payload_compare(
+            descriptor,
+            source,
+            left,
+            NormalizedComparisonOp::Eq,
+            right,
+        )?,
+        Predicate::Ne(left, right) => normalize_enum_payload_compare(
+            descriptor,
+            source,
+            left,
+            NormalizedComparisonOp::Ne,
+            right,
+        )?,
+        Predicate::Gt(left, right) => normalize_enum_payload_compare(
+            descriptor,
+            source,
+            left,
+            NormalizedComparisonOp::Gt,
+            right,
+        )?,
+        Predicate::Gte(left, right) => normalize_enum_payload_compare(
+            descriptor,
+            source,
+            left,
+            NormalizedComparisonOp::Gte,
+            right,
+        )?,
+        Predicate::Lt(left, right) => normalize_enum_payload_compare(
+            descriptor,
+            source,
+            left,
+            NormalizedComparisonOp::Lt,
+            right,
+        )?,
+        Predicate::Lte(left, right) => normalize_enum_payload_compare(
+            descriptor,
+            source,
+            left,
+            NormalizedComparisonOp::Lte,
+            right,
+        )?,
+        Predicate::In(value, options) => {
+            let target_type = enum_payload_operand_type(descriptor, value)?;
+            NormalizedPredicateExpr::In {
+                value: normalize_enum_payload_operand(descriptor, source, value, None)?,
+                options: options
+                    .iter()
+                    .map(|operand| {
+                        normalize_enum_payload_operand(
+                            descriptor,
+                            source,
+                            operand,
+                            target_type.as_ref(),
+                        )
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?,
+            }
+        }
+        Predicate::Contains(value, needle) => {
+            let needle_type = enum_payload_contains_needle_type(descriptor, value)?;
+            NormalizedPredicateExpr::ArrayContains {
+                value: normalize_enum_payload_operand(descriptor, source, value, None)?,
+                needle: normalize_enum_payload_operand(
+                    descriptor,
+                    source,
+                    needle,
+                    needle_type.as_ref(),
+                )?,
+            }
+        }
+        Predicate::IsNull(value) => NormalizedPredicateExpr::IsNull(
+            normalize_enum_payload_operand(descriptor, source, value, None)?,
+        ),
+        Predicate::EnumMatch { .. } => {
+            return Err(Error::QueryLowering(
+                "nested payload enum matches are not supported".to_owned(),
+            ));
+        }
+    })
+}
+
+fn normalize_enum_payload_compare(
+    descriptor: &crate::groove::records::RecordDescriptor,
+    source: &SourceId,
+    left: &Operand,
+    op: NormalizedComparisonOp,
+    right: &Operand,
+) -> Result<NormalizedPredicateExpr, Error> {
+    let left_type = enum_payload_operand_type(descriptor, left)?;
+    let right_type = enum_payload_operand_type(descriptor, right)?;
+    Ok(NormalizedPredicateExpr::Compare {
+        left: normalize_enum_payload_operand(descriptor, source, left, right_type.as_ref())?,
+        op,
+        right: normalize_enum_payload_operand(descriptor, source, right, left_type.as_ref())?,
+    })
+}
+
+fn normalize_enum_payload_operand(
+    descriptor: &crate::groove::records::RecordDescriptor,
+    source: &SourceId,
+    operand: &Operand,
+    target_type: Option<&ColumnType>,
+) -> Result<NormalizedValueRef, Error> {
+    match operand {
+        Operand::Column(column) => {
+            if enum_payload_field_type(descriptor, column).is_none() {
+                return Err(Error::QueryLowering(format!(
+                    "unknown payload enum field {column}"
+                )));
+            }
+            Ok(NormalizedValueRef::SourceField {
+                source: source.clone(),
+                field: column.clone(),
+            })
+        }
+        Operand::Param(param) => Ok(NormalizedValueRef::Param(param.clone())),
+        Operand::Claim(claim) => Ok(NormalizedValueRef::Claim(ClaimPath(
+            claim.split('.').map(str::to_owned).collect(),
+        ))),
+        Operand::Literal(value) => {
+            let value = target_type
+                .map(|target_type| coerce_literal_for_column_type(value.clone(), target_type))
+                .unwrap_or_else(|| value.clone());
+            Ok(NormalizedValueRef::Literal(
+                postcard::to_allocvec(&value).map_err(|err| {
+                    Error::QueryLowering(format!("literal encoding failed: {err}"))
+                })?,
+            ))
+        }
+    }
+}
+
+fn enum_payload_operand_type(
+    descriptor: &crate::groove::records::RecordDescriptor,
+    operand: &Operand,
+) -> Result<Option<ColumnType>, Error> {
+    match operand {
+        Operand::Column(column) => enum_payload_field_type(descriptor, column)
+            .map(Some)
+            .ok_or_else(|| Error::QueryLowering(format!("unknown payload enum field {column}"))),
+        Operand::Literal(_) | Operand::Param(_) | Operand::Claim(_) => Ok(None),
+    }
+}
+
+fn enum_payload_field_type(
+    descriptor: &crate::groove::records::RecordDescriptor,
+    field: &str,
+) -> Option<ColumnType> {
+    descriptor
+        .fields()
+        .iter()
+        .find(|candidate| candidate.name.as_deref() == Some(field))
+        .map(|candidate| candidate.value_type.clone())
+}
+
+fn enum_payload_contains_needle_type(
+    descriptor: &crate::groove::records::RecordDescriptor,
+    value: &Operand,
+) -> Result<Option<ColumnType>, Error> {
+    Ok(match enum_payload_operand_type(descriptor, value)? {
+        Some(ColumnType::Array(member)) => Some(*member),
+        Some(ColumnType::Nullable(inner)) => match *inner {
+            ColumnType::Array(member) => Some(*member),
+            ColumnType::String => Some(ColumnType::String),
+            _ => None,
+        },
+        Some(ColumnType::String) => Some(ColumnType::String),
+        _ => None,
     })
 }
 
@@ -14670,6 +14874,42 @@ mod tests {
         for (value, column_type, expected) in cases {
             assert_eq!(coerce_prepared_binding_value(value, &column_type), expected);
         }
+    }
+
+    // This lowerer-level assertion protects the case-local descriptor lookup;
+    // public one-shot and maintained behavior is exercised by the enum query
+    // integration coverage.
+    #[test]
+    fn payload_enum_normalization_uses_case_local_field_types() {
+        let descriptor = RecordDescriptor::new([
+            ("shared", ValueType::Uuid),
+            ("case_only", ValueType::String),
+        ]);
+        let source = root_source_id("events");
+        let uuid = uuid::Uuid::from_u128(7);
+        let predicate = Predicate::Eq(
+            Operand::Column("shared".to_owned()),
+            Operand::Literal(Value::String(uuid.to_string())),
+        );
+
+        let normalized = normalize_enum_payload_predicate(&descriptor, &source, &predicate)
+            .expect("case-local field normalizes");
+        let NormalizedPredicateExpr::Compare { right, .. } = normalized else {
+            panic!("expected comparison");
+        };
+        let NormalizedValueRef::Literal(bytes) = right else {
+            panic!("expected literal");
+        };
+        assert_eq!(
+            postcard::from_bytes::<Value>(&bytes).unwrap(),
+            Value::Uuid(uuid)
+        );
+
+        let outer_only = Predicate::Eq(
+            Operand::Column("outer_only".to_owned()),
+            Operand::Literal(Value::String("not a payload field".to_owned())),
+        );
+        assert!(normalize_enum_payload_predicate(&descriptor, &source, &outer_only).is_err());
     }
 
     #[test]

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -13249,8 +13249,8 @@ fn collect_claim_field_params_from_predicate(
         // record. They can still contain claim parameters, so walk the nested
         // predicate while only collecting the enclosing record value here.
         NormalizedPredicateExpr::EnumMatch { value, payload, .. } => {
-            collect_claim_field_param(value, ColumnType::Uuid, params);
-            collect_claim_field_params_from_predicate(payload, params);
+            collect_claim_field_param(value, param_types, params);
+            collect_claim_field_params_from_predicate(payload, param_types, params);
         }
     }
 }

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -4733,6 +4733,58 @@ mod tests {
     }
 
     #[test]
+    fn enum_match_validation_uses_selected_case_fields_not_outer_table_fields() {
+        let payload =
+            RecordDescriptor::new([("case_only", ValueType::String), ("shared", ValueType::I32)]);
+        let schema = JazzSchema::new([TableSchema::new(
+            "events",
+            [
+                ColumnSchema::new("shared", ColumnType::String),
+                ColumnSchema::new("outer_only", ColumnType::String),
+                ColumnSchema::new(
+                    "event",
+                    ColumnType::Enum(Box::new(
+                        EnumSchema::new("event", [EnumCase::new("message", payload)]).unwrap(),
+                    )),
+                ),
+            ],
+        )]);
+        let matched = |payload| Predicate::EnumMatch {
+            column: "event".to_owned(),
+            case: "message".to_owned(),
+            payload: Box::new(payload),
+        };
+
+        assert!(
+            Query::from("events")
+                .filter(matched(Predicate::Eq(
+                    Operand::Column("case_only".to_owned()),
+                    Operand::Literal(Value::String("present only in the case".to_owned())),
+                )))
+                .validate(&schema)
+                .is_ok()
+        );
+        assert!(
+            Query::from("events")
+                .filter(matched(Predicate::Eq(
+                    Operand::Column("outer_only".to_owned()),
+                    Operand::Literal(Value::String("outer".to_owned())),
+                )))
+                .validate(&schema)
+                .is_err()
+        );
+        assert!(
+            Query::from("events")
+                .filter(matched(Predicate::Eq(
+                    Operand::Column("shared".to_owned()),
+                    Operand::Literal(Value::String("outer type".to_owned())),
+                )))
+                .validate(&schema)
+                .is_err()
+        );
+    }
+
+    #[test]
     fn contains_param_array_against_column_infers_array_type() {
         let validated = Query::from("issues")
             .filter(contains(param("teams"), col("assignee")))

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -181,6 +181,13 @@ pub enum RelationPredicate {
         left: RelationColumnRef,
         right: RelationValueRef,
     },
+    /// Match one tagged payload-enum case. The nested predicate's column refs
+    /// name fields in the selected case payload and are deliberately unscoped.
+    EnumMatch {
+        column: RelationColumnRef,
+        case: String,
+        payload: Box<RelationPredicate>,
+    },
     And(Vec<RelationPredicate>),
     Or(Vec<RelationPredicate>),
     Not(Box<RelationPredicate>),
@@ -679,6 +686,7 @@ fn relation_gather_step_predicates(
         | RelationPredicate::IsNotNull { .. }
         | RelationPredicate::In { .. }
         | RelationPredicate::Contains { .. }
+        | RelationPredicate::EnumMatch { .. }
         | RelationPredicate::Or(_)
         | RelationPredicate::Not(_) => {
             filters.push(predicate.clone());
@@ -983,6 +991,18 @@ fn relation_predicate_to_query_predicate(
                 relation_value_to_operand(right)?,
             ),
         ))),
+        RelationPredicate::EnumMatch {
+            column,
+            case,
+            payload,
+        } => Ok(Some((
+            relation_scope(column)?,
+            Predicate::EnumMatch {
+                column: column.column.clone(),
+                case: case.clone(),
+                payload: Box::new(relation_payload_predicate_to_predicate(payload)?),
+            },
+        ))),
         RelationPredicate::And(predicates) => relation_predicate_list(predicates, true),
         RelationPredicate::Or(predicates) => relation_predicate_list(predicates, false),
         RelationPredicate::Not(predicate) => {
@@ -996,6 +1016,68 @@ fn relation_predicate_to_query_predicate(
         }
         RelationPredicate::True => Ok(None),
         RelationPredicate::False => Ok(Some((String::new(), Predicate::Any(Vec::new())))),
+    }
+}
+
+fn relation_payload_predicate_to_predicate(
+    predicate: &RelationPredicate,
+) -> Result<Predicate, QueryError> {
+    let unscoped_column = |column: &RelationColumnRef| {
+        if column.scope.is_some() {
+            return Err(relation_unification_error(
+                "payload enum predicate fields must be unscoped",
+            ));
+        }
+        Ok(Operand::Column(column.column.clone()))
+    };
+    match predicate {
+        RelationPredicate::Cmp { left, op, right } => {
+            let left = unscoped_column(left)?;
+            let right = relation_value_to_operand(right)?;
+            Ok(match op {
+                RelationCmpOp::Eq => Predicate::Eq(left, right),
+                RelationCmpOp::Ne => Predicate::Ne(left, right),
+                RelationCmpOp::Lt => Predicate::Lt(left, right),
+                RelationCmpOp::Le => Predicate::Lte(left, right),
+                RelationCmpOp::Gt => Predicate::Gt(left, right),
+                RelationCmpOp::Ge => Predicate::Gte(left, right),
+            })
+        }
+        RelationPredicate::IsNull { column } => Ok(Predicate::IsNull(unscoped_column(column)?)),
+        RelationPredicate::IsNotNull { column } => Ok(Predicate::Not(Box::new(Predicate::IsNull(
+            unscoped_column(column)?,
+        )))),
+        RelationPredicate::In { left, values } => Ok(Predicate::In(
+            unscoped_column(left)?,
+            values
+                .iter()
+                .map(relation_value_to_operand)
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        RelationPredicate::Contains { left, right } => Ok(Predicate::Contains(
+            unscoped_column(left)?,
+            relation_value_to_operand(right)?,
+        )),
+        RelationPredicate::And(children) => Ok(Predicate::All(
+            children
+                .iter()
+                .map(relation_payload_predicate_to_predicate)
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        RelationPredicate::Or(children) => Ok(Predicate::Any(
+            children
+                .iter()
+                .map(relation_payload_predicate_to_predicate)
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        RelationPredicate::Not(child) => Ok(Predicate::Not(Box::new(
+            relation_payload_predicate_to_predicate(child)?,
+        ))),
+        RelationPredicate::True => Ok(Predicate::All(Vec::new())),
+        RelationPredicate::False => Ok(Predicate::Any(Vec::new())),
+        RelationPredicate::EnumMatch { .. } => Err(relation_unification_error(
+            "nested payload enum matches are not supported",
+        )),
     }
 }
 
@@ -2298,6 +2380,16 @@ pub enum Predicate {
     Lte(Operand, Operand),
     /// String substring or array membership.
     Contains(Operand, Operand),
+    /// Match one discriminated enum case, then evaluate the predicate against
+    /// that case's payload record fields.
+    EnumMatch {
+        /// Name of the enum column in the containing table.
+        column: String,
+        /// Name of the enum case that must be selected.
+        case: String,
+        /// Predicate evaluated against the selected case's payload record.
+        payload: Box<Predicate>,
+    },
     /// Nullable value is null.
     IsNull(Operand),
 }
@@ -3360,6 +3452,33 @@ fn validate_predicate(
                 (None, None) => Err(QueryError::OperandTypeMismatch),
             }
         }
+        Predicate::EnumMatch {
+            column,
+            case,
+            payload,
+        } => {
+            let column_type = planner_column_type(table, column)?;
+            let ColumnType::Enum(schema) = non_null_column_type(column_type) else {
+                return Err(QueryError::OperandTypeMismatch);
+            };
+            let enum_case = schema
+                .case(
+                    schema
+                        .tag(case)
+                        .map_err(|_| QueryError::OperandTypeMismatch)?,
+                )
+                .map_err(|_| QueryError::OperandTypeMismatch)?;
+            let payload_table = TableSchema::new(
+                "__enum_payload",
+                enum_case.payload.fields().iter().map(|field| {
+                    crate::schema::ColumnSchema::new(
+                        field.name.clone().unwrap_or_default(),
+                        field.value_type.clone(),
+                    )
+                }),
+            );
+            validate_predicate(&payload_table, payload, params)
+        }
         Predicate::IsNull(operand) => match operand_type(table, operand, params)? {
             Some(ColumnType::Nullable(_)) => Ok(()),
             Some(_) => Err(QueryError::OperandTypeMismatch),
@@ -4036,6 +4155,16 @@ fn canonical_predicate_key(predicate: &Predicate) -> Vec<u8> {
             bytes.push(b'0');
             put_bytes(&mut bytes, &canonical_operand_key(operand));
         }
+        Predicate::EnumMatch {
+            column,
+            case,
+            payload,
+        } => {
+            bytes.push(b'm');
+            put_str(&mut bytes, column);
+            put_str(&mut bytes, case);
+            put_bytes(&mut bytes, &canonical_predicate_key(payload));
+        }
     }
     bytes
 }
@@ -4450,6 +4579,7 @@ pub mod doctest_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use groove::records::{EnumCase, EnumSchema, RecordDescriptor, ValueType};
     use groove::schema::{ColumnSchema, ColumnType};
 
     fn schema() -> JazzSchema {
@@ -4534,6 +4664,72 @@ mod tests {
             relation_predicate_to_query_predicate(&predicate).unwrap(),
             Some((String::new(), Predicate::Any(Vec::new())))
         );
+    }
+
+    // This focused lowerer test is intentional: relation IR is the NAPI/WASM
+    // boundary, while end-to-end matching and subscription deltas are covered
+    // at the Groove runtime boundary below it.
+    #[test]
+    fn relation_payload_enum_match_lowers_and_validates_against_case_fields() {
+        let event_payload = RecordDescriptor::new([("level", ValueType::I32)]);
+        let schema = JazzSchema::new([TableSchema::new(
+            "events",
+            [ColumnSchema::new(
+                "event",
+                ColumnType::Enum(Box::new(
+                    EnumSchema::new("event", [EnumCase::new("message", event_payload)]).unwrap(),
+                )),
+            )],
+        )]);
+        let relation = RelationQuery {
+            rel: RelationExpr::Project {
+                input: Box::new(RelationExpr::Filter {
+                    input: Box::new(RelationExpr::TableScan {
+                        table: "events".to_owned(),
+                        alias: None,
+                    }),
+                    predicate: RelationPredicate::EnumMatch {
+                        column: RelationColumnRef {
+                            scope: Some("events".to_owned()),
+                            column: "event".to_owned(),
+                        },
+                        case: "message".to_owned(),
+                        payload: Box::new(RelationPredicate::Cmp {
+                            left: RelationColumnRef {
+                                scope: None,
+                                column: "level".to_owned(),
+                            },
+                            op: RelationCmpOp::Eq,
+                            right: RelationValueRef::Literal(serde_json::json!({
+                                "type": "Integer",
+                                "value": 2,
+                            })),
+                        }),
+                    },
+                }),
+                columns: vec![RelationProjectColumn {
+                    alias: "event".to_owned(),
+                    expr: RelationProjectExpr::Column(RelationColumnRef {
+                        scope: Some("events".to_owned()),
+                        column: "event".to_owned(),
+                    }),
+                }],
+            },
+        };
+
+        let query = relation_query_to_query(&relation).unwrap();
+        assert_eq!(
+            query.filters,
+            vec![Predicate::EnumMatch {
+                column: "event".to_owned(),
+                case: "message".to_owned(),
+                payload: Box::new(Predicate::Eq(
+                    Operand::Column("level".to_owned()),
+                    Operand::Literal(Value::I32(2)),
+                )),
+            }]
+        );
+        assert!(query.validate(&schema).is_ok());
     }
 
     #[test]

--- a/crates/jazz/src/tools/admin_catalogue_payload_codec.rs
+++ b/crates/jazz/src/tools/admin_catalogue_payload_codec.rs
@@ -10,8 +10,9 @@ use std::collections::HashMap;
 use crate::tools::object::ObjectId;
 use crate::tools::public_api::policy::{CmpOp, Operation, PolicyExpr, PolicyValue};
 use crate::tools::public_api::types::{
-    ColumnDescriptor, ColumnMergeStrategy, ColumnName, ColumnType, LargeValueKind, RowDescriptor,
-    Schema, SchemaHash, TableName, TablePolicies, TableSchema, Value,
+    ColumnDescriptor, ColumnMergeStrategy, ColumnName, ColumnType, EnumCaseDescriptor,
+    LargeValueKind, RowDescriptor, Schema, SchemaHash, TableName, TablePolicies, TableSchema,
+    Value,
 };
 
 use crate::tools::schema_lens::{LensOp, LensTransform};
@@ -334,6 +335,7 @@ const TYPE_DOUBLE: u8 = 10;
 const TYPE_BYTEA: u8 = 11;
 const TYPE_JSON: u8 = 12;
 const TYPE_BATCH_ID: u8 = 13;
+const TYPE_ENUM_PAYLOAD: u8 = 14;
 
 fn encode_column_type(buf: &mut Vec<u8>, col_type: &ColumnType) {
     match col_type {
@@ -366,6 +368,14 @@ fn encode_column_type(buf: &mut Vec<u8>, col_type: &ColumnType) {
             write_u32(buf, variants.len() as u32);
             for variant in variants {
                 write_string(buf, variant);
+            }
+        }
+        ColumnType::EnumPayload { cases } => {
+            buf.push(TYPE_ENUM_PAYLOAD);
+            write_u32(buf, cases.len() as u32);
+            for case in cases {
+                write_string(buf, &case.name);
+                encode_row_descriptor(buf, &RowDescriptor::new(case.fields.clone()));
             }
         }
         ColumnType::Array { element: elem } => {
@@ -419,6 +429,16 @@ fn decode_column_type(
                 variants.push(read_string(data, offset, "enum_variant")?);
             }
             Ok(ColumnType::Enum { variants })
+        }
+        TYPE_ENUM_PAYLOAD => {
+            let count = read_u32(data, offset)? as usize;
+            let mut cases = Vec::with_capacity(count);
+            for _ in 0..count {
+                let name = read_string(data, offset, "enum_case")?;
+                let fields = decode_row_descriptor(data, offset, schema_version)?.columns;
+                cases.push(EnumCaseDescriptor { name, fields });
+            }
+            Ok(ColumnType::EnumPayload { cases })
         }
         TYPE_ARRAY => {
             let elem = decode_column_type(data, offset, schema_version)?;
@@ -1398,6 +1418,7 @@ const VALUE_ROW: u8 = 8;
 const VALUE_DOUBLE: u8 = 10;
 const VALUE_BYTEA: u8 = 11;
 const VALUE_BATCH_ID: u8 = 12;
+const VALUE_ENUM: u8 = 13;
 
 fn encode_value(buf: &mut Vec<u8>, value: &Value) {
     match value {
@@ -1454,6 +1475,14 @@ fn encode_value(buf: &mut Vec<u8>, value: &Value) {
             write_u32(buf, values.len() as u32);
             for v in values {
                 encode_value(buf, v);
+            }
+        }
+        Value::Enum { case, values } => {
+            buf.push(VALUE_ENUM);
+            write_string(buf, case);
+            write_u32(buf, values.len() as u32);
+            for value in values {
+                encode_value(buf, value);
             }
         }
     }
@@ -1523,6 +1552,15 @@ fn decode_value(data: &[u8], offset: &mut usize) -> Result<Value, CatalogueEncod
                 values.push(decode_value(data, offset)?);
             }
             Ok(Value::Row { id: None, values })
+        }
+        VALUE_ENUM => {
+            let case = read_string(data, offset, "enum_value_case")?;
+            let count = read_u32(data, offset)?;
+            let mut values = Vec::with_capacity(count as usize);
+            for _ in 0..count {
+                values.push(decode_value(data, offset)?);
+            }
+            Ok(Value::Enum { case, values })
         }
         _ => Err(CatalogueEncodingError::InvalidTypeTag {
             tag,

--- a/crates/jazz/src/tools/admin_catalogue_row_format.rs
+++ b/crates/jazz/src/tools/admin_catalogue_row_format.rs
@@ -1211,6 +1211,7 @@ cfg_decode! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::public_api::types::EnumCaseDescriptor;
     use uuid::Uuid;
 
     fn test_descriptor() -> RowDescriptor {
@@ -1636,6 +1637,64 @@ mod tests {
 
         let err = encode_row(&descriptor, &[Value::Text("invalid".to_string())]).unwrap_err();
         assert!(matches!(err, EncodingError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn enum_payload_roundtrip_and_rejects_invalid_case_or_width() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new(
+            "event",
+            ColumnType::EnumPayload {
+                cases: vec![
+                    EnumCaseDescriptor {
+                        name: "ping".into(),
+                        fields: vec![],
+                    },
+                    EnumCaseDescriptor {
+                        name: "message".into(),
+                        fields: vec![
+                            ColumnDescriptor::new("body", ColumnType::Text),
+                            ColumnDescriptor::new("priority", ColumnType::Integer).nullable(),
+                            ColumnDescriptor::new(
+                                "tags",
+                                ColumnType::Array {
+                                    element: Box::new(ColumnType::Text),
+                                },
+                            ),
+                        ],
+                    },
+                ],
+            },
+        )]);
+        let value = Value::Enum {
+            case: "message".into(),
+            values: vec![
+                Value::Text("hello".into()),
+                Value::Null,
+                Value::Array(vec![Value::Text("x".into())]),
+            ],
+        };
+        let encoded = encode_row(&descriptor, &[value.clone()]).unwrap();
+        assert_eq!(decode_row(&descriptor, &encoded).unwrap(), vec![value]);
+        assert!(
+            encode_row(
+                &descriptor,
+                &[Value::Enum {
+                    case: "missing".into(),
+                    values: vec![]
+                }]
+            )
+            .is_err()
+        );
+        assert!(
+            encode_row(
+                &descriptor,
+                &[Value::Enum {
+                    case: "message".into(),
+                    values: vec![Value::Text("x".into())]
+                }]
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/jazz/src/tools/admin_catalogue_row_format.rs
+++ b/crates/jazz/src/tools/admin_catalogue_row_format.rs
@@ -1673,7 +1673,7 @@ mod tests {
                 Value::Array(vec![Value::Text("x".into())]),
             ],
         };
-        let encoded = encode_row(&descriptor, &[value.clone()]).unwrap();
+        let encoded = encode_row(&descriptor, std::slice::from_ref(&value)).unwrap();
         assert_eq!(decode_row(&descriptor, &encoded).unwrap(), vec![value]);
         assert!(
             encode_row(

--- a/crates/jazz/src/tools/admin_catalogue_row_format.rs
+++ b/crates/jazz/src/tools/admin_catalogue_row_format.rs
@@ -355,6 +355,22 @@ fn value_matches_column_type(value: &Value, column_type: &ColumnType) -> bool {
             Value::Text(s) => variants.contains(s),
             _ => false,
         },
+        ColumnType::EnumPayload { cases } => match value {
+            Value::Enum { case, values } => cases
+                .iter()
+                .find(|entry| entry.name == *case)
+                .is_some_and(|entry| {
+                    values.len() == entry.fields.len()
+                        && values.iter().zip(&entry.fields).all(|(value, field)| {
+                            if value.is_null() {
+                                field.nullable
+                            } else {
+                                value_matches_column_type(value, &field.column_type)
+                            }
+                        })
+                }),
+            _ => false,
+        },
         ColumnType::Array {
             element: element_type,
         } => match value {
@@ -492,6 +508,7 @@ fn encode_fixed_value(buf: &mut Vec<u8>, col: &ColumnDescriptor, val: &Value) {
         Value::LargeValue(_) => unreachable!("LargeValue is not fixed-size"),
         Value::Array(_) => unreachable!("Array is not fixed-size"),
         Value::Row { .. } => unreachable!("Row is not fixed-size"),
+        Value::Enum { .. } => unreachable!("Enum payload is not fixed-size"),
     }
 }
 
@@ -527,6 +544,23 @@ fn encode_variable_value(buf: &mut Vec<u8>, col: &ColumnDescriptor, val: &Value)
                 let row_bytes = encode_row(desc, values).unwrap_or_default();
                 buf.extend(row_bytes);
             }
+        }
+        Value::Enum { case, values } => {
+            let ColumnType::EnumPayload { cases } = &col.column_type else {
+                unreachable!("Enum value does not match column type")
+            };
+            let descriptor = cases
+                .iter()
+                .find(|entry| entry.name == *case)
+                .map(|entry| RowDescriptor::new(entry.fields.clone()))
+                .unwrap_or_else(|| unreachable!("validated enum case"));
+            let case_bytes = case.as_bytes();
+            buf.extend_from_slice(&(case_bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(case_bytes);
+            buf.extend(
+                encode_row(&descriptor, values)
+                    .unwrap_or_else(|_| unreachable!("validated enum payload")),
+            );
         }
         Value::Null => {} // Already handled above for nullable
         _ => unreachable!("Non-text/bytea/array/row types are fixed-size"),
@@ -682,7 +716,16 @@ cfg_decode! {
             }
             ColumnType::Bytea => Ok(Value::Bytea(data.to_vec())),
             ColumnType::Text | ColumnType::Json { schema: _ } => decode_text_value(data, None),
-            ColumnType::Enum { variants } => decode_enum_value(data, variants),
+        ColumnType::Enum { variants } => decode_enum_value(data, variants),
+            ColumnType::EnumPayload { cases } => {
+                if data.len() < 4 { return Err(EncodingError::MalformedData { message: "enum payload case length missing".to_string() }); }
+                let len = u32::from_le_bytes(data[..4].try_into().unwrap()) as usize;
+                if data.len() < 4 + len { return Err(EncodingError::MalformedData { message: "enum payload case truncated".to_string() }); }
+                let case = std::str::from_utf8(&data[4..4 + len]).map_err(|e| EncodingError::MalformedData { message: format!("invalid enum payload case utf8: {e}") })?.to_owned();
+                let entry = cases.iter().find(|entry| entry.name == case).ok_or_else(|| EncodingError::MalformedData { message: format!("unknown enum payload case: {case}") })?;
+                let values = decode_row(&RowDescriptor::new(entry.fields.clone()), &data[4 + len..])?;
+                Ok(Value::Enum { case, values })
+            }
             ColumnType::Array {
                 element: element_type,
             } => {
@@ -930,6 +973,9 @@ fn encode_value(value: &Value) -> Vec<u8> {
         }
         Value::Array(elements) => encode_array_simple(elements),
         Value::Row { .. } => panic!("Row values require a descriptor - use encode_value_with_type"),
+        Value::Enum { .. } => {
+            panic!("Enum payload values require a descriptor - use encode_value_with_type")
+        }
         Value::Null => vec![],
     }
 }

--- a/crates/jazz/src/tools/public_api/relation_ir.rs
+++ b/crates/jazz/src/tools/public_api/relation_ir.rs
@@ -62,6 +62,12 @@ pub enum PredicateExpr {
         left: ColumnRef,
         right: ValueRef,
     },
+    /// Match one payload enum case and evaluate its payload-record predicate.
+    EnumMatch {
+        column: ColumnRef,
+        case: String,
+        payload: Box<PredicateExpr>,
+    },
     And(Vec<PredicateExpr>),
     Or(Vec<PredicateExpr>),
     Not(Box<PredicateExpr>),

--- a/crates/jazz/src/tools/public_api/types/branch.rs
+++ b/crates/jazz/src/tools/public_api/types/branch.rs
@@ -290,12 +290,10 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
         }
         ColumnType::Enum { variants } => {
             hasher.update(&[9]);
-            // Enum variant ordering is normalized for hashing.
-            let mut normalized = variants.clone();
-            normalized.sort();
-            normalized.dedup();
-            hasher.update(&(normalized.len() as u64).to_le_bytes());
-            for variant in normalized {
+            // Scalar enum order assigns durable discriminant tags, so it is
+            // structural schema identity rather than presentation metadata.
+            hasher.update(&(variants.len() as u64).to_le_bytes());
+            for variant in variants {
                 hasher.update(variant.as_bytes());
                 hasher.update(&[0]);
             }

--- a/crates/jazz/src/tools/public_api/types/branch.rs
+++ b/crates/jazz/src/tools/public_api/types/branch.rs
@@ -255,6 +255,15 @@ fn hash_value(hasher: &mut blake3::Hasher, value: &Value) {
                 hash_value(hasher, inner);
             }
         }
+        Value::Enum { case, values } => {
+            hasher.update(&[14]);
+            hasher.update(case.as_bytes());
+            hasher.update(&[0]);
+            hasher.update(&(values.len() as u64).to_le_bytes());
+            for inner in values {
+                hash_value(hasher, inner);
+            }
+        }
         Value::Null => {
             hasher.update(&[9]);
         }
@@ -289,6 +298,21 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
             for variant in normalized {
                 hasher.update(variant.as_bytes());
                 hasher.update(&[0]);
+            }
+        }
+        ColumnType::EnumPayload { cases } => {
+            hasher.update(&[13]);
+            hasher.update(&(cases.len() as u64).to_le_bytes());
+            for case in cases {
+                hasher.update(case.name.as_bytes());
+                hasher.update(&[0]);
+                hasher.update(&(case.fields.len() as u64).to_le_bytes());
+                for field in &case.fields {
+                    hasher.update(field.name.as_str().as_bytes());
+                    hasher.update(&[0]);
+                    hash_column_type(hasher, &field.column_type);
+                    hasher.update(&[u8::from(field.nullable)]);
+                }
             }
         }
         ColumnType::Timestamp => {

--- a/crates/jazz/src/tools/public_api/types/schema.rs
+++ b/crates/jazz/src/tools/public_api/types/schema.rs
@@ -85,6 +85,9 @@ pub enum ColumnType {
     Text,
     /// Enumerated text constrained to a closed set of variants.
     Enum { variants: Vec<String> },
+    /// Discriminated enum whose selected case carries a named record payload.
+    /// This is a column type, never a top-level Jazz row union.
+    EnumPayload { cases: Vec<EnumCaseDescriptor> },
     /// 8-byte unsigned timestamp (microseconds since Unix epoch).
     Timestamp,
     /// 8-byte IEEE 754 double-precision float (f64).
@@ -122,7 +125,7 @@ impl ColumnType {
             ColumnType::Bytea => None,
             ColumnType::Json { .. } => None,
             ColumnType::Enum { variants } if variants.len() <= u8::MAX as usize + 1 => Some(1),
-            ColumnType::Enum { .. } => None,
+            ColumnType::Enum { .. } | ColumnType::EnumPayload { .. } => None,
             ColumnType::Array { .. } => None, // Arrays are variable-length
             ColumnType::Row { .. } => None,   // Rows are variable-length
         }
@@ -148,6 +151,13 @@ impl ColumnType {
             _ => None,
         }
     }
+}
+
+/// One named payload case of a column-local discriminated enum.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnumCaseDescriptor {
+    pub name: String,
+    pub fields: Vec<ColumnDescriptor>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/jazz/src/tools/public_api/types/tests.rs
+++ b/crates/jazz/src/tools/public_api/types/tests.rs
@@ -284,7 +284,7 @@ fn schema_hash_table_order_independent() {
 }
 
 #[test]
-fn schema_hash_enum_variant_order_independent() {
+fn schema_hash_enum_variant_order_sensitive() {
     let schema1 = SchemaBuilder::new()
         .table(TableSchema::builder("todos").column(
             "status",
@@ -313,7 +313,51 @@ fn schema_hash_enum_variant_order_independent() {
 
     let hash1 = SchemaHash::compute(&schema1);
     let hash2 = SchemaHash::compute(&schema2);
-    assert_eq!(hash1, hash2, "Enum variant order should not affect hash");
+    assert_ne!(
+        hash1, hash2,
+        "Enum variant order assigns durable tag meanings"
+    );
+}
+
+#[test]
+fn schema_hash_matches_ordered_enum_cross_runtime_fixture() {
+    #[derive(serde::Deserialize)]
+    struct EnumHashCase {
+        variants: Vec<String>,
+        hash: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct EnumHashFixture {
+        cases: Vec<EnumHashCase>,
+    }
+
+    let fixture: EnumHashFixture = serde_json::from_str(include_str!(
+        "../../../../../../packages/jazz-tools/src/testing/fixtures/ordered-enum-schema-hashes.json"
+    ))
+    .expect("ordered enum hash fixture is valid JSON");
+
+    let hashes: Vec<_> = fixture
+        .cases
+        .iter()
+        .map(|case| {
+            let schema = SchemaBuilder::new()
+                .table(TableSchema::builder("todos").column(
+                    "status",
+                    ColumnType::Enum {
+                        variants: case.variants.clone(),
+                    },
+                ))
+                .build();
+            let hash = SchemaHash::compute(&schema).to_hex();
+            assert_eq!(hash, case.hash, "fixture hash for {:?}", case.variants);
+            hash
+        })
+        .collect();
+
+    assert_ne!(
+        hashes[0], hashes[1],
+        "reordering variants changes durable tag meaning"
+    );
 }
 
 #[test]

--- a/crates/jazz/src/tools/public_api/types/value.rs
+++ b/crates/jazz/src/tools/public_api/types/value.rs
@@ -36,6 +36,11 @@ pub enum Value {
         id: Option<ObjectId>,
         values: Vec<Value>,
     },
+    /// Selected case and positional payload values for a column-local enum.
+    Enum {
+        case: String,
+        values: Vec<Value>,
+    },
     Null,
 }
 
@@ -114,6 +119,7 @@ enum ValueHuman {
     LargeValue(LargeValueHandle),
     Array(Vec<ValueHuman>),
     Row(RowHuman),
+    Enum(EnumHuman),
     Null,
 }
 
@@ -121,6 +127,11 @@ enum ValueHuman {
 struct RowHuman {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     id: Option<ObjectId>,
+    values: Vec<ValueHuman>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EnumHuman {
+    case: String,
     values: Vec<ValueHuman>,
 }
 
@@ -139,6 +150,7 @@ enum ValueBinary {
     LargeValue(LargeValueHandle),
     Array(Vec<ValueBinary>),
     Row(Vec<ValueBinary>),
+    Enum(String, Vec<ValueBinary>),
     Null,
 }
 
@@ -260,6 +272,10 @@ impl From<&Value> for ValueHuman {
                 id: *id,
                 values: values.iter().map(ValueHuman::from).collect(),
             }),
+            Value::Enum { case, values } => ValueHuman::Enum(EnumHuman {
+                case: case.clone(),
+                values: values.iter().map(ValueHuman::from).collect(),
+            }),
             Value::Null => ValueHuman::Null,
         }
     }
@@ -283,6 +299,10 @@ impl From<ValueHuman> for Value {
                 id: r.id,
                 values: r.values.into_iter().map(Value::from).collect(),
             },
+            ValueHuman::Enum(e) => Value::Enum {
+                case: e.case,
+                values: e.values.into_iter().map(Value::from).collect(),
+            },
             ValueHuman::Null => Value::Null,
         }
     }
@@ -304,6 +324,9 @@ impl From<&Value> for ValueBinary {
             Value::Array(v) => ValueBinary::Array(v.iter().map(ValueBinary::from).collect()),
             Value::Row { values, .. } => {
                 ValueBinary::Row(values.iter().map(ValueBinary::from).collect())
+            }
+            Value::Enum { case, values } => {
+                ValueBinary::Enum(case.clone(), values.iter().map(ValueBinary::from).collect())
             }
             Value::Null => ValueBinary::Null,
         }
@@ -327,6 +350,10 @@ impl From<ValueBinary> for Value {
             ValueBinary::Row(v) => Value::Row {
                 id: None,
                 values: v.into_iter().map(Value::from).collect(),
+            },
+            ValueBinary::Enum(case, values) => Value::Enum {
+                case,
+                values: values.into_iter().map(Value::from).collect(),
             },
             ValueBinary::Null => Value::Null,
         }
@@ -417,6 +444,7 @@ impl Value {
             }
             // Row type requires external schema, can't be inferred
             Value::Row { .. } => None,
+            Value::Enum { .. } => None,
             Value::Null => None,
         }
     }

--- a/crates/jazz/src/tools/public_api/types/value.rs
+++ b/crates/jazz/src/tools/public_api/types/value.rs
@@ -78,6 +78,11 @@ impl fmt::Debug for Value {
                 .field("id", id)
                 .field("values_len", &values.len())
                 .finish(),
+            Self::Enum { case, values } => f
+                .debug_struct("Enum")
+                .field("case", case)
+                .field("values_len", &values.len())
+                .finish(),
             Self::Null => f.write_str("Null"),
         }
     }

--- a/crates/jazz/src/tools/public_api/types/value.rs
+++ b/crates/jazz/src/tools/public_api/types/value.rs
@@ -399,6 +399,16 @@ impl PartialEq for Value {
             (Value::BatchId(a), Value::BatchId(b)) => a == b,
             (Value::Bytea(a), Value::Bytea(b)) => a == b,
             (Value::LargeValue(a), Value::LargeValue(b)) => a == b,
+            (
+                Value::Enum {
+                    case: a_case,
+                    values: a_values,
+                },
+                Value::Enum {
+                    case: b_case,
+                    values: b_values,
+                },
+            ) => a_case == b_case && a_values == b_values,
             (Value::Array(a), Value::Array(b)) => a == b,
             (
                 Value::Row {

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -2299,7 +2299,6 @@ mod tests {
         PredicateExpr as RelPredicateExpr, RecursionBound as RelRecursionBound,
         RelExpr as PublicRelExpr, RowIdRef as RelRowIdRef, ValueRef as RelValueRef,
     };
-
     #[test]
     fn rejects_user_columns_in_the_compiler_aggregate_namespace() {
         let schema = SchemaBuilder::new()
@@ -2316,6 +2315,8 @@ mod tests {
                 .contains("reserved aggregate-output namespace")
         );
     }
+
+    use crate::tools::public_api::types::EnumCaseDescriptor;
     use crate::tools::public_api::types::TableSchemaBuilder;
     use crate::tools::public_schema::{
         ColumnDescriptor, ColumnType, LargeValueKind, PolicyExpr, RowDescriptor, Schema,
@@ -2549,6 +2550,57 @@ mod tests {
                 .unwrap()
                 .default,
             Some(GrooveValue::String("x".to_owned()))
+        );
+    }
+
+    #[test]
+    fn converts_payload_enum_default_to_tagged_record() {
+        let schema = SchemaBuilder::new()
+            .table(TableSchema::builder("events").column_with_default(
+                "event",
+                ColumnType::EnumPayload {
+                    cases: vec![
+                        EnumCaseDescriptor {
+                            name: "message".to_owned(),
+                            fields: vec![
+                                ColumnDescriptor::new("text", ColumnType::Text),
+                                ColumnDescriptor::new("level", ColumnType::Integer).nullable(),
+                            ],
+                        },
+                        EnumCaseDescriptor {
+                            name: "closed".to_owned(),
+                            fields: vec![ColumnDescriptor::new("code", ColumnType::Integer)],
+                        },
+                    ],
+                },
+                Value::Enum {
+                    case: "message".to_owned(),
+                    values: vec![Value::Text("hello".to_owned()), Value::Null],
+                },
+            ))
+            .build();
+        let table = convert_public_schema(&schema)
+            .unwrap()
+            .tables
+            .into_iter()
+            .find(|table| table.name == "events")
+            .unwrap();
+        let default = table
+            .columns
+            .iter()
+            .find(|column| column.name == "event")
+            .and_then(|column| column.default.as_ref())
+            .unwrap();
+        let GrooveValue::Enum(value) = default else {
+            panic!("expected a payload enum default");
+        };
+        assert_eq!(value.tag(), 0);
+        assert_eq!(
+            value.record().to_values().unwrap(),
+            vec![
+                GrooveValue::String("hello".to_owned()),
+                GrooveValue::Nullable(None),
+            ]
         );
     }
 

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use crate::groove::records::{ScalarEnumSchema, Value as GrooveValue};
+use crate::groove::records::{
+    EnumCase, EnumSchema, RecordDescriptor, ScalarEnumSchema, Value as GrooveValue,
+};
 use crate::groove::schema::ColumnType as GrooveColumnType;
 use crate::query::{
     InheritsOperation, JoinCorrelation, JoinSourceLookup, JoinTarget, JoinVia, Operand,
@@ -608,6 +610,44 @@ fn convert_column_type(
         ColumnType::Uuid => Ok(GrooveColumnType::Uuid),
         ColumnType::Bytea => Ok(GrooveColumnType::Bytes),
         ColumnType::Enum { .. } => Ok(GrooveColumnType::String),
+        ColumnType::EnumPayload { cases } => {
+            let mut converted_cases = Vec::with_capacity(cases.len());
+            for case in cases {
+                if case.name.is_empty() {
+                    return Err(err(
+                        format!("$.{}.{}", table.as_str(), column),
+                        "enum case names cannot be empty",
+                    ));
+                }
+                let mut fields = Vec::with_capacity(case.fields.len());
+                for field in &case.fields {
+                    if field.references.is_some() {
+                        return Err(err(
+                            format!("$.{}.{}.{}", table.as_str(), column, field.name.as_str()),
+                            "enum payload fields cannot use references; use UUID values instead",
+                        ));
+                    }
+                    let mut value_type =
+                        convert_column_type(table, field.name.as_str(), &field.column_type)?;
+                    if field.nullable {
+                        value_type = value_type.nullable();
+                    }
+                    fields.push((field.name.as_str().to_owned(), value_type));
+                }
+                converted_cases.push(EnumCase::new(
+                    case.name.clone(),
+                    RecordDescriptor::new(fields),
+                ));
+            }
+            EnumSchema::new(format!("{}_{}", table.as_str(), column), converted_cases)
+                .map(|schema| GrooveColumnType::Enum(Box::new(schema)))
+                .map_err(|error| {
+                    err(
+                        format!("$.{}.{}", table.as_str(), column),
+                        error.to_string(),
+                    )
+                })
+        }
         ColumnType::Array { element } => {
             Ok(convert_column_type(table, column, element.as_ref())?.array_of())
         }

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -688,12 +688,7 @@ fn convert_column_type(
                 }
                 let mut fields = Vec::with_capacity(case.fields.len());
                 for field in &case.fields {
-                    if field.references.is_some() {
-                        return Err(err(
-                            format!("$.{}.{}.{}", table.as_str(), column, field.name.as_str()),
-                            "enum payload fields cannot use references; use UUID values instead",
-                        ));
-                    }
+                    validate_payload_enum_field(table, column, &case.name, field)?;
                     let mut value_type =
                         convert_column_type(table, field.name.as_str(), &field.column_type)?;
                     if field.nullable {
@@ -732,6 +727,60 @@ fn convert_column_type(
             "nested Row columns are not supported by core schema conversion yet",
         )),
     }
+}
+
+/// Enforce the same v1 payload-enum boundary for raw public-schema ingress as
+/// the TypeScript DSL. Schema JSON can bypass the DSL, so this must reject
+/// unsupported layouts before recursive column conversion admits them.
+fn validate_payload_enum_field(
+    table: &TableName,
+    column: &str,
+    case: &str,
+    field: &ColumnDescriptor,
+) -> Result<(), SchemaConversionError> {
+    let path = format!(
+        "$.{}.{}.{}.{}",
+        table.as_str(),
+        column,
+        case,
+        field.name.as_str()
+    );
+    if field.name.as_str() == "type" {
+        return Err(err(
+            path,
+            "enum payload field name \"type\" is reserved for the discriminant",
+        ));
+    }
+    if field.name.as_str().starts_with('$') {
+        return Err(err(
+            path,
+            "enum payload field names starting with \"$\" are reserved for magic columns",
+        ));
+    }
+    if field.references.is_some() {
+        return Err(err(
+            path,
+            "enum payload fields cannot use references; use UUID values instead",
+        ));
+    }
+    if !matches!(
+        field.column_type,
+        ColumnType::Boolean
+            | ColumnType::Text
+            | ColumnType::Timestamp
+            | ColumnType::Double
+            | ColumnType::Uuid
+            | ColumnType::Bytea
+            | ColumnType::Json { .. }
+            | ColumnType::Integer
+            | ColumnType::BigInt
+    ) {
+        return Err(err(
+            path,
+            "payload enum v1 fields must be scalar columns; arrays, rows, and nested enums are not supported",
+        ));
+    }
+    Ok(())
 }
 
 fn convert_merge_strategy(
@@ -2623,6 +2672,91 @@ mod tests {
                 GrooveValue::Nullable(None),
             ]
         );
+    }
+
+    #[test]
+    fn raw_payload_enum_ingress_rejects_non_scalar_and_reserved_fields() {
+        let nested_row = ColumnType::Row {
+            columns: Box::new(RowDescriptor::new(vec![ColumnDescriptor::new(
+                "nested",
+                ColumnType::Text,
+            )])),
+        };
+        let nested_payload_enum = ColumnType::EnumPayload {
+            cases: vec![EnumCaseDescriptor {
+                name: "nested".to_owned(),
+                fields: vec![ColumnDescriptor::new("value", ColumnType::Text)],
+            }],
+        };
+        let cases = [
+            (
+                ColumnDescriptor::new("type", ColumnType::Text),
+                "reserved for the discriminant",
+            ),
+            (
+                ColumnDescriptor::new("$createdAt", ColumnType::Timestamp),
+                "reserved for magic columns",
+            ),
+            (
+                ColumnDescriptor::new("owner", ColumnType::Uuid).references("users"),
+                "cannot use references",
+            ),
+            (
+                ColumnDescriptor::new(
+                    "owners",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Uuid),
+                    },
+                ),
+                "must be scalar columns",
+            ),
+            (
+                ColumnDescriptor::new(
+                    "owner_refs",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Uuid),
+                    },
+                )
+                .references("users"),
+                "cannot use references",
+            ),
+            (
+                ColumnDescriptor::new("row", nested_row),
+                "must be scalar columns",
+            ),
+            (
+                ColumnDescriptor::new(
+                    "tag",
+                    ColumnType::Enum {
+                        variants: vec!["a".to_owned()],
+                    },
+                ),
+                "must be scalar columns",
+            ),
+            (
+                ColumnDescriptor::new("nested", nested_payload_enum),
+                "must be scalar columns",
+            ),
+        ];
+
+        for (field, message) in cases {
+            let schema = SchemaBuilder::new()
+                .table(TableSchema::builder("events").column(
+                    "event",
+                    ColumnType::EnumPayload {
+                        cases: vec![EnumCaseDescriptor {
+                            name: "message".to_owned(),
+                            fields: vec![field],
+                        }],
+                    },
+                ))
+                .build();
+            let error = convert_public_schema(&schema).expect_err("raw payload field is rejected");
+            assert!(
+                error.to_string().contains(message),
+                "expected {message:?}, got {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use crate::groove::records::{
-    EnumCase, EnumSchema, RecordDescriptor, ScalarEnumSchema, Value as GrooveValue,
+    EnumCase, EnumSchema, EnumValue, RecordDescriptor, ScalarEnumSchema, Value as GrooveValue,
 };
 use crate::groove::schema::ColumnType as GrooveColumnType;
 use crate::query::{
@@ -570,6 +570,70 @@ fn convert_default_for_column_type(
             ColumnType::Text | ColumnType::Json { .. } | ColumnType::Enum { .. },
             Value::Text(value),
         ) => Ok(GrooveValue::String(value.clone())),
+        (ColumnType::EnumPayload { cases }, Value::Enum { case, values }) => {
+            let (case_index, entry) = cases
+                .iter()
+                .enumerate()
+                .find(|(_, entry)| entry.name == *case)
+                .ok_or_else(|| {
+                    err(
+                        format!("$.{}.{}", table.as_str(), column),
+                        format!("payload enum default case {case:?} is not declared"),
+                    )
+                })?;
+            if entry.fields.len() != values.len() {
+                return Err(err(
+                    format!("$.{}.{}", table.as_str(), column),
+                    "payload enum default field count does not match its case",
+                ));
+            }
+            let mut fields = Vec::with_capacity(entry.fields.len());
+            let mut converted = Vec::with_capacity(values.len());
+            for (field, value) in entry.fields.iter().zip(values) {
+                let mut value_type =
+                    convert_column_type(table, field.name.as_str(), &field.column_type)?;
+                if field.nullable {
+                    value_type = value_type.nullable();
+                }
+                let value = if matches!(value, Value::Null) {
+                    if !field.nullable {
+                        return Err(err(
+                            format!("$.{}.{}.{}", table.as_str(), column, field.name.as_str()),
+                            "payload enum default cannot use null for a required field",
+                        ));
+                    }
+                    GrooveValue::Nullable(None)
+                } else {
+                    let inner = convert_default_for_column_type(
+                        table,
+                        field.name.as_str(),
+                        &field.column_type,
+                        value,
+                    )?;
+                    if field.nullable {
+                        GrooveValue::Nullable(Some(Box::new(inner)))
+                    } else {
+                        inner
+                    }
+                };
+                fields.push((field.name.as_str().to_owned(), value_type));
+                converted.push(value);
+            }
+            let case_tag = u32::try_from(case_index).map_err(|_| {
+                err(
+                    format!("$.{}.{}", table.as_str(), column),
+                    "payload enum case index exceeds u32",
+                )
+            })?;
+            EnumValue::create(case_tag, RecordDescriptor::new(fields), &converted)
+                .map(GrooveValue::Enum)
+                .map_err(|error| {
+                    err(
+                        format!("$.{}.{}", table.as_str(), column),
+                        error.to_string(),
+                    )
+                })
+        }
         (ColumnType::Timestamp, Value::Timestamp(value)) => Ok(GrooveValue::U64(*value)),
         (ColumnType::Double, Value::Double(value)) => Ok(GrooveValue::F64(*value)),
         (ColumnType::Uuid, Value::Uuid(value)) => Ok(GrooveValue::Uuid(*value.uuid())),

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -247,6 +247,9 @@ fn coerce_predicate_typed_literals(
             }
         }
         Predicate::IsNull(_) => {}
+        Predicate::EnumMatch { payload, .. } => {
+            coerce_predicate_typed_literals(table, payload, column_types);
+        }
     }
 }
 
@@ -1802,6 +1805,24 @@ fn rel_predicate_to_policy(
             Ok(vec![LoweredRelPredicate {
                 predicate: Predicate::Contains(Operand::Column(left.column.clone()), operand),
                 column: Some(left.column.clone()),
+                value: None,
+            }])
+        }
+        RelPredicateExpr::EnumMatch {
+            column,
+            case,
+            payload,
+        } => {
+            let payload = rel_predicate_to_policy(table, path, payload)?;
+            Ok(vec![LoweredRelPredicate {
+                predicate: Predicate::EnumMatch {
+                    column: column.column.clone(),
+                    case: case.clone(),
+                    payload: Box::new(Predicate::All(
+                        payload.into_iter().map(|part| part.predicate).collect(),
+                    )),
+                },
+                column: Some(column.column.clone()),
                 value: None,
             }])
         }

--- a/crates/jazz/src/tools/server/runtime_catalogue.rs
+++ b/crates/jazz/src/tools/server/runtime_catalogue.rs
@@ -250,6 +250,9 @@ fn public_value_to_core(value: Value) -> Result<CoreValue, String> {
             .map(public_value_to_core)
             .collect::<Result<Vec<_>, _>>()
             .map(CoreValue::Array),
+        Value::Enum { .. } => Err(
+            "migration lens enum payload default is not supported by the runtime core".to_owned(),
+        ),
         Value::BatchId(_) | Value::LargeValue(_) | Value::Row { .. } => {
             Err("migration lens default is not supported by the runtime core".to_owned())
         }

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -58,6 +58,9 @@ function sqlTypeToWasm(sqlType: SqlType): ColumnType {
           })),
         };
       }
+      if (!sqlType.variants) {
+        throw new Error("Enum columns must declare variants or payload cases.");
+      }
       return { type: "Enum", variants: [...sqlType.variants] };
     }
     if (sqlType.kind === "JSON") {

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -42,6 +42,22 @@ const map: Record<ScalarSqlType, ColumnType> = {
 function sqlTypeToWasm(sqlType: SqlType): ColumnType {
   if (typeof sqlType !== "string") {
     if (sqlType.kind === "ENUM") {
+      if (sqlType.cases) {
+        return {
+          type: "EnumPayload",
+          cases: sqlType.cases.map((entry) => ({
+            name: entry.name,
+            fields: entry.fields.map((field) => ({
+              name: field.name,
+              column_type: sqlTypeToWasm(field.sqlType),
+              nullable: field.nullable,
+              ...(field.default === undefined
+                ? {}
+                : { default: toValue(field.default, sqlTypeToWasm(field.sqlType)) }),
+            })),
+          })),
+        };
+      }
       return { type: "Enum", variants: [...sqlType.variants] };
     }
     if (sqlType.kind === "JSON") {

--- a/packages/jazz-tools/src/dev/catalogue.ts
+++ b/packages/jazz-tools/src/dev/catalogue.ts
@@ -286,6 +286,9 @@ function sqlTypeToWasmColumnType(sqlType: SqlType): WasmColumnType {
   }
 
   if (sqlType.kind === "ENUM") {
+    if (!sqlType.variants) {
+      throw new Error("Payload enum schema lowering is not implemented yet.");
+    }
     return {
       type: "Enum",
       variants: [...sqlType.variants],

--- a/packages/jazz-tools/src/dev/migrations.ts
+++ b/packages/jazz-tools/src/dev/migrations.ts
@@ -81,6 +81,8 @@ function baseBuilderExpression(columnType: WasmColumnType, references?: string):
       return columnType.schema ? `s.json(${JSON.stringify(columnType.schema)})` : "s.json()";
     case "Enum":
       return `s.enum(${columnType.variants.map((variant) => JSON.stringify(variant)).join(", ")})`;
+    case "EnumPayload":
+      throw new Error("Migration stub generation does not yet support payload enums.");
     case "Uuid":
       if (!references) {
         throw new Error("Migration stub generation does not yet support bare UUID columns.");
@@ -157,6 +159,8 @@ function renderAddOperationExpression(column: ColumnDescriptor, defaultExpressio
       return `s.add.enum(${column.column_type.variants
         .map((variant) => JSON.stringify(variant))
         .join(", ")}, { default: ${defaultExpression} })`;
+    case "EnumPayload":
+      throw new Error("Migration stub generation does not yet support payload enums.");
     case "Uuid":
       if (column.references) {
         return `s.add.ref(${JSON.stringify(column.references)}, { default: ${defaultExpression} })`;
@@ -196,6 +200,8 @@ function renderDropOperationExpression(
       return `s.drop.enum(${column.column_type.variants
         .map((variant) => JSON.stringify(variant))
         .join(", ")}, { backwardsDefault: ${defaultExpression} })`;
+    case "EnumPayload":
+      throw new Error("Migration stub generation does not yet support payload enums.");
     case "Uuid":
       if (column.references) {
         return `s.drop.ref(${JSON.stringify(column.references)}, { backwardsDefault: ${defaultExpression} })`;

--- a/packages/jazz-tools/src/dev/schema-utils.test.ts
+++ b/packages/jazz-tools/src/dev/schema-utils.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { structuralSchemaHash } from "./schema-utils.js";
+
+function enumSchema(variants: string[]) {
+  return {
+    todos: {
+      columns: [
+        {
+          name: "status",
+          column_type: { type: "Enum" as const, variants },
+          nullable: false,
+        },
+      ],
+    },
+  };
+}
+
+describe("structuralSchemaHash", () => {
+  const orderedEnumFixture = JSON.parse(
+    readFileSync(
+      new URL("../testing/fixtures/ordered-enum-schema-hashes.json", import.meta.url),
+      "utf8",
+    ),
+  ) as { cases: Array<{ variants: string[]; hash: string }> };
+
+  it("treats enum declaration order as durable tag meaning", () => {
+    expect(structuralSchemaHash(enumSchema(["draft", "active"]))).not.toBe(
+      structuralSchemaHash(enumSchema(["active", "draft"])),
+    );
+    expect(structuralSchemaHash(enumSchema(["draft", "active"]))).not.toBe(
+      structuralSchemaHash(enumSchema(["draft"])),
+    );
+  });
+
+  it("matches the Rust ordered-enum structural hash fixture", () => {
+    const hashes = orderedEnumFixture.cases.map(({ variants, hash }) => {
+      const actual = structuralSchemaHash(enumSchema(variants));
+      expect(actual).toBe(hash);
+      return actual;
+    });
+
+    expect(hashes[0]).not.toBe(hashes[1]);
+  });
+});

--- a/packages/jazz-tools/src/dev/schema-utils.ts
+++ b/packages/jazz-tools/src/dev/schema-utils.ts
@@ -203,9 +203,8 @@ function hashColumnType(writer: StructuralHashWriter, columnType: WasmColumnType
       return;
     case "Enum": {
       writer.byte(9);
-      const variants = [...new Set(columnType.variants)].sort();
-      writer.u64(variants.length);
-      for (const variant of variants) {
+      writer.u64(columnType.variants.length);
+      for (const variant of columnType.variants) {
         writer.stringBytes(variant);
         writer.byte(0);
       }

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -116,6 +116,7 @@ export type ColumnType =
   | { type: "Text" }
   | { type: "Json"; schema?: Record<string, unknown> }
   | { type: "Enum"; variants: string[] }
+  | { type: "EnumPayload"; cases: Array<{ name: string; fields: ColumnDescriptor[] }> }
   | { type: "Timestamp" }
   | { type: "Uuid" }
   | { type: "Bytea" }

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -18,6 +18,7 @@ export type Value =
   | { type: "Bytea"; value: Uint8Array }
   | { type: "Array"; value: Value[] }
   | { type: "Row"; value: { id?: string; values: Value[] } }
+  | { type: "Enum"; value: { case: string; values: Value[] } }
   | { type: "Null" };
 
 export type InsertValues = Record<string, Value>;

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -9,6 +9,7 @@ import {
   table,
 } from "./dsl.js";
 import { schemaToWasm } from "./codegen/schema-reader.js";
+import { structuralSchemaHash } from "./dev/schema-utils.js";
 import type { AddOp } from "./schema.js";
 
 describe("enum DSL invariants", () => {
@@ -24,6 +25,31 @@ describe("enum DSL invariants", () => {
 
   it("rejects duplicate variants", () => {
     expect(() => col.enum("todo", "todo")).toThrow("Enum variants must be unique.");
+  });
+
+  it("rejects more scalar variants than the native tag space supports", () => {
+    const variants = Array.from({ length: 257 }, (_, index) => `variant-${index}`);
+    expect(() => (col.enum as (...values: string[]) => unknown)(...variants)).toThrow(
+      "at most 256 variants",
+    );
+  });
+
+  it("preserves scalar enum declaration order in both schema data and identity", () => {
+    const wasmSchemaFor = (variants: [string, ...string[]]) => {
+      resetCollectedState();
+      table("tasks", { status: col.enum(...variants) });
+      return schemaToWasm(getCollectedSchema());
+    };
+
+    const declared = wasmSchemaFor(["complete", "incomplete", "blocked"]);
+    expect(declared.tasks!.columns[0]!.column_type).toEqual({
+      type: "Enum",
+      variants: ["complete", "incomplete", "blocked"],
+    });
+
+    expect(structuralSchemaHash(wasmSchemaFor(["complete", "incomplete"]))).not.toBe(
+      structuralSchemaHash(wasmSchemaFor(["incomplete", "complete"])),
+    );
   });
 
   it("builds scalar payload enum cases and rejects unsupported payload shapes", () => {
@@ -161,7 +187,7 @@ describe("schema default DSL", () => {
       { name: "done", sqlType: "BOOLEAN", nullable: false, default: false },
       {
         name: "status",
-        sqlType: { kind: "ENUM", variants: ["done", "todo"] },
+        sqlType: { kind: "ENUM", variants: ["todo", "done"] },
         nullable: false,
         default: "todo",
       },

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -26,6 +26,33 @@ describe("enum DSL invariants", () => {
     expect(() => col.enum("todo", "todo")).toThrow("Enum variants must be unique.");
   });
 
+  it("builds scalar payload enum cases and rejects unsupported payload shapes", () => {
+    const event = col.enum({
+      message: { text: col.string(), level: col.int().optional() },
+      closed: { code: col.int() },
+    });
+    expect(event._sqlType).toEqual({
+      kind: "ENUM",
+      cases: [
+        {
+          name: "message",
+          fields: [
+            { name: "text", sqlType: "TEXT", nullable: false },
+            { name: "level", sqlType: "INTEGER", nullable: true },
+          ],
+        },
+        { name: "closed", fields: [{ name: "code", sqlType: "INTEGER", nullable: false }] },
+      ],
+    });
+    expect(() => col.enum({ bad: { type: col.string() } })).toThrow("reserved");
+    expect(() => col.enum({ bad: { tags: col.array(col.string()) } })).toThrow(
+      "must be scalar columns",
+    );
+    expect(() => col.enum({ bad: { authorId: col.ref("users") } })).toThrow(
+      "cannot use references",
+    );
+  });
+
   describe("add enum", () => {
     it("rejects duplicate variants in add enum migration", () => {
       expect(() => col.add.enum("todo", "todo", { default: "todo" })).toThrow(

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -25,9 +25,14 @@ import type {
 } from "./schema.js";
 import { assertUserColumnNameAllowed } from "./magic-columns.js";
 
+const MAX_ENUM_VARIANTS = 256;
+
 function normalizeEnumVariants(variants: readonly string[]): string[] {
   if (variants.length === 0) {
     throw new Error("Enum columns require at least one variant.");
+  }
+  if (variants.length > MAX_ENUM_VARIANTS) {
+    throw new Error(`Enum columns support at most ${MAX_ENUM_VARIANTS} variants.`);
   }
   for (const variant of variants) {
     if (variant.length === 0) {
@@ -38,7 +43,9 @@ function normalizeEnumVariants(variants: readonly string[]): string[] {
   if (unique.size !== variants.length) {
     throw new Error("Enum variants must be unique.");
   }
-  return [...unique].sort((a, b) => a.localeCompare(b));
+  // Scalar-enum discriminants are declaration-order-sensitive. Keeping this
+  // order lets later schemas append a case without retagging existing values.
+  return [...variants];
 }
 
 type JsonSchemaSource<Output = JsonValue> = StandardJSONSchemaV1<unknown, Output> | JsonSchema;
@@ -308,7 +315,7 @@ export type ColumnAlias<
                             cases: infer Cases extends readonly EnumCaseSqlType[];
                           }
                         ? EnumCasesColumn<Cases, Optional, HasDefault, Value>
-                      : TypedColumnBuilder<Sql, Optional, Ref, HasDefault, Value>;
+                        : TypedColumnBuilder<Sql, Optional, Ref, HasDefault, Value>;
 
 type RefColumnKey = `${string}Id` | `${string}_id`;
 type RefArrayColumnKey = `${string}Ids` | `${string}_ids`;

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -8,6 +8,7 @@ import type {
   Schema,
   Table,
   SqlType,
+  EnumCaseSqlType,
   EnumSqlType,
   JsonSqlType,
   JsonSchema,
@@ -233,6 +234,12 @@ export type EnumColumn<
   HasDefault,
   Value
 >;
+export type EnumCasesColumn<
+  Cases extends readonly EnumCaseSqlType[] = readonly EnumCaseSqlType[],
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+  Value = TSTypeFromSqlType<{ kind: "ENUM"; cases: Cases }>,
+> = TypedColumnBuilder<{ kind: "ENUM"; cases: Cases }, Optional, undefined, HasDefault, Value>;
 export type RefColumn<
   TargetTable extends string,
   Optional extends boolean = false,
@@ -404,8 +411,39 @@ class EnumBuilder implements ColumnBuilder {
   public _sqlType: EnumSqlType;
   _transform?: ColumnTransform<unknown, unknown>;
 
-  constructor(...variants: string[]) {
-    this._sqlType = { kind: "ENUM", variants: normalizeEnumVariants(variants) };
+  constructor(variantsOrCases: string[] | Record<string, ColumnBuilder>) {
+    if (Array.isArray(variantsOrCases)) {
+      this._sqlType = { kind: "ENUM", variants: normalizeEnumVariants(variantsOrCases) };
+      return;
+    }
+    const cases: EnumCaseSqlType[] = [];
+    for (const [caseName, payload] of Object.entries(variantsOrCases)) {
+      if (!caseName) throw new Error("Enum case names cannot be empty strings.");
+      const fields: Column[] = [];
+      for (const [fieldName, builder] of Object.entries(
+        payload as unknown as Record<string, ColumnBuilder>,
+      )) {
+        if (fieldName === "type") {
+          throw new Error('Enum payload field name "type" is reserved for the discriminant.');
+        }
+        if (builder._references !== undefined) {
+          throw new Error("Enum payload fields cannot use references; use a UUID value instead.");
+        }
+        const field = builder._build(fieldName);
+        if (containsReference(field.sqlType)) {
+          throw new Error(
+            "Enum payload fields cannot contain references; use UUID values instead.",
+          );
+        }
+        fields.push(field);
+      }
+      cases.push({ name: caseName, fields });
+    }
+    if (cases.length === 0) throw new Error("Payload enums must declare at least one case.");
+    if (new Set(cases.map((entry) => entry.name)).size !== cases.length) {
+      throw new Error("Enum case names must be unique.");
+    }
+    this._sqlType = { kind: "ENUM", cases };
   }
 
   optional(): this {
@@ -444,6 +482,12 @@ class EnumBuilder implements ColumnBuilder {
   get _references(): string | undefined {
     return undefined;
   }
+}
+
+function containsReference(sqlType: SqlType): boolean {
+  return (
+    typeof sqlType === "object" && sqlType.kind === "ARRAY" && containsReference(sqlType.element)
+  );
 }
 
 class JsonBuilder<Output = JsonValue> implements ColumnBuilder {
@@ -840,8 +884,31 @@ export const col = {
     ): JsonColumn<StandardJSONSchemaV1.InferOutput<Schema>>;
     (schema: JsonSchema): JsonColumn;
   },
-  enum: <const Variants extends readonly [string, ...string[]]>(...variants: Variants) =>
-    new EnumBuilder(...variants) as unknown as EnumColumn<Variants>,
+  enum: ((...input: unknown[]) => {
+    if (input.length === 1 && typeof input[0] === "object" && input[0] !== null) {
+      return new EnumBuilder(input[0] as Record<string, ColumnBuilder>);
+    }
+    return new EnumBuilder(input as string[]);
+  }) as unknown as {
+    <const Variants extends readonly [string, ...string[]]>(
+      ...variants: Variants
+    ): EnumColumn<Variants>;
+    <const Cases extends Record<string, Record<string, AnyTypedColumnBuilder>>>(
+      cases: Cases,
+    ): EnumCasesColumn<
+      {
+        [Name in keyof Cases & string]: {
+          name: Name;
+          fields: {
+            [Field in keyof Cases[Name] & string]: Column & {
+              name: Field;
+              sqlType: ColumnBuilderSqlType<Cases[Name][Field]>;
+            };
+          }[keyof Cases[Name] & string][];
+        };
+      }[keyof Cases & string][]
+    >;
+  },
   ref: <const TargetTable extends string>(targetTable: TargetTable) =>
     new RefBuilder(targetTable) as unknown as RefColumn<TargetTable>,
   array: <Builder extends AnyTypedColumnBuilder>(element: Builder) =>

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -426,10 +426,16 @@ class EnumBuilder implements ColumnBuilder {
         if (fieldName === "type") {
           throw new Error('Enum payload field name "type" is reserved for the discriminant.');
         }
+        assertUserColumnNameAllowed(fieldName);
         if (builder._references !== undefined) {
           throw new Error("Enum payload fields cannot use references; use a UUID value instead.");
         }
         const field = builder._build(fieldName);
+        if (typeof field.sqlType !== "string") {
+          throw new Error(
+            "Payload enum v1 fields must be scalar columns; arrays and nested enums are not supported yet.",
+          );
+        }
         if (containsReference(field.sqlType)) {
           throw new Error(
             "Enum payload fields cannot contain references; use UUID values instead.",

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -152,12 +152,19 @@ export type TypedColumnBuilder<
   optional(): ColumnAlias<Sql, true, Ref, HasDefault, Value>;
 };
 
-export type AnyTypedColumnBuilder = TypedColumnBuilder<
-  SqlType,
-  boolean,
-  string | undefined,
-  boolean
->;
+// This is a constraint for builder input positions, not a public builder
+// surface. Omitting its generic mutator methods avoids contravariant method
+// parameter collapse when a payload enum's discriminated SQL type is widened.
+export type AnyTypedColumnBuilder = Omit<
+  ColumnBuilder,
+  "optional" | "default" | "merge" | "transform"
+> & {
+  readonly __jazzSqlType: SqlType;
+  readonly __jazzOptional: boolean;
+  readonly __jazzReferences: string | undefined;
+  readonly __jazzHasDefault: boolean;
+  readonly __jazzValue: unknown;
+};
 export type ColumnBuilderSqlType<TBuilder extends AnyTypedColumnBuilder> =
   TBuilder["__jazzSqlType"];
 export type ColumnBuilderOptional<TBuilder extends AnyTypedColumnBuilder> =
@@ -296,6 +303,11 @@ export type ColumnAlias<
                           variants: infer Variants extends readonly string[];
                         }
                       ? EnumColumn<Variants, Optional, HasDefault, Value>
+                      : Sql extends {
+                            kind: "ENUM";
+                            cases: infer Cases extends readonly EnumCaseSqlType[];
+                          }
+                        ? EnumCasesColumn<Cases, Optional, HasDefault, Value>
                       : TypedColumnBuilder<Sql, Optional, Ref, HasDefault, Value>;
 
 type RefColumnKey = `${string}Id` | `${string}_id`;
@@ -918,7 +930,7 @@ export const col = {
   ref: <const TargetTable extends string>(targetTable: TargetTable) =>
     new RefBuilder(targetTable) as unknown as RefColumn<TargetTable>,
   array: <Builder extends AnyTypedColumnBuilder>(element: Builder) =>
-    new ArrayBuilder(element) as unknown as ArrayColumn<
+    new ArrayBuilder(element as unknown as ColumnBuilder) as unknown as ArrayColumn<
       ColumnBuilderSqlType<Builder>,
       false,
       ColumnBuilderReferences<Builder>

--- a/packages/jazz-tools/src/ir.ts
+++ b/packages/jazz-tools/src/ir.ts
@@ -27,6 +27,7 @@ export type RelPredicateExpr =
   | { IsNotNull: { column: RelColumnRef } }
   | { In: { left: RelColumnRef; values: RelValueRef[] } }
   | { Contains: { left: RelColumnRef; right: RelValueRef } }
+  | { EnumMatch: { column: RelColumnRef; case: string; payload: RelPredicateExpr } }
   | { And: RelPredicateExpr[] }
   | { Or: RelPredicateExpr[] }
   | { Not: RelPredicateExpr }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
@@ -191,6 +191,12 @@ export type QueryPredicate =
     }
   | {
       column: string;
+      op: "EnumMatch";
+      case: string;
+      payload: QueryPredicate;
+    }
+  | {
+      column: string;
       op: "IsNull";
     }
   | {
@@ -377,11 +383,18 @@ function writePredicate(writer: PostcardWriter, predicate: QueryPredicate): void
     writeLiteralOperand(writer, predicate.value);
     return;
   }
+  if (predicate.op === "EnumMatch") {
+    writer.u64(11); // Predicate::EnumMatch
+    writeColumnOperand(writer, predicate.column);
+    writer.string(predicate.case);
+    writePredicate(writer, predicate.payload);
+    return;
+  }
   if (predicate.op === "IsNull" || predicate.op === "IsNotNull") {
     if (predicate.op === "IsNotNull") {
       writer.u64(2); // Predicate::Not
     }
-    writer.u64(11); // Predicate::IsNull
+    writer.u64(12); // Predicate::IsNull
     writeColumnOperand(writer, predicate.column);
     return;
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-query-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-query-codec.test.ts
@@ -9,6 +9,26 @@ type NativeQueryCodecFixture = {
 };
 
 describe("native query codec", () => {
+  it("encodes a payload enum match as the core predicate with a nested payload tree", () => {
+    expect(
+      bytesToHex(
+        queryWithPredicates("events", [
+          {
+            column: "event",
+            op: "EnumMatch",
+            case: "message",
+            payload: {
+              op: "All",
+              predicates: [{ column: "level", op: "Eq", value: { type: "Integer", value: 2 } }],
+            },
+          },
+        ]),
+      ),
+    ).toBe(
+      "066576656e7473010b00056576656e74076d65737361676500010300056c6576656c030e04000000000000000000000000",
+    );
+  });
+
   it("pins forward, reverse, nested, projected, and required relation query layouts", () => {
     const fixture = nativeQueryCodecFixture();
     for (const [name, table, arraySubqueries, select, orderBy] of queryCases()) {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -107,6 +107,56 @@ describe("native row codec", () => {
     );
   });
 
+  it("requires payload enum terminal descriptors to preserve their declared case layouts", () => {
+    const columns: ColumnDescriptor[] = [
+      {
+        name: "event",
+        column_type: {
+          type: "EnumPayload",
+          cases: [
+            {
+              name: "message",
+              fields: [
+                { name: "text", column_type: { type: "Text" }, nullable: false },
+                { name: "level", column_type: { type: "Integer" }, nullable: true },
+              ],
+            },
+          ],
+        },
+        nullable: false,
+      },
+    ];
+    const descriptor = [
+      { name: "__jazz_terminal_row_key", valueType: { tag: 10 } },
+      {
+        name: "event",
+        valueType: {
+          tag: 16,
+          enumSchema: {
+            registryId: 37,
+            name: "physical_event",
+            cases: [
+              {
+                name: "message",
+                payload: [
+                  { name: "text", valueType: { tag: 8 } },
+                  { name: "level", valueType: { tag: 14, inner: { tag: 4 } } },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ];
+    const wrongFieldType = structuredClone(descriptor);
+    wrongFieldType[1]!.valueType.enumSchema!.cases![0]!.payload[1]!.valueType = { tag: 8 };
+
+    expect(() => assertTerminalRootDescriptorCompatible(descriptor, columns)).not.toThrow();
+    expect(() => assertTerminalRootDescriptorCompatible(wrongFieldType, columns)).toThrow(
+      "terminal root descriptor does not match the public projection",
+    );
+  });
+
   it("keeps mutation cells byte-for-byte aligned with packed row values", () => {
     const nestedColumns: ColumnDescriptor[] = [
       { name: "label", column_type: { type: "Text" }, nullable: false },

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -231,6 +231,51 @@ describe("native row codec", () => {
     expect(bytesToHex(row)).toMatchInlineSnapshot(`"01010576616c75650e0e08020100"`);
   });
 
+  it("round-trips scalar payload enum cases, nullable fields, and descriptor metadata", () => {
+    const columns = [
+      {
+        name: "event",
+        column_type: {
+          type: "EnumPayload" as const,
+          cases: [
+            {
+              name: "message",
+              fields: [
+                { name: "text", column_type: { type: "Text" as const }, nullable: false },
+                { name: "level", column_type: { type: "Integer" as const }, nullable: true },
+              ],
+            },
+            {
+              name: "closed",
+              fields: [
+                { name: "code", column_type: { type: "Integer" as const }, nullable: false },
+              ],
+            },
+          ],
+        },
+        nullable: true,
+      },
+    ];
+    const payload = {
+      type: "Enum" as const,
+      value: {
+        case: "message",
+        values: [{ type: "Text" as const, value: "hello" }, { type: "Null" as const }],
+      },
+    };
+    const encoded = encodeNativeRowValues(columns, [payload]);
+    expect(decodeNativeRowValues(columns, encoded)).toEqual([payload]);
+    const storage = storageColumnValueType(columns[0]!);
+    expect(storage).toMatchObject({ tag: 14, inner: { tag: 16, enumSchema: { name: "event" } } });
+    expect(storage.inner?.enumSchema?.cases?.[0]?.payload[0]).toMatchObject({
+      name: "text",
+      valueType: { tag: 8 },
+    });
+    expect(() =>
+      encodeNativeRowValues(columns, [{ type: "Enum", value: { case: "missing", values: [] } }]),
+    ).toThrow("invalid Enum payload case or width");
+  });
+
   it("round-trips the Record descriptor payload before reading the next field", () => {
     const writer = new PostcardWriter();
     writeDescriptor(writer, [

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -1024,6 +1024,16 @@ function encodeNativeNonNullValue(type: ColumnType, value: Value): Uint8Array {
     case "Enum":
       if (value.type !== "Text") throw new Error(`expected ${type.type} value`);
       return new TextEncoder().encode(value.value);
+    case "EnumPayload": {
+      if (value.type !== "Enum") throw new Error("expected Enum payload value");
+      const entry = type.cases.find((candidate) => candidate.name === value.value.case);
+      if (!entry || entry.fields.length !== value.value.values.length) {
+        throw new Error("invalid Enum payload case or width");
+      }
+      const name = new TextEncoder().encode(entry.name);
+      const payload = encodeNativeRowValue(entry.fields, { values: value.value.values });
+      return concatBytes([encodeU32Le(name.length), name, payload]);
+    }
     case "Uuid":
       if (value.type !== "Uuid") throw new Error("expected Uuid value");
       return parseUuid(value.value);
@@ -1092,7 +1102,7 @@ function parseUuid(value: string): Uint8Array {
 }
 
 export function storageColumnValueType(column: ColumnDescriptor): ValueType {
-  let valueType = storageColumnTypeToValueType(column.column_type);
+  let valueType = storageColumnTypeToValueType(column.column_type, column.name);
   if (column.nullable) valueType = { tag: 14, inner: valueType };
   return column.sparse ? { tag: 14, inner: valueType } : valueType;
 }
@@ -1122,7 +1132,7 @@ export function logicalStorageColumns(
   }));
 }
 
-export function storageColumnTypeToValueType(type: ColumnType): ValueType {
+export function storageColumnTypeToValueType(type: ColumnType, enumName = "enum"): ValueType {
   switch (type.type) {
     case "Boolean":
       return { tag: 7 };
@@ -1138,12 +1148,26 @@ export function storageColumnTypeToValueType(type: ColumnType): ValueType {
     case "Json":
     case "Enum":
       return { tag: 8 };
+    case "EnumPayload":
+      return {
+        tag: 16,
+        enumSchema: {
+          name: enumName,
+          cases: type.cases.map((entry) => ({
+            name: entry.name,
+            payload: entry.fields.map((field) => ({
+              name: field.name,
+              valueType: storageColumnValueType(field),
+            })),
+          })),
+        },
+      };
     case "Bytea":
       return { tag: 9 };
     case "Uuid":
       return { tag: 10 };
     case "Array":
-      return { tag: 13, inner: storageColumnTypeToValueType(type.element) };
+      return { tag: 13, inner: storageColumnTypeToValueType(type.element, enumName) };
     case "Row":
       return { tag: 9 };
   }
@@ -1166,6 +1190,21 @@ function decodeBytes(type: ColumnType, bytes: Uint8Array): Value {
     case "Json":
     case "Enum":
       return { type: "Text", value: textDecoder.decode(bytes) };
+    case "EnumPayload": {
+      if (bytes.length < 4) throw new Error("invalid Enum payload value");
+      const nameLength = view.getUint32(0, true);
+      if (bytes.length < 4 + nameLength) throw new Error("invalid Enum payload case");
+      const caseName = textDecoder.decode(bytes.subarray(4, 4 + nameLength));
+      const entry = type.cases.find((candidate) => candidate.name === caseName);
+      if (!entry) throw new Error("unknown Enum payload case");
+      return {
+        type: "Enum",
+        value: {
+          case: caseName,
+          values: decodeRowValue(entry.fields, bytes.subarray(4 + nameLength)).values,
+        },
+      };
+    }
     case "Uuid":
       return { type: "Uuid", value: formatUuid(bytes) };
     case "Bytea":
@@ -1217,6 +1256,7 @@ function decodePlainValue(type: ColumnType, bytes: Uint8Array, columnName?: stri
       return decodePlainArray(type.element, bytes);
     case "Text":
     case "Enum":
+    case "EnumPayload":
     case "Bytea":
     case "Uuid":
     case "Boolean":

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -645,6 +645,32 @@ function terminalValueTypeMatchesColumn(
     case "Json":
     case "Enum":
       return valueType.tag === 8;
+    case "EnumPayload": {
+      const payloadColumn = column.column_type;
+      if (payloadColumn.type !== "EnumPayload") return false;
+      const payloadCases = valueType.enumSchema?.cases;
+      return (
+        valueType.tag === 16 &&
+        payloadCases !== undefined &&
+        payloadCases.length === payloadColumn.cases.length &&
+        payloadCases.every((payloadCase, caseIndex) => {
+          const declaredCase = payloadColumn.cases[caseIndex]!;
+          return (
+            payloadCase.name === declaredCase.name &&
+            payloadCase.payload.length === declaredCase.fields.length &&
+            payloadCase.payload.every(
+              (field, fieldIndex) =>
+                field.name === declaredCase.fields[fieldIndex]?.name &&
+                terminalValueTypeMatchesColumn(
+                  field.valueType,
+                  declaredCase.fields[fieldIndex]!,
+                  false,
+                ),
+            )
+          );
+        })
+      );
+    }
     case "Uuid":
       return valueType.tag === 10;
     case "Bytea":

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -3828,6 +3828,8 @@ function decodeBytes(
     case "Json":
     case "Enum":
       return { type: "Text", value: textDecoder.decode(bytes) };
+    case "EnumPayload":
+      return decodePayloadEnumBytes(type, bytes, storageType, nestedRowCarrier);
     case "Uuid":
       return { type: "Uuid", value: formatUuid(bytes) };
     case "Bytea":
@@ -3853,6 +3855,49 @@ function decodeBytes(
         ),
       };
   }
+}
+
+function decodePayloadEnumBytes(
+  type: Extract<ColumnType, { type: "EnumPayload" }>,
+  bytes: Uint8Array,
+  storageType: ValueType | undefined,
+  nestedRowCarrier: NestedRowCarrier,
+): Value {
+  if (bytes.byteLength < 4) throw new Error("invalid Enum payload value");
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const nameLength = view.getUint32(0, true);
+  if (bytes.byteLength < 4 + nameLength) throw new Error("invalid Enum payload case");
+  const caseName = textDecoder.decode(bytes.subarray(4, 4 + nameLength));
+  const entry = type.cases.find((candidate) => candidate.name === caseName);
+  if (!entry) throw new Error("unknown Enum payload case");
+  const enumStorage = nonNullableStorageType(storageType);
+  const payloadDescriptor =
+    enumStorage?.tag === 16
+      ? enumStorage.enumSchema?.cases?.find((candidate) => candidate.name === caseName)?.payload
+      : undefined;
+  if (!payloadDescriptor || payloadDescriptor.length !== entry.fields.length) {
+    throw new Error("Enum payload descriptor mismatch");
+  }
+  const raw = bytes.subarray(4 + nameLength);
+  const decodeRecord = createRecordValueDecoder(payloadDescriptor);
+  return {
+    type: "Enum",
+    value: {
+      case: caseName,
+      values: entry.fields.map((field, index) => {
+        const fieldBytes = decodeRecord(raw, index);
+        return fieldBytes == null
+          ? { type: "Null" }
+          : decodeBytes(
+              field.column_type,
+              fieldBytes,
+              field.name,
+              payloadDescriptor[index]?.valueType,
+              nestedRowCarrier,
+            );
+      }),
+    },
+  };
 }
 
 function nonNullableStorageType(storageType?: ValueType): ValueType | undefined {
@@ -4478,6 +4523,12 @@ function valueEqual(left: Value, right: Value | undefined): boolean {
       return right.type === "Bytea" && bytesEqual(left.value, right.value);
     case "Array":
       return right.type === "Array" && rowValuesEqual(left.value, right.value);
+    case "Enum":
+      return (
+        right.type === "Enum" &&
+        left.value.case === right.value.case &&
+        rowValuesEqual(left.value.values, right.value.values)
+      );
     case "Null":
       return right.type === "Null";
     case "Boolean":

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2245,15 +2245,6 @@ function readSession(sessionJson?: string | null): RuntimeSession | null {
   };
 }
 
-function runtimeSessionFromPublicSession(session: Session | undefined): RuntimeSession | null {
-  if (!session) return null;
-  return {
-    user_id: session.user_id,
-    claims: sessionClaims(session.user_id, session.claims),
-    identity: authorBytesForSubject(session.user_id),
-  };
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -2904,6 +2895,22 @@ function coerceQueryPredicate(
           : coerceQueryLiteral(table, filter.column, filter.value, schema),
     };
   }
+  if (filter.op === "EnumMatch") {
+    const columnType = schema[table]?.columns.find(
+      (entry) => entry.name === filter.column,
+    )?.column_type;
+    if (columnType?.type !== "EnumPayload") {
+      throw new Error(`enum match requires payload enum column "${filter.column}"`);
+    }
+    const entry = columnType.cases.find((candidate) => candidate.name === filter.case);
+    if (!entry) {
+      throw new Error(`unknown payload enum case "${filter.case}"`);
+    }
+    return {
+      ...filter,
+      payload: coerceEnumPayloadPredicate(filter.payload, entry.fields),
+    };
+  }
   if (filter.op === "IsNull" || filter.op === "IsNotNull") return filter;
   if (isQueryPredicateCmp(filter)) {
     return {
@@ -2912,6 +2919,43 @@ function coerceQueryPredicate(
     };
   }
   throw new Error(`unsupported query predicate ${JSON.stringify(filter)}`);
+}
+
+function coerceEnumPayloadPredicate(
+  predicate: QueryPredicate,
+  fields: ColumnDescriptor[],
+): QueryPredicate {
+  if (predicate.op === "All" || predicate.op === "Any") {
+    return {
+      ...predicate,
+      predicates: predicate.predicates.map((child) => coerceEnumPayloadPredicate(child, fields)),
+    };
+  }
+  if (predicate.op === "EnumMatch") {
+    throw new Error("payload enum matches cannot be nested");
+  }
+  if (!("column" in predicate)) {
+    throw new Error("payload enum predicate must target a payload field");
+  }
+  const field = fields.find((candidate) => candidate.name === predicate.column);
+  if (!field) {
+    throw new Error(`unknown payload enum field "${predicate.column}"`);
+  }
+  if (predicate.op === "In") {
+    return {
+      ...predicate,
+      values: predicate.values.map((value) =>
+        coerceLiteralForColumnType(value, field.column_type, field.nullable),
+      ),
+    };
+  }
+  if (predicate.op === "Contains" || isQueryPredicateCmp(predicate)) {
+    return {
+      ...predicate,
+      value: coerceLiteralForColumnType(predicate.value, field.column_type, field.nullable),
+    };
+  }
+  return predicate;
 }
 
 function isQueryPredicateCmp(
@@ -3270,6 +3314,15 @@ function predicateToFilters(predicate: unknown): QueryPredicate[] | null {
   }
   if (Array.isArray(record.Or)) return null;
   if (record.Not) return null;
+  const enumMatch = record.EnumMatch;
+  if (enumMatch && typeof enumMatch === "object") {
+    const match = enumMatch as { column?: unknown; case?: unknown; payload?: unknown };
+    const column = readColumnRef(match.column);
+    const payload = predicateToFilterTree(match.payload);
+    return column && typeof match.case === "string" && payload
+      ? [{ column, op: "EnumMatch", case: match.case, payload }]
+      : null;
+  }
   const isNull = record.IsNull;
   if (isNull && typeof isNull === "object") {
     const column = readColumnRef((isNull as { column?: unknown }).column);
@@ -3305,6 +3358,24 @@ function predicateToFilters(predicate: unknown): QueryPredicate[] | null {
   const column = readColumnRef(cmpRecord.left);
   const value = readLiteral(cmpRecord.right);
   return column && value ? [{ column, op, value }] : null;
+}
+
+function predicateToFilterTree(predicate: unknown): QueryPredicate | null {
+  if (predicate === "True") return { op: "All", predicates: [] };
+  if (predicate === "False") return { op: "Any", predicates: [] };
+  if (!predicate || typeof predicate !== "object") return null;
+  const record = predicate as Record<string, unknown>;
+  if (Array.isArray(record.And) || Array.isArray(record.Or)) {
+    const op = Array.isArray(record.And) ? "All" : "Any";
+    const children = (record.And ?? record.Or) as unknown[];
+    const predicates = children.map(predicateToFilterTree);
+    return predicates.every((child): child is QueryPredicate => child !== null)
+      ? { op, predicates }
+      : null;
+  }
+  if (record.Not) return null;
+  const filters = predicateToFilters(predicate);
+  return filters?.length === 1 ? filters[0]! : null;
 }
 
 function valueToQueryLiteral(value: unknown): QueryLiteral {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -2271,6 +2271,94 @@ describe("NativeRuntimeAdapter server transport", () => {
     });
   });
 
+  it("lowers a payload enum match relation filter into the native prepared query", () => {
+    let preparedBytes: Uint8Array | undefined;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            prepareQuery: (query: Uint8Array) => {
+              preparedBytes = query;
+              return {};
+            },
+            subscribe: () => new ReadableStream(),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      {
+        events: {
+          columns: [
+            {
+              name: "event",
+              column_type: {
+                type: "EnumPayload",
+                cases: [
+                  {
+                    name: "message",
+                    fields: [{ name: "level", column_type: { type: "Integer" }, nullable: false }],
+                  },
+                ],
+              },
+              nullable: false,
+            },
+          ],
+        },
+      },
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    const handle = runtime.createSubscription(
+      JSON.stringify({
+        table: "events",
+        relation_ir: {
+          Project: {
+            input: {
+              Filter: {
+                input: { TableScan: { table: "events" } },
+                predicate: {
+                  EnumMatch: {
+                    column: { column: "event", scope: "events" },
+                    case: "message",
+                    payload: {
+                      Cmp: {
+                        left: { column: "level" },
+                        op: "Eq",
+                        right: { Literal: { type: "Integer", value: 2 } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            columns: [{ alias: "event", expr: { Column: { column: "event", scope: "events" } } }],
+          },
+        },
+      }),
+    );
+
+    expect(handle).toBe(1);
+    expect(preparedBytes).toEqual(
+      queryWithPredicates(
+        "events",
+        [
+          {
+            column: "event",
+            op: "EnumMatch",
+            case: "message",
+            payload: { column: "level", op: "Eq", value: { type: "Integer", value: 2 } },
+          },
+        ],
+        { select: ["event"] },
+      ),
+    );
+  });
+
   it("trusts native subscription snapshots for simple equality relation filters", async () => {
     let controller: ReadableStreamDefaultController<unknown> | undefined;
     let preparedBytes: Uint8Array | undefined;

--- a/packages/jazz-tools/src/runtime/native-runtime/schema-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/schema-codec.ts
@@ -8,6 +8,11 @@ import type {
   WasmSchema,
 } from "../../drivers/types.js";
 import { PostcardWriter, writeValueType, type ValueType } from "./native-codec.js";
+import {
+  encodeNativeRowValues,
+  storageColumnValueType,
+  writeDescriptor,
+} from "./native-row-codec.js";
 
 const OUTER_ROW_SESSION_PREFIX = "__jazz_outer_row";
 
@@ -187,6 +192,23 @@ function writeDefaultValue(writer: PostcardWriter, columnType: ColumnType, value
       writer.u64(6); // groove::records::Value::String
       writer.string(value.value);
       return;
+    case "EnumPayload": {
+      if (value.type !== "Enum") throw new Error("expected payload enum default");
+      const caseIndex = columnType.cases.findIndex((entry) => entry.name === value.value.case);
+      const entry = columnType.cases[caseIndex];
+      if (!entry || entry.fields.length !== value.value.values.length) {
+        throw new Error("invalid payload enum default case or width");
+      }
+      writer.u64(17); // groove::records::Value::Enum(EnumValue)
+      writer.u64(caseIndex);
+      const descriptor = entry.fields.map((field) => ({
+        name: field.name,
+        valueType: storageColumnValueType(field),
+      }));
+      writeDescriptor(writer, descriptor);
+      writer.bytes(encodeNativeRowValues(entry.fields, value.value.values));
+      return;
+    }
     case "Uuid":
       if (value.type !== "Uuid") throw new Error("expected Uuid default");
       writer.u64(8); // groove::records::Value::Uuid
@@ -253,6 +275,20 @@ export function columnTypeToValueType(type: ColumnType): ValueType {
     case "Json":
     case "Enum":
       return { tag: 8 };
+    case "EnumPayload":
+      return {
+        tag: 16,
+        enumSchema: {
+          name: "public_payload_enum",
+          cases: type.cases.map((entry) => ({
+            name: entry.name,
+            payload: entry.fields.map((field) => ({
+              name: field.name,
+              valueType: storageColumnValueType(field),
+            })),
+          })),
+        },
+      };
     case "Bytea":
       return { tag: 9 };
     case "Uuid":

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -11,6 +11,12 @@ const app = s.defineApp({
     done: s.boolean(),
     ownerId: s.ref("users").optional(),
   }),
+  events: s.table({
+    event: s.enum({
+      message: { text: s.string(), level: s.int() },
+      closed: { code: s.int() },
+    }),
+  }),
 });
 
 describe("translateQuery", () => {
@@ -49,6 +55,49 @@ describe("translateQuery", () => {
 
     expect(translated.relation_ir).toBeDefined();
     expect(translated.conditions).toBeUndefined();
+  });
+
+  it("lowers a payload enum match to the first-class relation predicate", () => {
+    const translated = JSON.parse(
+      translateQuery(
+        app.events.where({ event: { match: { type: "message", where: { level: 2 } } } })._build(),
+        app.wasmSchema,
+      ),
+    );
+
+    expect(translated.relation_ir).toEqual({
+      Project: {
+        input: {
+          Filter: {
+            input: { TableScan: { table: "events" } },
+            predicate: {
+              EnumMatch: {
+                column: { column: "event", scope: "events" },
+                case: "message",
+                payload: {
+                  Cmp: {
+                    left: { column: "level" },
+                    op: "Eq",
+                    right: { Literal: { type: "Integer", value: 2 } },
+                  },
+                },
+              },
+            },
+          },
+        },
+        columns: [{ alias: "event", expr: { Column: { column: "event", scope: "events" } } }],
+      },
+    });
+  });
+
+  it("rejects a payload enum match against an absent case field", () => {
+    const built = JSON.parse(app.events._build());
+    built.conditions = [
+      { column: "event", op: "match", value: { type: "closed", where: { level: 2 } } },
+    ];
+    expect(() => translateQuery(JSON.stringify(built), app.wasmSchema)).toThrow(
+      'unknown payload enum field "level" for case "closed"',
+    );
   });
 
   it("treats an omitted include limit as unbounded", () => {

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -385,6 +385,46 @@ function conditionToRelPredicate(
   if (!columnType) {
     throw new Error(`Unknown column "${column}" in table "${table}"`);
   }
+  if (cond.op === "match") {
+    if (columnType.type !== "EnumPayload") {
+      throw new Error(`match is only supported on payload enum column "${column}".`);
+    }
+    if (typeof cond.value !== "object" || cond.value === null || Array.isArray(cond.value)) {
+      throw new Error('"match" requires { type, where } input.');
+    }
+    const match = cond.value as { type?: unknown; where?: unknown };
+    if (typeof match.type !== "string") throw new Error('"match.type" must be a string.');
+    const entry = columnType.cases.find((candidate) => candidate.name === match.type);
+    if (!entry) throw new Error(`unknown payload enum case "${match.type}".`);
+    if (
+      match.where !== undefined &&
+      (typeof match.where !== "object" || match.where === null || Array.isArray(match.where))
+    ) {
+      throw new Error('"match.where" must be an object.');
+    }
+    const filters = Object.entries((match.where ?? {}) as Record<string, unknown>).map(
+      ([field, value]) => {
+        const descriptor = entry.fields.find((candidate) => candidate.name === field);
+        if (!descriptor)
+          throw new Error(`unknown payload enum field "${field}" for case "${match.type}".`);
+        return {
+          Cmp: {
+            left: relColumn(field),
+            op: "Eq" as const,
+            right: { Literal: toRuntimeValue(value, descriptor.column_type, field) },
+          },
+        } satisfies RelPredicateExpr;
+      },
+    );
+    return {
+      EnumMatch: {
+        column: columnRef,
+        case: match.type,
+        payload:
+          filters.length === 0 ? "True" : filters.length === 1 ? filters[0]! : { And: filters },
+      },
+    };
+  }
   if (cond.op === "in") {
     if (!Array.isArray(cond.value)) {
       throw new Error('"in" operator requires an array value');
@@ -768,6 +808,23 @@ function translateBuilderToRelationIr(builderJson: string, schema: WasmSchema): 
     relationTable = translated.outputTable;
   }
 
+  // The Rust relation facade identifies its output scope through Project. A
+  // payload match can be the only relation feature, so preserve the ordinary
+  // root-table result shape with an explicit identity projection in that case.
+  if (builder.hops.length === 0 && builder.gather === undefined) {
+    const columns = schema[relationTable]?.columns;
+    if (!columns) throw new Error(`Unknown table "${relationTable}" in relation query.`);
+    relation = {
+      Project: {
+        input: relation,
+        columns: columns.map((column) => ({
+          alias: column.name,
+          expr: { Column: relColumn(column.name, relationTable) },
+        })),
+      },
+    };
+  }
+
   if (Array.isArray(builder.orderBy) && builder.orderBy.length > 0) {
     for (const [column] of builder.orderBy) {
       const columnType = getColumnType(schema, relationTable, stripQualifier(column));
@@ -810,7 +867,14 @@ function translateBuilderToRelationIr(builderJson: string, schema: WasmSchema): 
 }
 
 function usesNativeRelationFeatures(builder: ReturnType<typeof normalizeBuiltQuery>): boolean {
-  return builder.hops.length > 0 || builder.gather !== undefined;
+  // Flat queries predate payload enum matching and have no representation for
+  // its nested predicate. Route it through the relation IR even without a hop
+  // so the public enum-match node reaches the Rust query compiler.
+  return (
+    builder.hops.length > 0 ||
+    builder.gather !== undefined ||
+    builder.conditions.some((condition) => condition.op === "match")
+  );
 }
 
 function toRuntimeOrderBy(

--- a/packages/jazz-tools/src/runtime/schema-fetch.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.ts
@@ -345,6 +345,7 @@ export type PublishedMigrationValue =
   | { type: "Bytea"; value: number[] }
   | { type: "Array"; value: PublishedMigrationValue[] }
   | { type: "Row"; value: { id?: string; values: PublishedMigrationValue[] } }
+  | { type: "Enum"; value: { case: string; values: PublishedMigrationValue[] } }
   | { type: "Null" };
 
 export type PublishedMigrationOp =
@@ -404,6 +405,14 @@ export function encodePublishedMigrationValue(value: WasmValue): PublishedMigrat
         type: "Row",
         value: {
           id: value.value.id,
+          values: value.value.values.map(encodePublishedMigrationValue),
+        },
+      };
+    case "Enum":
+      return {
+        type: "Enum",
+        value: {
+          case: value.value.case,
           values: value.value.values.map(encodePublishedMigrationValue),
         },
       };

--- a/packages/jazz-tools/src/runtime/value-converter.test.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.test.ts
@@ -120,6 +120,35 @@ describe("toValue", () => {
     expect(() => toValue("invalid", colType)).toThrow("Invalid enum value");
   });
 
+  it("converts payload enum values with scalar fields and fails closed", () => {
+    const colType: ColumnType = {
+      type: "EnumPayload",
+      cases: [
+        {
+          name: "message",
+          fields: [
+            { name: "text", column_type: { type: "Text" }, nullable: false },
+            { name: "level", column_type: { type: "Integer" }, nullable: true },
+          ],
+        },
+      ],
+    };
+    expect(toValue({ type: "message", text: "hello", level: null }, colType)).toEqual({
+      type: "Enum",
+      value: {
+        case: "message",
+        values: [{ type: "Text", value: "hello" }, { type: "Null" }],
+      },
+    });
+    expect(() => toValue({ type: "message" }, colType)).toThrow("Missing required payload field");
+    expect(() => toValue({ type: "message", text: "hello", extra: true }, colType)).toThrow(
+      "Unknown payload field",
+    );
+    expect(() => toValue({ type: "missing", text: "hello" }, colType)).toThrow(
+      "Invalid payload enum case",
+    );
+  });
+
   it("converts Array values", () => {
     const colType: ColumnType = { type: "Array", element: { type: "Text" } };
     expect(toValue(["a", "b", "c"], colType)).toEqual({

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -91,6 +91,43 @@ export function toValue(value: unknown, columnType: ColumnType): WasmValue {
       }
       return { type: "Text", value: enumValue };
     }
+    case "EnumPayload": {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error("Invalid payload enum value. Expected an object with a string type.");
+      }
+      const input = value as Record<string, unknown>;
+      const caseName = input.type;
+      if (typeof caseName !== "string") {
+        throw new Error("Invalid payload enum value. Expected a string type discriminant.");
+      }
+      const entry = columnType.cases.find((candidate) => candidate.name === caseName);
+      if (!entry) throw new Error(`Invalid payload enum case "${caseName}".`);
+      const allowed = new Set(["type", ...entry.fields.map((field) => field.name)]);
+      for (const key of Object.keys(input)) {
+        if (!allowed.has(key))
+          throw new Error(`Unknown payload field "${key}" for enum case "${caseName}".`);
+      }
+      return {
+        type: "Enum",
+        value: {
+          case: caseName,
+          values: entry.fields.map((field) => {
+            const fieldValue = input[field.name];
+            if (fieldValue === undefined && !field.nullable && field.default === undefined) {
+              throw new Error(
+                `Missing required payload field "${field.name}" for enum case "${caseName}".`,
+              );
+            }
+            if (fieldValue === null && !field.nullable) {
+              throw new Error(`Cannot set required payload field "${field.name}" to null.`);
+            }
+            return fieldValue === undefined && field.default !== undefined
+              ? field.default
+              : toValue(fieldValue, field.column_type);
+          }),
+        },
+      };
+    }
     case "Array": {
       if (!Array.isArray(value)) {
         throw new Error(`Expected array for Array column type, got ${typeof value}`);

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -103,6 +103,19 @@ function columnTypeToSqlType(columnType: ColumnType): SqlType {
       return columnType.schema ? { kind: "JSON", schema: columnType.schema } : { kind: "JSON" };
     case "Enum":
       return { kind: "ENUM", variants: [...columnType.variants] };
+    case "EnumPayload":
+      return {
+        kind: "ENUM",
+        cases: columnType.cases.map((entry) => ({
+          name: entry.name,
+          fields: entry.fields.map((field) => ({
+            name: field.name,
+            sqlType: columnTypeToSqlType(field.column_type),
+            nullable: field.nullable,
+            ...(field.default === undefined ? {} : { default: field.default }),
+          })),
+        })),
+      };
     case "Array":
       return { kind: "ARRAY", element: columnTypeToSqlType(columnType.element) };
     case "Row":

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -19,7 +19,14 @@ export type JsonSchemaToTs<Schema extends JsonSchema> = FromSchema<Schema>;
 
 export interface EnumSqlType {
   kind: "ENUM";
-  variants: string[];
+  /** The established zero-payload scalar enum form. */
+  variants?: readonly string[];
+  /** Payload-bearing cases. This form is deliberately distinct from variants. */
+  cases?: readonly EnumCaseSqlType[];
+}
+export interface EnumCaseSqlType {
+  name: string;
+  fields: Column[];
 }
 export interface ArraySqlType {
   kind: "ARRAY";
@@ -43,8 +50,11 @@ export function sqlTypeToString(sqlType: SqlType): string {
     return sqlType;
   }
   if (sqlType.kind === "ENUM") {
-    const variants = sqlType.variants.map((variant) => `'${variant.replace(/'/g, "''")}'`);
-    return `ENUM(${variants.join(",")})`;
+    if (sqlType.variants) {
+      const variants = sqlType.variants.map((variant) => `'${variant.replace(/'/g, "''")}'`);
+      return `ENUM(${variants.join(",")})`;
+    }
+    return `ENUM(${(sqlType.cases ?? []).map((entry) => entry.name).join(",")})`;
   }
   if (sqlType.kind === "JSON") {
     if (!sqlType.schema) {
@@ -78,7 +88,11 @@ export type TSTypeFromSqlType<T extends SqlType> = T extends ScalarSqlType
   : T extends ArraySqlType
     ? TSTypeFromSqlType<T["element"]>[]
     : T extends EnumSqlType
-      ? T["variants"][number]
+      ? T["variants"] extends readonly string[]
+        ? T["variants"][number]
+        : T["cases"] extends readonly EnumCaseSqlType[]
+          ? EnumValueFromCases<T["cases"]>
+          : never
       : T extends JsonSqlType<infer Output>
         ? Output
         : never;
@@ -92,6 +106,12 @@ export interface Column {
   mergeStrategy?: ColumnMergeStrategy;
   largeValue?: "blob" | "text";
 }
+
+export type EnumValueFromCases<Cases extends readonly EnumCaseSqlType[]> = {
+  [Case in Cases[number] as Case["name"]]: { type: Case["name"] } & {
+    [Field in Case["fields"][number] as Field["name"]]: TSTypeFromSqlType<Field["sqlType"]>;
+  };
+}[Cases[number]["name"]];
 
 export type PolicyOperation = "Select" | "Insert" | "Update" | "Delete";
 export type PolicyCmpOp = "Eq" | "Ne" | "Lt" | "Le" | "Gt" | "Ge";

--- a/packages/jazz-tools/src/testing/fixtures/ordered-enum-schema-hashes.json
+++ b/packages/jazz-tools/src/testing/fixtures/ordered-enum-schema-hashes.json
@@ -1,0 +1,12 @@
+{
+  "cases": [
+    {
+      "variants": ["draft", "active", "archived"],
+      "hash": "462dcb43747b0be89b4eb320e2d61f322fe8d9871baf87876d79b5d8611cfb75"
+    },
+    {
+      "variants": ["active", "draft", "archived"],
+      "hash": "37d743b0897361d13e0364d0933bf7d5c6380b356cfe936c6eb71ea0e60e2e04"
+    }
+  ]
+}

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -241,6 +241,9 @@ type UuidWhere<TOptional extends boolean> = WhereEqNe<
   TOptional,
   TOptional extends true ? { in?: string[]; isNull?: boolean } : { in?: string[] }
 >;
+type PayloadEnumMatch<T> = T extends { type: infer Case extends string }
+  ? { type: Case; where?: Partial<Omit<T, "type">> }
+  : never;
 
 type WhereInputForBuilder<TBuilder extends AnyTypedColumnBuilder> =
   ColumnBuilderSqlType<TBuilder> extends "TEXT"
@@ -271,18 +274,23 @@ type WhereInputForBuilder<TBuilder extends AnyTypedColumnBuilder> =
                     }
                   ? WhereEqNe<TVariant, ColumnBuilderOptional<TBuilder>, { in?: TVariant[] }>
                   : ColumnBuilderSqlType<TBuilder> extends {
-                        kind: "ARRAY";
-                        element: infer TElementSql extends SqlType;
+                        kind: "ENUM";
+                        cases: readonly unknown[];
                       }
-                    ? WhereEqNe<
-                        StoredColumnValue<TBuilder>,
-                        ColumnBuilderOptional<TBuilder>,
-                        {
-                          contains?: TSTypeFromSqlType<TElementSql>;
-                          in?: StoredColumnValue<TBuilder>[];
+                    ? { match?: PayloadEnumMatch<StoredColumnValue<TBuilder>> }
+                    : ColumnBuilderSqlType<TBuilder> extends {
+                          kind: "ARRAY";
+                          element: infer TElementSql extends SqlType;
                         }
-                      >
-                    : never;
+                      ? WhereEqNe<
+                          StoredColumnValue<TBuilder>,
+                          ColumnBuilderOptional<TBuilder>,
+                          {
+                            contains?: TSTypeFromSqlType<TElementSql>;
+                            in?: StoredColumnValue<TBuilder>[];
+                          }
+                        >
+                      : never;
 
 export type TableWhereInput<
   TSchema extends SchemaLike,

--- a/packages/jazz-tools/src/where-operators.ts
+++ b/packages/jazz-tools/src/where-operators.ts
@@ -47,6 +47,10 @@ function operatorsForColumn(
       return ["eq", "ne", "in"];
     case "Enum":
       return ["eq", "ne", "in"];
+    case "EnumPayload":
+      // Payload enums deliberately use their dedicated `match` operator rather
+      // than pretending that a whole discriminated record is comparable.
+      return [];
     case "Array":
       return ["eq", "contains", "in"];
     case "Row":


### PR DESCRIPTION
🤖 Stacked on #1373, completing the enum stack above #1348.

## What changed

- lowers string enum columns to Groove `EnumTag` values with a durable registry per physical column occurrence
- adds object-map payload enums such as `{ type: "message", body: string }`, including nullable, defaulted, and array fields
- carries payload cases through public schema/value wire types, catalogue codecs, native row codecs, NAPI/WASM adapters, reads, writes, and subscriptions
- adds typed payload-case query matching with case-local field validation and literal coercion
- keeps declaration order schema-significant and rejects unsafe reorder/removal, invalid payload fields, unsupported nested references/modifiers, and tag overflow
- preserves independent registry identities across schema evolution and derived history/global/ahead storage
- adds exact Rust↔TypeScript structural-hash and registry-ID fixtures, including lossless `u64` decoding

## Why

Enum alternatives need stable physical tag identity across schema versions without combining independent columns into a central row-variant registry. Payload enums extend that model to Rust-style discriminated unions while retaining ordinary object-shaped Jazz rows and precise TypeScript inference.

## Validation

- focused TypeScript payload codec/query/runtime suite: 175 passed, 1 skipped
- `pnpm exec tsc --noEmit`
- `cargo check -p jazz -p groove`
- Jazz enum tests: 30 passed
- Groove enum tests: 14 passed
- all-target Jazz/Groove Clippy with warnings denied
- scalar, nullable, array, default, query-match, subscription, and codec round-trip coverage
- planted regressions for tag/string fallback, descriptor layout, selected-case validation, registry rebinding, and unsafe schema evolution

The restack is based on the independently reviewed concurrent-enum identity, projection, subscription, and introduction-order stack.
