### PR TITLE
fix(schema): preserve enum introduction order

### DIFF
--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -82,18 +82,17 @@ fn compare_scalar_enum_cases(
     left: &GlobalScalarEnumCaseId,
     right: &GlobalScalarEnumCaseId,
 ) -> std::cmp::Ordering {
-    // Every descendant repeats its inherited cases at their original authored
-    // ordinal. That ordinal therefore preserves the existing physical prefix;
-    // authoritative catalogue aliases linearize only genuinely concurrent
-    // introductions at the same next ordinal. UUID is solely a deterministic
-    // tie-breaker for corrupt/incomplete catalogues.
-    left.introducing_ordinal
-        .cmp(&right.introducing_ordinal)
-        .then_with(|| {
-            aliases
-                .get(&left.introducing_schema)
-                .cmp(&aliases.get(&right.introducing_schema))
-        })
+    // A case's *introducing* schema alias is its authoritative, durable
+    // introduction position.  Descendants retain the original identity, so
+    // ordering by alias preserves the inherited physical prefix and appends a
+    // later sibling even when that sibling's authored ordinal is shallower
+    // than a case introduced earlier on another branch.  Ordinal only orders
+    // multiple cases introduced by the same schema. UUID is solely a
+    // deterministic tie-breaker for corrupt/incomplete catalogues.
+    aliases
+        .get(&left.introducing_schema)
+        .cmp(&aliases.get(&right.introducing_schema))
+        .then_with(|| left.introducing_ordinal.cmp(&right.introducing_ordinal))
         .then_with(|| left.introducing_schema.cmp(&right.introducing_schema))
 }
 
