### PR TITLE
ci: use trusted pool for internal checks

### DIFF
--- a/.github/actions/install-rust-tool/action.yml
+++ b/.github/actions/install-rust-tool/action.yml
@@ -1,0 +1,21 @@
+name: Install Rust tool
+description: Install a pinned Rust development tool in a job-local action home.
+
+inputs:
+  tool:
+    description: Tool name and version accepted by taiki-e/install-action.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # install-action stages downloads under $HOME/.install-action and can use
+    # $CARGO_HOME/bin for Cargo-crate fallback. Self-hosted runner agents can
+    # share HOME/CARGO_HOME, so isolate both mutable roots to this job. These
+    # step-scoped variables do not change later Cargo registry/cache use.
+    - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+      with:
+        tool: ${{ inputs.tool }}
+      env:
+        HOME: ${{ runner.temp }}/jazz-install-action
+        CARGO_HOME: ${{ runner.temp }}/jazz-install-action/cargo

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -133,10 +133,14 @@ runs:
       if: inputs.sccache == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
-        # SCCACHE_DIR also owns the local daemon/socket state. RUNNER_TEMP is
-        # unique to an agent; HOME may be shared by concurrent agents.
+        # SCCACHE_DIR owns cached objects, while sccache's default server port
+        # is host-wide. Keep both the cache directory and the Unix-domain
+        # socket job-local so concurrent runner agents cannot share a daemon.
         sccache_dir="${RUNNER_TEMP}/sccache"
+        sccache_socket="${sccache_dir}/server.sock"
         mkdir -p "${sccache_dir}"
+        SCCACHE_DIR="${sccache_dir}" SCCACHE_SERVER_UDS="${sccache_socket}" sccache --start-server
         echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
         echo "SCCACHE_DIR=${sccache_dir}" >> "${GITHUB_ENV}"
+        echo "SCCACHE_SERVER_UDS=${sccache_socket}" >> "${GITHUB_ENV}"
         echo "SCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE:-8G}" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -64,6 +64,9 @@ runs:
       with:
         version: 10.14.0
         run_install: false
+        # Self-hosted runner agents may share HOME. Keep action-setup's
+        # mutable installation directory scoped to this job's temporary dir.
+        dest: ${{ runner.temp }}/setup-pnpm
 
     - name: Set up Node.js
       if: inputs.setup-node == 'true'
@@ -118,14 +121,10 @@ runs:
     - name: Export sccache environment
       if: inputs.sccache == 'true' && runner.os == 'Linux'
       shell: bash
-      env:
-        SCCACHE_STICKY_DISK: ${{ inputs.sccache-sticky-disk }}
       run: |
-        if [[ "${SCCACHE_STICKY_DISK}" == "true" ]]; then
-          sccache_dir="${RUNNER_TEMP}/sccache"
-        else
-          sccache_dir="${HOME}/.cache/sccache"
-        fi
+        # SCCACHE_DIR also owns the local daemon/socket state. RUNNER_TEMP is
+        # unique to an agent; HOME may be shared by concurrent agents.
+        sccache_dir="${RUNNER_TEMP}/sccache"
         mkdir -p "${sccache_dir}"
         echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
         echo "SCCACHE_DIR=${sccache_dir}" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -83,6 +83,17 @@ runs:
       shell: bash
       run: pnpm install --frozen-lockfile
 
+    - name: Isolate Rustup state
+      if: inputs.rust-toolchain != ''
+      shell: bash
+      run: |
+        # rustup replaces toolchains in RUSTUP_HOME while installing/updating.
+        # Runner agents share HOME, but RUNNER_TEMP is job-local; leave
+        # CARGO_HOME, target, and sccache alone so their caches remain usable.
+        rustup_home="${RUNNER_TEMP}/rustup"
+        mkdir -p "${rustup_home}"
+        echo "RUSTUP_HOME=${rustup_home}" >> "${GITHUB_ENV}"
+
     - name: Install Rust toolchain
       if: inputs.rust-toolchain != ''
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -107,7 +107,7 @@ runs:
 
     - name: Install sccache
       if: inputs.sccache == 'true' && runner.os == 'Linux'
-      uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+      uses: ./.github/actions/install-rust-tool
       with:
         tool: sccache
 

