### PR TITLE
fix(runtime): decode related subscription batches by table

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -3765,9 +3765,9 @@ export function applySubscriptionDeltaWithWireDelta(
     rowIndexByKey,
     wireDelta: {
       ...nativeDeltaFromChanges(
-        addedRows,
-        updatedRows,
-        removedEntries,
+        subscriptionOutputRows(addedRows, outputColumns),
+        subscriptionOutputRows(updatedRows, outputColumns),
+        subscriptionOutputRemovals(removedEntries, outputColumns),
         rowIndexByKey,
         schema,
         outputColumns,
@@ -3775,6 +3775,20 @@ export function applySubscriptionDeltaWithWireDelta(
       ...(reset ? { reset: true } : {}),
     },
   };
+}
+
+function subscriptionOutputRows(
+  rows: RowState[],
+  outputColumns: SubscriptionOutputColumns | null,
+): RowState[] {
+  return outputColumns ? rows.filter((row) => row.table === outputColumns.rootTable) : rows;
+}
+
+function subscriptionOutputRemovals(
+  removed: Array<{ table: string; id: string; index: number; resultKeyBytes?: Uint8Array }>,
+  outputColumns: SubscriptionOutputColumns | null,
+): Array<{ id: string; index: number; resultKeyBytes?: Uint8Array }> {
+  return outputColumns ? removed.filter((row) => row.table === outputColumns.rootTable) : removed;
 }
 
 function applySubscriptionDeltaToState(
@@ -3787,14 +3801,19 @@ function applySubscriptionDeltaToState(
 ): {
   addedRows: RowState[];
   updatedRows: RowState[];
-  removedEntries: Array<{ id: string; index: number; resultKeyBytes?: Uint8Array }>;
+  removedEntries: Array<{ table: string; id: string; index: number; resultKeyBytes?: Uint8Array }>;
   rows: RowState[];
   rowIndexByKey: Map<string, number>;
 } {
   const rowsByKey = reset
     ? new Map<string, RowState>()
     : new Map(currentRows.map((row) => [rowStateKey(row), row]));
-  const removedEntries: Array<{ id: string; index: number; resultKeyBytes?: Uint8Array }> = [];
+  const removedEntries: Array<{
+    table: string;
+    id: string;
+    index: number;
+    resultKeyBytes?: Uint8Array;
+  }> = [];
 
   for (const [removedIndex, removed] of delta.removed.entries()) {
     const id = formatUuid(removed.rowId);
@@ -3802,14 +3821,28 @@ function applySubscriptionDeltaToState(
     const key = resultKeyBytes
       ? occurrenceStateKey(resultKeyBytes, removed.table, id)
       : rowKey(removed.table, id);
-    removedEntries.push({ id, index: currentIndexByKey.get(key) ?? 0, resultKeyBytes });
+    removedEntries.push({
+      table: removed.table,
+      id,
+      index: currentIndexByKey.get(key) ?? 0,
+      resultKeyBytes,
+    });
     rowsByKey.delete(key);
   }
 
-  const projectedColumns = outputColumns?.rootColumns;
   const nestedRowCarrier: NestedRowCarrier = "full-record";
-  const addedRows = rowsFromBatches(delta.added, schema, projectedColumns, nestedRowCarrier);
-  const updatedRows = rowsFromBatches(delta.updated, schema, projectedColumns, nestedRowCarrier);
+  const addedRows = rowsFromSubscriptionBatches(
+    delta.added,
+    schema,
+    outputColumns,
+    nestedRowCarrier,
+  );
+  const updatedRows = rowsFromSubscriptionBatches(
+    delta.updated,
+    schema,
+    outputColumns,
+    nestedRowCarrier,
+  );
   attachOccurrenceKeys(addedRows, delta.addedOccurrenceKeys);
   attachOccurrenceKeys(updatedRows, delta.updatedOccurrenceKeys);
   for (const row of addedRows.concat(updatedRows)) {
@@ -3825,6 +3858,22 @@ function applySubscriptionDeltaToState(
     rows,
     rowIndexByKey,
   };
+}
+
+function rowsFromSubscriptionBatches(
+  batches: NativeRowBatch[],
+  schema: WasmSchema,
+  outputColumns: SubscriptionOutputColumns | null,
+  nestedRowCarrier: NestedRowCarrier,
+): RowState[] {
+  return batches.flatMap((batch) =>
+    rowsFromBatches(
+      [batch],
+      schema,
+      batch.table === outputColumns?.rootTable ? outputColumns.rootColumns : undefined,
+      nestedRowCarrier,
+    ),
+  );
 }
 
 function indexRowsByKey(rows: RowState[]): Map<string, number> {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -7437,6 +7437,30 @@ function encodeSubscriptionDelta(delta: {
   return writer.finish();
 }
 
+function encodeSubscriptionDeltaWithTableColumns(
+  rows: Array<{ table: string; rowId: Uint8Array; column: string; value: string }>,
+): Uint8Array {
+  const writer = new PostcardWriter();
+  writer.vec((batch, index) => {
+    const row = rows[index]!;
+    const descriptor = [{ name: row.column, valueType: { tag: 8 } }];
+    batch.string(row.table);
+    writeDescriptor(batch, descriptor);
+    batch.vec((entry) => {
+      entry.bytes(row.rowId);
+      entry.bool(false);
+      entry.bytes(createRecord(descriptor, [new TextEncoder().encode(row.value)]));
+    }, 1);
+  }, rows.length);
+  writer.vec(() => undefined, 0);
+  writer.vec(() => undefined, 0);
+  const rowKey = (rowId: Uint8Array) => Uint8Array.from([1, ...rowId]);
+  writer.vec((key, index) => key.bytes(rowKey(rows[index]!.rowId)), rows.length);
+  writer.vec(() => undefined, 0);
+  writer.vec(() => undefined, 0);
+  return writer.finish();
+}
+
 it("preserves typed occurrence keys in the native subscription wire sidecar", () => {
   const typedKey = (label: string) => {
     const labelBytes = new TextEncoder().encode(label);
@@ -7650,6 +7674,45 @@ it("keeps same-row union occurrences distinct through apply, removal, and reopen
   expect(decodeNativeDelta(reopened.wireDelta, testSchema.todos.columns)[0]!.id).toBe(
     firstDelta[1]!.id,
   );
+});
+
+it("decodes related subscription batches with their own table schema", () => {
+  const schema = {
+    messages: {
+      columns: [{ name: "text", column_type: { type: "Text" }, nullable: false }],
+    },
+    profiles: {
+      columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+    },
+  } satisfies WasmSchema;
+  const messageId = uuidBytes("00000000-0000-0000-0000-000000000001");
+  const profileId = uuidBytes("00000000-0000-0000-0000-000000000002");
+  const delta = readNativeSubscriptionDelta(
+    new PostcardReader(
+      encodeSubscriptionDeltaWithTableColumns([
+        { table: "messages", rowId: messageId, column: "text", value: "visible message" },
+        { table: "profiles", rowId: profileId, column: "name", value: "Alice" },
+      ]),
+    ),
+  );
+
+  const applied = applySubscriptionDeltaWithWireDelta([], new Map(), delta, schema, true, {
+    rootTable: "messages",
+    rootColumns: schema.messages.columns,
+  });
+
+  expect(applied.rows).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        table: "messages",
+        values: [{ type: "Text", value: "visible message" }],
+      }),
+      expect.objectContaining({ table: "profiles", values: [{ type: "Text", value: "Alice" }] }),
+    ]),
+  );
+  expect(decodeNativeDelta(applied.wireDelta, schema.messages.columns)).toEqual([
+    expect.objectContaining({ id: formatUuid(messageId) }),
+  ]);
 });
 
 function encodeUserWrappedSubscriptionDelta(row: {


### PR DESCRIPTION
🤖 ## Summary

- decode each native relation batch with the projection for its own table
- keep related-table support rows out of the public root-row delta
- add a focused multi-table subscription regression that distinguishes Text from opaque Bytea fallback

## Why

The native adapter applied the root table's projected columns to every batch in a relation subscription. A related profile batch was therefore decoded as a message row, turning unknown fields into Bytea and producing invalid public values. Only root relation rows belong in the public row delta; related batches support relation materialization.

## Verification

- focused native-runtime Vitest regression
- planted restoration of root-only projection fails on the related Text field
- jazz-tools TypeScript check
- oxfmt, oxlint, diff check, and sensitive-data pre-commit gate

