### PR TITLE
fix(jazz): preserve prepared policy claim types

### DIFF
--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -546,6 +546,34 @@ fn owner_id_public_schema() -> JazzSchema {
     .with_write_policy(Policy::public())])
 }
 
+fn owner_id_session_write_schema() -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "messages",
+        [
+            ColumnSchema::new("body", ColumnType::String),
+            ColumnSchema::new("owner_id", ColumnType::String),
+        ],
+    )
+    .with_read_policy(Policy::public())
+    .with_write_policy(Policy::shape(
+        Query::from("messages").filter(eq(col("owner_id"), claim("user_id"))),
+    ))])
+}
+
+fn owner_uuid_session_write_schema() -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "messages",
+        [
+            ColumnSchema::new("body", ColumnType::String),
+            ColumnSchema::new("owner_id", ColumnType::Uuid),
+        ],
+    )
+    .with_read_policy(Policy::public())
+    .with_write_policy(Policy::shape(
+        Query::from("messages").filter(eq(col("owner_id"), claim("user_id"))),
+    ))])
+}
+
 fn benchmark_shaped_recursive_reachable_read_schema() -> JazzSchema {
     let resource_policy = Policy::shape(
         Query::from("res_a")
@@ -15049,6 +15077,185 @@ fn session_upload_uses_connection_identity_for_write_policy() {
     let rows = server.read(&Query::from("todos")).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].row_uuid(), row);
+}
+
+// This sync-boundary test is intentionally lower-level: the public policy
+// test app reaches this same prepared server write-policy path, but cannot
+// distinguish a malformed prepared claim binding from an ordinary denial.
+#[test]
+fn admitted_server_prepared_write_policy_binds_text_user_id_claim() {
+    let schema = owner_id_session_write_schema();
+    let alice = AuthorId::from_bytes([0xa1; 16]);
+    let bob = AuthorId::from_bytes([0xb2; 16]);
+    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    let alice_client = open_db(0xa1, alice, &schema);
+    let bob_client = open_db(0xb2, bob, &schema);
+    let alice_claims = BTreeMap::from([(
+        "user_id".to_owned(),
+        Value::String("alice-subject".to_owned()),
+    )]);
+    alice_client.set_identity_claims(alice, alice_claims.clone());
+    let bob_claims = BTreeMap::from([(
+        "user_id".to_owned(),
+        Value::String("bob-subject".to_owned()),
+    )]);
+    bob_client.set_identity_claims(bob, bob_claims.clone());
+
+    let (alice_transport, alice_server_transport) = duplex();
+    let _alice_upstream = alice_client.connect_upstream(alice_transport);
+    let _alice_subscriber =
+        server.accept_subscriber_with_claims(alice_server_transport, alice, alice_claims);
+    let (bob_transport, bob_server_transport) = duplex();
+    let _bob_upstream = bob_client.connect_upstream(bob_transport);
+    let _bob_subscriber =
+        server.accept_subscriber_with_claims(bob_server_transport, bob, bob_claims);
+
+    let accepted = alice_client
+        .insert(
+            "messages",
+            BTreeMap::from([
+                (
+                    "body".to_owned(),
+                    Value::String("owned by alice".to_owned()),
+                ),
+                (
+                    "owner_id".to_owned(),
+                    Value::String("alice-subject".to_owned()),
+                ),
+            ]),
+        )
+        .unwrap();
+    alice_client.tick().unwrap();
+    server.tick().unwrap();
+    alice_client.tick().unwrap();
+    assert_eq!(
+        block_on(accepted.wait(DurabilityTier::Global)).unwrap(),
+        accepted.mergeable_tx_id(),
+        "the admitted server must bind public session.user_id as Text in its prepared write-policy plan"
+    );
+
+    let denied = bob_client
+        .insert_with_id_for_identity(
+            bob,
+            "messages",
+            row(0xb2),
+            BTreeMap::from([
+                (
+                    "body".to_owned(),
+                    Value::String("spoofed by bob".to_owned()),
+                ),
+                (
+                    "owner_id".to_owned(),
+                    Value::String("alice-subject".to_owned()),
+                ),
+            ]),
+        )
+        .unwrap();
+    assert_authority_rejects_staged_write(&bob_client, &server, &denied);
+    let rows = server.read(&Query::from("messages")).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].row_uuid(), accepted.row_uuid());
+}
+
+#[test]
+fn admitted_server_prepared_write_policy_coerces_string_user_id_to_uuid_column() {
+    let schema = owner_uuid_session_write_schema();
+    let alice = AuthorId::from_bytes([0xa3; 16]);
+    let bob = AuthorId::from_bytes([0xb3; 16]);
+    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    let alice_client = open_db(0xa3, alice, &schema);
+    let bob_client = open_db(0xb3, bob, &schema);
+    let alice_claims = BTreeMap::from([("user_id".to_owned(), Value::String(alice.0.to_string()))]);
+    let bob_claims = BTreeMap::from([("user_id".to_owned(), Value::String(bob.0.to_string()))]);
+    alice_client.set_identity_claims(alice, alice_claims.clone());
+    bob_client.set_identity_claims(bob, bob_claims.clone());
+
+    let (alice_transport, alice_server_transport) = duplex();
+    let _alice_upstream = alice_client.connect_upstream(alice_transport);
+    let _alice_subscriber =
+        server.accept_subscriber_with_claims(alice_server_transport, alice, alice_claims);
+    let (bob_transport, bob_server_transport) = duplex();
+    let _bob_upstream = bob_client.connect_upstream(bob_transport);
+    let _bob_subscriber =
+        server.accept_subscriber_with_claims(bob_server_transport, bob, bob_claims);
+
+    let accepted = alice_client
+        .insert(
+            "messages",
+            BTreeMap::from([
+                (
+                    "body".to_owned(),
+                    Value::String("owned by alice".to_owned()),
+                ),
+                ("owner_id".to_owned(), Value::Uuid(alice.0)),
+            ]),
+        )
+        .unwrap();
+    alice_client.tick().unwrap();
+    server.tick().unwrap();
+    alice_client.tick().unwrap();
+    assert_eq!(
+        block_on(accepted.wait(DurabilityTier::Global)).unwrap(),
+        accepted.mergeable_tx_id(),
+        "the prepared descriptor must preserve UUID policy columns while coercing public user_id text"
+    );
+
+    let denied = bob_client
+        .insert_with_id_for_identity(
+            bob,
+            "messages",
+            row(0xb3),
+            BTreeMap::from([
+                (
+                    "body".to_owned(),
+                    Value::String("spoofed by bob".to_owned()),
+                ),
+                ("owner_id".to_owned(), Value::Uuid(alice.0)),
+            ]),
+        )
+        .unwrap();
+    assert_authority_rejects_staged_write(&bob_client, &server, &denied);
+    let rows = server.read(&Query::from("messages")).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].row_uuid(), accepted.row_uuid());
+}
+
+#[test]
+fn admitted_server_prepared_write_policy_fails_closed_for_wrong_user_id_type() {
+    let schema = owner_id_session_write_schema();
+    let author = AuthorId::from_bytes([0xa4; 16]);
+    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    let client = open_db(0xa4, author, &schema);
+    let claims = BTreeMap::from([("user_id".to_owned(), Value::Bool(true))]);
+    client.set_identity_claims(author, claims.clone());
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let _subscriber = server.accept_subscriber_with_claims(server_transport, author, claims);
+    let write = client
+        .insert(
+            "messages",
+            BTreeMap::from([
+                (
+                    "body".to_owned(),
+                    Value::String("must not ingest".to_owned()),
+                ),
+                ("owner_id".to_owned(), Value::String("true".to_owned())),
+            ]),
+        )
+        .unwrap();
+
+    client.tick().unwrap();
+    let error = server.tick().unwrap_err();
+    assert!(
+        error.to_string().contains("user_id has wrong type"),
+        "a non-coercible claim must fail before authorization support can admit the write: {error}"
+    );
+    assert!(
+        server.read(&Query::from("messages")).unwrap().is_empty(),
+        "a malformed session claim must never ingest a protected row"
+    );
+    drop(write);
 }
 
 #[test]

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -6135,10 +6135,10 @@ where
                 binding,
                 query_binding_source_shape_for_parts_if_needed(
                     shape.params(),
-                    &binding_claim_params_for_shape(&input_shape),
+                    &binding_claim_params_for_shape(&input_shape, shape.params()),
                 ),
                 BTreeMap::new(),
