### PR TITLE
fix(auth): isolate concurrent session claims

### DIFF
--- a/TEST_BURNDOWN.md
+++ b/TEST_BURNDOWN.md
@@ -76,10 +76,6 @@ A future fix must remove both the matching visible skip marker and this entry, t
 | `groove::db::tests::indexed_batch_commit_timing_receipt_20k_and_single_row`                      | `crates/groove/src/db/tests.rs`               | timing receipt             |
 | `jazz::node::tests::harness::policy_graph_perf_dropdown_entry_reset_ingest_timing_receipt`       | `crates/jazz/src/node/tests/sync.rs`          | timing receipt             |
 
-## Active TypeScript/browser quarantine (1)
+## Active TypeScript/browser quarantine (0)
 
-Measured on CI run `31669333671` at `30dc070e1`: 8 Node test failures and 2 Chromium failures. The two unrelated load flakes observed in the same run (the artifact-lock timing test and the Rust teardown abort) are deliberately not quarantined here.
-
-| Test                                                                                                                 | Definition                                                              | Status | Category               | Failure signature / theory                                                                                    | Owner  |
-| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------- | ------ |
-| `chromium > raw websocket private read gate > converts a private chat invite code into normal membership visibility` | `packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts` | FAIL   | Browser private invite | `Bob should subscribe to private seed messages through normal membership` times out after 15s; `lastRows=[]`. | Anselm |
+None. The private-invite Chromium regression is active again and has a focused green receipt.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -5268,7 +5268,13 @@ where
         identity: AuthorId,
         trust: CommitUnitTrust,
     ) -> Rc<RefCell<PeerConnection<S>>> {
-        self.accept_subscriber_with_resume_and_trust(transport, identity, trust, None)
+        self.accept_subscriber_with_resume_and_trust(
+            transport,
+            identity,
+            trust,
+            BTreeMap::new(),
+            None,
+        )
     }
 
     /// Accept a subscriber connection with explicit auth claims and upload trust mode.
@@ -5279,8 +5285,7 @@ where
         claims: BTreeMap<String, Value>,
         trust: CommitUnitTrust,
     ) -> Rc<RefCell<PeerConnection<S>>> {
-        self.node.borrow_mut().set_session_claims(identity, claims);
-        self.accept_subscriber_with_resume_and_trust(transport, identity, trust, None)
+        self.accept_subscriber_with_resume_and_trust(transport, identity, trust, claims, None)
     }
 
     /// Accept an edge-terminated subscriber with explicit auth claims.
@@ -5290,11 +5295,11 @@ where
         identity: AuthorId,
         claims: BTreeMap<String, Value>,
     ) -> Rc<RefCell<PeerConnection<S>>> {
-        self.node.borrow_mut().set_session_claims(identity, claims);
         self.accept_subscriber_with_peer(
             transport,
             identity,
             CommitUnitTrust::Session,
+            claims,
             None,
             PeerState::edge_client(identity),
             false,
@@ -5308,11 +5313,11 @@ where
         identity: AuthorId,
         claims: BTreeMap<String, Value>,
     ) -> Rc<RefCell<PeerConnection<S>>> {
-        self.node.borrow_mut().set_session_claims(identity, claims);
         self.accept_subscriber_with_peer(
             transport,
             identity,
             CommitUnitTrust::Session,
+            claims,
             None,
             PeerState::edge_client(identity),
             true,
@@ -5330,6 +5335,7 @@ where
             transport,
             identity,
             CommitUnitTrust::Session,
+            BTreeMap::new(),
             Some(cursor),
         )
     }
@@ -5339,6 +5345,7 @@ where
         transport: Box<dyn Transport>,
         identity: AuthorId,
         trust: CommitUnitTrust,
+        claims: BTreeMap<String, Value>,
         cursor: Option<ResumeCursor>,
     ) -> Rc<RefCell<PeerConnection<S>>> {
         let peer = match trust {
@@ -5347,7 +5354,7 @@ where
             }
             CommitUnitTrust::Session => PeerState::client_link(identity),
         };
