### PR TITLE
fix(jazz): fail closed missing authorization claims

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -7183,6 +7183,11 @@ pub enum Error {
     /// Query-engine capability report for a currently unsupported program.
     #[error("query capability unsupported: {0}")]
     QueryCapability(String),
+    /// A terminal authorization-support subscription depends on a session
+    /// claim the permission subject did not provide. This is a denied proof,
+    /// not malformed persisted state.
+    #[error("authorization support policy claim is not bound: {0}")]
+    AuthorizationSupportMissingClaim(String),
     /// A membership-policy proof revisited a table already on its compilation
     /// stack. The named error prevents stack exhaustion while diagnosing a
     /// policy cycle.

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -65,6 +65,16 @@ use crate::tools::{ObjectId, OutputOccurrenceId};
 pub(crate) const JAZZ_APP_ROWS_SINK: &str = "app_rows";
 const PENDING_BINDING_SOURCE_SHAPE: &str = "__jazz_pending_binding_source";
 
+/// The caller-owned meaning of an absent claim while binding a prepared plan.
+/// Ordinary prepared queries require all declared bindings. Authorization
+/// support, on the other hand, must represent an absent policy claim as an
+/// empty proof for the commit's permission subject.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PreparedClaimBindingMode {
+    Strict,
+    FailClosedAuthorizationSupport,
+}
+
 /// Exact, action-specific policy support compiled for a hypothetical operation.
 ///
 /// The support key deliberately excludes the row/candidate operation key: two
@@ -4950,6 +4960,27 @@ where
         claim_params: BTreeMap<String, ProgramClaimParam>,
         policy: &PolicyContext,
     ) -> Result<ProgramBinding, Error> {
+        self.program_binding_for_shape_and_policy_with_prepared_claim_mode(
+            shape,
+            binding,
+            source_shape,
+            extra_user_params,
+            claim_params,
+            policy,
+            PreparedClaimBindingMode::Strict,
+        )
+    }
+
+    fn program_binding_for_shape_and_policy_with_prepared_claim_mode(
+        &self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        source_shape: Option<String>,
+        extra_user_params: BTreeMap<String, ColumnType>,
+        claim_params: BTreeMap<String, ProgramClaimParam>,
+        policy: &PolicyContext,
+        prepared_claim_binding_mode: PreparedClaimBindingMode,
+    ) -> Result<ProgramBinding, Error> {
         let mut program_binding = self.program_binding_for_shape(
             shape,
             binding,
@@ -4961,6 +4992,13 @@ where
             let mut values = binding.values().clone();
             for (name, claim) in &claim_params {
                 let Some(value) = prepared_claim_value(&claim.path, policy)? else {
+                    if prepared_claim_binding_mode
+                        == PreparedClaimBindingMode::FailClosedAuthorizationSupport
+                    {
+                        return Err(Error::AuthorizationSupportMissingClaim(
+                            claim.path.0.join("."),
+                        ));
+                    }
                     // An absent claim cannot establish a policy proof. Leave
                     // it as a capability gap so the policy source resolver
                     // lowers the proof to an empty authorization graph.
@@ -5818,7 +5856,7 @@ where
         settled_binding_view: Option<BindingViewKey>,
         authorization_mode: QueryAuthorizationMode,
     ) -> Result<QueryProgram, Error> {
-        let request = self.current_query_program_request(
+        self.compile_current_query_program_with_settled_view_and_prepared_claim_mode(
             shape,
             binding,
             tier,
@@ -5827,6 +5865,32 @@ where
             read_view,
             settled_binding_view,
             authorization_mode,
+            PreparedClaimBindingMode::Strict,
+        )
+    }
+
+    fn compile_current_query_program_with_settled_view_and_prepared_claim_mode(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        identity: AuthorId,
+        output: CurrentQueryProgramOutput,
+        read_view: &ReadViewSpec,
+        settled_binding_view: Option<BindingViewKey>,
+        authorization_mode: QueryAuthorizationMode,
+        prepared_claim_binding_mode: PreparedClaimBindingMode,
+    ) -> Result<QueryProgram, Error> {
+        let request = self.current_query_program_request_with_prepared_claim_mode(
+            shape,
+            binding,
+            tier,
+            identity,
+            output,
+            read_view,
+            settled_binding_view,
+            authorization_mode,
+            prepared_claim_binding_mode,
         )?;
         self.compile_query_program_request(request)
     }
@@ -6507,6 +6571,31 @@ where
         settled_binding_view: Option<BindingViewKey>,
         authorization_mode: QueryAuthorizationMode,
     ) -> Result<QueryProgramRequest, Error> {
+        self.current_query_program_request_with_prepared_claim_mode(
+            shape,
+            binding,
+            tier,
+            identity,
+            output,
+            read_view,
+            settled_binding_view,
+            authorization_mode,
+            PreparedClaimBindingMode::Strict,
+        )
+    }
+
+    fn current_query_program_request_with_prepared_claim_mode(
+        &self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        identity: AuthorId,
+        output: CurrentQueryProgramOutput,
+        read_view: &ReadViewSpec,
+        settled_binding_view: Option<BindingViewKey>,
+        authorization_mode: QueryAuthorizationMode,
+        prepared_claim_binding_mode: PreparedClaimBindingMode,
+    ) -> Result<QueryProgramRequest, Error> {
         let lowered_shape;
         let lowered_binding;
         // Prepared binding sources are a serving-side optimization. Client
@@ -6569,13 +6658,14 @@ where
             })
             .flatten();
         let input = RowSetProgramInput {
-            binding: self.program_binding_for_shape_and_policy(
+            binding: self.program_binding_for_shape_and_policy_with_prepared_claim_mode(
                 shape,
                 binding,
                 source_shape,
                 BTreeMap::new(),
                 binding_claim_params,
                 &policy,
+                prepared_claim_binding_mode,
             )?,
             shape: input_shape,
         };
@@ -7322,8 +7412,12 @@ where
                     self.database.query_graph(graph).map_err(Error::Groove)?
                 }
                 PreparedQueryPlan::Prepared { shape, params } => {
-                    let values =
-                        binding_values_for_plan(&binding, &params, &program.request.policy)?;
+                    let values = binding_values_for_plan(
+                        &binding,
+                        &params,
+                        &program.request.policy,
+                        PreparedClaimBindingMode::Strict,
+                    )?;
                     take_required_sink_deltas(
                         self.bind_shape_snapshot(shape, &values)?,
                         JAZZ_APP_ROWS_SINK,
@@ -7586,7 +7680,12 @@ where
                 .map_err(Error::Groove),
             Some(plan) => match plan.as_ref() {
                 PreparedQueryPlan::Prepared { shape, params } => {
-                    let values = binding_values_for_plan(binding, params, &policy)?;
+                    let values = binding_values_for_plan(
+                        binding,
+                        params,
+                        &policy,
+                        PreparedClaimBindingMode::Strict,
+                    )?;
                     self.bind_shape_snapshot(*shape, &values)
                         .and_then(|deltas| take_required_sink_deltas(deltas, JAZZ_APP_ROWS_SINK))
                 }
@@ -7742,7 +7841,12 @@ where
                 .map_err(Error::Groove),
             Some(plan) => match plan.as_ref() {
                 PreparedQueryPlan::Prepared { shape, params } => {
-                    let values = binding_values_for_plan(binding, params, &policy)?;
+                    let values = binding_values_for_plan(
+                        binding,
+                        params,
+                        &policy,
+                        PreparedClaimBindingMode::Strict,
+                    )?;
                     self.bind_shape_snapshot(*shape, &values)
                         .and_then(|deltas| take_required_sink_deltas(deltas, JAZZ_APP_ROWS_SINK))
                 }
@@ -8300,6 +8404,7 @@ where
                 read_view,
                 authorization_mode,
                 settled_binding_view,
+                PreparedClaimBindingMode::Strict,
             )?;
         let mut local = LocalMaintainedViewSubscription {
             subscription,
@@ -10669,6 +10774,39 @@ where
             read_view,
             QueryAuthorizationMode::TrustedServing,
             None,
+            PreparedClaimBindingMode::Strict,
+        )
+    }
+
+    /// Hydrate a terminal CommitUnit authorization-support clause. Unlike an
+    /// ordinary prepared query, a missing policy claim is a denied proof and
+    /// is surfaced to the peer as an empty, settled authorization view.
+    pub(crate) fn open_seeded_authorization_support_subscription_view(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorId,
+        tier: DurabilityTier,
+        read_view: &ReadViewSpec,
+    ) -> Result<
+        (
+            MultisinkSubscription,
+            MaintainedSubscriptionView,
+            MaintainedTerminalSchemas,
+            super::maintained_subscription_view::ResultTransitions,
+            BTreeMap<String, TableSchema>,
+        ),
+        Error,
+    > {
+        self.open_seeded_maintained_subscription_view_in_authorization_mode(
+            shape,
+            binding,
+            identity,
+            tier,
+            read_view,
+            QueryAuthorizationMode::TrustedServing,
+            None,
+            PreparedClaimBindingMode::FailClosedAuthorizationSupport,
         )
     }
 
@@ -10681,6 +10819,7 @@ where
         read_view: &ReadViewSpec,
         authorization_mode: QueryAuthorizationMode,
         settled_binding_view: Option<BindingViewKey>,
+        prepared_claim_binding_mode: PreparedClaimBindingMode,
     ) -> Result<
         (
             MultisinkSubscription,
@@ -10703,16 +10842,18 @@ where
             ParamBindingMode::RetainAllParams,
         )?;
         let binding = shape.bind(binding.values().clone())?;
-        let program = self.compile_current_query_program_with_settled_view(
-            &shape,
-            &binding,
-            tier,
-            identity,
-            CurrentQueryProgramOutput::MaintainedView,
-            read_view,
-            settled_binding_view,
-            authorization_mode,
-        )?;
+        let program = self
+            .compile_current_query_program_with_settled_view_and_prepared_claim_mode(
+                &shape,
+                &binding,
+                tier,
+                identity,
+                CurrentQueryProgramOutput::MaintainedView,
+                read_view,
+                settled_binding_view,
+                authorization_mode,
+                prepared_claim_binding_mode,
+            )?;
         let tables = program.lowered.maintained_terminal_tables.clone();
         let terminal_schemas = MaintainedSubscriptionView::terminal_schemas_for_program(&program);
         let binding_source_shape = program
@@ -10726,8 +10867,12 @@ where
                     &program.lowered.parameters,
                 ))
             });
