### PR TITLE
Fix typed NAPI subscription event marshalling

### DIFF
--- a/.changeset/typed-native-subscriptions.md
+++ b/.changeset/typed-native-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"jazz-napi": patch
+---
+
+Marshal raw native subscription deltas as `Uint8Array` and publish typed subscription event declarations.

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -108,8 +108,8 @@ export declare class Tx {
 export declare class Write {
   get batchId(): string
   get payload(): Uint8Array
-  wait(tier: string): Promise<undefined>
   writeState(): any
+  wait(tier: string): Promise<undefined>
   close(): boolean
 }
 
@@ -124,6 +124,7 @@ export interface SubscriptionDeltaEvent {
   reset: boolean
   delta: Uint8Array
   terminalOperations: Array<SubscriptionTerminalOperation>
+  terminalLayouts: Array<SubscriptionTerminalLayout>
   settled: boolean
   tier: 'None' | 'Local' | 'Edge' | 'Global'
 }
@@ -169,6 +170,20 @@ export interface SubscriptionTerminalKeyPathSegment {
   Key: Array<number>
 }
 
+/**
+ * Immutable producer-owned root record contract.  The descriptor and public
+ * slots are published once per NAPI subscription, before an operation may
+ * reference `id`; TypeScript never has to infer a CurrentRow/layout family.
+ */
+export interface SubscriptionTerminalLayout {
+  id: string
+  rootDescriptor: Array<number>
+  rootKeySlot: number
+  rootKeyFieldName: string
+  publicFields: Array<SubscriptionTerminalPublicField>
+  carrier: string
+}
+
 export interface SubscriptionTerminalMove {
   key: Array<number>
   index: number
@@ -179,7 +194,7 @@ export interface SubscriptionTerminalMoveEdit {
 }
 
 export interface SubscriptionTerminalOperation {
-  rootDescriptor: Array<number>
+  rootLayoutId: string
   root_key: Array<number>
   path: Array<SubscriptionTerminalPathSegment>
   edit: SubscriptionTerminalEdit
@@ -187,6 +202,13 @@ export interface SubscriptionTerminalOperation {
 
 export type SubscriptionTerminalPathSegment =
   SubscriptionTerminalCollectionPathSegment | SubscriptionTerminalKeyPathSegment
+
+export interface SubscriptionTerminalPublicField {
+  name: string
+  descriptorFieldName: string
+  slot: number
+  carrier: string
+}
 
 export interface SubscriptionTerminalRemove {
   key: Array<number>

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -75,8 +75,8 @@ export declare class QueryAttachment {
 }
 
 export declare class Subscription {
-  readAll(): Array<any>
-  drain(): Array<any>
+  readAll(): Array<SubscriptionEvent>
+  drain(): Array<SubscriptionEvent>
   close(): boolean
 }
 
@@ -114,6 +114,101 @@ export declare class Write {
 }
 
 export declare function mintLocalFirstToken(seedB64: string, audience: string, ttlSeconds: number): string
+
+export interface SubscriptionClosedEvent {
+  type: 'closed'
+}
+
+export interface SubscriptionDeltaEvent {
+  type: 'delta'
+  reset: boolean
+  delta: Uint8Array
+  terminalOperations: Array<SubscriptionTerminalOperation>
+  settled: boolean
+  tier: 'None' | 'Local' | 'Edge' | 'Global'
+}
+
+export type SubscriptionEvent =
+  SubscriptionDeltaEvent | SubscriptionRejectedEvent | SubscriptionClosedEvent
+
+export interface SubscriptionRejectedEvent {
+  type: 'rejected'
+  reason: SubscriptionRejectionReason
+}
+
+export type SubscriptionRejectionReason =
+  SubscriptionUnsupportedShapeCapabilityReason | SubscriptionShapeRegistrationPendingReason | SubscriptionServerFailureReason
+
+export interface SubscriptionServerFailureReason {
+  type: 'ServerFailure'
+  code: 'TableNotFound' | 'SchemaResolution' | 'QueryValidation' | 'QueryLowering' | 'PolicyEvaluation' | 'Internal'
+}
+
+export interface SubscriptionShapeRegistrationPendingReason {
+  type: 'ShapeRegistrationPendingCatalogueAdmission'
+}
+
+export interface SubscriptionTerminalCollectionPathSegment {
+  Collection: string
+}
+
+export type SubscriptionTerminalEdit =
+  SubscriptionTerminalInsertEdit | SubscriptionTerminalUpdateEdit | SubscriptionTerminalRemoveEdit | SubscriptionTerminalMoveEdit
+
+export interface SubscriptionTerminalInsert {
+  index: number
+  key: Array<number>
+  value: Array<number>
+}
+
+export interface SubscriptionTerminalInsertEdit {
+  Insert: SubscriptionTerminalInsert
+}
+
+export interface SubscriptionTerminalKeyPathSegment {
+  Key: Array<number>
+}
+
+export interface SubscriptionTerminalMove {
+  key: Array<number>
+  index: number
+}
+
+export interface SubscriptionTerminalMoveEdit {
+  Move: SubscriptionTerminalMove
+}
+
+export interface SubscriptionTerminalOperation {
+  rootDescriptor: Array<number>
+  root_key: Array<number>
+  path: Array<SubscriptionTerminalPathSegment>
+  edit: SubscriptionTerminalEdit
+}
+
+export type SubscriptionTerminalPathSegment =
+  SubscriptionTerminalCollectionPathSegment | SubscriptionTerminalKeyPathSegment
+
+export interface SubscriptionTerminalRemove {
+  key: Array<number>
+}
+
+export interface SubscriptionTerminalRemoveEdit {
+  Remove: SubscriptionTerminalRemove
+}
+
+export interface SubscriptionTerminalUpdate {
+  key: Array<number>
+  value: Array<number>
+}
+
+export interface SubscriptionTerminalUpdateEdit {
+  Update: SubscriptionTerminalUpdate
+}
+
+export interface SubscriptionUnsupportedShapeCapabilityReason {
+  type: 'UnsupportedShapeCapability'
+  detail: string
+}
 
 export declare function verifyLocalFirstIdentityProof(token: string | undefined | null, expectedAudience: string): VerifyTokenResult
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -49,9 +49,9 @@ use jazz::db::{
     PeerConnection as CorePeerConnection, PreparedQuery as PreparedQueryInner,
     Propagation as CorePropagation, QueryAttachment as CoreQueryAttachment,
     ReadOpts as CoreReadOpts, RowCells as CoreRowCells, SeededRowIdSource as CoreSeededRowIdSource,
-    SubscriptionEvent, SubscriptionStream, TickScheduler as CoreTickScheduler,
-    TickUrgency as CoreTickUrgency, WireTransportAdapter as CoreWireTransportAdapter, WriteHandle,
-    block_on as core_block_on,
+    SubscriptionEvent as CoreSubscriptionEvent, SubscriptionStream,
+    TickScheduler as CoreTickScheduler, TickUrgency as CoreTickUrgency,
+    WireTransportAdapter as CoreWireTransportAdapter, WriteHandle, block_on as core_block_on,
 };
 use jazz::groove::records::{
     BorrowedRecord as CoreBorrowedRecord, RecordDescriptor, Value as CoreValue,
@@ -227,6 +227,151 @@ pub struct Transport {
 pub struct Subscription {
     inner: Option<NapiSubscription>,
 }
+
+#[napi(object)]
+pub struct SubscriptionDeltaEvent {
+    #[napi(js_name = "type", ts_type = "'delta'")]
+    pub event_type: String,
+    pub reset: bool,
+    pub delta: Uint8Array,
+    #[napi(js_name = "terminalOperations")]
+    pub terminal_operations: Vec<SubscriptionTerminalOperation>,
+    pub settled: bool,
+    #[napi(ts_type = "'None' | 'Local' | 'Edge' | 'Global'")]
+    pub tier: String,
+}
+
+#[napi(object)]
+pub struct SubscriptionRejectedEvent {
+    #[napi(js_name = "type", ts_type = "'rejected'")]
+    pub event_type: String,
+    pub reason: SubscriptionRejectionReason,
+}
+
+#[napi(object)]
+pub struct SubscriptionClosedEvent {
+    #[napi(js_name = "type", ts_type = "'closed'")]
+    pub event_type: String,
+}
+
+#[napi(object)]
+pub struct SubscriptionUnsupportedShapeCapabilityReason {
+    #[napi(js_name = "type", ts_type = "'UnsupportedShapeCapability'")]
+    pub reason_type: String,
+    pub detail: String,
+}
+
+#[napi(object)]
+pub struct SubscriptionShapeRegistrationPendingReason {
+    #[napi(
+        js_name = "type",
+        ts_type = "'ShapeRegistrationPendingCatalogueAdmission'"
+    )]
+    pub reason_type: String,
+}
+
+#[napi(object)]
+pub struct SubscriptionServerFailureReason {
+    #[napi(js_name = "type", ts_type = "'ServerFailure'")]
+    pub reason_type: String,
+    #[napi(
+        ts_type = "'TableNotFound' | 'SchemaResolution' | 'QueryValidation' | 'QueryLowering' | 'PolicyEvaluation' | 'Internal'"
+    )]
+    pub code: String,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalOperation {
+    #[napi(js_name = "rootDescriptor")]
+    pub root_descriptor: Vec<u32>,
+    #[napi(js_name = "root_key")]
+    pub root_key: Vec<u32>,
+    pub path: Vec<SubscriptionTerminalPathSegment>,
+    pub edit: SubscriptionTerminalEdit,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalCollectionPathSegment {
+    #[napi(js_name = "Collection")]
+    pub collection: String,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalKeyPathSegment {
+    #[napi(js_name = "Key")]
+    pub key: Vec<u32>,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalInsertEdit {
+    #[napi(js_name = "Insert")]
+    pub insert: SubscriptionTerminalInsert,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalInsert {
+    pub index: f64,
+    pub key: Vec<u32>,
+    pub value: Vec<u32>,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalUpdateEdit {
+    #[napi(js_name = "Update")]
+    pub update: SubscriptionTerminalUpdate,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalUpdate {
+    pub key: Vec<u32>,
+    pub value: Vec<u32>,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalRemoveEdit {
+    #[napi(js_name = "Remove")]
+    pub remove: SubscriptionTerminalRemove,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalRemove {
+    pub key: Vec<u32>,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalMoveEdit {
+    #[napi(js_name = "Move")]
+    pub move_edit: SubscriptionTerminalMove,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalMove {
+    pub key: Vec<u32>,
+    pub index: f64,
+}
+
+#[napi]
+pub type SubscriptionEvent =
+    Either3<SubscriptionDeltaEvent, SubscriptionRejectedEvent, SubscriptionClosedEvent>;
+
+#[napi]
+pub type SubscriptionRejectionReason = Either3<
+    SubscriptionUnsupportedShapeCapabilityReason,
+    SubscriptionShapeRegistrationPendingReason,
+    SubscriptionServerFailureReason,
+>;
+
+#[napi]
+pub type SubscriptionTerminalPathSegment =
+    Either<SubscriptionTerminalCollectionPathSegment, SubscriptionTerminalKeyPathSegment>;
+
+#[napi]
+pub type SubscriptionTerminalEdit = Either4<
+    SubscriptionTerminalInsertEdit,
+    SubscriptionTerminalUpdateEdit,
+    SubscriptionTerminalRemoveEdit,
+    SubscriptionTerminalMoveEdit,
+>;
 
 enum NapiTransportInner {
     Memory {
@@ -419,7 +564,7 @@ impl Transport {
 #[napi]
 impl Subscription {
     #[napi(js_name = "readAll")]
-    pub fn read_all(&mut self) -> napi::Result<Vec<serde_json::Value>> {
+    pub fn read_all(&mut self) -> napi::Result<Vec<SubscriptionEvent>> {
         let subscription = self
             .inner
             .as_mut()
@@ -433,13 +578,13 @@ impl Subscription {
             let Some(event) = event else {
                 break;
             };
-            events.push(core_subscription_event_to_json(&event)?);
+            events.push(core_subscription_event_to_napi(&event)?);
         }
         Ok(events)
     }
 
     #[napi]
-    pub fn drain(&mut self) -> napi::Result<Vec<serde_json::Value>> {
+    pub fn drain(&mut self) -> napi::Result<Vec<SubscriptionEvent>> {
         self.read_all()
     }
 
@@ -2325,9 +2470,11 @@ fn core_row<'a>(row: &jazz::node::CurrentRow, raw: &'a [u8]) -> CoreRow<'a> {
     }
 }
 
-fn core_subscription_event_to_json(event: &SubscriptionEvent) -> napi::Result<serde_json::Value> {
+fn core_subscription_event_to_napi(
+    event: &CoreSubscriptionEvent,
+) -> napi::Result<SubscriptionEvent> {
     match event {
-        SubscriptionEvent::Delta {
+        CoreSubscriptionEvent::Delta {
             reset,
             added,
             updated,
@@ -2350,24 +2497,25 @@ fn core_subscription_event_to_json(event: &SubscriptionEvent) -> napi::Result<se
                 },
             )
             .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-            let terminal_operations = terminal_operations_to_json(terminal_operations)
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-            let payload = serde_json::json!({
-                "type": "delta",
-                "reset": reset,
-                "delta": delta,
-                "terminalOperations": terminal_operations,
-                "settled": settled,
-                "tier": format!("{tier:?}"),
-            });
-            Ok(payload)
+            let terminal_operations = terminal_operations
+                .iter()
+                .map(core_terminal_operation_to_napi)
+                .collect::<std::result::Result<_, _>>()?;
+            Ok(Either3::A(SubscriptionDeltaEvent {
+                event_type: "delta".to_string(),
+                reset: *reset,
+                delta: Uint8Array::new(delta),
+                terminal_operations,
+                settled: *settled,
+                tier: format!("{tier:?}"),
+            }))
         }
-        SubscriptionEvent::Rejected { reason } => {
+        CoreSubscriptionEvent::Rejected { reason } => {
             let reason = match reason {
                 jazz::protocol::SubscribeRejectReason::UnsupportedShapeCapability { detail } => {
-                    serde_json::json!({
-                        "type": "UnsupportedShapeCapability",
-                        "detail": detail,
+                    Either3::A(SubscriptionUnsupportedShapeCapabilityReason {
+                        reason_type: "UnsupportedShapeCapability".to_string(),
+                        detail: detail.clone(),
                     })
                 }
                 // Transient: the shape is awaiting catalogue admission and may
@@ -2375,52 +2523,90 @@ fn core_subscription_event_to_json(event: &SubscriptionEvent) -> napi::Result<se
                 // it for an unsupported capability, which is permanent — that
                 // conflation is the bug this variant was introduced to fix.
                 jazz::protocol::SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission => {
-                    serde_json::json!({
-                        "type": "ShapeRegistrationPendingCatalogueAdmission",
+                    Either3::B(SubscriptionShapeRegistrationPendingReason {
+                        reason_type: "ShapeRegistrationPendingCatalogueAdmission".to_string(),
                     })
                 }
                 jazz::protocol::SubscribeRejectReason::ServerFailure { code } => {
-                    serde_json::json!({
-                        "type": "ServerFailure",
-                        "code": format!("{code:?}"),
+                    Either3::C(SubscriptionServerFailureReason {
+                        reason_type: "ServerFailure".to_string(),
+                        code: format!("{code:?}"),
                     })
                 }
             };
-            Ok(serde_json::json!({
-                "type": "rejected",
-                "reason": reason,
+            Ok(Either3::B(SubscriptionRejectedEvent {
+                event_type: "rejected".to_string(),
+                reason,
             }))
         }
-        SubscriptionEvent::Closed => Ok(serde_json::json!({ "type": "closed" })),
+        CoreSubscriptionEvent::Closed => Ok(Either3::C(SubscriptionClosedEvent {
+            event_type: "closed".to_string(),
+        })),
     }
 }
 
-/// Serialize terminal edits with their exact root record layout.  The opaque
-/// descriptor bytes use the same postcard schema as packed subscription rows,
-/// which lets TypeScript decode the record layout without recreating it from
-/// the query projection.
-fn terminal_operations_to_json(
-    operations: &[jazz::groove::ivm::TerminalOperation],
-) -> std::result::Result<serde_json::Value, String> {
-    let mut encoded = serde_json::to_value(operations).map_err(|error| error.to_string())?;
-    let encoded_operations = encoded
-        .as_array_mut()
-        .expect("terminal operations serialize as an array");
-    for (operation, wire) in operations.iter().zip(encoded_operations) {
-        let serde_json::Value::Object(wire) = wire else {
-            unreachable!("terminal operation serializes as an object");
-        };
-        wire.remove("root_descriptor");
-        wire.insert(
-            "rootDescriptor".to_owned(),
-            serde_json::to_value(
-                postcard::to_allocvec(&operation.root_descriptor)
-                    .map_err(|error| error.to_string())?,
-            )
-            .map_err(|error| error.to_string())?,
-        );
-    }
-    Ok(encoded)
+/// Convert terminal edits without serde_json so binary subscription deltas keep
+/// their typed-array representation. Root descriptors retain the upstream
+/// postcard encoding; ordered keys and edit payloads retain their number-array
+/// representation for the existing TypeScript terminal consumer.
+fn core_terminal_operation_to_napi(
+    operation: &jazz::groove::ivm::TerminalOperation,
+) -> napi::Result<SubscriptionTerminalOperation> {
+    use jazz::groove::ivm::{TerminalEdit, TerminalPathSegment};
+
+    let root_descriptor = postcard::to_allocvec(&operation.root_descriptor)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    let path = operation
+        .path
+        .iter()
+        .map(|segment| match segment {
+            TerminalPathSegment::Collection(collection) => {
+                Either::A(SubscriptionTerminalCollectionPathSegment {
+                    collection: collection.clone(),
+                })
+            }
+            TerminalPathSegment::Key(key) => Either::B(SubscriptionTerminalKeyPathSegment {
+                key: terminal_bytes_to_numbers(key),
+            }),
+        })
+        .collect();
+    let edit = match &operation.edit {
+        TerminalEdit::Insert { index, key, value } => Either4::A(SubscriptionTerminalInsertEdit {
+            insert: SubscriptionTerminalInsert {
+                index: *index as f64,
+                key: terminal_bytes_to_numbers(key),
+                value: terminal_bytes_to_numbers(value),
+            },
+        }),
+        TerminalEdit::Update { key, value } => Either4::B(SubscriptionTerminalUpdateEdit {
+            update: SubscriptionTerminalUpdate {
+                key: terminal_bytes_to_numbers(key),
+                value: terminal_bytes_to_numbers(value),
+            },
+        }),
+        TerminalEdit::Remove { key } => Either4::C(SubscriptionTerminalRemoveEdit {
+            remove: SubscriptionTerminalRemove {
+                key: terminal_bytes_to_numbers(key),
+            },
+        }),
+        TerminalEdit::Move { key, index } => Either4::D(SubscriptionTerminalMoveEdit {
+            move_edit: SubscriptionTerminalMove {
+                key: terminal_bytes_to_numbers(key),
+                index: *index as f64,
+            },
+        }),
+    };
+
+    Ok(SubscriptionTerminalOperation {
+        root_descriptor: terminal_bytes_to_numbers(&root_descriptor),
+        root_key: terminal_bytes_to_numbers(&operation.root_key),
+        path,
+        edit,
+    })
+}
+
+fn terminal_bytes_to_numbers(bytes: &[u8]) -> Vec<u32> {
+    bytes.iter().copied().map(u32::from).collect()
 }
 
 fn core_relation_query_from_json(query_json: &str) -> napi::Result<CoreRelationQuery> {
@@ -2807,13 +2993,14 @@ mod tests {
 
     use crate::{
         NapiDbInnerStorage, NapiTxKind, Tx, authority_epoch_from_bigint, core_block_on,
-        core_read_opts_from_json, core_subscription_event_to_json, encode_core_subscription_delta,
+        core_read_opts_from_json, core_subscription_event_to_napi, encode_core_subscription_delta,
+        terminal_bytes_to_numbers,
     };
     use jazz::db::{
         Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,
-        MergeableTxOps, Propagation as CorePropagation, SubscriptionEvent,
+        MergeableTxOps, Propagation as CorePropagation, SubscriptionEvent as CoreSubscriptionEvent,
     };
-    use jazz::groove::ivm::{TerminalEdit, TerminalOperation};
+    use jazz::groove::ivm::{TerminalEdit, TerminalOperation, TerminalPathSegment};
     use jazz::groove::records::Value as CoreValue;
     use jazz::groove::records::{RecordDescriptor, ValueType};
     use jazz::groove::schema::ColumnType as GrooveColumnType;
@@ -2825,7 +3012,7 @@ mod tests {
     use jazz::tools::OpenBatchId as CoreOpenBatchId;
     use jazz::tools::{ColumnType, Schema, SchemaBuilder, TableName, TableSchema, Value};
     use jazz::tx::DurabilityTier;
-    use napi::bindgen_prelude::BigInt;
+    use napi::bindgen_prelude::{BigInt, Either, Either3, Either4};
     use serde_json::json;
 
     #[test]
@@ -2979,7 +3166,7 @@ mod tests {
 
     #[test]
     fn subscription_payload_exposes_only_terminal_rows() {
-        let payload = core_subscription_event_to_json(&SubscriptionEvent::Delta {
+        let payload = core_subscription_event_to_napi(&CoreSubscriptionEvent::Delta {
             reset: false,
             added: Vec::new(),
             updated: Vec::new(),
@@ -2990,41 +3177,173 @@ mod tests {
         })
         .expect("encode terminal delta");
 
-        assert!(payload.get("relation_delta").is_none());
-        assert!(payload.get("output_mode").is_none());
+        let Either3::A(payload) = payload else {
+            panic!("expected delta payload");
+        };
+        assert!(!payload.delta.is_empty());
+        assert!(payload.terminal_operations.is_empty());
+        assert_eq!(payload.tier, "Local");
     }
 
     #[test]
-    fn terminal_operations_use_json_objects_with_descriptor_bytes() {
-        let payload = super::terminal_operations_to_json(&[TerminalOperation {
-            root_descriptor: RecordDescriptor::new([
-                ("__jazz_terminal_row_key", ValueType::Uuid),
-                ("title", ValueType::String),
-            ]),
-            root_key: vec![10; 17],
-            path: Vec::new(),
-            edit: TerminalEdit::Insert {
-                index: 0,
-                key: vec![10; 17],
-                value: vec![0; 16],
+    fn subscription_payload_preserves_typed_terminal_operations_and_descriptor() {
+        let descriptor = RecordDescriptor::new([
+            ("__jazz_terminal_row_key", ValueType::Uuid),
+            ("title", ValueType::String),
+        ]);
+        let expected_descriptor = postcard::to_allocvec(&descriptor).unwrap();
+        let operations = vec![
+            TerminalOperation {
+                root_descriptor: descriptor,
+                root_key: vec![0, 255],
+                path: vec![
+                    TerminalPathSegment::Collection("children".to_owned()),
+                    TerminalPathSegment::Key(vec![1, 254]),
+                ],
+                edit: TerminalEdit::Insert {
+                    index: 3,
+                    key: vec![2, 253],
+                    value: (0_u8..=u8::MAX).collect(),
+                },
             },
-        }])
-        .expect("terminal operations serialize");
+            TerminalOperation {
+                root_descriptor: descriptor,
+                root_key: vec![4],
+                path: Vec::new(),
+                edit: TerminalEdit::Update {
+                    key: vec![5],
+                    value: vec![6],
+                },
+            },
+            TerminalOperation {
+                root_descriptor: descriptor,
+                root_key: vec![7],
+                path: Vec::new(),
+                edit: TerminalEdit::Remove { key: vec![8] },
+            },
+            TerminalOperation {
+                root_descriptor: descriptor,
+                root_key: vec![9],
+                path: Vec::new(),
+                edit: TerminalEdit::Move {
+                    key: vec![10],
+                    index: 11,
+                },
+            },
+        ];
+        let payload = core_subscription_event_to_napi(&CoreSubscriptionEvent::Delta {
+            reset: false,
+            added: Vec::new(),
+            updated: Vec::new(),
+            removed: Vec::new(),
+            terminal_operations: operations,
+            settled: false,
+            tier: DurabilityTier::Edge,
+        })
+        .expect("encode terminal operations");
 
-        let operation = payload
-            .as_array()
-            .and_then(|operations| operations.first())
-            .and_then(serde_json::Value::as_object)
-            .expect("terminal operation is a JSON object");
-        assert!(operation.get("path").is_some());
-        assert!(operation.get("edit").is_some());
-        assert!(
-            operation
-                .get("rootDescriptor")
-                .is_some_and(serde_json::Value::is_array)
+        let Either3::A(payload) = payload else {
+            panic!("expected delta payload");
+        };
+        assert_eq!(payload.tier, "Edge");
+        assert_eq!(payload.terminal_operations.len(), 4);
+        let insert = &payload.terminal_operations[0];
+        assert_eq!(
+            insert.root_descriptor,
+            terminal_bytes_to_numbers(&expected_descriptor)
         );
-        assert!(operation.get("root_descriptor").is_none());
+        assert_eq!(insert.root_key, vec![0, 255]);
+        assert!(matches!(
+            insert.path.as_slice(),
+            [Either::A(collection), Either::B(key)]
+                if collection.collection == "children" && key.key == vec![1, 254]
+        ));
+        assert!(matches!(
+            &insert.edit,
+            Either4::A(edit)
+                if edit.insert.index == 3.0
+                    && edit.insert.key == vec![2, 253]
+                    && edit.insert.value == (0_u32..=u8::MAX.into()).collect::<Vec<_>>()
+        ));
+        assert!(matches!(
+            &payload.terminal_operations[1].edit,
+            Either4::B(edit) if edit.update.key == vec![5] && edit.update.value == vec![6]
+        ));
+        assert!(matches!(
+            &payload.terminal_operations[2].edit,
+            Either4::C(edit) if edit.remove.key == vec![8]
+        ));
+        assert!(matches!(
+            &payload.terminal_operations[3].edit,
+            Either4::D(edit) if edit.move_edit.key == vec![10] && edit.move_edit.index == 11.0
+        ));
     }
+
+    #[test]
+    fn subscription_payload_preserves_rejection_and_closed_variants() {
+        use jazz::protocol::{SubscribeRejectReason, SubscribeServerFailureCode};
+
+        let unsupported = core_subscription_event_to_napi(&CoreSubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::UnsupportedShapeCapability {
+                detail: "unsupported maintained shape".to_owned(),
+            },
+        })
+        .expect("encode unsupported rejection");
+        assert!(matches!(
+            unsupported,
+            Either3::B(crate::SubscriptionRejectedEvent {
+                event_type,
+                reason: Either3::A(crate::SubscriptionUnsupportedShapeCapabilityReason {
+                    reason_type,
+                    detail,
+                }),
+            }) if event_type == "rejected"
+                && reason_type == "UnsupportedShapeCapability"
+                && detail == "unsupported maintained shape"
+        ));
+
+        let pending = core_subscription_event_to_napi(&CoreSubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
+        })
+        .expect("encode pending rejection");
+        assert!(matches!(
+            pending,
+            Either3::B(crate::SubscriptionRejectedEvent {
+                event_type,
+                reason: Either3::B(crate::SubscriptionShapeRegistrationPendingReason {
+                    reason_type,
+                }),
+            }) if event_type == "rejected"
+                && reason_type == "ShapeRegistrationPendingCatalogueAdmission"
+        ));
+
+        let server_failure = core_subscription_event_to_napi(&CoreSubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::ServerFailure {
+                code: SubscribeServerFailureCode::QueryValidation,
+            },
+        })
+        .expect("encode server rejection");
+        assert!(matches!(
+            server_failure,
+            Either3::B(crate::SubscriptionRejectedEvent {
+                event_type,
+                reason: Either3::C(crate::SubscriptionServerFailureReason {
+                    reason_type,
+                    code,
+                }),
+            }) if event_type == "rejected"
+                && reason_type == "ServerFailure"
+                && code == "QueryValidation"
+        ));
+
+        let closed = core_subscription_event_to_napi(&CoreSubscriptionEvent::Closed)
+            .expect("encode closed event");
+        assert!(matches!(
+            closed,
+            Either3::C(crate::SubscriptionClosedEvent { event_type }) if event_type == "closed"
+        ));
+    }
+
     /// A short-lived NAPI schema attachment must not own or abandon the
     /// owner-wide OpenBatch lifetime when its JS wrapper is collected.
     #[test]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2545,6 +2545,36 @@ fn core_subscription_event_to_napi(
     }
 }
 
+mod test_fixture_export {
+    #[cfg(debug_assertions)]
+    #[allow(dead_code)]
+    #[napi_derive::napi(js_name = "__testSubscriptionEvents", skip_typescript)]
+    pub fn subscription_events() -> napi::Result<Vec<super::SubscriptionEvent>> {
+        use jazz::db::SubscriptionEvent;
+        use jazz::protocol::{SubscribeRejectReason, SubscribeServerFailureCode};
+
+        [
+            SubscriptionEvent::Rejected {
+                reason: SubscribeRejectReason::UnsupportedShapeCapability {
+                    detail: "fixture unsupported shape".to_owned(),
+                },
+            },
+            SubscriptionEvent::Rejected {
+                reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
+            },
+            SubscriptionEvent::Rejected {
+                reason: SubscribeRejectReason::ServerFailure {
+                    code: SubscribeServerFailureCode::QueryValidation,
+                },
+            },
+            SubscriptionEvent::Closed,
+        ]
+        .iter()
+        .map(super::core_subscription_event_to_napi)
+        .collect()
+    }
+}
+
 /// Convert terminal edits without serde_json so binary subscription deltas keep
 /// their typed-array representation. Root descriptors retain the upstream
 /// postcard encoding; ordered keys and edit payloads retain their number-array
@@ -3344,6 +3374,18 @@ mod tests {
         ));
     }
 
+    #[test]
+    #[cfg(debug_assertions)]
+    fn debug_subscription_event_fixture_covers_rejection_and_closed_variants() {
+        let events = crate::test_fixture_export::subscription_events()
+            .expect("encode debug subscription event fixture");
+
+        assert_eq!(events.len(), 4);
+        assert!(matches!(events[0], Either3::B(_)));
+        assert!(matches!(events[1], Either3::B(_)));
+        assert!(matches!(events[2], Either3::B(_)));
+        assert!(matches!(events[3], Either3::C(_)));
+    }
     /// A short-lived NAPI schema attachment must not own or abandon the
     /// owner-wide OpenBatch lifetime when its JS wrapper is collected.
     #[test]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -34,7 +34,7 @@ use napi_derive::napi;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::rc::Rc;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
@@ -226,6 +226,9 @@ pub struct Transport {
 #[napi(js_name = "Subscription")]
 pub struct Subscription {
     inner: Option<NapiSubscription>,
+    /// Layout definitions are installed atomically with the first event that
+    /// references them.  Later terminal operations only carry this stable id.
+    published_terminal_layouts: HashSet<String>,
 }
 
 #[napi(object)]
@@ -236,6 +239,8 @@ pub struct SubscriptionDeltaEvent {
     pub delta: Uint8Array,
     #[napi(js_name = "terminalOperations")]
     pub terminal_operations: Vec<SubscriptionTerminalOperation>,
+    #[napi(js_name = "terminalLayouts")]
+    pub terminal_layouts: Vec<SubscriptionTerminalLayout>,
     pub settled: bool,
     #[napi(ts_type = "'None' | 'Local' | 'Edge' | 'Global'")]
     pub tier: String,
@@ -282,12 +287,38 @@ pub struct SubscriptionServerFailureReason {
 
 #[napi(object)]
 pub struct SubscriptionTerminalOperation {
-    #[napi(js_name = "rootDescriptor")]
-    pub root_descriptor: Vec<u32>,
+    #[napi(js_name = "rootLayoutId")]
+    pub root_layout_id: String,
     #[napi(js_name = "root_key")]
     pub root_key: Vec<u32>,
     pub path: Vec<SubscriptionTerminalPathSegment>,
     pub edit: SubscriptionTerminalEdit,
+}
+
+/// Immutable producer-owned root record contract.  The descriptor and public
+/// slots are published once per NAPI subscription, before an operation may
+/// reference `id`; TypeScript never has to infer a CurrentRow/layout family.
+#[napi(object)]
+pub struct SubscriptionTerminalLayout {
+    pub id: String,
+    #[napi(js_name = "rootDescriptor")]
+    pub root_descriptor: Vec<u32>,
+    #[napi(js_name = "rootKeySlot")]
+    pub root_key_slot: f64,
+    #[napi(js_name = "rootKeyFieldName")]
+    pub root_key_field_name: String,
+    #[napi(js_name = "publicFields")]
+    pub public_fields: Vec<SubscriptionTerminalPublicField>,
+    pub carrier: String,
+}
+
+#[napi(object)]
+pub struct SubscriptionTerminalPublicField {
+    pub name: String,
+    #[napi(js_name = "descriptorFieldName")]
+    pub descriptor_field_name: String,
+    pub slot: f64,
+    pub carrier: String,
 }
 
 #[napi(object)]
@@ -578,7 +609,10 @@ impl Subscription {
             let Some(event) = event else {
                 break;
             };
-            events.push(core_subscription_event_to_napi(&event)?);
+            events.push(core_subscription_event_to_napi(
+                &event,
+                &mut self.published_terminal_layouts,
+            )?);
         }
         Ok(events)
     }
@@ -1327,7 +1361,10 @@ impl NapiDb {
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
             ),
         };
-        Ok(Subscription { inner: Some(inner) })
+        Ok(Subscription {
+            inner: Some(inner),
+            published_terminal_layouts: HashSet::new(),
+        })
     }
 
     #[napi(js_name = "subscribeForIdentity")]
@@ -1356,7 +1393,10 @@ impl NapiDb {
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
             ),
         };
-        Ok(Subscription { inner: Some(inner) })
+        Ok(Subscription {
+            inner: Some(inner),
+            published_terminal_layouts: HashSet::new(),
+        })
     }
 
     #[napi(js_name = "subscribeRelationQuery")]
@@ -1384,7 +1424,10 @@ impl NapiDb {
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
             ),
         };
-        Ok(Subscription { inner: Some(inner) })
+        Ok(Subscription {
+            inner: Some(inner),
+            published_terminal_layouts: HashSet::new(),
+        })
     }
 
     #[napi(js_name = "subscribeRelationQueryForIdentity")]
@@ -1414,7 +1457,10 @@ impl NapiDb {
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
             ),
         };
-        Ok(Subscription { inner: Some(inner) })
+        Ok(Subscription {
+            inner: Some(inner),
+            published_terminal_layouts: HashSet::new(),
+        })
     }
 
     #[napi(js_name = "insertWithIdEncoded")]
@@ -2472,6 +2518,7 @@ fn core_row<'a>(row: &jazz::node::CurrentRow, raw: &'a [u8]) -> CoreRow<'a> {
 
 fn core_subscription_event_to_napi(
     event: &CoreSubscriptionEvent,
+    published_terminal_layouts: &mut HashSet<String>,
 ) -> napi::Result<SubscriptionEvent> {
     match event {
         CoreSubscriptionEvent::Delta {
@@ -2480,6 +2527,7 @@ fn core_subscription_event_to_napi(
             updated,
             removed,
             terminal_operations,
+            terminal_layout,
             settled,
             tier,
             ..
@@ -2497,15 +2545,43 @@ fn core_subscription_event_to_napi(
                 },
             )
             .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-            let terminal_operations = terminal_operations
-                .iter()
-                .map(core_terminal_operation_to_napi)
-                .collect::<std::result::Result<_, _>>()?;
+            let (terminal_layouts, terminal_operations) = if terminal_operations.is_empty() {
+                (Vec::new(), Vec::new())
+            } else {
+                let terminal_layout = terminal_layout.as_ref().ok_or_else(|| {
+                    napi::Error::from_reason(
+                        "terminal operation arrived without a prepared root layout".to_owned(),
+                    )
+                })?;
+                if terminal_operations
+                    .iter()
+                    .any(|operation| operation.root_descriptor != terminal_layout.root_descriptor)
+                {
+                    return Err(napi::Error::from_reason(
+                        "terminal operation descriptor disagrees with its prepared root layout"
+                            .to_owned(),
+                    ));
+                }
+                let terminal_layouts = published_terminal_layouts
+                    .insert(terminal_layout.id.clone())
+                    .then(|| core_terminal_layout_to_napi(terminal_layout))
+                    .transpose()?
+                    .into_iter()
+                    .collect();
+                let terminal_operations = terminal_operations
+                    .iter()
+                    .map(|operation| {
+                        core_terminal_operation_to_napi(operation, terminal_layout.id.clone())
+                    })
+                    .collect::<std::result::Result<_, _>>()?;
+                (terminal_layouts, terminal_operations)
+            };
             Ok(Either3::A(SubscriptionDeltaEvent {
                 event_type: "delta".to_string(),
                 reset: *reset,
                 delta: Uint8Array::new(delta),
                 terminal_operations,
+                terminal_layouts,
                 settled: *settled,
                 tier: format!("{tier:?}"),
             }))
@@ -2570,7 +2646,9 @@ mod test_fixture_export {
             SubscriptionEvent::Closed,
         ]
         .iter()
-        .map(super::core_subscription_event_to_napi)
+        .scan(std::collections::HashSet::new(), |layouts, event| {
+            Some(super::core_subscription_event_to_napi(event, layouts))
+        })
         .collect()
     }
 }
@@ -2581,11 +2659,10 @@ mod test_fixture_export {
 /// representation for the existing TypeScript terminal consumer.
 fn core_terminal_operation_to_napi(
     operation: &jazz::groove::ivm::TerminalOperation,
+    root_layout_id: String,
 ) -> napi::Result<SubscriptionTerminalOperation> {
     use jazz::groove::ivm::{TerminalEdit, TerminalPathSegment};
 
-    let root_descriptor = postcard::to_allocvec(&operation.root_descriptor)
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
     let path = operation
         .path
         .iter()
@@ -2628,10 +2705,40 @@ fn core_terminal_operation_to_napi(
     };
 
     Ok(SubscriptionTerminalOperation {
-        root_descriptor: terminal_bytes_to_numbers(&root_descriptor),
+        root_layout_id,
         root_key: terminal_bytes_to_numbers(&operation.root_key),
         path,
         edit,
+    })
+}
+
+fn core_terminal_layout_to_napi(
+    layout: &jazz::db::TerminalRootLayout,
+) -> napi::Result<SubscriptionTerminalLayout> {
+    let root_descriptor = postcard::to_allocvec(&layout.root_descriptor)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    Ok(SubscriptionTerminalLayout {
+        id: layout.id.clone(),
+        root_descriptor: terminal_bytes_to_numbers(&root_descriptor),
+        root_key_slot: layout.root_key_slot as f64,
+        root_key_field_name: layout.root_key_field_name.clone(),
+        public_fields: layout
+            .public_fields
+            .iter()
+            .map(|field| SubscriptionTerminalPublicField {
+                name: field.name.clone(),
+                descriptor_field_name: field.descriptor_field_name.clone(),
+                slot: field.slot as f64,
+                carrier: match field.carrier {
+                    jazz::db::TerminalRootCarrier::CurrentRow => "CurrentRow".to_owned(),
+                    jazz::db::TerminalRootCarrier::Logical => "Logical".to_owned(),
+                },
+            })
+            .collect(),
+        carrier: match layout.carrier {
+            jazz::db::TerminalRootCarrier::CurrentRow => "CurrentRow".to_owned(),
+            jazz::db::TerminalRootCarrier::Logical => "Logical".to_owned(),
+        },
     })
 }
 
@@ -3018,7 +3125,7 @@ pub fn verify_local_first_identity_proof_napi(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashSet};
     use std::rc::Rc;
 
     use crate::{
@@ -3029,6 +3136,7 @@ mod tests {
     use jazz::db::{
         Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,
         MergeableTxOps, Propagation as CorePropagation, SubscriptionEvent as CoreSubscriptionEvent,
+        TerminalRootCarrier, TerminalRootLayout, TerminalRootPublicField,
     };
     use jazz::groove::ivm::{TerminalEdit, TerminalOperation, TerminalPathSegment};
     use jazz::groove::records::Value as CoreValue;
@@ -3196,15 +3304,19 @@ mod tests {
 
     #[test]
     fn subscription_payload_exposes_only_terminal_rows() {
-        let payload = core_subscription_event_to_napi(&CoreSubscriptionEvent::Delta {
-            reset: false,
-            added: Vec::new(),
-            updated: Vec::new(),
-            removed: Vec::new(),
-            terminal_operations: Vec::new(),
-            settled: true,
-            tier: DurabilityTier::Local,
-        })
+        let payload = core_subscription_event_to_napi(
+            &CoreSubscriptionEvent::Delta {
+                reset: false,
+                added: Vec::new(),
+                updated: Vec::new(),
+                removed: Vec::new(),
+                terminal_operations: Vec::new(),
+                terminal_layout: None,
+                settled: true,
+                tier: DurabilityTier::Local,
+            },
+            &mut HashSet::new(),
+        )
         .expect("encode terminal delta");
 
         let Either3::A(payload) = payload else {
@@ -3218,8 +3330,11 @@ mod tests {
     #[test]
     fn subscription_payload_preserves_typed_terminal_operations_and_descriptor() {
         let descriptor = RecordDescriptor::new([
-            ("__jazz_terminal_row_key", ValueType::Uuid),
-            ("title", ValueType::String),
+            ("row_uuid", ValueType::Uuid),
+            (
+                "user_title",
+                ValueType::Nullable(Box::new(ValueType::String)),
+            ),
         ]);
         let expected_descriptor = postcard::to_allocvec(&descriptor).unwrap();
         let operations = vec![
@@ -3261,15 +3376,32 @@ mod tests {
                 },
             },
         ];
-        let payload = core_subscription_event_to_napi(&CoreSubscriptionEvent::Delta {
-            reset: false,
-            added: Vec::new(),
-            updated: Vec::new(),
-            removed: Vec::new(),
-            terminal_operations: operations,
-            settled: false,
-            tier: DurabilityTier::Edge,
-        })
+        let terminal_layout = TerminalRootLayout {
+            id: "test-terminal-layout".to_owned(),
+            root_descriptor: descriptor,
+            root_key_slot: 0,
+            root_key_field_name: "row_uuid".to_owned(),
+            public_fields: vec![TerminalRootPublicField {
+                name: "title".to_owned(),
+                descriptor_field_name: "user_title".to_owned(),
+                slot: 1,
+                carrier: TerminalRootCarrier::CurrentRow,
+            }],
+            carrier: TerminalRootCarrier::CurrentRow,
+        };
+        let payload = core_subscription_event_to_napi(
+            &CoreSubscriptionEvent::Delta {
+                reset: false,
+                added: Vec::new(),
+                updated: Vec::new(),
+                removed: Vec::new(),
+                terminal_operations: operations,
+                terminal_layout: Some(terminal_layout),
+                settled: false,
+                tier: DurabilityTier::Edge,
+            },
+            &mut HashSet::new(),
+        )
         .expect("encode terminal operations");
 
         let Either3::A(payload) = payload else {
@@ -3278,8 +3410,9 @@ mod tests {
         assert_eq!(payload.tier, "Edge");
         assert_eq!(payload.terminal_operations.len(), 4);
         let insert = &payload.terminal_operations[0];
+        assert_eq!(insert.root_layout_id, "test-terminal-layout");
         assert_eq!(
-            insert.root_descriptor,
+            payload.terminal_layouts[0].root_descriptor,
             terminal_bytes_to_numbers(&expected_descriptor)
         );
         assert_eq!(insert.root_key, vec![0, 255]);
@@ -3313,11 +3446,14 @@ mod tests {
     fn subscription_payload_preserves_rejection_and_closed_variants() {
         use jazz::protocol::{SubscribeRejectReason, SubscribeServerFailureCode};
 
-        let unsupported = core_subscription_event_to_napi(&CoreSubscriptionEvent::Rejected {
-            reason: SubscribeRejectReason::UnsupportedShapeCapability {
-                detail: "unsupported maintained shape".to_owned(),
+        let unsupported = core_subscription_event_to_napi(
+            &CoreSubscriptionEvent::Rejected {
+                reason: SubscribeRejectReason::UnsupportedShapeCapability {
+                    detail: "unsupported maintained shape".to_owned(),
+                },
             },
-        })
+            &mut HashSet::new(),
+        )
         .expect("encode unsupported rejection");
         assert!(matches!(
             unsupported,
@@ -3332,9 +3468,12 @@ mod tests {
                 && detail == "unsupported maintained shape"
         ));
 
-        let pending = core_subscription_event_to_napi(&CoreSubscriptionEvent::Rejected {
-            reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
-        })
+        let pending = core_subscription_event_to_napi(
+            &CoreSubscriptionEvent::Rejected {
+                reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
+            },
+            &mut HashSet::new(),
+        )
         .expect("encode pending rejection");
         assert!(matches!(
             pending,
@@ -3347,11 +3486,14 @@ mod tests {
                 && reason_type == "ShapeRegistrationPendingCatalogueAdmission"
         ));
 
-        let server_failure = core_subscription_event_to_napi(&CoreSubscriptionEvent::Rejected {
-            reason: SubscribeRejectReason::ServerFailure {
-                code: SubscribeServerFailureCode::QueryValidation,
+        let server_failure = core_subscription_event_to_napi(
+            &CoreSubscriptionEvent::Rejected {
+                reason: SubscribeRejectReason::ServerFailure {
+                    code: SubscribeServerFailureCode::QueryValidation,
+                },
             },
-        })
+            &mut HashSet::new(),
+        )
         .expect("encode server rejection");
         assert!(matches!(
             server_failure,
@@ -3366,8 +3508,9 @@ mod tests {
                 && code == "QueryValidation"
         ));
 
-        let closed = core_subscription_event_to_napi(&CoreSubscriptionEvent::Closed)
-            .expect("encode closed event");
+        let closed =
+            core_subscription_event_to_napi(&CoreSubscriptionEvent::Closed, &mut HashSet::new())
+                .expect("encode closed event");
         assert!(matches!(
             closed,
             Either3::C(crate::SubscriptionClosedEvent { event_type }) if event_type == "closed"

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::pin::Pin;
 use std::rc::Rc;
 
@@ -1540,7 +1540,7 @@ impl WasmDb {
             .inner
             .subscribe(&query.inner, opts)
             .map_err(to_js_error)?;
-        readable_stream_from_stream(stream.map(subscription_chunk_to_js))
+        subscription_stream_to_js(stream)
     }
 
     #[wasm_bindgen(js_name = subscribeForIdentity)]
@@ -1556,7 +1556,7 @@ impl WasmDb {
             .inner
             .subscribe_for_identity(&query.inner, opts, author)
             .map_err(to_js_error)?;
-        readable_stream_from_stream(stream.map(subscription_chunk_to_js))
+        subscription_stream_to_js(stream)
     }
 
     #[wasm_bindgen(js_name = subscribeRelationQuery)]
@@ -1571,7 +1571,7 @@ impl WasmDb {
             .inner
             .subscribe_relation_query(&query, opts)
             .map_err(to_js_error)?;
-        readable_stream_from_stream(stream.map(subscription_chunk_to_js))
+        subscription_stream_to_js(stream)
     }
 
     #[wasm_bindgen(js_name = subscribeRelationQueryForIdentity)]
@@ -1588,7 +1588,7 @@ impl WasmDb {
             .inner
             .subscribe_relation_query_for_identity(&query, opts, author)
             .map_err(to_js_error)?;
-        readable_stream_from_stream(stream.map(subscription_chunk_to_js))
+        subscription_stream_to_js(stream)
     }
 
     #[wasm_bindgen(js_name = attachQuery)]
@@ -2719,7 +2719,18 @@ fn wasm_row<'a>(row: &jazz::node::CurrentRow, raw: &'a [u8]) -> WasmRow<'a> {
     }
 }
 
-fn subscription_chunk_to_js(event: SubscriptionEvent) -> Result<JsValue, JsValue> {
+fn subscription_stream_to_js(
+    stream: impl Stream<Item = SubscriptionEvent> + 'static,
+) -> Result<JsValue, JsValue> {
+    readable_stream_from_stream(stream.scan(HashSet::new(), |layouts, event| {
+        std::future::ready(Some(subscription_chunk_to_js(event, layouts)))
+    }))
+}
+
+fn subscription_chunk_to_js(
+    event: SubscriptionEvent,
+    published_terminal_layouts: &mut HashSet<String>,
+) -> Result<JsValue, JsValue> {
     let object = js_sys::Object::new();
     match event {
         SubscriptionEvent::Delta {
@@ -2728,6 +2739,7 @@ fn subscription_chunk_to_js(event: SubscriptionEvent) -> Result<JsValue, JsValue
             updated,
             removed,
             terminal_operations,
+            terminal_layout,
             settled,
             tier,
             ..
@@ -2739,6 +2751,16 @@ fn subscription_chunk_to_js(event: SubscriptionEvent) -> Result<JsValue, JsValue
             };
             let delta =
                 encode_subscription_delta(&added, &updated, &removed).map_err(to_js_error)?;
+            if let Some(layout) = terminal_layout.as_ref() {
+                if terminal_operations
+                    .iter()
+                    .any(|operation| operation.root_descriptor != layout.root_descriptor)
+                {
+                    return Err(JsValue::from_str(
+                        "terminal operation descriptor disagrees with its prepared root layout",
+                    ));
+                }
+            }
             set_prop(&object, "type", JsValue::from_str("delta"))?;
             set_prop(
                 &object,
@@ -2748,7 +2770,30 @@ fn subscription_chunk_to_js(event: SubscriptionEvent) -> Result<JsValue, JsValue
             set_prop(
                 &object,
                 "terminalOperations",
-                terminal_operations_to_json(&terminal_operations)?
+                terminal_operations_to_json(
+                    &terminal_operations,
+                    terminal_layout.as_ref().map(|layout| layout.id.as_str()),
+                )?
+                .serialize(&serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true))
+                .map_err(to_js_error)?,
+            )?;
+            let terminal_layouts = if terminal_operations.is_empty() {
+                Vec::new()
+            } else {
+                let layout = terminal_layout.as_ref().ok_or_else(|| {
+                    JsValue::from_str("terminal operation arrived without a prepared root layout")
+                })?;
+                published_terminal_layouts
+                    .insert(layout.id.clone())
+                    .then(|| terminal_layout_to_json(layout))
+                    .transpose()?
+                    .into_iter()
+                    .collect()
+            };
+            set_prop(
+                &object,
+                "terminalLayouts",
+                serde_json::Value::Array(terminal_layouts)
                     .serialize(
                         &serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true),
                     )
@@ -2805,23 +2850,54 @@ fn subscription_chunk_to_js(event: SubscriptionEvent) -> Result<JsValue, JsValue
 /// query projection.
 fn terminal_operations_to_json(
     operations: &[jazz::groove::ivm::TerminalOperation],
+    root_layout_id: Option<&str>,
 ) -> Result<serde_json::Value, JsValue> {
     let mut encoded = serde_json::to_value(operations).map_err(to_js_error)?;
+    if operations.is_empty() {
+        return Ok(encoded);
+    }
+    let root_layout_id = root_layout_id.ok_or_else(|| {
+        JsValue::from_str("terminal operation arrived without a prepared root layout")
+    })?;
     let encoded_operations = encoded
         .as_array_mut()
         .expect("terminal operations serialize as an array");
-    for (operation, wire) in operations.iter().zip(encoded_operations) {
+    for wire in encoded_operations {
         let serde_json::Value::Object(wire) = wire else {
             unreachable!("terminal operation serializes as an object");
         };
         wire.remove("root_descriptor");
-        let descriptor = postcard::to_allocvec(&operation.root_descriptor).map_err(to_js_error)?;
         wire.insert(
-            "rootDescriptor".to_owned(),
-            serde_json::to_value(descriptor).map_err(to_js_error)?,
+            "rootLayoutId".to_owned(),
+            serde_json::Value::String(root_layout_id.to_owned()),
         );
     }
     Ok(encoded)
+}
+
+fn terminal_layout_to_json(
+    layout: &jazz::db::TerminalRootLayout,
+) -> Result<serde_json::Value, JsValue> {
+    let descriptor = postcard::to_allocvec(&layout.root_descriptor).map_err(to_js_error)?;
+    Ok(serde_json::json!({
+        "id": layout.id,
+        "rootDescriptor": descriptor,
+        "rootKeySlot": layout.root_key_slot,
+        "rootKeyFieldName": layout.root_key_field_name,
+        "publicFields": layout.public_fields.iter().map(|field| serde_json::json!({
+            "name": field.name,
+            "descriptorFieldName": field.descriptor_field_name,
+            "slot": field.slot,
+            "carrier": match field.carrier {
+                jazz::db::TerminalRootCarrier::CurrentRow => "CurrentRow",
+                jazz::db::TerminalRootCarrier::Logical => "Logical",
+            },
+        })).collect::<Vec<_>>(),
+        "carrier": match layout.carrier {
+            jazz::db::TerminalRootCarrier::CurrentRow => "CurrentRow",
+            jazz::db::TerminalRootCarrier::Logical => "Logical",
+        },
+    }))
 }
 
 fn set_prop(object: &js_sys::Object, name: &str, value: JsValue) -> Result<(), JsValue> {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2071,6 +2071,7 @@ where
                 updated: Vec::new(),
                 removed: Vec::new(),
                 terminal_operations: Vec::new(),
+                terminal_layout: None,
                 settled,
                 tier: read_tier,
             })
@@ -5758,6 +5759,7 @@ where
                 updated: Vec::new(),
                 removed,
                 terminal_operations: Vec::new(),
+                terminal_layout: None,
                 settled,
                 tier: read_tier,
             };
@@ -6003,6 +6005,9 @@ where
                         )
                     } else {
                         if terminal_rows && !peer_terminal_operations.is_empty() {
+                            let terminal_layout = maintained_subscription
+                                .as_ref()
+                                .and_then(|maintained| maintained.terminal_root_layout().cloned());
                             if let Some(maintained) = maintained_subscription.as_mut() {
                                 // The serving terminal is authoritative for
                                 // structural publication. Advance the local
@@ -6027,6 +6032,7 @@ where
                                 updated: Vec::new(),
                                 removed: Vec::new(),
                                 terminal_operations: peer_terminal_operations,
+                                terminal_layout,
                                 settled,
                                 tier: snapshot_tier,
                             };
@@ -6081,6 +6087,7 @@ where
                                         updated: Vec::new(),
                                         removed: Vec::new(),
                                         terminal_operations: update.terminal_operations,
+                                        terminal_layout: update.terminal_layout,
                                         settled,
                                         tier: snapshot_tier,
                                     };
@@ -11172,6 +11179,51 @@ pub struct SubscriptionOutputRow {
     pub row: CurrentRow,
 }
 
+/// Immutable producer-owned decoding contract for a structured terminal root.
+///
+/// The maintained query compiler creates this alongside its app-row terminal.
+/// Consumers install it before applying operations which name `id`; the
+/// descriptor remains the source of truth for encoded types while these slots
+/// map public fields to their physical record positions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalRootLayout {
+    /// Stable hash of the descriptor, slots, identities and carrier.
+    pub id: String,
+    /// Exact physical root descriptor used to decode packed bytes.
+    pub root_descriptor: RecordDescriptor,
+    /// Descriptor slot containing the stable root UUID.
+    pub root_key_slot: usize,
+    /// Exact descriptor identity of the root UUID slot.
+    pub root_key_field_name: String,
+    /// Public field-to-descriptor slot mappings, in public output order.
+    pub public_fields: Vec<TerminalRootPublicField>,
+    /// Physical representation used for public cells.
+    pub carrier: TerminalRootCarrier,
+}
+
+/// One public root field's immutable physical slot identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalRootPublicField {
+    /// Public column name.
+    pub name: String,
+    /// Physical descriptor field name at `slot`.
+    pub descriptor_field_name: String,
+    /// Physical descriptor slot.
+    pub slot: usize,
+    /// Encoded representation of this individual slot.
+    pub carrier: TerminalRootCarrier,
+}
+
+/// The producer representation applied around declared public column types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerminalRootCarrier {
+    /// A physical `CurrentRow`: each application cell has one extra nullable
+    /// carrier around its declared storage type.
+    CurrentRow,
+    /// A logical collector/projection record with declared storage types.
+    Logical,
+}
+
 impl std::ops::Deref for SubscriptionOutputRow {
     type Target = CurrentRow;
 
@@ -11197,6 +11249,9 @@ pub enum SubscriptionEvent {
         removed: Vec<RemovedRow>,
         /// Typed structural edits to already hydrated terminal rows.
         terminal_operations: Vec<groove::ivm::TerminalOperation>,
+        /// Immutable root decoding contract for `terminal_operations`, when
+        /// this event carries structured terminal changes.
+        terminal_layout: Option<TerminalRootLayout>,
         /// Whether the result is complete at the requested read tier.
         settled: bool,
         /// Read tier used to materialize the rows.
@@ -11393,6 +11448,7 @@ fn subscription_terminal_delta_event(
         updated,
         removed,
         terminal_operations: Vec::new(),
+        terminal_layout: None,
         settled,
         tier,
     }
@@ -11446,6 +11502,7 @@ fn subscription_delta_event_with_reset(
         updated,
         removed,
         terminal_operations: Vec::new(),
+        terminal_layout: None,
         settled,
         tier,
     }
@@ -11465,6 +11522,7 @@ fn apply_maintained_update_to_snapshot(
         added_edges: update_added_edges,
         removed_edges: update_removed_edges,
         terminal_operations,
+        terminal_layout,
     } = update;
 
     if snapshot.rows.is_empty()
@@ -11493,6 +11551,7 @@ fn apply_maintained_update_to_snapshot(
                 updated: Vec::new(),
                 removed: Vec::new(),
                 terminal_operations: terminal_operations.clone(),
+                terminal_layout: terminal_layout.clone(),
                 settled,
                 tier,
             };
@@ -11543,6 +11602,7 @@ fn apply_maintained_update_to_snapshot(
             updated: Vec::new(),
             removed: Vec::new(),
             terminal_operations: terminal_operations.clone(),
+            terminal_layout: terminal_layout.clone(),
             settled,
             tier,
         };
@@ -11671,6 +11731,7 @@ fn apply_maintained_update_to_snapshot(
         updated,
         removed,
         terminal_operations,
+        terminal_layout,
         settled,
         tier,
     }

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -10,10 +10,12 @@ use super::codec::{
     tx_ids_from_value, version_tx_id_from_aliases,
 };
 use super::query_engine::{
-    AggregateResultSchema, AppRowSchema, OutputTerminalSchema, ProgramFactKey, ProgramFactSchema,
-    ProgramFactTerminal, QueryProgram, RelationEdgeSchema, ResultMembershipSchema,
-    ResultMembershipVersionSchema, VersionWitnessSchema, VersionedRowRefSchema,
+    AggregateResultSchema, AppRowCarrier, AppRowSchema, OutputTerminalSchema, ProgramFactKey,
+    ProgramFactSchema, ProgramFactTerminal, QueryProgram, RelationEdgeSchema,
+    ResultMembershipSchema, ResultMembershipVersionSchema, VersionWitnessSchema,
+    VersionedRowRefSchema, logical_user_column,
 };
+use crate::db::{TerminalRootCarrier, TerminalRootLayout, TerminalRootPublicField};
 use crate::ids::{AuthorId, NodeAlias, NodeUuid, RowUuid};
 use crate::protocol::{
     ProgramFactEntry, RealRowMemberEntry, RelationEdgeEntry, ResultMemberEntry,
@@ -170,7 +172,10 @@ enum MaintainedTerminalKind {
     ReplacementContent(VersionWitnessSchema),
     ReplacementDeletion(VersionWitnessSchema),
     RelationEdge(RelationEdgeSchema),
-    StructuredAppRows(AppRowSchema),
+    StructuredAppRows {
+        schema: AppRowSchema,
+        layout: TerminalRootLayout,
+    },
     /// Public aggregate rows are a one-shot output sibling. Maintained state
     /// is driven by the typed AggregateResult fact terminal instead.
     IgnoredAggregateAppRows,
@@ -250,10 +255,14 @@ impl MaintainedSubscriptionView {
     ) -> Result<ResultTransitions, super::Error> {
         let mut transitions = ResultTransitions::default();
         for (sink, terminal) in &deltas.terminal_sinks {
-            if matches!(
-                schemas.get(sink)?,
-                MaintainedTerminalKind::StructuredAppRows(_)
-            ) {
+            if let MaintainedTerminalKind::StructuredAppRows { layout, .. } = schemas.get(sink)? {
+                for operation in &terminal.operations {
+                    if operation.root_descriptor != layout.root_descriptor {
+                        return Err(super::Error::InvalidStoredValue(
+                            "structured terminal operation descriptor disagrees with prepared root layout",
+                        ));
+                    }
+                }
                 transitions
                     .terminal_operations
                     .extend(terminal.operations.iter().cloned());
@@ -657,7 +666,10 @@ impl MaintainedTerminalSchemas {
                 if rows.descriptor.field_index("row_uuid").is_some() {
                     sinks.insert(
                         terminal.sink.clone(),
-                        MaintainedTerminalKind::StructuredAppRows(rows.clone()),
+                        MaintainedTerminalKind::StructuredAppRows {
+                            schema: rows.clone(),
+                            layout: terminal_root_layout(rows),
+                        },
                     );
                 } else {
                     sinks.insert(
@@ -731,6 +743,85 @@ impl MaintainedTerminalSchemas {
         self.sinks.get(sink).ok_or(super::Error::InvalidStoredValue(
             "maintained view delta arrived for an unknown query-engine terminal",
         ))
+    }
+
+    pub(crate) fn terminal_root_layout(&self) -> Option<&TerminalRootLayout> {
+        self.sinks.values().find_map(|kind| match kind {
+            MaintainedTerminalKind::StructuredAppRows { layout, .. } => Some(layout),
+            _ => None,
+        })
+    }
+}
+
+fn terminal_root_layout(rows: &AppRowSchema) -> TerminalRootLayout {
+    let root_key_slot = rows
+        .descriptor
+        .field_index("row_uuid")
+        .expect("structured app-row terminal has a row_uuid slot");
+    // Bind every public descriptor slot, including collector-owned trailing
+    // arrays/records. A collector root may contain both physical `user_*`
+    // source cells and logical nested fields, so the presence of one family
+    // must not hide the other.
+    let public_fields = rows
+        .descriptor
+        .fields()
+        .iter()
+        .enumerate()
+        .filter_map(|(slot, field)| {
+            let name = field.name.as_deref()?;
+            (slot != root_key_slot && !rows.hidden_fields.contains(name)).then(|| {
+                TerminalRootPublicField {
+                    name: logical_user_column(name).to_owned(),
+                    descriptor_field_name: name.to_owned(),
+                    slot,
+                    carrier: match rows
+                        .field_carriers
+                        .get(name)
+                        .copied()
+                        .unwrap_or(rows.carrier)
+                    {
+                        AppRowCarrier::CurrentRow => TerminalRootCarrier::CurrentRow,
+                        AppRowCarrier::Logical => TerminalRootCarrier::Logical,
+                    },
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"jazz terminal root layout v1");
+    hasher.update(
+        &postcard::to_allocvec(&rows.descriptor)
+            .expect("record descriptors are postcard serializable"),
+    );
+    hasher.update(&(root_key_slot as u64).to_le_bytes());
+    hasher.update(&[match rows.carrier {
+        AppRowCarrier::CurrentRow => 0,
+        AppRowCarrier::Logical => 1,
+    }]);
+    for field in &public_fields {
+        hasher.update(field.name.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(field.descriptor_field_name.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(&(field.slot as u64).to_le_bytes());
+        hasher.update(&[match field.carrier {
+            TerminalRootCarrier::CurrentRow => 0,
+            TerminalRootCarrier::Logical => 1,
+        }]);
+    }
+    TerminalRootLayout {
+        id: format!("terminal:{}", hasher.finalize().to_hex()),
+        root_descriptor: rows.descriptor,
+        root_key_slot,
+        root_key_field_name: rows.descriptor.fields()[root_key_slot]
+            .name
+            .clone()
+            .expect("structured app-row row_uuid field is named"),
+        public_fields,
+        carrier: match rows.carrier {
+            AppRowCarrier::CurrentRow => TerminalRootCarrier::CurrentRow,
+            AppRowCarrier::Logical => TerminalRootCarrier::Logical,
+        },
     }
 }
 
@@ -935,7 +1026,7 @@ fn decode_typed_terminal_record(
             decode_typed_relation_edge(record, schema, tables, node_aliases)
                 .map(DecodedMaintainedEvent::RelationEdge)
         }
-        MaintainedTerminalKind::StructuredAppRows(schema) => {
+        MaintainedTerminalKind::StructuredAppRows { schema, .. } => {
             let root = RowUuid(record.get_uuid(field_idx(record, "row_uuid")?)?);
             Ok(DecodedMaintainedEvent::StructuredAppRow {
                 root,
@@ -1656,7 +1747,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use groove::ivm::RecordDelta;
-    use groove::records::Value;
+    use groove::records::{Value, ValueType};
     use groove::schema::ColumnType;
 
     use super::*;
@@ -1681,6 +1772,60 @@ mod tests {
 
     fn aliases() -> BTreeMap<NodeUuid, NodeAlias> {
         BTreeMap::from([(node(1), NodeAlias(10)), (node(2), NodeAlias(20))])
+    }
+
+    #[test]
+    fn terminal_layout_includes_nested_public_slots_and_excludes_hidden_routes() {
+        let descriptor = RecordDescriptor::new([
+            ("row_uuid", ValueType::Uuid),
+            (
+                "user_title",
+                ValueType::Nullable(Box::new(ValueType::String)),
+            ),
+            (
+                "todosViaOrg",
+                ValueType::Array(Box::new(ValueType::Record(Box::new(
+                    RecordDescriptor::new([
+                        ("row_uuid", ValueType::Uuid),
+                        ("title", ValueType::String),
+                    ]),
+                )))),
+            ),
+            ("__route_org", ValueType::Uuid),
+        ]);
+        let rows = AppRowSchema {
+            descriptor: descriptor.clone(),
+            hidden_fields: BTreeSet::from(["__route_org".to_owned()]),
+            carrier: AppRowCarrier::Logical,
+            field_carriers: BTreeMap::from([
+                ("user_title".to_owned(), AppRowCarrier::CurrentRow),
+                ("todosViaOrg".to_owned(), AppRowCarrier::Logical),
+            ]),
+        };
+        let layout = terminal_root_layout(&rows);
+        assert_eq!(
+            layout.public_fields,
+            vec![
+                TerminalRootPublicField {
+                    name: "title".to_owned(),
+                    descriptor_field_name: "user_title".to_owned(),
+                    slot: 1,
+                    carrier: TerminalRootCarrier::CurrentRow,
+                },
+                TerminalRootPublicField {
+                    name: "todosViaOrg".to_owned(),
+                    descriptor_field_name: "todosViaOrg".to_owned(),
+                    slot: 2,
+                    carrier: TerminalRootCarrier::Logical,
+                },
+            ]
+        );
+
+        let mut without_nested = rows;
+        without_nested
+            .hidden_fields
+            .insert("todosViaOrg".to_owned());
+        assert_ne!(layout.id, terminal_root_layout(&without_nested).id);
     }
 
     fn table() -> TableSchema {

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -5313,90 +5313,106 @@ fn lowered_terminals(
     // cannot retain any routed binding fields yet.
     if let Some(app_rows) = &request.output.app_rows {
         let projected_output = projected_multisource_terminal(plan, source);
-        let (graph, descriptor, hidden_fields) = match app_rows.projection.clone() {
-            _ if !app_rows.public_terminal => (
-                closure.visible_root.clone(),
-                source.row_shape.descriptor.clone(),
-                hidden_source_fields(&source.row_shape),
-            ),
-            PayloadProjection::Tree(tree) => {
-                let collected = lower_collect_by_app_rows(
+        let (graph, descriptor, hidden_fields, carrier, field_carriers) =
+            match app_rows.projection.clone() {
+                _ if !app_rows.public_terminal => (
                     closure.visible_root.clone(),
-                    &tree,
-                    plan,
-                    source,
-                    resolved_sources,
-                    request,
-                    &root_route_fields,
-                    available_fields,
-                )?;
-                (
-                    collected.graph,
-                    collected.descriptor,
-                    collected.hidden_fields,
-                )
-            }
-            _ if projected_output.is_some() => {
-                let (output_source_id, output_fields, _is_flat) = projected_output
-                    .as_ref()
-                    .expect("guarded projected multi-source output");
-                let output_source = resolved_sources.get(output_source_id).ok_or_else(|| {
-                    single_gap_report(UnsupportedReason::Runtime(format!(
-                        "projected output source {output_source_id:?} was not resolved"
-                    )))
-                })?;
-                let hidden_fields = hidden_source_fields(&output_source.row_shape)
-                    .into_iter()
-                    .chain(
-                        output_fields
-                            .iter()
-                            .filter(|field| field.name.starts_with("__flat_join_row_"))
-                            .map(|field| field.name.clone()),
+                    source.row_shape.descriptor.clone(),
+                    hidden_source_fields(&source.row_shape),
+                    AppRowCarrier::CurrentRow,
+                    BTreeMap::new(),
+                ),
+                PayloadProjection::Tree(tree) => {
+                    let collected = lower_collect_by_app_rows(
+                        closure.visible_root.clone(),
+                        &tree,
+                        plan,
+                        source,
+                        resolved_sources,
+                        request,
+                        &root_route_fields,
+                        available_fields,
+                    )?;
+                    (
+                        collected.graph,
+                        collected.descriptor,
+                        collected.hidden_fields,
+                        collected.carrier,
+                        collected.field_carriers,
                     )
-                    .collect::<BTreeSet<_>>();
-                let public_fields = output_fields
-                    .iter()
-                    .filter(|field| !hidden_fields.contains(&field.name))
-                    .collect::<Vec<_>>();
-                let descriptor = RecordDescriptor::new(
-                    public_fields
+                }
+                _ if projected_output.is_some() => {
+                    let (output_source_id, output_fields, _is_flat) = projected_output
+                        .as_ref()
+                        .expect("guarded projected multi-source output");
+                    let output_source =
+                        resolved_sources.get(output_source_id).ok_or_else(|| {
+                            single_gap_report(UnsupportedReason::Runtime(format!(
+                                "projected output source {output_source_id:?} was not resolved"
+                            )))
+                        })?;
+                    let hidden_fields = hidden_source_fields(&output_source.row_shape)
+                        .into_iter()
+                        .chain(
+                            output_fields
+                                .iter()
+                                .filter(|field| field.name.starts_with("__flat_join_row_"))
+                                .map(|field| field.name.clone()),
+                        )
+                        .collect::<BTreeSet<_>>();
+                    let public_fields = output_fields
                         .iter()
-                        .map(|field| (field.name.clone(), field.ty.clone())),
-                );
-                let graph = graph.clone().project_fields(
-                    public_fields
-                        .iter()
-                        .map(|field| ProjectField::named(&field.name)),
-                );
-                (graph, descriptor, BTreeSet::new())
-            }
-            _ => {
-                let collected = lower_collect_by_app_rows(
-                    closure.visible_root.clone(),
-                    &AppProjectionTree {
-                        fields: FieldProjection::All,
-                        paths: Vec::new(),
-                    },
-                    plan,
-                    source,
-                    resolved_sources,
-                    request,
-                    &root_route_fields,
-                    available_fields,
-                )?;
-                (
-                    collected.graph,
-                    collected.descriptor,
-                    collected.hidden_fields,
-                )
-            }
-        };
+                        .filter(|field| !hidden_fields.contains(&field.name))
+                        .collect::<Vec<_>>();
+                    let descriptor = RecordDescriptor::new(
+                        public_fields
+                            .iter()
+                            .map(|field| (field.name.clone(), field.ty.clone())),
+                    );
+                    let graph = graph.clone().project_fields(
+                        public_fields
+                            .iter()
+                            .map(|field| ProjectField::named(&field.name)),
+                    );
+                    (
+                        graph,
+                        descriptor,
+                        BTreeSet::new(),
+                        AppRowCarrier::Logical,
+                        BTreeMap::new(),
+                    )
+                }
+                _ => {
+                    let collected = lower_collect_by_app_rows(
+                        closure.visible_root.clone(),
+                        &AppProjectionTree {
+                            fields: FieldProjection::All,
+                            paths: Vec::new(),
+                        },
+                        plan,
+                        source,
+                        resolved_sources,
+                        request,
+                        &root_route_fields,
+                        available_fields,
+                    )?;
+                    (
+                        collected.graph,
+                        collected.descriptor,
+                        collected.hidden_fields,
+                        collected.carrier,
+                        collected.field_carriers,
+                    )
+                }
+            };
         terminals.push(LoweredTerminal {
             sink: "app_rows".to_owned(),
             graph,
             output: OutputTerminalSchema::AppRows(AppRowSchema {
                 descriptor,
                 hidden_fields,
+                carrier,
+                field_carriers,
             }),
         });
     }
@@ -5677,6 +5693,8 @@ struct LoweredCollectByAppRows {
     graph: GraphBuilder,
     descriptor: RecordDescriptor,
     hidden_fields: BTreeSet<String>,
+    carrier: AppRowCarrier,
+    field_carriers: BTreeMap<String, AppRowCarrier>,
 }
 
 fn lower_collect_by_app_rows(
@@ -5704,6 +5722,36 @@ fn lower_collect_by_app_rows(
     align_collect_root_window(&mut layout, plan)?;
     align_collect_join_key_types(&mut layout.slots, plan, resolved_sources, request)?;
     if layout.slots.is_empty() {
+        // A collect-all root preserves the source CurrentRow application-cell
+        // wrappers. Explicit projections unwrap those cells to their declared
+        // logical types. Bind that distinction here while both input and
+        // output types are authoritative; consumers must never infer it from
+        // the eventual descriptor's field names.
+        let carrier = if layout
+            .root_fields
+            .iter()
+            .filter(|field| field.is_output && !field.is_row_id)
+            .all(|field| field.value_type == field.output_value_type)
+        {
+            AppRowCarrier::CurrentRow
+        } else {
+            AppRowCarrier::Logical
+        };
+        let field_carriers = layout
+            .root_fields
+            .iter()
+            .filter(|field| field.is_output && !field.is_row_id)
+            .map(|field| {
+                (
+                    field.output.clone(),
+                    if field.value_type == field.output_value_type {
+                        AppRowCarrier::CurrentRow
+                    } else {
+                        AppRowCarrier::Logical
+                    },
+                )
+            })
+            .collect();
         let anchor = collect_anchor_graph(visible_root, &layout)?;
         let has_window = root_linear_steps(plan).is_some_and(|steps| {
             steps
@@ -5754,10 +5802,37 @@ fn lower_collect_by_app_rows(
         return Ok(LoweredCollectByAppRows {
             graph,
             descriptor,
-            hidden_fields: BTreeSet::new(),
+            // Route parameters are retained in the collector record so the
+            // maintained graph can partition results, but they are not part
+            // of the app projection. Nested collectors already apply the same
+            // boundary below.
+            hidden_fields: route_fields.clone(),
+            carrier,
+            field_carriers,
         });
     }
     let root_context = root_collect_context_graph(visible_root.clone(), &layout)?;
+    let mut field_carriers = layout
+        .root_fields
+        .iter()
+        .filter(|field| field.is_output && !field.is_row_id)
+        .map(|field| {
+            (
+                field.output.clone(),
+                if field.value_type == field.output_value_type {
+                    AppRowCarrier::CurrentRow
+                } else {
+                    AppRowCarrier::Logical
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    field_carriers.extend(
+        layout
+            .slots
+            .iter()
+            .map(|slot| (slot.collection_field.clone(), AppRowCarrier::Logical)),
+    );
     let mut association_graphs = Vec::new();
     for slot in &layout.slots {
         let path = find_correlated_path(plan, &slot.path).ok_or_else(|| {
@@ -5823,6 +5898,8 @@ fn lower_collect_by_app_rows(
         graph,
         descriptor,
         hidden_fields,
+        carrier: AppRowCarrier::Logical,
+        field_carriers,
     })
 }
 
@@ -6722,6 +6799,8 @@ fn lowered_aggregate_terminals(
             output: OutputTerminalSchema::AppRows(AppRowSchema {
                 descriptor: aggregate_app_row_descriptor(plan, source)?,
                 hidden_fields: root_route_fields.clone(),
+                carrier: AppRowCarrier::Logical,
+                field_carriers: BTreeMap::new(),
             }),
         });
     }

--- a/crates/jazz/src/node/query_engine/schemas.rs
+++ b/crates/jazz/src/node/query_engine/schemas.rs
@@ -23,6 +23,18 @@ pub(crate) struct AppRowSchema {
     pub(crate) descriptor: RecordDescriptor,
     /// Hidden fields retained by the graph and stripped before app delivery.
     pub(crate) hidden_fields: BTreeSet<String>,
+    /// Physical value representation emitted by this lowered terminal.
+    pub(crate) carrier: AppRowCarrier,
+    /// Per-field override for mixed collector records, keyed by descriptor name.
+    pub(crate) field_carriers: BTreeMap<String, AppRowCarrier>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AppRowCarrier {
+    /// Source CurrentRow cells retain their outer presence wrapper.
+    CurrentRow,
+    /// Collector/projection cells use their declared logical value types.
+    Logical,
 }
 
 /// Typed fact row schema plus the fact identity that requested it.

--- a/crates/jazz/src/node/query_engine/tests.rs
+++ b/crates/jazz/src/node/query_engine/tests.rs
@@ -964,6 +964,7 @@ fn simple_current_table_root_query_lowers_for_local_edge_and_global_sync_outputs
                 OutputTerminalSchema::AppRows(AppRowSchema {
                     descriptor,
                     hidden_fields,
+                    carrier: AppRowCarrier::CurrentRow,
                     ..
                 }) if descriptor.field_index("user_title").is_some()
                     && hidden_fields.is_empty()
@@ -2355,13 +2356,15 @@ fn collector_layout_retains_public_magic_timestamp_fields_on_child_rows() {
     let program = lower_query_program(request, &mut InlineCollectorResolver::new(None))
         .expect("magic timestamp child projection should lower");
     let ProgramOutputSchemas::RowSet(outputs) = &program.lowered.output;
-    let descriptor = outputs
+    let schema = outputs
         .iter()
         .find_map(|output| match output {
-            OutputTerminalSchema::AppRows(schema) => Some(&schema.descriptor),
+            OutputTerminalSchema::AppRows(schema) => Some(schema),
             OutputTerminalSchema::Fact(_) => None,
         })
         .expect("app rows descriptor");
+    assert_eq!(schema.carrier, AppRowCarrier::Logical);
+    let descriptor = &schema.descriptor;
     let tags = descriptor
         .fields()
         .iter()
@@ -2379,6 +2382,57 @@ fn collector_layout_retains_public_magic_timestamp_fields_on_child_rows() {
     assert!(row.field_index("$updatedAt").is_some());
     assert!(row.field_index("$createdBy").is_none());
     assert!(row.field_index("$updatedBy").is_none());
+}
+
+#[test]
+fn flat_collectors_bind_preserved_and_unwrapped_root_carriers() {
+    let mut collect_all = collector_request(system_policy_context());
+    let PayloadProjection::Tree(projection) = &mut collect_all
+        .output
+        .app_rows
+        .as_mut()
+        .expect("app rows")
+        .projection
+    else {
+        panic!("collector request must use a tree projection");
+    };
+    projection.paths.clear();
+    let program = lower_query_program(collect_all, &mut InlineCollectorResolver::new(None))
+        .expect("flat collect-all should lower");
+    let ProgramOutputSchemas::RowSet(outputs) = &program.lowered.output;
+    let schema = outputs
+        .iter()
+        .find_map(|output| match output {
+            OutputTerminalSchema::AppRows(schema) => Some(schema),
+            OutputTerminalSchema::Fact(_) => None,
+        })
+        .expect("app rows descriptor");
+    assert_eq!(schema.carrier, AppRowCarrier::CurrentRow);
+
+    let mut projected = collector_request(system_policy_context());
+    let PayloadProjection::Tree(projection) = &mut projected
+        .output
+        .app_rows
+        .as_mut()
+        .expect("app rows")
+        .projection
+    else {
+        panic!("collector request must use a tree projection");
+    };
+    projection.paths.clear();
+    projection.fields =
+        FieldProjection::Fields(BTreeSet::from(["title".to_owned(), "todo".to_owned()]));
+    let program = lower_query_program(projected, &mut InlineCollectorResolver::new(None))
+        .expect("flat projected collector should lower");
+    let ProgramOutputSchemas::RowSet(outputs) = &program.lowered.output;
+    let schema = outputs
+        .iter()
+        .find_map(|output| match output {
+            OutputTerminalSchema::AppRows(schema) => Some(schema),
+            OutputTerminalSchema::Fact(_) => None,
+        })
+        .expect("app rows descriptor");
+    assert_eq!(schema.carrier, AppRowCarrier::Logical);
 }
 
 #[test]
@@ -3424,6 +3478,20 @@ fn equality_filter_param_lowers_to_prepared_binding_join() {
     assert!(graph.contains("BindingSource"), "{graph}");
     assert!(graph.contains("query-binding"), "{graph}");
     assert!(graph.contains("title"), "{graph}");
+    let ProgramOutputSchemas::RowSet(outputs) = &program.lowered.output;
+    let app_rows = outputs
+        .iter()
+        .find_map(|output| match output {
+            OutputTerminalSchema::AppRows(rows) => Some(rows),
+            OutputTerminalSchema::Fact(_) => None,
+        })
+        .expect("app rows schema");
+    let route = route_param_field("title");
+    assert!(app_rows.descriptor.field_index(&route).is_some());
+    assert!(
+        app_rows.hidden_fields.contains(&route),
+        "prepared binding route must remain internal to the flat collector"
+    );
 }
 
 // Internal compiler-boundary test: the public query API cannot expose which

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -156,6 +156,12 @@ pub(crate) struct LocalMaintainedViewSubscription {
     root_occurrence_ids: Vec<OutputOccurrenceId>,
 }
 
+impl LocalMaintainedViewSubscription {
+    pub(crate) fn terminal_root_layout(&self) -> Option<&crate::db::TerminalRootLayout> {
+        self.terminal_schemas.terminal_root_layout()
+    }
+}
+
 /// A plan retained solely to keep a maintained subscription graph alive.
 /// Its provenance is established by the compiler path that produced it, so a
 /// caller cannot relabel a ClientLocal plan as TrustedServing after the fact.
@@ -682,6 +688,7 @@ pub(crate) struct LocalMaintainedViewSubscriptionUpdate {
     pub(crate) added_edges: Vec<(RelationEdge, Option<CurrentRow>)>,
     pub(crate) removed_edges: Vec<RelationEdge>,
     pub(crate) terminal_operations: Vec<groove::ivm::TerminalOperation>,
+    pub(crate) terminal_layout: Option<crate::db::TerminalRootLayout>,
 }
 
 pub(crate) struct LocalMaintainedRelationSnapshot {
@@ -8650,6 +8657,9 @@ where
         let structured_output = !local.result_query.array_subqueries.is_empty();
         let structured_app_row_changes = transitions.structured_app_row_changes.clone();
         let terminal_operations = transitions.terminal_operations.clone();
+        let terminal_layout = (!terminal_operations.is_empty())
+            .then(|| local.terminal_schemas.terminal_root_layout().cloned())
+            .flatten();
         let aggregate_replacements = transitions
             .adds
             .iter()
@@ -8799,6 +8809,7 @@ where
             added_edges,
             removed_edges,
             terminal_operations,
+            terminal_layout,
         })
     }
 

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -66,8 +66,24 @@ export type NativeTerminalEdit =
   | { Update: { key: number[]; value: number[] } }
   | { Remove: { key: number[] } }
   | { Move: { key: number[]; index: number } };
+/** Immutable producer-owned root descriptor contract, registered before use. */
+export interface NativeTerminalRootLayout {
+  id: string;
+  rootDescriptor: number[];
+  rootKeySlot: number;
+  rootKeyFieldName: string;
+  publicFields: Array<{
+    name: string;
+    descriptorFieldName: string;
+    slot: number;
+    carrier?: "CurrentRow" | "Logical";
+  }>;
+  carrier: "CurrentRow" | "Logical";
+}
 export interface NativeTerminalOperation {
-  /** Postcard-encoded Groove root record descriptor for this terminal tree. */
+  /** Stable ID of a layout published in the same or an earlier delta. */
+  rootLayoutId?: string;
+  /** Legacy self-describing operation; new native producers must not send it. */
   rootDescriptor?: number[];
   root_key: number[];
   path: NativeTerminalPathSegment[];
@@ -86,6 +102,7 @@ export interface NativeRowDelta {
   addedOccurrenceKeys?: Uint8Array[];
   updatedOccurrenceKeys?: Uint8Array[];
   removedOccurrenceKeys?: Uint8Array[];
+  terminalLayouts?: NativeTerminalRootLayout[];
   terminalOperations?: NativeTerminalOperation[];
 }
 

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -669,14 +669,14 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
     const delivered = updates[1]?.delta[0];
     expect(delivered?.id).toBe(inserted.id);
-    const deliveredValue = delivered?.item?.values[0];
+    if (!delivered || !("item" in delivered)) {
+      throw new Error("expected a delivered row item");
+    }
+    const deliveredValue = delivered.item?.values[0];
     expect(deliveredValue?.type).toBe("Bytea");
     if (deliveredValue?.type !== "Bytea") throw new Error("expected a delivered Bytea value");
-    // Groove terminal rows retain the latest inline/non-null carrier byte.
     expect(deliveredValue.value).toBeInstanceOf(Uint8Array);
-    expect(deliveredValue.value.byteLength).toBe(fullByteRange.byteLength + 1);
-    expect(deliveredValue.value[0]).toBe(1);
-    expect(deliveredValue.value.subarray(1)).toEqual(fullByteRange);
+    expect(deliveredValue.value).toEqual(fullByteRange);
 
     runtime.unsubscribe(handle);
   });

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -555,7 +555,7 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     runtime.unsubscribe(handle);
   });
 
-  it("returns raw NAPI subscription payloads as Uint8Array with descriptor-aware terminal operations", async () => {
+  it("returns raw NAPI subscription payloads as Uint8Array with registered terminal layouts", async () => {
     const { NapiDb } = await loadNapiModule();
     const node = deterministicBytes("jazz-napi-native-runtime-raw-subscription:node");
     const author = deterministicBytes("jazz-napi-native-runtime-raw-subscription:author");
@@ -649,11 +649,12 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     const rawIncremental = expectRawBinaryPayload(rawDelta);
     expect(rawIncremental.terminalOperations).toHaveLength(1);
     const rawOperation = rawIncremental.terminalOperations[0];
-    expect(rawOperation?.rootDescriptor.length).toBeGreaterThan(0);
+    expect(rawIncremental.terminalLayouts).toHaveLength(1);
+    const rawLayout = rawIncremental.terminalLayouts[0];
+    expect(rawOperation?.rootLayoutId).toBe(rawLayout?.id);
+    expect(rawLayout?.rootDescriptor.length).toBeGreaterThan(0);
     expect(
-      rawOperation?.rootDescriptor.every(
-        (byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255,
-      ),
+      rawLayout?.rootDescriptor.every((byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255),
     ).toBe(true);
     expect(rawOperation?.root_key.length).toBeGreaterThan(0);
     expect(

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -1,8 +1,10 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WebSocket } from "undici";
 import { afterEach, describe, expect, it } from "vitest";
+import type { SubscriptionEvent as NapiSubscriptionEvent } from "jazz-napi";
 import type { ColumnType, Value, WasmSchema } from "../drivers/types.js";
 import { startLocalJazzServer, type LocalJazzServerHandle } from "../testing/index.js";
 import { webSocketUrl } from "./native-runtime/websocket.js";
@@ -13,6 +15,15 @@ import { hasJazzNapiBuild, loadNapiModule } from "./testing/napi-runtime-test-ut
 import { SubscriptionManager } from "./subscription-manager.js";
 import type { WasmRow } from "../drivers/types.js";
 import { createOpenBatchId, type BatchId, type OpenBatchId, type WriteReceipt } from "./client.js";
+
+const require = createRequire(import.meta.url);
+const debugSubscriptionEventFixture = hasJazzNapiBuild()
+  ? (
+      require("jazz-napi") as typeof import("jazz-napi") & {
+        __testSubscriptionEvents?: () => NapiSubscriptionEvent[];
+      }
+    ).__testSubscriptionEvents
+  : undefined;
 
 function beginTestBatch(runtime: NativeRuntimeAdapter): OpenBatchId {
   const id = createOpenBatchId();
@@ -49,6 +60,12 @@ const DEFAULTS_SCHEMA: WasmSchema = {
         default: { type: "BigInt", value: 9007199254740993n },
       },
     ],
+  },
+};
+
+const BYTEA_SCHEMA: WasmSchema = {
+  blobs: {
+    columns: [{ name: "data", column_type: { type: "Bytea" }, nullable: false }],
   },
 };
 
@@ -537,6 +554,282 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
     runtime.unsubscribe(handle);
   });
+
+  it("returns raw NAPI subscription payloads as Uint8Array with descriptor-aware terminal operations", async () => {
+    const { NapiDb } = await loadNapiModule();
+    const node = deterministicBytes("jazz-napi-native-runtime-raw-subscription:node");
+    const author = deterministicBytes("jazz-napi-native-runtime-raw-subscription:author");
+    const rawEvents: NapiSubscriptionEvent[] = [];
+    const expectRawBinaryPayload = (event: (typeof rawEvents)[number] | undefined) => {
+      expect(event).toBeDefined();
+      if (!event) throw new Error("expected a raw subscription event");
+      expect(event.type).toBe("delta");
+      if (event.type !== "delta") throw new Error(`expected a delta event, received ${event.type}`);
+      expect(event.delta).toBeInstanceOf(Uint8Array);
+      expect(Array.isArray(event.delta)).toBe(false);
+      expect(Buffer.isBuffer(event.delta)).toBe(false);
+      expect((event.delta as Uint8Array).byteLength).toBeGreaterThan(0);
+      expect(Array.isArray(event.terminalOperations)).toBe(true);
+      return event;
+    };
+
+    const observeDb = (nativeDb: ReturnType<typeof NapiDb.openMemory>) =>
+      new Proxy(nativeDb, {
+        get(target, property) {
+          const value = Reflect.get(target, property, target) as unknown;
+          if (property === "subscribe" && typeof value === "function") {
+            return (...args: unknown[]) => {
+              const source = Reflect.apply(value, target, args) as object;
+              return new Proxy(source, {
+                get(sourceTarget, sourceProperty) {
+                  const sourceValue = Reflect.get(
+                    sourceTarget,
+                    sourceProperty,
+                    sourceTarget,
+                  ) as unknown;
+                  if (sourceProperty === "readAll" && typeof sourceValue === "function") {
+                    return () => {
+                      const events = Reflect.apply(
+                        sourceValue,
+                        sourceTarget,
+                        [],
+                      ) as NapiSubscriptionEvent[];
+                      rawEvents.push(...events);
+                      return events;
+                    };
+                  }
+                  return typeof sourceValue === "function"
+                    ? sourceValue.bind(sourceTarget)
+                    : sourceValue;
+                },
+              });
+            };
+          }
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: (schema, config) => observeDb(NapiDb.openMemory(schema, config)) as never,
+      },
+      BYTEA_SCHEMA,
+      node,
+      author,
+      23,
+      true,
+    );
+    runtimes.push(runtime);
+
+    const manager = new SubscriptionManager<WasmRow>();
+    const updates: ReturnType<SubscriptionManager<WasmRow>["handleDelta"]>[] = [];
+    const handle = runtime.createSubscription(JSON.stringify({ table: "blobs" }), null, "local");
+    runtime.executeSubscription(handle, (delta: unknown) => {
+      updates.push(
+        manager.handleDelta(
+          delta as Parameters<SubscriptionManager<WasmRow>["handleDelta"]>[0],
+          (row) => row,
+          BYTEA_SCHEMA.blobs.columns,
+        ),
+      );
+    });
+
+    const initialReset = rawEvents.find((event) => event.type === "delta" && event.reset === true);
+    const rawReset = expectRawBinaryPayload(initialReset);
+    expect(rawReset.terminalOperations).toEqual([]);
+
+    const eventsBeforeInsert = rawEvents.length;
+    const fullByteRange = Uint8Array.from(Array.from({ length: 256 }, (_, index) => index));
+    const inserted = runtime.insert("blobs", {
+      data: { type: "Bytea", value: fullByteRange },
+    });
+    const rawDelta = rawEvents
+      .slice(eventsBeforeInsert)
+      .find((event) => event.type === "delta" && event.reset === false);
+
+    const rawIncremental = expectRawBinaryPayload(rawDelta);
+    expect(rawIncremental.terminalOperations).toHaveLength(1);
+    const rawOperation = rawIncremental.terminalOperations[0];
+    expect(rawOperation?.rootDescriptor.length).toBeGreaterThan(0);
+    expect(
+      rawOperation?.rootDescriptor.every(
+        (byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255,
+      ),
+    ).toBe(true);
+    expect(rawOperation?.root_key.length).toBeGreaterThan(0);
+    expect(
+      rawOperation?.root_key.every((byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255),
+    ).toBe(true);
+    expect(rawOperation?.path).toEqual([]);
+    if (!rawOperation || !("Insert" in rawOperation.edit)) {
+      throw new Error("expected an inserted terminal operation");
+    }
+    const rawTerminalValue = rawOperation.edit.Insert.value;
+    expect(rawOperation.edit.Insert.key).toEqual(rawOperation.root_key);
+    expect(rawTerminalValue.slice(-fullByteRange.byteLength)).toEqual(Array.from(fullByteRange));
+
+    const delivered = updates[1]?.delta[0];
+    expect(delivered?.id).toBe(inserted.id);
+    const deliveredValue = delivered?.item?.values[0];
+    expect(deliveredValue?.type).toBe("Bytea");
+    if (deliveredValue?.type !== "Bytea") throw new Error("expected a delivered Bytea value");
+    // Groove terminal rows retain the latest inline/non-null carrier byte.
+    expect(deliveredValue.value).toBeInstanceOf(Uint8Array);
+    expect(deliveredValue.value.byteLength).toBe(fullByteRange.byteLength + 1);
+    expect(deliveredValue.value[0]).toBe(1);
+    expect(deliveredValue.value.subarray(1)).toEqual(fullByteRange);
+
+    runtime.unsubscribe(handle);
+  });
+
+  // The fixture is deliberately absent from release addons. These complementary
+  // tests report that profile boundary explicitly instead of silently returning.
+  it.skipIf(debugSubscriptionEventFixture !== undefined)(
+    "release addons omit the debug-only subscription event fixture",
+    () => {
+      expect(debugSubscriptionEventFixture).toBeUndefined();
+    },
+  );
+
+  it.skipIf(debugSubscriptionEventFixture === undefined)(
+    "debug addons normalize real Rust rejection and closed subscription events",
+    async () => {
+      const { NapiDb } = await loadNapiModule();
+      const fixture = debugSubscriptionEventFixture!;
+      const [unsupportedEvent, pendingEvent, serverFailureEvent, closedEvent] = fixture();
+      expect([unsupportedEvent, pendingEvent, serverFailureEvent, closedEvent]).toStrictEqual([
+        {
+          type: "rejected",
+          reason: {
+            type: "UnsupportedShapeCapability",
+            detail: "fixture unsupported shape",
+          },
+        },
+        {
+          type: "rejected",
+          reason: { type: "ShapeRegistrationPendingCatalogueAdmission" },
+        },
+        {
+          type: "rejected",
+          reason: { type: "ServerFailure", code: "QueryValidation" },
+        },
+        { type: "closed" },
+      ]);
+      if (!unsupportedEvent || !pendingEvent || !serverFailureEvent || !closedEvent) {
+        throw new Error("jazz-napi test fixture returned incomplete events");
+      }
+
+      const openHarness = (label: string) => {
+        const injectedEvents: NapiSubscriptionEvent[] = [];
+        const observedEvents: NapiSubscriptionEvent[] = [];
+        const observeDb = (nativeDb: ReturnType<typeof NapiDb.openMemory>) =>
+          new Proxy(nativeDb, {
+            get(target, property) {
+              const value = Reflect.get(target, property, target) as unknown;
+              if (property === "subscribe" && typeof value === "function") {
+                return (...args: unknown[]) => {
+                  const source = Reflect.apply(value, target, args) as object;
+                  return new Proxy(source, {
+                    get(sourceTarget, sourceProperty) {
+                      const sourceValue = Reflect.get(
+                        sourceTarget,
+                        sourceProperty,
+                        sourceTarget,
+                      ) as unknown;
+                      if (sourceProperty === "readAll" && typeof sourceValue === "function") {
+                        return () => {
+                          const events = Reflect.apply(
+                            sourceValue,
+                            sourceTarget,
+                            [],
+                          ) as NapiSubscriptionEvent[];
+                          const injected = injectedEvents.splice(0);
+                          observedEvents.push(...injected, ...events);
+                          return [...injected, ...events];
+                        };
+                      }
+                      return typeof sourceValue === "function"
+                        ? sourceValue.bind(sourceTarget)
+                        : sourceValue;
+                    },
+                  });
+                };
+              }
+              return typeof value === "function" ? value.bind(target) : value;
+            },
+          });
+        const runtime = new NativeRuntimeAdapter(
+          {
+            openMemory: (schema, config) => observeDb(NapiDb.openMemory(schema, config)) as never,
+          },
+          TEST_SCHEMA,
+          deterministicBytes(`jazz-napi-native-runtime-event-variants:${label}:node`),
+          deterministicBytes(`jazz-napi-native-runtime-event-variants:${label}:author`),
+          24,
+          true,
+        );
+        runtimes.push(runtime);
+        const notifications: unknown[][] = [];
+        const handle = runtime.createSubscription(
+          JSON.stringify({ table: "todos" }),
+          null,
+          "local",
+        );
+        runtime.executeSubscription(handle, (...args: unknown[]) => notifications.push(args));
+        expect(notifications).toHaveLength(1);
+        return { runtime, injectedEvents, observedEvents, notifications };
+      };
+
+      const pending = openHarness("pending");
+      pending.injectedEvents.push(pendingEvent);
+      expect(pending.notifications).toHaveLength(1);
+      pending.runtime.insert("todos", {
+        title: { type: "Text", value: "still subscribed after pending admission" },
+        done: { type: "Boolean", value: false },
+      });
+      expect(pending.observedEvents).toContainEqual({
+        type: "rejected",
+        reason: { type: "ShapeRegistrationPendingCatalogueAdmission" },
+      });
+      expect(pending.notifications).toHaveLength(2);
+
+      const unsupported = openHarness("unsupported");
+      unsupported.injectedEvents.push(unsupportedEvent);
+      unsupported.runtime.insert("todos", {
+        title: { type: "Text", value: "unsupported before delivery" },
+        done: { type: "Boolean", value: false },
+      });
+      expect(unsupported.notifications).toHaveLength(2);
+      expect(unsupported.notifications[1]?.[0]).toBeInstanceOf(Error);
+      expect(String(unsupported.notifications[1]?.[0])).toContain(
+        "UnsupportedShapeCapability: fixture unsupported shape",
+      );
+      expect(unsupported.notifications[1]?.[1]).toBeNull();
+
+      const rejected = openHarness("rejected");
+      rejected.injectedEvents.push(serverFailureEvent);
+      rejected.runtime.insert("todos", {
+        title: { type: "Text", value: "rejected before delivery" },
+        done: { type: "Boolean", value: false },
+      });
+      expect(rejected.observedEvents).toContainEqual({
+        type: "rejected",
+        reason: { type: "ServerFailure", code: "QueryValidation" },
+      });
+      expect(rejected.notifications).toHaveLength(2);
+      expect(rejected.notifications[1]?.[0]).toBeInstanceOf(Error);
+      expect(String(rejected.notifications[1]?.[0])).toContain("ServerFailure: QueryValidation");
+      expect(rejected.notifications[1]?.[1]).toBeNull();
+
+      const closed = openHarness("closed");
+      closed.injectedEvents.push(closedEvent);
+      closed.runtime.insert("todos", {
+        title: { type: "Text", value: "not delivered after close" },
+        done: { type: "Boolean", value: false },
+      });
+      expect(closed.observedEvents).toContainEqual({ type: "closed" });
+      expect(closed.notifications).toHaveLength(1);
+    },
+  );
 
   it("delivers a multi-write mergeable transaction as one subscription delta", async () => {
     const { NapiDb } = await loadNapiModule();

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -10,6 +10,7 @@ import {
   decodeNativeRowValues,
   decodeRecordValue,
   encodeNativeRowValues,
+  assertTerminalRootDescriptorCompatible,
   readDescriptor,
   storageColumnValueType,
   writeDescriptor,
@@ -27,6 +28,58 @@ type NativeRowCodecCase = {
 };
 
 describe("native row codec", () => {
+  it("accepts nested terminal descriptors with producer fields beyond the root output", () => {
+    const columns: ColumnDescriptor[] = [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+    ];
+    const descriptor = [
+      { name: "__jazz_terminal_row_key", valueType: { tag: 10 } },
+      { name: "title", valueType: { tag: 8 } },
+      {
+        name: "members",
+        valueType: { tag: 13, inner: { tag: 15, record: [] } },
+      },
+    ];
+
+    expect(() => assertTerminalRootDescriptorCompatible(descriptor, columns)).not.toThrow();
+  });
+
+  it("rejects terminal descriptors that omit, reorder, rename, or change required root fields", () => {
+    const columns: ColumnDescriptor[] = [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "body", column_type: { type: "Text" }, nullable: false },
+    ];
+    const missingRootField = [{ name: "__jazz_terminal_row_key", valueType: { tag: 10 } }];
+    const wrongRootType = [
+      { name: "__jazz_terminal_row_key", valueType: { tag: 10 } },
+      { name: "title", valueType: { tag: 4 } },
+      { name: "members", valueType: { tag: 13, inner: { tag: 15, record: [] } } },
+    ];
+    const reorderedSameTypeFields = [
+      { name: "__jazz_terminal_row_key", valueType: { tag: 10 } },
+      { name: "body", valueType: { tag: 8 } },
+      { name: "title", valueType: { tag: 8 } },
+    ];
+    const wrongKeyName = [
+      { name: "not_the_terminal_key", valueType: { tag: 10 } },
+      { name: "title", valueType: { tag: 8 } },
+      { name: "body", valueType: { tag: 8 } },
+    ];
+
+    expect(() => assertTerminalRootDescriptorCompatible(missingRootField, columns)).toThrow(
+      "terminal root descriptor does not match the public projection",
+    );
+    expect(() => assertTerminalRootDescriptorCompatible(wrongRootType, columns)).toThrow(
+      "terminal root descriptor does not match the public projection",
+    );
+    expect(() => assertTerminalRootDescriptorCompatible(reorderedSameTypeFields, columns)).toThrow(
+      "terminal root descriptor does not match the public projection",
+    );
+    expect(() => assertTerminalRootDescriptorCompatible(wrongKeyName, columns)).toThrow(
+      "terminal root descriptor does not match the public projection",
+    );
+  });
+
   it("keeps mutation cells byte-for-byte aligned with packed row values", () => {
     const nestedColumns: ColumnDescriptor[] = [
       { name: "label", column_type: { type: "Text" }, nullable: false },

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.test.ts
@@ -80,6 +80,33 @@ describe("native row codec", () => {
     );
   });
 
+  it("accepts only the canonical CurrentRow carrier layout", () => {
+    const columns: ColumnDescriptor[] = [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "done", column_type: { type: "Boolean" }, nullable: false },
+    ];
+    const currentRow = [
+      { name: "row_uuid", valueType: { tag: 10 } },
+      { name: "user_title", valueType: { tag: 14, inner: { tag: 8 } } },
+      { name: "user_done", valueType: { tag: 14, inner: { tag: 7 } } },
+      { name: "$createdBy", valueType: { tag: 10 } },
+    ];
+    const nullableLogicalNames = [
+      { name: "__jazz_terminal_row_key", valueType: { tag: 10 } },
+      { name: "title", valueType: { tag: 14, inner: { tag: 8 } } },
+      { name: "done", valueType: { tag: 14, inner: { tag: 7 } } },
+    ];
+    const reorderedCarriers = [currentRow[0]!, currentRow[2]!, currentRow[1]!];
+
+    expect(() => assertTerminalRootDescriptorCompatible(currentRow, columns)).not.toThrow();
+    expect(() => assertTerminalRootDescriptorCompatible(nullableLogicalNames, columns)).toThrow(
+      "terminal root descriptor does not match the public projection",
+    );
+    expect(() => assertTerminalRootDescriptorCompatible(reorderedCarriers, columns)).toThrow(
+      "terminal root descriptor does not match the public projection",
+    );
+  });
+
   it("keeps mutation cells byte-for-byte aligned with packed row values", () => {
     const nestedColumns: ColumnDescriptor[] = [
       { name: "label", column_type: { type: "Text" }, nullable: false },

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -448,34 +448,56 @@ export function assertTerminalRootDescriptorCompatible(
   descriptor: DescriptorField[],
   columns: readonly ColumnDescriptor[],
 ): void {
-  if (
-    descriptor.length < columns.length + 1 ||
-    descriptor[0]?.name !== "__jazz_terminal_row_key" ||
-    descriptor[0]?.valueType.tag !== 10 ||
-    !isKnownValueType(descriptor[0].valueType)
-  ) {
-    throw new Error("terminal root descriptor does not match the public projection");
-  }
-
   const publicColumns = logicalStorageColumns(columns);
-  const matchesLogical = publicColumns.every(
-    (column, index) =>
-      descriptor[index + 1]?.name === column.name &&
-      terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, false),
+  const matchesLogical = matchesNamedTerminalLayout(
+    descriptor,
+    "__jazz_terminal_row_key",
+    publicColumns,
+    (column) => column.name,
+    false,
   );
-  const matchesPhysical = columns.every(
-    (column, index) =>
-      descriptor[index + 1]?.name === column.name &&
-      terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, false),
+  const matchesPhysical = matchesNamedTerminalLayout(
+    descriptor,
+    "__jazz_terminal_row_key",
+    columns,
+    (column) => column.name,
+    false,
   );
-  const matchesCurrentRow = publicColumns.every(
-    (column, index) =>
-      descriptor[index + 1]?.name === column.name &&
-      terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, true),
+  // CurrentRow is a distinct physical layout. Its row key is named row_uuid
+  // and its nullable application-cell carriers live in the user_ namespace.
+  // Do not accept a nullable logical descriptor here: doing so would make an
+  // arbitrary reordering of same-typed fields indistinguishable from a native
+  // CurrentRow record.
+  const matchesCurrentRow = matchesNamedTerminalLayout(
+    descriptor,
+    "row_uuid",
+    publicColumns,
+    (column) => `user_${column.name}`,
+    true,
   );
   if (!matchesLogical && !matchesPhysical && !matchesCurrentRow) {
     throw new Error("terminal root descriptor does not match the public projection");
   }
+}
+
+function matchesNamedTerminalLayout(
+  descriptor: readonly DescriptorField[],
+  keyName: string,
+  columns: readonly ColumnDescriptor[],
+  fieldName: (column: ColumnDescriptor) => string,
+  forceNullable: boolean,
+): boolean {
+  return (
+    descriptor.length >= columns.length + 1 &&
+    descriptor[0]?.name === keyName &&
+    descriptor[0]?.valueType.tag === 10 &&
+    isKnownValueType(descriptor[0].valueType) &&
+    columns.every(
+      (column, index) =>
+        descriptor[index + 1]?.name === fieldName(column) &&
+        terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, forceNullable),
+    )
+  );
 }
 
 function terminalValueTypeMatchesColumn(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -449,7 +449,8 @@ export function assertTerminalRootDescriptorCompatible(
   columns: readonly ColumnDescriptor[],
 ): void {
   if (
-    descriptor.length !== columns.length + 1 ||
+    descriptor.length < columns.length + 1 ||
+    descriptor[0]?.name !== "__jazz_terminal_row_key" ||
     descriptor[0]?.valueType.tag !== 10 ||
     !isKnownValueType(descriptor[0].valueType)
   ) {
@@ -457,14 +458,20 @@ export function assertTerminalRootDescriptorCompatible(
   }
 
   const publicColumns = logicalStorageColumns(columns);
-  const matchesLogical = publicColumns.every((column, index) =>
-    terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, false),
+  const matchesLogical = publicColumns.every(
+    (column, index) =>
+      descriptor[index + 1]?.name === column.name &&
+      terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, false),
   );
-  const matchesPhysical = columns.every((column, index) =>
-    terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, false),
+  const matchesPhysical = columns.every(
+    (column, index) =>
+      descriptor[index + 1]?.name === column.name &&
+      terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, false),
   );
-  const matchesCurrentRow = publicColumns.every((column, index) =>
-    terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, true),
+  const matchesCurrentRow = publicColumns.every(
+    (column, index) =>
+      descriptor[index + 1]?.name === column.name &&
+      terminalValueTypeMatchesColumn(descriptor[index + 1]?.valueType, column, true),
   );
   if (!matchesLogical && !matchesPhysical && !matchesCurrentRow) {
     throw new Error("terminal root descriptor does not match the public projection");

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -1,4 +1,10 @@
-import type { ColumnDescriptor, ColumnType, Value, WasmRow } from "../../drivers/types.js";
+import type {
+  ColumnDescriptor,
+  ColumnType,
+  NativeTerminalRootLayout,
+  Value,
+  WasmRow,
+} from "../../drivers/types.js";
 import { isProvenanceMagicTimestampColumn } from "../../magic-columns.js";
 
 const textDecoder = new TextDecoder();
@@ -436,6 +442,106 @@ export function decodeNativeTerminalRowWithDescriptor(
     configurable: true,
   });
   return row;
+}
+
+/**
+ * Compile the hot terminal-root decoder from an immutable producer-owned
+ * layout. The descriptor's field identities and slots are checked once; each
+ * operation thereafter carries only the layout ID and packed edit bytes.
+ */
+export function compileNativeTerminalRootDecoder(
+  layout: NativeTerminalRootLayout,
+  descriptor: DescriptorField[],
+  columns: readonly ColumnDescriptor[],
+): (id: string, raw: Uint8Array) => WasmRow {
+  assertTerminalRootLayoutCompatible(descriptor, columns, layout);
+  const slots = layout.publicFields.map((field) => field.slot);
+  return (id, raw) => {
+    assertRecordLayoutIsComplete(descriptor, raw);
+    const key = decodeRecordValue(descriptor, raw, layout.rootKeySlot);
+    if (key == null || formatUuid(key) !== id) {
+      throw new Error("terminal record key does not match addressed key");
+    }
+    const values = columns.map((column, index) => {
+      const bytes = decodeRecordValue(descriptor, raw, slots[index]!);
+      return bytes == null
+        ? ({ type: "Null" } satisfies Value)
+        : decodeTerminalBytes(column.column_type, bytes);
+    });
+    const valuesByColumn = new Map(columns.map((column, index) => [column.name, values[index]!]));
+    const row = { id, values };
+    Object.defineProperty(row, "valuesByColumn", {
+      value: valuesByColumn,
+      enumerable: false,
+      configurable: true,
+    });
+    return row;
+  };
+}
+
+function assertTerminalRootLayoutCompatible(
+  descriptor: readonly DescriptorField[],
+  columns: readonly ColumnDescriptor[],
+  layout: NativeTerminalRootLayout,
+): void {
+  if (layout.carrier !== "CurrentRow" && layout.carrier !== "Logical") {
+    throw new Error(`unsupported terminal root carrier ${String(layout.carrier)}`);
+  }
+  const root = descriptor[layout.rootKeySlot];
+  if (
+    !Number.isSafeInteger(layout.rootKeySlot) ||
+    root?.name !== layout.rootKeyFieldName ||
+    root.valueType.tag !== 10 ||
+    !isKnownValueType(root.valueType)
+  ) {
+    throw new Error("terminal root layout key slot does not match its descriptor");
+  }
+  if (layout.publicFields.length !== columns.length) {
+    throw new Error("terminal root layout does not match the public projection");
+  }
+  const seenSlots = new Set<number>([layout.rootKeySlot]);
+  for (let index = 0; index < columns.length; index++) {
+    const column = columns[index]!;
+    const field = layout.publicFields[index]!;
+    const descriptorField = descriptor[field.slot];
+    if (
+      field.name !== column.name ||
+      !Number.isSafeInteger(field.slot) ||
+      seenSlots.has(field.slot) ||
+      descriptorField?.name !== field.descriptorFieldName ||
+      !terminalLayoutValueTypeMatchesColumn(
+        descriptorField?.valueType,
+        column,
+        field.carrier ?? layout.carrier,
+      )
+    ) {
+      throw new Error(
+        `terminal root layout does not match the public projection at ${index}: ` +
+          `${field.name}/${field.descriptorFieldName}@${field.slot} vs ${column.name}/` +
+          `${descriptorField?.name ?? "<missing>"} (descriptor tag ${descriptorField?.valueType.tag ?? "?"}, ` +
+          `nullable ${String(column.nullable)}, sparse ${String(column.sparse)})`,
+      );
+    }
+    seenSlots.add(field.slot);
+  }
+}
+
+function terminalLayoutValueTypeMatchesColumn(
+  valueType: ValueType | undefined,
+  column: ColumnDescriptor,
+  carrier: NativeTerminalRootLayout["carrier"],
+): boolean {
+  // `sparse` describes the TS wildcard/storage carrier, not the declared
+  // public value. Rust collector descriptors have already removed it.
+  const logicalColumn = logicalStorageColumns([column])[0]!;
+  if (carrier === "Logical") {
+    return terminalValueTypeMatchesColumn(valueType, logicalColumn, false);
+  }
+  return (
+    valueType?.tag === 14 &&
+    valueType.inner !== undefined &&
+    terminalValueTypeMatchesColumn(valueType.inner, logicalColumn, false)
+  );
 }
 
 /**

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -4,6 +4,7 @@ import type {
   InsertValues,
   NativeRowDelta,
   NativeTerminalOperation,
+  NativeTerminalRootLayout,
   TablePolicies,
   Value,
   WasmSchema,
@@ -334,6 +335,7 @@ type SubscriptionState = {
   deferredVisiblePublication: boolean;
   deferredVisibleReset: boolean;
   deferredTerminalOperations: NativeTerminalOperation[];
+  deferredTerminalLayouts: NativeTerminalRootLayout[];
   deferredPlaceholderChunks: number;
   deferredPlaceholderRows: number;
   deferredPlaceholderBytes: number;
@@ -1014,6 +1016,7 @@ export class NativeRuntimeAdapter implements Runtime {
       deferredVisiblePublication: false,
       deferredVisibleReset: false,
       deferredTerminalOperations: [],
+      deferredTerminalLayouts: [],
       deferredPlaceholderChunks: 0,
       deferredPlaceholderRows: 0,
       deferredPlaceholderBytes: 0,
@@ -1696,6 +1699,7 @@ export class NativeRuntimeAdapter implements Runtime {
         subscription.packedResetRows = packedResetRows;
         subscription.opened = true;
         packedResetRows.terminalOperations = chunk.terminalOperations;
+        packedResetRows.terminalLayouts = chunk.terminalLayouts;
         this.publishSubscriptionRows(subscription, packedResetRows, chunk.settled, true);
       } else {
         materializePackedResetRows(subscription, this.schema);
@@ -1736,6 +1740,7 @@ export class NativeRuntimeAdapter implements Runtime {
             this.deferSubscriptionRows(
               subscription,
               chunk.terminalOperations,
+              chunk.terminalLayouts,
               chunk.reset === true,
               chunk.delta,
             );
@@ -1761,12 +1766,14 @@ export class NativeRuntimeAdapter implements Runtime {
           this.deferSubscriptionRows(
             subscription,
             chunk.terminalOperations,
+            chunk.terminalLayouts,
             chunk.reset === true,
             chunk.delta,
           );
           return;
         }
         applied.wireDelta.terminalOperations = chunk.terminalOperations;
+        applied.wireDelta.terminalLayouts = chunk.terminalLayouts;
         this.publishSubscriptionRows(
           subscription,
           applied.wireDelta,
@@ -1787,6 +1794,7 @@ export class NativeRuntimeAdapter implements Runtime {
       subscription.deferredVisiblePublication = true;
       subscription.deferredVisibleReset ||= reset;
       subscription.deferredTerminalOperations.push(...(wireDelta.terminalOperations ?? []));
+      subscription.deferredTerminalLayouts.push(...(wireDelta.terminalLayouts ?? []));
       return;
     }
 
@@ -1819,9 +1827,14 @@ export class NativeRuntimeAdapter implements Runtime {
       ...subscription.deferredTerminalOperations,
       ...(wireDelta.terminalOperations ?? []),
     ];
+    const terminalLayouts = [
+      ...subscription.deferredTerminalLayouts,
+      ...(wireDelta.terminalLayouts ?? []),
+    ];
     if (terminalOperations.length > 0) {
       visibleDelta.terminalOperations = terminalOperations;
     }
+    if (terminalLayouts.length > 0) visibleDelta.terminalLayouts = terminalLayouts;
 
     subscription.callback?.(visibleDelta);
     if (visibleDelta === subscription.packedResetRows) {
@@ -1842,12 +1855,14 @@ export class NativeRuntimeAdapter implements Runtime {
   private deferSubscriptionRows(
     subscription: SubscriptionState,
     terminalOperations: NativeTerminalOperation[] | undefined,
+    terminalLayouts: NativeTerminalRootLayout[] | undefined,
     reset: boolean,
     delta: NativeSubscriptionDelta,
   ): void {
     subscription.deferredVisiblePublication = true;
     subscription.deferredVisibleReset ||= reset;
     subscription.deferredTerminalOperations.push(...(terminalOperations ?? []));
+    subscription.deferredTerminalLayouts.push(...(terminalLayouts ?? []));
     subscription.deferredPlaceholderChunks = reset ? 1 : subscription.deferredPlaceholderChunks + 1;
     subscription.deferredPlaceholderRows = subscription.rows.length;
     subscription.deferredPlaceholderBytes = reset
@@ -2057,6 +2072,7 @@ function clearDeferredPlaceholderBuffer(subscription: SubscriptionState): void {
   subscription.deferredVisiblePublication = false;
   subscription.deferredVisibleReset = false;
   subscription.deferredTerminalOperations = [];
+  subscription.deferredTerminalLayouts = [];
   subscription.deferredPlaceholderChunks = 0;
   subscription.deferredPlaceholderRows = 0;
   subscription.deferredPlaceholderBytes = 0;
@@ -3978,6 +3994,7 @@ function normalizeSubscriptionChunk(chunk: unknown):
       reset?: boolean;
       delta: NativeSubscriptionDelta;
       terminalOperations?: NativeTerminalOperation[];
+      terminalLayouts?: NativeTerminalRootLayout[];
       settled?: boolean;
     }
   | {
@@ -3997,6 +4014,7 @@ function normalizeSubscriptionChunk(chunk: unknown):
     reset?: unknown;
     settled?: unknown;
     terminalOperations?: unknown;
+    terminalLayouts?: unknown;
   };
   if (record.type === "closed" || record.type === "Closed") {
     return { type: "closed" };
@@ -4017,6 +4035,9 @@ function normalizeSubscriptionChunk(chunk: unknown):
       ),
       terminalOperations: Array.isArray(record.terminalOperations)
         ? (record.terminalOperations as NativeTerminalOperation[])
+        : undefined,
+      terminalLayouts: Array.isArray(record.terminalLayouts)
+        ? (record.terminalLayouts as NativeTerminalRootLayout[])
         : undefined,
       settled: typeof record.settled === "boolean" ? record.settled : undefined,
     };
@@ -4290,7 +4311,7 @@ function subscriptionDeltaPayloadBytes(
 }
 
 function nativeTerminalOperationBytes(operation: NativeTerminalOperation): number {
-  const descriptorBytes = operation.rootDescriptor?.length ?? 0;
+  const layoutIdBytes = operation.rootLayoutId?.length ?? operation.rootDescriptor?.length ?? 0;
   const rootKeyBytes = operation.root_key.length;
   const pathBytes = operation.path.reduce((sum, segment) => {
     if ("Collection" in segment) {
@@ -4306,7 +4327,7 @@ function nativeTerminalOperationBytes(operation: NativeTerminalOperation): numbe
         : "Remove" in operation.edit
           ? operation.edit.Remove.key.length
           : operation.edit.Move.key.length;
-  return descriptorBytes + rootKeyBytes + pathBytes + editBytes;
+  return layoutIdBytes + rootKeyBytes + pathBytes + editBytes;
 }
 
 function utf8ByteLength(value: string): number {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-protocol.ts
@@ -175,6 +175,7 @@ export type PersistentBrowserSubscriptionFrame = {
   addedCount: number;
   removedCount: number;
   updatedCount: number;
+  terminalLayouts?: NativeRowDelta["terminalLayouts"];
   terminalOperations?: NativeRowDelta["terminalOperations"];
 };
 

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.ts
@@ -903,6 +903,7 @@ function nativeDeltaFromFrame(
     addedCount: message.frame.addedCount,
     removedCount: message.frame.removedCount,
     updatedCount: message.frame.updatedCount,
+    terminalLayouts: message.frame.terminalLayouts,
     terminalOperations: message.frame.terminalOperations,
   };
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -341,6 +341,7 @@ function subscriptionFrameFromDelta(delta: unknown): PersistentBrowserSubscripti
     addedCount: delta.addedCount,
     removedCount: delta.removedCount,
     updatedCount: delta.updatedCount,
+    terminalLayouts: delta.terminalLayouts,
     terminalOperations: delta.terminalOperations,
   };
 }

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -7,6 +7,7 @@ import { SubscriptionManager, applySubscriptionDelta } from "./subscription-mana
 import type { SubscriptionDelta } from "./subscription-manager.js";
 import {
   encodeNativeRowValues,
+  logicalStorageColumns,
   storageColumnValueType,
   writeDescriptor,
 } from "./native-runtime/native-row-codec.js";
@@ -153,6 +154,19 @@ function currentRowTerminalDescriptor(columns: readonly ColumnDescriptor[]): num
   writeDescriptor(writer, [
     { name: "row_uuid", valueType: { tag: 10 } },
     ...currentRowColumns(columns).map((column) => ({
+      name: `user_${column.name}`,
+      valueType: storageColumnValueType(column),
+    })),
+  ]);
+  return [...writer.finish()];
+}
+
+function collectorTerminalDescriptor(columns: readonly ColumnDescriptor[]): number[] {
+  const logicalColumns = logicalStorageColumns(columns);
+  const writer = new PostcardWriter();
+  writeDescriptor(writer, [
+    { name: "row_uuid", valueType: { tag: 10 } },
+    ...logicalColumns.map((column) => ({
       name: `user_${column.name}`,
       valueType: storageColumnValueType(column),
     })),
@@ -958,6 +972,182 @@ describe("SubscriptionManager", () => {
     );
 
     expect(result.all).toEqual([{ id, name: "logical" }]);
+  });
+
+  it("registers a producer-owned root layout before decoding its operations", () => {
+    const id = "00000000-0000-4000-8000-000000000001";
+    const key = [10, ...uuidBytes(id)];
+    const manager = new SubscriptionManager<TestItem>();
+    const result = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalLayouts: [
+          {
+            id: "current-row-v1",
+            rootDescriptor: currentRowTerminalDescriptor(nativeColumns),
+            rootKeySlot: 0,
+            rootKeyFieldName: "row_uuid",
+            publicFields: [
+              { name: "name", descriptorFieldName: "user_name", slot: 1 },
+              { name: "count", descriptorFieldName: "user_count", slot: 2 },
+            ],
+            carrier: "CurrentRow",
+          },
+        ],
+        terminalOperations: [
+          {
+            rootLayoutId: "current-row-v1",
+            root_key: key,
+            path: [],
+            edit: { Insert: { index: 0, key, value: [...terminalRowData(id, "layout", 9)] } },
+          },
+        ],
+      },
+      transform,
+      nativeColumns,
+    );
+    expect(result.all).toEqual([{ id, name: "layout", count: 9 }]);
+  });
+
+  it("decodes logical collector roots and rejects the wrong carrier kind", () => {
+    const id = "00000000-0000-4000-8000-000000000001";
+    const key = [10, ...uuidBytes(id)];
+    const sparseLogicalColumns = nativeColumns.map((column) => ({ ...column, sparse: true }));
+    const descriptor = collectorTerminalDescriptor(sparseLogicalColumns);
+    const value = [
+      ...uuidBytes(id),
+      ...encodeNativeRowValues(nativeColumns, [
+        { type: "Text", value: "collector" },
+        { type: "Integer", value: 11 },
+      ]),
+    ];
+    const delta = (carrier: "Logical" | "CurrentRow"): NativeRowDelta => ({
+      __jazzNativeRowDelta: true,
+      added: new Uint8Array(),
+      removed: new Uint8Array(),
+      updated: new Uint8Array(),
+      addedCount: 0,
+      removedCount: 0,
+      updatedCount: 0,
+      terminalLayouts: [
+        {
+          id: `collector-${carrier}`,
+          rootDescriptor: descriptor,
+          rootKeySlot: 0,
+          rootKeyFieldName: "row_uuid",
+          publicFields: [
+            { name: "name", descriptorFieldName: "user_name", slot: 1 },
+            { name: "count", descriptorFieldName: "user_count", slot: 2 },
+          ],
+          carrier,
+        },
+      ],
+      terminalOperations: [
+        {
+          rootLayoutId: `collector-${carrier}`,
+          root_key: key,
+          path: [],
+          edit: { Insert: { index: 0, key, value } },
+        },
+      ],
+    });
+
+    expect(
+      new SubscriptionManager<TestItem>().handleDelta(
+        delta("Logical"),
+        transform,
+        sparseLogicalColumns,
+      ).all,
+    ).toEqual([{ id, name: "collector", count: 11 }]);
+    expect(() =>
+      new SubscriptionManager<TestItem>().handleDelta(
+        delta("CurrentRow"),
+        transform,
+        sparseLogicalColumns,
+      ),
+    ).toThrow(/terminal root layout does not match/);
+  });
+
+  it("normalizes sparse logical trees but preserves CurrentRow nullable carriers", () => {
+    const columns: ColumnDescriptor[] = [
+      {
+        name: "profile",
+        column_type: {
+          type: "Row",
+          columns: [{ name: "label", column_type: { type: "Text" }, nullable: true, sparse: true }],
+        },
+        nullable: true,
+        sparse: true,
+      },
+    ];
+    const layoutDelta = (
+      id: string,
+      carrier: "Logical" | "CurrentRow",
+      rootDescriptor: number[],
+      fieldCarrier = carrier,
+    ): NativeRowDelta => ({
+      __jazzNativeRowDelta: true,
+      added: new Uint8Array(),
+      removed: new Uint8Array(),
+      updated: new Uint8Array(),
+      addedCount: 0,
+      removedCount: 0,
+      updatedCount: 0,
+      terminalLayouts: [
+        {
+          id,
+          rootDescriptor,
+          rootKeySlot: 0,
+          rootKeyFieldName: "row_uuid",
+          publicFields: [
+            {
+              name: "profile",
+              descriptorFieldName: "user_profile",
+              slot: 1,
+              carrier: fieldCarrier,
+            },
+          ],
+          carrier,
+        },
+      ],
+    });
+    expect(() =>
+      new SubscriptionManager().handleDelta(
+        layoutDelta("logical-tree", "CurrentRow", collectorTerminalDescriptor(columns), "Logical"),
+        (row) => row,
+        columns,
+      ),
+    ).not.toThrow();
+
+    const normalized = { ...columns[0]!, sparse: undefined };
+    const writer = new PostcardWriter();
+    writeDescriptor(writer, [
+      { name: "row_uuid", valueType: { tag: 10 } },
+      {
+        name: "user_profile",
+        valueType: { tag: 14, inner: storageColumnValueType(normalized) },
+      },
+    ]);
+    expect(() =>
+      new SubscriptionManager().handleDelta(
+        layoutDelta("current-row-nullable", "CurrentRow", [...writer.finish()]),
+        (row) => row,
+        columns,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      new SubscriptionManager().handleDelta(
+        layoutDelta("wrong-current-row", "CurrentRow", collectorTerminalDescriptor(columns)),
+        (row) => row,
+        columns,
+      ),
+    ).toThrow(/terminal root layout does not match/);
   });
 
   it("applies root insert positions in producer order after earlier removals", () => {

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -149,7 +149,15 @@ function terminalDescriptor(columns: readonly ColumnDescriptor[]): number[] {
 }
 
 function currentRowTerminalDescriptor(columns: readonly ColumnDescriptor[]): number[] {
-  return terminalDescriptor(currentRowColumns(columns));
+  const writer = new PostcardWriter();
+  writeDescriptor(writer, [
+    { name: "row_uuid", valueType: { tag: 10 } },
+    ...currentRowColumns(columns).map((column) => ({
+      name: `user_${column.name}`,
+      valueType: storageColumnValueType(column),
+    })),
+  ]);
+  return [...writer.finish()];
 }
 
 function terminalTextChild(id: string, name: string): Uint8Array {

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -9,6 +9,7 @@ import type {
   ColumnDescriptor,
   NativeRowDelta,
   NativeTerminalOperation,
+  NativeTerminalRootLayout,
   SubscriptionWireDelta,
   Value,
   WasmRow,
@@ -19,6 +20,7 @@ import {
   decodeNativeRow,
   decodeNativeTerminalRow,
   decodeNativeTerminalRowWithDescriptor,
+  compileNativeTerminalRootDecoder,
   logicalStorageColumns,
   readDescriptor,
 } from "./native-runtime/native-row-codec.js";
@@ -62,6 +64,12 @@ type SubscriptionManagerSnapshot<T> = {
   terminalOccurrenceAddresses: Map<string, string>;
   orderedIds: string[];
   orderedIdIndex: Map<string, number>;
+  terminalRootDecoders: Map<string, TerminalRootDecoder>;
+};
+
+type TerminalRootDecoder = {
+  signature: string;
+  decode: (id: string, raw: Uint8Array) => WasmRow;
 };
 
 /**
@@ -240,6 +248,7 @@ export class SubscriptionManager<T extends { id: string }> {
   private terminalOccurrenceAddresses = new Map<string, string>();
   private orderedIds: string[] = [];
   private orderedIdIndex = new Map<string, number>();
+  private terminalRootDecoders = new Map<string, TerminalRootDecoder>();
 
   private removeId(id: string): void {
     const index = this.orderedIdIndex.get(id);
@@ -281,8 +290,9 @@ export class SubscriptionManager<T extends { id: string }> {
       const snapshot = this.snapshot(nativeColumns);
       try {
         if (reset) {
-          this.clear();
+          this.clearRows();
         }
+        this.registerTerminalRootLayouts(delta.terminalLayouts, nativeColumns);
         for (const key of [
           ...(delta.addedOccurrenceKeys ?? []),
           ...(delta.updatedOccurrenceKeys ?? []),
@@ -340,6 +350,7 @@ export class SubscriptionManager<T extends { id: string }> {
       terminalOccurrenceAddresses: new Map(this.terminalOccurrenceAddresses),
       orderedIds: [...this.orderedIds],
       orderedIdIndex: new Map(this.orderedIdIndex),
+      terminalRootDecoders: new Map(this.terminalRootDecoders),
     };
   }
 
@@ -349,6 +360,56 @@ export class SubscriptionManager<T extends { id: string }> {
     this.terminalOccurrenceAddresses = snapshot.terminalOccurrenceAddresses;
     this.orderedIds = snapshot.orderedIds;
     this.orderedIdIndex = snapshot.orderedIdIndex;
+    this.terminalRootDecoders = snapshot.terminalRootDecoders;
+  }
+
+  private registerTerminalRootLayouts(
+    layouts: readonly NativeTerminalRootLayout[] | undefined,
+    columns: readonly ColumnDescriptor[],
+  ): void {
+    for (const layout of layouts ?? []) {
+      const signature = JSON.stringify(layout);
+      const existing = this.terminalRootDecoders.get(layout.id);
+      if (existing) {
+        if (existing.signature !== signature) {
+          throw new Error(`terminal root layout ${layout.id} was redefined`);
+        }
+        continue;
+      }
+      const reader = new PostcardReader(Uint8Array.from(layout.rootDescriptor));
+      const descriptor = readDescriptor(reader);
+      if (!reader.done()) throw new Error("terminal root layout descriptor has trailing bytes");
+      this.terminalRootDecoders.set(layout.id, {
+        signature,
+        decode: compileNativeTerminalRootDecoder(layout, descriptor, columns),
+      });
+    }
+  }
+
+  private decodeNativeTerminalRoot(
+    id: string,
+    operation: NativeTerminalOperation,
+    columns: readonly ColumnDescriptor[],
+    raw: Uint8Array,
+  ): WasmRow {
+    if (operation.rootLayoutId) {
+      const decoder = this.terminalRootDecoders.get(operation.rootLayoutId);
+      if (!decoder) {
+        throw new Error(
+          `terminal operation references unknown root layout ${operation.rootLayoutId}`,
+        );
+      }
+      return decoder.decode(id, raw);
+    }
+    // Kept solely for older test fixtures and a mixed-version native addon.
+    // Current Rust producers publish a layout before emitting any operation.
+    if (!operation.rootDescriptor) {
+      throw new Error("terminal operation is missing its root descriptor or layout ID");
+    }
+    const reader = new PostcardReader(Uint8Array.from(operation.rootDescriptor));
+    const descriptor = readDescriptor(reader);
+    if (!reader.done()) throw new Error("terminal root descriptor has trailing bytes");
+    return decodeNativeTerminalRowWithDescriptor(id, descriptor, columns, raw);
   }
 
   private handleTerminalOperations(
@@ -371,7 +432,7 @@ export class SubscriptionManager<T extends { id: string }> {
       if (!("Insert" in edit)) throw new Error("terminal root insert partition is invalid");
       this.terminalRows.set(
         rootId,
-        decodeNativeTerminalRoot(
+        this.decodeNativeTerminalRoot(
           rootRowId,
           operation,
           rootColumns,
@@ -398,7 +459,7 @@ export class SubscriptionManager<T extends { id: string }> {
           }
           this.terminalRows.set(
             rootId,
-            decodeNativeTerminalRoot(
+            this.decodeNativeTerminalRoot(
               terminalPayloadRowId(operation.root_key),
               operation,
               rootColumns,
@@ -663,6 +724,11 @@ export class SubscriptionManager<T extends { id: string }> {
    * Called when unsubscribing to free memory.
    */
   clear(): void {
+    this.clearRows();
+    this.terminalRootDecoders.clear();
+  }
+
+  private clearRows(): void {
     this.currentResults.clear();
     this.terminalRows.clear();
     this.terminalOccurrenceAddresses.clear();
@@ -682,23 +748,6 @@ export class SubscriptionManager<T extends { id: string }> {
   get size(): number {
     return this.currentResults.size;
   }
-}
-
-function decodeNativeTerminalRoot(
-  id: string,
-  operation: NativeTerminalOperation,
-  columns: readonly ColumnDescriptor[],
-  raw: Uint8Array,
-): WasmRow {
-  if (!operation.rootDescriptor) {
-    throw new Error("terminal operation is missing its root descriptor");
-  }
-  const reader = new PostcardReader(Uint8Array.from(operation.rootDescriptor));
-  const descriptor = readDescriptor(reader);
-  if (!reader.done()) {
-    throw new Error("terminal root descriptor has trailing bytes");
-  }
-  return decodeNativeTerminalRowWithDescriptor(id, descriptor, columns, raw);
 }
 
 export function isNativeRowDelta(delta: SubscriptionWireDelta): delta is NativeRowDelta {


### PR DESCRIPTION
🤖 Replaces JSON-shaped NAPI subscription events with typed native objects and makes Rust and TypeScript agree on terminal-row decoding by construction.

## Motivating problem

The query engine can produce several legitimate terminal record shapes: complete CurrentRow carriers, explicitly projected logical rows, flat collectors, and nested tree collectors. TypeScript previously tried to infer which shape it received from descriptor names and nullable wrappers. That was both brittle and hostile to fast decoding: internal layout changes could either reject valid rows or silently swap same-typed fields.

## Early-bound decoding contract

Rust now builds an immutable `TerminalRootLayout` when the maintained result shape is prepared, at the point where the authoritative public `AppRowSchema` and the emitted record representation are both known.

The layout records:

- a stable identity hashed from all decoding semantics
- row-key and every public output slot index, including nested collection fields
- exact public column types and ordering
- the authoritative encoded representation for each slot (`Logical` or `CurrentRow`)
- authoritative hidden fields, so binding/claim route metadata remains internal

NAPI and WASM publish the layout definition before any operation references its ID. TypeScript validates and installs it atomically, compiles a monomorphic decoder once, and caches that decoder per subscription manager. Per-event decoding then uses only the layout ID and fixed slots; it performs no field-name or carrier inference.

Each slot representation is derived during lowering:

- flat collect-all scalar slots that preserve storage wrappers are `CurrentRow`
- explicitly unwrapped projections are `Logical`
- nested/tree collection slots are `Logical`, even when sibling scalar slots remain `CurrentRow`
- bound-query route fields stay in the internal descriptor for result partitioning but are excluded from the public layout

Logical layouts recursively strip TypeScript-only sparse/wildcard metadata. CurrentRow layouts use that same normalized logical shape plus exactly one outer carrier wrapper, preserving a declared nullable value as a distinct inner nullable layer.

## Typed NAPI events

- packed subscription deltas are `Uint8Array`
- delta, rejected, and closed events are discriminated TypeScript unions
- descriptors, terminal ordering, edit payloads, reset semantics, and nested producer fields are preserved
- unknown layout IDs and immutable-ID redefinitions are protocol errors

Direct raw NAPI consumers now receive `delta` as `Uint8Array` instead of `number[]`.

## Stack cleanup

The old PR tip contained a broad claim-routing workaround and unrelated policy-test changes. Those are removed; merged #1396 owns the core claim-routing behavior. No policy tests are skipped and no serving-host escape hatch is included.

## Validation

- native codec and subscription-manager contract: 48/48
- fresh NAPI registered-layout integration: 1/1
- fresh-WASM `alpha-public-flow-gate`: 12/12
- Rust flat/explicit/nested collector carrier regressions
- NAPI and WASM layout serialization checks
- planted wrong-carrier, sparse-wrapper, reordered-slot, unknown-ID, and ID-redefinition failures
- `cargo check -p jazz-napi -p jazz-wasm`
- TypeScript runtime build and typecheck
- full artifact build
- formatting, lint, clippy, rustfmt, diff, and sensitive-data checks
- independent adversarial review: no P0/P1/P2 findings

Known friction: artifact provenance includes Git HEAD, so even a TypeScript-only amendment requires rebuilding both NAPI and WASM before claiming fresh cross-language evidence; release WASM optimization took approximately four minutes in this review loop.
