### PR TITLE
fix(schema): keep enum evolution compatible with old clients

### DIFF
--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -468,6 +468,30 @@ where
         self.register_variant_projection_case(table, target, variant_tag, fields)
     }
 
+    /// Refresh an existing raw projection case after its source descriptor
+    /// grows only by append-only enum registry evolution.
+    ///
+    /// This is deliberately narrower than normal case registration: it never
+    /// accepts a changed projection mapping or incompatible field/type change.
+    pub fn refresh_variant_case_for_registry_evolution(
+        &mut self,
+        table: &str,
+        target: &str,
+        variant_tag: u32,
+        fields: impl IntoIterator<Item = ProjectField>,
+    ) -> Result<(), Error> {
+        self.ensure_not_poisoned()?;
+        let fields = fields.into_iter().collect::<Vec<_>>();
+        self.ivm_runtime
+            .refresh_variant_projection_case_for_registry_evolution(
+                table,
+                target,
+                variant_tag,
+                &fields,
+            )
+            .map_err(Error::IvmRuntime)
+    }
+
     /// Append a physical source case that constructs one stable logical enum
     /// value in the projection's fixed output descriptor.
     ///

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -435,6 +435,28 @@ where
             .map_err(Error::IvmRuntime)
     }
 
+    /// Append a schema-read projection case that omits only rows containing an
+    /// enum case the target descriptor cannot represent. Other projection
+    /// errors remain errors.
+    pub fn register_variant_projection_case_omitting_unrepresentable_enums(
+        &mut self,
+        table: &str,
+        target: &str,
+        variant_tag: u32,
+        fields: impl IntoIterator<Item = ProjectField>,
+    ) -> Result<(), Error> {
+        self.ensure_not_poisoned()?;
+        let fields = fields.into_iter().collect::<Vec<_>>();
+        self.ivm_runtime
+            .register_variant_projection_case_omitting_unrepresentable_enums(
+                table,
+                target,
+                variant_tag,
+                &fields,
+            )
+            .map_err(Error::IvmRuntime)
+    }
+
     /// Append one generic source-case mapping to a fixed-output projection.
     pub fn register_variant_case(
         &mut self,

--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -940,6 +940,27 @@ impl ProjectField {
                 source: FieldRef::name(source_name),
                 target,
                 remaps,
+                omit_unrepresentable: false,
+            },
+            output_name: output_name.into(),
+        }
+    }
+
+    /// Recursively re-encode enum tags and omit a row when a target schema
+    /// cannot represent one of its cases. This is reserved for Jazz's
+    /// compatibility boundary; ordinary descriptor errors still surface.
+    pub fn recursive_enum_remap_omitting_unrepresentable(
+        source_name: impl Into<String>,
+        output_name: impl Into<String>,
+        target: ValueType,
+        remaps: RecursiveEnumRemaps,
+    ) -> Self {
+        Self {
+            expression: ProjectExpr::RecursiveEnumRemap {
+                source: FieldRef::name(source_name),
+                target,
+                remaps,
+                omit_unrepresentable: true,
             },
             output_name: output_name.into(),
         }
@@ -983,6 +1004,7 @@ pub enum ProjectExpr {
         source: FieldRef,
         target: ValueType,
         remaps: RecursiveEnumRemaps,
+        omit_unrepresentable: bool,
     },
 }
 

--- a/crates/groove/src/ivm/op_types.rs
+++ b/crates/groove/src/ivm/op_types.rs
@@ -443,6 +443,7 @@ pub enum PlanExpr {
     RecursiveEnumRemap {
         field: String,
         remaps: RecursiveEnumRemaps,
+        omit_unrepresentable: bool,
     },
 }
 

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -75,6 +75,10 @@ enum VariantProjectionCase {
         source: RecordDescriptor,
         project: MapProjectOp,
         raw_projection: Option<Arc<[RawProjectionField]>>,
+        /// A Jazz schema-read boundary may exclude rows containing a case the
+        /// target schema cannot represent. This is deliberately narrower than
+        /// a general projection error: malformed values still fail loudly.
+        omit_unrepresentable_enum_rows: bool,
     },
     Ignore {
         source: RecordDescriptor,
@@ -437,6 +441,26 @@ impl IvmRuntime {
             VariantProjectionTarget::Named(target.to_owned()),
             variant_tag,
             Some(fields),
+            false,
+        )
+    }
+
+    /// Register a schema-read case whose unrepresentable enum values are
+    /// source-local row exclusions. This keeps old-client compatibility at
+    /// the source boundary rather than swallowing errors downstream.
+    pub(crate) fn register_variant_projection_case_omitting_unrepresentable_enums(
+        &mut self,
+        table: &str,
+        target: &str,
+        variant_tag: u32,
+        fields: &[ProjectField],
+    ) -> Result<(), IvmRuntimeError> {
+        self.register_variant_projection_target_case(
+            table,
+            VariantProjectionTarget::Named(target.to_owned()),
+            variant_tag,
+            Some(fields),
+            true,
         )
     }
 
@@ -570,6 +594,7 @@ impl IvmRuntime {
             VariantProjectionTarget::Named(target.to_owned()),
             variant_tag,
             None,
+            false,
         )
     }
 
