### PR TITLE
fix(jazz): keep collector route keys internal

### DIFF
--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -225,6 +225,22 @@ fn collect_tree_schema() -> DatabaseSchema {
     .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
 }
 
+fn routed_collect_tree_schema() -> DatabaseSchema {
+    DatabaseSchema::new([TableSchema::new(
+        "routed_tree",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("root", ColumnType::U64),
+            ColumnSchema::new("route", ColumnType::U64),
+            ColumnSchema::new("child", ColumnType::U64),
+            ColumnSchema::new("child_order", ColumnType::U64),
+            ColumnSchema::new("grandchild", ColumnType::U64),
+            ColumnSchema::new("grandchild_order", ColumnType::U64),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
+}
+
 fn collect_tree_values(
     [
         id,
@@ -298,6 +314,34 @@ fn collect_tree_graph() -> GraphBuilder {
                 TopByLimit::Finite(1),
             ),
         ],
+    )
+}
+
+fn routed_collect_tree_graph() -> GraphBuilder {
+    GraphBuilder::collect_by_tree(
+        GraphBuilder::table("routed_tree"),
+        ["root", "route"],
+        [CollectByField::named("root")],
+        [CollectBySlotBuilder::new(
+            ["root", "route"],
+            [CollectByField::named("child")],
+            "children",
+            [CollectBySlotBuilder::new(
+                ["child", "route"],
+                [CollectByField::named("grandchild")],
+                "grandchildren",
+                [],
+                [TopByOrder::asc("grandchild_order")],
+                ["grandchild"],
+                0,
+                TopByLimit::Unbounded,
+            )],
+            [TopByOrder::asc("child_order")],
+            ["child"],
+            0,
+            TopByLimit::Unbounded,
+        )
+        .with_owner_key_cols(["route"])],
     )
 }
 
@@ -5456,6 +5500,103 @@ fn collect_by_tree_renders_sibling_slots_and_grandchildren_with_independent_wind
             expected
         );
     }
