### PR TITLE
fix(jazz): retain nested include join keys

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -1852,6 +1852,24 @@ fn source_requirements(
         requirements.insert(source, SourceRequirements::default());
     }
 
+    // Every closure hop consumes its parent reference as an executable join
+    // key, even when that intermediate source contributes no application
+    // payload.  Source projections are allowed to elide unrequested fields;
+    // without this requirement a nested include such as `project.org` can
+    // resolve `projects` with `user_org` replaced by its sparse projection
+    // default, making the second hop look universally missing.
+    for path in &request.input.shape.closure_paths {
+        for segment in closure_path_segments(path) {
+            let source_requirements = requirements.get_mut(&segment.parent).ok_or_else(|| {
+                single_gap_report(UnsupportedReason::Runtime(format!(
+                    "closure parent source {:?} was not initialized",
+                    segment.parent
+                )))
+            })?;
+            add_required_app_field(source_requirements, segment.source_field.clone());
+        }
+    }
+
     // A flat output carries an occurrence-addressed tuple. Keep source
     // version metadata available at the source boundary so joined-side
     // changes can be represented as maintained replacements.
@@ -1904,10 +1922,13 @@ fn source_requirements(
                 SourceMetadataRequirement::Provenance(ProvenanceField::UpdatedBy),
             ]);
         }
