### PR TITLE
fix: preserve numeric claim source semantics

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2192,15 +2192,11 @@ fn core_claim_value_from_json(value: JsonValue) -> napi::Result<CoreValue> {
     Ok(match value {
         JsonValue::Null => CoreValue::Nullable(None),
         JsonValue::Bool(value) => CoreValue::Bool(value),
-        JsonValue::Number(value) => {
-            if let Some(value) = value.as_u64() {
-                CoreValue::U64(value)
-            } else if let Some(value) = value.as_f64() {
-                CoreValue::F64(value)
-            } else {
-                return Err(napi::Error::from_reason("unsupported numeric claim value"));
-            }
-        }
+        JsonValue::Number(value) => jazz::tools::policy_claims::json_number_to_policy_claim(
+            value,
+            jazz::tools::policy_claims::NumericClaimOrigin::JavaScript,
+        )
+        .map_err(napi::Error::from_reason)?,
         JsonValue::String(value) => CoreValue::String(value),
         JsonValue::Array(values) => CoreValue::Array(
             values
@@ -3130,8 +3126,8 @@ mod tests {
 
     use crate::{
         NapiDbInnerStorage, NapiTxKind, Tx, authority_epoch_from_bigint, core_block_on,
-        core_read_opts_from_json, core_subscription_event_to_napi, encode_core_subscription_delta,
-        terminal_bytes_to_numbers,
+        core_claim_value_from_json, core_read_opts_from_json, core_subscription_event_to_napi,
+        encode_core_subscription_delta, terminal_bytes_to_numbers,
     };
     use jazz::db::{
         Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,
@@ -3152,6 +3148,39 @@ mod tests {
     use jazz::tx::DurabilityTier;
     use napi::bindgen_prelude::{BigInt, Either, Either3, Either4};
     use serde_json::json;
+
+    #[test]
+    fn javascript_numeric_claims_preserve_safe_integers_and_fail_closed_when_lossy() {
+        assert_eq!(
+            core_claim_value_from_json(json!(7)).unwrap(),
+            CoreValue::U64(7)
+        );
+        assert_eq!(
+            core_claim_value_from_json(json!(-7)).unwrap(),
+            CoreValue::I64(-7)
+        );
+        assert_eq!(
+            core_claim_value_from_json(serde_json::Value::Number(
+                serde_json::Number::from_f64(7.0).unwrap()
+            ))
+            .unwrap(),
+            CoreValue::U64(7),
+            "JS-number deserialization must agree with integer JSON"
+        );
+        assert_eq!(
+            core_claim_value_from_json(json!(7.5)).unwrap(),
+            CoreValue::F64(7.5)
+        );
+        assert_eq!(
+            core_claim_value_from_json(json!(9_007_199_254_740_992_u64)).unwrap(),
+            CoreValue::F64(9_007_199_254_740_992.0),
+            "integers beyond Number.MAX_SAFE_INTEGER must not participate in integer policy matching"
+        );
+        assert_eq!(
+            core_claim_value_from_json(json!(-9_007_199_254_740_992_i64)).unwrap(),
+            CoreValue::F64(-9_007_199_254_740_992.0)
+        );
+    }
 
     #[test]
     fn authority_epoch_bigint_rejects_lossy_values_and_preserves_u64() {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -2499,13 +2499,11 @@ fn claim_value_from_json(value: serde_json::Value) -> Result<Value, JsValue> {
         serde_json::Value::Null => Value::Nullable(None),
         serde_json::Value::Bool(value) => Value::Bool(value),
         serde_json::Value::Number(value) => {
-            if let Some(value) = value.as_u64() {
-                Value::U64(value)
-            } else if let Some(value) = value.as_f64() {
-                Value::F64(value)
-            } else {
-                return Err(JsValue::from_str("unsupported numeric claim value"));
-            }
+            jazz::tools::policy_claims::json_number_to_policy_claim(
+                value,
+                jazz::tools::policy_claims::NumericClaimOrigin::JavaScript,
+            )
+            .map_err(to_js_error)?
         }
         serde_json::Value::String(value) => Value::String(value),
         serde_json::Value::Array(values) => Value::Array(
@@ -2989,6 +2987,39 @@ mod dynamic_schema_view_tests {
     use jazz::db::{DbConfig, DbIdentity, ExclusiveTxOps};
     use jazz::groove::schema::ColumnType;
     use jazz::schema::{ColumnSchema, Policy, TableSchema};
+
+    #[test]
+    fn javascript_numeric_claims_preserve_safe_integers_and_fail_closed_when_lossy() {
+        assert_eq!(
+            claim_value_from_json(serde_json::json!(7)).unwrap(),
+            Value::U64(7)
+        );
+        assert_eq!(
+            claim_value_from_json(serde_json::json!(-7)).unwrap(),
+            Value::I64(-7)
+        );
+        assert_eq!(
+            claim_value_from_json(serde_json::Value::Number(
+                serde_json::Number::from_f64(7.0).unwrap()
+            ))
+            .unwrap(),
+            Value::U64(7),
+            "WASM's f64 JS-number path must agree with integer JSON"
+        );
+        assert_eq!(
+            claim_value_from_json(serde_json::json!(7.5)).unwrap(),
+            Value::F64(7.5)
+        );
+        assert_eq!(
+            claim_value_from_json(serde_json::json!(9_007_199_254_740_992_u64)).unwrap(),
+            Value::F64(9_007_199_254_740_992.0),
+            "integers beyond Number.MAX_SAFE_INTEGER must not participate in integer policy matching"
+        );
+        assert_eq!(
+            claim_value_from_json(serde_json::json!(-9_007_199_254_740_992_i64)).unwrap(),
+            Value::F64(-9_007_199_254_740_992.0)
+        );
+    }
 
     #[test]
     fn wasm_delta_preserves_typed_union_occurrence_keys() {

--- a/crates/jazz/src/serving/auth_admission.rs
+++ b/crates/jazz/src/serving/auth_admission.rs
@@ -10,7 +10,6 @@ use crate::groove::records::Value;
 use crate::ids::AuthorId;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
-use serde_json::Number;
 
 /// Admission policy used by loopback transports.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -383,17 +382,22 @@ fn jwt_json_claims_to_policy_claims(
         }
         if name == "claims" {
             let serde_json::Value::Object(nested) = value else {
-                continue;
+                return Err(AuthAdmissionError::InvalidJwt(
+                    "JWT claims claim must be an object".to_owned(),
+                ));
             };
             for (nested_name, nested_value) in nested {
-                if let Some(nested_value) = json_claim_to_policy_claim(nested_value) {
-                    claims.insert(nested_name, nested_value?);
-                }
+                let value = json_claim_to_policy_claim(nested_value)?.ok_or_else(|| {
+                    AuthAdmissionError::InvalidJwt(
+                        "nested JWT claim objects are not supported".to_owned(),
+                    )
+                })?;
+                claims.insert(nested_name, value);
             }
             continue;
         }
-        if let Some(value) = json_claim_to_policy_claim(value) {
-            claims.insert(name, value?);
+        if let Some(value) = json_claim_to_policy_claim(value)? {
+            claims.insert(name, value);
         }
     }
     Ok(claims)
@@ -401,45 +405,38 @@ fn jwt_json_claims_to_policy_claims(
 
 fn json_claim_to_policy_claim(
     value: serde_json::Value,
-) -> Option<Result<Value, AuthAdmissionError>> {
+) -> Result<Option<Value>, AuthAdmissionError> {
     match value {
-        serde_json::Value::Null => Some(Ok(Value::Nullable(None))),
-        serde_json::Value::Bool(value) => Some(Ok(Value::Bool(value))),
-        serde_json::Value::Number(number) => Some(number_to_policy_claim(number)),
-        serde_json::Value::String(value) => Some(Ok(value
-            .parse()
-            .map(Value::Uuid)
-            .unwrap_or(Value::String(value)))),
+        serde_json::Value::Null => Ok(Some(Value::Nullable(None))),
+        serde_json::Value::Bool(value) => Ok(Some(Value::Bool(value))),
+        serde_json::Value::Number(number) => {
+            crate::tools::policy_claims::json_number_to_policy_claim(
+                number,
+                crate::tools::policy_claims::NumericClaimOrigin::ExactJson,
+            )
+            .map_err(AuthAdmissionError::InvalidJwt)
+            .map(Some)
+        }
+        serde_json::Value::String(value) => Ok(Some(
+            value
+                .parse()
+                .map(Value::Uuid)
+                .unwrap_or(Value::String(value)),
+        )),
         serde_json::Value::Array(values) => {
             let mut claims = Vec::with_capacity(values.len());
             for value in values {
-                let value = json_claim_to_policy_claim(value)?;
-                match value {
-                    Ok(value) => claims.push(value),
-                    Err(error) => return Some(Err(error)),
-                }
+                let Some(value) = json_claim_to_policy_claim(value)? else {
+                    return Ok(None);
+                };
+                claims.push(value);
             }
-            Some(Ok(Value::Array(claims)))
+            Ok(Some(Value::Array(claims)))
         }
-        serde_json::Value::Object(_) => None,
+        // OIDC providers routinely attach unrelated nested metadata. It is not
+        // representable in policy claims, so omit this claim as before.
+        serde_json::Value::Object(_) => Ok(None),
     }
-}
-
-fn number_to_policy_claim(number: Number) -> Result<Value, AuthAdmissionError> {
-    if let Some(value) = number.as_u64() {
-        return Ok(Value::U64(value));
-    }
-    let Some(value) = number.as_f64() else {
-        return Err(AuthAdmissionError::InvalidJwt(
-            "unsupported numeric claim".to_owned(),
-        ));
-    };
-    if !value.is_finite() {
-        return Err(AuthAdmissionError::InvalidJwt(
-            "unsupported numeric claim".to_owned(),
-        ));
-    }
-    Ok(Value::F64(value))
 }
 
 /// Deterministically map an auth subject to a Jazz author id.
@@ -478,6 +475,39 @@ mod tests {
         assert_eq!(
             author_id_from_subject(subject),
             AuthorId::from_bytes(*uuid::Uuid::parse_str(subject).unwrap().as_bytes())
+        );
+    }
+
+    #[test]
+    fn jwt_claim_admission_preserves_exact_integers_and_ignores_oidc_metadata() {
+        let claims = jwt_json_claims_to_policy_claims(BTreeMap::from([
+            ("positive".to_owned(), serde_json::json!(7)),
+            ("negative".to_owned(), serde_json::json!(-7)),
+            (
+                "unsafe".to_owned(),
+                serde_json::json!(9_007_199_254_740_992_u64),
+            ),
+        ]))
+        .unwrap();
+        assert_eq!(claims["positive"], Value::U64(7));
+        assert_eq!(claims["negative"], Value::I64(-7));
+        assert_eq!(claims["unsafe"], Value::U64(9_007_199_254_740_992));
+        let claims = jwt_json_claims_to_policy_claims(BTreeMap::from([(
+            "https://issuer.example/profile".to_owned(),
+            serde_json::json!({ "department": "engineering" }),
+        )]))
+        .unwrap();
+        assert!(
+            claims.is_empty(),
+            "unrepresentable OIDC metadata stays ignored"
+        );
+        assert!(
+            jwt_json_claims_to_policy_claims(BTreeMap::from([(
+                "claims".to_owned(),
+                serde_json::json!({ "profile": { "department": "engineering" } }),
+            )]))
+            .is_err(),
+            "the dedicated policy claims object rejects nested objects"
         );
     }
 }

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -1765,21 +1765,11 @@ fn json_claim_to_core_value(value: serde_json::Value) -> Result<CoreValue> {
         serde_json::Value::Bool(value) => Ok(CoreValue::Bool(value)),
         serde_json::Value::String(value) => Ok(CoreValue::String(value)),
         serde_json::Value::Number(value) => {
-            if let Some(value) = value.as_u64() {
-                u32::try_from(value)
-                    .map(CoreValue::U32)
-                    .or(Ok(CoreValue::U64(value)))
-            } else if let Some(value) = value.as_i64() {
-                i32::try_from(value)
-                    .map(|value| CoreValue::I64(i64::from(value)))
-                    .or(Ok(CoreValue::I64(value)))
-            } else if let Some(value) = value.as_f64() {
-                Ok(CoreValue::F64(value))
-            } else {
-                Err(JazzError::Connection(
-                    "JWT claim number is not representable".to_string(),
-                ))
-            }
+            crate::tools::policy_claims::json_number_to_policy_claim(
+                value,
+                crate::tools::policy_claims::NumericClaimOrigin::ExactJson,
+            )
+            .map_err(JazzError::Connection)
         }
         serde_json::Value::Array(values) => values
             .into_iter()
@@ -3313,6 +3303,23 @@ mod tests {
             public_to_core_value(Value::Integer(0)).expect("encode zero"),
             CoreValue::I32(0)
         );
+    }
+
+    #[test]
+    fn client_session_claim_numbers_match_admission_classification() {
+        assert_eq!(
+            json_claim_to_core_value(json!(7)).unwrap(),
+            CoreValue::U64(7)
+        );
+        assert_eq!(
+            json_claim_to_core_value(json!(-7)).unwrap(),
+            CoreValue::I64(-7)
+        );
+        assert_eq!(
+            json_claim_to_core_value(json!(9_007_199_254_740_992_u64)).unwrap(),
+            CoreValue::U64(9_007_199_254_740_992)
+        );
+        assert!(json_claim_to_core_value(json!({ "role": "admin" })).is_err());
     }
 
     // This narrow internal test is necessary because the wire crossing is an

--- a/crates/jazz/src/tools/mod.rs
+++ b/crates/jazz/src/tools/mod.rs
@@ -11,6 +11,7 @@ pub mod middleware;
 mod object;
 #[cfg(feature = "otel-core")]
 pub mod otel;
+pub mod policy_claims;
 pub(crate) mod public_api;
 pub mod public_schema;
 pub mod schema_lens;

--- a/crates/jazz/src/tools/policy_claims.rs
+++ b/crates/jazz/src/tools/policy_claims.rs
@@ -1,0 +1,117 @@
+//! Shared conversion rules for JSON session claims at public transport boundaries.
+
+use crate::groove::records::Value;
+
+/// Largest integer that a JavaScript `number` represents exactly.
+pub const MAX_SAFE_JS_INTEGER: u64 = 9_007_199_254_740_991;
+
+/// Describes whether a JSON number originated at a JavaScript binding boundary
+/// or in a parsed JSON payload such as a JWT.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NumericClaimOrigin {
+    /// A JavaScript `number`, whose integral precision is limited to the safe range.
+    JavaScript,
+    /// Parsed JSON, whose serde number preserves an exact signed or unsigned 64-bit integer.
+    ExactJson,
+}
+
+/// Classify a JSON number for policy evaluation.
+///
+/// Integral JSON numbers preserve their exact 64-bit representation. At a
+/// JavaScript boundary, only safe integral numbers participate as integers;
+/// larger values remain doubles and cannot match integer policy columns.
+pub fn json_number_to_policy_claim(
+    number: serde_json::Number,
+    origin: NumericClaimOrigin,
+) -> Result<Value, String> {
+    if let Some(value) = number.as_u64() {
+        return Ok(
+            if origin == NumericClaimOrigin::ExactJson || value <= MAX_SAFE_JS_INTEGER {
+                Value::U64(value)
+            } else {
+                Value::F64(value as f64)
+            },
+        );
+    }
+    if let Some(value) = number.as_i64() {
+        return Ok(
+            if origin == NumericClaimOrigin::ExactJson
+                || value.unsigned_abs() <= MAX_SAFE_JS_INTEGER
+            {
+                Value::I64(value)
+            } else {
+                Value::F64(value as f64)
+            },
+        );
+    }
+    let Some(value) = number.as_f64() else {
+        return Err("unsupported numeric claim".to_owned());
+    };
+    if !value.is_finite() {
+        return Err("unsupported numeric claim".to_owned());
+    }
+    if value.fract() == 0.0 && value.abs() <= MAX_SAFE_JS_INTEGER as f64 {
+        return Ok(if value < 0.0 {
+            Value::I64(value as i64)
+        } else {
+            Value::U64(value as u64)
+        });
+    }
+    Ok(Value::F64(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn numeric_claims_preserve_safe_integers_and_fail_closed_when_lossy() {
+        assert_eq!(
+            json_number_to_policy_claim(
+                json!(7).as_number().unwrap().clone(),
+                NumericClaimOrigin::JavaScript,
+            )
+            .unwrap(),
+            Value::U64(7)
+        );
+        assert_eq!(
+            json_number_to_policy_claim(
+                json!(-7).as_number().unwrap().clone(),
+                NumericClaimOrigin::JavaScript,
+            )
+            .unwrap(),
+            Value::I64(-7)
+        );
+        assert_eq!(
+            json_number_to_policy_claim(
+                json!(7.5).as_number().unwrap().clone(),
+                NumericClaimOrigin::JavaScript,
+            )
+            .unwrap(),
+            Value::F64(7.5)
+        );
+        assert_eq!(
+            json_number_to_policy_claim(
+                json!(9_007_199_254_740_992_u64)
+                    .as_number()
+                    .unwrap()
+                    .clone(),
+                NumericClaimOrigin::JavaScript,
+            )
+            .unwrap(),
+            Value::F64(9_007_199_254_740_992.0)
+        );
+        assert_eq!(
+            json_number_to_policy_claim(
+                json!(9_007_199_254_740_992_u64)
+                    .as_number()
+                    .unwrap()
+                    .clone(),
+                NumericClaimOrigin::ExactJson,
+            )
+            .unwrap(),
+            Value::U64(9_007_199_254_740_992)
+        );
+    }
+}

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -279,12 +279,12 @@ fn json_claim_to_core_value(value: serde_json::Value) -> Result<CoreValue, Strin
     match value {
         serde_json::Value::Null => Ok(CoreValue::Nullable(None)),
         serde_json::Value::Bool(value) => Ok(CoreValue::Bool(value)),
-        serde_json::Value::Number(value) => value
-            .as_u64()
-            .map(CoreValue::U64)
-            .or_else(|| value.as_i64().map(CoreValue::I64))
-            .or_else(|| value.as_f64().map(CoreValue::F64))
-            .ok_or_else(|| "claim number is not representable".to_owned()),
+        serde_json::Value::Number(value) => {
+            crate::tools::policy_claims::json_number_to_policy_claim(
+                value,
+                crate::tools::policy_claims::NumericClaimOrigin::ExactJson,
+            )
+        }
         serde_json::Value::String(value) => Ok(CoreValue::String(value)),
         serde_json::Value::Array(values) => values
             .into_iter()
@@ -967,6 +967,23 @@ mod tests {
         assert!(ws_has_auth_cookie(&headers, Some("jazz-auth")));
         assert!(!ws_has_auth_cookie(&headers, Some("missing")));
         assert!(!ws_has_auth_cookie(&headers, None));
+    }
+
+    #[test]
+    fn websocket_session_claim_numbers_match_admission_classification() {
+        assert_eq!(
+            json_claim_to_core_value(serde_json::json!(7)).unwrap(),
+            CoreValue::U64(7)
+        );
+        assert_eq!(
+            json_claim_to_core_value(serde_json::json!(-7)).unwrap(),
+            CoreValue::I64(-7)
+        );
+        assert_eq!(
+            json_claim_to_core_value(serde_json::json!(9_007_199_254_740_992_u64)).unwrap(),
+            CoreValue::U64(9_007_199_254_740_992)
+        );
+        assert!(json_claim_to_core_value(serde_json::json!({ "role": "admin" })).is_err());
     }
 
     #[test]


### PR DESCRIPTION
🤖 ## Summary

- classify numeric policy claims by their actual source representation
- preserve exact full-width signed and unsigned integers from JWT/server JSON
- coerce JavaScript-origin integers outside the safe range to floating point so they cannot accidentally satisfy integer policies
- retain compatibility with ordinary nested OIDC metadata while keeping the dedicated `claims` object strict

## Why

JavaScript numbers cannot exactly represent integers beyond ±(2^53−1), while serde JSON from JWT/server ingress can. Applying one conversion rule to both either admitted rounded JavaScript authorization claims or broke legitimate exact JWT integer claims.

## Verification

- focused NAPI and WASM numeric claim tests
- focused JWT admission, client session, and websocket claim tests
- adversarial plants for unsafe JavaScript integers and nested OIDC objects
- clippy, rustfmt, and sensitive-data guard
