### PR TITLE
(dx) build correctness artifacts concurrently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,18 +131,12 @@ jobs:
           key: turbo-cache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: ${{ github.workspace }}/.turbo/cache
 
-      - run: pnpm build:ci
-      # Turbo cache hits have reproducibly restored jazz-napi without a loadable
-      # .node binding (CI rounds 9/9-rerun, 2026-07-19); verify and force-rebuild
-      # if needed. See dev/CI_NOTES.md.
-      # Cached jazz-napi archives have restored .node files that fail dlopen
-      # (likely sticky-disk corruption across concurrent runs); build the
-      # binding fresh and verify it loads. Tests then run with --only so no
-      # turbo build dependency can restore a cached artifact over it.
-      - name: Rebuild and verify jazz-napi native binding
-        run: |
-          pnpm turbo run build --filter=jazz-napi --force
-          node -e "require('./crates/jazz-napi')"
+      # Correctness tests use an unoptimised, provenance-checked WASM build.
+      # Package/publish workflows continue to use jazz-wasm's release build.
+      # The script starts CLI, WASM and NAPI builds together and only repairs
+      # NAPI if its first load check proves the artifact unusable.
+      - name: Build correctness-test artifacts
+        run: pnpm build:test-artifacts
       - name: Mount Playwright sticky disk
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:

