### PR TITLE
ci: skip Vercel previews for new-core PRs

### DIFF
--- a/dev/scripts/README.md
+++ b/dev/scripts/README.md
@@ -1,0 +1,35 @@
+# Deployment helper scripts
+
+## Skip new-core Vercel previews
+
+`skip-new-core-vercel-preview.mjs` is an intentionally fail-open Vercel
+Ignored Build Step helper. It skips only pull-request previews whose GitHub
+base branch is `codex/jazz-core-engine-swap`; all other cases continue their
+build. Production deployments always continue.
+
+`jazz2-inspector` is configured in its checked-in `vercel.json`. `jazz2-docs`
+has no checked-in Vercel configuration, so the following dashboard setting is a
+required provisioning prerequisite: merging this change alone does **not**
+change docs builds.
+
+Configure `jazz2-docs` under **Settings → Build and Deployment → Ignored Build
+Step**:
+
+For `jazz2-docs` (repository root):
+
+```sh
+node dev/scripts/skip-new-core-vercel-preview.mjs
+```
+
+Also add `VERCEL_GITHUB_READ_TOKEN` as an encrypted Vercel environment
+variable for **Preview only**. It must be a fine-grained GitHub token restricted
+to `garden-co/jazz` with **Pull requests: Read-only** permission.
+Vercel must have **Automatically expose System Environment Variables** enabled
+so `VERCEL_GIT_REPO_OWNER`, `VERCEL_GIT_REPO_SLUG`, and
+`VERCEL_GIT_PULL_REQUEST_ID` are available. The helper logs neither its token
+nor the GitHub response. Keep Vercel **Git Fork Protection** enabled and never
+authorize an untrusted fork deployment while this token is configured.
+
+The command exits `0` only after GitHub positively reports the exact new-core
+base branch within five seconds; Vercel interprets `0` as skip and `1` as
+continue building.

