### PR TITLE
ci: contract the release starter gate

### DIFF
--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -38,7 +38,7 @@ jobs:
   prepare:
     # On PR events, only fire on the changesets release PR. Manual dispatch is
     # always allowed (handy for testing a starter in isolation).
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'changeset-release/') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.head_ref == 'changeset-release/main' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -109,7 +109,7 @@ jobs:
 
   e2e:
     needs: prepare
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'changeset-release/') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.head_ref == 'changeset-release/main' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -4,8 +4,8 @@ name: Starters E2E
 # changesets release PR if any starter fails to scaffold, install, build, or
 # pass its Playwright suite against the production build.
 #
-# Trigger: any push to the changesets-managed release branch
-# (`changeset-release/main`), plus manual dispatch for ad-hoc runs.
+# Trigger: a changesets-managed release pull request targeting `main`, plus
+# manual dispatch for ad-hoc runs. Ordinary pull requests are skipped.
 #
 # Shape: the `prepare` job builds the workspace once and packs the three
 # workspace tarballs (jazz-tools, jazz-napi, jazz-wasm) plus the runtime

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -41,7 +41,7 @@ test("CI runs the workflow contract test through its package script", () => {
   const lint = job("lint", "test-rust");
   assert.equal(
     packageJson.scripts["test:ci-workflow"],
-    "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs",
+    "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs",
   );
   assert.match(lint, /run: pnpm test:ci-workflow/);
 });

--- a/dev/gates/test/release-gates.test.mjs
+++ b/dev/gates/test/release-gates.test.mjs
@@ -22,6 +22,13 @@ function listedStarters(source) {
   return [...source.matchAll(/^\s+- ([-a-z]+)$/gm)].map((match) => match[1]);
 }
 