--- a/dev/gates/build-test-artifacts.mjs
+++ b/dev/gates/build-test-artifacts.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Assemble the artifacts used exclusively by the TypeScript correctness job.
+ *
+ * This deliberately does not use Turbo's generic `build` task: that task is
+ * the packaging graph and builds the release WASM artifact. Browser tests do
+ * not observe WASM optimisation, but they do need a binding whose provenance
+ * matches this checkout. Keep the fast artifact's profile explicit here so a
+ * future package build cannot silently change test semantics.
+ */
+import { spawn } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+export function command(command, args, label = [command, ...args].join(" "), env) {
+  const started = performance.now();
+  console.log(`test-artifacts: start ${label}`);
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd: root,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+      env: { ...process.env, ...env },
+    });
+    child.once("error", reject);
+    child.once("exit", (status, signal) => {
+      const seconds = ((performance.now() - started) / 1000).toFixed(1);
+      if (status === 0) {
+        console.log(`test-artifacts: done ${label} (${seconds}s)`);
+        resolvePromise();
+      } else {
+        reject(
+          new Error(`${label} failed with ${signal ?? `exit ${status ?? 1}`} after ${seconds}s`),
+        );
+      }
+    });
+  });
+}
+
+export async function buildTestArtifacts(run = command) {
+  // These are independent Cargo invocations. In particular, neither binding
+  // needs the CLI binary, and jazz-tools only needs that binary plus WASM.
+  const cli = run("pnpm", ["--filter", "@jazz/rust", "build:crates"], "CLI");
+  // Separate target directories avoid Cargo's artifact-directory lock while
+  // preserving stable per-lane incremental caches. CI's sccache still shares
+  // compiled units across the target directories.
+  const wasm = run("pnpm", ["--filter", "jazz-wasm", "build:fast"], "fast WASM", {
+    CARGO_BUILD_JOBS: "2",
+    CARGO_TARGET_DIR: "target/test-artifacts-wasm",
+  });
+  const napi = run("pnpm", ["--filter", "jazz-napi", "build"], "release NAPI", {
+    CARGO_BUILD_JOBS: "2",
+    CARGO_TARGET_DIR: "target/test-artifacts-napi",
+  });
+
+  const tools = Promise.all([cli, wasm]).then(() =>
+    run("pnpm", ["--filter", "jazz-tools", "build"], "jazz-tools"),
+  );
+  await Promise.all([tools, napi]);
+
+  // A manifest is the contract that makes a cached/generated artifact safe to
+  // consume. NAPI is built release because that is the loadable Linux mode;
+  // the fast profile is intentionally WASM-only and correctness-only.
+  await run(
+    "node",
+    ["dev/artifacts/provenance.mjs", "verify", "wasm", "fast"],
+    "verify fast WASM provenance",
+  );
+  await run(
+    "node",
+    ["dev/artifacts/provenance.mjs", "verify", "napi", "release"],
+    "verify release NAPI provenance",
+  );
+
+  try {
+    await run("node", ["-e", "require('./crates/jazz-napi')"], "load release NAPI");
+  } catch (error) {
+    // A damaged native artifact must not make every run pay a second build.
+    // Repair only after the first load proves it necessary, then prove repair.
+    console.warn(`test-artifacts: release NAPI did not load; repairing (${error.message})`);
+    await run("pnpm", ["--filter", "jazz-napi", "build"], "repair release NAPI", {
+      CARGO_BUILD_JOBS: "2",
+      CARGO_TARGET_DIR: "target/test-artifacts-napi",
+    });
+    await run(
+      "node",
+      ["dev/artifacts/provenance.mjs", "verify", "napi", "release"],
+      "verify repaired NAPI provenance",
+    );
+    await run("node", ["-e", "require('./crates/jazz-napi')"], "load repaired release NAPI");
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  buildTestArtifacts().catch((error) => {
+    console.error(`test-artifacts: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/dev/gates/build-test-artifacts.mjs
+++ b/dev/gates/build-test-artifacts.mjs
@@ -14,26 +14,73 @@ import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
 const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+export const testArtifactTargets = {
+  napi: resolve(root, "target/test-artifacts-napi"),
+  wasm: resolve(root, "target/test-artifacts-wasm"),
+};
 
-export function command(command, args, label = [command, ...args].join(" "), env) {
+export function command(command, args, label = [command, ...args].join(" "), options = {}) {
+  const { env, signal } = options;
   const started = performance.now();
   console.log(`test-artifacts: start ${label}`);
   return new Promise((resolvePromise, reject) => {
+    let settled = false;
+    let forceKillTimer;
     const child = spawn(command, args, {
       cwd: root,
       stdio: "inherit",
       shell: process.platform === "win32",
       env: { ...process.env, ...env },
+      // pnpm, wasm-pack and napi all spawn Cargo. A process group lets one
+      // failed sibling terminate the complete command tree instead of leaving
+      // compilers running after the pipeline has already failed.
+      detached: process.platform !== "win32",
     });
-    child.once("error", reject);
+    const finish = (callback) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(forceKillTimer);
+      signal?.removeEventListener("abort", abort);
+      process.removeListener("SIGINT", abort);
+      process.removeListener("SIGTERM", abort);
+      callback();
+    };
+    const abort = () => {
+      if (child.exitCode !== null) return;
+      if (process.platform === "win32") {
+        spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      } else {
+        try {
+          process.kill(-child.pid, "SIGTERM");
+        } catch (error) {
+          if (error.code !== "ESRCH") throw error;
+        }
+        forceKillTimer = setTimeout(() => {
+          try {
+            process.kill(-child.pid, "SIGKILL");
+          } catch (error) {
+            if (error.code !== "ESRCH")
+              console.warn(`test-artifacts: force-kill failed: ${error.message}`);
+          }
+        }, 5_000);
+        forceKillTimer.unref();
+      }
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    process.once("SIGINT", abort);
+    process.once("SIGTERM", abort);
+    if (signal?.aborted) abort();
+    child.once("error", (error) => finish(() => reject(error)));
     child.once("exit", (status, signal) => {
       const seconds = ((performance.now() - started) / 1000).toFixed(1);
       if (status === 0) {
         console.log(`test-artifacts: done ${label} (${seconds}s)`);
-        resolvePromise();
+        finish(resolvePromise);
       } else {
-        reject(
-          new Error(`${label} failed with ${signal ?? `exit ${status ?? 1}`} after ${seconds}s`),
+        finish(() =>
+          reject(
+            new Error(`${label} failed with ${signal ?? `exit ${status ?? 1}`} after ${seconds}s`),
+          ),
         );
       }
     });
@@ -41,57 +88,73 @@ export function command(command, args, label = [command, ...args].join(" "), env
 }
 
 export async function buildTestArtifacts(run = command) {
+  const controller = new AbortController();
+  let firstBuildError;
+  const guardedRun = (command, args, label, env) =>
+    run(command, args, label, { env, signal: controller.signal }).catch((error) => {
+      if (!firstBuildError) {
+        firstBuildError = error;
+        controller.abort(error);
+      }
+      throw error;
+    });
+
   // These are independent Cargo invocations. In particular, neither binding
   // needs the CLI binary, and jazz-tools only needs that binary plus WASM.
-  const cli = run("pnpm", ["--filter", "@jazz/rust", "build:crates"], "CLI");
+  const cli = guardedRun("pnpm", ["--filter", "@jazz/rust", "build:crates"], "CLI");
   // Separate target directories avoid Cargo's artifact-directory lock while
   // preserving stable per-lane incremental caches. CI's sccache still shares
   // compiled units across the target directories.
-  const wasm = run("pnpm", ["--filter", "jazz-wasm", "build:fast"], "fast WASM", {
-    CARGO_BUILD_JOBS: "2",
-    CARGO_TARGET_DIR: "target/test-artifacts-wasm",
+  const wasm = guardedRun("pnpm", ["--filter", "jazz-wasm", "build:fast"], "fast WASM", {
+    CARGO_TARGET_DIR: testArtifactTargets.wasm,
   });
-  const napi = run("pnpm", ["--filter", "jazz-napi", "build"], "release NAPI", {
-    CARGO_BUILD_JOBS: "2",
-    CARGO_TARGET_DIR: "target/test-artifacts-napi",
+  const napi = guardedRun("pnpm", ["--filter", "jazz-napi", "build"], "release NAPI", {
+    CARGO_TARGET_DIR: testArtifactTargets.napi,
   });
 
   const tools = Promise.all([cli, wasm]).then(() =>
-    run("pnpm", ["--filter", "jazz-tools", "build"], "jazz-tools"),
+    guardedRun("pnpm", ["--filter", "jazz-tools", "build"], "jazz-tools"),
   );
-  await Promise.all([tools, napi]);
+  try {
+    await Promise.all([tools, napi]);
+  } catch (error) {
+    throw firstBuildError ?? error;
+  }
 
   // A manifest is the contract that makes a cached/generated artifact safe to
   // consume. NAPI is built release because that is the loadable Linux mode;
   // the fast profile is intentionally WASM-only and correctness-only.
-  await run(
+  await guardedRun(
     "node",
     ["dev/artifacts/provenance.mjs", "verify", "wasm", "fast"],
     "verify fast WASM provenance",
   );
+
+  try {
+    await guardedRun("node", ["-e", "require('./crates/jazz-napi')"], "load release NAPI");
+  } catch (error) {
+    // A damaged native artifact must not make every run pay a second build.
+    // Repair only after the first load proves it necessary, then prove repair.
+    console.warn(`test-artifacts: release NAPI did not load; repairing (${error.message})`);
+    // The first load failure aborts only the already-completed first phase.
+    // Use a fresh controller for the bounded repair and its validation.
+    controller.abort(error);
+    const repairController = new AbortController();
+    const repairRun = (command, args, label, env) =>
+      run(command, args, label, { env, signal: repairController.signal }).catch((repairError) => {
+        repairController.abort(repairError);
+        throw repairError;
+      });
+    await repairRun("pnpm", ["--filter", "jazz-napi", "build"], "repair release NAPI", {
+      CARGO_TARGET_DIR: testArtifactTargets.napi,
+    });
+    await repairRun("node", ["-e", "require('./crates/jazz-napi')"], "load repaired release NAPI");
+  }
   await run(
     "node",
     ["dev/artifacts/provenance.mjs", "verify", "napi", "release"],
     "verify release NAPI provenance",
   );
-
-  try {
-    await run("node", ["-e", "require('./crates/jazz-napi')"], "load release NAPI");
-  } catch (error) {
-    // A damaged native artifact must not make every run pay a second build.
-    // Repair only after the first load proves it necessary, then prove repair.
-    console.warn(`test-artifacts: release NAPI did not load; repairing (${error.message})`);
-    await run("pnpm", ["--filter", "jazz-napi", "build"], "repair release NAPI", {
-      CARGO_BUILD_JOBS: "2",
-      CARGO_TARGET_DIR: "target/test-artifacts-napi",
-    });
-    await run(
-      "node",
-      ["dev/artifacts/provenance.mjs", "verify", "napi", "release"],
-      "verify repaired NAPI provenance",
-    );
-    await run("node", ["-e", "require('./crates/jazz-napi')"], "load repaired release NAPI");
-  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -1,13 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFileSync } from "node:fs";
-import { buildTestArtifacts } from "../build-test-artifacts.mjs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { buildTestArtifacts, command, testArtifactTargets } from "../build-test-artifacts.mjs";
 
 test("test artifact pipeline overlaps independent bindings and repairs NAPI only after a failed load", async () => {
   const calls = [];
   let releaseLoadAttempts = 0;
-  await buildTestArtifacts(async (command, args, label, env) => {
-    calls.push({ command, args, label, env });
+  await buildTestArtifacts(async (command, args, label, options) => {
+    calls.push({ command, args, label, options });
     if (label === "load release NAPI" && ++releaseLoadAttempts === 1)
       throw new Error("simulated corrupt binding");
   });
@@ -18,12 +20,66 @@ test("test artifact pipeline overlaps independent bindings and repairs NAPI only
   assert.equal(labels.filter((label) => label === "repair release NAPI").length, 1);
   assert.ok(labels.indexOf("jazz-tools") > labels.indexOf("fast WASM"));
   assert.ok(labels.indexOf("verify fast WASM provenance") < labels.indexOf("load release NAPI"));
-  assert.ok(labels.indexOf("verify release NAPI provenance") < labels.indexOf("load release NAPI"));
   assert.ok(labels.indexOf("load repaired release NAPI") > labels.indexOf("repair release NAPI"));
-  assert.equal(calls[1].env.CARGO_TARGET_DIR, "target/test-artifacts-wasm");
-  assert.equal(calls[2].env.CARGO_TARGET_DIR, "target/test-artifacts-napi");
-  assert.equal(calls[1].env.CARGO_BUILD_JOBS, "2");
-  assert.equal(calls[2].env.CARGO_BUILD_JOBS, "2");
+  assert.ok(
+    labels.indexOf("verify release NAPI provenance") > labels.indexOf("load repaired release NAPI"),
+  );
+  assert.equal(calls[1].options.env.CARGO_TARGET_DIR, testArtifactTargets.wasm);
+  assert.equal(calls[2].options.env.CARGO_TARGET_DIR, testArtifactTargets.napi);
+  assert.ok(isAbsolute(calls[1].options.env.CARGO_TARGET_DIR));
+  assert.ok(isAbsolute(calls[2].options.env.CARGO_TARGET_DIR));
+});
+
+test("a failed build aborts its still-running sibling commands", async () => {
+  const aborted = [];
+  await assert.rejects(
+    buildTestArtifacts((unusedCommand, unusedArgs, label, { signal }) => {
+      if (label === "CLI") return Promise.reject(new Error("simulated CLI failure"));
+      return new Promise((resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            aborted.push(label);
+            reject(new Error(`${label} aborted`));
+          },
+          { once: true },
+        );
+      });
+    }),
+    /simulated CLI failure/,
+  );
+  assert.deepEqual(aborted.sort(), ["fast WASM", "release NAPI"]);
+});
+
+test("real subprocess receives an absolute target directory", async () => {
+  await command(
+    process.execPath,
+    [
+      "-e",
+      "const {isAbsolute}=require('node:path'); if(!isAbsolute(process.env.CARGO_TARGET_DIR)) process.exit(42)",
+    ],
+    "absolute target smoke",
+    { env: { CARGO_TARGET_DIR: testArtifactTargets.wasm } },
+  );
+});
+
+test("aborting a real subprocess terminates its spawned child", async () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-cancel-"));
+  const marker = join(fixture, "orphaned-child");
+  const controller = new AbortController();
+  const parentScript = [
+    "const {spawn}=require('node:child_process')",
+    `spawn(process.execPath,['-e',${JSON.stringify(`setTimeout(()=>require('node:fs').writeFileSync(${JSON.stringify(marker)},'orphan'),400)`)}],{stdio:'ignore'})`,
+    "setInterval(()=>{},1000)",
+  ].join(";");
+  const running = command(process.execPath, ["-e", parentScript], "cancellation smoke", {
+    signal: controller.signal,
+  });
+  setTimeout(() => controller.abort(), 100);
+  await assert.rejects(running, /cancellation smoke failed/);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  assert.equal(existsSync(marker), false);
+  rmSync(fixture, { recursive: true, force: true });
 });
 
 test("CI uses the correctness artifact path while package builds keep release WASM", () => {
@@ -41,15 +97,19 @@ test("CI uses the correctness artifact path while package builds keep release WA
 });
 
 test("Turbo invalidates each native artifact only for its Cargo closure", () => {
-  const turbo = readFileSync(new URL("../../../turbo.json", import.meta.url), "utf8");
-  assert.match(turbo, /"jazz-wasm#build"[\s\S]*?"\$TURBO_ROOT\$\/crates\/jazz-wasm\/\*\*"/);
-  assert.match(turbo, /"jazz-wasm#build"[\s\S]*?"\$TURBO_ROOT\$\/crates\/opfs-btree\/\*\*"/);
-  assert.match(turbo, /"jazz-napi#build"[\s\S]*?"\$TURBO_ROOT\$\/crates\/jazz-napi\/\*\*"/);
-  const napi = turbo.slice(turbo.indexOf('"jazz-napi#build"'), turbo.indexOf('"jazz-wasm#build"'));
-  const wasm = turbo.slice(turbo.indexOf('"jazz-wasm#build"'), turbo.indexOf('"build:crates"'));
-  assert.doesNotMatch(napi, /dependsOn/);
-  assert.doesNotMatch(wasm, /dependsOn/);
-  assert.doesNotMatch(napi, /crates\/\*\*\/\.rs/);
-  assert.doesNotMatch(wasm, /crates\/\*\*\/\.rs/);
-  assert.doesNotMatch(napi, /crates\/opfs-btree/);
+  const turbo = JSON.parse(readFileSync(new URL("../../../turbo.json", import.meta.url), "utf8"));
+  const napi = turbo.tasks["jazz-napi#build"];
+  const wasm = turbo.tasks["jazz-wasm#build"];
+  const cli = turbo.tasks["build:crates"];
+  assert.equal(napi.dependsOn, undefined);
+  assert.equal(wasm.dependsOn, undefined);
+  for (const [task, closure] of [
+    [napi, ["jazz-napi", "jazz", "groove", "opfs-btree"]],
+    [wasm, ["jazz-wasm", "jazz", "groove", "opfs-btree"]],
+    [cli, ["jazz", "groove", "opfs-btree"]],
+  ]) {
+    for (const crate of closure)
+      assert.ok(task.inputs.includes(`$TURBO_ROOT$/crates/${crate}/**`), crate);
+    assert.equal(task.inputs.includes("$TURBO_ROOT$/crates/**/*.rs"), false);
+  }
 });

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -103,13 +103,28 @@ test("Turbo invalidates each native artifact only for its Cargo closure", () => 
   const cli = turbo.tasks["build:crates"];
   assert.equal(napi.dependsOn, undefined);
   assert.equal(wasm.dependsOn, undefined);
-  for (const [task, closure] of [
-    [napi, ["jazz-napi", "jazz", "groove", "opfs-btree"]],
-    [wasm, ["jazz-wasm", "jazz", "groove", "opfs-btree"]],
-    [cli, ["jazz", "groove", "opfs-btree"]],
+  for (const [task, inputs] of [
+    [
+      napi,
+      ["jazz-napi", "jazz", "groove", "opfs-btree"].map(
+        (crate) => `$TURBO_ROOT$/crates/${crate}/**`,
+      ),
+    ],
+    [
+      wasm,
+      ["jazz-wasm", "jazz", "groove", "opfs-btree"].map(
+        (crate) => `$TURBO_ROOT$/crates/${crate}/**`,
+      ),
+    ],
+    [
+      cli,
+      ["jazz", "groove", "opfs-btree"].flatMap((crate) => [
+        `$TURBO_ROOT$/crates/${crate}/Cargo.toml`,
+        `$TURBO_ROOT$/crates/${crate}/src/**/*.rs`,
+      ]),
+    ],
   ]) {
-    for (const crate of closure)
-      assert.ok(task.inputs.includes(`$TURBO_ROOT$/crates/${crate}/**`), crate);
+    for (const input of inputs) assert.ok(task.inputs.includes(input), input);
     assert.equal(task.inputs.includes("$TURBO_ROOT$/crates/**/*.rs"), false);
   }
 });

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { buildTestArtifacts } from "../build-test-artifacts.mjs";
+
+test("test artifact pipeline overlaps independent bindings and repairs NAPI only after a failed load", async () => {
+  const calls = [];
+  let releaseLoadAttempts = 0;
+  await buildTestArtifacts(async (command, args, label, env) => {
+    calls.push({ command, args, label, env });
+    if (label === "load release NAPI" && ++releaseLoadAttempts === 1)
+      throw new Error("simulated corrupt binding");
+  });
+
+  const labels = calls.map((call) => call.label);
+  assert.deepEqual(labels.slice(0, 3), ["CLI", "fast WASM", "release NAPI"]);
+  assert.equal(labels.filter((label) => label === "release NAPI").length, 1);
+  assert.equal(labels.filter((label) => label === "repair release NAPI").length, 1);
+  assert.ok(labels.indexOf("jazz-tools") > labels.indexOf("fast WASM"));
+  assert.ok(labels.indexOf("verify fast WASM provenance") < labels.indexOf("load release NAPI"));
+  assert.ok(labels.indexOf("verify release NAPI provenance") < labels.indexOf("load release NAPI"));
+  assert.ok(labels.indexOf("load repaired release NAPI") > labels.indexOf("repair release NAPI"));
+  assert.equal(calls[1].env.CARGO_TARGET_DIR, "target/test-artifacts-wasm");
+  assert.equal(calls[2].env.CARGO_TARGET_DIR, "target/test-artifacts-napi");
+  assert.equal(calls[1].env.CARGO_BUILD_JOBS, "2");
+  assert.equal(calls[2].env.CARGO_BUILD_JOBS, "2");
+});
+
+test("CI uses the correctness artifact path while package builds keep release WASM", () => {
+  const workflow = readFileSync(
+    new URL("../../../.github/workflows/ci.yml", import.meta.url),
+    "utf8",
+  );
+  const packageJson = readFileSync(new URL("../../../package.json", import.meta.url), "utf8");
+  assert.match(workflow, /pnpm build:test-artifacts/);
+  assert.match(packageJson, /"build:test-artifacts": "node dev\/gates\/build-test-artifacts\.mjs"/);
+  assert.match(
+    packageJson,
+    /"build:ci": "turbo run build:crates.*jazz-wasm.*jazz-napi.*jazz-tools/,
+  );
+});
+
+test("Turbo invalidates each native artifact only for its Cargo closure", () => {
+  const turbo = readFileSync(new URL("../../../turbo.json", import.meta.url), "utf8");
+  assert.match(turbo, /"jazz-wasm#build"[\s\S]*?"\$TURBO_ROOT\$\/crates\/jazz-wasm\/\*\*"/);
+  assert.match(turbo, /"jazz-wasm#build"[\s\S]*?"\$TURBO_ROOT\$\/crates\/opfs-btree\/\*\*"/);
+  assert.match(turbo, /"jazz-napi#build"[\s\S]*?"\$TURBO_ROOT\$\/crates\/jazz-napi\/\*\*"/);
+  const napi = turbo.slice(turbo.indexOf('"jazz-napi#build"'), turbo.indexOf('"jazz-wasm#build"'));
+  const wasm = turbo.slice(turbo.indexOf('"jazz-wasm#build"'), turbo.indexOf('"build:crates"'));
+  assert.doesNotMatch(napi, /dependsOn/);
+  assert.doesNotMatch(wasm, /dependsOn/);
+  assert.doesNotMatch(napi, /crates\/\*\*\/\.rs/);
+  assert.doesNotMatch(wasm, /crates\/\*\*\/\.rs/);
+  assert.doesNotMatch(napi, /crates\/opfs-btree/);
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=!jazz-wasm --only",
     "build:core": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=./packages/** --filter=jazz-napi --only",
     "build:ci": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=jazz-napi --filter=jazz-tools --only",
+    "build:test-artifacts": "node dev/gates/build-test-artifacts.mjs",
     "build:all": "pnpm build",
     "release:version": "changeset version",
     "release:version:alpha": "changeset version --snapshot alpha",

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,6 @@
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "jazz-napi#build": {
-      "dependsOn": ["@jazz/rust#build:crates"],
       "inputs": [
         "package.json",
         "Cargo.toml",
@@ -49,7 +48,6 @@
       "outputs": ["*.node", "index.js", "index.d.ts", ".jazz-artifact-manifest.json"]
     },
     "jazz-wasm#build": {
-      "dependsOn": ["@jazz/rust#build:crates"],
       "inputs": [
         "package.json",
         "Cargo.toml",


### PR DESCRIPTION
🤖 Builds correctness-test artifacts directly, concurrently, and at the quality level the tests require.

## What changed

- adds an explicit `build:test-artifacts` pipeline;
- builds fast/unoptimized WASM, release NAPI, and the CLI concurrently with isolated stable Cargo target directories and shared compiler cache;
- starts Jazz Tools after its actual prerequisites rather than serializing all native work;
- loads NAPI first and repairs it only after a failed load, then verifies provenance;
- cancels sibling process groups when one build fails;
- keeps optimized release WASM/NAPI assembly unchanged in package and publish workflows;
- switches required `test-ts` CI to the correctness-artifact path.

## Expected impact

The recent #1348 `build:ci` phase took 6m52s, including more than two minutes of release WASM post-processing and a 42-second unconditional NAPI rebuild. The reviewed warm lane completed its artifact critical path in about 36 seconds. A fresh combined-stack run completed successfully in 2m34s, dominated by a cold release NAPI build; GitHub CI will provide the authoritative repeated receipt.

## Validation

- full `pnpm build:test-artifacts` with fresh WASM/NAPI provenance and NAPI load
- `node --test dev/gates/test/test-artifact-pipeline.test.mjs`
- `pnpm test:turbo-cache-inputs`
- `pnpm test:ci-workflow`
- focused native and Chromium correctness tests in the implementation lane
- independent adversarial review with planted target-path, dependency, cancellation, and repair regressions
