### PR TITLE
ci: reuse starter dependencies and avoid duplicate gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
       # count. Builds reuse the workspace test build above.
       - name: Differential gates
         run: |
-          cargo test -p jazz --test incremental_delivery_canary
-          cargo test -p jazz --test shared_coverage_differential
-          cargo test -p jazz --test warm_reopen_differential
+          # The three integration-test binaries above are already selected by
+          # the workspace runner's `--tests` argument. Keep the M3 oracle
+          # separate: its CI seed count is wider than the default test run.
           JAZZ_SEED_COUNT=50 cargo test -p jazz m3_maintained_one_shot_differential_oracle
 
   test-ts:

--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -54,6 +54,19 @@ jobs:
           node-version-file: .nvmrc
 
       - run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: starters-e2e-pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            starters-e2e-pnpm-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
 
       - name: Install Rust prerequisites
@@ -136,6 +149,19 @@ jobs:
           node-version-file: .nvmrc
 
       - run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: starters-e2e-pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            starters-e2e-pnpm-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
 
       - name: Restore prebuilt artifacts

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -175,6 +175,26 @@ test("Rust tool installation is isolated from shared self-hosted runner state", 
   );
 });
 
+test("Rust CI does not rerun differential integration binaries selected by the workspace test gate", () => {
+  const rust = job("test-rust", "test-ts");
+
+  assert.match(
+    rust,
+    /run-rust-tests\.mjs --timeout-seconds 780 -- --workspace --lib --bins --tests --features test/,
+  );
+  for (const testTarget of [
+    "incremental_delivery_canary",
+    "shared_coverage_differential",
+    "warm_reopen_differential",
+  ]) {
+    assert.doesNotMatch(rust, new RegExp(`cargo test -p jazz --test ${testTarget}`));
+  }
+  assert.match(
+    rust,
+    /JAZZ_SEED_COUNT=50 cargo test -p jazz m3_maintained_one_shot_differential_oracle/,
+  );
+});
+
 test("the TypeScript CI job checks the integration workspace before TypeScript artifacts", () => {
   const typescript = job("test-ts");
 

--- a/dev/gates/test/release-gates.test.mjs
+++ b/dev/gates/test/release-gates.test.mjs
@@ -70,3 +70,16 @@ test("release starter gate exercises packaged artifacts through create-jazz-e2e"
   assert.match(e2e, /--tarball-dir "\$GITHUB_WORKSPACE\/_e2e-state\/tarballs"/);
   assert.match(e2e, /--verbose --keep/);
 });
+
+test("release starter gate reuses its pnpm store across the prepare and matrix jobs", () => {
+  const expectedCache =
+    /name: Cache pnpm store[\s\S]*path: \$\{\{ steps\.pnpm-store\.outputs\.path \}\}[\s\S]*key: starters-e2e-pnpm-\$\{\{ runner\.os \}\}-\$\{\{ hashFiles\('pnpm-lock\.yaml'\) \}\}/;
+  for (const source of [job("prepare", "e2e"), job("e2e")]) {
+    assert.match(source, /name: Get pnpm store directory/);
+    assert.match(source, expectedCache);
+    assert.ok(
+      source.indexOf("name: Cache pnpm store") < source.indexOf("pnpm install --frozen-lockfile"),
+      "restore the pnpm store before installing dependencies",
+    );
+  }
+});


### PR DESCRIPTION
🤖 Reduce CI duplication and reuse starter dependency downloads.

This is stacked on #1423 because that PR repairs the required Nextest partition gate exercised by Rust CI.

## What changed

- Remove three standalone Rust integration-binary launches already selected by the canonical workspace Nextest run: incremental delivery canary, shared coverage differential, and warm-reopen differential.
- Retain the separate M3 oracle invocation because it supplies the CI-specific `JAZZ_SEED_COUNT=50` coverage beyond the default fixed seeds.
- Cache the pnpm v10 store in starter preparation and restore the same lockfile-keyed cache in all 12 starter E2E jobs.
- Add workflow contract tests for both guarantees.

## Impact

- Eliminates three complete duplicate cargo-test launches from every Rust CI run.
- Avoids repeating dependency downloads/resolution independently across the 12 release starter jobs.
- Does not change test selection or packaged artifact payloads.

## Verification

- Canonical Nextest inventory contains all three removed binaries and their five tests.
- Independent review confirmed no special environment, serial, or feature behavior was lost.
- `pnpm test:ci-workflow` — 28/28.
- Reversible duplicate-target and cache-path mutations fail the workflow contracts.
