### PR TITLE
fix: restore browser websocket authority sessions

### DIFF
--- a/crates/jazz-napi/Cargo.toml
+++ b/crates/jazz-napi/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 jazz = { path = "../jazz", default-features = false, features = ["test-utils", "otel-core"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 base64 = "0.22"
-napi = { version = "3", features = ["napi5", "serde-json", "async"] }
+napi = { version = "3", features = ["napi6", "serde-json", "async"] }
 napi-derive = "3"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 postcard = { version = "1.1", features = ["alloc"] }

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -59,7 +59,7 @@ export declare class NapiDb {
   restoreEncodedForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
   tick(): void
   connectUpstream(): Transport
-  connectUpstreamWithSession(protocolVersion: number, features: number, remoteNode: Buffer, remoteEpoch: number, localNode: Buffer, localEpoch: number): Transport
+  connectUpstreamWithSession(protocolVersion: number, features: number, remoteNode: Buffer, remoteEpoch: bigint, localNode: Buffer, localEpoch: bigint): Transport
   mergeableTx(openBatchId: string): Tx
   mergeableTxForIdentity(openBatchId: string, author: Uint8Array): Tx
   close(): void

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -59,6 +59,7 @@ export declare class NapiDb {
   restoreEncodedForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
   tick(): void
   connectUpstream(): Transport
+  connectUpstreamWithSession(protocolVersion: number, features: number, remoteNode: Buffer, remoteEpoch: number, localNode: Buffer, localEpoch: number): Transport
   mergeableTx(openBatchId: string): Tx
   mergeableTxForIdentity(openBatchId: string, author: Uint8Array): Tx
   close(): void

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2779,7 +2779,11 @@ mod tests {
         };
         let near_safe_integer = BigInt {
             sign_bit: false,
-            words: vec![9_007_199_254_740_992],
+            words: vec![9_007_199_254_740_993],
+        };
+        let maximum_u64 = BigInt {
+            sign_bit: false,
+            words: vec![u64::MAX],
         };
         assert_eq!(
             authority_epoch_from_bigint(above_u32, "authority").unwrap(),
@@ -2787,7 +2791,11 @@ mod tests {
         );
         assert_eq!(
             authority_epoch_from_bigint(near_safe_integer, "authority").unwrap(),
-            9_007_199_254_740_992
+            9_007_199_254_740_993
+        );
+        assert_eq!(
+            authority_epoch_from_bigint(maximum_u64, "authority").unwrap(),
+            u64::MAX
         );
         assert!(
             authority_epoch_from_bigint(

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1637,9 +1637,19 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let queues = WireQueues::default();
-        let transport = Box::new(CoreWireTransportAdapter::current(NapiWireTransport {
-            queues: queues.clone(),
-        }));
+        // The JS WebSocket carrier has no authenticated endpoint context for
+        // scoped receipt/view frames. Keep this upstream transport aligned
+        // with its authority-unbound Hello until such a context is plumbed.
+        let transport = Box::new(CoreWireTransportAdapter::new(
+            NapiWireTransport {
+                queues: queues.clone(),
+            },
+            jazz::wire::WIRE_PROTOCOL_VERSION,
+            jazz::wire::current_wire_features()
+                & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
+                    | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
+            None,
+        ));
         let inner = match db {
             NapiDbInnerStorage::Memory(db) => NapiTransportInner::Memory {
                 db: Rc::clone(db),

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1673,9 +1673,9 @@ impl NapiDb {
         protocol_version: u16,
         features: u32,
         remote_node: Buffer,
-        remote_epoch: u32,
+        remote_epoch: BigInt,
         local_node: Buffer,
-        local_epoch: u32,
+        local_epoch: BigInt,
     ) -> napi::Result<Transport> {
         let remote_node: [u8; 16] = remote_node.as_ref().try_into().map_err(|_| {
             napi::Error::from_reason("server hello authority node must be 16 bytes")
@@ -1684,6 +1684,9 @@ impl NapiDb {
             .as_ref()
             .try_into()
             .map_err(|_| napi::Error::from_reason("local peer identity must be 16 bytes"))?;
+        let remote_epoch =
+            authority_epoch_from_bigint(remote_epoch, "server hello authority epoch")?;
+        let local_epoch = authority_epoch_from_bigint(local_epoch, "local connection epoch")?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
@@ -1692,11 +1695,11 @@ impl NapiDb {
         let session_context = CoreConnectionSessionContext {
             local: CoreWireAuthorityEndpoint {
                 node: CoreNodeUuid::from_bytes(local_node),
-                epoch: local_epoch as u64,
+                epoch: local_epoch,
             },
             remote: CoreWireAuthorityEndpoint {
                 node: CoreNodeUuid::from_bytes(remote_node),
-                epoch: remote_epoch as u64,
+                epoch: remote_epoch,
             },
             link_identity: CoreAuthorId::from_bytes(local_node),
             negotiated_features: features as u64,
@@ -1812,6 +1815,16 @@ impl NapiDb {
         }
         Ok(())
     }
+}
+
+fn authority_epoch_from_bigint(value: BigInt, label: &str) -> napi::Result<u64> {
+    let (negative, epoch, lossless) = value.get_u64();
+    if negative || !lossless {
+        return Err(napi::Error::from_reason(format!(
+            "{label} must be an unsigned 64-bit integer"
+        )));
+    }
+    Ok(epoch)
 }
 
 fn decode_core_open_args(
@@ -2738,8 +2751,8 @@ mod tests {
     use std::rc::Rc;
 
     use crate::{
-        NapiDbInnerStorage, NapiTxKind, Tx, core_block_on, core_read_opts_from_json,
-        core_subscription_event_to_json, encode_core_subscription_delta,
+        NapiDbInnerStorage, NapiTxKind, Tx, authority_epoch_from_bigint, core_block_on,
+        core_read_opts_from_json, core_subscription_event_to_json, encode_core_subscription_delta,
     };
     use jazz::db::{
         Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,
@@ -2755,7 +2768,48 @@ mod tests {
     use jazz::tools::OpenBatchId as CoreOpenBatchId;
     use jazz::tools::{ColumnType, Schema, SchemaBuilder, TableName, TableSchema, Value};
     use jazz::tx::DurabilityTier;
+    use napi::bindgen_prelude::BigInt;
     use serde_json::json;
+
+    #[test]
+    fn authority_epoch_bigint_rejects_lossy_values_and_preserves_u64() {
+        let above_u32 = BigInt {
+            sign_bit: false,
+            words: vec![u32::MAX as u64 + 1],
+        };
+        let near_safe_integer = BigInt {
+            sign_bit: false,
+            words: vec![9_007_199_254_740_992],
+        };
+        assert_eq!(
+            authority_epoch_from_bigint(above_u32, "authority").unwrap(),
+            u32::MAX as u64 + 1
+        );
+        assert_eq!(
+            authority_epoch_from_bigint(near_safe_integer, "authority").unwrap(),
+            9_007_199_254_740_992
+        );
+        assert!(
+            authority_epoch_from_bigint(
+                BigInt {
+                    sign_bit: true,
+                    words: vec![1],
+                },
+                "authority",
+            )
+            .is_err()
+        );
+        assert!(
+            authority_epoch_from_bigint(
+                BigInt {
+                    sign_bit: false,
+                    words: vec![0, 1],
+                },
+                "authority",
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn native_delta_preserves_typed_union_occurrence_keys() {

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -42,7 +42,8 @@ use std::time::Duration;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jazz::db::{
-    Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,
+    ConnectionSessionContext as CoreConnectionSessionContext, Db as CoreDb,
+    DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,
     InitialSyncFlushCadence as CoreInitialSyncFlushCadence, LocalUpdates as CoreLocalUpdates,
     MergeableTxOps, PeerConnection as CorePeerConnection, PreparedQuery as PreparedQueryInner,
     Propagation as CorePropagation, QueryAttachment as CoreQueryAttachment,
@@ -72,7 +73,10 @@ use jazz::tools::server::{
 };
 use jazz::tools::{AppId, BatchId};
 use jazz::tx::{DurabilityTier as CoreDurabilityTier, Fate as CoreFate, TxId};
-use jazz::wire::{TransportError, WireTransport as CoreWireTransport};
+use jazz::wire::{
+    TransportError, WireAuthorityEndpoint as CoreWireAuthorityEndpoint,
+    WireTransport as CoreWireTransport,
+};
 
 #[derive(Clone, Debug, Deserialize)]
 struct CoreOpenDbConfig {
@@ -1649,6 +1653,62 @@ impl NapiDb {
                 & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
                     | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
             None,
+        ));
+        let inner = match db {
+            NapiDbInnerStorage::Memory(db) => NapiTransportInner::Memory {
+                db: Rc::clone(db),
+                connection: Some(db.connect_upstream(transport)),
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiTransportInner::Persistent {
+                db: Rc::clone(db),
+                connection: Some(db.connect_upstream(transport)),
+            },
+        };
+        Ok(Transport { inner, queues })
+    }
+
+    #[napi(js_name = "connectUpstreamWithSession")]
+    pub fn connect_upstream_with_session(
+        &self,
+        protocol_version: u16,
+        features: u32,
+        remote_node: Buffer,
+        remote_epoch: u32,
+        local_node: Buffer,
+        local_epoch: u32,
+    ) -> napi::Result<Transport> {
+        let remote_node: [u8; 16] = remote_node.as_ref().try_into().map_err(|_| {
+            napi::Error::from_reason("server hello authority node must be 16 bytes")
+        })?;
+        let local_node: [u8; 16] = local_node
+            .as_ref()
+            .try_into()
+            .map_err(|_| napi::Error::from_reason("local peer identity must be 16 bytes"))?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let queues = WireQueues::default();
+        let session_context = CoreConnectionSessionContext {
+            local: CoreWireAuthorityEndpoint {
+                node: CoreNodeUuid::from_bytes(local_node),
+                epoch: local_epoch as u64,
+            },
+            remote: CoreWireAuthorityEndpoint {
+                node: CoreNodeUuid::from_bytes(remote_node),
+                epoch: remote_epoch as u64,
+            },
+            link_identity: CoreAuthorId::from_bytes(local_node),
+            negotiated_features: features as u64,
+        };
+        let transport = Box::new(CoreWireTransportAdapter::new_with_session_context(
+            NapiWireTransport {
+                queues: queues.clone(),
+            },
+            protocol_version,
+            features as u64,
+            None,
+            Some(session_context),
         ));
         let inner = match db {
             NapiDbInnerStorage::Memory(db) => NapiTransportInner::Memory {

--- a/crates/jazz-sim/benches/s2_canvas.rs
+++ b/crates/jazz-sim/benches/s2_canvas.rs
@@ -21,6 +21,7 @@ use jazz::schema::{JazzSchema, Policy, TableSchema};
 use jazz::time::GlobalSeq;
 use jazz::tx::{DurabilityTier, Fate};
 use jazz_sim::distributions::Lcg;
+use jazz_sim::view_accounting::{bytes_floor, view_update_bytes};
 use jazz_sim::{
     DeterministicDriver, DriverContext, Metrics, NodeRole, PeerProfile, SimulatorTransportCodec,
     ThreadedDriver, Topology, bench_profile, emit_json_line, loopback_transport_message, mem,
@@ -2532,96 +2533,6 @@ fn is_ancestor(
         }
     }
     false
-}
-
-fn view_update_bytes(update: &SyncMessage) -> u64 {
-    match update {
-        SyncMessage::ViewUpdate {
-            version_bundles,
-            peer_payload_inventory,
-            result_member_adds,
-            result_member_removes,
-            ..
-        } => {
-            version_bundles
-                .iter()
-                .map(version_bundle_bytes)
-                .sum::<u64>()
-                + (peer_payload_inventory.complete_tx_payloads.len() as u64 * tx_id_wire_bytes())
-                + result_rows_bytes(result_member_adds)
-                + result_rows_bytes(result_member_removes)
-        }
-        SyncMessage::CommitUnit { tx, versions } => {
-            transaction_wire_bytes(tx) + versions.iter().map(version_record_bytes).sum::<u64>()
-        }
-        SyncMessage::FateUpdate { .. } => tx_id_wire_bytes() + 16,
-        SyncMessage::ContentExtents { extents } => {
-            extents.iter().map(|extent| extent.bytes.len() as u64).sum()
-        }
-        SyncMessage::BranchMetadata(_)
-        | SyncMessage::FetchBranchMetadata { .. }
-        | SyncMessage::RegisterShape { .. }
-        | SyncMessage::Subscribe(_)
-        | SyncMessage::PublishSchema { .. }
-        | SyncMessage::PublishSchemaWithLens { .. }
-        | SyncMessage::PublishLens { .. }
-        | SyncMessage::SetCurrentWriteSchema { .. }
-        | SyncMessage::CatalogueAck(_)
-        | SyncMessage::FetchContentExtent { .. }
-        | SyncMessage::SessionClaims { .. }
-        | SyncMessage::SubscribeRejected { .. }
-        | SyncMessage::Unsubscribe { .. }
-        | SyncMessage::FetchRowVersions { .. }
-        | SyncMessage::RowVersionPayloads { .. }
-        | SyncMessage::CatalogueSnapshot(_) => 0,
-    }
-}
-
-fn bytes_floor(update: &SyncMessage) -> u64 {
-    match update {
-        SyncMessage::ViewUpdate {
-            version_bundles, ..
-        } => version_bundles
-            .iter()
-            .flat_map(|bundle| &bundle.versions)
-            .map(version_record_bytes)
-            .sum(),
-        _ => 0,
-    }
-}
-
-fn version_bundle_bytes(bundle: &jazz::protocol::VersionBundle) -> u64 {
-    transaction_wire_bytes(&bundle.tx)
-        + bundle
-            .versions
-            .iter()
-            .map(version_record_bytes)
-            .sum::<u64>()
-        + 16
-}
-
-fn version_record_bytes(version: &jazz::protocol::VersionRecord) -> u64 {
-    version.table().len() as u64 + version.record().raw().len() as u64
-}
-
-fn transaction_wire_bytes(tx: &jazz::tx::Transaction) -> u64 {
-    tx_id_wire_bytes()
-        + 4
-        + 16
-        + tx.user_metadata_json
-            .as_ref()
-            .map_or(0, |metadata| metadata.len() as u64)
-}
-
-fn result_rows_bytes(rows: &[jazz::protocol::ResultMemberEntry]) -> u64 {
-    rows.iter()
-        .filter_map(|entry| entry.as_row())
-        .map(|(table, _, _)| table.len() as u64 + 16 + tx_id_wire_bytes())
-        .sum()
-}
-
-fn tx_id_wire_bytes() -> u64 {
-    8 + 16
 }
 
 fn result_output_count(update: &SyncMessage, table: &str) -> usize {

--- a/crates/jazz-sim/src/lib.rs
+++ b/crates/jazz-sim/src/lib.rs
@@ -5,6 +5,7 @@ pub mod fixture;
 pub mod mem;
 pub mod policy_graph_fixture;
 pub mod profiling;
+pub mod view_accounting;
 
 use hdrhistogram::Histogram;
 use jazz::protocol::SyncMessage;

--- a/crates/jazz-sim/src/view_accounting.rs
+++ b/crates/jazz-sim/src/view_accounting.rs
@@ -1,0 +1,208 @@
+//! Shared simulation accounting for sync-message row delivery payloads.
+
+use jazz::protocol::{ResultMemberEntry, SyncMessage, VersionBundle, VersionRecord};
+use jazz::tx::Transaction;
+
+/// Estimate row-delivery bytes carried by a sync message.
+pub fn view_update_bytes(update: &SyncMessage) -> u64 {
+    match update {
+        SyncMessage::ViewUpdate {
+            version_bundles,
+            peer_payload_inventory,
+            result_member_adds,
+            result_member_removes,
+            ..
+        } => {
+            version_bundles
+                .iter()
+                .map(version_bundle_bytes)
+                .sum::<u64>()
+                + (peer_payload_inventory.complete_tx_payloads.len() as u64 * tx_id_wire_bytes())
+                + result_rows_bytes(result_member_adds)
+                + result_rows_bytes(result_member_removes)
+        }
+        SyncMessage::CommitUnit { tx, versions } => {
+            transaction_wire_bytes(tx) + versions.iter().map(version_record_bytes).sum::<u64>()
+        }
+        SyncMessage::FateUpdate { .. } => tx_id_wire_bytes() + 16,
+        SyncMessage::ContentExtents { extents } => {
+            extents.iter().map(|extent| extent.bytes.len() as u64).sum()
+        }
+        // An authority scope view carries an ordinary settlement-bearing view
+        // update. Its row payload is part of the simulated delivery cost.
+        SyncMessage::AuthorizationScopeView { view, .. } => view_update_bytes(view),
+        SyncMessage::BranchMetadata(_)
+        | SyncMessage::FetchBranchMetadata { .. }
+        | SyncMessage::RegisterShape { .. }
+        | SyncMessage::Subscribe(_)
+        | SyncMessage::PublishSchema { .. }
+        | SyncMessage::PublishSchemaWithLens { .. }
+        | SyncMessage::PublishLens { .. }
+        | SyncMessage::SetCurrentWriteSchema { .. }
+        | SyncMessage::CatalogueAck(_)
+        | SyncMessage::FetchContentExtent { .. }
+        | SyncMessage::SessionClaims { .. }
+        | SyncMessage::SubscribeRejected { .. }
+        | SyncMessage::Unsubscribe { .. }
+        | SyncMessage::FetchRowVersions { .. }
+        | SyncMessage::RowVersionPayloads { .. }
+        | SyncMessage::CatalogueSnapshot(_)
+        | SyncMessage::PermissionAdviceRequest { .. }
+        | SyncMessage::PermissionAdviceResponse { .. }
+        | SyncMessage::AuthorizationScopeSubscribe { .. }
+        | SyncMessage::AuthorizationScopeReceipt { .. }
+        | SyncMessage::AuthorizationScopeIntent { .. }
+        | SyncMessage::AuthorizationScopeAggregateReceipt { .. }
+        | SyncMessage::AuthorizationScopeUnavailable { .. }
+        | SyncMessage::AuthorizationScopeDecision { .. } => 0,
+    }
+}
+
+/// Estimate the irreducible row-version payload bytes carried by a sync message.
+pub fn bytes_floor(update: &SyncMessage) -> u64 {
+    match update {
+        SyncMessage::ViewUpdate {
+            version_bundles, ..
+        } => version_bundles
+            .iter()
+            .flat_map(|bundle| &bundle.versions)
+            .map(version_record_bytes)
+            .sum(),
+        SyncMessage::AuthorizationScopeView { view, .. } => bytes_floor(view),
+        _ => 0,
+    }
+}
+
+fn version_bundle_bytes(bundle: &VersionBundle) -> u64 {
+    transaction_wire_bytes(&bundle.tx)
+        + bundle
+            .versions
+            .iter()
+            .map(version_record_bytes)
+            .sum::<u64>()
+        + 16
+}
+
+fn version_record_bytes(version: &VersionRecord) -> u64 {
+    version.table().len() as u64 + version.record().raw().len() as u64
+}
+
+fn transaction_wire_bytes(tx: &Transaction) -> u64 {
+    tx_id_wire_bytes()
+        + 4
+        + 16
+        + tx.user_metadata_json
+            .as_ref()
+            .map_or(0, |metadata| metadata.len() as u64)
+}
+
+fn result_rows_bytes(rows: &[ResultMemberEntry]) -> u64 {
+    rows.iter()
+        .filter_map(|entry| entry.as_row())
+        .map(|(table, _, _)| table.len() as u64 + 16 + tx_id_wire_bytes())
+        .sum()
+}
+
+fn tx_id_wire_bytes() -> u64 {
+    8 + 16
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use jazz::groove::records::Value;
+    use jazz::groove::schema::ColumnType;
+    use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+    use jazz::protocol::{
+        AuthorizationSupportScopeKey, PeerPayloadInventory, PermissionAdviceRequestId, ReadViewKey,
+        SubscriptionKey,
+    };
+    use jazz::query::{BindingId, ShapeId};
+    use jazz::schema::{ColumnSchema, JazzSchema, TableSchema};
+    use jazz::time::{GlobalSeq, TxTime};
+    use jazz::tx::{BranchLineage, DurabilityTier, Fate, Transaction, TxId, TxKind};
+
+    use super::*;
+
+    // This is necessarily internal: accounting helpers measure simulation
+    // instrumentation, not public database behavior.
+    #[test]
+    fn authorization_scope_view_accounts_for_nested_payload_and_floor() {
+        let tx_id = TxId::new(TxTime::new(1, 0), NodeUuid(uuid::Uuid::nil()));
+        let schema = JazzSchema::new([TableSchema::new(
+            "items",
+            [ColumnSchema::new("name", ColumnType::String)],
+        )]);
+        let version = VersionRecord::from_cells(
+            &schema.tables[0],
+            schema.version_id(),
+            RowUuid(uuid::Uuid::nil()),
+            Vec::new(),
+            AuthorId(uuid::Uuid::nil()),
+            tx_id.time,
+            AuthorId(uuid::Uuid::nil()),
+            tx_id.time,
+            &BTreeMap::<String, Value>::from([("name".to_owned(), Value::String("value".into()))]),
+            None,
+        )
+        .expect("valid test wire record");
+        let nested = SyncMessage::ViewUpdate {
+            subscription: SubscriptionKey {
+                shape_id: ShapeId(uuid::Uuid::nil()),
+                binding_id: BindingId(uuid::Uuid::nil()),
+                read_view: ReadViewKey::default(),
+            },
+            settled_through: GlobalSeq::default(),
+            reset_result_set: false,
+            version_carriers: Vec::new(),
+            version_bundles: vec![VersionBundle {
+                tx: Transaction {
+                    tx_id,
+                    kind: TxKind::Mergeable,
+                    n_total_writes: 1,
+                    made_by: AuthorId(uuid::Uuid::nil()),
+                    permission_subject: None,
+                    base_snapshot: None,
+                    row_read_set: None,
+                    absent_read_set: None,
+                    predicate_read_set: None,
+                    user_metadata_json: None,
+                    target_lineage: BranchLineage::Root,
+                    branch_merge: None,
+                    merge_strategy: None,
+                },
+                versions: vec![version],
+                fate: Fate::Accepted,
+                global_seq: Some(GlobalSeq(1)),
+                durability: DurabilityTier::Global,
+            }],
+            peer_payload_inventory: PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        };
+        let nested_bytes = view_update_bytes(&nested);
+        let nested_floor = bytes_floor(&nested);
+        assert!(nested_bytes > 0);
+        assert!(nested_floor > 0);
+
+        let wrapped = SyncMessage::AuthorizationScopeView {
+            request_id: PermissionAdviceRequestId([0; 16]),
+            key: AuthorizationSupportScopeKey {
+                support_shape_digest: [0; 32],
+                subject: AuthorId(uuid::Uuid::nil()),
+                claims_digest: [0; 32],
+                policy_digest: [0; 32],
+            },
+            clause_index: 0,
+            clause_count: 1,
+            view: Box::new(nested),
+        };
+
+        assert_eq!(view_update_bytes(&wrapped), nested_bytes);
+        assert_eq!(bytes_floor(&wrapped), nested_floor);
+    }
+}

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1971,9 +1971,9 @@ impl WasmDb {
         protocol_version: u16,
         features: u32,
         remote_node: Vec<u8>,
-        remote_epoch: u32,
+        remote_epoch: u64,
         local_node: Vec<u8>,
-        local_epoch: u32,
+        local_epoch: u64,
     ) -> Result<WasmTransport, JsValue> {
         let remote_node: [u8; 16] = remote_node
             .try_into()
@@ -1985,11 +1985,11 @@ impl WasmDb {
         let session_context = ConnectionSessionContext {
             local: WireAuthorityEndpoint {
                 node: NodeUuid::from_bytes(local_node),
-                epoch: local_epoch as u64,
+                epoch: local_epoch,
             },
             remote: WireAuthorityEndpoint {
                 node: NodeUuid::from_bytes(remote_node),
-                epoch: remote_epoch as u64,
+                epoch: remote_epoch,
             },
             link_identity: AuthorId::from_bytes(local_node),
             negotiated_features: features as u64,

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1933,9 +1933,20 @@ impl WasmDb {
     #[wasm_bindgen(js_name = connectUpstream)]
     pub fn connect_upstream(&self) -> Result<WasmTransport, JsValue> {
         let queues = WasmWireQueues::default();
-        let transport = Box::new(WireTransportAdapter::current(WasmWireTransport {
-            queues: queues.clone(),
-        }));
+        // Browser WebSocket carriers negotiate ordinary sync only. They do not
+        // receive the authenticated endpoint context required for scoped
+        // receipt/view frames, so their transport must not self-advertise
+        // those features before the carrier can bind that context.
+        let transport = Box::new(WireTransportAdapter::new(
+            WasmWireTransport {
+                queues: queues.clone(),
+            },
+            jazz::wire::WIRE_PROTOCOL_VERSION,
+            jazz::wire::current_wire_features()
+                & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
+                    | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
+            None,
+        ));
         let inner = match &self.inner {
             WasmDbInner::Memory(db) => WasmTransportInner::Memory {
                 db: Rc::clone(db),

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -7,10 +7,10 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use futures_util::{Stream, StreamExt};
 use jazz::db::{
-    block_on, Db, DbConfig, DbIdentity, ExclusiveTxOps, InitialSyncFlushCadence, LocalUpdates,
-    MergeableTxOps, PeerConnection, PermissionAdvice, PreparedQuery, Propagation, QueryAttachment,
-    ReadOpts, RowCells, SeededRowIdSource, SubscriptionEvent, TickScheduler, TickUrgency,
-    WireTransportAdapter, WriteHandle,
+    block_on, ConnectionSessionContext, Db, DbConfig, DbIdentity, ExclusiveTxOps,
+    InitialSyncFlushCadence, LocalUpdates, MergeableTxOps, PeerConnection, PermissionAdvice,
+    PreparedQuery, Propagation, QueryAttachment, ReadOpts, RowCells, SeededRowIdSource,
+    SubscriptionEvent, TickScheduler, TickUrgency, WireTransportAdapter, WriteHandle,
 };
 use jazz::groove::records::{BorrowedRecord, RecordDescriptor, Value};
 #[cfg(target_arch = "wasm32")]
@@ -22,7 +22,7 @@ use jazz::query::{Query, RelationExpr, RelationQuery};
 use jazz::schema::JazzSchema;
 use jazz::tools::{BatchId, OpenBatchId};
 use jazz::tx::{DurabilityTier, TxId};
-use jazz::wire::{TransportError, WireTransport};
+use jazz::wire::{TransportError, WireAuthorityEndpoint, WireTransport};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -1946,6 +1946,62 @@ impl WasmDb {
                 & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
                     | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
             None,
+        ));
+        let inner = match &self.inner {
+            WasmDbInner::Memory(db) => WasmTransportInner::Memory {
+                db: Rc::clone(db),
+                connection: Some(db.connect_upstream(transport)),
+            },
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => WasmTransportInner::Browser {
+                db: Rc::clone(db),
+                connection: Some(db.connect_upstream(transport)),
+            },
+            WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+        };
+        Ok(WasmTransport { inner, queues })
+    }
+
+    /// Connect after the browser carrier has accepted the server Hello. The
+    /// browser never asserts an authority endpoint itself; this context binds
+    /// the authority advertised by the authenticated server response.
+    #[wasm_bindgen(js_name = connectUpstreamWithSession)]
+    pub fn connect_upstream_with_session(
+        &self,
+        protocol_version: u16,
+        features: u32,
+        remote_node: Vec<u8>,
+        remote_epoch: u32,
+        local_node: Vec<u8>,
+        local_epoch: u32,
+    ) -> Result<WasmTransport, JsValue> {
+        let remote_node: [u8; 16] = remote_node
+            .try_into()
+            .map_err(|_| JsValue::from_str("server hello authority node must be 16 bytes"))?;
+        let local_node: [u8; 16] = local_node
+            .try_into()
+            .map_err(|_| JsValue::from_str("local peer identity must be 16 bytes"))?;
+        let queues = WasmWireQueues::default();
+        let session_context = ConnectionSessionContext {
+            local: WireAuthorityEndpoint {
+                node: NodeUuid::from_bytes(local_node),
+                epoch: local_epoch as u64,
+            },
+            remote: WireAuthorityEndpoint {
+                node: NodeUuid::from_bytes(remote_node),
+                epoch: remote_epoch as u64,
+            },
+            link_identity: AuthorId::from_bytes(local_node),
+            negotiated_features: features as u64,
+        };
+        let transport = Box::new(WireTransportAdapter::new_with_session_context(
+            WasmWireTransport {
+                queues: queues.clone(),
+            },
+            protocol_version,
+            features as u64,
+            None,
+            Some(session_context),
         ));
         let inner = match &self.inner {
             WasmDbInner::Memory(db) => WasmTransportInner::Memory {

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -564,6 +564,13 @@ async fn handle_ws_connection(
         let _ = socket.close().await;
         return;
     };
+    // Every admitted server link receives a fresh server endpoint. A browser
+    // client need not (and must not) self-assert one merely to learn which
+    // authority issued its downstream fates.
+    let server_endpoint = WireAuthorityEndpoint {
+        node: NodeUuid::from_bytes([0x5e; 16]),
+        epoch: WS_NEXT_CONNECTION_EPOCH.fetch_add(1, Ordering::Relaxed),
+    };
     let session_context = if negotiated.features
         & (crate::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
             | crate::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS)
@@ -572,10 +579,7 @@ async fn handle_ws_connection(
         remote_hello
             .authority
             .map(|remote| ConnectionSessionContext {
-                local: WireAuthorityEndpoint {
-                    node: NodeUuid::from_bytes([0x5e; 16]),
-                    epoch: WS_NEXT_CONNECTION_EPOCH.fetch_add(1, Ordering::Relaxed),
-                },
+                local: server_endpoint,
                 remote,
                 link_identity: admission.identity,
                 negotiated_features: negotiated.features,
@@ -604,11 +608,10 @@ async fn handle_ws_connection(
             return;
         }
     };
-    let server_hello = WireFrame::Hello(match session_context {
-        Some(context) => WireHello::current(WirePeerRole::Core, negotiated.features)
-            .with_authority(context.local.node, context.local.epoch),
-        None => WireHello::current(WirePeerRole::Core, negotiated.features),
-    });
+    let server_hello = WireFrame::Hello(
+        WireHello::current(WirePeerRole::Core, negotiated.features)
+            .with_authority(server_endpoint.node, server_endpoint.epoch),
+    );
     let server_hello = match encode_frame(&server_hello) {
         Ok(frame) => frame,
         Err(error) => {
@@ -1378,6 +1381,10 @@ mod tests {
             panic!("expected server hello");
         };
         assert_eq!(server_hello.role, WirePeerRole::Core);
+        assert!(
+            server_hello.authority.is_some(),
+            "an admitted server must bind its own downstream authority endpoint"
+        );
         ws
     }
 

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -518,7 +518,7 @@ async fn handle_ws_connection(
         return;
     };
 
-    let mut negotiated = match negotiate_wire(
+    let negotiated = match negotiate_wire(
         &remote_hello,
         WIRE_PROTOCOL_VERSION,
         WIRE_PROTOCOL_VERSION,
@@ -544,12 +544,11 @@ async fn handle_ws_connection(
             return;
         }
     };
-    // A receipt-capable peer must bind its endpoint in the admission hello.
-    // Old hellos retain ordinary sync but never negotiate receipt semantics.
-    if remote_hello.authority.is_none() {
-        negotiated.features &= !(crate::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
-            | crate::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS);
-    }
+    // A downstream browser may be authority-unbound while still accepting the
+    // server's authenticated authority in its response Hello.  The server
+    // never installs scoped authority semantics without an admitted remote
+    // endpoint (below), so this directional capability advertisement does not
+    // turn a client self-assertion into authority proof.
 
     let Some(core_server_shell) = state.core_server_shell() else {
         send_ws_error(
@@ -1476,15 +1475,14 @@ mod tests {
             .await
             .expect("open client db");
             let transport = TestWireTransport::default();
-            // The route-test hello intentionally has no authority endpoint,
-            // so the server correctly declines scoped receipt/view features.
-            // Keep the local adapter on that exact negotiated feature set.
+            // Match the authority-unbound test hello's negotiated features.
+            // Scoped semantics are not installed without an admitted remote
+            // endpoint, even though a browser may accept the server endpoint
+            // from its response Hello.
             db.connect_upstream(Box::new(WireTransportAdapter::new(
                 transport.clone(),
                 WIRE_PROTOCOL_VERSION,
-                current_wire_features()
-                    & !(crate::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
-                        | crate::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
+                FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS,
                 None,
             )));
             Self {

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -1469,7 +1469,17 @@ mod tests {
             .await
             .expect("open client db");
             let transport = TestWireTransport::default();
-            db.connect_upstream(Box::new(WireTransportAdapter::current(transport.clone())));
+            // The route-test hello intentionally has no authority endpoint,
+            // so the server correctly declines scoped receipt/view features.
+            // Keep the local adapter on that exact negotiated feature set.
+            db.connect_upstream(Box::new(WireTransportAdapter::new(
+                transport.clone(),
+                WIRE_PROTOCOL_VERSION,
+                current_wire_features()
+                    & !(crate::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
+                        | crate::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
+                None,
+            )));
             Self {
                 db,
                 transport,

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -691,15 +691,7 @@ pub fn negotiate_wire(
             ),
         ));
     }
-    let mut features = remote.features & local_features;
-    // Receipt semantics need a handshake-bound issuer epoch.  A peer that
-    // merely advertises the bit but cannot provide that endpoint is treated as
-    // old for this feature, so semantic receipt variants stay fail-closed.
-    if features & (FEATURE_AUTHORIZATION_SCOPE_RECEIPTS | FEATURE_AUTHORIZATION_SCOPE_VIEWS) != 0
-        && remote.authority.is_none()
-    {
-        features &= !(FEATURE_AUTHORIZATION_SCOPE_RECEIPTS | FEATURE_AUTHORIZATION_SCOPE_VIEWS);
-    }
+    let features = remote.features & local_features;
     Ok(WireNegotiated {
         protocol_version: max,
         features,
@@ -743,7 +735,8 @@ mod tests {
                     "min_protocol_version": 6,
                     "max_protocol_version": 6,
                     "features": 5,
-                    "role": "client"
+                    "role": "client",
+                    "authority": null
                 }
             })
         );
@@ -1344,15 +1337,20 @@ mod tests {
     }
 
     #[test]
-    fn receipt_feature_requires_handshake_bound_authority_endpoint() {
+    fn negotiation_keeps_directional_scope_capability_without_remote_authority() {
         let feature = FEATURE_AUTHORIZATION_SCOPE_RECEIPTS;
-        let old = WireHello::current(WirePeerRole::Core, feature);
+        let unbound = WireHello::current(WirePeerRole::Core, feature);
         assert_eq!(
-            negotiate_wire(&old, WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION, feature)
-                .unwrap()
-                .features
+            negotiate_wire(
+                &unbound,
+                WIRE_PROTOCOL_VERSION,
+                WIRE_PROTOCOL_VERSION,
+                feature
+            )
+            .unwrap()
+            .features
                 & feature,
-            0
+            feature
         );
         let accepted = WireHello::current(WirePeerRole::Core, feature)
             .with_authority(NodeUuid::from_bytes([0x71; 16]), 9);

--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -14,15 +14,24 @@ const commands = {
   },
   napi: {
     debug: ["pnpm", ["--dir", "crates/jazz-napi", "exec", "napi", "build", "--platform"]],
-    release: ["pnpm", ["--dir", "crates/jazz-napi", "exec", "napi", "build", "--platform", "--release"]],
+    release: [
+      "pnpm",
+      ["--dir", "crates/jazz-napi", "exec", "napi", "build", "--platform", "--release"],
+    ],
   },
 };
 const selected = commands[kind]?.[profile];
-if (!selected) throw new Error("usage: build.mjs <wasm fast|release|profiling | napi debug|release>");
+if (!selected)
+  throw new Error("usage: build.mjs <wasm fast|release|profiling | napi debug|release>");
 const [command, args] = selected;
-if (kind !== "napi" && extraArgs.length) throw new Error("only napi builds accept extra napi CLI arguments");
+if (kind !== "napi" && extraArgs.length)
+  throw new Error("only napi builds accept extra napi CLI arguments");
 args.push(...extraArgs);
-const result = spawnSync(command, args, { cwd: root, stdio: "inherit", shell: process.platform === "win32" });
+const result = spawnSync(command, args, {
+  cwd: root,
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
 if (result.error) throw result.error;
 if (result.status !== 0) process.exit(result.status ?? 1);
 const targetIndex = extraArgs.indexOf("--target");

--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -23,30 +23,45 @@ function toolVersion(root, name, args = ["--version"]) {
   const injected = process.env[toolEnvName(name)];
   if (injected) return injected;
   const command = name === "napi" ? "pnpm" : name;
-  const commandArgs = name === "napi" ? ["--dir", "crates/jazz-napi", "exec", "napi", ...args] : args;
-  const result = spawnSync(command, commandArgs, { cwd: root, encoding: "utf8", shell: process.platform === "win32" });
+  const commandArgs =
+    name === "napi" ? ["--dir", "crates/jazz-napi", "exec", "napi", ...args] : args;
+  const result = spawnSync(command, commandArgs, {
+    cwd: root,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
   if (result.status === 0) return result.stdout.trim() || result.stderr.trim();
-  if (name === "wasm-pack") return "unavailable: install wasm-pack (run pnpm ensure:rust-toolchain), then rebuild via pnpm --filter jazz-wasm build";
+  if (name === "wasm-pack")
+    return "unavailable: install wasm-pack (run pnpm ensure:rust-toolchain), then rebuild via pnpm --filter jazz-wasm build";
   return `unavailable: ${name} is not on PATH`;
 }
 
 function wasmPackToolVersion(root, name) {
   const direct = toolVersion(root, name);
   if (!direct.startsWith("unavailable:")) return direct;
-  if (process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE === "1") return `unavailable: ${name} is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build`;
-  const caches = [process.env.XDG_CACHE_HOME, join(homedir(), ".cache"), join(homedir(), "Library", "Caches")].filter(Boolean);
+  if (process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE === "1")
+    return `unavailable: ${name} is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build`;
+  const caches = [
+    process.env.XDG_CACHE_HOME,
+    join(homedir(), ".cache"),
+    join(homedir(), "Library", "Caches"),
+  ].filter(Boolean);
   const candidates = [];
   for (const cache of caches) {
     const wasmPackCache = join(cache, ".wasm-pack");
     if (!existsSync(wasmPackCache)) continue;
     for (const entry of readdirSync(wasmPackCache)) {
       if (!entry.startsWith(`${name}-`)) continue;
-      const executable = name === "wasm-opt" ? join(wasmPackCache, entry, "bin", name) : join(wasmPackCache, entry, name);
+      const executable =
+        name === "wasm-opt"
+          ? join(wasmPackCache, entry, "bin", name)
+          : join(wasmPackCache, entry, name);
       if (existsSync(executable)) candidates.push(executable);
     }
   }
   candidates.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
-  if (!candidates.length) return `unavailable: ${name} is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build`;
+  if (!candidates.length)
+    return `unavailable: ${name} is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build`;
   return toolVersion(root, candidates[0]);
 }
 
@@ -55,10 +70,11 @@ function files(root, paths) {
   const visit = (path) => {
     if (!existsSync(path)) return;
     const stat = statSync(path);
-    if (stat.isDirectory()) for (const name of readdirSync(path).sort()) {
-      if (["pkg", "target", "node_modules"].includes(name)) continue;
-      visit(join(path, name));
-    }
+    if (stat.isDirectory())
+      for (const name of readdirSync(path).sort()) {
+        if (["pkg", "target", "node_modules"].includes(name)) continue;
+        visit(join(path, name));
+      }
     else if (stat.isFile()) {
       const repoPath = relative(root, path);
       if (repoPath.endsWith(".node") || repoPath.endsWith(".jazz-artifact-manifest.json")) return;
@@ -70,17 +86,52 @@ function files(root, paths) {
 }
 
 const inputsFor = {
-  wasm: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "turbo.json", "dev/artifacts", "crates/jazz-wasm", "crates/jazz", "crates/groove", "crates/opfs-btree", "crates/wasm-tracing"],
-  napi: ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "turbo.json", "dev/artifacts", "crates/jazz-napi", "crates/jazz", "crates/groove", "crates/opfs-btree"],
+  wasm: [
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain.toml",
+    ".cargo/config",
+    ".cargo/config.toml",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "turbo.json",
+    "dev/artifacts",
+    "crates/jazz-wasm",
+    "crates/jazz",
+    "crates/groove",
+    "crates/opfs-btree",
+    "crates/wasm-tracing",
+  ],
+  napi: [
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain.toml",
+    ".cargo/config",
+    ".cargo/config.toml",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "turbo.json",
+    "dev/artifacts",
+    "crates/jazz-napi",
+    "crates/jazz",
+    "crates/groove",
+    "crates/opfs-btree",
+  ],
 };
 
 function artifactHashes(root, kind) {
-  const paths = kind === "wasm"
-    ? [join(root, "crates/jazz-wasm/pkg/jazz_wasm_bg.wasm")]
-    : readdirSync(join(root, "crates/jazz-napi"), { withFileTypes: true })
-      .filter((entry) => entry.isFile() && entry.name.endsWith(".node"))
-      .map((entry) => join(root, "crates/jazz-napi", entry.name));
-  return paths.filter(existsSync).sort().map((path) => ({ file: basename(path), sha256: sha256(readFileSync(path)) }));
+  const paths =
+    kind === "wasm"
+      ? [join(root, "crates/jazz-wasm/pkg/jazz_wasm_bg.wasm")]
+      : readdirSync(join(root, "crates/jazz-napi"), { withFileTypes: true })
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".node"))
+          .map((entry) => join(root, "crates/jazz-napi", entry.name));
+  return paths
+    .filter(existsSync)
+    .sort()
+    .map((path) => ({ file: basename(path), sha256: sha256(readFileSync(path)) }));
 }
 
 export function expectedManifest(root, kind, profile, targetOverride) {
@@ -88,11 +139,17 @@ export function expectedManifest(root, kind, profile, targetOverride) {
   const trackedInputs = files(root, inputsFor[kind]);
   const inputHash = createHash("sha256");
   for (const path of trackedInputs) {
-    inputHash.update(`${path}\0`).update(readFileSync(join(root, path))).update("\0");
+    inputHash
+      .update(`${path}\0`)
+      .update(readFileSync(join(root, path)))
+      .update("\0");
   }
   const cargoLock = join(root, "Cargo.lock");
   const toolchain = join(root, "rust-toolchain.toml");
-  const injectedGit = process.env.JAZZ_ARTIFACT_GIT_HEAD && process.env.JAZZ_ARTIFACT_GIT_TREE && process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF;
+  const injectedGit =
+    process.env.JAZZ_ARTIFACT_GIT_HEAD &&
+    process.env.JAZZ_ARTIFACT_GIT_TREE &&
+    process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF;
   const tools = {
     rustc: toolVersion(root, "rustc", ["-Vv"]),
     wasmPack: kind === "wasm" ? toolVersion(root, "wasm-pack") : "not-applicable",
@@ -105,51 +162,95 @@ export function expectedManifest(root, kind, profile, targetOverride) {
     kind,
     profile,
     git: {
-      head: injectedGit ? process.env.JAZZ_ARTIFACT_GIT_HEAD : run(root, "git", ["rev-parse", "HEAD"]),
-      tree: injectedGit ? process.env.JAZZ_ARTIFACT_GIT_TREE : run(root, "git", ["rev-parse", "HEAD^{tree}"]),
+      head: injectedGit
+        ? process.env.JAZZ_ARTIFACT_GIT_HEAD
+        : run(root, "git", ["rev-parse", "HEAD"]),
+      tree: injectedGit
+        ? process.env.JAZZ_ARTIFACT_GIT_TREE
+        : run(root, "git", ["rev-parse", "HEAD^{tree}"]),
       // Include staged, unstaged and untracked changes. A dirty build is valid
       // only for that exact dirty checkout, never merely for its HEAD commit.
-      dirtyDiff: injectedGit ? process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF : sha256(`${run(root, "git", ["diff", "--binary", "HEAD"])}\n${run(root, "git", ["status", "--porcelain=v1", "--untracked-files=all", "--", ".", ":(exclude)crates/jazz-wasm/pkg/.jazz-artifact-manifest.json", ":(exclude)crates/jazz-napi/.jazz-artifact-manifest.json"])}`),
+      dirtyDiff: injectedGit
+        ? process.env.JAZZ_ARTIFACT_GIT_DIRTY_DIFF
+        : sha256(
+            `${run(root, "git", ["diff", "--binary", "HEAD"])}\n${run(root, "git", ["status", "--porcelain=v1", "--untracked-files=all", "--", ".", ":(exclude)crates/jazz-wasm/pkg/.jazz-artifact-manifest.json", ":(exclude)crates/jazz-napi/.jazz-artifact-manifest.json"])}`,
+          ),
     },
     cargoLock: existsSync(cargoLock) ? sha256(readFileSync(cargoLock)) : "missing",
     rustToolchain: existsSync(toolchain) ? sha256(readFileSync(toolchain)) : "missing",
     tools,
     toolchainInputs: sha256(JSON.stringify(tools)),
-    target: targetOverride ?? (kind === "wasm" ? "wasm32-unknown-unknown" : toolVersion(root, "rustc", ["-vV"]).match(/^host: (.+)$/m)?.[1] ?? "unknown"),
+    target:
+      targetOverride ??
+      (kind === "wasm"
+        ? "wasm32-unknown-unknown"
+        : (toolVersion(root, "rustc", ["-vV"]).match(/^host: (.+)$/m)?.[1] ?? "unknown")),
     features: "default",
     packageInputs: inputHash.digest("hex"),
     artifacts: artifactHashes(root, kind),
   };
 }
 
-export const manifestPath = (root, kind) => join(root, kind === "wasm" ? "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json" : "crates/jazz-napi/.jazz-artifact-manifest.json");
+export const manifestPath = (root, kind) =>
+  join(
+    root,
+    kind === "wasm"
+      ? "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json"
+      : "crates/jazz-napi/.jazz-artifact-manifest.json",
+  );
 
 export function writeManifest(root, kind, profile, targetOverride) {
   const path = manifestPath(root, kind);
-  writeFileSync(path, `${JSON.stringify(expectedManifest(root, kind, profile, targetOverride), null, 2)}\n`);
+  writeFileSync(
+    path,
+    `${JSON.stringify(expectedManifest(root, kind, profile, targetOverride), null, 2)}\n`,
+  );
 }
 
 export function verifyManifest(root, kind, profile, targetOverride) {
   const path = manifestPath(root, kind);
   if (!existsSync(path)) return `manifest is missing (${path})`;
   let actual;
-  try { actual = JSON.parse(readFileSync(path, "utf8")); } catch { return `manifest is invalid (${path})`; }
+  try {
+    actual = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return `manifest is invalid (${path})`;
+  }
   const expected = expectedManifest(root, kind, profile, targetOverride);
-  for (const key of ["schema", "kind", "profile", "cargoLock", "rustToolchain", "toolchainInputs", "target", "features", "packageInputs", "artifacts"]) {
-    if (JSON.stringify(actual[key]) !== JSON.stringify(expected[key])) return `${key} differs (built ${JSON.stringify(actual[key])}, expected ${JSON.stringify(expected[key])})`;
+  for (const key of [
+    "schema",
+    "kind",
+    "profile",
+    "cargoLock",
+    "rustToolchain",
+    "toolchainInputs",
+    "target",
+    "features",
+    "packageInputs",
+    "artifacts",
+  ]) {
+    if (JSON.stringify(actual[key]) !== JSON.stringify(expected[key]))
+      return `${key} differs (built ${JSON.stringify(actual[key])}, expected ${JSON.stringify(expected[key])})`;
   }
   for (const key of ["rustc", "wasmPack", "wasmBindgen", "wasmOpt", "napi"]) {
-    if (actual.tools?.[key] !== expected.tools[key]) return `tools.${key} differs (built ${JSON.stringify(actual.tools?.[key])}, expected ${JSON.stringify(expected.tools[key])})`;
+    if (actual.tools?.[key] !== expected.tools[key])
+      return `tools.${key} differs (built ${JSON.stringify(actual.tools?.[key])}, expected ${JSON.stringify(expected.tools[key])})`;
   }
-  for (const key of ["head", "tree", "dirtyDiff"]) if (actual.git?.[key] !== expected.git[key]) return `git.${key} differs`;
+  for (const key of ["head", "tree", "dirtyDiff"])
+    if (actual.git?.[key] !== expected.git[key]) return `git.${key} differs`;
   return null;
 }
 
 export function verifyPublishedNapiManifest(manifest, target, nodePath) {
-  if (manifest.kind !== "napi" || manifest.profile !== "release" || manifest.target !== target) return `manifest is for ${manifest.kind}/${manifest.profile}/${manifest.target}, expected napi/release/${target}`;
+  if (manifest.kind !== "napi" || manifest.profile !== "release" || manifest.target !== target)
+    return `manifest is for ${manifest.kind}/${manifest.profile}/${manifest.target}, expected napi/release/${target}`;
   if (!existsSync(nodePath)) return `native binding is missing (${nodePath})`;
   const expected = { file: basename(nodePath), sha256: sha256(readFileSync(nodePath)) };
-  return manifest.artifacts?.some((artifact) => artifact.file === expected.file && artifact.sha256 === expected.sha256) ? null : `manifest does not match ${expected.file}`;
+  return manifest.artifacts?.some(
+    (artifact) => artifact.file === expected.file && artifact.sha256 === expected.sha256,
+  )
+    ? null
+    : `manifest does not match ${expected.file}`;
 }
 
 function main(args) {
@@ -158,17 +259,28 @@ function main(args) {
   const root = rootFlag === -1 ? here : resolve(args[rootFlag + 1]);
   const targetFlag = args.indexOf("--target");
   const target = targetFlag === -1 ? undefined : args[targetFlag + 1];
-  if (!command || !kind || !profile || !["wasm", "napi"].includes(kind)) throw new Error("usage: provenance.mjs <write|verify> <wasm|napi> <profile> [--root path]");
-  if (command === "write") { writeManifest(root, kind, profile, target); return; }
+  if (!command || !kind || !profile || !["wasm", "napi"].includes(kind))
+    throw new Error("usage: provenance.mjs <write|verify> <wasm|napi> <profile> [--root path]");
+  if (command === "write") {
+    writeManifest(root, kind, profile, target);
+    return;
+  }
   if (command === "verify") {
     const problem = verifyManifest(root, kind, profile, target);
-    if (problem) { console.error(`STALE ${kind} ${profile}: ${problem}`); process.exitCode = 1; }
-    else console.log(`FRESH ${kind} ${profile}`);
+    if (problem) {
+      console.error(`STALE ${kind} ${profile}: ${problem}`);
+      process.exitCode = 1;
+    } else console.log(`FRESH ${kind} ${profile}`);
     return;
   }
   throw new Error(`unknown command: ${command}`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  try { main(process.argv.slice(2)); } catch (error) { console.error(`artifact provenance: ${error.message}`); process.exitCode = 2; }
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(`artifact provenance: ${error.message}`);
+    process.exitCode = 2;
+  }
 }

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -3,13 +3,39 @@ import test from "node:test";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { expectedManifest, manifestPath, verifyManifest, verifyPublishedNapiManifest, writeManifest } from "./provenance.mjs";
+import {
+  expectedManifest,
+  manifestPath,
+  verifyManifest,
+  verifyPublishedNapiManifest,
+  writeManifest,
+} from "./provenance.mjs";
 import { stageNapiManifests } from "./stage-napi-manifests.mjs";
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "jazz-artifact-provenance-"));
-  for (const dir of [".cargo", "crates/jazz-wasm/pkg", "crates/jazz-wasm/src", "crates/jazz/src", "crates/groove/src", "crates/opfs-btree/src", "crates/wasm-tracing/src", "crates/jazz-napi/src"]) mkdirSync(join(root, dir), { recursive: true });
-  for (const [path, content] of Object.entries({ "Cargo.toml": "[workspace]\n", "Cargo.lock": "lock-a\n", "rust-toolchain.toml": "[toolchain]\nchannel = 'stable'\n", ".cargo/config.toml": "[build]\n", "package.json": "{}\n", "pnpm-lock.yaml": "lockfileVersion: '9.0'\n", "crates/jazz-wasm/Cargo.toml": "[package]\nname = 'wasm'\n", "crates/jazz-wasm/src/lib.rs": "// source\n" })) writeFileSync(join(root, path), content);
+  for (const dir of [
+    ".cargo",
+    "crates/jazz-wasm/pkg",
+    "crates/jazz-wasm/src",
+    "crates/jazz/src",
+    "crates/groove/src",
+    "crates/opfs-btree/src",
+    "crates/wasm-tracing/src",
+    "crates/jazz-napi/src",
+  ])
+    mkdirSync(join(root, dir), { recursive: true });
+  for (const [path, content] of Object.entries({
+    "Cargo.toml": "[workspace]\n",
+    "Cargo.lock": "lock-a\n",
+    "rust-toolchain.toml": "[toolchain]\nchannel = 'stable'\n",
+    ".cargo/config.toml": "[build]\n",
+    "package.json": "{}\n",
+    "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+    "crates/jazz-wasm/Cargo.toml": "[package]\nname = 'wasm'\n",
+    "crates/jazz-wasm/src/lib.rs": "// source\n",
+  }))
+    writeFileSync(join(root, path), content);
   return root;
 }
 
@@ -45,7 +71,10 @@ test("dirty source changes invalidate the manifest", () => {
   const root = fixture();
   writeManifest(root, "wasm", "release");
   writeFileSync(join(root, "crates/jazz-wasm/src/lib.rs"), "// changed\n");
-  assert.match(verifyManifest(root, "wasm", "release"), /packageInputs differs|git.dirtyDiff differs/);
+  assert.match(
+    verifyManifest(root, "wasm", "release"),
+    /packageInputs differs|git.dirtyDiff differs/,
+  );
 });
 
 test("provenance rejects tool and root-package configuration drift", () => {
@@ -83,15 +112,27 @@ test("missing optional tools have an explicit remediation value", () => {
   const root = fixture();
   delete process.env.JAZZ_ARTIFACT_TOOL_WASM_OPT;
   process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE = "1";
-  assert.match(expectedManifest(root, "wasm", "fast").tools.wasmOpt, /unavailable: wasm-opt is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build/);
+  assert.match(
+    expectedManifest(root, "wasm", "fast").tools.wasmOpt,
+    /unavailable: wasm-opt is supplied by wasm-pack; rebuild via pnpm --filter jazz-wasm build/,
+  );
   process.env.JAZZ_ARTIFACT_TOOL_WASM_OPT = "wasm-opt test";
   delete process.env.JAZZ_ARTIFACT_DISABLE_WASM_PACK_CACHE;
 });
 
 test("release NAPI CI builds use the manifest-producing wrapper", () => {
-  const workflow = readFileSync(new URL("../../.github/workflows/build-jazz-packages.yml", import.meta.url), "utf8");
-  assert.match(workflow, /node dev\/artifacts\/build\.mjs napi release --target \$\{\{ matrix\.target \}\}/);
-  assert.match(workflow, /node dev\/artifacts\/provenance\.mjs verify napi release --target \$\{\{ matrix\.target \}\}/);
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/build-jazz-packages.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    workflow,
+    /node dev\/artifacts\/build\.mjs napi release --target \$\{\{ matrix\.target \}\}/,
+  );
+  assert.match(
+    workflow,
+    /node dev\/artifacts\/provenance\.mjs verify napi release --target \$\{\{ matrix\.target \}\}/,
+  );
 });
 
 test("assembled NAPI packages carry only matching manifests and reject stale or missing inputs", () => {
@@ -113,17 +154,33 @@ test("assembled NAPI packages carry only matching manifests and reject stale or 
   mkdirSync(join(root, "crates/jazz-napi/artifacts"), { recursive: true });
   for (const [platform, target] of Object.entries(platforms)) {
     const manifest = expectedManifest(root, "napi", "release", target);
-    writeFileSync(join(root, "crates/jazz-napi/artifacts", `jazz-napi.${platform}.manifest.json`), JSON.stringify(manifest));
+    writeFileSync(
+      join(root, "crates/jazz-napi/artifacts", `jazz-napi.${platform}.manifest.json`),
+      JSON.stringify(manifest),
+    );
   }
   stageNapiManifests(root);
   const node = join(root, "crates/jazz-napi/npm/linux-x64-gnu/jazz-napi.linux-x64-gnu.node");
-  const manifest = JSON.parse(readFileSync(join(root, "crates/jazz-napi/npm/linux-x64-gnu/jazz-napi.linux-x64-gnu.manifest.json"), "utf8"));
+  const manifest = JSON.parse(
+    readFileSync(
+      join(root, "crates/jazz-napi/npm/linux-x64-gnu/jazz-napi.linux-x64-gnu.manifest.json"),
+      "utf8",
+    ),
+  );
   assert.equal(verifyPublishedNapiManifest(manifest, platforms["linux-x64-gnu"], node), null);
-  assert.match(readFileSync(join(root, "crates/jazz-napi/package.json"), "utf8"), /provenance\/\*\.manifest\.json/);
+  assert.match(
+    readFileSync(join(root, "crates/jazz-napi/package.json"), "utf8"),
+    /provenance\/\*\.manifest\.json/,
+  );
 
   writeFileSync(node, "stale");
-  assert.match(verifyPublishedNapiManifest(manifest, platforms["linux-x64-gnu"], node), /does not match/);
+  assert.match(
+    verifyPublishedNapiManifest(manifest, platforms["linux-x64-gnu"], node),
+    /does not match/,
+  );
   writeFileSync(node, "linux-x64-gnu");
-  rmSync(join(root, "crates/jazz-napi/artifacts/jazz-napi.darwin-x64.manifest.json"), { force: true });
+  rmSync(join(root, "crates/jazz-napi/artifacts/jazz-napi.darwin-x64.manifest.json"), {
+    force: true,
+  });
   assert.throws(() => stageNapiManifests(root), /missing provenance manifest/);
 });

--- a/dev/artifacts/stage-napi-manifests.mjs
+++ b/dev/artifacts/stage-napi-manifests.mjs
@@ -27,7 +27,8 @@ export function stageNapiManifests(root) {
     const file = `jazz-napi.${platform}.manifest.json`;
     const source = join(artifacts, file);
     const node = join(napiRoot, "npm", platform, `jazz-napi.${platform}.node`);
-    if (!existsSync(source)) throw new Error(`missing provenance manifest for ${platform}: ${source}`);
+    if (!existsSync(source))
+      throw new Error(`missing provenance manifest for ${platform}: ${source}`);
     const manifest = JSON.parse(readFileSync(source, "utf8"));
     const problem = verifyPublishedNapiManifest(manifest, target, node);
     if (problem) throw new Error(`invalid provenance for ${platform}: ${problem}`);
@@ -40,5 +41,10 @@ export function stageNapiManifests(root) {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const root = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
-  try { stageNapiManifests(root); } catch (error) { console.error(`stage NAPI manifests: ${error.message}`); process.exitCode = 1; }
+  try {
+    stageNapiManifests(root);
+  } catch (error) {
+    console.error(`stage NAPI manifests: ${error.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
@@ -541,7 +541,17 @@ export class PostcardWriter {
     return Uint8Array.from(this.chunks);
   }
 
-  u64(value: number): void {
+  u64(value: number | bigint): void {
+    if (typeof value === "bigint") {
+      if (value < 0n || value > 0xffff_ffff_ffff_ffffn) {
+        throw new Error(`u64 out of range: ${value}`);
+      }
+      this.u64Big(value);
+      return;
+    }
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`u64 must be a non-negative safe integer, got ${value}`);
+    }
     let remaining = value;
     do {
       let byte = remaining & 0x7f;
@@ -639,6 +649,19 @@ export class PostcardReader {
       result += (byte & 0x7f) * 2 ** shift;
       if ((byte & 0x80) === 0) return result;
       shift += 7;
+    }
+  }
+
+  u64BigInt(): bigint {
+    let result = 0n;
+    let shift = 0n;
+    while (true) {
+      const byte = this.readByte();
+      result += BigInt(byte & 0x7f) << shift;
+      if (result > 0xffff_ffff_ffff_ffffn) throw new Error("postcard u64 overflow");
+      if ((byte & 0x80) === 0) return result;
+      shift += 7n;
+      if (shift >= 64n) throw new Error("postcard u64 overflow");
     }
   }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -40,7 +40,11 @@ import {
   type ValueType,
 } from "./native-codec.js";
 import { encodeSchema } from "./schema-codec.js";
-import { WebSocketCarrier, wireAuthFailureReason } from "./websocket.js";
+import {
+  WebSocketCarrier,
+  type WebSocketNegotiation,
+  wireAuthFailureReason,
+} from "./websocket.js";
 import {
   createNativeRowValueEncoder,
   createRecord,
@@ -194,6 +198,14 @@ type NativeDb = {
       | ((error: Error | null, urgency: string) => void),
   ): void;
   connectUpstream(): Transport;
+  connectUpstreamWithSession?(
+    protocolVersion: number,
+    features: number,
+    remoteNode: Uint8Array,
+    remoteEpoch: number,
+    localNode: Uint8Array,
+    localEpoch: number,
+  ): Transport;
   tick(): void;
   close?(): void;
   free?(): void;
@@ -384,6 +396,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverCarrierPromise: Promise<WebSocketCarrier> | null = null;
   private serverTransportError: Error | null = null;
   private serverTransportErrorWaiters: ServerTransportErrorWaiter[] = [];
+  private nextServerConnectionEpoch = 1;
   private serverEndpointUrl: string | null = null;
   private readonly queuedServerFrames: Uint8Array[] = [];
   private readonly pendingInboundServerFrames: Uint8Array[] = [];
@@ -1041,8 +1054,6 @@ export class NativeRuntimeAdapter implements Runtime {
     void this.disconnect({ rejectWaiters: false });
     this.serverTransportError = null;
     this.serverEndpointUrl = url;
-    const transport = this.db.connectUpstream();
-    this.serverTransport = transport;
     const carrier = new WebSocketCarrier({
       endpointUrl: url,
       peerIdentity: this.peerIdentity,
@@ -1058,7 +1069,9 @@ export class NativeRuntimeAdapter implements Runtime {
       },
     });
     this.serverCarrier = carrier;
-    this.serverCarrierPromise = carrier.ready().then(() => {
+    this.serverCarrierPromise = carrier.ready().then((negotiation) => {
+      const transport = this.connectNegotiatedUpstream(negotiation);
+      this.serverTransport = transport;
       this.flushQueuedServerFrames(carrier);
       this.pumpServerTransport();
       this.pumpSubscriptions();
@@ -1067,7 +1080,22 @@ export class NativeRuntimeAdapter implements Runtime {
     this.serverCarrierPromise.catch((error) => {
       this.handleServerTransportError(error);
     });
-    this.scheduleServerPump();
+  }
+
+  private connectNegotiatedUpstream(negotiation: WebSocketNegotiation): Transport {
+    const authority = negotiation.authority;
+    const connectWithSession = this.db.connectUpstreamWithSession;
+    if (!authority || !connectWithSession) return this.db.connectUpstream();
+    const localEpoch = this.nextServerConnectionEpoch++;
+    return connectWithSession.call(
+      this.db,
+      negotiation.protocolVersion,
+      negotiation.features,
+      authority.node,
+      authority.epoch,
+      this.peerIdentity,
+      localEpoch,
+    );
   }
 
   disconnect(options: { rejectWaiters?: boolean } = {}): Promise<void> {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -40,11 +40,7 @@ import {
   type ValueType,
 } from "./native-codec.js";
 import { encodeSchema } from "./schema-codec.js";
-import {
-  WebSocketCarrier,
-  type WebSocketNegotiation,
-  wireAuthFailureReason,
-} from "./websocket.js";
+import { WebSocketCarrier, type WebSocketNegotiation, wireAuthFailureReason } from "./websocket.js";
 import {
   createNativeRowValueEncoder,
   createRecord,
@@ -302,6 +298,11 @@ type ServerTransportErrorWaiter = {
   reject: (error: Error) => void;
 };
 
+type ServerTransportWorkWaiter = {
+  active: boolean;
+  resolve: () => void;
+};
+
 type RuntimeSession = {
   user_id: string;
   claims: Record<string, unknown>;
@@ -396,6 +397,8 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverCarrierPromise: Promise<WebSocketCarrier> | null = null;
   private serverTransportError: Error | null = null;
   private serverTransportErrorWaiters: ServerTransportErrorWaiter[] = [];
+  private serverTransportWorkEpoch = 0;
+  private serverTransportWorkWaiters: ServerTransportWorkWaiter[] = [];
   private nextServerConnectionEpoch = 1;
   private serverEndpointUrl: string | null = null;
   private readonly queuedServerFrames: Uint8Array[] = [];
@@ -512,6 +515,7 @@ export class NativeRuntimeAdapter implements Runtime {
     this.completedTxs.clear();
     this.writes.clear();
     this.clearServerTransportErrorWaiters();
+    this.resolveServerTransportWorkWaiters();
     this.queuedServerFrames.length = 0;
     this.pendingInboundServerFrames.length = 0;
     this.serverTransport?.close();
@@ -822,6 +826,7 @@ export class NativeRuntimeAdapter implements Runtime {
         if (!isPendingWaitError(error)) throw error;
         this.pumpSubscriptions();
         const change = write.nextWriteStateChange();
+        const observedServerWorkEpoch = this.serverTransportWorkEpoch;
         try {
           this.pumpServerTransport();
           this.throwServerTransportErrorForTier(tier);
@@ -834,10 +839,15 @@ export class NativeRuntimeAdapter implements Runtime {
           if (!isPendingWaitError(secondError)) throw secondError;
         }
         const transportError = this.waitForServerTransportError(tier);
+        const transportWork = this.waitForServerTransportWork(tier, observedServerWorkEpoch);
         try {
-          await (transportError ? Promise.race([change, transportError.promise]) : change);
+          const wakes: Promise<unknown>[] = [change];
+          if (transportError) wakes.push(transportError.promise);
+          if (transportWork) wakes.push(transportWork.promise);
+          await Promise.race(wakes);
         } finally {
           transportError?.cancel();
+          transportWork?.cancel();
         }
       }
     }
@@ -1060,6 +1070,7 @@ export class NativeRuntimeAdapter implements Runtime {
       authJson,
       onFrame: (frame) => {
         this.pendingInboundServerFrames.push(frame);
+        this.notifyServerTransportWork();
         this.scheduleServerPump();
       },
       onError: (error) => {
@@ -1109,6 +1120,7 @@ export class NativeRuntimeAdapter implements Runtime {
     } else {
       this.clearServerTransportErrorWaiters();
     }
+    this.resolveServerTransportWorkWaiters();
     this.serverTransport?.close();
     this.serverTransport = null;
     this.serverEndpointUrl = null;
@@ -1942,7 +1954,10 @@ export class NativeRuntimeAdapter implements Runtime {
     return {
       promise,
       cancel: () => {
+        if (!waiter.active) return;
         waiter.active = false;
+        const index = this.serverTransportErrorWaiters.indexOf(waiter);
+        if (index >= 0) this.serverTransportErrorWaiters.splice(index, 1);
       },
     };
   }
@@ -1959,6 +1974,48 @@ export class NativeRuntimeAdapter implements Runtime {
       waiter.active = false;
     }
     this.serverTransportErrorWaiters.length = 0;
+  }
+
+  private waitForServerTransportWork(
+    tier: string,
+    observedEpoch: number,
+  ): { promise: Promise<void>; cancel: () => void } | null {
+    if (tier !== "edge" && tier !== "global") return null;
+    if (
+      this.serverTransportWorkEpoch !== observedEpoch ||
+      this.pendingInboundServerFrames.length > 0
+    ) {
+      return { promise: Promise.resolve(), cancel: () => {} };
+    }
+    const waiter: ServerTransportWorkWaiter = {
+      active: true,
+      resolve: () => {},
+    };
+    const promise = new Promise<void>((resolve) => {
+      waiter.resolve = resolve;
+    });
+    this.serverTransportWorkWaiters.push(waiter);
+    return {
+      promise,
+      cancel: () => {
+        if (!waiter.active) return;
+        waiter.active = false;
+        const index = this.serverTransportWorkWaiters.indexOf(waiter);
+        if (index >= 0) this.serverTransportWorkWaiters.splice(index, 1);
+      },
+    };
+  }
+
+  private notifyServerTransportWork(): void {
+    this.serverTransportWorkEpoch += 1;
+    this.resolveServerTransportWorkWaiters();
+  }
+
+  private resolveServerTransportWorkWaiters(): void {
+    const waiters = this.serverTransportWorkWaiters.splice(0);
+    for (const waiter of waiters) {
+      if (waiter.active) waiter.resolve();
+    }
   }
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -198,9 +198,9 @@ type NativeDb = {
     protocolVersion: number,
     features: number,
     remoteNode: Uint8Array,
-    remoteEpoch: number,
+    remoteEpoch: bigint,
     localNode: Uint8Array,
-    localEpoch: number,
+    localEpoch: bigint,
   ): Transport;
   tick(): void;
   close?(): void;
@@ -399,7 +399,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverTransportErrorWaiters: ServerTransportErrorWaiter[] = [];
   private serverTransportWorkEpoch = 0;
   private serverTransportWorkWaiters: ServerTransportWorkWaiter[] = [];
-  private nextServerConnectionEpoch = 1;
+  private nextServerConnectionEpoch = 1n;
   private serverEndpointUrl: string | null = null;
   private readonly queuedServerFrames: Uint8Array[] = [];
   private readonly pendingInboundServerFrames: Uint8Array[] = [];

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -217,6 +217,75 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(sockets[1]!.closed).toBe(true);
   });
 
+  it("retries a pending edge wait when a websocket frame arrives without a native callback", async () => {
+    let settled = false;
+    let transportTicks = 0;
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const transport = new FakeTransport([]);
+    transport.tick = () => {
+      transportTicks += 1;
+      if (transportTicks >= 3) settled = true;
+      return 0;
+    };
+    const write = {
+      batchId: "00000000000070008000000000000007",
+      payload: new Uint8Array(),
+      wait: () => {
+        if (!settled) throw new Error("transaction has not reached requested tier Edge");
+      },
+      writeState: () => ({}),
+      nextWriteStateChange: () => new Promise<void>(() => {}),
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insertWithIdEncoded: () => write,
+            connectUpstream: () => transport,
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([encodeWireServerHello()]));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    transportTicks = 0;
+
+    const inserted = runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "pump delayed fate" } },
+      null,
+      "00000000-0000-0000-0000-000000000007",
+    );
+
+    const wait = runtime.waitForTransaction(await committedBatchId(inserted), "edge");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(transportTicks).toBe(2);
+
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([Uint8Array.from([1, 42])]));
+    await wait;
+
+    expect(transportTicks).toBe(3);
+  });
+
   it("uses the binding scheduler to drive native db ticks outside server pumps", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {
@@ -6414,6 +6483,17 @@ function encodeWireError(code: number, retry: number, message: string): Uint8Arr
   writer.u64(code);
   writer.u64(retry);
   writer.string(message);
+  return writer.finish();
+}
+
+function encodeWireServerHello(): Uint8Array {
+  const writer = new PostcardWriter();
+  writer.u64(0); // WireFrame::Hello
+  writer.u64(6); // min_protocol_version
+  writer.u64(6); // max_protocol_version
+  writer.u64(0); // accepted features
+  writer.u64(1); // WirePeerRole::Core
+  writer.none(); // WireHello::authority
   return writer.finish();
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -640,6 +640,66 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(transport.received).toEqual([]);
   });
 
+  it("reports pre-hello auth failures and reconnects with refreshed auth", async () => {
+    const sockets: FakeWebSocket[] = [];
+    let allowServerHello = false;
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+
+      override send(data: Uint8Array | string): void {
+        if (allowServerHello) super.send(data);
+        else this.sent.push(data);
+      }
+    } as unknown as typeof WebSocket;
+    const transport = new FakeTransport([]);
+    let upstreamConnections = 0;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              upstreamConnections += 1;
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+    const authFailures: string[] = [];
+    runtime.onAuthFailure((reason) => authFailures.push(reason));
+
+    runtime.connect(
+      "ws://127.0.0.1:4200/apps/app-a/ws",
+      JSON.stringify({ jwt_token: "invalid.jwt" }),
+    );
+    await waitForFakeWebSocketNegotiation();
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([encodeWireError(3, 1, "invalid token")]));
+    await waitForFakeWebSocketNegotiation();
+
+    expect(authFailures).toEqual(["invalid"]);
+    expect(upstreamConnections).toBe(0);
+    expect(sockets[0]!.closed).toBe(true);
+
+    allowServerHello = true;
+    await runtime.updateAuth(JSON.stringify({ jwt_token: "fresh.jwt" }));
+    await waitForFakeWebSocketNegotiation();
+
+    expect(sockets).toHaveLength(2);
+    expect(upstreamConnections).toBe(1);
+    expect(JSON.parse(sockets[1]!.sent[0] as string).jwt_token).toBe("fresh.jwt");
+  });
+
   it("does not report non-auth websocket errors as auth failures", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   CLIENT_WIRE_FEATURES,
   decodeWebSocketFrameBatch,
+  encodeWireClientHello,
   encodeWebSocketPrelude,
   encodeWebSocketFrameBatch,
   isWireHello,
@@ -220,6 +221,26 @@ describe("NativeRuntimeAdapter server transport", () => {
     runtime.disconnect();
 
     expect(sockets[1]!.closed).toBe(true);
+  });
+
+  it("does not emit the fake server hello before the client prelude and hello", async () => {
+    const socket = new FakeWebSocket("ws://127.0.0.1:4200/apps/app-a/ws");
+    const received: Uint8Array[] = [];
+    socket.addEventListener("message", (event) => received.push(event.data as Uint8Array));
+
+    socket.send(encodeWebSocketFrameBatch([Uint8Array.from([1, 42])]));
+    await Promise.resolve();
+    expect(received).toEqual([]);
+
+    socket.send(encodeWebSocketPrelude("{}", new Uint8Array(16)));
+    await Promise.resolve();
+    expect(received).toEqual([]);
+
+    socket.send(encodeWebSocketFrameBatch([encodeWireClientHello()]));
+    await Promise.resolve();
+
+    expect(received).toHaveLength(1);
+    expect(isWireHello(decodeWebSocketFrameBatch(received[0]!)[0]!)).toBe(true);
   });
 
   it("retries a pending edge wait when a websocket frame arrives without a native callback", async () => {
@@ -6459,14 +6480,23 @@ class FakeWebSocket {
   private readonly messageListeners: Array<(event: { data: unknown }) => void> = [];
   closed = false;
 
-  constructor(readonly url: string) {
-    queueMicrotask(() => {
-      if (!this.closed) this.emitMessage(encodeWebSocketFrameBatch([encodeWireServerHello()]));
-    });
-  }
+  private sawClientPrelude = false;
+  private serverHelloScheduled = false;
+
+  constructor(readonly url: string) {}
 
   send(data: Uint8Array | string): void {
     this.sent.push(data);
+    if (typeof data === "string") {
+      this.sawClientPrelude = isClientPrelude(data);
+      return;
+    }
+    if (!this.sawClientPrelude || this.serverHelloScheduled) return;
+    if (!isClientHelloBatch(data)) return;
+    this.serverHelloScheduled = true;
+    queueMicrotask(() => {
+      if (!this.closed) this.emitMessage(encodeWebSocketFrameBatch([encodeWireServerHello()]));
+    });
   }
 
   close(): void {
@@ -6506,6 +6536,34 @@ function encodeWireServerHello(epoch: bigint = 1n): Uint8Array {
     authority.u64(epoch);
   });
   return writer.finish();
+}
+
+function isClientPrelude(data: string): boolean {
+  try {
+    const prelude = JSON.parse(data) as { peer_identity?: unknown; auth?: unknown };
+    return (
+      typeof prelude.peer_identity === "string" &&
+      prelude.auth !== null &&
+      typeof prelude.auth === "object"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isClientHelloBatch(data: Uint8Array): boolean {
+  try {
+    const frames = decodeWebSocketFrameBatch(data);
+    if (frames.length !== 1 || !isWireHello(frames[0]!)) return false;
+    const hello = new PostcardReader(frames[0]!);
+    hello.u64(); // WireFrame::Hello
+    hello.u64(); // min_protocol_version
+    hello.u64(); // max_protocol_version
+    hello.u64(); // features
+    return hello.u64() === 0; // WirePeerRole::Client
+  } catch {
+    return false;
+  }
 }
 
 type EncodedTestRow = {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -11,10 +11,12 @@ import {
   writeDescriptor,
 } from "./native-codec.js";
 import {
+  CLIENT_WIRE_FEATURES,
   decodeWebSocketFrameBatch,
   encodeWebSocketPrelude,
   encodeWebSocketFrameBatch,
   isWireHello,
+  WIRE_PROTOCOL_VERSION,
 } from "./websocket.js";
 import {
   decodeNestedRowBytes,
@@ -143,6 +145,10 @@ async function waitForServerPumpTimer(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 20));
 }
 
+async function waitForFakeWebSocketNegotiation(): Promise<void> {
+  for (let turn = 0; turn < 6; turn += 1) await Promise.resolve();
+}
+
 describe("NativeRuntimeAdapter server transport", () => {
   afterEach(() => {
     globalThis.WebSocket = previousWebSocket;
@@ -176,8 +182,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     await waitForServerPumpTimer();
 
     expect(sockets).toHaveLength(1);
@@ -262,9 +267,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([encodeWireServerHello()]));
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     await Promise.resolve();
     transportTicks = 0;
 
@@ -322,8 +325,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(schedulerCallback).toBeTypeOf("function");
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     await waitForServerPumpTimer();
 
     expect(transport.tickCount).toBeGreaterThan(0);
@@ -364,8 +366,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     transport.tickCount = 0;
 
     const frames = [Uint8Array.from([1]), Uint8Array.from([1, 42]), Uint8Array.from([1, 43])];
@@ -406,8 +407,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     transport.tickCount = 0;
 
     const first = Uint8Array.from([1, 10]);
@@ -511,8 +511,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     await waitForServerPumpTimer();
 
     expect(transport.tickCount).toBeGreaterThan(0);
@@ -549,11 +548,9 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     await runtime.updateAuth(JSON.stringify({ jwt_token: "fresh.jwt" }));
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
 
     expect(sockets).toHaveLength(2);
     expect(decodeWebSocketFrameBatch(sockets[1]!.sent[2]! as Uint8Array)).toEqual([
@@ -613,7 +610,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     runtime.onAuthFailure((reason) => authFailures.push(reason));
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
 
     sockets[0]!.emitMessage(encodeWebSocketFrameBatch([encodeWireError(3, 1, "token expired")]));
     await Promise.resolve();
@@ -652,7 +649,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     runtime.onAuthFailure((reason) => authFailures.push(reason));
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
 
     sockets[0]!.emitMessage(
       encodeWebSocketFrameBatch([encodeWireError(5, 3, "conflicting commit unit")]),
@@ -701,6 +698,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await waitForFakeWebSocketNegotiation();
     const handle = runtime.createSubscription(JSON.stringify({ table: "todos" }), null, "edge");
     const updates = vi.fn();
     runtime.executeSubscription(handle, updates);
@@ -2753,6 +2751,7 @@ describe("NativeRuntimeAdapter server transport", () => {
       true,
     );
     await runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await waitForFakeWebSocketNegotiation();
 
     await Promise.all([
       runtime.query(
@@ -2877,6 +2876,7 @@ describe("NativeRuntimeAdapter server transport", () => {
         true,
       );
       await runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+      await waitForFakeWebSocketNegotiation();
 
       const query = runtime.query(JSON.stringify({ table: "todos" }), null, "edge");
       await vi.advanceTimersByTimeAsync(40);
@@ -2929,6 +2929,7 @@ describe("NativeRuntimeAdapter server transport", () => {
       true,
     );
     await runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await waitForFakeWebSocketNegotiation();
 
     const query = runtime.query(JSON.stringify({ table: "todos" }), null, "edge");
     await Promise.resolve();
@@ -6458,7 +6459,11 @@ class FakeWebSocket {
   private readonly messageListeners: Array<(event: { data: unknown }) => void> = [];
   closed = false;
 
-  constructor(readonly url: string) {}
+  constructor(readonly url: string) {
+    queueMicrotask(() => {
+      if (!this.closed) this.emitMessage(encodeWebSocketFrameBatch([encodeWireServerHello()]));
+    });
+  }
 
   send(data: Uint8Array | string): void {
     this.sent.push(data);
@@ -6486,14 +6491,20 @@ function encodeWireError(code: number, retry: number, message: string): Uint8Arr
   return writer.finish();
 }
 
-function encodeWireServerHello(): Uint8Array {
+function encodeWireServerHello(epoch: bigint = 1n): Uint8Array {
   const writer = new PostcardWriter();
   writer.u64(0); // WireFrame::Hello
-  writer.u64(6); // min_protocol_version
-  writer.u64(6); // max_protocol_version
-  writer.u64(0); // accepted features
+  writer.u64(WIRE_PROTOCOL_VERSION);
+  writer.u64(WIRE_PROTOCOL_VERSION);
+  writer.u64(CLIENT_WIRE_FEATURES);
   writer.u64(1); // WirePeerRole::Core
-  writer.none(); // WireHello::authority
+  writer.some((authority) => {
+    authority.bytes(
+      Uint8Array.from({ length: 16 }, () => 0x5e),
+      false,
+    );
+    authority.u64(epoch);
+  });
   return writer.finish();
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -690,6 +690,10 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(authFailures).toEqual(["invalid"]);
     expect(upstreamConnections).toBe(0);
     expect(sockets[0]!.closed).toBe(true);
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([encodeWireServerHello()]));
+    await waitForFakeWebSocketNegotiation();
+    expect(authFailures).toEqual(["invalid"]);
+    expect(upstreamConnections).toBe(0);
 
     allowServerHello = true;
     await runtime.updateAuth(JSON.stringify({ jwt_token: "fresh.jwt" }));

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -240,11 +240,13 @@ describe("websocket frame carrier", () => {
       },
     });
 
-    socket!.emitMessage(
-      encodeWebSocketFrameBatch([encodeWireError(3, 1, "invalid token"), encodeServerHello(1n)]),
-    );
+    socket!.emitMessage(encodeWebSocketFrameBatch([encodeWireError(3, 1, "invalid token")]));
 
     await expect(carrier.ready()).rejects.toThrow("authentication failed before server hello");
+    socket!.emitMessage(encodeWebSocketFrameBatch([encodeServerHello(1n)]));
+    socket!.emitMessage(encodeWebSocketFrameBatch([Uint8Array.of(1, 6, 0, 0)]));
+    await Promise.resolve();
+
     expect(errors).toEqual([
       { code: "auth_failed", retry: "after_auth", message: "invalid token" },
     ]);

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -161,7 +161,7 @@ describe("websocket frame carrier", () => {
   });
 
   it("preserves full u64 server authority epochs across stale/current hellos", async () => {
-    const staleEpoch = 9_007_199_254_740_991n;
+    const staleEpoch = 9_007_199_254_740_993n;
     const currentEpoch = staleEpoch + 1n;
     const sockets: MessageWebSocket[] = [];
     const WebSocket = class extends MessageWebSocket {
@@ -191,6 +191,12 @@ describe("websocket frame carrier", () => {
     expect(staleNegotiation.authority?.epoch).toBe(staleEpoch);
     expect(currentNegotiation.authority?.epoch).toBe(currentEpoch);
     expect(currentNegotiation.authority!.epoch > staleNegotiation.authority!.epoch).toBe(true);
+
+    const writer = new PostcardWriter();
+    writer.u64(staleEpoch);
+    const encodedEpoch = writer.finish();
+    expect(new PostcardReader(encodedEpoch).u64BigInt()).toBe(staleEpoch);
+    expect(BigInt(new PostcardReader(encodedEpoch).u64())).not.toBe(staleEpoch);
   });
 
   it("does not send or deliver semantic frames before the server hello", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -111,6 +111,47 @@ describe("websocket frame carrier", () => {
     expect(reader.u64()).toBe(MAX_WIRE_PROTOCOL_VERSION);
     expect(reader.u64()).toBe(CLIENT_WIRE_FEATURES);
     expect(reader.u64()).toBe(0);
+    expect(reader.option((authority) => authority.bytes(false))).toBeUndefined();
+  });
+
+  it("sends an authority-unbound hello first on every reconnect", async () => {
+    const sockets: RecordingWebSocket[] = [];
+    const peerIdentity = Uint8Array.from({ length: 16 }, (_, index) => index + 1);
+    const WebSocket = class extends RecordingWebSocket {
+      constructor(url: string) {
+        super(url, (socket) => sockets.push(socket));
+      }
+    };
+
+    const first = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity,
+      onFrame: () => {},
+      WebSocket,
+    });
+    await first.ready();
+    first.close();
+    const second = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity,
+      onFrame: () => {},
+      WebSocket,
+    });
+    await second.ready();
+
+    const hello = (socket: RecordingWebSocket) => {
+      expect(socket.sent[0]).toEqual(encodeWebSocketPrelude("{}", peerIdentity));
+      const frame = decodeWebSocketFrameBatch(socket.sent[1] as Uint8Array)[0]!;
+      const reader = new PostcardReader(frame);
+      expect(reader.u64()).toBe(0);
+      reader.u64();
+      reader.u64();
+      reader.u64();
+      reader.u64();
+      return reader.option((authority) => authority.bytes(false));
+    };
+    expect(hello(sockets[0]!)).toBeUndefined();
+    expect(hello(sockets[1]!)).toBeUndefined();
   });
 
   it("decodes structured wire error frames", () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -208,8 +208,9 @@ describe("websocket frame carrier", () => {
       onFrame: (frame) => delivered.push(frame),
       WebSocket: class extends MessageWebSocket {
         constructor(url: string) {
-          super(url);
-          socket = this;
+          super(url, (created) => {
+            socket = created;
+          });
         }
       },
     });
@@ -218,6 +219,62 @@ describe("websocket frame carrier", () => {
     await expect(carrier.ready()).rejects.toThrow("before server hello");
     await expect(carrier.send(Uint8Array.of(1))).rejects.toThrow("before server hello");
     expect(delivered).toEqual([]);
+    expect(socket!.closed).toBe(true);
+  });
+
+  it("surfaces an authentication failure before server hello without negotiating", async () => {
+    let socket: MessageWebSocket | undefined;
+    const frames: Uint8Array[] = [];
+    const errors: unknown[] = [];
+    const carrier = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity: new Uint8Array(16),
+      onFrame: (frame) => frames.push(frame),
+      onError: (error) => errors.push(error),
+      WebSocket: class extends MessageWebSocket {
+        constructor(url: string) {
+          super(url, (created) => {
+            socket = created;
+          });
+        }
+      },
+    });
+
+    socket!.emitMessage(
+      encodeWebSocketFrameBatch([encodeWireError(3, 1, "invalid token"), encodeServerHello(1n)]),
+    );
+
+    await expect(carrier.ready()).rejects.toThrow("authentication failed before server hello");
+    expect(errors).toEqual([
+      { code: "auth_failed", retry: "after_auth", message: "invalid token" },
+    ]);
+    expect(frames).toEqual([]);
+    expect(socket!.closed).toBe(true);
+  });
+
+  it("rejects non-authentication errors before server hello", async () => {
+    let socket: MessageWebSocket | undefined;
+    const errors: unknown[] = [];
+    const carrier = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity: new Uint8Array(16),
+      onFrame: () => {},
+      onError: (error) => errors.push(error),
+      WebSocket: class extends MessageWebSocket {
+        constructor(url: string) {
+          super(url, (created) => {
+            socket = created;
+          });
+        }
+      },
+    });
+
+    socket!.emitMessage(
+      encodeWebSocketFrameBatch([encodeWireError(5, 3, "conflicting commit unit")]),
+    );
+
+    await expect(carrier.ready()).rejects.toThrow("semantic frame before server hello");
+    expect(errors).toEqual([]);
     expect(socket!.closed).toBe(true);
   });
 
@@ -240,8 +297,9 @@ describe("websocket frame carrier", () => {
       onError: (error) => errors.push(error),
       WebSocket: class extends MessageWebSocket {
         constructor(url: string) {
-          super(url);
-          socket = this;
+          super(url, (created) => {
+            socket = created;
+          });
         }
       },
     });
@@ -339,7 +397,12 @@ class MessageWebSocket {
   readonly readyState = 1;
   private readonly messageListeners: Array<(event: { data: unknown }) => void> = [];
 
-  constructor(readonly url: string) {}
+  constructor(
+    readonly url: string,
+    onCreate?: (socket: MessageWebSocket) => void,
+  ) {
+    onCreate?.(this);
+  }
 
   send(_data: Uint8Array | string): void {}
 

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -154,10 +154,43 @@ describe("websocket frame carrier", () => {
     expect(hello(sockets[1]!)).toBeUndefined();
     const firstNegotiation = await first.ready();
     const secondNegotiation = await second.ready();
-    expect(firstNegotiation.authority?.node).toEqual(
-      Uint8Array.from({ length: 16 }, () => 0x5e),
+    expect(firstNegotiation.authority?.node).toEqual(Uint8Array.from({ length: 16 }, () => 0x5e));
+    expect(secondNegotiation.authority?.epoch).toBeGreaterThan(
+      firstNegotiation.authority?.epoch ?? 0n,
     );
-    expect(secondNegotiation.authority?.epoch).toBeGreaterThan(firstNegotiation.authority?.epoch ?? 0);
+  });
+
+  it("preserves full u64 server authority epochs across stale/current hellos", async () => {
+    const staleEpoch = 9_007_199_254_740_991n;
+    const currentEpoch = staleEpoch + 1n;
+    const sockets: MessageWebSocket[] = [];
+    const WebSocket = class extends MessageWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    };
+    const stale = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity: new Uint8Array(16),
+      onFrame: () => {},
+      WebSocket,
+    });
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([encodeServerHello(staleEpoch)]));
+    const current = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity: new Uint8Array(16),
+      onFrame: () => {},
+      WebSocket,
+    });
+    sockets[1]!.emitMessage(encodeWebSocketFrameBatch([encodeServerHello(currentEpoch)]));
+
+    const staleNegotiation = await stale.ready();
+    const currentNegotiation = await current.ready();
+
+    expect(staleNegotiation.authority?.epoch).toBe(staleEpoch);
+    expect(currentNegotiation.authority?.epoch).toBe(currentEpoch);
+    expect(currentNegotiation.authority!.epoch > staleNegotiation.authority!.epoch).toBe(true);
   });
 
   it("does not send or deliver semantic frames before the server hello", async () => {
@@ -208,10 +241,7 @@ describe("websocket frame carrier", () => {
     });
 
     socket!.emitMessage(
-      encodeWebSocketFrameBatch([
-        encodeServerHello(1),
-        encodeWireError(3, 1, "expired"),
-      ]),
+      encodeWebSocketFrameBatch([encodeServerHello(1n), encodeWireError(3, 1, "expired")]),
     );
     await Promise.resolve();
 
@@ -281,7 +311,7 @@ function encodeWireError(code: number, retry: number, message: string): Uint8Arr
   return writer.finish();
 }
 
-function encodeServerHello(epoch: number): Uint8Array {
+function encodeServerHello(epoch: bigint): Uint8Array {
   const writer = new PostcardWriter();
   writer.u64(0); // WireFrame::Hello
   writer.u64(WIRE_PROTOCOL_VERSION);
@@ -289,7 +319,10 @@ function encodeServerHello(epoch: number): Uint8Array {
   writer.u64(CLIENT_WIRE_FEATURES);
   writer.u64(1); // WirePeerRole::Core
   writer.some((authority) => {
-    authority.bytes(Uint8Array.from({ length: 16 }, () => 0x5e), false);
+    authority.bytes(
+      Uint8Array.from({ length: 16 }, () => 0x5e),
+      false,
+    );
     authority.u64(epoch);
   });
   return writer.finish();
@@ -343,5 +376,5 @@ class RecordingWebSocket extends MessageWebSocket {
     }
   }
 
-  private static epoch = 1;
+  private static epoch = 1n;
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -152,6 +152,34 @@ describe("websocket frame carrier", () => {
     };
     expect(hello(sockets[0]!)).toBeUndefined();
     expect(hello(sockets[1]!)).toBeUndefined();
+    const firstNegotiation = await first.ready();
+    const secondNegotiation = await second.ready();
+    expect(firstNegotiation.authority?.node).toEqual(
+      Uint8Array.from({ length: 16 }, () => 0x5e),
+    );
+    expect(secondNegotiation.authority?.epoch).toBeGreaterThan(firstNegotiation.authority?.epoch ?? 0);
+  });
+
+  it("does not send or deliver semantic frames before the server hello", async () => {
+    let socket: MessageWebSocket | undefined;
+    const delivered: Uint8Array[] = [];
+    const carrier = new WebSocketCarrier({
+      endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+      peerIdentity: new Uint8Array(16),
+      onFrame: (frame) => delivered.push(frame),
+      WebSocket: class extends MessageWebSocket {
+        constructor(url: string) {
+          super(url);
+          socket = this;
+        }
+      },
+    });
+
+    socket!.emitMessage(encodeWebSocketFrameBatch([Uint8Array.of(1, 6, 0, 0)]));
+    await expect(carrier.ready()).rejects.toThrow("before server hello");
+    await expect(carrier.send(Uint8Array.of(1))).rejects.toThrow("before server hello");
+    expect(delivered).toEqual([]);
+    expect(socket!.closed).toBe(true);
   });
 
   it("decodes structured wire error frames", () => {
@@ -179,7 +207,12 @@ describe("websocket frame carrier", () => {
       },
     });
 
-    socket!.emitMessage(encodeWebSocketFrameBatch([encodeWireError(3, 1, "expired")]));
+    socket!.emitMessage(
+      encodeWebSocketFrameBatch([
+        encodeServerHello(1),
+        encodeWireError(3, 1, "expired"),
+      ]),
+    );
     await Promise.resolve();
 
     expect(frames).toEqual([]);
@@ -248,6 +281,20 @@ function encodeWireError(code: number, retry: number, message: string): Uint8Arr
   return writer.finish();
 }
 
+function encodeServerHello(epoch: number): Uint8Array {
+  const writer = new PostcardWriter();
+  writer.u64(0); // WireFrame::Hello
+  writer.u64(WIRE_PROTOCOL_VERSION);
+  writer.u64(WIRE_PROTOCOL_VERSION);
+  writer.u64(CLIENT_WIRE_FEATURES);
+  writer.u64(1); // WirePeerRole::Core
+  writer.some((authority) => {
+    authority.bytes(Uint8Array.from({ length: 16 }, () => 0x5e), false);
+    authority.u64(epoch);
+  });
+  return writer.finish();
+}
+
 class MessageWebSocket {
   binaryType: "arraybuffer" | "blob" = "arraybuffer";
   readonly readyState = 1;
@@ -257,7 +304,11 @@ class MessageWebSocket {
 
   send(_data: Uint8Array | string): void {}
 
-  close(): void {}
+  closed = false;
+
+  close(): void {
+    this.closed = true;
+  }
 
   addEventListener(type: "open", listener: () => void): void;
   addEventListener(type: "message", listener: (event: { data: unknown }) => void): void;
@@ -287,5 +338,10 @@ class RecordingWebSocket extends MessageWebSocket {
 
   override send(data: Uint8Array | string): void {
     this.sent.push(data);
+    if (data instanceof Uint8Array && isWireHello(decodeWebSocketFrameBatch(data)[0]!)) {
+      this.emitMessage(encodeWebSocketFrameBatch([encodeServerHello(RecordingWebSocket.epoch++)]));
+    }
   }
+
+  private static epoch = 1;
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -15,7 +15,7 @@ export type WireError = {
 export type WebSocketNegotiation = {
   protocolVersion: number;
   features: number;
-  authority?: { node: Uint8Array; epoch: number };
+  authority?: { node: Uint8Array; epoch: bigint };
 };
 
 export type WebSocketCarrierOptions = {
@@ -146,10 +146,13 @@ export class WebSocketCarrier {
       this.resolveNegotiation = resolve;
       this.rejectNegotiation = reject;
     });
-    void waitForOpen(this.socket).then(() => {
-      this.socket.send(encodeWebSocketPrelude(options.authJson ?? "{}", options.peerIdentity));
-      this.socket.send(encodeWebSocketFrameBatch([encodeWireClientHello()]));
-    }, (error) => this.rejectNegotiation(error));
+    void waitForOpen(this.socket).then(
+      () => {
+        this.socket.send(encodeWebSocketPrelude(options.authJson ?? "{}", options.peerIdentity));
+        this.socket.send(encodeWebSocketFrameBatch([encodeWireClientHello()]));
+      },
+      (error) => this.rejectNegotiation(error),
+    );
     this.socket.addEventListener("message", (event) => {
       void this.handleMessage(event.data).catch((error) => {
         this.rejectNegotiation(error);
@@ -250,7 +253,10 @@ function decodeServerHello(frame: Uint8Array): WebSocketNegotiation {
     throw new Error(`server accepted unsupported wire features 0x${features.toString(16)}`);
   }
   if (reader.u64() !== 1) throw new Error("expected WirePeerRole::Core server hello");
-  const authority = reader.option((value) => ({ node: value.bytes(false), epoch: value.u64() }));
+  const authority = reader.option((value) => ({
+    node: value.bytes(false),
+    epoch: value.u64BigInt(),
+  }));
   return { protocolVersion: WIRE_PROTOCOL_VERSION, features, authority };
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -12,6 +12,12 @@ export type WireError = {
   message: string;
 };
 
+export type WebSocketNegotiation = {
+  protocolVersion: number;
+  features: number;
+  authority?: { node: Uint8Array; epoch: number };
+};
+
 export type WebSocketCarrierOptions = {
   endpointUrl: string;
   peerIdentity: Uint8Array;
@@ -44,11 +50,15 @@ export const FEATURE_SYNC_MESSAGE_PAYLOAD = 1 << 0;
 export const FEATURE_STRUCTURED_ERRORS = 1 << 2;
 export const FEATURE_PAYLOAD_ZSTD = 1 << 4;
 export const FEATURE_MESSAGE_FRAGMENTATION = 1 << 5;
+export const FEATURE_AUTHORIZATION_SCOPE_RECEIPTS = 1 << 6;
+export const FEATURE_AUTHORIZATION_SCOPE_VIEWS = 1 << 7;
 export const CLIENT_WIRE_FEATURES =
   FEATURE_SYNC_MESSAGE_PAYLOAD |
   FEATURE_STRUCTURED_ERRORS |
   FEATURE_PAYLOAD_ZSTD |
-  FEATURE_MESSAGE_FRAGMENTATION;
+  FEATURE_MESSAGE_FRAGMENTATION |
+  FEATURE_AUTHORIZATION_SCOPE_RECEIPTS |
+  FEATURE_AUTHORIZATION_SCOPE_VIEWS;
 
 // The server route accepts WebSocket messages up to one MiB. Reserve enough
 // postcard framing bytes that a burst of otherwise-valid wire frames remains
@@ -119,7 +129,10 @@ export class WebSocketCarrier {
   private readonly socket: BrowserWebSocket;
   private readonly onFrame: WebSocketFrameHandler;
   private readonly onError?: WebSocketErrorHandler;
-  private readonly opened: Promise<void>;
+  private readonly opened: Promise<WebSocketNegotiation>;
+  private resolveNegotiation!: (value: WebSocketNegotiation) => void;
+  private rejectNegotiation!: (reason: unknown) => void;
+  private negotiated = false;
   private closing = false;
 
   constructor(options: WebSocketCarrierOptions) {
@@ -129,15 +142,23 @@ export class WebSocketCarrier {
     this.onError = options.onError;
     this.socket = new WebSocketCtor(this.url);
     this.socket.binaryType = "arraybuffer";
-    this.opened = waitForOpen(this.socket).then(() => {
+    this.opened = new Promise<WebSocketNegotiation>((resolve, reject) => {
+      this.resolveNegotiation = resolve;
+      this.rejectNegotiation = reject;
+    });
+    void waitForOpen(this.socket).then(() => {
       this.socket.send(encodeWebSocketPrelude(options.authJson ?? "{}", options.peerIdentity));
       this.socket.send(encodeWebSocketFrameBatch([encodeWireClientHello()]));
-    });
+    }, (error) => this.rejectNegotiation(error));
     this.socket.addEventListener("message", (event) => {
-      void this.handleMessage(event.data);
+      void this.handleMessage(event.data).catch((error) => {
+        this.rejectNegotiation(error);
+        this.close();
+      });
     });
     this.socket.addEventListener("error", () => {
       if (this.closing) return;
+      this.rejectNegotiation(new Error("websocket transport error"));
       this.onError?.({
         code: "websocket_error",
         retry: "later",
@@ -146,6 +167,7 @@ export class WebSocketCarrier {
     });
     this.socket.addEventListener("close", (event) => {
       if (this.closing) return;
+      this.rejectNegotiation(new Error("websocket transport closed during negotiation"));
       const close = websocketCloseDetails(event);
       this.onError?.({
         code: "websocket_closed",
@@ -178,7 +200,7 @@ export class WebSocketCarrier {
     }
   }
 
-  ready(): Promise<void> {
+  ready(): Promise<WebSocketNegotiation> {
     return this.opened;
   }
 
@@ -195,7 +217,17 @@ export class WebSocketCarrier {
 
   private async handleMessage(data: unknown): Promise<void> {
     for (const frame of decodeWebSocketFrameBatch(await bytesFromWebSocketMessage(data))) {
-      if (isWireHello(frame)) continue;
+      if (isWireHello(frame)) {
+        if (this.negotiated) continue;
+        this.negotiated = true;
+        this.resolveNegotiation(decodeServerHello(frame));
+        continue;
+      }
+      if (!this.negotiated) {
+        this.rejectNegotiation(new Error("websocket received semantic frame before server hello"));
+        this.close();
+        return;
+      }
       if (isWireError(frame)) {
         this.onError?.(decodeWireError(frame));
         continue;
@@ -203,6 +235,23 @@ export class WebSocketCarrier {
       this.onFrame(frame);
     }
   }
+}
+
+function decodeServerHello(frame: Uint8Array): WebSocketNegotiation {
+  const reader = new PostcardReader(frame);
+  if (reader.u64() !== 0) throw new Error("expected WireFrame::Hello");
+  const min = reader.u64();
+  const max = reader.u64();
+  if (min > WIRE_PROTOCOL_VERSION || max < WIRE_PROTOCOL_VERSION) {
+    throw new Error(`server does not support wire protocol ${WIRE_PROTOCOL_VERSION}`);
+  }
+  const features = reader.u64();
+  if (features & ~CLIENT_WIRE_FEATURES) {
+    throw new Error(`server accepted unsupported wire features 0x${features.toString(16)}`);
+  }
+  if (reader.u64() !== 1) throw new Error("expected WirePeerRole::Core server hello");
+  const authority = reader.option((value) => ({ node: value.bytes(false), epoch: value.u64() }));
+  return { protocolVersion: WIRE_PROTOCOL_VERSION, features, authority };
 }
 
 function websocketCloseDetails(event: unknown): { code?: number; reason?: string } {

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -79,6 +79,10 @@ export function encodeWireClientHello(): Uint8Array {
   writer.u64(MAX_WIRE_PROTOCOL_VERSION); // max_protocol_version
   writer.u64(CLIENT_WIRE_FEATURES);
   writer.u64(0); // WirePeerRole::Client
+  // Browser carriers do not receive the authenticated session context needed
+  // to validate scoped receipts. Do not self-assert an authority endpoint:
+  // preserve ordinary sync and let the server fail closed for scoped features.
+  writer.none(); // WireHello::authority
   return writer.finish();
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -220,6 +220,7 @@ export class WebSocketCarrier {
 
   private async handleMessage(data: unknown): Promise<void> {
     for (const frame of decodeWebSocketFrameBatch(await bytesFromWebSocketMessage(data))) {
+      if (this.closing) return;
       if (isWireHello(frame)) {
         if (this.negotiated) continue;
         this.negotiated = true;
@@ -227,6 +228,17 @@ export class WebSocketCarrier {
         continue;
       }
       if (!this.negotiated) {
+        if (isWireError(frame)) {
+          const error = decodeWireError(frame);
+          if (wireAuthFailureReason(error)) {
+            this.onError?.(error);
+            this.rejectNegotiation(
+              new Error("websocket authentication failed before server hello"),
+            );
+            this.close();
+            return;
+          }
+        }
         this.rejectNegotiation(new Error("websocket received semantic frame before server hello"));
         this.close();
         return;

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -160,9 +160,9 @@ declare module "jazz-wasm" {
       protocolVersion: number,
       features: number,
       remoteNode: Uint8Array,
-      remoteEpoch: number,
+      remoteEpoch: bigint,
       localNode: Uint8Array,
-      localEpoch: number,
+      localEpoch: bigint,
     ): WasmTransport;
     acceptSubscriber(identity: Uint8Array): WasmTransport;
     mergeableTx(openBatchId: string): WasmTx;

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -156,6 +156,14 @@ declare module "jazz-wasm" {
     tick(): void;
     close(): boolean;
     connectUpstream(): WasmTransport;
+    connectUpstreamWithSession(
+      protocolVersion: number,
+      features: number,
+      remoteNode: Uint8Array,
+      remoteEpoch: number,
+      localNode: Uint8Array,
+      localEpoch: number,
+    ): WasmTransport;
     acceptSubscriber(identity: Uint8Array): WasmTransport;
     mergeableTx(openBatchId: string): WasmTx;
     mergeableTxForIdentity(openBatchId: string, author: Uint8Array): WasmTx;


### PR DESCRIPTION
🤖 ## What changed

- Fixes browser WebSocket Hello framing and directional authority-session negotiation after #1349.
- Preserves authority connection epochs losslessly as `u64`/`bigint` through TS, NAPI, and WASM.
- Replaces polling with an event-driven inbound-frame wake for pending Edge/Global waits.
- Updates test transports to model client-first Hello ordering and strict semantic-before-Hello rejection.

## Root cause

Browser clients emitted the legacy truncated Hello and did not propagate the server's negotiated authority context. Once the server returned a terminal FateUpdate, pending write waits had no direct transport-frame wake, so they could remain parked even though the authority response had arrived.

## Validation

- Independent adversarial review: no P0/P1/P2.
- Full native runtime suite: 104 passed, 1 skipped.
- WebSocket carrier suite: 13 passed.
- Rust WebSocket route suite: 24 passed.
- Fresh NAPI/WASM checks and bigint boundary tests passed.
- Browser public convergence passed.
- Reversible plants proved inbound-wake, client-first ordering, and lossless >2^53 epoch coverage.
- Sensitive-data and diff checks passed.