-        let subscription =
-            self.subscribe_lowered_program(program, &binding, binding_source_shape)?;
+        let subscription = self.subscribe_lowered_program(
+            program,
+            &binding,
+            binding_source_shape,
+            prepared_claim_binding_mode,
+        )?;
         let mut maintained = MaintainedSubscriptionView::default();
         let mut transitions = super::maintained_subscription_view::ResultTransitions::default();
         let snapshot = subscription.recv().map_err(|_| {
@@ -10805,6 +10950,7 @@ where
         program: QueryProgram,
         binding: &Binding,
         binding_source_shape: String,
+        prepared_claim_binding_mode: PreparedClaimBindingMode,
     ) -> Result<MultisinkSubscription, Error> {
         let params = prepared_params_from_domain(&program.lowered.parameters);
         let route_params = prepared_route_param_names(&program.lowered.parameters);
@@ -10827,7 +10973,12 @@ where
                 .cloned()
                 .zip(params.iter().map(|param| param.ty.clone())),
         );
-        let values = binding_values_for_plan(binding, &params, &program.request.policy)?;
+        let values = binding_values_for_plan(
+            binding,
+            &params,
+            &program.request.policy,
+            prepared_claim_binding_mode,
+        )?;
         let terminals = program
             .lowered
             .terminals
@@ -13163,6 +13314,7 @@ fn binding_values_for_plan(
     binding: &Binding,
     params: &[PreparedQueryParam],
     policy: &PolicyContext,
+    prepared_claim_binding_mode: PreparedClaimBindingMode,
 ) -> Result<Vec<Value>, Error> {
     params
         .iter()
@@ -13176,9 +13328,19 @@ fn binding_values_for_plan(
                 Ok::<_, Error>(coerce_prepared_binding_value(value, &param.ty))
             }
             PreparedQueryParamSource::Claim(ref path) => {
-                let value = prepared_claim_value(path, policy)?.ok_or(
-                    Error::InvalidStoredValue("claim prepared param is not bound"),
-                )?;
+                let value = match prepared_claim_value(path, policy)? {
+                    Some(value) => value,
+                    None if prepared_claim_binding_mode
+                        == PreparedClaimBindingMode::FailClosedAuthorizationSupport =>
+                    {
+                        return Err(Error::AuthorizationSupportMissingClaim(path.0.join(".")));
+                    }
+                    None => {
+                        return Err(Error::InvalidStoredValue(
+                            "claim prepared param is not bound",
+                        ));
+                    }
+                };
                 Ok::<_, Error>(coerce_prepared_binding_value(value, &param.ty))
             }
         })
