### PR TITLE
fix: ship canonical whole-row version payloads

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -3253,8 +3253,8 @@ where
         column: &str,
         kind: LargeValueKind,
     ) -> Result<Vec<u8>, Error> {
-        let canonical = self.canonical_maintained_view_witness(version)?;
-        let version = canonical.as_ref().unwrap_or(version);
+        let canonical = self.canonical_history_version_for_maintained_witness(version)?;
+        let version = &canonical;
         let authored_schema = self
             .schema_version_for_alias(version.schema_version_alias())
             .ok_or(Error::InvalidStoredValue(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1358,6 +1358,23 @@ where
         request: &SourceRequest,
         table: &TableSchema,
     ) -> BTreeSet<String> {
+        // The public query may select a subset of columns, but a maintained
+        // version witness feeds `VersionRecord` serialization. A row version
+        // is a complete replicated commit unit, so its source must retain all
+        // logical user columns before the terminal applies app projection
+        // (INV-DATA-18 and INV-SYNC-16). Policy and relation facts have their
+        // own typed terminals; they never express omitted VersionRecord cells.
+        if request
+            .requirements
+            .metadata
+            .contains(&SourceMetadataRequirement::VersionWitnesses)
+        {
+            return table
+                .columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect();
+        }
         match &request.requirements.app_fields {
             // `All` still goes through the query-local boundary. The durable
             // all-fields projection predates compatibility-sensitive reads and
@@ -9273,8 +9290,8 @@ where
         kind: LargeValueKind,
         cache: &mut LocalMaintainedMaterializationCache,
     ) -> Result<Vec<u8>, Error> {
-        let canonical = self.canonical_maintained_view_witness(version)?;
-        let version = canonical.as_ref().unwrap_or(version);
+        let canonical = self.canonical_history_version_for_maintained_witness(version)?;
+        let version = &canonical;
         let authored_schema = self
             .schema_version_for_alias(version.schema_version_alias())
             .ok_or(Error::InvalidStoredValue(

--- a/crates/jazz/src/node/tests/lens_projected_maintained.rs
+++ b/crates/jazz/src/node/tests/lens_projected_maintained.rs
@@ -114,6 +114,17 @@ fn maintained_projected_current_picks_winner_before_lens_projection() {
     assert_eq!(bundles.len(), 1);
     assert_eq!(bundles[0].versions.len(), 1);
     let shipped = &bundles[0].versions[0];
+    let canonical = core
+        .query_versions_for_tx(new_tx)
+        .unwrap()
+        .into_iter()
+        .find(|version| version.row_uuid() == shared_row)
+        .map(|version| core.version_record_from_row(&version).unwrap())
+        .expect("new winner must remain in canonical history");
+    assert_eq!(
+        shipped, &canonical,
+        "the title-only read projection must not change the replicated VersionRecord (INV-DATA-16/18; INV-SYNC-16; C.3)"
+    );
     assert_eq!(shipped.schema_version(), evolved_payload.id);
     assert_eq!(shipped.table(), "todos");
     assert_eq!(shipped.cell_at(0), Some(v("new-name")));

--- a/crates/jazz/src/node/tests/policies_rls.rs
+++ b/crates/jazz/src/node/tests/policies_rls.rs
@@ -2294,6 +2294,101 @@ fn edge_query_rehydrate_ships_public_chat_from_chat_policy_schema() {
     assert_view_update_only_ships_rows(&update, BTreeSet::from([public_chat]));
 }
 
+/// A source-harness regression for row-scoped read policy plus query output
+/// projection. Two fresh edge-client links ask for the same readable chat via
+/// different public projections; both wire payloads must be the identical
+/// complete canonical row version. `select` shapes terminal output only.
+#[test]
+fn public_chat_projections_ship_identical_complete_row_versions() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "chats",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("visibility", ColumnType::String),
+        ],
+    )
+    .with_read_policy(Policy::shape(
+        Query::from("chats").filter(eq(col("visibility"), lit("public"))),
+    ))
+    .with_write_policy(Policy::public())]);
+    let (_core_dir, mut core) = open_node_with_schema(node(0x62), schema.clone());
+    let reader = user(0x63);
+    let public_chat = row(0x64);
+    let private_chat = row(0x65);
+    let public_tx = accept_global(
+        &mut core,
+        MergeableCommit::new("chats", public_chat, 10).cells(BTreeMap::from([
+            ("title".to_owned(), v("public title")),
+            ("visibility".to_owned(), v("public")),
+        ])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("chats", private_chat, 11).cells(BTreeMap::from([
+            ("title".to_owned(), v("private title")),
+            ("visibility".to_owned(), v("private")),
+        ])),
+    );
+
+    let full_shape = Query::from("chats").validate(&schema).unwrap();
+    let title_shape = Query::from("chats")
+        .select(["title"])
+        .validate(&schema)
+        .unwrap();
+    let mut full_link = PeerState::edge_client(reader);
+    let full_update = full_link
+        .rehydrate_query(&mut core, &full_shape, &full_shape.bind(BTreeMap::new()).unwrap())
+        .unwrap();
+    let mut title_link = PeerState::edge_client(reader);
+    let title_update = title_link
+        .rehydrate_query(
+            &mut core,
+            &title_shape,
+            &title_shape.bind(BTreeMap::new()).unwrap(),
+        )
+        .unwrap();
+
+    for update in [&full_update, &title_update] {
+        assert_view_update_only_references_rows(update, BTreeSet::from([public_chat]));
+        assert_view_update_only_ships_rows(update, BTreeSet::from([public_chat]));
+    }
+    let full_version = version_bundles_for_update(&full_update)
+        .into_iter()
+        .flat_map(|bundle| bundle.versions)
+        .find(|version| version.table() == "chats" && version.row_uuid() == public_chat)
+        .expect("full query must ship public chat payload");
+    let title_version = version_bundles_for_update(&title_update)
+        .into_iter()
+        .flat_map(|bundle| bundle.versions)
+        .find(|version| version.table() == "chats" && version.row_uuid() == public_chat)
+        .expect("title query must ship public chat payload");
+    let canonical = core
+        .query_versions_for_tx(public_tx)
+        .unwrap()
+        .into_iter()
+        .find(|version| version.table() == "chats" && version.row_uuid() == public_chat)
+        .map(|version| core.version_record_from_row(&version).unwrap())
+        .expect("public chat must have canonical history payload");
+    assert_eq!(full_version, canonical);
+    assert_eq!(title_version, canonical);
+
+    let title_rows = core
+        .query_rows_for_link(
+            &title_shape,
+            &title_shape.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Global,
+            reader,
+        )
+        .unwrap();
+    assert_eq!(title_rows.len(), 1);
+    assert_eq!(title_rows[0].cell(&schema.tables[0], "title"), Some(v("public title")));
+    assert_eq!(
+        title_rows[0].cell(&schema.tables[0], "visibility"),
+        None,
+        "select projection belongs to terminal output, not VersionRecord payloads"
+    );
+}
+
 #[test]
 fn nullable_join_code_claim_branch_allows_edge_chat_read() {
     let schema = JazzSchema::new([TableSchema::new(

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -703,8 +703,11 @@ fn receiver_batch_coalesces_partial_bundles_for_same_tx() {
     assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);
 }
 
+// This stays internal because it directly exercises the protocol receiver's
+// receiver-batch boundary. The public serving tests below assert the matching
+// producer-side whole-row payload rule.
 #[test]
-fn receiver_batch_merges_complementary_projections_for_same_version() {
+fn receiver_batch_replays_identical_whole_versions_and_rejects_conflicts() {
     let projection_schema = JazzSchema::new([TableSchema::new(
         "todos",
         [
@@ -741,26 +744,25 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
         panic!("expected accepted fate");
     };
     let full = versions.into_iter().next().unwrap();
-    let projection = |cells: Vec<Option<Value>>| {
-        VersionRecord::encode(
-            &projection_schema.tables[0],
-            full.schema_version(),
-            full.row_uuid(),
-            full.parents(),
-            full.created_by(),
-            full.created_at(),
-            full.updated_by(),
-            full.updated_at(),
-            &cells,
-            full.deletion(),
-        )
-        .unwrap()
-        .with_authored_columns(full.authored_columns().cloned())
-    };
-    let title_only = projection(vec![full.cell_at(0), None]);
-    let body_only = projection(vec![None, full.cell_at(1)]);
+    let conflicting = VersionRecord::encode(
+        &projection_schema.tables[0],
+        full.schema_version(),
+        full.row_uuid(),
+        full.parents(),
+        full.created_by(),
+        full.created_at(),
+        full.updated_by(),
+        full.updated_at(),
+        &[
+            Some(Value::String("conflicting title".to_owned())),
+            full.cell_at(1),
+        ],
+        full.deletion(),
+    )
+    .unwrap()
+    .with_authored_columns(full.authored_columns().cloned());
     let subscription = reader.whole_table_subscription_key("todos").unwrap();
-    let update = |version, result_member_adds| ViewUpdateParts {
+    let update = |version, fate, update_global_seq, update_durability, result_member_adds| ViewUpdateParts {
         subscription,
         settled_through: global_seq,
         defer_settlement: false,
@@ -769,9 +771,9 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
         version_bundles: vec![VersionBundle {
             tx: tx.clone(),
             versions: vec![version],
-            fate: Fate::Accepted,
-            global_seq: Some(global_seq),
-            durability,
+            fate,
+            global_seq: update_global_seq,
+            durability: update_durability,
         }],
         peer_complete_tx_payload_refs: Vec::new(),
         authorization_progress: None,
@@ -782,10 +784,33 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
         program_fact_removes: Vec::new(),
     };
 
+    assert!(matches!(
+        reader.apply_view_updates_in_batch(vec![
+            update(
+                full.clone(),
+                Fate::Accepted,
+                Some(global_seq),
+                durability,
+                Vec::new(),
+            ),
+            update(
+                conflicting.clone(),
+                Fate::Accepted,
+                Some(global_seq),
+                durability,
+                Vec::new(),
+            ),
+        ]),
+        Err(Error::ConflictingCommitUnit(conflicting_tx)) if conflicting_tx == tx_id
+    ));
+
     reader
         .apply_view_updates_in_batch(vec![
             update(
-                title_only,
+                full.clone(),
+                Fate::Accepted,
+                Some(global_seq),
+                durability,
                 vec![ResultMemberEntry::row((
                     "todos".to_owned().into(),
                     row_uuid,
@@ -793,7 +818,10 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
                 ))],
             ),
             update(
-                body_only,
+                full.clone(),
+                Fate::Accepted,
+                Some(global_seq),
+                durability,
                 vec![ResultMemberEntry::row((
                     "todos".to_owned().into(),
                     row_uuid,
@@ -820,6 +848,34 @@ fn receiver_batch_merges_complementary_projections_for_same_version() {
     );
     assert_eq!(reader.sync_metrics().receiver_bulk_bundle_ingests, 1);
     assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);
+
+    // A later subscription can replay the exact same immutable row payload
+    // with weaker fate metadata. The payload stays idempotent while fate and
+    // durability remain monotone.
+    reader
+        .apply_view_updates_in_batch(vec![update(
+            full.clone(),
+            Fate::Pending,
+            None,
+            DurabilityTier::Edge,
+            Vec::new(),
+        )])
+        .unwrap();
+    assert_eq!(
+        reader.transaction_state(tx_id).unwrap(),
+        (Fate::Accepted, Some(global_seq), DurabilityTier::Global),
+    );
+
+    assert!(matches!(
+        reader.apply_view_updates_in_batch(vec![update(
+            conflicting,
+            Fate::Accepted,
+            Some(global_seq),
+            durability,
+            Vec::new(),
+        )]),
+        Err(Error::ConflictingCommitUnit(conflicting_tx)) if conflicting_tx == tx_id
+    ));
 }
 
 // This stays internal because it directly exercises the protocol receiver's

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -64,11 +64,9 @@ fn merge_receiver_version_bundle_ref(
         .collect::<BTreeMap<_, VersionRecord>>();
     for version in bundle.versions {
         let key = version_bundle_record_key(version);
-        match seen.get_mut(&key) {
-            Some(existing) => match existing.merge_view_projection(version) {
-                Ok(merged) => *existing = merged,
-                Err(()) => return Err(Error::ConflictingCommitUnit(bundle.tx.tx_id)),
-            },
+        match seen.get(&key) {
+            Some(existing) if existing == version => {}
+            Some(_) => return Err(Error::ConflictingCommitUnit(bundle.tx.tx_id)),
             None => {
                 seen.insert(key, version.clone());
             }
@@ -1278,8 +1276,13 @@ where
         };
         let mut versions = Vec::with_capacity(tx_versions.len());
         for version in tx_versions {
-            let canonical = self.canonical_maintained_view_witness(version)?;
-            versions.push(self.version_record_from_row(canonical.as_ref().unwrap_or(version))?);
+            // A maintained terminal may use a current-row source projected for
+            // query evaluation, but a VersionRecord is replicated history, not
+            // query output. Resolve its identity back to the stored authored
+            // row before crossing the wire boundary (INV-DATA-16/18,
+            // INV-SYNC-16, and C.3's byte-fidelity rule).
+            let canonical = self.canonical_history_version_for_maintained_witness(version)?;
+            versions.push(self.version_record_from_row(&canonical)?);
         }
         Ok(VersionBundle {
             tx: tx_payload,
@@ -1290,14 +1293,17 @@ where
         })
     }
 
-    /// Maintained query evaluation uses rows projected into the subscription's
-    /// schema. Sync must still ship the immutable payload authored under the
-    /// row's stored schema alias, so recover that exact history row only when
-    /// the projected witness no longer has its authored logical layout.
-    pub(super) fn canonical_maintained_view_witness(
+    /// Return the stored, authored history row for a maintained witness.
+    ///
+    /// The maintained graph may evaluate a schema-compatible current source,
+    /// whereas a wire `VersionRecord` is always the complete immutable row
+    /// version under its authored schema. This producer-side normalization is
+    /// deliberately before serialization; receivers reject non-identical
+    /// duplicate row versions rather than repairing them.
+    pub(super) fn canonical_history_version_for_maintained_witness(
         &mut self,
         version: &VersionRow,
-    ) -> Result<Option<VersionRow>, Error> {
+    ) -> Result<VersionRow, Error> {
         let authored_schema = self
             .schema_version_for_alias(version.schema_version_alias())
             .ok_or(Error::InvalidStoredValue(
@@ -1320,7 +1326,7 @@ where
                     })
             });
         if has_authored_layout {
-            return Ok(None);
+            return Ok(version.clone());
         }
 
         for storage_table in
@@ -1337,11 +1343,11 @@ where
                 continue;
             };
             if canonical.schema_version_alias() == version.schema_version_alias() {
-                return Ok(Some(canonical));
+                return Ok(canonical);
             }
         }
         Err(Error::MaintainedViewMissingBundleWitness(
-            "projected maintained witness is missing its canonical history row",
+            "maintained witness is missing its canonical history row",
         ))
     }
 }

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -759,55 +759,6 @@ impl VersionRecord {
             .ok()
             .flatten()
     }
-
-    /// Combines two compatible, view-scoped projections of the same immutable
-    /// version. A subscription may carry a row once as a full result and once
-    /// as an authorization or relation witness, where hidden cells are absent.
-    /// Only absent/present cells may be combined; different present values are
-    /// a protocol conflict.
-    pub(crate) fn merge_view_projection(&self, other: &Self) -> Result<Self, ()> {
-        if self.table != other.table
-            || self.schema_version != other.schema_version
-            || self.authored_columns != other.authored_columns
-            || self.record.descriptor() != other.record.descriptor()
-        {
-            return Err(());
-        }
-        let descriptor = self.record.descriptor().clone();
-        let mut values = Vec::with_capacity(descriptor.fields().len());
-        for index in 0..descriptor.fields().len() {
-            let left = self.record.borrowed().get_idx(index).map_err(|_| ())?;
-            let right = other.record.borrowed().get_idx(index).map_err(|_| ())?;
-            let value = if index < WireRowRecord::USER_CELLS {
-                if left != right {
-                    return Err(());
-                }
-                left
-            } else {
-                match (left, right) {
-                    (Value::Nullable(None), Value::Nullable(None)) => Value::Nullable(None),
-                    (Value::Nullable(Some(value)), Value::Nullable(None))
-                    | (Value::Nullable(None), Value::Nullable(Some(value))) => {
-                        Value::Nullable(Some(value))
-                    }
-                    (Value::Nullable(Some(left)), Value::Nullable(Some(right)))
-                        if left == right =>
-                    {
-                        Value::Nullable(Some(left))
-                    }
-                    _ => return Err(()),
-                }
-            };
-            values.push(value);
-        }
-        let raw = descriptor.create(&values).map_err(|_| ())?;
-        Ok(Self {
-            table: self.table.clone(),
-            schema_version: self.schema_version,
-            record: OwnedRecord::new(raw, descriptor),
-            authored_columns: self.authored_columns.clone(),
-        })
-    }
 }
 
 trait NullableValue {
@@ -3090,61 +3041,6 @@ mod tests {
 
         assert_ne!(base, authored);
         assert_ne!(base.cmp(&authored), Ordering::Equal);
-    }
-
-    #[test]
-    fn version_record_merges_compatible_view_projections_without_hiding_payload() {
-        let table = TableSchema::new("todos", [ColumnSchema::new("title", ColumnType::String)]);
-        let full = VersionRecord::from_cells(
-            &table,
-            schema_id(1),
-            RowUuid::from_bytes([1; 16]),
-            Vec::new(),
-            AuthorId::SYSTEM,
-            TxTime(1),
-            AuthorId::SYSTEM,
-            TxTime(1),
-            &BTreeMap::from([("title".to_owned(), Value::String("visible".to_owned()))]),
-            None,
-        )
-        .unwrap();
-        let hidden = VersionRecord::from_cells(
-            &table,
-            schema_id(1),
-            RowUuid::from_bytes([1; 16]),
-            Vec::new(),
-            AuthorId::SYSTEM,
-            TxTime(1),
-            AuthorId::SYSTEM,
-            TxTime(1),
-            &BTreeMap::<String, Value>::new(),
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(
-            hidden.merge_view_projection(&full).unwrap().cell_at(0),
-            Some(Value::String("visible".to_owned()))
-        );
-        assert_eq!(
-            full.merge_view_projection(&hidden).unwrap().cell_at(0),
-            Some(Value::String("visible".to_owned()))
-        );
-
-        let conflicting = VersionRecord::from_cells(
-            &table,
-            schema_id(1),
-            RowUuid::from_bytes([1; 16]),
-            Vec::new(),
-            AuthorId::SYSTEM,
-            TxTime(1),
-            AuthorId::SYSTEM,
-            TxTime(1),
-            &BTreeMap::from([("title".to_owned(), Value::String("other".to_owned()))]),
-            None,
-        )
-        .unwrap();
-        assert!(full.merge_view_projection(&conflicting).is_err());
     }
 
     fn sample_lens() -> MigrationLens {


### PR DESCRIPTION
🤖 Replaces the previous partial-projection approach with the specified whole-row sync model.

Jazz permissions and sync operate at row granularity. Query `select(...)` narrows terminal application output, but every replicated `VersionRecord` remains the complete canonical materialized row version. Partial transaction delivery means a subset of complete row versions; partial writes remain represented by `authored_columns` after omitted cells are materialized. Neither means cell-level version transport.

The previous implementation incorrectly allowed maintained query sources to serialize selected columns while padding other real columns with null, then attempted to repair those malformed versions by unioning complementary cells at the receiver. This change removes that machinery completely.

What changed:

- remove `VersionRecord::merge_view_projection` and all receiver-side absent/present cell unioning;
- restore strict immutable-version semantics: identical replays are idempotent and any non-identical duplicate is `ConflictingCommitUnit`;
- require version-witness source plans to retain every logical table column even when terminal output uses `select(...)`;
- canonicalize version and large-value witnesses through the authored history payload before serialization;
- keep public query projection exclusively at the terminal/output boundary;
- preserve fate, global-sequence, and durability monotonicity for identical replay.

The regression coverage proves:

- a full query and `select(["title"])` ship byte-identical complete row-version payloads;
- the selected terminal output still contains only `title`;
- a private row is not shipped at all under row-level policy;
- identical duplicates replay cleanly while padded or divergent duplicates conflict;
- lens-projected maintained witnesses remain byte-identical to canonical stored history.

Validation:

- `node::tests::harness::receiver_batch_replays_identical_whole_versions_and_rejects_conflicts`
- `node::tests::harness::public_chat_projections_ship_identical_complete_row_versions`
- `node::tests::harness::maintained_projected_current_picks_winner_before_lens_projection`
- `node::query_eval::tests::denormalized_current_content_witness_matches_history_payload_bytes`
- `cargo fmt --check`
- `cargo clippy -p jazz -- -D warnings`
- sensitive-data guard
- independent adversarial review, including producer-narrowing and receiver-acceptance plants

This follows the row-level authorization contract, `INV-SYNC-7`, `INV-SYNC-16`, `INV-DATA-18`, and the canonical current/history byte-fidelity requirement.
