### PR TITLE
test: add binding codec golden contract

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -103,42 +103,6 @@ impl From<CoreOpenDbIdentity> for CoreDbIdentity {
 }
 
 #[derive(Clone, Debug, serde::Serialize)]
-struct CoreRowBatch<'a> {
-    table: &'a str,
-    descriptor: RecordDescriptor,
-    rows: Vec<CoreRow<'a>>,
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-struct CoreRow<'a> {
-    row_id: CoreRowUuid,
-    deleted: bool,
-    raw: &'a [u8],
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-struct CoreRelationSnapshot<'a> {
-    root_count: u64,
-    rows: Vec<CoreRowBatch<'a>>,
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-struct CoreSubscriptionDelta<'a> {
-    added: Vec<CoreRowBatch<'a>>,
-    updated: Vec<CoreRowBatch<'a>>,
-    removed: Vec<CoreRemovedRow>,
-    added_occurrence_keys: Vec<jazz::tools::ResultKey>,
-    updated_occurrence_keys: Vec<jazz::tools::ResultKey>,
-    removed_occurrence_keys: Vec<jazz::tools::ResultKey>,
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-struct CoreRemovedRow {
-    table: String,
-    row_id: CoreRowUuid,
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
 struct WriteResult {
     row_id: CoreRowUuid,
     tx_id: TxId,
@@ -2439,16 +2403,13 @@ fn optional_json_bool_prop(value: &JsonValue, name: &str) -> napi::Result<Option
 fn encode_core_rows(
     rows: &[jazz::node::CurrentRow],
 ) -> std::result::Result<Vec<u8>, postcard::Error> {
-    postcard::to_allocvec(&core_row_batches(rows))
+    jazz::binding_codec::encode_rows(rows)
 }
 
 fn encode_core_relation_snapshot(
     snapshot: &jazz::node::RelationSnapshot,
 ) -> std::result::Result<Vec<u8>, postcard::Error> {
-    postcard::to_allocvec(&CoreRelationSnapshot {
-        root_count: snapshot.root_count as u64,
-        rows: core_row_batches(&snapshot.rows),
-    })
+    jazz::binding_codec::encode_relation_snapshot(snapshot)
 }
 
 fn encode_core_subscription_delta<'a>(
@@ -2456,60 +2417,7 @@ fn encode_core_subscription_delta<'a>(
     updated: &'a [jazz::db::SubscriptionOutputRow],
     removed: &[jazz::db::RemovedRow],
 ) -> std::result::Result<Vec<u8>, postcard::Error> {
-    let added_rows = added.iter().map(|row| row.row.clone()).collect::<Vec<_>>();
-    let updated_rows = updated
-        .iter()
-        .map(|row| row.row.clone())
-        .collect::<Vec<_>>();
-    postcard::to_allocvec(&CoreSubscriptionDelta {
-        added: core_row_batches(&added_rows),
-        updated: core_row_batches(&updated_rows),
-        removed: removed
-            .iter()
-            .map(|row| CoreRemovedRow {
-                table: row.table.clone(),
-                row_id: row.row_uuid,
-            })
-            .collect(),
-        added_occurrence_keys: added
-            .iter()
-            .map(|row| jazz::tools::ResultKey::from_occurrence(row.occurrence_id.clone()))
-            .collect(),
-        updated_occurrence_keys: updated
-            .iter()
-            .map(|row| jazz::tools::ResultKey::from_occurrence(row.occurrence_id.clone()))
-            .collect(),
-        removed_occurrence_keys: removed
-            .iter()
-            .map(|row| jazz::tools::ResultKey::from_occurrence(row.occurrence_id.clone()))
-            .collect(),
-    })
-}
-
-fn core_row_batches(rows: &[jazz::node::CurrentRow]) -> Vec<CoreRowBatch<'_>> {
-    let mut batches: Vec<CoreRowBatch<'_>> = Vec::new();
-    for row in rows {
-        let (descriptor, raw) = row.encoded_record();
-        match batches.last_mut() {
-            Some(batch) if batch.table == row.table() && batch.descriptor == *descriptor => {
-                batch.rows.push(core_row(row, raw));
-            }
-            _ => batches.push(CoreRowBatch {
-                table: row.table(),
-                descriptor: *descriptor,
-                rows: vec![core_row(row, raw)],
-            }),
-        }
-    }
-    batches
-}
-
-fn core_row<'a>(row: &jazz::node::CurrentRow, raw: &'a [u8]) -> CoreRow<'a> {
-    CoreRow {
-        row_id: row.row_uuid(),
-        deleted: row.is_deleted(),
-        raw,
-    }
+    jazz::binding_codec::encode_subscription_delta(added, updated, removed)
 }
 
 fn core_subscription_event_to_napi(

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -182,42 +182,6 @@ impl From<WasmDbIdentity> for DbIdentity {
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct WasmRowBatch<'a> {
-    table: &'a str,
-    descriptor: RecordDescriptor,
-    rows: Vec<WasmRow<'a>>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct WasmRow<'a> {
-    row_id: RowUuid,
-    deleted: bool,
-    raw: &'a [u8],
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct WasmRelationSnapshot<'a> {
-    root_count: u64,
-    rows: Vec<WasmRowBatch<'a>>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct WasmSubscriptionDelta<'a> {
-    added: Vec<WasmRowBatch<'a>>,
-    updated: Vec<WasmRowBatch<'a>>,
-    removed: Vec<WasmRemovedRow>,
-    added_occurrence_keys: Vec<jazz::tools::ResultKey>,
-    updated_occurrence_keys: Vec<jazz::tools::ResultKey>,
-    removed_occurrence_keys: Vec<jazz::tools::ResultKey>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct WasmRemovedRow {
-    table: String,
-    row_id: RowUuid,
-}
-
-#[derive(Clone, Debug, Serialize)]
 pub struct WasmWriteResult {
     row_id: RowUuid,
     tx_id: jazz::tx::TxId,
@@ -2644,16 +2608,13 @@ fn optional_bool_prop(value: &JsValue, name: &str) -> Result<Option<bool>, JsVal
 }
 
 fn encode_rows(rows: &[jazz::node::CurrentRow]) -> Result<Vec<u8>, postcard::Error> {
-    postcard::to_allocvec(&row_batches(rows))
+    jazz::binding_codec::encode_rows(rows)
 }
 
 fn encode_relation_snapshot(
     snapshot: &jazz::node::RelationSnapshot,
 ) -> Result<Vec<u8>, postcard::Error> {
-    postcard::to_allocvec(&WasmRelationSnapshot {
-        root_count: snapshot.root_count as u64,
-        rows: row_batches(&snapshot.rows),
-    })
+    jazz::binding_codec::encode_relation_snapshot(snapshot)
 }
 
 fn encode_subscription_delta<'a>(
@@ -2661,60 +2622,7 @@ fn encode_subscription_delta<'a>(
     updated: &'a [jazz::db::SubscriptionOutputRow],
     removed: &[jazz::db::RemovedRow],
 ) -> Result<Vec<u8>, postcard::Error> {
-    let added_rows = added.iter().map(|row| row.row.clone()).collect::<Vec<_>>();
-    let updated_rows = updated
-        .iter()
-        .map(|row| row.row.clone())
-        .collect::<Vec<_>>();
-    postcard::to_allocvec(&WasmSubscriptionDelta {
-        added: row_batches(&added_rows),
-        updated: row_batches(&updated_rows),
-        removed: removed
-            .iter()
-            .map(|row| WasmRemovedRow {
-                table: row.table.clone(),
-                row_id: row.row_uuid,
-            })
-            .collect(),
-        added_occurrence_keys: added
-            .iter()
-            .map(|row| jazz::tools::ResultKey::from_occurrence(row.occurrence_id.clone()))
-            .collect(),
-        updated_occurrence_keys: updated
-            .iter()
-            .map(|row| jazz::tools::ResultKey::from_occurrence(row.occurrence_id.clone()))
-            .collect(),
-        removed_occurrence_keys: removed
-            .iter()
-            .map(|row| jazz::tools::ResultKey::from_occurrence(row.occurrence_id.clone()))
-            .collect(),
-    })
-}
-
-fn row_batches(rows: &[jazz::node::CurrentRow]) -> Vec<WasmRowBatch<'_>> {
-    let mut batches: Vec<WasmRowBatch<'_>> = Vec::new();
-    for row in rows {
-        let (descriptor, raw) = row.encoded_record();
-        match batches.last_mut() {
-            Some(batch) if batch.table == row.table() && batch.descriptor == *descriptor => {
-                batch.rows.push(wasm_row(row, raw));
-            }
-            _ => batches.push(WasmRowBatch {
-                table: row.table(),
-                descriptor: *descriptor,
-                rows: vec![wasm_row(row, raw)],
-            }),
-        }
-    }
-    batches
-}
-
-fn wasm_row<'a>(row: &jazz::node::CurrentRow, raw: &'a [u8]) -> WasmRow<'a> {
-    WasmRow {
-        row_id: row.row_uuid(),
-        deleted: row.is_deleted(),
-        raw,
-    }
+    jazz::binding_codec::encode_subscription_delta(added, updated, removed)
 }
 
 fn subscription_stream_to_js(
@@ -2759,6 +2667,19 @@ fn subscription_chunk_to_js(
                     ));
                 }
             }
