### PR TITLE
fix: type terminal layout and WASM mutation contracts

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/wasm-mutation-error-contract.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/wasm-mutation-error-contract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWasmRuntime, hasJazzWasmBuild } from "../testing/wasm-runtime-test-utils.js";
+
+describe("WasmDb mutation error callback contract", () => {
+  it.skipIf(!hasJazzWasmBuild())(
+    "registers a mutation error callback through the native adapter",
+    async () => {
+      const runtime = await createWasmRuntime({});
+
+      expect(() => runtime.onMutationError(vi.fn())).not.toThrow();
+    },
+  );
+});

--- a/packages/jazz-tools/src/runtime/terminal-layout-contract-matrix.test.ts
+++ b/packages/jazz-tools/src/runtime/terminal-layout-contract-matrix.test.ts
@@ -18,6 +18,8 @@ import type {
   ColumnDescriptor,
   NativeRowDelta,
   NativeTerminalRootLayout,
+  Value,
+  WasmRow,
 } from "../drivers/types.js";
 import { SubscriptionManager } from "./subscription-manager.js";
 import {
@@ -36,6 +38,21 @@ const ROOT_ID = "00000000-0000-4000-8000-000000000001";
 
 type Carrier = "Logical" | "CurrentRow";
 type Shape = "scalar" | "array" | "row" | "nested-nullable";
+type Include =
+  | "plain"
+  | "forward"
+  | "reverse"
+  | "multi-hop"
+  | "nested-collector"
+  | "sibling-collectors";
+
+interface MatrixCase {
+  carrier: Carrier;
+  nullable: boolean;
+  sparse: boolean;
+  projection: "collect-all" | "explicit";
+  include: Include;
+}
 
 const shapes: Record<Shape, ColumnDescriptor> = {
   scalar: { name: "title", column_type: { type: "Text" }, nullable: false },
@@ -136,13 +153,20 @@ function emptyDelta(layouts: NativeTerminalRootLayout[]): NativeRowDelta {
 // 2 carriers * nullable * sparse * projection * include family = 96 real
 // packed root records. Include families add logical slots; explicit projection
 // aliases the scalar physical slot rather than only changing an ID.
-const cases = (["Logical", "CurrentRow"] as const).flatMap((carrier) =>
-  [false, true].flatMap((nullable) =>
-    [false, true].flatMap((sparse) =>
-      ["collect-all", "explicit"].flatMap((projection) =>
-        ["plain", "forward", "reverse", "multi-hop", "nested-collector", "sibling-collectors"].map(
-          (include) => ({ carrier, nullable, sparse, projection, include }),
-        ),
+const cases: MatrixCase[] = (["Logical", "CurrentRow"] as const).flatMap((carrier) =>
+  ([false, true] as const).flatMap((nullable) =>
+    ([false, true] as const).flatMap((sparse) =>
+      (["collect-all", "explicit"] as const).flatMap((projection) =>
+        (
+          [
+            "plain",
+            "forward",
+            "reverse",
+            "multi-hop",
+            "nested-collector",
+            "sibling-collectors",
+          ] as const
+        ).map((include): MatrixCase => ({ carrier, nullable, sparse, projection, include })),
       ),
     ),
   ),
@@ -177,7 +201,7 @@ describe("TerminalRootLayout encoding contract matrix", () => {
         ];
         const carriers: Carrier[] = [
           entry.carrier,
-          ...Array.from({ length: includeCount }, () => "Logical"),
+          ...Array.from({ length: includeCount }, (): Carrier => "Logical"),
         ];
         const layout = layoutFor(
           columns,
@@ -235,7 +259,7 @@ describe("TerminalRootLayout encoding contract matrix", () => {
         entry.projection === "explicit" ? "projected_title" : "user_title",
         ...includes.map((include) => include.name),
       ];
-      const carriers: Carrier[] = [entry.carrier, ...includes.map(() => "Logical")];
+      const carriers: Carrier[] = [entry.carrier, ...includes.map((): Carrier => "Logical")];
       const layout = layoutFor(columns, physicalNames, carriers, entry.carrier, `matrix-${index}`);
       const descriptor = readDescriptor(new PostcardReader(Uint8Array.from(layout.rootDescriptor)));
       const raw = createRecord(descriptor, [
@@ -279,7 +303,9 @@ describe("TerminalRootLayout encoding contract matrix", () => {
           (row) => ({
             id: row.id,
             values: row.values.map((value) => (value as { type: "Text"; value: string }).value),
-            names: [...row.valuesByColumn.keys()],
+            names: [
+              ...(row as WasmRow & { valuesByColumn: Map<string, Value> }).valuesByColumn.keys(),
+            ],
           }),
           columns,
         ).all,

--- a/packages/jazz-tools/src/types/jazz-wasm-mutation-error.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm-mutation-error.d.ts
@@ -1,0 +1,13 @@
+import "jazz-wasm";
+import type { MutationErrorEvent } from "../runtime/client.js";
+
+/**
+ * The wasm-bindgen package is generated at build time. Keep the runtime's
+ * rejection callback contract available to TypeScript while a workspace still
+ * contains artifacts generated before the binding was added.
+ */
+declare module "jazz-wasm" {
+  interface WasmDb {
+    onMutationError(callback: (event: MutationErrorEvent) => void): void;
+  }
+}

--- a/packages/jazz-tools/tsconfig.react-native-tests.json
+++ b/packages/jazz-tools/tsconfig.react-native-tests.json
@@ -11,7 +11,8 @@
     "src/expo/**/*.typecheck.ts",
     "src/expo/**/*.typecheck.tsx",
     "src/expo/vendor.d.ts",
-    "src/dev/expo.typecheck.ts"
+    "src/dev/expo.typecheck.ts",
+    "src/types/jazz-wasm-mutation-error.d.ts"
   ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
🤖 Repair the TypeScript build regressions currently red on the new-core integration branch.

## What changed

- Give the terminal-layout contract matrix explicit carrier and decoded-row test types so TypeScript checks the intended assertions instead of widening literals to `string` or hiding decoder metadata.
- Add an ambient WASM `onMutationError` declaration matching the Rust export, covering workspaces where ignored generated wasm-bindgen declarations are stale.
- Load that declaration in both ordinary and React Native test typechecks.
- Add a focused WASM adapter contract test for callback registration.

## Why

The integration branch fails `pnpm build:test`: the layout matrix has three type errors, followed by a stale generated WASM declaration that does not satisfy the post-#1369 `NativeDb` interface. Runtime Rust already exposes the callback; the source declaration makes the contract stable without requiring generated artifacts to be current before typechecking.

## Verification

- `pnpm build:test` — fully green.
- `pnpm test:terminal-layout-contract` — 6/6.
- Focused WASM mutation callback test — 1/1.
- With `onMutationError` removed from ignored generated WASM declarations, full `pnpm build:test` still passes, including React Native.
- Independent review found no weakened matrix assertions.