-                binding_claim_params_for_shape(&input_shape),
+                binding_claim_params_for_shape(&input_shape, shape.params()),
             ),
             shape: input_shape,
         };
@@ -6167,10 +6167,10 @@ where
                 binding,
                 query_binding_source_shape_for_parts_if_needed(
                     shape.params(),
-                    &binding_claim_params_for_shape(&input_shape),
+                    &binding_claim_params_for_shape(&input_shape, shape.params()),
                 ),
                 BTreeMap::new(),
-                binding_claim_params_for_shape(&input_shape),
+                binding_claim_params_for_shape(&input_shape, shape.params()),
             ),
             shape: input_shape,
         };
@@ -6224,10 +6224,10 @@ where
                 &binding,
                 query_binding_source_shape_for_parts_if_needed(
                     lowered_shape.params(),
-                    &binding_claim_params_for_shape(&input_shape),
+                    &binding_claim_params_for_shape(&input_shape, lowered_shape.params()),
                 ),
                 BTreeMap::new(),
-                binding_claim_params_for_shape(&input_shape),
+                binding_claim_params_for_shape(&input_shape, lowered_shape.params()),
             ),
             shape: input_shape,
         };
@@ -6270,10 +6270,10 @@ where
                 &binding,
                 query_binding_source_shape_for_parts_if_needed(
                     lowered_shape.params(),
-                    &binding_claim_params_for_shape(&input_shape),
+                    &binding_claim_params_for_shape(&input_shape, lowered_shape.params()),
                 ),
                 BTreeMap::new(),