-        self.accept_subscriber_with_peer(transport, identity, trust, cursor, peer, false)
+        self.accept_subscriber_with_peer(transport, identity, trust, claims, cursor, peer, false)
     }
 
     fn accept_subscriber_with_peer(
@@ -5355,12 +5362,35 @@ where
         transport: Box<dyn Transport>,
         identity: AuthorId,
         trust: CommitUnitTrust,
+        claims: BTreeMap<String, Value>,
         cursor: Option<ResumeCursor>,
         peer: PeerState,
         edge_authority: bool,
     ) -> Rc<RefCell<PeerConnection<S>>> {
-        let peer = cursor.map(|cursor| cursor.peer).unwrap_or(peer);
-        let session_claim_revision = self.node.borrow().session_claim_revision(identity);
+        let (peer, ingest_context, session_claims, session_claim_revision) = match cursor {
+            Some(cursor) => {
+                assert_eq!(
+                    cursor.ingest_context.identity, identity,
+                    "a resume cursor may only be used by its authenticated identity"
+                );
+                (
+                    cursor.peer,
+                    cursor.ingest_context,
+                    cursor.session_claims,
+                    cursor.session_claim_revision,
+                )
+            }
+            None => (
+                peer,
+                CommitUnitIngestContext {
+                    identity,
+                    trust,
+                    edge_authority,
+                },
+                claims,
+                0,
+            ),
+        };
         let connection_epoch = transport
             .connection_session_context()
             .map(|context| context.local.epoch)
@@ -5384,11 +5414,9 @@ where
             connection_epoch,
             link: ConnectionLink::Subscriber {
                 peer,
-                ingest_context: CommitUnitIngestContext {
-                    identity,
-                    trust,
-                    edge_authority,
-                },
+                ingest_context,
+                session_claims,
+                session_claim_revision,
                 outbox: Rc::clone(&self.outbox),
                 upstream_subscriptions: Rc::clone(&self.upstream_subscriptions),
                 served: BTreeMap::new(),
@@ -6519,6 +6547,12 @@ enum ConnectionLink {
     Subscriber {
         peer: PeerState,
         ingest_context: CommitUnitIngestContext,
+        /// Claims authenticated for this connection. They must not be shared
+        /// with another concurrent connection using the same author identity.
+        session_claims: BTreeMap<String, Value>,
+        /// Connection-local claim generation used to rebuild only this link's
+        /// maintained views when its session is refreshed.
+        session_claim_revision: u64,
         /// Accepted subscriber commit units awaiting upstream relay.
         outbox: Outbox,
         /// Subscriber-maintained views that must be announced upstream.
@@ -6593,17 +6627,51 @@ fn next_branch_metadata_repairs(
 ///
 /// Bindings keep this after a disconnect and pass it into
 /// [`Node::accept_subscriber_with_resume`] for the reconnecting subscriber. It is
-/// the facade handle for the peer-layer complete-tx payload inventory and
-/// result-set cursor.
+/// the facade handle for the peer-layer complete-tx payload inventory,
+/// result-set cursor, and authenticated connection context. Resume must never
+/// fall back to identity-global claim state because same-identity sessions can
+/// legitimately hold different admission claims.
 #[derive(Debug)]
 pub struct ResumeCursor {
     peer: PeerState,
+    ingest_context: CommitUnitIngestContext,
+    session_claims: BTreeMap<String, Value>,
+    session_claim_revision: u64,
 }
 
 impl<S> PeerConnection<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
+    /// Bind the process-local query compiler to this subscriber's authenticated
+    /// session immediately before it serves work for that subscriber. NodeState
+    /// retains a cache keyed by identity, while several websocket sessions can
+    /// legitimately share an identity with different claim maps.
+    fn bind_subscriber_session_claims(&self) {
+        let ConnectionLink::Subscriber {
+            ingest_context,
+            session_claims,
+            ..
+        } = &self.link
+        else {
+            return;
+        };
+        self.node
+            .borrow_mut()
+            .set_session_claims(ingest_context.identity, session_claims.clone());
+    }
+
+    fn subscriber_session_claim_revision(&self) -> u64 {
+        let ConnectionLink::Subscriber {
+            session_claim_revision,
+            ..
+        } = &self.link
+        else {
+            return 0;
+        };
+        *session_claim_revision
+    }
+
     /// Rebuild this subscriber's maintained views if its process-local claims
     /// changed. Policy claim values are bound when a maintained view opens, so
     /// retaining the old view after a claim change would retain its authority.
@@ -6613,7 +6681,8 @@ where
             ConnectionLink::Subscriber { ingest_context, .. } => ingest_context.identity,
             ConnectionLink::Upstream { .. } => return Ok(false),
         };
-        let current_revision = self.node.borrow().session_claim_revision(identity);
+        self.bind_subscriber_session_claims();
+        let current_revision = self.subscriber_session_claim_revision();
         if self.observed_session_claim_revision.get() == current_revision {
             return Ok(false);
         }
@@ -6785,12 +6854,22 @@ where
 
     /// Extract this subscriber connection's resume cursor for a reconnect.
     pub fn take_resume_cursor(&mut self) -> Option<ResumeCursor> {
-        let ConnectionLink::Subscriber { peer, .. } = &mut self.link else {
+        let ConnectionLink::Subscriber {
+            peer,
+            ingest_context,
+            session_claims,
+            session_claim_revision,
+            ..
+        } = &mut self.link
+        else {
             return None;
         };
         let replacement = PeerState::client_link(peer.link_identity());
         Some(ResumeCursor {
             peer: std::mem::replace(peer, replacement),
+            ingest_context: *ingest_context,
+            session_claims: std::mem::take(session_claims),
+            session_claim_revision: *session_claim_revision,
         })
     }
 
@@ -6799,6 +6878,7 @@ where
     /// tighter one: the client keeps the same subscription, but its visible
     /// membership must be recalculated immediately.
     fn rehydrate_subscriber_views(&mut self) -> Result<(), Error> {
+        self.bind_subscriber_session_claims();
         let connection_epoch = self.connection_epoch;
         let ConnectionLink::Subscriber {
             peer,
@@ -6897,6 +6977,7 @@ where
         let mut stats = DbTickStats::default();
         let connection_epoch = self.connection_epoch;
         self.observe_shared_subscriber_dirty_epoch();
+        self.bind_subscriber_session_claims();
         self.rebind_subscriber_views_after_claim_change()?;
         match &mut self.link {
             ConnectionLink::Upstream {
@@ -7713,6 +7794,8 @@ where
             ConnectionLink::Subscriber {
                 peer,
                 ingest_context,
+                session_claims: _,
+                session_claim_revision: _,
                 outbox,
                 upstream_subscriptions,
                 served,
@@ -8443,6 +8526,15 @@ where
                         // record only when its creator matches the authenticated
                         // link and its declared dependencies are available.
                         other => {
+                            if matches!(other, SyncMessage::SessionClaims { .. })
+                                && ingest_context.trust == CommitUnitTrust::Session
+                            {
+                                // Claims are fixed when the host admits or resumes this
+                                // connection. A subscriber can otherwise self-assert a
+                                // broader policy context after authentication.
+                                drop_peer_request(&self.node);
+                                continue;
+                            }
                             if let SyncMessage::BranchMetadata(metadata) = &other
                                 && ingest_context.trust == CommitUnitTrust::Session
                             {

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -1251,6 +1251,106 @@ fn relation_schema() -> JazzSchema {
     ])
 }
 
+fn membership_scoped_relation_schema() -> JazzSchema {
+    JazzSchema::new([
+        TableSchema::new(
+            "chats",
+            [
+                ColumnSchema::new("name", ColumnType::String),
+                ColumnSchema::new("is_public", ColumnType::Bool),
+                ColumnSchema::new("created_by", ColumnType::String),
+                ColumnSchema::new("join_code", ColumnType::String.nullable()),
+            ],
+        )
+        .with_read_policy(Policy::shape(
+            Query::from("chats")
+                .filter(any_of([]))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from("chats").filter(eq(col("is_public"), lit(true))),
+                ))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from("chats").filter(eq(col("join_code"), claim("join_code"))),
+                ))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from("chats").join_via_column(
+                        "chat_members",
+                        "chat_id",
+                        "id",
+                        [eq(col("user_id"), claim("user_id"))],
+                    ),
+                )),
+        ))
+        .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "chat_members",
+            [
+                ColumnSchema::new("chat_id", ColumnType::Uuid),
+                ColumnSchema::new("user_id", ColumnType::String),
+                ColumnSchema::new("join_code", ColumnType::String.nullable()),
+            ],
+        )
+        .with_reference("chat_id", "chats")
+        .with_read_policy(Policy::shape(
+            Query::from("chat_members")
+                .filter(any_of([]))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from("chat_members").filter(eq(col("user_id"), claim("user_id"))),
+                ))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from("chat_members").join_via_column(
+                        "chat_members",
+                        "chat_id",
+                        "chat_id",
+                        [eq(col("user_id"), claim("user_id"))],
+                    ),
+                )),
+        ))
+        .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "profiles",
+            [
+                ColumnSchema::new("user_id", ColumnType::String),
+                ColumnSchema::new("name", ColumnType::String),
+                ColumnSchema::new("avatar", ColumnType::String.nullable()),
+            ],
+        )
+        .with_read_policy(Policy::public())
+        .with_write_policy(Policy::public()),
+        TableSchema::new(
+            "messages",
+            [
+                ColumnSchema::new("chat_id", ColumnType::Uuid),
+                ColumnSchema::new("sender_id", ColumnType::Uuid),
+                ColumnSchema::new("text", ColumnType::String),
+                ColumnSchema::new("created_at", ColumnType::U64),
+            ],
+        )
+        .with_reference("chat_id", "chats")
+        .with_reference("sender_id", "profiles")
+        .with_read_policy(Policy::shape(
+            Query::from("messages")
+                .filter(any_of([]))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from("messages").join_via_column(
+                        "chats",
+                        "id",
+                        "chat_id",
+                        [eq(col("is_public"), lit(true))],
+                    ),
+                ))
+                .policy_branch(PolicyBranch::single_alternative_from_query(
+                    Query::from("messages").join_via_column(
+                        "chat_members",
+                        "chat_id",
+                        "chat_id",
+                        [eq(col("user_id"), claim("user_id"))],
+                    ),
+                )),
+        ))
+        .with_write_policy(Policy::public()),
+    ])
+}
+
 fn relation_hop_schema() -> JazzSchema {
     JazzSchema::new([
         TableSchema::new("orgs", [ColumnSchema::new("name", ColumnType::String)])
@@ -3965,6 +4065,385 @@ fn structured_subscription_splices_in_terminal_root_order_after_insert() {
                 }] if path.is_empty()
             )
     ));
