### PR TITLE
(cleanup) unify terminal subscription payloads

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2330,10 +2330,6 @@ fn core_subscription_event_to_json(event: &SubscriptionEvent) -> napi::Result<se
                 "reset": reset,
                 "delta": delta,
                 "terminalOperations": terminal_operations,
-                // Terminal operation bytes originate from Rust CurrentRow
-                // records, whose app cells retain their nullable carrier.
-                // WASM's older logical terminal payloads omit that envelope.
-                "terminalPayloadEncoding": "current-row",
                 "settled": settled,
                 "tier": format!("{tier:?}"),
             });

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -85,8 +85,6 @@ export interface NativeRowDelta {
   updatedOccurrenceKeys?: Uint8Array[];
   removedOccurrenceKeys?: Uint8Array[];
   terminalOperations?: NativeTerminalOperation[];
-  /** Indices of terminal operations encoded as NAPI CurrentRow payloads. */
-  terminalCurrentRowOperationIndexes?: number[];
 }
 
 export type SubscriptionWireDelta = RowDelta | NativeRowDelta;

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1753,6 +1753,7 @@ export class NativeRuntimeAdapter implements Runtime {
         subscription.packedResetBatches = chunk.delta.added;
         subscription.packedResetRows = packedResetRows;
         subscription.opened = true;
+        packedResetRows.terminalOperations = chunk.terminalOperations;
         this.publishSubscriptionRows(subscription, packedResetRows, chunk.settled, true);
       } else {
         materializePackedResetRows(subscription, this.schema);

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -332,10 +332,7 @@ type SubscriptionState = {
   visibleOpened: boolean;
   deferredVisiblePublication: boolean;
   deferredVisibleReset: boolean;
-  deferredTerminalOperations: Array<{
-    operation: NativeTerminalOperation;
-    currentRowCarrier: boolean;
-  }>;
+  deferredTerminalOperations: NativeTerminalOperation[];
   callback?: Function;
   cancelled: boolean;
 };
@@ -1771,11 +1768,6 @@ export class NativeRuntimeAdapter implements Runtime {
         subscription.rowIndexByKey = applied.rowIndexByKey;
         subscription.opened = true;
         applied.wireDelta.terminalOperations = chunk.terminalOperations;
-        applied.wireDelta.terminalCurrentRowOperationIndexes = chunk.terminalCurrentRowCarrier
-          ? chunk.terminalOperations?.flatMap((operation, index) =>
-              operation.path.length === 0 ? [index] : [],
-            )
-          : undefined;
         this.publishSubscriptionRows(
           subscription,
           applied.wireDelta,
@@ -1795,12 +1787,7 @@ export class NativeRuntimeAdapter implements Runtime {
     if (this.subscriptionCallbacksAreSettledGated(subscription) && settled === false) {
       subscription.deferredVisiblePublication = true;
       subscription.deferredVisibleReset ||= reset;
-      subscription.deferredTerminalOperations.push(
-        ...(wireDelta.terminalOperations ?? []).map((operation, index) => ({
-          operation,
-          currentRowCarrier: wireDelta.terminalCurrentRowOperationIndexes?.includes(index) ?? false,
-        })),
-      );
+      subscription.deferredTerminalOperations.push(...(wireDelta.terminalOperations ?? []));
       return;
     }
 
@@ -1831,16 +1818,10 @@ export class NativeRuntimeAdapter implements Runtime {
 
     const terminalOperations = [
       ...subscription.deferredTerminalOperations,
-      ...(wireDelta.terminalOperations ?? []).map((operation, index) => ({
-        operation,
-        currentRowCarrier: wireDelta.terminalCurrentRowOperationIndexes?.includes(index) ?? false,
-      })),
+      ...(wireDelta.terminalOperations ?? []),
     ];
     if (terminalOperations.length > 0) {
-      visibleDelta.terminalOperations = terminalOperations.map(({ operation }) => operation);
-      visibleDelta.terminalCurrentRowOperationIndexes = terminalOperations.flatMap(
-        ({ currentRowCarrier }, index) => (currentRowCarrier ? [index] : []),
-      );
+      visibleDelta.terminalOperations = terminalOperations;
     }
 
     subscription.callback?.(visibleDelta);
@@ -3937,7 +3918,6 @@ function normalizeSubscriptionChunk(chunk: unknown):
       reset?: boolean;
       delta: NativeSubscriptionDelta;
       terminalOperations?: NativeTerminalOperation[];
-      terminalCurrentRowCarrier?: boolean;
       settled?: boolean;
     }
   | {
@@ -3957,7 +3937,6 @@ function normalizeSubscriptionChunk(chunk: unknown):
     reset?: unknown;
     settled?: unknown;
     terminalOperations?: unknown;
-    terminalPayloadEncoding?: unknown;
   };
   if (record.type === "closed" || record.type === "Closed") {
     return { type: "closed" };
@@ -3979,7 +3958,6 @@ function normalizeSubscriptionChunk(chunk: unknown):
       terminalOperations: Array.isArray(record.terminalOperations)
         ? (record.terminalOperations as NativeTerminalOperation[])
         : undefined,
-      terminalCurrentRowCarrier: record.terminalPayloadEncoding === "current-row",
       settled: typeof record.settled === "boolean" ? record.settled : undefined,
     };
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -60,7 +60,7 @@ class FakeWorker {
   emitSubscription(subscription: number, delta: NativeRowDelta): void {
     queueMicrotask(() => {
       this.onmessage?.({
-        data: {
+        data: structuredClone({
           subscription,
           frame: {
             kind: "native-row-delta",
@@ -80,8 +80,9 @@ class FakeWorker {
             addedCount: delta.addedCount,
             removedCount: delta.removedCount,
             updatedCount: delta.updatedCount,
+            terminalOperations: delta.terminalOperations,
           },
-        },
+        }),
       } as MessageEvent);
     });
   }
@@ -982,6 +983,70 @@ describe("PersistentBrowserOpfsRuntime", () => {
     });
     expect([...updates[0]!.added]).toEqual([...added]);
 
+    await runtime.close();
+  });
+
+  it("round-trips canonical terminal operations through the worker subscription frame", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-terminal-operations-frame-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+    const subscriptionHandle = runtime.createSubscription(
+      JSON.stringify({ table: "todos" }),
+      null,
+      "local",
+      null,
+    );
+    const updates: NativeRowDelta[] = [];
+    runtime.executeSubscription(subscriptionHandle, (delta: NativeRowDelta) => updates.push(delta));
+
+    await vi.waitFor(() => {
+      expect(
+        worker.messages.some((message) => message.method === "createExecutedSubscription"),
+      ).toBe(true);
+    });
+    worker.respond(
+      worker.messages.find((message) => message.method === "createExecutedSubscription")!.id,
+      7,
+    );
+
+    const rootId = "00000000-0000-0000-0000-000000000123";
+    const childId = "00000000-0000-0000-0000-000000000124";
+    const rootKey = [10, ...uuidBytes(rootId)];
+    const childKey = [10, ...uuidBytes(childId)];
+    // CurrentRow root: key followed by the nullable-carried Text field.
+    const rootPayload = [...uuidBytes(rootId), 1, ...new TextEncoder().encode("root")];
+    const terminalOperations = [
+      {
+        root_key: rootKey,
+        path: [],
+        edit: { Insert: { index: 0, key: rootKey, value: rootPayload } },
+      },
+      {
+        root_key: rootKey,
+        path: [{ Collection: "children" }],
+        edit: { Insert: { index: 0, key: childKey, value: [...uuidBytes(childId), 99] } },
+      },
+    ];
+    worker.emitSubscription(subscriptionHandle, {
+      __jazzNativeRowDelta: true,
+      added: new Uint8Array(),
+      removed: new Uint8Array(),
+      updated: new Uint8Array(),
+      addedCount: 0,
+      removedCount: 0,
+      updatedCount: 0,
+      terminalOperations,
+    });
+
+    await vi.waitFor(() => expect(updates).toHaveLength(1));
+    expect(updates[0]!.terminalOperations).toEqual(terminalOperations);
     await runtime.close();
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -4399,6 +4399,37 @@ describe("NativeRuntimeAdapter server transport", () => {
     ordinary.close();
   });
 
+  it("preserves terminal operations through settle-gated packed Gather reset delivery", () => {
+    const rowId = uuidBytes("00000000-0000-0000-0000-000000000501");
+    const key = [10, ...rowId];
+    const terminalOperations = [{ root_key: key, path: [], edit: { Move: { key, index: 0 } } }];
+    const runtime = runtimeWithNativeRelationSubscriptionChunks([
+      {
+        ...relationSubscriptionChunk({
+          reset: true,
+          settled: false,
+          rootAdded: [{ table: "todos", rowId, title: "packed gather root" }],
+        }),
+        terminalOperations,
+      },
+      relationSubscriptionChunk({ settled: true }),
+    ]);
+    const deltas: NativeRowDelta[] = [];
+    const handle = runtime.createSubscription(
+      JSON.stringify({ table: "todos", relation_ir: { Gather: {} } }),
+      null,
+      "global",
+      null,
+    );
+
+    runtime.executeSubscription(handle, (delta: NativeRowDelta) => deltas.push(delta));
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]!.reset).toBe(true);
+    expect(deltas[0]!.terminalOperations).toEqual(terminalOperations);
+    runtime.close();
+  });
+
   it("rewraps user field option bytes when packed reset frames filter engine records", () => {
     const schema = {
       notes: {
@@ -5785,11 +5816,13 @@ function runtimeWithNativeRelationSubscriptionChunks(chunks: unknown[]): NativeR
 
 function relationSubscriptionChunk({
   reset = false,
+  settled = true,
   rootAdded = [],
   rootUpdated = [],
   rootRemoved = [],
 }: {
   reset?: boolean;
+  settled?: boolean;
   rootAdded?: EncodedTestRow[];
   rootUpdated?: EncodedTestRow[];
   rootRemoved?: Array<{ table: string; rowId: Uint8Array }>;
@@ -5797,7 +5830,7 @@ function relationSubscriptionChunk({
   return {
     type: "delta",
     reset,
-    settled: true,
+    settled,
     delta: encodeSubscriptionDelta({
       added: rootAdded,
       updated: rootUpdated,

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import { SubscriptionManager, applySubscriptionDelta } from "./subscription-manager.js";
 import type { SubscriptionDelta } from "./subscription-manager.js";
+import { encodeNativeRowValues } from "./native-runtime/native-row-codec.js";
 import type {
   ColumnDescriptor,
   NativeRowDelta,
@@ -98,15 +99,22 @@ function nativeRowData(name: string, count: number): Uint8Array {
 }
 
 function terminalRowData(id: string, name: string, count: number): Uint8Array {
-  return Uint8Array.from([...uuidBytes(id), ...nativeRowData(name, count)]);
+  return Uint8Array.from([
+    ...uuidBytes(id),
+    ...encodeNativeRowValues(currentRowColumns(nativeColumns), [
+      { type: "Text", value: name },
+      { type: "Integer", value: count },
+    ]),
+  ]);
 }
 
 function terminalRootWithEmptyChildren(id: string, title: string): Uint8Array {
   const text = new TextEncoder().encode(title);
   const bytes: number[] = [...uuidBytes(id)];
-  pushU32(bytes, 20 + text.byteLength);
-  bytes.push(...text);
-  pushU32(bytes, 0);
+  // The root uses CurrentRow's nullable carrier. The child collection stays a
+  // terminal record when it is populated by a descendant operation.
+  pushU32(bytes, 21 + text.byteLength);
+  bytes.push(1, ...text, 1, 0, 0, 0, 0);
   return Uint8Array.from(bytes);
 }
 
@@ -117,6 +125,10 @@ function nativeRootWithEmptyChildren(title: string): Uint8Array {
   bytes.push(...text);
   pushU32(bytes, 0);
   return Uint8Array.from(bytes);
+}
+
+function currentRowColumns(columns: readonly ColumnDescriptor[]): readonly ColumnDescriptor[] {
+  return columns.map((column) => ({ ...column, nullable: true, sparse: undefined }));
 }
 
 function terminalTextChild(id: string, name: string): Uint8Array {
@@ -718,6 +730,55 @@ describe("SubscriptionManager", () => {
       nativeColumns,
     );
     expect(removed).toEqual({ delta: [{ kind: 1, id, index: 0 }], all: [] });
+  });
+
+  it("decodes every root terminal payload through the CurrentRow nullable carrier", () => {
+    type NullableRoot = { id: string; title: string | null; done: boolean | null };
+    const manager = new SubscriptionManager<NullableRoot>();
+    const id = "00000000-0000-4000-8000-000000000001";
+    const key = [10, ...uuidBytes(id)];
+    const columns: ColumnDescriptor[] = [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "done", column_type: { type: "Boolean" }, nullable: false },
+    ];
+    const currentRowPayload = Uint8Array.from([
+      ...uuidBytes(id),
+      ...encodeNativeRowValues(currentRowColumns(columns), [
+        { type: "Null" },
+        { type: "Boolean", value: false },
+      ]),
+    ]);
+
+    const result = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: key,
+            path: [],
+            edit: { Insert: { index: 0, key, value: [...currentRowPayload] } },
+          },
+        ],
+      },
+      (row) => {
+        const title = row.values[0];
+        const done = row.values[1];
+        return {
+          id: row.id,
+          title: title?.type === "Text" ? title.value : null,
+          done: done?.type === "Boolean" ? done.value : null,
+        };
+      },
+      columns,
+    );
+
+    expect(result.all).toEqual([{ id, title: null, done: false }]);
   });
 
   it("applies root insert positions in producer order after earlier removals", () => {

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -313,7 +313,6 @@ export class SubscriptionManager<T extends { id: string }> {
             delta.terminalOperations,
             transform,
             nativeColumns,
-            new Set(delta.terminalCurrentRowOperationIndexes),
           );
           return reset
             ? { delta: terminalResult.delta, all: terminalResult.all ?? this.all(), reset: true }
@@ -353,7 +352,6 @@ export class SubscriptionManager<T extends { id: string }> {
     operations: NativeTerminalOperation[],
     transform: (row: WasmRow) => T,
     rootColumns: readonly ColumnDescriptor[],
-    currentRowOperationIndexes: ReadonlySet<number>,
   ): SubscriptionDelta<T> {
     const beforeIndices = new Map(this.orderedIdIndex);
     const affectedRoots = new Set<string>();
@@ -361,7 +359,7 @@ export class SubscriptionManager<T extends { id: string }> {
     // batches are addressable. Positional insertion remains in producer order:
     // applying its index before an earlier root Remove makes the outcome depend
     // on operation-key ordering.
-    for (const [operationIndex, operation] of operations.entries()) {
+    for (const operation of operations) {
       if (operation.path.length !== 0 || !("Insert" in operation.edit)) continue;
       const rootId = this.terminalAddress(operation.root_key);
       const rootRowId = terminalPayloadRowId(operation.root_key);
@@ -372,15 +370,13 @@ export class SubscriptionManager<T extends { id: string }> {
         rootId,
         decodeNativeTerminalRow(
           rootRowId,
-          currentRowOperationIndexes.has(operationIndex)
-            ? rootTerminalCurrentRowColumns(rootColumns)
-            : rootColumns,
+          rootTerminalCurrentRowColumns(rootColumns),
           Uint8Array.from(edit.Insert.value),
         ),
       );
     }
 
-    for (const [operationIndex, operation] of operations.entries()) {
+    for (const operation of operations) {
       const rootId = this.terminalRootId(operation.root_key);
       const edit = operation.edit;
       if (operation.path.length === 0) {
@@ -400,9 +396,7 @@ export class SubscriptionManager<T extends { id: string }> {
             rootId,
             decodeNativeTerminalRow(
               terminalPayloadRowId(operation.root_key),
-              currentRowOperationIndexes.has(operationIndex)
-                ? rootTerminalCurrentRowColumns(rootColumns)
-                : rootColumns,
+              rootTerminalCurrentRowColumns(rootColumns),
               Uint8Array.from(edit.Update.value),
             ),
           );


### PR DESCRIPTION
🤖 This removes the temporary dual-format compatibility between NAPI and WASM terminal subscription payloads.

## What changed

- removed the `terminalPayloadEncoding` producer discriminator
- removed operation-index/current-row carrier sidecars and conditional decoding
- made root terminal operations consistently use the nullable `CurrentRow` carrier across NAPI and WASM
- retained the structurally distinct child terminal-record representation
- preserved terminal operations through packed relation resets and settle deferral/replay
- added persistent-browser structured-clone coverage for root and child terminal operations

## Why

This is a new runtime boundary, so carrying both a legacy logical representation and the canonical Rust `CurrentRow` representation adds branching, operation-index bookkeeping, and opportunities for producer-dependent behavior without providing useful compatibility.

The cleanup also exposed an existing packed-reset fast-path bug that silently dropped terminal operations; this stack fixes it and plants a regression.

## Validation

- focused subscription-manager, native-runtime, and persistent-browser Vitest suites: 171 passed, 1 skipped
- TypeScript no-emit check
- `cargo check -p jazz-napi -p jazz-wasm`
- independent adversarial review, including planted nullable-carrier, ordering/coalescing, packed-reset, and structured-clone regressions