@@ -617,12 +642,14 @@ impl IvmRuntime {
             VariantProjectionCase::Project {
                 project,
                 raw_projection,
+                omit_unrepresentable_enum_rows,
                 ..
             } => NodeState::update_map_project(
                 project,
                 projection.output,
                 &input,
                 raw_projection.as_deref(),
+                *omit_unrepresentable_enum_rows,
             )?,
             VariantProjectionCase::Enum {
                 tag,
@@ -640,11 +667,9 @@ impl IvmRuntime {
             )?,
             VariantProjectionCase::Ignore { .. } => return Ok(None),
         };
-        let record = projected
-            .deltas
-            .into_iter()
-            .next()
-            .ok_or(IvmRuntimeError::GraphOutputMismatch)?;
+        let Some(record) = projected.deltas.into_iter().next() else {
+            return Ok(None);
+        };
         Ok(Some(OwnedRecord::new(
             record.record.to_vec(),
             projection.output,
@@ -657,6 +682,7 @@ impl IvmRuntime {
         target: VariantProjectionTarget,
         variant_tag: u32,
         fields: Option<&[ProjectField]>,
+        omit_unrepresentable_enum_rows: bool,
     ) -> Result<(), IvmRuntimeError> {
         let source = self
             .schema
@@ -730,6 +756,7 @@ impl IvmRuntime {
                 source,
                 project,
                 raw_projection,
+                omit_unrepresentable_enum_rows,
             }
         } else {
             VariantProjectionCase::Ignore { source }
@@ -808,6 +835,7 @@ impl IvmRuntime {
             VariantProjectionTarget::SchemaIndex(index.name.clone()),
             variant_tag,
             fields.as_deref(),
+            false,
         )
     }
 
@@ -6017,6 +6045,7 @@ impl NodeState {
                     VariantProjectionCase::Project {
                         project,
                         raw_projection,
+                        omit_unrepresentable_enum_rows,
                         ..
                     } => {
                         projected = Self::update_map_project(
@@ -6027,6 +6056,7 @@ impl NodeState {
                                 deltas: delta.deltas.clone(),
                             },
                             raw_projection.as_deref(),
+                            *omit_unrepresentable_enum_rows,
                         )?;
                         &projected.deltas
                     }
@@ -6202,6 +6232,7 @@ impl NodeState {
         output_desc: RecordDescriptor,
         input: &RecordDeltas,
         raw_projection: Option<&[RawProjectionField]>,
+        omit_unrepresentable_enum_rows: bool,
     ) -> Result<RecordDeltas, IvmRuntimeError> {
         let estimated_output_bytes = input
             .deltas
@@ -6224,20 +6255,27 @@ impl NodeState {
                     .map_err(IvmRuntimeError::RecordEncoding)?
             } else {
                 let start = output.len();
-                let record = project_record(
+                let record = match project_record(
                     &project.expressions,
                     &project.mapping,
                     output_desc,
                     &input.descriptor,
                     delta.raw(),
-                )?;
+                ) {
+                    Ok(record) => record,
+                    Err(
+                        IvmRuntimeError::EnumTagProjectionAbsent { .. }
+                        | IvmRuntimeError::EnumProjectionAbsent { .. },
+                    ) if omit_unrepresentable_enum_rows => continue,
+                    Err(error) => return Err(error),
+                };
                 output.extend_from_slice(&record);
                 start..output.len()
             };
             spans.push((span, delta.weight));
         }
         let output = output.freeze();
-        let deltas = spans
+        let deltas: Vec<_> = spans
             .into_iter()
             .map(|(span, weight)| RecordDelta {
                 record: output.slice(span),
@@ -6258,7 +6296,8 @@ impl NodeState {
         input: &RecordDeltas,
         raw_projection: Option<&[RawProjectionField]>,
     ) -> Result<RecordDeltas, IvmRuntimeError> {
-        let payloads = Self::update_map_project(project, payload_desc, input, raw_projection)?;
+        let payloads =
+            Self::update_map_project(project, payload_desc, input, raw_projection, false)?;
         let mut deltas = Vec::with_capacity(payloads.deltas.len());
         for payload in payloads.deltas {
             let value = Value::Enum(EnumValue::new(
@@ -7040,6 +7079,7 @@ where
                     output_desc,
                     &input,
                     raw_projection.as_deref(),
+                    false,
                 );
                 #[cfg(feature = "cold-settle-attribution")]
                 if let Ok(output) = &result {
@@ -9291,13 +9331,22 @@ fn remap_recursive_enum_value(
             Value::Nullable(Some(value)),
             ValueType::Nullable(source),
             ValueType::Nullable(target),
-        ) => Ok(Value::Nullable(Some(Box::new(remap_recursive_enum_value(
-            *value,
-            source,
-            target,
-            remaps,
-            &format!("{path}/nullable"),
-        )?)))),
+        ) => {
+            // Jazz storage adds one nullable carrier around every user cell.
+            // That carrier is not an authored enum occurrence, so a direct
+            // enum stored in a nullable cell remains rooted at `path`. An
+            // authored nullable enum *does* have a `path/nullable` occurrence
+            // entry. Prefer that structural child whenever it exists.
+            let nullable_path = format!("{path}/nullable");
+            let child_path = if remap_path_with_enum_occurrence_below(remaps, &nullable_path) {
+                nullable_path.as_str()
+            } else {
+                path
+            };
+            Ok(Value::Nullable(Some(Box::new(remap_recursive_enum_value(
+                *value, source, target, remaps, child_path,
+            )?))))
+        }
         (Value::Array(values), ValueType::Array(source), ValueType::Array(target)) => {
             Ok(Value::Array(
                 values
@@ -9427,6 +9476,16 @@ fn remap_recursive_enum_value(
             path: path.to_owned(),
         }),
     }
+}
+
+fn remap_path_with_enum_occurrence_below(remaps: &RecursiveEnumRemaps, path: &str) -> bool {
+    let below = format!("{path}/");
+    remaps
+        .scalar
+        .keys()
+        .chain(remaps.payload.keys())
+        .chain(remaps.payload_children.keys())
+        .any(|candidate| candidate == path || candidate.starts_with(&below))
 }
 
 fn projection_uses_raw_copy(

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -100,6 +100,37 @@ impl VariantProjectionCase {
             }
         }
     }
+
+    /// A raw source case may refresh after live registry evolution only when
+    /// its projection program is unchanged and its input descriptor advances
+    /// append-only. In particular, this rejects a replacement mapping, a
+    /// dropped/renamed field, and an enum payload/type mutation.
+    fn can_refresh_registries_to(&self, next: &Self) -> bool {
+        match (self, next) {
+            (
+                Self::Project {
+                    source: current_source,
+                    project: current_project,
+                    omit_unrepresentable_enum_rows: current_omit,
+                    ..
+                },
+                Self::Project {
+                    source: next_source,
+                    project: next_project,
+                    omit_unrepresentable_enum_rows: next_omit,
+                    ..
+                },
+            ) => {
+                current_omit == next_omit
+                    && current_project == next_project
+                    && current_source.can_evolve_registry_to(next_source)
+            }
+            (Self::Ignore { source: current }, Self::Ignore { source: next }) => {
+                current.can_evolve_registry_to(next)
+            }
+            _ => false,
+        }
+    }
 }
 
 // These maps are keyed by local runtime/schema/graph metadata produced after
@@ -442,6 +473,26 @@ impl IvmRuntime {
             variant_tag,
             Some(fields),
             false,
+            false,
+        )
+    }
+
+    /// Refresh a raw variant source descriptor after append-only enum registry
+    /// evolution. The existing mapping must remain byte-for-byte identical.
+    pub(crate) fn refresh_variant_projection_case_for_registry_evolution(
+        &mut self,
+        table: &str,
+        target: &str,
+        variant_tag: u32,
+        fields: &[ProjectField],
+    ) -> Result<(), IvmRuntimeError> {
+        self.register_variant_projection_target_case(
+            table,
+            VariantProjectionTarget::Named(target.to_owned()),
+            variant_tag,
+            Some(fields),
+            false,
+            true,
         )
     }
 
@@ -461,6 +512,7 @@ impl IvmRuntime {
             variant_tag,
             Some(fields),
             true,
+            false,
         )
     }
 
@@ -595,6 +647,7 @@ impl IvmRuntime {
             variant_tag,
             None,
             false,
+            false,
         )
     }
 
@@ -683,6 +736,7 @@ impl IvmRuntime {
         variant_tag: u32,
         fields: Option<&[ProjectField]>,
         omit_unrepresentable_enum_rows: bool,
+        allow_registry_refresh: bool,
     ) -> Result<(), IvmRuntimeError> {
         let source = self
             .schema
@@ -775,6 +829,12 @@ impl IvmRuntime {
                 entry.insert(case);
                 true
             }
+            std::collections::hash_map::Entry::Occupied(mut entry)
+                if allow_registry_refresh && entry.get().can_refresh_registries_to(&case) =>
+            {
+                entry.insert(case);
+                true
+            }
             std::collections::hash_map::Entry::Occupied(_) => {
                 return Err(IvmRuntimeError::VariantProjectionCaseAlreadyRegistered {
                     table: table.to_owned(),
@@ -835,6 +895,7 @@ impl IvmRuntime {
             VariantProjectionTarget::SchemaIndex(index.name.clone()),
             variant_tag,
             fields.as_deref(),
+            false,
             false,
         )
     }
@@ -12352,6 +12413,49 @@ mod tests {
         ColumnSchema, ColumnType, DatabaseSchema, IndexSchema, IntegerKeyType, PrimaryKey,
     };
     use crate::storage::{RecordStore, RocksDbStorage};
+
+    #[test]
+    fn raw_variant_case_registry_refresh_rejects_projection_replacement() {
+        // A live physical registry may append a case, but refreshing its raw
+        // source descriptor must not become a back door for changing how an
+        // already-installed case maps its fields.
+        let descriptor = |variants: &[&str]| {
+            RecordDescriptor::new([(
+                "status",
+                ValueType::EnumTag(
+                    records::ScalarEnumSchema::new("status", variants.iter().copied())
+                        .unwrap()
+                        .with_registry_id(0x71),
+                ),
+            )])
+        };
+        let case = |source, mapping| VariantProjectionCase::Project {
+            source,
+            project: MapProjectOp {
+                expressions: Vec::new(),
+                mapping,
+            },
+            raw_projection: None,
+            omit_unrepresentable_enum_rows: false,
+        };
+        let current = case(descriptor(&["open"]), vec![(0, 0)]);
+        let appended = case(descriptor(&["open", "closed"]), vec![(0, 0)]);
+        assert!(current.can_refresh_registries_to(&appended));
+
+        let replaced_mapping = case(descriptor(&["open", "closed"]), Vec::new());
+        assert!(
+            !current.can_refresh_registries_to(&replaced_mapping),
+            "registry refresh must not replace an existing projection mapping"
+        );
+        let incompatible_type = case(
+            RecordDescriptor::new([("status", ValueType::String)]),
+            vec![(0, 0)],
+        );
+        assert!(
+            !current.can_refresh_registries_to(&incompatible_type),
+            "registry refresh must reject a field-type mutation"
+        );
+    }
 
     #[test]
     fn payload_enum_remap_changes_only_the_case_tag() {

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -5234,15 +5234,25 @@ fn lift_literal_filter(
                             source,
                             target,
                             remaps,
+                            omit_unrepresentable,
                         } => {
                             let source =
                                 project_source_from_joined_filter_input(&input_output, source)?;
-                            Ok(ProjectField::recursive_enum_remap(
-                                source,
-                                field.output_name.clone(),
-                                target.clone(),
-                                remaps.clone(),
-                            ))
+                            Ok(if *omit_unrepresentable {
+                                ProjectField::recursive_enum_remap_omitting_unrepresentable(
+                                    source,
+                                    field.output_name.clone(),
+                                    target.clone(),
+                                    remaps.clone(),
+                                )
+                            } else {
+                                ProjectField::recursive_enum_remap(
+                                    source,
+                                    field.output_name.clone(),
+                                    target.clone(),
+                                    remaps.clone(),
+                                )
+                            })
                         }
                     })
                     .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
@@ -5552,17 +5562,27 @@ fn project_fields_against_rewritten_input(
                     source,
                     target,
                     remaps,
+                    omit_unrepresentable,
                 } => {
                     let source = field_ref_name(&original_output, source)?;
                     if rewritten_output.field_index(&source).is_none() {
                         return Err(IvmRuntimeError::GraphFieldNotFound(source));
                     }
-                    return Ok(ProjectField::recursive_enum_remap(
-                        source,
-                        field.output_name.clone(),
-                        target.clone(),
-                        remaps.clone(),
-                    ));
+                    return Ok(if *omit_unrepresentable {
+                        ProjectField::recursive_enum_remap_omitting_unrepresentable(
+                            source,
+                            field.output_name.clone(),
+                            target.clone(),
+                            remaps.clone(),
+                        )
+                    } else {
+                        ProjectField::recursive_enum_remap(
+                            source,
+                            field.output_name.clone(),
+                            target.clone(),
+                            remaps.clone(),
+                        )
+                    });
                 }
                 ProjectExpr::Literal(_)
                 | ProjectExpr::TypedLiteral { .. }
@@ -6234,6 +6254,16 @@ impl NodeState {
         raw_projection: Option<&[RawProjectionField]>,
         omit_unrepresentable_enum_rows: bool,
     ) -> Result<RecordDeltas, IvmRuntimeError> {
+        let omit_unrepresentable_enum_rows = omit_unrepresentable_enum_rows
+            || project.expressions.iter().any(|expression| {
+                matches!(
+                    expression.expression,
+                    PlanExpr::RecursiveEnumRemap {
+                        omit_unrepresentable: true,
+                        ..
+                    }
+                )
+            });
         let estimated_output_bytes = input
             .deltas
             .iter()
@@ -9200,12 +9230,16 @@ fn project_field_expr(
             field: field_ref_name(input, source)?,
             tags: tags.clone(),
         }),
-        ProjectExpr::RecursiveEnumRemap { source, remaps, .. } => {
-            Ok(PlanExpr::RecursiveEnumRemap {
-                field: field_ref_name(input, source)?,
-                remaps: remaps.clone(),
-            })
-        }
+        ProjectExpr::RecursiveEnumRemap {
+            source,
+            remaps,
+            omit_unrepresentable,
+            ..
+        } => Ok(PlanExpr::RecursiveEnumRemap {
+            field: field_ref_name(input, source)?,
+            remaps: remaps.clone(),
+            omit_unrepresentable: *omit_unrepresentable,
+        }),
     }
 }
 
@@ -9244,7 +9278,7 @@ fn project_record(
                 remap_enum_tag(input.get(field)?.clone(), tags)?
             }
             PlanExpr::EnumRemap { field, tags } => remap_enum(input.get(field)?.clone(), tags)?,
-            PlanExpr::RecursiveEnumRemap { field, remaps } => {
+            PlanExpr::RecursiveEnumRemap { field, remaps, .. } => {
                 let source_idx = input_desc
                     .field_index(field)
                     .ok_or_else(|| IvmRuntimeError::GraphFieldNotFound(field.clone()))?;
@@ -10767,12 +10801,15 @@ fn resolve_aggregate_expr(
             field: resolve_field_name(input, field)?,
             tags: tags.clone(),
         }),
-        Some(PlanExpr::RecursiveEnumRemap { field, remaps }) => {
-            Some(PlanExpr::RecursiveEnumRemap {
-                field: resolve_field_name(input, field)?,
-                remaps: remaps.clone(),
-            })
-        }
+        Some(PlanExpr::RecursiveEnumRemap {
+            field,
+            remaps,
+            omit_unrepresentable,
+        }) => Some(PlanExpr::RecursiveEnumRemap {
+            field: resolve_field_name(input, field)?,
+            remaps: remaps.clone(),
+            omit_unrepresentable: *omit_unrepresentable,
+        }),
         Some(PlanExpr::Literal(_)) | Some(PlanExpr::Null(_)) | None => aggregate.expression.clone(),
     };
     Ok(AggregateExpr {

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -700,7 +700,8 @@ where
             }
             OpType::MapProject(project) => {
                 let input = self.eval_unary_input(graph_node, node)?;
-                let result = NodeState::update_map_project(project, output_desc, &input, None);
+                let result =
+                    NodeState::update_map_project(project, output_desc, &input, None, false);
                 #[cfg(feature = "cold-settle-attribution")]
                 if let Ok(output) = &result {
                     crate::cold_settle_attribution::record_map(

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -144,6 +144,20 @@ impl RecordDescriptor {
             })
     }
 
+    /// Whether this descriptor may advance to `next` solely by appending enum
+    /// registry cases while preserving every existing field's interpretation.
+    pub(crate) fn can_evolve_registry_to(&self, next: &Self) -> bool {
+        self.fields.len() == next.fields.len()
+            && self
+                .fields
+                .iter()
+                .zip(next.fields())
+                .all(|(current, next)| {
+                    current.name == next.name
+                        && current.value_type.can_evolve_registry_to(&next.value_type)
+                })
+    }
+
     pub fn field_index(&self, field_name: &str) -> Option<usize> {
         self.fields
             .iter()

--- a/crates/jazz/SPEC/14_lowering_to_groove.md
+++ b/crates/jazz/SPEC/14_lowering_to_groove.md
@@ -47,6 +47,7 @@ Invariant digest:
 - `INV-LOWER-25`: A lens-projected maintained source MUST emit the same net weighted current-row and witness deltas as applying the selected natural lens path to the authoritative source.
 - `INV-LOWER-26`: A structured query MUST expose one authoritative terminal output relation. Groove MUST assemble nested paths into that terminal; a child change semantically replaces or patches its owning root output, and public carriers MUST NOT require a second relation-edge delta stream.
 - `INV-LOWER-27`: An enum case's authored discriminant is scoped to its row `SchemaVersionId`; lowering MUST translate it through the persistent case identity of its physical occurrence before using a local storage tag, predicate, grouping key, or ordering key.
+- `INV-LOWER-28`: An additive enum case MUST be a row-level incompatibility for an older read schema, never a query or subscription error. Sources remove an unrepresentable row before any semantic consumer (filter, ordering, grouping, aggregation, policy, relation requirement, pagination, or maintained delta) observes it; unused enum occurrences remain undecoded and do not affect row visibility.
 
 ## Details
 
@@ -130,16 +131,25 @@ incompatible payload layouts reject rather than merge. The same translation
 recurs at nested enum occurrences.
 
 Projection from a physical case back into an authored schema is non-total. If a
-query does not read, filter, join, order, group, or authorize through that column,
-the row remains usable without decoding it. If a query semantically requires a
-case absent from its target schema, it MUST fail explicitly unless an authored
-down-grade lens supplies a default or nullable mapping. It MUST NOT silently hide
-the row or substitute an old case. Equality predicates for a known case may treat
-an absent newer case as non-matching.
+query does not read, filter, join, order, group, authorize, or otherwise require
+that occurrence, the row remains usable without decoding it. If a query
+semantically requires a case absent from its target schema, the physical source
+MUST deterministically omit that row before pagination, aggregation, or any
+maintained-view delta processing. It MUST NOT surface an old-client query or
+subscription error, substitute an old case, or invent a default. A policy
+dependency is fail-closed and therefore also omits the row. An optional relation
+or include may omit only its incompatible child while retaining its readable
+parent; a required relation follows its explicit requirement semantics. Equality
+against a known case consequently treats an absent newer case as non-matching.
 
 _Further invariant._ `INV-LOWER-27` — local enum tags are only interned
 representations of schema-qualified case identities; simultaneous sibling ordinal
 allocations cannot alias one another.
+
+_Further invariant._ `INV-LOWER-28` — enum compatibility is evaluated at the
+source boundary, so one-shot and maintained reads have the same row-membership
+semantics and no downstream operator can turn an unrepresentable value into a
+runtime failure.
 
 _Further invariants._ `INV-LOWER-2`, `INV-LOWER-4` — content and deletion lower
 to distinct tables belonging to the resolved `PhysicalTableId`, each with PK

--- a/crates/jazz/SPEC/14_lowering_to_groove.md
+++ b/crates/jazz/SPEC/14_lowering_to_groove.md
@@ -47,7 +47,7 @@ Invariant digest:
 - `INV-LOWER-25`: A lens-projected maintained source MUST emit the same net weighted current-row and witness deltas as applying the selected natural lens path to the authoritative source.
 - `INV-LOWER-26`: A structured query MUST expose one authoritative terminal output relation. Groove MUST assemble nested paths into that terminal; a child change semantically replaces or patches its owning root output, and public carriers MUST NOT require a second relation-edge delta stream.
 - `INV-LOWER-27`: An enum case's authored discriminant is scoped to its row `SchemaVersionId`; lowering MUST translate it through the persistent case identity of its physical occurrence before using a local storage tag, predicate, grouping key, or ordering key.
-- `INV-LOWER-28`: An additive enum case MUST be a row-level incompatibility for an older read schema, never a query or subscription error. Sources remove an unrepresentable row before any semantic consumer (filter, ordering, grouping, aggregation, policy, relation requirement, pagination, or maintained delta) observes it; unused enum occurrences remain undecoded and do not affect row visibility.
+- `INV-LOWER-28`: An additive enum case MUST be a row-level incompatibility for an older read schema, never a query or subscription error. For a current read, Global/Ahead candidates first choose their single canonical winner; the compatibility boundary then removes that unrepresentable winner before any semantic consumer (filter, ordering, grouping, aggregation, policy, relation requirement, pagination, or maintained delta) observes it. It MUST NOT fall back to an older compatible candidate. Unused enum occurrences remain undecoded and do not affect row visibility.
 
 ## Details
 
@@ -147,9 +147,11 @@ representations of schema-qualified case identities; simultaneous sibling ordina
 allocations cannot alias one another.
 
 _Further invariant._ `INV-LOWER-28` — enum compatibility is evaluated at the
-source boundary, so one-shot and maintained reads have the same row-membership
-semantics and no downstream operator can turn an unrepresentable value into a
-runtime failure.
+source boundary immediately after Global/Ahead currentness selection (or after
+the equivalent historical/branch winner materialization), so one-shot and
+maintained reads have the same row-membership semantics. A later incompatible
+winner retracts rather than exposing a stale compatible predecessor, and no
+downstream operator can turn it into a runtime failure.
 
 _Further invariants._ `INV-LOWER-2`, `INV-LOWER-4` — content and deletion lower
 to distinct tables belonging to the resolved `PhysicalTableId`, each with PK

--- a/crates/jazz/src/node/branches.rs
+++ b/crates/jazz/src/node/branches.rs
@@ -1113,11 +1113,11 @@ where
             if projected_table.as_deref() != Some(table) {
                 continue;
             }
-            rows.push(current_row_from_materialized_cells(
-                table_schema,
-                &content,
-                &cells,
-            )?);
+            match current_row_from_materialized_cells(table_schema, &content, &cells) {
+                Ok(row) => rows.push(row),
+                Err(error) if is_unrepresentable_enum_projection(&error) => {}
+                Err(error) => return Err(error),
+            }
         }
         sort_current_rows(&mut rows);
         Ok(rows)

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -7131,6 +7131,21 @@ pub enum Error {
     SubscriptionClosed,
 }
 
+/// Whether encoding a projected current row failed solely because the read
+/// schema does not know the selected enum case.
+///
+/// Schema projection is deliberately fail-closed at this boundary: callers
+/// omit that row, while every other lens, materialization, and record error
+/// remains visible to the query caller.
+pub(super) fn is_unrepresentable_enum_projection(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::Record(
+            records::Error::InvalidEnumDiscriminant { .. } | records::Error::UnknownEnumTag { .. }
+        )
+    )
+}
+
 impl From<QueryError> for Error {
     fn from(error: QueryError) -> Self {
         Self::Query(Box::new(error))

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -1620,7 +1620,7 @@ where
                             }
                         })
                         .collect::<Result<Vec<_>, _>>()?;
-                    self.database.register_variant_case(
+                    self.database.refresh_variant_case_for_registry_evolution(
                         storage_table,
                         &projection_target,
                         tag,
@@ -1722,7 +1722,29 @@ where
             }
         }
         self.register_physical_history_variant_projections()?;
-        self.register_physical_current_variant_projections()
+        self.register_physical_current_variant_projections()?;
+        self.register_physical_current_winner_projections()
+    }
+
+    /// Keep the raw Global/Ahead winner targets live as the physical enum
+    /// registries evolve, so a subsequent query-local lowering pass can read
+    /// every newly introduced source variant.
+    fn register_physical_current_winner_projections(&mut self) -> Result<(), Error> {
+        let targets = self
+            .catalogue
+            .physical_mappings
+            .iter()
+            .flat_map(|(schema_version, mapping)| {
+                mapping
+                    .tables
+                    .keys()
+                    .map(|table_name| (*schema_version, table_name.clone()))
+            })
+            .collect::<BTreeSet<_>>();
+        for (schema_version, table_name) in targets {
+            self.ensure_physical_current_winner_projection(schema_version, &table_name)?;
+        }
+        Ok(())
     }
 
     fn physical_history_projection_case(

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -416,6 +416,13 @@ pub(super) fn physical_current_projection_target(
     format!("schema_{}_{}_current", schema_alias.0, logical_table)
 }
 
+/// A schema-agnostic physical current-row target used only until the
+/// Global/Ahead winner has been selected. Its enum tags retain their durable
+/// physical meaning; authored decoding belongs strictly after that selection.
+fn physical_current_winner_projection_target(table_id: PhysicalTableId) -> String {
+    format!("physical_{}_current_winner", table_id.0)
+}
+
 /// A query-local current-source target.  The ordinary target projects every
 /// authored enum occurrence, which is correct for a whole-row read but makes
 /// an older schema fail while decoding an enum cell that the query never
@@ -1504,6 +1511,166 @@ where
         Ok(projection_target)
     }
 
+    /// Register the common physical descriptor used to choose the latest
+    /// Global/Ahead version before a query-local old-schema projection can
+    /// omit an unrepresentable enum case.
+    pub(super) fn ensure_physical_current_winner_projection(
+        &mut self,
+        target_schema: SchemaVersionId,
+        target_table_name: &str,
+    ) -> Result<(String, Vec<String>), Error> {
+        let target_mapping = self
+            .catalogue
+            .physical_mappings
+            .get(&target_schema)
+            .and_then(|mapping| mapping.tables.get(target_table_name))
+            .cloned()
+            .ok_or(Error::InvalidStoredValue(
+                "target current winner physical mapping missing",
+            ))?;
+        let projection_target = physical_current_winner_projection_target(target_mapping.table_id);
+        let storage_tables = [
+            physical_global_current_table_name(target_mapping.table_id),
+            physical_ahead_current_table_name(target_mapping.table_id),
+        ];
+        let mut output_fields = None;
+        for storage_table in &storage_tables {
+            let output = self.database.table_schema(storage_table)?.record_schema();
+            let fields = output
+                .fields()
+                .iter()
+                .map(|field| {
+                    field.name.clone().ok_or(Error::InvalidStoredValue(
+                        "physical current winner field unnamed",
+                    ))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if let Some(existing) = &output_fields {
+                if existing != &fields {
+                    return Err(Error::InvalidStoredValue(
+                        "physical current winner descriptors disagree",
+                    ));
+                }
+            } else {
+                output_fields = Some(fields);
+            }
+            self.database
+                .define_variant_projection(storage_table, &projection_target, output)?;
+        }
+
+        let sources = self
+            .catalogue
+            .physical_mappings
+            .iter()
+            .flat_map(|(schema_version, mapping)| {
+                mapping
+                    .tables
+                    .iter()
+                    .filter(|(_, table)| table.table_id == target_mapping.table_id)
+                    .map(|(logical_table, table)| {
+                        (*schema_version, logical_table.clone(), table.clone())
+                    })
+            })
+            .collect::<Vec<_>>();
+        for (source_schema, source_table_name, source_mapping) in sources {
+            let source_alias = self
+                .catalogue
+                .schema_version_aliases
+                .get(&source_schema)
+                .copied()
+                .ok_or(Error::InvalidStoredValue(
+                    "physical current winner source schema alias missing",
+                ))?;
+            let source_table = self.table_in_schema(&source_table_name, source_schema)?;
+            let cases = if source_mapping.variant_cases.is_empty() {
+                vec![(groove_variant_tag(source_alias)?, None)]
+            } else {
+                source_mapping
+                    .variant_cases
+                    .iter()
+                    .map(|case| (case.tag, Some(&case.fields)))
+                    .collect()
+            };
+            for (tag, present) in cases {
+                let available =
+                    physical_current_field_names_for_case(&source_table, &source_mapping, present)?
+                        .into_iter()
+                        .collect::<BTreeSet<_>>();
+                for storage_table in &storage_tables {
+                    let output = self.database.table_schema(storage_table)?.record_schema();
+                    let fields = output
+                        .fields()
+                        .iter()
+                        .map(|field| {
+                            let name = field.name.clone().ok_or(Error::InvalidStoredValue(
+                                "physical current winner field unnamed",
+                            ))?;
+                            if available.contains(&name) {
+                                Ok(ProjectField::named(name))
+                            } else if matches!(field.value_type, records::ValueType::Nullable(_)) {
+                                Ok(ProjectField::literal_typed(
+                                    name,
+                                    Value::Nullable(None),
+                                    field.value_type.clone(),
+                                ))
+                            } else {
+                                Err(Error::InvalidStoredValue(
+                                    "physical current winner source misses required field",
+                                ))
+                            }
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    self.database.register_variant_case(
+                        storage_table,
+                        &projection_target,
+                        tag,
+                        fields,
+                    )?;
+                }
+            }
+        }
+        Ok((projection_target, output_fields.unwrap_or_default()))
+    }
+
+    /// Build the logical query-local projection placed after physical current
+    /// winner selection. Its enum remaps are intentionally non-total row
+    /// omissions, never generic query errors.
+    pub(super) fn physical_current_post_winner_projection_fields(
+        &mut self,
+        target_schema: SchemaVersionId,
+        target_table_name: &str,
+        required_fields: &BTreeSet<String>,
+    ) -> Result<Vec<ProjectField>, Error> {
+        let target_mapping = self
+            .catalogue
+            .physical_mappings
+            .get(&target_schema)
+            .and_then(|mapping| mapping.tables.get(target_table_name))
+            .cloned()
+            .ok_or(Error::InvalidStoredValue(
+                "target post-winner physical mapping missing",
+            ))?;
+        let target_table = self.table_in_schema(target_table_name, target_schema)?;
+        let required_enum_columns = target_table
+            .columns
+            .iter()
+            .filter(|column| required_fields.contains(&column.name))
+            .filter_map(|column| target_mapping.columns.get(&column.name).copied())
+            .collect::<BTreeSet<_>>();
+        self.physical_current_projection_case_for_enum_columns(
+            target_schema,
+            target_table_name,
+            &target_mapping,
+            target_schema,
+            target_table_name,
+            None,
+            Some(&required_enum_columns),
+        )?
+        .ok_or(Error::InvalidStoredValue(
+            "post-winner current projection unexpectedly lacks fields",
+        ))
+    }
+
     pub(super) fn synchronize_physical_version_tables(&mut self) -> Result<(), Error> {
         for desired in physical_version_storage_tables(
             &self.catalogue.catalogue_schemas,
@@ -1833,19 +2000,21 @@ where
                                 _ => unreachable!("direct enum checked above"),
                             }
                         };
-                        fields.push(ProjectField::recursive_enum_remap(
-                            source,
-                            output,
-                            projection_output
-                                .field_index(&user_column_field(&column.name))
-                                .and_then(|index| projection_output.fields().get(index))
-                                .ok_or(Error::InvalidStoredValue(
-                                    "target enum projection output field missing",
-                                ))?
-                                .value_type
-                                .clone(),
-                            remaps,
-                        ));
+                        let target = projection_output
+                            .field_index(&user_column_field(&column.name))
+                            .and_then(|index| projection_output.fields().get(index))
+                            .ok_or(Error::InvalidStoredValue(
+                                "target enum projection output field missing",
+                            ))?
+                            .value_type
+                            .clone();
+                        fields.push(if required_enum_columns.is_some() {
+                            ProjectField::recursive_enum_remap_omitting_unrepresentable(
+                                source, output, target, remaps,
+                            )
+                        } else {
+                            ProjectField::recursive_enum_remap(source, output, target, remaps)
+                        });
                     } else {
                         fields.push(ProjectField::renamed(source, output));
                     }

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -1432,12 +1432,11 @@ where
         ];
         for storage_table in &storage_tables {
             let logical_output = target_table.global_current_storage_tables()[0].record_schema();
-            let physical_names = physical_current_field_names(&target_table, &target_mapping)?;
-            let output = widened_projection_descriptor(
-                &logical_output,
-                &physical_names,
-                self.database.table_schema(storage_table)?,
-            )?;
+            // This query-local target is the semantic read boundary. Unlike
+            // the durable all-fields storage target, it must expose the
+            // authored descriptor itself: enum tags are translated into that
+            // descriptor, and an absent target case excludes only this row.
+            let output = logical_output;
             self.database
                 .define_variant_projection(storage_table, &projection_target, output)?;
         }
@@ -1485,12 +1484,13 @@ where
                 )?;
                 for storage_table in &storage_tables {
                     if let Some(fields) = fields.clone() {
-                        self.database.register_variant_case(
-                            storage_table,
-                            &projection_target,
-                            tag,
-                            fields,
-                        )?;
+                        self.database
+                            .register_variant_projection_case_omitting_unrepresentable_enums(
+                                storage_table,
+                                &projection_target,
+                                tag,
+                                fields,
+                            )?;
                     } else {
                         self.database.register_variant_ignore_case(
                             storage_table,
@@ -1728,11 +1728,18 @@ where
                 physical_global_current_table_name(target_mapping.table_id)
             }
         };
-        let projection_output = widened_projection_descriptor(
-            &target_storage.record_schema(),
-            &physical_names,
-            self.database.table_schema(&physical_storage)?,
-        )?;
+        let projection_output = if required_enum_columns.is_some() {
+            // Query-local enum targets are authored-descriptor boundaries;
+            // their recursive remap must validate/encode against the old
+            // schema rather than the physical registry descriptor.
+            target_storage.record_schema()
+        } else {
+            widened_projection_descriptor(
+                &target_storage.record_schema(),
+                &physical_names,
+                self.database.table_schema(&physical_storage)?,
+            )?
+        };
         let mut fields = target_storage
             .record_schema()
             .fields()
@@ -2777,8 +2784,33 @@ pub(super) fn physical_version_storage_tables(
 
         let mut nested_scalar_enum_registries =
             BTreeMap::<(PhysicalColumnId, String), BTreeSet<GlobalScalarEnumCaseId>>::new();
-        for (_, _, mapping) in &variants {
-            for (column_id, paths) in &mapping.nested_scalar_enum_cases {
+        for (schema_version, logical_table, mapping) in &variants {
+            // Bootstrap constructs physical tables before the freshly
+            // introduced mapping is hydrated into the catalogue. Seed nested
+            // occurrences from the authored descriptor in that one state;
+            // otherwise the first table gets a generic registry id and the
+            // next synchronization sees an incompatible field definition.
+            let mut bootstrap_paths = mapping.nested_scalar_enum_cases.clone();
+            if bootstrap_paths.is_empty() {
+                for column in &logical_table.columns {
+                    if matches!(column.column_type, records::ValueType::EnumTag(_)) {
+                        continue;
+                    }
+                    hydrate_nested_scalar_enum_cases(
+                        &column.column_type,
+                        *schema_version,
+                        "root",
+                        bootstrap_paths
+                            .entry(mapping.columns.get(&column.name).copied().ok_or(
+                                Error::InvalidStoredValue(
+                                    "physical nested scalar enum column mapping missing",
+                                ),
+                            )?)
+                            .or_default(),
+                    )?;
+                }
+            }
+            for (column_id, paths) in &bootstrap_paths {
                 for (path, cases) in paths {
                     nested_scalar_enum_registries
                         .entry((*column_id, path.clone()))
@@ -2808,7 +2840,7 @@ pub(super) fn physical_version_storage_tables(
             (PhysicalColumnId, String, GlobalScalarEnumCaseId),
             records::RecordDescriptor,
         >::new();
-        for (_, logical_table, mapping) in &variants {
+        for (schema_version, logical_table, mapping) in &variants {
             for column in &logical_table.columns {
                 let column_id =
                     mapping
@@ -2818,7 +2850,20 @@ pub(super) fn physical_version_storage_tables(
                         .ok_or(Error::InvalidStoredValue(
                             "physical nested payload enum column mapping missing",
                         ))?;
-                let Some(paths) = mapping.nested_payload_enum_cases.get(&column_id) else {
+                // As for nested scalar cases above, the first physical-table
+                // construction precedes catalogue hydration. Seed payload
+                // identities from the authored descriptor so reopening does
+                // not try to replace a generic nested registry.
+                let mut bootstrap_paths = mapping.nested_payload_enum_cases.clone();
+                if bootstrap_paths.is_empty() {
+                    hydrate_nested_payload_enum_cases(
+                        &column.column_type,
+                        *schema_version,
+                        "root",
+                        bootstrap_paths.entry(column_id).or_default(),
+                    )?;
+                }
+                let Some(paths) = bootstrap_paths.get(&column_id) else {
                     continue;
                 };
                 for (path, cases) in paths {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1340,19 +1340,15 @@ where
             return Ok(target.clone());
         }
         let required_fields = match &request.requirements.app_fields {
-            FieldRequirement::All => {
-                return Ok(physical_current_projection_target(
-                    self.node
-                        .catalogue
-                        .schema_version_aliases
-                        .get(&self.read_view.read_schema)
-                        .copied()
-                        .ok_or_else(|| {
-                            source_resolution_error(request, SourceGap::SchemaProjection)
-                        })?,
-                    &table.name,
-                ));
-            }
+            // `All` still goes through the query-local boundary. The durable
+            // all-fields projection predates compatibility-sensitive reads and
+            // reports a non-total enum remap as an execution error; a read
+            // must instead omit precisely that row before its query graph.
+            FieldRequirement::All => table
+                .columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect(),
             FieldRequirement::None => BTreeSet::new(),
             FieldRequirement::Fields(fields) => fields.clone(),
         };

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1339,19 +1339,7 @@ where
         if let Some(target) = self.current_projection_targets.get(&request.source) {
             return Ok(target.clone());
         }
-        let required_fields = match &request.requirements.app_fields {
-            // `All` still goes through the query-local boundary. The durable
-            // all-fields projection predates compatibility-sensitive reads and
-            // reports a non-total enum remap as an execution error; a read
-            // must instead omit precisely that row before its query graph.
-            FieldRequirement::All => table
-                .columns
-                .iter()
-                .map(|column| column.name.clone())
-                .collect(),
-            FieldRequirement::None => BTreeSet::new(),
-            FieldRequirement::Fields(fields) => fields.clone(),
-        };
+        let required_fields = self.current_projection_required_fields(request, table);
         let target = self
             .node
             .ensure_physical_current_projection_for_enum_columns(
@@ -1363,6 +1351,26 @@ where
         self.current_projection_targets
             .insert(request.source.clone(), target.clone());
         Ok(target)
+    }
+
+    fn current_projection_required_fields(
+        &self,
+        request: &SourceRequest,
+        table: &TableSchema,
+    ) -> BTreeSet<String> {
+        match &request.requirements.app_fields {
+            // `All` still goes through the query-local boundary. The durable
+            // all-fields projection predates compatibility-sensitive reads and
+            // reports a non-total enum remap as an execution error; a read
+            // must instead omit precisely that row before its query graph.
+            FieldRequirement::All => table
+                .columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect(),
+            FieldRequirement::None => BTreeSet::new(),
+            FieldRequirement::Fields(fields) => fields.clone(),
+        }
     }
 
     fn selected_global_current_source_graph(
@@ -1551,7 +1559,22 @@ where
         exclude_deleted: bool,
     ) -> Result<GraphBuilder, SourceResolutionError> {
         let fields = global_current_storage_fields(read_table, true, include_global_seq);
-        let projection_target = self.current_projection_target(request, read_table)?;
+        let required_fields = self.current_projection_required_fields(request, read_table);
+        let (projection_target, physical_fields) = self
+            .node
+            .ensure_physical_current_winner_projection(
+                self.read_view.read_schema,
+                &request.source.table,
+            )
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        let post_winner_fields = self
+            .node
+            .physical_current_post_winner_projection_fields(
+                self.read_view.read_schema,
+                &request.source.table,
+                &required_fields,
+            )
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
         let access_path = self.access_paths.get(&request.source).cloned();
         let global = match &access_path {
             Some(CurrentAccessPath::PrimaryKey(prefix)) => {
@@ -1566,17 +1589,19 @@ where
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?
             }
-            Some(CurrentAccessPath::Index { column, prefix }) if tier == DurabilityTier::Global => {
-                self.node.query_engine_read_metrics.source_index_probes += 1;
+            Some(CurrentAccessPath::Index { .. }) if tier == DurabilityTier::Global => {
+                // The physical index's eager variant projection would decode
+                // before current-winner selection. Keep this path as a normal
+                // physical scan until index probing can return raw winners.
+                self.node.query_engine_read_metrics.source_full_scans += 1;
                 self.node
-                    .physical_global_current_source_for_index_scan(
-                        read_table,
+                    .physical_current_source_graph_with_projection_target(
                         self.read_view.read_schema,
-                        column,
-                        prefix,
-                        &projection_target,
+                        &request.source.table,
+                        PhysicalCurrentClass::Global,
+                        projection_target.clone(),
                     )
-                    .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
+                    .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?
             }
             _ => {
                 self.node.query_engine_read_metrics.source_full_scans += 1;
@@ -1593,7 +1618,7 @@ where
         let content = if tier == DurabilityTier::Global {
             global
         } else {
-            let global = global.project(fields.clone());
+            let global = global.project(physical_fields.clone());
             let ahead = match &access_path {
                 Some(CurrentAccessPath::PrimaryKey(prefix)) => self
                     .node
@@ -1615,17 +1640,18 @@ where
             }
             .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
             let ahead = if tier == DurabilityTier::Edge {
-                edge_visible_ahead_current_source_graph(ahead, fields.clone())
+                edge_visible_ahead_current_source_graph(ahead, physical_fields.clone())
             } else {
-                ahead.project(fields.clone())
+                ahead.project(physical_fields.clone())
             };
             GraphBuilder::arg_max_by(
                 GraphBuilder::union([global, ahead]),
                 ["row_uuid"],
                 ["tx_time", "tx_node_id"],
             )
-            .project(fields.clone())
+            .project(physical_fields)
         };
+        let content = content.project_fields(post_winner_fields);
         if !exclude_deleted {
             return Ok(content.project(fields));
         }

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1575,6 +1575,17 @@ where
                 &required_fields,
             )
             .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        let raw_global_output = self
+            .node
+            .physical_table_id_for_schema(self.read_view.read_schema, &request.source.table)
+            .and_then(|table_id| {
+                self.node
+                    .database
+                    .table_schema(&physical_global_current_table_name(table_id))
+                    .map(|schema| schema.record_schema())
+                    .map_err(Error::Groove)
+            })
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
         let access_path = self.access_paths.get(&request.source).cloned();
         let global = match &access_path {
             Some(CurrentAccessPath::PrimaryKey(prefix)) => {
@@ -1589,19 +1600,21 @@ where
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?
             }
-            Some(CurrentAccessPath::Index { .. }) if tier == DurabilityTier::Global => {
-                // The physical index's eager variant projection would decode
-                // before current-winner selection. Keep this path as a normal
-                // physical scan until index probing can return raw winners.
-                self.node.query_engine_read_metrics.source_full_scans += 1;
+            Some(CurrentAccessPath::Index { column, prefix }) if tier == DurabilityTier::Global => {
+                // A Global index already selects from the canonical settled
+                // winner relation. Project those raw physical rows first, then
+                // apply the compatibility boundary below.
+                self.node.query_engine_read_metrics.source_index_probes += 1;
                 self.node
-                    .physical_current_source_graph_with_projection_target(
+                    .physical_global_current_source_for_index_scan_with_output(
+                        read_table,
                         self.read_view.read_schema,
-                        &request.source.table,
-                        PhysicalCurrentClass::Global,
-                        projection_target.clone(),
+                        column,
+                        prefix,
+                        &projection_target,
+                        raw_global_output.clone(),
                     )
-                    .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?
+                    .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
             }
             _ => {
                 self.node.query_engine_read_metrics.source_full_scans += 1;
@@ -5893,6 +5906,25 @@ where
         prefix: &[Value],
         projection_target: &str,
     ) -> Result<GraphBuilder, Error> {
+        self.physical_global_current_source_for_index_scan_with_output(
+            table,
+            schema_version,
+            column,
+            prefix,
+            projection_target,
+            table.global_current_storage_tables()[0].record_schema(),
+        )
+    }
+
+    fn physical_global_current_source_for_index_scan_with_output(
+        &self,
+        table: &TableSchema,
+        schema_version: SchemaVersionId,
+        column: &str,
+        prefix: &[Value],
+        projection_target: &str,
+        output: RecordDescriptor,
+    ) -> Result<GraphBuilder, Error> {
         let mapping = self
             .catalogue
             .physical_mappings
@@ -5925,10 +5957,7 @@ where
                 records.push(projected.raw().to_vec());
             }
         }
-        Ok(GraphBuilder::inline_records(
-            table.global_current_storage_tables()[0].record_schema(),
-            records,
-        ))
+        Ok(GraphBuilder::inline_records(output, records))
     }
 
     fn compile_historical_query_program(

--- a/crates/jazz/src/node/source_resolution.rs
+++ b/crates/jazz/src/node/source_resolution.rs
@@ -82,7 +82,11 @@ where
                 continue;
             };
             if projected_table == table {
-                rows.push(current_row_from_cells(&read_table, row_uuid, &cells)?);
+                match current_row_from_cells(&read_table, row_uuid, &cells) {
+                    Ok(row) => rows.push(row),
+                    Err(error) if is_unrepresentable_enum_projection(&error) => {}
+                    Err(error) => return Err(error),
+                }
             }
         }
         sort_current_rows(&mut rows);
@@ -153,7 +157,11 @@ where
                 continue;
             };
             if projected_table == table {
-                rows.push(current_row_from_cells(&read_table, row_uuid, &cells)?);
+                match current_row_from_cells(&read_table, row_uuid, &cells) {
+                    Ok(row) => rows.push(row),
+                    Err(error) if is_unrepresentable_enum_projection(&error) => {}
+                    Err(error) => return Err(error),
+                }
             }
         }
         sort_current_rows(&mut rows);
@@ -239,16 +247,17 @@ where
                         )
                     })
                     .unwrap_or(&version);
-                rows.push((
-                    current_row_from_materialized_cells_with_layer_provenance(
-                        &read_table,
-                        &version,
-                        &version,
-                        updated,
-                        &cells,
-                    )?,
-                    deleted,
-                ));
+                match current_row_from_materialized_cells_with_layer_provenance(
+                    &read_table,
+                    &version,
+                    &version,
+                    updated,
+                    &cells,
+                ) {
+                    Ok(row) => rows.push((row, deleted)),
+                    Err(error) if is_unrepresentable_enum_projection(&error) => {}
+                    Err(error) => return Err(error),
+                }
             }
         }
         rows.sort_by(|(left, _), (right, _)| {

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -2003,6 +2003,7 @@ fn publishing_schema_registers_new_tables_without_storage_reopen() {
         panic!("current-row subscription should produce a view update");
     };
     assert_eq!(result_member_adds.len(), 1);
+
     assert_eq!(version_bundles.len(), 1);
 }
 
@@ -3109,6 +3110,49 @@ fn payload_enum_projection_schema(cases: &[&str]) -> JazzSchema {
     )])
 }
 
+fn nested_scalar_enum_projection_schema(statuses: &[&str]) -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new(
+                "statuses",
+                ColumnType::Array(Box::new(ColumnType::EnumTag(
+                    groove::records::ScalarEnumSchema::new("status", statuses.iter().copied())
+                        .unwrap(),
+                ))),
+            ),
+        ],
+    )])
+}
+
+fn nested_payload_enum_projection_schema(cases: &[&str]) -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new(
+                "statuses",
+                ColumnType::Array(Box::new(ColumnType::Enum(Box::new(
+                    groove::records::EnumSchema::new(
+                        "status",
+                        cases.iter().map(|case| {
+                            groove::records::EnumCase::new(
+                                *case,
+                                groove::records::RecordDescriptor::new([(
+                                    "note",
+                                    groove::records::ValueType::String,
+                                )]),
+                            )
+                        }),
+                    )
+                    .unwrap(),
+                )))),
+            ),
+        ],
+    )])
+}
+
 /// This is an internal physical-activation regression: public clients cannot
 /// directly observe Groove's live descriptors, but a payload-enum append must
 /// activate and survive recovery before a newer client can write its new case.
@@ -3197,17 +3241,191 @@ fn payload_enum_unknown_case_is_ignored_only_when_unselected() {
     publish_schema_lineage(&mut core, evolved.clone(), MigrationLens::new(base.version_id(), evolved.id, vec![TableLens { source_table: "items".into(), target_table: "items".into(), ops: vec![LensOp::TransformColumn { column: "status".into(), transform: "jazz.identity".into() }] }]), Vec::<String>::new(), Vec::<String>::new()).unwrap();
     core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema { author: AuthorId::SYSTEM, pointer: CurrentWriteSchema { revision: 1, schema: evolved.id } }).unwrap();
     let payload = groove::records::RecordDescriptor::new([("x", groove::records::ValueType::String)]);
-    core.commit_mergeable(MergeableCommit::new("items", row(0x76), 1).cells(BTreeMap::from([
+    let unknown = row(0x76);
+    core.commit_mergeable(MergeableCommit::new("items", unknown, 1).cells(BTreeMap::from([
         ("title".into(), v("ok")), ("status".into(), Value::Enum(groove::records::EnumValue::create(1, payload, &[v("closed")]).unwrap()))
+    ]))).unwrap();
+    let known = row(0x77);
+    let known_payload = groove::records::RecordDescriptor::new([("x", groove::records::ValueType::String)]);
+    core.commit_mergeable(MergeableCommit::new("items", known, 2).cells(BTreeMap::from([
+        ("title".into(), v("known")), ("status".into(), Value::Enum(groove::records::EnumValue::create(0, known_payload, &[v("open")]).unwrap()))
     ]))).unwrap();
     let title = Query::from("items").select(["title"]).validate(&base).unwrap();
     assert!(core.query_rows(&title, &title.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local).is_ok());
     let all = Query::from("items").validate(&base).unwrap();
-    assert!(core.query_rows(&all, &all.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local).is_err());
+    assert_eq!(
+        core.query_rows(&all, &all.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([known]),
+    );
+}
+
+/// Old-schema reads omit only rows whose nested enum occurrence has an
+/// unrepresentable case; Alice's compatible row remains visible beside Bob's
+/// later case.
+///
+/// ```text
+/// alice ──writes open──► old reader ──► visible
+/// bob   ──writes closed► old reader ──► omitted
+/// ```
+#[test]
+fn nested_scalar_enum_unknown_case_omits_only_that_row() {
+    let base = nested_scalar_enum_projection_schema(&["open"]);
+    let evolved = SchemaVersion::new(nested_scalar_enum_projection_schema(&["open", "closed"]));
+    let (_dir, mut core) = open_node_with_schema(node(0x78), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![LensOp::TransformColumn {
+                    column: "statuses".to_owned(),
+                    transform: "jazz.identity".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved.id,
+        },
+    })
+    .unwrap();
+    let unknown = row(0x78);
+    let known = row(0x79);
+    for (row_uuid, title, status, tx_time) in [
+        (unknown, "new nested case", 1, 1),
+        (known, "known nested case", 0, 2),
+    ] {
+        core.commit_mergeable(
+            MergeableCommit::new("items", row_uuid, tx_time).cells(BTreeMap::from([
+                ("title".to_owned(), v(title)),
+                (
+                    "statuses".to_owned(),
+                    Value::Array(vec![Value::EnumTag(status)]),
+                ),
+            ])),
+        )
+        .unwrap();
+    }
+
+    let title_only = Query::from("items").select(["title"]).validate(&base).unwrap();
+    assert_eq!(
+        core.query_rows(
+            &title_only,
+            &title_only.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .unwrap()
+        .len(),
+        2,
+    );
+    let all = Query::from("items").validate(&base).unwrap();
+    assert_eq!(
+        core.query_rows(&all, &all.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([known]),
+    );
+}
+
+/// A nested payload enum follows the same source-local compatibility rule as
+/// a scalar enum: Bob's later case is omitted while Alice's older case stays
+/// visible to an old-schema whole-row read.
+#[test]
+fn nested_payload_enum_unknown_case_omits_only_that_row() {
+    let base = nested_payload_enum_projection_schema(&["open"]);
+    let evolved = SchemaVersion::new(nested_payload_enum_projection_schema(&["open", "closed"]));
+    let (_dir, mut core) = open_node_with_schema(node(0x7a), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![LensOp::TransformColumn {
+                    column: "statuses".to_owned(),
+                    transform: "jazz.identity".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved.id,
+        },
+    })
+    .unwrap();
+    let payload = groove::records::RecordDescriptor::new([(
+        "note",
+        groove::records::ValueType::String,
+    )]);
+    let unknown = row(0x7a);
+    let known = row(0x7b);
+    for (row_uuid, title, status, note, tx_time) in [
+        (unknown, "new nested case", 1, "closed", 1),
+        (known, "known nested case", 0, "open", 2),
+    ] {
+        core.commit_mergeable(
+            MergeableCommit::new("items", row_uuid, tx_time).cells(BTreeMap::from([
+                ("title".to_owned(), v(title)),
+                (
+                    "statuses".to_owned(),
+                    Value::Array(vec![Value::Enum(
+                        groove::records::EnumValue::create(status, payload, &[v(note)]).unwrap(),
+                    )]),
+                ),
+            ])),
+        )
+        .unwrap();
+    }
+
+    let title_only = Query::from("items").select(["title"]).validate(&base).unwrap();
+    assert_eq!(
+        core.query_rows(
+            &title_only,
+            &title_only.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .unwrap()
+        .len(),
+        2,
+    );
+    let all = Query::from("items").validate(&base).unwrap();
+    assert_eq!(
+        core.query_rows(&all, &all.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([known]),
+    );
 }
 
 #[test]
-fn maintained_old_enum_subscriptions_only_fail_when_their_requirement_uses_new_cases() {
+fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     // This is an internal subscription-boundary regression. PeerState is the
     // server-side maintained subscription driver; public clients receive its
     // ViewUpdates, but cannot themselves install a catalogue lineage.
@@ -3299,18 +3517,70 @@ fn maintained_old_enum_subscriptions_only_fail_when_their_requirement_uses_new_c
     }));
 
     // A separate old-schema subscription that semantically consumes status
-    // must reject the same physical row. In particular, it may not reinterpret
-    // the new tag as `open` or suppress the row as an ordinary filter miss.
+    // must omit the same physical row. In particular, it may not reinterpret
+    // the new tag as `open`, and must never error just because a newer client
+    // introduced an additive case.
     let status_required = Query::from("items").validate(&base).unwrap();
     let status_binding = status_required.bind(BTreeMap::new()).unwrap();
+    let whole_rows = core.query_rows(&status_required, &status_binding, DurabilityTier::Local)
+        .expect("one-shot whole-row read omits only the unknown row");
+    assert_eq!(
+        whole_rows.into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([known]),
+    );
     let mut status_peer = PeerState::new();
-    assert!(status_peer
+    let update = status_peer
         .rehydrate_query(&mut core, &status_required, &status_binding)
-        .is_err(), "required unknown enum case must fail explicitly");
+        .expect("required unknown enum case is a row exclusion");
+    let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
+        panic!("expected initial maintained view update");
+    };
+    assert_eq!(result_member_adds.len(), 1);
+    assert!(result_member_adds.iter().all(|member| {
+        member.as_row().is_some_and(|(_, row_uuid, _)| row_uuid == known)
+    }));
+
+    // Maintained membership follows the same compatibility boundary on every
+    // delta: moving a visible old row into an unknown case removes it, and
+    // moving it back to a known case re-adds it without a subscription error.
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", known, 3).cells(BTreeMap::from([
+            ("title".to_owned(), v("now incompatible")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    );
+    let update = status_peer
+        .query_update(&mut core, &status_required, &status_binding)
+        .expect("newly incompatible delta removes the row");
+    let SyncMessage::ViewUpdate { result_member_removes, .. } = update else {
+        panic!("expected maintained view update");
+    };
+    assert!(result_member_removes.iter().any(|member| {
+        member.as_row().is_some_and(|(_, row_uuid, _)| row_uuid == known)
+    }));
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", known, 4).cells(BTreeMap::from([
+            ("title".to_owned(), v("compatible again")),
+            ("status".to_owned(), Value::EnumTag(0)),
+        ])),
+    );
+    let update = status_peer
+        .query_update(&mut core, &status_required, &status_binding)
+        .expect("newly compatible delta re-adds the row");
+    let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
+        panic!("expected maintained view update");
+    };
+    assert!(result_member_adds.iter().any(|member| {
+        member.as_row().is_some_and(|(_, row_uuid, _)| row_uuid == known)
+    }));
 }
 
 #[test]
-fn maintained_old_payload_enum_subscription_rejects_new_case_without_aliasing() {
+fn maintained_old_payload_enum_subscription_omits_new_case_without_aliasing() {
     let base = payload_enum_projection_schema(&["draft"]);
     let evolved = SchemaVersion::new(payload_enum_projection_schema(&["draft", "published"]));
     let (_dir, mut core) = open_node_with_schema(node(0x7d), base.clone());
@@ -3363,7 +3633,13 @@ fn maintained_old_payload_enum_subscription_rejects_new_case_without_aliasing() 
     let required = Query::from("items").validate(&base).unwrap();
     let binding = required.bind(BTreeMap::new()).unwrap();
     let mut required_peer = PeerState::new();
-    assert!(required_peer.rehydrate_query(&mut core, &required, &binding).is_err());
+    let update = required_peer
+        .rehydrate_query(&mut core, &required, &binding)
+        .expect("unknown payload case is a row exclusion");
+    let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
+        panic!("expected initial maintained view update");
+    };
+    assert!(result_member_adds.is_empty());
 }
 
 #[test]
@@ -3420,6 +3696,14 @@ fn old_enum_schema_only_decodes_cases_required_by_the_query() {
         ])),
     )
     .unwrap();