+}
+
+#[test]
+fn propagated_structured_subscription_rehydrates_after_membership_scoped_one_shot() {
+    let schema = membership_scoped_relation_schema();
+    let reader = AuthorId::from_bytes([0xb2; 16]);
+    let normal_claims =
+        BTreeMap::from([("user_id".to_owned(), Value::String(reader.0.to_string()))]);
+    let invite_claims = BTreeMap::from([
+        ("user_id".to_owned(), Value::String(reader.0.to_string())),
+        (
+            "join_code".to_owned(),
+            Value::String("invite-code".to_owned()),
+        ),
+    ]);
+    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    let client = open_db(0xc4, reader, &schema);
+    let invite_client = open_db(0xc5, reader, &schema);
+    client.set_identity_claims(reader, normal_claims.clone());
+    invite_client.set_identity_claims(reader, invite_claims.clone());
+    // The normal connection remains live while a separately scoped invite
+    // connection writes its membership. This is the production handoff.
+    let (client_transport, server_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let _subscriber = server.accept_subscriber_with_claims(server_transport, reader, normal_claims);
+    let (invite_transport, server_invite_transport) = duplex();
+    let _invite_upstream = invite_client.connect_upstream(invite_transport);
+    let _invite_subscriber =
+        server.accept_subscriber_with_claims(server_invite_transport, reader, invite_claims);
+    let chat = row(0xc1);
+    let sender = row(0xa1);
+    let message = row(0xb1);
+    server
+        .insert_with_id(
+            "chats",
+            chat,
+            BTreeMap::from([
+                ("name".to_owned(), Value::String("private".to_owned())),
+                ("is_public".to_owned(), Value::Bool(false)),
+                ("created_by".to_owned(), Value::String("author".to_owned())),
+                (
+                    "join_code".to_owned(),
+                    Value::Nullable(Some(Box::new(Value::String("invite-code".to_owned())))),
+                ),
+            ]),
+        )
+        .unwrap();
+    server
+        .insert_with_id(
+            "profiles",
+            sender,
+            BTreeMap::from([
+                ("user_id".to_owned(), Value::String("alice".to_owned())),
+                ("name".to_owned(), Value::String("alice".to_owned())),
+                ("avatar".to_owned(), Value::Nullable(None)),
+            ]),
+        )
+        .unwrap();
+    // The browser fixture also has another visible profile which is unrelated
+    // to the message's sender. Keep that cardinality here: correlated include
+    // lowering must not lose the root because a support table has extra rows.
+    server
+        .insert_with_id(
+            "profiles",
+            row(0xa2),
+            BTreeMap::from([
+                ("user_id".to_owned(), Value::String("unrelated".to_owned())),
+                ("name".to_owned(), Value::String("unrelated".to_owned())),
+                ("avatar".to_owned(), Value::Nullable(None)),
+            ]),
+        )
+        .unwrap();
+    server
+        .insert_with_id(
+            "messages",
+            message,
+            BTreeMap::from([
+                ("chat_id".to_owned(), Value::Uuid(chat.0)),
+                ("sender_id".to_owned(), Value::Uuid(sender.0)),
+                ("text".to_owned(), Value::String("visible".to_owned())),
+                ("created_at".to_owned(), Value::U64(1_700_000_000_000)),
+            ]),
+        )
+        .unwrap();
+
+    let invite_chat_query = prepared(
+        &invite_client,
+        &Query::from("chats").filter(eq(col("id"), lit(chat.0))),
+    );
+    let invite_attachment = invite_client
+        .attach_query_with_opts(&invite_chat_query, edge_subscribe_opts())
+        .unwrap();
+    invite_client.tick().unwrap();
+    server.tick().unwrap();
+    invite_client.tick().unwrap();
+    assert!(invite_client.query_attachment_is_covered(&invite_attachment));
+    assert_eq!(
+        block_on(invite_client.all(&invite_chat_query, edge_subscribe_opts()))
+            .unwrap()
+            .len(),
+        1,
+        "the invite-scoped connection can read the private chat before acceptance",
+    );
+    invite_client.detach_query(invite_attachment);
+
+    // The ordinary session has the same authenticated identity, but not the
+    // invite claim. Its view must remain private until the separate invite
+    // session commits membership.
+    let normal_chat_query = prepared(
+        &client,
+        &Query::from("chats").filter(eq(col("id"), lit(chat.0))),
+    );
+    let normal_chat_attachment = client
+        .attach_query_with_opts(&normal_chat_query, edge_subscribe_opts())
+        .unwrap();
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert!(client.query_attachment_is_covered(&normal_chat_attachment));
+    assert!(
+        block_on(client.all(&normal_chat_query, edge_subscribe_opts()))
+            .unwrap()
+            .is_empty(),
+        "the invite claim must not leak from its connection into Bob's normal session",
+    );
+    client.detach_query(normal_chat_attachment);
+
+    let accepted_membership = invite_client
+        .insert_with_id(
+            "chat_members",
+            row(0xc2),
+            BTreeMap::from([
+                ("chat_id".to_owned(), Value::Uuid(chat.0)),
+                ("user_id".to_owned(), Value::String(reader.0.to_string())),
+                ("join_code".to_owned(), Value::Nullable(None)),
+            ]),
+        )
+        .unwrap();
+    invite_client.tick().unwrap();
+    server.tick().unwrap();
+    invite_client.tick().unwrap();
+    client.tick().unwrap();
+    block_on(accepted_membership.wait(DurabilityTier::Global))
+        .expect("the invite connection's membership write must settle");
+
+    let member_query = prepared(
+        &client,
+        &Query::from("chat_members").filter(eq(col("chat_id"), lit(chat.0))),
+    );
+    let member_attachment = client
+        .attach_query_with_opts(&member_query, edge_subscribe_opts())
+        .unwrap();
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert!(client.query_attachment_is_covered(&member_attachment));
+    assert_eq!(
+        block_on(client.all(&member_query, edge_subscribe_opts()))
+            .unwrap()
+            .len(),
+        1,
+        "the client first receives its membership through ordinary coverage",
+    );
+    client.detach_query(member_attachment);
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+
+    let plain_message_query = prepared(
+        &client,
+        &Query::from("messages").filter(eq(col("chat_id"), lit(chat.0))),
+    );
+    let plain_attachment = client
+        .attach_query_with_opts(&plain_message_query, edge_subscribe_opts())
+        .unwrap();
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert!(client.query_attachment_is_covered(&plain_attachment));
+    assert_eq!(
+        block_on(client.all(&plain_message_query, edge_subscribe_opts()))
+            .unwrap()
+            .len(),
+        1,
+        "the client receives the root before it requests the structured shape",
+    );
+    client.detach_query(plain_attachment);
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+
+    let query = Query::from("messages")
+        .filter(eq(col("chat_id"), lit(chat.0)))
+        .array_subquery(ArraySubquery::new("sender", "profiles", "id", "sender_id"))
+        .order_by("created_at", OrderDirection::Desc)
+        .limit(21);
+    let prepared_query = prepared(&client, &query);
+    let attachment = client
+        .attach_query_with_opts(&prepared_query, edge_subscribe_opts())
+        .unwrap();
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert!(client.query_attachment_is_covered(&attachment));
+    assert_eq!(
+        block_on(client.all_relation_snapshot(&prepared_query, edge_subscribe_opts()))
+            .unwrap()
+            .root_count,
+        1,
+    );
+    client.detach_query(attachment);
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+
+    let mut subscription =
+        block_on(client.subscribe(&prepared_query, edge_subscribe_opts())).unwrap();
+    assert!(opened_rows(block_on(subscription.next_event()).unwrap()).is_empty());
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+
+    let snapshot = snapshot_from_event(block_on(subscription.next_event()).unwrap());
+    assert!(
+        snapshot
+            .rows
+            .iter()
+            .any(|row| row.table() == "messages" && row.row_uuid() == message)
+    );
+}
+
+#[test]
+fn resume_cursor_restores_connection_claims_before_serving_same_identity_siblings() {
+    let schema = membership_scoped_relation_schema();
+    let reader = AuthorId::from_bytes([0xb3; 16]);
+    let normal_claims = BTreeMap::new();
+    let invite_claims = BTreeMap::from([
+        ("user_id".to_owned(), Value::String(reader.0.to_string())),
+        (
+            "join_code".to_owned(),
+            Value::String("resume-only-invite".to_owned()),
+        ),
+    ]);
+    let server = open_core(0x5f, AuthorId::SYSTEM, &schema);
+    let client = open_db(0xc6, reader, &schema);
+    let sibling = open_db(0xc7, reader, &schema);
+    let chat = row(0xc3);
+    server
+        .insert_with_id(
+            "chats",
+            chat,
+            BTreeMap::from([
+                ("name".to_owned(), Value::String("secret".to_owned())),
+                ("is_public".to_owned(), Value::Bool(false)),
+                ("created_by".to_owned(), Value::String("author".to_owned())),
+                (
+                    "join_code".to_owned(),
+                    Value::Nullable(Some(Box::new(Value::String(
+                        "resume-only-invite".to_owned(),
+                    )))),
+                ),
+            ]),
+        )
+        .unwrap();
+
+    let (client_transport, server_transport) = duplex();
+    let upstream = client.connect_upstream(client_transport);
+    let subscriber = server.accept_subscriber_with_claims(server_transport, reader, normal_claims);
+    let cursor = subscriber.borrow_mut().take_resume_cursor().unwrap();
+    assert!(server.server.detach_connection(&subscriber));
+    assert!(client.detach_connection(&upstream));
+
+    // This same-identity sibling is admitted with a broader invite claim. The
+    // resumed ordinary session must restore its own empty invite context, not
+    // inherit the process-local compiler cache that this sibling last bound.
+    let (sibling_transport, sibling_server_transport) = duplex();
+    let _sibling_upstream = sibling.connect_upstream(sibling_transport);
+    let _sibling_subscriber =
+        server.accept_subscriber_with_claims(sibling_server_transport, reader, invite_claims);
+    let (resumed_transport, resumed_server_transport) = duplex();
+    let _resumed_upstream = client.connect_upstream(resumed_transport);
+    let _resumed = server.accept_subscriber_with_resume(resumed_server_transport, reader, cursor);
+
+    let query = prepared(
+        &client,
+        &Query::from("chats").filter(eq(col("id"), lit(chat.0))),
+    );
+    let attachment = client
+        .attach_query_with_opts(&query, edge_subscribe_opts())
+        .unwrap();
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+
+    assert!(client.query_attachment_is_covered(&attachment));
+    assert!(
+        block_on(client.all(&query, edge_subscribe_opts()))
+            .unwrap()
+            .is_empty(),
+        "a resumed empty-claim session must not inherit its sibling's invite claim",
+    );
+}
+
+#[test]
+fn subscriber_wire_claims_cannot_escalate_host_admission() {
+    let schema = membership_scoped_relation_schema();
+    let reader = AuthorId::from_bytes([0xb4; 16]);
+    let normal_claims =
+        BTreeMap::from([("user_id".to_owned(), Value::String(reader.0.to_string()))]);
+    let self_asserted_invite = BTreeMap::from([
+        ("user_id".to_owned(), Value::String(reader.0.to_string())),
+        (
+            "join_code".to_owned(),
+            Value::String("self-asserted-invite".to_owned()),
+        ),
+    ]);
+    let server = open_core(0x60, AuthorId::SYSTEM, &schema);
+    let client = open_db(0xc8, reader, &schema);
+    let chat = row(0xc4);
+    server
+        .insert_with_id(
+            "chats",
+            chat,
+            BTreeMap::from([
+                ("name".to_owned(), Value::String("secret".to_owned())),
+                ("is_public".to_owned(), Value::Bool(false)),
+                ("created_by".to_owned(), Value::String("author".to_owned())),
+                (
+                    "join_code".to_owned(),
+                    Value::Nullable(Some(Box::new(Value::String(
+                        "self-asserted-invite".to_owned(),
+                    )))),
+                ),
+            ]),
+        )
+        .unwrap();
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let _subscriber = server.accept_subscriber_with_claims(server_transport, reader, normal_claims);
+    let dropped_before = server
+        .node()
+        .borrow()
+        .sync_metrics()
+        .dropped_peer_request_messages;
+
+    // This is an unverified wire message from an already admitted session,
+    // not an authenticated host refresh. It must not replace the admission
+    // claim map even though it carries the connection's real identity.
+    client.set_identity_claims(reader, self_asserted_invite);
+    client.tick().unwrap();
+    server.tick().unwrap();
+    assert_eq!(
+        server
+            .node()
+            .borrow()
+            .sync_metrics()
+            .dropped_peer_request_messages,
+        dropped_before + 1,
+    );
+
+    let query = prepared(
+        &client,
+        &Query::from("chats").filter(eq(col("id"), lit(chat.0))),
+    );
+    let attachment = client
+        .attach_query_with_opts(&query, edge_subscribe_opts())
+        .unwrap();
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+
+    assert!(client.query_attachment_is_covered(&attachment));
+    assert!(
+        block_on(client.all(&query, edge_subscribe_opts()))
+            .unwrap()
+            .is_empty(),
+        "a subscriber cannot grant itself an invite claim after host admission",
+    );
 }
 
 #[test]

--- a/crates/jazz/tests/branch_claims_integration.rs
+++ b/crates/jazz/tests/branch_claims_integration.rs
@@ -11,8 +11,8 @@ use jazz::row_input;
 use jazz::tools::public_schema::{PolicyExpr, TablePolicies};
 use jazz::tools::server::JazzServer;
 use jazz::tools::{
-    ColumnType, DurabilityTier, QueryBuilder, Schema, SchemaBuilder, SubscriptionStreamItem,
-    TableSchema, Value, policy_expr,
+    ColumnType, DurabilityTier, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
+    policy_expr,
 };
 use serde_json::json;
 use support::{
@@ -607,7 +607,7 @@ async fn subscription_matches_claims_select_query() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn claim_revocation_stops_existing_subscription_from_serving_future_rows() {
+async fn same_identity_sessions_keep_claims_isolated() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = admin_claims_gated_schema();
@@ -657,7 +657,7 @@ async fn claim_revocation_stops_existing_subscription_from_serving_future_rows()
             )
             .await;
 
-            let revoked = TestingClient::builder()
+            let non_admin = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema.clone())
                 .with_user_id(identity)
@@ -665,88 +665,48 @@ async fn claim_revocation_stops_existing_subscription_from_serving_future_rows()
                 .ready_on("admin_rooms", READY_TIMEOUT)
                 .connect()
                 .await;
-            let revoked_rows = revoked
+            let non_admin_rows = non_admin
                 .query(query.clone(), Some(DurabilityTier::EdgeServer))
                 .await
-                .expect("revoked identity performs one-shot read");
+                .expect("non-admin sibling performs one-shot read");
             assert!(
-                revoked_rows.is_empty(),
-                "one-shot read must fail closed after claim revocation: {revoked_rows:?}"
+                non_admin_rows.is_empty(),
+                "the non-admin sibling must fail closed: {non_admin_rows:?}"
             );
 
-            // A claim change must rebuild the maintained view under the new
-            // authorization, not merely drain its pending deltas. In
-            // particular, this removal has to arrive before a later write can
-            // trigger another view update.
-            wait_for_subscription_update(
-                &mut stream,
-                &mut stream_log,
-                QUERY_TIMEOUT,
-                "claim revocation removes rows already materialized under the old claim",
-                |updates| has_removed(updates, initial_id),
-            )
-            .await;
-
+            // A second JWT is a distinct authenticated session, even when it
+            // has the same user id. It must not implicitly revoke or widen
+            // the existing session's authorization; global revocation requires
+            // a distinct authenticated control signal.
             let (future_id, _, future_batch) = writer
-                .insert("admin_rooms", row_input!("name" => "must remain private"))
-                .expect("writer inserts post-revocation room");
+                .insert("admin_rooms", row_input!("name" => "visible to original session"))
+                .expect("writer inserts a later room");
             writer
                 .wait_for_batch(future_batch.expect("ordinary mutation commits immediately"), DurabilityTier::EdgeServer)
                 .await
-                .expect("post-revocation room reaches edge");
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
-            while tokio::time::Instant::now() < deadline {
-                let wait = (deadline - tokio::time::Instant::now()).min(Duration::from_millis(50));
-                match tokio::time::timeout(wait, stream.next()).await {
-                    Ok(Some(SubscriptionStreamItem::Delta(delta))) => stream_log.push(delta),
-                    Ok(Some(SubscriptionStreamItem::Rejected { reason })) => {
-                        panic!(
-                            "claim revocation rejected instead of keeping the stream live: {reason:?}"
-                        )
-                    }
-                    Ok(None) => panic!("claim revocation closed the existing subscription"),
-                    Err(_) => {}
-                }
-            }
-            assert!(
-                !has_added(&stream_log, future_id),
-                "revoked subscription must never receive post-revocation rows: {stream_log:#?}"
-            );
-
-            let restored = TestingClient::builder()
-                .with_server(&server)
-                .with_schema(schema)
-                .with_user_id(identity)
-                .with_claims(json!({"admin": true}))
-                .ready_on("admin_rooms", READY_TIMEOUT)
-                .connect()
-                .await;
-            let (restored_id, _, restored_batch) = writer
-                .insert(
-                    "admin_rooms",
-                    row_input!("name" => "visible after restoration"),
-                )
-                .expect("writer inserts post-restoration room");
-            writer
-                .wait_for_batch(restored_batch.expect("ordinary mutation commits immediately"), DurabilityTier::EdgeServer)
-                .await
-                .expect("post-restoration room reaches edge");
+                .expect("later room reaches edge");
             wait_for_subscription_update(
                 &mut stream,
                 &mut stream_log,
                 QUERY_TIMEOUT,
-                "restored claim keeps the existing subscription live",
-                |updates| has_added(updates, restored_id),
+                "the original authorized session receives later authorized rows",
+                |updates| has_added(updates, future_id),
             )
             .await;
+            assert!(
+                !has_removed(&stream_log, initial_id),
+                "a second same-identity JWT must not retract the original session's rows: {stream_log:#?}"
+            );
 
             writer.shutdown().await.expect("shutdown writer");
             authorized
                 .shutdown()
                 .await
                 .expect("shutdown authorized client");
-            revoked.shutdown().await.expect("shutdown revoked client");
-            restored.shutdown().await.expect("shutdown restored client");
+            non_admin
+                .shutdown()
+                .await
+                .expect("shutdown non-admin client");
             server.shutdown().await;
         })
         .await;

