### PR TITLE
test: restore NAPI session subscription coverage

### DIFF
--- a/TEST_BURNDOWN.md
+++ b/TEST_BURNDOWN.md
@@ -76,11 +76,10 @@ A future fix must remove both the matching visible skip marker and this entry, t
 | `groove::db::tests::indexed_batch_commit_timing_receipt_20k_and_single_row`                      | `crates/groove/src/db/tests.rs`               | timing receipt             |
 | `jazz::node::tests::harness::policy_graph_perf_dropdown_entry_reset_ingest_timing_receipt`       | `crates/jazz/src/node/tests/sync.rs`          | timing receipt             |
 
-## Active TypeScript/browser quarantine (2)
+## Active TypeScript/browser quarantine (1)
 
 Measured on CI run `31669333671` at `30dc070e1`: 8 Node test failures and 2 Chromium failures. The two unrelated load flakes observed in the same run (the artifact-lock timing test and the Rust teardown abort) are deliberately not quarantined here.
 
 | Test                                                                                                                 | Definition                                                              | Status | Category               | Failure signature / theory                                                                                    | Owner  |
 | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------- | ------ |
-| `jazz-napi native runtime memory DB > delivers all client-local subscription rows even when callers supply sessions` | `packages/jazz-tools/src/runtime/napi.core.test.ts`                     | FAIL   | Native terminal layout | `terminal operation references unknown root layout`; session-scoped terminal layout registration diverges.    | Anselm |
 | `chromium > raw websocket private read gate > converts a private chat invite code into normal membership visibility` | `packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts` | FAIL   | Browser private invite | `Bob should subscribe to private seed messages through normal membership` times out after 15s; `lastRows=[]`. | Anselm |

--- a/dev/gates/test-burndown-ts.mjs
+++ b/dev/gates/test-burndown-ts.mjs
@@ -23,7 +23,7 @@ function documentedRows(doc) {
     if (identities.has(identity)) fail(`duplicate documented TS/browser test: ${identity}`);
     identities.add(identity);
   }
-  if (active.length !== 2) fail(`expected 2 active TS/browser rows, got ${active.length}`);
+  if (active.length !== 1) fail(`expected 1 active TS/browser rows, got ${active.length}`);
   return { active, identities };
 }
 function sourceMarkers() {
@@ -87,4 +87,4 @@ for (const row of active)
   if (!fs.existsSync(row.path)) fail(`documented path does not exist: ${row.path}`);
 const source = sourceMarkers();
 if (!same(documented, source)) fail("TS/browser source markers differ from documented active set");
-console.log("TS/browser burndown: exact 2 active identity bijection.");
+console.log("TS/browser burndown: exact 1 active identity bijection.");

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -986,9 +986,7 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     expect(aliceRowsAfterBobInsert).toHaveLength(3);
   });
 
-  // TEST_BURNDOWN_TS: jazz-napi native runtime memory DB > delivers all client-local subscription rows even when callers supply sessions
-  // known red; tracked in TEST_BURNDOWN.md — terminal root layout registration rejects this session-scoped subscription.
-  it.skip("delivers all client-local subscription rows even when callers supply sessions", async () => {
+  it("delivers all client-local subscription rows even when callers supply sessions", async () => {
     const { NapiDb } = await loadNapiModule();
     const runtime = new NativeRuntimeAdapter(
       { openMemory: (schema, config) => NapiDb.openMemory(schema, config) as never },
@@ -1004,19 +1002,25 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     const bobSession = JSON.stringify({ user_id: BOB_ID });
     const query = JSON.stringify({ table: "todos" });
     const aliceUpdates: unknown[] = [];
+    // Terminal layouts are registered once at the subscription boundary and
+    // later deltas reference that stable id. Keep one decoder for the whole
+    // subscription rather than treating independent callbacks as snapshots.
+    const aliceSubscription = new SubscriptionManager<WasmRow>();
     const decodeAliceDelta = (delta: unknown) =>
-      new SubscriptionManager<WasmRow>().handleDelta(
+      aliceSubscription.handleDelta(
         delta as Parameters<SubscriptionManager<WasmRow>["handleDelta"]>[0],
         (row) => row,
         OWNED_TODOS_SCHEMA.todos.columns,
       );
+    const aliceDecodedUpdates: ReturnType<SubscriptionManager<WasmRow>["handleDelta"]>[] = [];
 
     const aliceHandle = runtime.createSubscription(query, aliceSession, "local");
     runtime.executeSubscription(aliceHandle, (delta: unknown) => {
       aliceUpdates.push(delta);
+      aliceDecodedUpdates.push(decodeAliceDelta(delta));
     });
 
-    expect(decodeAliceDelta(aliceUpdates[0])).toEqual({ all: [], delta: [], reset: true });
+    expect(aliceDecodedUpdates[0]).toEqual({ all: [], delta: [], reset: true });
 
     const aliceTodo = runtime.insert(
       "todos",
@@ -1056,7 +1060,7 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     );
 
     expect(aliceUpdates).toHaveLength(3);
-    expect(decodeAliceDelta(aliceUpdates[1])).toEqual(
+    expect(aliceDecodedUpdates[1]).toEqual(
       expect.objectContaining({
         all: [expect.objectContaining({ id: aliceTodo.id })],
         delta: [
@@ -1075,10 +1079,10 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
         ],
       }),
     );
-    expect(decodeAliceDelta(aliceUpdates[2]).all).toEqual([
-      expect.objectContaining({ id: bobTodo.id }),
-    ]);
-    expect(decodeAliceDelta(aliceUpdates[2]).delta).toEqual([
+    const finalRows = aliceDecodedUpdates[2]?.all;
+    expect(finalRows).toHaveLength(2);
+    expect(finalRows?.map((row) => row.id).sort()).toEqual([aliceTodo.id, bobTodo.id].sort());
+    expect(aliceDecodedUpdates[2]?.delta).toEqual([
       expect.objectContaining({ kind: 0, id: bobTodo.id }),
     ]);
 


### PR DESCRIPTION
🤖 Removes one measured TypeScript quarantine.

The early-bound layout stream was correct; this direct-adapter test incorrectly created a new `SubscriptionManager` for every callback, discarding registered layouts before later operations referenced their stable IDs. It now retains one reducer for the subscription lifetime and decodes each callback once, matching the production `subscribeAll` consumer contract.

The regression asserts exactly Alice and Bob’s two row identities. The exact skip and burndown row are removed; active TS/browser quarantine drops from 2 to 1 on this stacked branch.

Validation: fresh NAPI artifact, focused repetitions, TypeScript and burndown gates, formatting/lint/sensitive-data checks, independent review, per-callback-manager regression plant, and wrong-cardinality plant.
