### PR TITLE
ci: avoid serializing trusted-runner phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,35 +17,6 @@ env:
   CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
 
 jobs:
-  # Does the integration branch still compile after a merge?
-  #
-  # PR-level checks cannot answer this. Each PR is built against the base as it
-  # was, so two PRs that are individually green can merge cleanly and produce a
-  # tree that does not build. That happened on 2026-07-29: one PR removed
-  # `RecursionBound::iteration_cap`, another kept a call to it, neither
-  # conflicted, and `codex/jazz-core-engine-swap` was left unable to compile —
-  # unnoticed until it broke unrelated work hours later.
-  #
-  # Deliberately narrow. The full suites are not yet green, so gating on them
-  # would force routine overrides and make "red" meaningless. This checks the
-  # one property we can guarantee, and is fast and flake-free. Promote the other
-  # jobs to gates individually as each goes green.
-  build-integration:
-    # Trusted branches use the persistent runner; fork PRs remain isolated on
-    # hosted infrastructure because this job executes repository code.
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-build
-        with:
-          rust-targets: wasm32-unknown-unknown
-          sccache: "true"
-          sccache-sticky-disk: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'true' || 'false' }}
-
-      - run: cargo check --workspace --all-targets
-
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
@@ -119,6 +90,18 @@ jobs:
           rust-targets: wasm32-unknown-unknown
           sccache: "true"
           sccache-sticky-disk: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'true' || 'false' }}
+
+      # Keep the integration-branch compile gate, but run it as the first
+      # phase of the only trusted-runner job. `jazz-ci` currently has one
+      # worker: separate build-integration and test-ts jobs otherwise queue
+      # behind one another, so their setup/checkout overhead is on the PR
+      # critical path rather than overlapping.
+      #
+      # PR-level checks cannot catch two independently green PRs whose merged
+      # tree no longer compiles. This runs on every push to the integration
+      # branch before building the TypeScript correctness artifacts.
+      - name: Check integration workspace
+        run: cargo check --workspace --all-targets
 
       - name: Install WASM packager
         # Only this job builds jazz-wasm. Other Rust jobs receive their target

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -17,7 +17,6 @@ const job = (name, nextName) => {
 };
 
 test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for wasm-pack", () => {
-  const buildIntegration = job("build-integration", "lint");
   const lint = job("lint", "test-rust");
   const rust = job("test-rust", "test-ts");
   const typescript = job("test-ts");
@@ -27,8 +26,25 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
   assert.doesNotMatch(rust, /ensure:rust-toolchain|wasm-pack/);
   assert.doesNotMatch(rust, /rust-components:/);
   assert.doesNotMatch(lint, /ensure:rust-toolchain|wasm-pack/);
-  assert.doesNotMatch(buildIntegration, /ensure:rust-toolchain|wasm-pack/);
   assert.match(typescript, /tool: wasm-pack@0\.13\.1/);
+});
+
+test("the single trusted-runner job checks the integration workspace before TypeScript artifacts", () => {
+  const typescript = job("test-ts");
+
+  // The dedicated jazz-ci runner has one worker. Splitting these phases into
+  // jobs serializes their checkout/setup work in GitHub's runner queue.
+  assert.doesNotMatch(workflow, /^  build-integration:/m);
+  assert.match(
+    typescript,
+    /name: Check integration workspace\s+run: cargo check --workspace --all-targets/,
+  );
+  assert.ok(
+    typescript.indexOf("name: Check integration workspace") <
+      typescript.indexOf("name: Build correctness-test artifacts"),
+    "workspace check must fail before the expensive correctness artifact build",
+  );
+  assert.match(typescript, /runs-on: \$\{\{ github\.event_name == 'pull_request'.*'jazz-ci' \}\}/);
 });
 
 test("lint keeps its one workspace Clippy invocation inside pnpm lint", () => {

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -15,6 +15,27 @@ const job = (name, nextName) => {
   assert.notEqual(end, -1, `missing boundary after ${name} job`);
   return workflow.slice(start, end);
 };
+const integrationCheckStep = (typescriptJob) => {
+  const start = typescriptJob.indexOf("name: Check integration workspace");
+  assert.notEqual(start, -1, "missing integration workspace check");
+  const end = typescriptJob.indexOf("\n      - ", start + 1);
+  return typescriptJob.slice(start, end === -1 ? typescriptJob.length : end);
+};
+const assertIntegrationCheckIsGating = (typescriptJob) => {
+  // Job-level continue-on-error makes every failed step non-gating. Reject the
+  // property rather than only the literal `true`, because expressions are
+  // equally able to accidentally suppress an integration failure.
+  assert.doesNotMatch(
+    typescriptJob,
+    /^    continue-on-error:/m,
+    "test-ts must not suppress job failures",
+  );
+  assert.doesNotMatch(
+    integrationCheckStep(typescriptJob),
+    /^\s+continue-on-error:/m,
+    "integration workspace check must not suppress its failure",
+  );
+};
 
 test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for wasm-pack", () => {
   const lint = job("lint", "test-rust");
@@ -39,12 +60,37 @@ test("the single trusted-runner job checks the integration workspace before Type
     typescript,
     /name: Check integration workspace\s+run: cargo check --workspace --all-targets/,
   );
+  assertIntegrationCheckIsGating(typescript);
   assert.ok(
     typescript.indexOf("name: Check integration workspace") <
       typescript.indexOf("name: Build correctness-test artifacts"),
     "workspace check must fail before the expensive correctness artifact build",
   );
   assert.match(typescript, /runs-on: \$\{\{ github\.event_name == 'pull_request'.*'jazz-ci' \}\}/);
+});
+
+test("integration workspace check contract rejects planted failure suppression", () => {
+  const typescript = job("test-ts");
+  const check =
+    "name: Check integration workspace\n        run: cargo check --workspace --all-targets";
+
+  assert.throws(
+    () =>
+      assertIntegrationCheckIsGating(
+        typescript.replace(check, `${check}\n        continue-on-error: true`),
+      ),
+    /integration workspace check must not suppress its failure/,
+  );
+  assert.throws(
+    () =>
+      assertIntegrationCheckIsGating(
+        typescript.replace(
+          "    timeout-minutes: 20",
+          "    continue-on-error: true\n    timeout-minutes: 20",
+        ),
+      ),
+    /test-ts must not suppress job failures/,
+  );
 });
 
 test("lint keeps its one workspace Clippy invocation inside pnpm lint", () => {


### PR DESCRIPTION
🤖 Removes avoidable serialization on the single dedicated `jazz-ci` runner.

`build-integration` and `test-ts` previously competed for the same one-job runner, so the workspace compile check added a strict 48–55 second queue tail after the TypeScript job. This moves the exact `cargo check --workspace --all-targets` gate to the beginning of `test-ts`, before artifact construction, and removes the redundant separate trusted-runner job.

Fork fallback behavior and failure semantics are preserved. Workflow contracts require the check to exist, run before artifacts, and remain gating; planted step- and job-level `continue-on-error` suppressions fail the contract.

Validation:

- `pnpm test:ci-workflow` (14/14)
- `pnpm format:check`
- diff and sensitive-data checks
- read-only runner inventory: exactly one online `jazz-ci` runner
- observed queue tail on recent integration runs: 48–55 seconds
- independent adversarial review: approved

Papercut noted: local `actionlint` is not installed, so YAML validation uses the plant-sensitive workflow contract plus GitHub's parser.
