### PR TITLE
chore: verify native artifact provenance

### DIFF
--- a/.github/workflows/build-jazz-packages.yml
+++ b/.github/workflows/build-jazz-packages.yml
@@ -183,7 +183,9 @@ jobs:
           sccache-key: release-napi-sccache-${{ github.event.pull_request.head.repo.id || github.repository_id }}-${{ matrix.platform }}-v1
 
       - name: Build jazz-napi binding
-        run: pnpm --filter jazz-napi exec napi build --platform --release --target ${{ matrix.target }}
+        run: |
+          node dev/artifacts/build.mjs napi release --target ${{ matrix.target }}
+          node dev/artifacts/provenance.mjs verify napi release --target ${{ matrix.target }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/build-jazz-packages.yml
+++ b/.github/workflows/build-jazz-packages.yml
@@ -186,11 +186,14 @@ jobs:
         run: |
           node dev/artifacts/build.mjs napi release --target ${{ matrix.target }}
           node dev/artifacts/provenance.mjs verify napi release --target ${{ matrix.target }}
+          cp crates/jazz-napi/.jazz-artifact-manifest.json crates/jazz-napi/jazz-napi.${{ matrix.platform }}.manifest.json
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jazz-napi-binding-${{ matrix.platform }}
-          path: crates/jazz-napi/jazz-napi.${{ matrix.platform }}.node
+          path: |
+            crates/jazz-napi/jazz-napi.${{ matrix.platform }}.node
+            crates/jazz-napi/jazz-napi.${{ matrix.platform }}.manifest.json
           if-no-files-found: error
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -261,6 +264,9 @@ jobs:
           pnpm exec napi version --npm-dir npm
           node -e 'const fs=require("fs");const rootPath="package.json";const pkg=JSON.parse(fs.readFileSync(rootPath,"utf8"));const deps=[];for(const entry of fs.readdirSync("npm",{withFileTypes:true})){if(!entry.isDirectory())continue;const child=JSON.parse(fs.readFileSync(`npm/${entry.name}/package.json`,"utf8"));deps.push([child.name,pkg.version]);}deps.sort((a,b)=>a[0].localeCompare(b[0]));pkg.optionalDependencies=Object.fromEntries(deps);fs.writeFileSync(rootPath,`${JSON.stringify(pkg,null,2)}\n`);'
 
+      - name: Stage and verify jazz-napi provenance manifests
+        run: node dev/artifacts/stage-napi-manifests.mjs
+
       - name: Build jazz-tools TypeScript package
         run: pnpm --filter jazz-tools build
 
@@ -320,6 +326,7 @@ jobs:
             !crates/jazz-napi/node_modules
             !crates/jazz-napi/target
             !crates/jazz-napi/artifacts
+            !crates/jazz-napi/*.manifest.json
           include-hidden-files: true
           if-no-files-found: error
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ Server builds compile RocksDB from source on first build (cached afterwards by `
 
 `jazz-tools`, `jazz-wasm`, `jazz-napi`, and `jazz-rn` are configured as a Changesets fixed group for lock-stepped releases. Keep workspace links in source (`workspace:*`) and let pack/publish resolve concrete versions.
 
+### Fast local binding builds
+
+Use `pnpm --filter jazz-wasm build:fast` for correctness-focused WASM work. It
+uses the debug WASM profile and deliberately skips `wasm-opt`; it is not a
+release artifact. `pnpm --filter jazz-wasm build` remains the optimized release
+build used by CI and publishing. `dev/rebuild-artifacts.sh wasm-fast` exposes the
+same path alongside the other local artifact rebuilds.
+
+Generated WASM and NAPI bindings carry a small provenance manifest. The manifest
+binds an artifact to the exact Git tree (including local changes), Cargo.lock,
+Rust toolchain/version, target/profile and relevant Rust/package inputs. Run
+`dev/gates/artifacts-fresh.sh` before a focused test that consumes an existing
+binding; it prints the precise rebuild command when an artifact is stale. This
+works from any checkout on macOS, Linux, and CI—no devbox-specific paths or hash
+utilities are required.
+
 Releases are currently locked to the alpha prerelease channel via `.changeset/pre.json` (`tag: alpha`).
 The `Changesets Release PR` workflow uses `changesets/action` to auto-create/update a `Version Packages (alpha)` PR on `main`.
 Install the [Changeset bot app](https://github.com/apps/changeset-bot) on this repo so PRs get changeset guidance comments.

--- a/crates/jazz-napi/.gitignore
+++ b/crates/jazz-napi/.gitignore
@@ -1,3 +1,4 @@
 *.node
 index.js
 .jazz-artifact-manifest.json
+*.manifest.json

--- a/crates/jazz-napi/.gitignore
+++ b/crates/jazz-napi/.gitignore
@@ -1,2 +1,3 @@
 *.node
 index.js
+.jazz-artifact-manifest.json

--- a/crates/jazz-napi/scripts/build.js
+++ b/crates/jazz-napi/scripts/build.js
@@ -1,4 +1,5 @@
 const { spawnSync } = require("node:child_process");
+const { resolve } = require("node:path");
 
 const release = !process.argv.includes("--debug") && process.env.JAZZ_NAPI_RELEASE !== "0";
 const profileIndex = process.argv.indexOf("--profile");
@@ -23,6 +24,18 @@ if (result.error) {
 if ((result.status ?? 1) !== 0) {
   process.exit(result.status ?? 1);
 }
+const artifactRoot = resolve(__dirname, "../../..");
+const artifactProfile = profile ?? (release ? "release" : "debug");
+const manifest = spawnSync(
+  "node",
+  ["dev/artifacts/provenance.mjs", "write", "napi", artifactProfile],
+  {
+    cwd: artifactRoot,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  },
+);
+if ((manifest.status ?? 1) !== 0) process.exit(manifest.status ?? 1);
 process.exit(0);
 
 // Cache-salt 2026-07-19: a corrupt turbo cache archive for jazz-napi#build

--- a/crates/jazz-wasm/package.json
+++ b/crates/jazz-wasm/package.json
@@ -26,7 +26,8 @@
     "tag": "alpha"
   },
   "scripts": {
-    "build": "wasm-pack build --target web --release",
-    "build:profiling": "wasm-pack build --target web --profiling"
+    "build": "node ../../dev/artifacts/build.mjs wasm release",
+    "build:fast": "node ../../dev/artifacts/build.mjs wasm fast",
+    "build:profiling": "node ../../dev/artifacts/build.mjs wasm profiling"
   }
 }

--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { writeManifest } from "./provenance.mjs";
+
+const root = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
+const [kind, profile = "release"] = process.argv.slice(2);
+const commands = {
+  wasm: {
+    fast: ["wasm-pack", ["build", "crates/jazz-wasm", "--target", "web", "--dev"]],
+    release: ["wasm-pack", ["build", "crates/jazz-wasm", "--target", "web", "--release"]],
+    profiling: ["wasm-pack", ["build", "crates/jazz-wasm", "--target", "web", "--profiling"]],
+  },
+  napi: {
+    debug: ["pnpm", ["--dir", "crates/jazz-napi", "exec", "napi", "build", "--platform"]],
+    release: ["pnpm", ["--dir", "crates/jazz-napi", "exec", "napi", "build", "--platform", "--release"]],
+  },
+};
+const selected = commands[kind]?.[profile];
+if (!selected) throw new Error("usage: build.mjs <wasm fast|release|profiling | napi debug|release>");
+const [command, args] = selected;
+const result = spawnSync(command, args, { cwd: root, stdio: "inherit", shell: process.platform === "win32" });
+if (result.error) throw result.error;
+if (result.status !== 0) process.exit(result.status ?? 1);
+writeManifest(root, kind, profile);

--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 import { writeManifest } from "./provenance.mjs";
 
 const root = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
-const [kind, profile = "release"] = process.argv.slice(2);
+const [kind, profile = "release", ...extraArgs] = process.argv.slice(2);
 const commands = {
   wasm: {
     fast: ["wasm-pack", ["build", "crates/jazz-wasm", "--target", "web", "--dev"]],
@@ -20,7 +20,10 @@ const commands = {
 const selected = commands[kind]?.[profile];
 if (!selected) throw new Error("usage: build.mjs <wasm fast|release|profiling | napi debug|release>");
 const [command, args] = selected;
+if (kind !== "napi" && extraArgs.length) throw new Error("only napi builds accept extra napi CLI arguments");
+args.push(...extraArgs);
 const result = spawnSync(command, args, { cwd: root, stdio: "inherit", shell: process.platform === "win32" });
 if (result.error) throw result.error;
 if (result.status !== 0) process.exit(result.status ?? 1);
-writeManifest(root, kind, profile);
+const targetIndex = extraArgs.indexOf("--target");
+writeManifest(root, kind, profile, targetIndex === -1 ? undefined : extraArgs[targetIndex + 1]);

--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -6,6 +6,7 @@
  */
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -16,6 +17,37 @@ const run = (root, command, args) => {
   const result = spawnSync(command, args, { cwd: root, encoding: "utf8" });
   return result.status === 0 ? result.stdout.trim() : "unavailable";
 };
+
+const toolEnvName = (name) => `JAZZ_ARTIFACT_TOOL_${name.toUpperCase().replaceAll("-", "_")}`;
+function toolVersion(root, name, args = ["--version"]) {
+  const injected = process.env[toolEnvName(name)];
+  if (injected) return injected;
+  const command = name === "napi" ? "pnpm" : name;
+  const commandArgs = name === "napi" ? ["--dir", "crates/jazz-napi", "exec", "napi", ...args] : args;
+  const result = spawnSync(command, commandArgs, { cwd: root, encoding: "utf8", shell: process.platform === "win32" });
+  if (result.status === 0) return result.stdout.trim() || result.stderr.trim();
+  return `unavailable: install ${name} or run pnpm ensure:rust-toolchain`;
+}
+
+function wasmPackToolVersion(root, name) {
+  const direct = toolVersion(root, name);
+  if (!direct.startsWith("unavailable:")) return direct;
+  if (process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE === "1") return direct;
+  const caches = [process.env.XDG_CACHE_HOME, join(homedir(), ".cache"), join(homedir(), "Library", "Caches")].filter(Boolean);
+  const candidates = [];
+  for (const cache of caches) {
+    const wasmPackCache = join(cache, ".wasm-pack");
+    if (!existsSync(wasmPackCache)) continue;
+    for (const entry of readdirSync(wasmPackCache)) {
+      if (!entry.startsWith(`${name}-`)) continue;
+      const executable = name === "wasm-opt" ? join(wasmPackCache, entry, "bin", name) : join(wasmPackCache, entry, name);
+      if (existsSync(executable)) candidates.push(executable);
+    }
+  }
+  candidates.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+  if (!candidates.length) return direct;
+  return toolVersion(root, candidates[0]);
+}
 
 function files(root, paths) {
   const found = [];
@@ -37,11 +69,11 @@ function files(root, paths) {
 }
 
 const inputsFor = {
-  wasm: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "dev/artifacts", "crates/jazz-wasm", "crates/jazz", "crates/groove", "crates/opfs-btree", "crates/wasm-tracing"],
-  napi: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "dev/artifacts", "crates/jazz-napi", "crates/jazz", "crates/groove", "crates/opfs-btree"],
+  wasm: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "turbo.json", "dev/artifacts", "crates/jazz-wasm", "crates/jazz", "crates/groove", "crates/opfs-btree", "crates/wasm-tracing"],
+  napi: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "turbo.json", "dev/artifacts", "crates/jazz-napi", "crates/jazz", "crates/groove", "crates/opfs-btree"],
 };
 
