### PR TITLE
(cleanup) key native row plans by complete descriptors

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-descriptor-key.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-descriptor-key.ts
@@ -1,0 +1,33 @@
+import { PostcardWriter, type NativeRowBatch } from "./native-codec.js";
+import { writeDescriptor, writeValueType, type ValueType } from "./native-row-codec.js";
+
+const byteHex = Array.from({ length: 256 }, (_, byte) => byte.toString(16).padStart(2, "0"));
+
+/**
+ * A wire-exact key for a native ValueType.
+ *
+ * ValueType is recursive and several tags carry semantic data beyond their
+ * numeric tag (record fields, enum registry ids, and payload enum cases). The
+ * native wire codec is the canonical representation of that data, so using it
+ * here keeps cache identity aligned with the protocol rather than maintaining
+ * a second partial structural encoder.
+ */
+export function valueTypeCacheKey(type: ValueType): string {
+  const writer = new PostcardWriter();
+  writeValueType(writer, type);
+  return bytesToHex(writer.finish());
+}
+
+/** A wire-exact cache key for the descriptor that controls row decoding. */
+export function nativeRowFieldPlanCacheKey(
+  batch: Pick<NativeRowBatch, "table" | "descriptor">,
+): string {
+  const writer = new PostcardWriter();
+  writer.string(batch.table);
+  writeDescriptor(writer, [...batch.descriptor]);
+  return bytesToHex(writer.finish());
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byteHex[byte]).join("");
+}

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -40,6 +40,7 @@ import {
   type ValueType,
 } from "./native-codec.js";
 import { encodeSchema } from "./schema-codec.js";
+import { nativeRowFieldPlanCacheKey, valueTypeCacheKey } from "./native-row-descriptor-key.js";
 import { WebSocketCarrier, type WebSocketNegotiation, wireAuthFailureReason } from "./websocket.js";
 import {
   createNativeRowValueEncoder,
@@ -3590,7 +3591,7 @@ function readRelationSnapshot(payload: Uint8Array): NativeRelationSubscriptionSn
   return readNativeRelationSubscriptionSnapshot(new PostcardReader(payload));
 }
 