--- a/.github/workflows/build-jazz-packages.yml
+++ b/.github/workflows/build-jazz-packages.yml
@@ -57,7 +57,7 @@ jobs:
           version: 0.14.0
           cache-key: ${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ matrix.target }}
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+      - uses: ./.github/actions/install-rust-tool
         with:
           tool: cargo-zigbuild
 
@@ -128,7 +128,7 @@ jobs:
           sccache: "true"
           sccache-key: release-wasm-sccache-${{ github.event.pull_request.head.repo.id || github.repository_id }}-v1
 
-      - uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+      - uses: ./.github/actions/install-rust-tool
         with:
           tool: wasm-pack@0.13.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           sccache: "true"
 
       - name: Install bounded Rust test runner
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        uses: ./.github/actions/install-rust-tool
         with:
           # Download the release asset rather than compiling the runner in
           # every job. Keep this explicit so test selection is reproducible.
@@ -104,7 +104,7 @@ jobs:
       - name: Install WASM packager
         # Only this job builds jazz-wasm. Other Rust jobs receive their target
         # through setup-build but do not pay to install the packager.
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        uses: ./.github/actions/install-rust-tool
         with:
           tool: wasm-pack@0.13.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -37,7 +37,7 @@ jobs:
         run: pnpm test:turbo-cache-inputs
 
   test-rust:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -76,7 +76,7 @@ jobs:
           JAZZ_SEED_COUNT=50 cargo test -p jazz m3_maintained_one_shot_differential_oracle
 
   test-ts:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
     timeout-minutes: 20
     # JAZZ_NAPI_RELEASE=0 (debug builds) removed 2026-07-19: debug-profile
     # jazz-napi .node files fail dlopen on the Linux runners deterministically
@@ -89,13 +89,11 @@ jobs:
         with:
           rust-targets: wasm32-unknown-unknown
           sccache: "true"
-          sccache-sticky-disk: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'true' || 'false' }}
+          sccache-sticky-disk: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'true' || 'false' }}
 
       # Keep the integration-branch compile gate, but run it as the first
-      # phase of the only trusted-runner job. `jazz-ci` currently has one
-      # worker: separate build-integration and test-ts jobs otherwise queue
-      # behind one another, so their setup/checkout overhead is on the PR
-      # critical path rather than overlapping.
+      # phase of this trusted-runner job. Keeping it here avoids a separate
+      # checkout/setup phase on the PR critical path.
       #
       # PR-level checks cannot catch two independently green PRs whose merged
       # tree no longer compiles. This runs on every push to the integration
@@ -111,7 +109,7 @@ jobs:
           tool: wasm-pack@0.13.1
 
       - name: Mount Turbo sticky disk
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]')
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: turbo-cache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
@@ -125,7 +123,7 @@ jobs:
       - name: Build correctness-test artifacts
         run: pnpm build:test-artifacts
       - name: Mount Playwright sticky disk
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]')
         uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
         with:
           key: playwright-browsers-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -105,6 +105,29 @@ test("build setup scopes mutable pnpm and sccache state to the agent temp direct
   );
 });
 