+            let terminal_layout_id = if terminal_operations.is_empty() {
+                ""
+            } else {
+                terminal_layout
+                    .as_ref()
+                    .ok_or_else(|| {
+                        JsValue::from_str(
+                            "terminal operation arrived without a prepared root layout",
+                        )
+                    })?
+                    .id
+                    .as_str()
+            };
             set_prop(&object, "type", JsValue::from_str("delta"))?;
             set_prop(
                 &object,
@@ -2768,10 +2689,11 @@ fn subscription_chunk_to_js(
             set_prop(
                 &object,
                 "terminalOperations",
-                terminal_operations_to_json(
+                jazz::binding_codec::terminal_operations_to_json(
                     &terminal_operations,
-                    terminal_layout.as_ref().map(|layout| layout.id.as_str()),
-                )?
+                    terminal_layout_id,
+                )
+                .map_err(to_js_error)?
                 .serialize(&serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true))
                 .map_err(to_js_error)?,
             )?;
@@ -2783,7 +2705,9 @@ fn subscription_chunk_to_js(
                 })?;
                 published_terminal_layouts
                     .insert(layout.id.clone())
-                    .then(|| terminal_layout_to_json(layout))
+                    .then(|| {
+                        jazz::binding_codec::terminal_layout_to_json(layout).map_err(to_js_error)
+                    })
                     .transpose()?
                     .into_iter()
                     .collect()
@@ -2840,62 +2764,6 @@ fn subscription_chunk_to_js(
         }
     };
     Ok(object.into())
