### PR TITLE
fix: bound debug output for binary values

### DIFF
--- a/crates/jazz/src/node/query_engine/read.rs
+++ b/crates/jazz/src/node/query_engine/read.rs
@@ -328,8 +328,20 @@ pub(crate) struct ResolvedOverlay {
 }
 
 /// Canonical batch identity.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct BatchId(pub(crate) Vec<u8>);
+
+impl std::fmt::Debug for BatchId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fingerprint = blake3::hash(&self.0).to_hex();
+        write!(
+            f,
+            "BatchId {{ len: {}, fingerprint: {} }}",
+            self.0.len(),
+            &fingerprint[..12]
+        )
+    }
+}
 
 /// Settled-frontier fact identity. Propagation, waiting, and retry behavior are
 /// runtime policy outside the compiler; the lowered program only emits the fact.
@@ -393,4 +405,27 @@ pub(crate) struct ResolvedPartitionLens {
     pub(crate) storage_schema: SchemaVersionId,
     /// Canonical fingerprint of applied lens/projection path.
     pub(crate) lens_path_fingerprint: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BatchId;
+
+    #[test]
+    fn internal_batch_id_debug_is_bounded_and_content_safe() {
+        let empty = format!("{:?}", BatchId(vec![]));
+        assert_eq!(empty, "BatchId { len: 0, fingerprint: af1349b9f5f9 }");
+
+        let payload = vec![b'x'; 1_000_000];
+        let debug = format!("{:?}", BatchId(payload));
+        assert!(debug.starts_with("BatchId { len: 1000000, fingerprint: "));
+        assert!(debug.len() < 80);
+        assert!(!debug.contains("xxxxx"));
+
+        let first = format!("{:?}", BatchId(b"same-length-a".to_vec()));
+        let second = format!("{:?}", BatchId(b"same-length-b".to_vec()));
+        assert_ne!(first, second);
+        assert!(!first.contains("same-length-a"));
+        assert!(!second.contains("same-length-b"));
+    }
 }

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -1290,7 +1290,7 @@ fn common_run_table(bundles: &[VersionBundle]) -> Option<groove::Intern<String>>
 }
 
 /// Bytes for one immutable content extent.
-#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct ContentExtent {
     /// Owner/version/read-view context for this immutable extent.
     pub owner: LargeValueOwnerRef,
@@ -1298,6 +1298,16 @@ pub struct ContentExtent {
     pub extent: Extent,
     /// Immutable bytes stored at the extent.
     pub bytes: Vec<u8>,
+}
+
+impl std::fmt::Debug for ContentExtent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ContentExtent")
+            .field("owner", &self.owner)
+            .field("extent", &self.extent)
+            .field("bytes_len", &self.bytes.len())
+            .finish()
+    }
 }
 
 /// Authorized owner context for a binary large value extent.
