### PR TITLE
fix(jazz): preserve whole rows across catalogue lenses

### DIFF
--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -1482,6 +1482,11 @@ where
             updates.extend(self.cascade_rejections_from(tx.tx_id)?);
             return Ok(updates);
         }
+        if commit_unit_write_count_matches(&tx, versions.len())
+            && let Some(reason) = self.malformed_authored_version_reason(&versions)
+        {
+            return self.reject_malformed_commit(tx, reason);
+        }
         self.prepare_branch_target_partitions_if_ready(&tx, &versions)?;
         let mut updates = self.ingest_commit_unit_once(tx, versions, now_ms, ingest_context)?;
         updates.extend(self.drain_parked_commit_units()?);
@@ -1502,6 +1507,12 @@ where
     where
         S: ReopenableStorage,
     {
+        if commit_unit_limit_violation(&versions).is_none()
+            && commit_unit_write_count_matches(&tx, versions.len())
+            && let Some(reason) = self.malformed_authored_version_reason(&versions)
+        {
+            return self.reject_malformed_commit(tx, reason);
+        }
         if commit_unit_limit_violation(&versions).is_none()
             && commit_unit_write_count_matches(&tx, versions.len())
         {
@@ -1525,6 +1536,12 @@ where
     where
         S: ReopenableStorage,
     {
+        if commit_unit_limit_violation(&versions).is_none()
+            && commit_unit_write_count_matches(&tx, versions.len())
+            && let Some(reason) = self.malformed_authored_version_reason(&versions)
+        {
+            return self.reject_malformed_commit(tx, reason);
+        }
         if commit_unit_limit_violation(&versions).is_none()
             && commit_unit_write_count_matches(&tx, versions.len())
         {
@@ -1691,6 +1708,9 @@ where
             updates.extend(self.cascade_rejections_from(tx.tx_id)?);
             return Ok(updates);
         }
+        if let Some(reason) = self.malformed_authored_version_reason(&versions) {
+            return self.reject_malformed_commit(tx, reason);
+        }
         if let Some(existing) = self.query_transaction(tx.tx_id)? {
             let mut existing_versions = self
                 .query_versions_for_tx(tx.tx_id)?
@@ -1846,6 +1866,9 @@ where
         {
             return Err(Error::UnsupportedCommitUnit("malformed relay commit unit"));
         }
+        if self.malformed_authored_version_reason(&versions).is_some() {
+            return Err(Error::UnsupportedCommitUnit("malformed relay commit unit"));
+        }
         self.prepare_branch_target_partitions_if_ready(&tx, &versions)?;
         self.ingest_relay_commit_unit_once(tx, versions)?;
         self.drain_parked_relay_commit_units()?;
@@ -1953,6 +1976,9 @@ where
             }];
             updates.extend(self.cascade_rejections_from(tx.tx_id)?);
             return Ok(updates);
+        }
+        if let Some(reason) = self.malformed_authored_version_reason(&versions) {
+            return self.reject_malformed_commit(tx, reason);
         }
         if let Some(existing) = self.query_transaction(tx.tx_id)? {
             if tx.kind == TxKind::Exclusive || matches!(existing.fate, Fate::Rejected(_)) {
@@ -2171,6 +2197,9 @@ where
             updates.extend(self.cascade_rejections_from(tx.tx_id)?);
             return Ok(updates);
         }
+        if let Some(reason) = self.malformed_authored_version_reason(&versions) {
+            return self.reject_malformed_commit(tx, reason);
+        }
         if let Some(existing) = self.query_transaction(tx.tx_id)? {
             let mut existing_versions = self
                 .query_versions_for_tx(tx.tx_id)?
@@ -2363,8 +2392,13 @@ where
             global_seq.is_none() || durability == DurabilityTier::Global,
             "a global sequence requires Global durability"
         );
-        self.merge_tx_time(tx.tx_id.time);
         let versions = canonical_versions(versions);
+        // This is entered by the batched ViewUpdate path, which has no
+        // authority role and therefore cannot synthesize a fate. The caller
+        // validates its entire frame before staging, and this is the central
+        // storage-ingress backstop for other direct callers.
+        self.validate_view_payload_versions(&versions)?;
+        self.merge_tx_time(tx.tx_id.time);
         if self.query_transaction(tx.tx_id)?.is_some() {
             return self.ingest_known_transaction(tx, versions, fate, global_seq, durability);
         }
@@ -3316,12 +3350,23 @@ where
                 break;
             }
             for tx_id in ready {
-                if let Some(unit) = self.parking.parked_commit_units.get(&tx_id).cloned() {
-                    self.prepare_branch_target_partitions_if_ready(&unit.tx, &unit.versions)?;
-                }
                 let Some(unit) = self.parking.parked_commit_units.remove(&tx_id) else {
                     continue;
                 };
+                // A relay has no fate authority. Once its deferred schema is
+                // known, an incomplete row record has a terminal local
+                // disposition: discard it without writing a synthetic rejected
+                // transaction or failing the catalogue publication that made
+                // the violation observable.
+                if self
+                    .malformed_authored_version_reason(&unit.versions)
+                    .is_some()
+                {
+                    self.parking.parked_catalogue_commit_units.remove(&tx_id);
+                    self.sync_metrics.dropped_malformed_relay_commit_units += 1;
+                    continue;
+                }
+                self.prepare_branch_target_partitions_if_ready(&unit.tx, &unit.versions)?;
                 self.sync_metrics.parked_orphans_resolved += 1;
                 if self.parking.parked_catalogue_commit_units.remove(&tx_id) {
                     self.sync_metrics.parked_catalogue_orphans_resolved += 1;
@@ -5727,6 +5772,91 @@ where
         Ok((source, table.to_owned()))
     }
 
+    /// A wire row version is a complete row under the schema id it declares.
+    /// An unknown schema cannot be checked until its catalogue value arrives,
+    /// but a known schema must never accept a descriptor borrowed from another
+    /// version: that would make the omitted trailing columns indistinguishable
+    /// from an authored value and reintroduce partial-row sync semantics.
+    fn malformed_authored_version_reason(&self, versions: &[VersionRecord]) -> Option<String> {
+        for version in versions {
+            let Some(schema) = self
+                .catalogue
+                .catalogue_schemas
+                .get(&version.schema_version())
+            else {
+                continue;
+            };
+            let Some(table) = schema
+                .schema
+                .tables
+                .iter()
+                .find(|table| table.name == version.table())
+            else {
+                return Some(format!(
+                    "row version table '{}' is absent from its authored schema",
+                    version.table()
+                ));
+            };
+            if version.record().descriptor() != &table.wire_record_descriptor() {
+                return Some(format!(
+                    "row version for table '{}' does not carry the complete descriptor of its authored schema",
+                    version.table()
+                ));
+            }
+        }
+        None
+    }
+
+    /// Validate row versions carried by a view or repair payload before that
+    /// payload may advance local receiver state. View payloads cannot park for
+    /// a missing catalogue entry: unlike an authored commit unit, they have no
+    /// protocol disposition that can defer a partial application of the frame.
+    pub(super) fn validate_view_payload_versions(
+        &self,
+        versions: &[VersionRecord],
+    ) -> Result<(), Error> {
+        for version in versions {
+            let schema = self
+                .catalogue
+                .catalogue_schemas
+                .get(&version.schema_version())
+                .ok_or(Error::MalformedViewUpdate(
+                    "row version names an unknown authored schema",
+                ))?;
+            let table = schema
+                .schema
+                .tables
+                .iter()
+                .find(|table| table.name == version.table())
+                .ok_or(Error::MalformedViewUpdate(
+                    "row version table is absent from its authored schema",
+                ))?;
+            if version.record().descriptor() != &table.wire_record_descriptor() {
+                return Err(Error::MalformedViewUpdate(
+                    "row version does not carry the complete descriptor of its authored schema",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn reject_malformed_commit(
+        &mut self,
+        tx: Transaction,
+        reason: String,
+    ) -> Result<Vec<SyncMessage>, Error> {
+        let fate = Fate::Rejected(RejectionReason::MalformedCommit(reason));
+        self.ingest_rejected_transaction(tx.clone(), fate.clone())?;
+        let mut updates = vec![SyncMessage::FateUpdate {
+            tx_id: tx.tx_id,
+            fate,
+            global_seq: None,
+            durability: None,
+        }];
+        updates.extend(self.cascade_rejections_from(tx.tx_id)?);
+        Ok(updates)
+    }
+
     /// Ensure every known authored schema named by an arriving commit has a
     /// local alias and registered shared-storage variant. Unknown schemas stay
     /// parked until their catalogue lineage arrives and re-enters this path.
@@ -5734,6 +5864,11 @@ where
         &mut self,
         versions: &[VersionRecord],
     ) -> Result<(), Error> {
+        if self.malformed_authored_version_reason(versions).is_some() {
+            return Err(Error::InvalidStoredValue(
+                "wire version record does not match authored schema",
+            ));
+        }
         if versions.iter().any(|version| {
             !self
                 .catalogue

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -5678,6 +5678,7 @@ where
             if versions.is_empty() {
                 continue;
             }
+            self.validate_view_payload_versions(&versions)?;
             self.ingest_known_transaction(
                 bundle.tx,
                 versions,
@@ -6311,6 +6312,11 @@ pub struct SyncMetrics {
     pub parked_catalogue_orphans: u64,
     /// Catalogue-orphan commit units later resolved.
     pub parked_catalogue_orphans_resolved: u64,
+    /// Relay-only commit units discarded after an unknown authored schema became
+    /// known and proved their row record incomplete for that schema. A relay
+    /// cannot assign a fate, so these are deliberately dropped rather than
+    /// stored as a synthetic rejected transaction.
+    pub dropped_malformed_relay_commit_units: u64,
     /// Shape registrations parked because their schema version was missing.
     pub parked_catalogue_shapes: u64,
     /// Parked shape registrations later resolved by catalogue arrival.

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -4956,6 +4956,15 @@ where
                     nested_payload,
                 )?;
             }
+            // Registry entries belong to a live physical column.  Leaving an
+            // entry behind for a dropped column makes otherwise identical
+            // cross-lens mappings compare unequal solely because one path had
+            // an intermediate column epoch.
+            let live_columns = columns.values().copied().collect::<BTreeSet<_>>();
+            scalar_enum_cases.retain(|column, _| live_columns.contains(column));
+            payload_enum_cases.retain(|column, _| live_columns.contains(column));
+            nested_scalar_enum_cases.retain(|column, _| live_columns.contains(column));
+            nested_payload_enum_cases.retain(|column, _| live_columns.contains(column));
             target_mapping.tables.insert(
                 table_lens.target_table.clone(),
                 TablePhysicalMapping {

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -757,6 +757,7 @@ struct ReadPolicyAuthorizationRequestCacheKey {
     tier: DurabilityTier,
     binding_source_shape: Option<String>,
     binding_user_params: String,
+    binding_claim_params: String,
     include_deleted_root: bool,
 }
 

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -52,6 +52,164 @@ pub(super) struct TablePhysicalMapping {
         BTreeMap<PhysicalColumnId, BTreeMap<String, Vec<GlobalScalarEnumCaseId>>>,
 }
 
+/// A source cell while lowering a migration-lens path into a physical current
+/// winner projection.  The symbolic field survives rename/copy chains until
+/// the projection is registered, whereas literal defaults are materialized at
+/// that projection boundary.
+#[derive(Clone)]
+enum CurrentWinnerCellProjection {
+    Field {
+        name: String,
+        column_id: PhysicalColumnId,
+        column_type: records::ValueType,
+    },
+    Literal(Value),
+    Null,
+}
+
+fn physical_mapping_has_enum_boundary(
+    mapping: &TablePhysicalMapping,
+    column_id: PhysicalColumnId,
+) -> bool {
+    mapping.scalar_enum_cases.contains_key(&column_id)
+        || mapping.payload_enum_cases.contains_key(&column_id)
+        || mapping
+            .nested_scalar_enum_cases
+            .get(&column_id)
+            .is_some_and(|paths| !paths.is_empty())
+        || mapping
+            .nested_payload_enum_cases
+            .get(&column_id)
+            .is_some_and(|paths| !paths.is_empty())
+}
+
+fn value_type_has_enum_boundary(value_type: &records::ValueType) -> bool {
+    use records::ValueType;
+    match value_type {
+        ValueType::EnumTag(_) | ValueType::Enum(_) => true,
+        ValueType::Nullable(inner) | ValueType::Array(inner) => value_type_has_enum_boundary(inner),
+        ValueType::Tuple(values) => values.iter().any(value_type_has_enum_boundary),
+        ValueType::Record(record) => record
+            .fields()
+            .iter()
+            .any(|field| value_type_has_enum_boundary(&field.value_type)),
+        _ => false,
+    }
+}
+
+/// Bootstrap mappings have no durable per-column registry entries yet. Their
+/// physical tags still follow the validated authored layout, so initialize the
+/// same recursive copy plan by ordinal and let durable mappings replace each
+/// occurrence as soon as they are available.
+fn bootstrap_copy_enum_remaps(
+    source: &records::ValueType,
+    target: &records::ValueType,
+    path: &str,
+    remaps: &mut EnumOccurrenceRemaps,
+) -> Result<(), Error> {
+    use records::ValueType;
+    match (source, target) {
+        (ValueType::EnumTag(source), ValueType::EnumTag(target)) => {
+            remaps.scalar.entry(path.to_owned()).or_insert(
+                source
+                    .variants
+                    .iter()
+                    .enumerate()
+                    .map(|(ordinal, _)| {
+                        target
+                            .variants
+                            .get(ordinal)
+                            .map(|_| {
+                                u8::try_from(ordinal).map_err(|_| {
+                                    Error::InvalidStoredValue(
+                                        "bootstrap copied scalar enum tag exhausted",
+                                    )
+                                })
+                            })
+                            .transpose()
+                    })
+                    .collect::<Result<_, _>>()?,
+            );
+        }
+        (ValueType::Enum(source), ValueType::Enum(target)) => {
+            remaps.payload.entry(path.to_owned()).or_insert(
+                source
+                    .cases
+                    .iter()
+                    .enumerate()
+                    .map(|(ordinal, _)| {
+                        target
+                            .cases
+                            .get(ordinal)
+                            .map(|_| {
+                                u32::try_from(ordinal).map_err(|_| {
+                                    Error::InvalidStoredValue(
+                                        "bootstrap copied payload enum tag exhausted",
+                                    )
+                                })
+                            })
+                            .transpose()
+                    })
+                    .collect::<Result<_, _>>()?,
+            );
+            remaps.payload_children.entry(path.to_owned()).or_insert(
+                source
+                    .cases
+                    .iter()
+                    .enumerate()
+                    .map(|(ordinal, _)| {
+                        target
+                            .cases
+                            .get(ordinal)
+                            .map(|_| format!("{path}/case/bootstrap/{ordinal}"))
+                    })
+                    .collect(),
+            );
+            for (ordinal, (source_case, target_case)) in
+                source.cases.iter().zip(&target.cases).enumerate()
+            {
+                bootstrap_copy_enum_remaps(
+                    &ValueType::Record(Box::new(source_case.payload.clone())),
+                    &ValueType::Record(Box::new(target_case.payload.clone())),
+                    &format!("{path}/case/bootstrap/{ordinal}"),
+                    remaps,
+                )?;
+            }
+        }
+        (ValueType::Nullable(source), ValueType::Nullable(target)) => {
+            bootstrap_copy_enum_remaps(source, target, &format!("{path}/nullable"), remaps)?;
+        }
+        (ValueType::Array(source), ValueType::Array(target)) => {
+            bootstrap_copy_enum_remaps(source, target, &format!("{path}/array"), remaps)?;
+        }
+        (ValueType::Tuple(source), ValueType::Tuple(target)) => {
+            for (index, (source, target)) in source.iter().zip(target).enumerate() {
+                bootstrap_copy_enum_remaps(
+                    source,
+                    target,
+                    &format!("{path}/tuple/{index}"),
+                    remaps,
+                )?;
+            }
+        }
+        (ValueType::Record(source), ValueType::Record(target)) => {
+            for (source, target) in source.fields().iter().zip(target.fields()) {
+                let name = source.name.as_deref().ok_or(Error::InvalidStoredValue(
+                    "bootstrap copied enum record field unnamed",
+                ))?;
+                bootstrap_copy_enum_remaps(
+                    &source.value_type,
+                    &target.value_type,
+                    &format!("{path}/record/{name}"),
+                    remaps,
+                )?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
 pub(super) struct GlobalScalarEnumCaseId {
     pub(super) introducing_schema: SchemaVersionId,
@@ -969,6 +1127,209 @@ where
         Ok(remaps)
     }
 
+    /// Re-encode a source physical enum occurrence into a distinct copied
+    /// column's physical registry. Copying an enum's raw tag is invalid: each
+    /// physical column owns an independent durable registry, even when the
+    /// authored enum layouts are identical. The lens validates compatible
+    /// layouts, so ordinal correspondence is the authored copy relation while
+    /// this remap translates both sides' physical tags and nested payload
+    /// paths.
+    fn physical_copy_enum_remaps(
+        &self,
+        source_mapping: &TablePhysicalMapping,
+        source_column_id: PhysicalColumnId,
+        target_mapping: &TablePhysicalMapping,
+        target_column_id: PhysicalColumnId,
+        source_column_type: &records::ValueType,
+        target_column_type: &records::ValueType,
+    ) -> Result<EnumOccurrenceRemaps, Error> {
+        let mut remaps = EnumOccurrenceRemaps::default();
+        if let Some(source_cases) = source_mapping.scalar_enum_cases.get(&source_column_id) {
+            let source_cases = self
+                .physical_scalar_enum_cases(source_mapping.table_id, source_column_id)
+                .unwrap_or_else(|_| source_cases.clone());
+            let target_cases = target_mapping
+                .scalar_enum_cases
+                .get(&target_column_id)
+                .map(|fallback| {
+                    self.physical_scalar_enum_cases(target_mapping.table_id, target_column_id)
+                        .unwrap_or_else(|_| fallback.clone())
+                })
+                .unwrap_or_default();
+            remaps.scalar.insert(
+                "root".to_owned(),
+                source_cases
+                    .iter()
+                    .enumerate()
+                    .map(|(ordinal, _)| {
+                        target_cases
+                            .get(ordinal)
+                            .map(|_| {
+                                u8::try_from(ordinal).map_err(|_| {
+                                    Error::InvalidStoredValue("copied scalar enum tag exhausted")
+                                })
+                            })
+                            .transpose()
+                    })
+                    .collect::<Result<_, _>>()?,
+            );
+        }
+        if let Some(source_cases) = source_mapping.payload_enum_cases.get(&source_column_id) {
+            let source_cases = self
+                .physical_payload_enum_cases(source_mapping.table_id, source_column_id)
+                .unwrap_or_else(|_| source_cases.clone());
+            let target_cases = target_mapping
+                .payload_enum_cases
+                .get(&target_column_id)
+                .map(|fallback| {
+                    self.physical_payload_enum_cases(target_mapping.table_id, target_column_id)
+                        .unwrap_or_else(|_| fallback.clone())
+                })
+                .unwrap_or_default();
+            remaps.payload.insert(
+                "root".to_owned(),
+                source_cases
+                    .iter()
+                    .enumerate()
+                    .map(|(ordinal, _)| {
+                        target_cases
+                            .get(ordinal)
+                            .map(|_| {
+                                u32::try_from(ordinal).map_err(|_| {
+                                    Error::InvalidStoredValue("copied payload enum tag exhausted")
+                                })
+                            })
+                            .transpose()
+                    })
+                    .collect::<Result<_, _>>()?,
+            );
+            remaps.payload_children.insert(
+                "root".to_owned(),
+                source_cases
+                    .iter()
+                    .enumerate()
+                    .map(|(ordinal, _)| {
+                        target_cases
+                            .get(ordinal)
+                            .map(|identity| global_case_path("root", identity))
+                    })
+                    .collect(),
+            );
+        }
+        if let Some(source_paths) = source_mapping
+            .nested_scalar_enum_cases
+            .get(&source_column_id)
+        {
+            for (path, source_cases) in source_paths {
+                if source_cases.is_empty() {
+                    continue;
+                }
+                let source_cases = self
+                    .physical_nested_scalar_enum_cases(
+                        source_mapping.table_id,
+                        source_column_id,
+                        path,
+                    )
+                    .unwrap_or_else(|_| source_cases.clone());
+                let target_cases = target_mapping
+                    .nested_scalar_enum_cases
+                    .get(&target_column_id)
+                    .and_then(|paths| paths.get(path))
+                    .map(|fallback| {
+                        self.physical_nested_scalar_enum_cases(
+                            target_mapping.table_id,
+                            target_column_id,
+                            path,
+                        )
+                        .unwrap_or_else(|_| fallback.clone())
+                    })
+                    .unwrap_or_default();
+                remaps.scalar.insert(
+                    path.clone(),
+                    source_cases
+                        .iter()
+                        .enumerate()
+                        .map(|(ordinal, _)| {
+                            target_cases
+                                .get(ordinal)
+                                .map(|_| {
+                                    u8::try_from(ordinal).map_err(|_| {
+                                        Error::InvalidStoredValue(
+                                            "copied nested scalar enum tag exhausted",
+                                        )
+                                    })
+                                })
+                                .transpose()
+                        })
+                        .collect::<Result<_, _>>()?,
+                );
+            }
+        }
+        if let Some(source_paths) = source_mapping
+            .nested_payload_enum_cases
+            .get(&source_column_id)
+        {
+            for (path, source_cases) in source_paths {
+                if source_cases.is_empty() {
+                    continue;
+                }
+                let source_cases = self
+                    .physical_nested_payload_enum_cases(
+                        source_mapping.table_id,
+                        source_column_id,
+                        path,
+                    )
+                    .unwrap_or_else(|_| source_cases.clone());
+                let target_cases = target_mapping
+                    .nested_payload_enum_cases
+                    .get(&target_column_id)
+                    .and_then(|paths| paths.get(path))
+                    .map(|fallback| {
+                        self.physical_nested_payload_enum_cases(
+                            target_mapping.table_id,
+                            target_column_id,
+                            path,
+                        )
+                        .unwrap_or_else(|_| fallback.clone())
+                    })
+                    .unwrap_or_default();
+                remaps.payload.insert(
+                    path.clone(),
+                    source_cases
+                        .iter()
+                        .enumerate()
+                        .map(|(ordinal, _)| {
+                            target_cases
+                                .get(ordinal)
+                                .map(|_| {
+                                    u32::try_from(ordinal).map_err(|_| {
+                                        Error::InvalidStoredValue(
+                                            "copied nested payload enum tag exhausted",
+                                        )
+                                    })
+                                })
+                                .transpose()
+                        })
+                        .collect::<Result<_, _>>()?,
+                );
+                remaps.payload_children.insert(
+                    path.clone(),
+                    source_cases
+                        .iter()
+                        .enumerate()
+                        .map(|(ordinal, _)| {
+                            target_cases
+                                .get(ordinal)
+                                .map(|identity| global_case_path(path, identity))
+                        })
+                        .collect(),
+                );
+            }
+        }
+        bootstrap_copy_enum_remaps(source_column_type, target_column_type, "root", &mut remaps)?;
+        Ok(remaps)
+    }
+
     pub(super) fn physical_table_id_for_schema(
         &self,
         schema_version: SchemaVersionId,
@@ -1608,6 +1969,12 @@ where
                 .ok_or(Error::InvalidStoredValue(
                     "physical current winner source schema alias missing",
                 ))?;
+            let source_table = self.table_in_schema(&source_table_name, source_schema)?;
+            let target_columns_by_physical_field = target_mapping
+                .columns
+                .iter()
+                .map(|(column, id)| (physical_user_column_field(*id), column.clone()))
+                .collect::<BTreeMap<_, _>>();
             let cases = if source_mapping.variant_cases.is_empty() {
                 vec![(groove_variant_tag(source_alias)?, None)]
             } else {
@@ -1618,92 +1985,124 @@ where
                     .collect()
             };
             for (tag, present) in cases {
+                let available =
+                    physical_current_field_names_for_case(&source_table, &source_mapping, present)?
+                        .into_iter()
+                        .collect::<BTreeSet<_>>();
                 for storage_table in &storage_tables {
-                    match self.physical_current_winner_projection_case(
-                        source_schema,
-                        &source_table_name,
-                        &source_mapping,
-                        target_schema,
-                        target_table_name,
-                        &target_mapping,
-                        output,
-                        present,
-                    )? {
-                        Some(fields) => self.database.refresh_variant_case_for_registry_evolution(
-                            storage_table,
-                            &projection_target,
-                            tag,
-                            fields,
-                        )?,
-                        None => self.database.register_variant_ignore_case(
-                            storage_table,
-                            &projection_target,
-                            tag,
-                        )?,
-                    }
+                    let fields = output
+                        .fields()
+                        .iter()
+                        .map(|field| {
+                            let name = field.name.clone().ok_or(Error::InvalidStoredValue(
+                                "physical current winner field unnamed",
+                            ))?;
+                            if available.contains(&name) {
+                                Ok(ProjectField::named(name))
+                            } else if let Some(column) = target_columns_by_physical_field.get(&name)
+                            {
+                                // Only mapped user columns can be absent because
+                                // of a lens. Witness and system fields must remain
+                                // raw physical fields. The resulting field may be
+                                // an Add default or a value carried through a
+                                // Rename/Copy chain from the source variant.
+                                Ok(self
+                                    .lens_projection_for_missing_current_field(
+                                        source_schema,
+                                        &source_table_name,
+                                        &source_mapping,
+                                        &available,
+                                        target_schema,
+                                        target_table_name,
+                                        &target_mapping,
+                                        column,
+                                        name.clone(),
+                                        field.value_type.clone(),
+                                    )?
+                                    .unwrap_or_else(|| {
+                                        ProjectField::literal_typed(
+                                            name,
+                                            Value::Nullable(None),
+                                            field.value_type.clone(),
+                                        )
+                                    }))
+                            } else if matches!(field.value_type, records::ValueType::Nullable(_)) {
+                                Ok(ProjectField::literal_typed(
+                                    name,
+                                    Value::Nullable(None),
+                                    field.value_type.clone(),
+                                ))
+                            } else {
+                                Err(Error::InvalidStoredValue(
+                                    "physical current winner source misses required field",
+                                ))
+                            }
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    self.database.refresh_variant_case_for_registry_evolution(
+                        storage_table,
+                        &projection_target,
+                        tag,
+                        fields,
+                    )?;
                 }
             }
         }
         Ok((projection_target, output_fields.unwrap_or_default()))
     }
 
-    /// Map one authored physical row into the shared winner layout.  This is
-    /// deliberately *not* the authored read boundary: enum cells remain in
-    /// their physical representation until after `arg_max_by` has selected
-    /// the Global/Ahead winner.  Ordinary lens operations do belong here,
-    /// though.  In particular an old authored row must acquire an `AddColumn`
-    /// default before the later target-layout projection decodes it.
-    fn physical_current_winner_projection_case(
+    /// Resolve a missing target user field through the migration path before
+    /// the Global/Ahead arg-max. This deliberately yields a projection field,
+    /// not only a literal: `CopyColumn` chains must read their actual source
+    /// physical field while the winner still has its source variant layout.
+    fn lens_projection_for_missing_current_field(
         &mut self,
         source_schema: SchemaVersionId,
         source_table_name: &str,
         source_mapping: &TablePhysicalMapping,
+        available: &BTreeSet<String>,
         target_schema: SchemaVersionId,
         target_table_name: &str,
         target_mapping: &TablePhysicalMapping,
-        output: records::RecordDescriptor,
-        present: Option<&BTreeSet<String>>,
-    ) -> Result<Option<Vec<ProjectField>>, Error> {
-        #[derive(Clone)]
-        enum CellProjection {
-            Field(String),
-            Literal(Value),
-        }
-
+        target_column: &str,
+        output_name: String,
+        output_type: records::ValueType,
+    ) -> Result<Option<ProjectField>, Error> {
         let source_table = self.table_in_schema(source_table_name, source_schema)?;
-        let target_table = self.table_in_schema(target_table_name, target_schema)?;
         let mut cells = source_table
             .columns
             .iter()
-            .filter(|column| present.is_none_or(|present| present.contains(&column.name)))
             .map(|column| {
-                let column_id = source_mapping.columns.get(&column.name).copied().ok_or(
-                    Error::InvalidStoredValue("physical winner source column mapping missing"),
-                )?;
-                Ok((
-                    column.name.clone(),
-                    CellProjection::Field(physical_user_column_field(column_id)),
-                ))
+                let projection = source_mapping
+                    .columns
+                    .get(&column.name)
+                    .and_then(|column_id| {
+                        let name = physical_user_column_field(*column_id);
+                        available
+                            .contains(&name)
+                            .then_some(CurrentWinnerCellProjection::Field {
+                                name,
+                                column_id: *column_id,
+                                column_type: column.column_type.clone(),
+                            })
+                    })
+                    .unwrap_or(CurrentWinnerCellProjection::Null);
+                (column.name.clone(), projection)
             })
-            .collect::<Result<BTreeMap<_, _>, Error>>()?;
-
-        if source_schema != target_schema || source_table_name != target_table_name {
-            let mut path = None;
-            for direction in [LensPathDirection::Forward, LensPathDirection::Reverse] {
-                if let Some(candidate) = self.compiled_lens_path(
-                    source_schema,
-                    target_schema,
-                    direction,
-                    source_table_name,
-                )? && candidate.target_table == target_table_name
-                {
-                    path = Some(candidate);
-                    break;
-                }
-            }
-            let Some(path) = path else {
-                return Ok(None);
+            .collect::<BTreeMap<_, _>>();
+        for direction in [LensPathDirection::Forward, LensPathDirection::Reverse] {
+            let Some(path) = self.compiled_lens_path(
+                source_schema,
+                target_schema,
+                direction,
+                source_table_name,
+            )?
+            else {
+                continue;
             };
+            if path.target_table != target_table_name {
+                continue;
+            }
             for op in path.ops {
                 match op {
                     CompiledLensOp::Rename { from, to } => {
@@ -1719,82 +2118,75 @@ where
                     CompiledLensOp::Add { column, default } => {
                         cells
                             .entry(column)
-                            .or_insert(CellProjection::Literal(default));
+                            .or_insert(CurrentWinnerCellProjection::Literal(default));
                     }
                     CompiledLensOp::Drop { column } => {
                         cells.remove(&column);
                     }
                 }
             }
-        }
-
-        let mut fields = output
-            .fields()
-            .iter()
-            .take(GlobalCurrentRowRecord::USER_CELLS)
-            .map(|field| {
-                field
-                    .name
-                    .clone()
-                    .map(ProjectField::named)
-                    .ok_or(Error::InvalidStoredValue(
-                        "physical current winner system field unnamed",
-                    ))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        for column in &target_table.columns {
-            let output_name = physical_user_column_field(
-                target_mapping.columns.get(&column.name).copied().ok_or(
-                    Error::InvalidStoredValue("physical winner target column mapping missing"),
-                )?,
-            );
-            let output_type = output
-                .field_index(&output_name)
-                .and_then(|index| output.fields().get(index))
-                .map(|field| field.value_type.clone())
-                .ok_or(Error::InvalidStoredValue(
-                    "physical winner target output field missing",
-                ))?;
-            match cells.remove(&column.name) {
-                Some(CellProjection::Field(source)) => {
-                    fields.push(ProjectField::renamed(source, output_name));
-                }
-                Some(CellProjection::Literal(Value::Nullable(None))) | None
-                    if present.is_some() =>
-                {
-                    fields.push(ProjectField::literal_typed(
-                        output_name,
-                        Value::Nullable(None),
-                        output_type,
-                    ));
-                }
-                Some(CellProjection::Literal(value)) => {
-                    fields.push(ProjectField::literal_typed(
-                        output_name,
-                        Value::Nullable(Some(Box::new(value))),
-                        output_type,
-                    ));
-                }
-                None => return Ok(None),
-            }
-        }
-        fields.extend(
-            output
-                .fields()
-                .iter()
-                .skip(GlobalCurrentRowRecord::USER_CELLS + target_table.columns.len())
-                .map(|field| {
-                    field
-                        .name
-                        .clone()
-                        .map(ProjectField::named)
+            return Ok(match cells.remove(target_column) {
+                Some(CurrentWinnerCellProjection::Field {
+                    name: source,
+                    column_id: source_column_id,
+                    column_type: source_column_type,
+                }) => {
+                    let target_column_id =
+                        target_mapping.columns.get(target_column).copied().ok_or(
+                            Error::InvalidStoredValue(
+                                "target current winner column mapping missing",
+                            ),
+                        )?;
+                    let target_column_type = self
+                        .table_in_schema(target_table_name, target_schema)?
+                        .columns
+                        .iter()
+                        .find(|column| column.name == target_column)
+                        .map(|column| column.column_type.clone())
                         .ok_or(Error::InvalidStoredValue(
-                            "physical current winner trailing field unnamed",
+                            "target current winner column schema missing",
+                        ))?;
+                    if source_column_id == target_column_id
+                        || !physical_mapping_has_enum_boundary(source_mapping, source_column_id)
+                            && !physical_mapping_has_enum_boundary(target_mapping, target_column_id)
+                            && !value_type_has_enum_boundary(&source_column_type)
+                            && !value_type_has_enum_boundary(&target_column_type)
+                    {
+                        Some(ProjectField::renamed(source, output_name))
+                    } else {
+                        Some(ProjectField::recursive_enum_remap(
+                            source,
+                            output_name,
+                            output_type,
+                            self.physical_copy_enum_remaps(
+                                source_mapping,
+                                source_column_id,
+                                target_mapping,
+                                target_column_id,
+                                &source_column_type,
+                                &target_column_type,
+                            )?,
                         ))
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-        );
-        Ok(Some(fields))
+                    }
+                }
+                Some(CurrentWinnerCellProjection::Literal(default)) => {
+                    let default = if matches!(output_type, records::ValueType::Nullable(_))
+                        && !matches!(default, Value::Nullable(_))
+                    {
+                        Value::Nullable(Some(Box::new(default)))
+                    } else {
+                        default
+                    };
+                    Some(ProjectField::literal_typed(
+                        output_name,
+                        default,
+                        output_type,
+                    ))
+                }
+                Some(CurrentWinnerCellProjection::Null) | None => None,
+            });
+        }
+        Ok(None)
     }
 
     /// Build the logical query-local projection placed after physical current

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -3762,6 +3762,24 @@ fn lower_value_source(
     }
 }
 
+#[cfg(test)]
+pub(super) fn binding_value_source_projection_fields_for_test(
+    request: &QueryProgramRequest,
+    columns: &[ValueSourceColumn],
+) -> Result<BTreeSet<String>, UnsupportedReason> {
+    let graph = lower_value_source(
+        "test-binding-source",
+        columns,
+        &ValueSourceMode::Binding,
+        request,
+    )?;
+    graph_declared_output_fields(&graph).ok_or_else(|| {
+        UnsupportedReason::Runtime(
+            "binding value-source projection must have a named descriptor".to_owned(),
+        )
+    })
+}
+
 fn lower_value_source_column(
     column: &ValueSourceColumn,
     request: &QueryProgramRequest,

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -5319,6 +5319,18 @@ fn lowered_terminals(
         &root_route_fields,
         &closure_root_carrier_fields,
     )?;
+    // Correlated include paths can preserve routes in the graph while their
+    // conservative root field set omits them. Use the graph's declared output
+    // after closure lowering when choosing the fields retained by maintained
+    // result-membership facts.
+    let root_route_fields = graph_declared_output_fields(&closure.visible_root)
+        .map(|fields| {
+            routing_param_fields
+                .intersection(&fields)
+                .cloned()
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or(root_route_fields);
     let visible_root_with_routes = if root_route_fields.is_empty() {
         closure.visible_root.clone()
     } else {

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -354,6 +354,7 @@ fn source_authorization_for_source(
                 protected_row_field: "row_uuid".to_owned(),
                 binding_source_shape: request.input.binding.source_shape.clone(),
                 binding_user_params: binding_user_param_types(&request.input.binding)?,
+                binding_claim_params: request.input.binding.claim_params.clone(),
             },
         }),
         // Auxiliary closure and payload sources do not establish policy
@@ -3706,12 +3707,17 @@ fn lower_value_source(
                     (!projected.contains(&route_field))
                         .then(|| ProjectField::renamed(param.clone(), route_field))
                 })
-                .chain(domain.claim_params.keys().filter_map(|param| {
-                    source_user_params
-                        .contains(param)
-                        .then(|| (!projected.contains(param)).then(|| ProjectField::named(param)))
-                        .flatten()
-                }))
+                // A nested policy graph can consume an enclosing claim only
+                // in a sibling/ancestor branch. The shared binding descriptor
+                // nevertheless needs that slot to survive this value-source
+                // projection so downstream authorization joins can route it.
+                .chain(
+                    domain
+                        .claim_params
+                        .keys()
+                        .filter(|param| !projected.contains(*param))
+                        .map(ProjectField::named),
+                )
                 .collect::<Vec<_>>();
             Ok(
                 GraphBuilder::binding_source(shape.to_owned(), input_descriptor).project_fields(

--- a/crates/jazz/src/node/query_engine/resolver.rs
+++ b/crates/jazz/src/node/query_engine/resolver.rs
@@ -52,6 +52,11 @@ pub(crate) struct PolicyAuthorizationPlan {
     /// User params from the enclosing prepared program that must be present in
     /// the shared binding descriptor.
     pub(crate) binding_user_params: BTreeMap<String, ColumnType>,
+    /// Typed claim slots from the enclosing prepared program. Nested policy
+    /// plans share this binding descriptor, so they must retain claims used by
+    /// an ancestor policy branch as claims, rather than reclassifying them as
+    /// ordinary parameters.
+    pub(crate) binding_claim_params: BTreeMap<String, ProgramClaimParam>,
 }
 
 /// Orthogonal source row requirements derived from app output and requested

--- a/crates/jazz/src/node/query_engine/tests.rs
+++ b/crates/jazz/src/node/query_engine/tests.rs
@@ -3600,6 +3600,7 @@ fn identity_policy_context_requests_policy_filtered_sources() {
                 protected_row_field: "row_uuid".to_owned(),
                 binding_source_shape: None,
                 binding_user_params: BTreeMap::new(),
+                binding_claim_params: BTreeMap::new(),
             },
         }
     );
@@ -3691,6 +3692,7 @@ fn binding_descriptor_types_do_not_depend_on_runtime_array_values() {
                     "teams".to_owned(),
                     ColumnType::Array(Box::new(ColumnType::Uuid)),
                 )]),
+                binding_claim_params: BTreeMap::new(),
             },
         }
     );

--- a/crates/jazz/src/node/query_engine/tests.rs
+++ b/crates/jazz/src/node/query_engine/tests.rs
@@ -3699,6 +3699,52 @@ fn binding_descriptor_types_do_not_depend_on_runtime_array_values() {
 }
 
 #[test]
+fn nested_binding_value_source_keeps_sibling_nullable_claim_route() {
+    let user_id = ClaimPath(vec!["user_id".to_owned()]);
+    let join_code = ClaimPath(vec!["join_code".to_owned()]);
+    let typed_user_id = claim_param_field(&user_id);
+    let typed_join_code = claim_param_field(&join_code);
+    let mut input = row_set_input(0xc5);
+    input.binding.source_shape = Some("test-binding-source".to_owned());
+    input.binding.claim_params = BTreeMap::from([
+        (
+            typed_user_id.clone(),
+            ProgramClaimParam {
+                path: user_id.clone(),
+                ty: ColumnType::String,
+            },
+        ),
+        (
+            typed_join_code.clone(),
+            ProgramClaimParam {
+                path: join_code,
+                ty: ColumnType::String.nullable(),
+            },
+        ),
+    ]);
+    let request = QueryProgramRequest {
+        authorization_mode: QueryAuthorizationMode::TrustedServing,
+        reads: QueryReadSet::primary(current_read_view()),
+        policy: policy_context(),
+        input,
+        output: row_set_output(BTreeSet::new()),
+    };
+    let fields = binding_value_source_projection_fields_for_test(
+        &request,
+        &[ValueSourceColumn {
+            name: "userId".to_owned(),
+            value: NormalizedValueRef::Claim(user_id),
+            ty: ColumnType::String,
+        }],
+    )
+    .expect("nested binding source lowers");
+    assert!(
+        fields.contains(&typed_join_code),
+        "a user-id proof source must retain its sibling nullable join-code route"
+    );
+}
+
+#[test]
 fn built_in_sub_claim_lowers_to_permission_subject() {
     let subject = author(0xa5);
     let request = QueryProgramRequest {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1582,6 +1582,68 @@ where
         exclude_deleted: bool,
     ) -> Result<GraphBuilder, SourceResolutionError> {
         let fields = global_current_storage_fields(read_table, true, include_global_seq);
+        // Global current storage has already selected the physical winner.  Apply
+        // the ordinary lens-aware projection directly so added-column defaults
+        // survive instead of being replaced with physical nulls by the raw
+        // winner projection.  Local and Edge reads still need to choose between
+        // Global and Ahead candidates before their compatibility boundary.
+        if tier == DurabilityTier::Global {
+            let projection_target = self.current_projection_target(request, read_table)?;
+            let content = match self.access_paths.get(&request.source).cloned() {
+                Some(CurrentAccessPath::PrimaryKey(prefix)) => {
+                    self.node.query_engine_read_metrics.source_primary_key_scans += 1;
+                    self.node
+                        .physical_current_source_scan_graph_with_projection_target(
+                            self.read_view.read_schema,
+                            &request.source.table,
+                            PhysicalCurrentClass::Global,
+                            projection_target,
+                            static_scan_for_prefix(prefix, 1),
+                        )
+                        .map_err(|_| {
+                            source_resolution_error(request, SourceGap::SchemaProjection)
+                        })?
+                }
+                Some(CurrentAccessPath::Index { column, prefix }) => {
+                    self.node.query_engine_read_metrics.source_index_probes += 1;
+                    self.node
+                        .physical_global_current_source_for_index_scan(
+                            read_table,
+                            self.read_view.read_schema,
+                            &column,
+                            &prefix,
+                            &projection_target,
+                        )
+                        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
+                }
+                None => {
+                    self.node.query_engine_read_metrics.source_full_scans += 1;
+                    self.node
+                        .physical_current_source_graph_with_projection_target(
+                            self.read_view.read_schema,
+                            &request.source.table,
+                            PhysicalCurrentClass::Global,
+                            projection_target,
+                        )
+                        .map_err(|_| {
+                            source_resolution_error(request, SourceGap::SchemaProjection)
+                        })?
+                }
+            };
+            if !exclude_deleted {
+                return Ok(content.project(fields));
+            }
+            let deleted_winners = self
+                .projected_deletion_register_current_source_graph(request, tier)?
+                .filter(PredicateExpr::eq("_deletion", Value::EnumTag(0)))
+                .project(["row_uuid"]);
+            return Ok(GraphBuilder::anti_join(
+                content,
+                deleted_winners,
+                ["row_uuid"],
+                ["row_uuid"],
+            ));
+        }
         let required_fields = self.current_projection_required_fields(request, read_table);
         let (projection_target, physical_fields) = self
             .node
@@ -14613,6 +14675,11 @@ mod tests {
 
         assert!(resolver.needs_projected_current_source("users"));
         let resolved = resolver.resolve_source(&source_request).unwrap();
+        assert_eq!(
+            resolver.current_projection_targets.len(),
+            1,
+            "the Global source and its content-version sidecar share one cached projection target",
+        );
         let content_version = resolved
             .content_version
             .expect("version-payload requirements need a content-version source");

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -978,6 +978,7 @@ where
                             position,
                             plan.binding_source_shape.clone(),
                             plan.binding_user_params.clone(),
+                            plan.binding_claim_params.clone(),
                         )
                         .map_err(|_| {
                             source_resolution_error(request, SourceGap::HistoricalStorageCut)
@@ -1053,6 +1054,7 @@ where
                             *permission_subject,
                             plan.binding_source_shape.clone(),
                             plan.binding_user_params.clone(),
+                            plan.binding_claim_params.clone(),
                         )
                         .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
                     let output_fields = descriptor_field_names(&descriptor)
@@ -1153,6 +1155,7 @@ where
                                 graph_tier.expect("visible current source has a tier"),
                                 plan.binding_source_shape.clone(),
                                 plan.binding_user_params.clone(),
+                                plan.binding_claim_params.clone(),
                             )
                             .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
                         self.node
@@ -1208,6 +1211,7 @@ where
                             tier,
                             plan.binding_source_shape.clone(),
                             plan.binding_user_params.clone(),
+                            plan.binding_claim_params.clone(),
                         )
                         .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
                     let mut output_fields = current_row_fields(&table);
@@ -1256,6 +1260,7 @@ where
                             tier,
                             plan.binding_source_shape.clone(),
                             plan.binding_user_params.clone(),
+                            plan.binding_claim_params.clone(),
                         )
                         .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
                     let mut output_fields = current_row_fields(&table);
@@ -2285,6 +2290,7 @@ where
             }
             let binding_source_shape = plan.binding_source_shape.clone();
             let binding_user_params = plan.binding_user_params.clone();
+            let binding_claim_params = plan.binding_claim_params.clone();
             let param_binding_mode = if binding_source_shape.is_some() {
                 ParamBindingMode::RetainAllParams
             } else {
@@ -2298,6 +2304,7 @@ where
                 tier,
                 binding_source_shape.clone(),
                 binding_user_params.clone(),
+                binding_claim_params,
             )?;
             let output_fields = global_current_storage_fields(
                 table,
@@ -4903,6 +4910,7 @@ where
                 );
             }
             program_binding.id = binding_id_for_values(&values);
+            program_binding.values = values;
         }
         Ok(program_binding)
     }
@@ -6475,6 +6483,12 @@ where
                 &input_shape,
                 &mut binding_claim_params,
             )?;
+        }
+        // System reads bypass policy evaluation and have no session from
+        // which a prepared claim can be bound. A policy-derived claim slot
+        // must therefore never survive into their shared descriptor.
+        if matches!(policy, PolicyContext::System) {
+            binding_claim_params.clear();
         }
         let source_shape = use_prepared_binding_source
             .then(|| {
@@ -10823,6 +10837,45 @@ where
     ) -> Result<PolicyAuthorizationGraph, Error> {
         self.query_engine_read_metrics
             .policy_authorized_source_joins += 1;
+        // The protected storage source has no binding fields of its own, but
+        // the authorization proof is routed by the enclosing prepared
+        // binding. Carry that descriptor alongside the source before joining
+        // the proof so a later storage delta has every route field the proof
+        // advertises.
+        let binding_routes = policy_request
+            .input
+            .binding
+            .source_shape
+            .as_ref()
+            .map(|shape| {
+                let descriptor = RecordDescriptor::new(
+                    policy_request
+                        .input
+                        .binding
+                        .param_types
+                        .iter()
+                        .map(|(name, ty)| (name.clone(), ty.clone()))
+                        .chain(
+                            policy_request
+                                .input
+                                .binding
+                                .claim_params
+                                .iter()
+                                .map(|(name, claim)| (name.clone(), claim.ty.clone())),
+                        ),
+                );
+                (
+                    GraphBuilder::binding_source(shape.clone(), descriptor),
+                    policy_request
+                        .input
+                        .binding
+                        .param_types
+                        .keys()
+                        .chain(policy_request.input.binding.claim_params.keys())
+                        .cloned()
+                        .collect::<BTreeSet<_>>(),
+                )
+            });
         let authorized = match self.policy_authorization_row_id_graph(policy_request) {
             Ok(authorized) => authorized,
             Err(Error::QueryCapability(err)) if err.contains("PolicyProofCycle") => {
@@ -10848,15 +10901,39 @@ where
             authorization_keys.clone(),
             authorization_keys,
         );
+        let (base, binding_route_fields) =
+            match binding_routes {
+                Some((binding, route_fields)) => (
+                    GraphBuilder::join(
+                        base,
+                        binding,
+                        std::iter::empty::<String>(),
+                        std::iter::empty::<String>(),
+                    )
+                    .project_fields(
+                        output_fields
+                            .iter()
+                            .map(|field| ProjectField::renamed(left_field(field), field.clone()))
+                            .chain(route_fields.iter().map(|field| {
+                                ProjectField::renamed(right_field(field), field.clone())
+                            }))
+                            .collect::<Vec<_>>(),
+                    ),
+                    route_fields,
+                ),
+                None => (base, BTreeSet::new()),
+            };
+        let mut join_keys = vec!["row_uuid".to_owned()];
+        join_keys.extend(authorized.route_fields.iter().cloned());
         if authorized.route_fields.is_empty() {
             let fields = output_fields
                 .iter()
                 .map(|field| ProjectField::renamed(left_field(&field), field.clone()))
                 .collect::<Vec<_>>();
             return Ok(PolicyAuthorizationGraph {
-                graph: GraphBuilder::join(base, authorized_graph, ["row_uuid"], ["row_uuid"])
+                graph: GraphBuilder::join(base, authorized_graph, join_keys.clone(), join_keys)
                     .project_fields(fields),
-                route_fields: authorized.route_fields,
+                route_fields: binding_route_fields,
             });
         }
         let mut fields = output_fields
@@ -10869,10 +10946,16 @@ where
                 .iter()
                 .map(|field| ProjectField::renamed(right_field(field), field.clone())),
         );
+        fields.extend(
+            binding_route_fields
+                .iter()
+                .filter(|field| !authorized.route_fields.contains(*field))
+                .map(|field| ProjectField::renamed(left_field(field), field.clone())),
+        );
         Ok(PolicyAuthorizationGraph {
-            graph: GraphBuilder::join(base, authorized_graph, ["row_uuid"], ["row_uuid"])
+            graph: GraphBuilder::join(base, authorized_graph, join_keys.clone(), join_keys)
                 .project_fields(fields),
-            route_fields: authorized.route_fields,
+            route_fields: binding_route_fields,
         })
     }
 
@@ -10885,6 +10968,7 @@ where
         tier: DurabilityTier,
         binding_source_shape: Option<String>,
         binding_user_params: BTreeMap<String, ColumnType>,
+        binding_claim_params: BTreeMap<String, ProgramClaimParam>,
     ) -> Result<QueryProgramRequest, Error> {
         self.table_read_policy_authorization_request_with_root_visibility(
             policy_schema_version,
@@ -10894,6 +10978,7 @@ where
             tier,
             binding_source_shape,
             binding_user_params,
+            binding_claim_params,
             false,
         )
     }
@@ -10907,6 +10992,7 @@ where
         position: GlobalSeq,
         binding_source_shape: Option<String>,
         binding_user_params: BTreeMap<String, ColumnType>,
+        binding_claim_params: BTreeMap<String, ProgramClaimParam>,
     ) -> Result<QueryProgramRequest, Error> {
         let policy_schema = if policy_schema_version == self.catalogue.current_schema_version_id {
             &self.catalogue.schema
@@ -10947,7 +11033,8 @@ where
         }
         let binding = policy_shape.bind(BTreeMap::new())?;
         let mut input_shape = self.normalized_row_set_shape(&policy_shape, &binding)?;
-        let mut claim_params = binding_claim_params_for_shape(&input_shape);
+        let mut claim_params = binding_claim_params;
+        claim_params.extend(binding_claim_params_for_shape(&input_shape));
         collect_reachable_seed_claim_params(
             policy_schema,
             policy_shape.query(),
@@ -11006,6 +11093,7 @@ where
         tier: DurabilityTier,
         binding_source_shape: Option<String>,
         binding_user_params: BTreeMap<String, ColumnType>,
+        binding_claim_params: BTreeMap<String, ProgramClaimParam>,
     ) -> Result<QueryProgramRequest, Error> {
         self.table_read_policy_authorization_request_with_root_visibility(
             policy_schema_version,
@@ -11015,6 +11103,7 @@ where
             tier,
             binding_source_shape,
             binding_user_params,
+            binding_claim_params,
             true,
         )
     }
@@ -11028,6 +11117,7 @@ where
         tier: DurabilityTier,
         binding_source_shape: Option<String>,
         binding_user_params: BTreeMap<String, ColumnType>,
+        binding_claim_params: BTreeMap<String, ProgramClaimParam>,
         include_deleted_root: bool,
     ) -> Result<QueryProgramRequest, Error> {
         let cache_key = ReadPolicyAuthorizationRequestCacheKey {
@@ -11038,6 +11128,7 @@ where
             tier,
             binding_source_shape: binding_source_shape.clone(),
             binding_user_params: binding_user_params_cache_key(&binding_user_params),
+            binding_claim_params: binding_claim_params_cache_key(&binding_claim_params),
             include_deleted_root,
         };
         if let Some(request) = self
@@ -11122,7 +11213,8 @@ where
         } else {
             self.normalized_row_set_shape(&policy_shape, &binding)?
         };
-        let mut claim_params = binding_claim_params_for_shape(&input_shape);
+        let mut claim_params = binding_claim_params;
+        claim_params.extend(binding_claim_params_for_shape(&input_shape));
         claim_params.extend(declared_claim_params);
         collect_reachable_seed_claim_params(
             policy_schema,
@@ -11180,6 +11272,7 @@ where
         identity: AuthorId,
         binding_source_shape: Option<String>,
         binding_user_params: BTreeMap<String, ColumnType>,
+        binding_claim_params: BTreeMap<String, ProgramClaimParam>,
     ) -> Result<QueryProgramRequest, Error> {
         let query = authorization_query_from_read_policy(table);
         if !query.includes.is_empty() {
@@ -11203,7 +11296,8 @@ where
         }
         let binding = policy_shape.bind(BTreeMap::new())?;
         let mut input_shape = self.normalized_row_set_shape(&policy_shape, &binding)?;
-        let mut claim_params = binding_claim_params_for_shape(&input_shape);
+        let mut claim_params = binding_claim_params;
+        claim_params.extend(binding_claim_params_for_shape(&input_shape));
         collect_reachable_seed_claim_params(
             &self.catalogue.schema,
             policy_shape.query(),
@@ -12270,6 +12364,10 @@ impl ParamBindingMode {
 }
 
 fn binding_user_params_cache_key(params: &BTreeMap<String, ColumnType>) -> String {
+    format!("{params:?}")
+}
+
+fn binding_claim_params_cache_key(params: &BTreeMap<String, ProgramClaimParam>) -> String {
     format!("{params:?}")
 }
 
@@ -14165,10 +14263,10 @@ mod tests {
         SchemaVersion, ShapeAst, Subscribe, SyncMessage, TableLens,
     };
     use crate::query::{
-        Aggregate, ArraySubquery, JoinSourceLookup, OrderDirection, Query, claim, col, contains,
-        eq, gt, in_list, lit, lte, param,
+        Aggregate, ArraySubquery, JoinSourceLookup, OrderDirection, PolicyBranch, Query, claim,
+        col, contains, eq, gt, in_list, lit, lte, param,
     };
-    use crate::schema::{JazzSchema, TableSchema};
+    use crate::schema::{JazzSchema, Policy, TableSchema};
 
     use super::*;
 
@@ -14596,6 +14694,445 @@ mod tests {
                 .collect::<BTreeSet<_>>(),
             BTreeSet::from([ClaimPath(vec!["access_level".to_owned()])])
         );
+    }
+
+    #[test]
+    fn prepared_nested_policy_claim_routes_keep_outer_descriptor_slots() {
+        // This intentionally exercises the compiler/prepare boundary rather
+        // than a public transport: a JS invite subscription previously failed
+        // while Groove prepared its shared binding descriptor, before any
+        // observable query could run. Keeping the reproducer here makes the
+        // descriptor contract cheap to validate without NAPI or a browser.
+        let schema = JazzSchema::new([
+            TableSchema::new(
+                "chats",
+                [
+                    ColumnSchema::new("name", ColumnType::String.nullable()),
+                    ColumnSchema::new("isPublic", ColumnType::Bool),
+                    ColumnSchema::new("createdBy", ColumnType::String),
+                    ColumnSchema::new("joinCode", ColumnType::String.nullable()),
+                ],
+            )
+            .with_read_policy(Policy::shape(
+                Query::from("chats")
+                    .filter(Predicate::Any(Vec::new()))
+                    .policy_branch(PolicyBranch::single_alternative_from_query(
+                        Query::from("chats").filter(eq(col("isPublic"), lit(true))),
+                    ))
+                    .policy_branch(PolicyBranch::single_alternative_from_query(
+                        Query::from("chats").filter(eq(col("joinCode"), claim("join_code"))),
+                    ))
+                    .policy_branch(PolicyBranch::single_alternative_from_query(
+                        Query::from("chats").join_via_column(
+                            "chatMembers",
+                            "chatId",
+                            "id",
+                            [eq(col("userId"), claim("user_id"))],
+                        ),
+                    )),
+            ))
+            .with_write_policy(Policy::public()),
+            TableSchema::new(
+                "chatMembers",
+                [
+                    ColumnSchema::new("chatId", ColumnType::Uuid),
+                    ColumnSchema::new("userId", ColumnType::String),
+                    ColumnSchema::new("joinCode", ColumnType::String.nullable()),
+                ],
+            )
+            .with_reference("chatId", "chats")
+            .with_read_policy(Policy::shape(
+                Query::from("chatMembers")
+                    .filter(Predicate::Any(Vec::new()))
+                    .policy_branch(PolicyBranch::single_alternative_from_query(
+                        Query::from("chatMembers").filter(eq(col("userId"), claim("user_id"))),
+                    ))
+                    .policy_branch(PolicyBranch::single_alternative_from_query(
+                        Query::from("chatMembers").join_via_column(
+                            "chatMembers",
+                            "chatId",
+                            "chatId",
+                            [eq(col("userId"), claim("user_id"))],
+                        ),
+                    )),
+            ))
+            .with_write_policy(Policy::public()),
+        ]);
+        let identity = author(0xa9);
+        let (_client_dir, mut client) =
+            open_node_with_uuid(NodeUuid::from_bytes([0xa7; 16]), schema.clone());
+        client.set_session_claims(
+            identity,
+            BTreeMap::from([(
+                "join_code".to_owned(),
+                Value::String("invite-123".to_owned()),
+            )]),
+        );
+        let client_shape = Query::from("chats")
+            .filter(eq(col("id"), param("id")))
+            .validate(&schema)
+            .unwrap();
+        let client_binding = client_shape
+            .bind(BTreeMap::from([(
+                "id".to_owned(),
+                Value::Uuid(row(0xaa).0),
+            )]))
+            .unwrap();
+        let (shape, binding, _client_plan) = client
+            .prepare_query_binding_for_link(
+                &client_shape,
+                &client_binding,
+                DurabilityTier::Edge,
+                identity,
+            )
+            .expect("prepare retained invite binding on the client before server coverage");
+        register_query_shape(
+            &mut client,
+            &shape,
+            RegisterShapeOptions {
+                tier: DurabilityTier::Edge,
+                ..RegisterShapeOptions::default()
+            },
+        );
+        subscribe_query_binding(&mut client, &shape, &binding);
+
+        let (_server_dir, mut node) =
+            open_node_with_uuid(NodeUuid::from_bytes([0xa8; 16]), schema.clone());
+        node.set_session_claims(
+            identity,
+            BTreeMap::from([(
+                "join_code".to_owned(),
+                Value::String("invite-123".to_owned()),
+            )]),
+        );
+        let chat = row(0xaa);
+        let chat_tx = node
+            .commit_mergeable(
+                MergeableCommit::new("chats", chat, 10).cells(BTreeMap::from([
+                    ("name".to_owned(), Value::Nullable(None)),
+                    ("isPublic".to_owned(), Value::Bool(false)),
+                    (
+                        "createdBy".to_owned(),
+                        Value::String(identity.0.to_string()),
+                    ),
+                    (
+                        "joinCode".to_owned(),
+                        Value::Nullable(Some(Box::new(Value::String("invite-123".to_owned())))),
+                    ),
+                ])),
+            )
+            .unwrap();
+        node.apply_fate_update(
+            chat_tx,
+            Fate::Accepted,
+            Some(GlobalSeq(1)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+        // Mirror the wire receiver: the server reconstructs the client
+        // binding from RegisterShape + Subscribe before it prepares the
+        // maintained graph under the invite-authenticated identity.
+        register_query_shape(
+            &mut node,
+            &shape,
+            RegisterShapeOptions {
+                tier: DurabilityTier::Edge,
+                ..RegisterShapeOptions::default()
+            },
+        );
+        subscribe_query_binding(&mut node, &shape, &binding);
+        let registered_values = node
+            .query
+            .registered_bindings
+            .get(&shape.shape_id())
+            .and_then(|bindings| bindings.get(&binding.binding_id()))
+            .map(|registered| registered.values.clone())
+            .expect("server reconstructed the subscribed invite binding");
+        let server_binding = shape
+            .bind(
+                shape
+                    .params()
+                    .keys()
+                    .cloned()
+                    .zip(registered_values)
+                    .collect(),
+            )
+            .expect("registered wire values reconstruct the invite binding");
+        let program = node
+            .compile_current_query_program_for_read_view(
+                &shape,
+                &server_binding,
+                DurabilityTier::Edge,
+                identity,
+                CurrentQueryProgramOutput::MaintainedView,
+                &ReadViewSpec::default(),
+            )
+            .expect("compile invite policy topology");
+        let typed_join_code = typed_claim_param_alias(
+            &claim_param_field(&ClaimPath(vec!["join_code".to_owned()])),
+            &ColumnType::String.nullable(),
+        );
+        assert!(
+            program
+                .request
+                .input
+                .binding
+                .values
+                .contains_key(&typed_join_code),
+            "the prepared invite binding must retain its nullable typed join-code slot"
+        );
+        let members = node.table("chatMembers").unwrap().clone();
+        let members_policy = node
+            .table_read_policy_authorization_request(
+                shape.schema_version(),
+                "chatMembers",
+                identity,
+                ParamBindingMode::RetainAllParams,
+                DurabilityTier::Edge,
+                program.request.input.binding.source_shape.clone(),
+                program.request.input.binding.extra_user_params.clone(),
+                program.request.input.binding.claim_params.clone(),
+            )
+            .expect("compile nested chat-members policy against the invite binding");
+        let members_authorized = node
+            .policy_filtered_current_source_graph_via_query_engine(
+                members_policy,
+                node.maintained_view_content_current_with_version(&members, DurabilityTier::Edge)
+                    .expect("compile chat-members storage source"),
+                &global_current_storage_fields(&members, true, true),
+            )
+            .expect("route nested chat-members policy through the invite binding");
+        assert!(
+            members_authorized.route_fields.contains(&typed_join_code),
+            "a nested policy source must carry the outer invite slot even when its own policy only consumes user_id"
+        );
+        let member_fields =
+            crate::node::query_engine::graph_declared_output_fields(&members_authorized.graph)
+                .expect("nested policy graph has a declared descriptor");
+        assert!(
+            member_fields.contains(&typed_join_code),
+            "a membership CommitUnit must reach the live invite subscription with its outer claim route"
+        );
+        let app_program = node
+            .compile_current_query_program_for_read_view(
+                &shape,
+                &server_binding,
+                DurabilityTier::Edge,
+                identity,
+                CurrentQueryProgramOutput::AppRows,
+                &ReadViewSpec::default(),
+            )
+            .expect("compile invite app-row topology");
+        let system_program = node
+            .compile_current_query_program_for_read_view(
+                &shape,
+                &server_binding,
+                DurabilityTier::Edge,
+                AuthorId::SYSTEM,
+                CurrentQueryProgramOutput::MaintainedView,
+                &ReadViewSpec::default(),
+            )
+            .expect("System/asBackend reads must not require invite claim values");
+        assert!(
+            system_program.request.input.binding.claim_params.is_empty(),
+            "System/asBackend prepared descriptors cannot retain session claim slots"
+        );
+        for terminal in &program.lowered.terminals {
+            let expected_routes = match &terminal.output {
+                OutputTerminalSchema::Fact(fact) => output_routing_fields_for_query_eval(fact),
+                OutputTerminalSchema::AppRows(_) => BTreeSet::new(),
+            };
+            let declared = crate::node::query_engine::graph_declared_output_fields(&terminal.graph)
+                .expect("the invite terminal has a statically declared output descriptor");
+            assert!(
+                expected_routes.is_subset(&declared),
+                "every advertised invite route must be produced by its terminal; expected {expected_routes:?}, declared {declared:?}"
+            );
+        }
+        let mut descriptors_by_shape = BTreeMap::new();
+        let mut projected_binding_fields = BTreeMap::new();
+        for terminal in program
+            .lowered
+            .terminals
+            .iter()
+            .chain(app_program.lowered.terminals.iter())
+        {
+            collect_binding_source_descriptor_fields(&terminal.graph, &mut descriptors_by_shape);
+            collect_binding_source_projected_fields(&terminal.graph, &mut projected_binding_fields);
+        }
+        assert!(
+            projected_binding_fields
+                .values()
+                .flatten()
+                .all(|fields| fields.contains(&typed_join_code)),
+            "every nested policy binding projection must preserve the outer nullable invite slot; {projected_binding_fields:?}"
+        );
+        assert!(
+            descriptors_by_shape
+                .values()
+                .all(|descriptors| descriptors.len() == 1),
+            "every binding-source shape must retain one shared descriptor; {descriptors_by_shape:?}"
+        );
+
+        node.open_seeded_maintained_subscription_view(
+            &shape,
+            &server_binding,
+            identity,
+            DurabilityTier::Edge,
+            &ReadViewSpec::default(),
+        )
+        .expect(
+            "nested policy claim routes must prepare and bind against the root binding descriptor",
+        );
+        node.query_rows_with_prepared_plan_for_identity(
+            &shape,
+            &server_binding,
+            DurabilityTier::Edge,
+            None,
+            identity,
+        )
+        .expect("one-shot nested policy claim routes must bind against the root descriptor");
+
+        let mut edge = PeerState::edge_client(identity);
+        let update = edge
+            .rehydrate_query_with_opts(
+                &mut node,
+                &shape,
+                &server_binding,
+                RegisterShapeOptions {
+                    tier: DurabilityTier::Edge,
+                    ..RegisterShapeOptions::default()
+                },
+            )
+            .expect("the serving maintained view must retain the invite claim route");
+        client
+            .apply_sync_message(update)
+            .expect("the client must materialize the invited chat update");
+
+        // The browser failure occurred only after the invite subscription was
+        // live and accepting membership was committed. This must wake the
+        // maintained graph without dropping its outer invite claim route.
+        let member_tx = node
+            .commit_mergeable(MergeableCommit::new("chatMembers", row(0xab), 11).cells(
+                BTreeMap::from([
+                    ("chatId".to_owned(), Value::Uuid(chat.0)),
+                    ("userId".to_owned(), Value::String(identity.0.to_string())),
+                    (
+                        "joinCode".to_owned(),
+                        Value::Nullable(Some(Box::new(Value::String("invite-123".to_owned())))),
+                    ),
+                ]),
+            ))
+            .unwrap();
+        node.apply_fate_update(
+            member_tx,
+            Fate::Accepted,
+            Some(GlobalSeq(2)),
+            Some(DurabilityTier::Global),
+        )
+        .expect("a live invite subscription must tolerate its membership CommitUnit");
+        edge.query_update(&mut node, &shape, &server_binding)
+            .expect("flushing the live invite subscription after membership must preserve its claim route");
+    }
+
+    fn collect_binding_source_descriptor_fields(
+        graph: &GraphBuilder,
+        descriptors_by_shape: &mut BTreeMap<String, BTreeSet<BTreeSet<String>>>,
+    ) {
+        match graph {
+            GraphBuilder::BindingSource { shape, output } => {
+                let fields = output
+                    .fields()
+                    .iter()
+                    .map(|field| field.name.clone().expect("binding fields are named"))
+                    .collect();
+                descriptors_by_shape
+                    .entry(shape.clone())
+                    .or_default()
+                    .insert(fields);
+            }
+            GraphBuilder::Recursive { seed, step, .. } => {
+                collect_binding_source_descriptor_fields(seed, descriptors_by_shape);
+                collect_binding_source_descriptor_fields(step, descriptors_by_shape);
+            }
+            GraphBuilder::Filter { input, .. }
+            | GraphBuilder::UnwrapNullable { input, .. }
+            | GraphBuilder::VariantProject { input, .. }
+            | GraphBuilder::Unnest { input, .. }
+            | GraphBuilder::Project { input, .. }
+            | GraphBuilder::ArgMaxBy { input, .. }
+            | GraphBuilder::ArgMinBy { input, .. }
+            | GraphBuilder::TopBy { input, .. }
+            | GraphBuilder::CollectBy { input, .. }
+            | GraphBuilder::Aggregate { input, .. } => {
+                collect_binding_source_descriptor_fields(input, descriptors_by_shape);
+            }
+            GraphBuilder::Union { inputs } => {
+                for input in inputs {
+                    collect_binding_source_descriptor_fields(input, descriptors_by_shape);
+                }
+            }
+            GraphBuilder::Join { left, right, .. }
+            | GraphBuilder::SemiJoin { left, right, .. }
+            | GraphBuilder::AntiJoin { left, right, .. } => {
+                collect_binding_source_descriptor_fields(left, descriptors_by_shape);
+                collect_binding_source_descriptor_fields(right, descriptors_by_shape);
+            }
+            GraphBuilder::Table { .. }
+            | GraphBuilder::InlineRecords { .. }
+            | GraphBuilder::Index { .. }
+            | GraphBuilder::FrontierSource { .. } => {}
+        }
+    }
+
+    fn collect_binding_source_projected_fields(
+        graph: &GraphBuilder,
+        projected_by_shape: &mut BTreeMap<String, BTreeSet<BTreeSet<String>>>,
+    ) {
+        match graph {
+            GraphBuilder::Project { input, fields } => {
+                if let GraphBuilder::BindingSource { shape, .. } = input.as_ref() {
+                    projected_by_shape.entry(shape.clone()).or_default().insert(
+                        fields
+                            .iter()
+                            .map(|field| field.output_name.clone())
+                            .collect(),
+                    );
+                }
+                collect_binding_source_projected_fields(input, projected_by_shape);
+            }
+            GraphBuilder::Recursive { seed, step, .. } => {
+                collect_binding_source_projected_fields(seed, projected_by_shape);
+                collect_binding_source_projected_fields(step, projected_by_shape);
+            }
+            GraphBuilder::Filter { input, .. }
+            | GraphBuilder::UnwrapNullable { input, .. }
+            | GraphBuilder::VariantProject { input, .. }
+            | GraphBuilder::Unnest { input, .. }
+            | GraphBuilder::ArgMaxBy { input, .. }
+            | GraphBuilder::ArgMinBy { input, .. }
+            | GraphBuilder::TopBy { input, .. }
+            | GraphBuilder::CollectBy { input, .. }
+            | GraphBuilder::Aggregate { input, .. } => {
+                collect_binding_source_projected_fields(input, projected_by_shape);
+            }
+            GraphBuilder::Union { inputs } => {
+                for input in inputs {
+                    collect_binding_source_projected_fields(input, projected_by_shape);
+                }
+            }
+            GraphBuilder::Join { left, right, .. }
+            | GraphBuilder::SemiJoin { left, right, .. }
+            | GraphBuilder::AntiJoin { left, right, .. } => {
+                collect_binding_source_projected_fields(left, projected_by_shape);
+                collect_binding_source_projected_fields(right, projected_by_shape);
+            }
+            GraphBuilder::BindingSource { .. }
+            | GraphBuilder::Table { .. }
+            | GraphBuilder::InlineRecords { .. }
+            | GraphBuilder::Index { .. }
+            | GraphBuilder::FrontierSource { .. } => {}
+        }
     }
 
     fn register_query_shape(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -14762,6 +14762,34 @@ mod tests {
                     )),
             ))
             .with_write_policy(Policy::public()),
+            TableSchema::new(
+                "profiles",
+                [
+                    ColumnSchema::new("userId", ColumnType::String),
+                    ColumnSchema::new("name", ColumnType::String),
+                    ColumnSchema::new("avatar", ColumnType::String.nullable()),
+                ],
+            )
+            .with_read_policy(Policy::public())
+            .with_write_policy(Policy::public()),
+            TableSchema::new(
+                "messages",
+                [
+                    ColumnSchema::new("chatId", ColumnType::Uuid),
+                    ColumnSchema::new("senderId", ColumnType::Uuid),
+                    ColumnSchema::new("text", ColumnType::String),
+                    ColumnSchema::new("createdAt", ColumnType::U64),
+                ],
+            )
+            .with_reference("chatId", "chats")
+            .with_reference("senderId", "profiles")
+            .with_read_policy(Policy::shape(Query::from("messages").join_via_column(
+                "chatMembers",
+                "chatId",
+                "chatId",
+                [eq(col("userId"), claim("user_id"))],
+            )))
+            .with_write_policy(Policy::public()),
         ]);
         let identity = author(0xa9);
         let (_client_dir, mut client) =
@@ -14831,6 +14859,44 @@ mod tests {
             chat_tx,
             Fate::Accepted,
             Some(GlobalSeq(1)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+        let profile = row(0xac);
+        let profile_tx = node
+            .commit_mergeable(
+                MergeableCommit::new("profiles", profile, 11).cells(BTreeMap::from([
+                    ("userId".to_owned(), Value::String(identity.0.to_string())),
+                    ("name".to_owned(), Value::String("Alice".to_owned())),
+                    ("avatar".to_owned(), Value::Nullable(None)),
+                ])),
+            )
+            .unwrap();
+        node.apply_fate_update(
+            profile_tx,
+            Fate::Accepted,
+            Some(GlobalSeq(2)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+        let message = row(0xad);
+        let message_tx = node
+            .commit_mergeable(
+                MergeableCommit::new("messages", message, 12).cells(BTreeMap::from([
+                    ("chatId".to_owned(), Value::Uuid(chat.0)),
+                    ("senderId".to_owned(), Value::Uuid(profile.0)),
+                    (
+                        "text".to_owned(),
+                        Value::String("invite-only seed".to_owned()),
+                    ),
+                    ("createdAt".to_owned(), Value::U64(1)),
+                ])),
+            )
+            .unwrap();
+        node.apply_fate_update(
+            message_tx,
+            Fate::Accepted,
+            Some(GlobalSeq(3)),
             Some(DurabilityTier::Global),
         )
         .unwrap();
@@ -15032,12 +15098,290 @@ mod tests {
         node.apply_fate_update(
             member_tx,
             Fate::Accepted,
-            Some(GlobalSeq(2)),
+            Some(GlobalSeq(4)),
             Some(DurabilityTier::Global),
         )
         .expect("a live invite subscription must tolerate its membership CommitUnit");
         edge.query_update(&mut node, &shape, &server_binding)
             .expect("flushing the live invite subscription after membership must preserve its claim route");
+
+        // The invite has now become ordinary membership. A later normal
+        // session must materialize an already-existing private message through
+        // its sender include and timestamp order, not merely discover chat
+        // membership itself.
+        node.set_session_claims(
+            identity,
+            BTreeMap::from([("user_id".to_owned(), Value::String(identity.0.to_string()))]),
+        );
+        let message_shape = Query::from("messages")
+            .filter(eq(col("chatId"), param("chat_id")))
+            .array_subquery(ArraySubquery::new("sender", "profiles", "id", "senderId"))
+            .order_by("createdAt", OrderDirection::Asc)
+            .validate(&schema)
+            .expect("validate normal-member message query");
+        let message_binding = message_shape
+            .bind(BTreeMap::from([(
+                "chat_id".to_owned(),
+                Value::Uuid(chat.0),
+            )]))
+            .expect("bind normal-member message query");
+        let message_rows = node
+            .query_rows_with_prepared_plan_for_identity(
+                &message_shape,
+                &message_binding,
+                DurabilityTier::Edge,
+                None,
+                identity,
+            )
+            .expect("materialize private seed message with sender include and timestamp order");
+        assert_eq!(
+            message_rows
+                .iter()
+                .map(|row| row.row_uuid())
+                .collect::<Vec<_>>(),
+            vec![message],
+            "normal membership reads the seed message after invite acceptance"
+        );
+        node.open_seeded_maintained_subscription_view(
+            &message_shape,
+            &message_binding,
+            identity,
+            DurabilityTier::Edge,
+            &ReadViewSpec::default(),
+        )
+        .expect("prepare and hydrate normal-member message include/order subscription");
+        let (_normal_client_dir, mut normal_client) =
+            open_node_with_uuid(NodeUuid::from_bytes([0xae; 16]), schema.clone());
+        normal_client.set_session_claims(
+            identity,
+            BTreeMap::from([("user_id".to_owned(), Value::String(identity.0.to_string()))]),
+        );
+        let mut normal_membership_peer = PeerState::edge_client(identity);
+        normal_client
+            .apply_sync_message(
+                normal_membership_peer
+                    .current_rows_update(&mut node, "chatMembers")
+                    .expect("serve the accepted membership to the normal client"),
+            )
+            .expect("normal client applies its accepted membership before querying messages");
+        let simple_message_shape = Query::from("messages")
+            .filter(eq(col("chatId"), param("chat_id")))
+            .validate(&schema)
+            .expect("validate normal-member message query without include");
+        let simple_message_binding = simple_message_shape
+            .bind(BTreeMap::from([(
+                "chat_id".to_owned(),
+                Value::Uuid(chat.0),
+            )]))
+            .expect("bind normal-member message query without include");
+        register_query_shape(
+            &mut normal_client,
+            &simple_message_shape,
+            RegisterShapeOptions {
+                tier: DurabilityTier::Edge,
+                ..RegisterShapeOptions::default()
+            },
+        );
+        subscribe_query_binding(
+            &mut normal_client,
+            &simple_message_shape,
+            &simple_message_binding,
+        );
+        let mut normal_simple_peer = PeerState::edge_client(identity);
+        normal_client
+            .apply_sync_message(
+                normal_simple_peer
+                    .rehydrate_query_with_opts(
+                        &mut node,
+                        &simple_message_shape,
+                        &simple_message_binding,
+                        RegisterShapeOptions {
+                            tier: DurabilityTier::Edge,
+                            ..RegisterShapeOptions::default()
+                        },
+                    )
+                    .expect("serve normal-member message snapshot without include"),
+            )
+            .expect("client applies normal-member message snapshot without include");
+        assert_eq!(
+            normal_client
+                .query_rows_for_client(
+                    &simple_message_shape,
+                    &simple_message_binding,
+                    DurabilityTier::Edge,
+                    identity,
+                )
+                .expect("client materializes the private seed message without include")
+                .iter()
+                .map(|row| row.row_uuid())
+                .collect::<Vec<_>>(),
+            vec![message],
+            "the normal client must first materialize the private seed message without include"
+        );
+        register_query_shape(
+            &mut normal_client,
+            &message_shape,
+            RegisterShapeOptions {
+                tier: DurabilityTier::Edge,
+                ..RegisterShapeOptions::default()
+            },
+        );
+        subscribe_query_binding(&mut normal_client, &message_shape, &message_binding);
+        let mut normal_peer = PeerState::edge_client(identity);
+        let normal_update = normal_peer
+            .rehydrate_query_with_opts(
+                &mut node,
+                &message_shape,
+                &message_binding,
+                RegisterShapeOptions {
+                    tier: DurabilityTier::Edge,
+                    ..RegisterShapeOptions::default()
+                },
+            )
+            .expect("serve normal-member message include/order snapshot");
+        let normal_versions = normal_update
+            .expand_version_carriers_for_receive()
+            .expect("expand normal-member message include/order payloads");
+        if let SyncMessage::ViewUpdate {
+            version_bundles, ..
+        } = &normal_versions
+        {
+            let (profile_bundle, profile_version) = version_bundles
+                .iter()
+                .find_map(|bundle| {
+                    bundle
+                        .versions
+                        .iter()
+                        .find(|version| {
+                            version.table() == "profiles" && version.row_uuid() == profile
+                        })
+                        .map(|version| (bundle, version))
+                })
+                .expect("the relation snapshot ships the sender version");
+            assert_eq!(
+                profile_bundle.tx.tx_id, profile_tx,
+                "the sender witness must retain the profile version identity rather than borrow the message anchor"
+            );
+            assert_eq!(
+                profile_version
+                    .record()
+                    .borrowed()
+                    .get_idx(7)
+                    .expect("decode sender wire userId"),
+                Value::Nullable(Some(Box::new(Value::String(identity.0.to_string())))),
+                "the relation sender version ships userId content"
+            );
+        } else {
+            panic!("expected normal-member view update")
+        }
+        let missing = normal_client
+            .missing_known_state_row_version_refs(&normal_versions)
+            .expect("inspect normal-member message include/order repair requirements");
+        assert!(
+            missing.is_empty(),
+            "the server snapshot already carries every visible row-version payload; missing {missing:?}"
+        );
+        if !missing.is_empty() {
+            let messages = normal_peer
+                .handle_row_versions_fetch(
+                    &mut node,
+                    SyncMessage::FetchRowVersions {
+                        requests: missing.clone(),
+                    },
+                )
+                .expect("serve normal-member message include/order repair payloads");
+            let [SyncMessage::RowVersionPayloads { version_bundles }] = messages.as_slice() else {
+                panic!("expected row-version repair payloads")
+            };
+            normal_client
+                .apply_row_version_payloads_for_requests(&missing, version_bundles.clone())
+                .expect("apply normal-member message include/order repair payloads");
+        }
+        normal_client
+            .apply_sync_message(normal_versions)
+            .expect("client applies normal-member message include/order snapshot");
+        assert!(
+            normal_client
+                .current_rows("profiles", DurabilityTier::Local)
+                .expect("inspect locally materialized sender rows")
+                .iter()
+                .any(|row| row.row_uuid() == profile),
+            "the include snapshot must deliver the sender row before local query evaluation"
+        );
+        assert_eq!(
+            normal_client
+                .current_rows("profiles", DurabilityTier::Local)
+                .expect("inspect the local sender table")
+                .iter()
+                .map(|row| row.row_uuid())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([profile]),
+            "the sender table must not receive the message row through relation delivery"
+        );
+        assert_eq!(
+            normal_client
+                .current_rows("profiles", DurabilityTier::Local)
+                .expect("inspect the local sender payload")
+                .into_iter()
+                .next()
+                .and_then(|row| row.cell(normal_client.table("profiles").unwrap(), "userId")),
+            Some(Value::String(identity.0.to_string())),
+            "the delivered sender version retains its required userId"
+        );
+        let (local_shape, local_binding, local_plan) = normal_client
+            .prepare_query_binding_for_link_in_authorization_mode(
+                &message_shape,
+                &message_binding,
+                DurabilityTier::Edge,
+                identity,
+                QueryAuthorizationMode::ClientLocal,
+            )
+            .expect(
+                "prepare the same client-local maintained relation subscription as the browser",
+            );
+        let (_local_subscription, local_snapshot) = normal_client
+            .open_maintained_view_subscription_in_authorization_mode(
+                &local_shape,
+                &local_binding,
+                identity,
+                DurabilityTier::Edge,
+                &ReadViewSpec::default(),
+                Some(local_plan),
+                QueryAuthorizationMode::ClientLocal,
+            )
+            .expect("open the client-local maintained relation subscription");
+        assert_eq!(
+            local_snapshot.root_count, 1,
+            "the maintained client-local relation subscription retains the seed message"
+        );
+        let local_one_shot = normal_client
+            .query_relation_snapshot_for_client(
+                &message_shape,
+                &message_binding,
+                DurabilityTier::Edge,
+                identity,
+                &ReadViewSpec::default(),
+            )
+            .expect("materialize the client-local relation snapshot API used by WASM");
+        assert_eq!(
+            local_one_shot.root_count, 1,
+            "the client-local relation snapshot API retains the seed message"
+        );
+        assert_eq!(
+            normal_client
+                .query_rows_for_client(
+                    &message_shape,
+                    &message_binding,
+                    DurabilityTier::Edge,
+                    identity,
+                )
+                .expect("client materializes normal-member message include/order snapshot")
+                .iter()
+                .map(|row| row.row_uuid())
+                .collect::<Vec<_>>(),
+            vec![message],
+            "the normal client must retain the seed message when the sender include is added"
+        );
     }
 
     fn collect_binding_source_descriptor_fields(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -10926,10 +10926,15 @@ where
         let mut join_keys = vec!["row_uuid".to_owned()];
         join_keys.extend(authorized.route_fields.iter().cloned());
         if authorized.route_fields.is_empty() {
-            let fields = output_fields
+            let mut fields = output_fields
                 .iter()
                 .map(|field| ProjectField::renamed(left_field(&field), field.clone()))
                 .collect::<Vec<_>>();
+            fields.extend(
+                binding_route_fields
+                    .iter()
+                    .map(|field| ProjectField::renamed(left_field(field), field.clone())),
+            );
             return Ok(PolicyAuthorizationGraph {
                 graph: GraphBuilder::join(base, authorized_graph, join_keys.clone(), join_keys)
                     .project_fields(fields),

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -1528,39 +1528,25 @@ fn catalogue_arrival_drains_schema_orphan_commit_units() {
         ("body".to_owned(), Value::String(String::new())),
         ("title".to_owned(), Value::String("parked".to_owned())),
     ]);
-    let (_writer_dir, mut writer) = open_node_with_schema(node(0x36), base.clone());
+    // The arriving unit is authored under the as-yet unknown evolved schema.
+    // Its wire record is nevertheless complete in that schema: unknown-schema
+    // parking delays admission; it does not turn an older, short row into an
+    // evolved row by changing only its schema id.
+    let (_writer_dir, mut writer) = open_node_with_schema(node(0x36), evolved.clone());
     let (core_dir, mut core) = open_node_with_schema(node(0x37), base.clone());
     let (_tx_id, unit) = writer
         .commit_mergeable_unit(
-            MergeableCommit::new("todos", row(0x55), 1_000).cells(title_cells("parked")),
+            MergeableCommit::new("todos", row(0x55), 1_000).cells(evolved_cells.clone()),
         )
         .unwrap();
     let SyncMessage::CommitUnit { tx, versions } = unit else {
         panic!("commit unit expected");
     };
-    let rewritten = versions
-        .into_iter()
-        .map(|version| {
-            VersionRecord::from_cells(
-                &base.tables[0],
-                evolved_id,
-                version.row_uuid(),
-                version.parents(),
-                version.created_by(),
-                version.created_at(),
-                version.updated_by(),
-                version.updated_at(),
-                &version_record_cells(&version, &base.tables[0]),
-                version.deletion(),
-            )
-            .unwrap()
-        })
-        .collect::<Vec<_>>();
 
     assert!(
         core.apply_sync_message(SyncMessage::CommitUnit {
             tx: tx.clone(),
-            versions: rewritten,
+            versions,
         })
         .unwrap()
         .is_empty()
@@ -1632,6 +1618,466 @@ fn catalogue_arrival_drains_schema_orphan_commit_units() {
             .get(&row(0x55)),
         Some(&evolved_cells)
     );
+}
+
+/// An unknown-schema unit may park, but once the catalogue identifies its
+/// schema the authority rejects a record whose wire descriptor belongs to an
+/// older schema instead of inventing a missing evolved column from a lens.
+#[test]
+fn catalogue_arrival_rejects_incomplete_row_claiming_evolved_schema() {
+    let base = schema();
+    let evolved = catalogue_evolved_schema();
+    let evolved_id = evolved.version_id();
+    let (_writer_dir, mut writer) = open_node_with_schema(node(0x58), base.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(0x59), base.clone());
+    let (_tx_id, unit) = writer
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", row(0x58), 1_003).cells(title_cells("invalid")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = unit else {
+        panic!("commit unit expected");
+    };
+    let incomplete = versions
+        .into_iter()
+        .map(|version| {
+            crate::protocol::VersionRecord::from_cells(
+                &base.tables[0],
+                evolved_id,
+                version.row_uuid(),
+                version.parents(),
+                version.created_by(),
+                version.created_at(),
+                version.updated_by(),
+                version.updated_at(),
+                &version_record_cells(&version, &base.tables[0]),
+                version.deletion(),
+            )
+            .unwrap()
+        })
+        .collect();
+
+    assert!(core
+        .apply_sync_message(SyncMessage::CommitUnit {
+            tx: tx.clone(),
+            versions: incomplete,
+        })
+        .unwrap()
+        .is_empty());
+    assert_eq!(core.sync_metrics().parked_catalogue_orphans, 1);
+
+    let updates = publish_schema_lineage(
+        &mut core,
+        SchemaVersion::new(evolved),
+        MigrationLens::new(
+            base.version_id(),
+            evolved_id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "body".to_owned(),
+                    default: Value::String(String::new()),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+
+    assert!(updates.iter().any(|message| matches!(
+        message,
+        SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Rejected(RejectionReason::MalformedCommit(reason)),
+            ..
+        } if *tx_id == tx.tx_id
+            && reason.contains("complete descriptor of its authored schema")
+    )));
+    assert!(core.row_history("todos", row(0x58)).unwrap().is_empty());
+}
+
+/// A relay has no fate authority: when schema arrival proves a parked row
+/// incomplete, it drops that unit without failing the catalogue publication or
+/// inventing a rejected transaction.
+#[test]
+fn catalogue_arrival_drops_incomplete_relay_row_without_failing_publication() {
+    let base = schema();
+    let evolved = catalogue_evolved_schema();
+    let evolved_id = evolved.version_id();
+    let (_writer_dir, mut writer) =
+        open_history_complete_node_with_schema(node(0x6a), base.clone());
+    let (_relay_dir, mut relay) =
+        open_history_complete_node_with_schema(node(0x6b), base.clone());
+    let (_tx_id, unit) = writer
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", row(0x6a), 1_004).cells(title_cells("invalid relay")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = unit else {
+        panic!("commit unit expected");
+    };
+    let incomplete = versions
+        .into_iter()
+        .map(|version| {
+            crate::protocol::VersionRecord::from_cells(
+                &base.tables[0],
+                evolved_id,
+                version.row_uuid(),
+                version.parents(),
+                version.created_by(),
+                version.created_at(),
+                version.updated_by(),
+                version.updated_at(),
+                &version_record_cells(&version, &base.tables[0]),
+                version.deletion(),
+            )
+            .unwrap()
+        })
+        .collect();
+
+    relay.ingest_relay_commit_unit(tx.clone(), incomplete).unwrap();
+    assert!(relay.query_transaction(tx.tx_id).unwrap().is_none());
+
+    publish_schema_lineage(
+        &mut relay,
+        SchemaVersion::new(evolved),
+        MigrationLens::new(
+            base.version_id(),
+            evolved_id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "body".to_owned(),
+                    default: Value::String(String::new()),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+
+    assert!(relay.query_transaction(tx.tx_id).unwrap().is_none());
+    assert!(relay.row_history("todos", row(0x6a)).unwrap().is_empty());
+    assert_eq!(relay.sync_metrics().dropped_malformed_relay_commit_units, 1);
+}
+
+fn zero_column_version_claiming_schema(
+    schema: &JazzSchema,
+    version: &crate::protocol::VersionRecord,
+) -> crate::protocol::VersionRecord {
+    crate::protocol::VersionRecord::from_cells(
+        &TableSchema::new("todos", Vec::<ColumnSchema>::new()),
+        schema.version_id(),
+        version.row_uuid(),
+        version.parents(),
+        version.created_by(),
+        version.created_at(),
+        version.updated_by(),
+        version.updated_at(),
+        &BTreeMap::<String, Value>::new(),
+        version.deletion(),
+    )
+    .unwrap()
+}
+
+/// A non-reset ViewUpdate stages its history payload in a shared receiver
+/// batch. A malformed row descriptor must reject the frame before that batch
+/// writes either its transaction or version.
+#[test]
+fn batched_view_update_rejects_incomplete_authored_row_before_storage() {
+    let base = schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(0x6c), base.clone());
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", row(0x6c), 1_005).cells(title_cells("view payload")),
+    );
+    let update = PeerState::new()
+        .current_rows_update(&mut core, "todos")
+        .unwrap();
+    let mut bundles = version_bundles_for_update(&update);
+    assert_eq!(bundles.len(), 1);
+    let version = bundles[0].versions[0].clone();
+    bundles[0].versions = vec![zero_column_version_claiming_schema(&base, &version)];
+    let SyncMessage::ViewUpdate {
+        subscription,
+        settled_through,
+        reset_result_set,
+        peer_payload_inventory,
+        result_member_adds,
+        result_member_removes,
+        terminal_operations,
+        program_fact_adds,
+        program_fact_removes,
+        ..
+    } = update
+    else {
+        panic!("expected view update");
+    };
+    assert!(!reset_result_set, "exercise shared non-reset receiver batching");
+
+    let (_reader_dir, mut reader) = open_node_with_schema(node(0x6d), base);
+    let error = reader
+        .apply_view_updates_in_batch(vec![ViewUpdateParts {
+            subscription,
+            settled_through,
+            defer_settlement: false,
+            reset_result_set,
+            version_carriers: Vec::new(),
+            version_bundles: bundles,
+            peer_complete_tx_payload_refs: peer_payload_inventory.complete_tx_payloads,
+            authorization_progress: None,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
+        }])
+        .expect_err("malformed ViewUpdate must not stage a row");
+    match error {
+        Error::MalformedViewUpdate(
+            "row version does not carry the complete descriptor of its authored schema",
+        ) => {}
+        other => panic!("expected malformed ViewUpdate, got {other:?}"),
+    }
+    assert!(reader.query_all_versions().unwrap().is_empty());
+}
+
+/// Ordinary ViewUpdate ingestion reaches the shared history boundary even
+/// without receiver batching, so an incomplete record cannot be stored there.
+#[test]
+fn view_update_rejects_incomplete_authored_row_before_storage() {
+    let base = schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(0x6e), base.clone());
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", row(0x6e), 1_006).cells(title_cells("ordinary view")),
+    );
+    let update = PeerState::new()
+        .current_rows_update(&mut core, "todos")
+        .unwrap();
+    let mut bundles = version_bundles_for_update(&update);
+    let version = bundles[0].versions[0].clone();
+    bundles[0].versions = vec![zero_column_version_claiming_schema(&base, &version)];
+    let SyncMessage::ViewUpdate {
+        subscription,
+        settled_through,
+        reset_result_set,
+        peer_payload_inventory,
+        result_member_adds,
+        result_member_removes,
+        terminal_operations,
+        program_fact_adds,
+        program_fact_removes,
+        ..
+    } = update
+    else {
+        panic!("expected view update");
+    };
+
+    let (_reader_dir, mut reader) = open_node_with_schema(node(0x6f), base);
+    assert!(matches!(
+        reader.apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through,
+            reset_result_set,
+            version_carriers: Vec::new(),
+            version_bundles: bundles,
+            peer_payload_inventory,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
+        }),
+        Err(Error::MalformedViewUpdate(
+            "row version does not carry the complete descriptor of its authored schema"
+        ))
+    ));
+    assert!(reader.query_all_versions().unwrap().is_empty());
+}
+
+/// Row-version repair payloads reach the same shared history boundary and
+/// reject an incomplete claimed row before transaction/history storage.
+#[test]
+fn row_version_repair_rejects_incomplete_authored_row_before_storage() {
+    let base = schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(0x70), base.clone());
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", row(0x70), 1_007).cells(title_cells("repair payload")),
+    );
+    let mut bundles = version_bundles_for_update(
+        &PeerState::new()
+            .current_rows_update(&mut core, "todos")
+            .unwrap(),
+    );
+    let version = bundles[0].versions[0].clone();
+    let request = crate::protocol::RowVersionRef::new(
+        version.table().to_owned(),
+        version.row_uuid(),
+        bundles[0].tx.tx_id,
+    );
+    bundles[0].versions = vec![zero_column_version_claiming_schema(&base, &version)];
+
+    let (_reader_dir, mut reader) = open_node_with_schema(node(0x71), base);
+    assert!(matches!(
+        reader.apply_row_version_payloads_for_requests(&[request], bundles),
+        Err(Error::MalformedViewUpdate(
+            "row version does not carry the complete descriptor of its authored schema"
+        ))
+    ));
+    assert!(reader.query_all_versions().unwrap().is_empty());
+}
+
+/// A rejected reset frame must not enable the relaxed initial-sync durability
+/// cadence or register a hydration before all of its row payloads are valid.
+#[test]
+fn reset_view_update_rejection_does_not_leave_initial_sync_flush_active() {
+    let base = schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(0x72), base.clone());
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", row(0x72), 1_008).cells(title_cells("reset payload")),
+    );
+    let update = PeerState::new()
+        .current_rows_update(&mut core, "todos")
+        .unwrap();
+    let mut bundles = version_bundles_for_update(&update);
+    let version = bundles[0].versions[0].clone();
+    bundles[0].versions = vec![zero_column_version_claiming_schema(&base, &version)];
+    let SyncMessage::ViewUpdate {
+        subscription,
+        settled_through,
+        peer_payload_inventory,
+        result_member_adds,
+        result_member_removes,
+        terminal_operations,
+        program_fact_adds,
+        program_fact_removes,
+        ..
+    } = update
+    else {
+        panic!("expected view update");
+    };
+
+    let (_reader_dir, mut reader) = open_node_with_schema(node(0x73), base);
+    reader.set_initial_sync_flush_cadence(2).unwrap();
+    assert!(!reader.initial_sync_flush_active);
+    assert!(reader.query.initial_hydration_binding_views.is_empty());
+    assert!(matches!(
+        reader.apply_view_updates_in_batch(vec![ViewUpdateParts {
+            subscription,
+            settled_through,
+            defer_settlement: false,
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: bundles,
+            peer_complete_tx_payload_refs: peer_payload_inventory.complete_tx_payloads,
+            authorization_progress: None,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
+        }]),
+        Err(Error::MalformedViewUpdate(
+            "row version does not carry the complete descriptor of its authored schema"
+        ))
+    ));
+    assert!(!reader.initial_sync_flush_active);
+    assert!(!reader.initial_sync_flush_completed);
+    assert!(reader.query.initial_hydration_binding_views.is_empty());
+    assert!(reader.query_all_versions().unwrap().is_empty());
+}
+
+/// A receiver frame validates every bundle before the first valid one can
+/// mutate its clock, aliases, catalogue mappings, or durable history.
+#[test]
+fn batched_view_update_rejection_is_atomic_across_valid_and_malformed_bundles() {
+    let base = schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(0x74), base.clone());
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", row(0x74), 1_009).cells(title_cells("valid first")),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", row(0x75), 1_010).cells(title_cells("malformed second")),
+    );
+    let update = PeerState::new()
+        .current_rows_update(&mut core, "todos")
+        .unwrap();
+    let mut bundles = version_bundles_for_update(&update);
+    assert_eq!(bundles.len(), 2, "one complete bundle per accepted write");
+    let malformed = bundles[1].versions[0].clone();
+    bundles[1].versions = vec![zero_column_version_claiming_schema(&base, &malformed)];
+    let valid_tx_id = bundles[0].tx.tx_id;
+    let SyncMessage::ViewUpdate {
+        subscription,
+        settled_through,
+        peer_payload_inventory,
+        result_member_adds,
+        result_member_removes,
+        terminal_operations,
+        program_fact_adds,
+        program_fact_removes,
+        ..
+    } = update
+    else {
+        panic!("expected view update");
+    };
+
+    let (_reader_dir, mut reader) = open_node_with_schema(node(0x76), base);
+    let clock_before = (
+        reader.clock.tx_time,
+        reader.clock.next_global_seq,
+        reader.clock.applied_global_watermark,
+        reader.clock.applied_global_above_watermark.clone(),
+    );
+    let node_aliases_before = reader.node_aliases.clone();
+    let schema_aliases_before = reader.catalogue.schema_version_aliases.clone();
+    let catalogue_schemas_before = reader.catalogue.catalogue_schemas.clone();
+    let history_before = reader.query_all_versions().unwrap();
+    assert!(matches!(
+        reader.apply_view_updates_in_batch(vec![ViewUpdateParts {
+            subscription,
+            settled_through,
+            defer_settlement: false,
+            reset_result_set: false,
+            version_carriers: Vec::new(),
+            version_bundles: bundles,
+            peer_complete_tx_payload_refs: peer_payload_inventory.complete_tx_payloads,
+            authorization_progress: None,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
+        }]),
+        Err(Error::MalformedViewUpdate(
+            "row version does not carry the complete descriptor of its authored schema"
+        ))
+    ));
+    assert_eq!(
+        (
+            reader.clock.tx_time,
+            reader.clock.next_global_seq,
+            reader.clock.applied_global_watermark,
+            reader.clock.applied_global_above_watermark.clone(),
+        ),
+        clock_before
+    );
+    assert_eq!(reader.node_aliases, node_aliases_before);
+    assert_eq!(reader.catalogue.schema_version_aliases, schema_aliases_before);
+    assert_eq!(reader.catalogue.catalogue_schemas, catalogue_schemas_before);
+    assert_eq!(reader.query_all_versions().unwrap(), history_before);
+    assert!(reader.query_transaction(valid_tx_id).unwrap().is_none());
+    assert!(!reader.initial_sync_flush_active);
+    assert!(reader.query.initial_hydration_binding_views.is_empty());
 }
 
 #[test]
@@ -1939,7 +2385,7 @@ fn catalogue_arrival_drains_branch_relay_into_branch_partition() {
     let evolved = catalogue_evolved_schema();
     let evolved_id = evolved.version_id();
     let (_writer_dir, mut writer) =
-        open_history_complete_node_with_schema(node(0x38), base.clone());
+        open_history_complete_node_with_schema(node(0x38), evolved.clone());
     let (relay_dir, mut relay) = open_history_complete_node_with_schema(node(0x39), base.clone());
     let branch_id = branch(0x66);
     writer.create_root_branch(branch_id).unwrap();
@@ -1947,33 +2393,18 @@ fn catalogue_arrival_drains_branch_relay_into_branch_partition() {
     let tx_id = writer
         .commit_mergeable_on_branch(
             branch_id,
-            MergeableCommit::new("todos", row(0x56), 1_001).cells(title_cells("relay parked")),
+            MergeableCommit::new("todos", row(0x56), 1_001).cells(BTreeMap::from([
+                ("body".to_owned(), Value::String(String::new())),
+                ("title".to_owned(), Value::String("relay parked".to_owned())),
+            ])),
         )
         .unwrap();
     let SyncMessage::CommitUnit { tx, versions } = writer.commit_unit_for(tx_id).unwrap() else {
         panic!("commit unit expected");
     };
-    let rewritten = versions
-        .into_iter()
-        .map(|version| {
-            VersionRecord::from_cells(
-                &base.tables[0],
-                evolved_id,
-                version.row_uuid(),
-                version.parents(),
-                version.created_by(),
-                version.created_at(),
-                version.updated_by(),
-                version.updated_at(),
-                &version_record_cells(&version, &base.tables[0]),
-                version.deletion(),
-            )
-            .unwrap()
-        })
-        .collect::<Vec<_>>();
 
     relay
-        .ingest_relay_commit_unit(tx.clone(), rewritten)
+        .ingest_relay_commit_unit(tx.clone(), versions)
         .unwrap();
     assert!(relay.query_transaction(tx.tx_id).unwrap().is_none());
     assert!(
@@ -2056,54 +2487,38 @@ fn parked_branch_ingress_role_keeps_authority_precedence_in_both_orders() {
     let evolved = catalogue_evolved_schema();
     let evolved_id = evolved.version_id();
     let (_writer_dir, mut writer) =
-        open_history_complete_node_with_schema(node(0x3a), base.clone());
+        open_history_complete_node_with_schema(node(0x3a), evolved.clone());
     let branch_id = branch(0x67);
     writer.create_root_branch(branch_id).unwrap();
     let tx_id = writer
         .commit_mergeable_on_branch(
             branch_id,
-            MergeableCommit::new("todos", row(0x57), 1_002).cells(title_cells("one unit")),
+            MergeableCommit::new("todos", row(0x57), 1_002).cells(BTreeMap::from([
+                ("body".to_owned(), Value::String(String::new())),
+                ("title".to_owned(), Value::String("one unit".to_owned())),
+            ])),
         )
         .unwrap();
     let SyncMessage::CommitUnit { tx, versions } = writer.commit_unit_for(tx_id).unwrap() else {
         panic!("commit unit expected");
     };
-    let rewritten = versions
-        .into_iter()
-        .map(|version| {
-            VersionRecord::from_cells(
-                &base.tables[0],
-                evolved_id,
-                version.row_uuid(),
-                version.parents(),
-                version.created_by(),
-                version.created_at(),
-                version.updated_by(),
-                version.updated_at(),
-                &version_record_cells(&version, &base.tables[0]),
-                version.deletion(),
-            )
-            .unwrap()
-        })
-        .collect::<Vec<_>>();
-
     for (idx, relay_first) in [false, true].into_iter().enumerate() {
         let node_id = node(0x3b + idx as u8);
         let (_dir, mut receiver) = open_history_complete_node_with_schema(node_id, base.clone());
         receiver.create_root_branch(branch_id).unwrap();
         let authority = || SyncMessage::CommitUnit {
             tx: tx.clone(),
-            versions: rewritten.clone(),
+            versions: versions.clone(),
         };
         if relay_first {
             receiver
-                .ingest_relay_commit_unit(tx.clone(), rewritten.clone())
+                .ingest_relay_commit_unit(tx.clone(), versions.clone())
                 .unwrap();
             assert!(receiver.apply_sync_message(authority()).unwrap().is_empty());
         } else {
             assert!(receiver.apply_sync_message(authority()).unwrap().is_empty());
             receiver
-                .ingest_relay_commit_unit(tx.clone(), rewritten.clone())
+                .ingest_relay_commit_unit(tx.clone(), versions.clone())
                 .unwrap();
         }
 

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -1524,7 +1524,10 @@ fn catalogue_arrival_drains_schema_orphan_commit_units() {
     let base = schema();
     let evolved = catalogue_evolved_schema();
     let evolved_id = evolved.version_id();
-    let authored_cells = title_cells("parked");
+    let evolved_cells = BTreeMap::from([
+        ("body".to_owned(), Value::String(String::new())),
+        ("title".to_owned(), Value::String("parked".to_owned())),
+    ]);
     let (_writer_dir, mut writer) = open_node_with_schema(node(0x36), base.clone());
     let (core_dir, mut core) = open_node_with_schema(node(0x37), base.clone());
     let (_tx_id, unit) = writer
@@ -1595,15 +1598,22 @@ fn catalogue_arrival_drains_schema_orphan_commit_units() {
     )));
     let shape = Query::from("todos").validate(&evolved).unwrap();
     let binding = shape.bind(BTreeMap::new()).unwrap();
-    assert_eq!(
-        core.query_rows(&shape, &binding, DurabilityTier::Global)
-            .unwrap()
-            .into_iter()
-            .map(current_row_pair)
-            .collect::<BTreeMap<_, _>>()
-            .get(&row(0x55)),
-        Some(&authored_cells)
-    );
+    for tier in [
+        DurabilityTier::Local,
+        DurabilityTier::Edge,
+        DurabilityTier::Global,
+    ] {
+        assert_eq!(
+            core.query_rows(&shape, &binding, tier)
+                .unwrap()
+                .into_iter()
+                .map(current_row_pair)
+                .collect::<BTreeMap<_, _>>()
+                .get(&row(0x55)),
+            Some(&evolved_cells),
+            "catalogue-drained rows retain lens defaults in {tier:?} current reads",
+        );
+    }
     drop(core);
     let mut reopened = reopen_node_at(&core_dir, node(0x37), base);
     assert!(
@@ -1620,7 +1630,306 @@ fn catalogue_arrival_drains_schema_orphan_commit_units() {
             .map(current_row_pair)
             .collect::<BTreeMap<_, _>>()
             .get(&row(0x55)),
-        Some(&authored_cells)
+        Some(&evolved_cells)
+    );
+}
+
+#[test]
+fn current_winner_projects_rename_copy_chains_across_durability_tiers() {
+    let base = JazzSchema::new([TableSchema::new(
+        "todos",
+        [ColumnSchema::new("title", ColumnType::String)],
+    )]);
+    let evolved = SchemaVersion::new(JazzSchema::new([TableSchema::new(
+        "todos",
+        [
+            ColumnSchema::new("name", ColumnType::String),
+            ColumnSchema::new("body", ColumnType::String),
+        ],
+    )]));
+    let (_dir, mut core) = open_node_with_schema(node(0x5c), base.clone());
+    let old_row = row(0x5c);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", old_row, 1).cells(title_cells("old title")),
+    );
+    publish_schema_lineage(
+        &mut core,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![
+                    LensOp::RenameColumn {
+                        from: "title".to_owned(),
+                        to: "name".to_owned(),
+                    },
+                    LensOp::CopyColumn {
+                        from: "name".to_owned(),
+                        to: "body".to_owned(),
+                    },
+                ],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved.id,
+        },
+    })
+    .unwrap();
+    let new_row = row(0x5d);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", new_row, 2).cells(BTreeMap::from([
+            ("name".to_owned(), v("new name")),
+            ("body".to_owned(), v("new body")),
+        ])),
+    );
+
+    let shape = Query::from("todos").validate(&evolved.schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let expected = BTreeMap::from([
+        (
+            old_row,
+            BTreeMap::from([
+                ("name".to_owned(), v("old title")),
+                ("body".to_owned(), v("old title")),
+            ]),
+        ),
+        (
+            new_row,
+            BTreeMap::from([
+                ("name".to_owned(), v("new name")),
+                ("body".to_owned(), v("new body")),
+            ]),
+        ),
+    ]);
+    for tier in [
+        DurabilityTier::Local,
+        DurabilityTier::Edge,
+        DurabilityTier::Global,
+    ] {
+        assert_eq!(
+            core.query_rows(&shape, &binding, tier)
+                .unwrap()
+                .into_iter()
+                .map(current_row_pair)
+                .collect::<BTreeMap<_, _>>(),
+            expected,
+            "Rename/Copy paths preserve old physical fields in {tier:?} reads",
+        );
+    }
+}
+
+fn assert_current_winner_copied_enum_remap(
+    marker: u8,
+    source_type: ColumnType,
+    copied_type: ColumnType,
+    latest_type: ColumnType,
+    old_value: Value,
+    unknown_value: Value,
+) {
+    let base = JazzSchema::new([TableSchema::new(
+        "items",
+        [ColumnSchema::new("source", source_type)],
+    )]);
+    let copied = SchemaVersion::new(JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("status", copied_type.clone()),
+            ColumnSchema::new("status_copy", copied_type),
+        ],
+    )]));
+    let latest = SchemaVersion::new(JazzSchema::new([TableSchema::new(
+        "items",
+        [
+            ColumnSchema::new("status", latest_type),
+            ColumnSchema::new("status_copy", copied.schema.tables[0].columns[1].column_type.clone()),
+        ],
+    )]));
+    let (_dir, mut core) = open_node_with_schema(node(marker), base.clone());
+    let old_row = row(marker);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", old_row, 1)
+            .cells(BTreeMap::from([("source".to_owned(), old_value.clone())])),
+    );
+    publish_schema_lineage(
+        &mut core,
+        copied.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            copied.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![
+                    LensOp::RenameColumn {
+                        from: "source".to_owned(),
+                        to: "status".to_owned(),
+                    },
+                    LensOp::CopyColumn {
+                        from: "status".to_owned(),
+                        to: "status_copy".to_owned(),
+                    },
+                ],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: copied.id,
+        },
+    })
+    .unwrap();
+    let shape = Query::from("items").validate(&copied.schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let expected = BTreeMap::from([(
+        old_row,
+        BTreeMap::from([
+            ("status".to_owned(), old_value.clone()),
+            ("status_copy".to_owned(), old_value.clone()),
+        ]),
+    )]);
+    for tier in [
+        DurabilityTier::Local,
+        DurabilityTier::Edge,
+        DurabilityTier::Global,
+    ] {
+        assert_eq!(
+            core.query_rows(&shape, &binding, tier)
+                .unwrap()
+                .into_iter()
+                .map(current_row_pair)
+                .collect::<BTreeMap<_, _>>(),
+            expected,
+            "copied enum row remaps through distinct registries in {tier:?}",
+        );
+    }
+    publish_schema_lineage(
+        &mut core,
+        latest.clone(),
+        MigrationLens::new(
+            copied.id,
+            latest.id,
+            vec![TableLens {
+                source_table: "items".to_owned(),
+                target_table: "items".to_owned(),
+                ops: vec![LensOp::TransformColumn {
+                    column: "status".to_owned(),
+                    transform: "jazz.identity".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 2,
+            schema: latest.id,
+        },
+    })
+    .unwrap();
+    accept_global(
+        &mut core,
+        MergeableCommit::new("items", old_row, 2).cells(BTreeMap::from([
+            ("status".to_owned(), unknown_value),
+            ("status_copy".to_owned(), old_value),
+        ])),
+    );
+    for tier in [
+        DurabilityTier::Local,
+        DurabilityTier::Edge,
+        DurabilityTier::Global,
+    ] {
+        assert_eq!(
+            core.query_rows(&shape, &binding, tier)
+                .unwrap()
+                .into_iter()
+                .map(current_row_pair)
+                .collect::<BTreeMap<_, _>>(),
+            BTreeMap::new(),
+            "the later unknown winner omits the same row after arg-max in {tier:?}",
+        );
+    }
+}
+
+#[test]
+fn current_winner_remaps_copied_scalar_enums_and_omits_later_winners() {
+    let base = enum_projection_schema(&["open", "selected"]);
+    let latest = enum_projection_schema(&["open", "selected", "closed"]);
+    assert_current_winner_copied_enum_remap(
+        0x5e,
+        base.tables[0].columns[1].column_type.clone(),
+        base.tables[0].columns[1].column_type.clone(),
+        latest.tables[0].columns[1].column_type.clone(),
+        Value::EnumTag(1),
+        Value::EnumTag(2),
+    );
+}
+
+#[test]
+fn current_winner_remaps_copied_payload_enums_and_omits_later_winners() {
+    let base = payload_enum_projection_schema(&["open"]);
+    let latest = payload_enum_projection_schema(&["open", "closed"]);
+    let payload = groove::records::RecordDescriptor::new([("note", ColumnType::String)]);
+    assert_current_winner_copied_enum_remap(
+        0x61,
+        base.tables[0].columns[1].column_type.clone(),
+        base.tables[0].columns[1].column_type.clone(),
+        latest.tables[0].columns[1].column_type.clone(),
+        Value::Enum(groove::records::EnumValue::create(0, payload.clone(), &[v("open")]).unwrap()),
+        Value::Enum(groove::records::EnumValue::create(1, payload, &[v("closed")]).unwrap()),
+    );
+}
+
+#[test]
+fn current_winner_remaps_copied_nested_scalar_enums_and_omits_later_winners() {
+    let base = nested_scalar_enum_projection_schema(&["open"]);
+    let latest = nested_scalar_enum_projection_schema(&["open", "closed"]);
+    assert_current_winner_copied_enum_remap(
+        0x63,
+        base.tables[0].columns[1].column_type.clone(),
+        base.tables[0].columns[1].column_type.clone(),
+        latest.tables[0].columns[1].column_type.clone(),
+        Value::Array(vec![Value::EnumTag(0)]),
+        Value::Array(vec![Value::EnumTag(1)]),
+    );
+}
+
+#[test]
+fn current_winner_remaps_copied_nested_payload_enums_and_omits_later_winners() {
+    let base = nested_payload_enum_projection_schema(&["open"]);
+    let latest = nested_payload_enum_projection_schema(&["open", "closed"]);
+    let payload = groove::records::RecordDescriptor::new([("note", ColumnType::String)]);
+    assert_current_winner_copied_enum_remap(
+        0x65,
+        base.tables[0].columns[1].column_type.clone(),
+        base.tables[0].columns[1].column_type.clone(),
+        latest.tables[0].columns[1].column_type.clone(),
+        Value::Array(vec![Value::Enum(
+            groove::records::EnumValue::create(0, payload.clone(), &[v("open")]).unwrap(),
+        )]),
+        Value::Array(vec![Value::Enum(
+            groove::records::EnumValue::create(1, payload, &[v("closed")]).unwrap(),
+        )]),
     );
 }
 

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -633,6 +633,7 @@ where
     /// Apply a downstream current-row view update.
     pub(super) fn apply_view_update(&mut self, update: ViewUpdateParts) -> Result<(), Error> {
         self.validate_received_view_update_global_seq_durability(&update)?;
+        self.validate_view_update_payloads(std::slice::from_ref(&update))?;
         self.apply_view_update_inner(update, None)
     }
 
@@ -646,6 +647,11 @@ where
         for update in &updates {
             self.validate_received_view_update_global_seq_durability(update)?;
         }
+        // A receiver tick is one atomic protocol frame. Validate every row
+        // descriptor before the first reset can change flush cadence, or a
+        // preceding valid bundle can advance clocks, allocate aliases, or
+        // stage history before a later malformed bundle rejects the frame.
+        self.validate_view_update_payloads(&updates)?;
         if updates.iter().any(|update| update.reset_result_set) {
             self.begin_initial_sync_flush_cadence()?;
         }
@@ -730,6 +736,19 @@ where
         }
         if self.initial_sync_flush_active && self.query.initial_hydration_binding_views.is_empty() {
             self.finish_initial_sync_flush_cadence()?;
+        }
+        Ok(())
+    }
+
+    /// Validate all row bundles carried by a receiver frame without changing
+    /// storage or in-memory receiver state.
+    fn validate_view_update_payloads(&self, updates: &[ViewUpdateParts]) -> Result<(), Error> {
+        for update in updates {
+            for bundle in
+                version_bundle_refs_for_carriers(&update.version_bundles, &update.version_carriers)?
+            {
+                self.validate_view_payload_versions(bundle.versions)?;
+            }
         }
         Ok(())
     }

--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -6,12 +6,13 @@ use crate::db::{CommitUnitTrust, ConnectionSessionContext, DbIdentity, RowCells,
 use crate::groove::records::Value;
 use crate::ids::{AuthorId, BranchId, NodeUuid, RowUuid, SchemaVersionId};
 use crate::node::EdgeCacheBudget;
-use crate::protocol::MigrationLens;
+use crate::protocol::{MigrationLens, SyncMessage};
 use crate::schema::JazzSchema;
 use crate::serving::{
     AbiBytes, InMemoryServerShell, InMemoryServerShellConfig, NodeRole, ServerSession,
     StorageConfig,
 };
+use crate::wire::{WireFrame, decode_frame, decode_sync_message};
 use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 
 /// Sendable handle for the thread that owns the in-memory server shell.
@@ -222,11 +223,20 @@ impl ServerShellHandle {
         self.jobs
             .send(Box::new(move |shell| {
                 for frame in frames {
+                    let phase = inbound_frame_phase(&frame);
                     let result = shell
                         .receive_frames(session, [frame])
-                        .and_then(|()| shell.tick())
-                        .and_then(|()| shell.take_frames(session))
-                        .map_err(|error| error.to_string());
+                        .map_err(|error| format!("server receive {phase}: {error}"))
+                        .and_then(|()| {
+                            shell
+                                .tick()
+                                .map_err(|error| format!("server tick after {phase}: {error}"))
+                        })
+                        .and_then(|()| {
+                            shell
+                                .take_frames(session)
+                                .map_err(|error| format!("server drain after {phase}: {error}"))
+                        });
                     let keep_streaming = result.is_ok();
                     if outbound_tx.send(result).is_err() {
                         return;
@@ -310,8 +320,101 @@ impl ServerShellHandle {
     }
 }
 
+fn inbound_frame_phase(frame: &[u8]) -> String {
+    let Ok(frame) = decode_frame(frame) else {
+        return "malformed wire frame".to_owned();
+    };
+    let WireFrame::Message(envelope) = frame else {
+        return match frame {
+            WireFrame::Hello(_) => "wire hello".to_owned(),
+            WireFrame::Error(_) => "wire error".to_owned(),
+            WireFrame::MessageFragment(_) => "wire message fragment".to_owned(),
+            WireFrame::Message(_) => unreachable!("message handled above"),
+        };
+    };
+    match decode_sync_message(&envelope.payload) {
+        Ok(message) => sync_message_name(&message).to_owned(),
+        Err(_) => "malformed SyncMessage".to_owned(),
+    }
+}
+
+fn sync_message_name(message: &SyncMessage) -> &'static str {
+    // This deliberately names only the protocol variant. Never format the
+    // message itself here: claims and row payloads must not escape through a
+    // transport diagnostic.
+    match message {
+        SyncMessage::BranchMetadata(_) => "BranchMetadata",
+        SyncMessage::FetchBranchMetadata { .. } => "FetchBranchMetadata",
+        SyncMessage::SessionClaims { .. } => "SessionClaims",
+        SyncMessage::CommitUnit { .. } => "CommitUnit",
+        SyncMessage::FateUpdate { .. } => "FateUpdate",
+        SyncMessage::RegisterShape { .. } => "RegisterShape",
+        SyncMessage::Subscribe(_) => "Subscribe",
+        SyncMessage::SubscribeRejected { .. } => "SubscribeRejected",
+        SyncMessage::Unsubscribe { .. } => "Unsubscribe",
+        SyncMessage::PublishSchema { .. } => "PublishSchema",
+        SyncMessage::PublishSchemaWithLens { .. } => "PublishSchemaWithLens",
+        SyncMessage::PublishLens { .. } => "PublishLens",
+        SyncMessage::SetCurrentWriteSchema { .. } => "SetCurrentWriteSchema",
+        SyncMessage::CatalogueAck(_) => "CatalogueAck",
+        SyncMessage::ViewUpdate { .. } => "ViewUpdate",
+        SyncMessage::FetchContentExtent { .. } => "FetchContentExtent",
+        SyncMessage::ContentExtents { .. } => "ContentExtents",
+        SyncMessage::FetchRowVersions { .. } => "FetchRowVersions",
+        SyncMessage::RowVersionPayloads { .. } => "RowVersionPayloads",
+        SyncMessage::CatalogueSnapshot(_) => "CatalogueSnapshot",
+        SyncMessage::PermissionAdviceRequest { .. } => "PermissionAdviceRequest",
+        SyncMessage::PermissionAdviceResponse { .. } => "PermissionAdviceResponse",
+        SyncMessage::AuthorizationScopeSubscribe { .. } => "AuthorizationScopeSubscribe",
+        SyncMessage::AuthorizationScopeReceipt { .. } => "AuthorizationScopeReceipt",
+        SyncMessage::AuthorizationScopeIntent { .. } => "AuthorizationScopeIntent",
+        SyncMessage::AuthorizationScopeView { .. } => "AuthorizationScopeView",
+        SyncMessage::AuthorizationScopeAggregateReceipt { .. } => {
+            "AuthorizationScopeAggregateReceipt"
+        }
+        SyncMessage::AuthorizationScopeUnavailable { .. } => "AuthorizationScopeUnavailable",
+        SyncMessage::AuthorizationScopeDecision { .. } => "AuthorizationScopeDecision",
+    }
+}
+
 fn notify_shell_activity(activity_tx: &watch::Sender<u64>) {
     activity_tx.send_modify(|version| {
         *version = version.wrapping_add(1);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{ReadViewKey, Subscribe, SubscriptionKey};
+    use crate::query::{BindingId, ShapeId};
+    use crate::wire::{WireEnvelope, encode_frame, encode_sync_message};
+
+    fn encode_message(message: SyncMessage) -> Vec<u8> {
+        let payload = encode_sync_message(&message).unwrap();
+        encode_frame(&WireFrame::Message(WireEnvelope::new(0, 0, payload))).unwrap()
+    }
+
+    #[test]
+    fn inbound_frame_phase_labels_semantic_transport_work() {
+        let encoded = encode_message(SyncMessage::SessionClaims {
+            identity: AuthorId::from_bytes([7; 16]),
+            claims: BTreeMap::new(),
+        });
+
+        assert_eq!(inbound_frame_phase(&encoded), "SessionClaims");
+        let shape_id = ShapeId(uuid::Uuid::from_bytes([3; 16]));
+        let subscribe = encode_message(SyncMessage::Subscribe(Subscribe {
+            shape_id,
+            subscription: SubscriptionKey {
+                shape_id,
+                binding_id: BindingId(uuid::Uuid::from_bytes([4; 16])),
+                read_view: ReadViewKey::default(),
+            },
+            values: Vec::new(),
+            known_state: None,
+        }));
+        assert_eq!(inbound_frame_phase(&subscribe), "Subscribe");
+        assert_eq!(inbound_frame_phase(&[0xff]), "malformed wire frame");
+    }
 }

--- a/crates/jazz/tests/prepared_claim_routing.rs
+++ b/crates/jazz/tests/prepared_claim_routing.rs
@@ -621,6 +621,175 @@ fn prepared_policy_claims_support_equal_custom_string_values() {
 }
 
 #[test]
+fn prepared_nested_claim_routes_keep_two_bindings_isolated_through_live_membership() {
+    const CHATS: &str = "chats";
+    const CHAT_MEMBERS: &str = "chat_members";
+
+    let schema = JazzSchema::new([
+        TableSchema::new(
+            CHATS,
+            [
+                ColumnSchema::new("name", ColumnType::String),
+                ColumnSchema::new("joinCode", ColumnType::String.nullable()),
+            ],
+        )
+        .with_read_policy(Policy::shape(
+            Query::from(CHATS)
+                .filter(eq(col("name"), lit("never-visible")))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from(CHATS).filter(eq(col("joinCode"), claim("join_code"))),
+                ))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from(CHATS).join_via_column(
+                        CHAT_MEMBERS,
+                        "chatId",
+                        "id",
+                        [eq(col("userId"), claim("user_id"))],
+                    ),
+                )),
+        ))
+        .with_write_policy(Policy::public()),
+        TableSchema::new(
+            CHAT_MEMBERS,
+            [
+                ColumnSchema::new("chatId", ColumnType::Uuid),
+                ColumnSchema::new("userId", ColumnType::String),
+            ],
+        )
+        .with_reference("chatId", CHATS)
+        .with_read_policy(Policy::shape(
+            Query::from(CHAT_MEMBERS).filter(eq(col("userId"), claim("user_id"))),
+        ))
+        .with_write_policy(Policy::public()),
+    ]);
+    let db = open_db_with_schema(schema);
+    let chat_a = row(0xc1);
+    let chat_b = row(0xc2);
+    let join_code_a = "invite-a";
+    let join_code_b = "invite-b";
+    let user_id_a = "member-a";
+    let user_id_b = "member-b";
+    for (chat, name, join_code) in [
+        (chat_a, "chat-a", join_code_a),
+        (chat_b, "chat-b", join_code_b),
+    ] {
+        db.insert_with_id(
+            CHATS,
+            chat,
+            BTreeMap::from([
+                ("name".to_owned(), Value::String(name.to_owned())),
+                (
+                    "joinCode".to_owned(),
+                    Value::Nullable(Some(Box::new(Value::String(format!("stored-{join_code}"))))),
+                ),
+            ]),
+        )
+        .expect("seed invite chat");
+    }
+    for (identity, join_code, user_id) in [
+        (USER_A, join_code_a, user_id_a),
+        (USER_B, join_code_b, user_id_b),
+    ] {
+        db.set_identity_claims(
+            identity,
+            BTreeMap::from([
+                (
+                    "join_code".to_owned(),
+                    Value::Nullable(Some(Box::new(Value::String(join_code.to_owned())))),
+                ),
+                ("user_id".to_owned(), Value::String(user_id.to_owned())),
+            ]),
+        );
+    }
+    let query = Query::from(CHATS).filter(eq(col("id"), param("id")));
+    let prepared = |chat: RowUuid| {
+        db.prepare_query_bound(
+            &query,
+            BTreeMap::from([("id".to_owned(), Value::Uuid(chat.0))]),
+        )
+        .expect("prepare chat binding")
+    };
+    let mut stream_a = block_on(db.subscribe_for_identity(&prepared(chat_a), opts(), USER_A))
+        .expect("subscribe invite binding A");
+    let mut stream_b = block_on(db.subscribe_for_identity(&prepared(chat_b), opts(), USER_B))
+        .expect("subscribe invite binding B");
+    let initial_rows = |event| match event {
+        SubscriptionEvent::Delta {
+            reset: true, added, ..
+        } => added
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>(),
+        other => panic!("expected initial reset, got {other:?}"),
+    };
+    assert!(
+        initial_rows(stream_a.try_next_event().expect("invite A reset")).is_empty(),
+        "a chat without its membership must not be visible"
+    );
+    assert!(
+        initial_rows(stream_b.try_next_event().expect("invite B reset")).is_empty(),
+        "a chat without its membership must not be visible"
+    );
+
+    db.insert_with_id(
+        CHAT_MEMBERS,
+        row(0xc3),
+        BTreeMap::from([
+            ("chatId".to_owned(), Value::Uuid(chat_a.0)),
+            ("userId".to_owned(), Value::String(user_id_a.to_owned())),
+        ]),
+    )
+    .expect("commit membership for binding A");
+    let added_rows = |event| match event {
+        SubscriptionEvent::Delta {
+            reset: false,
+            added,
+            ..
+        } => added
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>(),
+        other => panic!("expected live membership delta, got {other:?}"),
+    };
+    assert_eq!(
+        added_rows(
+            stream_a
+                .try_next_event()
+                .expect("binding A membership delta")
+        ),
+        vec![chat_a],
+        "the matching binding receives its live membership CommitUnit"
+    );
+    assert!(
+        stream_b.try_next_event().is_none(),
+        "binding A's CommitUnit must not leak into binding B"
+    );
+
+    db.insert_with_id(
+        CHAT_MEMBERS,
+        row(0xc4),
+        BTreeMap::from([
+            ("chatId".to_owned(), Value::Uuid(chat_b.0)),
+            ("userId".to_owned(), Value::String(user_id_b.to_owned())),
+        ]),
+    )
+    .expect("commit membership for binding B");
+    assert_eq!(
+        added_rows(
+            stream_b
+                .try_next_event()
+                .expect("binding B membership delta")
+        ),
+        vec![chat_b],
+        "the other nullable invite binding receives only its own CommitUnit"
+    );
+    assert!(
+        stream_a.try_next_event().is_none(),
+        "binding B's CommitUnit must not leak back into binding A"
+    );
+}
+
+#[test]
 fn policy_dependency_reads_do_not_expose_dependency_rows() {
     let membership_policy = Policy::shape(
         Query::from(MEMBERSHIPS).filter(eq(col("region"), claim("membership_region"))),


### PR DESCRIPTION
🤖 Preserves catalogue lens behavior while enforcing the simpler invariant that every synchronized row version is a complete row in its declared authored schema.

## Motivating example

Suppose schema v1 has `title`, and schema v2 adds `body` with a default. A real v1 row contains the complete v1 shape and may be projected through the lens into v2, producing the defaulted `body`. A record labelled as v2 but containing only `title` is not a v1 row and must not be interpreted as one: it is a malformed, incomplete v2 record.

This distinction prevents the query engine from having to guess whether an absent cell means an older schema, a projection, a legitimate nullable value, or corrupt sync data. Rows remain the unit of sync and permissions.

## What changed

- apply Rename, Copy, Add, and Drop semantics to complete historical rows after physical winner selection, while keeping enum decoding and unknown-case omission at the correct post-winner boundary
- recursively remap copied enum values when source and destination columns use distinct physical registries
- require wire row descriptors to match the complete authored schema before any row enters history/current storage
- keep unknown-schema authored CommitUnits parked until the catalogue arrives, then reject malformed authority input
- make relays observably drop malformed parked input without synthesizing authority or failing an already-durable catalogue publication
- validate an entire ViewUpdate frame before reset cadence, clocks, aliases, catalogue state, batch staging, or storage can change

Legitimate nullable values, deletion records, complete old-schema rows, and complete evolved-schema rows remain valid. The implementation does not restore partial-row merging or infer defaults from missing cells inside a record that claims the newer schema.

## Validation

- catalogue arrival and old/evolved-schema lens projection suites
- scalar, payload, nested scalar, and nested payload Copy/Rename enum matrices across Local/Edge/Global
- ordinary, reset, batched, and repair ViewUpdate completeness regressions
- malformed reset leaves flush/hydration state unchanged
- mixed valid+malformed batch leaves clocks, aliases, catalogue maps, history, and transaction storage unchanged
- authority park/reject and relay park/drop regressions
- deletion/register history and reopen behavior
- planted removal/inversion of completeness and frame-prevalidation guards fails the new regressions
- `cargo clippy -p jazz --no-default-features --features test -- -D warnings`
- `cargo fmt --check`
- sensitive-data and diff checks
- independent adversarial review: no P0/P1/P2 findings
