### PR TITLE
fix(jazz): isolate aggregate result fields

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -6257,7 +6257,12 @@ impl CurrentRow {
             .filter_map(|(idx, field)| {
                 let name = field.name.as_ref()?.as_str();
                 let name = if name.starts_with("user_") {
-                    self::query_engine::logical_user_column(name).to_owned()
+                    let name = self::query_engine::logical_user_column(name);
+                    self::query_engine::aggregate_output_logical_name(name)
+                        .unwrap_or(name)
+                        .to_owned()
+                } else if let Some(name) = self::query_engine::aggregate_output_logical_name(name) {
+                    name.to_owned()
                 } else if matches!(field.value_type, records::ValueType::Nullable(_))
                     && !matches!(name, "authored_columns" | "settle_position")
                 {

--- a/crates/jazz/src/node/query_engine/fields.rs
+++ b/crates/jazz/src/node/query_engine/fields.rs
@@ -1,6 +1,12 @@
 use super::ClaimPath;
 
 pub(crate) const USER_COLUMN_PREFIX: &str = "user_";
+/// Physical namespace for aggregate result values.
+///
+/// Aggregate aliases are public-facing names and can legally collide with a
+/// grouped source column (for example, `group_by("sum_score").sum("score")`).
+/// Keep aggregate values separate from source-row fields in compiler records.
+pub(crate) const AGGREGATE_OUTPUT_PREFIX: &str = "__jazz_aggregate_";
 pub(crate) const LEFT_JOIN_PREFIX: &str = "left.";
 pub(crate) const RIGHT_JOIN_PREFIX: &str = "right.";
 pub(crate) const CLOSURE_REQUIRED_ELEMENT: &str = "__closure_required_element";
@@ -14,6 +20,26 @@ pub(crate) fn user_column_field(column: &str) -> String {
 
 pub(crate) fn logical_user_column(field: &str) -> &str {
     field.strip_prefix(USER_COLUMN_PREFIX).unwrap_or(field)
+}
+
+pub(crate) fn aggregate_output_field(output: &str) -> String {
+    aggregate_output_column(output)
+}
+
+pub(crate) fn aggregate_output_app_field(output: &str) -> String {
+    user_column_field(&aggregate_output_field(output))
+}
+
+pub(crate) fn aggregate_output_column(output: &str) -> String {
+    if output.starts_with(AGGREGATE_OUTPUT_PREFIX) {
+        output.to_owned()
+    } else {
+        format!("{AGGREGATE_OUTPUT_PREFIX}{output}")
+    }
+}
+
+pub(crate) fn aggregate_output_logical_name(column: &str) -> Option<&str> {
+    column.strip_prefix(AGGREGATE_OUTPUT_PREFIX)
 }
 
 pub(crate) fn join_field(prefix: &str, field: &str) -> String {

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -4726,7 +4726,7 @@ fn lower_aggregate(
     fields.extend(
         outputs
             .iter()
-            .map(|aggregate| logical_user_column(&aggregate.output.name).to_owned()),
+            .map(|aggregate| aggregate_output_field(&aggregate.output.name)),
     );
     Ok(LoweredRelationInput {
         graph: GraphBuilder::aggregate(graph, group_cols, aggregates),
@@ -4762,7 +4762,7 @@ fn lower_aggregate_expr(
         },
         expression,
         distinct: false,
-        output_name: Some(logical_user_column(&aggregate.output.name).to_owned()),
+        output_name: Some(aggregate_output_field(&aggregate.output.name)),
     })
 }
 
@@ -7712,7 +7712,7 @@ fn fact_terminal_graph(
                             ) =>
                     {
                         graph.filter(GroovePredicateExpr::Neq {
-                            field: logical_user_column(&outputs[0].output.name).to_owned(),
+                            field: aggregate_output_field(&outputs[0].output.name),
                             value: LiteralValue::U64(0),
                         })
                     }
@@ -8096,7 +8096,7 @@ fn aggregate_app_row_descriptor(
             .iter()
             .map(|output| {
                 Ok((
-                    logical_user_column(&output.output.name).to_owned(),
+                    aggregate_output_field(&output.output.name),
                     aggregate_output_value_type(output, source)?,
                 ))
             })
@@ -8182,7 +8182,7 @@ fn aggregate_result_membership_fields(
     // runtime boundary, so it cannot be mistaken for row version metadata.
     if let Some(first_output) = outputs.first() {
         fields.push(ProjectField::renamed(
-            logical_user_column(&first_output.output.name),
+            aggregate_output_field(&first_output.output.name),
             "synthetic_replacement",
         ));
     } else {
@@ -8198,7 +8198,7 @@ fn aggregate_result_membership_fields(
     fields.extend(
         outputs
             .iter()
-            .map(|output| ProjectField::named(logical_user_column(&output.output.name))),
+            .map(|output| ProjectField::named(aggregate_output_field(&output.output.name))),
     );
     fields.extend(routing_param_fields.into_iter().map(ProjectField::named));
     Ok(fields)
@@ -8228,7 +8228,7 @@ fn aggregate_typed_output_field(
     source: &ResolvedSource,
 ) -> CapabilityResult<TypedOutputField> {
     Ok(TypedOutputField {
-        name: logical_user_column(&output.output.name).to_owned(),
+        name: aggregate_output_field(&output.output.name),
         ty: aggregate_output_value_type(output, source)?,
     })
 }

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -41,8 +41,9 @@ use super::query_engine::{
     SourceId, SourceMetadataFields, SourceMetadataRequirement, SourcePath, SourceRequest,
     SourceRequirements, SourceResolutionError, SourceResolver, SourceRole, SourceRowShape,
     StorageSchemaSelection, TypedOutputField, UnionInput, ValueSourceColumn, ValueSourceMode,
-    VersionIdentityFields, VersionedRowRefSchema, claim_param_field, claim_path_from_param_field,
-    left_field, logical_user_column, lower_query_program, right_field, route_param_field,
+    VersionIdentityFields, VersionedRowRefSchema, aggregate_output_app_field,
+    aggregate_output_column, aggregate_output_field, claim_param_field,
+    claim_path_from_param_field, left_field, lower_query_program, right_field, route_param_field,
     user_column_field,
 };
 use crate::protocol::{
@@ -3316,7 +3317,7 @@ fn normalized_aggregate_outputs(
         .map(|aggregate| {
             Ok(NormalizedAggregateExpr {
                 output: typed_output_field(
-                    user_column_field(&aggregate.alias),
+                    aggregate_output_field(&aggregate.alias),
                     normalized_aggregate_output_type(aggregate),
                 ),
                 function: normalized_aggregate_function(aggregate.function),
@@ -8158,35 +8159,15 @@ where
     fn materialize_aggregate_query_rows(
         &mut self,
         query: &crate::query::Query,
-        table: &TableSchema,
+        _table: &TableSchema,
         deltas: groove::ivm::RecordDeltas,
     ) -> Result<Vec<CurrentRow>, Error> {
         let mut rows = Vec::new();
         for (record, _weight) in deltas.iter().filter(|(_, weight)| *weight > 0) {
-            let mut cells = BTreeMap::new();
-            for field in record.descriptor().fields() {
-                let Some(name) = field.name.as_deref() else {
-                    continue;
-                };
-                let logical_name = logical_user_column(name);
-                if let Some(column) = table
-                    .columns
-                    .iter()
-                    .find(|column| column.name == logical_name)
-                {
-                    let value =
-                        record.get_idx(record.descriptor().field_index(name).ok_or(
-                            Error::InvalidStoredValue("aggregate record field missing"),
-                        )?)?;
-                    if let Some(value) = aggregate_payload_cell_value(query, &column.name, value) {
-                        cells.insert(column.name.clone(), value);
-                    }
-                }
-            }
-            rows.push(current_row_from_cells(
-                table,
+            rows.push(aggregate_current_row_from_record(
+                &query.table,
                 aggregate_query_row_uuid(query, &record)?,
-                &cells,
+                &record,
             )?);
         }
         Ok(rows)
@@ -9603,8 +9584,6 @@ where
         member: &ResultMemberEntry,
         payload: &ResultMemberPayloadEntry,
     ) -> Result<CurrentRow, Error> {
-        let source_table = self.table(query.table.as_str())?.clone();
-        let table = aggregate_result_table(query, &source_table)?;
         let fields: Vec<(Option<String>, ValueType)> = postcard::from_bytes(&payload.descriptor)
             .map_err(|_| Error::InvalidStoredValue("result payload descriptor is invalid"))?;
         let payload_descriptor = RecordDescriptor::new(
@@ -9619,21 +9598,11 @@ where
                 .collect::<Result<Vec<_>, _>>()?,
         );
         let payload_record = BorrowedRecord::new(&payload.record, &payload_descriptor);
-        let mut cells = BTreeMap::new();
-        for column in &table.columns {
-            let field = user_column_field(&column.name);
-            let index = payload_descriptor
-                .field_index(&field)
-                .or_else(|| payload_descriptor.field_index(&column.name))
-                .ok_or(Error::InvalidStoredValue(
-                    "aggregate result payload is missing an output column",
-                ))?;
-            let value = payload_record.get_idx(index)?;
-            if let Some(value) = aggregate_payload_cell_value(query, &column.name, value) {
-                cells.insert(column.name.clone(), value);
-            }
-        }
-        current_row_from_cells(&table, aggregate_result_member_row_uuid(member)?, &cells)
+        aggregate_current_row_from_record(
+            query.table.as_str(),
+            aggregate_result_member_row_uuid(member)?,
+            &payload_record,
+        )
     }
 
     fn current_row_from_result_payload(
@@ -10309,8 +10278,8 @@ where
                 |(left_row, left_occurrence), (right_row, right_occurrence)| {
                     for order in &query.order_by {
                         let ordering = compare_optional_values(
-                            aggregate_row_cell(left_row, &order.column),
-                            aggregate_row_cell(right_row, &order.column),
+                            aggregate_row_cell(left_row, query, &order.column),
+                            aggregate_row_cell(right_row, query, &order.column),
                         );
                         let ordering = match order.direction {
                             OrderDirection::Asc => ordering,
@@ -10378,8 +10347,8 @@ where
             rows.sort_by(|left, right| {
                 for order in &query.order_by {
                     let ordering = compare_optional_values(
-                        aggregate_row_cell(left, &order.column),
-                        aggregate_row_cell(right, &order.column),
+                        aggregate_row_cell(left, query, &order.column),
+                        aggregate_row_cell(right, query, &order.column),
                     );
                     let ordering = match order.direction {
                         OrderDirection::Asc => ordering,
@@ -11580,6 +11549,35 @@ where
     }
 }
 
+/// Wrap a compiler aggregate record in the minimal [`CurrentRow`] envelope.
+///
+/// Aggregate result fields deliberately retain their compiler names here: a
+/// grouped public column can have the same logical label as an aggregate
+/// output, and collapsing either into a table-schema cell map loses one of
+/// them. Consumers with a public aggregate query translate those names through
+/// the centralized helpers at their boundary.
+fn aggregate_current_row_from_record(
+    table: &str,
+    row_uuid: RowUuid,
+    record: &BorrowedRecord<'_>,
+) -> Result<CurrentRow, Error> {
+    let mut fields = vec![("row_uuid".to_owned(), ValueType::Uuid)];
+    let mut values = vec![Value::Uuid(row_uuid.0)];
+    for (index, field) in record.descriptor().fields().iter().enumerate() {
+        let name = field.name.clone().ok_or(Error::InvalidStoredValue(
+            "aggregate record field must be named",
+        ))?;
+        fields.push((name, field.value_type.clone()));
+        values.push(record.get_idx(index)?);
+    }
+    let descriptor = RecordDescriptor::new(fields);
+    let raw = descriptor.create(&values)?;
+    Ok(CurrentRow::new(
+        table.to_owned(),
+        OwnedRecord::new(raw, descriptor),
+    ))
+}
+
 #[cfg_attr(not(test), allow(dead_code))]
 fn compile_permission_scope_policy(
     mut query: JazzQuery,
@@ -11949,33 +11947,6 @@ mod authorization_scope_compiler_tests {
         );
         assert_ne!(insert.key, update.key);
         assert_ne!(update.key, delete.key);
-    }
-}
-
-/// Flatten the nullable aggregate-result representation into a current-row
-/// cell.  A non-count aggregate payload uses `Nullable(None)` for SQL NULL;
-/// the current row's outer nullable envelope represents that public NULL.
-/// This is deliberately called only after a [`ResultMemberPayloadEntry`] has
-/// been found, preserving the distinction between a present NULL and a
-/// genuinely missing payload.
-fn aggregate_payload_cell_value(
-    query: &crate::query::Query,
-    column: &str,
-    value: Value,
-) -> Option<Value> {
-    let aggregate = query.aggregate.as_ref().and_then(|aggregate| {
-        aggregate
-            .aggregates
-            .iter()
-            .find(|aggregate| aggregate.alias == column)
-    });
-    match aggregate {
-        Some(aggregate) if aggregate.function != AggregateFunction::Count => match value {
-            Value::Nullable(None) => None,
-            Value::Nullable(Some(value)) => Some(*value),
-            value => Some(value),
-        },
-        _ => Some(value),
     }
 }
 
@@ -13372,11 +13343,29 @@ fn default_query_row_order(left: &CurrentRow, right: &CurrentRow) -> Ordering {
         .then_with(|| left.record.raw().cmp(right.record.raw()))
 }
 
-fn aggregate_row_cell(row: &CurrentRow, column: &str) -> Option<Value> {
-    let user_name = user_column_field(column);
-    let idx = row.record.descriptor().fields().iter().position(|field| {
-        field.name.as_deref() == Some(user_name.as_str()) || field.name.as_deref() == Some(column)
-    })?;
+fn aggregate_row_cell(
+    row: &CurrentRow,
+    query: &crate::query::Query,
+    column: &str,
+) -> Option<Value> {
+    let field = if query
+        .aggregate
+        .as_ref()
+        .and_then(|aggregate| aggregate.group_by.as_deref())
+        == Some(column)
+    {
+        user_column_field(column)
+    } else if query.aggregate.as_ref().is_some_and(|aggregate| {
+        aggregate
+            .aggregates
+            .iter()
+            .any(|aggregate| aggregate.alias == column)
+    }) {
+        aggregate_output_app_field(column)
+    } else {
+        user_column_field(column)
+    };
+    let idx = row.record.descriptor().field_index(&field)?;
     nullable_value(row.record.borrowed().get_idx(idx).ok()?).ok()?
 }
 
@@ -13398,7 +13387,7 @@ fn aggregate_result_table(
     }
     for aggregate in &aggregate.aggregates {
         columns.push(ColumnSchema::new(
-            &aggregate.alias,
+            aggregate_output_column(&aggregate.alias),
             aggregate_result_column_type(aggregate, source_table)?,
         ));
     }
@@ -17544,6 +17533,31 @@ mod tests {
         assert_eq!(cells["avg_score"], Value::F64(-0.5));
         assert_eq!(cells["min_score"], Value::I64(-3));
         assert_eq!(cells["max_score"], Value::I64(2));
+    }
+
+    #[test]
+    fn aggregate_explicit_user_prefix_alias_remains_a_logical_name() {
+        let schema = signed_metric_schema();
+        let (_dir, mut node) =
+            open_node_with_uuid(NodeUuid::from_bytes([0xb6; 16]), schema.clone());
+        commit_signed_metric(&mut node, 0x12, "a", -3);
+        commit_signed_metric(&mut node, 0x13, "a", 2);
+        let shape = Query::from("metrics")
+            .aggregate([Aggregate::sum("score").alias("user_total")])
+            .validate(&schema)
+            .expect("explicit user-prefix aggregate alias is valid");
+        let rows = node
+            .query_rows(
+                &shape,
+                &shape.bind(BTreeMap::new()).unwrap(),
+                DurabilityTier::Local,
+            )
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].test_cells_by_descriptor()["user_total"],
+            Value::I64(-1),
+        );
     }
 
     #[test]

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -2582,6 +2582,9 @@ pub(crate) fn binding_id_for_values(values: &BTreeMap<String, Value>) -> Binding
 /// Query validation error.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum QueryError {
+    /// Aggregate aliases cannot occupy compiler-owned output names.
+    #[error("aggregate alias {0} uses a reserved compiler namespace")]
+    ReservedAggregateAlias(String),
     /// Flat tuple output currently has a deliberately narrow executable envelope.
     #[error("flat join cannot be combined with {feature}")]
     UnsupportedFlatJoinCombination {
@@ -2961,6 +2964,9 @@ fn validate_aggregate(table: &TableSchema, aggregate: &AggregateQuery) -> Result
         planner_column_type(table, group_by)?;
     }
     for aggregate in &aggregate.aggregates {
+        if aggregate.alias.starts_with("__jazz_aggregate_") {
+            return Err(QueryError::ReservedAggregateAlias(aggregate.alias.clone()));
+        }
         match aggregate.function {
             AggregateFunction::Count => {
                 if let Some(column) = &aggregate.column {
@@ -4978,6 +4984,26 @@ mod tests {
             .validate(&schema())
             .unwrap_err();
         assert!(matches!(err, QueryError::UnknownColumn { .. }));
+
+        let valid_user_alias = Query::from("issues")
+            .aggregate([Aggregate::sum("priority").alias("user_total")])
+            .validate(&schema())
+            .expect("explicit aliases are logical names, not compiler fields");
+        assert_eq!(
+            valid_user_alias
+                .query()
+                .aggregate
+                .as_ref()
+                .unwrap()
+                .aggregates[0]
+                .alias,
+            "user_total"
+        );
+        let err = Query::from("issues")
+            .aggregate([Aggregate::sum("priority").alias("__jazz_aggregate_user_total")])
+            .validate(&schema())
+            .unwrap_err();
+        assert!(matches!(err, QueryError::ReservedAggregateAlias(_)));
 
         let err = Query::from("issues")
             .count()

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -2104,7 +2104,11 @@ fn aggregate_public_values(
     let Some(aggregate) = &query.aggregate else {
         return Ok(Vec::new());
     };
-    let mut columns: Vec<(String, Option<ColumnType>)> = Vec::new();
+    // Aggregate result descriptors are compiler records, not public table
+    // rows. Like all compiler records, their application-facing fields carry
+    // the `user_` prefix. Keep the public label only for diagnostics and
+    // translate the lookup to that physical field name at this boundary.
+    let mut columns: Vec<(String, String, Option<ColumnType>)> = Vec::new();
     if let Some(group_by) = &aggregate.group_by {
         let idx = table_schema.columns.column_index(group_by).ok_or_else(|| {
             JazzError::Query(format!(
@@ -2114,12 +2118,15 @@ fn aggregate_public_values(
         })?;
         columns.push((
             group_by.clone(),
+            crate::node::query_engine::user_column_field(group_by),
             Some(table_schema.columns.columns[idx].column_type.clone()),
         ));
     }
     for output in &aggregate.outputs {
+        let public_name = aggregate_output_name(output);
         columns.push((
-            aggregate_output_name(output),
+            public_name.clone(),
+            crate::node::query_engine::aggregate_output_app_field(&public_name),
             aggregate_output_column_type(output, table_schema, query.table.as_str())?,
         ));
     }
@@ -2127,9 +2134,11 @@ fn aggregate_public_values(
     let borrowed = crate::groove::records::BorrowedRecord::new(raw, descriptor);
     columns
         .into_iter()
-        .map(|(column, column_type)| {
-            let idx = descriptor.field_index(&column).ok_or_else(|| {
-                JazzError::Query(format!("aggregate row missing column {column}"))
+        .map(|(public_column, physical_column, column_type)| {
+            let idx = descriptor.field_index(&physical_column).ok_or_else(|| {
+                JazzError::Query(format!(
+                    "aggregate row missing column {public_column} (physical field {physical_column})"
+                ))
             })?;
             let value = borrowed
                 .get_idx(idx)

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -25,6 +25,7 @@ use crate::tools::public_schema::{
 
 const DIRECT_USER_ID_CLAIM: &str = "user_id";
 const PUBLIC_USER_ID_SESSION_PATHS: &[&str] = &["user_id", "userId"];
+const RESERVED_AGGREGATE_OUTPUT_PREFIX: &str = "__jazz_aggregate_";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SchemaConversionError {
@@ -430,6 +431,16 @@ fn convert_table(
     let mut columns = Vec::with_capacity(table.columns.columns.len());
     let mut merge_strategies = BTreeMap::new();
     for column in &table.columns.columns {
+        if column
+            .name
+            .as_str()
+            .starts_with(RESERVED_AGGREGATE_OUTPUT_PREFIX)
+        {
+            return Err(err(
+                format!("$.{}.columns.{}", name.as_str(), column.name.as_str()),
+                "column name uses the reserved aggregate-output namespace",
+            ));
+        }
         let converted = convert_column(name, column)?;
         if let Some(reference) = &column.references {
             references.insert(
@@ -2184,6 +2195,23 @@ mod tests {
         PredicateExpr as RelPredicateExpr, RecursionBound as RelRecursionBound,
         RelExpr as PublicRelExpr, RowIdRef as RelRowIdRef, ValueRef as RelValueRef,
     };
+
+    #[test]
+    fn rejects_user_columns_in_the_compiler_aggregate_namespace() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("metrics")
+                    .column("__jazz_aggregate_sum_score", ColumnType::Integer),
+            )
+            .build();
+        let error =
+            convert_public_schema(&schema).expect_err("reserved column must fail conversion");
+        assert!(
+            error
+                .to_string()
+                .contains("reserved aggregate-output namespace")
+        );
+    }
     use crate::tools::public_api::types::TableSchemaBuilder;
     use crate::tools::public_schema::{
         ColumnDescriptor, ColumnType, LargeValueKind, PolicyExpr, RowDescriptor, Schema,

--- a/crates/jazz/tests/aggregate_subscriptions.rs
+++ b/crates/jazz/tests/aggregate_subscriptions.rs
@@ -38,6 +38,18 @@ fn nullable_metrics_schema() -> Schema {
         .build()
 }
 
+fn aggregate_alias_collision_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("metrics")
+                // This is a valid public column name which happens to match
+                // the public label for SUM(score).
+                .column("sum_score", ColumnType::Text)
+                .nullable_column("score", ColumnType::BigInt),
+        )
+        .build()
+}
+
 fn bigint_metrics_schema() -> Schema {
     SchemaBuilder::new()
         .table(
@@ -1372,6 +1384,73 @@ async fn aggregate_sum_bigint_survives_public_client_boundary() {
                 sum_query,
                 vec![vec![Value::BigInt(2)]],
                 "bigint sum decodes exact signed public value",
+            )
+            .await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn aggregate_outputs_do_not_collide_with_grouped_public_column_names() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = aggregate_alias_collision_schema();
+            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let client = JazzClient::connect(
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa6"),
+            )
+            .await
+            .expect("connect client");
+
+            let (_, _, batch) = client
+                .insert(
+                    "metrics",
+                    row_input!(
+                        "sum_score" => "negative",
+                        "score" => Value::BigInt(-3)
+                    ),
+                )
+                .expect("insert signed aggregate value");
+            client
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::Local,
+                )
+                .await
+                .expect("signed aggregate value settles");
+            let (_, _, batch) = client
+                .insert(
+                    "metrics",
+                    row_input!(
+                        "sum_score" => "negative",
+                        "score" => Value::Null
+                    ),
+                )
+                .expect("insert nullable aggregate value");
+            client
+                .wait_for_batch(
+                    batch.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::Local,
+                )
+                .await
+                .expect("nullable aggregate value settles");
+
+            let grouped = QueryBuilder::new("metrics")
+                .group_by("sum_score")
+                .sum("score")
+                .build();
+            wait_for_values(
+                &client,
+                grouped,
+                vec![vec![Value::Text("negative".to_owned()), Value::BigInt(-3)]],
+                "grouped public field and aggregate output stay distinct",
+            )
+            .await;
+            wait_for_values(
+                &client,
+                QueryBuilder::new("metrics").sum("score").build(),
+                vec![vec![Value::BigInt(-3)]],
+                "non-grouped signed nullable aggregate remains public",
             )
             .await;
         })


### PR DESCRIPTION
🤖 Fix aggregate result naming across compiler and public boundaries.

## What changed

- give aggregate outputs a compiler-only physical namespace distinct from ordinary `user_*` fields
- map compiler output, app-row terminal output, and public logical labels explicitly
- preserve legal explicit aliases such as `user_total`
- reject only the exact compiler-reserved aggregate prefix in schemas and explicit aliases

## Why

Aggregate result decoding looked up logical names in records whose fields are compiler-physical, causing deterministic missing-column failures for signed and nullable aggregates. Simply prefixing those outputs would collide with valid grouped user columns and broke internal ordering/offset consumers.

The final mapping is collision-free and consistent across lowering, result membership materialization, terminal projection, ordering, and public decoding.

## Validation

- public signed BigInt and nullable aggregate boundary tests
- valid grouped-column/generated-output collision regression
- explicit `user_total` alias preservation and reserved-prefix validation
- core signed multi-aggregate and filtered aggregate tests
- grouped count ordering, limit, and offset regression
- planted old namespace and alias-stripping regressions fail as expected
- `cargo clippy --package jazz -- -D warnings`
- `cargo fmt --check`
- independent adversarial review: no P0/P1/P2 findings