@@ -703,7 +702,7 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
-    fn physical_scalar_enum_cases(
+    pub(super) fn physical_scalar_enum_cases(
         &self,
         table_id: PhysicalTableId,
         column_id: PhysicalColumnId,
@@ -3688,6 +3687,13 @@ mod variant_case_tests {
         SchemaVersionId(uuid::Uuid::from_bytes([byte; 16]))
     }
 
+    fn case(schema: SchemaVersionId, ordinal: u8) -> GlobalScalarEnumCaseId {
+        GlobalScalarEnumCaseId {
+            introducing_schema: schema,
+            introducing_ordinal: ordinal,
+        }
+    }
+
     fn mapping(table_id: u64, columns: &[(&str, u64)]) -> SchemaPhysicalMapping {
         SchemaPhysicalMapping {
             tables: BTreeMap::from([(
@@ -3791,6 +3797,54 @@ mod variant_case_tests {
             &old,
             &value_type(&["new"]),
         ));
+    }
+
+    #[test]
+    fn later_sibling_with_a_shallower_ordinal_appends_after_deeper_introduction() {
+        // This is an internal lowering invariant. The same ordering primitive
+        // builds scalar, direct-payload, and nested-enum physical registries;
+        // their compact tags are not publicly observable on their own.
+        //
+        // base ──► A (+ ordinal 1) ──► A2 (+ ordinal 2)
+        //   └────────────────────────► B (+ ordinal 1)
+        //
+        // B is published later in the dense catalogue, so it must append
+        // after A2 rather than retag A2 merely because B's local ordinal is
+        // shallower. The test is sensitive to restoring ordinal-first order.
+        let base = schema(1);
+        let a = schema(2);
+        let a2 = schema(3);
+        let b = schema(4);
+        let aliases = BTreeMap::from([
+            (base, SchemaVersionAlias(1)),
+            (a, SchemaVersionAlias(2)),
+            (a2, SchemaVersionAlias(3)),
+            (b, SchemaVersionAlias(4)),
+        ]);
+        let base_case = case(base, 0);
+        let a_case = case(a, 1);
+        let a2_case = case(a2, 2);
+        let b_case = case(b, 1);
+
+        for registry_kind in ["scalar", "direct payload", "nested"] {
+            let mut registry = vec![
+                base_case.clone(),
+                a_case.clone(),
+                a2_case.clone(),
+                b_case.clone(),
+            ];
+            registry.sort_by(|left, right| compare_scalar_enum_cases(&aliases, left, right));
+            assert_eq!(
+                registry,
+                vec![
+                    base_case.clone(),
+                    a_case.clone(),
+                    a2_case.clone(),
+                    b_case.clone()
+                ],
+                "{registry_kind} registry"
+            );
+        }
     }
 
     #[test]

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -3848,7 +3848,7 @@ mod variant_case_tests {
     }
 
     #[test]
-    fn concurrent_scalar_enum_additions_preserve_schema_qualified_case_identity() {
+    fn concurrent_scalar_enum_merge_preserves_established_prefix_and_distinct_cases() {
         // This is deliberately an internal lowering test: the failure happens
         // before a public row can be decoded. Two concurrent authored schemas
         // both use ordinal 2, so accepting the raw tags as one physical tag
@@ -3866,17 +3866,32 @@ mod variant_case_tests {
         let merged_ab = merge_physical_value_type(&archived, &snoozed)
             .expect("concurrent enum cases must coexist in one physical registry");
         let merged_ba = merge_physical_value_type(&snoozed, &archived)
-            .expect("local arrival order must not choose semantic enum order");
-        assert_eq!(merged_ab, merged_ba);
+            .expect("the opposite established prefix also accepts its sibling");
 
-        // The implementation must additionally translate authored ordinal 2
-        // through a schema-qualified identity at both storage boundaries. This
-        // assertion only establishes the prerequisite: the physical registry
-        // has distinct slots for the sibling introductions.
-        let records::ValueType::EnumTag(registry) = merged_ab else {
+        // This compatibility helper operates on an already-established local
+        // physical descriptor. It is intentionally directional: canonical
+        // catalogue ordering has already happened before this point, so
+        // sorting or rebuilding this descriptor would retag stored values.
+        // The schema-qualified physical lowering path supplies that canonical
+        // order; this helper must only append a distinct sibling case.
+        let records::ValueType::EnumTag(merged_ab) = merged_ab else {
             panic!("expected scalar enum registry");
         };
-        assert_eq!(registry.variants.len(), 4);
+        let records::ValueType::EnumTag(merged_ba) = merged_ba else {
+            panic!("expected scalar enum registry");
+        };
+        assert_eq!(
+            merged_ab.variants,
+            vec!["draft", "published", "archived", "snoozed"],
+            "left registry stays an exact physical prefix"
+        );
+        assert_eq!(
+            merged_ba.variants,
+            vec!["draft", "published", "snoozed", "archived"],
+            "the reverse call preserves its own established prefix"
+        );
+        assert_eq!(merged_ab.variants.len(), 4);
+        assert_eq!(merged_ba.variants.len(), 4);
     }
 
     #[test]

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -2934,6 +2934,154 @@ fn enum_projection_schema(statuses: &[&str]) -> JazzSchema {
     )])
 }
 
+fn enum_identity_lens(source: SchemaVersionId, target: SchemaVersionId) -> MigrationLens {
+    MigrationLens::new(
+        source,
+        target,
+        vec![TableLens {
+            source_table: "items".to_owned(),
+            target_table: "items".to_owned(),
+            ops: vec![LensOp::TransformColumn {
+                column: "status".to_owned(),
+                transform: "jazz.identity".to_owned(),
+            }],
+        }],
+    )
+}
+
+/// Earlier catalogue introductions retain their physical scalar-enum tags
+/// when a later sibling introduces a shallower authored ordinal.
+///
+/// alice publishes `base -> A -> A2`; bob later publishes `base -> B`.
+///
+/// ```text
+/// base ──► A (+ a) ──► A2 (+ a2)
+///   └────────────────► B (+ b)
+/// ```
+///
+/// The node must append `b` after `a2`, activate the registry, and recover
+/// the same mapping after reopen. (Sorting observes the local read schema;
+/// the shared physical ordering is asserted below.)
+#[test]
+fn scalar_enum_later_sibling_appends_without_retagging_deeper_cases() {
+    let base = enum_projection_schema(&["base"]);
+    let a = SchemaVersion::new(enum_projection_schema(&["base", "a"]));
+    let a2 = SchemaVersion::new(enum_projection_schema(&["base", "a", "a2"]));
+    let b = SchemaVersion::new(enum_projection_schema(&["base", "b"]));
+    let (dir, mut core) = open_node_with_schema(node(0x78), base.clone());
+
+    publish_schema_lineage(
+        &mut core,
+        a.clone(),
+        enum_identity_lens(base.version_id(), a.id),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    publish_schema_lineage(
+        &mut core,
+        a2.clone(),
+        enum_identity_lens(a.id, a2.id),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: a2.id,
+        },
+    })
+    .unwrap();
+
+    let base_row = row(0x78);
+    let a_row = row(0x79);
+    let a2_row = row(0x7a);
+    for (row_uuid, title, status, tx_time) in [
+        (a2_row, "a2", 2, 1),
+        (base_row, "base", 0, 2),
+        (a_row, "a", 1, 3),
+    ] {
+        core.commit_mergeable(
+            MergeableCommit::new("items", row_uuid, tx_time).cells(BTreeMap::from([
+                ("title".to_owned(), v(title)),
+                ("status".to_owned(), Value::EnumTag(status)),
+            ])),
+        )
+        .unwrap();
+    }
+    // `b` has local ordinal 1, but it is catalogue-later than A2's ordinal
+    // 2. Ordinal-first physical ordering would attempt to insert it before
+    // A2, which Groove correctly rejects as a retagging evolution.
+    publish_schema_lineage(
+        &mut core,
+        b.clone(),
+        enum_identity_lens(base.version_id(), b.id),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    let b_mapping = &core.catalogue.physical_mappings[&b.id].tables["items"];
+    let physical_cases = core
+        .physical_scalar_enum_cases(b_mapping.table_id, b_mapping.columns["status"])
+        .unwrap();
+    assert_eq!(
+        physical_cases,
+        vec![
+            GlobalScalarEnumCaseId {
+                introducing_schema: base.version_id(),
+                introducing_ordinal: 0,
+            },
+            GlobalScalarEnumCaseId {
+                introducing_schema: a.id,
+                introducing_ordinal: 1,
+            },
+            GlobalScalarEnumCaseId {
+                introducing_schema: a2.id,
+                introducing_ordinal: 2,
+            },
+            GlobalScalarEnumCaseId {
+                introducing_schema: b.id,
+                introducing_ordinal: 1,
+            },
+        ],
+    );
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 2,
+            schema: b.id,
+        },
+    })
+    .unwrap();
+    let b_row = row(0x7b);
+    core.commit_mergeable(
+        MergeableCommit::new("items", b_row, 4).cells(BTreeMap::from([
+            ("title".to_owned(), v("b")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    )
+    .unwrap();
+    drop(core);
+
+    let mut reopened = reopen_node_at(&dir, node(0x78), base.clone());
+    let titles = Query::from("items").select(["title"]).validate(&base).unwrap();
+    assert_eq!(
+        reopened
+            .query_rows(
+                &titles,
+                &titles.bind(BTreeMap::new()).unwrap(),
+                DurabilityTier::Local,
+            )
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([base_row, a_row, a2_row, b_row]),
+    );
+}
+
 fn payload_enum_projection_schema(cases: &[&str]) -> JazzSchema {
     JazzSchema::new([TableSchema::new(
         "items",


### PR DESCRIPTION
🤖 Preserves enum case order by authoritative first introduction.

## What changed

- orders physical scalar, direct-payload, nested-scalar, and nested-payload registries by catalogue alias/first introduction
- uses authored ordinal only within the same introducing schema
- replaces an obsolete commutative merge assertion with directional established-prefix checks

## Why

Ordinal-first sorting could retag a case introduced on a deeper branch when a later sibling schema introduced a shallower ordinal. The physical registry must retain existing compact tags and append later-introduced cases.

## Validation

- base → A → A2, then later base → B activation/write/reopen regression
- durable order assertion `[base, A, A2, B]`
- plant-sensitive shared comparator and directional merge tests
- `cargo test -p jazz enum --lib`: 23 passed
- independent adversarial review found no remaining blockers

Stacked on the maintained-subscription PR.