+}
+
+#[test]
+fn collect_by_tree_keeps_routed_owner_keys_internal_and_isolated() {
+    let storage = MemoryStorage::new(&["routed_tree"]);
+    let mut database = Database::new(routed_collect_tree_schema(), storage).unwrap();
+    let subscription = database
+        .subscribe_one_sink(routed_collect_tree_graph())
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    // Two bindings deliberately share rendered root and child identities. The
+    // route must still keep their grandchildren isolated, while staying out
+    // of every rendered record descriptor.
+    let mut batch = database.open_batch();
+    batch.insert(
+        "routed_tree",
+        vec![
+            Value::U64(1),
+            Value::U64(10),
+            Value::U64(1),
+            Value::U64(20),
+            Value::U64(1),
+            Value::U64(100),
+            Value::U64(1),
+        ],
+    );
+    batch.insert(
+        "routed_tree",
+        vec![
+            Value::U64(2),
+            Value::U64(10),
+            Value::U64(2),
+            Value::U64(20),
+            Value::U64(1),
+            Value::U64(200),
+            Value::U64(1),
+        ],
+    );
+    database.commit_batch(batch).unwrap();
+    let rows = subscription.recv().unwrap().to_values().unwrap();
+    assert_eq!(rows.len(), 2);
+
+    let grandchildren = rows
+        .iter()
+        .map(|(root, weight)| {
+            assert_eq!(*weight, 1);
+            assert_eq!(root.len(), 2, "route must not be a root output field");
+            let Value::Array(children) = &root[1] else {
+                panic!("children must be an array");
+            };
+            assert_eq!(children.len(), 1);
+            let Value::Record(child) = &children[0] else {
+                panic!("children must contain records");
+            };
+            let child = child.to_values().unwrap();
+            assert_eq!(child.len(), 2, "route must not be a child output field");
+            let Value::Array(grandchildren) = &child[1] else {
+                panic!("grandchildren must be an array");
+            };
+            let Value::Record(grandchild) = &grandchildren[0] else {
+                panic!("grandchildren must contain records");
+            };
+            assert_eq!(grandchild.to_values().unwrap().len(), 1);
+            grandchild.to_values().unwrap()[0].clone()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(grandchildren, vec![Value::U64(100), Value::U64(200)]);
+}
+
+#[test]
+fn collect_by_tree_rejects_non_grouping_internal_owner_key() {
+    let graph = GraphBuilder::collect_by_tree(
+        GraphBuilder::table("routed_tree"),
+        ["root", "route"],
+        [CollectByField::named("root")],
+        [CollectBySlotBuilder::new(
+            ["root", "route"],
+            [CollectByField::named("child")],
+            "children",
+            [],
+            [TopByOrder::asc("child_order")],
+            ["child"],
+            0,
+            TopByLimit::Unbounded,
+        )
+        // A non-grouping raw input is not stable owner metadata and must not
+        // become an implicit hidden channel.
+        .with_owner_key_cols(["grandchild"])],
+    );
+    let storage = MemoryStorage::new(&["routed_tree"]);
+    let mut database = Database::new(routed_collect_tree_schema(), storage).unwrap();
+    assert!(matches!(
+        database.subscribe_one_sink(graph),
+        Err(Error::IvmRuntime(IvmRuntimeError::InvalidCollectBy(message)))
+            if message == "a slot owner key must also be a grouping field"
+    ));
 }
 
 #[test]

--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -266,6 +266,14 @@ pub struct CollectByBuilder {
 pub struct CollectBySlotBuilder {
     /// Source fields identifying the parent record that owns this slot.
     pub group_cols: Vec<FieldRef>,
+    /// Additional source fields carried with a child solely so nested slots
+    /// can address that child. These fields are intentionally not part of the
+    /// child projection or its rendered descriptor.
+    ///
+    /// Every owner-key field must also be a grouping field for this slot. That
+    /// makes it stable for the child record it accompanies and prevents this
+    /// metadata channel from changing the observable collection shape.
+    pub owner_key_cols: Vec<FieldRef>,
     pub child_fields: Vec<CollectByField>,
     pub collection_field: String,
     pub slots: Vec<CollectBySlotBuilder>,
@@ -298,6 +306,7 @@ impl CollectBySlotBuilder {
     ) -> Self {
         Self {
             group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
+            owner_key_cols: Vec::new(),
             child_fields: child_fields.into_iter().collect(),
             collection_field: collection_field.into(),
             slots: slots.into_iter().collect(),
@@ -313,6 +322,18 @@ impl CollectBySlotBuilder {
     /// this slot. Unmarked records still may serve as parent anchors.
     pub fn with_presence_col(mut self, presence_col: impl Into<String>) -> Self {
         self.presence_col = Some(FieldRef::name(presence_col));
+        self
+    }
+
+    /// Carry non-rendered grouping fields to nested slots.
+    ///
+    /// This is for execution metadata such as a maintained query's route key;
+    /// it deliberately does not alter the child record descriptor.
+    pub fn with_owner_key_cols(
+        mut self,
+        owner_key_cols: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.owner_key_cols = owner_key_cols.into_iter().map(FieldRef::name).collect();
         self
     }
 }

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -9065,7 +9065,25 @@ fn collect_by_slots(
                 .iter()
                 .map(|field| field.field_idx)
                 .collect::<Vec<_>>();
-            let slots = collect_by_slots(input, &builder.slots, &child_indices, depth + 1)?;
+            // Nested slots address the raw input record selected for this
+            // child, not its rendered descriptor. Most owner keys are child
+            // projection fields, but maintained routing keys must remain
+            // internal: carrying them through the app descriptor would leak
+            // binding metadata. `owner_key_cols` is the explicit internal
+            // channel for those stable grouping keys.
+            let mut owner_indices = child_indices.clone();
+            for owner_key in &builder.owner_key_cols {
+                let owner_key_index = resolve_field_ref(input, owner_key)?;
+                if !group_field_indices.contains(&owner_key_index) {
+                    return Err(IvmRuntimeError::InvalidCollectBy(
+                        "a slot owner key must also be a grouping field".into(),
+                    ));
+                }
+                if !owner_indices.contains(&owner_key_index) {
+                    owner_indices.push(owner_key_index);
+                }
+            }
+            let slots = collect_by_slots(input, &builder.slots, &owner_indices, depth + 1)?;
             Ok(CollectBySlot {
                 group_fields: group_field_indices
                     .iter()

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -6761,6 +6761,11 @@ fn collect_slot_builder(
         slot.offset,
         slot.limit,
     )
+    // Route fields identify a maintained binding, but are not application
+    // fields on nested records. Carry them only as execution owner keys so a
+    // grandchild can still group by the same binding without exposing them in
+    // the nested descriptor.
+    .with_owner_key_cols(route_fields.iter().cloned())
     .with_presence_col(&slot.presence_input)
 }
 

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -930,6 +930,37 @@ fn relation_snapshot_policy_schema() -> JazzSchema {
     ])
 }
 
+fn routed_nested_collector_schema() -> JazzSchema {
+    JazzSchema::new([
+        TableSchema::new("users", [ColumnSchema::new("name", ColumnType::String)]),
+        TableSchema::new(
+            "todos",
+            [
+                ColumnSchema::new("title", ColumnType::String),
+                ColumnSchema::new("owner_id", ColumnType::Uuid),
+            ],
+        )
+        .with_reference("owner_id", "users")
+        .with_read_policy(Policy::owner_only("todos", "owner_id")),
+        TableSchema::new(
+            "comments",
+            [
+                ColumnSchema::new("body", ColumnType::String),
+                ColumnSchema::new("todo_id", ColumnType::Uuid),
+            ],
+        )
+        .with_reference("todo_id", "todos"),
+        TableSchema::new(
+            "attachments",
+            [
+                ColumnSchema::new("name", ColumnType::String),
+                ColumnSchema::new("todo_id", ColumnType::Uuid),
+            ],
+        )
+        .with_reference("todo_id", "todos"),
+    ])
+}
+
 fn forward_include_schema() -> JazzSchema {
     JazzSchema::new([
         TableSchema::new(
@@ -1684,6 +1715,151 @@ fn maintained_array_collector_retains_authorized_parent_trees_incrementally() {
         bob_before,
         "unaffected parent tree is retained byte-for-byte"
     );
+    node.unsubscribe_groove_subscription(subscription.id());
+}
+
+#[test]
+fn maintained_nested_collector_keeps_two_route_keys_internal_across_sibling_arrays() {
+    // The root filter and owner policy contribute independent route keys. The
+    // nested siblings deliberately share the same routed todo so this covers
+    // lowering and maintained runtime, not only a hand-built Groove graph.
+    let schema = routed_nested_collector_schema();
+    let (_temp_dir, mut node) = open_node_with_schema(node(0x47), schema.clone());
+    let alice = user(0xa1);
+    let parent = row(0xa1);
+    let todo_row = row(0x11);
+    let comment = row(0x21);
+    let attachment = row(0x31);
+
+    node.commit_mergeable(
+        MergeableCommit::new("users", parent, 10)
+            .cells(BTreeMap::from([("name".to_owned(), v("alice"))])),
+    )
+    .unwrap();
+    node.commit_mergeable(
+        MergeableCommit::new("todos", todo_row, 11).cells(BTreeMap::from([
+            ("title".to_owned(), v("owned")),
+            ("owner_id".to_owned(), Value::Uuid(alice.0)),
+        ])),
+    )
+    .unwrap();
+    node.commit_mergeable(
+        MergeableCommit::new("comments", comment, 12).cells(BTreeMap::from([
+            ("body".to_owned(), v("first comment")),
+            ("todo_id".to_owned(), Value::Uuid(todo_row.0)),
+        ])),
+    )
+    .unwrap();
+    node.commit_mergeable(
+        MergeableCommit::new("attachments", attachment, 13).cells(BTreeMap::from([
+            ("name".to_owned(), v("first attachment")),
+            ("todo_id".to_owned(), Value::Uuid(todo_row.0)),
+        ])),
+    )
+    .unwrap();
+
+    let shape = Query::from("users")
+        .filter(eq(col("name"), param("rootName")))
+        .array_subquery(
+            ArraySubquery::new("todosViaOwner", "todos", "owner_id", "id")
+                .select(["title"])
+                .nested(
+                    ArraySubquery::new("commentsViaTodo", "comments", "todo_id", "id")
+                        .select(["body"]),
+                )
+                .nested(
+                    ArraySubquery::new(
+                        "attachmentsViaTodo",
+                        "attachments",
+                        "todo_id",
+                        "id",
+                    )
+                    .select(["name"]),
+                ),
+        )
+        .validate(&schema)
+        .unwrap();
+    let binding = shape
+        .bind(BTreeMap::from([("rootName".to_owned(), v("alice"))]))
+        .unwrap();
+    let (subscription, mut maintained, terminal_schemas, transitions, tables) = node
+        .open_seeded_maintained_subscription_view(
+            &shape,
+            &binding,
+            alice,
+            DurabilityTier::Local,
+            &crate::protocol::ReadViewSpec::default(),
+        )
+        .unwrap();
+    assert_eq!(transitions.structured_app_row_changes, BTreeSet::from([parent]));
+
+    let root = maintained
+        .structured_app_row(parent)
+        .expect("collector retained routed root");
+    let Value::Array(todos) = root.get("todosViaOwner").unwrap() else {
+        panic!("todos must be an array");
+    };
+    let Value::Record(todo) = &todos[0] else {
+        panic!("todos must contain records");
+    };
+    assert_eq!(
+        todo.descriptor()
+            .fields()
+            .iter()
+            .map(|field| field.name.as_deref())
+            .collect::<Vec<_>>(),
+        vec![
+            Some("row_uuid"),
+            Some("title"),
+            Some("commentsViaTodo"),
+            Some("attachmentsViaTodo"),
+        ],
+        "route keys must remain lowering/runtime metadata, not nested app fields"
+    );
+    for field in ["commentsViaTodo", "attachmentsViaTodo"] {
+        let Value::Array(children) = todo.get(field).unwrap() else {
+            panic!("{field} must be an array");
+        };
+        assert_eq!(children.len(), 1, "each sibling array retains its own child");
+    }
+
+    // A new comment changes only that sibling content, preserving the
+    // attachment subtree and the one rendered parent identity.
+    node.commit_mergeable(
+        MergeableCommit::new("comments", row(0x22), 14).cells(BTreeMap::from([
+            ("body".to_owned(), v("second comment")),
+            ("todo_id".to_owned(), Value::Uuid(todo_row.0)),
+        ])),
+    )
+    .unwrap();
+    node.flush_query_runtime().unwrap();
+    let mut changed_roots = BTreeSet::new();
+    while let Ok(deltas) = subscription.try_recv() {
+        changed_roots.extend(
+            maintained
+                .apply_multisink_deltas(deltas, &terminal_schemas, &tables, &node.node_aliases)
+                .unwrap()
+                .structured_app_row_changes,
+        );
+    }
+    assert_eq!(changed_roots, BTreeSet::from([parent]));
+    let root = maintained
+        .structured_app_row(parent)
+        .expect("updated routed root remains retained");
+    let Value::Array(todos) = root.get("todosViaOwner").unwrap() else {
+        panic!("todos must be an array");
+    };
+    let Value::Record(todo) = &todos[0] else {
+        panic!("todos must contain records");
+    };
+    let Value::Array(comments) = todo.get("commentsViaTodo").unwrap() else {
+        panic!("comments must be an array");
+    };
+    let Value::Array(attachments) = todo.get("attachmentsViaTodo").unwrap() else {
+        panic!("attachments must be an array");
+    };
+    assert_eq!(comments.len(), 2);
+    assert_eq!(attachments.len(), 1, "sibling route grouping remains isolated");
     node.unsubscribe_groove_subscription(subscription.id());
 }
 


### PR DESCRIPTION
🤖 Keep nested collector route keys internal.

## Root cause

Nested collect-by slots group by parent identity plus prepared route scope. Groove validated child-slot grouping only against rendered child fields, but route metadata is intentionally absent from those descriptors. Routed nested collectors therefore failed construction with `InvalidCollectBy`.

## What changed

- add an internal `owner_key_cols` channel constrained to existing grouping columns
- let recursive collector eligibility use those owner keys without projecting them into app rows
- propagate prepared route fields through nested slots while preserving public descriptor shape

## Validation

- original maintained nested collector regression
- Groove two-binding route isolation and malformed owner-key rejection
- Jazz-level root binding + owner-policy claim routes across sibling comment/attachment arrays
- nested descriptor non-leak and incremental sibling isolation
- planted propagation omission, wrong owner index, and descriptor leak fail as expected
- clippy, rustfmt, sensitive-data guard
- independent adversarial review: no P0/P1/P2 findings