-}
-
-/// Encode each terminal operation with the exact descriptor of its root
-/// payload.  Terminal bytes may be either logical output rows or nullable
-/// CurrentRow carriers, so consumers must not reconstruct this layout from a
-/// query projection.
-fn terminal_operations_to_json(
-    operations: &[jazz::groove::ivm::TerminalOperation],
-    root_layout_id: Option<&str>,
-) -> Result<serde_json::Value, JsValue> {
-    let mut encoded = serde_json::to_value(operations).map_err(to_js_error)?;
-    if operations.is_empty() {
-        return Ok(encoded);
-    }
-    let root_layout_id = root_layout_id.ok_or_else(|| {
-        JsValue::from_str("terminal operation arrived without a prepared root layout")
-    })?;
-    let encoded_operations = encoded
-        .as_array_mut()
-        .expect("terminal operations serialize as an array");
-    for wire in encoded_operations {
-        let serde_json::Value::Object(wire) = wire else {
-            unreachable!("terminal operation serializes as an object");
-        };
-        wire.remove("root_descriptor");
-        wire.insert(
-            "rootLayoutId".to_owned(),
-            serde_json::Value::String(root_layout_id.to_owned()),
-        );
-    }
-    Ok(encoded)
-}
-
-fn terminal_layout_to_json(
-    layout: &jazz::db::TerminalRootLayout,
-) -> Result<serde_json::Value, JsValue> {
-    let descriptor = postcard::to_allocvec(&layout.root_descriptor).map_err(to_js_error)?;
-    Ok(serde_json::json!({
-        "id": layout.id,
-        "rootDescriptor": descriptor,
-        "rootKeySlot": layout.root_key_slot,
-        "rootKeyFieldName": layout.root_key_field_name,
-        "publicFields": layout.public_fields.iter().map(|field| serde_json::json!({
-            "name": field.name,
-            "descriptorFieldName": field.descriptor_field_name,
-            "slot": field.slot,
-            "carrier": match field.carrier {
-                jazz::db::TerminalRootCarrier::CurrentRow => "CurrentRow",
-                jazz::db::TerminalRootCarrier::Logical => "Logical",
-            },
-        })).collect::<Vec<_>>(),
-        "carrier": match layout.carrier {
-            jazz::db::TerminalRootCarrier::CurrentRow => "CurrentRow",
-            jazz::db::TerminalRootCarrier::Logical => "Logical",
-        },
-    }))
 }
 
 fn set_prop(object: &js_sys::Object, name: &str, value: JsValue) -> Result<(), JsValue> {

--- a/crates/jazz/fixtures/binding_codec_golden.json
+++ b/crates/jazz/fixtures/binding_codec_golden.json
@@ -1,0 +1,158 @@
+{
+  "format": "jazz-binding-codec-golden-v1",
+  "relation_snapshots": [
+    {
+      "name": "empty_root_count_zero",
+      "payload_hex": "0000"
+    },
+    {
+      "name": "adjacent_and_nonadjacent_batches_with_deleted_row",
+      "payload_hex": "040305746f646f73020108726f775f757569640a010a757365725f7469746c650e080210111111111111111111111111111111110016111111111111111111111111111111110166697273741012121212121212121212121212121212001712121212121212121212121212121212017365636f6e64056e6f746573020108726f775f757569640a01057469746c65080110212121212121212121212121212121210014212121212121212121212121212121216e6f746505746f646f73020108726f775f757569640a010a757365725f7469746c650e0801101313131313131313131313131313131301111313131313131313131313131313131300"
+    }
+  ],
+  "subscription_deltas": [
+    {
+      "name": "added_updated_removed_with_v1_and_v2_occurrence_keys",
+      "payload_hex": "0105746f646f73020108726f775f757569640a010a757365725f7469746c650e0801101111111111111111111111111111111100161111111111111111111111111111111101666972737401056e6f746573020108726f775f757569640a01057469746c65080110212121212121212121212121212121210014212121212121212121212121212121216e6f74650105746f646f731013131313131313131313131313131313011101a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1013c02b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b100000001b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b200000001000000000000000b6d6174636865642d61726d013c02b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b100000001b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b200000001000000000000000b6d6174636865642d61726d"
+    }
+  ],
+  "terminal": {
+    "events": [
+      {
+        "terminalLayouts": [
+          {
+            "carrier": "CurrentRow",
+            "id": "current-row-v1",
+            "publicFields": [
+              {
+                "carrier": "CurrentRow",
+                "descriptorFieldName": "user_title",
+                "name": "title",
+                "slot": 1
+              }
+            ],
+            "rootDescriptor": [
+              2, 1, 8, 114, 111, 119, 95, 117, 117, 105, 100, 10, 1, 10, 117, 115, 101, 114, 95,
+              116, 105, 116, 108, 101, 14, 8
+            ],
+            "rootKeyFieldName": "row_uuid",
+            "rootKeySlot": 0
+          }
+        ],
+        "terminalOperations": [
+          {
+            "edit": {
+              "Insert": {
+                "index": 0,
+                "key": [10, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17],
+                "value": [
+                  17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 1, 102, 105, 114,
+                  115, 116
+                ]
+              }
+            },
+            "path": [],
+            "rootLayoutId": "current-row-v1",
+            "root_key": [10, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17]
+          }
+        ],
+        "type": "delta"
+      },
+      {
+        "terminalLayouts": [
+          {
+            "carrier": "Logical",
+            "id": "logical-v1",
+            "publicFields": [
+              {
+                "carrier": "Logical",
+                "descriptorFieldName": "title",
+                "name": "title",
+                "slot": 1
+              }
+            ],
+            "rootDescriptor": [
+              2, 1, 8, 114, 111, 119, 95, 117, 117, 105, 100, 10, 1, 5, 116, 105, 116, 108, 101, 8
+            ],
+            "rootKeyFieldName": "row_uuid",
+            "rootKeySlot": 0
+          }
+        ],
+        "terminalOperations": [
+          {
+            "edit": {
+              "Insert": {
+                "index": 0,
+                "key": [10, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33],
+                "value": [
+                  33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 110, 111, 116, 101
+                ]
+              }
+            },
+            "path": [],
+            "rootLayoutId": "logical-v1",
+            "root_key": [10, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33]
+          }
+        ],
+        "type": "delta"
+      },
+      {
+        "terminalLayouts": [],
+        "terminalOperations": [
+          {
+            "edit": {
+              "Update": {
+                "key": [10, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17],
+                "value": [
+                  17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 1, 117, 112, 100,
+                  97, 116, 101, 100
+                ]
+              }
+            },
+            "path": [],
+            "rootLayoutId": "current-row-v1",
+            "root_key": [10, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17]
+          }
+        ],
+        "type": "delta"
+      },
+      {
+        "terminalLayouts": [],
+        "terminalOperations": [
+          {
+            "edit": {
+              "Move": {
+                "index": 1,
+                "key": [10, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33]
+              }
+            },
+            "path": [],
+            "rootLayoutId": "logical-v1",
+            "root_key": [10, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33]
+          },
+          {
+            "edit": {
+              "Remove": {
+                "key": [10, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33]
+              }
+            },
+            "path": [],
+            "rootLayoutId": "logical-v1",
+            "root_key": [10, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33]
+          }
+        ],
+        "type": "delta"
+      }
+    ],
+    "rejections": [
+      {
+        "detail": "terminal layout missing",
+        "type": "UnsupportedShapeCapability"
+      },
+      {
+        "code": "TableNotFound",
+        "type": "ServerFailure"
+      }
+    ]
+  }
+}

--- a/crates/jazz/src/binding_codec.rs
+++ b/crates/jazz/src/binding_codec.rs
@@ -1,0 +1,199 @@
+//! Binary row payloads shared by the NAPI and WASM bindings.
+//!
+//! The JavaScript hosts differ only after this boundary.  Keeping the postcard
+//! envelope here makes row batching, relation snapshots, and occurrence-key
+//! sidecars one production contract rather than two lookalike serializers.
+
+use serde::Serialize;
+
+use crate::db::{RemovedRow, SubscriptionOutputRow, TerminalRootCarrier, TerminalRootLayout};
+use crate::ids::RowUuid;
+use crate::node::{CurrentRow, RelationSnapshot};
+use crate::tools::ResultKey;
+use groove::ivm::TerminalOperation;
+use groove::records::RecordDescriptor;
+
+/// A contiguous run of rows with one table and physical record descriptor.
+#[derive(Clone, Debug, Serialize)]
+pub struct RowBatch<'a> {
+    /// Logical table name.
+    pub table: &'a str,
+    /// Exact descriptor required to decode `rows.raw`.
+    pub descriptor: RecordDescriptor,
+    /// Rows in producer order.
+    pub rows: Vec<Row<'a>>,
+}
+
+/// One packed row inside a [`RowBatch`].
+#[derive(Clone, Debug, Serialize)]
+pub struct Row<'a> {
+    /// Stable source row identity.
+    pub row_id: RowUuid,
+    /// Whether the row is an opt-in deleted historical row.
+    pub deleted: bool,
+    /// Packed record bytes described by the enclosing batch.
+    pub raw: &'a [u8],
+}
+
+/// Relation snapshot envelope used by both native hosts.
+#[derive(Clone, Debug, Serialize)]
+pub struct RelationSnapshotPayload<'a> {
+    /// Number of root rows at the beginning of the flattened batch sequence.
+    pub root_count: u64,
+    /// Root and related rows in producer order.
+    pub rows: Vec<RowBatch<'a>>,
+}
+
+/// Incremental subscription envelope used by both native hosts.
+#[derive(Clone, Debug, Serialize)]
+pub struct SubscriptionDeltaPayload<'a> {
+    /// Newly visible rows.
+    pub added: Vec<RowBatch<'a>>,
+    /// Still-visible rows with changed bytes.
+    pub updated: Vec<RowBatch<'a>>,
+    /// Rows no longer visible.
+    pub removed: Vec<RemovedRowPayload>,
+    /// One opaque occurrence key per added row.
+    pub added_occurrence_keys: Vec<ResultKey>,
+    /// One opaque occurrence key per updated row.
+    pub updated_occurrence_keys: Vec<ResultKey>,
+    /// One opaque occurrence key per removed row.
+    pub removed_occurrence_keys: Vec<ResultKey>,
+}
+
+/// Removed-row wire identity.
+#[derive(Clone, Debug, Serialize)]
+pub struct RemovedRowPayload {
+    /// Logical table name.
+    pub table: String,
+    /// Stable source row identity.
+    pub row_id: RowUuid,
+}
+
+/// Encode a flat row sequence, preserving contiguous batch boundaries.
+pub fn encode_rows(rows: &[CurrentRow]) -> Result<Vec<u8>, postcard::Error> {
+    postcard::to_allocvec(&row_batches(rows))
+}
+
+/// Encode a relation snapshot.
+pub fn encode_relation_snapshot(snapshot: &RelationSnapshot) -> Result<Vec<u8>, postcard::Error> {
+    postcard::to_allocvec(&RelationSnapshotPayload {
+        root_count: snapshot.root_count as u64,
+        rows: row_batches(&snapshot.rows),
+    })
+}
+
+/// Encode an incremental subscription delta with aligned occurrence sidecars.
+pub fn encode_subscription_delta(
+    added: &[SubscriptionOutputRow],
+    updated: &[SubscriptionOutputRow],
+    removed: &[RemovedRow],
+) -> Result<Vec<u8>, postcard::Error> {
+    let added_rows = added.iter().map(|row| row.row.clone()).collect::<Vec<_>>();
+    let updated_rows = updated
+        .iter()
+        .map(|row| row.row.clone())
+        .collect::<Vec<_>>();
+    postcard::to_allocvec(&SubscriptionDeltaPayload {
+        added: row_batches(&added_rows),
+        updated: row_batches(&updated_rows),
+        removed: removed
+            .iter()
+            .map(|row| RemovedRowPayload {
+                table: row.table.clone(),
+                row_id: row.row_uuid,
+            })
+            .collect(),
+        added_occurrence_keys: added
+            .iter()
+            .map(|row| ResultKey::from_occurrence(row.occurrence_id.clone()))
+            .collect(),
+        updated_occurrence_keys: updated
+            .iter()
+            .map(|row| ResultKey::from_occurrence(row.occurrence_id.clone()))
+            .collect(),
+        removed_occurrence_keys: removed
+            .iter()
+            .map(|row| ResultKey::from_occurrence(row.occurrence_id.clone()))
+            .collect(),
+    })
+}
+
+/// Group only adjacent rows with equal table and descriptor.
+pub fn row_batches(rows: &[CurrentRow]) -> Vec<RowBatch<'_>> {
+    let mut batches: Vec<RowBatch<'_>> = Vec::new();
+    for row in rows {
+        let (descriptor, raw) = row.encoded_record();
+        match batches.last_mut() {
+            Some(batch) if batch.table == row.table() && batch.descriptor == *descriptor => {
+                batch.rows.push(Row {
+                    row_id: row.row_uuid(),
+                    deleted: row.is_deleted(),
+                    raw,
+                });
+            }
+            _ => batches.push(RowBatch {
+                table: row.table(),
+                descriptor: descriptor.clone(),
+                rows: vec![Row {
+                    row_id: row.row_uuid(),
+                    deleted: row.is_deleted(),
+                    raw,
+                }],
+            }),
+        }
+    }
+    batches
+}
+
+/// Encode a terminal root layout in the JavaScript-native object shape.
+pub fn terminal_layout_to_json(
+    layout: &TerminalRootLayout,
+) -> Result<serde_json::Value, postcard::Error> {
+    let descriptor = postcard::to_allocvec(&layout.root_descriptor)?;
+    Ok(serde_json::json!({
+        "id": layout.id,
+        "rootDescriptor": descriptor,
+        "rootKeySlot": layout.root_key_slot,
+        "rootKeyFieldName": layout.root_key_field_name,
+        "publicFields": layout.public_fields.iter().map(|field| serde_json::json!({
+            "name": field.name,
+            "descriptorFieldName": field.descriptor_field_name,
+            "slot": field.slot,
+            "carrier": terminal_carrier_name(field.carrier),
+        })).collect::<Vec<_>>(),
+        "carrier": terminal_carrier_name(layout.carrier),
+    }))
+}
+
+/// Encode terminal operations in the JavaScript-native object shape.
+pub fn terminal_operations_to_json(
+    operations: &[TerminalOperation],
+    root_layout_id: &str,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let mut encoded = serde_json::to_value(operations)?;
+    if operations.is_empty() {
+        return Ok(encoded);
+    }
+    let encoded_operations = encoded
+        .as_array_mut()
+        .expect("terminal operations serialize as an array");
+    for wire in encoded_operations {
+        let serde_json::Value::Object(wire) = wire else {
+            unreachable!("terminal operation serializes as an object");
+        };
+        wire.remove("root_descriptor");
+        wire.insert(
+            "rootLayoutId".to_owned(),
+            serde_json::Value::String(root_layout_id.to_owned()),
+        );
+    }
+    Ok(encoded)
+}
+
+fn terminal_carrier_name(carrier: TerminalRootCarrier) -> &'static str {
+    match carrier {
+        TerminalRootCarrier::CurrentRow => "CurrentRow",
+        TerminalRootCarrier::Logical => "Logical",
+    }
+}

