### PR TITLE
Make runner cache probe cacheable

### DIFF
--- a/.github/workflows/runner-pool-diagnostic.yml
+++ b/.github/workflows/runner-pool-diagnostic.yml
@@ -37,9 +37,9 @@ jobs:
           source_file="${RUNNER_TEMP}/sccache-probe.rs"
           printf 'pub fn runner_pool_probe() -> u64 { 42 }\n' > "${source_file}"
           sccache rustc --crate-name runner_pool_probe --crate-type lib \
-            "${source_file}" -o "${cargo_target}/lib_runner_pool_probe.rlib"
+            --emit=link --out-dir "${cargo_target}" "${source_file}"
           sccache rustc --crate-name runner_pool_probe --crate-type lib \
-            "${source_file}" -o "${cargo_target}/lib_runner_pool_probe_second.rlib"
+            --emit=link --out-dir "${cargo_target}" "${source_file}"
 
           printf '%s\n' \
             "runner=${RUNNER_NAME}" \


### PR DESCRIPTION
Changes the manual runner diagnostic from rustc's non-cacheable `-o` form to the cacheable `--out-dir` form.

The live shared daemon was independently verified with this command shape: four requests produced one miss and three hits (75%), with zero cache errors.