### PR TITLE
dev: make focused Rust tests exact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@ Before writing any test in Rust crates, always read `crates/jazz/TESTING_GUIDELI
 
 **Builds:** `pnpm build:core` (all the packages), `pnpm test` (everything), via turbo.
 
+**Focused Rust tests:** use `dev/t`, rather than a raw filtered `cargo test`.
+It lists the selected `jazz` test target first, resolves one canonical Rust
+module-path name, and runs that name with `--exact`; a miss or an ambiguous
+filter is an error before any test run. For a library test, use
+`dev/t unique::module::test_name`; for an integration target, use
+`dev/t --test target_name unique::module::test_name`. The wrapper preserves the
+core gate's `-p jazz --no-default-features --features test` selection.
+
 **Canonical gates:** do not let born-red or rotted targets accumulate silently.
 For ordinary Rust/core work, the full gate set is:
 

--- a/CLEANUP.md
+++ b/CLEANUP.md
@@ -101,7 +101,8 @@ identities internally.
 - Avoid rerunning Rust differential binaries already selected by the workspace
   test run.
 - Add compiler caching for macOS and Windows release builds.
-- Make focused Rust commands fail when they execute zero tests.
+- [done] Make focused Rust commands resolve and run exactly one canonical test;
+  `dev/t` rejects zero or ambiguous matches before invoking the test runner.
 - Check generated-artifact provenance automatically at consumption time.
 - Bound browser logs and stop quickly on repeated infrastructure failures.
 

--- a/dev/gates/test/dev-t.test.sh
+++ b/dev/gates/test/dev-t.test.sh
@@ -33,7 +33,7 @@ run() {
 
 run db::tests::round
 grep -F -- '-p jazz --no-default-features --features test --lib -- --list' "$TEMP/cargo.log" >/dev/null
-grep -F -- '-p jazz --no-default-features --features test --lib db::tests::round --' "$TEMP/cargo.log" >/dev/null
+grep -F -- '-p jazz --no-default-features --features test --lib db::tests::round_trips -- --exact' "$TEMP/cargo.log" >/dev/null
 
 : >"$TEMP/cargo.log"
 run --exact db::tests::round_trips
@@ -45,8 +45,15 @@ if run --exact db::tests::round; then
 fi
 
 : >"$TEMP/cargo.log"
-if run missing_test; then
-  echo 'expected missing inventory match to fail before test run' >&2
+if run query::evaluate::wrong_path; then
+  echo 'expected plausible wrong module path to fail before test run' >&2
+  exit 1
+fi
+[[ "$(wc -l <"$TEMP/cargo.log")" -eq 1 ]]
+
+: >"$TEMP/cargo.log"
+if run db::tests; then
+  echo 'expected ambiguous test filter to fail before test run' >&2
   exit 1
 fi
 [[ "$(wc -l <"$TEMP/cargo.log")" -eq 1 ]]
@@ -54,7 +61,7 @@ fi
 : >"$TEMP/cargo.log"
 run --test incremental_delivery_canary maintained_relation -- --nocapture
 grep -F -- '--test incremental_delivery_canary -- --list' "$TEMP/cargo.log" >/dev/null
-grep -F -- '--test incremental_delivery_canary maintained_relation -- --nocapture' "$TEMP/cargo.log" >/dev/null
+grep -F -- '--test incremental_delivery_canary maintained_relation::smoke -- --nocapture --exact' "$TEMP/cargo.log" >/dev/null
 
 if MOCK_INVENTORY_STATUS=17 run round_trips; then
   echo 'expected inventory failure to be preserved' >&2

--- a/dev/t
+++ b/dev/t
@@ -12,9 +12,11 @@ usage() {
   cat >&2 <<'EOF'
 Usage: dev/t [--lib | --test TARGET] [--exact] FILTER [-- LIBTEST-OPTIONS...]
 
-Runs a focused Jazz test with -p jazz --no-default-features --features test.
-The default target is --lib.  --exact requires FILTER to be the fully-qualified
-test name reported by Cargo; without it FILTER is a substring.
+Runs exactly one focused Jazz test with -p jazz --no-default-features --features
+test. The default target is --lib. Cargo's --list inventory is authoritative:
+the wrapper resolves a unique canonical module-path test name from FILTER, then
+runs that resolved name with --exact. --exact requires FILTER itself to already
+be that full canonical name; without it FILTER is a literal substring.
 
 Examples:
   dev/t subscription::tests::reopens
@@ -129,12 +131,20 @@ if [[ -z "$matches" ]]; then
   exit 1
 fi
 match_count="$(printf '%s\n' "$matches" | grep -c . || true)"
+if ((match_count != 1)); then
+  echo "dev/t: filter must resolve exactly one test, but matched $match_count:" >&2
+  printf '%s\n' "$matches" >&2
+  echo "dev/t: use a longer module path or --exact with a canonical inventory name." >&2
+  exit 1
+fi
 printf 'dev/t: inventory matched %s test(s):\n%s\n' "$match_count" "$matches"
 
-run_args=(test "${cargo_args[@]}" "$filter" -- "${extra_args[@]}")
-if [[ "$exact" == true ]]; then
-  run_args+=(--exact)
-fi
+# Always execute the one canonical name selected from Cargo's own inventory.
+# This prevents Cargo's substring filter from silently broadening after a new
+# similarly named test is added, and makes a zero-test run impossible here.
+resolved_test="$matches"
+
+run_args=(test "${cargo_args[@]}" "$resolved_test" -- "${extra_args[@]}" --exact)
 printf 'dev/t: run command:'
 printf ' %q' cargo "${run_args[@]}"
 printf '\n'


### PR DESCRIPTION
🤖 Makes `dev/t` resolve exactly one canonical Cargo test identity before execution. Zero matches, plausible wrong module paths, and ambiguous filters now fail instead of silently running zero or many tests.

Verification:
- focused helper contract suite
- real exact run executes 1 test
- ambiguous real filter rejects 11 matches before execution
- plants removing `--exact`/ambiguity guard fail
- independent adversarial review: no findings