--- a/dev/gates/test-burndown-ts.mjs
+++ b/dev/gates/test-burndown-ts.mjs
@@ -23,7 +23,7 @@ function documentedRows(doc) {
     if (identities.has(identity)) fail(`duplicate documented TS/browser test: ${identity}`);
     identities.add(identity);
   }
-  if (active.length !== 1) fail(`expected 1 active TS/browser rows, got ${active.length}`);
+  if (active.length !== 0) fail(`expected 0 active TS/browser rows, got ${active.length}`);
   return { active, identities };
 }
 function sourceMarkers() {
@@ -87,4 +87,4 @@ for (const row of active)
   if (!fs.existsSync(row.path)) fail(`documented path does not exist: ${row.path}`);
 const source = sourceMarkers();
 if (!same(documented, source)) fail("TS/browser source markers differ from documented active set");
-console.log("TS/browser burndown: exact 1 active identity bijection.");
+console.log("TS/browser burndown: exact 0 active identity bijection.");

--- a/packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts
+++ b/packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts
@@ -673,9 +673,7 @@ describe("raw websocket private read gate", () => {
     aliceAgainUnsubscribe();
   }, 60_000);
 
-  // TEST_BURNDOWN_TS: chromium > raw websocket private read gate > converts a private chat invite code into normal membership visibility
-  // known red; tracked in TEST_BURNDOWN.md — private invite flow times out before its expected browser state stabilizes.
-  it.skip("converts a private chat invite code into normal membership visibility", async () => {
+  it("converts a private chat invite code into normal membership visibility", async () => {
     const { appId, serverUrl, adminSecret } = await getJazzServerInfo(
       uniqueDbName("camel-chat-private-invite"),
     );


### PR DESCRIPTION
🤖 ## Summary

- bind claims and claim revision to each subscriber connection instead of a user-global mutable slot
- preserve claims and authenticated ingest context across resume before serving any work
- reject self-asserted SessionClaims on ordinary session links while retaining authenticated TrustedBackend propagation
- restore the private-invite Chromium subscription and remove its final TS/browser quarantine entry

## Why

Two concurrent sessions for the same user could overwrite one another's claim context. An invite-scoped connection could make a normal sibling compile maintained queries under the wrong claims. The first repair also exposed resume and wire-admission hazards: a resumed empty-claim session could inherit sibling access, and an ordinary client could attempt to assert elevated claims over the wire.

Claims are now mandatory connection-local state. Resume restores that state and its trust/edge context before serving. Ordinary session claim updates are rejected; authenticated backend claim propagation continues through the existing trust gate. Global revocation, if required, needs a distinct authenticated signal rather than an unrelated sibling login.

## Verification

- focused two-connection private-invite regression
- same-user resume isolation regression with planted global-fallback failure
- session wire self-escalation regression with planted acceptance failure
- authenticated TrustedBackend claim propagation regression
- focused branch/claims, authorization-scope, prepared-routing, and resume suites
- fresh committed-tree NAPI build and exact Chromium private-invite test
- TS/browser burndown gate and self-test: zero active quarantines
- TypeScript check, formatting, Clippy, diff check, and sensitive-data pre-commit gate

