### PR TITLE
ci: overlap TypeScript test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,16 +152,4 @@ jobs:
       # outputs. Running them together avoids extending the PR critical path
       # while retaining the complete Node and browser coverage in this gate.
       - name: Run Node and browser test suites in parallel
-        run: |
-          set +e
-          pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!auth-simple-chat --filter=!auth-workos-chat --filter=!auth-betterauth-chat --filter=!chat-react --filter=!world-tour --filter=!jazz-rn --concurrency=2 &
-          node_tests_pid=$!
-          pnpm --filter jazz-tools test:browser &
-          browser_tests_pid=$!
-          wait "${node_tests_pid}"
-          node_tests_status=$?
-          wait "${browser_tests_pid}"
-          browser_tests_status=$?
-          if [ "${node_tests_status}" -ne 0 ] || [ "${browser_tests_status}" -ne 0 ]; then
-            exit 1
-          fi
+        run: dev/gates/run-ts-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           rust-targets: wasm32-unknown-unknown
-          rust-components: clippy,rustfmt
           sccache: "true"
 
       - name: Install bounded Rust test runner
@@ -118,7 +117,6 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           rust-targets: wasm32-unknown-unknown
-          rust-components: clippy,rustfmt
           sccache: "true"
           sccache-sticky-disk: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'true' || 'false' }}
 
@@ -150,8 +148,20 @@ jobs:
           key: playwright-browsers-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
           path: /home/runner/.cache/ms-playwright
       - run: pnpm exec playwright install chromium
-      - name: Run Node and browser test suites
+      # Both suites consume the already-built artifacts and do not write shared
+      # outputs. Running them together avoids extending the PR critical path
+      # while retaining the complete Node and browser coverage in this gate.
+      - name: Run Node and browser test suites in parallel
         run: |
