### PR TITLE
fix: merge compatible subscription version projections

### DIFF
--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -705,13 +705,23 @@ fn receiver_batch_coalesces_partial_bundles_for_same_tx() {
 
 #[test]
 fn receiver_batch_merges_complementary_projections_for_same_version() {
-    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
-    let (_core_dir, mut core) = open_node_with_uuid(node(2));
-    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let projection_schema = JazzSchema::new([TableSchema::new(
+        "todos",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("body", ColumnType::String),
+        ],
+    )]);
+    let (_writer_dir, mut writer) = open_node_with_schema(node(1), projection_schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(2), projection_schema.clone());
+    let (_reader_dir, mut reader) = open_node_with_schema(node(3), projection_schema.clone());
     let row_uuid = row(1);
     let (tx_id, unit) = writer
         .commit_mergeable_unit(
-            MergeableCommit::new("todos", row_uuid, 10).cells(title_cells("visible")),
+            MergeableCommit::new("todos", row_uuid, 10).cells(BTreeMap::from([
+                ("title".to_owned(), Value::String("visible title".to_owned())),
+                ("body".to_owned(), Value::String("visible body".to_owned())),
+            ])),
         )
         .unwrap();
     let SyncMessage::CommitUnit { tx, versions } = unit else {
@@ -731,20 +741,24 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
         panic!("expected accepted fate");
     };
     let full = versions.into_iter().next().unwrap();
-    let hidden = VersionRecord::encode(
-        &schema().tables[0],
-        full.schema_version(),
-        full.row_uuid(),
-        full.parents(),
-        full.created_by(),
-        full.created_at(),
-        full.updated_by(),
-        full.updated_at(),
-        &[None],
-        full.deletion(),
-    )
-    .unwrap()
-    .with_authored_columns(full.authored_columns().cloned());
+    let projection = |cells: Vec<Option<Value>>| {
+        VersionRecord::encode(
+            &projection_schema.tables[0],
+            full.schema_version(),
+            full.row_uuid(),
+            full.parents(),
+            full.created_by(),
+            full.created_at(),
+            full.updated_by(),
+            full.updated_at(),
+            &cells,
+            full.deletion(),
+        )
+        .unwrap()
+        .with_authored_columns(full.authored_columns().cloned())
+    };
+    let title_only = projection(vec![full.cell_at(0), None]);
+    let body_only = projection(vec![None, full.cell_at(1)]);
     let subscription = reader.whole_table_subscription_key("todos").unwrap();
     let update = |version, result_member_adds| ViewUpdateParts {
         subscription,
@@ -770,9 +784,16 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
 
     reader
         .apply_view_updates_in_batch(vec![
-            update(hidden, Vec::new()),
             update(
-                full,
+                title_only,
+                vec![ResultMemberEntry::row((
+                    "todos".to_owned().into(),
+                    row_uuid,
+                    tx_id,
+                ))],
+            ),
+            update(
+                body_only,
                 vec![ResultMemberEntry::row((
                     "todos".to_owned().into(),
                     row_uuid,
@@ -789,7 +810,13 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
             .into_iter()
             .map(current_row_pair)
             .collect::<BTreeMap<_, _>>(),
-        BTreeMap::from([(row_uuid, title_cells("visible"))])
+        BTreeMap::from([(
+            row_uuid,
+            BTreeMap::from([
+                ("title".to_owned(), Value::String("visible title".to_owned())),
+                ("body".to_owned(), Value::String("visible body".to_owned())),
+            ]),
+        )])
     );
     assert_eq!(reader.sync_metrics().receiver_bulk_bundle_ingests, 1);
     assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -703,6 +703,98 @@ fn receiver_batch_coalesces_partial_bundles_for_same_tx() {
     assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);
 }
 
+#[test]
+fn receiver_batch_merges_complementary_projections_for_same_version() {
+    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
+    let (_core_dir, mut core) = open_node_with_uuid(node(2));
+    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let row_uuid = row(1);
+    let (tx_id, unit) = writer
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", row_uuid, 10).cells(title_cells("visible")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = unit else {
+        panic!("expected commit unit");
+    };
+    let [fate] = core
+        .ingest_commit_unit(tx.clone(), versions.clone(), u64::MAX - SKEW_TOLERANCE_MS)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let SyncMessage::FateUpdate {
+        global_seq: Some(global_seq),
+        durability: Some(durability),
+        ..
+    } = fate
+    else {
+        panic!("expected accepted fate");
+    };
+    let full = versions.into_iter().next().unwrap();
+    let hidden = VersionRecord::encode(
+        &schema().tables[0],
+        full.schema_version(),
+        full.row_uuid(),
+        full.parents(),
+        full.created_by(),
+        full.created_at(),
+        full.updated_by(),
+        full.updated_at(),
+        &[None],
+        full.deletion(),
+    )
+    .unwrap()
+    .with_authored_columns(full.authored_columns().cloned());
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let update = |version, result_member_adds| ViewUpdateParts {
+        subscription,
+        settled_through: global_seq,
+        defer_settlement: false,
+        reset_result_set: false,
+        version_carriers: Vec::new(),
+        version_bundles: vec![VersionBundle {
+            tx: tx.clone(),
+            versions: vec![version],
+            fate: Fate::Accepted,
+            global_seq: Some(global_seq),
+            durability,
+        }],
+        peer_complete_tx_payload_refs: Vec::new(),
+        authorization_progress: None,
+        result_member_adds,
+        result_member_removes: Vec::new(),
+        terminal_operations: Vec::new(),
+        program_fact_adds: Vec::new(),
+        program_fact_removes: Vec::new(),
+    };
+
+    reader
+        .apply_view_updates_in_batch(vec![
+            update(hidden, Vec::new()),
+            update(
+                full,
+                vec![ResultMemberEntry::row((
+                    "todos".to_owned().into(),
+                    row_uuid,
+                    tx_id,
+                ))],
+            ),
+        ])
+        .unwrap();
+
+    assert_eq!(
+        reader
+            .subscription_current_rows("todos", DurabilityTier::Global)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(row_uuid, title_cells("visible"))])
+    );
+    assert_eq!(reader.sync_metrics().receiver_bulk_bundle_ingests, 1);
+    assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);
+}
+
 // This stays internal because it directly exercises the protocol receiver's
 // single-message fragment assembly boundary.
 #[test]

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -59,24 +59,22 @@ fn merge_receiver_version_bundle_ref(
     let mut seen = existing
         .versions
         .iter()
-        .map(|version| {
-            (
-                version_bundle_record_key(version),
-                version.record().raw().to_vec(),
-            )
-        })
-        .collect::<BTreeMap<_, Vec<u8>>>();
+        .cloned()
+        .map(|version| (version_bundle_record_key(&version), version))
+        .collect::<BTreeMap<_, VersionRecord>>();
     for version in bundle.versions {
         let key = version_bundle_record_key(version);
-        match seen.get(&key) {
-            Some(raw) if raw.as_slice() == version.record().raw() => {}
-            Some(_) => return Err(Error::ConflictingCommitUnit(bundle.tx.tx_id)),
+        match seen.get_mut(&key) {
+            Some(existing) => match existing.merge_view_projection(version) {
+                Ok(merged) => *existing = merged,
+                Err(()) => return Err(Error::ConflictingCommitUnit(bundle.tx.tx_id)),
+            },
             None => {
-                seen.insert(key, version.record().raw().to_vec());
-                existing.versions.push(version.clone());
+                seen.insert(key, version.clone());
             }
         }
     }
+    existing.versions = seen.into_values().collect();
     Ok(())
 }
 

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -759,6 +759,55 @@ impl VersionRecord {
             .ok()
             .flatten()
     }
+
+    /// Combines two compatible, view-scoped projections of the same immutable
+    /// version. A subscription may carry a row once as a full result and once
+    /// as an authorization or relation witness, where hidden cells are absent.
+    /// Only absent/present cells may be combined; different present values are
+    /// a protocol conflict.
+    pub(crate) fn merge_view_projection(&self, other: &Self) -> Result<Self, ()> {
+        if self.table != other.table
+            || self.schema_version != other.schema_version
+            || self.authored_columns != other.authored_columns
+            || self.record.descriptor() != other.record.descriptor()
+        {
+            return Err(());
+        }
+        let descriptor = self.record.descriptor().clone();
+        let mut values = Vec::with_capacity(descriptor.fields().len());
+        for index in 0..descriptor.fields().len() {
+            let left = self.record.borrowed().get_idx(index).map_err(|_| ())?;
+            let right = other.record.borrowed().get_idx(index).map_err(|_| ())?;
+            let value = if index < WireRowRecord::USER_CELLS {
+                if left != right {
+                    return Err(());
+                }
+                left
+            } else {
+                match (left, right) {
+                    (Value::Nullable(None), Value::Nullable(None)) => Value::Nullable(None),
+                    (Value::Nullable(Some(value)), Value::Nullable(None))
+                    | (Value::Nullable(None), Value::Nullable(Some(value))) => {
+                        Value::Nullable(Some(value))
+                    }
+                    (Value::Nullable(Some(left)), Value::Nullable(Some(right)))
+                        if left == right =>
+                    {
+                        Value::Nullable(Some(left))
+                    }
+                    _ => return Err(()),
+                }
+            };
+            values.push(value);
+        }
+        let raw = descriptor.create(&values).map_err(|_| ())?;
+        Ok(Self {
+            table: self.table.clone(),
+            schema_version: self.schema_version,
+            record: OwnedRecord::new(raw, descriptor),
+            authored_columns: self.authored_columns.clone(),
+        })
+    }
 }
 
 trait NullableValue {
@@ -3041,6 +3090,61 @@ mod tests {
 
         assert_ne!(base, authored);
         assert_ne!(base.cmp(&authored), Ordering::Equal);
+    }
+
+    #[test]
+    fn version_record_merges_compatible_view_projections_without_hiding_payload() {
+        let table = TableSchema::new("todos", [ColumnSchema::new("title", ColumnType::String)]);
+        let full = VersionRecord::from_cells(
+            &table,
+            schema_id(1),
+            RowUuid::from_bytes([1; 16]),
+            Vec::new(),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            &BTreeMap::from([("title".to_owned(), Value::String("visible".to_owned()))]),
+            None,
+        )
+        .unwrap();
+        let hidden = VersionRecord::from_cells(
+            &table,
+            schema_id(1),
+            RowUuid::from_bytes([1; 16]),
+            Vec::new(),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            &BTreeMap::<String, Value>::new(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            hidden.merge_view_projection(&full).unwrap().cell_at(0),
+            Some(Value::String("visible".to_owned()))
+        );
+        assert_eq!(
+            full.merge_view_projection(&hidden).unwrap().cell_at(0),
+            Some(Value::String("visible".to_owned()))
+        );
+
+        let conflicting = VersionRecord::from_cells(
+            &table,
+            schema_id(1),
+            RowUuid::from_bytes([1; 16]),
+            Vec::new(),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            AuthorId::SYSTEM,
+            TxTime(1),
+            &BTreeMap::from([("title".to_owned(), Value::String("other".to_owned()))]),
+            None,
+        )
+        .unwrap();
+        assert!(full.merge_view_projection(&conflicting).is_err());
     }
 
     fn sample_lens() -> MigrationLens {


### PR DESCRIPTION
🤖 Fixes false `ConflictingCommitUnit` errors when one receiver tick contains compatible projections of the same immutable version from multiple subscriptions.

The receiver now merges projections cell-by-cell only when immutable identity, metadata, authored presence, descriptor, deletion state, and schema all agree. Absent and present nullable cells combine to preserve the visible value; unequal present values still fail as a real conflict.

This removes a deterministic source of downstream subscription and CI failures without weakening conflict detection.

Validation:

- focused immutable-record merge coverage
- end-to-end receiver batch with disjoint `title`-only and `body`-only projections
- existing multi-subscription and recursive policy regressions
- planted old-conflict behavior and dropped-side mutations all fail the strengthened test
- formatting, Clippy with warnings denied, diff, and sensitive-data checks
- independent adversarial review: approved with no findings
