### PR TITLE
fix: make staged Clippy hooks portable

### DIFF
--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -26,6 +26,15 @@ This requires a working C/C++ toolchain and `libclang` for `bindgen`:
 
 ## Testing
 
+### Pre-commit hooks in restricted shells
+
+The staged Rust hook receives its file list directly from Lefthook and invokes
+Cargo through `dev/scripts/clippy-staged.sh`. This avoids Node child-process
+invocations of `git` and `cargo`, which can be denied by sandboxed shells while
+ordinary Git commands still work. Run `pnpm test:tooling` to exercise this
+path, including propagation of Cargo failures. Direct invocations of
+`node dev/scripts/clippy-staged.mjs` remain available for local debugging.
+
 ### Running tests
 
 ```sh

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -29,11 +29,13 @@ This requires a working C/C++ toolchain and `libclang` for `bindgen`:
 ### Pre-commit hooks in restricted shells
 
 The staged Rust hook receives its file list directly from Lefthook and invokes
-Cargo through `dev/scripts/clippy-staged.sh`. This avoids Node child-process
-invocations of `git` and `cargo`, which can be denied by sandboxed shells while
-ordinary Git commands still work. Run `pnpm test:tooling` to exercise this
-path, including propagation of Cargo failures. Direct invocations of
-`node dev/scripts/clippy-staged.mjs` remain available for local debugging.
+Cargo through `dev/scripts/clippy-staged.sh`. It asks Cargo for authoritative
+workspace metadata once, then invokes Cargo directly; this avoids Node
+child-process invocations of `git` and `cargo`, which can be denied by
+sandboxed shells while ordinary Git commands still work. Run
+`pnpm test:tooling` to exercise workspace-member, standalone, excluded, and
+failure paths. Direct invocations of `node dev/scripts/clippy-staged.mjs`
+remain available for local debugging.
 
 ### Running tests
 

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -35,7 +35,7 @@ child-process invocations of `git` and `cargo`, which can be denied by
 sandboxed shells while ordinary Git commands still work. Run
 `pnpm test:tooling` to exercise workspace-member, standalone, excluded, and
 failure paths. Nonmember/auxiliary crates deliberately fall back to the root
-workspace all-targets guard; maintained standalone crates should have their
+workspace guard; maintained standalone crates should have their
 own explicit gates. Run `pnpm test:tooling:real` for the slower real-Cargo
 probe of that fallback. Direct invocations of
 `node dev/scripts/clippy-staged.mjs` remain available for local debugging.

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -34,8 +34,11 @@ workspace metadata once, then invokes Cargo directly; this avoids Node
 child-process invocations of `git` and `cargo`, which can be denied by
 sandboxed shells while ordinary Git commands still work. Run
 `pnpm test:tooling` to exercise workspace-member, standalone, excluded, and
-failure paths. Direct invocations of `node dev/scripts/clippy-staged.mjs`
-remain available for local debugging.
+failure paths. Nonmember/auxiliary crates deliberately fall back to the root
+workspace all-targets guard; maintained standalone crates should have their
+own explicit gates. Run `pnpm test:tooling:real` for the slower real-Cargo
+probe of that fallback. Direct invocations of
+`node dev/scripts/clippy-staged.mjs` remain available for local debugging.
 
 ### Running tests
 

--- a/dev/scripts/clippy-staged.mjs
+++ b/dev/scripts/clippy-staged.mjs
@@ -8,16 +8,24 @@ import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
 
 const workspaceRoot = process.cwd();
-const dryRun = process.argv[2] === "--dry-run";
+const dryRun = process.argv.includes("--dry-run");
+const stagedFilesIndex = process.argv.indexOf("--staged-files");
 
-const stagedFiles = dryRun
-  ? process.argv.slice(3)
-  : execFileSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMRD", "-z"], {
-      encoding: "buffer",
-    })
-      .toString("utf8")
-      .split("\0")
-      .filter(Boolean);
+// Lefthook supplies the staged paths to the hook.  This avoids starting a
+// second process from Node just to ask Git for information Lefthook already
+// collected (and works in restricted shells where child_process.spawnSync
+// cannot execute git).  Keep the Git fallback for direct local invocation.
+const stagedFiles =
+  stagedFilesIndex >= 0
+    ? process.argv.slice(stagedFilesIndex + 1).filter(Boolean)
+    : dryRun
+      ? process.argv.slice(2).filter((arg) => arg !== "--dry-run")
+      : execFileSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMRD", "-z"], {
+          encoding: "buffer",
+        })
+          .toString("utf8")
+          .split("\0")
+          .filter(Boolean);
 
 const clippyInputs = stagedFiles.filter(
   (file) => file.endsWith(".rs") || path.basename(file) === "Cargo.toml",

--- a/dev/scripts/clippy-staged.real.test.sh
+++ b/dev/scripts/clippy-staged.real.test.sh
@@ -3,8 +3,15 @@
 # mocked mapper test because it intentionally compiles the full workspace.
 set -eu
 root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+set +e
 output=$(sh "$root/dev/scripts/clippy-staged.sh" \
   "dev/benchmarks/storage/native/file with spaces.rs" \
-  examples/todo-server-rs/src/main.rs)
-printf '%s\n' "$output" | grep -F -- 'cargo clippy --workspace --all-targets -- -D warnings' >/dev/null
+  examples/todo-server-rs/src/main.rs 2>&1)
+status=$?
+set -e
+if [ "$status" -ne 0 ]; then
+  printf '%s\n' "$output" >&2
+  exit "$status"
+fi
+printf '%s\n' "$output" | grep -F -- 'cargo clippy --workspace -- -D warnings' >/dev/null
 echo "real nonmember workspace fallback passed"

--- a/dev/scripts/clippy-staged.real.test.sh
+++ b/dev/scripts/clippy-staged.real.test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Real Cargo probe for the nonmember fallback. Kept separate from the fast
+# mocked mapper test because it intentionally compiles the full workspace.
+set -eu
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+output=$(sh "$root/dev/scripts/clippy-staged.sh" \
+  "dev/benchmarks/storage/native/file with spaces.rs" \
+  examples/todo-server-rs/src/main.rs)
+printf '%s\n' "$output" | grep -F -- 'cargo clippy --workspace --all-targets -- -D warnings' >/dev/null
+echo "real nonmember workspace fallback passed"

--- a/dev/scripts/clippy-staged.sh
+++ b/dev/scripts/clippy-staged.sh
@@ -11,11 +11,8 @@ root=${JAZZ_REPO_ROOT:-.}
 cd "$root"
 root=$(pwd)
 packages=""
-standalone_manifests=""
 workspace=0
 seen=' '
-newline='
-'
 
 metadata=$(mktemp "${TMPDIR:-/tmp}/clippy-metadata.XXXXXX")
 members=$(mktemp "${TMPDIR:-/tmp}/clippy-members.XXXXXX")
@@ -63,9 +60,11 @@ for file in "$@"; do
         seen="$seen$package "
         esac
       else
-        case "$newline$standalone_manifests" in *"$newline$manifest$newline"*) : ;; *)
-          standalone_manifests="$standalone_manifests$manifest$newline"
-        esac
+        # Auxiliary crates may be standalone, excluded, or depend on
+        # workspace-only assumptions. Preserve the old safe behavior: lint
+        # the authoritative root workspace instead of making their own
+        # manifest a blocking hook target.
+        workspace=1
       fi
       break
     fi
@@ -77,7 +76,7 @@ for file in "$@"; do
 done
 
 if [ "$workspace" -eq 1 ]; then
-  set -- clippy --workspace -- -D warnings
+  set -- clippy --workspace --all-targets -- -D warnings
 elif [ -n "$packages" ]; then
   set -- clippy
   for package in $packages; do set -- "$@" --package "$package"; done
@@ -88,16 +87,7 @@ fi
 
 if [ "$#" -gt 0 ]; then
   echo "Clippy: cargo $*"
-  cargo "$@"
+  exec cargo "$@"
 fi
 
-while IFS= read -r manifest; do
-  [ -n "$manifest" ] || continue
-  echo "Clippy: cargo clippy --manifest-path $manifest -- -D warnings"
-  cargo clippy --manifest-path "$manifest" -- -D warnings
-done <<EOF
-$standalone_manifests
-EOF
-
-[ "$workspace" -eq 1 ] || [ -n "$packages" ] || [ -n "$standalone_manifests" ] ||
-  echo "Clippy: no staged Rust or Cargo.toml changes"
+echo "Clippy: no staged Rust or Cargo.toml changes"

--- a/dev/scripts/clippy-staged.sh
+++ b/dev/scripts/clippy-staged.sh
@@ -9,9 +9,31 @@ set -eu
 # callers invoking it elsewhere can set JAZZ_REPO_ROOT explicitly.
 root=${JAZZ_REPO_ROOT:-.}
 cd "$root"
+root=$(pwd)
 packages=""
+standalone_manifests=""
 workspace=0
 seen=' '
+newline='
+'
+
+root_members=$(sed -n '/^members[[:space:]]*=[[:space:]]*\[/,/^]/p' Cargo.toml |
+  sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p')
+
+is_root_member_manifest() {
+  manifest=$1
+  case "$manifest" in
+    /*) manifest_abs=$manifest ;;
+    *) manifest_abs=$root/$manifest ;;
+  esac
+  while IFS= read -r member; do
+    [ -n "$member" ] || continue
+    [ "$manifest_abs" = "$root/$member/Cargo.toml" ] && return 0
+  done <<EOF
+$root_members
+EOF
+  return 1
+}
 
 for file in "$@"; do
   case "$file" in
@@ -28,9 +50,15 @@ for file in "$@"; do
       package=$(sed -n 's/^name[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' "$manifest" | head -n 1)
       if [ -z "$package" ]; then
         workspace=1
-      elif case "$seen" in *" $package "*) false ;; *) true ;; esac; then
+      elif is_root_member_manifest "$manifest"; then
+        case "$seen" in *" $package "*) : ;; *)
         packages="$packages $package"
         seen="$seen$package "
+        esac
+      else
+        case "$newline$standalone_manifests" in *"$newline$manifest$newline"*) : ;; *)
+          standalone_manifests="$standalone_manifests$manifest$newline"
+        esac
       fi
       break
     fi
@@ -43,12 +71,26 @@ done
 
 if [ "$workspace" -eq 1 ]; then
   set -- clippy --workspace -- -D warnings
-else
-  [ -n "$packages" ] || { echo "Clippy: no staged Rust or Cargo.toml changes"; exit 0; }
+elif [ -n "$packages" ]; then
   set -- clippy
   for package in $packages; do set -- "$@" --package "$package"; done
   set -- "$@" -- -D warnings
+else
+  set --
 fi
 
-echo "Clippy: cargo $*"
-exec cargo "$@"
+if [ "$#" -gt 0 ]; then
+  echo "Clippy: cargo $*"
+  cargo "$@"
+fi
+
+while IFS= read -r manifest; do
+  [ -n "$manifest" ] || continue
+  echo "Clippy: cargo clippy --manifest-path $manifest -- -D warnings"
+  cargo clippy --manifest-path "$manifest" -- -D warnings
+done <<EOF
+$standalone_manifests
+EOF
+
+[ "$workspace" -eq 1 ] || [ -n "$packages" ] || [ -n "$standalone_manifests" ] ||
+  echo "Clippy: no staged Rust or Cargo.toml changes"

--- a/dev/scripts/clippy-staged.sh
+++ b/dev/scripts/clippy-staged.sh
@@ -76,7 +76,7 @@ for file in "$@"; do
 done
 
 if [ "$workspace" -eq 1 ]; then
-  set -- clippy --workspace --all-targets -- -D warnings
+  set -- clippy --workspace -- -D warnings
 elif [ -n "$packages" ]; then
   set -- clippy
   for package in $packages; do set -- "$@" --package "$package"; done

--- a/dev/scripts/clippy-staged.sh
+++ b/dev/scripts/clippy-staged.sh
@@ -17,8 +17,18 @@ seen=' '
 newline='
 '
 
-root_members=$(sed -n '/^members[[:space:]]*=[[:space:]]*\[/,/^]/p' Cargo.toml |
-  sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p')
+metadata=$(mktemp "${TMPDIR:-/tmp}/clippy-metadata.XXXXXX")
+members=$(mktemp "${TMPDIR:-/tmp}/clippy-members.XXXXXX")
+trap 'rm -f "$metadata" "$members"' EXIT HUP INT TERM
+if ! cargo metadata --no-deps --format-version 1 >"$metadata"; then
+  echo "Clippy: unable to determine Cargo workspace members" >&2
+  exit 1
+fi
+if ! node "$root/dev/scripts/clippy-workspace-metadata.mjs" \
+  <"$metadata" >"$members"; then
+  echo "Clippy: unable to parse Cargo workspace metadata" >&2
+  exit 1
+fi
 
 is_root_member_manifest() {
   manifest=$1
@@ -27,11 +37,8 @@ is_root_member_manifest() {
     *) manifest_abs=$root/$manifest ;;
   esac
   while IFS= read -r member; do
-    [ -n "$member" ] || continue
-    [ "$manifest_abs" = "$root/$member/Cargo.toml" ] && return 0
-  done <<EOF
-$root_members
-EOF
+    [ "$manifest_abs" = "$member" ] && return 0
+  done <"$members"
   return 1
 }
 

--- a/dev/scripts/clippy-staged.sh
+++ b/dev/scripts/clippy-staged.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Scoped clippy for Lefthook. The hook passes {staged_files}, so this script
+# can invoke Cargo directly without Node spawning git/cargo (some restricted
+# shells reject child_process.spawnSync even though direct commands work).
+set -eu
+
+# Lefthook runs commands from the repository root. Keeping the fallback as the
+# current directory means this hook has no child-process dependency at all;
+# callers invoking it elsewhere can set JAZZ_REPO_ROOT explicitly.
+root=${JAZZ_REPO_ROOT:-.}
+cd "$root"
+packages=""
+workspace=0
+seen=' '
+
+for file in "$@"; do
+  case "$file" in
+    *.rs|*/Cargo.toml|Cargo.toml) : ;;
+    *) continue ;;
+  esac
+  path=$file
+  case "$path" in ./*) path=${path#./} ;; esac
+  if [ "$path" = Cargo.toml ]; then workspace=1; break; fi
+  directory=$(dirname "$path")
+  while :; do
+    manifest=$directory/Cargo.toml
+    if [ -f "$manifest" ]; then
+      package=$(sed -n 's/^name[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' "$manifest" | head -n 1)
+      if [ -z "$package" ]; then
+        workspace=1
+      elif case "$seen" in *" $package "*) false ;; *) true ;; esac; then
+        packages="$packages $package"
+        seen="$seen$package "
+      fi
+      break
+    fi
+    [ "$directory" = . ] && { workspace=1; break; }
+    parent=$(dirname "$directory")
+    [ "$parent" = "$directory" ] && { workspace=1; break; }
+    directory=$parent
+  done
+done
+
+if [ "$workspace" -eq 1 ]; then
+  set -- clippy --workspace -- -D warnings
+else
+  [ -n "$packages" ] || { echo "Clippy: no staged Rust or Cargo.toml changes"; exit 0; }
+  set -- clippy
+  for package in $packages; do set -- "$@" --package "$package"; done
+  set -- "$@" -- -D warnings
+fi
+
+echo "Clippy: cargo $*"
+exec cargo "$@"

--- a/dev/scripts/clippy-staged.test.sh
+++ b/dev/scripts/clippy-staged.test.sh
@@ -29,17 +29,17 @@ log=$tmp/cargo.log
 output=$(PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml)
 
-grep -F -- '--workspace' "$log" >/dev/null
+grep -F -- '--workspace --all-targets' "$log" >/dev/null
 
 : >"$log"
 output=$(PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" \
     "dev/benchmarks/storage/native/file with spaces.rs")
-grep -F -- '--manifest-path dev/benchmarks/storage/native/Cargo.toml' "$log" >/dev/null
+grep -F -- '--workspace --all-targets' "$log" >/dev/null
 : >"$log"
 PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" examples/todo-server-rs/src/main.rs >/dev/null
-grep -F -- '--manifest-path examples/todo-server-rs/Cargo.toml' "$log" >/dev/null
+grep -F -- '--workspace --all-targets' "$log" >/dev/null
 if [ "$(grep -c -- '--package groove' "$log")" -ne 0 ]; then
   echo "root Cargo.toml must not be mixed with package mode" >&2
   exit 1

--- a/dev/scripts/clippy-staged.test.sh
+++ b/dev/scripts/clippy-staged.test.sh
@@ -13,6 +13,7 @@ EOF
 cat >"$tmp/cargo" <<'EOF'
 #!/bin/sh
 if [ "$1" = clippy ]; then
+  printf '%s\n' "$*" >> "${CLIPPY_TEST_LOG:?}"
   exit "${CLIPPY_TEST_EXIT:-0}"
 fi
 echo "unexpected cargo invocation: $*" >&2
@@ -20,11 +21,33 @@ exit 125
 EOF
 chmod +x "$tmp/git" "$tmp/cargo"
 
-PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" \
-  sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml >/dev/null
+log=$tmp/cargo.log
+output=$(PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+  sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml)
 
-if PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_EXIT=37 \
-  sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml >/dev/null 2>&1; then
+grep -F -- '--workspace' "$log" >/dev/null
+
+: >"$log"
+output=$(PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+  sh "$root/dev/scripts/clippy-staged.sh" \
+    "dev/benchmarks/storage/native/file with spaces.rs")
+grep -F -- '--manifest-path dev/benchmarks/storage/native/Cargo.toml' "$log" >/dev/null
+: >"$log"
+PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+  sh "$root/dev/scripts/clippy-staged.sh" examples/todo-server-rs/src/main.rs >/dev/null
+grep -F -- '--manifest-path examples/todo-server-rs/Cargo.toml' "$log" >/dev/null
+if [ "$(grep -c -- '--package groove' "$log")" -ne 0 ]; then
+  echo "root Cargo.toml must not be mixed with package mode" >&2
+  exit 1
+fi
+
+: >"$log"
+output=$(PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+  sh "$root/dev/scripts/clippy-staged.sh" crates/groove/removed.rs crates/groove/renamed.rs)
+[ "$(grep -c -- '--package groove' "$log")" -eq 1 ]
+
+if PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" CLIPPY_TEST_EXIT=37 \
+  sh "$root/dev/scripts/clippy-staged.sh" crates/groove/removed.rs >/dev/null 2>&1; then
   echo "expected cargo failure to propagate" >&2
   exit 1
 elif [ "$?" -ne 37 ]; then

--- a/dev/scripts/clippy-staged.test.sh
+++ b/dev/scripts/clippy-staged.test.sh
@@ -2,6 +2,7 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+real_cargo=$(command -v cargo)
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/clippy-staged-test.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
@@ -16,24 +17,27 @@ if [ "$1" = clippy ]; then
   printf '%s\n' "$*" >> "${CLIPPY_TEST_LOG:?}"
   exit "${CLIPPY_TEST_EXIT:-0}"
 fi
+if [ "$1" = metadata ]; then
+  exec "${REAL_CARGO:?}" "$@"
+fi
 echo "unexpected cargo invocation: $*" >&2
 exit 125
 EOF
 chmod +x "$tmp/git" "$tmp/cargo"
 
 log=$tmp/cargo.log
-output=$(PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+output=$(PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml)
 
 grep -F -- '--workspace' "$log" >/dev/null
 
 : >"$log"
-output=$(PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+output=$(PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" \
     "dev/benchmarks/storage/native/file with spaces.rs")
 grep -F -- '--manifest-path dev/benchmarks/storage/native/Cargo.toml' "$log" >/dev/null
 : >"$log"
-PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" examples/todo-server-rs/src/main.rs >/dev/null
 grep -F -- '--manifest-path examples/todo-server-rs/Cargo.toml' "$log" >/dev/null
 if [ "$(grep -c -- '--package groove' "$log")" -ne 0 ]; then
@@ -42,11 +46,11 @@ if [ "$(grep -c -- '--package groove' "$log")" -ne 0 ]; then
 fi
 
 : >"$log"
-output=$(PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
+output=$(PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" crates/groove/removed.rs crates/groove/renamed.rs)
 [ "$(grep -c -- '--package groove' "$log")" -eq 1 ]
 
-if PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" CLIPPY_TEST_EXIT=37 \
+if PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" CLIPPY_TEST_EXIT=37 \
   sh "$root/dev/scripts/clippy-staged.sh" crates/groove/removed.rs >/dev/null 2>&1; then
   echo "expected cargo failure to propagate" >&2
   exit 1

--- a/dev/scripts/clippy-staged.test.sh
+++ b/dev/scripts/clippy-staged.test.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/clippy-staged-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+cat >"$tmp/git" <<'EOF'
+#!/bin/sh
+# Simulate a restricted child process: the hook must not need this executable.
+exit 126
+EOF
+cat >"$tmp/cargo" <<'EOF'
+#!/bin/sh
+if [ "$1" = clippy ]; then
+  exit "${CLIPPY_TEST_EXIT:-0}"
+fi
+echo "unexpected cargo invocation: $*" >&2
+exit 125
+EOF
+chmod +x "$tmp/git" "$tmp/cargo"
+
+PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" \
+  sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml >/dev/null
+
+if PATH="$tmp:$PATH" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_EXIT=37 \
+  sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml >/dev/null 2>&1; then
+  echo "expected cargo failure to propagate" >&2
+  exit 1
+elif [ "$?" -ne 37 ]; then
+  echo "cargo failure was not propagated" >&2
+  exit 1
+fi
+
+echo "clippy-staged hook tests passed"

--- a/dev/scripts/clippy-staged.test.sh
+++ b/dev/scripts/clippy-staged.test.sh
@@ -29,17 +29,17 @@ log=$tmp/cargo.log
 output=$(PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" Cargo.toml)
 
-grep -F -- '--workspace --all-targets' "$log" >/dev/null
+grep -F -- '--workspace --' "$log" >/dev/null
 
 : >"$log"
 output=$(PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" \
     "dev/benchmarks/storage/native/file with spaces.rs")
-grep -F -- '--workspace --all-targets' "$log" >/dev/null
+grep -F -- '--workspace --' "$log" >/dev/null
 : >"$log"
 PATH="$tmp:$PATH" REAL_CARGO="$real_cargo" JAZZ_REPO_ROOT="$root" CLIPPY_TEST_LOG="$log" \
   sh "$root/dev/scripts/clippy-staged.sh" examples/todo-server-rs/src/main.rs >/dev/null
-grep -F -- '--workspace --all-targets' "$log" >/dev/null
+grep -F -- '--workspace --' "$log" >/dev/null
 if [ "$(grep -c -- '--package groove' "$log")" -ne 0 ]; then
   echo "root Cargo.toml must not be mixed with package mode" >&2
   exit 1

--- a/dev/scripts/clippy-workspace-metadata.mjs
+++ b/dev/scripts/clippy-workspace-metadata.mjs
@@ -1,0 +1,10 @@
+// Read Cargo's already-computed metadata from stdin and print the manifest
+// paths of actual workspace members. Keeping JSON parsing here avoids trying
+// to duplicate Cargo's workspace/glob/exclude semantics in POSIX shell.
+import { readFileSync } from "node:fs";
+
+const metadata = JSON.parse(readFileSync(0, "utf8"));
+const members = new Set(metadata.workspace_members);
+for (const pkg of metadata.packages) {
+  if (members.has(pkg.id)) console.log(pkg.manifest_path);
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,10 @@ pre-commit:
         - "*.rs"
         - "Cargo.toml"
         - "**/Cargo.toml"
-      run: node dev/scripts/clippy-staged.mjs
+      # `{staged_files}` is the exact staged-file list already computed by
+      # Lefthook. The native shell wrapper invokes Cargo directly, avoiding
+      # Node child_process spawns that restricted shells may reject.
+      run: sh dev/scripts/clippy-staged.sh {staged_files}
     oxfmt:
       glob: "*.{ts,tsx,js,jsx,md,mdx,json,html}"
       exclude: "{dev/benchmarks/SMOKE_LEDGER.md,crates/jazz-napi/index.d.ts}"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "format:check": "oxfmt --check --ignore-path .oxfmtignore . && cargo fmt --check",
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
     "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
+    "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
     "ensure:rust-toolchain": "rustup target add wasm32-unknown-unknown && (wasm-pack --version >/dev/null 2>&1 || cargo install wasm-pack@0.13.1 --locked)",
     "build:vercel-docs": "bash dev/scripts/install-vercel-deps.sh && turbo run --env-mode=loose build:crates --filter=@jazz/rust && turbo run --env-mode=loose build --filter=docs --only",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "format": "oxfmt --ignore-path .oxfmtignore .",
     "format:check": "oxfmt --check --ignore-path .oxfmtignore . && cargo fmt --check",
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
+    "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
     "ensure:rust-toolchain": "rustup target add wasm32-unknown-unknown && (wasm-pack --version >/dev/null 2>&1 || cargo install wasm-pack@0.13.1 --locked)",
     "build:vercel-docs": "bash dev/scripts/install-vercel-deps.sh && turbo run --env-mode=loose build:crates --filter=@jazz/rust && turbo run --env-mode=loose build --filter=docs --only",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",


### PR DESCRIPTION
🤖 ## What changed

- Replaces the staged-Clippy hook's Node child-process orchestration with a portable shell runner that invokes Cargo directly.
- Uses Cargo metadata to map staged Rust files to actual workspace members.
- Runs scoped package Clippy for members and preserves the existing workspace fallback for standalone or excluded paths.
- Keeps exact staged-file quoting, deduplication, exit propagation, formatting, and sensitive-data behavior.

## Why

The previous hook repeatedly failed with `spawnSync git EPERM` in restricted shells, forcing manual duplicate checks and `--no-verify` commits. The new path avoids spawning Git from Node while remaining portable across ordinary macOS/Linux development and CI.

## Validation

- Independent adversarial review: no P0/P1/P2.
- Fast tooling tests cover members, standalone/excluded paths, deletes/renames, spaces, deduplication, and failure propagation.
- Real-Cargo tests verify workspace metadata mapping, scoped member Clippy, and the exact legacy workspace fallback.
- Lefthook validation, shell syntax, formatting, and sensitive-data checks passed.