@@ -2981,6 +2991,28 @@ mod tests {
 
     fn schema_id(byte: u8) -> SchemaVersionId {
         SchemaVersionId::from_bytes([byte; 16])
+    }
+
+    #[test]
+    fn content_extent_debug_is_bounded_and_content_safe() {
+        let extent = ContentExtent {
+            owner: LargeValueOwnerRef::current_row(RowUuid::from_bytes([2; 16])),
+            extent: Extent {
+                schema: schema_id(1),
+                table: "documents".to_owned(),
+                writer: AuthorId::from_bytes([3; 16]),
+                row: RowUuid::from_bytes([2; 16]),
+                column: "body".to_owned(),
+                offset: 0,
+                len: 1_000_000,
+            },
+            bytes: vec![b'x'; 1_000_000],
+        };
+
+        let debug = format!("{extent:?}");
+        assert!(debug.contains("bytes_len: 1000000"));
+        assert!(debug.len() < 512);
+        assert!(!debug.contains("xxxxx"));
     }
 
     #[test]

--- a/crates/jazz/src/tools/public_api/types/row.rs
+++ b/crates/jazz/src/tools/public_api/types/row.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -46,8 +47,18 @@ impl QueryResult {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct RowBytes(Arc<[u8]>);
+
+impl fmt::Debug for RowBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Rows may contain arbitrary application data. Logging a length is
+        // enough to diagnose framing problems without leaking or flooding logs.
+        f.debug_struct("RowBytes")
+            .field("len", &self.0.len())
+            .finish()
+    }
+}
 
 impl RowBytes {
     pub fn to_vec(&self) -> Vec<u8> {
@@ -189,5 +200,25 @@ pub struct OrderedRowDelta {
 impl OrderedRowDelta {
     pub fn is_empty(&self) -> bool {
         self.added.is_empty() && self.removed.is_empty() && self.updated.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RowBytes;
+
+    #[test]
+    fn row_bytes_debug_is_stable_bounded_and_content_safe() {
+        assert_eq!(format!("{:?}", RowBytes::default()), "RowBytes { len: 0 }");
+        assert_eq!(
+            format!("{:?}", RowBytes::from(b"secret-row".as_slice())),
+            "RowBytes { len: 10 }"
+        );
+
+        let payload = vec![b'x'; 1_000_000];
+        let debug = format!("{:?}", RowBytes::from(payload));
+        assert_eq!(debug, "RowBytes { len: 1000000 }");
+        assert!(debug.len() < 64);
+        assert!(!debug.contains("secret-row"));
     }
 }

--- a/crates/jazz/src/tools/public_api/types/value.rs
+++ b/crates/jazz/src/tools/public_api/types/value.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -11,7 +13,7 @@ use super::*;
 /// `PartialEq`/`Eq` are implemented manually because `f64` does not implement
 /// `Eq`. We use bitwise comparison (`f64::to_bits`) so that NaN == NaN and
 /// -0.0 != 0.0, which is the correct semantics for storage identity.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum Value {
     Integer(i32),
     BigInt(i64),
@@ -37,9 +39,43 @@ pub enum Value {
     Null,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LargeValueHandle {
     bytes: Vec<u8>,
+}
+
+impl fmt::Debug for LargeValueHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LargeValueHandle")
+            .field("len", &self.bytes.len())
+            .finish()
+    }
+}
+
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Integer(value) => f.debug_tuple("Integer").field(value).finish(),
+            Self::BigInt(value) => f.debug_tuple("BigInt").field(value).finish(),
+            Self::Double(value) => f.debug_tuple("Double").field(value).finish(),
+            Self::Boolean(value) => f.debug_tuple("Boolean").field(value).finish(),
+            Self::Text(value) => f.debug_tuple("Text").field(value).finish(),
+            Self::Timestamp(value) => f.debug_tuple("Timestamp").field(value).finish(),
+            Self::Uuid(value) => f.debug_tuple("Uuid").field(value).finish(),
+            // Batch ids are fixed-size semantic identifiers, unlike payloads.
+            Self::BatchId(value) => write!(f, "BatchId({})", hex::encode(value)),
+            Self::Bytea(value) => f.debug_struct("Bytea").field("len", &value.len()).finish(),
+            Self::LargeValue(value) => f.debug_tuple("LargeValue").field(value).finish(),
+            // Avoid a collection of nested byte values making an error log unbounded.
+            Self::Array(values) => f.debug_struct("Array").field("len", &values.len()).finish(),
+            Self::Row { id, values } => f
+                .debug_struct("Row")
+                .field("id", id)
+                .field("values_len", &values.len())
+                .finish(),
+            Self::Null => f.write_str("Null"),
+        }
+    }
 }
 
 impl LargeValueHandle {
@@ -521,6 +557,36 @@ macro_rules! row_input {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn binary_value_debug_is_bounded_and_content_safe_even_when_nested() {
+        assert_eq!(format!("{:?}", Value::Bytea(vec![])), "Bytea { len: 0 }");
+        assert_eq!(
+            format!(
+                "{:?}",
+                Value::LargeValue(LargeValueHandle::from_bytes(vec![7; 3]))
+            ),
+            "LargeValue(LargeValueHandle { len: 3 })"
+        );
+
+        let secret = b"do-not-log-this-payload";
+        let nested = Value::Row {
+            id: None,
+            values: vec![Value::Array(vec![Value::Bytea(vec![b'x'; 1_000_000])])],
+        };
+        let debug = format!("{nested:?}");
+        assert_eq!(debug, "Row { id: None, values_len: 1 }");
+        assert!(debug.len() < 64);
+        assert!(!debug.contains(std::str::from_utf8(secret).unwrap()));
+    }
+
+    #[test]
+    fn batch_id_debug_keeps_the_compact_semantic_id() {
+        assert_eq!(
+            format!("{:?}", Value::BatchId([0xab; 16])),
+            "BatchId(abababababababababababababababab)"
+        );
+    }
 
     // ── From<bool> ──────────────────────────────────────────────────
 

--- a/crates/jazz/src/tools/transaction.rs
+++ b/crates/jazz/src/tools/transaction.rs
@@ -11,7 +11,7 @@ use crate::tx::TxId;
 macro_rules! batch_id {
     ($name:ident, $kind:literal, $doc:literal) => {
         #[doc = $doc]
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
         pub struct $name(pub(crate) [u8; 16]);
 
         impl $name {
@@ -23,6 +23,14 @@ macro_rules! batch_id {
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(f, "{}", hex::encode(self.0))
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                // These are compact semantic identifiers, so retain their
+                // established hex form rather than expanding to a byte array.
+                write!(f, concat!(stringify!($name), "({})"), self)
             }
         }
 
@@ -135,6 +143,23 @@ mod tests {
                 TxTime::from(43),
                 NodeUuid(Uuid::from_bytes([7; 16]))
             ))
+        );
+    }
+
+    #[test]
+    fn batch_id_debug_is_compact_and_stable() {
+        let id = BatchId::from_committed_tx(TxId::new(
+            TxTime::from(42),
+            NodeUuid(Uuid::from_bytes([7; 16])),
+        ));
+        let debug = format!("{id:?}");
+        assert_eq!(debug, format!("BatchId({id})"));
+        assert_eq!(debug.len(), "BatchId()".len() + 32);
+
+        let open = OpenBatchId([0xab; 16]);
+        assert_eq!(
+            format!("{open:?}"),
+            "OpenBatchId(abababababababababababababababab)"
         );
     }
 }

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -69,7 +69,7 @@ pub enum WireFrame {
 }
 
 /// A bounded physical extent of one encoded logical message.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WireMessageFragment {
     /// Negotiated protocol version used by the logical message.
     pub protocol_version: u16,
