### PR TITLE
fix(ci): parse nextest list document

### DIFF
--- a/dev/gates/test/fixtures/nextest-list-0.9.143.json
+++ b/dev/gates/test/fixtures/nextest-list-0.9.143.json
@@ -1,0 +1,19 @@
+{
+  "test-count": 4,
+  "rust-suites": {
+    "unit": {
+      "binary-id": "pkg::unit",
+      "testcases": {
+        "alpha": { "kind": "test", "ignored": false, "filter-match": { "status": "matches" } },
+        "beta": { "kind": "test", "ignored": false, "filter-match": { "status": "mismatch" } }
+      }
+    },
+    "integration": {
+      "binary-id": "pkg::integration",
+      "testcases": {
+        "gamma": { "kind": "test", "ignored": false, "filter-match": { "status": "matches" } },
+        "delta": { "kind": "test", "ignored": true, "filter-match": { "status": "matches" } }
+      }
+    }
+  }
+}

--- a/dev/gates/test/nextest-partitions.test.mjs
+++ b/dev/gates/test/nextest-partitions.test.mjs
@@ -1,10 +1,79 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const hasNextest = spawnSync("cargo", ["nextest", "--version"], { cwd: root }).status === 0;
+const fixture = fs.readFileSync(
+  path.join(root, "dev/gates/test/fixtures/nextest-list-0.9.143.json"),
+  "utf8",
+);
+const isPlainMap = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+const filterStatuses = new Set(["matches", "mismatch"]);
+
+function inventoryFromNextestJson(output) {
+  const document = JSON.parse(output);
+  assert.ok(isPlainMap(document), "nextest list must emit one JSON object");
+  assert.ok(
+    Number.isInteger(document["test-count"]) && document["test-count"] >= 0,
+    "nextest list is missing a non-negative integer test-count",
+  );
+  assert.ok(isPlainMap(document["rust-suites"]), "nextest list is missing rust-suites map");
+
+  const all = new Set();
+  const selected = new Set();
+  for (const suite of Object.values(document["rust-suites"])) {
+    assert.ok(isPlainMap(suite), "nextest rust-suites entry must be an object");
+    assert.equal(typeof suite?.["binary-id"], "string", "nextest suite is missing binary-id");
+    assert.ok(isPlainMap(suite.testcases), "nextest suite is missing testcases map");
+    for (const [name, testcase] of Object.entries(suite.testcases)) {
+      assert.ok(isPlainMap(testcase), "nextest testcase must be an object");
+      assert.ok(isPlainMap(testcase["filter-match"]), "nextest testcase is missing filter-match");
+      const status = testcase["filter-match"].status;
+      assert.ok(
+        filterStatuses.has(status),
+        `nextest testcase has unsupported filter-match status: ${String(status)}`,
+      );
+      const id = `${suite["binary-id"]}\0${name}`;
+      assert.ok(!all.has(id), `duplicate nextest testcase: ${id}`);
+      all.add(id);
+      if (status === "matches") selected.add(id);
+    }
+  }
+  assert.equal(all.size, document["test-count"], "nextest test-count disagrees with rust-suites");
+  return selected;
+}
+
+test("nextest 0.9.143 single-document output selects only partition matches", () => {
+  assert.deepEqual(
+    inventoryFromNextestJson(fixture),
+    new Set(["pkg::unit\0alpha", "pkg::integration\0gamma", "pkg::integration\0delta"]),
+  );
+});
+
+test("nextest JSON parser detects a planted partition-membership regression", () => {
+  const planted = fixture.replace(
+    '"beta": { "kind": "test", "ignored": false, "filter-match": { "status": "mismatch" } }',
+    '"beta": { "kind": "test", "ignored": false, "filter-match": { "status": "matches" } }',
+  );
+  assert.notDeepEqual(inventoryFromNextestJson(planted), inventoryFromNextestJson(fixture));
+});
+
+test("nextest JSON parser rejects unknown and missing partition membership", () => {
+  const unknown = fixture.replace('"status": "mismatch"', '"status": "future-status"');
+  const missing = fixture.replace('"filter-match": { "status": "mismatch" }', '"filter-match": {}');
+  assert.throws(
+    () => inventoryFromNextestJson(unknown),
+    /unsupported filter-match status: future-status/,
+  );
+  assert.throws(
+    () => inventoryFromNextestJson(missing),
+    /unsupported filter-match status: undefined/,
+  );
+});
+
 function inventory(partition) {
   const args = [
     "nextest",
@@ -25,14 +94,7 @@ function inventory(partition) {
     maxBuffer: 64 * 1024 * 1024,
   });
   assert.equal(result.status, 0, result.stderr);
-  return new Set(
-    result.stdout
-      .split(/\r?\n/)
-      .filter(Boolean)
-      .map(JSON.parse)
-      .filter((row) => row.type === "test")
-      .map((row) => `${row.binary_id}\0${row.name}`),
-  );
+  return inventoryFromNextestJson(result.stdout);
 }
 test(
   "nextest hash partitions cover its real inventory once",


### PR DESCRIPTION
🤖 Fix the required Nextest partition-coverage gate for the pinned cargo-nextest 0.9.143 output format.

## What changed

- Parse the single JSON document emitted by `cargo nextest list --message-format json` instead of treating it as newline-delimited test events.
- Validate the complete document shape and `test-count`.
- Fail closed unless every testcase has the known `matches` or `mismatch` filter status.
- Prove that hash partitions are disjoint and their union equals the full selected inventory.
- Add a pinned-format fixture and schema-drift/membership sensitivity tests.

## Why

The old gate selected zero tests because it expected an obsolete JSON shape, so the required CI step failed on the current pinned Nextest version. It could also have hidden future schema drift if unknown statuses were silently excluded.

## Verification

- `node --test dev/gates/test/nextest-partitions.test.mjs` — 4/4, including live cargo-nextest 0.9.143 inventory.
- `pnpm test:ci-workflow` — 26/26.
- Planted unknown and missing statuses fail closed.
- Planted partition overlap fails the disjoint-union assertion.
