### PR TITLE
(cleanup) make canonical validation gates truthful

### DIFF
--- a/crates/jazz/SPEC/17_integrability.md
+++ b/crates/jazz/SPEC/17_integrability.md
@@ -151,7 +151,7 @@ Milestone: **integrators can adopt jazz incrementally without bespoke glue.**
    WebSocket/byte-transport listener, publish health/metrics, and drain
    connections on shutdown while all product behavior still flows through the
    client API and shared sync protocol. The current `jazz-server` surface has
-   three canaries: `cargo run -p jazz-server -- dry-run`, which validates the
+   three canaries: `cargo run -p jazz --bin jazz-server -- dry-run`, which validates the
    default local shell plan without opening sockets;
    `jazz_server::loopback_http::LoopbackHttpServer`, which starts a
    loopback-only HTTP bridge around `InMemoryServerShell` for health, metrics,

--- a/crates/jazz/SPEC/D_testing_gates.md
+++ b/crates/jazz/SPEC/D_testing_gates.md
@@ -30,12 +30,11 @@ For ordinary Rust/core work, the full gate set is:
 1. `cargo test -p jazz`
 2. `cargo test -p groove`
 3. `cargo test -p jazz --no-default-features --features test`
-4. `cargo test -p jazz-server`
-5. `cargo check -p jazz-sim --benches`
-6. `dev/gates/ts-wire-codec.sh`
-7. `JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle`
-8. `cargo test -p jazz --test incremental_delivery_canary maintained_relation_include_single_row_changes_are_scale_independent -- --exact`
-9. the sensitive-data guard from `jazz-private/dev/gates/`, normally reached
+4. `cargo check -p jazz-sim --benches`
+5. `dev/gates/ts-wire-codec.sh`
+6. `JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle`
+7. `cargo test -p jazz --test incremental_delivery_canary maintained_relation_include_single_row_changes_are_scale_independent -- --exact`
+8. the sensitive-data guard from `jazz-private/dev/gates/`, normally reached
    through the optional lefthook hook
 
 Run `dev/benchmarks/smoke.sh` for any change touching protocol, engine,
@@ -47,8 +46,7 @@ replacing the former fixed `-j 2` guidance.
 
 ### D.2 The tiers
 
-- **Crate tests** — integration and crate tests for `jazz`, `groove`,
-  `jazz-tools` with its `test` feature, and `jazz-server`.
+- **Crate tests** — integration and crate tests for `jazz` and `groove`.
 - **Bench API compilation** — `cargo check -p jazz-sim --benches` is always in
   the ordinary gate set because benchmark API rot has previously hidden until
   late in a lane.
@@ -69,15 +67,9 @@ replacing the former fixed `-j 2` guidance.
   protocol, engine, storage, or benchmark harnesses.
 - **Public type changes** — changes to public `jazz` types additionally gate the
   full workspace, including examples.
-- **Server shell** — `cargo test -p jazz-server` exercises the in-memory Rust
-  server shell over the public frame pump, including subscriber accept, detach
-  for resume, resume-token rejection, drain/health transitions, and metrics. It
-  also starts the loopback HTTP byte-frame listener on `127.0.0.1:0` and covers
-  health, metrics, session creation, and newline-separated hex frame request
-  plumbing into `InMemoryServerShell`. The loopback WebSocket listener is also
-  covered with real ABI clients: each binary message is a postcard batch of raw
-  `WireFrame` bytes, and the test proves writer-to-reader sync through the
-  socket boundary.
+- **Server shell** — the server-shell tests are included in the `jazz` package
+  gates above. They exercise the in-memory Rust server shell over the public
+  frame pump, loopback HTTP and WebSocket listeners, and real ABI clients.
 
 ### D.3 Simulation-first discipline
 

--- a/dev/gates/run-canonical.sh
+++ b/dev/gates/run-canonical.sh
@@ -99,7 +99,6 @@ run_gate() {
 run_gate cargo-test-jazz cargo test -p jazz
 run_gate cargo-test-groove cargo test -p groove
 run_gate cargo-test-jazz-no-default-features cargo test -p jazz --no-default-features --features test
-run_gate cargo-test-jazz-server cargo test -p jazz-server
 run_gate cargo-check-jazz-sim-benches cargo check -p jazz-sim --benches
 run_gate ts-wire-codec dev/gates/ts-wire-codec.sh
 run_gate m3-maintained-one-shot env JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle

--- a/dev/gates/test/run-canonical.test.mjs
+++ b/dev/gates/test/run-canonical.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const runner = path.join(root, "dev/gates/run-canonical.sh");
+
+test("canonical gates do not advertise the removed jazz-server package gate", () => {
+  const source = fs.readFileSync(runner, "utf8");
+  assert.doesNotMatch(source, /cargo-test-jazz-server/);
+  assert.doesNotMatch(source, /cargo test -p\s+jazz-server/);
+});
+
+test("the removed jazz-server gate is rejected as an unknown selector", () => {
+  const result = spawnSync("bash", [runner, "--only", "cargo-test-jazz-server"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /unknown gate id/);
+});


### PR DESCRIPTION
🤖 ## What changed

- Removes the obsolete `cargo test -p jazz-server` selector from the canonical runner.
- Documents server-shell coverage under the actual `jazz` package.
- Corrects the dry-run command and adds a regression preventing the removed selector from returning.

## Why

The documented canonical path was guaranteed to fail because `jazz-server` is a binary, not a workspace package.

## Validation

- Independent review: no P0/P1/P2.
- Focused gate tests, shell syntax, formatting, and the real dry-run command pass.