### PR TITLE
feat: add `Db.onMutationError`

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -30,6 +30,7 @@ export declare class NapiDb {
   /** Roll back an owner-wide open batch by id. */
   rollbackTransaction(openBatchId: string): void
   setTickScheduler(callback: ((err: Error | null, arg: string) => void)): void
+  onMutationError(callback: (event: any) => void): void
   prepareQuery(query: Uint8Array): PreparedQuery
   all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
@@ -107,9 +108,8 @@ export declare class Tx {
 export declare class Write {
   get batchId(): string
   get payload(): Uint8Array
-  wait(tier: string): void
+  wait(tier: string): Promise<undefined>
   writeState(): any
-  nextWriteStateChange(): Promise<undefined>
   close(): boolean
 }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -45,7 +45,8 @@ use jazz::db::{
     ConnectionSessionContext as CoreConnectionSessionContext, Db as CoreDb,
     DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,
     InitialSyncFlushCadence as CoreInitialSyncFlushCadence, LocalUpdates as CoreLocalUpdates,
-    MergeableTxOps, PeerConnection as CorePeerConnection, PreparedQuery as PreparedQueryInner,
+    MergeableTxOps, MutationErrorCallback as CoreMutationErrorCallback,
+    PeerConnection as CorePeerConnection, PreparedQuery as PreparedQueryInner,
     Propagation as CorePropagation, QueryAttachment as CoreQueryAttachment,
     ReadOpts as CoreReadOpts, RowCells as CoreRowCells, SeededRowIdSource as CoreSeededRowIdSource,
     SubscriptionEvent, SubscriptionStream, TickScheduler as CoreTickScheduler,
@@ -72,7 +73,7 @@ use jazz::tools::server::{
     TestJwtIssuer as JazzTestJwtIssuer, TestJwtOptions,
 };
 use jazz::tools::{AppId, BatchId};
-use jazz::tx::{DurabilityTier as CoreDurabilityTier, Fate as CoreFate, TxId};
+use jazz::tx::{DurabilityTier as CoreDurabilityTier, TxId};
 use jazz::wire::{
     TransportError, WireAuthorityEndpoint as CoreWireAuthorityEndpoint,
     WireTransport as CoreWireTransport,
@@ -292,6 +293,39 @@ macro_rules! with_napi_exclusive_tx {
     }};
 }
 
+impl Write {
+    fn wait_promise(
+        &self,
+        env: Env,
+        tier: CoreDurabilityTier,
+    ) -> napi::Result<PromiseRaw<'static, ()>> {
+        let Some(write) = &self.inner else {
+            return Err(napi::Error::from_reason("write state is unavailable"));
+        };
+        let mut deferred = std::ptr::null_mut();
+        let mut promise = std::ptr::null_mut();
+        let env = env.raw();
+        let status = unsafe { sys::napi_create_promise(env, &mut deferred, &mut promise) };
+        if status != sys::Status::napi_ok {
+            return Err(napi::Error::from_reason(
+                "failed to create transaction wait promise",
+            ));
+        }
+        let callback = move |result: std::result::Result<TxId, jazz::db::Error>| {
+            finish_wait_promise(env, deferred, result);
+        };
+        match write {
+            NapiWrite::Memory { db, tx_id } => {
+                db.wait_for_transaction_with(*tx_id, tier, callback);
+            }
+            NapiWrite::Persistent { db, tx_id } => {
+                db.wait_for_transaction_with(*tx_id, tier, callback);
+            }
+        }
+        Ok(PromiseRaw::new(env, promise))
+    }
+}
+
 #[napi]
 impl Write {
     #[napi(getter, js_name = "batchId")]
@@ -302,18 +336,6 @@ impl Write {
     #[napi(getter)]
     pub fn payload(&self) -> Uint8Array {
         Uint8Array::new(self.payload.clone())
-    }
-
-    #[napi]
-    pub fn wait(&self, tier: String) -> napi::Result<()> {
-        let tier = core_durability_tier_from_str(&tier)?;
-        if let Some(write) = &self.inner {
-            match write {
-                NapiWrite::Memory { db, tx_id } => core_wait_for_tx(db, *tx_id, tier)?,
-                NapiWrite::Persistent { db, tx_id } => core_wait_for_tx(db, *tx_id, tier)?,
-            }
-        }
-        Ok(())
     }
 
     #[napi(js_name = "writeState")]
@@ -329,33 +351,9 @@ impl Write {
         Ok(core_write_state_to_json(&state))
     }
 
-    #[napi(js_name = "nextWriteStateChange")]
-    pub fn next_write_state_change(&self, env: Env) -> napi::Result<PromiseRaw<'static, ()>> {
-        let Some(write) = &self.inner else {
-            return Err(napi::Error::from_reason("write state is unavailable"));
-        };
-        let mut deferred = std::ptr::null_mut();
-        let mut promise = std::ptr::null_mut();
-        let env = env.raw();
-        let status = unsafe { sys::napi_create_promise(env, &mut deferred, &mut promise) };
-        if status != sys::Status::napi_ok {
-            return Err(napi::Error::from_reason(
-                "failed to create write-state promise",
-            ));
-        }
-        match write {
-            NapiWrite::Memory { db, tx_id } => {
-                db.on_next_write_state_change(*tx_id, move || {
-                    resolve_raw_promise(env, deferred);
-                });
-            }
-            NapiWrite::Persistent { db, tx_id } => {
-                db.on_next_write_state_change(*tx_id, move || {
-                    resolve_raw_promise(env, deferred);
-                });
-            }
-        }
-        Ok(PromiseRaw::new(env, promise))
+    #[napi]
+    pub fn wait(&self, env: Env, tier: String) -> napi::Result<PromiseRaw<'static, ()>> {
+        self.wait_promise(env, core_durability_tier_from_str(&tier)?)
     }
 
     #[napi]
@@ -837,6 +835,31 @@ impl NapiDb {
         match db {
             NapiDbInnerStorage::Memory(db) => db.set_tick_scheduler(Some(scheduler)),
             NapiDbInnerStorage::Persistent(db) => db.set_tick_scheduler(Some(scheduler)),
+        }
+        Ok(())
+    }
+
+    #[napi(
+        js_name = "onMutationError",
+        ts_args_type = "callback: (event: any) => void"
+    )]
+    pub fn on_mutation_error(
+        &self,
+        callback: ThreadsafeFunction<JsonValue, ()>,
+    ) -> napi::Result<()> {
+        let callback: CoreMutationErrorCallback = Rc::new(move |event| {
+            let Ok(event) = serde_json::to_value(event) else {
+                return;
+            };
+            let _ = callback.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+        });
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => db.on_mutation_error(Rc::clone(&callback)),
+            NapiDbInnerStorage::Persistent(db) => db.on_mutation_error(Rc::clone(&callback)),
         }
         Ok(())
     }
@@ -2031,37 +2054,6 @@ where
     Ok(stats.subscription_events as u32)
 }
 
-fn core_wait_for_tx<S>(db: &CoreDb<S>, tx_id: TxId, tier: CoreDurabilityTier) -> napi::Result<()>
-where
-    S: CoreOrderedKvStorage + CoreReopenableStorage + 'static,
-{
-    if tier <= CoreDurabilityTier::Local {
-        return Ok(());
-    }
-    let state = db
-        .write_state(tx_id)
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-    match state.fate {
-        CoreFate::Rejected(reason) => {
-            return Err(napi::Error::from_reason(format!(
-                "transaction was rejected: {reason:?}"
-            )));
-        }
-        CoreFate::Pending if tier >= CoreDurabilityTier::Edge => {
-            return Err(napi::Error::from_reason(format!(
-                "transaction has not been accepted at requested tier {tier:?}"
-            )));
-        }
-        CoreFate::Pending | CoreFate::Accepted => {}
-    }
-    if state.durability >= tier {
-        return Ok(());
-    }
-    Err(napi::Error::from_reason(format!(
-        "transaction has not reached requested tier {tier:?}"
-    )))
-}
-
 fn core_write_state_to_json(state: &jazz::db::WriteState) -> serde_json::Value {
     serde_json::to_value(state).unwrap_or_else(|_| serde_json::json!({}))
 }
@@ -2072,6 +2064,39 @@ fn resolve_raw_promise(env: sys::napi_env, deferred: sys::napi_deferred) {
     if status == sys::Status::napi_ok {
         let _ = unsafe { sys::napi_resolve_deferred(env, deferred, undefined) };
     }
+}
+
+fn finish_wait_promise(
+    env: sys::napi_env,
+    deferred: sys::napi_deferred,
+    result: std::result::Result<TxId, jazz::db::Error>,
+) {
+    let Err(error) = result else {
+        resolve_raw_promise(env, deferred);
+        return;
+    };
+    let message = error.to_string();
+    let mut js_message = std::ptr::null_mut();
+    let status = unsafe {
+        sys::napi_create_string_utf8(
+            env,
+            message.as_ptr().cast(),
+            message.len() as isize,
+            &mut js_message,
+        )
+    };
+    if status != sys::Status::napi_ok {
+        return;
+    }
+    let mut js_error = std::ptr::null_mut();
+    let status =
+        unsafe { sys::napi_create_error(env, std::ptr::null_mut(), js_message, &mut js_error) };
+    let rejection = if status == sys::Status::napi_ok {
+        js_error
+    } else {
+        js_message
+    };
+    let _ = unsafe { sys::napi_reject_deferred(env, deferred, rejection) };
 }
 
 fn core_commit_tx<S>(db: &CoreDb<S>, open_tx: CoreOpenBatchId) -> napi::Result<TxId>

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -8,9 +8,10 @@ use base64::Engine;
 use futures_util::{Stream, StreamExt};
 use jazz::db::{
     block_on, ConnectionSessionContext, Db, DbConfig, DbIdentity, ExclusiveTxOps,
-    InitialSyncFlushCadence, LocalUpdates, MergeableTxOps, PeerConnection, PermissionAdvice,
-    PreparedQuery, Propagation, QueryAttachment, ReadOpts, RowCells, SeededRowIdSource,
-    SubscriptionEvent, TickScheduler, TickUrgency, WireTransportAdapter, WriteHandle,
+    InitialSyncFlushCadence, LocalUpdates, MergeableTxOps, MutationErrorCallback, PeerConnection,
+    PermissionAdvice, PreparedQuery, Propagation, QueryAttachment, ReadOpts, RowCells,
+    SeededRowIdSource, SubscriptionEvent, TickScheduler, TickUrgency, WireTransportAdapter,
+    WriteHandle,
 };
 use jazz::groove::records::{BorrowedRecord, RecordDescriptor, Value};
 #[cfg(target_arch = "wasm32")]
@@ -278,40 +279,15 @@ impl WasmWrite {
     }
 
     #[wasm_bindgen(js_name = wait)]
-    pub fn wait(&self, tier: String) -> Result<(), JsValue> {
+    pub fn wait(&self, tier: String) -> Result<js_sys::Promise, JsValue> {
         let tier = durability_tier_from_str(&tier)?;
         match &self.inner {
             Some(WasmWriteInner::MemoryTx { db, tx_id }) => {
-                wait_for_tx(db, *tx_id, tier)?;
+                Ok(wait_promise(db.as_ref(), *tx_id, tier))
             }
             #[cfg(target_arch = "wasm32")]
             Some(WasmWriteInner::BrowserTx { db, tx_id }) => {
-                wait_for_tx(db, *tx_id, tier)?;
-            }
-            None => return Err(JsValue::from_str("write wait is unavailable")),
-        }
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = nextWriteStateChange)]
-    pub fn next_write_state_change(&self) -> Result<js_sys::Promise, JsValue> {
-        match &self.inner {
-            Some(WasmWriteInner::MemoryTx { db, tx_id }) => {
-                let db = Rc::clone(db);
-                let tx_id = *tx_id;
-                Ok(future_to_promise(async move {
-                    db.next_write_state_change(tx_id).await;
-                    Ok(JsValue::UNDEFINED)
-                }))
-            }
-            #[cfg(target_arch = "wasm32")]
-            Some(WasmWriteInner::BrowserTx { db, tx_id }) => {
-                let db = Rc::clone(db);
-                let tx_id = *tx_id;
-                Ok(future_to_promise(async move {
-                    db.next_write_state_change(tx_id).await;
-                    Ok(JsValue::UNDEFINED)
-                }))
+                Ok(wait_promise(db.as_ref(), *tx_id, tier))
             }
             None => Err(JsValue::from_str("write state is unavailable")),
         }
@@ -1662,6 +1638,23 @@ impl WasmDb {
         self.inner.set_tick_scheduler(callback);
     }
 
+    /// Register a callback for rejected writes that no active wait consumed.
+    #[wasm_bindgen(js_name = onMutationError)]
+    pub fn on_mutation_error(&self, callback: js_sys::Function) {
+        let callback: MutationErrorCallback = Rc::new(move |event| {
+            let Ok(value) = serde_wasm_bindgen::to_value(event) else {
+                return;
+            };
+            let _ = callback.call1(&JsValue::UNDEFINED, &value);
+        });
+        match &self.inner {
+            WasmDbInner::Memory(db) => db.on_mutation_error(Rc::clone(&callback)),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => db.on_mutation_error(Rc::clone(&callback)),
+            WasmDbInner::Closed => {}
+        }
+    }
+
     #[wasm_bindgen(js_name = insertEncoded)]
     pub fn insert_encoded(&self, table: String, cells: Vec<u8>) -> Result<WasmWrite, JsValue> {
         let cells = decode_cells(&cells)?;
@@ -2433,20 +2426,20 @@ where
     Ok(stats.subscription_events as u32)
 }
 
-fn wait_for_tx<S>(db: &Db<S>, tx_id: TxId, tier: DurabilityTier) -> Result<(), JsValue>
+fn wait_promise<S>(db: &Db<S>, tx_id: TxId, tier: DurabilityTier) -> js_sys::Promise
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
-    if tier <= DurabilityTier::Local {
-        return Ok(());
-    }
-    let state = db.write_state(tx_id).map_err(to_js_error)?;
-    if state.durability >= tier {
-        return Ok(());
-    }
-    Err(JsValue::from_str(&format!(
-        "transaction has not reached requested tier {tier:?}"
-    )))
+    js_sys::Promise::new(&mut |resolve, reject| {
+        db.wait_for_transaction_with(tx_id, tier, move |result| match result {
+            Ok(_) => {
+                let _ = resolve.call0(&JsValue::UNDEFINED);
+            }
+            Err(error) => {
+                let _ = reject.call1(&JsValue::UNDEFINED, &to_js_error(error));
+            }
+        });
+    })
 }
 
 fn row_uuid_from_bytes(bytes: &[u8]) -> Result<RowUuid, JsValue> {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -7657,24 +7657,23 @@ where
                             if let Some((tx_id, fate)) = routed_fate {
                                 let authority = *expected_scope_authority;
                                 let mut routes = self.edge_fate_routes.borrow_mut();
-                                let Some(pending) = routes.get_mut(&tx_id) else {
-                                    continue;
-                                };
-                                let mut remaining = Vec::new();
-                                for route in std::mem::take(pending) {
-                                    if Some(route.authority) == authority {
-                                        if let Some(queue) = route.queue.upgrade() {
-                                            queue.borrow_mut().push(fate.clone());
+                                if let Some(pending) = routes.get_mut(&tx_id) {
+                                    let mut remaining = Vec::new();
+                                    for route in std::mem::take(pending) {
+                                        if Some(route.authority) == authority {
+                                            if let Some(queue) = route.queue.upgrade() {
+                                                queue.borrow_mut().push(fate.clone());
+                                            }
+                                        } else {
+                                            remaining.push(route);
                                         }
-                                    } else {
-                                        remaining.push(route);
                                     }
-                                }
-                                if remaining.is_empty() {
-                                    routes.remove(&tx_id);
-                                } else {
-                                    *routes.get_mut(&tx_id).expect("route remains present") =
-                                        remaining;
+                                    if remaining.is_empty() {
+                                        routes.remove(&tx_id);
+                                    } else {
+                                        *routes.get_mut(&tx_id).expect("route remains present") =
+                                            remaining;
+                                    }
                                 }
                             }
                         }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -71,7 +71,7 @@ pub use crate::result_tree::{ResultNode, ResultRelation, ResultTree, ResultTreeR
 use crate::schema::{JazzSchema, TableSchema};
 use crate::time::GlobalSeq;
 use crate::tools::OpenBatchId;
-use crate::tools::{ObjectId, OutputOccurrenceId, ResultKey};
+use crate::tools::{BatchId, ObjectId, OutputOccurrenceId, ResultKey};
 use crate::tx::{DeletionEvent, DurabilityTier, Fate, RejectionReason, TxId, TxKind};
 use crate::wire::{TransportError, WireAuthorityEndpoint, WireFeatures, encode_sync_message};
 
@@ -97,6 +97,71 @@ pub trait TickScheduler {
     /// Schedule a future [`Db::tick`] for pending peer-connection work.
     fn schedule_tick(&self, urgency: TickUrgency);
 }
+
+/// A locally-originated transaction rejection that was not consumed by an
+/// active write waiter.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MutationErrorEvent {
+    /// Stable machine-readable rejection code.
+    pub code: String,
+    /// Human-readable rejection reason.
+    pub reason: String,
+    /// The rejected local transaction.
+    pub transaction: LocalTransactionRecord,
+}
+
+/// Binding-facing record for one locally committed transaction.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalTransactionRecord {
+    /// Stable public identity derived from the core transaction id.
+    pub batch_id: BatchId,
+    /// Transaction semantics used by the commit.
+    pub kind: TransactionKind,
+    /// Committed transaction records are immutable.
+    pub sealed: bool,
+    /// Latest authority settlement observed for the transaction.
+    pub latest_settlement: TransactionFate,
+}
+
+/// Binding-facing transaction kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TransactionKind {
+    /// CRDT-style mergeable transaction.
+    Mergeable,
+    /// Authority-validated exclusive transaction.
+    Exclusive,
+}
+
+impl From<TxKind> for TransactionKind {
+    fn from(kind: TxKind) -> Self {
+        match kind {
+            TxKind::Mergeable => Self::Mergeable,
+            TxKind::Exclusive => Self::Exclusive,
+        }
+    }
+}
+
+/// Binding-facing authority fate for a rejected transaction.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum TransactionFate {
+    /// The authority rejected the transaction.
+    Rejected {
+        /// Stable public identity derived from the core transaction id.
+        #[serde(rename = "batchId")]
+        batch_id: BatchId,
+        /// Stable machine-readable rejection code.
+        code: String,
+        /// Human-readable rejection reason.
+        reason: String,
+    },
+}
+
+/// Thread-affine callback used by bindings to surface unhandled rejections.
+pub type MutationErrorCallback = Rc<dyn Fn(&MutationErrorEvent) + 'static>;
 
 #[cfg(feature = "sync-autopsy")]
 /// Debug-build sync trace buffer used by integration-test timeout autopsies.
@@ -256,6 +321,7 @@ fn prune_edge_fate_routes(
         !pending.is_empty()
     });
 }
+type SharedMutationErrors = Rc<RefCell<MutationErrorState>>;
 type ShapeRegistrationKey = (ShapeId, ReadViewKey);
 
 /// Per-subscriber state for a shape/read-view registration.
@@ -410,6 +476,12 @@ struct WriteStateWaiter {
 enum WriteStateWaiterNotify {
     Future(oneshot::Sender<()>),
     Callback(Box<dyn FnOnce()>),
+}
+
+#[derive(Default)]
+struct MutationErrorState {
+    callback: Option<MutationErrorCallback>,
+    pending: BTreeMap<TxId, MutationErrorEvent>,
 }
 
 #[derive(Clone)]
@@ -1042,6 +1114,42 @@ where
         Ok(WriteState { fate, durability })
     }
 
+    /// Wait until `tx_id` reaches `tier` or is rejected.
+    ///
+    /// An explicit wait consumes a rejection, preventing the same failure from
+    /// subsequently being delivered through [`Db::on_mutation_error`]. The
+    /// check/register/recheck sequence keeps that ownership decision inside
+    /// the database and closes the race with an already-observed rejection.
+    pub async fn wait_for_transaction(
+        &self,
+        tx_id: TxId,
+        tier: DurabilityTier,
+    ) -> Result<TxId, Error> {
+        loop {
+            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier) {
+                return outcome;
+            }
+            let state_change = self.node.register_write_state_waiter(tx_id);
+            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier) {
+                drop(state_change);
+                return outcome;
+            }
+            state_change.await;
+        }
+    }
+
+    /// Callback form of [`Db::wait_for_transaction`] for bindings that cannot
+    /// drive a thread-affine Rust future directly.
+    pub fn wait_for_transaction_with(
+        &self,
+        tx_id: TxId,
+        tier: DurabilityTier,
+        callback: impl FnOnce(Result<TxId, Error>) + 'static,
+    ) {
+        self.node
+            .wait_for_transaction_with(tx_id, tier, Box::new(callback));
+    }
+
     /// Wait until this database observes another state transition for `tx_id`.
     ///
     /// Callers should always check [`Db::write_state`] before and after
