### PR TITLE
fix: canonicalize terminal collection deltas

### DIFF
--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -11487,11 +11487,18 @@ fn update_unbounded_collect_by_terminal_state(
         state.groups.clear();
         state.roots.clear();
     }
+    // A weighted update arrives as a post-image addition and pre-image
+    // removal. Consolidate exact records and canonicalize every surviving
+    // transition before emitting terminal edits: net removals first, then net
+    // additions. This makes replacement (`-before, +after`) unambiguous to
+    // consumers and cancels transient insert/delete pairs within one batch.
+    let deltas =
+        canonical_collect_by_terminal_deltas(input_desc, collect_by, direct_tree_slot, deltas)?;
     let root_groups_before = direct_tree_slot
         .is_none()
         .then(|| state.groups.keys().cloned().collect::<BTreeSet<_>>());
     let mut operations = Vec::new();
-    for delta in deltas {
+    for delta in &deltas {
         let group_key =
             encoded_record_key_part(input_desc, delta.raw(), &collect_by.group_field_indices)?;
         if let Some(presence_field) = direct_tree_slot.and_then(|slot| slot.presence_field_index)
@@ -11681,6 +11688,72 @@ fn update_unbounded_collect_by_terminal_state(
         }
     }
     Ok(operations)
+}
+
+fn canonical_collect_by_terminal_deltas(
+    input_desc: RecordDescriptor,
+    collect_by: &CollectByOp,
+    direct_tree_slot: Option<&CollectBySlot>,
+    deltas: &[RecordDelta],
+) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
+    let (sort_field_indices, sort_directions) = direct_tree_slot.map_or(
+        (
+            collect_by.sort_field_indices.as_slice(),
+            collect_by.sort_directions.as_slice(),
+        ),
+        |slot| {
+            (
+                slot.sort_field_indices.as_slice(),
+                slot.sort_directions.as_slice(),
+            )
+        },
+    );
+    let keyed = deltas
+        .iter()
+        .map(|delta| {
+            Ok::<_, IvmRuntimeError>((
+                encoded_record_key_part(input_desc, delta.raw(), &collect_by.group_field_indices)?,
+                collect_by_sort_key_for_fields(
+                    input_desc,
+                    delta.raw(),
+                    sort_field_indices,
+                    sort_directions,
+                )?,
+                delta.record.clone(),
+                delta.weight,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(canonicalize_collect_by_terminal_weights(keyed)
+        .into_iter()
+        .map(|(_, _, record, weight)| RecordDelta { record, weight })
+        .collect())
+}
+
+fn canonicalize_collect_by_terminal_weights(
+    keyed: Vec<(Vec<u8>, Vec<TopBySortPart>, Bytes, i64)>,
+) -> Vec<(Vec<u8>, Vec<TopBySortPart>, Bytes, i64)> {
+    let mut consolidated = BTreeMap::<(Vec<u8>, Vec<TopBySortPart>, Bytes), i64>::new();
+    for (group_key, sort_key, record, weight) in keyed {
+        *consolidated
+            .entry((group_key, sort_key, record))
+            .or_default() += weight;
+    }
+    let mut canonical = consolidated
+        .into_iter()
+        .filter_map(|((group_key, sort_key, record), weight)| {
+            (weight != 0).then_some((group_key, sort_key, record, weight))
+        })
+        .collect::<Vec<_>>();
+    canonical.sort_by(
+        |(left_group, left_sort, _, left_weight), (right_group, right_sort, _, right_weight)| {
+            left_group
+                .cmp(right_group)
+                .then_with(|| left_weight.is_positive().cmp(&right_weight.is_positive()))
+                .then_with(|| left_sort.cmp(right_sort))
+        },
+    );
+    canonical
 }
 
 fn update_collect_by_root_terminal_state(
@@ -12447,6 +12520,47 @@ mod tests {
         ColumnSchema, ColumnType, DatabaseSchema, IndexSchema, IntegerKeyType, PrimaryKey,
     };
     use crate::storage::{RecordStore, RocksDbStorage};
+
+    #[test]
+    fn terminal_collect_canonicalization_emits_net_remove_before_net_insert() {
+        let record = |label: u8| Bytes::from(vec![label]);
+        let keyed = |record: Bytes, weight| (vec![1], Vec::new(), record, weight);
+
+        // An update followed by deletion of its post-image is a final delete,
+        // not an ambiguous replacement. An intermediate update that cancels
+        // within the batch disappears, while independent roots stay ordered.
+        let canonical = canonicalize_collect_by_terminal_weights(vec![
+            keyed(record(1), -1),
+            keyed(record(2), 1),
+            keyed(record(2), -1),
+            keyed(record(3), 1),
+            (vec![2], Vec::new(), record(4), 1),
+            (vec![2], Vec::new(), record(4), -1),
+        ]);
+        assert_eq!(
+            canonical,
+            vec![
+                (vec![1], Vec::new(), record(1), -1),
+                (vec![1], Vec::new(), record(3), 1)
+            ]
+        );
+
+        // Grouped/interleaved multiple replacements retain only the final
+        // post-image and put the pre-image removal before it.
+        let replacements = canonicalize_collect_by_terminal_weights(vec![
+            keyed(record(1), -1),
+            keyed(record(2), 1),
+            keyed(record(2), -1),
+            keyed(record(3), 1),
+        ]);
+        assert_eq!(
+            replacements,
+            vec![
+                (vec![1], Vec::new(), record(1), -1),
+                (vec![1], Vec::new(), record(3), 1)
+            ]
+        );
+    }
 
     #[test]
     fn raw_variant_case_registry_refresh_rejects_projection_replacement() {

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -4051,14 +4051,33 @@ fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
         BTreeMap::from([("body".to_owned(), Value::String("edited".to_owned()))]),
     )
     .unwrap();
-    assert!(matches!(
-        block_on(subscription.next_event()).unwrap(),
-        SubscriptionEvent::Delta { terminal_operations, .. }
-            if terminal_operations.iter().any(|operation| matches!(
-                operation.edit,
-                groove::ivm::TerminalEdit::Insert { .. } | groove::ivm::TerminalEdit::Update { .. }
-            ))
-    ));
+    let SubscriptionEvent::Delta {
+        terminal_operations,
+        ..
+    } = block_on(subscription.next_event()).unwrap()
+    else {
+        panic!("child update must emit a terminal delta");
+    };
+    let child_operations = terminal_operations
+        .iter()
+        .filter(|operation| !operation.path.is_empty())
+        .collect::<Vec<_>>();
+    let [remove, insert] = child_operations.as_slice() else {
+        panic!("a child replacement must emit exactly one remove and one insert");
+    };
+    let groove::ivm::TerminalEdit::Remove { key: remove_key } = &remove.edit else {
+        panic!("a child replacement must begin with Remove");
+    };
+    let groove::ivm::TerminalEdit::Insert {
+        key: insert_key, ..
+    } = &insert.edit
+    else {
+        panic!("a child replacement must end with Insert");
+    };
+    assert_eq!(
+        remove_key, insert_key,
+        "canonical replacement must address one stable child identity"
+    );
 
     db.delete("comments", row(0xc1)).unwrap();
     assert!(matches!(

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -1170,6 +1170,41 @@ describe("SubscriptionManager", () => {
     ]);
     expect(result.delta).toEqual([{ kind: 0, id: rootId, index: 0, item: result.all![0] }]);
 
+    // Producers canonicalize a weighted child replacement as Remove(old),
+    // Insert(new); consumers apply that wire contract without inference.
+    const replacement = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: rootKey,
+            path: [{ Collection: "__jazz_include_project" }],
+            edit: { Remove: { key: childKey } },
+          },
+          {
+            root_key: rootKey,
+            path: [{ Collection: "__jazz_include_project" }],
+            edit: {
+              Insert: {
+                index: 0,
+                key: childKey,
+                value: [...terminalTextChild(childId, "Revised announcements")],
+              },
+            },
+          },
+        ],
+      },
+      transformIncluded,
+      rootColumns,
+    );
+    expect(replacement.all?.[0]?.project?.name).toBe("Revised announcements");
+
     expect(() =>
       manager.handleDelta(
         {
@@ -1197,7 +1232,7 @@ describe("SubscriptionManager", () => {
         rootColumns,
       ),
     ).toThrow(/does not match addressed key/);
-    expect(manager.all()).toEqual(result.all);
+    expect(manager.all()).toEqual(replacement.all);
 
     const nestedUpdate = manager.handleDelta(
       {


### PR DESCRIPTION
🤖 Fixes intermittent reverse-include subscription updates by canonicalizing terminal collection deltas at the Groove producer boundary.

Weighted collector inputs are consolidated by exact record first. The producer then emits net removals before net additions for each root, making child replacements unambiguous while preserving insert/delete cancellation, final deletion, repeated updates, and independent groups. The TypeScript consumer remains a simple ordered operation applier rather than guessing intent from ambiguous batches.

Validation:

- Groove characterization for grouped/interleaved updates, insert-delete cancellation, update-delete, and independent groups
- real Jazz producer-to-wire assertion requiring stable-key `Remove(old) → Insert(new)`
- subscription-manager suite: 27/27
- full `db.subscribeAll` browser file: 27/27
- focused reverse-include browser repetition: 5/5
- Clippy, formatting, and sensitive-data checks
- independent adversarial review with planted ordering regression: approved