+    let open = row(0x76);
+    core.commit_mergeable(
+        MergeableCommit::new("items", open, 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("still-compatible")),
+            ("status".to_owned(), Value::EnumTag(0)),
+        ])),
+    )
+    .unwrap();
 
     let title_only = Query::from("items").select(["title"]).validate(&base).unwrap();
     assert_eq!(
@@ -3432,23 +3716,31 @@ fn old_enum_schema_only_decodes_cases_required_by_the_query() {
         .into_iter()
         .map(current_row_pair)
         .collect::<BTreeMap<_, _>>(),
-        BTreeMap::from([(closed, BTreeMap::from([("title".to_owned(), v("still-readable"))]))])
+        BTreeMap::from([
+            (closed, BTreeMap::from([("title".to_owned(), v("still-readable"))])),
+            (open, BTreeMap::from([("title".to_owned(), v("still-compatible"))])),
+        ])
     );
 
-    // Whole-row output semantically consumes `status`, so the non-total
-    // projection must report the incompatible case rather than silently
-    // inventing an old value or suppressing the row.
+    // Whole-row output semantically consumes `status`, so its source boundary
+    // omits this incompatible row rather than inventing an old value or
+    // turning an additive schema change into an old-client query failure.
     let whole_row = Query::from("items").validate(&base).unwrap();
-    assert!(core
+    assert_eq!(core
         .query_rows(
             &whole_row,
             &whole_row.bind(BTreeMap::new()).unwrap(),
             DurabilityTier::Local,
         )
-        .is_err());
+        .unwrap()
+        .into_iter()
+        .map(|row| row.row_uuid())
+        .collect::<BTreeSet<_>>(),
+        BTreeSet::from([open]));
 
     // The closure is semantic rather than merely output-shaped: a hidden
-    // predicate or order key must force the same explicit incompatibility.
+    // predicate or order key must force the same source-local exclusion before
+    // those operators, including their pagination/aggregation consumers.
     for query in [
         Query::from("items")
             .select(["title"])
@@ -3461,25 +3753,32 @@ fn old_enum_schema_only_decodes_cases_required_by_the_query() {
             .validate(&base)
             .unwrap(),
     ] {
-        assert!(core
+        assert_eq!(core
             .query_rows(
                 &query,
                 &query.bind(BTreeMap::new()).unwrap(),
                 DurabilityTier::Local,
             )
-            .is_err());
+            .unwrap()
+            .len(),
+            1,
+            "known row survives a semantic enum boundary",
+        );
     }
     let grouped = Query::from("items").count().group_by("status").validate(&base).unwrap();
-    assert!(core
+    assert_eq!(core
         .query_rows(&grouped, &grouped.bind(BTreeMap::new()).unwrap(), DurabilityTier::Local)
-        .is_err());
+        .unwrap()
+        .len(),
+        1,
+    );
 }
 
 #[test]
 fn enum_projection_requirement_closure_includes_hidden_policy_fields() {
     // A policy field is not part of the public output, but it still decides
-    // whether the row exists.  It must therefore force a non-total enum
-    // projection instead of being treated like an unused cell.
+    // whether the row exists. It therefore excludes an incompatible row
+    // fail-closed rather than being treated like an unused cell.
     let base = JazzSchema::new([TableSchema::new(
         "items",
         [
@@ -3553,7 +3852,7 @@ fn enum_projection_requirement_closure_includes_hidden_policy_fields() {
         DurabilityTier::Local,
         user(0x77),
     );
-    assert!(result.is_err(), "policy result: {result:#?}");
+    assert!(result.unwrap().is_empty(), "policy must hide incompatible row");
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -3522,6 +3522,15 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     // introduced an additive case.
     let status_required = Query::from("items").validate(&base).unwrap();
     let status_binding = status_required.bind(BTreeMap::new()).unwrap();
+    let status_options = crate::protocol::RegisterShapeOptions {
+        tier: DurabilityTier::Local,
+        read_view: Default::default(),
+    };
+    let status_subscription = SubscriptionKey {
+        shape_id: status_required.shape_id(),
+        binding_id: status_binding.binding_id(),
+        read_view: status_options.read_view_key(),
+    };
     let whole_rows = core.query_rows(&status_required, &status_binding, DurabilityTier::Local)
         .expect("one-shot whole-row read omits only the unknown row");
     assert_eq!(
@@ -3532,7 +3541,12 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     );
     let mut status_peer = PeerState::new();
     let update = status_peer
-        .rehydrate_query(&mut core, &status_required, &status_binding)
+        .rehydrate_query_with_opts(
+            &mut core,
+            &status_required,
+            &status_binding,
+            status_options.clone(),
+        )
         .expect("required unknown enum case is a row exclusion");
     let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
         panic!("expected initial maintained view update");
@@ -3543,17 +3557,23 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     }));
 
     // Maintained membership follows the same compatibility boundary on every
-    // delta: moving a visible old row into an unknown case removes it, and
-    // moving it back to a known case re-adds it without a subscription error.
-    accept_global(
-        &mut core,
+    // delta: a newer local/Ahead unknown winner retracts the older Global row,
+    // then a newer known winner re-adds it without a subscription error.
+    core.commit_mergeable(
         MergeableCommit::new("items", known, 3).cells(BTreeMap::from([
             ("title".to_owned(), v("now incompatible")),
             ("status".to_owned(), Value::EnumTag(1)),
         ])),
-    );
+    )
+    .unwrap();
     let update = status_peer
-        .query_update(&mut core, &status_required, &status_binding)
+        .query_update_for_subscription_with_opts(
+            &mut core,
+            status_subscription,
+            &status_required,
+            &status_binding,
+            status_options.clone(),
+        )
         .expect("newly incompatible delta removes the row");
     let SyncMessage::ViewUpdate { result_member_removes, .. } = update else {
         panic!("expected maintained view update");
@@ -3561,15 +3581,21 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     assert!(result_member_removes.iter().any(|member| {
         member.as_row().is_some_and(|(_, row_uuid, _)| row_uuid == known)
     }));
-    accept_global(
-        &mut core,
+    core.commit_mergeable(
         MergeableCommit::new("items", known, 4).cells(BTreeMap::from([
             ("title".to_owned(), v("compatible again")),
             ("status".to_owned(), Value::EnumTag(0)),
         ])),
-    );
+    )
+    .unwrap();
     let update = status_peer
-        .query_update(&mut core, &status_required, &status_binding)
+        .query_update_for_subscription_with_opts(
+            &mut core,
+            status_subscription,
+            &status_required,
+            &status_binding,
+            status_options,
+        )
         .expect("newly compatible delta re-adds the row");
     let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
         panic!("expected maintained view update");
@@ -3836,9 +3862,17 @@ fn enum_projection_requirement_closure_includes_hidden_policy_fields() {
         pointer: CurrentWriteSchema { revision: 1, schema: evolved.id },
     })
     .unwrap();
+    let item = row(0x77);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", item, 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("globally allowed")),
+            ("status".to_owned(), Value::EnumTag(0)),
+        ])),
+    );
     core.commit_mergeable(
-        MergeableCommit::new("items", row(0x77), 1).cells(BTreeMap::from([
-            ("title".to_owned(), v("hidden-policy-dependency")),
+        MergeableCommit::new("items", item, 2).cells(BTreeMap::from([
+            ("title".to_owned(), v("new local case")),
             ("status".to_owned(), Value::EnumTag(1)),
         ])),
     )
@@ -3853,6 +3887,151 @@ fn enum_projection_requirement_closure_includes_hidden_policy_fields() {
         user(0x77),
     );
     assert!(result.unwrap().is_empty(), "policy must hide incompatible row");
+
+    // The same post-winner boundary applies before windowing and aggregation:
+    // an unknown newer local version cannot leak the older global winner into
+    // a page or count.
+    let whole = Query::from("items").validate(&base).unwrap();
+    assert!(core
+        .query_rows(
+            &whole,
+            &whole.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .unwrap()
+        .is_empty());
+    let page = Query::from("items")
+        .select(["title"])
+        .order_by("status", crate::query::OrderDirection::Asc)
+        .offset(0)
+        .limit(1)
+        .validate(&base)
+        .unwrap();
+    assert!(core
+        .query_rows(
+            &page,
+            &page.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .unwrap()
+        .is_empty());
+    let count = Query::from("items")
+        .count()
+        .group_by("status")
+        .validate(&base)
+        .unwrap();
+    assert!(core
+        .query_rows(
+            &count,
+            &count.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .unwrap()
+        .is_empty());
+
+    core.commit_mergeable(
+        MergeableCommit::new("items", item, 3).cells(BTreeMap::from([
+            ("title".to_owned(), v("local known again")),
+            ("status".to_owned(), Value::EnumTag(0)),
+        ])),
+    )
+    .unwrap();
+    assert_eq!(
+        core.query_rows(
+            &whole,
+            &whole.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Local,
+        )
+        .unwrap()
+        .len(),
+        1,
+    );
+}
+
+#[test]
+fn old_enum_schema_omits_unknown_rows_from_materialized_query_sources() {
+    // Contract: an old reader must receive an empty result—not an encoding
+    // failure—when a selected winner uses a later enum case, even along source
+    // paths that materialize projected rows before lowering.
+    //
+    // Actors: an evolved writer publishes `closed`; an old reader queries the
+    // same physical row through history, a branch overlay, and deleted-row
+    // inspection.
+    //
+    // ```text
+    // evolved writer: closed ──► old reader: omitted
+    //                         ├─ historical cut
+    //                         ├─ branch overlay
+    //                         └─ including-deleted source
+    // ```
+    let base = enum_projection_schema(&["open"]);
+    let evolved = SchemaVersion::new(enum_projection_schema(&["open", "closed"]));
+    let (_dir, mut core) = open_history_complete_node_with_schema(node(0x7b), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        enum_identity_lens(base.version_id(), evolved.id),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema { revision: 1, schema: evolved.id },
+    })
+    .unwrap();
+
+    let old_shape = Query::from("items").validate(&base).unwrap();
+    let old_binding = old_shape.bind(BTreeMap::new()).unwrap();
+    let global_row = row(0x7b);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", global_row, 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("later global case")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    );
+
+    assert!(core
+        .projected_historical_current_rows("items", base.version_id(), GlobalSeq(0))
+        .unwrap()
+        .is_empty());
+
+    assert!(core
+        .query_rows_at(&old_shape, &old_binding, GlobalSeq(0))
+        .unwrap()
+        .is_empty());
+
+    core.commit_mergeable(
+        MergeableCommit::new("items", global_row, 2).deletion(DeletionEvent::Deleted),
+    )
+    .unwrap();
+    assert!(core
+        .query_rows_including_deleted_in_authorization_mode(
+            &old_shape,
+            &old_binding,
+            DurabilityTier::Local,
+            None,
+            AuthorId::SYSTEM,
+            QueryAuthorizationMode::TrustedServing,
+        )
+        .unwrap()
+        .is_empty());
+
+    let branch_id = branch(0x7b);
+    core.create_root_branch(branch_id).unwrap();
+    core.commit_mergeable_on_branch(
+        branch_id,
+        MergeableCommit::new("items", row(0x7c), 3).cells(BTreeMap::from([
+            ("title".to_owned(), v("later branch case")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    )
+    .unwrap();
+    assert!(core
+        .query_rows_on_branch(branch_id, &old_shape, &old_binding)
+        .unwrap()
+        .is_empty());
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -4035,6 +4035,141 @@ fn old_enum_schema_omits_unknown_rows_from_materialized_query_sources() {
 }
 
 #[test]
+fn old_enum_winner_projection_refreshes_after_later_registry_append() {
+    // Contract: a raw current-winner projection installed for an old reader
+    // survives later append-only enum registry growth without accepting a
+    // changed projection mapping or type.
+    //
+    // Actors: an old reader opens while `closed` is the newest case; a latest
+    // writer subsequently introduces and writes `archived`.
+    //
+    // ```text
+    // base(open) ──► middle(+closed) ──► latest(+archived)
+    // old query installs raw winner target        old query skips archived
+    // ```
+    let base = enum_projection_schema(&["open"]);
+    let middle = SchemaVersion::new(enum_projection_schema(&["open", "closed"]));
+    let latest = SchemaVersion::new(enum_projection_schema(&["open", "closed", "archived"]));
+    let (_dir, mut core) = open_node_with_schema(node(0x7d), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        middle.clone(),
+        enum_identity_lens(base.version_id(), middle.id),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema { revision: 1, schema: middle.id },
+    })
+    .unwrap();
+
+    let item = row(0x7d);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", item, 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("compatible middle case")),
+            ("status".to_owned(), Value::EnumTag(0)),
+        ])),
+    );
+    let old_shape = Query::from("items").validate(&base).unwrap();
+    let old_binding = old_shape.bind(BTreeMap::new()).unwrap();
+    assert_eq!(
+        core.query_rows(&old_shape, &old_binding, DurabilityTier::Local)
+            .unwrap()
+            .len(),
+        1,
+        "old read installs a current-winner projection before later growth",
+    );
+    publish_schema_lineage(
+        &mut core,
+        latest.clone(),
+        enum_identity_lens(middle.id, latest.id),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema { revision: 2, schema: latest.id },
+    })
+    .unwrap();
+    core.commit_mergeable(
+        MergeableCommit::new("items", item, 2).cells(BTreeMap::from([
+            ("title".to_owned(), v("later archived case")),
+            ("status".to_owned(), Value::EnumTag(2)),
+        ])),
+    )
+    .unwrap();
+
+    assert!(core
+        .query_rows(&old_shape, &old_binding, DurabilityTier::Local)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn old_enum_index_read_uses_global_index_before_post_winner_omission() {
+    // Contract: an indexed Global read retains its physical index access path
+    // while the old-schema compatibility boundary still runs after the chosen
+    // winner. The unknown row must be omitted, not force a full table scan.
+    let schema = |statuses: &[&str]| {
+        JazzSchema::new([TableSchema::new(
+            "items",
+            [
+                ColumnSchema::new("title", ColumnType::String),
+                ColumnSchema::new(
+                    "status",
+                    ColumnType::EnumTag(
+                        groove::records::ScalarEnumSchema::new("status", statuses.iter().copied())
+                            .unwrap(),
+                    ),
+                ),
+            ],
+        )
+        .with_indexed_column("title")])
+    };
+    let base = schema(&["open"]);
+    let evolved = SchemaVersion::new(schema(&["open", "closed"]));
+    let (_dir, mut core) = open_node_with_schema(node(0x7e), base.clone());
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        enum_identity_lens(base.version_id(), evolved.id),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema { revision: 1, schema: evolved.id },
+    })
+    .unwrap();
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", row(0x7e), 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("indexed")),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    );
+
+    let query = Query::from("items")
+        .filter(eq(col("title"), lit("indexed")))
+        .validate(&base)
+        .unwrap();
+    let binding = query.bind(BTreeMap::new()).unwrap();
+    core.reset_query_engine_read_metrics();
+    assert!(core
+        .query_rows(&query, &binding, DurabilityTier::Global)
+        .unwrap()
+        .is_empty());
+    let metrics = core.query_engine_read_metrics();
+    assert_eq!(metrics.source_index_probes, 1);
+    assert_eq!(metrics.source_full_scans, 0);
+}
+
+#[test]
 fn enum_projection_requirement_none_allows_unused_relation_enum() {
     let schema = |states: &[&str]| JazzSchema::new([
         TableSchema::new("items", [


### PR DESCRIPTION
🤖 Makes additive enum evolution non-breaking for older schema views by treating unknown cases as row-level incompatibility instead of surfacing query or subscription errors.

## What changed

- keeps rows readable when an old query does not depend on the evolved enum field
- omits a row when its selected, filtered, ordered, grouped, aggregated, or authorized enum value is not representable in the target schema
- hides policy-incompatible rows and omits incompatible optional children without inventing defaults or substituting older cases
- chooses the canonical Global/Ahead winner before applying representability filtering, preventing stale global predecessors from reappearing
- supports direct and nested scalar and payload enums across one-shot, maintained, historical, branch, and including-deleted reads
- refreshes raw winner projections safely when live enum registries append, while rejecting mapping or field-type mutation
- preserves indexed Global reads and applies omission before pagination and aggregation

## Root cause

The previous source-boundary enum remap treated an absent target case as a projection error. A first omission implementation projected Global and Ahead sources independently, which could discard a newer unknown Ahead value before winner selection and resurrect an older Global row. Live registry growth could also conflict with an already-registered winner projection. This follow-up makes omission an explicit projection result after physical winner selection and adds a narrowly append-only refresh path.

## Validation

- direct and nested scalar/payload known/unknown row coverage
- known → unknown → known maintained transitions and reset/idempotence coverage
- stale Global versus newer unknown Ahead regression
- base → middle → latest live registry refresh regression
- policy, optional relation, ordering, grouping, aggregation, pagination, historical, branch, and including-deleted coverage
- indexed Global regression: one index probe, zero full scans
- refresh guard plants reject projection mapping and field-type replacement
- `cargo test -p groove --lib`: 405 passed, 1 ignored
- focused Jazz enum tests: 26 passed
- `cargo check -p jazz -p groove`
- independent adversarial review found no remaining P0/P1 issues

Follow-up to #1348 and the reopened forward-compatibility discussion.