+const expectedReleaseCondition =
+  "github.event_name == 'workflow_dispatch' || github.head_ref == 'changeset-release/main'";
+
+function releaseCondition(jobSource) {
+  return jobSource.match(/^    if: \$\{\{ (.*) \}\}$/m)?.[1];
+}
+
 test("release starter gate covers the canonical scaffold catalogue and no ordinary PR", () => {
   const canonical = starters.match(/export const KNOWN_STARTERS = \[([\s\S]*?)\] as const;/)?.[1];
   assert.ok(canonical, "could not find the canonical starter catalogue");
@@ -34,14 +41,23 @@ test("release starter gate covers the canonical scaffold catalogue and no ordina
 
   const prepare = job("prepare", "e2e");
   const e2e = job("e2e");
-  const releaseOnly =
-    /github\.event_name == 'workflow_dispatch' \|\| startsWith\(github\.head_ref, 'changeset-release\/'\)/;
-  assert.match(prepare, releaseOnly);
-  assert.match(e2e, releaseOnly);
+  assert.equal(releaseCondition(prepare), expectedReleaseCondition);
+  assert.equal(releaseCondition(e2e), expectedReleaseCondition);
 
   const matrix = e2e.match(/matrix:\n        starter:\n([\s\S]*?)\n    steps:/)?.[1];
   assert.ok(matrix, "could not find the starter E2E matrix");
   assert.deepEqual(listedStarters(matrix), expected);
+});
+
+test("release starter gate rejects prefix and unconditional trigger broadening", () => {
+  for (const broadened of [
+    "github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'changeset-release/')",
+    "github.event_name == 'workflow_dispatch' || true",
+  ]) {
+    assert.notEqual(broadened, expectedReleaseCondition);
+  }
+  assert.doesNotMatch(workflow, /startsWith\(github\.head_ref, 'changeset-release\/'/);
+  assert.doesNotMatch(workflow, /github\.event_name == 'workflow_dispatch' \|\| true/);
 });
 
 test("release starter gate exercises packaged artifacts through create-jazz-e2e", () => {

--- a/dev/gates/test/release-gates.test.mjs
+++ b/dev/gates/test/release-gates.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const workflow = fs.readFileSync(path.join(root, ".github/workflows/starters-e2e.yml"), "utf8");
+const starters = fs.readFileSync(
+  path.join(root, "packages/create-jazz-e2e/src/starters.ts"),
+  "utf8",
+);
+
+function job(name, nextName) {
+  const start = workflow.indexOf(`  ${name}:`);
+  const end = nextName ? workflow.indexOf(`  ${nextName}:`, start + 1) : workflow.length;
+  assert.notEqual(start, -1, `missing ${name} job`);
+  assert.notEqual(end, -1, `missing boundary after ${name} job`);
+  return workflow.slice(start, end);
+}
+
+function listedStarters(source) {
+  return [...source.matchAll(/^\s+- ([-a-z]+)$/gm)].map((match) => match[1]);
+}
+
+test("release starter gate covers the canonical scaffold catalogue and no ordinary PR", () => {
+  const canonical = starters.match(/export const KNOWN_STARTERS = \[([\s\S]*?)\] as const;/)?.[1];
+  assert.ok(canonical, "could not find the canonical starter catalogue");
+  const expected = [...canonical.matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+  assert.ok(expected.length > 0, "canonical starter catalogue is empty");
+
+  assert.match(workflow, /^  workflow_dispatch:/m);
+  assert.match(workflow, /^  pull_request:\n    branches: \[main\]$/m);
+  assert.doesNotMatch(workflow, /^  push:/m);
+
+  const prepare = job("prepare", "e2e");
+  const e2e = job("e2e");
+  const releaseOnly =
+    /github\.event_name == 'workflow_dispatch' \|\| startsWith\(github\.head_ref, 'changeset-release\/'\)/;
+  assert.match(prepare, releaseOnly);
+  assert.match(e2e, releaseOnly);
+
+  const matrix = e2e.match(/matrix:\n        starter:\n([\s\S]*?)\n    steps:/)?.[1];
+  assert.ok(matrix, "could not find the starter E2E matrix");
+  assert.deepEqual(listedStarters(matrix), expected);
+});
+
+test("release starter gate exercises packaged artifacts through create-jazz-e2e", () => {
+  const prepare = job("prepare", "e2e");
+  const e2e = job("e2e");
+  assert.match(prepare, /pnpm run build:core/);
+  assert.match(prepare, /for pkg in jazz-tools jazz-napi jazz-wasm;/);
+  assert.match(prepare, /name: starters-e2e-build-state/);
+  assert.match(e2e, /name: starters-e2e-build-state/);
+  assert.match(e2e, /--tarball-dir "\$GITHUB_WORKSPACE\/_e2e-state\/tarballs"/);
+  assert.match(e2e, /--verbose --keep/);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
     "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
-    "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs",
+    "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs",
     "ensure:rust-toolchain": "rustup target add wasm32-unknown-unknown && (wasm-pack --version >/dev/null 2>&1 || cargo install wasm-pack@0.13.1 --locked)",
     "build:vercel-docs": "bash dev/scripts/install-vercel-deps.sh && turbo run --env-mode=loose build:crates --filter=@jazz/rust && turbo run --env-mode=loose build --filter=docs --only",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",

--- a/packages/create-jazz-e2e/README.md
+++ b/packages/create-jazz-e2e/README.md
@@ -73,7 +73,8 @@ the ~10-minute `build:core` across 12 matrix runners:
 2. `e2e` (matrix) — downloads that artifact, installs Playwright browsers, and
    runs the harness with `--tarball-dir` so it skips the pack step.
 
-Fires on every push to a `changeset-release/*` branch (the release PR that the
-changesets action keeps updated against `main`). Failures block the release.
+Fires for the `changeset-release/*` pull request that the changesets action
+keeps updated against `main`; ordinary pull requests are skipped. Failures block
+the release.
 `workflow_dispatch` is also available for ad-hoc runs and accepts a single
 `starter` input to run just one matrix slot.


### PR DESCRIPTION
🤖 Adds a fast contract around the existing release-only starter/create-jazz E2E gate and corrects its trigger to match the actual Changesets release branch.

The full 12-starter packaging, scaffolding, production-build, and Playwright matrix remains release/manual-only. Both jobs now accept exactly `changeset-release/main` or `workflow_dispatch`; an ordinary similarly named PR cannot accidentally trigger the expensive matrix.

The contract keeps the workflow matrix synchronized with the canonical starter catalogue and protects the packed Jazz artifacts and create-jazz harness flags from silently drifting. Documentation now accurately describes the release-PR/manual trigger rather than claiming a push trigger.

Validation:

- `pnpm test:ci-workflow` (15/15)
- planted prefix and `|| true` trigger broadenings fail
- planted starter removal, package omission, and harness-flag omission fail
- `pnpm format:check`
- sensitive-data guard
- independent adversarial review: approved

Papercut noted: these workflow contracts use deliberate fast textual parsing because the repository has no shared YAML-aware condition helper yet.
