### PR TITLE
refactor: remove dead subscription transition counter

### DIFF
--- a/CLEANUP.md
+++ b/CLEANUP.md
@@ -47,8 +47,9 @@ can distinguish moved code from changed behavior.
 
 ### 3. Remove dead and obsolete seams
 
-- Remove the unused `ResultTransitions::observed_delta_batches` field.
-- Remove or justify the unused singular `structured_app_row` hook.
+- Remove or justify apparently dead hooks. For example, the singular
+  `structured_app_row` accessor is live: incremental updates use it to
+  materialize only the roots reported as changed.
 - Remove stale compatibility comments that refer to already-landed PRs.
 - Consolidate duplicated subscription-carrier normalization helpers.
 - Remove production paths retained only for compatibility tests, or explicitly

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -131,7 +131,6 @@ pub(crate) struct ResultTransitions {
     /// and are forwarded unchanged to the subscription boundary.
     pub(crate) terminal_operations: Vec<TerminalOperation>,
     pub(crate) allow_storage_witness_fallback: bool,
-    pub(crate) observed_delta_batches: usize,
     pub(crate) observed_result_delta_batches: usize,
 }
 
@@ -477,10 +476,9 @@ impl MaintainedSubscriptionView {
             .collect()
     }
 
-    /// The collector's current recursive rows, retained directly from its
-    /// incremental terminal. This is intentionally an internal hand-off for
-    /// the view-update builder; the existing wire still uses fact delivery.
-    #[allow(dead_code)] // PR 4 consumes this from `MaintainedViewBundleInputs`.
+    /// Returns the collector's current recursive row for one changed root.
+    ///
+    /// The incremental update builder uses this to replace just that root.
     pub(crate) fn structured_app_row(&self, root: RowUuid) -> Option<OwnedRecord> {
         let descriptor = self.structured_app_row_descriptor?;
         self.structured_app_rows

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -5650,7 +5650,6 @@ where
                 program_fact_removes,
                 structured_app_row_changes: BTreeSet::new(),
                 allow_storage_witness_fallback: true,
-                observed_delta_batches: 0,
                 observed_result_delta_batches: 0,
                 terminal_operations: Vec::new(),
             },

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -709,7 +709,6 @@ impl PeerState {
             program_fact_removes,
             structured_app_row_changes: _,
             allow_storage_witness_fallback,
-            observed_delta_batches: _,
             observed_result_delta_batches,
             terminal_operations,
         } = transitions;
@@ -926,7 +925,6 @@ impl PeerState {
         let mut program_fact_adds = Vec::new();
         let mut program_fact_removes = Vec::new();
         let mut allow_storage_witness_fallback = false;
-        let mut observed_delta_batches = 0_usize;
         let mut observed_result_delta_batches = 0_usize;
         let mut terminal_operations = Vec::new();
         {
@@ -941,7 +939,6 @@ impl PeerState {
                 match maintained_subscription_view.subscription.try_recv() {
                     Ok(deltas) => {
                         self.metrics.maintained_subscription_view.delta_batches_in += 1;
-                        observed_delta_batches += 1;
                         let transitions = maintained_subscription_view
                             .maintained
                             .apply_multisink_deltas(
@@ -1042,7 +1039,6 @@ impl PeerState {
             program_fact_removes,
             structured_app_row_changes: BTreeSet::new(),
             allow_storage_witness_fallback,
-            observed_delta_batches,
             observed_result_delta_batches,
             terminal_operations,
         })
@@ -1495,7 +1491,6 @@ impl PeerState {
             program_fact_removes: source_program_fact_removes,
             structured_app_row_changes: _,
             allow_storage_witness_fallback: source_allow_storage_witness_fallback,
-            observed_delta_batches: _,
             observed_result_delta_batches: _,
             terminal_operations: source_terminal_operations,
         } = source_transitions;


### PR DESCRIPTION
🤖 Removes the unused `ResultTransitions::observed_delta_batches` state and its writes, while retaining the live changed-root `structured_app_row` path.

Also updates CLEANUP.md so the roadmap reflects the completed work.

Verification:
- `cargo check -p jazz`
- focused maintained subscription tests
- `cargo fmt --check`
- independent adversarial review: no findings