@@ -1050,15 +1158,15 @@ where
         self.node.register_write_state_waiter(tx_id)
     }
 
-    /// Register a one-shot same-thread callback for the next state transition of
-    /// `tx_id`.
-    ///
-    /// This is the callback equivalent of [`Db::next_write_state_change`].
-    /// Callers should still read [`Db::write_state`] before and after
-    /// registration to avoid lost wakeups.
-    pub fn on_next_write_state_change(&self, tx_id: TxId, callback: impl FnOnce() + 'static) {
-        self.node
-            .register_write_state_callback(tx_id, Box::new(callback));
+    /// Register the binding callback for rejected local transactions that no
+    /// active application waiter consumed.
+    pub fn on_mutation_error(&self, callback: MutationErrorCallback) {
+        self.node.set_mutation_error_callback(Some(callback));
+    }
+
+    /// Remove the current mutation-error callback.
+    pub fn clear_mutation_error_callback(&self) {
+        self.node.set_mutation_error_callback(None);
     }
 
     /// Start a query rooted at `table`.
@@ -4660,6 +4768,7 @@ where
     edge_fate_routes: EdgeFateRoutes,
     admitted_upstream_authorities: AdmittedUpstreamAuthorities,
     admitted_upstream_authority: Rc<RefCell<Option<AuthorityContext>>>,
+    mutation_errors: SharedMutationErrors,
     next_write_state_waiter_id: Cell<u64>,
     next_subscription_nonce: Cell<u64>,
     subscriber_dirty_epoch: Rc<Cell<u64>>,
@@ -4672,6 +4781,14 @@ where
 {
     /// Wrap a node for serving subscriber links.
     pub fn new(node: NodeState<S>) -> Self {
+        let pending_mutation_errors = node
+            .rejected_transactions()
+            .into_iter()
+            .filter_map(|tx_id| {
+                node.rejected_transaction(tx_id)
+                    .map(|rejected| (tx_id, mutation_error_event(rejected)))
+            })
+            .collect();
         Self {
             node: Rc::new(RefCell::new(node)),
             subscriptions: Rc::new(RefCell::new(Vec::new())),
@@ -4684,6 +4801,10 @@ where
             connections: RefCell::new(Vec::new()),
             scheduler: Rc::new(RefCell::new(None)),
             write_state_waiters: Rc::new(RefCell::new(BTreeMap::new())),
+            mutation_errors: Rc::new(RefCell::new(MutationErrorState {
+                callback: None,
+                pending: pending_mutation_errors,
+            })),
             next_write_state_waiter_id: Cell::new(1),
             next_subscription_nonce: Cell::new(1),
             permission_advice_waiters: Rc::new(RefCell::new(BTreeMap::new())),
@@ -4800,6 +4921,82 @@ where
 
     fn schedule_tick(&self, urgency: TickUrgency) {
         schedule_tick_in(&self.scheduler, urgency);
+    }
+
+    fn set_mutation_error_callback(&self, callback: Option<MutationErrorCallback>) {
+        let should_schedule = {
+            let mut state = self.mutation_errors.borrow_mut();
+            state.callback = callback;
+            state.callback.is_some() && !state.pending.is_empty()
+        };
+        if should_schedule {
+            self.schedule_tick(TickUrgency::Immediate);
+        }
+    }
+
+    fn consume_mutation_error(&self, tx_id: TxId) -> Result<bool, Error> {
+        let pending = self.mutation_errors.borrow_mut().pending.remove(&tx_id);
+        let retained = self.node.borrow().rejected_transaction(tx_id).is_some();
+        if retained {
+            self.node.borrow_mut().discard_rejection(tx_id)?;
+        }
+        Ok(pending.is_some() || retained)
+    }
+
+    fn transaction_wait_outcome(
+        &self,
+        tx_id: TxId,
+        tier: DurabilityTier,
+    ) -> Option<Result<TxId, Error>> {
+        if tier <= DurabilityTier::Local {
+            return Some(Ok(tx_id));
+        }
+        let Some((fate, _, durability)) = self.node.borrow_mut().transaction_state(tx_id) else {
+            return Some(Err(Error::new(
+                ErrorCode::NotObserved,
+                "transaction is not known locally",
+            )));
+        };
+        match fate {
+            Fate::Rejected(reason) => {
+                if let Err(error) = self.consume_mutation_error(tx_id) {
+                    tracing::warn!(?tx_id, %error, "failed to consume waited mutation error");
+                }
+                Some(Err(write_rejected(reason)))
+            }
+            Fate::Pending | Fate::Accepted if durability >= tier => Some(Ok(tx_id)),
+            Fate::Pending | Fate::Accepted => None,
+        }
+    }
+
+    fn wait_for_transaction_with(
+        self: &Rc<Self>,
+        tx_id: TxId,
+        tier: DurabilityTier,
+        callback: Box<dyn FnOnce(Result<TxId, Error>)>,
+    ) {
+        if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier) {
+            callback(outcome);
+            return;
+        }
+        let node = Rc::clone(self);
+        self.register_write_state_callback(
+            tx_id,
+            Box::new(move || node.wait_for_transaction_with(tx_id, tier, callback)),
+        );
+    }
+
+    fn deliver_pending_mutation_errors(&self) {
+        let Some((callback, events)) = take_pending_mutation_error_delivery(&self.mutation_errors)
+        else {
+            return;
+        };
+        for (tx_id, event) in events {
+            if let Err(error) = self.node.borrow_mut().discard_rejection(tx_id) {
+                tracing::warn!(?tx_id, %error, "failed to acknowledge delivered mutation error");
+            }
+            callback(&event);
+        }
     }
 
     fn queue_content_extent_fetch(&self, extent: crate::node::content_store::Extent) {
@@ -5010,6 +5207,7 @@ where
             admitted_upstream_authorities: Rc::clone(&self.admitted_upstream_authorities),
             admitted_upstream_authority: Rc::clone(&self.admitted_upstream_authority),
             downstream_fates: Rc::new(RefCell::new(Vec::new())),
+            mutation_errors: Rc::clone(&self.mutation_errors),
             subscriber_dirty_epoch: Rc::clone(&self.subscriber_dirty_epoch),
             observed_subscriber_dirty_epoch: Cell::new(self.subscriber_dirty_epoch.get()),
             observed_session_claim_revision: Cell::new(0),
@@ -5178,6 +5376,7 @@ where
             admitted_upstream_authorities: Rc::clone(&self.admitted_upstream_authorities),
             admitted_upstream_authority: Rc::clone(&self.admitted_upstream_authority),
             downstream_fates: Rc::new(RefCell::new(Vec::new())),
+            mutation_errors: Rc::clone(&self.mutation_errors),
             subscriber_dirty_epoch: Rc::clone(&self.subscriber_dirty_epoch),
             observed_subscriber_dirty_epoch: Cell::new(self.subscriber_dirty_epoch.get()),
             observed_session_claim_revision: Cell::new(session_claim_revision),
@@ -5296,6 +5495,7 @@ where
 
     /// Service every accepted subscriber connection once.
     pub fn tick(&self) -> Result<DbTickStats, Error> {
+        self.deliver_pending_mutation_errors();
         let mut stats = DbTickStats::default();
         let mut remote_sync_applied = false;
         for connection in self.connections.borrow().iter() {
@@ -6256,6 +6456,7 @@ where
     admitted_upstream_authorities: AdmittedUpstreamAuthorities,
     admitted_upstream_authority: Rc<RefCell<Option<AuthorityContext>>>,
     downstream_fates: PendingDownstreamFates,
+    mutation_errors: SharedMutationErrors,
     subscriber_dirty_epoch: Rc<Cell<u64>>,
     observed_subscriber_dirty_epoch: Cell<u64>,
     observed_session_claim_revision: Cell<u64>,
@@ -7479,7 +7680,13 @@ where
                         }
                     }
                     if let Some(tx_id) = write_state_tx_id {
-                        notify_write_state_waiters(&self.write_state_waiters, tx_id);
+                        handle_write_state_update(
+                            &self.node,
+                            &self.write_state_waiters,
+                            &self.mutation_errors,
+                            &self.scheduler,
+                            tx_id,
+                        );
                     }
                     applied = true;
                 }
@@ -8434,7 +8641,13 @@ where
                                     )?,
                             };
                             if let Some(tx_id) = write_state_tx_id {
-                                notify_write_state_waiters(&self.write_state_waiters, tx_id);
+                                handle_write_state_update(
+                                    &self.node,
+                                    &self.write_state_waiters,
+                                    &self.mutation_errors,
+                                    &self.scheduler,
+                                    tx_id,
+                                );
                             }
                             for response in responses {
                                 send_with_content_extents(
@@ -9515,17 +9728,120 @@ fn write_state_update_tx_id(message: &SyncMessage) -> Option<TxId> {
     }
 }
 
-fn notify_write_state_waiters(waiters: &WriteStateWaiters, tx_id: TxId) {
+fn notify_write_state_waiters(waiters: &WriteStateWaiters, tx_id: TxId) -> bool {
     let Some(waiters) = waiters.borrow_mut().remove(&tx_id) else {
-        return;
+        return false;
     };
+    let mut handled_mutation_error = false;
     for waiter in waiters {
         match waiter.notify {
             WriteStateWaiterNotify::Future(sender) => {
-                let _ = sender.send(());
+                if sender.send(()).is_ok() {
+                    handled_mutation_error = true;
+                }
             }
-            WriteStateWaiterNotify::Callback(callback) => callback(),
+            WriteStateWaiterNotify::Callback(callback) => {
+                callback();
+                handled_mutation_error = true;
+            }
         }
+    }
+    handled_mutation_error
+}
+
+fn handle_write_state_update<S>(
+    node: &Rc<RefCell<NodeState<S>>>,
+    waiters: &WriteStateWaiters,
+    mutation_errors: &SharedMutationErrors,
+    scheduler: &SharedTickScheduler,
+    tx_id: TxId,
+) where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    let handled_by_waiter = notify_write_state_waiters(waiters, tx_id);
+    let rejected = node.borrow().rejected_transaction(tx_id);
+    let Some(rejected) = rejected else {
+        return;
+    };
+
+    if handled_by_waiter {
+        mutation_errors.borrow_mut().pending.remove(&tx_id);
+        if let Err(error) = node.borrow_mut().discard_rejection(tx_id) {
+            tracing::warn!(?tx_id, %error, "failed to acknowledge waited mutation error");
+        }
+        return;
+    }
+
+    let should_schedule = {
+        let mut state = mutation_errors.borrow_mut();
+        state
+            .pending
+            .entry(tx_id)
+            .or_insert_with(|| mutation_error_event(rejected));
+        state.callback.is_some()
+    };
+    if should_schedule {
+        schedule_tick_in(scheduler, TickUrgency::Immediate);
+    }
+}
+
+fn take_pending_mutation_error_delivery(
+    mutation_errors: &SharedMutationErrors,
+) -> Option<(MutationErrorCallback, BTreeMap<TxId, MutationErrorEvent>)> {
+    let mut state = mutation_errors.borrow_mut();
+    let callback = state.callback.clone()?;
+    if state.pending.is_empty() {
+        return None;
+    }
+    Some((callback, std::mem::take(&mut state.pending)))
+}
+
+fn mutation_error_event(rejected: crate::tx::RejectedTransaction) -> MutationErrorEvent {
+    let tx_id = rejected.tx_id();
+    let batch_id = BatchId::from_committed_tx(tx_id);
+    let (code, reason) = mutation_error_details(&rejected.reason());
+    MutationErrorEvent {
+        code: code.clone(),
+        reason: reason.clone(),
+        transaction: LocalTransactionRecord {
+            batch_id,
+            kind: rejected.kind().into(),
+            sealed: true,
+            latest_settlement: TransactionFate::Rejected {
+                batch_id,
+                code,
+                reason,
+            },
+        },
+    }
+}
+
+fn mutation_error_details(reason: &RejectionReason) -> (String, String) {
+    match reason {
+        RejectionReason::ClientClockTooFarAhead => (
+            "client_clock_too_far_ahead".to_owned(),
+            "Client clock is too far ahead".to_owned(),
+        ),
+        RejectionReason::AuthorizationDenied => (
+            "permission_denied".to_owned(),
+            "Write rejected by server authorization".to_owned(),
+        ),
+        RejectionReason::ExclusiveConflict => (
+            "exclusive_conflict".to_owned(),
+            "Exclusive transaction conflicted with another write".to_owned(),
+        ),
+        RejectionReason::CausalityViolation => (
+            "causality_violation".to_owned(),
+            "Transaction violated causal ordering".to_owned(),
+        ),
+        RejectionReason::Cascade { root } => (
+            "cascade_rejected".to_owned(),
+            format!("Transaction was rejected because ancestor {root:?} was rejected"),
+        ),
+        RejectionReason::MalformedCommit(reason) => (
+            "write_rejected".to_owned(),
+            format!("Malformed transaction: {reason}"),
+        ),
     }
 }
 

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -14626,7 +14626,9 @@ fn db_sync_surface_returns_exclusive_conflict_fate_to_client() {
 }
 
 /// An authority rejection with no application waiter is delivered once through
-/// the mutation-error callback on the following scheduled database tick.
+/// the mutation-error callback on the following scheduled database tick. This
+/// is an ordinary client connection, so the fate has no edge-forwarding route
+/// and must still run the local write-state handler.
 #[test]
 fn unhandled_rejection_is_delivered_as_mutation_error() {
     let schema = schema();
@@ -14658,6 +14660,13 @@ fn unhandled_rejection_is_delivered_as_mutation_error() {
 
     let events = events.borrow();
     assert_eq!(events.len(), 1);
+    assert_eq!(
+        client.write_state(write.mergeable_tx_id()).unwrap(),
+        WriteState {
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            durability: DurabilityTier::Edge,
+        }
+    );
     assert_eq!(events[0].code, "permission_denied");
     assert_eq!(
         events[0].transaction.batch_id,
@@ -14667,7 +14676,8 @@ fn unhandled_rejection_is_delivered_as_mutation_error() {
 }
 
 /// A live application waiter consumes an authority rejection and prevents the
-/// fallback mutation-error callback from firing.
+/// fallback mutation-error callback from firing, including when the fate has
+/// no edge-forwarding route and only the ordinary local handler can notify it.
 #[test]
 fn waited_rejection_is_not_delivered_as_mutation_error() {
     let schema = schema();

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -14625,6 +14625,231 @@ fn db_sync_surface_returns_exclusive_conflict_fate_to_client() {
     );
 }
 
+/// An authority rejection with no application waiter is delivered once through
+/// the mutation-error callback on the following scheduled database tick.
+#[test]
+fn unhandled_rejection_is_delivered_as_mutation_error() {
+    let schema = schema();
+    let author = AuthorId::from_bytes([0xc1; 16]);
+    let client = open_db(0xc1, author, &schema);
+    let (client_transport, mut authority_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let callback_events = Rc::clone(&events);
+    client.on_mutation_error(Rc::new(move |event| {
+        callback_events.borrow_mut().push(event.clone());
+    }));
+
+    let write = client
+        .insert("todos", cells("rejected", false, author))
+        .unwrap();
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id: write.mergeable_tx_id(),
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_seq: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .unwrap();
+
+    client.tick().unwrap();
+    assert!(events.borrow().is_empty());
+    client.tick().unwrap();
+
+    let events = events.borrow();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].code, "permission_denied");
+    assert_eq!(
+        events[0].transaction.batch_id,
+        BatchId::from_committed_tx(write.mergeable_tx_id())
+    );
+    assert_eq!(events[0].transaction.kind, TransactionKind::Mergeable);
+}
+
+/// A live application waiter consumes an authority rejection and prevents the
+/// fallback mutation-error callback from firing.
+#[test]
+fn waited_rejection_is_not_delivered_as_mutation_error() {
+    let schema = schema();
+    let author = AuthorId::from_bytes([0xc2; 16]);
+    let client = open_db(0xc2, author, &schema);
+    let (client_transport, mut authority_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let callback_events = Rc::clone(&events);
+    client.on_mutation_error(Rc::new(move |event| {
+        callback_events.borrow_mut().push(event.clone());
+    }));
+
+    let write = client
+        .insert("todos", cells("waited rejection", false, author))
+        .unwrap();
+    let wait_result = Rc::new(RefCell::new(None));
+    let callback_result = Rc::clone(&wait_result);
+    client.wait_for_transaction_with(
+        write.mergeable_tx_id(),
+        DurabilityTier::Edge,
+        move |result| *callback_result.borrow_mut() = Some(result),
+    );
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id: write.mergeable_tx_id(),
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_seq: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .unwrap();
+
+    client.tick().unwrap();
+    assert_eq!(
+        wait_result.borrow_mut().take().unwrap().unwrap_err().code,
+        ErrorCode::WriteRejected
+    );
+    client.tick().unwrap();
+
+    assert!(events.borrow().is_empty());
+    assert!(
+        client
+            .node
+            .node()
+            .borrow()
+            .rejected_transaction(write.mergeable_tx_id())
+            .is_none()
+    );
+}
+
+/// An explicit wait that begins after the rejection was queued still consumes
+/// it before the next-tick fallback callback can deliver it.
+#[test]
+fn wait_after_rejection_suppresses_queued_mutation_error() {
+    let schema = schema();
+    let author = AuthorId::from_bytes([0xc4; 16]);
+    let client = open_db(0xc4, author, &schema);
+    let (client_transport, mut authority_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let callback_events = Rc::clone(&events);
+    client.on_mutation_error(Rc::new(move |event| {
+        callback_events.borrow_mut().push(event.clone());
+    }));
+
+    let write = client
+        .insert("todos", cells("late wait rejection", false, author))
+        .unwrap();
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id: write.mergeable_tx_id(),
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_seq: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .unwrap();
+    client.tick().unwrap();
+
+    let error =
+        block_on(client.wait_for_transaction(write.mergeable_tx_id(), DurabilityTier::Edge))
+            .unwrap_err();
+    assert_eq!(error.code, ErrorCode::WriteRejected);
+    client.tick().unwrap();
+
+    assert!(events.borrow().is_empty());
+    assert!(
+        client
+            .node
+            .node()
+            .borrow()
+            .rejected_transaction(write.mergeable_tx_id())
+            .is_none()
+    );
+}
+
+/// A rejected transaction that was not delivered before shutdown is recovered
+/// from durable storage and delivered after the reopened client registers its
+/// callback.
+#[test]
+fn undelivered_mutation_error_is_recovered_after_reopen() {
+    let schema = schema();
+    let author = AuthorId::from_bytes([0xc3; 16]);
+    let identity = DbIdentity {
+        node: NodeUuid::from_bytes([0xc3; 16]),
+        author,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    let client = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage,
+        identity,
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc3))),
+        large_value_checkpoint_op_interval: crate::node::LARGE_VALUE_CHECKPOINT_OP_INTERVAL,
+    }))
+    .unwrap();
+    let (client_transport, mut authority_transport) = duplex();
+    let upstream = client.connect_upstream(client_transport);
+    let write = client
+        .insert("todos", cells("rejected before reopen", false, author))
+        .unwrap();
+    let tx_id = write.mergeable_tx_id();
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_seq: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .unwrap();
+    client.tick().unwrap();
+
+    drop(write);
+    drop(upstream);
+    drop(authority_transport);
+    drop(client);
+
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    let reopened = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage,
+        identity,
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc3))),
+        large_value_checkpoint_op_interval: crate::node::LARGE_VALUE_CHECKPOINT_OP_INTERVAL,
+    }))
+    .unwrap();
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let callback_events = Rc::clone(&events);
+    reopened.on_mutation_error(Rc::new(move |event| {
+        callback_events.borrow_mut().push(event.clone());
+    }));
+    reopened.tick().unwrap();
+
+    let events = events.borrow();
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].transaction.batch_id,
+        BatchId::from_committed_tx(tx_id)
+    );
+    drop(events);
+    drop(reopened);
+
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    let acknowledged_reopen = block_on(Db::open(DbConfig {
+        schema,
+        storage,
+        identity,
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc3))),
+        large_value_checkpoint_op_interval: crate::node::LARGE_VALUE_CHECKPOINT_OP_INTERVAL,
+    }))
+    .unwrap();
+    let replayed_events = Rc::new(RefCell::new(Vec::new()));
+    let callback_events = Rc::clone(&replayed_events);
+    acknowledged_reopen.on_mutation_error(Rc::new(move |event| {
+        callback_events.borrow_mut().push(event.clone());
+    }));
+    acknowledged_reopen.tick().unwrap();
+    assert!(replayed_events.borrow().is_empty());
+}
+
 #[test]
 fn write_fate_and_durability_are_queryable_through_facade() {
     let schema = schema();

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -8309,11 +8309,26 @@ where
         local: &mut LocalMaintainedViewSubscription,
         binding_view_key: BindingViewKey,
     ) -> Result<(), Error> {
+        // Settled result sets can include support members used to maintain relations or
+        // policies. The occurrence sidecar describes only public query roots, matching
+        // the authoritative snapshot's `root_count`, so exclude those support members.
         local.result_set = self
             .query
             .settled_result_sets
             .get(&binding_view_key)
-            .cloned()
+            .map(|members| {
+                members
+                    .iter()
+                    .filter(|member| {
+                        is_public_result_member(
+                            member,
+                            local.result_table.as_str(),
+                            local.result_query.aggregate.is_some(),
+                        )
+                    })
+                    .cloned()
+                    .collect()
+            })
             .unwrap_or_default();
         local.authoritative_result_set = local.result_set.clone();
         local.authoritative_result_generation =

--- a/docs/content/docs/writing/writing-data.mdx
+++ b/docs/content/docs/writing/writing-data.mdx
@@ -174,6 +174,14 @@ try {
 
 Writes that are not explicitly awaited remain fire-and-forget. Keep the returned write handle and call `wait(...)` when the application needs to observe durability or policy rejection.
 
+You can also set a global `onMutationError` handler that will be notified anytime a write that was not explicitly awaited fails:
+
+```ts
+db.onMutationError((error) => {
+  console.error("DB mutation failed: ", error);
+});
+```
+
 ## Transactions
 
 Use an exclusive transaction when several writes should settle together after an authority validates the sealed transaction:

--- a/packages/jazz-tools/src/runtime/client-tests/support.ts
+++ b/packages/jazz-tools/src/runtime/client-tests/support.ts
@@ -63,6 +63,7 @@ export const runtimeTransactionRecordStubs = {
   disconnect: async () => {},
   updateAuth: () => {},
   onAuthFailure: () => {},
+  onMutationError: () => {},
 };
 
 export function makeClient() {

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -102,6 +102,7 @@ function makeClient(runtimeOverrides: Partial<TransactionalRuntime> = {}) {
     disconnect: async () => {},
     updateAuth: () => {},
     onAuthFailure: () => {},
+    onMutationError: () => {},
     createSubscription: () => 0,
     executeSubscription: () => {},
     unsubscribe: () => {},

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -7,6 +7,7 @@ import {
   type TransactionalRuntime,
   PersistedWriteRejectedError,
   type BatchId,
+  type MutationErrorEvent,
   type OpenBatchId,
   type WriteReceipt,
 } from "./client.js";
@@ -14,6 +15,7 @@ import type { AppContext } from "./context.js";
 import type { WasmSchema } from "../drivers/types.js";
 
 function makeFakeRuntime() {
+  let mutationErrorCallback: ((event: MutationErrorEvent) => void) | null = null;
   let nextTransactionNumber = 0;
 
   function openBatchIdFromWriteContext(writeContextJson?: string | null): OpenBatchId | undefined {
@@ -86,6 +88,9 @@ function makeFakeRuntime() {
       >(),
     executeSubscription: vi.fn<(handle: number, on_update: Function) => void>(),
     unsubscribe: vi.fn<(handle: number) => void>(),
+    onMutationError: vi.fn<Runtime["onMutationError"]>((callback) => {
+      mutationErrorCallback = callback;
+    }),
     beginTransaction: vi.fn<TransactionalRuntime["beginTransaction"]>((_kind, id) => {
       nextTransactionNumber += 1;
       return id;
@@ -100,7 +105,11 @@ function makeFakeRuntime() {
     close: vi.fn(),
   } satisfies TransactionalRuntime;
 
-  return runtime;
+  return Object.assign(runtime, {
+    emitMutationError(event: MutationErrorEvent) {
+      mutationErrorCallback?.(event);
+    },
+  });
 }
 
 function makeContext(): AppContext {
@@ -366,5 +375,54 @@ describe("JazzClient runtime transaction waits", () => {
     });
 
     await expect(waitPromise).rejects.toBeInstanceOf(PersistedWriteRejectedError);
+  });
+});
+
+describe("JazzClient mutation error handling", () => {
+  function makeRejectedTransactionRecord(batchId: BatchId) {
+    return {
+      batchId,
+      kind: "mergeable" as const,
+      sealed: true,
+      latestSettlement: {
+        kind: "rejected" as const,
+        batchId,
+        code: "permission_denied",
+        reason: "write rejected by policy",
+      },
+    };
+  }
+
+  it("forwards pushed runtime mutation errors to the registered listener", () => {
+    const runtime = makeFakeRuntime();
+    const client = JazzClient.connectWithRuntime(runtime as any, makeContext());
+    const listener = vi.fn();
+    client.onMutationError(listener);
+    const batchId = "batch-rejected" as BatchId;
+    const event: MutationErrorEvent = {
+      code: "permission_denied",
+      reason: "write rejected by policy",
+      transaction: makeRejectedTransactionRecord(batchId),
+    };
+
+    runtime.emitMutationError(event);
+
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it("logs pushed mutation errors when no application listener replaces the fallback", () => {
+    const runtime = makeFakeRuntime();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    JazzClient.connectWithRuntime(runtime as any, makeContext());
+    const batchId = "batch-unhandled" as BatchId;
+    const event: MutationErrorEvent = {
+      code: "permission_denied",
+      reason: "write rejected by policy",
+      transaction: makeRejectedTransactionRecord(batchId),
+    };
+
+    runtime.emitMutationError(event);
+
+    expect(consoleError).toHaveBeenCalledWith("Unhandled Jazz mutation error", event);
   });
 });

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -87,6 +87,7 @@ export interface Runtime {
     objectId: string,
     session?: Session,
   ): Promise<PermissionAdvice>;
+  onMutationError(callback: (event: MutationErrorEvent) => void): void;
   waitForTransaction(batchId: BatchId | Promise<BatchId>, tier: string): Promise<void>;
   query(
     query_json: string,
@@ -280,6 +281,18 @@ export interface LocalTransactionRecord {
   sealed: boolean;
   latestSettlement: TransactionFate | null;
   encodedRecord?: Uint8Array;
+}
+
+/**
+ * A rejected write emitted by {@link JazzClient.onMutationError}.
+ *
+ * The event is a fallback for writes whose rejection was not handled by an
+ * active {@link WriteHandle.wait} call.
+ */
+export interface MutationErrorEvent {
+  code: string;
+  reason: string;
+  transaction: LocalTransactionRecord;
 }
 
 export interface CreateOptions extends TimestampOverrideOptions {
@@ -647,6 +660,10 @@ export class JazzClient {
         handler(mapAuthReason(reason));
       });
     }
+
+    this.runtime.onMutationError((event) => {
+      console.error("Unhandled Jazz mutation error", event);
+    });
   }
 
   /**
@@ -674,6 +691,10 @@ export class JazzClient {
       id,
       this.encodeWriteContext(effectiveSession, attribution),
     );
+  }
+
+  onMutationError(listener: (event: MutationErrorEvent) => void): void {
+    this.runtime.onMutationError(listener);
   }
 
   commitTransaction(id: OpenBatchId): Promise<WriteHandle> {

--- a/packages/jazz-tools/src/runtime/db.auth-state.test.ts
+++ b/packages/jazz-tools/src/runtime/db.auth-state.test.ts
@@ -52,6 +52,7 @@ function makeJwt(payload: Record<string, unknown>): string {
 function makeDbWithJwt(jwtToken: string) {
   const runtimeClient = {
     updateAuthToken: vi.fn(),
+    onMutationError: vi.fn(),
   };
 
   const db = new TestDb(
@@ -69,6 +70,7 @@ function makeDbWithCookieSession(cookieSession: Session) {
   const runtimeClient = {
     updateAuthToken: vi.fn(),
     updateCookieSession: vi.fn(),
+    onMutationError: vi.fn(),
   };
 
   const db = new TestDb(
@@ -112,6 +114,7 @@ describe("Db auth state", () => {
     };
     const runtimeClient = {
       updateAuthToken: vi.fn(),
+      onMutationError: vi.fn(),
     };
 
     const db = new TestDb(
@@ -140,6 +143,7 @@ describe("Db auth state", () => {
   it("does not leak scoped auth updates into a shared runtime client", () => {
     const runtimeClient = {
       updateAuthToken: vi.fn(),
+      onMutationError: vi.fn(),
     };
 
     const sharedDb = new TestDb(

--- a/packages/jazz-tools/src/runtime/db.one.test.ts
+++ b/packages/jazz-tools/src/runtime/db.one.test.ts
@@ -51,6 +51,7 @@ function makeClient() {
     getSchema: () => new Map(Object.entries(app.wasmSchema)),
     query,
     beginTransaction,
+    onMutationError: vi.fn(),
   } as unknown as JazzClient;
 
   return { client, query, beginTransaction };

--- a/packages/jazz-tools/src/runtime/db.persisted.test.ts
+++ b/packages/jazz-tools/src/runtime/db.persisted.test.ts
@@ -7,6 +7,7 @@ import {
   type JazzClient,
   type BatchId,
   type LocalTransactionRecord,
+  type MutationErrorEvent,
   type Row,
 } from "./client.js";
 import type { Session } from "./context.js";
@@ -283,5 +284,72 @@ describe("Db write handles", () => {
       "transaction-session-delete",
     );
     expect(deleteClient.waitForTransaction.mock.calls[0]?.[1]).toBe("local");
+  });
+});
+
+describe("Db mutation error handling", () => {
+  function makeRejectedEvent(batchId: BatchId): MutationErrorEvent {
+    return {
+      code: "permission_denied",
+      reason: "write rejected by policy",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "write rejected by policy",
+        },
+      },
+    };
+  }
+
+  it("replays an unhandled client rejection to the first Db listener and supports unsubscribe", () => {
+    let runtimeListener: ((event: MutationErrorEvent) => void) | undefined;
+    const batchId = "mutation-error-batch" as BatchId;
+    let client!: JazzClient;
+    const clientImpl = {
+      onMutationError: vi.fn((listener: (event: MutationErrorEvent) => void) => {
+        runtimeListener = listener;
+      }),
+      insert: vi.fn(
+        () =>
+          new WriteResult(
+            {
+              id: "todo-1",
+              values: [
+                { type: "Text", value: "Buy milk" },
+                { type: "Boolean", value: false },
+              ],
+            },
+            batchId,
+            client,
+          ),
+      ),
+      waitForTransaction: vi.fn(async () => undefined),
+    };
+    client = clientImpl as unknown as JazzClient;
+    class MutationErrorDb extends Db {
+      constructor() {
+        super({ appId: "mutation-error-db" }, new TestRuntimeSource(client));
+      }
+    }
+    const db = new MutationErrorDb();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    db.insert(todoTable(), { title: "Buy milk", done: false });
+    const event = makeRejectedEvent(batchId);
+    runtimeListener?.(event);
+
+    const listener = vi.fn();
+    const unsubscribe = db.onMutationError(listener);
+    expect(listener).toHaveBeenCalledWith(event);
+    expect(consoleError).toHaveBeenCalledWith("Unhandled Jazz mutation error", event);
+
+    unsubscribe();
+    runtimeListener?.(makeRejectedEvent("later-batch" as BatchId));
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/jazz-tools/src/runtime/db.transport.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transport.test.ts
@@ -91,6 +91,7 @@ function makeClientStub() {
     connectTransport: vi.fn(),
     disconnectTransport: vi.fn(async () => undefined),
     getRuntime: vi.fn(() => ({}) as never),
+    onMutationError: vi.fn(),
   } as unknown as JazzClient & {
     connectTransport: ReturnType<typeof vi.fn>;
     disconnectTransport: ReturnType<typeof vi.fn>;
@@ -118,6 +119,7 @@ function makeRuntimeStub(): Runtime {
     disconnect: vi.fn(),
     updateAuth: vi.fn(),
     onAuthFailure: vi.fn(),
+    onMutationError: vi.fn(),
   } as unknown as Runtime;
 }
 
@@ -322,6 +324,7 @@ describe("runtime/Db native runtime path upstream wiring", () => {
       updateAuthToken: vi.fn(),
       connectTransport: vi.fn(),
       getRuntime: vi.fn(() => ({}) as never),
+      onMutationError: vi.fn(),
     } as unknown as JazzClient & {
       insert: ReturnType<typeof vi.fn>;
       shutdown: ReturnType<typeof vi.fn>;

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -24,6 +24,7 @@ import {
   ExclusiveWriteResult,
   WriteResult,
   JazzClient,
+  type MutationErrorEvent,
   WriteHandle,
   type TransactionKind,
   type CreateOptions,
@@ -943,6 +944,8 @@ export class Db {
   >();
   private readonly activeQuerySubscriptionTraceListeners =
     new Set<ActiveQuerySubscriptionTraceListener>();
+  private readonly mutationErrorListeners = new Set<(event: MutationErrorEvent) => void>();
+  private readonly pendingMutationErrorEvents: MutationErrorEvent[] = [];
   private nextActiveQuerySubscriptionTraceId = 1;
   private isTransportDisconnected = false;
 
@@ -1080,6 +1083,8 @@ export class Db {
         },
       });
 
+      this.attachMutationErrorHandler(client);
+
       if (this.config.serverUrl && !this.isTransportDisconnected) {
         client.connectTransport(this.config.serverUrl, this.transportAuthConfig());
       } else if (this.config.serverUrl) {
@@ -1106,6 +1111,19 @@ export class Db {
 
   protected getRuntimeOperationContext(): DbRuntimeOperationContext | null {
     return this.runtimeOperationContextOverride;
+  }
+
+  private attachMutationErrorHandler(client: JazzClient): void {
+    client.onMutationError((event) => {
+      if (this.mutationErrorListeners.size === 0) {
+        console.error("Unhandled Jazz mutation error", event);
+        this.pendingMutationErrorEvents.push(event);
+        return;
+      }
+      for (const listener of this.mutationErrorListeners) {
+        listener(event);
+      }
+    });
   }
 
   /**
@@ -1174,6 +1192,22 @@ export class Db {
     return this.authStateStore.onChange((state) => {
       listener(state);
     });
+  }
+
+  /**
+   * Attach a fallback listener for write rejections that are not handled by an
+   * active {@link WriteHandle.wait} call.
+   *
+   * @returns an unsubscribe callback
+   */
+  onMutationError(listener: (event: MutationErrorEvent) => void): () => void {
+    this.mutationErrorListeners.add(listener);
+    while (this.pendingMutationErrorEvents.length > 0) {
+      listener(this.pendingMutationErrorEvents.shift()!);
+    }
+    return () => {
+      this.mutationErrorListeners.delete(listener);
+    };
   }
 
   getConfig(): DbConfig {
@@ -1784,6 +1818,7 @@ export class Db {
       this.localFirstRefreshTimer = null;
     }
     this.clearActiveQuerySubscriptionTraces();
+    this.mutationErrorListeners.clear();
 
     this.disposeCoreTelemetry?.();
     this.disposeCoreTelemetry = null;

--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -151,7 +151,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     author: Uint8Array,
     flushEvery: number,
   ): PersistentBrowserOpfsRuntime {
-    if (!this.persistentOwnerRuntime) {
+    if (!this.persistentOwnerRuntime || this.persistentOwnerRuntime.isClosed()) {
       this.persistentOwnerRuntime = new PersistentBrowserOpfsRuntime(
         config.runtimeSources,
         schema,

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -2,6 +2,7 @@ export {
   type CreateOptions,
   type AuthConfig,
   type LocalTransactionRecord,
+  type MutationErrorEvent,
   type TransactionFate,
   type LocalUpdatesMode,
   type PermissionAdvice,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -12,6 +12,7 @@ import { serializeRuntimeSchema } from "../../drivers/schema-wire.js";
 import type {
   BatchId,
   InsertResult,
+  MutationErrorEvent,
   MutationResult,
   OpenBatchId,
   PermissionAdvice,
@@ -198,6 +199,7 @@ type NativeDb = {
       | ((urgency: "immediate" | "deferred") => void)
       | ((error: Error | null, urgency: string) => void),
   ): void;
+  onMutationError(callback: (event: MutationErrorEvent) => void): void;
   connectUpstream(): Transport;
   connectUpstreamWithSession?(
     protocolVersion: number,
@@ -228,9 +230,8 @@ type Subscription = {
 type Write = {
   readonly batchId: string;
   payload: Uint8Array;
-  wait(tier: string): void;
+  wait(tier: string): Promise<void>;
   writeState(): unknown;
-  nextWriteStateChange(): Promise<void>;
   close?(): boolean;
 };
 
@@ -399,7 +400,6 @@ export class NativeRuntimeAdapter implements Runtime {
   private readonly writes: Map<string, Write>;
   private readonly ownerRuntime: NativeRuntimeAdapter;
   private readonly readAuthorizationHost: ReadAuthorizationHost;
-  private readonly serverPumpObservedWrites = new WeakSet<Write>();
   private readonly subscriptions = new Map<number, SubscriptionState>();
   private authFailureCallback: ((reason: string) => void) | null = null;
   private serverTransport: Transport | null = null;
@@ -811,55 +811,35 @@ export class NativeRuntimeAdapter implements Runtime {
     this.pendingTxs.delete(openBatchId);
     this.completedTxs.set(openBatchId, { kind: pending.kind, state: "committed" });
     this.pumpSubscriptions();
-    this.observeWriteForBoundaryEffects(write);
+    this.scheduleServerPump();
     return Promise.resolve(recordWrite(write, this.writes));
   }
 
   async waitForTransaction(batchId: BatchId | Promise<BatchId>, tier: string): Promise<void> {
-    if (this !== this.ownerRuntime) return this.ownerRuntime.waitForTransaction(batchId, tier);
+    if (this !== this.ownerRuntime) {
+      return this.ownerRuntime.waitForTransaction(batchId, tier);
+    }
     batchId = await batchId;
     const write = this.writes.get(batchId);
     if (!write) {
       throw new Error(`Wait for batch failed: unknown batch ${batchId}`);
     }
-    for (;;) {
-      this.throwServerTransportErrorForTier(tier);
-      try {
-        this.pumpServerTransport();
-        this.throwServerTransportErrorForTier(tier);
-        write.wait(tier);
-        this.pumpSubscriptions();
-        return;
-      } catch (error) {
-        const rejected = rejectedWaitError(batchId, error);
-        if (rejected) throw rejected;
-        if (!isPendingWaitError(error)) throw error;
-        this.pumpSubscriptions();
-        const change = write.nextWriteStateChange();
-        const observedServerWorkEpoch = this.serverTransportWorkEpoch;
-        try {
-          this.pumpServerTransport();
-          this.throwServerTransportErrorForTier(tier);
-          write.wait(tier);
-          this.pumpSubscriptions();
-          return;
-        } catch (secondError) {
-          const secondRejected = rejectedWaitError(batchId, secondError);
-          if (secondRejected) throw secondRejected;
-          if (!isPendingWaitError(secondError)) throw secondError;
-        }
-        const transportError = this.waitForServerTransportError(tier);
-        const transportWork = this.waitForServerTransportWork(tier, observedServerWorkEpoch);
-        try {
-          const wakes: Promise<unknown>[] = [change];
-          if (transportError) wakes.push(transportError.promise);
-          if (transportWork) wakes.push(transportWork.promise);
-          await Promise.race(wakes);
-        } finally {
-          transportError?.cancel();
-          transportWork?.cancel();
-        }
+    this.throwServerTransportErrorForTier(tier);
+    this.pumpServerTransport();
+    this.throwServerTransportErrorForTier(tier);
+    const settlement = write.wait(tier);
+    const transportError = this.waitForServerTransportError(tier);
+    try {
+      await (transportError ? Promise.race([settlement, transportError.promise]) : settlement);
+      this.pumpSubscriptions();
+    } catch (error) {
+      const rejected = rejectedWaitError(batchId, error);
+      if (rejected) {
+        throw rejected;
       }
+      throw error;
+    } finally {
+      transportError?.cancel();
     }
   }
 
@@ -1154,6 +1134,11 @@ export class NativeRuntimeAdapter implements Runtime {
     this.authFailureCallback = callback;
   }
 
+  onMutationError(callback: (event: MutationErrorEvent) => void): void {
+    if (this !== this.ownerRuntime) return this.ownerRuntime.onMutationError(callback);
+    this.db.onMutationError(callback);
+  }
+
   private finishInsert(
     table: string,
     rowId: Uint8Array,
@@ -1162,7 +1147,7 @@ export class NativeRuntimeAdapter implements Runtime {
   ): InsertResult {
     const batchId = recordWrite(write, this.writes);
     this.pumpSubscriptions();
-    this.observeWriteForBoundaryEffects(write);
+    this.scheduleServerPump();
     const row = this.rowStateFromValues(table, rowId, values);
     return { id: row.id, values: row.values, kind: "committed", batchId };
   }
@@ -1170,62 +1155,8 @@ export class NativeRuntimeAdapter implements Runtime {
   private finishMutation(write: Write): MutationResult {
     const batchId = recordWrite(write, this.writes);
     this.pumpSubscriptions();
-    this.observeWriteForBoundaryEffects(write);
-    return { kind: "committed", batchId };
-  }
-
-  private observeWriteForBoundaryEffects(write: Write): void {
-    if (this.serverPumpObservedWrites.has(write)) return;
-    this.serverPumpObservedWrites.add(write);
     this.scheduleServerPump();
-
-    const pumpUntilLocalVisible = async () => {
-      for (;;) {
-        if (this.closed) return;
-        try {
-          write.wait("local");
-          this.pumpSubscriptions();
-          return;
-        } catch (error) {
-          if (!isPendingWaitError(error)) return;
-        }
-
-        try {
-          await write.nextWriteStateChange();
-        } catch {
-          return;
-        }
-      }
-    };
-
-    const pumpUntilSettled = async () => {
-      for (;;) {
-        if (this.closed) return;
-        try {
-          write.wait("edge");
-          this.pumpSubscriptions();
-          this.scheduleServerPump();
-          return;
-        } catch (error) {
-          if (!isPendingWaitError(error)) return;
-        }
-
-        try {
-          await write.nextWriteStateChange();
-        } catch {
-          return;
-        }
-        // Write-state progression can make local maintained subscriptions
-        // observe inserts/updates/deletes even when the app fire-and-forgets
-        // the write handle. Keep subscription pumping paired with the server
-        // pump here so write acks are not the only path that drains changes.
-        this.pumpSubscriptions();
-        this.scheduleServerPump();
-      }
-    };
-
-    void pumpUntilLocalVisible();
-    void pumpUntilSettled();
+    return { kind: "committed", batchId };
   }
 
   private resultForRow(
@@ -2610,15 +2541,6 @@ function addNestedOuterColumnsToSubqueries(subqueries: unknown): void {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function isPendingWaitError(error: unknown): boolean {
-  const message = errorMessage(error);
-  return (
-    message.includes("NotObserved") ||
-    message.includes("has not been accepted at requested tier") ||
-    message.includes("has not reached requested tier")
-  );
 }
 
 function isPendingCoverageError(error: unknown): boolean {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
@@ -1,7 +1,7 @@
 import type { InsertValues, Value, WasmSchema } from "../../drivers/types.js";
 import type { RuntimeSourcesConfig, Session } from "../context.js";
 import type { NativeRowDelta } from "../../drivers/types.js";
-import type { BatchId, OpenBatchId } from "../client.js";
+import type { BatchId, MutationErrorEvent, OpenBatchId } from "../client.js";
 
 type OpenRequest = {
   id: number;
@@ -184,6 +184,23 @@ export type PersistentBrowserSubscriptionMessage = {
   | { frame: PersistentBrowserSubscriptionFrame }
   | { error: { name?: string; message?: string; stack?: string } }
 );
+
+export type PersistentBrowserWorkerError =
+  | { kind?: undefined; name?: string; message?: string; stack?: string }
+  | {
+      kind: "rejected";
+      batchId: BatchId;
+      code: string;
+      reason: string;
+      name?: undefined;
+      message?: undefined;
+      stack?: undefined;
+    };
+
+export type PersistentBrowserMutationErrorMessage = {
+  event: "mutationError";
+  payload: MutationErrorEvent;
+};
 
 export function isNativeRowDelta(value: unknown): value is NativeRowDelta {
   return (

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NativeRowDelta, WasmSchema } from "../../drivers/types.js";
-import { createOpenBatchId, type BatchId } from "../client.js";
+import { createOpenBatchId, type BatchId, type MutationErrorEvent } from "../client.js";
 import type { InsertResult, MutationResult } from "../client.js";
-import type { PersistentBrowserSubscriptionMessage } from "./persistent-browser-protocol.js";
+import type {
+  PersistentBrowserSubscriptionMessage,
+  PersistentBrowserWorkerError,
+} from "./persistent-browser-protocol.js";
 import {
   PersistentBrowserOpfsRuntime,
   type PersistentBrowserOpfsOwnerRequest,
@@ -51,9 +54,11 @@ class FakeWorker {
     });
   }
 
-  reject(id: number, message: string): void {
+  reject(id: number, error: string | PersistentBrowserWorkerError): void {
     queueMicrotask(() => {
-      this.onmessage?.({ data: { id, ok: false, error: { message } } } as MessageEvent);
+      this.onmessage?.({
+        data: { id, ok: false, error: typeof error === "string" ? { message: error } : error },
+      } as MessageEvent);
     });
   }
 
@@ -96,6 +101,12 @@ class FakeWorker {
       this.onmessage?.({
         data,
       } as MessageEvent);
+    });
+  }
+
+  emitMutationError(payload: MutationErrorEvent): void {
+    queueMicrotask(() => {
+      this.onmessage?.({ data: { event: "mutationError", payload } } as MessageEvent);
     });
   }
 }
@@ -148,6 +159,113 @@ describe("PersistentBrowserOpfsRuntime", () => {
     worker.respond(waitMessage!.id, undefined);
 
     await expect(wait).resolves.toBeUndefined();
+    await runtime.close();
+  });
+
+  it("preserves structured transaction rejections from the worker", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-rejected-wait-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+    const batchId = "00000000000070008000000000000046" as BatchId;
+
+    const wait = runtime.waitForTransaction(batchId, "edge");
+    await vi.waitFor(() => {
+      expect(worker.messages.some((message) => message.method === "waitForTransaction")).toBe(true);
+    });
+    const waitMessage = worker.messages.find((message) => message.method === "waitForTransaction");
+    worker.reject(waitMessage!.id, {
+      kind: "rejected",
+      batchId,
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+    });
+
+    await expect(wait).rejects.toEqual({
+      kind: "rejected",
+      batchId,
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+    });
+    await runtime.close();
+  });
+
+  it("forwards worker mutation errors to the registered runtime callback", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-mutation-error-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+    const batchId = "00000000000070008000000000000044" as BatchId;
+    const event: MutationErrorEvent = {
+      code: "permission_denied",
+      reason: "write rejected by policy",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "write rejected by policy",
+        },
+      },
+    };
+    const listener = vi.fn();
+    runtime.onMutationError(listener);
+
+    worker.emitMutationError(event);
+
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(event));
+    await runtime.close();
+  });
+
+  it("buffers worker mutation errors until the runtime callback is registered", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const runtime = new PersistentBrowserOpfsRuntime(
+      undefined,
+      schema,
+      "persistent-browser-runtime-buffered-mutation-error-test",
+      new Uint8Array(16),
+      new Uint8Array(16),
+    );
+    const worker = FakeWorker.instances[0];
+    const batchId = "00000000000070008000000000000045" as BatchId;
+    const event: MutationErrorEvent = {
+      code: "permission_denied",
+      reason: "write rejected by policy",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "write rejected by policy",
+        },
+      },
+    };
+
+    worker.emitMutationError(event);
+    await Promise.resolve();
+    const listener = vi.fn();
+    runtime.onMutationError(listener);
+
+    expect(listener).toHaveBeenCalledWith(event);
     await runtime.close();
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -139,6 +139,11 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   private closing = false;
   private readonly opened: Promise<void>;
 
+  /** @internal */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
   constructor(
     private readonly runtimeSources: RuntimeSourcesConfig | undefined,
     private readonly schema: WasmSchema,

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -1,6 +1,7 @@
 import type {
   BatchId,
   InsertResult,
+  MutationErrorEvent,
   MutationResult,
   OpenBatchId,
   PermissionAdvice,
@@ -11,10 +12,12 @@ import type { NativeRowDelta } from "../../drivers/types.js";
 import type { RuntimeSourcesConfig, Session } from "../context.js";
 import type { InsertValues, Value, WasmSchema } from "../../drivers/types.js";
 import type {
+  PersistentBrowserMutationErrorMessage,
   PersistentBrowserSubscriptionMessage,
   PersistentBrowserOpfsOwnerRequest,
   PersistentBrowserRequestArgs,
   PersistentBrowserWorkerMethod,
+  PersistentBrowserWorkerError,
   PersistentBrowserWriteRequest,
 } from "./persistent-browser-protocol.js";
 import {
@@ -33,8 +36,9 @@ type PendingCall = {
 
 type WorkerResponse =
   | { id: number; ok: true; result: unknown }
-  | { id: number; ok: false; error: { name?: string; message?: string; stack?: string } }
+  | { id: number; ok: false; error: PersistentBrowserWorkerError }
   | PersistentBrowserSubscriptionMessage
+  | PersistentBrowserMutationErrorMessage
   | { event: "authFailure"; reason: string };
 
 type CompletedTxState = "committed" | "rolled_back";
@@ -114,6 +118,8 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     return this.shared.remoteSubscriptions;
   }
   private authFailureCallback: ((reason: string) => void) | undefined;
+  private mutationErrorCallback: ((event: MutationErrorEvent) => void) | undefined;
+  private readonly pendingMutationErrorEvents: MutationErrorEvent[] = [];
   // Server-tier operations capture this gate while intentionally disconnected.
   // Reconnect resolves that same gate, so outstanding operations survive instead
   // of observing a replacement promise that can never settle.
@@ -637,6 +643,14 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     this.authFailureCallback = callback;
   }
 
+  onMutationError(callback: (event: MutationErrorEvent) => void): void {
+    if (this !== this.ownerRuntime) return this.ownerRuntime.onMutationError(callback);
+    this.mutationErrorCallback = callback;
+    while (this.pendingMutationErrorEvents.length > 0) {
+      callback(this.pendingMutationErrorEvents.shift()!);
+    }
+  }
+
   private rejectConnectionWaiters(): void {
     this.waitingForReconnect = false;
     this.connectionReady.reject(new Error("Persistent browser native runtime is closed"));
@@ -819,7 +833,15 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
   private handleWorkerMessage(message: WorkerResponse): void {
     if ("event" in message) {
       try {
-        this.authFailureCallback?.(message.reason);
+        if (message.event === "mutationError") {
+          if (this.mutationErrorCallback) {
+            this.mutationErrorCallback(message.payload);
+          } else {
+            this.pendingMutationErrorEvents.push(message.payload);
+          }
+        } else {
+          this.authFailureCallback?.(message.reason);
+        }
       } catch (error) {
         setTimeout(() => {
           throw error;
@@ -844,6 +866,8 @@ export class PersistentBrowserOpfsRuntime implements Runtime {
     if (message.ok) {
       setNamedRowValuesEnumerable(message.result, false);
       pending.resolve(message.result);
+    } else if (message.error.kind === "rejected") {
+      pending.reject(message.error);
     } else {
       const error = new Error(message.error.message ?? "Persistent browser worker call failed");
       if (message.error.stack) error.stack = message.error.stack;

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -249,10 +249,10 @@ async function openRuntime(message: OpenMessage): Promise<void> {
   const db = await wasmModule.WasmDb.openBrowser(
     dbName,
     encodeSchema(schema as never),
-    openConfig(node, author, 1, true, initialSyncFlushEvery),
+    openConfig(node, author, 1, false, initialSyncFlushEvery),
   );
 
-  runtime = NativeRuntimeAdapter.fromDb(db as never, schema as never, node, author, 1, true);
+  runtime = NativeRuntimeAdapter.fromDb(db as never, schema as never, node, author, 1, false);
   runtimeViews.clear();
   nextRuntimeViewId = 1;
   runtime.onAuthFailure((reason: string) => {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -7,6 +7,7 @@ import {
   isNativeRowDelta,
   type PersistentBrowserOpfsOwnerRequest,
   type PersistentBrowserSubscriptionFrame,
+  type PersistentBrowserWorkerError,
 } from "./persistent-browser-protocol.js";
 import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
 
@@ -257,6 +258,9 @@ async function openRuntime(message: OpenMessage): Promise<void> {
   runtime.onAuthFailure((reason: string) => {
     workerScope.postMessage({ event: "authFailure", reason });
   });
+  runtime.onMutationError((payload) => {
+    workerScope.postMessage({ event: "mutationError", payload });
+  });
 }
 
 async function closeForStorageClear(): Promise<string> {
@@ -294,11 +298,29 @@ function postError(id: number, error: unknown): void {
   workerScope.postMessage({
     id,
     ok: false,
-    error:
-      error instanceof Error
-        ? { name: error.name, message: error.message, stack: error.stack }
-        : { message: String(error) },
+    error: serializeError(error),
   });
+}
+
+function serializeError(error: unknown): PersistentBrowserWorkerError {
+  if (isRejectedWrite(error)) return error;
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+  return { message: String(error) };
+}
+
+function isRejectedWrite(
+  error: unknown,
+): error is Extract<PersistentBrowserWorkerError, { kind: "rejected" }> {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as Record<string, unknown>;
+  return (
+    candidate.kind === "rejected" &&
+    typeof candidate.batchId === "string" &&
+    typeof candidate.code === "string" &&
+    typeof candidate.reason === "string"
+  );
 }
 
 function subscriptionFrameFromDelta(delta: unknown): PersistentBrowserSubscriptionFrame {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -38,7 +38,13 @@ import { definePermissions } from "../../permissions/index.js";
 import { mergePermissionsIntoWasmSchema } from "../../schema-permissions.js";
 import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
 import { encodeNativeNullValue, storageColumnValueType } from "./native-row-codec.js";
-import { createOpenBatchId, type BatchId, type OpenBatchId, type WriteReceipt } from "../client.js";
+import {
+  createOpenBatchId,
+  type BatchId,
+  type MutationErrorEvent,
+  type OpenBatchId,
+  type WriteReceipt,
+} from "../client.js";
 
 function beginTestBatch(runtime: NativeRuntimeAdapter, userId?: string): OpenBatchId {
   const id = createOpenBatchId();
@@ -1112,7 +1118,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     const calls: unknown[] = [];
     const write = {
       payload: new Uint8Array(),
-      wait: () => undefined,
+      wait: async () => undefined,
       writeState: () => ({}),
     };
     const runtime = new NativeRuntimeAdapter(
@@ -1164,7 +1170,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     const insertedRowIds: Uint8Array[] = [];
     const write = {
       payload: new Uint8Array(),
-      wait: () => undefined,
+      wait: async () => undefined,
       writeState: () => ({}),
     };
     const runtime = new NativeRuntimeAdapter(
@@ -1787,6 +1793,128 @@ describe("NativeRuntimeAdapter server transport", () => {
     await expect(reopened.waitForTransaction(committed, "local")).rejects.toThrow(
       `Wait for batch failed: unknown batch ${committed}`,
     );
+  });
+
+  it("emits an onMutationError event for an unawaited rejected write", async () => {
+    const batchId = "00000000000070008000000000000042" as BatchId;
+    let mutationErrorCallback: ((event: MutationErrorEvent) => void) | undefined;
+    const write = {
+      batchId,
+      payload: new Uint8Array(),
+      wait: async () => undefined,
+      writeState: () => ({}),
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insertWithIdEncoded: () => write,
+            onMutationError: (callback: (event: MutationErrorEvent) => void) => {
+              mutationErrorCallback = callback;
+            },
+          }),
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+    const listener = vi.fn();
+    runtime.onMutationError(listener);
+
+    runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "rejected" } },
+      null,
+      "00000000-0000-0000-0000-000000000042",
+    );
+    mutationErrorCallback?.({
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "Write rejected by server authorization",
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
+    expect(listener).toHaveBeenCalledWith({
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "Write rejected by server authorization",
+        },
+      },
+    });
+  });
+
+  it("does not emit onMutationError when an active wait handles the rejection", async () => {
+    const batchId = "00000000000070008000000000000043" as BatchId;
+    let rejected = false;
+    const stateChangeWaiters: Array<() => void> = [];
+    const nextWriteStateChange = () =>
+      new Promise<void>((resolve) => {
+        stateChangeWaiters.push(resolve);
+      });
+    const write = {
+      batchId,
+      payload: new Uint8Array(),
+      wait: async () => {
+        await nextWriteStateChange();
+        if (rejected) throw new Error("WriteRejected: AuthorizationDenied");
+      },
+      writeState: () => ({}),
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insertWithIdEncoded: () => write,
+            onMutationError: () => undefined,
+          }),
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+    const listener = vi.fn();
+    runtime.onMutationError(listener);
+
+    runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "rejected" } },
+      null,
+      "00000000-0000-0000-0000-000000000043",
+    );
+    const wait = runtime.waitForTransaction(batchId, "edge");
+    await Promise.resolve();
+    rejected = true;
+    stateChangeWaiters.splice(0).forEach((resolve) => resolve());
+
+    await expect(wait).rejects.toMatchObject({
+      kind: "rejected",
+      batchId,
+      code: "permission_denied",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it("passes caller-supplied updatedAt into staged mergeable transaction writes", () => {
@@ -7615,6 +7743,7 @@ function fakeDb<T extends object>(
   };
   return {
     setTickScheduler: () => undefined,
+    onMutationError: () => undefined,
     beginTransaction: (openBatchId: string, kind: FakeOpenBatch["kind"], author?: Uint8Array) => {
       openBatches.set(openBatchId, { kind, author });
     },
@@ -7653,9 +7782,8 @@ function fakeWrite() {
   return {
     batchId: "00000000000070008000000000000001",
     payload: new Uint8Array(0),
-    wait: () => undefined,
+    wait: async () => undefined,
     writeState: () => ({}),
-    nextWriteStateChange: async () => undefined,
   };
 }
 

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -28,8 +28,7 @@ declare module "jazz-wasm" {
     readonly batchId: string;
     readonly payload: Uint8Array;
     writeState(): unknown;
-    nextWriteStateChange(): Promise<void>;
-    wait(tier: string): void;
+    wait(tier: string): Promise<void>;
     close(): boolean;
   }
 
@@ -153,6 +152,7 @@ declare module "jazz-wasm" {
       author: Uint8Array,
     ): WasmWrite;
     setTickScheduler(callback: (urgency: "immediate" | "deferred") => void): void;
+    onMutationError(callback: (event: any) => void): void;
     tick(): void;
     close(): boolean;
     connectUpstream(): WasmTransport;

--- a/packages/jazz-tools/tests/browser/support.ts
+++ b/packages/jazz-tools/tests/browser/support.ts
@@ -25,6 +25,18 @@ export function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+/** Abruptly terminate a Db's OPFS worker without running its normal close path. */
+export function simulateCrash(db: Db): void {
+  const runtime = (db as any).runtimeSource?.persistentOwnerRuntime;
+  const worker = runtime?.worker as Worker | undefined;
+  if (!runtime || !worker) {
+    throw new Error("persistent browser worker is unavailable");
+  }
+  worker.terminate();
+  // Prevent later test cleanup from trying to exchange messages with the dead worker.
+  runtime.closed = true;
+}
+
 // ---------------------------------------------------------------------------
 // Polling helpers  (cf. Rust wait_for / wait_for_query)
 // ---------------------------------------------------------------------------

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -634,7 +634,7 @@ describe("Worker Bridge with OPFS", () => {
     expect(rows).toEqual([]);
   });
 
-  it.fails("deletes OPFS storage for the current namespace and keeps the same Db usable", async () => {
+  it("deletes OPFS storage for the current namespace and keeps the same Db usable", async () => {
     const db = track(
       await createDb({
         appId: "test-app",
@@ -662,7 +662,7 @@ describe("Worker Bridge with OPFS", () => {
     expect(afterReinsert[0].done).toBe(true);
   });
 
-  it.fails("resolves a storage reset requested before any schema use", async () => {
+  it("resolves a storage reset requested before any schema use", async () => {
     const db = track(
       await createDb({
         appId: "test-app",

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -14,6 +14,7 @@ import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {
   TestCleanup,
   createSyncedDb,
+  simulateCrash,
   sleep,
   uniqueDbName,
   waitForCondition,
@@ -129,8 +130,12 @@ function getActiveRoleBridge(db: Db): any {
   return getBrowserConnection(db)?.activeRoleBridge ?? null;
 }
 
+function getPersistentBrowserRuntime(db: Db): any {
+  return (db as any).runtimeSource?.persistentOwnerRuntime ?? null;
+}
+
 function getPrivateWorker(db: Db): Worker | null {
-  return getActiveRoleBridge(db)?.worker ?? null;
+  return getPersistentBrowserRuntime(db)?.worker ?? getActiveRoleBridge(db)?.worker ?? null;
 }
 
 function getPrivateWorkerBridge(db: Db): any {
@@ -139,13 +144,6 @@ function getPrivateWorkerBridge(db: Db): any {
 
 function getFollowerPortBridge(db: Db): any {
   return getActiveRoleBridge(db)?.followerPortBridge ?? null;
-}
-
-function clearPrivateWorkerBridge(db: Db): void {
-  const roleBridge = getActiveRoleBridge(db);
-  if (roleBridge) {
-    roleBridge.workerBridge = null;
-  }
 }
 
 function summarizeWorkerMessage(
@@ -573,7 +571,7 @@ describe("Worker Bridge with OPFS", () => {
     expect(after[0].done).toBe(true);
   });
 
-  it.fails("recovers data from WAL after crash (no snapshot flush)", async () => {
+  it("recovers data from WAL after crash (no snapshot flush)", async () => {
     const dbName = uniqueDbName("crash-recovery");
 
     const db1 = track(
@@ -587,15 +585,8 @@ describe("Worker Bridge with OPFS", () => {
     await db1.insert(todos, { title: "Crash-proof", done: false }).wait({ tier: "local" });
     await db1.insert(todos, { title: "Also survives", done: true }).wait({ tier: "local" });
 
-    // Simulate crash: release OPFS handles WITHOUT flushing snapshot.
-    // WAL has the data, but snapshot is stale. Recovery must replay WAL.
-    // (Real worker.terminate() doesn't reliably release OPFS exclusive
-    // locks within the same page session — only a full page reload does.)
-    const worker = getPrivateWorker(db1);
-    await getActiveRoleBridge(db1).simulateCrash();
-    worker?.terminate();
-    // Null out dead worker bridge so Db shutdown only frees client-side resources.
-    clearPrivateWorkerBridge(db1);
+    // Crash without flushing the snapshot; recovery must replay the WAL.
+    simulateCrash(db1);
     await db1.shutdown();
 
     // New Db with same dbName — worker must recover from OPFS WAL

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1,0 +1,2722 @@
+/**
+ * Browser integration tests for Worker Bridge + OPFS persistence.
+ *
+ * Runs in a real Chromium browser via @vitest/browser + playwright.
+ * Uses real jazz-wasm, real dedicated Workers, real OPFS storage.
+ *
+ * Server sync tests use a real jazz-tools server spawned by global-setup.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
+import type { Schema, WasmSchema } from "../../src/drivers/types.js";
+import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
+import {
+  TestCleanup,
+  createSyncedDb,
+  sleep,
+  uniqueDbName,
+  waitForCondition,
+  waitForQuery,
+  withTimeout,
+} from "./support.js";
+import {
+  blockJazzServerNetwork,
+  getJazzServerInfo,
+  getJazzServerJwtForUser,
+  type JazzServerInfo,
+  unblockJazzServerNetwork,
+} from "./testing-server.js";
+import {
+  closeRemoteBrowserDb,
+  createRemoteBrowserDb,
+  waitForRemoteBrowserDbTitle,
+} from "./remote-browser-db.js";
+import { CompiledPermissions, schema as s } from "../../src/";
+import { deploy } from "../../src/dev/catalogue.js";
+
+// ---------------------------------------------------------------------------
+// Test schema — a simple "todos" table
+// ---------------------------------------------------------------------------
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    projectId: s.ref("projects").optional(),
+    tags: s.array(s.string()).optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+const app: s.App<AppSchema> = s.defineApp(schema);
+const { projects, todos } = app;
+type Todo = s.RowOf<typeof todos>;
+
+const readOnlyPermissions = s.definePermissions(app, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.never(),
+  policy.projects.allowUpdate.never(),
+  policy.projects.allowDelete.never(),
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.never(),
+  policy.todos.allowUpdate.never(),
+  policy.todos.allowDelete.never(),
+]);
+
+const noUpdatePermissions = s.definePermissions(app, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.always(),
+  policy.projects.allowUpdate.never(),
+  policy.projects.allowDelete.always(),
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.always(),
+  policy.todos.allowUpdate.never(),
+  policy.todos.allowDelete.always(),
+]);
+
+const noDeletePermissions = s.definePermissions(app, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.always(),
+  policy.projects.allowUpdate.always(),
+  policy.projects.allowDelete.never(),
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.always(),
+  policy.todos.allowUpdate.always(),
+  policy.todos.allowDelete.never(),
+]);
+
+const nullableSchema = {
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+  }),
+};
+
+type NullableSchema = s.Schema<typeof nullableSchema>;
+const nullableApp: s.App<NullableSchema> = s.defineApp(nullableSchema);
+const nullablePermissions = s.definePermissions(nullableApp, ({ policy }) => [
+  policy.todos.allowRead.always(),
+  policy.todos.allowInsert.always(),
+  policy.todos.allowUpdate.always(),
+  policy.todos.allowDelete.always(),
+]);
+
+interface WorkerMessageDebugEvent {
+  atMs: number;
+  type: string;
+  details?: Record<string, unknown>;
+}
+
+interface WorkerMessageProbe {
+  dispose(): void;
+  snapshot(): WorkerMessageDebugEvent[];
+}
+
+function getBrowserConnection(db: Db): any {
+  return (db as any).connection;
+}
+
+function getPrivateClient(db: Db): unknown {
+  return getBrowserConnection(db)?.client ?? null;
+}
+
+function getActiveRoleBridge(db: Db): any {
+  return getBrowserConnection(db)?.activeRoleBridge ?? null;
+}
+
+function getPrivateWorker(db: Db): Worker | null {
+  return getActiveRoleBridge(db)?.worker ?? null;
+}
+
+function getPrivateWorkerBridge(db: Db): any {
+  return getActiveRoleBridge(db)?.workerBridge ?? null;
+}
+
+function getFollowerPortBridge(db: Db): any {
+  return getActiveRoleBridge(db)?.followerPortBridge ?? null;
+}
+
+function clearPrivateWorkerBridge(db: Db): void {
+  const roleBridge = getActiveRoleBridge(db);
+  if (roleBridge) {
+    roleBridge.workerBridge = null;
+  }
+}
+
+function summarizeWorkerMessage(
+  data: { type?: string; [key: string]: unknown } | undefined,
+): Record<string, unknown> | undefined {
+  if (!data?.type) {
+    return undefined;
+  }
+
+  switch (data.type) {
+    case "init-ok":
+      return { clientId: data.clientId };
+    case "error":
+      return { message: data.message };
+    case "sync":
+      return {
+        payloadCount: Array.isArray(data.payload) ? data.payload.length : undefined,
+      };
+    case "peer-sync":
+      return {
+        peerId: data.peerId,
+        leadershipId: data.leadershipId,
+        payloadCount: Array.isArray(data.payload) ? data.payload.length : undefined,
+      };
+    default:
+      return undefined;
+  }
+}
+
+function attachWorkerMessageProbe(db: Db): WorkerMessageProbe {
+  const worker = getPrivateWorker(db);
+  const startedAt = Date.now();
+  const events: WorkerMessageDebugEvent[] = [];
+
+  if (!worker) {
+    return {
+      dispose() {},
+      snapshot() {
+        return [];
+      },
+    };
+  }
+
+  const handler = (event: MessageEvent<{ type?: string; [key: string]: unknown }>) => {
+    events.push({
+      atMs: Date.now() - startedAt,
+      type: event.data?.type ?? "unknown",
+      details: summarizeWorkerMessage(event.data),
+    });
+    if (events.length > 40) {
+      events.shift();
+    }
+  };
+
+  worker.addEventListener("message", handler);
+
+  return {
+    dispose() {
+      worker.removeEventListener("message", handler);
+    },
+    snapshot() {
+      return [...events];
+    },
+  };
+}
+
+/** QueryBuilder that selects all todos. */
+const allTodos: QueryBuilder<Todo> = app.todos;
+
+/**
+ * Structurally valid JWT with a deliberately invalid signature: parses fine on
+ * the client (sub/exp claims) but the testing server rejects it at handshake.
+ */
+function makeStructurallyValidJwt(userId: string): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const header = encode({ alg: "HS256", typ: "JWT" });
+  const payload = encode({
+    sub: userId,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  return `${header}.${payload}.invalid-signature`;
+}
+
+/** QueryBuilder that selects all todos by project. */
+function todosByProject(projectId: string): QueryBuilder<Todo> {
+  return app.todos.where({ projectId });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Worker Bridge with OPFS", () => {
+  const ctx = new TestCleanup();
+  const remoteBrowserDbIds = new Set<string>();
+
+  function trackRemoteBrowserDb(id: string): string {
+    remoteBrowserDbIds.add(id);
+    return id;
+  }
+
+  async function waitForRemoteTodoTitle(
+    id: string,
+    title: string,
+    label: string,
+    timeoutMs: number,
+    tier?: "local" | "edge",
+  ): Promise<Record<string, unknown>[]> {
+    try {
+      return await waitForRemoteBrowserDbTitle({ id, title, timeoutMs, tier });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`${label}: ${message}`);
+    }
+  }
+
+  /** Shorthand: track a Db for cleanup. */
+  function track(db: Db): Db {
+    return ctx.track(db);
+  }
+
+  /** Shorthand: track a subscription for cleanup. */
+  function trackSubscription(unsubscribe: () => void): () => void {
+    return ctx.trackSubscription(unsubscribe);
+  }
+
+  function untrack(db: Db): void {
+    ctx.untrack(db);
+  }
+
+  function getTabRole(db: Db): "leader" | "follower" | null {
+    const role = getBrowserConnection(db)?.tabRole;
+    if (role === "leader" || role === "follower") {
+      return role;
+    }
+    return null;
+  }
+
+  async function waitForLeaderAndFollower(a: Db, b: Db): Promise<{ leader: Db; follower: Db }> {
+    await waitForCondition(
+      async () => {
+        const roleA = getTabRole(a);
+        const roleB = getTabRole(b);
+        return roleA === "leader" && roleB === "follower";
+      },
+      12000,
+      "Expected one elected leader and one follower",
+    ).catch(async () => {
+      await waitForCondition(
+        async () => {
+          const roleA = getTabRole(a);
+          const roleB = getTabRole(b);
+          return roleA === "follower" && roleB === "leader";
+        },
+        12000,
+        "Expected one elected leader and one follower",
+      );
+    });
+
+    const roleA = getTabRole(a);
+    const roleB = getTabRole(b);
+    if (roleA === "leader" && roleB === "follower") {
+      return { leader: a, follower: b };
+    }
+    if (roleA === "follower" && roleB === "leader") {
+      return { leader: b, follower: a };
+    }
+    throw new Error("Unable to determine leader/follower roles");
+  }
+
+  async function waitForSingleLeader(tabs: Db[]): Promise<Db> {
+    await waitForCondition(
+      async () => {
+        let leaders = 0;
+        let knownRoles = 0;
+        for (const tab of tabs) {
+          const role = getTabRole(tab);
+          if (!role) continue;
+          knownRoles += 1;
+          if (role === "leader") leaders += 1;
+        }
+        return knownRoles === tabs.length && leaders === 1;
+      },
+      12000,
+      "Expected exactly one elected leader across tabs",
+    );
+
+    const leader = tabs.find((tab) => getTabRole(tab) === "leader");
+    if (!leader) {
+      throw new Error("Expected one leader after convergence");
+    }
+    return leader;
+  }
+
+  afterEach(async () => {
+    for (const id of remoteBrowserDbIds) {
+      try {
+        await closeRemoteBrowserDb(id);
+      } catch {
+        // Best effort
+      }
+    }
+    remoteBrowserDbIds.clear();
+    await ctx.cleanup();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Worker initialization
+  // -------------------------------------------------------------------------
+
+  it("creates Db with worker in browser environment", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent" },
+      }),
+    );
+    expect(db).toBeDefined();
+    expect(db).toBeInstanceOf(Db);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Insert + local query through worker bridge
+  // -------------------------------------------------------------------------
+
+  it("inserts a row and queries it back", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("insert-query") },
+      }),
+    );
+
+    // Insert (sync — runs on main-thread in-memory runtime)
+    const {
+      value: { id },
+    } = db.insert(todos, { title: "Buy milk", done: false });
+    expect(id).toBeTruthy();
+    expect(typeof id).toBe("string");
+
+    // Query (async — runs on main-thread runtime)
+    const results = await db.all(allTodos);
+    expect(results.length).toBe(1);
+    expect(results[0].id).toBe(id);
+    expect(results[0].title).toBe("Buy milk");
+    expect(results[0].done).toBe(false);
+  });
+
+  it("inserts multiple rows and queries all", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("multi-insert") },
+      }),
+    );
+
+    db.insert(todos, { title: "Task A", done: false });
+    db.insert(todos, { title: "Task B", done: true });
+    db.insert(todos, { title: "Task C", done: false });
+
+    const results = await db.all(allTodos);
+    expect(results.length).toBe(3);
+
+    const titles = results.map((r) => r.title).sort();
+    expect(titles).toEqual(["Task A", "Task B", "Task C"]);
+  });
+
+  it("sync insert before bridge init is persisted after init completes", async () => {
+    const dbName = uniqueDbName("sync-insert-before-bridge-ready");
+    const db1 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    // First I/O operation, bridge hasn't been initialized yet.
+    const {
+      value: { id },
+    } = db1.insert(todos, { title: "Test", done: false });
+
+    await waitForCondition(
+      async () => {
+        const row = await db1.one(allTodos, { tier: "local" });
+        return row?.id === id;
+      },
+      8_000,
+      "sync insert should be forwarded to worker after bridge init",
+    );
+
+    await db1.shutdown();
+    untrack(db1);
+
+    const db2 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    const persistedRow = await db2.one(allTodos, { tier: "local" });
+    expect(persistedRow?.id).toBe(id);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Update + delete through worker bridge
+  // -------------------------------------------------------------------------
+
+  it("updates a row", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("update") },
+      }),
+    );
+
+    const { value: inserted } = db.insert(todos, {
+      title: "Original",
+      done: false,
+    });
+    const { id } = inserted;
+    const result = db.update(todos, id, { done: true });
+    expect(result).toMatchObject({
+      wait: expect.any(Function),
+    });
+
+    const results = await db.all(allTodos);
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Original");
+    expect(results[0].done).toBe(true);
+  });
+
+  it("updates a row durably", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("update-durable") },
+      }),
+    );
+
+    const { id } = await db
+      .insert(todos, { title: "Original", done: false })
+      .wait({ tier: "local" });
+
+    const updateHandle = db.update(todos, id, { done: true });
+    await updateHandle.wait({ tier: "local" });
+
+    const results = await db.all(allTodos, { tier: "local" });
+    expect(results.length).toBe(1);
+    expect(results[0].done).toBe(true);
+  });
+
+  it("deletes a row", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("delete") },
+      }),
+    );
+
+    const { value: inserted } = db.insert(todos, {
+      title: "Ephemeral",
+      done: false,
+    });
+    const { id } = inserted;
+    expect((await db.all(allTodos)).length).toBe(1);
+
+    const result = db.delete(todos, id);
+    expect(result).toMatchObject({
+      wait: expect.any(Function),
+    });
+    const results = await db.all(allTodos);
+    expect(results.length).toBe(0);
+  });
+
+  it("deletes a row durably", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("delete-durable") },
+      }),
+    );
+
+    const { id } = await db
+      .insert(todos, { title: "Ephemeral", done: false })
+      .wait({ tier: "local" });
+    expect((await db.all(allTodos, { tier: "local" })).length).toBe(1);
+
+    const deleteHandle = db.delete(todos, id);
+    await deleteHandle.wait({ tier: "local" });
+
+    const results = await db.all(allTodos, { tier: "local" });
+    expect(results.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. OPFS persistence across shutdown + re-open
+  // -------------------------------------------------------------------------
+
+  it("persists data across shutdown and re-create (OPFS)", async () => {
+    const dbName = uniqueDbName("persistence");
+
+    const db1 = await createDb({
+      appId: "test-app",
+      driver: { type: "persistent", dbName },
+    });
+    db1.insert(todos, { title: "Survive reload", done: true });
+    const before = await db1.all(allTodos);
+    expect(before.length).toBe(1);
+    await db1.shutdown();
+
+    // New Db with same dbName — worker reopens OPFS, main thread starts empty.
+    // Using "local" settled tier makes the query wait for the worker's
+    // QuerySettled response, ensuring OPFS data arrives before resolving.
+    const db2 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const after = await db2.all(allTodos, { tier: "local" });
+    expect(after.length).toBe(1);
+    expect(after[0].title).toBe("Survive reload");
+    expect(after[0].done).toBe(true);
+  });
+
+  it.fails("recovers data from WAL after crash (no snapshot flush)", async () => {
+    const dbName = uniqueDbName("crash-recovery");
+
+    const db1 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    // wait({ tier: "local" }) ensures data is in OPFS WAL before we crash
+    await db1.insert(todos, { title: "Crash-proof", done: false }).wait({ tier: "local" });
+    await db1.insert(todos, { title: "Also survives", done: true }).wait({ tier: "local" });
+
+    // Simulate crash: release OPFS handles WITHOUT flushing snapshot.
+    // WAL has the data, but snapshot is stale. Recovery must replay WAL.
+    // (Real worker.terminate() doesn't reliably release OPFS exclusive
+    // locks within the same page session — only a full page reload does.)
+    const worker = getPrivateWorker(db1);
+    await getActiveRoleBridge(db1).simulateCrash();
+    worker?.terminate();
+    // Null out dead worker bridge so Db shutdown only frees client-side resources.
+    clearPrivateWorkerBridge(db1);
+    await db1.shutdown();
+
+    // New Db with same dbName — worker must recover from OPFS WAL
+    const db2 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const after = await db2.all(allTodos, { tier: "local" });
+    expect(after.length).toBe(2);
+
+    const titles = after.map((r) => r.title).sort();
+    expect(titles).toEqual(["Also survives", "Crash-proof"]);
+  });
+
+  it("recovers from OPFS handle conflict after abrupt worker termination", async () => {
+    // Hold a WritableStream on the OPFS file from the main thread — this
+    // blocks createSyncAccessHandle in the worker, exactly like a stale
+    // handle from a previous page load.
+    //
+    //  main thread: createWritable() ──── holds ──── close()
+    //  worker:            createSyncAccessHandle() → conflict → retry → success
+    //
+    const dbName = uniqueDbName("handle-conflict");
+    // Coupled to OpfsFile::file_name() in crates/opfs-btree/src/file.rs
+    const fileName = `${dbName}.opfsbtree`;
+
+    // Pre-create the OPFS file and hold a writable stream to block the worker.
+    const root = await navigator.storage.getDirectory();
+    const fileHandle = await root.getFileHandle(fileName, { create: true });
+    const writable = await fileHandle.createWritable();
+
+    // Start the Db — its worker will hit NoModificationAllowedError and retry.
+    const dbPromise = createDb({
+      appId: "test-app",
+      driver: { type: "persistent", dbName },
+    });
+
+    // Release the lock after 100ms so the retry can succeed.
+    setTimeout(() => writable.close(), 100);
+
+    const db = track(await dbPromise);
+    const rows = await db.all(allTodos, { tier: "local" });
+    expect(rows).toEqual([]);
+  });
+
+  it.fails("deletes OPFS storage for the current namespace and keeps the same Db usable", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("delete-storage") },
+      }),
+    );
+
+    await db.insert(todos, { title: "Should be deleted", done: false }).wait({ tier: "local" });
+    const before = await db.all(allTodos, { tier: "local" });
+    expect(before.length).toBe(1);
+    expect(before[0].title).toBe("Should be deleted");
+
+    await db.deleteClientStorage();
+
+    const afterDelete = await db.all(allTodos, { tier: "local" });
+    expect(afterDelete).toEqual([]);
+
+    const {
+      value: { id },
+    } = db.insert(todos, { title: "Fresh after delete", done: true });
+    const afterReinsert = await db.all(allTodos, { tier: "local" });
+    expect(afterReinsert).toHaveLength(1);
+    expect(afterReinsert[0].id).toBe(id);
+    expect(afterReinsert[0].title).toBe("Fresh after delete");
+    expect(afterReinsert[0].done).toBe(true);
+  });
+
+  it.fails("resolves a storage reset requested before any schema use", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("delete-storage-fresh") },
+      }),
+    );
+
+    // No table/query has run yet: no client exists anywhere in the namespace.
+    await db.deleteClientStorage();
+
+    // The same Db must come back to life through a normal election once the
+    // schema is used for the first time.
+    await db
+      .insert(todos, { title: "first row after fresh wipe", done: false })
+      .wait({ tier: "local" });
+    expect(await db.all(allTodos, { tier: "local" })).toHaveLength(1);
+  });
+
+  it.fails("resolves a fresh-namespace storage reset while a second fresh tab is open", async () => {
+    const dbName = uniqueDbName("delete-storage-fresh-two-tabs");
+    const dbA = track(
+      await createDb({ appId: "test-app", driver: { type: "persistent", dbName } }),
+    );
+    const dbB = track(
+      await createDb({ appId: "test-app", driver: { type: "persistent", dbName } }),
+    );
+
+    // Neither tab has used the schema; both join the reset as participants.
+    await dbB.deleteClientStorage();
+
+    // First schema use after the wipe elects a real leader; the other fresh
+    // tab must then get bridged as a follower and observe the write.
+    await dbA
+      .insert(todos, { title: "row after two-tab fresh wipe", done: false })
+      .wait({ tier: "local" });
+    await waitForCondition(
+      async () => (await dbB.all(allTodos, { tier: "local" })).length === 1,
+      8000,
+      "Second fresh tab should observe the row written after the wipe",
+    );
+  });
+
+  it.fails("retries OPFS storage deletion after a transient browser lock", async () => {
+    const dbName = uniqueDbName("delete-storage-transient-lock");
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    await db.insert(todos, { title: "Should be deleted after retry", done: false }).wait({
+      tier: "local",
+    });
+    expect(await db.all(allTodos, { tier: "local" })).toHaveLength(1);
+
+    const realRoot = await navigator.storage.getDirectory();
+    const realGetDirectory = navigator.storage.getDirectory.bind(navigator.storage);
+    let lockedAttempts = 0;
+    const proxyRoot = new Proxy(realRoot, {
+      get(target, property, receiver) {
+        if (property === "removeEntry") {
+          return async (name: string, options?: FileSystemRemoveOptions): Promise<void> => {
+            if (name === `${dbName}.opfsbtree` && lockedAttempts === 0) {
+              lockedAttempts += 1;
+              throw new DOMException("OPFS handle is still closing", "NoModificationAllowedError");
+            }
+            return await target.removeEntry(name, options);
+          };
+        }
+
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    const getDirectorySpy = vi
+      .spyOn(navigator.storage, "getDirectory")
+      .mockResolvedValue(proxyRoot);
+    try {
+      await db.deleteClientStorage();
+    } finally {
+      getDirectorySpy.mockRestore();
+      navigator.storage.getDirectory = realGetDirectory;
+    }
+
+    expect(lockedAttempts).toBe(1);
+    expect(await db.all(allTodos, { tier: "local" })).toEqual([]);
+  });
+
+  it.fails("deletes OPFS storage across leader and follower tabs when requested from a follower", async () => {
+    const dbName = uniqueDbName("delete-storage-follower");
+    const dbA = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const dbB = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const { leader, follower } = await waitForLeaderAndFollower(dbA, dbB);
+
+    await leader
+      .insert(todos, { title: "Leader data before follower wipe", done: false })
+      .wait({ tier: "local" });
+    await follower
+      .insert(todos, {
+        title: "Follower data before follower wipe",
+        done: true,
+      })
+      .wait({ tier: "local" });
+
+    await waitForCondition(
+      async () => {
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
+        return leaderRows.length === 2 && followerRows.length === 2;
+      },
+      8000,
+      "Leader and follower should both observe pre-wipe rows",
+    );
+
+    await follower.deleteClientStorage();
+
+    await waitForCondition(
+      async () => {
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
+        return leaderRows.length === 0 && followerRows.length === 0;
+      },
+      12000,
+      "Follower-initiated storage wipe should clear both leader and follower namespaces",
+    );
+
+    const marker = `fresh-after-follower-wipe-${Date.now()}`;
+    await leader.insert(todos, { title: marker, done: false }).wait({ tier: "local" });
+
+    await waitForCondition(
+      async () => {
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
+        const leaderHas = leaderRows.some((row) => row.title === marker);
+        const followerHas = followerRows.some((row) => row.title === marker);
+        return leaderHas && followerHas;
+      },
+      12000,
+      "Both tabs should recover cleanly after follower-initiated storage wipe",
+    );
+  });
+
+  it("logout with wipeData clears browser storage before the next session opens", async () => {
+    const dbName = uniqueDbName("logout-wipe");
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    await db
+      .insert(todos, { title: "Should be wiped on logout", done: false })
+      .wait({ tier: "local" });
+    expect((await db.all(allTodos, { tier: "local" })).length).toBe(1);
+
+    await db.logout({ wipeData: true });
+    untrack(db);
+
+    const reopened = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const rows = await reopened.all(allTodos, { tier: "local" });
+    expect(rows).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Durable insert resolves at local tier
+  // -------------------------------------------------------------------------
+
+  it("insert resolves when local acks", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("with-ack") },
+      }),
+    );
+
+    // insert("local") should resolve once the worker's OPFS has it
+    const result = db.insert(todos, { title: "Durable", done: false });
+    await result.wait({ tier: "local" });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Subscription through worker bridge
+  // -------------------------------------------------------------------------
+
+  it("subscriptions fire on insert", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("subscribe") },
+      }),
+    );
+
+    const received: Todo[][] = [];
+
+    const unsub = trackSubscription(
+      db.subscribeAll(allTodos, (delta) => {
+        received.push([...(delta.all ?? [])]);
+      }),
+    );
+
+    db.insert(todos, { title: "Observed", done: false });
+
+    // Wait for subscription to fire
+    await waitForCondition(
+      async () => received.some((r) => r.length > 0),
+      3000,
+      "Subscription should fire after insert",
+    );
+
+    const last = received[received.length - 1];
+    expect(last.length).toBe(1);
+    expect(last[0].title).toBe("Observed");
+
+    unsub();
+  });
+
+  it("subscriptions fire when using queries with filters", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("subscribe") },
+      }),
+    );
+
+    const received: Todo[][] = [];
+
+    const {
+      value: { id: projectId },
+    } = db.insert(projects, { name: "Observed Project" });
+    const unsub = trackSubscription(
+      db.subscribeAll(todosByProject(projectId), (delta) => {
+        received.push([...(delta.all ?? [])]);
+      }),
+    );
+
+    db.insert(todos, { title: "Observed", done: false, projectId });
+    const {
+      value: { id: anotherProjectId },
+    } = db.insert(projects, { name: "Ignored Project" });
+    db.insert(todos, {
+      title: "Not observed",
+      done: false,
+      projectId: anotherProjectId,
+    });
+
+    // Wait for subscription to fire
+    await waitForCondition(
+      async () => received.some((r) => r.length > 0),
+      3000,
+      "Subscription should fire after insert",
+    );
+
+    const last = received[received.length - 1];
+    expect(last.length).toBe(1);
+    expect(last[0].title).toBe("Observed");
+
+    unsub();
+  });
+
+  it.fails("tiered subscriptions gate the first callback until the worker's settled snapshot content is local", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("subscribe-global-gated");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const seeder = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("subscribe-global-gated-seeder"),
+        },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+
+    const {
+      value: { id: projectId },
+    } = seeder.insert(projects, { name: `server-project-${Date.now()}` });
+    await seeder.all(app.projects.where({ id: projectId }), { tier: "global" });
+
+    const expectedTitles: string[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      const title = `server-seeded-${i}`;
+      expectedTitles.push(title);
+      await seeder.insert(todos, { title, done: i % 2 === 0, projectId }).wait({ tier: "global" });
+    }
+    await seeder.shutdown();
+    ctx.untrack(seeder);
+
+    const fresh = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("subscribe-global-gated-fresh"),
+        },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+    (fresh as unknown as { getClient(schema: WasmSchema): unknown }).getClient(app.wasmSchema);
+    await waitForCondition(
+      async () => Boolean(getPrivateWorker(fresh)?.onmessage),
+      5000,
+      `fresh worker bridge should install its onmessage handler; diagnostics=${JSON.stringify({
+        tabRole: getTabRole(fresh),
+        workerExists: Boolean(getPrivateWorker(fresh)),
+        workerOnMessage: Boolean(getPrivateWorker(fresh)?.onmessage),
+        bridge: Boolean(getPrivateWorkerBridge(fresh)),
+        clientType: typeof getPrivateClient(fresh),
+        hasClient: Boolean(getPrivateClient(fresh)),
+      })}`,
+    );
+    const snapshots: Todo[][] = [];
+    const unsubscribe = trackSubscription(
+      fresh.subscribeAll(
+        todosByProject(projectId),
+        (delta) => {
+          snapshots.push([...(delta.all ?? [])]);
+        },
+        { tier: "global" },
+      ),
+    );
+
+    await waitForCondition(
+      async () => snapshots.some((snapshot) => snapshot.length === expectedTitles.length),
+      15000,
+      "global tier subscription should deliver the settled snapshot",
+    );
+
+    const firstSnapshot = snapshots[0];
+    expect(firstSnapshot).toHaveLength(expectedTitles.length);
+    expect(firstSnapshot.map((row) => row.title).sort()).toEqual([...expectedTitles].sort());
+
+    unsubscribe();
+  }, 90000);
+
+  it("delivers an initial scoped subscription snapshot after seeding many synced rows", async () => {
+    const sharedLocalAuthToken = generateAuthSecret();
+    const syncServer = await publishSyncServerSchemaAndPermissions("subscribe-initial-snapshot");
+    const db = await createSyncedDb(
+      ctx,
+      "subscribe-initial-snapshot",
+      sharedLocalAuthToken,
+      syncServer,
+    );
+
+    const insertedIds: string[] = [];
+    for (let i = 0; i < 120; i += 1) {
+      const { id } = await db
+        .insert(todos, { title: `seeded-${i}`, done: i % 2 === 0 })
+        .wait({ tier: "local" });
+      insertedIds.push(id);
+    }
+
+    const targetId = insertedIds[0];
+    const received: Todo[][] = [];
+    const unsub = trackSubscription(
+      db.subscribeAll(todos.where({ id: targetId }), (delta) => {
+        received.push([...(delta.all ?? [])]);
+      }),
+    );
+
+    await waitForCondition(
+      async () =>
+        received.some((rows) => rows.length === 1 && rows[0]?.id === targetId && rows[0]?.title),
+      8000,
+      "Seeded synced row should appear in initial scoped subscription snapshot",
+    );
+
+    const last = received[received.length - 1];
+    expect(last).toHaveLength(1);
+    expect(last[0].id).toBe(targetId);
+    expect(last[0].title).toBe("seeded-0");
+
+    unsub();
+  }, 60000);
+
+  it("delivers an initial scoped subscription snapshot for jwt-backed synced rows", async () => {
+    const { appId, serverUrl, adminSecret } =
+      await publishSyncServerSchemaAndPermissions("subscribe-initial-jwt");
+    const db = track(
+      await createDb({
+        appId,
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("subscribe-initial-jwt"),
+        },
+        serverUrl,
+        adminSecret,
+        jwtToken: await getJazzServerJwtForUser("subscribe-initial-jwt", undefined, appId),
+      }),
+    );
+
+    const insertedIds: string[] = [];
+    for (let i = 0; i < 120; i += 1) {
+      const { id } = await db
+        .insert(todos, { title: `seeded-jwt-${i}`, done: i % 2 === 0 })
+        .wait({ tier: "local" });
+      insertedIds.push(id);
+    }
+
+    const targetId = insertedIds[0];
+    const received: Todo[][] = [];
+    const unsub = trackSubscription(
+      db.subscribeAll(todos.where({ id: targetId }), (delta) => {
+        received.push([...(delta.all ?? [])]);
+      }),
+    );
+
+    await waitForCondition(
+      async () =>
+        received.some((rows) => rows.length === 1 && rows[0]?.id === targetId && rows[0]?.title),
+      8000,
+      "JWT-backed seeded row should appear in initial scoped subscription snapshot",
+    );
+
+    const last = received[received.length - 1];
+    expect(last).toHaveLength(1);
+    expect(last[0].id).toBe(targetId);
+    expect(last[0].title).toBe("seeded-jwt-0");
+
+    unsub();
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // 7. Server sync through worker
+  // -------------------------------------------------------------------------
+
+  it("propagates synced row from client A to client B", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-a-to-b");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const dbA = await createSyncedDb(ctx, "sync-a", sharedLocalAuthToken, syncServer);
+    const dbB = await createSyncedDb(ctx, "sync-b", sharedLocalAuthToken, syncServer);
+
+    const title = `sync-a-to-b-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await withTimeout(
+      dbA.insert(todos, { title, done: false }).wait({ tier: "local" }),
+      10000,
+      "A insert(worker) did not resolve",
+    );
+
+    const rowsOnB = await waitForTodos(
+      dbB,
+      (rows) => rows.some((row) => row.title === title),
+      "A -> B propagation",
+      20000,
+    );
+    expect(rowsOnB.some((row) => row.title === title)).toBe(true);
+  }, 60000);
+
+  it("propagates synced row from client B to client A", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-b-to-a");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const dbA = await createSyncedDb(ctx, "sync-a-reverse", sharedLocalAuthToken, syncServer);
+    const dbB = await createSyncedDb(ctx, "sync-b-reverse", sharedLocalAuthToken, syncServer);
+
+    const title = `sync-b-to-a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await withTimeout(
+      dbB.insert(todos, { title, done: true }).wait({ tier: "local" }),
+      10000,
+      "B insert(worker) did not resolve",
+    );
+
+    const rowsOnA = await waitForTodos(
+      dbA,
+      (rows) => rows.some((row) => row.title === title),
+      "B -> A propagation",
+      20000,
+    );
+    expect(rowsOnA.some((row) => row.title === title)).toBe(true);
+  }, 60000);
+
+  it("resolves insert wait at edge tier through the worker bridge", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-wait-edge");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+    const title = `wait-edge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const inserted = db.insert(todos, { title, done: false });
+    const { value: insertedTodo } = inserted;
+
+    await withTimeout(inserted.wait({ tier: "edge" }), 10000, "insert wait(edge) did not resolve");
+
+    expect(insertedTodo.id).toBeTruthy();
+    expect(insertedTodo.title).toBe(title);
+
+    const rowsAtEdge = await waitForTodos(
+      db,
+      (rows) => rows.some((row) => row.id === insertedTodo.id && row.title === title),
+      "insert wait(edge) row becomes queryable at edge",
+      20000,
+      "edge",
+    );
+    expect(rowsAtEdge.some((row) => row.id === insertedTodo.id)).toBe(true);
+  }, 60000);
+
+  it("server permissions check rejects client optimistic insert - wait notification", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-wait-edge",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+    const insertResult = db.insert(todos, { title: "Rejected", done: false });
+    const batchId = await insertResult.batchId;
+    await expect(insertResult.wait({ tier: "edge" })).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      batchId,
+      code: "permission_denied",
+    });
+
+    const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+    expect(todosAfterRevert.length).toBe(0);
+  });
+
+  it("server permissions check rejects client optimistic insert - onMutationError notification", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-wait-edge",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+    const mutationErrorSpy = vi.fn();
+    db.onMutationError(mutationErrorSpy);
+
+    const insertResult = db.insert(todos, { title: "Rejected", done: false });
+    const batchId = await insertResult.batchId;
+    await waitForCondition(
+      async () => mutationErrorSpy.mock.calls.length > 0,
+      1000,
+      "onMutationError handler should be called",
+    );
+    expect(mutationErrorSpy).toHaveBeenCalledWith({
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "Write rejected by server authorization",
+        },
+      },
+    });
+
+    const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+    expect(todosAfterRevert.length).toBe(0);
+  });
+
+  it("wait() prevents onMutationError handler from firing", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-wait-edge",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+    const mutationErrorSpy = vi.fn();
+    db.onMutationError(mutationErrorSpy);
+
+    const insertResult = db.insert(todos, { title: "Rejected", done: false });
+    await expect(insertResult.wait({ tier: "edge" })).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      batchId: insertResult.batchId,
+      code: "permission_denied",
+    });
+    expect(mutationErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not replay delivered rejected worker batches after restart", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-on-mutation-error-restart",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const dbName = uniqueDbName("sync-on-mutation-error-restart");
+    const createPersistentDb = () =>
+      createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent" as const, dbName },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      });
+
+    const dbBeforeRestart = track(await createPersistentDb());
+    const mutationErrorSpy = vi.fn();
+    dbBeforeRestart.onMutationError(mutationErrorSpy);
+
+    const insertResult = dbBeforeRestart.insert(todos, {
+      title: "Rejected across restart",
+      done: false,
+    });
+    const batchId = await insertResult.batchId;
+
+    await waitForCondition(
+      async () => mutationErrorSpy.mock.calls.length > 0,
+      5000,
+      "onMutationError handler should receive rejection before restart",
+    );
+    expect(mutationErrorSpy).toHaveBeenCalledWith({
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "Write rejected by server authorization",
+        },
+      },
+    });
+
+    await dbBeforeRestart.shutdown();
+    untrack(dbBeforeRestart);
+
+    const dbAfterAcknowledgement = track(await createPersistentDb());
+    const replayAfterAckSpy = vi.fn();
+    dbAfterAcknowledgement.onMutationError(replayAfterAckSpy);
+    await dbAfterAcknowledgement.all(allTodos, { tier: "local" });
+    await sleep(500);
+    expect(replayAfterAckSpy).not.toHaveBeenCalled();
+  });
+
+  it("replays undelivered rejected worker batches after restart", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-on-mutation-error-undelivered-restart",
+      readOnlyPermissions,
+    );
+
+    const sharedLocalAuthToken = generateAuthSecret();
+    const dbName = uniqueDbName("sync-on-mutation-error-undelivered-restart");
+    const createPersistentDb = (serverUrl?: string) =>
+      createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent" as const, dbName },
+        serverUrl,
+        secret: sharedLocalAuthToken,
+      });
+
+    const dbBeforeRestart = track(await createPersistentDb(undefined));
+    const mutationErrorSpy = vi.fn();
+    dbBeforeRestart.onMutationError(mutationErrorSpy);
+
+    const insertResult = dbBeforeRestart.insert(todos, {
+      title: "Rejected replayed after restart",
+      done: false,
+    });
+    const batchId = await insertResult.batchId;
+    await withTimeout(
+      insertResult.wait({ tier: "local" }),
+      5000,
+      "pending rejected insert should be durably recorded locally before restart",
+    );
+
+    await dbBeforeRestart.shutdown();
+    untrack(dbBeforeRestart);
+    expect(mutationErrorSpy).not.toHaveBeenCalled();
+
+    const dbAfterRestart = track(await createPersistentDb(syncServer.serverUrl));
+    const replayAfterRestartSpy = vi.fn();
+    dbAfterRestart.onMutationError(replayAfterRestartSpy);
+
+    // Run a query to set up the runtime
+    await dbAfterRestart.all(allTodos, { tier: "edge" });
+
+    await waitForCondition(
+      async () => replayAfterRestartSpy.mock.calls.length > 0,
+      5000,
+      "onMutationError handler should replay undelivered rejection after restart",
+    );
+    expect(replayAfterRestartSpy).toHaveBeenCalledWith({
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+      transaction: {
+        batchId,
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          batchId,
+          code: "permission_denied",
+          reason: "Write rejected by server authorization",
+        },
+      },
+    });
+  });
+
+  describe("optimistic writes are reverted on server rejection", () => {
+    it("insert", async () => {
+      const syncServer = await publishSyncServerSchemaAndPermissions(
+        "sync-wait-edge",
+        readOnlyPermissions,
+      );
+
+      const sharedLocalAuthToken = generateAuthSecret();
+      const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+      const insertResult = db.insert(todos, { title: "Rejected", done: false });
+      await expect(insertResult.wait({ tier: "edge" })).rejects.toMatchObject({
+        name: "PersistedWriteRejectedError",
+        batchId: insertResult.batchId,
+        code: "permission_denied",
+      });
+
+      const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosAfterRevert.length).toBe(0);
+    });
+
+    it("update", async () => {
+      const syncServer = await publishSyncServerSchemaAndPermissions(
+        "sync-wait-edge",
+        noUpdatePermissions,
+      );
+
+      const sharedLocalAuthToken = generateAuthSecret();
+      const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+      const insertResult = db.insert(todos, {
+        title: "Initial task",
+        done: false,
+      });
+      const todo = await insertResult.wait({ tier: "edge" });
+
+      const updateResult = db.update(todos, todo.id, { title: "Updated task" });
+      await expect(updateResult.wait({ tier: "edge" })).rejects.toMatchObject({
+        name: "PersistedWriteRejectedError",
+        batchId: updateResult.batchId,
+        code: "permission_denied",
+      });
+
+      const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosAfterRevert).toEqual([todo]);
+    });
+
+    it("delete", async () => {
+      const syncServer = await publishSyncServerSchemaAndPermissions(
+        "sync-wait-edge",
+        noDeletePermissions,
+      );
+
+      const sharedLocalAuthToken = generateAuthSecret();
+      const db = await createSyncedDb(ctx, "sync-wait-edge", sharedLocalAuthToken, syncServer);
+
+      const insertResult = db.insert(todos, {
+        title: "Initial task",
+        done: false,
+      });
+      const todo = await insertResult.wait({ tier: "edge" });
+
+      const deleteResult = db.delete(todos, todo.id);
+      await expect(deleteResult.wait({ tier: "edge" })).rejects.toMatchObject({
+        name: "PersistedWriteRejectedError",
+        batchId: deleteResult.batchId,
+        code: "permission_denied",
+      });
+
+      const todosAfterRevert = await db.all(allTodos, { tier: "local" });
+      expect(todosAfterRevert).toEqual([todo]);
+    });
+
+    describe("also reverts after restart", () => {
+      it("insert", async () => {
+        const syncServer = await publishSyncServerSchemaAndPermissions(
+          "sync-restart-revert-insert",
+          readOnlyPermissions,
+        );
+
+        const sharedLocalAuthToken = generateAuthSecret();
+        const dbName = uniqueDbName("sync-restart-revert-insert");
+        const createPersistentDb = (serverUrl?: string) =>
+          createDb({
+            appId: syncServer.appId,
+            driver: { type: "persistent" as const, dbName },
+            serverUrl,
+            secret: sharedLocalAuthToken,
+          });
+
+        const dbBeforeRestart = track(await createPersistentDb(undefined));
+        const insertResult = dbBeforeRestart.insert(todos, {
+          title: "Rejected after restart",
+          done: false,
+        });
+        const batchId = await insertResult.batchId;
+        await insertResult.wait({ tier: "local" });
+
+        const todosBeforeRestart = await dbBeforeRestart.all(allTodos, {
+          tier: "local",
+        });
+        expect(todosBeforeRestart).toEqual([insertResult.value]);
+
+        await dbBeforeRestart.shutdown();
+        untrack(dbBeforeRestart);
+
+        const dbAfterRestart = track(await createPersistentDb(syncServer.serverUrl));
+        const mutationErrorSpy = vi.fn();
+        dbAfterRestart.onMutationError(mutationErrorSpy);
+
+        // Run a query to set up the runtime
+        await dbAfterRestart.all(allTodos, { tier: "edge" });
+
+        await waitForCondition(
+          async () => {
+            const todosAfterRevert = await dbAfterRestart.all(allTodos, {
+              tier: "local",
+            });
+            return todosAfterRevert.length === 0;
+          },
+          5000,
+          "restarted rejected insert should remove the previous local row",
+        );
+        await waitForCondition(
+          async () => mutationErrorSpy.mock.calls.length > 0,
+          5000,
+          "restarted rejected insert should surface onMutationError",
+        );
+        expect(mutationErrorSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            code: "permission_denied",
+            transaction: expect.objectContaining({ batchId }),
+          }),
+        );
+      });
+
+      it("update", async () => {
+        const syncServer = await publishSyncServerSchemaAndPermissions(
+          "sync-restart-revert-update",
+        );
+
+        const sharedLocalAuthToken = generateAuthSecret();
+        const dbName = uniqueDbName("sync-restart-revert-update");
+        const createPersistentDb = (serverUrl?: string) =>
+          createDb({
+            appId: syncServer.appId,
+            driver: { type: "persistent" as const, dbName },
+            serverUrl,
+            secret: sharedLocalAuthToken,
+          });
+
+        const seeder = track(await createPersistentDb(syncServer.serverUrl));
+        const insertResult = seeder.insert(todos, {
+          title: "Initial task",
+          done: false,
+        });
+        const todo = insertResult.value;
+        await insertResult.wait({ tier: "edge" });
+        await seeder.shutdown();
+        untrack(seeder);
+
+        await publishPermissionsForServer(syncServer, noUpdatePermissions);
+
+        const dbBeforeRestart = track(await createPersistentDb(undefined));
+        expect(await dbBeforeRestart.all(allTodos, { tier: "local" })).toEqual([todo]);
+
+        const updateResult = dbBeforeRestart.update(todos, todo.id, {
+          title: "Rejected update after restart",
+        });
+        const batchId = await updateResult.batchId;
+        await updateResult.wait({ tier: "local" });
+
+        const todosBeforeRestart = await dbBeforeRestart.all(allTodos, {
+          tier: "local",
+        });
+        expect(todosBeforeRestart).toEqual([{ ...todo, title: "Rejected update after restart" }]);
+
+        await dbBeforeRestart.shutdown();
+        untrack(dbBeforeRestart);
+
+        const dbAfterRestart = track(await createPersistentDb(syncServer.serverUrl));
+        const mutationErrorSpy = vi.fn();
+        dbAfterRestart.onMutationError(mutationErrorSpy);
+        await dbAfterRestart.all(allTodos, { tier: "edge" });
+
+        await waitForCondition(
+          async () => {
+            const todosAfterRevert = await dbAfterRestart.all(allTodos, {
+              tier: "local",
+            });
+            return todosAfterRevert.length === 1 && todosAfterRevert[0]?.title === todo.title;
+          },
+          5000,
+          "restarted rejected update should restore the previous local row",
+        );
+        await waitForCondition(
+          async () => mutationErrorSpy.mock.calls.length > 0,
+          5000,
+          "restarted rejected update should surface onMutationError",
+        );
+        expect(mutationErrorSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            code: "permission_denied",
+            transaction: expect.objectContaining({ batchId }),
+          }),
+        );
+      });
+
+      it("delete", async () => {
+        const syncServer = await publishSyncServerSchemaAndPermissions(
+          "sync-restart-revert-delete",
+        );
+
+        const sharedLocalAuthToken = generateAuthSecret();
+        const dbName = uniqueDbName("sync-restart-revert-delete");
+        const createPersistentDb = (serverUrl?: string) =>
+          createDb({
+            appId: syncServer.appId,
+            driver: { type: "persistent" as const, dbName },
+            serverUrl,
+            secret: sharedLocalAuthToken,
+          });
+
+        const seeder = track(await createPersistentDb(syncServer.serverUrl));
+        const insertResult = seeder.insert(todos, {
+          title: "Initial task",
+          done: false,
+        });
+        const todo = insertResult.value;
+        await insertResult.wait({ tier: "edge" });
+        await seeder.shutdown();
+        untrack(seeder);
+
+        await publishPermissionsForServer(syncServer, noDeletePermissions);
+
+        const dbBeforeRestart = track(await createPersistentDb(undefined));
+        expect(await dbBeforeRestart.all(allTodos, { tier: "local" })).toEqual([todo]);
+
+        const deleteResult = dbBeforeRestart.delete(todos, todo.id);
+        const batchId = await deleteResult.batchId;
+        await deleteResult.wait({ tier: "local" });
+
+        const todosBeforeRestart = await dbBeforeRestart.all(allTodos, {
+          tier: "local",
+        });
+        expect(todosBeforeRestart).toEqual([]);
+
+        await dbBeforeRestart.shutdown();
+        untrack(dbBeforeRestart);
+
+        const dbAfterRestart = track(await createPersistentDb(syncServer.serverUrl));
+        const mutationErrorSpy = vi.fn();
+        dbAfterRestart.onMutationError(mutationErrorSpy);
+        await dbAfterRestart.all(allTodos, { tier: "edge" });
+
+        await waitForCondition(
+          async () => {
+            const todosAfterRevert = await dbAfterRestart.all(allTodos, {
+              tier: "local",
+            });
+            return todosAfterRevert.length === 1 && todosAfterRevert[0]?.title === todo.title;
+          },
+          5000,
+          "restarted rejected delete should restore the previous local row",
+        );
+        expect(await dbAfterRestart.all(allTodos, { tier: "local" })).toEqual([todo]);
+        await waitForCondition(
+          async () => mutationErrorSpy.mock.calls.length > 0,
+          5000,
+          "restarted rejected delete should surface onMutationError",
+        );
+        expect(mutationErrorSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            code: "permission_denied",
+            transaction: expect.objectContaining({ batchId }),
+          }),
+        );
+      });
+    });
+  });
+
+  it("recovers sync after browser-side network loss with B in a separate context", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-recover");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const { appId, serverUrl, adminSecret } = syncServer;
+    const dbA = await createSyncedDb(ctx, "sync-recover-a", sharedLocalAuthToken, syncServer);
+    const remoteDbId = trackRemoteBrowserDb(uniqueDbName("sync-recover-remote"));
+    await createRemoteBrowserDb({
+      id: remoteDbId,
+      appId,
+      dbName: uniqueDbName("sync-recover-b"),
+      table: "todos",
+      schemaJson: JSON.stringify(app.wasmSchema),
+      serverUrl,
+      adminSecret,
+      localFirstSecret: sharedLocalAuthToken,
+    });
+
+    const baselineTitle = `baseline-network-recover-${Date.now()}`;
+    await withTimeout(
+      dbA.insert(todos, { title: baselineTitle, done: false }).wait({ tier: "local" }),
+      10000,
+      "Baseline insert(worker) did not resolve",
+    );
+
+    await waitForRemoteTodoTitle(
+      remoteDbId,
+      baselineTitle,
+      "B sees baseline row before browser-side network block",
+      20000,
+    );
+
+    await blockJazzServerNetwork(serverUrl);
+    await sleep(500);
+    await unblockJazzServerNetwork(serverUrl);
+    await sleep(250);
+
+    getBrowserConnection(dbA)?.sendLifecycleHint?.("freeze");
+    await sleep(50);
+    getBrowserConnection(dbA)?.sendLifecycleHint?.("resume");
+    getActiveRoleBridge(dbA)?.replayServerConnection?.();
+
+    const recoveredTitle = `network-recovered-${Date.now()}`;
+    await withTimeout(
+      dbA.insert(todos, { title: recoveredTitle, done: false }).wait({ tier: "local" }),
+      10000,
+      "Recovered insert(worker) did not resolve",
+    );
+
+    const rowsOnB = await waitForRemoteTodoTitle(
+      remoteDbId,
+      recoveredTitle,
+      "B sees row written after browser-side network recovery",
+      20000,
+    );
+    expect(rowsOnB.some((row) => row.title === recoveredTitle)).toBe(true);
+  }, 60000);
+
+  /**
+   *   writer ──baseline write──► server
+   *   fresh probe starts while server traffic is blocked
+   *   probe ──edge query pending──X server
+   *   network unblocks
+   *   expected: the first fresh edge query completes without needing a second client recreate
+   */
+  it("replays a fresh edge query once upstream attaches after init", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("edge-late-attach");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const { serverUrl } = syncServer;
+    const dbWriter = await createSyncedDb(
+      ctx,
+      "edge-late-attach-writer",
+      sharedLocalAuthToken,
+      syncServer,
+    );
+    const writerProbe = attachWorkerMessageProbe(dbWriter);
+    let probeProbe: WorkerMessageProbe | null = null;
+
+    try {
+      const baselineTitle = `edge-late-baseline-${Date.now()}`;
+      await withTimeout(
+        dbWriter.insert(todos, { title: baselineTitle, done: false }).wait({ tier: "local" }),
+        10000,
+        "Baseline insert(worker) did not resolve",
+      );
+
+      await waitForTodos(
+        dbWriter,
+        (rows) => rows.some((row) => row.title === baselineTitle),
+        "Writer sees baseline row at edge before blocking",
+        20000,
+        "edge",
+      );
+
+      await blockJazzServerNetwork(serverUrl);
+      await sleep(250);
+
+      const dbProbe = await createSyncedDb(
+        ctx,
+        "edge-late-attach-probe",
+        sharedLocalAuthToken,
+        syncServer,
+      );
+      probeProbe = attachWorkerMessageProbe(dbProbe);
+      const probeRowsPromise = waitForTodos(
+        dbProbe,
+        (rows) => rows.some((row) => row.title === baselineTitle),
+        "Fresh edge query resolves after upstream attach",
+        20000,
+        "edge",
+      );
+
+      await sleep(500);
+      await unblockJazzServerNetwork(serverUrl);
+      await sleep(250);
+
+      const rowsOnProbe = await probeRowsPromise;
+      expect(rowsOnProbe.some((row) => row.title === baselineTitle)).toBe(true);
+    } finally {
+      probeProbe?.dispose();
+      writerProbe.dispose();
+      await unblockJazzServerNetwork(serverUrl);
+    }
+  }, 60000);
+
+  /**
+   *   A ──baseline write──► server ◄── B sees baseline
+   *   browser blocks Jazz server traffic without reloading the page
+   *   A ──offline write(worker)──X server
+   *   A ──new online write──► server ◄── B sees control write
+   *   expected: the earlier offline worker write also promotes to B + fresh edge client
+   */
+  it("promotes offline worker rows after reconnect while the worker stays alive", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-offline");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const { appId, serverUrl, adminSecret } = syncServer;
+    const dbA = await createSyncedDb(ctx, "sync-offline-a", sharedLocalAuthToken, syncServer);
+    const dbAProbe = attachWorkerMessageProbe(dbA);
+    const remoteDbId = trackRemoteBrowserDb(uniqueDbName("sync-offline-remote"));
+    await createRemoteBrowserDb({
+      id: remoteDbId,
+      appId,
+      dbName: uniqueDbName("sync-offline-b"),
+      table: "todos",
+      schemaJson: JSON.stringify(app.wasmSchema),
+      serverUrl,
+      adminSecret,
+      localFirstSecret: sharedLocalAuthToken,
+    });
+
+    const baselineTitle = `baseline-before-offline-${Date.now()}`;
+    await withTimeout(
+      dbA.insert(todos, { title: baselineTitle, done: false }).wait({ tier: "local" }),
+      10000,
+      "Baseline insert(worker) did not resolve",
+    );
+
+    await waitForRemoteTodoTitle(
+      remoteDbId,
+      baselineTitle,
+      "B sees baseline row before disconnect",
+      20000,
+    );
+
+    await blockJazzServerNetwork(serverUrl);
+    // Disconnect the WS transport so the block takes effect immediately.
+    // Playwright route blocking only intercepts new connections; the existing
+    // WebSocket must be closed explicitly for the offline simulation to hold.
+    await dbA.disconnect();
+    await sleep(250);
+
+    const offlineTitle = `offline-worker-row-${Date.now()}`;
+    await withTimeout(
+      dbA.insert(todos, { title: offlineTitle, done: true }).wait({ tier: "local" }),
+      10000,
+      "Offline insert(worker) did not resolve",
+    );
+
+    await waitForTodos(
+      dbA,
+      (rows) => rows.some((row) => row.title === offlineTitle),
+      "A sees offline worker row locally",
+      10000,
+      "local",
+    );
+
+    await expect(
+      waitForRemoteTodoTitle(
+        remoteDbId,
+        offlineTitle,
+        "B should not see offline row while A is disconnected",
+        2500,
+      ),
+    ).rejects.toThrow();
+
+    await unblockJazzServerNetwork(serverUrl);
+    // Re-establish the worker's upstream WebSocket now that the network is live again.
+    await dbA.reconnect();
+    await sleep(250);
+
+    getBrowserConnection(dbA)?.sendLifecycleHint?.("freeze");
+    await sleep(50);
+    getBrowserConnection(dbA)?.sendLifecycleHint?.("resume");
+    getActiveRoleBridge(dbA)?.replayServerConnection?.();
+
+    const postReconnectTitle = `post-reconnect-control-${Date.now()}`;
+    await withTimeout(
+      dbA.insert(todos, { title: postReconnectTitle, done: false }).wait({ tier: "local" }),
+      10000,
+      "Post-reconnect control insert(worker) did not resolve",
+    );
+
+    await waitForTodos(
+      dbA,
+      (rows) => rows.some((row) => row.title === postReconnectTitle),
+      "A sees control row locally after reconnect",
+      10000,
+      "local",
+    );
+    await waitForRemoteTodoTitle(
+      remoteDbId,
+      postReconnectTitle,
+      "B sees control row written after reconnect",
+      20000,
+    );
+
+    const rowsOnB = await waitForRemoteTodoTitle(
+      remoteDbId,
+      offlineTitle,
+      "B sees offline worker row after reconnect",
+      20000,
+    );
+    expect(rowsOnB.some((row) => row.title === offlineTitle)).toBe(true);
+
+    let dbProbeTrace: WorkerMessageProbe | null = null;
+    try {
+      const dbProbe = await createSyncedDb(
+        ctx,
+        "sync-offline-probe",
+        sharedLocalAuthToken,
+        syncServer,
+      );
+      dbProbeTrace = attachWorkerMessageProbe(dbProbe);
+      const rowsOnProbe = await waitForTodos(
+        dbProbe,
+        (rows) => rows.some((row) => row.title === offlineTitle),
+        "Fresh client sees offline worker row at edge after reconnect",
+        20000,
+        "edge",
+      );
+      expect(rowsOnProbe.some((row) => row.title === offlineTitle)).toBe(true);
+    } finally {
+      dbProbeTrace?.dispose();
+      dbAProbe.dispose();
+    }
+  }, 120000);
+
+  it("local-only subscriptions receive rows from opfs", async () => {
+    const dbName = uniqueDbName("sync-local-only");
+    const dbA = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    const snapshots: Todo[][] = [];
+    const unsub = trackSubscription(
+      dbA.subscribeAll(
+        allTodos,
+        (delta) => {
+          snapshots.push([...(delta.all ?? [])]);
+        },
+        { propagation: "local-only" },
+      ),
+    );
+
+    await dbA.insert(todos, { title: "local-only-local-1", done: true }).wait({ tier: "local" });
+
+    // Wait for initial local-only snapshot.
+    await waitForCondition(
+      async () => snapshots.length > 0,
+      5000,
+      "local-only subscription should receive in-memory insert",
+    );
+
+    unsub();
+
+    // Simulate a page refresh: close first instance, then reopen same namespace.
+    await dbA.shutdown();
+    untrack(dbA);
+
+    const dbB = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    await waitForCondition(
+      async () => {
+        const rows = await dbB.all(allTodos, { propagation: "local-only" });
+        return rows.some((row) => row.title === "local-only-local-1");
+      },
+      8000,
+      "local-only query should retrieve persisted OPFS rows after reopen",
+    );
+
+    const snapshotsB = await dbB.all(allTodos, { propagation: "local-only" });
+    expect(snapshotsB.length).toBe(1);
+    expect(snapshotsB[0].title).toBe("local-only-local-1");
+  }, 60000);
+
+  it("local-only subscriptions do not receive rows from sync server", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-local-only");
+    const sharedLocalAuthToken = generateAuthSecret();
+    const dbA = await createSyncedDb(ctx, "sync-local-only-a", sharedLocalAuthToken, syncServer);
+    const dbB = await createSyncedDb(ctx, "sync-local-only-b", sharedLocalAuthToken, syncServer);
+
+    const snapshots: Todo[][] = [];
+    const unsub = trackSubscription(
+      dbB.subscribeAll(
+        allTodos,
+        (delta) => {
+          snapshots.push([...(delta.all ?? [])]);
+        },
+        { propagation: "local-only" },
+      ),
+    );
+
+    // Wait for initial local-only snapshot.
+    await waitForCondition(
+      async () => snapshots.length > 0,
+      5000,
+      "local-only subscription should produce an initial snapshot",
+    );
+
+    const remoteTitle = `remote-for-local-only-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await withTimeout(
+      dbA.insert(todos, { title: remoteTitle, done: false }).wait({ tier: "local" }),
+      10000,
+      "A insert(worker) did not resolve",
+    );
+
+    // Give sync enough time; local-only must still not see remote data.
+    await sleep(3000);
+    const latestAfterRemote = snapshots[snapshots.length - 1] ?? [];
+    expect(latestAfterRemote.some((row) => row.title === remoteTitle)).toBe(false);
+
+    const localTitle = `local-only-local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    dbB.insert(todos, { title: localTitle, done: true });
+
+    await waitForCondition(
+      async () => {
+        const latest = snapshots[snapshots.length - 1] ?? [];
+        return latest.some((row) => row.title === localTitle);
+      },
+      8000,
+      "local-only subscription should still include local inserts",
+    );
+
+    const latest = snapshots[snapshots.length - 1] ?? [];
+    expect(latest.some((row) => row.title === localTitle)).toBe(true);
+    expect(latest.some((row) => row.title === remoteTitle)).toBe(false);
+
+    unsub();
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // 8. Leader election + cross-tab peer routing
+  // -------------------------------------------------------------------------
+
+  it.fails("routes follower writes through the elected leader", async () => {
+    const dbName = uniqueDbName("leader-route");
+    const dbA = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const dbB = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const { leader, follower } = await waitForLeaderAndFollower(dbA, dbB);
+
+    await waitForCondition(
+      async () => getPrivateWorker(leader) !== null && getPrivateWorker(follower) === null,
+      8000,
+      "Broker should keep exactly one dedicated worker for the elected leader",
+    );
+    expect(getTabRole(follower)).toBe("follower");
+
+    const receivedByLeader: string[] = [];
+    const unsubscribe = leader.subscribeAll(
+      allTodos as QueryBuilder<Todo & { id: string }>,
+      (delta) => {
+        for (const todo of delta.all ?? []) {
+          receivedByLeader.push(todo.title);
+        }
+      },
+    );
+
+    follower.insert(todos, { title: "Routed via leader", done: false });
+
+    await waitForCondition(
+      async () => receivedByLeader.includes("Routed via leader"),
+      8000,
+      "Leader should receive follower write through peer routing",
+    );
+
+    await waitForCondition(
+      async () => {
+        const leaderRows = await leader.all(allTodos, { tier: "local" });
+        const followerRows = await follower.all(allTodos, { tier: "local" });
+        const leaderHas = leaderRows.some((row) => row.title === "Routed via leader");
+        const followerHas = followerRows.some((row) => row.title === "Routed via leader");
+        return leaderHas && followerHas;
+      },
+      8000,
+      "Both leader and follower should observe routed write",
+    );
+
+    unsubscribe();
+  });
+
+  it.fails("syncs a follower opened after the leader is already ready", async () => {
+    const dbName = uniqueDbName("late-follower-route");
+    const leader = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    leader.insert(todos, { title: "Created before second tab", done: false });
+    await waitForCondition(
+      async () => {
+        const rows = await leader.all(allTodos, { tier: "local" });
+        return rows.some((row) => row.title === "Created before second tab");
+      },
+      8000,
+      "Leader should persist the initial row before opening the follower",
+    );
+    await waitForCondition(
+      async () => getTabRole(leader) === "leader" && getPrivateWorker(leader) !== null,
+      8000,
+      "Leader should be durable-ready before the follower connects",
+    );
+
+    const follower = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    await waitForCondition(
+      async () => getTabRole(follower) === "follower" && getPrivateWorker(follower) === null,
+      8000,
+      "Late second tab should join as a follower without spawning a worker",
+    );
+
+    const followerRows = await withTimeout(
+      follower.all(allTodos, { tier: "local" }),
+      8000,
+      "Late follower initial query should wait for the leader data port",
+    );
+    expect(followerRows.some((row) => row.title === "Created before second tab")).toBe(true);
+  });
+
+  it.fails("gates a late follower subscription's first snapshot on the leader data port", async () => {
+    const dbName = uniqueDbName("late-follower-subscribe");
+    const leader = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    const title = "Persisted before follower subscription";
+    leader.insert(todos, { title, done: false });
+    await waitForCondition(
+      async () => {
+        const rows = await leader.all(allTodos, { tier: "local" });
+        return rows.some((row) => row.title === title);
+      },
+      8000,
+      "Leader should persist the seed row before opening the follower",
+    );
+    await waitForCondition(
+      async () => getTabRole(leader) === "leader" && getPrivateWorker(leader) !== null,
+      8000,
+      "Leader should be durable-ready before the follower connects",
+    );
+
+    const follower = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const snapshots: Todo[][] = [];
+    const unsubscribe = trackSubscription(
+      follower.subscribeAll(allTodos, (delta) => {
+        snapshots.push([...(delta.all ?? [])]);
+      }),
+    );
+
+    await waitForCondition(
+      async () => snapshots.length > 0,
+      8000,
+      "Late follower subscription should produce an initial snapshot",
+    );
+
+    expect(snapshots[0].some((row) => row.title === title)).toBe(true);
+
+    unsubscribe();
+  });
+
+  it.fails("surfaces schema mismatch errors and recovers after the pinning tab closes", async () => {
+    const dbName = uniqueDbName("schema-mismatch-recovery");
+    const oldTab = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    oldTab.insert(todos, { title: "Old schema row", done: false });
+    await waitForCondition(
+      async () => {
+        const rows = await oldTab.all(allTodos, { tier: "local" });
+        return rows.some((row) => row.title === "Old schema row");
+      },
+      8000,
+      "Old tab should be durable-ready with the original schema",
+    );
+
+    const nextApp = s.defineApp({
+      todos: s.table({
+        title: s.string(),
+        done: s.boolean(),
+        priority: s.string().optional(),
+      }),
+    });
+
+    const newTab = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    await expect(
+      withTimeout(
+        newTab.all(nextApp.todos, { tier: "local" }),
+        8000,
+        "Schema-blocked tab query should reject instead of hanging",
+      ),
+    ).rejects.toThrow("incompatible persistent browser schema");
+
+    await oldTab.shutdown();
+
+    await waitForCondition(
+      async () => getTabRole(newTab) === "leader",
+      8000,
+      "Blocked tab should be promoted after the pinning tab closes",
+    );
+    const rows = await withTimeout(
+      newTab.all(nextApp.todos, { tier: "local" }),
+      8000,
+      "Recovered tab should be able to query with its own schema",
+    );
+    expect(Array.isArray(rows)).toBe(true);
+  });
+
+  it.fails("fans out an auth failure to follower tabs", async () => {
+    const { appId, serverUrl } = await getJazzServerInfo(uniqueDbName("auth-fanout"));
+    const dbName = uniqueDbName("auth-fanout");
+    const validJwt = await getJazzServerJwtForUser("auth-fanout-user", undefined, appId);
+    const invalidJwt = makeStructurallyValidJwt("auth-fanout-user");
+
+    const dbA = track(
+      await createDb({
+        appId,
+        serverUrl,
+        jwtToken: validJwt,
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const dbB = track(
+      await createDb({
+        appId,
+        serverUrl,
+        jwtToken: validJwt,
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const { leader, follower } = await waitForLeaderAndFollower(dbA, dbB);
+
+    leader.insert(todos, { title: "leader-init", done: false });
+    await withTimeout(
+      leader.all(allTodos, { tier: "local" }),
+      15000,
+      "Leader bridge init did not complete",
+    );
+    follower.insert(todos, { title: "follower-init", done: false });
+    await withTimeout(
+      follower.all(allTodos, { tier: "local" }),
+      15000,
+      "Follower data-port bridge init did not complete",
+    );
+
+    expect(leader.getAuthState().error).toBeUndefined();
+    expect(follower.getAuthState().error).toBeUndefined();
+
+    leader.updateAuthToken(invalidJwt);
+    getActiveRoleBridge(leader)?.replayServerConnection?.();
+
+    await waitForCondition(
+      async () => leader.getAuthState().error === "invalid",
+      20000,
+      "Leader should turn unauthenticated when the server rejects its JWT",
+    );
+    await waitForCondition(
+      async () => follower.getAuthState().error === "invalid",
+      20000,
+      "Follower should turn unauthenticated through the worker auth fan-out",
+    );
+  }, 60000);
+
+  it.fails("fails over to follower after leader shutdown", async () => {
+    const dbName = uniqueDbName("leader-failover");
+    const dbA = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const dbB = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const { leader, follower } = await waitForLeaderAndFollower(dbA, dbB);
+
+    await leader.shutdown();
+    untrack(leader);
+
+    await waitForCondition(
+      async () => getTabRole(follower) === "leader",
+      12000,
+      "Follower should be promoted to leader after shutdown",
+    );
+
+    const {
+      value: { id },
+    } = follower.insert(todos, { title: "Post-failover", done: true });
+    await waitForCondition(
+      async () => {
+        const rows = await follower.all(allTodos, { tier: "local" });
+        return rows.some((row) => row.id === id && row.title === "Post-failover");
+      },
+      8000,
+      "New leader should continue processing writes after failover",
+    );
+  });
+
+  it.fails("reconciles a follower write that was pending when the leader crashes", async () => {
+    const dbName = uniqueDbName("leader-crash-pending-follower-write");
+    const dbA = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const dbB = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const { leader, follower } = await waitForLeaderAndFollower(dbA, dbB);
+
+    const marker = `pending-follower-write-${Date.now()}`;
+    let pendingWrite!: Promise<unknown>;
+    let pendingWriteState: "pending" | "resolved" | "rejected" = "pending";
+    await waitForCondition(
+      async () => getPrivateWorker(leader) !== null && getPrivateWorker(follower) === null,
+      8000,
+      "Broker should keep the follower bridged through the elected leader",
+    );
+    await leader.all(allTodos, { tier: "local" });
+    await waitForCondition(
+      async () => {
+        void getBrowserConnection(follower)?.followerReady?.catch(() => {});
+        await follower.all(allTodos, { tier: "local" });
+        return (
+          Boolean(getFollowerPortBridge(follower)) &&
+          getBrowserConnection(follower)?.resolveFollowerReady === null
+        );
+      },
+      8000,
+      "Follower should have a ready data port before the pending write test",
+    );
+
+    // The follower stays alive: the write must not be lost if the leader
+    // crashes before confirming local durability.
+    getBrowserConnection(follower).closeActiveRoleBridge(undefined, {
+      preserveOutbox: true,
+    });
+
+    pendingWrite = follower.insert(todos, { title: marker, done: false }).wait({
+      tier: "local",
+    });
+    void pendingWrite.then(
+      () => {
+        pendingWriteState = "resolved";
+      },
+      () => {
+        pendingWriteState = "rejected";
+      },
+    );
+
+    await sleep(250);
+    expect(pendingWriteState).toBe("pending");
+
+    const leaderWorker = getPrivateWorker(leader);
+    await getActiveRoleBridge(leader)?.simulateCrash?.();
+    leaderWorker?.terminate();
+    clearPrivateWorkerBridge(leader);
+    await leader.shutdown();
+    untrack(leader);
+
+    await waitForCondition(
+      async () => getTabRole(follower) === "leader" && getPrivateWorker(follower) !== null,
+      12000,
+      "Follower should be promoted to durable leader after the old leader crashes",
+    );
+
+    await withTimeout(
+      pendingWrite,
+      12000,
+      "Pending follower write did not resolve after leader crash failover",
+    );
+
+    await waitForCondition(
+      async () => {
+        const rows = await follower.all(allTodos, { tier: "local" });
+        return rows.some((row) => row.title === marker);
+      },
+      8000,
+      "Promoted follower should retain the pending write locally",
+    );
+
+    await follower.shutdown();
+    untrack(follower);
+
+    const fresh = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const rows = await fresh.all(allTodos, { tier: "local" });
+    expect(rows.some((row) => row.title === marker)).toBe(true);
+  });
+
+  it.fails("resolves a pending follower local-wait when the bridged leader crashes with the write in flight", async () => {
+    // Faithful version of the failover-during-pending-write case. Unlike a write
+    // made while the follower is detached (which only ever buffers locally and
+    // replays on self-promotion), here the follower stays *bridged* to the
+    // leader, so the write actually travels to the leader and is persisted there
+    // before the crash. This is the path the design worries about: the leader
+    // produces a BatchFate that is lost when it dies, and the follower's wait
+    // must still resolve via failover reconciliation rather than hang forever.
+    const dbName = uniqueDbName("leader-crash-inflight-follower-wait");
+
+    // Bring the leader up first and let it become durable-ready before the second
+    // tab joins. Two tabs created back-to-back race the election (the second can
+    // win and demote the first), which would leave the `leader`/`follower`
+    // references below pointing at the wrong tab. Electing the leader before the
+    // follower connects keeps the roles stable.
+    const leader = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    leader.insert(todos, { title: "seed", done: false });
+    await waitForCondition(
+      async () => {
+        const rows = await leader.all(allTodos, { tier: "local" });
+        return rows.some((row) => row.title === "seed");
+      },
+      8000,
+      "Leader should persist its seed row before the follower connects",
+    );
+    await waitForCondition(
+      async () => getTabRole(leader) === "leader" && getPrivateWorker(leader) !== null,
+      8000,
+      "Leader should be durable-ready before the follower connects",
+    );
+
+    const follower = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    await waitForCondition(
+      async () => getTabRole(follower) === "follower" && getPrivateWorker(follower) === null,
+      8000,
+      "Second tab should join as a follower without spawning a worker",
+    );
+    // Reading the leader's seed row over the data port is a black-box proof that
+    // the follower is genuinely bridged to the leader's worker, so the pending
+    // write below will actually reach the leader (not just buffer locally).
+    await waitForCondition(
+      async () => {
+        const rows = await follower.all(allTodos, { tier: "local" });
+        return rows.some((row) => row.title === "seed");
+      },
+      8000,
+      "Follower should receive the leader's row through the live data port",
+    );
+
+    // Issue the write + local wait but do NOT await it: the batch travels to the
+    // leader's worker over the live data port while the wait stays pending.
+    const marker = "pending-when-bridged-leader-crashed";
+    const pendingWrite = follower
+      .insert(todos, { title: marker, done: false })
+      .wait({ tier: "local" });
+    let settled = false;
+    void pendingWrite.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    // Local durability needs a follower -> leader -> follower round trip that
+    // cannot have happened synchronously, so the wait must still be pending.
+    expect(settled).toBe(false);
+
+    // Crash the leader's worker while the wait is in flight. `simulateCrash`
+    // drains the already-delivered follower batch and flushes the WAL (see
+    // handle_shutdown in crates/jazz-wasm/src/worker_host.rs), so the write is
+    // persisted on the leader's OPFS, but the noop sender it then installs means
+    // the BatchFate is never delivered back to the follower -- the exact
+    // "lost BatchFate" case. (If the batch had not reached the leader yet,
+    // failover retransmit still drives it to durability; either way the wait
+    // must resolve.)
+    const leaderWorker = getPrivateWorker(leader);
+    await getActiveRoleBridge(leader).simulateCrash();
+    leaderWorker?.terminate();
+    // Null the dead bridge so shutdown only frees client-side resources, then
+    // shut the leader down so its tab releases its Web Locks. A real
+    // closed/crashed tab releases them automatically; releasing them here is
+    // what lets the broker elect the surviving follower.
+    clearPrivateWorkerBridge(leader);
+    await leader.shutdown();
+    untrack(leader);
+
+    // The surviving follower is promoted and opens its own durable worker, which
+    // reopens the same OPFS namespace (and replays the persisted write).
+    await waitForCondition(
+      async () => getTabRole(follower) === "leader" && getPrivateWorker(follower) !== null,
+      12000,
+      "Surviving follower should be promoted to a durable leader after the crash",
+    );
+
+    // The assertion that bites: the pending wait resolves through failover
+    // reconciliation instead of hanging forever on the lost BatchFate.
+    await withTimeout(
+      pendingWrite,
+      12000,
+      "Pending follower wait did not resolve after the bridged leader crashed",
+    );
+
+    // And the write is genuinely durable: visible on the promoted follower and
+    // on a freshly opened tab reading the same OPFS namespace.
+    const promotedRows = await follower.all(allTodos, { tier: "local" });
+    expect(promotedRows.some((row) => row.title === marker)).toBe(true);
+
+    await follower.shutdown();
+    untrack(follower);
+
+    const reopened = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const reopenedRows = await reopened.all(allTodos, { tier: "local" });
+    expect(reopenedRows.some((row) => row.title === marker)).toBe(true);
+  });
+
+  it.fails("re-elects cleanly when a closed leader tab is reopened", async () => {
+    const dbName = uniqueDbName("leader-reopen");
+    const dbA = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const dbB = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const { leader: initialLeader, follower: survivor } = await waitForLeaderAndFollower(dbA, dbB);
+
+    await initialLeader.shutdown();
+    untrack(initialLeader);
+
+    await waitForCondition(
+      async () => getTabRole(survivor) === "leader",
+      12000,
+      "Surviving tab should become leader after leader closes",
+    );
+
+    const reopened = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    const currentLeader = await waitForSingleLeader([survivor, reopened]);
+    const currentFollower = currentLeader === survivor ? reopened : survivor;
+    await currentLeader.all(allTodos, { tier: "local" });
+
+    const marker = `reopen-${Date.now()}`;
+    await withTimeout(
+      currentFollower.insert(todos, { title: marker, done: false }).wait({ tier: "local" }),
+      10000,
+      "Follower insert during reopen re-election did not resolve",
+    );
+
+    await waitForCondition(
+      async () => {
+        const leaderRows = await currentLeader.all(allTodos, { tier: "local" });
+        const followerRows = await currentFollower.all(allTodos, {
+          tier: "local",
+        });
+        const leaderHas = leaderRows.some((row) => row.title === marker);
+        const followerHas = followerRows.some((row) => row.title === marker);
+        return leaderHas && followerHas;
+      },
+      8000,
+      "Reopened tab and current leader should converge after re-election",
+    );
+  });
+
+  it("can update an optional row field to null", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "null-update-repro",
+      nullablePermissions,
+      nullableApp.wasmSchema,
+    );
+    const sharedLocalAuthToken = generateAuthSecret();
+    const db = await createSyncedDb(
+      ctx,
+      "sync-null-update-repro",
+      sharedLocalAuthToken,
+      syncServer,
+    );
+
+    const inserted = db.insert(nullableApp.todos, {
+      title: "nullable-description-repro",
+      done: false,
+      description: "server-original",
+    });
+    const insertedTodo = inserted.value;
+    await inserted.wait({ tier: "local" });
+
+    const updateResult = db.update(nullableApp.todos, insertedTodo.id, {
+      description: null,
+    });
+    await updateResult.wait({ tier: "local" });
+
+    const rowAfterNullUpdate = await db.one(nullableApp.todos.where({ id: insertedTodo.id }), {
+      tier: "local",
+      localUpdates: "immediate",
+    });
+    expect(rowAfterNullUpdate).not.toBeNull();
+    expect(rowAfterNullUpdate?.description ?? null).toBeNull();
+  }, 60000);
+});
+
+// ---------------------------------------------------------------------------
+// Local helpers (thin wrappers over support.ts using local schema types)
+// ---------------------------------------------------------------------------
+
+async function waitForTodos(
+  db: Db,
+  predicate: (rows: Todo[]) => boolean,
+  label: string,
+  timeoutMs = 15000,
+  tier?: "local" | "edge",
+): Promise<Todo[]> {
+  return waitForQuery(db, allTodos, predicate, label, timeoutMs, tier);
+}
+
+async function publishSyncServerSchemaAndPermissions(
+  scope: string,
+  permissions?: CompiledPermissions,
+  schema?: Schema,
+): Promise<JazzServerInfo> {
+  const testingServer = await getJazzServerInfo(uniqueDbName(`worker-bridge-${scope}`));
+  const permissionsToPublish = permissions ?? {
+    todos: {
+      select: { using: { type: "True" } },
+      insert: { with_check: { type: "True" } },
+      update: {
+        using: { type: "True" },
+        with_check: { type: "True" },
+      },
+      delete: { using: { type: "True" } },
+    },
+    projects: {
+      select: { using: { type: "True" } },
+      insert: { with_check: { type: "True" } },
+      update: {
+        using: { type: "True" },
+        with_check: { type: "True" },
+      },
+      delete: { using: { type: "True" } },
+    },
+  };
+  await publishPermissionsForServer(testingServer, permissionsToPublish, schema);
+  return testingServer;
+}
+
+async function publishPermissionsForServer(
+  testingServer: JazzServerInfo,
+  permissions: CompiledPermissions,
+  schema?: Schema,
+): Promise<void> {
+  const { appId, serverUrl, adminSecret } = testingServer;
+  await deploy({
+    appId,
+    serverUrl,
+    adminSecret,
+    schema: schema ?? app.wasmSchema,
+    permissions,
+  });
+}

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
-import type { Schema, WasmSchema } from "../../src/drivers/types.js";
+import type { Schema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {
   TestCleanup,
@@ -122,10 +122,6 @@ function getBrowserConnection(db: Db): any {
   return (db as any).connection;
 }
 
-function getPrivateClient(db: Db): unknown {
-  return getBrowserConnection(db)?.client ?? null;
-}
-
 function getActiveRoleBridge(db: Db): any {
   return getBrowserConnection(db)?.activeRoleBridge ?? null;
 }
@@ -136,10 +132,6 @@ function getPersistentBrowserRuntime(db: Db): any {
 
 function getPrivateWorker(db: Db): Worker | null {
   return getPersistentBrowserRuntime(db)?.worker ?? getActiveRoleBridge(db)?.worker ?? null;
-}
-
-function getPrivateWorkerBridge(db: Db): any {
-  return getActiveRoleBridge(db)?.workerBridge ?? null;
 }
 
 function getFollowerPortBridge(db: Db): any {
@@ -940,7 +932,7 @@ describe("Worker Bridge with OPFS", () => {
     unsub();
   });
 
-  it.fails("tiered subscriptions gate the first callback until the worker's settled snapshot content is local", async () => {
+  it("tiered subscriptions gate the first callback until the worker's settled snapshot content is local", async () => {
     const syncServer = await publishSyncServerSchemaAndPermissions("subscribe-global-gated");
     const sharedLocalAuthToken = generateAuthSecret();
     const seeder = track(
@@ -979,19 +971,6 @@ describe("Worker Bridge with OPFS", () => {
         serverUrl: syncServer.serverUrl,
         secret: sharedLocalAuthToken,
       }),
-    );
-    (fresh as unknown as { getClient(schema: WasmSchema): unknown }).getClient(app.wasmSchema);
-    await waitForCondition(
-      async () => Boolean(getPrivateWorker(fresh)?.onmessage),
-      5000,
-      `fresh worker bridge should install its onmessage handler; diagnostics=${JSON.stringify({
-        tabRole: getTabRole(fresh),
-        workerExists: Boolean(getPrivateWorker(fresh)),
-        workerOnMessage: Boolean(getPrivateWorker(fresh)?.onmessage),
-        bridge: Boolean(getPrivateWorkerBridge(fresh)),
-        clientType: typeof getPrivateClient(fresh),
-        hasClient: Boolean(getPrivateClient(fresh)),
-      })}`,
     );
     const snapshots: Todo[][] = [];
     const unsubscribe = trackSubscription(


### PR DESCRIPTION
## Description

Add the missing `Db.onMutationError` and restores browser integration tests.

Note: several browser integration tests related to multi-tab support are still failing (they are marked with `it.fails`). I'll fix them as a follow-up.