### PR TITLE
ci: pilot representative builds on Latitude runner

### DIFF
--- a/.github/workflows/latitude-ci-pilot.yml
+++ b/.github/workflows/latitude-ci-pilot.yml
@@ -2,7 +2,9 @@ name: Latitude CI pilot
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - perf/latitude-ci-pilot
     paths:
       - .github/workflows/latitude-ci-pilot.yml
 
@@ -16,12 +18,30 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # This runner is dedicated to trusted Jazz branches. Preserve its
+          # Cargo target between pilot runs so we can measure warm builds.
+          clean: false
 
       - uses: ./.github/actions/setup-build
         with:
           rust-targets: wasm32-unknown-unknown
           rust-components: clippy,rustfmt
-          sccache: "true"
+          # Blacksmith's sticky-disk action hard-codes /home/runner. Configure
+          # the persistent runner's compiler cache portably below instead.
+          sccache: "false"
+
+      - name: Install compiler cache
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: sccache
+
+      - name: Configure persistent compiler cache
+        run: |
+          mkdir -p "$HOME/.cache/sccache"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=32G" >> "$GITHUB_ENV"
 
       - name: Install WASM packager
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2

--- a/.github/workflows/latitude-ci-pilot.yml
+++ b/.github/workflows/latitude-ci-pilot.yml
@@ -1,0 +1,44 @@
+name: Latitude CI pilot
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/latitude-ci-pilot.yml
+
+permissions:
+  contents: read
+
+jobs:
+  representative-build:
+    name: Representative build on persistent runner
+    runs-on: [self-hosted, linux, x64, jazz-ci]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-build
+        with:
+          rust-targets: wasm32-unknown-unknown
+          rust-components: clippy,rustfmt
+          sccache: "true"
+
+      - name: Install WASM packager
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - name: Report warm-cache baseline
+        run: |
+          df -h "$GITHUB_WORKSPACE"
+          sccache --show-stats || true
+
+      - name: Check complete Rust workspace
+        run: cargo check --workspace --all-targets
+
+      - name: Build correctness-test artifacts
+        run: pnpm build:test-artifacts
+
+      - name: Report resulting compiler cache
+        if: always()
+        run: sccache --show-stats || true


### PR DESCRIPTION
🤖 Runs a representative Rust workspace check and correctness-artifact build on the new persistent `jazz-ci` runner.

This is intentionally an experimental, non-required workflow. It records compiler-cache state before and after the build so we can compare the first run with a warm rerun before moving required CI jobs away from Blacksmith.

Base: `codex/enum-pr-1`.