-                binding_claim_params_for_shape(&input_shape),
+                binding_claim_params_for_shape(&input_shape, lowered_shape.params()),
             ),
             shape: input_shape,
         };
@@ -6506,7 +6506,7 @@ where
                 &binding,
                 None,
                 BTreeMap::new(),
-                binding_claim_params_for_shape(&input_shape),
+                binding_claim_params_for_shape(&input_shape, policy_shape.params()),
             ),
             shape: input_shape,
         };
@@ -6627,7 +6627,7 @@ where
             shape.schema_version(),
             &input_shape,
         );
-        let mut binding_claim_params = binding_claim_params_for_shape(&input_shape);
+        let mut binding_claim_params = binding_claim_params_for_shape(&input_shape, shape.params());
         if use_prepared_binding_source {
             let policy_schema = self
                 .catalogue
@@ -7141,7 +7141,7 @@ where
             reachable_contributions,
             nodes,
         };
-        let claim_params = binding_claim_params_for_shape(&normalized);
+        let claim_params = binding_claim_params_for_shape(&normalized, shape.params());
         let binding_source_shape =
             query_binding_source_shape_for_parts(shape.params(), &claim_params);
         retarget_binding_value_sources(&mut normalized, &binding_source_shape);
@@ -7317,10 +7317,10 @@ where
                 &binding,
                 query_binding_source_shape_for_parts_if_needed(
                     policy_shape.params(),
-                    &binding_claim_params_for_shape(&input_shape),
+                    &binding_claim_params_for_shape(&input_shape, policy_shape.params()),
                 ),
                 BTreeMap::new(),
-                binding_claim_params_for_shape(&input_shape),
+                binding_claim_params_for_shape(&input_shape, policy_shape.params()),
             ),
             shape: input_shape,
         };
