### PR TITLE
(cleanup) share native row value encoding

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -33,7 +33,11 @@ describe("native row codec", () => {
     ];
     const columns: ColumnDescriptor[] = [
       { name: "active", column_type: { type: "Boolean" }, nullable: false },
-      { name: "choice", column_type: { type: "Enum" }, nullable: false },
+      {
+        name: "choice",
+        column_type: { type: "Enum", variants: ["draft", "published"] },
+        nullable: false,
+      },
       {
         name: "labels",
         column_type: { type: "Array", element: { type: "Text" } },
@@ -116,7 +120,11 @@ describe("native row codec", () => {
                 nullable: false,
               }
             : _kind === "enum"
-              ? { name: "value", column_type: { type: "Enum" }, nullable: false }
+              ? {
+                  name: "value",
+                  column_type: { type: "Enum", variants: ["draft", "published"] },
+                  nullable: false,
+                }
               : { name: "value", column_type: { type: "Boolean" }, nullable: false };
 
     expect(() =>

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { PostcardReader, PostcardWriter } from "./native-codec.js";
+import { encodeCellsForPatch, encodeCellsForRow } from "./native-runtime-adapter.js";
 import {
   createRecord,
   decodeNativeTerminalRow,
@@ -10,8 +11,10 @@ import {
   decodeRecordValue,
   encodeNativeRowValues,
   readDescriptor,
+  storageColumnValueType,
   writeDescriptor,
 } from "./native-row-codec.js";
+import type { ColumnDescriptor, Value } from "../../drivers/types.js";
 
 type NativeRowCodecFixture = {
   cases: NativeRowCodecCase[];
@@ -24,6 +27,122 @@ type NativeRowCodecCase = {
 };
 
 describe("native row codec", () => {
+  it("keeps mutation cells byte-for-byte aligned with packed row values", () => {
+    const nestedColumns: ColumnDescriptor[] = [
+      { name: "label", column_type: { type: "Text" }, nullable: false },
+    ];
+    const columns: ColumnDescriptor[] = [
+      { name: "active", column_type: { type: "Boolean" }, nullable: false },
+      { name: "choice", column_type: { type: "Enum" }, nullable: false },
+      {
+        name: "labels",
+        column_type: { type: "Array", element: { type: "Text" } },
+        nullable: false,
+      },
+      { name: "note", column_type: { type: "Text" }, nullable: true },
+      {
+        name: "nested",
+        column_type: { type: "Row", columns: nestedColumns },
+        nullable: false,
+      },
+      { name: "sparse", column_type: { type: "Integer" }, nullable: false, sparse: true },
+    ];
+    const values: Record<string, Value> = {
+      active: { type: "Boolean", value: false },
+      choice: { type: "Text", value: "published" },
+      labels: {
+        type: "Array",
+        value: [
+          { type: "Text", value: "one" },
+          { type: "Text", value: "two" },
+        ],
+      },
+      note: { type: "Null" },
+      nested: {
+        type: "Row",
+        value: {
+          id: "00000000-0000-4000-8000-000000000001",
+          values: [{ type: "Text", value: "child" }],
+        },
+      },
+      sparse: { type: "Integer", value: 7 },
+    };
+    const sortedColumns = [...columns].sort((left, right) => left.name.localeCompare(right.name));
+    const writer = new PostcardWriter();
+    writeDescriptor(
+      writer,
+      sortedColumns.map((column) => ({
+        name: column.name,
+        valueType: storageColumnValueType(column),
+      })),
+    );
+    writer.bytes(
+      encodeNativeRowValues(
+        sortedColumns,
+        sortedColumns.map((column) => values[column.name]!),
+      ),
+    );
+
+    const cells = encodeCellsForRow({ columns }, values);
+    expect(cells).toEqual(writer.finish());
+    expect(bytesToHex(cells)).toMatchInlineSnapshot(
+      `"06010661637469766507010663686f6963650801066c6162656c730d0801066e65737465640901046e6f74650e0801067370617273650e04440001070000001b00000029000000430000007075626c6973686564020000000b0000006f6e6574776f0100000000000040008000000000000001050000006368696c6400"`,
+    );
+  });
+
+  it.each([
+    ["scalar", { type: "Text", value: "wrong" }],
+    ["nullable", { type: "Text", value: "wrong" }],
+    ["array", { type: "Text", value: "wrong" }],
+    ["row", { type: "Text", value: "wrong" }],
+    ["enum", { type: "Boolean", value: true }],
+  ] as const)("rejects an invalid %s value tag rather than encoding a fallback", (_kind, value) => {
+    const column: ColumnDescriptor =
+      _kind === "nullable"
+        ? { name: "value", column_type: { type: "Boolean" }, nullable: true }
+        : _kind === "array"
+          ? {
+              name: "value",
+              column_type: { type: "Array", element: { type: "Text" } },
+              nullable: false,
+            }
+          : _kind === "row"
+            ? {
+                name: "value",
+                column_type: {
+                  type: "Row",
+                  columns: [{ name: "label", column_type: { type: "Text" }, nullable: false }],
+                },
+                nullable: false,
+              }
+            : _kind === "enum"
+              ? { name: "value", column_type: { type: "Enum" }, nullable: false }
+              : { name: "value", column_type: { type: "Boolean" }, nullable: false };
+
+    expect(() =>
+      encodeCellsForRow({ columns: [column] }, { value } as Record<string, Value>),
+    ).toThrow();
+  });
+
+  it("keeps an explicit sparse nullable null present for both rows and patches", () => {
+    const column: ColumnDescriptor = {
+      name: "value",
+      column_type: { type: "Text" },
+      nullable: true,
+      sparse: true,
+    };
+    const writer = new PostcardWriter();
+    writeDescriptor(writer, [{ name: column.name, valueType: storageColumnValueType(column) }]);
+    writer.bytes(encodeNativeRowValues([column], [{ type: "Null" }]));
+    const expected = writer.finish();
+
+    const row = encodeCellsForRow({ columns: [column] }, { value: { type: "Null" } });
+    const patch = encodeCellsForPatch({ columns: [column] }, { value: { type: "Null" } });
+    expect(row).toEqual(expected);
+    expect(patch).toEqual(expected);
+    expect(bytesToHex(row)).toMatchInlineSnapshot(`"01010576616c75650e0e08020100"`);
+  });
+
   it("round-trips the Record descriptor payload before reading the next field", () => {
     const writer = new PostcardWriter();
     writeDescriptor(writer, [

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -459,7 +459,7 @@ export function createNativeRowValueEncoder(
     const encoded: Uint8Array[] = [];
     encoded.length = columns.length;
     for (let index = 0; index < columns.length; index += 1) {
-      encoded[index] = encodeValueForColumn(columns[index], values[index]);
+      encoded[index] = encodeNativeColumnValue(columns[index], values[index]);
     }
     return createRecordWithLayout(layout, encoded);
   };
@@ -611,31 +611,42 @@ function descriptorFromColumns(columns: readonly ColumnDescriptor[]): Descriptor
   }));
 }
 
-function encodeValueForColumn(column: ColumnDescriptor, value: Value | undefined): Uint8Array {
+/**
+ * Encode a physical storage value for a declared column.
+ *
+ * This is the single authority for the value bytes shared by packed rows and
+ * mutation-cell records. Callers retain responsibility for their distinct
+ * omission/default policies, but a present value must always use this path so
+ * nullable and sparse carrier layers remain part of the descriptor contract.
+ */
+export function encodeNativeColumnValue(
+  column: ColumnDescriptor,
+  value: Value | undefined,
+): Uint8Array {
   const logicalType = storageColumnTypeToValueType(column.column_type);
   const nullableType: ValueType = column.nullable ? { tag: 14, inner: logicalType } : logicalType;
 
   if (!value) {
-    if (column.sparse) return encodeNullValue({ tag: 14, inner: nullableType });
+    if (column.sparse) return encodeNativeNullValue({ tag: 14, inner: nullableType });
     if (!column.nullable) {
       throw new Error(`missing non-nullable value for ${column.name}`);
     }
-    return encodeNullValue(nullableType);
+    return encodeNativeNullValue(nullableType);
   }
   if (value.type === "Null") {
     if (!column.nullable) {
       throw new Error(`missing non-nullable value for ${column.name}`);
     }
-    const encodedNull = encodeNullValue(nullableType);
-    return column.sparse ? encodePresentValue(encodedNull, nullableType) : encodedNull;
+    const encodedNull = encodeNativeNullValue(nullableType);
+    return column.sparse ? encodeNativePresentValue(encodedNull, nullableType) : encodedNull;
   }
-  let encoded = encodeNonNullValue(column.column_type, value);
-  if (column.nullable) encoded = encodePresentValue(encoded, logicalType);
-  return column.sparse ? encodePresentValue(encoded, nullableType) : encoded;
+  let encoded = encodeNativeNonNullValue(column.column_type, value);
+  if (column.nullable) encoded = encodeNativePresentValue(encoded, logicalType);
+  return column.sparse ? encodeNativePresentValue(encoded, nullableType) : encoded;
 }
 
-function encodePresentValue(encoded: Uint8Array, inner: ValueType): Uint8Array {
-  if (fixedSize(inner) == null) {
+function encodeNativePresentValue(encoded: Uint8Array, inner: ValueType): Uint8Array {
+  if (nativeFixedValueSize(inner) == null) {
     return concatBytes([Uint8Array.of(1), encoded]);
   }
   const output = new Uint8Array(1 + encoded.length);
@@ -644,12 +655,12 @@ function encodePresentValue(encoded: Uint8Array, inner: ValueType): Uint8Array {
   return output;
 }
 
-function encodeNullValue(valueType: ValueType): Uint8Array {
-  const width = fixedSize(valueType);
+export function encodeNativeNullValue(valueType: ValueType): Uint8Array {
+  const width = nativeFixedValueSize(valueType);
   return width == null ? Uint8Array.of(0) : new Uint8Array(width);
 }
 
-function encodeNonNullValue(type: ColumnType, value: Value): Uint8Array {
+function encodeNativeNonNullValue(type: ColumnType, value: Value): Uint8Array {
   switch (type.type) {
     case "Boolean":
       if (value.type !== "Boolean") throw new Error("expected Boolean value");
@@ -693,14 +704,14 @@ function encodeNonNullValue(type: ColumnType, value: Value): Uint8Array {
       return value.value;
     case "Array":
       if (value.type !== "Array") throw new Error("expected Array value");
-      return encodeArrayValue(type.element, value.value);
+      return encodeNativeArrayValue(type.element, value.value);
     case "Row":
       if (value.type !== "Row") throw new Error("expected Row value");
-      return encodeRowValue(type.columns, value.value);
+      return encodeNativeRowValue(type.columns, value.value);
   }
 }
 
-function encodeRowValue(
+function encodeNativeRowValue(
   columns: readonly ColumnDescriptor[],
   value: { id?: string; values: Value[]; valuesByColumn?: Map<string, Value> },
 ): Uint8Array {
@@ -718,14 +729,14 @@ function encodeRowValue(
   return concatBytes([
     Uint8Array.of(value.id ? 1 : 0),
     idBytes,
-    u32Le(encodedValues.byteLength),
+    encodeU32Le(encodedValues.byteLength),
     encodedValues,
   ]);
 }
 
-function encodeArrayValue(elementType: ColumnType, values: readonly Value[]): Uint8Array {
-  const encoded = values.map((value) => encodeNonNullValue(elementType, value));
-  const elementWidth = fixedSize(storageColumnTypeToValueType(elementType));
+function encodeNativeArrayValue(elementType: ColumnType, values: readonly Value[]): Uint8Array {
+  const encoded = values.map((value) => encodeNativeNonNullValue(elementType, value));
+  const elementWidth = nativeFixedValueSize(storageColumnTypeToValueType(elementType));
   if (elementWidth != null) return concatBytes(encoded);
 
   const offsets = new Uint8Array(Math.max(0, values.length - 1) * 4);
@@ -735,10 +746,10 @@ function encodeArrayValue(elementType: ColumnType, values: readonly Value[]): Ui
     nextOffset += chunk.length;
     view.setUint32(index * 4, nextOffset, true);
   });
-  return concatBytes([u32Le(values.length), offsets, ...encoded]);
+  return concatBytes([encodeU32Le(values.length), offsets, ...encoded]);
 }
 
-function u32Le(value: number): Uint8Array {
+export function encodeU32Le(value: number): Uint8Array {
   const bytes = new Uint8Array(4);
   new DataView(bytes.buffer).setUint32(0, value, true);
   return bytes;
@@ -905,7 +916,7 @@ function decodeArrayElements<T>(
   bytes: Uint8Array,
   decodeElement: (bytes: Uint8Array) => T,
 ): T[] {
-  const elementWidth = fixedSize(storageColumnTypeToValueType(elementType));
+  const elementWidth = nativeFixedValueSize(storageColumnTypeToValueType(elementType));
   if (elementWidth != null) {
     if (elementWidth === 0) return [];
     if (bytes.length % elementWidth !== 0) {
@@ -957,7 +968,7 @@ function formatUuid(bytes: Uint8Array): string {
   )}-${hex.slice(20)}`;
 }
 
-function fixedSize(valueType: ValueType): number | undefined {
+export function nativeFixedValueSize(valueType: ValueType): number | undefined {
   switch (valueType.tag) {
     case 0:
     case 7:
@@ -978,14 +989,14 @@ function fixedSize(valueType: ValueType): number | undefined {
       const members = valueType.members ?? (valueType.inner ? [valueType.inner] : []);
       return members.reduce<number | undefined>((total, member) => {
         if (total == null) return undefined;
-        const memberSize = fixedSize(member);
+        const memberSize = nativeFixedValueSize(member);
         return memberSize == null ? undefined : total + memberSize;
       }, 0);
     }
     case 13:
       return undefined;
     case 14: {
-      const innerSize = valueType.inner ? fixedSize(valueType.inner) : undefined;
+      const innerSize = valueType.inner ? nativeFixedValueSize(valueType.inner) : undefined;
       return innerSize == null ? undefined : innerSize + 1;
     }
     default:
@@ -1019,7 +1030,7 @@ function recordLayout(descriptor: DescriptorField[]): {
   let fixedOffset = 0;
 
   for (let logicalIndex = 0; logicalIndex < descriptor.length; logicalIndex += 1) {
-    const size = fixedSize(descriptor[logicalIndex].valueType);
+    const size = nativeFixedValueSize(descriptor[logicalIndex].valueType);
     if (size == null) continue;
     const layout = { kind: "fixed" as const, logicalIndex, offset: fixedOffset, size };
     fields[logicalIndex] = layout;
@@ -1028,7 +1039,7 @@ function recordLayout(descriptor: DescriptorField[]): {
   }
 
   for (let logicalIndex = 0; logicalIndex < descriptor.length; logicalIndex += 1) {
-    if (fixedSize(descriptor[logicalIndex].valueType) != null) continue;
+    if (nativeFixedValueSize(descriptor[logicalIndex].valueType) != null) continue;
     const layout = {
       kind: "variable" as const,
       logicalIndex,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -47,7 +47,11 @@ import {
   createRecord,
   createRecordValueDecoder,
   decodeNativeRowValues,
+  encodeNativeColumnValue,
+  encodeNativeNullValue,
+  encodeU32Le,
   logicalStorageColumns,
+  nativeFixedValueSize,
   storageColumnTypeToValueType,
   storageColumnValueType,
   writeDescriptor,
@@ -363,7 +367,6 @@ type NativeRowFieldPlan = {
   includeInValues: boolean;
 };
 
-const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 const byteHex = Array.from({ length: 256 }, (_, byte) => byte.toString(16).padStart(2, "0"));
 const nativeRowFieldPlanCache = new WeakMap<WasmSchema, Map<string, NativeRowFieldPlan[]>>();
@@ -3411,7 +3414,7 @@ function encodeCells(
     .sort((left, right) => left.name.localeCompare(right.name))
     .map((column) => ({ name: column.name, valueType: storageColumnValueType(column), column }));
   const values = descriptor.map(({ column }) =>
-    encodeValue(column, valueFor(column), requireMissingDefaults),
+    encodeCellValue(column, valueFor(column), requireMissingDefaults),
   );
   const writer = new PostcardWriter();
   writeDescriptor(writer, descriptor);
@@ -3436,151 +3439,30 @@ function assertRequiredRowColumnsPresent(
   }
 }
 
-function encodeValue(
+/**
+ * Mutation cells deliberately differ from packed rows only when a field is
+ * omitted: inserts can leave a server default unresolved, whereas patches
+ * never synthesize a missing field. Every present value is encoded by the row
+ * codec so scalar tags, arrays, nested rows, nullable values, and sparse
+ * carriers have one binary authority.
+ */
+function encodeCellValue(
   column: ColumnDescriptor,
   value: Value | undefined,
   requireMissingDefaults: boolean,
 ): Uint8Array {
   const resolved = value;
-  if (!resolved || resolved.type === "Null") {
-    if (column.nullable) return encodeNullValue(storageColumnValueType(column));
+  if (!resolved) {
+    if (column.nullable) return encodeNativeNullValue(storageColumnValueType(column));
     if (column.column_type.type === "Array") {
-      return encodeNonNullValue(column.column_type, { type: "Array", value: [] });
+      return encodeNativeColumnValue(column, { type: "Array", value: [] });
     }
     if (requireMissingDefaults && column.default == null) {
       throw new Error(`missing required column ${column.name}`);
     }
     return new Uint8Array();
   }
-  const bytes = encodeNonNullValue(column.column_type, resolved);
-  return column.nullable ? concatBytes([Uint8Array.of(1), bytes]) : bytes;
-}
-
-function encodeNonNullValue(type: ColumnType, value: Value): Uint8Array {
-  const view = new DataView(new ArrayBuffer(8));
-  switch (type.type) {
-    case "Boolean":
-      return Uint8Array.of(value.type === "Boolean" && value.value ? 1 : 0);
-    case "Integer":
-      view.setInt32(0, expectI32(value, "Integer"), true);
-      return new Uint8Array(view.buffer, 0, 4);
-    case "Timestamp":
-      view.setBigUint64(0, BigInt(expectNumber(value, type.type)), true);
-      return new Uint8Array(view.buffer);
-    case "BigInt":
-      view.setBigInt64(0, expectI64(value, "BigInt"), true);
-      return new Uint8Array(view.buffer);
-    case "Double":
-      view.setFloat64(0, expectNumber(value, "Double"), true);
-      return new Uint8Array(view.buffer);
-    case "Text":
-    case "Json":
-    case "Enum":
-      return textEncoder.encode(expectString(value, type.type));
-    case "Uuid":
-      return parseUuid(expectString(value, "Uuid"));
-    case "Bytea":
-      if (value.type !== "Bytea") throw new Error("expected Bytea value");
-      return value.value;
-    case "Array":
-      return encodeArrayValue(type.element, value);
-    case "Row":
-      throw new Error(`Native runtime does not encode ${type.type} values yet`);
-  }
-}
-
-function encodeArrayValue(elementType: ColumnType, value: Value): Uint8Array {
-  if (value.type !== "Array") throw new Error("expected Array value");
-  const encoded = value.value.map((item) => encodeNonNullValue(elementType, item));
-  const elementWidth = fixedValueSize(storageColumnTypeToValueType(elementType));
-  if (elementWidth != null) return concatBytes(encoded);
-
-  const offsets = new PostcardWriter();
-  let nextOffset = 4 + Math.max(0, encoded.length - 1) * 4;
-  for (const chunk of encoded.slice(0, -1)) {
-    nextOffset += chunk.length;
-    offsets.u32Le(nextOffset);
-  }
-  return concatBytes([u32Le(encoded.length), offsets.finish(), ...encoded]);
-}
-
-function u32Le(value: number): Uint8Array {
-  const bytes = new Uint8Array(4);
-  new DataView(bytes.buffer).setUint32(0, value, true);
-  return bytes;
-}
-
-function encodeNullValue(valueType: ValueType): Uint8Array {
-  const width = fixedValueSize(valueType);
-  return width == null ? Uint8Array.of(0) : new Uint8Array(width);
-}
-
-function fixedValueSize(valueType: ValueType): number | undefined {
-  switch (valueType.tag) {
-    case 0:
-    case 7:
-    case 11:
-      return 1;
-    case 1:
-      return 2;
-    case 2:
-    case 4:
-      return 4;
-    case 3:
-    case 5:
-    case 6:
-      return 8;
-    case 10:
-      return 16;
-    case 12: {
-      const members = valueType.members ?? (valueType.inner ? [valueType.inner] : []);
-      return members.reduce<number | undefined>((total, member) => {
-        if (total == null) return undefined;
-        const memberSize = fixedValueSize(member);
-        return memberSize == null ? undefined : total + memberSize;
-      }, 0);
-    }
-    case 14: {
-      const innerSize = valueType.inner ? fixedValueSize(valueType.inner) : undefined;
-      return innerSize == null ? undefined : innerSize + 1;
-    }
-    default:
-      return undefined;
-  }
-}
-
-function expectNumber(value: Value, type: string): number {
-  if (
-    (value.type === "Integer" || value.type === "Double" || value.type === "Timestamp") &&
-    typeof value.value === "number"
-  ) {
-    return value.value;
-  }
-  throw new Error(`expected ${type} value`);
-}
-
-function expectI32(value: Value, type: string): number {
-  const number = expectNumber(value, type);
-  if (!Number.isSafeInteger(number) || number < -0x80000000 || number > 0x7fffffff) {
-    throw new Error(`${type} value must be a signed 32-bit integer`);
-  }
-  return number;
-}
-
-function expectI64(value: Value, type: string): bigint {
-  if (value.type !== "BigInt") throw new Error(`expected ${type} value`);
-  const number = BigInt(value.value);
-  if (number < -(1n << 63n) || number > (1n << 63n) - 1n) {
-    throw new Error(`${type} value must be a signed 64-bit integer`);
-  }
-  return number;
-}
-
-function expectString(value: Value, type: string): string {
-  if ((value.type === "Text" || value.type === "Uuid") && typeof value.value === "string") {
-    return value.value;
-  }
-  throw new Error(`expected ${type} value`);
+  return encodeNativeColumnValue(column, resolved);
 }
 
 function readRowBatches(payload: Uint8Array): NativeRowBatch[] {
@@ -3995,7 +3877,7 @@ function decodeArrayBytes(
   storageElementType?: ValueType,
   nestedRowCarrier: NestedRowCarrier = "full-record",
 ): Value[] {
-  const elementWidth = fixedValueSize(
+  const elementWidth = nativeFixedValueSize(
     storageElementType ?? storageColumnTypeToValueType(elementType),
   );
   if (elementWidth != null) {
@@ -4227,7 +4109,7 @@ function nativeResetDeltaFromBatches(
       : (raw: Uint8Array) => raw;
     for (const row of batch.rows) {
       const raw = encodeFrameRow(row.raw);
-      chunks.push(row.rowId, u32Le(rowIndex), u32Le(raw.byteLength), raw);
+      chunks.push(row.rowId, encodeU32Le(rowIndex), encodeU32Le(raw.byteLength), raw);
       rowIndex += 1;
     }
   }
@@ -4302,9 +4184,9 @@ function createRawNativeFrameRowEncoder(
     const values = columns.map((column) => {
       const sourceIndex = sourceIndexesByPublicName.get(column.name);
       const outputValueType = storageColumnValueType(column);
-      if (sourceIndex === undefined) return encodeNullValue(outputValueType);
+      if (sourceIndex === undefined) return encodeNativeNullValue(outputValueType);
       const decoded = decodeRecord(raw, sourceIndex);
-      if (decoded == null) return encodeNullValue(outputValueType);
+      if (decoded == null) return encodeNativeNullValue(outputValueType);
       return encodeFrameColumnValue(decoded, outputValueType);
     });
     return createRecord(outputDescriptor, values);
@@ -4403,9 +4285,9 @@ function encodeNativeRows(
         `${String(error)} while encoding ${row.table}: ${columns.map((column, index) => `${column.name}:${column.column_type.type}=${frameValues[index]?.type}`).join(", ")}`,
       );
     }
-    chunks.push(requiredUuidBytes(row.id), u32Le(rowIndexByKey.get(rowStateKey(row)) ?? 0));
+    chunks.push(requiredUuidBytes(row.id), encodeU32Le(rowIndexByKey.get(rowStateKey(row)) ?? 0));
     if (updated) chunks.push(Uint8Array.of(1));
-    chunks.push(u32Le(raw.byteLength), raw);
+    chunks.push(encodeU32Le(raw.byteLength), raw);
   }
   return concatBytes(chunks);
 }
@@ -4426,7 +4308,7 @@ function valuesForNativeFrame(row: RowState, columns: readonly ColumnDescriptor[
 }
 
 function encodeNativeRemoves(removed: Array<{ id: string; index: number }>): Uint8Array {
-  return concatBytes(removed.flatMap((row) => [requiredUuidBytes(row.id), u32Le(row.index)]));
+  return concatBytes(removed.flatMap((row) => [requiredUuidBytes(row.id), encodeU32Le(row.index)]));
 }
 
 function legacyResultKey(id: string): Uint8Array {


### PR DESCRIPTION
🤖 ## What changed

- Makes the native row codec the shared low-level value encoder for mutation and packed-row paths.
- Leaves insert/patch omission and default policy in the runtime adapter.
- Rejects invalid Boolean tags, supports nested rows, and aligns nullable/sparse explicit-null bytes for rows and patches.

## Why

Two independent encoders had already diverged on Boolean validation, nested rows, and sparse-null semantics.

## Validation

- Independent adversarial review: no P0/P1/P2 after the sparse-null follow-up.
- 120 focused runtime/codec tests pass, with one intentional skip.
- Fresh NAPI build/load and focused native subscription test pass.
- Combined stack workspace check and 124 TS runtime/codec tests pass.