### PR TITLE
test(jazz): decode aggregate payload namespace

### DIFF
--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -3609,7 +3609,12 @@ mod tests {
                 .map(|(name, value_type)| (name.unwrap(), value_type)),
         );
         let record = BorrowedRecord::new(&payload.record, &descriptor);
-        record.get("count").unwrap().clone()
+        // Aggregate aliases are logical app names, but maintained-program
+        // payload descriptors use the dedicated physical aggregate namespace
+        // so they cannot collide with grouped source columns. Decode the
+        // protocol boundary instead of treating `count` as a record field.
+        let count_field = crate::node::query_engine::aggregate_output_field("count");
+        record.get(&count_field).unwrap().clone()
     }
 
     fn aggregate_cells(row: &crate::node::CurrentRow) -> BTreeMap<String, Value> {


### PR DESCRIPTION
🤖 This removes two deterministic Rust CI failures in the maintained aggregate subscription tests.

The aggregate payload protocol intentionally stores compiler fields in the collision-free `__jazz_aggregate_<alias>` namespace and converts them back to logical names only at the public result boundary. The peer test helper was still decoding payload records with the logical `count` field, so both tests failed with `FieldNotFound("count")` even though the product payload was correct.

The helper now derives the physical field through the same aggregate namespace function used by lowering. This is test-only and does not change runtime behavior.

Validation:

- `peer::tests::maintained_subscription_view_aggregate_rehydrate_ships_payload_fact`
- `peer::tests::maintained_subscription_view_aggregate_updates_incrementally`
- planted old and wrong namespace mappings both reproduce `FieldNotFound`
- `cargo fmt --check`
- `cargo clippy -p jazz -- -D warnings`
- sensitive-data guard
- independent adversarial review

Tooling note: Cargo's short `--exact` filters silently ran zero tests; validation used fully-qualified test names and verified one executed test per command.