-        root_requirements.app_fields = match &app_rows.projection {
-            PayloadProjection::ShapeDefault => FieldRequirement::All,
-            PayloadProjection::Tree(tree) => tree.fields.clone().into(),
-        };
+        merge_field_requirement(
+            &mut root_requirements.app_fields,
+            match &app_rows.projection {
+                PayloadProjection::ShapeDefault => FieldRequirement::All,
+                PayloadProjection::Tree(tree) => tree.fields.clone().into(),
+            },
+        );
         if let PayloadProjection::Tree(tree) = &app_rows.projection {
             if let FieldProjection::Fields(fields) = &tree.fields {
                 for field in fields {
@@ -2013,6 +2034,19 @@ fn source_requirements(
     collect_plan_requirements(plan, &mut requirements)?;
 
     Ok(requirements)
+}
+
+#[cfg(test)]
+pub(super) fn source_requirements_for_test(
+    request: &QueryProgramRequest,
+) -> CapabilityResult<BTreeMap<SourceId, SourceRequirements>> {
+    let plan = analyze_query_plan(request).map_err(|gaps| {
+        Box::new(CapabilityReport {
+            gaps,
+            explain: ExplainPlan::default(),
+        })
+    })?;
+    source_requirements(request, &plan)
 }
 
 fn collect_app_path_projection_requirements(

--- a/crates/jazz/src/node/query_engine/tests.rs
+++ b/crates/jazz/src/node/query_engine/tests.rs
@@ -870,6 +870,160 @@ fn compiler_boundary_has_no_usage_or_lifecycle_mode() {
     );
 }
 
+/// Closure hops must retain their executable parent keys even when sparse
+/// public projection asks for only the root title.
+///
+/// system ──reads roots.{project, backup, members, owner}──► closure targets
+#[test]
+fn closure_requirements_merge_sparse_root_and_every_alias_hop_key() {
+    let root = source("roots", SourceRole::Root);
+    let project = source("projects", SourceRole::Alias("include:0:0".to_owned()));
+    let org = source("orgs", SourceRole::Alias("include:0:1".to_owned()));
+    let backup = source("projects", SourceRole::Alias("include:1:0".to_owned()));
+    let backup_org = source("orgs", SourceRole::Alias("include:1:1".to_owned()));
+    let member = source("profiles", SourceRole::Alias("include:2:0".to_owned()));
+    let owner = source("users", SourceRole::Alias("reference:owner".to_owned()));
+    let mut input = row_set_input(0x2a);
+    input.shape.result = ResultId::RealRow {
+        table: "roots".to_owned(),
+        row: ResultRowRef::Source(root.clone()),
+    };
+    input.shape.nodes = BTreeMap::from([(
+        input.shape.root.clone(),
+        RowSetExpr::Source {
+            source: root.clone(),
+            visibility: RowVisibility::Visible,
+        },
+    )]);
+    input.shape.auxiliary_sources = BTreeSet::from([
+        project.clone(),
+        org.clone(),
+        backup.clone(),
+        backup_org.clone(),
+        member.clone(),
+        owner.clone(),
+    ]);
+    input.shape.closure_paths = vec![
+        ClosurePath::ExplicitInclude {
+            id: "include:0:project.org".to_owned(),
+            segments: vec![
+                ClosurePathSegment {
+                    parent: root.clone(),
+                    target: project.clone(),
+                    source_field: "project".to_owned(),
+                },
+                ClosurePathSegment {
+                    parent: project.clone(),
+                    target: org.clone(),
+                    source_field: "org".to_owned(),
+                },
+            ],
+            root_gate: Some(ClosureRootGate::Inner),
+        },
+        ClosurePath::ExplicitInclude {
+            id: "include:1:backup.org".to_owned(),
+            segments: vec![
+                ClosurePathSegment {
+                    parent: root.clone(),
+                    target: backup.clone(),
+                    source_field: "backup".to_owned(),
+                },
+                ClosurePathSegment {
+                    parent: backup.clone(),
+                    target: backup_org.clone(),
+                    source_field: "org".to_owned(),
+                },
+            ],
+            root_gate: Some(ClosureRootGate::Inner),
+        },
+        ClosurePath::ExplicitInclude {
+            id: "include:2:members".to_owned(),
+            segments: vec![ClosurePathSegment {
+                parent: root.clone(),
+                target: member.clone(),
+                source_field: "members".to_owned(),
+            }],
+            root_gate: Some(ClosureRootGate::Required),
+        },
+        ClosurePath::ImplicitRootReference {
+            id: "reference:owner".to_owned(),
+            segment: ClosurePathSegment {
+                parent: root.clone(),
+                target: owner.clone(),
+                source_field: "owner".to_owned(),
+            },
+        },
+    ];
+    let mut output = row_set_output(BTreeSet::new());
+    output.app_rows.as_mut().expect("app rows").projection =
+        PayloadProjection::Tree(AppProjectionTree {
+            fields: FieldProjection::Fields(BTreeSet::from(["title".to_owned()])),
+            paths: Vec::new(),
+        });
+    let request = QueryProgramRequest {
+        authorization_mode: QueryAuthorizationMode::TrustedServing,
+        reads: QueryReadSet::primary(ReadView {
+            read_schema: schema(0x10),
+            policy_schema: schema(0x11),
+            sources: BTreeMap::from([
+                (
+                    root.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    project.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    org.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    backup.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    backup_org.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    member.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    owner.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+            ]),
+        }),
+        policy: system_policy_context(),
+        input,
+        output,
+    };
+
+    let requirements = source_requirements_for_test(&request).expect("collect closure fields");
+
+    let expected_root = BTreeSet::from([
+        "title".to_owned(),
+        "project".to_owned(),
+        "backup".to_owned(),
+        "members".to_owned(),
+        "owner".to_owned(),
+    ]);
+    assert!(matches!(
+        requirements.get(&root).map(|requirements| &requirements.app_fields),
+        Some(FieldRequirement::Fields(fields)) if *fields == expected_root
+    ));
+    for source in [&project, &backup] {
+        assert!(matches!(
+            requirements
+                .get(source)
+                .map(|requirements| &requirements.app_fields),
+            Some(FieldRequirement::Fields(fields)) if *fields == BTreeSet::from(["org".to_owned()])
+        ));
+    }
+}
+
 #[test]
 fn simple_current_table_root_query_lowers_for_local_edge_and_global_sync_outputs() {
     for tier in [

--- a/crates/jazz/src/node/tests/policies_rls.rs
+++ b/crates/jazz/src/node/tests/policies_rls.rs
@@ -2918,6 +2918,31 @@ fn inner_multi_segment_include_missing_or_unreadable_second_hop_drops_parent() {
     );
 }
 
+/// A title-only root projection still retains its hidden `project` join key
+/// long enough to gate the nested `project.org` include.
+///
+/// alice ──reads title──► root.project ──requires──► project.org
+#[test]
+fn sparse_root_projection_preserves_multisegment_inner_include_join_key() {
+    let schema = multi_segment_required_include_rls_schema();
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let reader = user(0xa1);
+    seed_multi_segment_include_fixture(&mut core, reader);
+    let shape = Query::from("roots")
+        .select(["title"])
+        .include_with(Include::new("project.org"))
+        .validate(&core.catalogue.schema)
+        .unwrap();
+
+    let rows = required_include_rows(&mut core, &shape, reader);
+    assert_eq!(
+        rows.into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([row(0xd2)])
+    );
+}
+
 #[test]
 fn maintained_subscription_view_multi_segment_inner_include_payload_references_visible_path() {
     let schema = multi_segment_required_include_rls_schema();


### PR DESCRIPTION
🤖 Preserve nested include join keys in sparse source projections.

## Root cause

For a composed include such as `roots.project → projects.org → orgs`, source requirement collection kept the root result fields but omitted the intermediate reference key. Schema-aware sparse projection therefore defaulted `projects.org`, and the second-hop validity gate treated every nested path as missing.

## What changed

- collect each closure segment's parent reference field as a required app field
- merge sparse root projection requirements instead of overwriting previously collected closure keys
- retain the existing row-authorization boundary; this changes projected columns, not authorized rows

## Validation

- compiler requirement matrix: sparse root, scalar two-hop, array hop, implicit root reference, duplicate aliases
- black-box `select([title]).include(project.org)` regression
- inner and holes one-shot, maintained, payload-reference, and prepared-delta regressions
- planted merge-to-assignment and missing-closure requirements fail as expected
- `cargo clippy --package jazz -- -D warnings`
- `cargo fmt --check`
- independent adversarial review: no P0/P1/P2 findings
