### PR TITLE
ci: tolerate cross-job Rust test contention

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,3 +4,11 @@
 [profile.jazz]
 fail-fast = false
 slow-timeout = { period = "60s", terminate-after = 1 }
+
+# CI shares a 16-core host with independently scheduled jobs.  Compiling the
+# TypeScript correctness artifacts can briefly starve CPU-bound Rust tests, so
+# use a wider but still finite per-test watchdog there.  Local runs retain the
+# tighter jazz profile above for fast hang attribution.
+[profile.jazz-ci]
+fail-fast = false
+slow-timeout = { period = "180s", terminate-after = 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           # every job. Keep this explicit so test selection is reproducible.
           tool: cargo-nextest@0.9.143
       - name: Workspace Rust tests (bounded, sharded, receipted)
-        run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 -- --workspace --lib --bins --tests --features test
+        run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features test
       - name: Verify Nextest partition coverage
         run: node --test dev/gates/test/nextest-partitions.test.mjs
       - name: Upload Rust test receipt

--- a/dev/gates/run-rust-tests.mjs
+++ b/dev/gates/run-rust-tests.mjs
@@ -26,6 +26,7 @@ Options:
   --shard-index N       one-based deterministic shard index (default: 1)
   --shard-count N       number of deterministic shards (default: 1)
   --timeout-seconds N   fallback whole-command timeout (default: 900)
+  --nextest-profile N   Nextest profile (default: jazz)
   --receipt PATH        JSON receipt path (default: target/test-receipts/...)
   --require-nextest     fail rather than use the Cargo fallback
 
@@ -35,6 +36,7 @@ const args = process.argv.slice(2);
 let shardIndex = 1,
   shardCount = 1,
   timeoutSeconds = 900,
+  nextestProfile = "jazz",
   receiptPath,
   requireNextest = false;
 let split = args.indexOf("--");
@@ -49,6 +51,7 @@ for (let i = 0; i < options.length; i += 1) {
   if (option === "--shard-index") shardIndex = Number(options[++i]);
   else if (option === "--shard-count") shardCount = Number(options[++i]);
   else if (option === "--timeout-seconds") timeoutSeconds = Number(options[++i]);
+  else if (option === "--nextest-profile") nextestProfile = options[++i];
   else if (option === "--receipt") receiptPath = options[++i];
   else if (option === "--require-nextest") requireNextest = true;
   else {
@@ -63,7 +66,9 @@ if (
   shardIndex < 1 ||
   shardIndex > shardCount ||
   !Number.isFinite(timeoutSeconds) ||
-  timeoutSeconds <= 0
+  timeoutSeconds <= 0 ||
+  typeof nextestProfile !== "string" ||
+  !nextestProfile
 ) {
   usage();
   throw new Error("invalid test command, shard, or timeout");
@@ -84,7 +89,7 @@ const commandArgs = useNextest
       "nextest",
       "run",
       "--profile",
-      "jazz",
+      nextestProfile,
       "--no-fail-fast",
       "--partition",
       `hash:${shardIndex}/${shardCount}`,
@@ -134,7 +139,8 @@ const data = {
   spawnError: result.error ?? null,
   timedOut,
   runner: useNextest ? "cargo-nextest" : "cargo-fallback",
-  perTestTimeout: useNextest ? "60s + one termination interval" : null,
+  nextestProfile: useNextest ? nextestProfile : null,
+  perTestTimeout: useNextest ? "configured Nextest slow-timeout + one termination interval" : null,
   hangIdentification: useNextest
     ? "nextest test-name output"
     : "whole command only; install cargo-nextest for per-test attribution",

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -216,7 +216,7 @@ test("Rust CI does not rerun differential integration binaries selected by the w
 
   assert.match(
     rust,
-    /run-rust-tests\.mjs --timeout-seconds 780 -- --workspace --lib --bins --tests --features test/,
+    /run-rust-tests\.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features test/,
   );
   for (const testTarget of [
     "incremental_delivery_canary",
@@ -228,6 +228,24 @@ test("Rust CI does not rerun differential integration binaries selected by the w
   assert.match(
     rust,
     /JAZZ_SEED_COUNT=50 cargo test -p jazz m3_maintained_one_shot_differential_oracle/,
+  );
+});
+
+test("Rust CI uses a contention-tolerant but finite Nextest watchdog", () => {
+  const nextest = fs.readFileSync(path.join(root, ".config/nextest.toml"), "utf8");
+  const localProfile = nextest.match(/\[profile\.jazz\]([\s\S]*?)(?=\n\[|$)/)?.[1] ?? "";
+  const ciProfile = nextest.match(/\[profile\.jazz-ci\]([\s\S]*?)(?=\n\[|$)/)?.[1] ?? "";
+
+  assert.match(localProfile, /slow-timeout = \{ period = "60s", terminate-after = 1 \}/);
+  assert.match(ciProfile, /fail-fast = false/);
+  assert.match(ciProfile, /slow-timeout = \{ period = "180s", terminate-after = 1 \}/);
+  assert.throws(
+    () =>
+      assert.match(
+        ciProfile.replace("terminate-after = 1", "terminate-after = 0"),
+        /terminate-after = 1/,
+      ),
+    /terminate-after = 1/,
   );
 });
 

--- a/dev/gates/test/run-rust-tests.test.mjs
+++ b/dev/gates/test/run-rust-tests.test.mjs
@@ -8,6 +8,8 @@ import { spawnSync } from "node:child_process";
 const root = path.resolve(import.meta.dirname, "../../..");
 const runner = path.join(root, "dev/gates/run-rust-tests.mjs");
 const temp = () => fs.mkdtempSync(path.join(os.tmpdir(), "jazz-rust-receipt-"));
+const hasNextest =
+  spawnSync("cargo", ["nextest", "--version"], { cwd: root, stdio: "ignore" }).status === 0;
 test("writes source, command, cache, and failure metadata", () => {
   const dir = temp(),
     receipt = path.join(dir, "receipt.json");
@@ -23,6 +25,13 @@ test("writes source, command, cache, and failure metadata", () => {
   assert.match(value.source.commit, /^[0-9a-f]{40}$/);
   assert.equal(value.command[0], "cargo");
   assert.ok("cargoTargetDir" in value.environment);
+  assert.equal(value.nextestProfile, hasNextest ? "jazz" : null);
+});
+test("forwards the requested Nextest profile and records it in the receipt", () => {
+  const source = fs.readFileSync(runner, "utf8");
+  assert.match(source, /--nextest-profile N\s+Nextest profile \(default: jazz\)/);
+  assert.match(source, /"--profile",\s*nextestProfile/);
+  assert.match(source, /nextestProfile: useNextest \? nextestProfile : null/);
 });
 test("timeout propagates exit 124 and is recorded", () => {
   const dir = temp(),
@@ -48,15 +57,19 @@ test("rejects invalid shard partitions", () => {
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /invalid test command, shard, or timeout/);
 });
-test("does not duplicate a Cargo-fallback run across requested shards", () => {
-  const result = spawnSync(
-    "node",
-    [runner, "--shard-index", "1", "--shard-count", "2", "--", "--version"],
-    { cwd: root, encoding: "utf8" },
-  );
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /sharding requires cargo-nextest/);
-});
+test(
+  "does not duplicate a Cargo-fallback run across requested shards",
+  { skip: hasNextest && "cargo-nextest installed" },
+  () => {
+    const result = spawnSync(
+      "node",
+      [runner, "--shard-index", "1", "--shard-count", "2", "--", "--version"],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /sharding requires cargo-nextest/);
+  },
+);
 test("partition specification is complete and non-overlapping", () => {
   // The launcher forwards this exact syntax to Nextest, whose hash partition
   // owns each discovered test in exactly one shard. Keep the one-based bounds


### PR DESCRIPTION
🤖 Keeps maximum job/PR concurrency while making the bounded Rust test runner tolerant of expected CPU contention on the four-runner host.

The first fully concurrent run passed 2,216 Rust tests but three otherwise-green tests hit the same 60-second per-test ceiling while the TS job compiled correctness artifacts. CI now uses a dedicated `jazz-ci` Nextest profile with a 180-second slow timeout and one termination period. Local/default focused feedback remains at 60 seconds, and the existing 780-second whole-command watchdog still bounds the job.

The launcher accepts and receipts the selected Nextest profile. Workflow and runner contracts protect profile forwarding, the CI termination bound, and the unchanged local timeout.

Validation: standalone launcher tests, 39 CI workflow contracts, formatting, diff check, sensitive-data guard, live profile/receipt verification, reversible profile/termination/local-timeout plants, and independent adversarial review all pass.