@@ -16143,6 +16305,87 @@ mod tests {
             .map(|row| row.row_uuid())
             .collect::<BTreeSet<_>>();
         assert_eq!(allowed_rows, BTreeSet::from([resource]));
+    }
+
+    #[test]
+    fn missing_policy_seed_claim_denies_authorization_support_rehydration() {
+        // Terminal CommitUnit admission rehydrates a compiled read-policy
+        // support subscription. This is distinct from the one-shot policy
+        // read above: the support shape itself has no user parameter, while
+        // its protected source carries the seed claim as a prepared route.
+        let schema = missing_session_seed_policy_schema();
+        let (_dir, mut node) =
+            open_node_with_uuid(NodeUuid::from_bytes([0xc7; 16]), schema.clone());
+        let writer = author(0xc8);
+        let team = row(0xc9);
+        let resource = row(0xca);
+        commit_global_cells(
+            &mut node,
+            "resources",
+            resource,
+            BTreeMap::from([("name".to_owned(), Value::String("secret".to_owned()))]),
+            1,
+            1,
+        );
+        commit_global_cells(
+            &mut node,
+            "resourceAccess",
+            row(0xcb),
+            BTreeMap::from([
+                ("resource".to_owned(), Value::Uuid(resource.0)),
+                ("team".to_owned(), Value::Uuid(team.0)),
+            ]),
+            2,
+            2,
+        );
+        commit_global_cells(
+            &mut node,
+            "teamSeeds",
+            row(0xcc),
+            BTreeMap::from([
+                ("team".to_owned(), Value::Uuid(team.0)),
+                ("user".to_owned(), Value::Uuid(writer.0)),
+            ]),
+            3,
+            3,
+        );
+
+        let scope = node
+            .authorization_support_scope(
+                writer,
+                &PermissionAdviceAction::Read {
+                    table: "resources".to_owned(),
+                    row: resource,
+                },
+            )
+            .expect("missing policy claim is represented by a denied support shape");
+        let options = scope.options.clone();
+        let (shape, binding) = scope
+            .subscriptions
+            .into_iter()
+            .next()
+            .expect("read policy requires one support subscription");
+        let mut peer = PeerState::client_link(writer);
+        let ordinary_error = peer
+            .rehydrate_query(&mut node, &shape, &binding)
+            .expect_err(
+                "ordinary prepared subscription hydration must retain missing-claim errors",
+            );
+        assert!(matches!(ordinary_error, Error::InvalidStoredValue(_)));
+
+        let update = peer
+            .rehydrate_authorization_support_query(&mut node, &shape, &binding, options)
+            .expect("missing policy seed claim must hydrate as an empty authorization proof");
+        let SyncMessage::ViewUpdate {
+            result_member_adds,
+            result_member_removes,
+            ..
+        } = update
+        else {
+            panic!("authorization support must return a settled view update");
+        };
+        assert!(result_member_adds.is_empty());
+        assert!(result_member_removes.is_empty());
     }
 
     fn commit_global_cells(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -976,21 +976,16 @@ where
                             SourceGap::HistoricalStorageCut,
                         ));
                     }
-                    let policy_request = self
-                        .node
-                        .table_read_policy_authorization_request_at(
-                            self.read_view.policy_schema,
-                            &table.name,
-                            *permission_subject,
-                            ParamBindingMode::InlineAllReachableSeeds,
-                            position,
-                            plan.binding_source_shape.clone(),
-                            plan.binding_user_params.clone(),
-                            plan.binding_claim_params.clone(),
-                        )
-                        .map_err(|_| {
-                            source_resolution_error(request, SourceGap::HistoricalStorageCut)
-                        })?;
+                    let policy_request = self.node.table_read_policy_authorization_request_at(
+                        self.read_view.policy_schema,
+                        &table.name,
+                        *permission_subject,
+                        ParamBindingMode::InlineAllReachableSeeds,
+                        position,
+                        plan.binding_source_shape.clone(),
+                        plan.binding_user_params.clone(),
+                        plan.binding_claim_params.clone(),
+                    );
                     self.node
                         .policy_filtered_current_source_graph_via_query_engine(
                             policy_request,
@@ -1054,17 +1049,14 @@ where
                     {
                         return Err(source_resolution_error(request, SourceGap::Coverage));
                     }
-                    let policy_request = self
-                        .node
-                        .branch_table_read_policy_authorization_request(
-                            branch_id,
-                            &table,
-                            *permission_subject,
-                            plan.binding_source_shape.clone(),
-                            plan.binding_user_params.clone(),
-                            plan.binding_claim_params.clone(),
-                        )
-                        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+                    let policy_request = self.node.branch_table_read_policy_authorization_request(
+                        branch_id,
+                        &table,
+                        *permission_subject,
+                        plan.binding_source_shape.clone(),
+                        plan.binding_user_params.clone(),
+                        plan.binding_claim_params.clone(),
+                    );
                     let output_fields = descriptor_field_names(&descriptor)
                         .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
                     self.node
@@ -1153,19 +1145,16 @@ where
                         {
                             return Err(source_resolution_error(request, SourceGap::Coverage));
                         }
-                        let policy_request = self
-                            .node
-                            .table_read_policy_authorization_request(
-                                self.read_view.policy_schema,
-                                &table.name,
-                                *permission_subject,
-                                ParamBindingMode::InlineAllReachableSeeds,
-                                graph_tier.expect("visible current source has a tier"),
-                                plan.binding_source_shape.clone(),
-                                plan.binding_user_params.clone(),
-                                plan.binding_claim_params.clone(),
-                            )
-                            .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+                        let policy_request = self.node.table_read_policy_authorization_request(
+                            self.read_view.policy_schema,
+                            &table.name,
+                            *permission_subject,
+                            ParamBindingMode::InlineAllReachableSeeds,
+                            graph_tier.expect("visible current source has a tier"),
+                            plan.binding_source_shape.clone(),
+                            plan.binding_user_params.clone(),
+                            plan.binding_claim_params.clone(),
+                        );
                         self.node
                             .policy_filtered_current_source_graph_via_query_engine(
                                 policy_request,
@@ -1220,8 +1209,7 @@ where
                             plan.binding_source_shape.clone(),
                             plan.binding_user_params.clone(),
                             plan.binding_claim_params.clone(),
-                        )
-                        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+                        );
                     let mut output_fields = current_row_fields(&table);
                     output_fields.push("__jazz_deleted".to_owned());
                     self.node
@@ -1269,8 +1257,7 @@ where
                             plan.binding_source_shape.clone(),
                             plan.binding_user_params.clone(),
                             plan.binding_claim_params.clone(),
