### PR TITLE
(dx) narrow native artifact cache inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
       - run: pnpm lint
       # Keep workflow assertions required without adding another Rust build.
       - run: pnpm test:ci-workflow
+      - name: Verify Turbo artifact cache inputs
+        run: pnpm test:turbo-cache-inputs
 
   test-rust:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/dev/gates/test/turbo-cache-inputs.test.mjs
+++ b/dev/gates/test/turbo-cache-inputs.test.mjs
@@ -6,7 +6,7 @@
  */
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const root = resolve(import.meta.dirname, "../../..");
@@ -44,36 +44,51 @@ function containsInput(graph, task, suffix) {
   return Object.keys(graph.get(task).inputs).some((path) => path.endsWith(suffix));
 }
 
-const relevant = resolve(root, "crates/jazz/src/lib.rs");
+const closures = [
+  { name: "jazz", file: resolve(root, "crates/jazz/src/lib.rs") },
+  { name: "groove", file: resolve(root, "crates/groove/src/lib.rs") },
+  { name: "opfs-btree", file: resolve(root, "crates/opfs-btree/src/lib.rs") },
+];
 const unrelated = resolve(root, "crates/jazz-sim/src/lib.rs");
-const relevantOriginal = readFileSync(relevant, "utf8");
+const originals = new Map(closures.map(({ file }) => [file, readFileSync(file, "utf8")]));
 const unrelatedOriginal = readFileSync(unrelated, "utf8");
 
 try {
   const baseline = dryGraph();
-  assert(containsInput(baseline, "@jazz/rust#build:crates", "jazz/src/lib.rs"));
-  assert(containsInput(baseline, "jazz-wasm#build", "jazz/src/lib.rs"));
-  assert(containsInput(baseline, "jazz-napi#build", "jazz/src/lib.rs"));
+  for (const { name } of closures)
+    for (const task of tasks)
+      assert(
+        containsInput(baseline, task, `${name}/src/lib.rs`),
+        `${task} omits its ${name} dependency`,
+      );
   for (const task of tasks)
     assert(
       !containsInput(baseline, task, "jazz-sim/src/lib.rs"),
       `${task} includes unrelated jazz-sim`,
     );
 
-  const beforeRelevant = hashes(baseline);
-  writeFileSync(relevant, `${relevantOriginal}\n// turbo cache-input sensitivity probe\n`);
-  const afterRelevant = hashes(dryGraph());
-  for (const task of tasks)
-    assert.notEqual(afterRelevant[task], beforeRelevant[task], `${task} missed a shared Rust edit`);
+  const baselineHashes = hashes(baseline);
+  for (const { name, file } of closures) {
+    const original = originals.get(file);
+    writeFileSync(file, `${original}\n// turbo cache-input ${name} edit probe\n`);
+    const afterEdit = hashes(dryGraph());
+    for (const task of tasks)
+      assert.notEqual(afterEdit[task], baselineHashes[task], `${task} missed a ${name} edit`);
 
-  writeFileSync(relevant, relevantOriginal);
-  const beforeUnrelated = hashes(dryGraph());
+    writeFileSync(file, original);
+    rmSync(file);
+    const afterRemoval = hashes(dryGraph());
+    for (const task of tasks)
+      assert.notEqual(afterRemoval[task], baselineHashes[task], `${task} missed a ${name} removal`);
+    writeFileSync(file, original);
+  }
+
   writeFileSync(unrelated, `${unrelatedOriginal}\n// turbo cache-input isolation probe\n`);
   const afterUnrelated = hashes(dryGraph());
   for (const task of tasks)
-    assert.equal(afterUnrelated[task], beforeUnrelated[task], `${task} hashes unrelated jazz-sim`);
+    assert.equal(afterUnrelated[task], baselineHashes[task], `${task} hashes unrelated jazz-sim`);
 } finally {
-  writeFileSync(relevant, relevantOriginal);
+  for (const { file } of closures) writeFileSync(file, originals.get(file));
   writeFileSync(unrelated, unrelatedOriginal);
 }
 

