### PR TITLE
fix(api): reject lossy binary public values

### DIFF
--- a/crates/jazz/src/tools/public_api/query.rs
+++ b/crates/jazz/src/tools/public_api/query.rs
@@ -590,52 +590,145 @@ pub struct RecursiveSpec {
 }
 
 /// A query specification (DNF: disjunction of conjunctions).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Query {
     pub table: TableName,
     /// Optional table alias (for self-joins).
-    #[serde(default)]
     pub alias: Option<String>,
     /// Branches to query (required - at least one must be specified).
     /// For multi-branch queries, results are combined with LWW merge for same ObjectId.
-    #[serde(default)]
     pub branches: Vec<String>,
     /// Joined tables.
-    #[serde(default)]
     pub joins: Vec<JoinSpec>,
     /// OR groups (disjunction of conjunctions).
-    #[serde(default = "default_disjuncts")]
     pub disjuncts: Vec<Conjunction>,
     /// Order by specification.
-    #[serde(default)]
     pub order_by: Vec<(String, SortDirection)>,
     /// Limit.
-    #[serde(default)]
     pub limit: Option<usize>,
     /// Offset.
-    #[serde(default)]
     pub offset: usize,
     /// If true, also scan _id_deleted to include soft-deleted rows.
-    #[serde(default)]
     pub include_deleted: bool,
     /// Columns to select (None = all columns).
-    #[serde(default)]
     pub select_columns: Option<Vec<String>>,
     /// Array subqueries (correlated subqueries producing array columns).
-    #[serde(default)]
     pub array_subqueries: Vec<ArraySubquerySpec>,
     /// Optional recursive relation expansion.
-    #[serde(default)]
     pub recursive: Option<RecursiveSpec>,
     /// Optional output tuple element index for join queries.
     ///
     /// When set, join query output is projected to this tuple element
     /// instead of returning flattened combined rows.
-    #[serde(default)]
     pub result_element_index: Option<usize>,
     /// Optional scalar/grouped aggregate output.
