### PR TITLE
test: make focused Rust runs explicit

### DIFF
--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -47,6 +47,26 @@ pnpm test          # everything (via turbo)
 cargo test -p jazz --no-default-features --features test   # rust core only
 ```
 
+### Focus one Rust test safely
+
+`dev/t` first asks Cargo for the test inventory using the same target and
+features it will run. It refuses an empty selection, prints the selected binary,
+feature and cache context, and separately reports inventory/compile and test-run
+elapsed time.
+
+```sh
+# Default: Jazz library tests, substring matching.
+dev/t subscription::tests::reopens
+
+# Fully-qualified exact library test.
+dev/t --exact db::tests::round_trips
+
+# An integration target is explicit, so Cargo cannot search an unintended bin.
+dev/t --test incremental_delivery_canary maintained_relation -- --nocapture
+```
+
+Run `pnpm test:focused-rust` to test the wrapper with a mocked Cargo inventory.
+
 ### Bounded Rust runs and receipts
 
 Use the repository launcher when a test could hang or when comparing local and

--- a/dev/gates/test/dev-t.test.sh
+++ b/dev/gates/test/dev-t.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TEMP="$(mktemp -d "${TMPDIR:-/tmp}/jazz-dev-t-test.XXXXXX")"
+trap 'rm -rf "$TEMP"' EXIT
+mkdir "$TEMP/bin"
+
+cat >"$TEMP/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$MOCK_CARGO_LOG"
+if [[ " $* " == *" -- --list "* ]]; then
+  if [[ " $* " == *" --test incremental_delivery_canary "* ]]; then
+    printf '%s\n' 'maintained_relation::smoke: test'
+  else
+    printf '%s\n' 'db::tests::round_trips: test' 'db::tests::other: test'
+  fi
+  exit "${MOCK_INVENTORY_STATUS:-0}"
+fi
+printf '%s\n' 'running 1 test' 'test db::tests::round_trips ... ok' 'test result: ok. 1 passed; 0 failed;'
+exit "${MOCK_RUN_STATUS:-0}"
+EOF
+chmod +x "$TEMP/bin/cargo"
+
+run() {
+  PATH="$TEMP/bin:$PATH" \
+    MOCK_CARGO_LOG="$TEMP/cargo.log" \
+    MOCK_INVENTORY_STATUS="${MOCK_INVENTORY_STATUS:-}" \
+    MOCK_RUN_STATUS="${MOCK_RUN_STATUS:-}" \
+    "$ROOT/dev/t" "$@"
+}
+
+run db::tests::round
+grep -F -- '-p jazz --no-default-features --features test --lib -- --list' "$TEMP/cargo.log" >/dev/null
+grep -F -- '-p jazz --no-default-features --features test --lib db::tests::round --' "$TEMP/cargo.log" >/dev/null
+
+: >"$TEMP/cargo.log"
+run --exact db::tests::round_trips
+grep -F -- 'db::tests::round_trips -- --exact' "$TEMP/cargo.log" >/dev/null
+
+if run --exact db::tests::round; then
+  echo 'expected exact non-match to fail' >&2
+  exit 1
+fi
+
+: >"$TEMP/cargo.log"
+if run missing_test; then
+  echo 'expected missing inventory match to fail before test run' >&2
+  exit 1
+fi
+[[ "$(wc -l <"$TEMP/cargo.log")" -eq 1 ]]
+
+: >"$TEMP/cargo.log"
+run --test incremental_delivery_canary maintained_relation -- --nocapture
+grep -F -- '--test incremental_delivery_canary -- --list' "$TEMP/cargo.log" >/dev/null
+grep -F -- '--test incremental_delivery_canary maintained_relation -- --nocapture' "$TEMP/cargo.log" >/dev/null
+
+if MOCK_INVENTORY_STATUS=17 run round_trips; then
+  echo 'expected inventory failure to be preserved' >&2
+  exit 1
+else
+  [[ "$?" -eq 17 ]]
+fi
+
+if MOCK_RUN_STATUS=23 run round_trips; then
+  echo 'expected test failure to be preserved' >&2
+  exit 1
+else
+  [[ "$?" -eq 23 ]]
+fi
+
+echo 'dev/t focused test wrapper checks passed'

--- a/dev/t
+++ b/dev/t
@@ -1,69 +1,149 @@
 #!/usr/bin/env bash
-# Run a cargo-test filter, refusing Cargo's successful "running 0 tests" result.
+# Run one focused Jazz Rust test without Cargo's successful zero-test trap.
+#
+# The default deliberately matches the core-only gate.  Use --test for an
+# integration target rather than relying on Cargo's package-wide target search.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 usage() {
-  echo "Usage: dev/t <filter> [cargo test arguments...]" >&2
+  cat >&2 <<'EOF'
+Usage: dev/t [--lib | --test TARGET] [--exact] FILTER [-- LIBTEST-OPTIONS...]
+
+Runs a focused Jazz test with -p jazz --no-default-features --features test.
+The default target is --lib.  --exact requires FILTER to be the fully-qualified
+test name reported by Cargo; without it FILTER is a substring.
+
+Examples:
+  dev/t subscription::tests::reopens
+  dev/t --exact db::tests::round_trips
+  dev/t --test incremental_delivery_canary maintained_relation -- --nocapture
+EOF
 }
 
-(($# >= 1)) || {
-  usage
-  exit 2
-}
+target_kind="lib"
+target_name=""
+exact=false
+while (($#)); do
+  case "$1" in
+    --lib)
+      target_kind="lib"
+      target_name=""
+      shift
+      ;;
+    --test)
+      (($# >= 2)) || { usage; exit 2; }
+      target_kind="test"
+      target_name="$2"
+      shift 2
+      ;;
+    --exact)
+      exact=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      usage
+      echo "dev/t: unknown option: $1" >&2
+      exit 2
+      ;;
+    *) break ;;
+  esac
+done
 
-for required in cargo rg mktemp cat grep; do
+(($# >= 1)) || { usage; exit 2; }
+filter="$1"
+shift
+extra_args=("$@")
+# The separator belongs to this wrapper's syntax; Cargo receives it once,
+# between its filter and libtest's options.
+if ((${#extra_args[@]})) && [[ "${extra_args[0]}" == "--" ]]; then
+  extra_args=("${extra_args[@]:1}")
+fi
+
+for required in cargo mktemp grep sed date; do
   command -v "$required" >/dev/null 2>&1 || {
     echo "dev/t: required command not found: $required" >&2
     exit 127
   }
 done
 
-filter="$1"
-shift
-output="$(mktemp "${TMPDIR:-/tmp}/jazz-dev-t.XXXXXX")"
-trap 'rm -f "$output"' EXIT
-
-# Redirect to a file instead of teeing through a pipe so the captured status is
-# Cargo's actual status, not a pipeline's status.
-set +e
-cargo test "$filter" "$@" >"$output" 2>&1
-status=$?
-set -e
-cat "$output"
-
-if ((status != 0)); then
-  exit "$status"
+cargo_args=(-p jazz --no-default-features --features test)
+if [[ "$target_kind" == "lib" ]]; then
+  cargo_args+=(--lib)
+  selected_binary="jazz lib tests"
+else
+  cargo_args+=(--test "$target_name")
+  selected_binary="jazz integration test: $target_name"
 fi
 
-# Cargo may also print zero-test doctest targets after a real match. It only
-# matched nothing when no result line reports one or more passed tests.
-if grep -q 'running 0 tests' "$output" && ! grep -Eq 'test result: ok\. [1-9][0-9]* passed;' "$output"; then
-  test_name="${filter##*::}"
-  echo "dev/t: filter matched nothing: $filter" >&2
-  echo "Likely location(s) for $test_name:" >&2
-  matches="$(rg -l -F "$test_name" --glob '*.rs' crates 2>/dev/null || true)"
-  if [[ -n "$matches" ]]; then
-    while IFS= read -r file; do
-      echo "  $file" >&2
-      base="$(basename "$file")"
-      includers="$(rg -l -F "include!(\"$base\")" --glob '*.rs' crates 2>/dev/null || true)"
-      if [[ -n "$includers" ]]; then
-        while IFS= read -r includer; do
-          module="${includer#crates/*/src/}"
-          module="${module%.rs}"
-          module="${module%/mod}"
-          module="${module//\//::}"
-          echo "    likely module path: $module::$test_name (included by $includer)" >&2
-        done <<<"$includers"
-      fi
-    done <<<"$matches"
-  else
-    echo "  no Rust source mention found" >&2
-  fi
+target_dir="${CARGO_TARGET_DIR:-$ROOT/target}"
+printf 'dev/t: target=%s\n' "$selected_binary"
+printf 'dev/t: features=no-default-features,test; cache target=%s rustc_wrapper=%s sccache_dir=%s incremental=%s\n' \
+  "$target_dir" "${RUSTC_WRAPPER:-none}" "${SCCACHE_DIR:-none}" "${CARGO_INCREMENTAL:-default}"
+printf 'dev/t: inventory command:'
+printf ' %q' cargo test "${cargo_args[@]}" -- --list
+printf '\n'
+
+inventory="$(mktemp "${TMPDIR:-/tmp}/jazz-dev-t-inventory.XXXXXX")"
+output="$(mktemp "${TMPDIR:-/tmp}/jazz-dev-t.XXXXXX")"
+trap 'rm -f "$inventory" "$output"' EXIT
+
+started="$(date +%s)"
+echo 'dev/t: resolving Cargo test inventory (may compile selected target)...'
+set +e
+cargo test "${cargo_args[@]}" -- --list >"$inventory" 2>&1
+inventory_status=$?
+set -e
+inventory_elapsed=$(( $(date +%s) - started ))
+printf 'dev/t: inventory compile/list elapsed=%ss\n' "$inventory_elapsed"
+if ((inventory_status != 0)); then
+  cat "$inventory"
+  echo "dev/t: inventory command failed (exit $inventory_status); test was not run" >&2
+  exit "$inventory_status"
+fi
+
+# Cargo writes each discovered unit test as "fully::qualified::name: test".
+# Inspect that authoritative inventory before the run so a spelling, target, or
+# feature mismatch cannot look like a successful focused test invocation.
+names="$(sed -n 's/: test$//p' "$inventory")"
+inventory_count="$(printf '%s\n' "$names" | grep -c . || true)"
+printf 'dev/t: selected inventory has %s test(s)\n' "$inventory_count"
+if [[ "$exact" == true ]]; then
+  matches="$(printf '%s\n' "$names" | grep -F -x -- "$filter" || true)"
+else
+  matches="$(printf '%s\n' "$names" | grep -F -- "$filter" || true)"
+fi
+if [[ -z "$matches" ]]; then
+  echo "dev/t: filter matched no selected test inventory entries: $filter" >&2
+  echo "dev/t: check --lib versus --test TARGET, feature selection, or use a shorter substring." >&2
   exit 1
 fi
+match_count="$(printf '%s\n' "$matches" | grep -c . || true)"
+printf 'dev/t: inventory matched %s test(s):\n%s\n' "$match_count" "$matches"
 
-exit 0
+run_args=(test "${cargo_args[@]}" "$filter" -- "${extra_args[@]}")
+if [[ "$exact" == true ]]; then
+  run_args+=(--exact)
+fi
+printf 'dev/t: run command:'
+printf ' %q' cargo "${run_args[@]}"
+printf '\n'
+started="$(date +%s)"
+set +e
+cargo "${run_args[@]}" >"$output" 2>&1
+status=$?
+set -e
+run_elapsed=$(( $(date +%s) - started ))
+cat "$output"
+printf 'dev/t: test run elapsed=%ss exit=%s\n' "$run_elapsed" "$status"
+exit "$status"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "format:check": "oxfmt --check --ignore-path .oxfmtignore . && cargo fmt --check",
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
     "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
+    "test:focused-rust": "bash dev/gates/test/dev-t.test.sh",
     "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
     "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs",


### PR DESCRIPTION
🤖 Adds `dev/t`, a small focused Rust test runner that makes the selected feature set, test binary, inventory match, cache context, and timing explicit.

It defaults to Jazz's real core test configuration (`--no-default-features --features test --lib`), validates the authoritative Cargo/libtest inventory before running, and refuses a zero-match invocation. It supports substring selection, fully-qualified `--exact` names, and explicit integration-test targets while preserving Cargo/list/test exit codes.

This addresses repeated overnight cases where a plausible `cargo test` command exited successfully after running zero tests, or appeared hung while compiling a different feature-specific test binary.

Validation:

- `pnpm test:focused-rust`
- `bash -n dev/t`
- mock-Cargo contracts for zero/exact/target matching and inventory/run exit propagation
- real inventory probe found 1,327 Jazz lib tests under the intended feature set
- formatting and sensitive-data checks
- independent adversarial review: approved

Friction captured: the first inventory compile still costs about 43–45 seconds in a cold lane; remote/shared compiler caching and a possible cached inventory manifest are the next levers.