-                        )
-                        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+                        );
                     let mut output_fields = current_row_fields(&table);
                     output_fields.push("__jazz_deleted".to_owned());
                     self.node
@@ -2375,7 +2362,7 @@ where
                 binding_source_shape.clone(),
                 binding_user_params.clone(),
                 binding_claim_params,
-            )?;
+            );
             let output_fields = global_current_storage_fields(
                 table,
                 needs_version_witnesses,
@@ -4973,7 +4960,20 @@ where
         if !claim_params.is_empty() {
             let mut values = binding.values().clone();
             for (name, claim) in &claim_params {
-                let value = prepared_claim_value(&claim.path, policy)?;
+                let Some(value) = prepared_claim_value(&claim.path, policy)? else {
+                    // An absent claim cannot establish a policy proof. Leave
+                    // it as a capability gap so the policy source resolver
+                    // lowers the proof to an empty authorization graph.
+                    if matches!(policy, PolicyContext::AuthorizationSubplan { .. }) {
+                        return Err(Error::QueryCapability(format!(
+                            "policy authorization requires unbound claim {}",
+                            claim.path.0.join(".")
+                        )));
+                    }
+                    return Err(Error::InvalidStoredValue(
+                        "claim prepared param is not bound",
+                    ));
+                };
                 values.insert(
                     name.clone(),
                     coerce_prepared_binding_value(value, &claim.ty),
@@ -10873,12 +10873,25 @@ where
 
     fn policy_filtered_current_source_graph_via_query_engine(
         &mut self,
-        policy_request: QueryProgramRequest,
+        policy_request: Result<QueryProgramRequest, Error>,
         base: GraphBuilder,
         output_fields: &[String],
     ) -> Result<PolicyAuthorizationGraph, Error> {
         self.query_engine_read_metrics
             .policy_authorized_source_joins += 1;
+        let policy_request = match policy_request {
+            Ok(policy_request) => policy_request,
+            Err(Error::QueryCapability(err)) if err.contains("PolicyProofCycle") => {
+                return Err(Error::QueryCapability(err));
+            }
+            Err(Error::QueryCapability(_)) => {
+                return Ok(empty_policy_filtered_current_source_graph(
+                    base,
+                    output_fields,
+                ));
+            }
+            Err(err) => return Err(err),
+        };
         // The protected storage source has no binding fields of its own, but
         // the authorization proof is routed by the enclosing prepared
         // binding. Carry that descriptor alongside the source before joining
@@ -11546,6 +11559,23 @@ where
             options,
             subscriptions,
         })
+    }
+}
+
+fn empty_policy_filtered_current_source_graph(
+    base: GraphBuilder,
+    output_fields: &[String],
+) -> PolicyAuthorizationGraph {
+    let keys = ["row_uuid".to_owned()];
+    PolicyAuthorizationGraph {
+        graph: GraphBuilder::join(base, empty_authorized_row_id_graph(), keys.clone(), keys)
+            .project_fields(
+                output_fields
+                    .iter()
+                    .map(|field| ProjectField::renamed(left_field(field), field.clone()))
+                    .collect::<Vec<_>>(),
+            ),
+        route_fields: BTreeSet::new(),
     }
 }
 
@@ -13146,14 +13176,16 @@ fn binding_values_for_plan(
                 Ok::<_, Error>(coerce_prepared_binding_value(value, &param.ty))
             }
             PreparedQueryParamSource::Claim(ref path) => {
-                let value = prepared_claim_value(path, policy)?;
+                let value = prepared_claim_value(path, policy)?.ok_or(
+                    Error::InvalidStoredValue("claim prepared param is not bound"),
+                )?;
                 Ok::<_, Error>(coerce_prepared_binding_value(value, &param.ty))
             }
         })
         .collect()
 }
 