+    pub aggregate: Option<AggregateSpec>,
+}
+
+/// Human-readable serde representation for the public query API.
+///
+/// Binary query preparation uses the native query codec rather than generic
+/// postcard serialization of this host-facing structure.
+#[derive(Serialize, Deserialize)]
+struct QueryHuman {
+    pub table: TableName,
+    #[serde(default)]
+    pub alias: Option<String>,
+    #[serde(default)]
+    pub branches: Vec<String>,
+    #[serde(default)]
+    pub joins: Vec<JoinSpec>,
+    #[serde(default = "default_disjuncts")]
+    pub disjuncts: Vec<Conjunction>,
+    #[serde(default)]
+    pub order_by: Vec<(String, SortDirection)>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub offset: usize,
+    #[serde(default)]
+    pub include_deleted: bool,
+    #[serde(default)]
+    pub select_columns: Option<Vec<String>>,
+    #[serde(default)]
+    pub array_subqueries: Vec<ArraySubquerySpec>,
+    #[serde(default)]
+    pub recursive: Option<RecursiveSpec>,
+    #[serde(default)]
+    pub result_element_index: Option<usize>,
     #[serde(default)]
     pub aggregate: Option<AggregateSpec>,
+}
+
+const NON_HUMAN_QUERY_CODEC_ERROR: &str =
+    "public Query does not support non-human serde codecs; use the native query codec";
+
+impl From<&Query> for QueryHuman {
+    fn from(query: &Query) -> Self {
+        Self {
+            table: query.table.clone(),
+            alias: query.alias.clone(),
+            branches: query.branches.clone(),
+            joins: query.joins.clone(),
+            disjuncts: query.disjuncts.clone(),
+            order_by: query.order_by.clone(),
+            limit: query.limit,
+            offset: query.offset,
+            include_deleted: query.include_deleted,
+            select_columns: query.select_columns.clone(),
+            array_subqueries: query.array_subqueries.clone(),
+            recursive: query.recursive.clone(),
+            result_element_index: query.result_element_index,
+            aggregate: query.aggregate.clone(),
+        }
+    }
+}
+
+impl From<QueryHuman> for Query {
+    fn from(query: QueryHuman) -> Self {
+        Self {
+            table: query.table,
+            alias: query.alias,
+            branches: query.branches,
+            joins: query.joins,
+            disjuncts: query.disjuncts,
+            order_by: query.order_by,
+            limit: query.limit,
+            offset: query.offset,
+            include_deleted: query.include_deleted,
+            select_columns: query.select_columns,
+            array_subqueries: query.array_subqueries,
+            recursive: query.recursive,
+            result_element_index: query.result_element_index,
+            aggregate: query.aggregate,
+        }
+    }
+}
+
+impl Serialize for Query {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            QueryHuman::from(self).serialize(serializer)
+        } else {
+            Err(serde::ser::Error::custom(NON_HUMAN_QUERY_CODEC_ERROR))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Query {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            QueryHuman::deserialize(deserializer).map(Query::from)
+        } else {
+            Err(serde::de::Error::custom(NON_HUMAN_QUERY_CODEC_ERROR))
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2131,7 +2224,7 @@ mod tests {
     }
 
     #[test]
-    fn query_round_trip_binary_serialization() {
+    fn query_binary_serialization_is_unsupported_when_it_contains_public_values() {
         let query = QueryBuilder::new("users")
             .filter_eq("org_id", Value::Integer(42))
             .filter_ge("score", Value::Integer(50))
@@ -2140,10 +2233,14 @@ mod tests {
             .limit(10)
             .build();
 
-        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
-        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
-
-        assert_eq!(query, decoded);
+        assert_eq!(
+            postcard::to_allocvec(&query).unwrap_err(),
+            postcard::Error::SerdeSerCustom
+        );
+        assert_eq!(
+            postcard::from_bytes::<Query>(&[]).unwrap_err(),
+            postcard::Error::SerdeDeCustom
+        );
     }
 
     #[test]
@@ -2163,7 +2260,7 @@ mod tests {
     }
 
     #[test]
-    fn query_with_join_binary_serialization() {
+    fn query_with_join_binary_serialization_is_unsupported() {
         let query = QueryBuilder::new("users")
             .alias("u")
             .join("posts")
@@ -2172,10 +2269,10 @@ mod tests {
             .branch("main")
             .build();
 
-        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
-        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
-
-        assert_eq!(query, decoded);
+        assert_eq!(
+            postcard::to_allocvec(&query).unwrap_err(),
+            postcard::Error::SerdeSerCustom
+        );
     }
 
     #[test]
@@ -2192,16 +2289,16 @@ mod tests {
     }
 
     #[test]
-    fn query_with_array_subquery_binary_serialization() {
+    fn query_with_array_subquery_binary_serialization_is_unsupported() {
         let query = QueryBuilder::new("orgs")
             .branch("main")
             .with_array("users", |b| b.from("users").correlate("id", "org_id"))
             .build();
 
-        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
-        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
-
-        assert_eq!(query, decoded);
+        assert_eq!(
+            postcard::to_allocvec(&query).unwrap_err(),
+            postcard::Error::SerdeSerCustom
+        );
     }
 
     #[test]
@@ -2239,7 +2336,7 @@ mod tests {
     }
 
     #[test]
-    fn query_with_recursive_binary_serialization() {
+    fn query_with_recursive_binary_serialization_is_unsupported() {
         let query = QueryBuilder::new("teams")
             .select(&["team_id"])
             .with_recursive(|r| {
@@ -2251,10 +2348,10 @@ mod tests {
             .branch("main")
             .build();
 
-        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
-        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
-
-        assert_eq!(query, decoded);
+        assert_eq!(
+            postcard::to_allocvec(&query).unwrap_err(),
+            postcard::Error::SerdeSerCustom
+        );
     }
 
     #[test]
@@ -2274,7 +2371,7 @@ mod tests {
     }
 
     #[test]
-    fn query_disjunction_binary_serialization() {
+    fn query_disjunction_binary_serialization_is_unsupported() {
         let query = QueryBuilder::new("users")
             .filter_eq("status", Value::Text("active".into()))
             .or()
@@ -2282,10 +2379,9 @@ mod tests {
             .branch("main")
             .build();
 
-        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
-        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
-
-        assert_eq!(query, decoded);
-        assert_eq!(decoded.disjuncts.len(), 2);
+        assert_eq!(
+            postcard::to_allocvec(&query).unwrap_err(),
+            postcard::Error::SerdeSerCustom
+        );
     }
 }

--- a/crates/jazz/src/tools/public_api/types/value.rs
+++ b/crates/jazz/src/tools/public_api/types/value.rs
@@ -140,24 +140,13 @@ struct EnumHuman {
     values: Vec<ValueHuman>,
 }
 
-/// Use externally-tagged enum for binary serialization (postcard does not support internally-tagged enums).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-enum ValueBinary {
-    Integer(i32),
-    BigInt(i64),
-    Double(f64),
-    Boolean(bool),
-    Text(String),
-    Timestamp(u64),
-    Uuid(ObjectId),
-    BatchId([u8; 16]),
-    Bytea(Vec<u8>),
-    LargeValue(LargeValueHandle),
-    Array(Vec<ValueBinary>),
-    Row(Vec<ValueBinary>),
-    Enum(String, Vec<ValueBinary>),
-    Null,
-}
+/// Public `Value` is a host-facing shape, not a generic postcard payload.
+///
+/// JSON preserves all row metadata. Production binary row boundaries instead
+/// use the descriptor/raw-record codecs in `admin_catalogue_row_format` and the
+/// native runtime, which carry an optional nested-row id explicitly.
+const NON_HUMAN_VALUE_CODEC_ERROR: &str =
+    "public Value does not support non-human serde codecs; use the descriptor/raw row codec";
 
 fn deserialize_timestamp_value<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
@@ -313,58 +302,6 @@ impl From<ValueHuman> for Value {
     }
 }
 
-impl From<&Value> for ValueBinary {
-    fn from(value: &Value) -> Self {
-        match value {
-            Value::Integer(v) => ValueBinary::Integer(*v),
-            Value::BigInt(v) => ValueBinary::BigInt(*v),
-            Value::Double(v) => ValueBinary::Double(*v),
-            Value::Boolean(v) => ValueBinary::Boolean(*v),
-            Value::Text(v) => ValueBinary::Text(v.clone()),
-            Value::Timestamp(v) => ValueBinary::Timestamp(*v),
-            Value::Uuid(v) => ValueBinary::Uuid(*v),
-            Value::BatchId(v) => ValueBinary::BatchId(*v),
-            Value::Bytea(v) => ValueBinary::Bytea(v.clone()),
-            Value::LargeValue(v) => ValueBinary::LargeValue(v.clone()),
-            Value::Array(v) => ValueBinary::Array(v.iter().map(ValueBinary::from).collect()),
-            Value::Row { values, .. } => {
-                ValueBinary::Row(values.iter().map(ValueBinary::from).collect())
-            }
-            Value::Enum { case, values } => {
-                ValueBinary::Enum(case.clone(), values.iter().map(ValueBinary::from).collect())
-            }
-            Value::Null => ValueBinary::Null,
-        }
-    }
-}
-
-impl From<ValueBinary> for Value {
-    fn from(value: ValueBinary) -> Self {
-        match value {
-            ValueBinary::Integer(v) => Value::Integer(v),
-            ValueBinary::BigInt(v) => Value::BigInt(v),
-            ValueBinary::Double(v) => Value::Double(v),
-            ValueBinary::Boolean(v) => Value::Boolean(v),
-            ValueBinary::Text(v) => Value::Text(v),
-            ValueBinary::Timestamp(v) => Value::Timestamp(v),
-            ValueBinary::Uuid(v) => Value::Uuid(v),
-            ValueBinary::BatchId(v) => Value::BatchId(v),
-            ValueBinary::Bytea(v) => Value::Bytea(v),
-            ValueBinary::LargeValue(v) => Value::LargeValue(v),
-            ValueBinary::Array(v) => Value::Array(v.into_iter().map(Value::from).collect()),
-            ValueBinary::Row(v) => Value::Row {
-                id: None,
-                values: v.into_iter().map(Value::from).collect(),
-            },
-            ValueBinary::Enum(case, values) => Value::Enum {
-                case,
-                values: values.into_iter().map(Value::from).collect(),
-            },
-            ValueBinary::Null => Value::Null,
-        }
-    }
-}
-
 impl Serialize for Value {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -373,7 +310,7 @@ impl Serialize for Value {
         if serializer.is_human_readable() {
             ValueHuman::from(self).serialize(serializer)
         } else {
-            ValueBinary::from(self).serialize(serializer)
+            Err(serde::ser::Error::custom(NON_HUMAN_VALUE_CODEC_ERROR))
         }
     }
 }
@@ -386,7 +323,7 @@ impl<'de> Deserialize<'de> for Value {
         if deserializer.is_human_readable() {
             ValueHuman::deserialize(deserializer).map(Value::from)
         } else {
-            ValueBinary::deserialize(deserializer).map(Value::from)
+            Err(serde::de::Error::custom(NON_HUMAN_VALUE_CODEC_ERROR))
         }
     }
 }
@@ -722,6 +659,36 @@ mod tests {
         let json = serde_json::to_string(&value).expect("serialize batch id");
         let decoded: Value = serde_json::from_str(&json).expect("deserialize batch id");
         assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn json_round_trip_preserves_nested_row_identity() {
+        let value = Value::Array(vec![Value::Row {
+            id: Some(ObjectId::from_uuid(uuid::Uuid::from_u128(0x42))),
+            values: vec![Value::Text("included child".to_owned())],
+        }]);
+
+        let json = serde_json::to_string(&value).expect("serialize public value");
+        let decoded = serde_json::from_str::<Value>(&json).expect("deserialize public value");
+
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn postcard_rejects_public_values_instead_of_dropping_nested_row_identity() {
+        let value = Value::Array(vec![Value::Row {
+            id: Some(ObjectId::from_uuid(uuid::Uuid::from_u128(0x42))),
+            values: vec![Value::Text("included child".to_owned())],
+        }]);
+
+        assert_eq!(
+            postcard::to_allocvec(&value).unwrap_err(),
+            postcard::Error::SerdeSerCustom
+        );
+        assert_eq!(
+            postcard::from_bytes::<Value>(&[]).unwrap_err(),
+            postcard::Error::SerdeDeCustom
+        );
     }
 
     // ── From<Vec<Value>> ────────────────────────────────────────────


### PR DESCRIPTION
🤖 Remove a misleading, lossy generic binary serialization path from the public Rust `Value` and `Query` APIs.

## What changed

- Preserve the existing human-readable/JSON representations exactly, including nested row source IDs.
- Remove the private `ValueBinary` mirror that silently discarded `Value::Row.id`.
- Make non-human Serde serialization/deserialization of public `Value` and public `Query` fail explicitly.
- Replace stale postcard round-trip tests with explicit unsupported-codec tests while retaining exact JSON round-trip coverage.
- Document that descriptor-aware raw/admin/native codecs are the supported production binary row boundaries.

## Why

`Value::Row` promises to carry the included source row ID. Generic postcard serialization silently erased it, producing plausible but semantically corrupted data. Repository-wide audit found no production consumer of generic binary serialization for these public types; production NAPI/WASM/storage paths use named descriptor-aware codecs and preserve IDs.

## Compatibility

This intentionally removes externally observable generic binary Serde support for the public Rust `Value` and `Query` types. Existing JSON behavior and production wire/storage codecs are unchanged. Downstream code attempting postcard/bincode-style serialization will now receive an explicit unsupported-codec error instead of silently losing identity.

## Verification

- Public API focused suite: 122 passed.
- Public Query tests: 50 passed.
- Public Value tests: 23 passed.
- `cargo fmt --check` and Clippy with warnings denied.
- Planted restoration of the old lossy binary path fails the new rejection test.
- Independent review found no production generic-binary consumer.