--- a/dev/gates/test/turbo-cache-inputs.test.mjs
+++ b/dev/gates/test/turbo-cache-inputs.test.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Turbo's dry graph exposes both the resolved input set and its task hash. Keep
+ * this test deliberately build-free: it proves the cache key changes for a
+ * shared Rust dependency, but not for a crate outside these artifact closures.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "../../..");
+const tasks = ["@jazz/rust#build:crates", "jazz-wasm#build", "jazz-napi#build"];
+
+function dryGraph() {
+  const output = execFileSync(
+    "pnpm",
+    [
+      "exec",
+      "turbo",
+      "run",
+      "build:crates",
+      "build",
+      "--filter=@jazz/rust",
+      "--filter=jazz-wasm",
+      "--filter=jazz-napi",
+      "--dry=json",
+    ],
+    { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
+  );
+  const graph = JSON.parse(output);
+  const selected = new Map(
+    graph.tasks.filter((task) => tasks.includes(task.taskId)).map((task) => [task.taskId, task]),
+  );
+  assert.equal(selected.size, tasks.length, "dry graph omitted an artifact task");
+  return selected;
+}
+
+function hashes(graph) {
+  return Object.fromEntries(tasks.map((task) => [task, graph.get(task).hash]));
+}
+
+function containsInput(graph, task, suffix) {
+  return Object.keys(graph.get(task).inputs).some((path) => path.endsWith(suffix));
+}
+
+const relevant = resolve(root, "crates/jazz/src/lib.rs");
+const unrelated = resolve(root, "crates/jazz-sim/src/lib.rs");
+const relevantOriginal = readFileSync(relevant, "utf8");
+const unrelatedOriginal = readFileSync(unrelated, "utf8");
+
+try {
+  const baseline = dryGraph();
+  assert(containsInput(baseline, "@jazz/rust#build:crates", "jazz/src/lib.rs"));
+  assert(containsInput(baseline, "jazz-wasm#build", "jazz/src/lib.rs"));
+  assert(containsInput(baseline, "jazz-napi#build", "jazz/src/lib.rs"));
+  for (const task of tasks)
+    assert(
+      !containsInput(baseline, task, "jazz-sim/src/lib.rs"),
+      `${task} includes unrelated jazz-sim`,
+    );
+
+  const beforeRelevant = hashes(baseline);
+  writeFileSync(relevant, `${relevantOriginal}\n// turbo cache-input sensitivity probe\n`);
+  const afterRelevant = hashes(dryGraph());
+  for (const task of tasks)
+    assert.notEqual(afterRelevant[task], beforeRelevant[task], `${task} missed a shared Rust edit`);
+
+  writeFileSync(relevant, relevantOriginal);
+  const beforeUnrelated = hashes(dryGraph());
+  writeFileSync(unrelated, `${unrelatedOriginal}\n// turbo cache-input isolation probe\n`);
+  const afterUnrelated = hashes(dryGraph());
+  for (const task of tasks)
+    assert.equal(afterUnrelated[task], beforeUnrelated[task], `${task} hashes unrelated jazz-sim`);
+} finally {
+  writeFileSync(relevant, relevantOriginal);
+  writeFileSync(unrelated, unrelatedOriginal);
+}
+
+console.log("Turbo artifact cache inputs are sensitive to closure edits only.");

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "format:check": "oxfmt --check --ignore-path .oxfmtignore . && cargo fmt --check",
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
     "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
+    "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
     "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs",
     "ensure:rust-toolchain": "rustup target add wasm32-unknown-unknown && (wasm-pack --version >/dev/null 2>&1 || cargo install wasm-pack@0.13.1 --locked)",

--- a/turbo.json
+++ b/turbo.json
@@ -27,33 +27,64 @@
     "jazz-napi#build": {
       "dependsOn": ["@jazz/rust#build:crates"],
       "inputs": [
-        "$TURBO_DEFAULT$",
+        "package.json",
+        "Cargo.toml",
+        "build.rs",
+        "scripts/build.js",
+        "src/**/*.rs",
         "$TURBO_ROOT$/dev/artifacts/**",
-        "$TURBO_ROOT$/crates/**/*.rs",
+        "$TURBO_ROOT$/crates/jazz-napi/**",
+        "$TURBO_ROOT$/crates/jazz/**",
+        "$TURBO_ROOT$/crates/groove/**",
+        "$TURBO_ROOT$/crates/opfs-btree/**",
         "$TURBO_ROOT$/Cargo.toml",
-        "$TURBO_ROOT$/Cargo.lock"
+        "$TURBO_ROOT$/Cargo.lock",
+        "$TURBO_ROOT$/rust-toolchain.toml",
+        "$TURBO_ROOT$/.cargo/**",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/pnpm-lock.yaml",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/turbo.json"
       ],
       "outputs": ["*.node", "index.js", "index.d.ts", ".jazz-artifact-manifest.json"]
     },
     "jazz-wasm#build": {
       "dependsOn": ["@jazz/rust#build:crates"],
       "inputs": [
-        "$TURBO_DEFAULT$",
+        "package.json",
+        "Cargo.toml",
+        "src/**/*.rs",
         "$TURBO_ROOT$/dev/artifacts/**",
-        "$TURBO_ROOT$/crates/**/*.rs",
-        "$TURBO_ROOT$/crates/**/Cargo.toml",
+        "$TURBO_ROOT$/crates/jazz-wasm/**",
+        "$TURBO_ROOT$/crates/jazz/**",
+        "$TURBO_ROOT$/crates/groove/**",
+        "$TURBO_ROOT$/crates/opfs-btree/**",
+        "$TURBO_ROOT$/crates/wasm-tracing/**",
         "$TURBO_ROOT$/Cargo.toml",
-        "$TURBO_ROOT$/Cargo.lock"
+        "$TURBO_ROOT$/Cargo.lock",
+        "$TURBO_ROOT$/rust-toolchain.toml",
+        "$TURBO_ROOT$/.cargo/**",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/pnpm-lock.yaml",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/turbo.json"
       ],
       "outputs": ["pkg/**"]
     },
     "build:crates": {
       "dependsOn": ["^build:crates"],
       "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/crates/**/*.rs",
+        "package.json",
+        "$TURBO_ROOT$/crates/jazz/Cargo.toml",
+        "$TURBO_ROOT$/crates/jazz/src/**/*.rs",
+        "$TURBO_ROOT$/crates/groove/Cargo.toml",
+        "$TURBO_ROOT$/crates/groove/src/**/*.rs",
+        "$TURBO_ROOT$/crates/opfs-btree/Cargo.toml",
+        "$TURBO_ROOT$/crates/opfs-btree/src/**/*.rs",
         "$TURBO_ROOT$/Cargo.toml",
-        "$TURBO_ROOT$/Cargo.lock"
+        "$TURBO_ROOT$/Cargo.lock",
+        "$TURBO_ROOT$/rust-toolchain.toml",
+        "$TURBO_ROOT$/.cargo/**"
       ],
       "outputs": ["$TURBO_ROOT$/target/debug/jazz-tools"]
     },


### PR DESCRIPTION
🤖 Makes Turbo artifact cache keys describe the actual Rust dependency closures instead of every Rust crate in the repository.

## What changed

- narrows CLI, NAPI, and WASM task inputs to their real Jazz/Groove/OPFS and binding-specific sources;
- preserves artifact-provenance inputs, including WASM tracing inputs;
- adds required dry-graph sensitivity tests for Jazz, Groove, and OPFS edits/removals;
- proves unrelated `jazz-sim` edits do not invalidate binding artifacts.

## Expected impact

Recent #1348 runs had identical artifact task hashes but repeated cache misses, while unrelated crate edits also invalidated every binding task. This change makes future local/remote Turbo reuse both safer and substantially less coarse.

## Validation

- `pnpm test:ci-workflow`
- `pnpm test:turbo-cache-inputs`
- `node --test dev/artifacts/provenance.test.mjs`
- `git diff --check`
- independent adversarial review with planted dependency omissions
