### PR TITLE
ci: use public PR metadata for Vercel skips

### DIFF
--- a/dev/scripts/README.md
+++ b/dev/scripts/README.md
@@ -21,14 +21,11 @@ For `jazz2-docs` (repository root):
 node dev/scripts/skip-new-core-vercel-preview.mjs
 ```
 
-Also add `VERCEL_GITHUB_READ_TOKEN` as an encrypted Vercel environment
-variable for **Preview only**. It must be a fine-grained GitHub token restricted
-to `garden-co/jazz` with **Pull requests: Read-only** permission.
 Vercel must have **Automatically expose System Environment Variables** enabled
 so `VERCEL_GIT_REPO_OWNER`, `VERCEL_GIT_REPO_SLUG`, and
-`VERCEL_GIT_PULL_REQUEST_ID` are available. The helper logs neither its token
-nor the GitHub response. Keep Vercel **Git Fork Protection** enabled and never
-authorize an untrusted fork deployment while this token is configured.
+`VERCEL_GIT_PULL_REQUEST_ID` are available. The repository is public, so the
+helper uses GitHub's unauthenticated pull-request endpoint and does not require
+or expose a credential. Keep Vercel **Git Fork Protection** enabled.
 
 The command exits `0` only after GitHub positively reports the exact new-core
 base branch within five seconds; Vercel interprets `0` as skip and `1` as

--- a/dev/scripts/skip-new-core-vercel-preview.mjs
+++ b/dev/scripts/skip-new-core-vercel-preview.mjs
@@ -1,7 +1,6 @@
 import { pathToFileURL } from "node:url";
 
 const NEW_CORE_BASE_REF = "codex/jazz-core-engine-swap";
-const TOKEN_ENV = "VERCEL_GITHUB_READ_TOKEN";
 const GITHUB_LOOKUP_TIMEOUT_MS = 5_000;
 
 function isNonEmptyString(value) {
@@ -33,14 +32,7 @@ export async function shouldSkipNewCorePreview({
   createAbortSignal = (timeoutMs) => AbortSignal.timeout(timeoutMs),
 } = {}) {
   const url = pullRequestUrl(env);
-  const token = env[TOKEN_ENV];
-
-  if (
-    env.VERCEL_ENV !== "preview" ||
-    !url ||
-    !isNonEmptyString(token) ||
-    typeof fetchImpl !== "function"
-  ) {
+  if (env.VERCEL_ENV !== "preview" || !url || typeof fetchImpl !== "function") {
     return false;
   }
 
@@ -50,7 +42,6 @@ export async function shouldSkipNewCorePreview({
       signal,
       headers: {
         Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     });

--- a/dev/scripts/skip-new-core-vercel-preview.test.mjs
+++ b/dev/scripts/skip-new-core-vercel-preview.test.mjs
@@ -8,7 +8,6 @@ const requiredEnv = {
   VERCEL_GIT_REPO_OWNER: "garden-co",
   VERCEL_GIT_REPO_SLUG: "jazz",
   VERCEL_GIT_PULL_REQUEST_ID: "1398",
-  VERCEL_GITHUB_READ_TOKEN: "read_only_token",
 };
 
 function jsonResponse(body, init = {}) {
@@ -36,7 +35,7 @@ test("skips only a PR targeting the new-core integration branch", async () => {
   assert.equal(requests.length, 1);
   assert.equal(requests[0].url, "https://api.github.com/repos/garden-co/jazz/pulls/1398");
   assert.equal(requests[0].headers.Accept, "application/vnd.github+json");
-  assert.equal(requests[0].headers.Authorization, "Bearer read_only_token");
+  assert.equal("Authorization" in requests[0].headers, false);
   assert.equal(requests[0].headers["X-GitHub-Api-Version"], "2022-11-28");
 });
 
@@ -67,13 +66,12 @@ test("builds PRs targeting every other branch", async () => {
   assert.equal(skip, false);
 });
 
-test("fails open outside preview or without a Vercel PR id, repository coordinates, or token", async () => {
+test("fails open outside preview or without a Vercel PR id or repository coordinates", async () => {
   for (const missing of [
     "VERCEL_ENV",
     "VERCEL_GIT_PULL_REQUEST_ID",
     "VERCEL_GIT_REPO_OWNER",
     "VERCEL_GIT_REPO_SLUG",
-    "VERCEL_GITHUB_READ_TOKEN",
   ]) {
     const env = { ...requiredEnv };
     delete env[missing];


### PR DESCRIPTION
🤖 Follow-up to #1417: `garden-co/jazz` is public, so Vercel does not need a stored GitHub credential to read a pull request's base branch.

This removes the preview token requirement and Authorization header. The ignored-build helper continues to use GitHub's public PR endpoint with a five-second timeout and fails open on rate limits, malformed metadata, network failures, or any other uncertainty.

The Vercel docs project has already been configured with the helper command; inspector reads the command from its checked-in `vercel.json`. Both projects already expose Vercel system variables and retain Git Fork Protection.

Validation: focused helper suite 5/5, oxfmt, diff check, and sensitive-data guard.