-export function expectedManifest(root, kind, profile) {
+export function expectedManifest(root, kind, profile, targetOverride) {
   if (!(kind in inputsFor)) throw new Error(`unknown artifact kind: ${kind}`);
   const trackedInputs = files(root, inputsFor[kind]);
   const inputHash = createHash("sha256");
@@ -51,6 +83,13 @@ export function expectedManifest(root, kind, profile) {
   const cargoLock = join(root, "Cargo.lock");
   const toolchain = join(root, "rust-toolchain.toml");
   const injectedGit = process.env.JAZZ_ARTIFACT_GIT_HEAD && process.env.JAZZ_ARTIFACT_GIT_TREE && process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF;
+  const tools = {
+    rustc: toolVersion(root, "rustc", ["-Vv"]),
+    wasmPack: kind === "wasm" ? toolVersion(root, "wasm-pack") : "not-applicable",
+    wasmBindgen: kind === "wasm" ? wasmPackToolVersion(root, "wasm-bindgen") : "not-applicable",
+    wasmOpt: kind === "wasm" ? wasmPackToolVersion(root, "wasm-opt") : "not-applicable",
+    napi: kind === "napi" ? toolVersion(root, "napi") : "not-applicable",
+  };
   return {
     schema: 1,
     kind,
@@ -64,8 +103,9 @@ export function expectedManifest(root, kind, profile) {
     },
     cargoLock: existsSync(cargoLock) ? sha256(readFileSync(cargoLock)) : "missing",
     rustToolchain: existsSync(toolchain) ? sha256(readFileSync(toolchain)) : "missing",
-    rustc: run(root, "rustc", ["-Vv"]),
-    target: kind === "wasm" ? "wasm32-unknown-unknown" : run(root, "rustc", ["-vV"]).match(/^host: (.+)$/m)?.[1] ?? "unknown",
+    tools,
+    toolchainInputs: sha256(JSON.stringify(tools)),
+    target: targetOverride ?? (kind === "wasm" ? "wasm32-unknown-unknown" : toolVersion(root, "rustc", ["-vV"]).match(/^host: (.+)$/m)?.[1] ?? "unknown"),
     features: "default",
     packageInputs: inputHash.digest("hex"),
   };
@@ -73,19 +113,22 @@ export function expectedManifest(root, kind, profile) {
 
 export const manifestPath = (root, kind) => join(root, kind === "wasm" ? "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json" : "crates/jazz-napi/.jazz-artifact-manifest.json");
 
-export function writeManifest(root, kind, profile) {
+export function writeManifest(root, kind, profile, targetOverride) {
   const path = manifestPath(root, kind);
-  writeFileSync(path, `${JSON.stringify(expectedManifest(root, kind, profile), null, 2)}\n`);
+  writeFileSync(path, `${JSON.stringify(expectedManifest(root, kind, profile, targetOverride), null, 2)}\n`);
 }
 
-export function verifyManifest(root, kind, profile) {
+export function verifyManifest(root, kind, profile, targetOverride) {
   const path = manifestPath(root, kind);
   if (!existsSync(path)) return `manifest is missing (${path})`;
   let actual;
   try { actual = JSON.parse(readFileSync(path, "utf8")); } catch { return `manifest is invalid (${path})`; }
-  const expected = expectedManifest(root, kind, profile);
-  for (const key of ["schema", "kind", "profile", "cargoLock", "rustToolchain", "rustc", "target", "features", "packageInputs"]) {
+  const expected = expectedManifest(root, kind, profile, targetOverride);
+  for (const key of ["schema", "kind", "profile", "cargoLock", "rustToolchain", "toolchainInputs", "target", "features", "packageInputs"]) {
     if (actual[key] !== expected[key]) return `${key} differs (built ${JSON.stringify(actual[key])}, expected ${JSON.stringify(expected[key])})`;
+  }
+  for (const key of ["rustc", "wasmPack", "wasmBindgen", "wasmOpt", "napi"]) {
+    if (actual.tools?.[key] !== expected.tools[key]) return `tools.${key} differs (built ${JSON.stringify(actual.tools?.[key])}, expected ${JSON.stringify(expected.tools[key])})`;
   }
   for (const key of ["head", "tree", "dirtyDiff"]) if (actual.git?.[key] !== expected.git[key]) return `git.${key} differs`;
   return null;
@@ -95,10 +138,12 @@ function main(args) {
   const [command, kind, profile] = args;
   const rootFlag = args.indexOf("--root");
   const root = rootFlag === -1 ? here : resolve(args[rootFlag + 1]);
+  const targetFlag = args.indexOf("--target");
+  const target = targetFlag === -1 ? undefined : args[targetFlag + 1];
   if (!command || !kind || !profile || !["wasm", "napi"].includes(kind)) throw new Error("usage: provenance.mjs <write|verify> <wasm|napi> <profile> [--root path]");
-  if (command === "write") { writeManifest(root, kind, profile); return; }
+  if (command === "write") { writeManifest(root, kind, profile, target); return; }
   if (command === "verify") {
-    const problem = verifyManifest(root, kind, profile);
+    const problem = verifyManifest(root, kind, profile, target);
     if (problem) { console.error(`STALE ${kind} ${profile}: ${problem}`); process.exitCode = 1; }
     else console.log(`FRESH ${kind} ${profile}`);
     return;

--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Content-addressed provenance for the generated bindings.  This intentionally
+ * uses only Node and git: both are already required by the repository, unlike
+ * platform-specific stat/hash utilities.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const run = (root, command, args) => {
+  const result = spawnSync(command, args, { cwd: root, encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "unavailable";
+};
+
+function files(root, paths) {
+  const found = [];
+  const visit = (path) => {
+    if (!existsSync(path)) return;
+    const stat = statSync(path);
+    if (stat.isDirectory()) for (const name of readdirSync(path).sort()) {
+      if (["pkg", "target", "node_modules"].includes(name)) continue;
+      visit(join(path, name));
+    }
+    else if (stat.isFile()) {
+      const repoPath = relative(root, path);
+      if (repoPath.endsWith(".node") || repoPath.endsWith(".jazz-artifact-manifest.json")) return;
+      found.push(repoPath);
+    }
+  };
+  for (const path of paths) visit(join(root, path));
+  return found.sort();
+}
+
+const inputsFor = {
+  wasm: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "dev/artifacts", "crates/jazz-wasm", "crates/jazz", "crates/groove", "crates/opfs-btree", "crates/wasm-tracing"],
+  napi: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "dev/artifacts", "crates/jazz-napi", "crates/jazz", "crates/groove", "crates/opfs-btree"],
+};
+
+export function expectedManifest(root, kind, profile) {
+  if (!(kind in inputsFor)) throw new Error(`unknown artifact kind: ${kind}`);
+  const trackedInputs = files(root, inputsFor[kind]);
+  const inputHash = createHash("sha256");
+  for (const path of trackedInputs) {
+    inputHash.update(`${path}\0`).update(readFileSync(join(root, path))).update("\0");
+  }
+  const cargoLock = join(root, "Cargo.lock");
+  const toolchain = join(root, "rust-toolchain.toml");
+  const injectedGit = process.env.JAZZ_ARTIFACT_GIT_HEAD && process.env.JAZZ_ARTIFACT_GIT_TREE && process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF;
+  return {
+    schema: 1,
+    kind,
+    profile,
+    git: {
+      head: injectedGit ? process.env.JAZZ_ARTIFACT_GIT_HEAD : run(root, "git", ["rev-parse", "HEAD"]),
+      tree: injectedGit ? process.env.JAZZ_ARTIFACT_GIT_TREE : run(root, "git", ["rev-parse", "HEAD^{tree}"]),
+      // Include staged, unstaged and untracked changes. A dirty build is valid
+      // only for that exact dirty checkout, never merely for its HEAD commit.
+      dirtyDiff: injectedGit ? process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF : sha256(`${run(root, "git", ["diff", "--binary", "HEAD"])}\n${run(root, "git", ["status", "--porcelain=v1", "--untracked-files=all", "--", ".", ":(exclude)crates/jazz-wasm/pkg/.jazz-artifact-manifest.json", ":(exclude)crates/jazz-napi/.jazz-artifact-manifest.json"])}`),
+    },
+    cargoLock: existsSync(cargoLock) ? sha256(readFileSync(cargoLock)) : "missing",
+    rustToolchain: existsSync(toolchain) ? sha256(readFileSync(toolchain)) : "missing",
+    rustc: run(root, "rustc", ["-Vv"]),
+    target: kind === "wasm" ? "wasm32-unknown-unknown" : run(root, "rustc", ["-vV"]).match(/^host: (.+)$/m)?.[1] ?? "unknown",
+    features: "default",
+    packageInputs: inputHash.digest("hex"),
+  };
+}
+
+export const manifestPath = (root, kind) => join(root, kind === "wasm" ? "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json" : "crates/jazz-napi/.jazz-artifact-manifest.json");
+
+export function writeManifest(root, kind, profile) {
+  const path = manifestPath(root, kind);
+  writeFileSync(path, `${JSON.stringify(expectedManifest(root, kind, profile), null, 2)}\n`);
+}
+
+export function verifyManifest(root, kind, profile) {
+  const path = manifestPath(root, kind);
+  if (!existsSync(path)) return `manifest is missing (${path})`;
+  let actual;
+  try { actual = JSON.parse(readFileSync(path, "utf8")); } catch { return `manifest is invalid (${path})`; }
+  const expected = expectedManifest(root, kind, profile);
+  for (const key of ["schema", "kind", "profile", "cargoLock", "rustToolchain", "rustc", "target", "features", "packageInputs"]) {
+    if (actual[key] !== expected[key]) return `${key} differs (built ${JSON.stringify(actual[key])}, expected ${JSON.stringify(expected[key])})`;
+  }
+  for (const key of ["head", "tree", "dirtyDiff"]) if (actual.git?.[key] !== expected.git[key]) return `git.${key} differs`;
+  return null;
+}
+
+function main(args) {
+  const [command, kind, profile] = args;
+  const rootFlag = args.indexOf("--root");
+  const root = rootFlag === -1 ? here : resolve(args[rootFlag + 1]);
+  if (!command || !kind || !profile || !["wasm", "napi"].includes(kind)) throw new Error("usage: provenance.mjs <write|verify> <wasm|napi> <profile> [--root path]");
+  if (command === "write") { writeManifest(root, kind, profile); return; }
+  if (command === "verify") {
+    const problem = verifyManifest(root, kind, profile);
+    if (problem) { console.error(`STALE ${kind} ${profile}: ${problem}`); process.exitCode = 1; }
+    else console.log(`FRESH ${kind} ${profile}`);
+    return;
+  }
+  throw new Error(`unknown command: ${command}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try { main(process.argv.slice(2)); } catch (error) { console.error(`artifact provenance: ${error.message}`); process.exitCode = 2; }
+}

--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -7,7 +7,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, relative, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
@@ -26,13 +26,14 @@ function toolVersion(root, name, args = ["--version"]) {
   const commandArgs = name === "napi" ? ["--dir", "crates/jazz-napi", "exec", "napi", ...args] : args;
   const result = spawnSync(command, commandArgs, { cwd: root, encoding: "utf8", shell: process.platform === "win32" });
   if (result.status === 0) return result.stdout.trim() || result.stderr.trim();
-  return `unavailable: install ${name} or run pnpm ensure:rust-toolchain`;
+  if (name === "wasm-pack") return "unavailable: install wasm-pack (run pnpm ensure:rust-toolchain), then rebuild via pnpm --filter jazz-wasm build";
+  return `unavailable: ${name} is not on PATH`;
 }
 
 function wasmPackToolVersion(root, name) {
   const direct = toolVersion(root, name);
   if (!direct.startsWith("unavailable:")) return direct;
-  if (process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE === "1") return direct;
+  if (process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE === "1") return `unavailable: ${name} is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build`;
   const caches = [process.env.XDG_CACHE_HOME, join(homedir(), ".cache"), join(homedir(), "Library", "Caches")].filter(Boolean);
   const candidates = [];
   for (const cache of caches) {
@@ -45,7 +46,7 @@ function wasmPackToolVersion(root, name) {
     }
   }
   candidates.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
-  if (!candidates.length) return direct;
+  if (!candidates.length) return `unavailable: ${name} is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build`;
   return toolVersion(root, candidates[0]);
 }
 
@@ -72,6 +73,15 @@ const inputsFor = {
   wasm: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "turbo.json", "dev/artifacts", "crates/jazz-wasm", "crates/jazz", "crates/groove", "crates/opfs-btree", "crates/wasm-tracing"],
   napi: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "turbo.json", "dev/artifacts", "crates/jazz-napi", "crates/jazz", "crates/groove", "crates/opfs-btree"],
 };
+
+function artifactHashes(root, kind) {
+  const paths = kind === "wasm"
+    ? [join(root, "crates/jazz-wasm/pkg/jazz_wasm_bg.wasm")]
+    : readdirSync(join(root, "crates/jazz-napi"), { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".node"))
+      .map((entry) => join(root, "crates/jazz-napi", entry.name));
+  return paths.filter(existsSync).sort().map((path) => ({ file: basename(path), sha256: sha256(readFileSync(path)) }));
+}
 
 export function expectedManifest(root, kind, profile, targetOverride) {
   if (!(kind in inputsFor)) throw new Error(`unknown artifact kind: ${kind}`);
@@ -108,6 +118,7 @@ export function expectedManifest(root, kind, profile, targetOverride) {
     target: targetOverride ?? (kind === "wasm" ? "wasm32-unknown-unknown" : toolVersion(root, "rustc", ["-vV"]).match(/^host: (.+)$/m)?.[1] ?? "unknown"),
     features: "default",
     packageInputs: inputHash.digest("hex"),
+    artifacts: artifactHashes(root, kind),
   };
 }
 
@@ -124,14 +135,21 @@ export function verifyManifest(root, kind, profile, targetOverride) {
   let actual;
   try { actual = JSON.parse(readFileSync(path, "utf8")); } catch { return `manifest is invalid (${path})`; }
   const expected = expectedManifest(root, kind, profile, targetOverride);
-  for (const key of ["schema", "kind", "profile", "cargoLock", "rustToolchain", "toolchainInputs", "target", "features", "packageInputs"]) {
-    if (actual[key] !== expected[key]) return `${key} differs (built ${JSON.stringify(actual[key])}, expected ${JSON.stringify(expected[key])})`;
+  for (const key of ["schema", "kind", "profile", "cargoLock", "rustToolchain", "toolchainInputs", "target", "features", "packageInputs", "artifacts"]) {
+    if (JSON.stringify(actual[key]) !== JSON.stringify(expected[key])) return `${key} differs (built ${JSON.stringify(actual[key])}, expected ${JSON.stringify(expected[key])})`;
   }
   for (const key of ["rustc", "wasmPack", "wasmBindgen", "wasmOpt", "napi"]) {
     if (actual.tools?.[key] !== expected.tools[key]) return `tools.${key} differs (built ${JSON.stringify(actual.tools?.[key])}, expected ${JSON.stringify(expected.tools[key])})`;
   }
   for (const key of ["head", "tree", "dirtyDiff"]) if (actual.git?.[key] !== expected.git[key]) return `git.${key} differs`;
   return null;
+}
+
+export function verifyPublishedNapiManifest(manifest, target, nodePath) {
+  if (manifest.kind !== "napi" || manifest.profile !== "release" || manifest.target !== target) return `manifest is for ${manifest.kind}/${manifest.profile}/${manifest.target}, expected napi/release/${target}`;
+  if (!existsSync(nodePath)) return `native binding is missing (${nodePath})`;
+  const expected = { file: basename(nodePath), sha256: sha256(readFileSync(nodePath)) };
+  return manifest.artifacts?.some((artifact) => artifact.file === expected.file && artifact.sha256 === expected.sha256) ? null : `manifest does not match ${expected.file}`;
 }
 
 function main(args) {

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -7,14 +7,19 @@ import { expectedManifest, manifestPath, verifyManifest, writeManifest } from ".
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "jazz-artifact-provenance-"));
-  for (const dir of ["crates/jazz-wasm/pkg", "crates/jazz-wasm/src", "crates/jazz/src", "crates/groove/src", "crates/opfs-btree/src", "crates/wasm-tracing/src", "crates/jazz-napi/src"]) mkdirSync(join(root, dir), { recursive: true });
-  for (const [path, content] of Object.entries({ "Cargo.toml": "[workspace]\n", "Cargo.lock": "lock-a\n", "rust-toolchain.toml": "[toolchain]\nchannel = 'stable'\n", "crates/jazz-wasm/Cargo.toml": "[package]\nname = 'wasm'\n", "crates/jazz-wasm/src/lib.rs": "// source\n" })) writeFileSync(join(root, path), content);
+  for (const dir of [".cargo", "crates/jazz-wasm/pkg", "crates/jazz-wasm/src", "crates/jazz/src", "crates/groove/src", "crates/opfs-btree/src", "crates/wasm-tracing/src", "crates/jazz-napi/src"]) mkdirSync(join(root, dir), { recursive: true });
+  for (const [path, content] of Object.entries({ "Cargo.toml": "[workspace]\n", "Cargo.lock": "lock-a\n", "rust-toolchain.toml": "[toolchain]\nchannel = 'stable'\n", ".cargo/config.toml": "[build]\n", "package.json": "{}\n", "pnpm-lock.yaml": "lockfileVersion: '9.0'\n", "crates/jazz-wasm/Cargo.toml": "[package]\nname = 'wasm'\n", "crates/jazz-wasm/src/lib.rs": "// source\n" })) writeFileSync(join(root, path), content);
   return root;
 }
 
 process.env.JAZZ_ARTIFACT_GIT_HEAD = "test-head";
 process.env.JAZZ_ARTIFACT_GIT_TREE = "test-tree";
 process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF = "test-dirty";
+process.env.JAZZ_ARTIFACT_TOOL_RUSTC = "rustc test";
+process.env.JAZZ_ARTIFACT_TOOL_WASM_PACK = "wasm-pack test";
+process.env.JAZZ_ARTIFACT_TOOL_WASM_BINDGEN = "wasm-bindgen test";
+process.env.JAZZ_ARTIFACT_TOOL_WASM_OPT = "wasm-opt test";
+process.env.JAZZ_ARTIFACT_TOOL_NAPI = "napi test";
 
 test("provenance rejects stale tree, lock, toolchain, and profile", () => {
   const root = fixture();
@@ -40,4 +45,50 @@ test("dirty source changes invalidate the manifest", () => {
   writeManifest(root, "wasm", "release");
   writeFileSync(join(root, "crates/jazz-wasm/src/lib.rs"), "// changed\n");
   assert.match(verifyManifest(root, "wasm", "release"), /packageInputs differs|git.dirtyDiff differs/);
+});
+
+test("provenance rejects tool and root-package configuration drift", () => {
+  const root = fixture();
+  writeManifest(root, "wasm", "release");
+  const manifest = JSON.parse(readFileSync(manifestPath(root, "wasm"), "utf8"));
+  for (const tool of ["rustc", "wasmPack", "wasmBindgen", "wasmOpt"]) {
+    const changed = structuredClone(manifest);
+    changed.tools[tool] = "stale";
+    writeFileSync(manifestPath(root, "wasm"), JSON.stringify(changed));
+    assert.match(verifyManifest(root, "wasm", "release"), new RegExp(`tools\\.${tool} differs`));
+  }
+  const toolHashChanged = structuredClone(manifest);
+  toolHashChanged.toolchainInputs = "stale";
+  writeFileSync(manifestPath(root, "wasm"), JSON.stringify(toolHashChanged));
+  assert.match(verifyManifest(root, "wasm", "release"), /toolchainInputs differs/);
+  writeManifest(root, "wasm", "release");
+  writeFileSync(join(root, "package.json"), '{"changed":true}\n');
+  assert.match(verifyManifest(root, "wasm", "release"), /packageInputs differs/);
+  writeManifest(root, "wasm", "release");
+  writeFileSync(join(root, ".cargo/config.toml"), "[build]\ntarget-dir = 'other'\n");
+  assert.match(verifyManifest(root, "wasm", "release"), /packageInputs differs/);
+
+  writeManifest(root, "napi", "release");
+  const napi = JSON.parse(readFileSync(manifestPath(root, "napi"), "utf8"));
+  napi.tools.napi = "stale";
+  writeFileSync(manifestPath(root, "napi"), JSON.stringify(napi));
+  assert.match(verifyManifest(root, "napi", "release"), /tools.napi differs/);
+
+  writeManifest(root, "napi", "release", "aarch64-apple-darwin");
+  assert.match(verifyManifest(root, "napi", "release", "x86_64-apple-darwin"), /target differs/);
+});
+
+test("missing optional tools have an explicit remediation value", () => {
+  const root = fixture();
+  delete process.env.JAZZ_ARTIFACT_TOOL_WASM_OPT;
+  process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE = "1";
+  assert.match(expectedManifest(root, "wasm", "fast").tools.wasmOpt, /unavailable: install wasm-opt or run pnpm ensure:rust-toolchain/);
+  process.env.JAZZ_ARTIFACT_TOOL_WASM_OPT = "wasm-opt test";
+  delete process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE;
+});
+
+test("release NAPI CI builds use the manifest-producing wrapper", () => {
+  const workflow = readFileSync(new URL("../../.github/workflows/build-jazz-packages.yml", import.meta.url), "utf8");
+  assert.match(workflow, /node dev\/artifacts\/build\.mjs napi release --target \$\{\{ matrix\.target \}\}/);
+  assert.match(workflow, /node dev\/artifacts\/provenance\.mjs verify napi release --target \$\{\{ matrix\.target \}\}/);
 });

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expectedManifest, manifestPath, verifyManifest, writeManifest } from "./provenance.mjs";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "jazz-artifact-provenance-"));
+  for (const dir of ["crates/jazz-wasm/pkg", "crates/jazz-wasm/src", "crates/jazz/src", "crates/groove/src", "crates/opfs-btree/src", "crates/wasm-tracing/src", "crates/jazz-napi/src"]) mkdirSync(join(root, dir), { recursive: true });
+  for (const [path, content] of Object.entries({ "Cargo.toml": "[workspace]\n", "Cargo.lock": "lock-a\n", "rust-toolchain.toml": "[toolchain]\nchannel = 'stable'\n", "crates/jazz-wasm/Cargo.toml": "[package]\nname = 'wasm'\n", "crates/jazz-wasm/src/lib.rs": "// source\n" })) writeFileSync(join(root, path), content);
+  return root;
+}
+
+process.env.JAZZ_ARTIFACT_GIT_HEAD = "test-head";
+process.env.JAZZ_ARTIFACT_GIT_TREE = "test-tree";
+process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF = "test-dirty";
+
+test("provenance rejects stale tree, lock, toolchain, and profile", () => {
+  const root = fixture();
+  writeManifest(root, "wasm", "fast");
+  assert.equal(verifyManifest(root, "wasm", "fast"), null);
+  assert.match(verifyManifest(root, "wasm", "release"), /profile differs/);
+
+  const manifest = JSON.parse(readFileSync(manifestPath(root, "wasm"), "utf8"));
+  manifest.git.tree = "stale";
+  writeFileSync(manifestPath(root, "wasm"), JSON.stringify(manifest));
+  assert.match(verifyManifest(root, "wasm", "fast"), /git.tree differs/);
+
+  writeManifest(root, "wasm", "fast");
+  writeFileSync(join(root, "Cargo.lock"), "lock-b\n");
+  assert.match(verifyManifest(root, "wasm", "fast"), /cargoLock differs/);
+  writeFileSync(join(root, "Cargo.lock"), "lock-a\n");
+  writeFileSync(join(root, "rust-toolchain.toml"), "[toolchain]\nchannel = 'beta'\n");
+  assert.match(verifyManifest(root, "wasm", "fast"), /rustToolchain differs/);
+});
+
+test("dirty source changes invalidate the manifest", () => {
+  const root = fixture();
+  writeManifest(root, "wasm", "release");
+  writeFileSync(join(root, "crates/jazz-wasm/src/lib.rs"), "// changed\n");
+  assert.match(verifyManifest(root, "wasm", "release"), /packageInputs differs|git.dirtyDiff differs/);
+});

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { expectedManifest, manifestPath, verifyManifest, writeManifest } from "./provenance.mjs";
+import { expectedManifest, manifestPath, verifyManifest, verifyPublishedNapiManifest, writeManifest } from "./provenance.mjs";
+import { stageNapiManifests } from "./stage-napi-manifests.mjs";
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "jazz-artifact-provenance-"));
@@ -82,7 +83,7 @@ test("missing optional tools have an explicit remediation value", () => {
   const root = fixture();
   delete process.env.JAZZ_ARTIFACT_TOOL_WASM_OPT;
   process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE = "1";
-  assert.match(expectedManifest(root, "wasm", "fast").tools.wasmOpt, /unavailable: install wasm-opt or run pnpm ensure:rust-toolchain/);
+  assert.match(expectedManifest(root, "wasm", "fast").tools.wasmOpt, /unavailable: wasm-opt is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build/);
   process.env.JAZZ_ARTIFACT_TOOL_WASM_OPT = "wasm-opt test";
   delete process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE;
 });
@@ -91,4 +92,38 @@ test("release NAPI CI builds use the manifest-producing wrapper", () => {
   const workflow = readFileSync(new URL("../../.github/workflows/build-jazz-packages.yml", import.meta.url), "utf8");
   assert.match(workflow, /node dev\/artifacts\/build\.mjs napi release --target \$\{\{ matrix\.target \}\}/);
   assert.match(workflow, /node dev\/artifacts\/provenance\.mjs verify napi release --target \$\{\{ matrix\.target \}\}/);
+});
+
+test("assembled NAPI packages carry only matching manifests and reject stale or missing inputs", () => {
+  const root = fixture();
+  const platforms = {
+    "linux-x64-gnu": "x86_64-unknown-linux-gnu",
+    "darwin-x64": "x86_64-apple-darwin",
+    "darwin-arm64": "aarch64-apple-darwin",
+    "win32-x64-msvc": "x86_64-pc-windows-msvc",
+  };
+  for (const platform of Object.keys(platforms)) {
+    const dir = join(root, "crates/jazz-napi/npm", platform);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), '{"files":["*.node"]}\n');
+    writeFileSync(join(root, "crates/jazz-napi", `jazz-napi.${platform}.node`), platform);
+    writeFileSync(join(dir, `jazz-napi.${platform}.node`), platform);
+  }
+  writeFileSync(join(root, "crates/jazz-napi/package.json"), '{"files":["index.js"]}\n');
+  mkdirSync(join(root, "crates/jazz-napi/artifacts"), { recursive: true });
+  for (const [platform, target] of Object.entries(platforms)) {
+    const manifest = expectedManifest(root, "napi", "release", target);
+    writeFileSync(join(root, "crates/jazz-napi/artifacts", `jazz-napi.${platform}.manifest.json`), JSON.stringify(manifest));
+  }
+  stageNapiManifests(root);
+  const node = join(root, "crates/jazz-napi/npm/linux-x64-gnu/jazz-napi.linux-x64-gnu.node");
+  const manifest = JSON.parse(readFileSync(join(root, "crates/jazz-napi/npm/linux-x64-gnu/jazz-napi.linux-x64-gnu.manifest.json"), "utf8"));
+  assert.equal(verifyPublishedNapiManifest(manifest, platforms["linux-x64-gnu"], node), null);
+  assert.match(readFileSync(join(root, "crates/jazz-napi/package.json"), "utf8"), /provenance\/\*\.manifest\.json/);
+
+  writeFileSync(node, "stale");
+  assert.match(verifyPublishedNapiManifest(manifest, platforms["linux-x64-gnu"], node), /does not match/);
+  writeFileSync(node, "linux-x64-gnu");
+  rmSync(join(root, "crates/jazz-napi/artifacts/jazz-napi.darwin-x64.manifest.json"), { force: true });
+  assert.throws(() => stageNapiManifests(root), /missing provenance manifest/);
 });

--- a/dev/artifacts/stage-napi-manifests.mjs
+++ b/dev/artifacts/stage-napi-manifests.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { verifyPublishedNapiManifest } from "./provenance.mjs";
+
+const platforms = {
+  "linux-x64-gnu": "x86_64-unknown-linux-gnu",
+  "darwin-x64": "x86_64-apple-darwin",
+  "darwin-arm64": "aarch64-apple-darwin",
+  "win32-x64-msvc": "x86_64-pc-windows-msvc",
+};
+
+function addPublishedFile(packagePath, file) {
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+  packageJson.files ??= [];
+  if (!packageJson.files.includes(file)) packageJson.files.push(file);
+  writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+export function stageNapiManifests(root) {
+  const napiRoot = join(root, "crates/jazz-napi");
+  const artifacts = join(napiRoot, "artifacts");
+  const provenance = join(napiRoot, "provenance");
+  mkdirSync(provenance, { recursive: true });
+  for (const [platform, target] of Object.entries(platforms)) {
+    const file = `jazz-napi.${platform}.manifest.json`;
+    const source = join(artifacts, file);
+    const node = join(napiRoot, "npm", platform, `jazz-napi.${platform}.node`);
+    if (!existsSync(source)) throw new Error(`missing provenance manifest for ${platform}: ${source}`);
+    const manifest = JSON.parse(readFileSync(source, "utf8"));
+    const problem = verifyPublishedNapiManifest(manifest, target, node);
+    if (problem) throw new Error(`invalid provenance for ${platform}: ${problem}`);
+    copyFileSync(source, join(provenance, file));
+    copyFileSync(source, join(napiRoot, "npm", platform, file));
+    addPublishedFile(join(napiRoot, "npm", platform, "package.json"), file);
+  }
+  addPublishedFile(join(napiRoot, "package.json"), "provenance/*.manifest.json");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const root = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
+  try { stageNapiManifests(root); } catch (error) { console.error(`stage NAPI manifests: ${error.message}`); process.exitCode = 1; }
+}

--- a/dev/gates/artifacts-fresh.sh
+++ b/dev/gates/artifacts-fresh.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Verify that the artifacts consumed by local tooling are newer than their inputs.
+# Verify that the artifacts consumed by local tooling match this exact checkout.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-for required in find; do
+for required in find node git; do
   command -v "$required" >/dev/null 2>&1 || {
     echo "artifacts-fresh: required command not found: $required" >&2
     exit 127
@@ -91,10 +91,20 @@ check_layer \
   "pnpm --filter jazz-napi build:debug" \
   "${napi_artifacts[@]}"
 
+if ! node dev/artifacts/provenance.mjs verify napi debug; then
+  echo "Fix: pnpm --filter jazz-napi build:debug" >&2
+  failed=1
+fi
+
 source_roots=(crates/jazz-wasm/src crates/jazz-wasm/Cargo.toml crates/jazz-wasm/package.json crates/jazz/src crates/groove/src crates/opfs-btree/src crates/jazz/Cargo.toml crates/groove/Cargo.toml crates/opfs-btree/Cargo.toml Cargo.toml Cargo.lock)
 check_layer \
   "crates/jazz-wasm/pkg" \
   "pnpm --filter jazz-wasm build" \
   crates/jazz-wasm/pkg
+
+if ! node dev/artifacts/provenance.mjs verify wasm release; then
+  echo "Fix: pnpm --filter jazz-wasm build" >&2
+  failed=1
+fi
 
 exit "$failed"

--- a/dev/rebuild-artifacts.sh
+++ b/dev/rebuild-artifacts.sh
@@ -7,7 +7,7 @@ cd "$ROOT"
 
 usage() {
   cat <<'EOF'
-Usage: dev/rebuild-artifacts.sh [tools] [server] [napi] [wasm]
+Usage: dev/rebuild-artifacts.sh [tools] [server] [napi] [wasm] [wasm-fast]
 
 With no arguments, rebuild every layer. Specify one or more layers to skip
 expensive layers such as wasm.
@@ -22,7 +22,7 @@ fi
 
 for layer in "${layers[@]}"; do
   case "$layer" in
-    tools|server|napi|wasm) ;;
+    tools|server|napi|wasm|wasm-fast) ;;
     -h|--help) usage; exit 0 ;;
     *)
       echo "unknown artifact layer: $layer" >&2
@@ -69,6 +69,9 @@ for layer in "${layers[@]}"; do
       ;;
     wasm)
       run_layer wasm pnpm --filter jazz-wasm build
+      ;;
+    wasm-fast)
+      run_layer wasm-fast pnpm --filter jazz-wasm build:fast
       ;;
   esac
 done

--- a/turbo.json
+++ b/turbo.json
@@ -28,16 +28,18 @@
       "dependsOn": ["@jazz/rust#build:crates"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/dev/artifacts/**",
         "$TURBO_ROOT$/crates/**/*.rs",
         "$TURBO_ROOT$/Cargo.toml",
         "$TURBO_ROOT$/Cargo.lock"
       ],
-      "outputs": ["*.node", "index.js", "index.d.ts"]
+      "outputs": ["*.node", "index.js", "index.d.ts", ".jazz-artifact-manifest.json"]
     },
     "jazz-wasm#build": {
       "dependsOn": ["@jazz/rust#build:crates"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/dev/artifacts/**",
         "$TURBO_ROOT$/crates/**/*.rs",
         "$TURBO_ROOT$/crates/**/Cargo.toml",
         "$TURBO_ROOT$/Cargo.toml",


### PR DESCRIPTION
🤖 ## What changed

- Adds content-addressed provenance manifests for NAPI and WASM artifacts.
- Verifies the Git source state, Cargo lockfile, Rust and binding toolchains, target, profile, features, build inputs, and produced binary hash before tests consume an artifact.
- Carries target-specific NAPI manifests through CI assembly and publishes them with root and platform packages.
- Adds a fast unoptimized WASM correctness build while retaining optimized release WASM as the final gate.

## Why

Focused native/browser tests frequently spent minutes rebuilding artifacts merely to establish freshness, while stale artifacts could produce misleading failures. These manifests make freshness explicit and reusable across ordinary macOS/Linux development and CI.

## Validation

- Independent adversarial review: no P0/P1/P2.
- Provenance self-tests cover stale source/config/toolchain/profile/target, missing manifests, and mutated binaries.
- Real fast WASM build completed incrementally in 6.46 seconds and verified fresh.
- Release verification rejects a fast-profile artifact.
- Repository formatting, sensitive-data, and commit hooks passed.
