### PR TITLE
Add Latitude CI runner smoke test

### DIFF
--- a/.github/workflows/self-hosted-runner-smoke.yml
+++ b/.github/workflows/self-hosted-runner-smoke.yml
@@ -1,0 +1,29 @@
+name: Self-hosted runner smoke test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Latitude CI runner
+    runs-on: [self-hosted, linux, x64, jazz-ci]
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Verify runner tools
+        run: |
+          set -euxo pipefail
+          test "$(hostname)" = "ci-runner"
+          git --version
+          git lfs version
+          curl --version
+          cmake --version
+          clang --version
+          jq --version
+          test "$(nproc)" -ge 32
+          test "$(awk '/MemTotal/ { print int($2 / 1024) }' /proc/meminfo)" -ge 180000


### PR DESCRIPTION
## What changed

Adds a manually triggered smoke workflow pinned to the new dedicated Latitude runner via the `jazz-ci` label.

## Why

This validates scheduling, checkout, required system tools, and the expected CPU/memory capacity before any existing CI jobs are moved from Blacksmith.

## Validation

- Runner `latitude-ci-1` is online and idle in the repository
- Labels: `self-hosted`, `Linux`, `X64`, `jazz-ci`
- Workflow syntax and whitespace checked locally

After merge, dispatch **Self-hosted runner smoke test** once to complete end-to-end validation.