### PR TITLE
fix(subscriptions): preserve enum projection boundaries

### DIFF
--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -622,6 +622,31 @@ impl RecordProjector {
         target: RecordDescriptor,
         mapping: impl IntoIterator<Item = (usize, usize)>,
     ) -> Result<Self, Error> {
+        Self::new_inner(source, target, mapping, false)
+    }
+
+    /// Construct a byte-copy projector across descriptors that have identical
+    /// encoded layouts but were rebound to different enum registry IDs.
+    ///
+    /// This is intentionally narrower than general enum compatibility: every
+    /// case and nested payload layout must match exactly, so no tag can be
+    /// silently reinterpreted. Callers that cross evolved enum schemas must
+    /// use an explicit enum remap instead.
+    #[doc(hidden)]
+    pub fn new_registry_rebound(
+        source: RecordDescriptor,
+        target: RecordDescriptor,
+        mapping: impl IntoIterator<Item = (usize, usize)>,
+    ) -> Result<Self, Error> {
+        Self::new_inner(source, target, mapping, true)
+    }
+
+    fn new_inner(
+        source: RecordDescriptor,
+        target: RecordDescriptor,
+        mapping: impl IntoIterator<Item = (usize, usize)>,
+        allow_registry_rebinding: bool,
+    ) -> Result<Self, Error> {
         let mut target_to_source = vec![None; target.fields.len()];
         for (source_idx, target_idx) in mapping {
             let source_field =
@@ -643,7 +668,12 @@ impl RecordProjector {
             if target_to_source[target_idx].is_some() {
                 return Err(Error::ProjectDuplicateTarget { target_idx });
             }
-            if source_field.value_type != target_field.value_type {
+            if source_field.value_type != target_field.value_type
+                && !(allow_registry_rebinding
+                    && source_field
+                        .value_type
+                        .registry_rebound_layout_compatible_with(&target_field.value_type))
+            {
                 return Err(Error::ProjectTypeMismatch {
                     source_idx,
                     target_idx,

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -1364,6 +1364,39 @@ fn record_projector_rejects_incomplete_duplicate_and_type_mismatched_mappings() 
 }
 
 #[test]
+fn rebound_registry_projector_allows_identical_layout_but_not_added_tags() {
+    let source_status = ValueType::EnumTag(
+        ScalarEnumSchema::new("status", ["open"])
+            .unwrap()
+            .with_registry_id(11),
+    );
+    let rebound_status = ValueType::EnumTag(
+        ScalarEnumSchema::new("status", ["open"])
+            .unwrap()
+            .with_registry_id(22),
+    );
+    let source = RecordDescriptor::new([("status", source_status)]);
+    let rebound = RecordDescriptor::new([("status", rebound_status)]);
+    let projector = RecordProjector::new_registry_rebound(source, rebound, [(0, 0)])
+        .expect("same enum encoding may cross a registry rebinding");
+    let raw = source.create(&[Value::EnumTag(0)]).unwrap();
+    assert_eq!(projector.project(source.bind(&raw)).unwrap().raw(), raw);
+
+    let evolved = RecordDescriptor::new([(
+        "status",
+        ValueType::EnumTag(
+            ScalarEnumSchema::new("status", ["open", "closed"])
+                .unwrap()
+                .with_registry_id(33),
+        ),
+    )]);
+    assert!(matches!(
+        RecordProjector::new_registry_rebound(source, evolved, [(0, 0)]),
+        Err(Error::ProjectTypeMismatch { .. })
+    ));
+}
+
+#[test]
 fn patch_field_overwrites_fixed_width_values_without_shifting_layout() {
     let schema = RecordDescriptor::new([
         ("id", ValueType::U64),

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -477,6 +477,54 @@ impl ValueType {
         }
     }
 
+    /// True when two descriptors have exactly the same byte layout and differ
+    /// only in the durable identities assigned to their enum registries.
+    ///
+    /// Unlike [`Self::registry_compatible_with`], this deliberately does not
+    /// admit append-only growth: a raw record projector copies enum bytes, so
+    /// the target must be able to decode every tag without a semantic remap.
+    pub(crate) fn registry_rebound_layout_compatible_with(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::EnumTag(left), Self::EnumTag(right)) => left.variants == right.variants,
+            (Self::Enum(left), Self::Enum(right)) => {
+                left.cases.len() == right.cases.len()
+                    && left.cases.iter().zip(&right.cases).all(|(a, b)| {
+                        a.name == b.name
+                            && a.payload.fields().len() == b.payload.fields().len()
+                            && a.payload
+                                .fields()
+                                .iter()
+                                .zip(b.payload.fields())
+                                .all(|(x, y)| {
+                                    x.name == y.name
+                                        && x.value_type
+                                            .registry_rebound_layout_compatible_with(&y.value_type)
+                                })
+                    })
+            }
+            (Self::Tuple(left), Self::Tuple(right)) => {
+                left.len() == right.len()
+                    && left
+                        .iter()
+                        .zip(right)
+                        .all(|(a, b)| a.registry_rebound_layout_compatible_with(b))
+            }
+            (Self::Array(left), Self::Array(right))
+            | (Self::Nullable(left), Self::Nullable(right)) => {
+                left.registry_rebound_layout_compatible_with(right)
+            }
+            (Self::Record(left), Self::Record(right)) => {
+                left.fields().len() == right.fields().len()
+                    && left.fields().iter().zip(right.fields()).all(|(a, b)| {
+                        a.name == b.name
+                            && a.value_type
+                                .registry_rebound_layout_compatible_with(&b.value_type)
+                    })
+            }
+            _ => self == other,
+        }
+    }
+
     /// Whether this durable value occurrence may advance to `next` without
     /// changing the interpretation of any value already stored under `self`.
     ///

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -1212,9 +1212,13 @@ fn build_content_witness_projector(
         field_idx_in_descriptor(terminal_descriptor, &schema.authored_columns_field)?,
         9 + table.columns.len(),
     ));
-    RecordProjector::new(terminal_descriptor, storage_descriptor, mapping).map_err(|_| {
-        super::Error::InvalidStoredValue("content witness projector construction failed")
-    })
+    // Current-source tables bind enum registries to physical occurrences,
+    // while version carriers bind the same authored layout to history-table
+    // occurrences. The projector copies the encoded value only after the
+    // narrow rebound-layout check has proved every tag/payload layout equal.
+    RecordProjector::new_registry_rebound(terminal_descriptor, storage_descriptor, mapping).map_err(
+        |_| super::Error::InvalidStoredValue("content witness projector construction failed"),
+    )
 }
 
 fn tagged_deletion(value: Value) -> Result<Option<crate::tx::DeletionEvent>, super::Error> {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1532,44 +1532,15 @@ where
         table: &TableSchema,
         tier: DurabilityTier,
     ) -> Result<CurrentSourceGraph, SourceResolutionError> {
-        // Keep the schema-aware projected payload as the row source. Version
-        // witnesses are joined alongside it solely to provide authoritative
-        // provenance/version metadata; using the physical witness graph as
-        // the payload source would bypass lenses and large-value projection.
+        // The schema-aware projection already retains the complete current
+        // version witness tuple.  Joining it to the generic physical witness
+        // graph would independently decode every enum cell, defeating a
+        // title-only old-schema subscription before its narrowed source has a
+        // chance to replace unused enum values with typed nulls.
         let projected =
             self.projected_content_current_source_graph(request, table, tier, true, true)?;
-        let witnesses = self
-            .node
-            .maintained_view_content_current_with_version_in_schema(
-                table,
-                tier,
-                self.read_view.read_schema,
-            )
-            .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
-        let mut fields = vec![ProjectField::renamed(left_field("row_uuid"), "row_uuid")];
-        fields.extend(table.columns.iter().map(|column| {
-            let field = user_column_field(&column.name);
-            ProjectField::renamed(left_field(&field), field)
-        }));
-        fields.extend(
-            [
-                "schema_version",
-                "parents",
-                "authored_columns",
-                "created_by",
-                "created_at",
-                "updated_by",
-                "updated_at",
-                "tx_time",
-                "tx_node_id",
-                "global_seq",
-            ]
-            .into_iter()
-            .map(|field| ProjectField::renamed(right_field(field), field)),
-        );
         Ok(CurrentSourceGraph {
-            graph: GraphBuilder::join(projected, witnesses, ["row_uuid"], ["row_uuid"])
-                .project_fields(fields),
+            graph: projected,
             descriptor: current_row_descriptor(table),
             metadata: BTreeMap::new(),
         })

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -3059,6 +3059,166 @@ fn payload_enum_unknown_case_is_ignored_only_when_unselected() {
 }
 
 #[test]
+fn maintained_old_enum_subscriptions_only_fail_when_their_requirement_uses_new_cases() {
+    // This is an internal subscription-boundary regression. PeerState is the
+    // server-side maintained subscription driver; public clients receive its
+    // ViewUpdates, but cannot themselves install a catalogue lineage.
+    let base = enum_projection_schema(&["open"]);
+    let evolved = SchemaVersion::new(enum_projection_schema(&["open", "closed"]));
+    let (_dir, mut core) = open_node_with_schema(node(0x7b), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![LensOp::TransformColumn {
+                    column: "status".to_owned(),
+                    transform: "jazz.identity".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema { revision: 1, schema: evolved.id },
+    })
+    .unwrap();
+
+    let known = row(0x7b);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", known, 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("known case")),
+            ("status".to_owned(), Value::EnumTag(0)),
+        ])),
+    );
+
+    let title_only = Query::from("items").select(["title"]).validate(&base).unwrap();
+    let title_binding = title_only.bind(BTreeMap::new()).unwrap();
+    let mut title_peer = PeerState::new();
+    let initial = title_peer
+        .rehydrate_query(&mut core, &title_only, &title_binding)
+        .expect("old-schema title subscription opens over known case");
+    let SyncMessage::ViewUpdate { reset_result_set, result_member_adds, .. } = initial else {
+        panic!("expected initial maintained view update");
+    };
+    assert!(reset_result_set);
+    assert_eq!(result_member_adds.len(), 1);
+
+    // Recompiling exactly the same target must leave the maintained graph in
+    // place: target registration is idempotent, not a hidden reset mechanism.
+    let unchanged = title_peer
+        .query_update(&mut core, &title_only, &title_binding)
+        .expect("identical projection target remains registered");
+    let SyncMessage::ViewUpdate {
+        reset_result_set,
+        result_member_adds,
+        result_member_removes,
+        terminal_operations,
+        ..
+    } = unchanged else {
+        panic!("expected maintained view update");
+    };
+    assert!(!reset_result_set, "idempotent target registration must not reset");
+    assert!(result_member_adds.is_empty());
+    assert!(result_member_removes.is_empty());
+    assert!(terminal_operations.is_empty());
+
+    let unknown = row(0x7c);
+    let unknown_tx = accept_global(
+        &mut core,
+        MergeableCommit::new("items", unknown, 2).cells(BTreeMap::from([
+            ("title".to_owned(), v("new case is harmless when unselected")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    );
+    let update = title_peer
+        .query_update(&mut core, &title_only, &title_binding)
+        .expect("unused unknown enum must not break maintained title output");
+    let SyncMessage::ViewUpdate { reset_result_set, result_member_adds, .. } = update else {
+        panic!("expected maintained view update");
+    };
+    assert!(!reset_result_set);
+    assert!(result_member_adds.iter().any(|member| {
+        member.as_row().is_some_and(|(_, row_uuid, tx_id)| row_uuid == unknown && tx_id == unknown_tx)
+    }));
+
+    // A separate old-schema subscription that semantically consumes status
+    // must reject the same physical row. In particular, it may not reinterpret
+    // the new tag as `open` or suppress the row as an ordinary filter miss.
+    let status_required = Query::from("items").validate(&base).unwrap();
+    let status_binding = status_required.bind(BTreeMap::new()).unwrap();
+    let mut status_peer = PeerState::new();
+    assert!(status_peer
+        .rehydrate_query(&mut core, &status_required, &status_binding)
+        .is_err(), "required unknown enum case must fail explicitly");
+}
+
+#[test]
+fn maintained_old_payload_enum_subscription_rejects_new_case_without_aliasing() {
+    let base = payload_enum_projection_schema(&["draft"]);
+    let evolved = SchemaVersion::new(payload_enum_projection_schema(&["draft", "published"]));
+    let (_dir, mut core) = open_node_with_schema(node(0x7d), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![LensOp::TransformColumn {
+                    column: "status".to_owned(),
+                    transform: "jazz.identity".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema { revision: 1, schema: evolved.id },
+    })
+    .unwrap();
+    let payload = groove::records::RecordDescriptor::new([(
+        "note",
+        groove::records::ValueType::String,
+    )]);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", row(0x7d), 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("new payload case")),
+            (
+                "status".to_owned(),
+                Value::Enum(
+                    groove::records::EnumValue::create(1, payload, &[v("published")]).unwrap(),
+                ),
+            ),
+        ])),
+    );
+
+    let title_only = Query::from("items").select(["title"]).validate(&base).unwrap();
+    let binding = title_only.bind(BTreeMap::new()).unwrap();
+    let mut title_peer = PeerState::new();
+    assert!(title_peer.rehydrate_query(&mut core, &title_only, &binding).is_ok());
+
+    let required = Query::from("items").validate(&base).unwrap();
+    let binding = required.bind(BTreeMap::new()).unwrap();
+    let mut required_peer = PeerState::new();
+    assert!(required_peer.rehydrate_query(&mut core, &required, &binding).is_err());
+}
+
+#[test]
 fn old_enum_schema_only_decodes_cases_required_by_the_query() {
     // This is an internal current-source boundary test.  The public query API
     // supplies the requirement closure; the old read schema must not decode a


### PR DESCRIPTION
🤖 Preserves projection-sensitive enum behavior for maintained subscriptions.

## What changed

- carries version witnesses from the narrowed maintained source rather than joining a generic enum-decoding witness
- adds a strict registry-rebound projector for byte-identical scalar, payload, and nested enum layouts
- rejects appended or otherwise incompatible layouts instead of treating them as harmless registry rebinding

## Why

Old-schema subscriptions selecting unrelated fields must survive rows containing newer enum cases, including reset and later-delta paths. Required enum dependencies must continue to fail explicitly without tag aliasing.

## Validation

- scalar initial/reset and later unknown-case delta coverage
- required scalar enum failure coverage
- payload unused-field success and required-field failure coverage
- exact-layout registry-rebound positive and appended-tag rejection plants
- focused Jazz/Groove tests, Cargo check, Clippy, formatting, and sensitive-data gates

Stacked on the projection-sensitive query PR.