-function rowsFromBatches(
+export function rowsFromBatches(
   batches: NativeRowBatch[],
   schema: WasmSchema,
   projectedColumns?: readonly ColumnDescriptor[],
@@ -3674,18 +3675,6 @@ function isCurrentRowPhysicalField(fieldName: string): boolean {
   return (
     fieldName === "schema_version" || fieldName === "parents" || fieldName === "authored_columns"
   );
-}
-
-function nativeRowFieldPlanCacheKey(batch: NativeRowBatch): string {
-  let key = batch.table;
-  for (const field of batch.descriptor) {
-    key += `\0${field.name ?? ""}:${valueTypeCacheKey(field.valueType)}`;
-  }
-  return key;
-}
-
-function valueTypeCacheKey(type: ValueType): string {
-  return type.inner ? `${type.tag}<${valueTypeCacheKey(type.inner)}>` : String(type.tag);
 }
 
 function rowsFromRelationSnapshot(

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -24,8 +24,10 @@ import {
   formatUuid,
   NativeRuntimeAdapter,
   applySubscriptionDeltaWithWireDelta,
+  rowsFromBatches,
   type Transport,
 } from "./native-runtime-adapter.js";
+import { nativeRowFieldPlanCacheKey, valueTypeCacheKey } from "./native-row-descriptor-key.js";
 import { encodeSchema } from "./schema-codec.js";
 import {
   applySubscriptionDelta,
@@ -63,6 +65,207 @@ describe("formatUuid", () => {
     ]);
 
     expect(formatUuid(bytes.subarray(2, 18))).toBe("00010203-0405-0607-0809-0a0b0c0d0e0f");
+  });
+});
+
+describe("native row descriptor cache keys", () => {
+  it("includes the table identity", () => {
+    const descriptor = [{ name: "value", valueType: { tag: 8 } }];
+
+    expect(nativeRowFieldPlanCacheKey({ table: "first", descriptor })).not.toBe(
+      nativeRowFieldPlanCacheKey({ table: "second", descriptor }),
+    );
+  });
+
+  it("includes payload enum registry identity when cases match", () => {
+    const firstRegistry = {
+      tag: 16,
+      enumSchema: {
+        registryId: 3,
+        name: "event",
+        cases: [{ name: "message", payload: [{ name: "body", valueType: { tag: 8 } }] }],
+      },
+    };
+    const secondRegistry = {
+      tag: 16,
+      enumSchema: {
+        registryId: 4,
+        name: "event",
+        cases: [{ name: "message", payload: [{ name: "body", valueType: { tag: 8 } }] }],
+      },
+    };
+
+    expect(valueTypeCacheKey(firstRegistry)).not.toBe(valueTypeCacheKey(secondRegistry));
+  });
+
+  it("includes recursive descriptor and enum schema data", () => {
+    const nestedText = {
+      tag: 15,
+      record: [{ name: "body", valueType: { tag: 8 } }],
+    };
+    const nestedInteger = {
+      tag: 15,
+      record: [{ name: "body", valueType: { tag: 4 } }],
+    };
+    const tupleWithText = { tag: 12, members: [{ tag: 7 }, { tag: 8 }] };
+    const tupleWithInteger = { tag: 12, members: [{ tag: 7 }, { tag: 4 }] };
+    const textArray = { tag: 13, inner: { tag: 8 } };
+    const integerArray = { tag: 13, inner: { tag: 4 } };
+    const nullableText = { tag: 14, inner: { tag: 8 } };
+    const nullableInteger = { tag: 14, inner: { tag: 4 } };
+    const scalarEnum = {
+      tag: 11,
+      enumSchema: { registryId: 7, name: "status", variants: ["draft", "published"] },
+    };
+    const otherScalarEnumRegistry = {
+      tag: 11,
+      enumSchema: { registryId: 8, name: "status", variants: ["draft", "published"] },
+    };
+    const otherScalarEnumVariants = {
+      tag: 11,
+      enumSchema: { registryId: 7, name: "status", variants: ["draft", "archived"] },
+    };
+    const payloadEnum = {
+      tag: 16,
+      enumSchema: {
+        registryId: 3,
+        name: "event",
+        cases: [{ name: "message", payload: [{ name: "body", valueType: { tag: 8 } }] }],
+      },
+    };
+    const changedPayloadEnum = {
+      tag: 16,
+      enumSchema: {
+        registryId: 3,
+        name: "event",
+        cases: [{ name: "message", payload: [{ name: "body", valueType: { tag: 4 } }] }],
+      },
+    };
+    const changedPayloadEnumCase = {
+      tag: 16,
+      enumSchema: {
+        registryId: 3,
+        name: "event",
+        cases: [{ name: "reaction", payload: [{ name: "body", valueType: { tag: 8 } }] }],
+      },
+    };
+
+    expect(valueTypeCacheKey(nestedText)).not.toBe(valueTypeCacheKey(nestedInteger));
+    expect(valueTypeCacheKey(tupleWithText)).not.toBe(valueTypeCacheKey(tupleWithInteger));
+    expect(valueTypeCacheKey(textArray)).not.toBe(valueTypeCacheKey(integerArray));
+    expect(valueTypeCacheKey(nullableText)).not.toBe(valueTypeCacheKey(nullableInteger));
+    expect(valueTypeCacheKey(scalarEnum)).not.toBe(valueTypeCacheKey(otherScalarEnumRegistry));
+    expect(valueTypeCacheKey(scalarEnum)).not.toBe(valueTypeCacheKey(otherScalarEnumVariants));
+    expect(valueTypeCacheKey(payloadEnum)).not.toBe(valueTypeCacheKey(changedPayloadEnum));
+    expect(valueTypeCacheKey(payloadEnum)).not.toBe(valueTypeCacheKey(changedPayloadEnumCase));
+    expect(
+      nativeRowFieldPlanCacheKey({
+        table: "events",
+        descriptor: [{ name: "event", valueType: payloadEnum }],
+      }),
+    ).not.toBe(
+      nativeRowFieldPlanCacheKey({
+        table: "events",
+        descriptor: [{ name: "event", valueType: changedPayloadEnum }],
+      }),
+    );
+  });
+
+  it("rebuilds a row decoder plan when a nested record descriptor changes", () => {
+    const childColumns: ColumnDescriptor[] = [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+    ];
+    const schema = {
+      parents: {
+        columns: [
+          {
+            name: "child",
+            column_type: { type: "Row", columns: childColumns },
+            nullable: false,
+          },
+        ],
+      },
+    } satisfies WasmSchema;
+    const firstChildDescriptor = [
+      { name: "row_uuid", valueType: { tag: 10 } },
+      { name: "title", valueType: { tag: 8 } },
+    ];
+    const secondChildDescriptor = [
+      { name: "row_uuid", valueType: { tag: 10 } },
+      { name: "title", valueType: { tag: 8 } },
+      { name: "ignored_fixed_field", valueType: { tag: 4 } },
+    ];
+    const firstDescriptor = [
+      { name: "child", valueType: { tag: 15, record: firstChildDescriptor } },
+    ];
+    const secondDescriptor = [
+      { name: "child", valueType: { tag: 15, record: secondChildDescriptor } },
+    ];
+    const childId = "00000000-0000-0000-0000-0000000000c1";
+    const firstBatch = {
+      table: "parents",
+      descriptor: firstDescriptor,
+      rows: [
+        {
+          rowId: uuidBytes("00000000-0000-0000-0000-0000000000a1"),
+          deleted: false,
+          raw: createRecord(firstDescriptor, [
+            createRecord(firstChildDescriptor, [
+              uuidBytes(childId),
+              new TextEncoder().encode("first"),
+            ]),
+          ]),
+        },
+      ],
+    };
+    const secondBatch = {
+      table: "parents",
+      descriptor: secondDescriptor,
+      rows: [
+        {
+          rowId: uuidBytes("00000000-0000-0000-0000-0000000000a2"),
+          deleted: false,
+          raw: createRecord(secondDescriptor, [
+            createRecord(secondChildDescriptor, [
+              uuidBytes(childId),
+              new TextEncoder().encode("second"),
+              i32Bytes(42),
+            ]),
+          ]),
+        },
+      ],
+    };
+
+    expect(rowsFromBatches([firstBatch], schema)).toEqual([
+      {
+        table: "parents",
+        id: "00000000-0000-0000-0000-0000000000a1",
+        values: [
+          {
+            type: "Row",
+            value: {
+              id: childId,
+              values: [{ type: "Text", value: "first" }],
+            },
+          },
+        ],
+      },
+    ]);
+    expect(rowsFromBatches([secondBatch], schema)).toEqual([
+      {
+        table: "parents",
+        id: "00000000-0000-0000-0000-0000000000a2",
+        values: [
+          {
+            type: "Row",
+            value: {
+              id: childId,
+              values: [{ type: "Text", value: "second" }],
+            },
+          },
+        ],
+      },
+    ]);
   });
 });
 
@@ -7166,6 +7369,12 @@ function formatUuidForTest(bytes: Uint8Array): string {
 function doubleBytes(value: number): Uint8Array {
   const bytes = new Uint8Array(8);
   new DataView(bytes.buffer).setFloat64(0, value, true);
+  return bytes;
+}
+
+function i32Bytes(value: number): Uint8Array {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setInt32(0, value, true);
   return bytes;
 }
 


### PR DESCRIPTION
🤖 ## What changed

- Replaces the partial tag-only native row-plan cache key with an exact canonical descriptor key.
- Includes table identity, recursive records/tuples/arrays/nullability, and scalar/payload enum registry identity.
- Adds behavioral stale-plan and direct identity regressions.

## Why

The prior key omitted descriptor structure and could reuse decoding plans with stale nested or enum metadata.

## Validation

- Independent adversarial review: no P0/P1.
- Both P2 sensitivity gaps were fixed and re-reviewed.
- 117 focused runtime/codec tests pass, with one intentional skip.
- TypeScript build, formatting, lint, and precommit checks pass.