### PR TITLE
test: restore sorted-subscription convergence window

### DIFF
--- a/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
@@ -51,6 +51,11 @@ function makeTodosQuery(body: {
 
 const sortedByRankAscQuery = makeTodosQuery({ orderBy: [["rank", "asc"]] });
 
+// Browser subscription delivery is asynchronous. Keep this aligned with the
+// rest of this suite's convergence waits: a sub-second deadline flakes when
+// the full browser suite is sharing a worker, without testing a latency SLO.
+const SUBSCRIPTION_CONVERGENCE_TIMEOUT_MS = 10_000;
+
 function uniqueDbName(label: string): string {
   return `db-subscribe-all-sort-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -163,7 +168,7 @@ describe("db.subscribeAll sorting browser integration", () => {
 
         await waitForCondition(
           () => deltas.some((delta) => delta.all.length === 3),
-          500,
+          SUBSCRIPTION_CONVERGENCE_TIMEOUT_MS,
           "expected initial sorted snapshot",
         );
 
@@ -174,7 +179,7 @@ describe("db.subscribeAll sorting browser integration", () => {
 
         await waitForCondition(
           () => deltas.some((delta) => hasUpdateForId(delta, idB)),
-          500,
+          SUBSCRIPTION_CONVERGENCE_TIMEOUT_MS,
           "expected update delta for row B",
         );
 


### PR DESCRIPTION
🤖 Restores the sorted-subscription browser test's original suite convergence window.

History shows both waits were 10 seconds when introduced. A RowDelta-format migration accidentally changed them to 500ms, and later sync-reentrancy work restored only the initial wait to 2 seconds. Full-suite CI can legitimately exceed those sub-second limits even though isolated execution passes.

This is harness-only: it centralizes the established 10-second timeout in a named constant and changes no product code, predicates, ordering assertions, or expected results.

Verification:
- focused Chromium sort suite: 17/17 passed;
- TypeScript test typecheck and formatting passed;
- a planted reversed-order expectation fails the focused test;
- independent review confirmed the history and found no weakened semantic assertion.
