### PR TITLE
dev: document node focused test discovery

### DIFF
--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -50,9 +50,14 @@ cargo test -p jazz --no-default-features --features test   # rust core only
 ### Focus one Rust test safely
 
 `dev/t` first asks Cargo for the test inventory using the same target and
-features it will run. It refuses an empty selection, prints the selected binary,
+features it will run. A filter must resolve to exactly one inventory entry; the
+wrapper then invokes that canonical name with Cargo's `--exact`. It refuses an
+empty or ambiguous selection before a test runs, prints the selected binary,
 feature and cache context, and separately reports inventory/compile and test-run
-elapsed time.
+elapsed time. This is useful for files under `src/node/tests/`: their test names
+are wrapped as `node::tests::harness::…` (rather than retaining their source
+file in the module path), but a distinctive test-name suffix is enough for
+`dev/t` to discover and run the canonical name.
 
 ```sh
 # Default: Jazz library tests, substring matching.
@@ -60,6 +65,9 @@ dev/t subscription::tests::reopens
 
 # Fully-qualified exact library test.
 dev/t --exact db::tests::round_trips
+
+# A node test: resolve its canonical harness path from the unique suffix.
+dev/t query_rows_at_lowers_filters_against_historical_current_rows
 
 # An integration target is explicit, so Cargo cannot search an unintended bin.
 dev/t --test incremental_delivery_canary maintained_relation -- --nocapture

--- a/dev/gates/test/dev-t.test.sh
+++ b/dev/gates/test/dev-t.test.sh
@@ -14,7 +14,10 @@ if [[ " $* " == *" -- --list "* ]]; then
   if [[ " $* " == *" --test incremental_delivery_canary "* ]]; then
     printf '%s\n' 'maintained_relation::smoke: test'
   else
-    printf '%s\n' 'db::tests::round_trips: test' 'db::tests::other: test'
+    printf '%s\n' \
+      'db::tests::round_trips: test' \
+      'db::tests::other: test' \
+      'node::tests::harness::query_rows_at_lowers_filters_against_historical_current_rows: test'
   fi
   exit "${MOCK_INVENTORY_STATUS:-0}"
 fi
@@ -38,6 +41,14 @@ grep -F -- '-p jazz --no-default-features --features test --lib db::tests::round
 : >"$TEMP/cargo.log"
 run --exact db::tests::round_trips
 grep -F -- 'db::tests::round_trips -- --exact' "$TEMP/cargo.log" >/dev/null
+
+# Rust files under src/node/tests are wired through node::tests::harness.  A
+# human should be able to supply the distinctive test-name suffix without
+# knowing that internal module wrapper, and dev/t must still invoke Cargo with
+# the canonical name and --exact.
+: >"$TEMP/cargo.log"
+run query_rows_at_lowers_filters_against_historical_current_rows
+grep -F -- 'node::tests::harness::query_rows_at_lowers_filters_against_historical_current_rows -- --exact' "$TEMP/cargo.log" >/dev/null
 
 if run --exact db::tests::round; then
   echo 'expected exact non-match to fail' >&2


### PR DESCRIPTION
🤖 Stacked developer-experience cleanup.

Documents why tests defined under `node/tests/*.rs` compile as `node::tests::harness::*`, and adds a contract proving a distinctive short suffix resolves to that canonical name while preserving #1443’s exact-one execution guarantee.

Validation: focused helper contract suite, real 1-of-1391 node test invocation, diff/format checks, and independent source/layout review.

Depends on #1443.