@@ -87,6 +87,21 @@ pub struct WireMessageFragment {
     pub offset: u64,
     /// Bytes at `offset`.
     pub payload: Vec<u8>,
+}
+
+impl std::fmt::Debug for WireMessageFragment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WireMessageFragment")
+            .field("protocol_version", &self.protocol_version)
+            .field("features", &self.features)
+            .field("session", &self.session)
+            .field("message_id", &self.message_id)
+            .field("message_digest", &hex::encode(self.message_digest))
+            .field("total_len", &self.total_len)
+            .field("offset", &self.offset)
+            .field("payload_len", &self.payload.len())
+            .finish()
+    }
 }
 
 /// Link role advertised during handshake.
@@ -197,7 +212,7 @@ impl WireCompression {
 }
 
 /// Session metadata carried by message frames after handshake/admission.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WireSession {
     /// Binding/server assigned resumable session id.
     pub session_id: String,
@@ -207,8 +222,20 @@ pub struct WireSession {
     pub identity: Option<AuthorId>,
 }
 
+impl std::fmt::Debug for WireSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fingerprint = blake3::hash(self.session_id.as_bytes()).to_hex();
+        f.debug_struct("WireSession")
+            .field("session_id_len", &self.session_id.len())
+            .field("session_id_fingerprint", &&fingerprint[..12])
+            .field("epoch", &self.epoch)
+            .field("identity", &self.identity)
+            .finish()
+    }
+}
+
 /// Metadata and payload for one semantic sync message.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WireEnvelope {
     /// Negotiated protocol version used to encode this payload.
     pub protocol_version: u16,
