### PR TITLE
fix(query): decode only required enum fields

### DIFF
--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -287,13 +287,22 @@ where
             ));
         }
         let mut added_columns = Vec::new();
+        let mut evolved_columns = Vec::new();
         for column in columns {
             match updated
                 .columns
-                .iter()
+                .iter_mut()
                 .find(|existing| existing.name == column.name)
             {
                 Some(existing) if existing == &column => {}
+                Some(existing)
+                    if existing
+                        .column_type
+                        .can_evolve_registry_to(&column.column_type) =>
+                {
+                    *existing = column.clone();
+                    evolved_columns.push(column);
+                }
                 Some(_) => {
                     return Err(Error::TableFieldDefinitionMismatch {
                         table: table.to_owned(),
@@ -308,6 +317,11 @@ where
         }
         updated.variants.push(variant.clone());
         validate_table_schema_variants(&updated)?;
+        if !evolved_columns.is_empty() {
+            self.ivm_runtime
+                .evolve_table_variant_registries(table, &evolved_columns)
+                .map_err(Error::IvmRuntime)?;
+        }
         self.ivm_runtime
             .register_table_variant_with_columns(table, added_columns, variant)
             .map_err(Error::IvmRuntime)
@@ -329,7 +343,7 @@ where
                 .find(|column| column.name == desired.name)
                 && !current
                     .column_type
-                    .registry_compatible_with(&desired.column_type)
+                    .can_evolve_registry_to(&desired.column_type)
             {
                 return Err(Error::TableFieldDefinitionMismatch {
                     table: table.to_owned(),

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -19,10 +19,10 @@ use crate::queries::{
     BinaryOp, ColumnRef, Cte, Expr, JoinConstraint, JoinKind, Query, Select, SelectItem, TableRef,
     UnaryOp, WithQuery,
 };
-use crate::records::{RecordDescriptor, ScalarEnumSchema, ValueType};
+use crate::records::{EnumCase, EnumSchema, RecordDescriptor, ScalarEnumSchema, ValueType};
 use crate::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, DirectRecordStoreSchema, IndexSchema, IntegerKeyType,
-    PrimaryKey, PrimaryKeyColumn, PrimaryKeyType,
+    PrimaryKey, PrimaryKeyColumn, PrimaryKeyType, TableVariant, TableVariantField,
 };
 use crate::storage::{MemoryStorage, OrderedKvStorage, RocksDbStorage, StorageLayout};
 
@@ -466,6 +466,244 @@ fn enum_tasks_schema() -> DatabaseSchema {
     )
     .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))
     .with_index(IndexSchema::new("tasks_by_status", ["status"]))])
+}
+
+fn payload_enum_type(
+    registry_id: u64,
+    cases: impl IntoIterator<Item = (&'static str, ValueType)>,
+) -> ValueType {
+    ValueType::Enum(Box::new(
+        EnumSchema::new(
+            "state",
+            cases.into_iter().map(|(name, value_type)| {
+                EnumCase::new(name, RecordDescriptor::new([("value", value_type)]))
+            }),
+        )
+        .unwrap()
+        .with_registry_id(registry_id),
+    ))
+}
+
+fn live_variant_enum_table(state: ValueType) -> TableSchema {
+    TableSchema::new_with_bound_registries(
+        "items",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("state", state.clone()),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))
+    .with_variant_payload(
+        1,
+        [
+            TableVariantField::shared("id", ColumnType::U64, "id"),
+            TableVariantField::shared("state", state, "state"),
+        ],
+    )
+}
+
+/// A live variant table advances one direct payload-enum registry, then adds a
+/// new row layout. Existing layouts must use the widened descriptor too, so
+/// old and new rows share one durable physical registry after restart.
+#[test]
+fn live_variant_table_evolves_direct_payload_enum_registry_before_new_layout() {
+    let old_state = payload_enum_type(41, [("draft", ValueType::U64)]).nullable();
+    let next_state = payload_enum_type(
+        41,
+        [("draft", ValueType::U64), ("published", ValueType::String)],
+    )
+    .nullable();
+    let schema = DatabaseSchema::new([live_variant_enum_table(old_state)]);
+    let storage = MemoryStorage::new(&schema.column_families());
+    let mut database = Database::new(schema, storage).unwrap();
+
+    database
+        .evolve_table_variant_registries("items", &[ColumnSchema::new("state", next_state.clone())])
+        .unwrap();
+    database
+        .register_table_variant_with_columns(
+            "items",
+            [],
+            TableVariant::with_payload(
+                2,
+                [
+                    TableVariantField::shared("id", ColumnType::U64, "id"),
+                    TableVariantField::shared("state", next_state.clone(), "state"),
+                ],
+            ),
+        )
+        .unwrap();
+
+    let table = database.table_schema("items").unwrap();
+    assert_eq!(
+        table
+            .columns
+            .iter()
+            .find(|column| column.name == "state")
+            .unwrap()
+            .column_type,
+        next_state
+    );
+    for tag in [1, 2] {
+        let field = table
+            .variant(tag)
+            .unwrap()
+            .payload_fields
+            .iter()
+            .find(|field| field.shared_column.as_deref() == Some("state"))
+            .unwrap();
+        assert_eq!(
+            field.value_type, next_state,
+            "variant {tag} retained a stale enum descriptor"
+        );
+    }
+}
+
+/// Nested payload and scalar enum occurrences advance through nullable,
+/// array, record, and tuple wrappers without replacing their physical registry
+/// identities.
+#[test]
+fn live_table_evolves_nested_payload_and_scalar_enum_registries() {
+    let old_payload = payload_enum_type(42, [("draft", ValueType::U64)]);
+    let next_payload = payload_enum_type(
+        42,
+        [("draft", ValueType::U64), ("published", ValueType::String)],
+    );
+    let old_scalar = ValueType::EnumTag(
+        ScalarEnumSchema::new("phase", ["one", "two"])
+            .unwrap()
+            .with_registry_id(43),
+    );
+    let next_scalar = ValueType::EnumTag(
+        ScalarEnumSchema::new("phase", ["one", "two", "three"])
+            .unwrap()
+            .with_registry_id(43),
+    );
+    let old_nested_payload = ValueType::Nullable(Box::new(ValueType::Array(Box::new(old_payload))));
+    let next_nested_payload =
+        ValueType::Nullable(Box::new(ValueType::Array(Box::new(next_payload))));
+    let old_nested_scalar = ValueType::Record(Box::new(RecordDescriptor::new([(
+        "phase",
+        old_scalar.clone(),
+    )])));
+    let next_nested_scalar = ValueType::Record(Box::new(RecordDescriptor::new([(
+        "phase",
+        next_scalar.clone(),
+    )])));
+    let old_tuple_scalar = ValueType::Tuple(vec![
+        ValueType::EnumTag(
+            ScalarEnumSchema::new("tuple_phase", ["one", "two"])
+                .unwrap()
+                .with_registry_id(46),
+        ),
+        ValueType::U64,
+    ]);
+    let next_tuple_scalar = ValueType::Tuple(vec![
+        ValueType::EnumTag(
+            ScalarEnumSchema::new("tuple_phase", ["one", "two", "three"])
+                .unwrap()
+                .with_registry_id(46),
+        ),
+        ValueType::U64,
+    ]);
+    let schema = DatabaseSchema::new([TableSchema::new_with_bound_registries(
+        "items",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("payload", old_nested_payload),
+            ColumnSchema::new("scalar", old_nested_scalar),
+            ColumnSchema::new("tuple_scalar", old_tuple_scalar),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let storage = MemoryStorage::new(&schema.column_families());
+    let mut database = Database::new(schema, storage).unwrap();
+
+    database
+        .evolve_table_variant_registries(
+            "items",
+            &[
+                ColumnSchema::new("payload", next_nested_payload.clone()),
+                ColumnSchema::new("scalar", next_nested_scalar.clone()),
+                ColumnSchema::new("tuple_scalar", next_tuple_scalar.clone()),
+            ],
+        )
+        .unwrap();
+
+    let table = database.table_schema("items").unwrap();
+    assert_eq!(
+        table
+            .columns
+            .iter()
+            .find(|column| column.name == "payload")
+            .unwrap()
+            .column_type,
+        next_nested_payload
+    );
+    assert_eq!(
+        table
+            .columns
+            .iter()
+            .find(|column| column.name == "scalar")
+            .unwrap()
+            .column_type,
+        next_nested_scalar
+    );
+    assert_eq!(
+        table
+            .columns
+            .iter()
+            .find(|column| column.name == "tuple_scalar")
+            .unwrap()
+            .column_type,
+        next_tuple_scalar
+    );
+}
+
+/// A registry may only append cases. Reordering, renaming, changing an
+/// existing payload, changing its arity, or replacing a registry identity must
+/// leave the live descriptor untouched and fail before a new layout is staged.
+#[test]
+fn live_table_rejects_non_additive_enum_registry_mutations() {
+    let old_payload = payload_enum_type(44, [("draft", ValueType::U64)]).nullable();
+    let schema = DatabaseSchema::new([live_variant_enum_table(old_payload.clone())]);
+    let storage = MemoryStorage::new(&schema.column_families());
+    let mut database = Database::new(schema, storage).unwrap();
+    let incompatible = [
+        payload_enum_type(44, [("renamed", ValueType::U64)]).nullable(),
+        payload_enum_type(44, [("draft", ValueType::String)]).nullable(),
+        ValueType::Enum(Box::new(
+            EnumSchema::new(
+                "state",
+                [EnumCase::new(
+                    "draft",
+                    RecordDescriptor::new([("value", ValueType::U64), ("extra", ValueType::Bool)]),
+                )],
+            )
+            .unwrap()
+            .with_registry_id(44),
+        ))
+        .nullable(),
+        payload_enum_type(45, [("draft", ValueType::U64)]).nullable(),
+    ];
+
+    for next in incompatible {
+        assert!(matches!(
+            database.evolve_table_variant_registries("items", &[ColumnSchema::new("state", next)]),
+            Err(Error::TableFieldDefinitionMismatch { .. })
+        ));
+    }
+
+    let table = database.table_schema("items").unwrap();
+    assert_eq!(
+        table
+            .columns
+            .iter()
+            .find(|column| column.name == "state")
+            .unwrap()
+            .column_type,
+        old_payload
+    );
 }
 
 #[test]

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -695,17 +695,19 @@ impl IvmRuntime {
         } else {
             VariantProjectionCase::Ignore { source }
         };
-        match projection.cases.entry(variant_tag) {
+        let changed = match projection.cases.entry(variant_tag) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert(case);
+                true
             }
-            std::collections::hash_map::Entry::Occupied(entry) if entry.get() == &case => {}
+            std::collections::hash_map::Entry::Occupied(entry) if entry.get() == &case => false,
             std::collections::hash_map::Entry::Occupied(mut entry)
                 if allow_recursive_replacement =>
             {
                 // The physical registry can append while this authored target
                 // stays fixed. Refresh its non-total tag map in place.
                 entry.insert(case);
+                true
             }
             std::collections::hash_map::Entry::Occupied(_) => {
                 return Err(IvmRuntimeError::VariantProjectionCaseAlreadyRegistered {
@@ -714,8 +716,10 @@ impl IvmRuntime {
                     version: u64::from(variant_tag),
                 });
             }
+        };
+        if changed {
+            self.invalidate_table_inputs(table);
         }
-        self.invalidate_table_inputs(table);
         Ok(())
     }
 

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -286,21 +286,53 @@ impl IvmRuntime {
         for desired in columns {
             let Some(existing) = table_schema
                 .columns
-                .iter_mut()
+                .iter()
                 .find(|column| column.name == desired.name)
             else {
                 continue;
             };
             if !existing
                 .column_type
-                .registry_compatible_with(&desired.column_type)
+                .can_evolve_registry_to(&desired.column_type)
             {
                 return Err(IvmRuntimeError::TableFieldAlreadyExists {
                     table: table.to_owned(),
                     field: desired.name.clone(),
                 });
             }
+            for variant in &table_schema.variants {
+                for field in &variant.payload_fields {
+                    if field.shared_column.as_deref() != Some(desired.name.as_str()) {
+                        continue;
+                    }
+                    if !field
+                        .value_type
+                        .can_evolve_registry_to(&desired.column_type)
+                    {
+                        return Err(IvmRuntimeError::TableFieldAlreadyExists {
+                            table: table.to_owned(),
+                            field: desired.name.clone(),
+                        });
+                    }
+                }
+            }
+        }
+        for desired in columns {
+            let Some(existing) = table_schema
+                .columns
+                .iter_mut()
+                .find(|column| column.name == desired.name)
+            else {
+                continue;
+            };
             existing.column_type = desired.column_type.clone();
+            for variant in &mut table_schema.variants {
+                for field in &mut variant.payload_fields {
+                    if field.shared_column.as_deref() == Some(desired.name.as_str()) {
+                        field.value_type = desired.column_type.clone();
+                    }
+                }
+            }
             desired
                 .column_type
                 .collect_variant_registries(&mut table_schema.value_variant_registries);

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -677,10 +677,17 @@ impl IvmRuntime {
                 target: variant_projection_target_name(&target).to_owned(),
             }
         })?;
+        // An explicitly typed literal is also a descriptor boundary: it does
+        // not copy the source cell at all, so a physical enum registry in the
+        // input cannot leak through it.  Jazz uses this for requirement-none
+        // auxiliary sources, whose enum cells are deliberately typed-null.
         let allow_recursive_replacement = fields.is_some_and(|fields| {
-            fields
-                .iter()
-                .any(|field| matches!(field.expression, ProjectExpr::RecursiveEnumRemap { .. }))
+            fields.iter().any(|field| {
+                matches!(
+                    field.expression,
+                    ProjectExpr::RecursiveEnumRemap { .. } | ProjectExpr::TypedLiteral { .. }
+                )
+            })
         });
         let case = if let Some(fields) = fields {
             let projected = project_descriptor(&source, fields)?;

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -477,6 +477,69 @@ impl ValueType {
         }
     }
 
+    /// Whether this durable value occurrence may advance to `next` without
+    /// changing the interpretation of any value already stored under `self`.
+    ///
+    /// `registry_compatible_with` is deliberately symmetric: it is useful at
+    /// read/projection boundaries where either descriptor may describe an
+    /// existing value.  Live table evolution is stricter.  It is directional:
+    /// only `next` may append cases, while names, payload layouts, nesting and
+    /// registry identities remain fixed.
+    pub(crate) fn can_evolve_registry_to(&self, next: &Self) -> bool {
+        match (self, next) {
+            (Self::EnumTag(current), Self::EnumTag(next))
+                if current.registry_id == next.registry_id =>
+            {
+                next.variants.starts_with(&current.variants)
+            }
+            (Self::Enum(current), Self::Enum(next)) if current.registry_id == next.registry_id => {
+                next.cases.len() >= current.cases.len()
+                    && current
+                        .cases
+                        .iter()
+                        .zip(&next.cases)
+                        .all(|(current, next)| {
+                            current.name == next.name
+                                && current.payload.fields().len() == next.payload.fields().len()
+                                && current
+                                    .payload
+                                    .fields()
+                                    .iter()
+                                    .zip(next.payload.fields())
+                                    .all(|(current, next)| {
+                                        current.name == next.name
+                                            && current
+                                                .value_type
+                                                .can_evolve_registry_to(&next.value_type)
+                                    })
+                        })
+            }
+            (Self::Tuple(current), Self::Tuple(next)) => {
+                current.len() == next.len()
+                    && current
+                        .iter()
+                        .zip(next)
+                        .all(|(current, next)| current.can_evolve_registry_to(next))
+            }
+            (Self::Array(current), Self::Array(next))
+            | (Self::Nullable(current), Self::Nullable(next)) => {
+                current.can_evolve_registry_to(next)
+            }
+            (Self::Record(current), Self::Record(next)) => {
+                current.fields().len() == next.fields().len()
+                    && current
+                        .fields()
+                        .iter()
+                        .zip(next.fields())
+                        .all(|(current, next)| {
+                            current.name == next.name
+                                && current.value_type.can_evolve_registry_to(&next.value_type)
+                        })
+            }
+            _ => self == next,
+        }
+    }
+
     pub(crate) fn collect_variant_registries(&self, output: &mut BTreeMap<u64, VariantRegistry>) {
         match self {
             Self::EnumTag(schema) => {

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -417,6 +417,27 @@ pub(super) fn physical_current_projection_target(
     format!("schema_{}_{}_current", schema_alias.0, logical_table)
 }
 
+/// A query-local current-source target.  The ordinary target projects every
+/// authored enum occurrence, which is correct for a whole-row read but makes
+/// an older schema fail while decoding an enum cell that the query never
+/// consumes.  A narrowed target keeps the fixed logical row shape while
+/// replacing unneeded enum cells with typed nulls; the query compiler's
+/// requirement closure is therefore the only route by which an enum value is
+/// materialized into an authored descriptor.
+fn physical_current_projection_target_for_enum_columns(
+    schema_alias: SchemaVersionAlias,
+    logical_table: &str,
+    enum_columns: &BTreeSet<PhysicalColumnId>,
+) -> String {
+    let base = physical_current_projection_target(schema_alias, logical_table);
+    let suffix = enum_columns
+        .iter()
+        .map(|column| column.0.to_string())
+        .collect::<Vec<_>>()
+        .join("_");
+    format!("{base}_enum_fields_{suffix}")
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum PhysicalCurrentClass {
     Global,
@@ -1021,6 +1042,26 @@ where
         ))
     }
 
+    pub(super) fn physical_current_source_graph_with_projection_target(
+        &self,
+        schema_version: SchemaVersionId,
+        logical_table: &str,
+        class: PhysicalCurrentClass,
+        projection_target: impl Into<String>,
+    ) -> Result<GraphBuilder, Error> {
+        let binding = physical_current_binding(
+            &self.catalogue.catalogue_schemas,
+            &self.catalogue.physical_mappings,
+            schema_version,
+            logical_table,
+            class,
+        )?;
+        Ok(GraphBuilder::variant_source(
+            binding.storage_table,
+            projection_target,
+        ))
+    }
+
     pub(super) fn physical_current_source_scan_graph(
         &self,
         schema_version: SchemaVersionId,
@@ -1046,6 +1087,28 @@ where
         Ok(GraphBuilder::variant_source_scan(
             binding.storage_table,
             physical_current_projection_target(alias, logical_table),
+            scan,
+        ))
+    }
+
+    pub(super) fn physical_current_source_scan_graph_with_projection_target(
+        &self,
+        schema_version: SchemaVersionId,
+        logical_table: &str,
+        class: PhysicalCurrentClass,
+        projection_target: impl Into<String>,
+        scan: groove::ivm::StaticScanSpec,
+    ) -> Result<GraphBuilder, Error> {
+        let binding = physical_current_binding(
+            &self.catalogue.catalogue_schemas,
+            &self.catalogue.physical_mappings,
+            schema_version,
+            logical_table,
+            class,
+        )?;
+        Ok(GraphBuilder::variant_source_scan(
+            binding.storage_table,
+            projection_target,
             scan,
         ))
     }
@@ -1308,6 +1371,140 @@ where
         Ok(())
     }
 
+    /// Register (or refresh) a current-source projection that decodes only
+    /// the enum columns required by one query source.  The fixed output shape
+    /// deliberately retains the ordinary logical row descriptor: callers can
+    /// share the normal current-source lowering, while enum values outside the
+    /// requirement closure are represented by typed nulls and never expose a
+    /// physical tag.
+    pub(super) fn ensure_physical_current_projection_for_enum_columns(
+        &mut self,
+        target_schema: SchemaVersionId,
+        target_table_name: &str,
+        required_fields: &BTreeSet<String>,
+    ) -> Result<String, Error> {
+        let target_alias = self
+            .catalogue
+            .schema_version_aliases
+            .get(&target_schema)
+            .copied()
+            .ok_or(Error::InvalidStoredValue(
+                "physical current projection target schema alias missing",
+            ))?;
+        let target_table = self.table_in_schema(target_table_name, target_schema)?;
+        let target_mapping = self
+            .catalogue
+            .physical_mappings
+            .get(&target_schema)
+            .and_then(|mapping| mapping.tables.get(target_table_name))
+            .cloned()
+            .ok_or(Error::InvalidStoredValue(
+                "target enum physical mapping missing",
+            ))?;
+        let required_enum_columns = target_table
+            .columns
+            .iter()
+            .filter(|column| required_fields.contains(&column.name))
+            .filter_map(|column| {
+                let column_id = target_mapping.columns.get(&column.name).copied()?;
+                let has_enum_boundary = target_mapping.scalar_enum_cases.contains_key(&column_id)
+                    || target_mapping.payload_enum_cases.contains_key(&column_id)
+                    || target_mapping
+                        .nested_scalar_enum_cases
+                        .contains_key(&column_id)
+                    || target_mapping
+                        .nested_payload_enum_cases
+                        .contains_key(&column_id)
+                    || matches!(
+                        column.column_type,
+                        records::ValueType::EnumTag(_) | records::ValueType::Enum(_)
+                    );
+                has_enum_boundary.then_some(column_id)
+            })
+            .collect::<BTreeSet<_>>();
+        let projection_target = physical_current_projection_target_for_enum_columns(
+            target_alias,
+            target_table_name,
+            &required_enum_columns,
+        );
+        let storage_tables = [
+            physical_global_current_table_name(target_mapping.table_id),
+            physical_ahead_current_table_name(target_mapping.table_id),
+        ];
+        for storage_table in &storage_tables {
+            let logical_output = target_table.global_current_storage_tables()[0].record_schema();
+            let physical_names = physical_current_field_names(&target_table, &target_mapping)?;
+            let output = widened_projection_descriptor(
+                &logical_output,
+                &physical_names,
+                self.database.table_schema(storage_table)?,
+            )?;
+            self.database
+                .define_variant_projection(storage_table, &projection_target, output)?;
+        }
+        let sources = self
+            .catalogue
+            .physical_mappings
+            .iter()
+            .flat_map(|(schema_version, mapping)| {
+                mapping
+                    .tables
+                    .iter()
+                    .filter(|(_, table)| table.table_id == target_mapping.table_id)
+                    .map(|(logical_table, table)| {
+                        (*schema_version, logical_table.clone(), table.clone())
+                    })
+            })
+            .collect::<Vec<_>>();
+        for (source_schema, source_table_name, source_mapping) in sources {
+            let source_alias = self
+                .catalogue
+                .schema_version_aliases
+                .get(&source_schema)
+                .copied()
+                .ok_or(Error::InvalidStoredValue(
+                    "physical current projection source schema alias missing",
+                ))?;
+            let cases = if source_mapping.variant_cases.is_empty() {
+                vec![(groove_variant_tag(source_alias)?, None)]
+            } else {
+                source_mapping
+                    .variant_cases
+                    .iter()
+                    .map(|case| (case.tag, Some(&case.fields)))
+                    .collect()
+            };
+            for (tag, present) in cases {
+                let fields = self.physical_current_projection_case_for_enum_columns(
+                    source_schema,
+                    &source_table_name,
+                    &source_mapping,
+                    target_schema,
+                    target_table_name,
+                    present,
+                    Some(&required_enum_columns),
+                )?;
+                for storage_table in &storage_tables {
+                    if let Some(fields) = fields.clone() {
+                        self.database.register_variant_case(
+                            storage_table,
+                            &projection_target,
+                            tag,
+                            fields,
+                        )?;
+                    } else {
+                        self.database.register_variant_ignore_case(
+                            storage_table,
+                            &projection_target,
+                            tag,
+                        )?;
+                    }
+                }
+            }
+        }
+        Ok(projection_target)
+    }
+
     pub(super) fn synchronize_physical_version_tables(&mut self) -> Result<(), Error> {
         for desired in physical_version_storage_tables(
             &self.catalogue.catalogue_schemas,
@@ -1379,6 +1576,7 @@ where
             target_table_name,
             ContentProjectionShape::History,
             present,
+            None,
         )
     }
 
@@ -1391,6 +1589,27 @@ where
         target_table_name: &str,
         present: Option<&BTreeSet<String>>,
     ) -> Result<Option<Vec<ProjectField>>, Error> {
+        self.physical_current_projection_case_for_enum_columns(
+            source_schema,
+            source_table_name,
+            source_mapping,
+            target_schema,
+            target_table_name,
+            present,
+            None,
+        )
+    }
+
+    fn physical_current_projection_case_for_enum_columns(
+        &mut self,
+        source_schema: SchemaVersionId,
+        source_table_name: &str,
+        source_mapping: &TablePhysicalMapping,
+        target_schema: SchemaVersionId,
+        target_table_name: &str,
+        present: Option<&BTreeSet<String>>,
+        required_enum_columns: Option<&BTreeSet<PhysicalColumnId>>,
+    ) -> Result<Option<Vec<ProjectField>>, Error> {
         self.physical_content_projection_case(
             source_schema,
             source_table_name,
@@ -1399,6 +1618,7 @@ where
             target_table_name,
             ContentProjectionShape::Current,
             present,
+            required_enum_columns,
         )
     }
 
@@ -1411,6 +1631,7 @@ where
         target_table_name: &str,
         shape: ContentProjectionShape,
         present: Option<&BTreeSet<String>>,
+        required_enum_columns: Option<&BTreeSet<PhysicalColumnId>>,
     ) -> Result<Option<Vec<ProjectField>>, Error> {
         #[derive(Clone)]
         enum CellProjection {
@@ -1553,6 +1774,21 @@ where
                         records::ValueType::EnumTag(_) | records::ValueType::Enum(_)
                     );
                     if has_enum_boundary || direct_enum {
+                        if required_enum_columns
+                            .is_some_and(|required| !required.contains(&column_id))
+                        {
+                            // This source does not semantically consume the
+                            // cell.  Do not decode an unknown physical case
+                            // merely to populate an otherwise unused logical
+                            // field, and do not let the physical tag cross the
+                            // boundary as an authored value.
+                            fields.push(ProjectField::literal_typed(
+                                output,
+                                Value::Nullable(None),
+                                records::ValueType::Nullable(Box::new(column.column_type.clone())),
+                            ));
+                            continue;
+                        }
                         let remaps = if has_enum_boundary {
                             self.physical_to_authored_enum_remaps(target_mapping, column_id)?
                         } else {

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -3330,27 +3330,25 @@ fn merge_physical_value_type(
         (ValueType::Enum(left), ValueType::Enum(right))
             if left.registry_id == right.registry_id =>
         {
-            // As with scalar cases, ordinal is local to the authored schema.
-            // This fallback cannot carry the catalogue's schema-qualified case
-            // identities (the physical table path does), but it can still
-            // combine independent payload layouts deterministically and reject
-            // same-name payload incompatibilities rather than aliasing tags.
-            let mut by_name = BTreeMap::<String, records::RecordDescriptor>::new();
-            for case in left.cases.iter().chain(&right.cases) {
-                match by_name.entry(case.name.clone()) {
-                    std::collections::btree_map::Entry::Vacant(entry) => {
-                        entry.insert(case.payload.clone());
-                    }
-                    std::collections::btree_map::Entry::Occupied(mut entry) => {
-                        let payload = merge_physical_record_descriptor(entry.get(), &case.payload)?;
-                        entry.insert(payload);
-                    }
+            // Preserve the established physical tag prefix. These names are
+            // opaque spellings of catalogue identities; sorting them would
+            // silently retag stored values merely because two schema IDs sort
+            // differently. New identities append in the incoming descriptor's
+            // already-canonical catalogue order.
+            let mut cases = left.cases.clone();
+            for incoming_case in &right.cases {
+                if let Some(existing_case) = cases
+                    .iter_mut()
+                    .find(|existing| existing.name == incoming_case.name)
+                {
+                    existing_case.payload = merge_physical_record_descriptor(
+                        &existing_case.payload,
+                        &incoming_case.payload,
+                    )?;
+                } else {
+                    cases.push(incoming_case.clone());
                 }
             }
-            let cases = by_name
-                .into_iter()
-                .map(|(name, payload)| records::EnumCase::new(name, payload))
-                .collect::<Vec<_>>();
             Ok(ValueType::Enum(Box::new(
                 records::EnumSchema::new(right.name.clone(), cases)
                     .map_err(|_| Error::InvalidStoredValue("invalid physical enum registry"))?

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -26,15 +26,15 @@ use super::query_engine::{
     AppProjectionTree, AppRowOutputRequest, AppRowSchema, CapabilityReport, ClaimPath, ClosurePath,
     ClosurePathSegment, ClosureRootGate, ComparisonOp as NormalizedComparisonOp,
     ContentVersionSource, CorrelationRequirement, DataSource, DeletionRegisterSource,
-    FieldProjection, FrontierId, JoinContribution, JoinMode as NormalizedJoinMode, LensSelection,
-    NormalizedRowSetShape, NormalizedShapeIdentity, NormalizedValueRef,
-    OrderKey as NormalizedOrderKey, OutputTerminalSchema, OverlayRef, OverlayStack,
-    PathCardinality, PathHolePolicy, PayloadProjection, PolicyContext, PolicyDecisionRole,
-    PolicyEnforcementMode, PredicateExpr as NormalizedPredicateExpr, ProgramBinding,
-    ProgramClaimParam, ProgramFactKey, ProgramOutputSchemas, ProgramPathId, ProvenanceField,
-    QueryAuthorizationMode, QueryProgram, QueryProgramRequest, QueryReadSet, ReachableContribution,
-    ReadView, RequestedReadSet, RequestedSourceStage, ResolvedSource, ResultId,
-    ResultMembershipVersionSchema, ResultRowRef, RowIdRef, RowProjection,
+    FieldProjection, FieldRequirement, FrontierId, JoinContribution,
+    JoinMode as NormalizedJoinMode, LensSelection, NormalizedRowSetShape, NormalizedShapeIdentity,
+    NormalizedValueRef, OrderKey as NormalizedOrderKey, OutputTerminalSchema, OverlayRef,
+    OverlayStack, PathCardinality, PathHolePolicy, PayloadProjection, PolicyContext,
+    PolicyDecisionRole, PolicyEnforcementMode, PredicateExpr as NormalizedPredicateExpr,
+    ProgramBinding, ProgramClaimParam, ProgramFactKey, ProgramOutputSchemas, ProgramPathId,
+    ProvenanceField, QueryAuthorizationMode, QueryProgram, QueryProgramRequest, QueryReadSet,
+    ReachableContribution, ReadView, RequestedReadSet, RequestedSourceStage, ResolvedSource,
+    ResultId, ResultMembershipVersionSchema, ResultRowRef, RowIdRef, RowProjection,
     RowRefSchema as QueryEngineRowRefSchema, RowSetExpr, RowSetNodeId, RowSetOutputRequest,
     RowSetProgramInput, RowVisibility, SchemaFamilySelection, SchemaProjection,
     SortDirection as NormalizedSortDirection, SourceAuthorizationRequest, SourceExpr, SourceGap,
@@ -702,6 +702,10 @@ struct CurrentQuerySourceResolver<'a, S> {
     read_view: &'a ReadView<RequestedSourceStage>,
     inline_sources: BTreeMap<SourceId, Vec<CurrentRow>>,
     access_paths: BTreeMap<SourceId, CurrentAccessPath>,
+    /// Query-local enum boundary targets, keyed by logical source.  Defining
+    /// a variant target invalidates table inputs, so reuse it across the main
+    /// source, access path, and metadata sidecars of one compiled program.
+    current_projection_targets: BTreeMap<SourceId, String>,
 }
 
 struct CurrentSourceGraph {
@@ -1327,6 +1331,44 @@ impl<S> CurrentQuerySourceResolver<'_, S>
 where
     S: OrderedKvStorage,
 {
+    fn current_projection_target(
+        &mut self,
+        request: &SourceRequest,
+        table: &TableSchema,
+    ) -> Result<String, SourceResolutionError> {
+        if let Some(target) = self.current_projection_targets.get(&request.source) {
+            return Ok(target.clone());
+        }
+        let required_fields = match &request.requirements.app_fields {
+            FieldRequirement::All => {
+                return Ok(physical_current_projection_target(
+                    self.node
+                        .catalogue
+                        .schema_version_aliases
+                        .get(&self.read_view.read_schema)
+                        .copied()
+                        .ok_or_else(|| {
+                            source_resolution_error(request, SourceGap::SchemaProjection)
+                        })?,
+                    &table.name,
+                ));
+            }
+            FieldRequirement::None => BTreeSet::new(),
+            FieldRequirement::Fields(fields) => fields.clone(),
+        };
+        let target = self
+            .node
+            .ensure_physical_current_projection_for_enum_columns(
+                self.read_view.read_schema,
+                &table.name,
+                &required_fields,
+            )
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        self.current_projection_targets
+            .insert(request.source.clone(), target.clone());
+        Ok(target)
+    }
+
     fn selected_global_current_source_graph(
         &mut self,
         request: &SourceRequest,
@@ -1347,6 +1389,7 @@ where
                 if tier != DurabilityTier::Global {
                     return Ok(None);
                 }
+                let projection_target = self.current_projection_target(request, table)?;
                 let rows = self
                     .node
                     .physical_global_current_source_for_index_scan(
@@ -1354,6 +1397,7 @@ where
                         self.read_view.read_schema,
                         &column,
                         &prefix,
+                        &projection_target,
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
                 self.node.query_engine_read_metrics.source_index_probes += 1;
@@ -1540,15 +1584,17 @@ where
         exclude_deleted: bool,
     ) -> Result<GraphBuilder, SourceResolutionError> {
         let fields = global_current_storage_fields(read_table, true, include_global_seq);
+        let projection_target = self.current_projection_target(request, read_table)?;
         let access_path = self.access_paths.get(&request.source).cloned();
         let global = match &access_path {
             Some(CurrentAccessPath::PrimaryKey(prefix)) => {
                 self.node.query_engine_read_metrics.source_primary_key_scans += 1;
                 self.node
-                    .physical_current_source_scan_graph(
+                    .physical_current_source_scan_graph_with_projection_target(
                         self.read_view.read_schema,
                         &request.source.table,
                         PhysicalCurrentClass::Global,
+                        projection_target.clone(),
                         static_scan_for_prefix(prefix.clone(), 1),
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?
@@ -1561,16 +1607,18 @@ where
                         self.read_view.read_schema,
                         column,
                         prefix,
+                        &projection_target,
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
             }
             _ => {
                 self.node.query_engine_read_metrics.source_full_scans += 1;
                 self.node
-                    .physical_current_source_graph(
+                    .physical_current_source_graph_with_projection_target(
                         self.read_view.read_schema,
                         &request.source.table,
                         PhysicalCurrentClass::Global,
+                        projection_target.clone(),
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?
             }
@@ -1580,19 +1628,23 @@ where
         } else {
             let global = global.project(fields.clone());
             let ahead = match &access_path {
-                Some(CurrentAccessPath::PrimaryKey(prefix)) => {
-                    self.node.physical_current_source_scan_graph(
+                Some(CurrentAccessPath::PrimaryKey(prefix)) => self
+                    .node
+                    .physical_current_source_scan_graph_with_projection_target(
                         self.read_view.read_schema,
                         &request.source.table,
                         PhysicalCurrentClass::Ahead,
+                        projection_target.clone(),
                         static_scan_for_prefix(prefix.clone(), 3),
-                    )
-                }
-                _ => self.node.physical_current_source_graph(
-                    self.read_view.read_schema,
-                    &request.source.table,
-                    PhysicalCurrentClass::Ahead,
-                ),
+                    ),
+                _ => self
+                    .node
+                    .physical_current_source_graph_with_projection_target(
+                        self.read_view.read_schema,
+                        &request.source.table,
+                        PhysicalCurrentClass::Ahead,
+                        projection_target,
+                    ),
             }
             .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
             let ahead = if tier == DurabilityTier::Edge {
@@ -5846,6 +5898,7 @@ where
         schema_version: SchemaVersionId,
         column: &str,
         prefix: &[Value],
+        projection_target: &str,
     ) -> Result<GraphBuilder, Error> {
         let mapping = self
             .catalogue
@@ -5863,15 +5916,6 @@ where
                 "physical current index column mapping missing",
             ))?;
         let storage_table = physical_global_current_table_name(mapping.table_id);
-        let alias = self
-            .catalogue
-            .schema_version_aliases
-            .get(&schema_version)
-            .copied()
-            .ok_or(Error::InvalidStoredValue(
-                "physical current index schema alias missing",
-            ))?;
-        let target = physical_current_projection_target(alias, &table.name);
         let indexed = self.database.index_scan_raw(
             &storage_table,
             &physical_current_index_name(column_id),
@@ -5883,7 +5927,7 @@ where
             let record = groove::records::VariantRecord::new(variant_tag, raw.owned_record());
             if let Some(projected) =
                 self.database
-                    .project_variant_record(&storage_table, &target, &record)?
+                    .project_variant_record(&storage_table, projection_target, &record)?
             {
                 records.push(projected.raw().to_vec());
             }
@@ -6163,6 +6207,7 @@ where
             read_view: &read_view,
             inline_sources,
             access_paths,
+            current_projection_targets: BTreeMap::new(),
         };
         let node_uuid = resolver.node.node_uuid;
         let node_alias = resolver.node.self_node_alias;
@@ -14379,6 +14424,7 @@ mod tests {
             read_view: &read_view,
             inline_sources: BTreeMap::new(),
             access_paths: BTreeMap::new(),
+            current_projection_targets: BTreeMap::new(),
         };
 
         assert!(resolver.needs_projected_current_source("users"));

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -3152,6 +3152,10 @@ fn old_enum_schema_only_decodes_cases_required_by_the_query() {
             )
             .is_err());
     }
+    let grouped = Query::from("items").count().group_by("status").validate(&base).unwrap();
+    assert!(core
+        .query_rows(&grouped, &grouped.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local)
+        .is_err());
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -3159,6 +3159,87 @@ fn old_enum_schema_only_decodes_cases_required_by_the_query() {
 }
 
 #[test]
+fn enum_projection_requirement_closure_includes_hidden_policy_fields() {
+    // A policy field is not part of the public output, but it still decides
+    // whether the row exists.  It must therefore force a non-total enum
+    // projection instead of being treated like an unused cell.
+    let base = JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new(
+                "status",
+                ColumnType::EnumTag(
+                    groove::records::ScalarEnumSchema::new("status", ["open"]).unwrap(),
+                ),
+            ),
+        ],
+    )
+    .with_read_policy(Policy::shape(
+        Query::from("items").filter(eq(col("status"), lit(Value::EnumTag(0)))),
+    ))]);
+    let evolved_schema = JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new(
+                "status",
+                ColumnType::EnumTag(
+                    groove::records::ScalarEnumSchema::new("status", ["open", "closed"])
+                        .unwrap(),
+                ),
+            ),
+        ],
+    )
+    .with_read_policy(Policy::shape(
+        Query::from("items").filter(eq(col("status"), lit(Value::EnumTag(0)))),
+    ))]);
+    let evolved = SchemaVersion::new(evolved_schema);
+    let (_dir, mut core) = open_node_with_schema(node(0x77), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![LensOp::TransformColumn {
+                    column: "status".to_owned(),
+                    transform: "jazz.identity".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema { revision: 1, schema: evolved.id },
+    })
+    .unwrap();
+    core.commit_mergeable(
+        MergeableCommit::new("items", row(0x77), 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("hidden-policy-dependency")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    )
+    .unwrap();
+
+    let title_only = Query::from("items").select(["title"]).validate(&base).unwrap();
+    let binding = title_only.bind(BTreeMap::new()).unwrap();
+    let result = core.query_rows_for_link(
+        &title_only,
+        &binding,
+        DurabilityTier::Local,
+        user(0x77),
+    );
+    assert!(result.is_err(), "policy result: {result:#?}");
+}
+
+#[test]
 fn independent_column_enum_registries_evolve_additively_across_reopen() {
     // Registry allocation is physical catalogue metadata, so this internal
     // test asserts both user-visible decoding and the non-Cartesian boundary.

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -2934,6 +2934,105 @@ fn enum_projection_schema(statuses: &[&str]) -> JazzSchema {
     )])
 }
 
+fn payload_enum_projection_schema(cases: &[&str]) -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new(
+                "status",
+                ColumnType::Enum(Box::new(
+                    groove::records::EnumSchema::new(
+                        "status",
+                        cases.iter().map(|case| {
+                            groove::records::EnumCase::new(
+                                *case,
+                                groove::records::RecordDescriptor::new([(
+                                    "note",
+                                    groove::records::ValueType::String,
+                                )]),
+                            )
+                        }),
+                    )
+                    .unwrap(),
+                )),
+            ),
+        ],
+    )])
+}
+
+/// This is an internal physical-activation regression: public clients cannot
+/// directly observe Groove's live descriptors, but a payload-enum append must
+/// activate and survive recovery before a newer client can write its new case.
+#[test]
+fn direct_payload_enum_append_activates_and_recovers() {
+    let base = payload_enum_projection_schema(&["draft"]);
+    let evolved_schema = payload_enum_projection_schema(&["draft", "published"]);
+    let evolved = SchemaVersion::new(evolved_schema.clone());
+    let (dir, mut core) = open_node_with_schema(node(0x76), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![LensOp::TransformColumn {
+                    column: "status".to_owned(),
+                    transform: "jazz.identity".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved.id,
+        },
+    })
+    .unwrap();
+    let published_payload = groove::records::RecordDescriptor::new([(
+        "note",
+        groove::records::ValueType::String,
+    )]);
+    core.commit_mergeable(
+        MergeableCommit::new("items", row(0x76), 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("new-case")),
+            (
+                "status".to_owned(),
+                Value::Enum(groove::records::EnumValue::create(
+                    1,
+                    published_payload,
+                    &[v("written after activation")],
+                )
+                .unwrap()),
+            ),
+        ])),
+    )
+    .unwrap();
+    let table_id = core.catalogue.physical_mappings[&evolved.id].tables["items"].table_id;
+    let physical_history = physical_history_table_name(table_id);
+    assert_eq!(core.query_table_versions("items").unwrap().len(), 1);
+    drop(core);
+
+    let mut reopened = reopen_node_at(&dir, node(0x76), base);
+    assert_eq!(reopened.query_table_versions("items").unwrap().len(), 1);
+    let table = reopened.database.table_schema(&physical_history).unwrap();
+    assert!(table.value_variant_registries.values().any(|registry| {
+        matches!(
+            registry,
+            groove::records::VariantRegistry::Enum { cases }
+                if cases.len() == 2
+        )
+    }));
+}
+
 #[test]
 fn old_enum_schema_only_decodes_cases_required_by_the_query() {
     // This is an internal current-source boundary test.  The public query API

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -3067,6 +3067,15 @@ fn old_enum_schema_only_decodes_cases_required_by_the_query() {
     let evolved_schema = enum_projection_schema(&["open", "closed"]);
     let evolved = SchemaVersion::new(evolved_schema.clone());
     let (_dir, mut core) = open_node_with_schema(node(0x75), base.clone());
+    // Requirement-none auxiliary sources still need a physical row shape for
+    // relation closure, but their unrequested enum cell must be typed-null.
+    assert!(core
+        .ensure_physical_current_projection_for_enum_columns(
+            base.version_id(),
+            "items",
+            &BTreeSet::new(),
+        )
+        .is_ok());
     let enum_lens = MigrationLens::new(
         base.version_id(),
         evolved.id,

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -3034,6 +3034,31 @@ fn direct_payload_enum_append_activates_and_recovers() {
 }
 
 #[test]
+fn payload_enum_unknown_case_is_ignored_only_when_unselected() {
+    let schema = |extra| {
+        let record = groove::records::RecordDescriptor::new([("x", groove::records::ValueType::String)]);
+        let mut cases = vec![groove::records::EnumCase::new("open", record.clone())];
+        if extra { cases.push(groove::records::EnumCase::new("closed", record)); }
+        JazzSchema::new([TableSchema::new("items", [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("status", ColumnType::Enum(Box::new(groove::records::EnumSchema::new("status", cases).unwrap()))),
+        ])])
+    };
+    let base = schema(false); let evolved = SchemaVersion::new(schema(true));
+    let (_dir, mut core) = open_node_with_schema(node(0x76), base.clone());
+    publish_schema_lineage(&mut core, evolved.clone(), MigrationLens::new(base.version_id(), evolved.id, vec![TableLens { source_table: "items".into(), target_table: "items".into(), ops: vec![LensOp::TransformColumn { column: "status".into(), transform: "jazz.identity".into() }] }]), Vec::<String>::new(), Vec::<String>::new()).unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema { author: AuthorId::SYSTEM, pointer: CurrentWriteSchema { revision: 1, schema: evolved.id } }).unwrap();
+    let payload = groove::records::RecordDescriptor::new([("x", groove::records::ValueType::String)]);
+    core.commit_mergeable(MergeableCommit::new("items", row(0x76), 1).cells(BTreeMap::from([
+        ("title".into(), v("ok")), ("status".into(), Value::Enum(groove::records::EnumValue::create(1, payload, &[v("closed")]).unwrap()))
+    ]))).unwrap();
+    let title = Query::from("items").select(["title"]).validate(&base).unwrap();
+    assert!(core.query_rows(&title, &title.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local).is_ok());
+    let all = Query::from("items").validate(&base).unwrap();
+    assert!(core.query_rows(&all, &all.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local).is_err());
+}
+
+#[test]
 fn old_enum_schema_only_decodes_cases_required_by_the_query() {
     // This is an internal current-source boundary test.  The public query API
     // supplies the requirement closure; the old read schema must not decode a

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -3249,6 +3249,41 @@ fn enum_projection_requirement_closure_includes_hidden_policy_fields() {
 }
 
 #[test]
+fn enum_projection_requirement_none_allows_unused_relation_enum() {
+    let schema = |states: &[&str]| JazzSchema::new([
+        TableSchema::new("items", [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("state", ColumnType::Uuid),
+        ]).with_reference("state", "states"),
+        TableSchema::new("states", [ColumnSchema::new("status", ColumnType::EnumTag(
+            groove::records::ScalarEnumSchema::new("status", states.iter().copied()).unwrap(),
+        ))]),
+    ]);
+    let base = schema(&["open"]);
+    let evolved = SchemaVersion::new(schema(&["open", "closed"]));
+    let (_dir, mut core) = open_node_with_schema(node(0x78), base.clone());
+    publish_schema_lineage(&mut core, evolved.clone(), MigrationLens::new(
+        base.version_id(), evolved.id, vec![
+            TableLens { source_table: "items".into(), target_table: "items".into(), ops: vec![] },
+            TableLens { source_table: "states".into(), target_table: "states".into(), ops: vec![LensOp::TransformColumn { column: "status".into(), transform: "jazz.identity".into() }] },
+        ],
+    ), Vec::<String>::new(), Vec::<String>::new()).unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema { author: AuthorId::SYSTEM, pointer: CurrentWriteSchema { revision: 1, schema: evolved.id } }).unwrap();
+    let state = row(0x79);
+    core.commit_mergeable(MergeableCommit::new("states", state, 1).cells(BTreeMap::from([("status".into(), Value::EnumTag(1))]))).unwrap();
+    core.commit_mergeable(MergeableCommit::new("items", row(0x7a), 2).cells(BTreeMap::from([
+        ("title".into(), v("root remains readable")), ("state".into(), Value::Uuid(state.0)),
+    ]))).unwrap();
+
+    let root_only = Query::from("items").select(["title"]).validate(&base).unwrap();
+    assert!(core.query_rows(&root_only, &root_only.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local).is_ok());
+    // Includes are hydrated by a separate path; this compilation path still
+    // proves the implicit relation source has no accidental enum dependency.
+    let included = Query::from("items").select(["title"]).include("state").validate(&base).unwrap();
+    assert!(core.query_rows(&included, &included.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local).is_ok());
+}
+
+#[test]
 fn independent_column_enum_registries_evolve_additively_across_reopen() {
     // Registry allocation is physical catalogue metadata, so this internal
     // test asserts both user-visible decoding and the non-Cartesian boundary.

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -2918,6 +2918,118 @@ fn independent_enum_schema(a: &[&str], b: &[&str]) -> JazzSchema {
     )])
 }
 
+fn enum_projection_schema(statuses: &[&str]) -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new(
+                "status",
+                ColumnType::EnumTag(
+                    groove::records::ScalarEnumSchema::new("status", statuses.iter().copied())
+                        .unwrap(),
+                ),
+            ),
+        ],
+    )])
+}
+
+#[test]
+fn old_enum_schema_only_decodes_cases_required_by_the_query() {
+    // This is an internal current-source boundary test.  The public query API
+    // supplies the requirement closure; the old read schema must not decode a
+    // physical case it neither returns nor uses semantically.
+    let base = enum_projection_schema(&["open"]);
+    let evolved_schema = enum_projection_schema(&["open", "closed"]);
+    let evolved = SchemaVersion::new(evolved_schema.clone());
+    let (_dir, mut core) = open_node_with_schema(node(0x75), base.clone());
+    let enum_lens = MigrationLens::new(
+        base.version_id(),
+        evolved.id,
+        vec![TableLens {
+            source_table: "items".to_owned(),
+            target_table: "items".to_owned(),
+            ops: vec![LensOp::TransformColumn {
+                column: "status".to_owned(),
+                transform: "jazz.identity".to_owned(),
+            }],
+        }],
+    );
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        enum_lens,
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved.id,
+        },
+    })
+    .unwrap();
+    let closed = row(0x75);
+    core.commit_mergeable(
+        MergeableCommit::new("items", closed, 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("still-readable")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    )
+    .unwrap();
+
+    let title_only = Query::from("items").select(["title"]).validate(&base).unwrap();
+    assert_eq!(
+        core.query_rows(
+            &title_only,
+            &title_only.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .unwrap()
+        .into_iter()
+        .map(current_row_pair)
+        .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(closed, BTreeMap::from([("title".to_owned(), v("still-readable"))]))])
+    );
+
+    // Whole-row output semantically consumes `status`, so the non-total
+    // projection must report the incompatible case rather than silently
+    // inventing an old value or suppressing the row.
+    let whole_row = Query::from("items").validate(&base).unwrap();
+    assert!(core
+        .query_rows(
+            &whole_row,
+            &whole_row.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .is_err());
+
+    // The closure is semantic rather than merely output-shaped: a hidden
+    // predicate or order key must force the same explicit incompatibility.
+    for query in [
+        Query::from("items")
+            .select(["title"])
+            .filter(eq(col("status"), lit(Value::EnumTag(0))))
+            .validate(&base)
+            .unwrap(),
+        Query::from("items")
+            .select(["title"])
+            .order_by("status", crate::query::OrderDirection::Asc)
+            .validate(&base)
+            .unwrap(),
+    ] {
+        assert!(core
+            .query_rows(
+                &query,
+                &query.bind(BTreeMap::new()).unwrap(),
+                DurabilityTier::Local,
+            )
+            .is_err());
+    }
+}
+
 #[test]
 fn independent_column_enum_registries_evolve_additively_across_reopen() {
     // Registry allocation is physical catalogue metadata, so this internal


### PR DESCRIPTION
🤖 Makes enum decoding depend on the fields a query actually requires.

## What changed

- derives current-source projections from query source requirements
- emits typed nulls for unused enum fields instead of decoding unknown physical tags
- preserves explicit incompatibility when a selected, filtered, ordered, grouped, aggregated, related, or policy field requires an unknown case
- avoids invalidation/reset churn when an identical dynamic projection is registered repeatedly
- permits typed enum-null projection boundaries and append-only live enum registry evolution

## Why

An old schema view should remain able to read unrelated fields from rows containing a newer enum case. It must still fail explicitly whenever query semantics depend on the incompatible enum value.

## Validation

- scalar and payload selected-versus-unused regressions
- filter, order, group, and aggregate dependency tests
- hidden policy dependency test
- relation auxiliary-source closure test
- planted projection-boundary mutations
- focused Cargo check, Clippy, formatting, and sensitive-data gates

Stacked on the concurrent enum identity PR.
