### PR TITLE
fix(jazz): bind terminal policy proofs to writer

### DIFF
--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -1976,9 +1976,17 @@ impl PeerState {
                     )
                 } else {
                     let previous_role = self.role;
+                    let previous_permission_identity = self.permission_identity;
                     self.role = PeerRole::ClientLink { identity: writer };
+                    // The support proof must evaluate claims as the commit's
+                    // permission subject. Trusted backend links normally use
+                    // `SYSTEM` for their served reads, so changing only the
+                    // transient client role would still bind policy claims as
+                    // `SYSTEM` here.
+                    self.permission_identity = Some(writer);
                     let update = self.rehydrate_query(node, &shape, &binding);
                     self.role = previous_role;
+                    self.permission_identity = previous_permission_identity;
                     let SyncMessage::ViewUpdate {
                         settled_through, ..
                     } = update?


### PR DESCRIPTION
🤖 Binds terminal authorization support proofs to the commit writer's permission identity while temporarily evaluating them as a writer.

Previously the proof hydration path changed `peer_role` to writer but retained `SYSTEM` as `permission_identity`. Claim-prepared policies then failed because a system policy context cannot supply identity claims. The path now overrides and restores both fields together.

Verification:
- trusted-backend upload, delete, and claim-backed upload pass;
- terminal insert/update/delete proof coverage passes;
- session identity and forged-author rejection coverage passes;
- planting the prior `SYSTEM` identity reproduces `claim prepared params require an identity policy context`;
- clippy, rustfmt, and sensitive-data hooks pass;
- independent adversarial security review found no cross-user proof-cache or identity-restoration issue.

Several separate tests still expect synchronous local client rejection. Current INV-API-14/28 semantics intentionally stage Local writes optimistically and reject them at the authority; that test debt is not changed here.