-          pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!auth-simple-chat --filter=!auth-workos-chat --filter=!auth-betterauth-chat --filter=!chat-react --filter=!world-tour --filter=!jazz-rn --concurrency=2 || status=1
-          pnpm --filter jazz-tools test:browser || status=1
-          exit "${status:-0}"
+          set +e
+          pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!auth-simple-chat --filter=!auth-workos-chat --filter=!auth-betterauth-chat --filter=!chat-react --filter=!world-tour --filter=!jazz-rn --concurrency=2 &
+          node_tests_pid=$!
+          pnpm --filter jazz-tools test:browser &
+          browser_tests_pid=$!
+          wait "${node_tests_pid}"
+          node_tests_status=$?
+          wait "${browser_tests_pid}"
+          browser_tests_status=$?
+          if [ "${node_tests_status}" -ne 0 ] || [ "${browser_tests_status}" -ne 0 ]; then
+            exit 1
+          fi

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# The dedicated runner has four CPUs. Turbo gets at most two test tasks while
+# the jazz-tools browser suite gets the remaining capacity; both reuse the one
+# artifact build completed by the workflow before this script starts.
+set -u
+
+node_tests_command=${JAZZ_NODE_TEST_COMMAND:-"pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!auth-simple-chat --filter=!auth-workos-chat --filter=!auth-betterauth-chat --filter=!chat-react --filter=!world-tour --filter=!jazz-rn --concurrency=2"}
+browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --filter jazz-tools test:browser"}
+node_tests_pid=""
+browser_tests_pid=""
+
+terminate_children() {
+  trap - INT TERM
+  for child_pid in "${node_tests_pid}" "${browser_tests_pid}"; do
+    if [[ -n "${child_pid}" ]] && kill -0 "${child_pid}" 2>/dev/null; then
+      # Each suite starts in its own session, so this reaches pnpm and every
+      # descendant it spawned instead of leaving Vitest/Turbo processes behind.
+      kill -TERM -- "-${child_pid}" 2>/dev/null || true
+    fi
+  done
+  [[ -z "${node_tests_pid}" ]] || wait "${node_tests_pid}" 2>/dev/null || true
+  [[ -z "${browser_tests_pid}" ]] || wait "${browser_tests_pid}" 2>/dev/null || true
+}
+
+interrupt() {
+  local signal_status=$1
+  terminate_children
+  exit "${signal_status}"
+}
+
+trap 'interrupt 130' INT
+trap 'interrupt 143' TERM
+
+setsid bash -c "${node_tests_command}" &
+node_tests_pid=$!
+setsid bash -c "${browser_tests_command}" &
+browser_tests_pid=$!
+
+wait "${node_tests_pid}"
+node_tests_status=$?
+wait "${browser_tests_pid}"
+browser_tests_status=$?
+trap - INT TERM
+
+echo "Node test suite exit status: ${node_tests_status}"
+echo "Browser test suite exit status: ${browser_tests_status}"
+
+if [[ "${node_tests_status}" -ne 0 || "${browser_tests_status}" -ne 0 ]]; then
+  exit 1
+fi

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -46,11 +48,78 @@ test("CI runs the workflow contract test through its package script", () => {
 
 test("TypeScript CI overlaps independent Node and browser suites after one artifact build", () => {
   const typescript = job("test-ts");
-  assert.match(typescript, /name: Build correctness-test artifacts\s+run: pnpm build:test-artifacts/);
+  const runner = fs.readFileSync(path.join(root, "dev/gates/run-ts-tests.sh"), "utf8");
+  assert.match(
+    typescript,
+    /name: Build correctness-test artifacts\s+run: pnpm build:test-artifacts/,
+  );
   assert.match(typescript, /name: Run Node and browser test suites in parallel/);
-  assert.match(typescript, /pnpm test .* &\s+node_tests_pid=\$!/);
-  assert.match(typescript, /pnpm --filter jazz-tools test:browser &\s+browser_tests_pid=\$!/);
-  assert.match(typescript, /wait "\$\{node_tests_pid\}"/);
-  assert.match(typescript, /wait "\$\{browser_tests_pid\}"/);
+  assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
+  assert.match(runner, /--concurrency=2/);
+  assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" &/);
+  assert.match(runner, /setsid bash -c "\$\{browser_tests_command\}" &/);
+  assert.match(runner, /trap 'interrupt 130' INT/);
+  assert.match(runner, /trap 'interrupt 143' TERM/);
+  assert.match(runner, /kill -TERM -- "-\$\{child_pid\}"/);
+  assert.match(runner, /wait "\$\{node_tests_pid\}"/);
+  assert.match(runner, /node_tests_status=\$\?/);
+  assert.match(runner, /wait "\$\{browser_tests_pid\}"/);
+  assert.match(runner, /browser_tests_status=\$\?/);
+  assert.match(runner, /Node test suite exit status:/);
+  assert.match(runner, /Browser test suite exit status:/);
+  assert.match(runner, /node_tests_status.*-ne 0 \|\|.*browser_tests_status.*-ne 0/);
   assert.doesNotMatch(typescript, /rust-components: clippy,rustfmt/);
+});
+
+test("parallel TypeScript runner waits for both suites and combines their failures", () => {
+  const runner = path.join(root, "dev/gates/run-ts-tests.sh");
+  const cases = [
+    { node: 0, browser: 0, expected: 0 },
+    { node: 7, browser: 0, expected: 1 },
+    { node: 0, browser: 9, expected: 1 },
+    { node: 7, browser: 9, expected: 1 },
+  ];
+  for (const testCase of cases) {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-runner-"));
+    const nodeMarker = path.join(fixture, "node");
+    const browserMarker = path.join(fixture, "browser");
+    const result = spawnSync("bash", [runner], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        JAZZ_NODE_TEST_COMMAND: `sleep 0.05; touch ${JSON.stringify(nodeMarker)}; exit ${testCase.node}`,
+        JAZZ_BROWSER_TEST_COMMAND: `sleep 0.1; touch ${JSON.stringify(browserMarker)}; exit ${testCase.browser}`,
+      },
+    });
+    assert.equal(result.status, testCase.expected, result.stderr);
+    assert.equal(fs.existsSync(nodeMarker), true, "node suite was not reaped");
+    assert.equal(fs.existsSync(browserMarker), true, "browser suite was not reaped");
+    assert.match(result.stdout, new RegExp(`Node test suite exit status: ${testCase.node}`));
+    assert.match(result.stdout, new RegExp(`Browser test suite exit status: ${testCase.browser}`));
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("parallel TypeScript runner terminates both child process groups", async () => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-interrupt-"));
+  const nodeMarker = path.join(fixture, "node-orphan");
+  const browserMarker = path.join(fixture, "browser-orphan");
+  const child = spawn("bash", [path.join(root, "dev/gates/run-ts-tests.sh")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      JAZZ_NODE_TEST_COMMAND: `sleep 0.5; touch ${JSON.stringify(nodeMarker)}`,
+      JAZZ_BROWSER_TEST_COMMAND: `sleep 0.5; touch ${JSON.stringify(browserMarker)}`,
+    },
+    stdio: "ignore",
+  });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  child.kill("SIGTERM");
+  const status = await new Promise((resolve) => child.once("exit", (code) => resolve(code)));
+  assert.equal(status, 143);
+  await new Promise((resolve) => setTimeout(resolve, 550));
+  assert.equal(fs.existsSync(nodeMarker), false, "node descendant survived TERM");
+  assert.equal(fs.existsSync(browserMarker), false, "browser descendant survived TERM");
+  fs.rmSync(fixture, { recursive: true, force: true });
 });

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -23,6 +23,7 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
   assert.doesNotMatch(workflow, /cargo install cargo-nextest/);
   assert.match(rust, /tool: cargo-nextest@0\.9\.143/);
   assert.doesNotMatch(rust, /ensure:rust-toolchain|wasm-pack/);
+  assert.doesNotMatch(rust, /rust-components:/);
   assert.doesNotMatch(lint, /ensure:rust-toolchain|wasm-pack/);
   assert.doesNotMatch(buildIntegration, /ensure:rust-toolchain|wasm-pack/);
   assert.match(typescript, /tool: wasm-pack@0\.13\.1/);
@@ -41,4 +42,15 @@ test("CI runs the workflow contract test through its package script", () => {
     "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs",
   );
   assert.match(lint, /run: pnpm test:ci-workflow/);
+});
+
+test("TypeScript CI overlaps independent Node and browser suites after one artifact build", () => {
+  const typescript = job("test-ts");
+  assert.match(typescript, /name: Build correctness-test artifacts\s+run: pnpm build:test-artifacts/);
+  assert.match(typescript, /name: Run Node and browser test suites in parallel/);
+  assert.match(typescript, /pnpm test .* &\s+node_tests_pid=\$!/);
+  assert.match(typescript, /pnpm --filter jazz-tools test:browser &\s+browser_tests_pid=\$!/);
+  assert.match(typescript, /wait "\$\{node_tests_pid\}"/);
+  assert.match(typescript, /wait "\$\{browser_tests_pid\}"/);
+  assert.doesNotMatch(typescript, /rust-components: clippy,rustfmt/);
 });


### PR DESCRIPTION
🤖 Runs the existing Node/Turbo and browser correctness suites concurrently after the single shared artifact build.

This removes unused Clippy/rustfmt setup from test-only jobs and moves the parallel orchestration into a checked shell helper. The helper preserves both suite results, prints individual exit receipts, and terminates/reaps both process trees on cancellation.

Expected impact: save the duration of the shorter TypeScript suite (tens of seconds on the dedicated four-core runner) without duplicating artifact work or reducing coverage.

Validation:

- `pnpm test:ci-workflow` (12/12)
- `bash -n dev/gates/run-ts-tests.sh`
- `git diff --check`
- independent adversarial review, including all four exit-status combinations and TERM orphan prevention

The first dedicated-runner receipt should be treated as the authoritative performance measurement.
