### PR TITLE
refactor: split aggregate query result helpers

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -62,6 +62,12 @@ use crate::query::{
 use crate::schema::{ColumnSchema, JazzSchema, branch_metadata_table_schema};
 use crate::tools::{ObjectId, OutputOccurrenceId};
 
+mod query_result_rows;
+
+use query_result_rows::{
+    aggregate_query_row_uuid, aggregate_result_table, aggregate_row_cell, compare_optional_values,
+};
+
 pub(crate) const JAZZ_APP_ROWS_SINK: &str = "app_rows";
 const PENDING_BINDING_SOURCE_SHAPE: &str = "__jazz_pending_binding_source";
 
@@ -13802,15 +13808,6 @@ fn contiguous_tx_time_spans(times: &BTreeSet<TxTime>) -> Vec<(TxTime, Option<TxT
     spans
 }
 
-fn compare_optional_values(left: Option<Value>, right: Option<Value>) -> Ordering {
-    match (left, right) {
-        (Some(left), Some(right)) => compare_order_values(&left, &right),
-        (None, Some(_)) => Ordering::Less,
-        (Some(_), None) => Ordering::Greater,
-        (None, None) => Ordering::Equal,
-    }
-}
-
 fn sort_query_default_rows(rows: &mut [CurrentRow]) {
     rows.sort_by(default_query_row_order);
 }
@@ -13842,120 +13839,6 @@ fn default_query_row_order(left: &CurrentRow, right: &CurrentRow) -> Ordering {
         .then_with(|| left.record.raw().cmp(right.record.raw()))
 }
 
-fn aggregate_row_cell(
-    row: &CurrentRow,
-    query: &crate::query::Query,
-    column: &str,
-) -> Option<Value> {
-    let field = if query
-        .aggregate
-        .as_ref()
-        .and_then(|aggregate| aggregate.group_by.as_deref())
-        == Some(column)
-    {
-        user_column_field(column)
-    } else if query.aggregate.as_ref().is_some_and(|aggregate| {
-        aggregate
-            .aggregates
-            .iter()
-            .any(|aggregate| aggregate.alias == column)
-    }) {
-        aggregate_output_app_field(column)
-    } else {
-        user_column_field(column)
-    };
-    let idx = row.record.descriptor().field_index(&field)?;
-    nullable_value(row.record.borrowed().get_idx(idx).ok()?).ok()?
-}
-
-fn aggregate_result_table(
-    query: &crate::query::Query,
-    source_table: &TableSchema,
-) -> Result<TableSchema, Error> {
-    let aggregate = query.aggregate.as_ref().ok_or(Error::InvalidStoredValue(
-        "aggregate query missing aggregate",
-    ))?;
-    let mut columns = Vec::new();
-    if let Some(group_by) = &aggregate.group_by {
-        let column = source_table
-            .columns
-            .iter()
-            .find(|column| &column.name == group_by)
-            .ok_or(Error::InvalidStoredValue("aggregate group column missing"))?;
-        columns.push(ColumnSchema::new(&column.name, column.column_type.clone()));
-    }
-    for aggregate in &aggregate.aggregates {
-        columns.push(ColumnSchema::new(
-            aggregate_output_column(&aggregate.alias),
-            aggregate_result_column_type(aggregate, source_table)?,
-        ));
-    }
-    Ok(TableSchema::new(&query.table, columns))
-}
-
-fn aggregate_result_column_type(
-    aggregate: &Aggregate,
-    source_table: &TableSchema,
-) -> Result<ColumnType, Error> {
-    match aggregate.function {
-        AggregateFunction::Count => Ok(ColumnType::U64),
-        AggregateFunction::Sum | AggregateFunction::Min | AggregateFunction::Max => {
-            let column = aggregate
-                .column
-                .as_ref()
-                .ok_or(Error::InvalidStoredValue("aggregate input column missing"))?;
-            let column_type = source_table
-                .columns
-                .iter()
-                .find(|candidate| &candidate.name == column)
-                .map(|column| column.column_type.clone())
-                .ok_or(Error::InvalidStoredValue("aggregate input column missing"))?;
-            // `CurrentRow` supplies the public nullable envelope.  The
-            // aggregate payload itself carries the SQL nullable layer, which
-            // `current_row_from_aggregate_result_payload` flattens before it
-            // reaches this synthetic table schema.
-            Ok(match column_type {
-                ColumnType::Nullable(inner) => *inner,
-                column_type => column_type,
-            })
-        }
-        AggregateFunction::Avg => Ok(ColumnType::F64),
-    }
-}
-
-/// Use the same stable identity for direct aggregate reads and maintained
-/// aggregate delivery.  A global aggregate is keyed by `"global"`; grouped
-/// aggregates are keyed by their lowered group value.
-fn aggregate_query_row_uuid(
-    query: &crate::query::Query,
-    record: &BorrowedRecord<'_>,
-) -> Result<RowUuid, Error> {
-    let aggregate = query.aggregate.as_ref().ok_or(Error::InvalidStoredValue(
-        "aggregate query missing aggregate",
-    ))?;
-    let row_value = match &aggregate.group_by {
-        Some(group_by) => {
-            let field = user_column_field(group_by);
-            let index = record
-                .descriptor()
-                .field_index(&field)
-                .or_else(|| record.descriptor().field_index(group_by))
-                .ok_or(Error::InvalidStoredValue(
-                    "aggregate record is missing group identity",
-                ))?;
-            record.get_idx(index)?
-        }
-        None => Value::String("global".to_owned()),
-    };
-    let row = postcard::to_allocvec(&row_value)
-        .map_err(|_| Error::InvalidStoredValue("aggregate result row encoding failed"))?;
-    aggregate_result_member_row_uuid(&ResultMemberEntry::Synthetic {
-        table: "aggregate_result".to_owned(),
-        row,
-        replacement: SyntheticReplacementToken::from_encoded_record(Vec::new()),
-    })
-}
-
 fn apply_query_window(query: &crate::query::Query, rows: &mut Vec<CurrentRow>) {
     let offset = query.offset.min(rows.len());
     let limit = query.limit.unwrap_or(rows.len().saturating_sub(offset));
@@ -13963,43 +13846,6 @@ fn apply_query_window(query: &crate::query::Query, rows: &mut Vec<CurrentRow>) {
     if offset > 0 || end < rows.len() {
         *rows = rows[offset..end].to_vec();
     }
-}
-
-fn compare_order_values(left: &Value, right: &Value) -> Ordering {
-    match (left, right) {
-        (Value::U8(left), Value::U8(right)) => left.cmp(right),
-        (Value::U16(left), Value::U16(right)) => left.cmp(right),
-        (Value::U32(left), Value::U32(right)) => left.cmp(right),
-        (Value::U64(left), Value::U64(right)) => left.cmp(right),
-        (Value::I32(left), Value::I32(right)) => left.cmp(right),
-        (Value::I64(left), Value::I64(right)) => left.cmp(right),
-        (Value::F64(left), Value::F64(right)) => left.total_cmp(right),
-        (Value::Bool(left), Value::Bool(right)) => left.cmp(right),
-        (Value::String(left), Value::String(right)) => left.cmp(right),
-        (Value::Bytes(left), Value::Bytes(right)) => left.cmp(right),
-        (Value::Uuid(left), Value::Uuid(right)) => left.as_bytes().cmp(right.as_bytes()),
-        (Value::EnumTag(left), Value::EnumTag(right)) => left.cmp(right),
-        (Value::Tuple(left), Value::Tuple(right)) | (Value::Array(left), Value::Array(right)) => {
-            compare_order_value_slices(left, right)
-        }
-        (Value::Nullable(left), Value::Nullable(right)) => match (left, right) {
-            (Some(left), Some(right)) => compare_order_values(left, right),
-            (None, Some(_)) => Ordering::Less,
-            (Some(_), None) => Ordering::Greater,
-            (None, None) => Ordering::Equal,
-        },
-        _ => Ordering::Equal,
-    }
-}
-
-fn compare_order_value_slices(left: &[Value], right: &[Value]) -> Ordering {
-    for (left, right) in left.iter().zip(right) {
-        let ordering = compare_order_values(left, right);
-        if ordering != Ordering::Equal {
-            return ordering;
-        }
-    }
-    left.len().cmp(&right.len())
 }
 
 fn magic_current_column_type(column: &str) -> Option<&'static groove::schema::ColumnType> {

--- a/crates/jazz/src/node/query_eval/query_result_rows.rs
+++ b/crates/jazz/src/node/query_eval/query_result_rows.rs
@@ -1,0 +1,171 @@
+//! Aggregate result shaping and ordering for query evaluation.
+
+use std::cmp::Ordering;
+
+use groove::records::BorrowedRecord;
+use groove::schema::ColumnType;
+
+use super::{
+    Aggregate, AggregateFunction, ColumnSchema, CurrentRow, Error, ResultMemberEntry, RowUuid,
+    SyntheticReplacementToken, TableSchema, Value, aggregate_output_app_field,
+    aggregate_output_column, aggregate_result_member_row_uuid, nullable_value, user_column_field,
+};
+
+pub(super) fn compare_optional_values(left: Option<Value>, right: Option<Value>) -> Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => compare_order_values(&left, &right),
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+pub(super) fn aggregate_row_cell(
+    row: &CurrentRow,
+    query: &crate::query::Query,
+    column: &str,
+) -> Option<Value> {
+    let field = if query
+        .aggregate
+        .as_ref()
+        .and_then(|aggregate| aggregate.group_by.as_deref())
+        == Some(column)
+    {
+        user_column_field(column)
+    } else if query.aggregate.as_ref().is_some_and(|aggregate| {
+        aggregate
+            .aggregates
+            .iter()
+            .any(|aggregate| aggregate.alias == column)
+    }) {
+        aggregate_output_app_field(column)
+    } else {
+        user_column_field(column)
+    };
+    let idx = row.record.descriptor().field_index(&field)?;
+    nullable_value(row.record.borrowed().get_idx(idx).ok()?).ok()?
+}
+
+pub(super) fn aggregate_result_table(
+    query: &crate::query::Query,
+    source_table: &TableSchema,
+) -> Result<TableSchema, Error> {
+    let aggregate = query.aggregate.as_ref().ok_or(Error::InvalidStoredValue(
+        "aggregate query missing aggregate",
+    ))?;
+    let mut columns = Vec::new();
+    if let Some(group_by) = &aggregate.group_by {
+        let column = source_table
+            .columns
+            .iter()
+            .find(|column| &column.name == group_by)
+            .ok_or(Error::InvalidStoredValue("aggregate group column missing"))?;
+        columns.push(ColumnSchema::new(&column.name, column.column_type.clone()));
+    }
+    for aggregate in &aggregate.aggregates {
+        columns.push(ColumnSchema::new(
+            aggregate_output_column(&aggregate.alias),
+            aggregate_result_column_type(aggregate, source_table)?,
+        ));
+    }
+    Ok(TableSchema::new(&query.table, columns))
+}
+
+fn aggregate_result_column_type(
+    aggregate: &Aggregate,
+    source_table: &TableSchema,
+) -> Result<ColumnType, Error> {
+    match aggregate.function {
+        AggregateFunction::Count => Ok(ColumnType::U64),
+        AggregateFunction::Sum | AggregateFunction::Min | AggregateFunction::Max => {
+            let column = aggregate
+                .column
+                .as_ref()
+                .ok_or(Error::InvalidStoredValue("aggregate input column missing"))?;
+            let column_type = source_table
+                .columns
+                .iter()
+                .find(|candidate| &candidate.name == column)
+                .map(|column| column.column_type.clone())
+                .ok_or(Error::InvalidStoredValue("aggregate input column missing"))?;
+            // `CurrentRow` supplies the public nullable envelope. The aggregate
+            // payload carries the SQL nullable layer, flattened before it reaches
+            // this synthetic table schema.
+            Ok(match column_type {
+                ColumnType::Nullable(inner) => *inner,
+                column_type => column_type,
+            })
+        }
+        AggregateFunction::Avg => Ok(ColumnType::F64),
+    }
+}
+
+/// Use the same stable identity for direct aggregate reads and maintained
+/// aggregate delivery. A global aggregate is keyed by `"global"`; grouped
+/// aggregates are keyed by their lowered group value.
+pub(super) fn aggregate_query_row_uuid(
+    query: &crate::query::Query,
+    record: &BorrowedRecord<'_>,
+) -> Result<RowUuid, Error> {
+    let aggregate = query.aggregate.as_ref().ok_or(Error::InvalidStoredValue(
+        "aggregate query missing aggregate",
+    ))?;
+    let row_value = match &aggregate.group_by {
+        Some(group_by) => {
+            let field = user_column_field(group_by);
+            let index = record
+                .descriptor()
+                .field_index(&field)
+                .or_else(|| record.descriptor().field_index(group_by))
+                .ok_or(Error::InvalidStoredValue(
+                    "aggregate record is missing group identity",
+                ))?;
+            record.get_idx(index)?
+        }
+        None => Value::String("global".to_owned()),
+    };
+    let row = postcard::to_allocvec(&row_value)
+        .map_err(|_| Error::InvalidStoredValue("aggregate result row encoding failed"))?;
+    aggregate_result_member_row_uuid(&ResultMemberEntry::Synthetic {
+        table: "aggregate_result".to_owned(),
+        row,
+        replacement: SyntheticReplacementToken::from_encoded_record(Vec::new()),
+    })
+}
+
+fn compare_order_values(left: &Value, right: &Value) -> Ordering {
+    match (left, right) {
+        (Value::U8(left), Value::U8(right)) => left.cmp(right),
+        (Value::U16(left), Value::U16(right)) => left.cmp(right),
+        (Value::U32(left), Value::U32(right)) => left.cmp(right),
+        (Value::U64(left), Value::U64(right)) => left.cmp(right),
+        (Value::I32(left), Value::I32(right)) => left.cmp(right),
+        (Value::I64(left), Value::I64(right)) => left.cmp(right),
+        (Value::F64(left), Value::F64(right)) => left.total_cmp(right),
+        (Value::Bool(left), Value::Bool(right)) => left.cmp(right),
+        (Value::String(left), Value::String(right)) => left.cmp(right),
+        (Value::Bytes(left), Value::Bytes(right)) => left.cmp(right),
+        (Value::Uuid(left), Value::Uuid(right)) => left.as_bytes().cmp(right.as_bytes()),
+        (Value::EnumTag(left), Value::EnumTag(right)) => left.cmp(right),
+        (Value::Tuple(left), Value::Tuple(right)) | (Value::Array(left), Value::Array(right)) => {
+            compare_order_value_slices(left, right)
+        }
+        (Value::Nullable(left), Value::Nullable(right)) => match (left, right) {
+            (Some(left), Some(right)) => compare_order_values(left, right),
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        },
+        _ => Ordering::Equal,
+    }
+}
+
+fn compare_order_value_slices(left: &[Value], right: &[Value]) -> Ordering {
+    for (left, right) in left.iter().zip(right) {
+        let ordering = compare_order_values(left, right);
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    left.len().cmp(&right.len())
+}


### PR DESCRIPTION
🤖 Mechanically extracts aggregate public-result shaping and ordering from the 19k-line query evaluator into a private 171-line module. No behavior or public API change.

Line count: query_eval.rs 19,241 → 19,087.

Verification:
- `cargo check -p jazz`
- aggregate subscription suite 11/11 active tests
- formatting/hooks
- independent review: no findings