### PR TITLE
(dx) install prebuilt CI tools once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
           rust-targets: wasm32-unknown-unknown
           sccache: "true"
 
-      - name: Install Rust prerequisites
-        run: pnpm run ensure:rust-toolchain
-
       - run: cargo check --workspace --all-targets
 
   lint:
@@ -58,12 +55,8 @@ jobs:
           rust-components: clippy,rustfmt
           sccache: "true"
 
-      - name: Install Rust prerequisites
-        run: pnpm run ensure:rust-toolchain
-
       - run: pnpm format:check
       - run: pnpm lint
-      - run: cargo clippy --workspace -- -D warnings
 
   test-rust:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -77,11 +70,12 @@ jobs:
           rust-components: clippy,rustfmt
           sccache: "true"
 
-      - name: Install Rust prerequisites
-        run: pnpm run ensure:rust-toolchain
-
       - name: Install bounded Rust test runner
-        run: cargo install cargo-nextest --locked
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          # Download the release asset rather than compiling the runner in
+          # every job. Keep this explicit so test selection is reproducible.
+          tool: cargo-nextest@0.9.143
       - name: Workspace Rust tests (bounded, sharded, receipted)
         run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 -- --workspace --lib --bins --tests --features test
       - name: Verify Nextest partition coverage
@@ -120,8 +114,12 @@ jobs:
           rust-components: clippy,rustfmt
           sccache: "true"
 
-      - name: Install Rust prerequisites
-        run: pnpm run ensure:rust-toolchain
+      - name: Install WASM packager
+        # Only this job builds jazz-wasm. Other Rust jobs receive their target
+        # through setup-build but do not pay to install the packager.
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: wasm-pack@0.13.1
 
       - name: Mount Turbo sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
 
       - run: pnpm format:check
       - run: pnpm lint
+      # Keep workflow assertions required without adding another Rust build.
+      - run: pnpm test:ci-workflow
 
   test-rust:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/crates/jazz/SPEC/C_performance.md
+++ b/crates/jazz/SPEC/C_performance.md
@@ -171,6 +171,18 @@ The near-term implementation plan is:
 - preserve fast PR diagnosis and a complete merge gate rather than silently
   skipping coverage.
 
+**Implemented first step (2026-08-11).** `test-rust` installs the pinned
+prebuilt `cargo-nextest` release instead of compiling it from source; repeated
+#1348 GitHub runs measured that source build at **115–169 seconds**. In the
+main CI workflow, the `wasm-pack` installer now runs only in `test-ts`, the
+sole job which invokes the WASM packager (the previous source install there was
+about **20 seconds**), and the lint job relies on the one workspace Clippy
+invocation already contained in `pnpm lint` rather than running it again. These
+changes retain the same test selection and lint command; expected savings are
+roughly **two minutes** from the Rust test job plus one complete duplicate
+workspace-Clippy pass and the unneeded installer work in the Rust-only jobs.
+Follow-up receipts must replace these estimates with before/after step timings.
+
 Cache correctness precedes cache scale. Turbo task inputs should describe each
 artifact's actual dependency closure rather than all `crates/**/*.rs`; native
 artifacts remain content-addressed and provenance-checked. CI reports Turbo and

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const workflow = fs.readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
+const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 const job = (name, nextName) => {
   const start = workflow.indexOf(`  ${name}:`);
   const end = nextName ? workflow.indexOf(`  ${nextName}:`, start + 1) : workflow.length;
@@ -31,4 +32,13 @@ test("lint keeps its one workspace Clippy invocation inside pnpm lint", () => {
   const lint = job("lint", "test-rust");
   assert.match(lint, /run: pnpm lint/);
   assert.doesNotMatch(lint, /^\s*- run: cargo clippy/m);
+});
+
+test("CI runs the workflow contract test through its package script", () => {
+  const lint = job("lint", "test-rust");
+  assert.equal(
+    packageJson.scripts["test:ci-workflow"],
+    "node --test dev/gates/test/ci-rust-throughput.test.mjs",
+  );
+  assert.match(lint, /run: pnpm test:ci-workflow/);
 });

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const workflow = fs.readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
+const job = (name, nextName) => {
+  const start = workflow.indexOf(`  ${name}:`);
+  const end = nextName ? workflow.indexOf(`  ${nextName}:`, start + 1) : workflow.length;
+  assert.notEqual(start, -1, `missing ${name} job`);
+  assert.notEqual(end, -1, `missing boundary after ${name} job`);
+  return workflow.slice(start, end);
+};
+
+test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for wasm-pack", () => {
+  const buildIntegration = job("build-integration", "lint");
+  const lint = job("lint", "test-rust");
+  const rust = job("test-rust", "test-ts");
+  const typescript = job("test-ts");
+
+  assert.doesNotMatch(workflow, /cargo install cargo-nextest/);
+  assert.match(rust, /tool: cargo-nextest@0\.9\.143/);
+  assert.doesNotMatch(rust, /ensure:rust-toolchain|wasm-pack/);
+  assert.doesNotMatch(lint, /ensure:rust-toolchain|wasm-pack/);
+  assert.doesNotMatch(buildIntegration, /ensure:rust-toolchain|wasm-pack/);
+  assert.match(typescript, /tool: wasm-pack@0\.13\.1/);
+});
+
+test("lint keeps its one workspace Clippy invocation inside pnpm lint", () => {
+  const lint = job("lint", "test-rust");
+  assert.match(lint, /run: pnpm lint/);
+  assert.doesNotMatch(lint, /^\s*- run: cargo clippy/m);
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
     "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
+    "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs",
     "ensure:rust-toolchain": "rustup target add wasm32-unknown-unknown && (wasm-pack --version >/dev/null 2>&1 || cargo install wasm-pack@0.13.1 --locked)",
     "build:vercel-docs": "bash dev/scripts/install-vercel-deps.sh && turbo run --env-mode=loose build:crates --filter=@jazz/rust && turbo run --env-mode=loose build --filter=docs --only",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",


### PR DESCRIPTION
🤖 Removes repeated tool compilation and duplicate lint work from required CI without changing coverage.

## What changed

- installs pinned prebuilt `cargo-nextest` and `wasm-pack` releases;
- stops Rust-only jobs from installing the WASM toolchain;
- removes the second identical workspace Clippy invocation while retaining `pnpm lint` as the owner;
- adds a required workflow contract test that prevents those costs from returning;
- records the measured #1348 timing receipt and expected savings in the non-normative performance appendix.

## Expected impact

Recent Rust jobs spent 115–169 seconds compiling Nextest from source. WASM setup also ran in jobs that never used it. This should remove roughly two minutes from `test-rust` setup plus smaller repeated setup/lint costs.

## Validation

- `pnpm test:ci-workflow`
- targeted `oxfmt`
- `git diff --check`
- sensitive-data guard
- independent adversarial review with planted version and invocation regressions
