### PR TITLE
ci: serialize shared test artifact builds

### DIFF
--- a/dev/gates/build-test-artifacts.mjs
+++ b/dev/gates/build-test-artifacts.mjs
@@ -8,12 +8,150 @@
  * matches this checkout. Keep the fast artifact's profile explicit here so a
  * future package build cannot silently change test semantics.
  */
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
-import { resolve } from "node:path";
 
 const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+function sharedGitDirectory(cwd = root) {
+  const directory = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+  return isAbsolute(directory) ? directory : resolve(cwd, directory);
+}
+
+function ownerIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but belongs to another user. This is
+    // common on shared CI hosts and must never be mistaken for a stale lock.
+    if (error.code === "EPERM") return true;
+    if (error.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+/**
+ * The common Git directory is shared by every linked worktree in a clone.
+ * Put the lock there rather than in a checkout so separately checked-out
+ * branches serialize only when they can share Cargo/package state. A test
+ * hook overrides the exact path without exposing a real checkout in receipts.
+ */
+export function artifactLockPath(cwd = root) {
+  return (
+    process.env.JAZZ_TEST_ARTIFACT_LOCK_PATH ??
+    resolve(sharedGitDirectory(cwd), "jazz-test-artifacts.lock")
+  );
+}
+
+function readLockOwner(lockPath) {
+  try {
+    return JSON.parse(readFileSync(resolve(lockPath, "owner.json"), "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT") return undefined;
+    throw new Error(
+      `test-artifacts: lock at ${lockPath} has unreadable owner metadata: ${error.message}`,
+    );
+  }
+}
+
+function lockError(lockPath, owner) {
+  const started = typeof owner.startedAt === "string" ? owner.startedAt : "unknown";
+  const cwd = typeof owner.cwd === "string" ? owner.cwd : "unknown";
+  return new Error(
+    `test-artifacts: another artifact build is active (pid ${owner.pid}, cwd ${cwd}, started ${started}). ` +
+      `Wait for it to finish, or if it is no longer running retry to recover its stale lock. Lock: ${lockPath}`,
+  );
+}
+
+/** Acquire an exclusive, clone-wide artifact build lock. */
+export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
+  const owner = {
+    pid: process.pid,
+    cwd: process.cwd(),
+    startedAt: new Date().toISOString(),
+    token: `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  };
+  try {
+    mkdirSync(lockPath);
+  } catch (error) {
+    if (error.code !== "EEXIST") throw error;
+    const existing = readLockOwner(lockPath);
+    if (!existing || !Number.isInteger(existing.pid) || existing.pid <= 0)
+      throw new Error(
+        `test-artifacts: lock at ${lockPath} has no usable owner metadata; refusing to delete it.`,
+      );
+    if (ownerIsAlive(existing.pid)) throw lockError(lockPath, existing);
+    // Only a positively dead owner is safe to recover. Compare the metadata
+    // again before removal so a newly acquired lock can never be deleted.
+    const unchanged = readLockOwner(lockPath);
+    if (unchanged?.token !== existing.token)
+      throw new Error(
+        `test-artifacts: lock at ${lockPath} changed while checking it; retry safely.`,
+      );
+    rmSync(lockPath, { recursive: true, force: false });
+    try {
+      mkdirSync(lockPath);
+    } catch (retryError) {
+      if (retryError.code === "EEXIST") {
+        const retryOwner = readLockOwner(lockPath);
+        if (retryOwner) throw lockError(lockPath, retryOwner);
+      }
+      throw retryError;
+    }
+  }
+  try {
+    writeFileSync(resolve(lockPath, "owner.json"), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+  } catch (error) {
+    rmSync(lockPath, { recursive: true, force: true });
+    throw error;
+  }
+  console.log(`test-artifacts: acquired shared artifact lock (pid ${owner.pid})`);
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      released = true;
+      const current = readLockOwner(lockPath);
+      if (current?.token !== owner.token)
+        throw new Error(`test-artifacts: lock ownership changed before release at ${lockPath}`);
+      rmSync(lockPath, { recursive: true, force: false });
+      console.log("test-artifacts: released shared artifact lock");
+    },
+  };
+}
+
+export async function withArtifactBuildLock(run, lockPath = artifactLockPath()) {
+  const lock = acquireArtifactBuildLock(lockPath);
+  let signal;
+  const releaseForSignal = (received) => {
+    signal = received;
+    try {
+      lock.release();
+    } finally {
+      // Let command()'s handler stop child process groups first, then restore
+      // normal signal semantics after the lock has been made available.
+      setImmediate(() => process.kill(process.pid, received));
+    }
+  };
+  const onSigint = () => releaseForSignal("SIGINT");
+  const onSigterm = () => releaseForSignal("SIGTERM");
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+  try {
+    return await run();
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+    process.removeListener("SIGTERM", onSigterm);
+    if (!signal) lock.release();
+  }
+}
 
 export function command(command, args, label = [command, ...args].join(" "), options = {}) {
   const { env, signal } = options;
@@ -146,7 +284,7 @@ export async function buildTestArtifacts(run = command) {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  buildTestArtifacts().catch((error) => {
+  withArtifactBuildLock(buildTestArtifacts).catch((error) => {
     console.error(`test-artifacts: ${error.message}`);
     process.exitCode = 1;
   });

--- a/dev/gates/build-test-artifacts.mjs
+++ b/dev/gates/build-test-artifacts.mjs
@@ -9,7 +9,7 @@
  * future package build cannot silently change test semantics.
  */
 import { execFileSync, spawn } from "node:child_process";
-import { linkSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { linkSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { basename, isAbsolute, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
@@ -80,9 +80,13 @@ function readLockOwner(lockPath) {
 function lockError(lockPath, owner) {
   const started = typeof owner.startedAt === "string" ? owner.startedAt : "unknown";
   const cwd = typeof owner.cwd === "string" ? basename(owner.cwd) : "unknown";
+  const state = ownerIsAlive(owner) ? "active" : "stale";
+  const action =
+    state === "active"
+      ? "Wait for it to finish."
+      : "Run `pnpm artifacts:unlock` to verify and clear it.";
   return new Error(
-    `test-artifacts: another artifact build is active (pid ${owner.pid}, cwd ${cwd}, started ${started}). ` +
-      "Wait for it to finish, or if it is no longer running retry to recover its stale lock.",
+    `test-artifacts: ${state} artifact lock (pid ${owner.pid}, cwd ${cwd}, started ${started}). ${action}`,
   );
 }
 
@@ -102,52 +106,23 @@ export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
     rmSync(staging, { force: true });
     throw error;
   }
-  for (;;) {
-    try {
-      // Hard-linking the fully-written receipt is atomic and unlike rename
-      // never replaces an existing live or malformed lock on POSIX/Windows.
-      linkSync(staging, lockPath);
+  try {
+    // Hard-linking the fully-written receipt is atomic and unlike rename
+    // never replaces an existing live or malformed lock on POSIX/Windows.
+    linkSync(staging, lockPath);
+    rmSync(staging, { force: true });
+  } catch (error) {
+    if (error.code !== "EEXIST" && error.code !== "ENOTEMPTY") {
       rmSync(staging, { force: true });
-      break;
-    } catch (error) {
-      if (error.code !== "EEXIST" && error.code !== "ENOTEMPTY") {
-        rmSync(staging, { force: true });
-        throw error;
-      }
+      throw error;
     }
     const existing = readLockOwner(lockPath);
     if (!existing || !Number.isInteger(existing.pid) || existing.pid <= 0) {
       rmSync(staging, { force: true });
       throw new Error("test-artifacts: lock has no usable owner metadata; refusing to delete it.");
     }
-    if (ownerIsAlive(existing)) {
-      rmSync(staging, { force: true });
-      throw lockError(lockPath, existing);
-    }
-    // rename is atomic on all supported local filesystems. Exactly one stale
-    // recovery contender can quarantine the observed directory; it never
-    // recursively removes the canonical name after observing it.
-    const quarantine = `${lockPath}.stale-${owner.token}`;
-    try {
-      renameSync(lockPath, quarantine);
-    } catch (renameError) {
-      if (renameError.code === "ENOENT" || renameError.code === "EEXIST") continue;
-      rmSync(staging, { force: true });
-      throw renameError;
-    }
-    try {
-      const quarantined = readLockOwner(quarantine);
-      if (quarantined?.token !== existing.token || ownerIsAlive(quarantined))
-        throw new Error(
-          "test-artifacts: stale lock changed while quarantining it; refusing to remove it.",
-        );
-      rmSync(quarantine, { force: false });
-    } catch (quarantineError) {
-      // Preserve an ambiguous quarantine for inspection. Its distinct name
-      // cannot block a fresh canonical acquisition.
-      rmSync(staging, { force: true });
-      throw quarantineError;
-    }
+    rmSync(staging, { force: true });
+    throw lockError(lockPath, existing);
   }
   console.log(`test-artifacts: acquired shared artifact lock (pid ${owner.pid})`);
   let released = false;
@@ -162,6 +137,31 @@ export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
       console.log("test-artifacts: released shared artifact lock");
     },
   };
+}
+
+export function unlockArtifactBuildLock(lockPath = artifactLockPath()) {
+  const guard = `${lockPath}.unlocking`;
+  const receipt = `${guard}-${process.pid}-${Date.now()}`;
+  try {
+    writeFileSync(receipt, `${process.pid}\n`, { flag: "wx", mode: 0o600 });
+    linkSync(receipt, guard);
+  } catch (error) {
+    rmSync(receipt, { force: true });
+    if (error.code === "EEXIST" || error.code === "ENOTEMPTY")
+      throw new Error("test-artifacts: another unlock is in progress; retry shortly.");
+    throw error;
+  }
+  rmSync(receipt, { force: true });
+  try {
+    const owner = readLockOwner(lockPath);
+    if (!owner || !Number.isInteger(owner.pid) || owner.pid <= 0)
+      throw new Error("test-artifacts: lock has no usable owner metadata; refusing to delete it.");
+    if (ownerIsAlive(owner)) throw lockError(lockPath, owner);
+    rmSync(lockPath, { force: false });
+    console.log("test-artifacts: cleared verified stale artifact lock");
+  } finally {
+    rmSync(guard, { force: true });
+  }
 }
 
 export async function withArtifactBuildLock(run, lockPath = artifactLockPath()) {
@@ -320,24 +320,21 @@ export async function buildTestArtifacts(run = command, scope = createBuildScope
   );
 
   try {
-    await guardedRun("node", ["-e", "require('./crates/jazz-napi')"], "load release NAPI");
+    // A load failure is expected to enter the bounded repair path, so unlike a
+    // build failure it must not abort the parent scope before repair starts.
+    await scope.track(
+      run("node", ["-e", "require('./crates/jazz-napi')"], "load release NAPI", {
+        signal: scope.signal,
+      }),
+    );
   } catch (error) {
     // A damaged native artifact must not make every run pay a second build.
     // Repair only after the first load proves it necessary, then prove repair.
     console.warn(`test-artifacts: release NAPI did not load; repairing (${error.message})`);
-    // The first load failure aborts only the already-completed first phase.
-    // Use a fresh controller for the bounded repair and its validation.
-    scope.abort(error);
-    const repairController = new AbortController();
-    const repairRun = (command, args, label, env) =>
-      run(command, args, label, { env, signal: repairController.signal }).catch((repairError) => {
-        repairController.abort(repairError);
-        throw repairError;
-      });
-    await repairRun("pnpm", ["--filter", "jazz-napi", "build"], "repair release NAPI");
-    await repairRun("node", ["-e", "require('./crates/jazz-napi')"], "load repaired release NAPI");
+    await guardedRun("pnpm", ["--filter", "jazz-napi", "build"], "repair release NAPI");
+    await guardedRun("node", ["-e", "require('./crates/jazz-napi')"], "load repaired release NAPI");
   }
-  await run(
+  await guardedRun(
     "node",
     ["dev/artifacts/provenance.mjs", "verify", "napi", "release"],
     "verify release NAPI provenance",
@@ -345,8 +342,19 @@ export async function buildTestArtifacts(run = command, scope = createBuildScope
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  withArtifactBuildLock((scope) => buildTestArtifacts(command, scope)).catch((error) => {
-    console.error(`test-artifacts: ${error.message}`);
+  if (process.argv[2] === "unlock") {
+    try {
+      unlockArtifactBuildLock();
+    } catch (error) {
+      console.error(`test-artifacts: ${error.message}`);
+      process.exitCode = 1;
+    }
+  } else if (process.argv[2]) {
+    console.error("test-artifacts: expected no argument or `unlock`");
     process.exitCode = 1;
-  });
+  } else
+    withArtifactBuildLock((scope) => buildTestArtifacts(command, scope)).catch((error) => {
+      console.error(`test-artifacts: ${error.message}`);
+      process.exitCode = 1;
+    });
 }

--- a/dev/gates/build-test-artifacts.mjs
+++ b/dev/gates/build-test-artifacts.mjs
@@ -9,8 +9,8 @@
  * future package build cannot silently change test semantics.
  */
 import { execFileSync, spawn } from "node:child_process";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { isAbsolute, resolve } from "node:path";
+import { linkSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { basename, isAbsolute, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 
@@ -24,9 +24,26 @@ function sharedGitDirectory(cwd = root) {
   return isAbsolute(directory) ? directory : resolve(cwd, directory);
 }
 
-function ownerIsAlive(pid) {
+function processStartIdentity(pid = process.pid) {
+  // Linux supplies a monotonic process-start tick, making PID reuse
+  // distinguishable. Other platforms deliberately fall back to conservative
+  // live-PID handling rather than guessing from locale-specific tooling.
+  if (process.platform !== "linux") return undefined;
   try {
-    process.kill(pid, 0);
+    return readFileSync(`/proc/${pid}/stat`, "utf8").trim().split(" ")[21];
+  } catch (error) {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function ownerIsAlive(owner) {
+  try {
+    process.kill(owner.pid, 0);
+    if (owner.processStartIdentity) {
+      const actual = processStartIdentity(owner.pid);
+      if (actual && actual !== owner.processStartIdentity) return false;
+    }
     return true;
   } catch (error) {
     // EPERM means the process exists but belongs to another user. This is
@@ -39,9 +56,10 @@ function ownerIsAlive(pid) {
 
 /**
  * The common Git directory is shared by every linked worktree in a clone.
- * Put the lock there rather than in a checkout so separately checked-out
- * branches serialize only when they can share Cargo/package state. A test
- * hook overrides the exact path without exposing a real checkout in receipts.
+ * Put the lock there rather than in a checkout: linked worktrees share this
+ * clone's default Cargo target and generated package outputs. Separate clones
+ * do not share those resources and intentionally do not contend. A test hook
+ * overrides the exact path without exposing a real checkout in receipts.
  */
 export function artifactLockPath(cwd = root) {
   return (
@@ -52,21 +70,19 @@ export function artifactLockPath(cwd = root) {
 
 function readLockOwner(lockPath) {
   try {
-    return JSON.parse(readFileSync(resolve(lockPath, "owner.json"), "utf8"));
+    return JSON.parse(readFileSync(lockPath, "utf8"));
   } catch (error) {
     if (error.code === "ENOENT") return undefined;
-    throw new Error(
-      `test-artifacts: lock at ${lockPath} has unreadable owner metadata: ${error.message}`,
-    );
+    throw new Error(`test-artifacts: lock has unreadable owner metadata: ${error.message}`);
   }
 }
 
 function lockError(lockPath, owner) {
   const started = typeof owner.startedAt === "string" ? owner.startedAt : "unknown";
-  const cwd = typeof owner.cwd === "string" ? owner.cwd : "unknown";
+  const cwd = typeof owner.cwd === "string" ? basename(owner.cwd) : "unknown";
   return new Error(
     `test-artifacts: another artifact build is active (pid ${owner.pid}, cwd ${cwd}, started ${started}). ` +
-      `Wait for it to finish, or if it is no longer running retry to recover its stale lock. Lock: ${lockPath}`,
+      "Wait for it to finish, or if it is no longer running retry to recover its stale lock.",
   );
 }
 
@@ -76,41 +92,62 @@ export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
     pid: process.pid,
     cwd: process.cwd(),
     startedAt: new Date().toISOString(),
+    processStartIdentity: processStartIdentity(),
     token: `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   };
+  const staging = `${lockPath}.acquiring-${owner.token}`;
   try {
-    mkdirSync(lockPath);
+    writeFileSync(staging, `${JSON.stringify(owner)}\n`, { mode: 0o600, flag: "wx" });
   } catch (error) {
-    if (error.code !== "EEXIST") throw error;
-    const existing = readLockOwner(lockPath);
-    if (!existing || !Number.isInteger(existing.pid) || existing.pid <= 0)
-      throw new Error(
-        `test-artifacts: lock at ${lockPath} has no usable owner metadata; refusing to delete it.`,
-      );
-    if (ownerIsAlive(existing.pid)) throw lockError(lockPath, existing);
-    // Only a positively dead owner is safe to recover. Compare the metadata
-    // again before removal so a newly acquired lock can never be deleted.
-    const unchanged = readLockOwner(lockPath);
-    if (unchanged?.token !== existing.token)
-      throw new Error(
-        `test-artifacts: lock at ${lockPath} changed while checking it; retry safely.`,
-      );
-    rmSync(lockPath, { recursive: true, force: false });
-    try {
-      mkdirSync(lockPath);
-    } catch (retryError) {
-      if (retryError.code === "EEXIST") {
-        const retryOwner = readLockOwner(lockPath);
-        if (retryOwner) throw lockError(lockPath, retryOwner);
-      }
-      throw retryError;
-    }
-  }
-  try {
-    writeFileSync(resolve(lockPath, "owner.json"), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
-  } catch (error) {
-    rmSync(lockPath, { recursive: true, force: true });
+    rmSync(staging, { force: true });
     throw error;
+  }
+  for (;;) {
+    try {
+      // Hard-linking the fully-written receipt is atomic and unlike rename
+      // never replaces an existing live or malformed lock on POSIX/Windows.
+      linkSync(staging, lockPath);
+      rmSync(staging, { force: true });
+      break;
+    } catch (error) {
+      if (error.code !== "EEXIST" && error.code !== "ENOTEMPTY") {
+        rmSync(staging, { force: true });
+        throw error;
+      }
+    }
+    const existing = readLockOwner(lockPath);
+    if (!existing || !Number.isInteger(existing.pid) || existing.pid <= 0) {
+      rmSync(staging, { force: true });
+      throw new Error("test-artifacts: lock has no usable owner metadata; refusing to delete it.");
+    }
+    if (ownerIsAlive(existing)) {
+      rmSync(staging, { force: true });
+      throw lockError(lockPath, existing);
+    }
+    // rename is atomic on all supported local filesystems. Exactly one stale
+    // recovery contender can quarantine the observed directory; it never
+    // recursively removes the canonical name after observing it.
+    const quarantine = `${lockPath}.stale-${owner.token}`;
+    try {
+      renameSync(lockPath, quarantine);
+    } catch (renameError) {
+      if (renameError.code === "ENOENT" || renameError.code === "EEXIST") continue;
+      rmSync(staging, { force: true });
+      throw renameError;
+    }
+    try {
+      const quarantined = readLockOwner(quarantine);
+      if (quarantined?.token !== existing.token || ownerIsAlive(quarantined))
+        throw new Error(
+          "test-artifacts: stale lock changed while quarantining it; refusing to remove it.",
+        );
+      rmSync(quarantine, { force: false });
+    } catch (quarantineError) {
+      // Preserve an ambiguous quarantine for inspection. Its distinct name
+      // cannot block a fresh canonical acquisition.
+      rmSync(staging, { force: true });
+      throw quarantineError;
+    }
   }
   console.log(`test-artifacts: acquired shared artifact lock (pid ${owner.pid})`);
   let released = false;
@@ -121,7 +158,7 @@ export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
       const current = readLockOwner(lockPath);
       if (current?.token !== owner.token)
         throw new Error(`test-artifacts: lock ownership changed before release at ${lockPath}`);
-      rmSync(lockPath, { recursive: true, force: false });
+      rmSync(lockPath, { force: false });
       console.log("test-artifacts: released shared artifact lock");
     },
   };
@@ -129,28 +166,56 @@ export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
 
 export async function withArtifactBuildLock(run, lockPath = artifactLockPath()) {
   const lock = acquireArtifactBuildLock(lockPath);
-  let signal;
+  const scope = createBuildScope();
+  let receivedSignal;
+  let signalShutdown;
   const releaseForSignal = (received) => {
-    signal = received;
-    try {
+    if (signalShutdown) return;
+    receivedSignal = received;
+    signalShutdown = (async () => {
+      scope.abort(new Error(`received ${received}`));
+      await scope.drain();
       lock.release();
-    } finally {
-      // Let command()'s handler stop child process groups first, then restore
-      // normal signal semantics after the lock has been made available.
-      setImmediate(() => process.kill(process.pid, received));
-    }
+      process.kill(process.pid, received);
+    })().catch((error) => {
+      console.error(`test-artifacts: failed to shut down cleanly: ${error.message}`);
+      process.exitCode = 1;
+    });
   };
   const onSigint = () => releaseForSignal("SIGINT");
   const onSigterm = () => releaseForSignal("SIGTERM");
   process.once("SIGINT", onSigint);
   process.once("SIGTERM", onSigterm);
   try {
-    return await run();
+    return await run(scope);
   } finally {
     process.removeListener("SIGINT", onSigint);
     process.removeListener("SIGTERM", onSigterm);
-    if (!signal) lock.release();
+    if (receivedSignal) await signalShutdown;
+    else {
+      await scope.drain();
+      lock.release();
+    }
   }
+}
+
+export function createBuildScope() {
+  const controller = new AbortController();
+  const active = new Set();
+  return {
+    signal: controller.signal,
+    abort(reason) {
+      if (!controller.signal.aborted) controller.abort(reason);
+    },
+    track(promise) {
+      active.add(promise);
+      promise.finally(() => active.delete(promise)).catch(() => {});
+      return promise;
+    },
+    async drain() {
+      while (active.size) await Promise.allSettled([...active]);
+    },
+  };
 }
 
 export function command(command, args, label = [command, ...args].join(" "), options = {}) {
@@ -175,8 +240,6 @@ export function command(command, args, label = [command, ...args].join(" "), opt
       settled = true;
       clearTimeout(forceKillTimer);
       signal?.removeEventListener("abort", abort);
-      process.removeListener("SIGINT", abort);
-      process.removeListener("SIGTERM", abort);
       callback();
     };
     const abort = () => {
@@ -201,8 +264,6 @@ export function command(command, args, label = [command, ...args].join(" "), opt
       }
     };
     signal?.addEventListener("abort", abort, { once: true });
-    process.once("SIGINT", abort);
-    process.once("SIGTERM", abort);
     if (signal?.aborted) abort();
     child.once("error", (error) => finish(() => reject(error)));
     child.once("exit", (status, signal) => {
@@ -221,14 +282,13 @@ export function command(command, args, label = [command, ...args].join(" "), opt
   });
 }
 
-export async function buildTestArtifacts(run = command) {
-  const controller = new AbortController();
+export async function buildTestArtifacts(run = command, scope = createBuildScope()) {
   let firstBuildError;
   const guardedRun = (command, args, label, env) =>
-    run(command, args, label, { env, signal: controller.signal }).catch((error) => {
+    scope.track(run(command, args, label, { env, signal: scope.signal })).catch((error) => {
       if (!firstBuildError) {
         firstBuildError = error;
-        controller.abort(error);
+        scope.abort(error);
       }
       throw error;
     });
@@ -245,6 +305,7 @@ export async function buildTestArtifacts(run = command) {
   try {
     await Promise.all([cli, wasm]);
   } catch (error) {
+    await scope.drain();
     throw firstBuildError ?? error;
   }
   await guardedRun("pnpm", ["--filter", "jazz-tools", "build"], "jazz-tools");
@@ -266,7 +327,7 @@ export async function buildTestArtifacts(run = command) {
     console.warn(`test-artifacts: release NAPI did not load; repairing (${error.message})`);
     // The first load failure aborts only the already-completed first phase.
     // Use a fresh controller for the bounded repair and its validation.
-    controller.abort(error);
+    scope.abort(error);
     const repairController = new AbortController();
     const repairRun = (command, args, label, env) =>
       run(command, args, label, { env, signal: repairController.signal }).catch((repairError) => {
@@ -284,7 +345,7 @@ export async function buildTestArtifacts(run = command) {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  withArtifactBuildLock(buildTestArtifacts).catch((error) => {
+  withArtifactBuildLock((scope) => buildTestArtifacts(command, scope)).catch((error) => {
     console.error(`test-artifacts: ${error.message}`);
     process.exitCode = 1;
   });

--- a/dev/gates/build-test-artifacts.mjs
+++ b/dev/gates/build-test-artifacts.mjs
@@ -17,11 +17,29 @@ import { fileURLToPath } from "node:url";
 const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
 function sharedGitDirectory(cwd = root) {
-  const directory = execFileSync("git", ["rev-parse", "--git-common-dir"], {
-    cwd,
-    encoding: "utf8",
-  }).trim();
-  return isAbsolute(directory) ? directory : resolve(cwd, directory);
+  try {
+    const directory = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return isAbsolute(directory) ? directory : resolve(cwd, directory);
+  } catch (error) {
+    throw lockFilesystemError("find shared Git directory", error);
+  }
+}
+
+function lockFilesystemError(operation, error) {
+  const code = typeof error?.code === "string" ? error.code : "unknown error";
+  return new Error(`test-artifacts: ${operation} failed (${code}).`);
+}
+
+function removeQuietly(path) {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // A cleanup failure must not replace the primary, already-redacted error.
+  }
 }
 
 function processStartIdentity(pid = process.pid) {
@@ -33,7 +51,7 @@ function processStartIdentity(pid = process.pid) {
     return readFileSync(`/proc/${pid}/stat`, "utf8").trim().split(" ")[21];
   } catch (error) {
     if (error.code === "ENOENT") return undefined;
-    throw error;
+    throw lockFilesystemError("read process identity", error);
   }
 }
 
@@ -73,7 +91,7 @@ function readLockOwner(lockPath) {
     return JSON.parse(readFileSync(lockPath, "utf8"));
   } catch (error) {
     if (error.code === "ENOENT") return undefined;
-    throw new Error(`test-artifacts: lock has unreadable owner metadata: ${error.message}`);
+    throw lockFilesystemError("read lock receipt", error);
   }
 }
 
@@ -103,25 +121,29 @@ export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
   try {
     writeFileSync(staging, `${JSON.stringify(owner)}\n`, { mode: 0o600, flag: "wx" });
   } catch (error) {
-    rmSync(staging, { force: true });
-    throw error;
+    removeQuietly(staging);
+    throw lockFilesystemError("create lock receipt", error);
   }
   try {
     // Hard-linking the fully-written receipt is atomic and unlike rename
     // never replaces an existing live or malformed lock on POSIX/Windows.
     linkSync(staging, lockPath);
-    rmSync(staging, { force: true });
+    try {
+      rmSync(staging, { force: true });
+    } catch (error) {
+      throw lockFilesystemError("remove published lock receipt", error);
+    }
   } catch (error) {
     if (error.code !== "EEXIST" && error.code !== "ENOTEMPTY") {
-      rmSync(staging, { force: true });
-      throw error;
+      removeQuietly(staging);
+      throw lockFilesystemError("publish lock receipt", error);
     }
     const existing = readLockOwner(lockPath);
     if (!existing || !Number.isInteger(existing.pid) || existing.pid <= 0) {
-      rmSync(staging, { force: true });
+      removeQuietly(staging);
       throw new Error("test-artifacts: lock has no usable owner metadata; refusing to delete it.");
     }
-    rmSync(staging, { force: true });
+    removeQuietly(staging);
     throw lockError(lockPath, existing);
   }
   console.log(`test-artifacts: acquired shared artifact lock (pid ${owner.pid})`);
@@ -132,8 +154,12 @@ export function acquireArtifactBuildLock(lockPath = artifactLockPath()) {
       released = true;
       const current = readLockOwner(lockPath);
       if (current?.token !== owner.token)
-        throw new Error(`test-artifacts: lock ownership changed before release at ${lockPath}`);
-      rmSync(lockPath, { force: false });
+        throw new Error("test-artifacts: lock ownership changed before release.");
+      try {
+        rmSync(lockPath, { force: false });
+      } catch (error) {
+        throw lockFilesystemError("release lock", error);
+      }
       console.log("test-artifacts: released shared artifact lock");
     },
   };
@@ -146,21 +172,34 @@ export function unlockArtifactBuildLock(lockPath = artifactLockPath()) {
     writeFileSync(receipt, `${process.pid}\n`, { flag: "wx", mode: 0o600 });
     linkSync(receipt, guard);
   } catch (error) {
-    rmSync(receipt, { force: true });
+    removeQuietly(receipt);
     if (error.code === "EEXIST" || error.code === "ENOTEMPTY")
       throw new Error("test-artifacts: another unlock is in progress; retry shortly.");
-    throw error;
+    throw lockFilesystemError("acquire unlock guard", error);
   }
-  rmSync(receipt, { force: true });
+  try {
+    rmSync(receipt, { force: true });
+  } catch (error) {
+    removeQuietly(guard);
+    throw lockFilesystemError("remove unlock receipt", error);
+  }
   try {
     const owner = readLockOwner(lockPath);
     if (!owner || !Number.isInteger(owner.pid) || owner.pid <= 0)
       throw new Error("test-artifacts: lock has no usable owner metadata; refusing to delete it.");
     if (ownerIsAlive(owner)) throw lockError(lockPath, owner);
-    rmSync(lockPath, { force: false });
+    try {
+      rmSync(lockPath, { force: false });
+    } catch (error) {
+      throw lockFilesystemError("clear stale lock", error);
+    }
     console.log("test-artifacts: cleared verified stale artifact lock");
   } finally {
-    rmSync(guard, { force: true });
+    try {
+      rmSync(guard, { force: true });
+    } catch (error) {
+      throw lockFilesystemError("release unlock guard", error);
+    }
   }
 }
 

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import test from "node:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { acquireArtifactBuildLock, buildTestArtifacts, command } from "../build-test-artifacts.mjs";
+import {
+  acquireArtifactBuildLock,
+  buildTestArtifacts,
+  command,
+  withArtifactBuildLock,
+} from "../build-test-artifacts.mjs";
 
 const pipelineUrl = new URL("../build-test-artifacts.mjs", import.meta.url).href;
 
@@ -14,7 +19,7 @@ function childWithLock(lockPath, body) {
     [
       "--input-type=module",
       "-e",
-      `import { withArtifactBuildLock } from ${JSON.stringify(pipelineUrl)}; ${body}`,
+      `import { command, withArtifactBuildLock } from ${JSON.stringify(pipelineUrl)}; ${body}`,
     ],
     {
       env: { ...process.env, JAZZ_TEST_ARTIFACT_LOCK_PATH: lockPath },
@@ -49,7 +54,7 @@ test("artifact lock rejects a concurrent real subprocess with actionable ownersh
     "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
   );
   try {
-    await waitFor(() => existsSync(join(lockPath, "owner.json")), "holder did not acquire lock");
+    await waitFor(() => existsSync(lockPath), "holder did not acquire lock");
     const contender = childWithLock(lockPath, "await withArtifactBuildLock(async () => {});");
     const result = await contender.closed;
     assert.equal(result.code, 1);
@@ -57,7 +62,8 @@ test("artifact lock rejects a concurrent real subprocess with actionable ownersh
       contender.output(),
       /another artifact build is active \(pid \d+, cwd .+, started .+\)/,
     );
-    assert.match(contender.output(), /Lock:/);
+    const message = contender.output().match(/Error: ([^\n]+)/)?.[1] ?? "";
+    assert.doesNotMatch(message, /Lock:|\/tmp\/|\/work\//);
   } finally {
     holder.child.kill("SIGTERM");
     await holder.closed;
@@ -68,9 +74,8 @@ test("artifact lock rejects a concurrent real subprocess with actionable ownersh
 test("artifact lock recovers only a positively stale owner", () => {
   const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-stale-"));
   const lockPath = join(fixture, "lock");
-  mkdirSync(lockPath);
   writeFileSync(
-    join(lockPath, "owner.json"),
+    lockPath,
     JSON.stringify({
       pid: 999_999_999,
       cwd: "stale-checkout",
@@ -79,17 +84,52 @@ test("artifact lock recovers only a positively stale owner", () => {
     }),
   );
   const lock = acquireArtifactBuildLock(lockPath);
-  assert.equal(existsSync(join(lockPath, "owner.json")), true);
+  assert.equal(existsSync(lockPath), true);
   lock.release();
   assert.equal(existsSync(lockPath), false);
   rmSync(fixture, { recursive: true, force: true });
 });
 
+test("simultaneous stale recovery contenders produce exactly one owner", async () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-stale-race-"));
+  const lockPath = join(fixture, "lock");
+  writeFileSync(
+    lockPath,
+    JSON.stringify({
+      pid: 999_999_999,
+      cwd: "stale-checkout",
+      startedAt: "2000-01-01T00:00:00.000Z",
+      token: "dead",
+    }),
+  );
+  const contenders = Array.from({ length: 8 }, () =>
+    childWithLock(
+      lockPath,
+      "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
+    ),
+  );
+  try {
+    await waitFor(() => existsSync(lockPath), "no contender acquired lock");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const active = contenders.filter((contender) => contender.child.exitCode === null);
+    assert.equal(active.length, 1);
+    for (const contender of contenders.filter((contender) => contender !== active[0])) {
+      const result = await contender.closed;
+      assert.equal(result.code, 1);
+      assert.match(contender.output(), /another artifact build is active/);
+    }
+  } finally {
+    for (const contender of contenders) contender.child.kill("SIGTERM");
+    await Promise.all(contenders.map((contender) => contender.closed));
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
 test("artifact lock refuses an unowned directory instead of deleting a possibly live lock", () => {
   const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-unowned-"));
   const lockPath = join(fixture, "lock");
-  mkdirSync(lockPath);
-  assert.throws(() => acquireArtifactBuildLock(lockPath), /no usable owner metadata/);
+  writeFileSync(lockPath, "not a receipt");
+  assert.throws(() => acquireArtifactBuildLock(lockPath), /unreadable owner metadata/);
   assert.equal(existsSync(lockPath), true);
   rmSync(fixture, { recursive: true, force: true });
 });
@@ -104,19 +144,92 @@ test("artifact lock cleans up after a real failure and termination signal", asyn
   assert.equal((await failure.closed).code, 1);
   assert.equal(existsSync(failingLock), false);
 
-  const signalLock = join(fixture, "signal-lock");
-  const running = childWithLock(
-    signalLock,
-    "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    const signalLock = join(fixture, `signal-lock-${signal}`);
+    const running = childWithLock(
+      signalLock,
+      "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
+    );
+    await waitFor(() => existsSync(signalLock), "signal child did not acquire lock");
+    // The receipt is written just before the signal listeners; give the
+    // subprocess one event-loop turn to install them before injecting a signal.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    running.child.kill(signal);
+    const terminated = await running.closed;
+    assert.equal(terminated.signal, signal);
+    assert.equal(existsSync(signalLock), false);
+  }
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+test("signal keeps the lock until its delayed child has exited", async () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-signal-drain-"));
+  const lockPath = join(fixture, "lock");
+  const received = join(fixture, "received");
+  const ready = join(fixture, "ready");
+  const delayedChild = `
+    const fs = require('node:fs');
+    fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+    process.on('SIGTERM', () => {
+      fs.writeFileSync(${JSON.stringify(received)}, 'received');
+      setTimeout(() => process.exit(0), 180);
+    });
+    setInterval(() => {}, 1000);
+  `;
+  const holder = childWithLock(
+    lockPath,
+    `await withArtifactBuildLock(async (scope) => scope.track(command(process.execPath, ['-e', ${JSON.stringify(delayedChild)}], 'delayed child', { signal: scope.signal })));`,
   );
-  await waitFor(
-    () => existsSync(join(signalLock, "owner.json")),
-    "signal child did not acquire lock",
+  try {
+    await waitFor(() => existsSync(lockPath), "holder did not acquire lock");
+    await waitFor(() => existsSync(ready), "delayed child did not start");
+    holder.child.kill("SIGTERM");
+    await waitFor(() => existsSync(received), "child did not receive SIGTERM");
+    assert.equal(existsSync(lockPath), true, "lock released before child exit");
+    const contender = childWithLock(lockPath, "await withArtifactBuildLock(async () => {});");
+    assert.equal((await contender.closed).code, 1);
+    assert.match(contender.output(), /another artifact build is active/);
+    assert.equal((await holder.closed).signal, "SIGTERM");
+    assert.equal(existsSync(lockPath), false);
+  } finally {
+    holder.child.kill("SIGKILL");
+    await holder.closed;
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("parallel build failure drains an aborting sibling before leaving the lock", async () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-failure-drain-"));
+  const lockPath = join(fixture, "lock");
+  let siblingExited = false;
+  const started = Date.now();
+  await assert.rejects(
+    withArtifactBuildLock(
+      (scope) =>
+        buildTestArtifacts((unusedCommand, unusedArgs, label, { signal }) => {
+          if (label === "release NAPI") return Promise.resolve();
+          if (label === "CLI") return Promise.reject(new Error("expected failure"));
+          if (label === "fast WASM")
+            return new Promise((unusedResolve, reject) =>
+              signal.addEventListener(
+                "abort",
+                () =>
+                  setTimeout(() => {
+                    siblingExited = true;
+                    reject(new Error("slow sibling stopped"));
+                  }, 100),
+                { once: true },
+              ),
+            );
+          return Promise.resolve();
+        }, scope),
+      lockPath,
+    ),
+    /expected failure/,
   );
-  running.child.kill("SIGTERM");
-  const terminated = await running.closed;
-  assert.equal(terminated.signal, "SIGTERM");
-  assert.equal(existsSync(signalLock), false);
+  assert.equal(siblingExited, true);
+  assert.ok(Date.now() - started >= 90);
+  assert.equal(existsSync(lockPath), false);
   rmSync(fixture, { recursive: true, force: true });
 });
 

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -135,8 +135,25 @@ test("artifact lock refuses an unowned directory instead of deleting a possibly 
   const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-unowned-"));
   const lockPath = join(fixture, "lock");
   writeFileSync(lockPath, "not a receipt");
-  assert.throws(() => acquireArtifactBuildLock(lockPath), /unreadable owner metadata/);
+  assert.throws(() => acquireArtifactBuildLock(lockPath), /read lock receipt failed/);
   assert.equal(existsSync(lockPath), true);
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+test("lock filesystem failures redact missing absolute paths", () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-path-redaction-"));
+  const missingParent = join(fixture, "missing-parent");
+  const lockPath = join(missingParent, "lock");
+  // This planted raw filesystem call proves the underlying diagnostic would
+  // disclose the absolute path if the lock layer ever rethrows it directly.
+  assert.throws(() => writeFileSync(lockPath, "raw"), new RegExp(missingParent));
+  assert.throws(
+    () => acquireArtifactBuildLock(lockPath),
+    (error) =>
+      /create lock receipt failed \(ENOENT\)/.test(error.message) &&
+      !error.message.includes(fixture) &&
+      !error.message.includes(lockPath),
+  );
   rmSync(fixture, { recursive: true, force: true });
 });
 

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -8,6 +8,7 @@ import {
   acquireArtifactBuildLock,
   buildTestArtifacts,
   command,
+  unlockArtifactBuildLock,
   withArtifactBuildLock,
 } from "../build-test-artifacts.mjs";
 
@@ -19,7 +20,7 @@ function childWithLock(lockPath, body) {
     [
       "--input-type=module",
       "-e",
-      `import { command, withArtifactBuildLock } from ${JSON.stringify(pipelineUrl)}; ${body}`,
+      `import fs from 'node:fs'; import { buildTestArtifacts, command, withArtifactBuildLock } from ${JSON.stringify(pipelineUrl)}; ${body}`,
     ],
     {
       env: { ...process.env, JAZZ_TEST_ARTIFACT_LOCK_PATH: lockPath },
@@ -58,10 +59,7 @@ test("artifact lock rejects a concurrent real subprocess with actionable ownersh
     const contender = childWithLock(lockPath, "await withArtifactBuildLock(async () => {});");
     const result = await contender.closed;
     assert.equal(result.code, 1);
-    assert.match(
-      contender.output(),
-      /another artifact build is active \(pid \d+, cwd .+, started .+\)/,
-    );
+    assert.match(contender.output(), /active artifact lock \(pid \d+, cwd .+, started .+\)/);
     const message = contender.output().match(/Error: ([^\n]+)/)?.[1] ?? "";
     assert.doesNotMatch(message, /Lock:|\/tmp\/|\/work\//);
   } finally {
@@ -71,7 +69,7 @@ test("artifact lock rejects a concurrent real subprocess with actionable ownersh
   }
 });
 
-test("artifact lock recovers only a positively stale owner", () => {
+test("artifact lock refuses stale owners until explicit verified unlock", () => {
   const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-stale-"));
   const lockPath = join(fixture, "lock");
   writeFileSync(
@@ -83,14 +81,16 @@ test("artifact lock recovers only a positively stale owner", () => {
       token: "dead",
     }),
   );
-  const lock = acquireArtifactBuildLock(lockPath);
+  assert.throws(() => acquireArtifactBuildLock(lockPath), /stale artifact lock.*artifacts:unlock/);
   assert.equal(existsSync(lockPath), true);
+  unlockArtifactBuildLock(lockPath);
+  const lock = acquireArtifactBuildLock(lockPath);
   lock.release();
   assert.equal(existsSync(lockPath), false);
   rmSync(fixture, { recursive: true, force: true });
 });
 
-test("simultaneous stale recovery contenders produce exactly one owner", async () => {
+test("80 simultaneous stale contenders never auto-steal; unlock permits exactly one next owner", async () => {
   const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-stale-race-"));
   const lockPath = join(fixture, "lock");
   writeFileSync(
@@ -102,22 +102,28 @@ test("simultaneous stale recovery contenders produce exactly one owner", async (
       token: "dead",
     }),
   );
-  const contenders = Array.from({ length: 8 }, () =>
+  const contenders = Array.from({ length: 80 }, () =>
     childWithLock(
       lockPath,
       "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
     ),
   );
   try {
-    await waitFor(() => existsSync(lockPath), "no contender acquired lock");
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    const active = contenders.filter((contender) => contender.child.exitCode === null);
-    assert.equal(active.length, 1);
-    for (const contender of contenders.filter((contender) => contender !== active[0])) {
+    for (const contender of contenders) {
       const result = await contender.closed;
       assert.equal(result.code, 1);
-      assert.match(contender.output(), /another artifact build is active/);
+      assert.match(contender.output(), /stale artifact lock.*artifacts:unlock/);
     }
+    assert.equal(existsSync(lockPath), true);
+    unlockArtifactBuildLock(lockPath);
+    const winner = childWithLock(
+      lockPath,
+      "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
+    );
+    await waitFor(() => existsSync(lockPath), "next contender did not acquire lock");
+    assert.equal(winner.child.exitCode, null);
+    winner.child.kill("SIGTERM");
+    await winner.closed;
   } finally {
     for (const contender of contenders) contender.child.kill("SIGTERM");
     await Promise.all(contenders.map((contender) => contender.closed));
@@ -188,8 +194,42 @@ test("signal keeps the lock until its delayed child has exited", async () => {
     assert.equal(existsSync(lockPath), true, "lock released before child exit");
     const contender = childWithLock(lockPath, "await withArtifactBuildLock(async () => {});");
     assert.equal((await contender.closed).code, 1);
-    assert.match(contender.output(), /another artifact build is active/);
+    assert.match(contender.output(), /active artifact lock/);
     assert.equal((await holder.closed).signal, "SIGTERM");
+    assert.equal(existsSync(lockPath), false);
+  } finally {
+    holder.child.kill("SIGKILL");
+    await holder.closed;
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("signal during NAPI repair drains the parent scope before unlock", async () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-repair-signal-"));
+  const lockPath = join(fixture, "lock");
+  const repairing = join(fixture, "repairing");
+  const received = join(fixture, "received");
+  const stopped = join(fixture, "stopped");
+  const holder = childWithLock(
+    lockPath,
+    `await withArtifactBuildLock((scope) => buildTestArtifacts((command, args, label, { signal }) => {
+      if (label === 'load release NAPI') return Promise.reject(new Error('load failed'));
+      if (label === 'repair release NAPI') return new Promise((resolve) => {
+        fs.writeFileSync(${JSON.stringify(repairing)}, 'repairing');
+        const timer = setInterval(() => {}, 1000);
+        signal.addEventListener('abort', () => { fs.writeFileSync(${JSON.stringify(received)}, 'received'); setTimeout(() => { clearInterval(timer); fs.writeFileSync(${JSON.stringify(stopped)}, 'stopped'); resolve(); }, 150); }, { once: true });
+      });
+      return Promise.resolve();
+    }, scope));`,
+  );
+  try {
+    await waitFor(() => existsSync(repairing), "repair did not start");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    holder.child.kill("SIGTERM");
+    await waitFor(() => existsSync(received), "repair did not receive shutdown");
+    assert.equal(existsSync(lockPath), true, "lock released during repair shutdown");
+    assert.equal((await holder.closed).signal, "SIGTERM");
+    assert.equal(existsSync(stopped), true);
     assert.equal(existsSync(lockPath), false);
   } finally {
     holder.child.kill("SIGKILL");
@@ -371,6 +411,10 @@ test("CI uses the correctness artifact path while package builds keep release WA
   const pipeline = readFileSync(new URL("../build-test-artifacts.mjs", import.meta.url), "utf8");
   assert.match(workflow, /pnpm build:test-artifacts/);
   assert.match(packageJson, /"build:test-artifacts": "node dev\/gates\/build-test-artifacts\.mjs"/);
+  assert.match(
+    packageJson,
+    /"artifacts:unlock": "node dev\/gates\/build-test-artifacts\.mjs unlock"/,
+  );
   assert.match(
     packageJson,
     /"build:ci": "turbo run build:crates.*jazz-wasm.*jazz-napi.*jazz-tools/,

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -1,9 +1,124 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import test from "node:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildTestArtifacts, command } from "../build-test-artifacts.mjs";
+import { acquireArtifactBuildLock, buildTestArtifacts, command } from "../build-test-artifacts.mjs";
+
+const pipelineUrl = new URL("../build-test-artifacts.mjs", import.meta.url).href;
+
+function childWithLock(lockPath, body) {
+  const child = spawn(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `import { withArtifactBuildLock } from ${JSON.stringify(pipelineUrl)}; ${body}`,
+    ],
+    {
+      env: { ...process.env, JAZZ_TEST_ARTIFACT_LOCK_PATH: lockPath },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let output = "";
+  child.stdout.on("data", (chunk) => (output += chunk));
+  child.stderr.on("data", (chunk) => (output += chunk));
+  return {
+    child,
+    output: () => output,
+    closed: new Promise((resolve) =>
+      child.once("close", (code, signal) => resolve({ code, signal })),
+    ),
+  };
+}
+
+async function waitFor(condition, message) {
+  for (let attempts = 0; attempts < 100; attempts++) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}
+
+test("artifact lock rejects a concurrent real subprocess with actionable ownership", async () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-lock-"));
+  const lockPath = join(fixture, "lock");
+  const holder = childWithLock(
+    lockPath,
+    "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
+  );
+  try {
+    await waitFor(() => existsSync(join(lockPath, "owner.json")), "holder did not acquire lock");
+    const contender = childWithLock(lockPath, "await withArtifactBuildLock(async () => {});");
+    const result = await contender.closed;
+    assert.equal(result.code, 1);
+    assert.match(
+      contender.output(),
+      /another artifact build is active \(pid \d+, cwd .+, started .+\)/,
+    );
+    assert.match(contender.output(), /Lock:/);
+  } finally {
+    holder.child.kill("SIGTERM");
+    await holder.closed;
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("artifact lock recovers only a positively stale owner", () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-stale-"));
+  const lockPath = join(fixture, "lock");
+  mkdirSync(lockPath);
+  writeFileSync(
+    join(lockPath, "owner.json"),
+    JSON.stringify({
+      pid: 999_999_999,
+      cwd: "stale-checkout",
+      startedAt: "2000-01-01T00:00:00.000Z",
+      token: "dead",
+    }),
+  );
+  const lock = acquireArtifactBuildLock(lockPath);
+  assert.equal(existsSync(join(lockPath, "owner.json")), true);
+  lock.release();
+  assert.equal(existsSync(lockPath), false);
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+test("artifact lock refuses an unowned directory instead of deleting a possibly live lock", () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-unowned-"));
+  const lockPath = join(fixture, "lock");
+  mkdirSync(lockPath);
+  assert.throws(() => acquireArtifactBuildLock(lockPath), /no usable owner metadata/);
+  assert.equal(existsSync(lockPath), true);
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+test("artifact lock cleans up after a real failure and termination signal", async () => {
+  const fixture = mkdtempSync(join(tmpdir(), "jazz-test-artifact-cleanup-"));
+  const failingLock = join(fixture, "failure-lock");
+  const failure = childWithLock(
+    failingLock,
+    "await withArtifactBuildLock(async () => { throw new Error('deliberate failure'); });",
+  );
+  assert.equal((await failure.closed).code, 1);
+  assert.equal(existsSync(failingLock), false);
+
+  const signalLock = join(fixture, "signal-lock");
+  const running = childWithLock(
+    signalLock,
+    "await withArtifactBuildLock(() => new Promise(() => setInterval(() => {}, 1000)));",
+  );
+  await waitFor(
+    () => existsSync(join(signalLock, "owner.json")),
+    "signal child did not acquire lock",
+  );
+  running.child.kill("SIGTERM");
+  const terminated = await running.closed;
+  assert.equal(terminated.signal, "SIGTERM");
+  assert.equal(existsSync(signalLock), false);
+  rmSync(fixture, { recursive: true, force: true });
+});
 
 test("test artifact pipeline overlaps independent bindings and repairs NAPI only after a failed load", async () => {
   const calls = [];

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:core": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=./packages/** --filter=jazz-napi --only",
     "build:ci": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=jazz-napi --filter=jazz-tools --only",
     "build:test-artifacts": "node dev/gates/build-test-artifacts.mjs",
+    "artifacts:unlock": "node dev/gates/build-test-artifacts.mjs unlock",
     "build:all": "pnpm build",
     "release:version": "changeset version",
     "release:version:alpha": "changeset version --snapshot alpha",


### PR DESCRIPTION
🤖 Prevents concurrent linked-worktree artifact builds from corrupting or invalidating shared test artifacts after expensive compilation.

The build pipeline now acquires an atomic clone-wide lock before launching NAPI/WASM/CLI work. Contention fails immediately with a redacted owner receipt. Stale locks are never stolen automatically: `pnpm artifacts:unlock` explicitly verifies that the owner is dead under a maintenance guard before clearing it.

All child process groups—including conditional NAPI repair—are aborted and fully drained before the lock is released on failure, SIGINT, or SIGTERM. Filesystem diagnostics redact absolute checkout and temporary paths.

Validation:

- `pnpm test:ci-workflow` (24/24)
- 80 simultaneous stale-lock contenders: zero unsafe owners
- fresh contender vs explicit unlock stress: exactly one owner
- live/malformed locks preserved
- delayed child, sibling failure, INT/TERM, and NAPI-repair shutdown retain the lock until quiescence
- missing-path error redaction regression
- sensitive-data and formatting checks
- independent adversarial review: approved

Developer-experience rationale: multiple overnight lanes independently lost full builds to late `STALE napi release` provenance failures. This turns that confusing, expensive outcome into an immediate actionable contention error.
