### PR TITLE
cleanup: isolate node database rebuild slot

### DIFF
--- a/crates/jazz/src/node/database_slot.rs
+++ b/crates/jazz/src/node/database_slot.rs
@@ -1,0 +1,55 @@
+//! Temporary ownership of the Groove database during node rebuilds.
+//!
+//! Rebuilding a [`super::NodeState`] needs to move the database out while its
+//! catalogue-derived layouts are reconstructed. Keeping that transition in a
+//! dedicated slot makes the `Option` invariant local and leaves the node core
+//! focused on node state and lifecycle.
+
+use std::ops::{Deref, DerefMut};
+
+use groove::db::Database;
+
+pub(super) struct DatabaseSlot<S> {
+    database: Option<Database<S>>,
+}
+
+impl<S> DatabaseSlot<S> {
+    pub(super) fn new(database: Database<S>) -> Self {
+        Self {
+            database: Some(database),
+        }
+    }
+
+    pub(super) fn take(&mut self) -> Database<S> {
+        self.database
+            .take()
+            .expect("node database slot must be populated outside rebuild")
+    }
+
+    pub(super) fn replace(&mut self, database: Database<S>) {
+        debug_assert!(self.database.is_none());
+        self.database = Some(database);
+    }
+
+    pub(super) fn into_inner(mut self) -> Database<S> {
+        self.take()
+    }
+}
+
+impl<S> Deref for DatabaseSlot<S> {
+    type Target = Database<S>;
+
+    fn deref(&self) -> &Self::Target {
+        self.database
+            .as_ref()
+            .expect("node database slot must be populated")
+    }
+}
+
+impl<S> DerefMut for DatabaseSlot<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.database
+            .as_mut()
+            .expect("node database slot must be populated")
+    }
+}

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -7,7 +7,6 @@
 //! `Db` facade and groove storage/IVM.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "testing")]
@@ -373,6 +372,7 @@ mod branches;
 mod codec;
 pub mod content_store;
 mod currency;
+mod database_slot;
 mod eviction;
 mod global_state;
 mod ingest;
@@ -398,6 +398,7 @@ type ResultRowMembershipKey = crate::tools::OutputOccurrenceId;
 use branches::BranchRecord;
 use codec::*;
 use content_store::ContentStore;
+use database_slot::DatabaseSlot;
 use open_tx::*;
 use physical::*;
 use text_oplog::{Content as TextContent, Op as TextOp};
@@ -6688,51 +6689,6 @@ enum CatalogueActivationFailpoint {
     AfterStaged,
     AfterRegistration,
     BeforeSnapshotActivationCommit,
-}
-
-struct DatabaseSlot<S> {
-    database: Option<Database<S>>,
-}
-
-impl<S> DatabaseSlot<S> {
-    fn new(database: Database<S>) -> Self {
-        Self {
-            database: Some(database),
-        }
-    }
-
-    fn take(&mut self) -> Database<S> {
-        self.database
-            .take()
-            .expect("node database slot must be populated outside rebuild")
-    }
-
-    fn replace(&mut self, database: Database<S>) {
-        debug_assert!(self.database.is_none());
-        self.database = Some(database);
-    }
-
-    fn into_inner(mut self) -> Database<S> {
-        self.take()
-    }
-}
-
-impl<S> Deref for DatabaseSlot<S> {
-    type Target = Database<S>;
-
-    fn deref(&self) -> &Self::Target {
-        self.database
-            .as_ref()
-            .expect("node database slot must be populated")
-    }
-}
-
-impl<S> DerefMut for DatabaseSlot<S> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.database
-            .as_mut()
-            .expect("node database slot must be populated")
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
🤖 Behavior-neutral node-state cleanup.

Moves the database take/replace/deref invariant from `node/mod.rs` into a private 55-line `database_slot.rs` module. The field representation, panic messages, replacement assertion, visibility, and Send/Sync behavior remain unchanged.

Validation: cargo check, reopen/recovery and catalogue rollback tests, fmt/diff/clippy/sensitive-data gates, and independent review of drop/rebuild/empty-slot/replace semantics.