--- a/dev/scripts/skip-new-core-vercel-preview.mjs
+++ b/dev/scripts/skip-new-core-vercel-preview.mjs
@@ -1,0 +1,76 @@
+import { pathToFileURL } from "node:url";
+
+const NEW_CORE_BASE_REF = "codex/jazz-core-engine-swap";
+const TOKEN_ENV = "VERCEL_GITHUB_READ_TOKEN";
+const GITHUB_LOOKUP_TIMEOUT_MS = 5_000;
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function pullRequestUrl(env) {
+  const {
+    VERCEL_GIT_REPO_OWNER: owner,
+    VERCEL_GIT_REPO_SLUG: repo,
+    VERCEL_GIT_PULL_REQUEST_ID: pullRequestId,
+  } = env;
+
+  if (!isNonEmptyString(owner) || !isNonEmptyString(repo) || !/^\d+$/.test(pullRequestId ?? "")) {
+    return null;
+  }
+
+  return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${pullRequestId}`;
+}
+
+/**
+ * Return true only when Vercel positively identifies this preview as a PR
+ * targeting the new-core integration branch. All missing or failed lookups
+ * deliberately return false, so Vercel continues with the build.
+ */
+export async function shouldSkipNewCorePreview({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  createAbortSignal = (timeoutMs) => AbortSignal.timeout(timeoutMs),
+} = {}) {
+  const url = pullRequestUrl(env);
+  const token = env[TOKEN_ENV];
+
+  if (
+    env.VERCEL_ENV !== "preview" ||
+    !url ||
+    !isNonEmptyString(token) ||
+    typeof fetchImpl !== "function"
+  ) {
+    return false;
+  }
+
+  try {
+    const signal = createAbortSignal(GITHUB_LOOKUP_TIMEOUT_MS);
+    const response = await fetchImpl(url, {
+      signal,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const pullRequest = await response.json();
+    return pullRequest?.base?.ref === NEW_CORE_BASE_REF;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  // Vercel ignore-command semantics: 0 means skip; 1 means build.
+  process.exitCode = (await shouldSkipNewCorePreview()) ? 0 : 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/dev/scripts/skip-new-core-vercel-preview.test.mjs
+++ b/dev/scripts/skip-new-core-vercel-preview.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldSkipNewCorePreview } from "./skip-new-core-vercel-preview.mjs";
+
+const requiredEnv = {
+  VERCEL_ENV: "preview",
+  VERCEL_GIT_REPO_OWNER: "garden-co",
+  VERCEL_GIT_REPO_SLUG: "jazz",
+  VERCEL_GIT_PULL_REQUEST_ID: "1398",
+  VERCEL_GITHUB_READ_TOKEN: "read_only_token",
+};
+
+function jsonResponse(body, init = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    async json() {
+      return body;
+    },
+  };
+}
+
+test("skips only a PR targeting the new-core integration branch", async () => {
+  const requests = [];
+
+  const skip = await shouldSkipNewCorePreview({
+    env: requiredEnv,
+    fetchImpl: async (url, init) => {
+      requests.push({ url: String(url), headers: init.headers });
+      return jsonResponse({ base: { ref: "codex/jazz-core-engine-swap" } });
+    },
+  });
+
+  assert.equal(skip, true);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "https://api.github.com/repos/garden-co/jazz/pulls/1398");
+  assert.equal(requests[0].headers.Accept, "application/vnd.github+json");
+  assert.equal(requests[0].headers.Authorization, "Bearer read_only_token");
+  assert.equal(requests[0].headers["X-GitHub-Api-Version"], "2022-11-28");
+});
+
+test("fails open when the GitHub lookup exceeds its short abort timeout", async () => {
+  const skip = await shouldSkipNewCorePreview({
+    env: requiredEnv,
+    createAbortSignal: () => AbortSignal.timeout(1),
+    fetchImpl: async (_url, init) => {
+      await new Promise((_, reject) => {
+        if (init.signal.aborted) {
+          reject(init.signal.reason);
+          return;
+        }
+        init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+      });
+    },
+  });
+
+  assert.equal(skip, false);
+});
+
+test("builds PRs targeting every other branch", async () => {
+  const skip = await shouldSkipNewCorePreview({
+    env: requiredEnv,
+    fetchImpl: async () => jsonResponse({ base: { ref: "main" } }),
+  });
+
+  assert.equal(skip, false);
+});
+
+test("fails open outside preview or without a Vercel PR id, repository coordinates, or token", async () => {
+  for (const missing of [
+    "VERCEL_ENV",
+    "VERCEL_GIT_PULL_REQUEST_ID",
+    "VERCEL_GIT_REPO_OWNER",
+    "VERCEL_GIT_REPO_SLUG",
+    "VERCEL_GITHUB_READ_TOKEN",
+  ]) {
+    const env = { ...requiredEnv };
+    delete env[missing];
+    let fetched = false;
+
+    const skip = await shouldSkipNewCorePreview({
+      env,
+      fetchImpl: async () => {
+        fetched = true;
+        throw new Error("must not fetch without complete inputs");
+      },
+    });
+
+    assert.equal(skip, false, missing);
+    assert.equal(fetched, false, missing);
+  }
+});
+
+test("fails open for a malformed PR id, unsuccessful response, malformed response, and network error", async () => {
+  const malformedId = await shouldSkipNewCorePreview({
+    env: { ...requiredEnv, VERCEL_GIT_PULL_REQUEST_ID: "1398/../../secrets" },
+    fetchImpl: async () => {
+      throw new Error("must not fetch a malformed id");
+    },
+  });
+  assert.equal(malformedId, false);
+
+  for (const fetchImpl of [
+    async () => jsonResponse({}, { ok: false, status: 403 }),
+    async () => jsonResponse({ base: {} }),
+    async () => {
+      throw new Error("network unavailable");
+    },
+  ]) {
+    assert.equal(await shouldSkipNewCorePreview({ env: requiredEnv, fetchImpl }), false);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
     "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
     "test:focused-rust": "bash dev/gates/test/dev-t.test.sh",
+    "test:vercel-preview-skip": "node --test dev/scripts/skip-new-core-vercel-preview.test.mjs",
     "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
     "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs",

--- a/packages/inspector/vercel.json
+++ b/packages/inspector/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "node ../../dev/scripts/skip-new-core-vercel-preview.mjs",
   "buildCommand": "pnpm build:vercel",
   "outputDirectory": "dist",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]


### PR DESCRIPTION
🤖 New-core PRs currently trigger docs and inspector previews even though those builds do not exercise the Rust-core changes under review. This adds a narrowly scoped, fail-open ignored-build helper.

The helper uses Vercel's preview PR metadata to read the PR base through GitHub's API. It skips only when the base is exactly `codex/jazz-core-engine-swap`; missing metadata or credentials, non-preview deployments, malformed responses, network failures, and a five-second timeout all build normally.

Inspector's ignored-build command is checked into `packages/inspector/vercel.json`. The docs Vercel project has no authoritative repository config, so its required dashboard command and preview-only read-token setup are documented explicitly. Merging this PR alone does not suppress docs builds until that setting is provisioned. Git Fork Protection must remain enabled and untrusted fork deployments must not be authorized while the token is configured.

Validation:

- focused helper suite: 5/5;
- real timer-abort coverage for a pending GitHub request;
- planted wrong-base and never-aborting mutations fail the focused contract;
- oxfmt, diff check, and sensitive-data guard pass.