-fn prepared_claim_value(path: &ClaimPath, policy: &PolicyContext) -> Result<Value, Error> {
+fn prepared_claim_value(path: &ClaimPath, policy: &PolicyContext) -> Result<Option<Value>, Error> {
     let (permission_subject, claims) = match policy {
         PolicyContext::Identity {
             permission_subject,
@@ -13177,14 +13209,12 @@ fn prepared_claim_value(path: &ClaimPath, policy: &PolicyContext) -> Result<Valu
         ));
     };
     if let Some(value) = claims.get(name) {
-        return Ok(value.clone());
+        return Ok(Some(value.clone()));
     }
     if let Some(value) = default_policy_claim_values(*permission_subject).get(name) {
-        return Ok(value.clone());
+        return Ok(Some(value.clone()));
     }
-    Err(Error::InvalidStoredValue(
-        "claim prepared param is not bound",
-    ))
+    Ok(None)
 }
 
 fn coerce_prepared_binding_value(value: Value, column_type: &groove::schema::ColumnType) -> Value {
@@ -15034,7 +15064,7 @@ mod tests {
             .expect("compile nested chat-members policy against the invite binding");
         let members_authorized = node
             .policy_filtered_current_source_graph_via_query_engine(
-                members_policy,
+                Ok(members_policy),
                 node.maintained_view_content_current_with_version(&members, DurabilityTier::Edge)
                     .expect("compile chat-members storage source"),
                 &global_current_storage_fields(&members, true, true),
@@ -15970,10 +16000,149 @@ mod tests {
         open_node_with_uuid(NodeUuid::from_bytes([9; 16]), recursive_schema())
     }
 
+    fn missing_session_seed_policy_schema() -> JazzSchema {
+        let mut policy = Query::from("resources").reachable_via(
+            "resourceAccess",
+            "resource",
+            "team",
+            lit("seeded-by-session"),
+            "teamMemberships",
+            "member",
+            "parent",
+            [],
+        );
+        policy.reachable[0].seed = Some(crate::query::ReachableSeed {
+            table: "teamSeeds".to_owned(),
+            user_column: Some("user".to_owned()),
+            user_claim: Some("session_id".to_owned()),
+            team_column: "team".to_owned(),
+            filters: Vec::new(),
+        });
+        JazzSchema::new([
+            TableSchema::new("teams", [ColumnSchema::new("name", ColumnType::String)]),
+            TableSchema::new("resources", [ColumnSchema::new("name", ColumnType::String)])
+                .with_read_policy(policy),
+            TableSchema::new(
+                "teamSeeds",
+                [
+                    ColumnSchema::new("team", ColumnType::Uuid),
+                    ColumnSchema::new("user", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("team", "teams"),
+            TableSchema::new(
+                "resourceAccess",
+                [
+                    ColumnSchema::new("resource", ColumnType::Uuid),
+                    ColumnSchema::new("team", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("resource", "resources")
+            .with_reference("team", "teams"),
+            TableSchema::new(
+                "teamMemberships",
+                [
+                    ColumnSchema::new("member", ColumnType::Uuid),
+                    ColumnSchema::new("parent", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("member", "teams")
+            .with_reference("parent", "teams"),
+        ])
+    }
+
     fn row(idx: usize) -> RowUuid {
         let mut bytes = [0_u8; 16];
         bytes[0..8].copy_from_slice(&(idx as u64 + 1).to_be_bytes());
         RowUuid::from_bytes(bytes)
+    }
+
+    #[test]
+    fn missing_policy_relation_seed_claim_fails_closed_without_breaking_prepared_bindings() {
+        // This reproduces the server-side shape of a SessionRef policy graph:
+        // the outer query is prepared first, then the protected source builds
+        // a nested authorization subplan whose reachable seed needs a custom
+        // session claim. An absent claim is a denied proof, not malformed
+        // stored state or an unavailable source.
+        let schema = missing_session_seed_policy_schema();
+        let (_dir, mut node) =
+            open_node_with_uuid(NodeUuid::from_bytes([0xc1; 16]), schema.clone());
+        let reader = author(0xc2);
+        let team = row(0xc3);
+        let resource = row(0xc4);
+        commit_global_cells(
+            &mut node,
+            "resources",
+            resource,
+            BTreeMap::from([("name".to_owned(), Value::String("secret".to_owned()))]),
+            1,
+            1,
+        );
+        commit_global_cells(
+            &mut node,
+            "resourceAccess",
+            row(0xc5),
+            BTreeMap::from([
+                ("resource".to_owned(), Value::Uuid(resource.0)),
+                ("team".to_owned(), Value::Uuid(team.0)),
+            ]),
+            2,
+            2,
+        );
+        commit_global_cells(
+            &mut node,
+            "teamSeeds",
+            row(0xc6),
+            BTreeMap::from([
+                ("team".to_owned(), Value::Uuid(team.0)),
+                ("user".to_owned(), Value::Uuid(reader.0)),
+            ]),
+            3,
+            3,
+        );
+
+        let shape = Query::from("resources").validate(&schema).unwrap();
+        let binding = shape.bind(BTreeMap::new()).unwrap();
+        let missing_rows = node
+            .query_rows_for_link(&shape, &binding, DurabilityTier::Global, reader)
+            .expect("an absent policy seed claim must compile to a denied proof")
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>();
+        assert!(
+            missing_rows.is_empty(),
+            "missing custom claim must deny access"
+        );
+
+        let ordinary_error = node
+            .program_binding_for_shape_and_policy(
+                &shape,
+                &binding,
+                None,
+                BTreeMap::new(),
+                BTreeMap::from([(
+                    claim_param_field(&ClaimPath(vec!["session_id".to_owned()])),
+                    ProgramClaimParam {
+                        path: ClaimPath(vec!["session_id".to_owned()]),
+                        ty: ColumnType::Uuid,
+                    },
+                )]),
+                &node.query_program_policy_context(reader),
+            )
+            .expect_err("ordinary prepared bindings must still reject missing claims");
+        assert!(matches!(ordinary_error, Error::InvalidStoredValue(_)));
+
+        node.set_session_claims(
+            reader,
+            BTreeMap::from([("session_id".to_owned(), Value::Uuid(reader.0))]),
+        );
+        let allowed_rows = node
+            .query_rows_for_link(&shape, &binding, DurabilityTier::Global, reader)
+            .expect("bound policy seed claim must compile")
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(allowed_rows, BTreeSet::from([resource]));
     }
 
     fn commit_global_cells(

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -188,6 +188,15 @@ struct MaintainedRehydrateRequest<'a> {
     result_table_filter: Option<&'a str>,
     tier: DurabilityTier,
     read_view: &'a ReadViewSpec,
+    purpose: RehydratePurpose,
+}
+
+/// Regular queries require all prepared values. CommitUnit authorization
+/// support turns an absent policy claim into an empty proof instead.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RehydratePurpose {
+    Query,
+    AuthorizationSupport,
 }
 
 type RowKey = OutputOccurrenceId;
@@ -481,6 +490,7 @@ impl PeerState {
                     result_table_filter: Some(table),
                     tier: DurabilityTier::Global,
                     read_view: &ReadViewSpec::default(),
+                    purpose: RehydratePurpose::Query,
                 },
             );
         }
@@ -659,6 +669,7 @@ impl PeerState {
                 result_table_filter: None,
                 tier: opts.tier,
                 read_view: &opts.read_view,
+                purpose: RehydratePurpose::Query,
             },
         )
     }
@@ -737,6 +748,7 @@ impl PeerState {
                     result_table_filter,
                     tier,
                     read_view: &ReadViewSpec::default(),
+                    purpose: RehydratePurpose::Query,
                 },
             );
         }
@@ -1053,20 +1065,57 @@ impl PeerState {
             result_table_filter,
             tier,
             read_view,
+            purpose,
         } = request;
         let trace_rehydrate = std::env::var_os("JAZZ_REHYDRATE_TRACE").is_some();
         let open_start = Instant::now();
         if trace_rehydrate {
             node.reset_storage_read_metrics();
         }
-        let (receiver, maintained, terminal_schemas, transitions, tables) = node
-            .open_seeded_maintained_subscription_view(
+        let opened = match purpose {
+            RehydratePurpose::Query => node.open_seeded_maintained_subscription_view(
                 shape,
                 binding,
                 self.identity(),
                 tier,
                 read_view,
-            )?;
+            ),
+            RehydratePurpose::AuthorizationSupport => node
+                .open_seeded_authorization_support_subscription_view(
+                    shape,
+                    binding,
+                    self.identity(),
+                    tier,
+                    read_view,
+                ),
+        };
+        let (receiver, maintained, terminal_schemas, transitions, tables) = match opened {
+            Ok(opened) => opened,
+            Err(Error::AuthorizationSupportMissingClaim(_))
+                if purpose == RehydratePurpose::AuthorizationSupport =>
+            {
+                let update = SyncMessage::ViewUpdate {
+                    subscription,
+                    settled_through: node.applied_global_watermark(),
+                    reset_result_set,
+                    version_carriers: Vec::new(),
+                    version_bundles: Vec::new(),
+                    peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+                    result_member_adds: Vec::new(),
+                    result_member_removes: previous_member_result_set.iter().cloned().collect(),
+                    terminal_operations: Vec::new(),
+                    program_fact_adds: Vec::new(),
+                    program_fact_removes: Vec::new(),
+                };
+                self.record_outgoing_view_update(&update);
+                self.subscriptions
+                    .entry(subscription)
+                    .or_default()
+                    .has_served_authorization_progress = true;
+                return Ok(update);
+            }
+            Err(error) => return Err(error),
+        };
         let open_elapsed = open_start.elapsed();
         let open_reads = trace_rehydrate.then(|| node.take_storage_read_metrics());
         let raw_add_count = transitions.adds.len();
@@ -1314,6 +1363,28 @@ impl PeerState {
     where
         S: OrderedKvStorage,
     {
+        self.rehydrate_query_for_subscription_with_purpose(
+            node,
+            subscription,
+            shape,
+            binding,
+            opts,
+            RehydratePurpose::Query,
+        )
+    }
+
+    fn rehydrate_query_for_subscription_with_purpose<S>(
+        &mut self,
+        node: &mut NodeState<S>,
+        subscription: SubscriptionKey,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        opts: RegisterShapeOptions,
+        purpose: RehydratePurpose,
+    ) -> Result<SyncMessage, Error>
+    where
+        S: OrderedKvStorage,
+    {
         self.clear_stale_groove_runtime_handles(node, subscription);
         self.ensure_query_subscription_registered(node, subscription, shape, binding)?;
         let previous_member_result_set = self
@@ -1365,7 +1436,33 @@ impl PeerState {
                 result_table_filter: None,
                 tier: opts.tier,
                 read_view: &opts.read_view,
+                purpose,
             },
+        )
+    }
+
+    pub(crate) fn rehydrate_authorization_support_query<S>(
+        &mut self,
+        node: &mut NodeState<S>,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        opts: RegisterShapeOptions,
+    ) -> Result<SyncMessage, Error>
+    where
+        S: OrderedKvStorage,
+    {
+        let subscription = SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: binding.binding_id(),
+            read_view: opts.read_view_key(),
+        };
+        self.rehydrate_query_for_subscription_with_purpose(
+            node,
+            subscription,
+            shape,
+            binding,
+            opts,
+            RehydratePurpose::AuthorizationSupport,
         )
     }
 
@@ -1984,7 +2081,12 @@ impl PeerState {
                     // transient client role would still bind policy claims as
                     // `SYSTEM` here.
                     self.permission_identity = Some(writer);
-                    let update = self.rehydrate_query(node, &shape, &binding);
+                    let update = self.rehydrate_authorization_support_query(
+                        node,
+                        &shape,
+                        &binding,
+                        scope.options.clone(),
+                    );
                     self.role = previous_role;
                     self.permission_identity = previous_permission_identity;
                     let SyncMessage::ViewUpdate {
@@ -2080,9 +2182,17 @@ impl PeerState {
                     continue;
                 }
                 let previous_role = self.role;
+                let previous_permission_identity = self.permission_identity;
                 self.role = PeerRole::ClientLink { identity: writer };
-                let rehydrate = self.rehydrate_query(node, &shape, &binding);
+                self.permission_identity = Some(writer);
+                let rehydrate = self.rehydrate_authorization_support_query(
+                    node,
+                    &shape,
+                    &binding,
+                    scope.options.clone(),
+                );
                 self.role = previous_role;
+                self.permission_identity = previous_permission_identity;
                 let update = rehydrate?;
                 let SyncMessage::ViewUpdate {
                     settled_through, ..
@@ -2569,7 +2679,7 @@ mod tests {
         Aggregate, ArraySubquery, OrderDirection, Query, claim, col, eq, gt, is_null, lit, ne, not,
         param,
     };
-    use crate::schema::{JazzSchema, Policy, TableSchema};
+    use crate::schema::{JazzSchema, Policy, TableSchema, WritePolicies};
     use crate::time::{GlobalSeq, TxTime};
     use crate::tools::OpenBatchId;
     use crate::tx::DeletionEvent;
@@ -2990,6 +3100,189 @@ mod tests {
             )
             .with_reference("doc", "docs"),
         ])
+    }
+
+    fn session_claim_read_policy_schema() -> JazzSchema {
+        let policy = Query::from("resources").filter(eq(col("owner"), claim("session_id")));
+        JazzSchema::new([TableSchema::new(
+            "resources",
+            [ColumnSchema::new("owner", ColumnType::Uuid)],
+        )
+        .with_read_policy(policy.clone())
+        .with_write_policies(WritePolicies {
+            insert_check: Some(policy),
+            ..WritePolicies::default()
+        })])
+    }
+
+    fn session_seed_write_policy_schema() -> JazzSchema {
+        let mut policy = Query::from("resources").reachable_via(
+            "resourceAccess",
+            "resource",
+            "team",
+            lit("seeded-by-session"),
+            "teamMemberships",
+            "member",
+            "parent",
+            [],
+        );
+        policy.reachable[0].seed = Some(crate::query::ReachableSeed {
+            table: "teamSeeds".to_owned(),
+            user_column: Some("user".to_owned()),
+            user_claim: Some("session_id".to_owned()),
+            team_column: "team".to_owned(),
+            filters: Vec::new(),
+        });
+        JazzSchema::new([
+            TableSchema::new("resources", [ColumnSchema::new("owner", ColumnType::Uuid)])
+                .with_write_policies(WritePolicies {
+                    insert_check: Some(policy),
+                    ..WritePolicies::default()
+                }),
+            TableSchema::new("teams", [ColumnSchema::new("name", ColumnType::String)]),
+            TableSchema::new(
+                "teamSeeds",
+                [
+                    ColumnSchema::new("team", ColumnType::Uuid),
+                    ColumnSchema::new("user", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("team", "teams"),
+            TableSchema::new(
+                "resourceAccess",
+                [
+                    ColumnSchema::new("resource", ColumnType::Uuid),
+                    ColumnSchema::new("team", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("resource", "resources")
+            .with_reference("team", "teams"),
+            TableSchema::new(
+                "teamMemberships",
+                [
+                    ColumnSchema::new("member", ColumnType::Uuid),
+                    ColumnSchema::new("parent", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("member", "teams")
+            .with_reference("parent", "teams"),
+        ])
+    }
+
+    fn resource_commit_unit(
+        writer: &mut NodeState<RocksDbStorage>,
+        author: AuthorId,
+        row_uuid: RowUuid,
+    ) -> (Transaction, Vec<VersionRecord>) {
+        let (_, unit) = writer
+            .commit_mergeable_unit(
+                MergeableCommit::new("resources", row_uuid, 10)
+                    .made_by(author)
+                    .cells(BTreeMap::from([(
+                        "owner".to_owned(),
+                        Value::Uuid(author.0),
+                    )])),
+            )
+            .expect("writer creates policy-protected resource commit");
+        let SyncMessage::CommitUnit { tx, versions } = unit else {
+            panic!("mergeable unit must carry a CommitUnit");
+        };
+        (tx, versions)
+    }
+
+    #[test]
+    fn edge_support_hydration_uses_writer_claims_and_fails_closed_when_missing() {
+        let schema = session_claim_read_policy_schema();
+        let writer = AuthorId::from_bytes([0xa1; 16]);
+        let transport_identity = AuthorId::from_bytes([0xa2; 16]);
+        let resource = row(0xa3);
+        let (_writer_dir, mut writer_node) = open_node_with_schema(node(0xa4), schema.clone());
+        let (tx, versions) = resource_commit_unit(&mut writer_node, writer, resource);
+
+        // The public edge/deferred entrypoint must turn a missing custom
+        // session claim into a settled empty support view, not a binding
+        // error. The edge parks the first hydration turn by design.
+        let (_missing_dir, mut missing_edge) = open_node_with_schema(node(0xa5), schema.clone());
+        let mut missing_peer = PeerState::edge_client(writer);
+        let missing_updates = missing_peer
+            .ingest_edge_mergeable_commit_unit(&mut missing_edge, tx.clone(), versions.clone(), 10)
+            .expect("missing policy claim must fail closed, not abort edge ingest");
+        assert!(missing_updates.is_empty(), "{missing_updates:?}");
+        assert_eq!(missing_peer.deferred_edge_fate_count(), 1);
+
+        // A backend/transport identity is not the commit permission subject.
+        // The support rehydrate must temporarily evaluate the writer's bound
+        // session claim even while the peer normally serves as another user.
+        let (_bound_dir, mut bound_edge) = open_node_with_schema(node(0xa6), schema.clone());
+        bound_edge.set_session_claims(
+            writer,
+            BTreeMap::from([("session_id".to_owned(), Value::Uuid(writer.0))]),
+        );
+        let prior = bound_edge
+            .commit_mergeable(
+                MergeableCommit::new("resources", row(0xa8), 1)
+                    .made_by(AuthorId::SYSTEM)
+                    .cells(BTreeMap::from([(
+                        "owner".to_owned(),
+                        Value::Uuid(writer.0),
+                    )])),
+            )
+            .expect("seed readable resource at the edge");
+        accept_global(&mut bound_edge, prior, 1);
+        let mut wrong_subject_peer =
+            PeerState::edge_client_with_permission_identity(transport_identity, transport_identity);
+        let bound_subscriptions = wrong_subject_peer
+            .unsettled_authority_scope_subscriptions(&mut bound_edge, writer, &versions, true)
+            .expect("edge support must bind the writer rather than the transport identity");
+        let bound_subscription = bound_subscriptions
+            .and_then(|subscriptions| subscriptions.into_iter().next())
+            .expect("write support must register one policy subscription");
+        assert!(
+            !wrong_subject_peer
+                .subscriptions
+                .get(&bound_subscription)
+                .expect("bound support subscription state")
+                .result_member_set
+                .is_empty(),
+            "the writer's bound claim must authorize the seeded resource"
+        );
+        assert_eq!(wrong_subject_peer.link_identity(), transport_identity);
+        assert_eq!(wrong_subject_peer.identity(), transport_identity);
+
+        // A present but ill-typed claim remains a real binding error; only an
+        // absent claim receives the fail-closed empty-proof treatment.
+        let (_wrong_type_dir, mut wrong_type_edge) = open_node_with_schema(node(0xa7), schema);
+        wrong_type_edge.set_session_claims(
+            writer,
+            BTreeMap::from([(
+                "session_id".to_owned(),
+                Value::String("not-a-uuid".to_owned()),
+            )]),
+        );
+        let mut wrong_type_peer =
+            PeerState::edge_client_with_permission_identity(transport_identity, transport_identity);
+        wrong_type_peer
+            .unsettled_authority_scope_subscriptions(&mut wrong_type_edge, writer, &versions, true)
+            .expect_err("present ill-typed claim must remain an error");
+        assert_eq!(wrong_type_peer.link_identity(), transport_identity);
+        assert_eq!(wrong_type_peer.identity(), transport_identity);
+    }
+
+    #[test]
+    fn edge_ingest_turns_missing_prepared_seed_claim_into_deferred_empty_support() {
+        let schema = session_seed_write_policy_schema();
+        let writer = AuthorId::from_bytes([0xb1; 16]);
+        let resource = row(0xb2);
+        let (_writer_dir, mut writer_node) = open_node_with_schema(node(0xb3), schema.clone());
+        let (tx, versions) = resource_commit_unit(&mut writer_node, writer, resource);
+        let (_edge_dir, mut edge) = open_node_with_schema(node(0xb4), schema);
+        let mut peer = PeerState::edge_client(writer);
+
+        let updates = peer
+            .ingest_edge_mergeable_commit_unit(&mut edge, tx, versions, 10)
+            .expect("missing prepared seed claim must be a deferred empty support proof");
+        assert!(updates.is_empty());
+        assert_eq!(peer.deferred_edge_fate_count(), 1);
     }
 
     fn scored_doc_cells(title: impl Into<String>, score: u64) -> BTreeMap<String, Value> {

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -1201,12 +1201,25 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
       runtime.query(JSON.stringify({ table: "todos" }), aliceSession, "local"),
     ).resolves.toHaveLength(2);
 
-    await expect(
-      runtime.waitForTransaction(await committedBatchId(aliceTodo), "edge"),
-    ).rejects.toThrow("AuthorizationDenied");
-    await expect(
-      runtime.waitForTransaction(await committedBatchId(bobTodo), "edge"),
-    ).rejects.toThrow("AuthorizationDenied");
+    const aliceDenied = runtime.waitForTransaction(await committedBatchId(aliceTodo), "edge");
+    await expect(aliceDenied).rejects.toMatchObject({
+      kind: "rejected",
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+    });
+    const aliceRejection = await aliceDenied.catch((error) => error);
+    expect(Object.getOwnPropertyDescriptor(aliceRejection, "message")).toMatchObject({
+      enumerable: false,
+      value: expect.stringContaining("AuthorizationDenied"),
+    });
+    await expect(aliceDenied).rejects.toThrow("AuthorizationDenied");
+    const bobDenied = runtime.waitForTransaction(await committedBatchId(bobTodo), "edge");
+    await expect(bobDenied).rejects.toMatchObject({
+      kind: "rejected",
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+    });
+    await expect(bobDenied).rejects.toThrow("AuthorizationDenied");
   }, 15_000);
 
   it("keeps persistent client-local session writes optimistic until the authority rejects them", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2571,15 +2571,34 @@ function isPendingCoverageError(error: unknown): boolean {
 function rejectedWaitError(
   batchId: BatchId,
   error: unknown,
-): { kind: "rejected"; batchId: BatchId; code: string; reason: string } | null {
+): {
+  kind: "rejected";
+  batchId: BatchId;
+  code: string;
+  reason: string;
+  /** An Error-compatible diagnostic for direct native callers. */
+  message: string;
+} | null {
   const message = errorMessage(error);
   if (!message.includes("WriteRejected")) return null;
-  return {
+  const rejection: {
+    kind: "rejected";
+    batchId: BatchId;
+    code: string;
+    reason: string;
+    message: string;
+  } = {
     kind: "rejected",
     batchId,
     code: rejectionCode(message),
     reason: rejectionReason(message),
+    message,
   };
+  // Worker transport intentionally carries only the enumerable structured
+  // fields. Native callers also inspect rejected promises like Errors, so
+  // retain Rust's diagnostic without widening that transport payload.
+  Object.defineProperty(rejection, "message", { enumerable: false });
+  return rejection;
 }
 
 function writeOrNormalizeRejection<T>(

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-error.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-error.ts
@@ -1,0 +1,34 @@
+import type { PersistentBrowserWorkerError } from "./persistent-browser-protocol.js";
+
+/**
+ * Converts runtime failures into the stable worker transport payload.
+ *
+ * Native waits may carry a non-enumerable diagnostic `message` for direct
+ * callers. Rejected-write transport is deliberately structural, so that
+ * diagnostic must not cross the worker boundary.
+ */
+export function serializePersistentBrowserWorkerError(
+  error: unknown,
+): PersistentBrowserWorkerError {
+  if (isRejectedWrite(error)) {
+    const { kind, batchId, code, reason } = error;
+    return { kind, batchId, code, reason };
+  }
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+  return { message: String(error) };
+}
+
+function isRejectedWrite(
+  error: unknown,
+): error is Extract<PersistentBrowserWorkerError, { kind: "rejected" }> {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as Record<string, unknown>;
+  return (
+    candidate.kind === "rejected" &&
+    typeof candidate.batchId === "string" &&
+    typeof candidate.code === "string" &&
+    typeof candidate.reason === "string"
+  );
+}

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-runtime.test.ts
@@ -6,6 +6,7 @@ import type {
   PersistentBrowserSubscriptionMessage,
   PersistentBrowserWorkerError,
 } from "./persistent-browser-protocol.js";
+import { serializePersistentBrowserWorkerError } from "./persistent-browser-error.js";
 import {
   PersistentBrowserOpfsRuntime,
   type PersistentBrowserOpfsOwnerRequest,
@@ -194,6 +195,26 @@ describe("PersistentBrowserOpfsRuntime", () => {
       reason: "Write rejected by server authorization",
     });
     await runtime.close();
+  });
+
+  it("keeps direct rejection diagnostics out of the worker transport payload", () => {
+    const batchId = "00000000000070008000000000000047" as BatchId;
+    const rejection = {
+      kind: "rejected" as const,
+      batchId,
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+      message: "WriteRejected: AuthorizationDenied",
+    };
+    Object.defineProperty(rejection, "message", { enumerable: false });
+
+    expect(Object.getOwnPropertyDescriptor(rejection, "message")?.enumerable).toBe(false);
+    expect(serializePersistentBrowserWorkerError(rejection)).toEqual({
+      kind: "rejected",
+      batchId,
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+    });
   });
 
   it("forwards worker mutation errors to the registered runtime callback", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/persistent-browser-worker.ts
@@ -3,11 +3,11 @@ import type { MutationResult } from "../client.js";
 import { openConfig } from "./native-codec.js";
 import { encodeSchema } from "./schema-codec.js";
 import { NativeRuntimeAdapter } from "./native-runtime-adapter.js";
+import { serializePersistentBrowserWorkerError } from "./persistent-browser-error.js";
 import {
   isNativeRowDelta,
   type PersistentBrowserOpfsOwnerRequest,
   type PersistentBrowserSubscriptionFrame,
-  type PersistentBrowserWorkerError,
 } from "./persistent-browser-protocol.js";
 import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
 
@@ -298,29 +298,8 @@ function postError(id: number, error: unknown): void {
   workerScope.postMessage({
     id,
     ok: false,
-    error: serializeError(error),
+    error: serializePersistentBrowserWorkerError(error),
   });
-}
-
-function serializeError(error: unknown): PersistentBrowserWorkerError {
-  if (isRejectedWrite(error)) return error;
-  if (error instanceof Error) {
-    return { name: error.name, message: error.message, stack: error.stack };
-  }
-  return { message: String(error) };
-}
-
-function isRejectedWrite(
-  error: unknown,
-): error is Extract<PersistentBrowserWorkerError, { kind: "rejected" }> {
-  if (!error || typeof error !== "object") return false;
-  const candidate = error as Record<string, unknown>;
-  return (
-    candidate.kind === "rejected" &&
-    typeof candidate.batchId === "string" &&
-    typeof candidate.code === "string" &&
-    typeof candidate.reason === "string"
-  );
 }
 
 function subscriptionFrameFromDelta(delta: unknown): PersistentBrowserSubscriptionFrame {


### PR DESCRIPTION
🤖 Fail closed when authorization-support hydration lacks a policy claim.

## Root cause

Terminal CommitUnit authorization support can contain policy dependencies whose session claim is absent. Ordinary prepared queries correctly treat an unbound claim as invalid, but the authorization-support path must instead produce no proof. The missing claim previously escaped as `InvalidStoredValue`/`Source(Coverage)`, aborting otherwise valid server ticks.

## What changed

- add an explicit prepared-claim binding mode used only by authorization-support rehydration
- turn missing policy claims into an empty settled support view while preserving strict ordinary prepared-query errors
- bind terminal edge support to the writer's role and permission identity, restoring transport state on success and error
- apply the same behavior to deferred edge authority-scope hydration

## Validation

- exact formerly failing NAPI policy-graph integration passed after fresh binding build
- public edge ingest with a prepared reachable seed and missing SessionRef claim defers with empty support
- bound writer claim authorizes even when transport identity differs
- wrong-type claims remain errors
- ordinary prepared missing claims remain `InvalidStoredValue`
- role and permission identity restore after success and error
- planted strict-mode and wrong-identity regressions fail as expected
- clippy, rustfmt, sensitive-data guard
- independent security review: approved, no remaining findings
