### PR TITLE
test(jazz): decode physical aggregate oracle fields

### DIFF
--- a/crates/jazz/src/node/tests/m3_differential.rs
+++ b/crates/jazz/src/node/tests/m3_differential.rs
@@ -1715,7 +1715,12 @@ fn aggregate_payload_value(
     let Value::U64(bucket) = record.get("user_bucket").unwrap() else {
         panic!("aggregate bucket must be U64");
     };
-    let value = match record.get(output).unwrap() {
+    // Aggregate output aliases cross the maintained program boundary in their
+    // dedicated physical namespace. Decode that boundary here instead of
+    // assuming the public alias is a compiler-record field name: aliases can
+    // collide with grouped source columns.
+    let output_field = crate::node::query_engine::aggregate_output_field(output);
+    let value = match record.get(&output_field).unwrap() {
         Value::Nullable(None) => None,
         Value::Nullable(Some(value)) => Some((*value).clone()),
         value => Some(value.clone()),


### PR DESCRIPTION
🤖 Decode aggregate compiler fields in the M3 differential oracle.

## Why

#1404 moves aggregate outputs into a collision-free compiler namespace. The M3 oracle still looked up public aliases directly, so five fast differential tests failed before comparing any product behavior.

## What changed

- use the central aggregate physical-field mapper when extracting oracle payload values
- preserve the public logical labels used by the reference model and diagnostics

## Validation

- bounded main M3 oracle across count/sum/min/max, signed and unsigned integers, nullable initialization, and F64 churn
- F64 control, null semantics, and seeded determinism regressions
- planted public-alias and wrong-app-namespace lookups fail as expected
- independent review confirms the diff is harness-only and masks no product behavior

The normal longer seed now advances past aggregate decoding and exposes a separate inherited-relation divergence, which remains intentionally unfixed here.
