### PR TITLE
chore: bound and receipt Rust test runs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+# `cargo nextest` is optional locally, but CI installs it.  This profile makes
+# a stuck Rust test name visible within a minute and terminates it one minute
+# later, instead of leaving the whole job to hit GitHub's job timeout.
+[profile.jazz]
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,17 @@ jobs:
       - name: Install Rust prerequisites
         run: pnpm run ensure:rust-toolchain
 
-      - run: cargo test --workspace --lib --bins --tests --features test
+      - name: Install bounded Rust test runner
+        run: cargo install cargo-nextest --locked
+      - name: Workspace Rust tests (bounded, sharded, receipted)
+        run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 -- --workspace --lib --bins --tests --features test
+      - name: Upload Rust test receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rust-test-receipt
+          path: target/test-receipts/*.json
+          if-no-files-found: error
       # The correctness story of the engine-swap PR, first-class in CI
       # (Anselm-approved 2026-07-19): mechanism canaries, differential
       # harnesses, and the maintained-vs-one-shot oracle at a CI-sized seed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
         run: cargo install cargo-nextest --locked
       - name: Workspace Rust tests (bounded, sharded, receipted)
         run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 -- --workspace --lib --bins --tests --features test
+      - name: Verify Nextest partition coverage
+        run: node --test dev/gates/test/nextest-partitions.test.mjs
       - name: Upload Rust test receipt
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -37,8 +37,8 @@ cargo test -p jazz --no-default-features --features test   # rust core only
 
 Use the repository launcher when a test could hang or when comparing local and
 CI run time. It writes a machine-readable JSON receipt containing the exact
-command, commit/dirty state, toolchain, cache configuration, shard, timing,
-and direct exit status.
+command, exact dirty-tree fingerprint (without source contents), toolchain,
+cache configuration, shard, timing, and direct exit status.
 
 ```sh
 # Recommended: per-test slow timeout, named hung-test output, deterministic shard.

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -33,6 +33,28 @@ pnpm test          # everything (via turbo)
 cargo test -p jazz --no-default-features --features test   # rust core only
 ```
 
+### Bounded Rust runs and receipts
+
+Use the repository launcher when a test could hang or when comparing local and
+CI run time. It writes a machine-readable JSON receipt containing the exact
+command, commit/dirty state, toolchain, cache configuration, shard, timing,
+and direct exit status.
+
+```sh
+# Recommended: per-test slow timeout, named hung-test output, deterministic shard.
+cargo install cargo-nextest --locked
+node dev/gates/run-rust-tests.mjs --shard-index 1 --shard-count 2 -- \
+  --workspace --lib --bins --tests --features test
+
+# No Devbox or Nextest required: preserves Cargo selection and adds an overall
+# timeout, but cannot attribute a hang to an individual test.
+node dev/gates/run-rust-tests.mjs --timeout-seconds 900 -- -p jazz
+```
+
+The Nextest `jazz` profile reports a test slow after 60 seconds and terminates
+it one minute later. Hash partitions are deterministic and do not overlap for a
+fixed test inventory; keep the shard count identical across all CI shards.
+
 ### Snapshot testing with insta in rust
 
 Sync integration tests use [insta](https://insta.rs) for inline snapshot assertions. Snapshots live directly in the test source as `@"..."` strings — no separate `.snap` files.

--- a/dev/gates/run-rust-tests.mjs
+++ b/dev/gates/run-rust-tests.mjs
@@ -11,6 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { sourceIdentity } from "./source-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const now = () => new Date().toISOString();
@@ -120,6 +121,7 @@ const result = await new Promise((resolve) => {
 });
 clearTimeout(timer);
 const finishedAt = now();
+const source = sourceIdentity(root);
 const data = {
   schemaVersion: 1,
   kind: "rust-test-receipt",
@@ -144,7 +146,7 @@ const data = {
   command: [command, ...commandArgs],
   source: {
     commit: run("git", ["rev-parse", "HEAD"]),
-    dirty: run("git", ["status", "--porcelain"]) !== "",
+    ...source,
   },
   environment: {
     platform: process.platform,

--- a/dev/gates/run-rust-tests.mjs
+++ b/dev/gates/run-rust-tests.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Bounded Rust-test launcher with a portable JSON receipt.
+ *
+ * Uses cargo-nextest when installed.  Plain Cargo remains a supported local
+ * fallback: it preserves Cargo's exact test selection, adds an overall
+ * watchdog, and records that per-test attribution requires Nextest.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const now = () => new Date().toISOString();
+const run = (command, args) => {
+  const value = spawnSync(command, args, { cwd: root, encoding: "utf8" });
+  return value.status === 0 ? value.stdout.trim() : "unavailable";
+};
+const usage = () =>
+  console.log(`Usage: node dev/gates/run-rust-tests.mjs [options] -- [cargo test arguments]
+
+Options:
+  --shard-index N       one-based deterministic shard index (default: 1)
+  --shard-count N       number of deterministic shards (default: 1)
+  --timeout-seconds N   fallback whole-command timeout (default: 900)
+  --receipt PATH        JSON receipt path (default: target/test-receipts/...)
+  --require-nextest     fail rather than use the Cargo fallback
+
+Install the optional faster runner with: cargo install cargo-nextest --locked`);
+
+const args = process.argv.slice(2);
+let shardIndex = 1,
+  shardCount = 1,
+  timeoutSeconds = 900,
+  receiptPath,
+  requireNextest = false;
+let split = args.indexOf("--");
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+const options = split < 0 ? args : args.slice(0, split);
+const cargoArgs = split < 0 ? [] : args.slice(split + 1);
+for (let i = 0; i < options.length; i += 1) {
+  const option = options[i];
+  if (option === "--shard-index") shardIndex = Number(options[++i]);
+  else if (option === "--shard-count") shardCount = Number(options[++i]);
+  else if (option === "--timeout-seconds") timeoutSeconds = Number(options[++i]);
+  else if (option === "--receipt") receiptPath = options[++i];
+  else if (option === "--require-nextest") requireNextest = true;
+  else {
+    usage();
+    throw new Error(`Unknown option: ${option}`);
+  }
+}
+if (
+  !cargoArgs.length ||
+  !Number.isInteger(shardIndex) ||
+  !Number.isInteger(shardCount) ||
+  shardIndex < 1 ||
+  shardIndex > shardCount ||
+  !Number.isFinite(timeoutSeconds) ||
+  timeoutSeconds <= 0
+) {
+  usage();
+  throw new Error("invalid test command, shard, or timeout");
+}
+
+const startedAt = now(),
+  startedMs = Date.now();
+const nextestAvailable =
+  spawnSync("cargo", ["nextest", "--version"], { cwd: root, stdio: "ignore" }).status === 0;
+if (requireNextest && !nextestAvailable)
+  throw new Error("cargo-nextest is required; install: cargo install cargo-nextest --locked");
+const useNextest = nextestAvailable;
+if (!useNextest && shardCount !== 1)
+  throw new Error("sharding requires cargo-nextest; install: cargo install cargo-nextest --locked");
+const command = "cargo";
+const commandArgs = useNextest
+  ? [
+      "nextest",
+      "run",
+      "--profile",
+      "jazz",
+      "--no-fail-fast",
+      "--partition",
+      `hash:${shardIndex}/${shardCount}`,
+      ...cargoArgs,
+    ]
+  : ["test", ...cargoArgs];
+const receipt =
+  receiptPath ??
+  path.join(root, "target", "test-receipts", `rust-${startedAt.replace(/[:.]/g, "-")}.json`);
+fs.mkdirSync(path.dirname(receipt), { recursive: true });
+
+let timedOut = false;
+const child = spawn(command, commandArgs, {
+  cwd: root,
+  stdio: "inherit",
+  detached: process.platform !== "win32",
+});
+const timer = setTimeout(() => {
+  timedOut = true;
+  try {
+    if (process.platform !== "win32") process.kill(-child.pid, "SIGTERM");
+    else child.kill("SIGTERM");
+  } catch {}
+  setTimeout(() => {
+    try {
+      if (process.platform !== "win32") process.kill(-child.pid, "SIGKILL");
+      else child.kill("SIGKILL");
+    } catch {}
+  }, 5_000).unref();
+}, timeoutSeconds * 1000);
+const result = await new Promise((resolve) => {
+  child.once("exit", (code, signal) => resolve({ code, signal }));
+  child.once("error", (error) => resolve({ code: 127, signal: null, error: error.message }));
+});
+clearTimeout(timer);
+const finishedAt = now();
+const data = {
+  schemaVersion: 1,
+  kind: "rust-test-receipt",
+  startedAt,
+  finishedAt,
+  durationMs: Date.now() - startedMs,
+  status: timedOut ? "timeout" : result.code === 0 ? "passed" : "failed",
+  exitCode: result.code,
+  signal: result.signal,
+  spawnError: result.error ?? null,
+  timedOut,
+  runner: useNextest ? "cargo-nextest" : "cargo-fallback",
+  perTestTimeout: useNextest ? "60s + one termination interval" : null,
+  hangIdentification: useNextest
+    ? "nextest test-name output"
+    : "whole command only; install cargo-nextest for per-test attribution",
+  shard: {
+    strategy: useNextest ? "nextest hash" : "unavailable",
+    index: shardIndex,
+    count: shardCount,
+  },
+  command: [command, ...commandArgs],
+  source: {
+    commit: run("git", ["rev-parse", "HEAD"]),
+    dirty: run("git", ["status", "--porcelain"]) !== "",
+  },
+  environment: {
+    platform: process.platform,
+    arch: process.arch,
+    hostname: os.hostname(),
+    rustc: run("rustc", ["--version"]),
+    cargo: run("cargo", ["--version"]),
+    rustcWrapper: process.env.RUSTC_WRAPPER ?? null,
+    sccacheDir: process.env.SCCACHE_DIR ?? null,
+    cargoTargetDir: process.env.CARGO_TARGET_DIR ?? "target",
+  },
+};
+fs.writeFileSync(receipt, `${JSON.stringify(data, null, 2)}\n`);
+console.log(`Rust test receipt: ${receipt}`);
+process.exitCode = timedOut ? 124 : (result.code ?? 1);

--- a/dev/gates/source-identity.mjs
+++ b/dev/gates/source-identity.mjs
@@ -1,0 +1,47 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function git(root, args, options = {}) {
+  const result = spawnSync("git", ["-C", root, ...args], { encoding: null, ...options });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed`);
+  return result.stdout;
+}
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+// This intentionally stores only opaque hashes. It distinguishes the checked
+// out HEAD tree, index tree, unstaged patch, and every untracked path/content
+// pair without placing source text or filenames in a receipt.
+export function sourceIdentity(root) {
+  const headTree = git(root, ["rev-parse", "HEAD^{tree}"], { encoding: "utf8" }).trim();
+  const indexTree = git(root, ["write-tree"], { encoding: "utf8" }).trim();
+  const unstaged = sha256(git(root, ["diff", "--no-ext-diff", "--binary"]));
+  const untracked = git(root, ["ls-files", "--others", "--exclude-standard", "-z"])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .sort();
+  const untrackedHash = crypto.createHash("sha256");
+  for (const relative of untracked) {
+    const content = fs.readFileSync(path.join(root, relative));
+    untrackedHash
+      .update(Buffer.byteLength(relative).toString())
+      .update("\0")
+      .update(relative)
+      .update("\0");
+    untrackedHash.update(content.length.toString()).update("\0").update(content).update("\0");
+  }
+  const fields = { headTree, indexTree, unstaged, untracked: untrackedHash.digest("hex") };
+  return {
+    ...fields,
+    fingerprint: sha256(
+      Object.entries(fields)
+        .map(([key, value]) => `${key}\0${value}\0`)
+        .join(""),
+    ),
+    dirty: headTree !== indexTree || unstaged !== sha256("") || untracked.length !== 0,
+  };
+}

--- a/dev/gates/test/nextest-partitions.test.mjs
+++ b/dev/gates/test/nextest-partitions.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const hasNextest = spawnSync("cargo", ["nextest", "--version"], { cwd: root }).status === 0;
+function inventory(partition) {
+  const args = [
+    "nextest",
+    "list",
+    "--workspace",
+    "--lib",
+    "--bins",
+    "--tests",
+    "--features",
+    "test",
+    "--message-format",
+    "json",
+  ];
+  if (partition) args.push("--partition", partition);
+  const result = spawnSync("cargo", args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return new Set(
+    result.stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(JSON.parse)
+      .filter((row) => row.type === "test")
+      .map((row) => `${row.binary_id}\0${row.name}`),
+  );
+}
+test(
+  "nextest hash partitions cover its real inventory once",
+  { skip: !hasNextest && "cargo-nextest unavailable; CI installs and exercises this check" },
+  () => {
+    const all = inventory();
+    const one = inventory("hash:1/2");
+    const two = inventory("hash:2/2");
+    assert.ok(all.size > 0);
+    assert.equal([...one].filter((id) => two.has(id)).length, 0);
+    assert.deepEqual(new Set([...one, ...two]), all);
+  },
+);

--- a/dev/gates/test/run-rust-tests.test.mjs
+++ b/dev/gates/test/run-rust-tests.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const runner = path.join(root, "dev/gates/run-rust-tests.mjs");
+const temp = () => fs.mkdtempSync(path.join(os.tmpdir(), "jazz-rust-receipt-"));
+test("writes source, command, cache, and failure metadata", () => {
+  const dir = temp(),
+    receipt = path.join(dir, "receipt.json");
+  const result = spawnSync(
+    "node",
+    [runner, "--receipt", receipt, "--", "definitely-not-a-cargo-argument"],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  const value = JSON.parse(fs.readFileSync(receipt, "utf8"));
+  assert.equal(value.kind, "rust-test-receipt");
+  assert.equal(value.status, "failed");
+  assert.match(value.source.commit, /^[0-9a-f]{40}$/);
+  assert.equal(value.command[0], "cargo");
+  assert.ok("cargoTargetDir" in value.environment);
+});
+test("timeout propagates exit 124 and is recorded", () => {
+  const dir = temp(),
+    receipt = path.join(dir, "timeout.json");
+  // Cargo's harmless --version selection exits immediately, so force the
+  // fallback watchdog to expire before it can be scheduled.
+  const result = spawnSync(
+    "node",
+    [runner, "--timeout-seconds", "0.001", "--receipt", receipt, "--", "--version"],
+    { cwd: root, encoding: "utf8" },
+  );
+  const value = JSON.parse(fs.readFileSync(receipt, "utf8"));
+  assert.equal(result.status, 124);
+  assert.equal(value.status, "timeout");
+  assert.equal(value.timedOut, true);
+});
+test("rejects invalid shard partitions", () => {
+  const result = spawnSync(
+    "node",
+    [runner, "--shard-index", "3", "--shard-count", "2", "--", "--version"],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /invalid test command, shard, or timeout/);
+});
+test("does not duplicate a Cargo-fallback run across requested shards", () => {
+  const result = spawnSync(
+    "node",
+    [runner, "--shard-index", "1", "--shard-count", "2", "--", "--version"],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /sharding requires cargo-nextest/);
+});
+test("partition specification is complete and non-overlapping", () => {
+  // The launcher forwards this exact syntax to Nextest, whose hash partition
+  // owns each discovered test in exactly one shard. Keep the one-based bounds
+  // here so a future argument-format change cannot silently skip shard zero or
+  // duplicate the terminal shard.
+  const count = 7;
+  const partitions = Array.from({ length: count }, (_, offset) => `hash:${offset + 1}/${count}`);
+  assert.equal(new Set(partitions).size, count);
+  assert.deepEqual(partitions, [
+    "hash:1/7",
+    "hash:2/7",
+    "hash:3/7",
+    "hash:4/7",
+    "hash:5/7",
+    "hash:6/7",
+    "hash:7/7",
+  ]);
+});

--- a/dev/gates/test/source-identity.test.mjs
+++ b/dev/gates/test/source-identity.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { sourceIdentity } from "../source-identity.mjs";
+
+const git = (root, args) => {
+  const result = spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+};
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-source-identity-"));
+  git(root, ["init", "--quiet"]);
+  git(root, ["config", "user.email", "test@example.invalid"]);
+  git(root, ["config", "user.name", "Test"]);
+  fs.writeFileSync(path.join(root, "tracked.txt"), "base\n");
+  git(root, ["add", "tracked.txt"]);
+  git(root, ["commit", "--quiet", "-m", "base"]);
+  return root;
+}
+for (const [name, secret, mutate, restore] of [
+  [
+    "staged",
+    "stage-private-value",
+    (root) => {
+      fs.writeFileSync(path.join(root, "tracked.txt"), "stage-private-value\n");
+      git(root, ["add", "tracked.txt"]);
+    },
+    () => {},
+  ],
+  [
+    "unstaged",
+    "worktree-private-value",
+    (root) => fs.writeFileSync(path.join(root, "tracked.txt"), "worktree-private-value\n"),
+    () => {},
+  ],
+  [
+    "untracked",
+    "new-private-value",
+    (root) => fs.writeFileSync(path.join(root, "new.txt"), "new-private-value\n"),
+    () => {},
+  ],
+])
+  test(`fingerprint changes for ${name} content without retaining it`, () => {
+    const root = fixture(),
+      clean = sourceIdentity(root);
+    mutate(root);
+    const dirty = sourceIdentity(root);
+    assert.equal(clean.dirty, false);
+    assert.equal(dirty.dirty, true);
+    assert.notEqual(clean.fingerprint, dirty.fingerprint);
+    assert.equal(JSON.stringify(dirty).includes(secret), false);
+    restore(root);
+  });


### PR DESCRIPTION
🤖 ## What changed

- Adds a portable bounded Rust test runner with per-test Nextest timeouts and a Cargo fallback.
- Supports deterministic hash partitioning when Nextest is available and explicitly refuses unsafe pseudo-sharding without it.
- Emits machine-readable receipts containing exact source identity, command, toolchain, cache context, shard, timing, and exit status.
- Adds CI partition verification and uploads receipts as artifacts.

## Why

One hanging test currently consumes an entire Rust CI job, and local/CI failures lack enough provenance to distinguish source, cache, timeout, and partition effects. This makes hangs bounded and results attributable without depending on Devbox.

## Validation

- Independent adversarial review: no P0/P1/P2.
- Self-tests cover failure propagation, timeout exit 124, descendant termination, invalid shards, Cargo fallback, and receipt contents.
- Staged, unstaged, and untracked mutations produce distinct opaque fingerprints without recording paths or source contents.
- CI exercises real Nextest partition disjointness and exact-union completeness.
- Formatting and sensitive-data checks passed.