@@ -11245,7 +11245,10 @@ where
         let binding = policy_shape.bind(BTreeMap::new())?;
         let mut input_shape = self.normalized_row_set_shape(&policy_shape, &binding)?;
         let mut claim_params = binding_claim_params;
-        claim_params.extend(binding_claim_params_for_shape(&input_shape));
+        claim_params.extend(binding_claim_params_for_shape(
+            &input_shape,
+            policy_shape.params(),
+        ));
         collect_reachable_seed_claim_params(
             policy_schema,
             policy_shape.query(),
@@ -11425,7 +11428,10 @@ where
             self.normalized_row_set_shape(&policy_shape, &binding)?
         };
         let mut claim_params = binding_claim_params;
-        claim_params.extend(binding_claim_params_for_shape(&input_shape));
+        claim_params.extend(binding_claim_params_for_shape(
+            &input_shape,
+            policy_shape.params(),
+        ));
         claim_params.extend(declared_claim_params);
         collect_reachable_seed_claim_params(
             policy_schema,
@@ -11508,7 +11514,10 @@ where
         let binding = policy_shape.bind(BTreeMap::new())?;
         let mut input_shape = self.normalized_row_set_shape(&policy_shape, &binding)?;
         let mut claim_params = binding_claim_params;
-        claim_params.extend(binding_claim_params_for_shape(&input_shape));
+        claim_params.extend(binding_claim_params_for_shape(
+            &input_shape,
+            policy_shape.params(),
+        ));
         collect_reachable_seed_claim_params(
             &self.catalogue.schema,
             policy_shape.query(),
@@ -11802,6 +11811,7 @@ fn compile_permission_scope_policy(
     let mut values = BTreeMap::new();
     bind_scope_claim_operands(&mut query, claim_values, &mut values);
     let shape = query.validate(schema)?;
+    coerce_binding_values_for_shape(&shape, &mut values);
     let binding = shape.bind(values)?;
     Ok((shape, binding))
 }
@@ -12772,6 +12782,7 @@ fn retarget_binding_value_sources(shape: &mut NormalizedRowSetShape, binding_sou
 
 fn binding_claim_params_for_shape(
     shape: &NormalizedRowSetShape,
+    param_types: &BTreeMap<String, ColumnType>,
 ) -> BTreeMap<String, ProgramClaimParam> {
     let mut params = BTreeMap::new();
     for node in shape.nodes.values() {
@@ -12794,7 +12805,7 @@ fn binding_claim_params_for_shape(
                 );
             }
         }
-        collect_claim_field_params_from_node(node, &mut params);
+        collect_claim_field_params_from_node(node, param_types, &mut params);
     }
     params
 }
@@ -12859,20 +12870,21 @@ fn collect_reachable_seed_claim_params(
 
 fn collect_claim_field_params_from_node(
     node: &RowSetExpr,
+    param_types: &BTreeMap<String, ColumnType>,
     params: &mut BTreeMap<String, ProgramClaimParam>,
 ) {
     match node {
         RowSetExpr::Filter { predicate, .. } | RowSetExpr::Join { on: predicate, .. } => {
-            collect_claim_field_params_from_predicate(predicate, params);
+            collect_claim_field_params_from_predicate(predicate, param_types, params);
         }
         RowSetExpr::RecursiveRelation {
             frontier_key,
             dedupe_keys,
             ..
         } => {
-            collect_claim_field_param(frontier_key, ColumnType::Uuid, params);
+            collect_claim_field_param_authoritative(frontier_key, ColumnType::Uuid, params);
             for key in dedupe_keys {
-                collect_claim_field_param(key, ColumnType::Uuid, params);
+                collect_claim_field_param_authoritative(key, ColumnType::Uuid, params);
             }
         }
         RowSetExpr::Project { columns, .. } => {
@@ -12886,15 +12898,15 @@ fn collect_claim_field_params_from_node(
         }
         RowSetExpr::Distinct { keys, .. } => {
             for key in keys {
-                collect_claim_field_param(key, ColumnType::Uuid, params);
+                collect_claim_field_param_authoritative(key, ColumnType::Uuid, params);
             }
         }
         RowSetExpr::CorrelatedPathProjection { correlation, .. } => {
-            collect_claim_field_params_from_predicate(correlation, params);
+            collect_claim_field_params_from_predicate(correlation, param_types, params);
         }
         RowSetExpr::OrderBy { keys, .. } => {
             for key in keys {
-                collect_claim_field_param(&key.value, ColumnType::Uuid, params);
+                collect_claim_field_param_authoritative(&key.value, ColumnType::Uuid, params);
             }
         }
         RowSetExpr::Slice {
@@ -12903,18 +12915,22 @@ fn collect_claim_field_params_from_node(
             ..
         } => {
             for value in partition_by.iter().chain(tie_breaker) {
-                collect_claim_field_param(value, ColumnType::Uuid, params);
+                collect_claim_field_param_authoritative(value, ColumnType::Uuid, params);
             }
         }
         RowSetExpr::Aggregate {
             group_by, outputs, ..
         } => {
             for value in group_by {
-                collect_claim_field_param(value, ColumnType::Uuid, params);
+                collect_claim_field_param_authoritative(value, ColumnType::Uuid, params);
             }
             for output in outputs {
                 if let Some(input) = &output.input {
-                    collect_claim_field_param(input, output.output.ty.clone(), params);
+                    collect_claim_field_param_authoritative(
+                        input,
+                        output.output.ty.clone(),
+                        params,
+                    );
                 }
             }
         }
@@ -12927,48 +12943,52 @@ fn collect_claim_field_params_from_node(
 
 fn collect_claim_field_params_from_predicate(
     predicate: &NormalizedPredicateExpr,
+    param_types: &BTreeMap<String, ColumnType>,
     params: &mut BTreeMap<String, ProgramClaimParam>,
 ) {
     match predicate {
         NormalizedPredicateExpr::True | NormalizedPredicateExpr::False => {}
         NormalizedPredicateExpr::Compare { left, right, .. } => {
-            collect_claim_field_param(left, ColumnType::Uuid, params);
-            collect_claim_field_param(right, ColumnType::Uuid, params);
+            collect_claim_field_param(left, param_types, params);
+            collect_claim_field_param(right, param_types, params);
         }
         NormalizedPredicateExpr::In { value, options } => {
-            collect_claim_field_param(value, ColumnType::Uuid, params);
+            collect_claim_field_param(value, param_types, params);
             for option in options {
-                collect_claim_field_param(option, ColumnType::Uuid, params);
+                collect_claim_field_param(option, param_types, params);
             }
         }
         NormalizedPredicateExpr::ArrayContains { value, needle }
         | NormalizedPredicateExpr::TextContains { value, needle } => {
-            collect_claim_field_param(value, ColumnType::Uuid, params);
-            collect_claim_field_param(needle, ColumnType::Uuid, params);
+            collect_claim_field_param(value, param_types, params);
+            collect_claim_field_param(needle, param_types, params);
         }
         NormalizedPredicateExpr::IsNull(value) | NormalizedPredicateExpr::IsNotNull(value) => {
-            collect_claim_field_param(value, ColumnType::Uuid, params);
+            collect_claim_field_param(value, param_types, params);
         }
         NormalizedPredicateExpr::And(children) | NormalizedPredicateExpr::Or(children) => {
             for child in children {
-                collect_claim_field_params_from_predicate(child, params);
+                collect_claim_field_params_from_predicate(child, param_types, params);
             }
         }
         NormalizedPredicateExpr::Not(child) => {
-            collect_claim_field_params_from_predicate(child, params);
+            collect_claim_field_params_from_predicate(child, param_types, params);
         }
     }
 }
 
 fn collect_claim_field_param(
     value: &NormalizedValueRef,
-    ty: ColumnType,
+    param_types: &BTreeMap<String, ColumnType>,
     params: &mut BTreeMap<String, ProgramClaimParam>,
 ) {
     let NormalizedValueRef::Param(param) = value else {
         return;
     };
     let Some(path) = claim_path_from_param_field(param) else {
+        return;
+    };
+    let Some(ty) = param_types.get(param).cloned() else {
         return;
     };
     params
@@ -14646,6 +14666,57 @@ mod tests {
                 coerce_prepared_binding_value(out_of_range.clone(), &column_type),
                 out_of_range,
                 "out-of-range nullable integers must not wrap or narrow"
+            );
+        }
+    }
+
+    #[test]
+    fn prepared_claim_descriptor_uses_validated_param_type_for_both_equality_orders() {
+        let schema = JazzSchema::new([
+            TableSchema::new(
+                "text_owners",
+                [ColumnSchema::new("owner", ColumnType::String)],
+            ),
+            TableSchema::new(
+                "nullable_owners",
+                [ColumnSchema::new("owner", ColumnType::String.nullable())],
+            ),
+            TableSchema::new(
+                "uuid_owners",
+                [ColumnSchema::new("owner", ColumnType::Uuid)],
+            ),
+        ]);
+        let (_dir, node) = open_node_with_uuid(NodeUuid::from_bytes([0xb4; 16]), schema.clone());
+        let claim_param = claim_param_field(&ClaimPath(vec!["user_id".to_owned()]));
+        let cases = [
+            (
+                Query::from("text_owners").filter(eq(col("owner"), param(&claim_param))),
+                ColumnType::String,
+                Value::String("alice".to_owned()),
+            ),
+            (
+                Query::from("nullable_owners").filter(eq(param(&claim_param), col("owner"))),
+                ColumnType::String.nullable(),
+                Value::Nullable(Some(Box::new(Value::String("alice".to_owned())))),
+            ),
+            (
+                Query::from("uuid_owners").filter(eq(col("owner"), param(&claim_param))),
+                ColumnType::Uuid,
+                Value::Uuid(uuid::Uuid::from_bytes([0xb5; 16])),
+            ),
+        ];
+
+        for (query, expected_type, value) in cases {
+            let shape = query.validate(&schema).unwrap();
+            let binding = shape
+                .bind(BTreeMap::from([(claim_param.clone(), value)]))
+                .unwrap();
+            let normalized = node.normalized_row_set_shape(&shape, &binding).unwrap();
+            let claims = binding_claim_params_for_shape(&normalized, shape.params());
+            assert_eq!(
+                claims.get(&claim_param).map(|claim| &claim.ty),
+                Some(&expected_type),
+                "prepared descriptor must retain the validator's paired-column type",
             );
         }
     }


### PR DESCRIPTION
🤖 Preserve validated schema types for prepared policy claims.

## Root cause

The server authorization-support path rebuilt predicate claim descriptors by hard-coding every session claim as UUID. A valid policy comparing a Text owner column with `Session.user_id` therefore produced a UUID prepared slot and failed admission with `value does not match type Uuid`.

## What changed

- derive prepared predicate claim types from the schema-validated query parameter descriptor
- apply claim value coercion only after schema validation
- retain UUID behavior when the paired column is UUID and Text behavior when it is Text

## Validation

- server prepared write-policy tests for Text and UUID ownership
- reversed and nullable predicate descriptor coverage
- separate-session authorization and cross-session rejection
- malicious Bool-to-Text value fails closed
- planted old UUID hard-code and unsafe coercion fail the new regressions
- full prepared-claim routing suite: 11 pass, 1 existing ignored
- clippy, rustfmt, sensitive-data guard
- independent adversarial review: no P0/P1/P2 findings

After a fresh NAPI rebuild, the original JS write-type failure is gone. The test then reaches a separate read-path failure (Alice receives an empty result), intentionally left for a follow-up.
