### PR TITLE
Run Latitude smoke test on workflow changes

### DIFF
--- a/.github/workflows/self-hosted-runner-smoke.yml
+++ b/.github/workflows/self-hosted-runner-smoke.yml
@@ -2,6 +2,9 @@ name: Self-hosted runner smoke test
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/self-hosted-runner-smoke.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a narrowly scoped pull-request trigger so the new runner workflow can validate itself before the CI experiment branch reaches `main`. It only runs when this workflow file changes.

This PR itself should schedule the first end-to-end test on `latitude-ci-1`.