### PR TITLE
Fix runner diagnostic context

### DIFF
--- a/.github/workflows/runner-pool-diagnostic.yml
+++ b/.github/workflows/runner-pool-diagnostic.yml
@@ -15,8 +15,6 @@ jobs:
   probe:
     runs-on: jazz-ci
     timeout-minutes: 10
-    env:
-      RUNNER_NAME: ${{ runner.name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
Removes the invalid job-level `runner.name` expression. GitHub Actions already exports `RUNNER_NAME` as a default environment variable, which the diagnostic step reads directly.

The failed dispatch was rejected during workflow parsing; no runner job started.