--- a/crates/jazz/src/lib.rs
+++ b/crates/jazz/src/lib.rs
@@ -99,6 +99,8 @@ pub use groove;
 
 /// Shared, fail-closed state for authority-issued authorization-scope receipts.
 pub mod authorization_scope;
+/// Shared binary row payload contract for the NAPI and WASM bindings.
+pub mod binding_codec;
 
 /// Disabled-by-default counters used by the native cold-settle attribution bench.
 #[cfg(feature = "cold-settle-attribution")]

--- a/crates/jazz/tests/wire_fixtures.rs
+++ b/crates/jazz/tests/wire_fixtures.rs
@@ -3,6 +3,9 @@ use std::collections::BTreeMap;
 use groove::ivm::{TerminalEdit, TerminalOperation, TerminalPathSegment};
 use groove::records::{RecordDescriptor, Value, ValueType};
 use groove::schema::ColumnType;
+use jazz::binding_codec::{
+    RelationSnapshotPayload, RemovedRowPayload, Row, RowBatch, SubscriptionDeltaPayload,
+};
 use jazz::ids::{AuthorId, BranchId, MigrationLensId, NodeUuid, RowUuid, SchemaVersionId};
 use jazz::node::content_store::Extent;
 use jazz::protocol::{
@@ -18,6 +21,7 @@ use jazz::query::{
 };
 use jazz::schema::{ColumnSchema, JazzSchema, TableSchema};
 use jazz::time::{GlobalSeq, TxTime};
+use jazz::tools::{ObjectId, ResultKey};
 use jazz::tx::{DurabilityTier, Fate, Transaction, TxId, TxKind};
 use jazz::wire::{
     FEATURE_SYNC_MESSAGE_PAYLOAD, WIRE_PROTOCOL_VERSION, WireEnvelope, WireFrame,
@@ -36,6 +40,10 @@ const NATIVE_ROW_CODEC_FIXTURE_PATH: &str = concat!(
 const NATIVE_QUERY_CODEC_FIXTURE_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/fixtures/native_query_codec.json"
+);
+const BINDING_CODEC_GOLDEN_FIXTURE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/fixtures/binding_codec_golden.json"
 );
 
 #[derive(Serialize)]
@@ -75,6 +83,30 @@ struct NativeRowCodecField {
     name: String,
     encoded_hex: String,
     decoded_hex: Option<String>,
+}
+
+/// Rust owns this fixture because the concrete wire values are emitted by the
+/// native Rust bindings.  NAPI and WASM intentionally have duplicate adapter
+/// structs today; TypeScript consumes these bytes too.  Keep the compact
+/// binary cases here until those adapters share one production encoder.
+#[derive(Deserialize, Serialize)]
+struct BindingCodecGoldenFixture {
+    format: String,
+    relation_snapshots: Vec<BindingCodecGoldenBinaryCase>,
+    subscription_deltas: Vec<BindingCodecGoldenBinaryCase>,
+    terminal: BindingCodecGoldenTerminal,
+}
+
+#[derive(Deserialize, Serialize)]
+struct BindingCodecGoldenBinaryCase {
+    name: String,
+    payload_hex: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct BindingCodecGoldenTerminal {
+    events: serde_json::Value,
+    rejections: serde_json::Value,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -758,6 +790,292 @@ fn native_query_codec_fixture_round_trips_relation_shapes() {
             decoded, expected,
             "{name} fixture decodes to the expected query"
         );
+    }
+}
+
+// The native NAPI and WASM bindings currently own duplicate postcard adapter
+// structs.  This fixture freezes their common byte contract before the later
+// extraction makes them thin adapters.  It is intentionally lower-level than
+// a public DB test: the thing under test is the binding representation itself.
+#[test]
+fn binding_codec_golden_fixture_is_current() {
+    let actual = binding_codec_golden_fixture();
+
+    if std::env::var_os("JAZZ_UPDATE_BINDING_CODEC_GOLDENS").is_some() {
+        std::fs::write(
+            BINDING_CODEC_GOLDEN_FIXTURE_PATH,
+            serde_json::to_string_pretty(&actual).expect("binding codec fixture serializes") + "\n",
+        )
+        .expect("binding codec fixture writes");
+        return;
+    }
+
+    let expected = include_str!("../fixtures/binding_codec_golden.json");
+    // `oxfmt` owns JSON whitespace and deliberately compacts short byte
+    // arrays. The fixture contract is its parsed, ordered JSON value; compare
+    // that value so the explicit Rust updater and the repository formatter can
+    // both be canonical without creating a born-red formatting loop.
+    let expected: serde_json::Value =
+        serde_json::from_str(expected).expect("binding codec fixture parses");
+    assert_eq!(
+        serde_json::to_value(actual).expect("binding codec fixture value serializes"),
+        expected,
+        "binding codec goldens changed; review the NAPI/WASM compatibility contract and run \\
+         `JAZZ_UPDATE_BINDING_CODEC_GOLDENS=1 cargo test -p jazz --test wire_fixtures \\
+         binding_codec_golden_fixture_is_current -- --exact` to accept"
+    );
+}
+
+fn binding_codec_golden_fixture() -> BindingCodecGoldenFixture {
+    use groove::records::Value;
+
+    let current_descriptor = RecordDescriptor::new([
+        ("row_uuid", ValueType::Uuid),
+        (
+            "user_title",
+            ValueType::Nullable(Box::new(ValueType::String)),
+        ),
+    ]);
+    let logical_descriptor =
+        RecordDescriptor::new([("row_uuid", ValueType::Uuid), ("title", ValueType::String)]);
+    let todo_one_id = RowUuid::from_bytes([0x11; 16]);
+    let todo_two_id = RowUuid::from_bytes([0x12; 16]);
+    let note_id = RowUuid::from_bytes([0x21; 16]);
+    let deleted_todo_id = RowUuid::from_bytes([0x13; 16]);
+    let todo_one = current_descriptor
+        .create(&[
+            Value::Uuid(todo_one_id.0),
+            Value::Nullable(Some(Box::new(Value::String("first".to_owned())))),
+        ])
+        .expect("golden current row encodes");
+    let todo_two = current_descriptor
+        .create(&[
+            Value::Uuid(todo_two_id.0),
+            Value::Nullable(Some(Box::new(Value::String("second".to_owned())))),
+        ])
+        .expect("golden current row encodes");
+    let todo_updated = current_descriptor
+        .create(&[
+            Value::Uuid(todo_one_id.0),
+            Value::Nullable(Some(Box::new(Value::String("updated".to_owned())))),
+        ])
+        .expect("golden updated row encodes");
+    let note = logical_descriptor
+        .create(&[Value::Uuid(note_id.0), Value::String("note".to_owned())])
+        .expect("golden logical row encodes");
+    let deleted_todo = current_descriptor
+        .create(&[Value::Uuid(deleted_todo_id.0), Value::Nullable(None)])
+        .expect("golden deleted row encodes");
+
+    let empty_snapshot = RelationSnapshotPayload {
+        root_count: 0,
+        rows: Vec::new(),
+    };
+    let batching_snapshot = RelationSnapshotPayload {
+        root_count: 4,
+        rows: vec![
+            RowBatch {
+                table: "todos",
+                descriptor: current_descriptor.clone(),
+                rows: vec![
+                    Row {
+                        row_id: todo_one_id,
+                        deleted: false,
+                        raw: &todo_one,
+                    },
+                    Row {
+                        row_id: todo_two_id,
+                        deleted: false,
+                        raw: &todo_two,
+                    },
+                ],
+            },
+            RowBatch {
+                table: "notes",
+                descriptor: logical_descriptor.clone(),
+                rows: vec![Row {
+                    row_id: note_id,
+                    deleted: false,
+                    raw: &note,
+                }],
+            },
+            // Batching is contiguous only: returning to `todos` after `notes`
+            // must create a new batch, even though its descriptor is identical.
+            RowBatch {
+                table: "todos",
+                descriptor: current_descriptor.clone(),
+                rows: vec![Row {
+                    row_id: deleted_todo_id,
+                    deleted: true,
+                    raw: &deleted_todo,
+                }],
+            },
+        ],
+    };
+    let v1 = ResultKey::from(ObjectId::from_uuid(uuid::Uuid::from_bytes([0xa1; 16])));
+    let v2 = ResultKey::from_union_occurrence(
+        ObjectId::from_uuid(uuid::Uuid::from_bytes([0xb1; 16])),
+        [ObjectId::from_uuid(uuid::Uuid::from_bytes([0xb2; 16]))],
+        [(0, "matched-arm".to_owned())],
+    )
+    .expect("typed golden occurrence is valid");
+    let delta = SubscriptionDeltaPayload {
+        added: vec![RowBatch {
+            table: "todos",
+            descriptor: current_descriptor.clone(),
+            rows: vec![Row {
+                row_id: todo_one_id,
+                deleted: false,
+                raw: &todo_one,
+            }],
+        }],
+        updated: vec![RowBatch {
+            table: "notes",
+            descriptor: logical_descriptor.clone(),
+            rows: vec![Row {
+                row_id: note_id,
+                deleted: false,
+                raw: &note,
+            }],
+        }],
+        removed: vec![RemovedRowPayload {
+            table: "todos".to_owned(),
+            row_id: deleted_todo_id,
+        }],
+        added_occurrence_keys: vec![v1],
+        updated_occurrence_keys: vec![v2.clone()],
+        removed_occurrence_keys: vec![v2],
+    };
+
+    let current_layout = jazz::db::TerminalRootLayout {
+        id: "current-row-v1".to_owned(),
+        root_descriptor: current_descriptor.clone(),
+        root_key_slot: 0,
+        root_key_field_name: "row_uuid".to_owned(),
+        public_fields: vec![jazz::db::TerminalRootPublicField {
+            name: "title".to_owned(),
+            descriptor_field_name: "user_title".to_owned(),
+            slot: 1,
+            carrier: jazz::db::TerminalRootCarrier::CurrentRow,
+        }],
+        carrier: jazz::db::TerminalRootCarrier::CurrentRow,
+    };
+    let logical_layout = jazz::db::TerminalRootLayout {
+        id: "logical-v1".to_owned(),
+        root_descriptor: logical_descriptor.clone(),
+        root_key_slot: 0,
+        root_key_field_name: "row_uuid".to_owned(),
+        public_fields: vec![jazz::db::TerminalRootPublicField {
+            name: "title".to_owned(),
+            descriptor_field_name: "title".to_owned(),
+            slot: 1,
+            carrier: jazz::db::TerminalRootCarrier::Logical,
+        }],
+        carrier: jazz::db::TerminalRootCarrier::Logical,
+    };
+    let current_key = std::iter::once(10)
+        .chain(todo_one_id.0.as_bytes().iter().copied())
+        .collect::<Vec<_>>();
+    let logical_key = std::iter::once(10)
+        .chain(note_id.0.as_bytes().iter().copied())
+        .collect::<Vec<_>>();
+    let current_insert = TerminalOperation {
+        root_descriptor: current_descriptor.clone(),
+        root_key: current_key.clone(),
+        path: Vec::new(),
+        edit: TerminalEdit::Insert {
+            index: 0,
+            key: current_key.clone(),
+            value: todo_one.clone(),
+        },
+    };
+    let logical_insert = TerminalOperation {
+        root_descriptor: logical_descriptor.clone(),
+        root_key: logical_key.clone(),
+        path: Vec::new(),
+        edit: TerminalEdit::Insert {
+            index: 0,
+            key: logical_key.clone(),
+            value: note.clone(),
+        },
+    };
+    let current_update = TerminalOperation {
+        root_descriptor: current_descriptor.clone(),
+        root_key: current_key.clone(),
+        path: Vec::new(),
+        edit: TerminalEdit::Update {
+            key: current_key.clone(),
+            value: todo_updated,
+        },
+    };
+    let logical_remove = TerminalOperation {
+        root_descriptor: logical_descriptor.clone(),
+        root_key: logical_key.clone(),
+        path: Vec::new(),
+        edit: TerminalEdit::Remove {
+            key: logical_key.clone(),
+        },
+    };
+    let logical_move = TerminalOperation {
+        root_descriptor: logical_descriptor,
+        root_key: logical_key.clone(),
+        path: Vec::new(),
+        edit: TerminalEdit::Move {
+            key: logical_key,
+            index: 1,
+        },
+    };
+    BindingCodecGoldenFixture {
+        format: "jazz-binding-codec-golden-v1".to_owned(),
+        relation_snapshots: vec![
+            BindingCodecGoldenBinaryCase {
+                name: "empty_root_count_zero".to_owned(),
+                payload_hex: hex(
+                    &postcard::to_allocvec(&empty_snapshot).expect("empty snapshot encodes")
+                ),
+            },
+            BindingCodecGoldenBinaryCase {
+                name: "adjacent_and_nonadjacent_batches_with_deleted_row".to_owned(),
+                payload_hex: hex(
+                    &postcard::to_allocvec(&batching_snapshot).expect("snapshot encodes")
+                ),
+            },
+        ],
+        subscription_deltas: vec![BindingCodecGoldenBinaryCase {
+            name: "added_updated_removed_with_v1_and_v2_occurrence_keys".to_owned(),
+            payload_hex: hex(&postcard::to_allocvec(&delta).expect("subscription delta encodes")),
+        }],
+        terminal: BindingCodecGoldenTerminal {
+            // These are the exact NAPI/WASM event field names.  Publication is
+            // represented by a non-empty `terminalLayouts` list, not an
+            // invented flag on a layout object.
+            events: serde_json::json!([
+                {
+                    "type": "delta",
+                    "terminalLayouts": [jazz::binding_codec::terminal_layout_to_json(&current_layout).expect("current layout encodes")],
+                    "terminalOperations": jazz::binding_codec::terminal_operations_to_json(&[current_insert], &current_layout.id).expect("current insert encodes")
+                },
+                {
+                    "type": "delta",
+                    "terminalLayouts": [jazz::binding_codec::terminal_layout_to_json(&logical_layout).expect("logical layout encodes")],
+                    "terminalOperations": jazz::binding_codec::terminal_operations_to_json(&[logical_insert], &logical_layout.id).expect("logical insert encodes")
+                },
+                {
+                    "type": "delta",
+                    "terminalLayouts": [],
+                    "terminalOperations": jazz::binding_codec::terminal_operations_to_json(&[current_update], &current_layout.id).expect("current update encodes")
+                },
+                {
+                    "type": "delta",
+                    "terminalLayouts": [],
+                    "terminalOperations": jazz::binding_codec::terminal_operations_to_json(&[logical_move, logical_remove], &logical_layout.id).expect("logical move/remove encodes")
+                }
+            ]),
+            rejections: serde_json::json!([
+                { "type": "UnsupportedShapeCapability", "detail": "terminal layout missing" },
+                { "type": "ServerFailure", "code": "TableNotFound" }
+            ]),
+        },
     }
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/binding-codec-golden.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/binding-codec-golden.test.ts
@@ -1,0 +1,189 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  ColumnDescriptor,
+  NativeRowDelta,
+  NativeTerminalRootLayout,
+  Value,
+} from "../../drivers/types.js";
+import { SubscriptionManager } from "../subscription-manager.js";
+import { PostcardReader } from "./native-codec.js";
+import {
+  readNativeRelationSubscriptionSnapshot,
+  readNativeSubscriptionDelta,
+} from "./native-row-codec.js";
+
+type BindingCodecGoldenFixture = {
+  format: string;
+  relation_snapshots: Array<{ name: string; payload_hex: string }>;
+  subscription_deltas: Array<{ name: string; payload_hex: string }>;
+  terminal: {
+    events: Array<{
+      type: "delta";
+      terminalLayouts: NativeTerminalRootLayout[];
+      terminalOperations: NonNullable<NativeRowDelta["terminalOperations"]>;
+    }>;
+    rejections: Array<Record<string, unknown>>;
+  };
+};
+
+const columns: ColumnDescriptor[] = [
+  { name: "title", column_type: { type: "Text" }, nullable: false },
+];
+
+// Rust owns the fixture and both NAPI/WASM call the same production postcard
+// encoder. This keeps byte-level representations and the actual TS reducer in
+// one fast contract, rather than waiting for a browser integration failure.
+describe("binding codec golden contract", () => {
+  it("decodes empty, adjacent, nonadjacent, and deleted-row relation snapshots", () => {
+    const fixture = bindingCodecGoldenFixture();
+    expect(fixture.format).toBe("jazz-binding-codec-golden-v1");
+    const empty = relationCase(fixture, "empty_root_count_zero");
+    expect(
+      readNativeRelationSubscriptionSnapshot(new PostcardReader(hexToBytes(empty.payload_hex))),
+    ).toEqual({
+      rootCount: 0,
+      rows: [],
+    });
+
+    const batching = relationCase(fixture, "adjacent_and_nonadjacent_batches_with_deleted_row");
+    const snapshot = readNativeRelationSubscriptionSnapshot(
+      new PostcardReader(hexToBytes(batching.payload_hex)),
+    );
+    expect(snapshot.rootCount).toBe(4);
+    expect(snapshot.rows.map((batch) => [batch.table, batch.rows.length])).toEqual([
+      ["todos", 2],
+      ["notes", 1],
+      ["todos", 1],
+    ]);
+    expect(snapshot.rows[2]!.rows[0]!.deleted).toBe(true);
+    expect(bytesToHex(snapshot.rows[0]!.rows[0]!.rowId)).toBe("11".repeat(16));
+    expect(bytesToHex(snapshot.rows[1]!.rows[0]!.rowId)).toBe("21".repeat(16));
+  });
+
+  it("keeps added, updated, removed, and both ResultKey wire versions aligned", () => {
+    const fixture = bindingCodecGoldenFixture();
+    const deltaCase = fixture.subscription_deltas.find(
+      (candidate) => candidate.name === "added_updated_removed_with_v1_and_v2_occurrence_keys",
+    )!;
+    const delta = readNativeSubscriptionDelta(
+      new PostcardReader(hexToBytes(deltaCase.payload_hex)),
+    );
+
+    expect(delta.added.map((batch) => batch.table)).toEqual(["todos"]);
+    expect(delta.updated.map((batch) => batch.table)).toEqual(["notes"]);
+    expect(delta.removed).toEqual([{ table: "todos", rowId: expect.any(Uint8Array) }]);
+    expect(delta.addedOccurrenceKeys.map((key) => key[0])).toEqual([1]);
+    expect(delta.updatedOccurrenceKeys.map((key) => key[0])).toEqual([2]);
+    expect(delta.removedOccurrenceKeys.map((key) => key[0])).toEqual([2]);
+  });
+
+  it("applies actual terminal publication, layout reuse, and edits through SubscriptionManager", () => {
+    const fixture = bindingCodecGoldenFixture();
+    const manager = new SubscriptionManager<{ id: string; title: string }>();
+
+    const first = manager.handleDelta(
+      nativeTerminalDelta(fixture.terminal.events[0]!),
+      terminalRow,
+      columns,
+    );
+    expect(first.all).toEqual([{ id: "11111111-1111-1111-1111-111111111111", title: "first" }]);
+
+    const reusedLayout = fixture.terminal.events[2]!;
+    expect(reusedLayout.terminalLayouts).toEqual([]);
+    const updated = manager.handleDelta(nativeTerminalDelta(reusedLayout), terminalRow, columns);
+    expect(updated.all).toEqual([{ id: "11111111-1111-1111-1111-111111111111", title: "updated" }]);
+
+    const logicalManager = new SubscriptionManager<{ id: string; title: string }>();
+    const logicalInserted = logicalManager.handleDelta(
+      nativeTerminalDelta(fixture.terminal.events[1]!),
+      terminalRow,
+      columns,
+    );
+    expect(logicalInserted.all).toEqual([
+      { id: "21212121-2121-2121-2121-212121212121", title: "note" },
+    ]);
+    const logicalRemoved = logicalManager.handleDelta(
+      nativeTerminalDelta(fixture.terminal.events[3]!),
+      terminalRow,
+      columns,
+    );
+    expect(logicalRemoved.all).toEqual([]);
+
+    const operationKinds = fixture.terminal.events.flatMap((event) =>
+      event.terminalOperations.map((operation) => Object.keys(operation.edit)[0]),
+    );
+    expect(operationKinds).toEqual(["Insert", "Insert", "Update", "Move", "Remove"]);
+    expect(fixture.terminal.rejections).toEqual([
+      { type: "UnsupportedShapeCapability", detail: "terminal layout missing" },
+      { type: "ServerFailure", code: "TableNotFound" },
+    ]);
+  });
+
+  it("fails closed when a planted CurrentRow or Logical descriptor byte drifts", () => {
+    const fixture = bindingCodecGoldenFixture();
+    for (const source of [fixture.terminal.events[0]!, fixture.terminal.events[1]!]) {
+      const event = structuredClone(source);
+      const descriptor = event.terminalLayouts[0]!.rootDescriptor;
+      descriptor[descriptor.length - 1] = 4; // String -> I32, still a valid descriptor.
+      const manager = new SubscriptionManager<{ id: string; title: string }>();
+      expect(() => manager.handleDelta(nativeTerminalDelta(event), terminalRow, columns)).toThrow(
+        /terminal root layout/,
+      );
+    }
+  });
+});
+
+function terminalRow(row: { id: string; values: Value[] }): { id: string; title: string } {
+  const title = row.values[0];
+  if (title?.type !== "Text") throw new Error("golden terminal title did not decode as text");
+  return { id: row.id, title: title.value };
+}
+
+function nativeTerminalDelta(
+  event: BindingCodecGoldenFixture["terminal"]["events"][number],
+): NativeRowDelta {
+  return {
+    __jazzNativeRowDelta: true,
+    added: new Uint8Array(),
+    updated: new Uint8Array(),
+    removed: new Uint8Array(),
+    addedCount: 0,
+    updatedCount: 0,
+    removedCount: 0,
+    terminalLayouts: event.terminalLayouts,
+    terminalOperations: event.terminalOperations,
+  };
+}
+
+function bindingCodecGoldenFixture(): BindingCodecGoldenFixture {
+  return JSON.parse(
+    readFileSync(
+      new URL("../../../../../crates/jazz/fixtures/binding_codec_golden.json", import.meta.url),
+      "utf8",
+    ),
+  ) as BindingCodecGoldenFixture;
+}
+
+function relationCase(
+  fixture: BindingCodecGoldenFixture,
+  name: string,
+): { name: string; payload_hex: string } {
+  const testCase = fixture.relation_snapshots.find((candidate) => candidate.name === name);
+  if (!testCase) throw new Error(`missing ${name} binding codec fixture`);
+  return testCase;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}


### PR DESCRIPTION
🤖 Shared binding codec cleanup.

## What changed

- Extracts the production postcard row, relation snapshot, and subscription delta encoders into `jazz::binding_codec`.
- Makes both NAPI and WASM delegate to that shared implementation.
- Adds a Rust-owned golden contract consumed through the TypeScript `SubscriptionManager`, covering CurrentRow and Logical layouts, layout reuse, row edits, removals, moves, and rejection events.
- Keeps fixture regeneration explicit and checks semantic JSON content so repository formatting cannot make the golden born-red.

## Why

The two native bindings previously maintained parallel serializers, making drift easy and cross-runtime failures hard to localize. The shared production encoder and cross-language golden provide one executable contract before further codec/JIT cleanup.

## Validation

- Exact Rust golden currentness test
- TypeScript binding golden and terminal-layout contract tests (10/10)
- NAPI unit tests (10/10)
- WASM unit tests (3/3)
- TypeScript check, rustfmt, oxfmt, oxlint, clippy, diff check, and sensitive-data guard
- Independent adversarial review with CurrentRow and Logical descriptor-drift plants