+test("build setup isolates mutable Rustup toolchains without moving Cargo caches", () => {
+  const rustupSetup =
+    /name: Isolate Rustup state[\s\S]*rustup_home="\$\{RUNNER_TEMP\}\/rustup"[\s\S]*echo "RUSTUP_HOME=\$\{rustup_home\}" >> "\$\{GITHUB_ENV\}"/;
+  assert.match(setupBuildAction, rustupSetup);
+  assert.ok(
+    setupBuildAction.indexOf("name: Isolate Rustup state") <
+      setupBuildAction.indexOf("name: Install Rust toolchain"),
+    "RUSTUP_HOME must be exported before rustup installs a toolchain",
+  );
+  assert.doesNotMatch(setupBuildAction, /RUSTUP_HOME=.*\$\{HOME\}/);
+  assert.throws(
+    () =>
+      assert.match(
+        setupBuildAction.replace(
+          'echo "RUSTUP_HOME=${rustup_home}" >> "${GITHUB_ENV}"',
+          'echo "RUST_UP_HOME=${rustup_home}" >> "${GITHUB_ENV}"',
+        ),
+        rustupSetup,
+      ),
+    /Isolate Rustup state/,
+  );
+});
+
 test("Rust tool installation is isolated from shared self-hosted runner state", () => {
   const installAction = "taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9";
   assert.match(installRustTool, new RegExp(`uses: ${installAction}`));

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -98,10 +98,36 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
 test("build setup scopes mutable pnpm and sccache state to the agent temp directory", () => {
   assert.match(setupBuildAction, /dest: \$\{\{ runner\.temp \}\}\/setup-pnpm/);
   assert.match(setupBuildAction, /sccache_dir="\$\{RUNNER_TEMP\}\/sccache"/);
+  assert.match(setupBuildAction, /sccache_socket="\$\{sccache_dir\}\/server\.sock"/);
+  assert.match(
+    setupBuildAction,
+    /SCCACHE_DIR="\$\{sccache_dir\}" SCCACHE_SERVER_UDS="\$\{sccache_socket\}" sccache --start-server/,
+  );
+  const serverSocketExport = /echo "SCCACHE_SERVER_UDS=\$\{sccache_socket\}" >> "\$\{GITHUB_ENV\}"/;
+  assert.match(setupBuildAction, serverSocketExport);
+  const stickyMount = setupBuildAction.indexOf("name: Mount sccache sticky disk");
+  const serverStart = setupBuildAction.indexOf("sccache --start-server");
+  const environmentExport = setupBuildAction.indexOf('echo "RUSTC_WRAPPER=sccache"');
+  assert.ok(stickyMount !== -1 && serverStart !== -1 && environmentExport !== -1);
+  assert.ok(
+    stickyMount < serverStart && serverStart < environmentExport,
+    "mount the restored cache before starting its server and exporting it to compilers",
+  );
   assert.doesNotMatch(
     setupBuildAction,
     /\$\{HOME\}\/(?:setup-pnpm|\.cache\/sccache)/,
     "shared HOME must not hold mutable pnpm or sccache state",
+  );
+  assert.throws(
+    () =>
+      assert.match(
+        setupBuildAction.replace(
+          'echo "SCCACHE_SERVER_UDS=${sccache_socket}" >> "${GITHUB_ENV}"',
+          "",
+        ),
+        serverSocketExport,
+      ),
+    /SCCACHE_SERVER_UDS/,
   );
 });
 

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -7,14 +7,51 @@ import test from "node:test";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const workflow = fs.readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
+const setupBuildAction = fs.readFileSync(
+  path.join(root, ".github/actions/setup-build/action.yml"),
+  "utf8",
+);
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
-const job = (name, nextName) => {
-  const start = workflow.indexOf(`  ${name}:`);
-  const end = nextName ? workflow.indexOf(`  ${nextName}:`, start + 1) : workflow.length;
-  assert.notEqual(start, -1, `missing ${name} job`);
-  assert.notEqual(end, -1, `missing boundary after ${name} job`);
-  return workflow.slice(start, end);
+const jobs = (() => {
+  const jobsStart = workflow.indexOf("\njobs:\n");
+  assert.notEqual(jobsStart, -1, "missing jobs section");
+  const matches = [...workflow.slice(jobsStart).matchAll(/^  ([A-Za-z0-9_-]+):\s*$/gm)];
+  assert.ok(matches.length > 0, "CI workflow must define at least one job");
+  return new Map(
+    matches.map((match, index) => [
+      match[1],
+      workflow.slice(
+        jobsStart + match.index,
+        index + 1 < matches.length ? jobsStart + matches[index + 1].index : workflow.length,
+      ),
+    ]),
+  );
+})();
+const job = (name) => {
+  const source = jobs.get(name);
+  assert.notEqual(source, undefined, `missing ${name} job`);
+  return source;
 };
+const trustedRunnerExpression =
+  "${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}";
+const untrustedPullRequestPredicate =
+  "github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]')";
+const assertUsesTrustedRunnerPool = (jobName, jobSource) => {
+  assert.ok(
+    jobSource.includes(`runs-on: ${trustedRunnerExpression}`),
+    `${jobName} must use jazz-ci for pushes and trusted PRs, while fork PRs use Blacksmith`,
+  );
+  assert.doesNotMatch(
+    jobSource,
+    /^    runs-on: jazz-ci$/m,
+    `${jobName} must not run fork or Dependabot PRs unconditionally on jazz-ci`,
+  );
+};
+const expectedRunner = ({ eventName, headRepository, repository, pullRequestUser }) =>
+  eventName === "pull_request" &&
+  (headRepository !== repository || pullRequestUser === "dependabot[bot]")
+    ? "blacksmith-4vcpu-ubuntu-2404"
+    : "jazz-ci";
 const integrationCheckStep = (typescriptJob) => {
   const start = typescriptJob.indexOf("name: Check integration workspace");
   assert.notEqual(start, -1, "missing integration workspace check");
@@ -38,8 +75,8 @@ const assertIntegrationCheckIsGating = (typescriptJob) => {
 };
 
 test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for wasm-pack", () => {
-  const lint = job("lint", "test-rust");
-  const rust = job("test-rust", "test-ts");
+  const lint = job("lint");
+  const rust = job("test-rust");
   const typescript = job("test-ts");
 
   assert.doesNotMatch(workflow, /cargo install cargo-nextest/);
@@ -50,11 +87,20 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
   assert.match(typescript, /tool: wasm-pack@0\.13\.1/);
 });
 
-test("the single trusted-runner job checks the integration workspace before TypeScript artifacts", () => {
+test("build setup scopes mutable pnpm and sccache state to the agent temp directory", () => {
+  assert.match(setupBuildAction, /dest: \$\{\{ runner\.temp \}\}\/setup-pnpm/);
+  assert.match(setupBuildAction, /sccache_dir="\$\{RUNNER_TEMP\}\/sccache"/);
+  assert.doesNotMatch(
+    setupBuildAction,
+    /\$\{HOME\}\/(?:setup-pnpm|\.cache\/sccache)/,
+    "shared HOME must not hold mutable pnpm or sccache state",
+  );
+});
+
+test("the TypeScript CI job checks the integration workspace before TypeScript artifacts", () => {
   const typescript = job("test-ts");
 
-  // The dedicated jazz-ci runner has one worker. Splitting these phases into
-  // jobs serializes their checkout/setup work in GitHub's runner queue.
+  // Keeping these phases together avoids a separate checkout/setup phase.
   assert.doesNotMatch(workflow, /^  build-integration:/m);
   assert.match(
     typescript,
@@ -66,7 +112,67 @@ test("the single trusted-runner job checks the integration workspace before Type
       typescript.indexOf("name: Build correctness-test artifacts"),
     "workspace check must fail before the expensive correctness artifact build",
   );
-  assert.match(typescript, /runs-on: \$\{\{ github\.event_name == 'pull_request'.*'jazz-ci' \}\}/);
+  assertUsesTrustedRunnerPool("test-ts", typescript);
+});
+
+test("every CI job uses jazz-ci only for trusted work and Blacksmith for untrusted PRs", () => {
+  for (const [name, source] of jobs) {
+    assertUsesTrustedRunnerPool(name, source);
+  }
+});
+
+test("trusted-runner policy keeps forks and same-repository Dependabot PRs hosted", () => {
+  const repository = "gardencmp/jazz";
+  assert.equal(expectedRunner({ eventName: "push", repository }), "jazz-ci");
+  assert.equal(
+    expectedRunner({ eventName: "pull_request", headRepository: repository, repository }),
+    "jazz-ci",
+  );
+  assert.equal(
+    expectedRunner({ eventName: "pull_request", headRepository: "fork/jazz", repository }),
+    "blacksmith-4vcpu-ubuntu-2404",
+  );
+  assert.equal(
+    expectedRunner({
+      eventName: "pull_request",
+      headRepository: repository,
+      repository,
+      pullRequestUser: "dependabot[bot]",
+    }),
+    "blacksmith-4vcpu-ubuntu-2404",
+  );
+  assert.match(workflow, /github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'/);
+  assert.doesNotMatch(workflow, /github\.actor/);
+});
+
+test("TypeScript cache mounts use the same untrusted-PR predicate as the runner", () => {
+  const typescript = job("test-ts");
+  assert.ok(
+    typescript.includes(
+      `sccache-sticky-disk: \${{ ${untrustedPullRequestPredicate} && 'true' || 'false' }}`,
+    ),
+  );
+  assert.equal(
+    typescript.split(`if: ${untrustedPullRequestPredicate}`).length - 1,
+    2,
+    "Turbo and Playwright sticky-disk mounts must both follow the runner trust boundary",
+  );
+});
+
+test("trusted-runner contract rejects planted unsafe runner changes", () => {
+  const lint = job("lint");
+  assert.throws(
+    () => assertUsesTrustedRunnerPool("lint", lint.replace(trustedRunnerExpression, "jazz-ci")),
+    /must use jazz-ci for pushes and trusted PRs, while fork PRs use Blacksmith/,
+  );
+  assert.throws(
+    () =>
+      assertUsesTrustedRunnerPool(
+        "lint",
+        lint.replace(" || github.event.pull_request.user.login == 'dependabot[bot]'", ""),
+      ),
+    /must use jazz-ci for pushes and trusted PRs, while fork PRs use Blacksmith/,
+  );
 });
 
 test("integration workspace check contract rejects planted failure suppression", () => {
@@ -94,13 +200,13 @@ test("integration workspace check contract rejects planted failure suppression",
 });
 
 test("lint keeps its one workspace Clippy invocation inside pnpm lint", () => {
-  const lint = job("lint", "test-rust");
+  const lint = job("lint");
   assert.match(lint, /run: pnpm lint/);
   assert.doesNotMatch(lint, /^\s*- run: cargo clippy/m);
 });
 
 test("CI runs the workflow contract test through its package script", () => {
-  const lint = job("lint", "test-rust");
+  const lint = job("lint");
   assert.equal(
     packageJson.scripts["test:ci-workflow"],
     "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs",

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -11,6 +11,14 @@ const setupBuildAction = fs.readFileSync(
   path.join(root, ".github/actions/setup-build/action.yml"),
   "utf8",
 );
+const installRustTool = fs.readFileSync(
+  path.join(root, ".github/actions/install-rust-tool/action.yml"),
+  "utf8",
+);
+const packageBuild = fs.readFileSync(
+  path.join(root, ".github/workflows/build-jazz-packages.yml"),
+  "utf8",
+);
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 const jobs = (() => {
   const jobsStart = workflow.indexOf("\njobs:\n");
@@ -94,6 +102,27 @@ test("build setup scopes mutable pnpm and sccache state to the agent temp direct
     setupBuildAction,
     /\$\{HOME\}\/(?:setup-pnpm|\.cache\/sccache)/,
     "shared HOME must not hold mutable pnpm or sccache state",
+  );
+});
+
+test("Rust tool installation is isolated from shared self-hosted runner state", () => {
+  const installAction = "taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9";
+  assert.match(installRustTool, new RegExp(`uses: ${installAction}`));
+  assert.match(installRustTool, /HOME: \$\{\{ runner\.temp \}\}\/jazz-install-action/);
+  assert.match(installRustTool, /CARGO_HOME: \$\{\{ runner\.temp \}\}\/jazz-install-action\/cargo/);
+  for (const caller of [workflow, setupBuildAction, packageBuild]) {
+    assert.doesNotMatch(caller, new RegExp(installAction));
+  }
+  assert.throws(
+    () =>
+      assert.match(
+        installRustTool.replace(
+          "        CARGO_HOME: ${{ runner.temp }}/jazz-install-action/cargo\n",
+          "",
+        ),
+        /CARGO_HOME: \$\{\{ runner\.temp \}\}\/jazz-install-action\/cargo/,
+      ),
+    /CARGO_HOME/,
   );
 });
 


### PR DESCRIPTION
🤖 Use the new four-agent `jazz-ci` pool for every trusted CI job while preserving hosted isolation for untrusted code.

## What changed

- Route `lint`, `test-rust`, and `test-ts` to `jazz-ci` for trusted same-repository PRs, pushes, and manual dispatches.
- Keep external/internal fork PRs on Blacksmith.
- Keep same-repository Dependabot PRs on Blacksmith using `pull_request.user.login`, including maintainer reruns.
- Add a structural workflow contract that discovers every top-level CI job and requires the trusted/fork-safe runner policy, so newly added jobs cannot silently escape the pool.

## Why

The trusted host now has four isolated GitHub runner agents with the same `jazz-ci` label. The old workflow used the pool for only `test-ts`, leaving the other agents idle while trusted checks ran on hosted runners.

## Verification

- GitHub reports `latitude-ci-1` through `latitude-ci-4` online with label `jazz-ci`.
- `pnpm test:ci-workflow` — 29/29.
- `pnpm format:check`.
- Planted unconditional/hosted new job fails the dynamic policy contract.
- Independent security review verified fork, Dependabot, push, dispatch, and maintainer-rerun behavior.
