### PR TITLE
Release NAPI callbacks on runtime shutdown

### DIFF
--- a/.changeset/napi-shutdown-callbacks.md
+++ b/.changeset/napi-shutdown-callbacks.md
@@ -1,0 +1,5 @@
+---
+"jazz-napi": patch
+---
+
+Release native JavaScript callbacks when `NapiRuntime.close()` is called so Node.js processes can exit without waiting for garbage collection.

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -822,10 +822,11 @@ impl NapiRuntime {
     /// Flush and close the underlying storage, releasing filesystem locks.
     #[napi]
     pub fn close(&self) -> napi::Result<()> {
-        let core = self
+        let mut core = self
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
+        core.clear_host_callbacks();
         let flush_result = core.storage().flush();
         let flush_wal_result = core.storage().flush_wal();
         let close_result = core.storage().close();

--- a/crates/jazz-tools/src/runtime_core/mod.rs
+++ b/crates/jazz-tools/src/runtime_core/mod.rs
@@ -527,6 +527,15 @@ impl<S: Storage, Sch: Scheduler> RuntimeCore<S, Sch> {
         self.schedule_mutation_error_delivery_if_needed();
     }
 
+    /// Release callbacks owned by the host binding during runtime shutdown.
+    pub fn clear_host_callbacks(&mut self) {
+        self.mutation_error_callback = None;
+        self.rejected_batch_acknowledged_callback = None;
+        self.auth_failure_callback = None;
+        self.subscriptions.clear();
+        self.subscription_reverse.clear();
+    }
+
     pub fn set_rejected_batch_acknowledged_callback(
         &mut self,
         callback: Option<RejectedBatchAcknowledgedCallback>,

--- a/packages/jazz-tools/src/runtime/__fixtures__/napi-shutdown-callbacks.ts
+++ b/packages/jazz-tools/src/runtime/__fixtures__/napi-shutdown-callbacks.ts
@@ -1,0 +1,27 @@
+import { NapiRuntime } from "jazz-napi";
+import { schema as s } from "../../index.js";
+import { serializeRuntimeSchema } from "../../drivers/schema-wire.js";
+import { JazzClient, type Runtime } from "../client.js";
+
+const app = s.defineApp({
+  items: s.table({ text: s.string() }),
+});
+const runtime = NapiRuntime.inMemory(
+  serializeRuntimeSchema(app.wasmSchema),
+  "napi-callback-exit-test",
+  "test",
+  "main",
+);
+const client = JazzClient.connectWithRuntime(
+  runtime as unknown as Runtime,
+  {
+    appId: "napi-callback-exit-test",
+    schema: app.wasmSchema,
+  },
+  { onAuthFailure() {} },
+);
+
+client.subscribe(app.items, () => {});
+await new Promise<void>((resolve) => setImmediate(resolve));
+await client.shutdown();
+console.log("runtime closed");

--- a/packages/jazz-tools/src/runtime/__fixtures__/napi-shutdown-context.ts
+++ b/packages/jazz-tools/src/runtime/__fixtures__/napi-shutdown-context.ts
@@ -1,0 +1,27 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJazzContext } from "../../backend/create-jazz-context.js";
+import { schema as s } from "../../index.js";
+
+const dataPath = await mkdtemp(join(tmpdir(), "jazz-napi-exit-"));
+const app = s.defineApp({
+  items: s.table({ text: s.string() }),
+});
+const context = createJazzContext({
+  app,
+  appId: "napi-exit-test",
+  driver: {
+    dataPath: join(dataPath, "db.jazz"),
+    type: "persistent",
+  },
+  permissions: {},
+});
+
+try {
+  context.db();
+  await context.shutdown();
+  console.log("shutdown complete");
+} finally {
+  await rm(dataPath, { force: true, recursive: true });
+}

--- a/packages/jazz-tools/src/runtime/napi.shutdown.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.shutdown.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const contextFixture = join(here, "__fixtures__/napi-shutdown-context.ts");
+const callbacksFixture = join(here, "__fixtures__/napi-shutdown-callbacks.ts");
+const execFileAsync = promisify(execFile);
+
+function runFixture(fixturePath: string) {
+  return execFileAsync(process.execPath, ["--import", import.meta.resolve("tsx"), fixturePath], {
+    encoding: "utf8",
+    timeout: 5_000,
+  });
+}
+
+describe("NAPI shutdown", () => {
+  it("allows the Node process to exit after JazzContext.shutdown()", async () => {
+    const result = await runFixture(contextFixture);
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("shutdown complete\n");
+  }, 10_000);
+
+  it("releases all registered host callbacks when the runtime closes", async () => {
+    const result = await runFixture(callbacksFixture);
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("runtime closed\n");
+  }, 10_000);
+});

--- a/packages/jazz-tools/src/runtime/napi.shutdown.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.shutdown.test.ts
@@ -12,7 +12,7 @@ const execFileAsync = promisify(execFile);
 function runFixture(fixturePath: string) {
   return execFileAsync(process.execPath, ["--import", import.meta.resolve("tsx"), fixturePath], {
     encoding: "utf8",
-    timeout: 5_000,
+    timeout: 9_000,
   });
 }
 


### PR DESCRIPTION
## Summary

After `await JazzContext.shutdown()` resolves, a Node.js process can remain alive because a `napi_rs_threadsafe_function` owned by `NapiRuntime` is still referenced. Storage has been closed, but the native JavaScript callback is not released until the runtime wrapper is garbage-collected.

This PR:

- releases JavaScript-owned callbacks when `NapiRuntime.close()` runs
- clears mutation-error, auth-failure, rejected-batch acknowledgement, and active subscription callbacks before storage shutdown
- adds child-process regressions for `JazzContext.shutdown()` and direct N-API callback ownership
- adds a `jazz-napi` patch changeset

## Minimal reproduction

```js
// repro.mjs
import { mkdtemp, rm } from "node:fs/promises";
import { tmpdir } from "node:os";
import { join } from "node:path";
import { createJazzContext } from "jazz-tools/backend";
import { schema as s } from "jazz-tools";

const started = performance.now();
const dataPath = await mkdtemp(join(tmpdir(), "jazz-exit-repro-"));

const app = s.defineApp({
  items: s.table({
    text: s.string(),
  }),
});

const context = createJazzContext({
  app,
  appId: "exit-repro",
  driver: {
    dataPath: join(dataPath, "db.jazz"),
    type: "persistent",
  },
  permissions: {},
});

context.db();

await context.shutdown();
await rm(dataPath, { force: true, recursive: true });

console.log(
  `shutdown resolved after ${Math.round(performance.now() - started)}ms`,
);

if (process.env.FORCE_GC === "1") {
  globalThis.gc?.();
}

process.on("exit", () => {
  console.log(
    `process exited after ${Math.round(performance.now() - started)}ms`,
  );
});
```

Without forced garbage collection:

```sh
timeout 3s node repro.mjs
echo $?
```

Observed:

```text
shutdown resolved after 5ms
124
```

The process did not exit before `timeout` killed it.

With forced garbage collection:

```sh
NODE_OPTIONS=--expose-gc FORCE_GC=1 node repro.mjs
```

Observed:

```text
shutdown resolved after 5ms
process exited after 20ms
```

The fact that forced GC immediately allows the process to exit points to a native wrapper/callback lifetime issue rather than unfinished JavaScript work.

## Diagnostics and root cause

The issue originally appeared as a roughly six-second pause after a Vitest integration suite completed.

- `perf` showed no CPU activity during the pause.
- `strace` showed the main thread sleeping in `epoll` and native Tokio threads sleeping in `futex`/`epoll_wait`.
- `process._getActiveHandles()` showed no relevant JavaScript handles.
- Async-hook tracing found one remaining `napi_rs_threadsafe_function` created while constructing `JazzClient`.
- Forcing GC destroyed that handle, after which the process exited immediately.

`JazzClient` always registers a mutation-error callback. The N-API binding wraps it in a `ThreadsafeFunction` and stores it on `RuntimeCore`, but `NapiRuntime.close()` previously only flushed and closed storage. The callback therefore remained referenced until the complete runtime wrapper was garbage-collected.

The React Native close path already clears its mutation-error callback explicitly. Auditing the N-API path also found the same lifecycle issue for optional auth-failure callbacks and active subscription callbacks.

## Fix

`NapiRuntime.close()` now clears callbacks owned by the host binding before performing the fallible storage flush/close operations. This deterministically drops their `ThreadsafeFunction` values even if storage shutdown later returns an error.

## Validation

- confirmed both regression tests time out without the cleanup and pass with it restored
- `pnpm --filter jazz-napi build` (release)
- `pnpm --filter jazz-napi build:debug`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/napi.shutdown.test.ts`
- targeted Oxlint and Oxfmt checks
- `cargo fmt --all -- --check`
- `cargo clippy -p jazz-napi --no-deps -- -D warnings`
- `git diff --check`