@@ -218,6 +245,17 @@ pub struct WireEnvelope {
     pub session: Option<WireSession>,
     /// Encoded semantic payload, usually a [`crate::protocol::SyncMessage`].
     pub payload: Vec<u8>,
+}
+
+impl std::fmt::Debug for WireEnvelope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WireEnvelope")
+            .field("protocol_version", &self.protocol_version)
+            .field("features", &self.features)
+            .field("session", &self.session)
+            .field("payload_len", &self.payload.len())
+            .finish()
+    }
 }
 
 impl WireEnvelope {
@@ -767,6 +805,72 @@ mod tests {
                 WireEnvelope::new(1, FEATURE_SESSION_FRAME, vec![1, 2, 3, 4]).with_session(session)
             )
         );
+    }
+
+    #[test]
+    fn wire_payload_debug_is_bounded_and_content_safe() {
+        let secret = b"do-not-log-wire-payload";
+        let envelope = WireEnvelope::new(1, 0, vec![b'x'; 1_000_000]);
+        let envelope_debug = format!("{envelope:?}");
+        assert_eq!(
+            envelope_debug,
+            "WireEnvelope { protocol_version: 1, features: 0, session: None, payload_len: 1000000 }"
+        );
+        assert!(envelope_debug.len() < 128);
+        assert!(!envelope_debug.contains(std::str::from_utf8(secret).unwrap()));
+
+        let fragment = WireMessageFragment {
+            protocol_version: 1,
+            features: 0,
+            session: None,
+            message_id: 7,
+            message_digest: [0xab; 32],
+            total_len: 1_000_000,
+            offset: 0,
+            payload: vec![b'x'; 1_000_000],
+        };
+        let fragment_debug = format!("{fragment:?}");
+        assert!(fragment_debug.contains("message_digest: \"abab"));
+        assert!(fragment_debug.contains("payload_len: 1000000"));
+        assert!(fragment_debug.len() < 256);
+        assert!(!fragment_debug.contains("xxxxx"));
+    }
+
+    #[test]
+    fn wire_session_debug_stays_bounded_when_nested_in_payload_frames() {
+        let session = WireSession {
+            session_id: "credential-bearing-session-id".repeat(10_000),
+            epoch: 3,
+            identity: Some(AuthorId::from_bytes([0x42; 16])),
+        };
+        let distinct_session = WireSession {
+            session_id: "credential-bearing-session-ix".repeat(10_000),
+            ..session.clone()
+        };
+        let session_debug = format!("{session:?}");
+        assert!(session_debug.contains("session_id_len: 290000"));
+        assert!(session_debug.len() < 256);
+        assert!(!session_debug.contains("credential-bearing-session-id"));
+        assert_ne!(session_debug, format!("{distinct_session:?}"));
+
+        let envelope = WireEnvelope::new(1, 0, vec![]).with_session(session.clone());
+        let envelope_debug = format!("{envelope:?}");
+        assert!(envelope_debug.len() < 384);
+        assert!(!envelope_debug.contains("credential-bearing-session-id"));
+
+        let fragment = WireMessageFragment {
+            protocol_version: 1,
+            features: 0,
+            session: Some(session),
+            message_id: 7,
+            message_digest: [0xab; 32],
+            total_len: 0,
+            offset: 0,
+            payload: vec![],
+        };
+        let fragment_debug = format!("{fragment:?}");
+        assert!(fragment_debug.len() < 512);
+        assert!(!fragment_debug.contains("credential-bearing-session-id"));
     }
 
     #[test]


### PR DESCRIPTION
🤖 Binary-bearing values currently derive `Debug`, which can dump megabytes of opaque payload into failed assertions and CI traces.

This replaces those high-fanout representations with bounded, useful summaries:

- byte payloads report their length rather than their contents;
- public batch IDs keep their compact semantic hex form;
- variable-length internal batch and wire-session IDs include length plus a short deterministic fingerprint, so equal-length identities remain distinguishable without exposing raw values;
- wire envelopes, fragments, content extents, and nested public values retain useful structural metadata without recursively printing payloads.

This changes diagnostics only; serialization, equality, hashing, and protocol behavior are unchanged.

Validation:

- focused Debug tests cover empty, small, and 1 MB payloads;
- credential-like session IDs remain bounded and absent from nested envelope/fragment output;
- equal-length distinct IDs produce distinct fingerprints;
- planted raw-payload Debug regressions fail the focused tests;
- `cargo clippy --package jazz -- -D warnings`, rustfmt, and the sensitive-data guard pass.
