### PR TITLE
fix(ci): verify browser test artifact bindings

### DIFF
--- a/crates/jazz-napi/scripts/build.js
+++ b/crates/jazz-napi/scripts/build.js
@@ -4,40 +4,8 @@ const { resolve } = require("node:path");
 const release = !process.argv.includes("--debug") && process.env.JAZZ_NAPI_RELEASE !== "0";
 const profileIndex = process.argv.indexOf("--profile");
 const profile = profileIndex === -1 ? undefined : process.argv[profileIndex + 1];
-const args = ["build", "--platform"];
-if (profile) {
-  args.push("--profile", profile);
-} else if (release) {
-  args.push("--release");
-}
-
-const result = spawnSync("napi", args, {
-  stdio: "inherit",
-  shell: process.platform === "win32",
-});
-
-if (result.error) {
-  console.error(result.error.message);
-  process.exit(1);
-}
-
-if ((result.status ?? 1) !== 0) {
-  process.exit(result.status ?? 1);
-}
-const artifactRoot = resolve(__dirname, "../../..");
 const artifactProfile = profile ?? (release ? "release" : "debug");
-const manifest = spawnSync(
-  "node",
-  ["dev/artifacts/provenance.mjs", "write", "napi", artifactProfile],
-  {
-    cwd: artifactRoot,
-    stdio: "inherit",
-    shell: process.platform === "win32",
-  },
-);
-if ((manifest.status ?? 1) !== 0) process.exit(manifest.status ?? 1);
-process.exit(0);
-
-// Cache-salt 2026-07-19: a corrupt turbo cache archive for jazz-napi#build
-// reproducibly restored the package without a loadable .node on CI
-// (see dev/CI_NOTES.md). Changing this file busts the poisoned key.
+const args = [resolve(__dirname, "../../../dev/artifacts/build.mjs"), "napi", artifactProfile];
+const result = spawnSync(process.execPath, args, { stdio: "inherit" });
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { existsSync, renameSync, rmSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { writeManifest } from "./provenance.mjs";
 
 const root = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
@@ -18,6 +19,10 @@ const commands = {
       "pnpm",
       ["--dir", "crates/jazz-napi", "exec", "napi", "build", "--platform", "--release"],
     ],
+    perf: [
+      "pnpm",
+      ["--dir", "crates/jazz-napi", "exec", "napi", "build", "--platform", "--profile", "perf"],
+    ],
   },
 };
 const selected = commands[kind]?.[profile];
@@ -27,12 +32,59 @@ const [command, args] = selected;
 if (kind !== "napi" && extraArgs.length)
   throw new Error("only napi builds accept extra napi CLI arguments");
 args.push(...extraArgs);
+const targetIndex = extraArgs.indexOf("--target");
+const target = targetIndex === -1 ? undefined : extraArgs[targetIndex + 1];
+const napiBindingForTarget = {
+  "x86_64-unknown-linux-gnu": "jazz-napi.linux-x64-gnu.node",
+  "x86_64-pc-windows-msvc": "jazz-napi.win32-x64-msvc.node",
+  "x86_64-apple-darwin": "jazz-napi.darwin-x64.node",
+  "aarch64-apple-darwin": "jazz-napi.darwin-arm64.node",
+};
+const hostTarget = {
+  "linux-x64": "x86_64-unknown-linux-gnu",
+  "win32-x64": "x86_64-pc-windows-msvc",
+  "darwin-x64": "x86_64-apple-darwin",
+  "darwin-arm64": "aarch64-apple-darwin",
+}[`${process.platform}-${process.arch}`];
+const resolvedNapiTarget = target ?? hostTarget;
+const expectedNapiBinding = kind === "napi" && napiBindingForTarget[resolvedNapiTarget];
+if (kind === "napi" && !expectedNapiBinding)
+  throw new Error(`unsupported NAPI target ${resolvedNapiTarget ?? "unknown"}`);
+const napiPath = expectedNapiBinding && join(root, "crates/jazz-napi", expectedNapiBinding);
+const stagedNapiPath = napiPath && `${napiPath}.staged-${process.pid}-${Date.now()}`;
+if (napiPath && existsSync(napiPath)) renameSync(napiPath, stagedNapiPath);
 const result = spawnSync(command, args, {
   cwd: root,
   stdio: "inherit",
   shell: process.platform === "win32",
 });
-if (result.error) throw result.error;
-if (result.status !== 0) process.exit(result.status ?? 1);
-const targetIndex = extraArgs.indexOf("--target");
-writeManifest(root, kind, profile, targetIndex === -1 ? undefined : extraArgs[targetIndex + 1]);
+const restoreStagedNapi = () => {
+  if (stagedNapiPath && existsSync(stagedNapiPath)) {
+    if (!existsSync(napiPath)) renameSync(stagedNapiPath, napiPath);
+    else rmSync(stagedNapiPath, { force: true });
+  }
+};
+if (result.error) {
+  restoreStagedNapi();
+  throw result.error;
+}
+if (result.status !== 0) {
+  restoreStagedNapi();
+  process.exit(result.status ?? 1);
+}
+if (napiPath && !existsSync(napiPath)) {
+  restoreStagedNapi();
+  throw new Error(`NAPI build produced no ${expectedNapiBinding}; refusing to write provenance`);
+}
+if (napiPath && resolvedNapiTarget === hostTarget) {
+  const load = spawnSync(process.execPath, ["-e", "require(process.argv[1])", napiPath], {
+    stdio: "inherit",
+  });
+  if ((load.status ?? 1) !== 0) {
+    rmSync(napiPath, { force: true });
+    restoreStagedNapi();
+    throw new Error("NAPI build produced an unloadable host binding; refusing to write provenance");
+  }
+}
+if (stagedNapiPath) rmSync(stagedNapiPath, { force: true });
+writeManifest(root, kind, profile, target);

--- a/dev/artifacts/napi-build-contract.test.mjs
+++ b/dev/artifacts/napi-build-contract.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const build = readFileSync(new URL("./build.mjs", import.meta.url), "utf8");
+const wrapper = readFileSync(
+  new URL("../../crates/jazz-napi/scripts/build.js", import.meta.url),
+  "utf8",
+);
+
+test("all NAPI entrypoints use one target-aware fail-closed build path", () => {
+  assert.match(wrapper, /dev\/artifacts\/build\.mjs/);
+  assert.match(build, /const expectedNapiBinding/);
+  assert.match(build, /NAPI build produced no \$\{expectedNapiBinding\}/);
+  assert.match(build, /NAPI build produced an unloadable host binding/);
+  assert.match(build, /writeManifest\(root, kind, profile, target\)/);
+});
+
+test("a direct cross-target build stages only its expected binding", () => {
+  // The plant is the unrelated target name: selecting this would discard a
+  // valid foreign artifact when a direct --target build succeeds.
+  const unrelated = "jazz-napi.darwin-arm64.node";
+  assert.equal(
+    build.includes(`join(root, "crates/jazz-napi", ${JSON.stringify(unrelated)})`),
+    false,
+  );
+  assert.match(build, /const napiPath = expectedNapiBinding/);
+  assert.match(build, /if \(napiPath && existsSync\(napiPath\)\) renameSync/);
+});

--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -124,7 +124,16 @@ const inputsFor = {
 function artifactHashes(root, kind) {
   const paths =
     kind === "wasm"
-      ? [join(root, "crates/jazz-wasm/pkg/jazz_wasm_bg.wasm")]
+      ? // Browser tests import the generated JS and declarations as well as the
+        // binary.  Hash the complete generated binding surface: a stale glue
+        // file can silently drop a new Rust argument while the `.wasm` itself is
+        // perfectly current.
+        [
+          join(root, "crates/jazz-wasm/pkg/jazz_wasm_bg.wasm"),
+          join(root, "crates/jazz-wasm/pkg/jazz_wasm.js"),
+          join(root, "crates/jazz-wasm/pkg/jazz_wasm.d.ts"),
+          join(root, "crates/jazz-wasm/pkg/jazz_wasm_bg.wasm.d.ts"),
+        ]
       : readdirSync(join(root, "crates/jazz-napi"), { withFileTypes: true })
           .filter((entry) => entry.isFile() && entry.name.endsWith(".node"))
           .map((entry) => join(root, "crates/jazz-napi", entry.name));

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -77,6 +77,20 @@ test("dirty source changes invalidate the manifest", () => {
   );
 });
 
+test("WASM provenance covers generated glue and declarations, not only the binary", () => {
+  const root = fixture();
+  for (const file of [
+    "jazz_wasm_bg.wasm",
+    "jazz_wasm.js",
+    "jazz_wasm.d.ts",
+    "jazz_wasm_bg.wasm.d.ts",
+  ])
+    writeFileSync(join(root, "crates/jazz-wasm/pkg", file), "current");
+  writeManifest(root, "wasm", "fast");
+  writeFileSync(join(root, "crates/jazz-wasm/pkg/jazz_wasm.js"), "stale glue");
+  assert.match(verifyManifest(root, "wasm", "fast"), /artifacts differs/);
+});
+
 test("provenance rejects tool and root-package configuration drift", () => {
   const root = fixture();
   writeManifest(root, "wasm", "release");

--- a/dev/artifacts/verify-correctness-test-artifacts.mjs
+++ b/dev/artifacts/verify-correctness-test-artifacts.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/** Verify the generated artifacts actually loaded by browser correctness tests. */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { verifyManifest } from "./provenance.mjs";
+
+const root = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
+
+function text(path, rootDir = root) {
+  const full = resolve(rootDir, path);
+  if (!existsSync(full)) throw new Error(`missing ${path}`);
+  return readFileSync(full, "utf8");
+}
+
+function classBody(source, name) {
+  const start = source.indexOf(`class ${name}`);
+  if (start < 0) throw new Error(`missing ${name} declaration`);
+  const open = source.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    if (source[i] === "}" && --depth === 0) return source.slice(open + 1, i);
+  }
+  throw new Error(`unterminated ${name} declaration`);
+}
+
+function arityFromDeclaration(body, method) {
+  const match = body.match(new RegExp(`(?:^|\\n)\\s*(?:static\\s+)?${method}\\(([^)]*)\\)`, "m"));
+  if (!match) throw new Error(`missing WasmDb.${method}`);
+  return match[1].trim() === "" ? 0 : match[1].split(",").length;
+}
+
+function arityFromGlue(body, method) {
+  const match = body.match(new RegExp(`\\n\\s*${method}\\(([^)]*)\\)\\s*\\{`, "m"));
+  if (!match) throw new Error(`generated JS is missing WasmDb.${method}`);
+  return match[1].trim() === "" ? 0 : match[1].split(",").length;
+}
+
+export function verifyCorrectnessTestArtifacts(rootDir = root) {
+  const failures = [];
+  for (const [kind, profile] of [
+    ["wasm", "fast"],
+    ["napi", "release"],
+  ]) {
+    try {
+      const problem = verifyManifest(rootDir, kind, profile);
+      if (problem) failures.push(`STALE ${kind} ${profile}: ${problem}`);
+    } catch (error) {
+      failures.push(`STALE ${kind} ${profile}: ${error.message}`);
+    }
+  }
+  try {
+    const expected = classBody(
+      text("packages/jazz-tools/src/types/jazz-wasm.d.ts", rootDir),
+      "WasmDb",
+    );
+    const generatedTypes = classBody(
+      text("crates/jazz-wasm/pkg/jazz_wasm.d.ts", rootDir),
+      "WasmDb",
+    );
+    const generatedGlue = classBody(text("crates/jazz-wasm/pkg/jazz_wasm.js", rootDir), "WasmDb");
+    // These are the worker-boundary entry points whose arity is observable at
+    // runtime and has previously drifted when bindgen glue was stale.
+    for (const method of ["connectUpstream", "acceptSubscriber"]) {
+      const sourceArity = arityFromDeclaration(expected, method);
+      const typeArity = arityFromDeclaration(generatedTypes, method);
+      const glueArity = arityFromGlue(generatedGlue, method);
+      if (sourceArity !== typeArity || sourceArity !== glueArity)
+        failures.push(
+          `WASM ABI drift for WasmDb.${method}: consumer=${sourceArity}, d.ts=${typeArity}, glue=${glueArity}`,
+        );
+    }
+    const rust = text("crates/jazz/src/wire.rs", rootDir);
+    const ts = text("packages/jazz-tools/src/runtime/native-runtime/websocket.ts", rootDir);
+    const rustVersion = rust.match(/^pub const WIRE_PROTOCOL_VERSION: u16 = (\d+);$/m)?.[1];
+    const tsVersion = ts.match(/^export const WIRE_PROTOCOL_VERSION = (\d+);$/m)?.[1];
+    if (!rustVersion || !tsVersion) failures.push("could not read Rust/TS wire protocol versions");
+    else if (rustVersion !== tsVersion)
+      failures.push(`wire protocol version mismatch: Rust=${rustVersion}, TS=${tsVersion}`);
+  } catch (error) {
+    failures.push(error.message);
+  }
+  return failures;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const failures = verifyCorrectnessTestArtifacts();
+  if (failures.length) {
+    for (const failure of failures) console.error(`correctness-artifacts: ${failure}`);
+    console.error("Fix: pnpm build:test-artifacts");
+    process.exitCode = 1;
+  } else console.log("correctness-artifacts: release NAPI + fast WASM binding surface is current");
+}

--- a/dev/artifacts/verify-correctness-test-artifacts.test.mjs
+++ b/dev/artifacts/verify-correctness-test-artifacts.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { verifyCorrectnessTestArtifacts } from "./verify-correctness-test-artifacts.mjs";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "jazz-correctness-artifacts-"));
+  for (const dir of [
+    "crates/jazz-wasm/pkg",
+    "packages/jazz-tools/src/types",
+    "packages/jazz-tools/src/runtime/native-runtime",
+    "crates/jazz/src",
+  ])
+    mkdirSync(join(root, dir), { recursive: true });
+  // Deliberately leave manifests absent: these tests exercise the bounded ABI
+  // checks and prove their planted drift is reported alongside provenance.
+  writeFileSync(
+    join(root, "packages/jazz-tools/src/types/jazz-wasm.d.ts"),
+    `declare module "jazz-wasm" { export class WasmDb {\nconnectUpstream(): any;\nconnectUpstreamWithSession(a: number): any;\nacceptSubscriber(a: Uint8Array, claims: any): any;\n} }`,
+  );
+  writeFileSync(
+    join(root, "crates/jazz-wasm/pkg/jazz_wasm.d.ts"),
+    `export class WasmDb {\nconnectUpstream(): any;\nconnectUpstreamWithSession(a: number): any;\nacceptSubscriber(a: Uint8Array, claims: any): any;\n}`,
+  );
+  writeFileSync(
+    join(root, "crates/jazz-wasm/pkg/jazz_wasm.js"),
+    `export class WasmDb {\nconnectUpstream() {}\nconnectUpstreamWithSession(a) {}\nacceptSubscriber(a, claims) {}\n}`,
+  );
+  writeFileSync(
+    join(root, "crates/jazz/src/wire.rs"),
+    "pub const WIRE_PROTOCOL_VERSION: u16 = 9;\n",
+  );
+  writeFileSync(
+    join(root, "packages/jazz-tools/src/runtime/native-runtime/websocket.ts"),
+    "export const WIRE_PROTOCOL_VERSION = 9;\n",
+  );
+  return root;
+}
+
+test("reports a stale generated WASM method even when source declarations are current", () => {
+  const root = fixture();
+  writeFileSync(
+    join(root, "crates/jazz-wasm/pkg/jazz_wasm.js"),
+    `export class WasmDb {\nconnectUpstream() {}\nconnectUpstreamWithSession(a) {}\nacceptSubscriber(a) {}\n}`,
+  );
+  assert.match(
+    verifyCorrectnessTestArtifacts(root).join("\n"),
+    /acceptSubscriber: consumer=2, d.ts=2, glue=1/,
+  );
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("reports a wire-version mismatch", () => {
+  const root = fixture();
+  writeFileSync(
+    join(root, "packages/jazz-tools/src/runtime/native-runtime/websocket.ts"),
+    "export const WIRE_PROTOCOL_VERSION = 8;\n",
+  );
+  assert.match(
+    verifyCorrectnessTestArtifacts(root).join("\n"),
+    /wire protocol version mismatch: Rust=9, TS=8/,
+  );
+  rmSync(root, { recursive: true, force: true });
+});

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -132,7 +132,7 @@
     "test:svelte": "vitest run --config vitest.config.svelte.ts",
     "build:test": "node dist/cli.js validate --schema-dir tests/ts-dsl/fixtures/basic && tsc --project tsconfig.tests.json && pnpm typecheck:react-native",
     "typecheck:react-native": "tsc --project tsconfig.react-native-tests.json",
-    "test:browser": "vitest run --config vitest.config.browser.ts",
+    "test:browser": "node ../../dev/artifacts/verify-correctness-test-artifacts.mjs && vitest run --config vitest.config.browser.ts",
     "test:browser:focused": "node scripts/test-browser-focused.mjs",
     "test:browser:contract": "node scripts/test-browser-focused.test.mjs",
     "test:terminal-layout-contract": "vitest run --config vitest.config.ts src/runtime/terminal-layout-contract-matrix.test.ts --reporter=verbose --passWithNoTests=false",

--- a/packages/jazz-tools/scripts/test-browser-focused.mjs
+++ b/packages/jazz-tools/scripts/test-browser-focused.mjs
@@ -52,6 +52,11 @@ export function parseArgs(argv) {
 
 export function run(argv, spawn = spawnSync) {
   const { file, args } = parseArgs(argv);
+  const preflight = spawn("node", ["../../dev/artifacts/verify-correctness-test-artifacts.mjs"], {
+    cwd: fileURLToPath(new URL("..", import.meta.url)),
+    stdio: "inherit",
+  });
+  if ((preflight.status ?? 1) !== 0) return preflight.status ?? 1;
   const result = spawn("pnpm", args, {
     cwd: fileURLToPath(new URL("..", import.meta.url)),
     stdio: "inherit",

--- a/packages/jazz-tools/scripts/test-browser-focused.test.mjs
+++ b/packages/jazz-tools/scripts/test-browser-focused.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { resolve, join } from "node:path";
 import { mkdirSync, rmdirSync, symlinkSync, unlinkSync } from "node:fs";
 import { win32 } from "node:path";
-import { isInsideBrowserRoot, parseArgs } from "./test-browser-focused.mjs";
+import { isInsideBrowserRoot, parseArgs, run } from "./test-browser-focused.mjs";
 
 test("builds a Vitest command scoped to one file", () => {
   const result = parseArgs(["tests/browser/alpha-public-flow-gate.test.ts"]);
@@ -29,6 +29,36 @@ test("accepts pnpm's forwarded argument separator", () => {
     parseArgs(["--", "tests/browser/alpha-public-flow-gate.test.ts"]).file,
     resolve("tests/browser/alpha-public-flow-gate.test.ts"),
   );
+});
+
+test("runs the artifact preflight before Vitest and stops on a red preflight", () => {
+  const calls = [];
+  const spawn = (command, args) => {
+    calls.push({ command, args });
+    return { status: 17 };
+  };
+  assert.equal(run(["tests/browser/alpha-public-flow-gate.test.ts"], spawn), 17);
+  assert.deepEqual(calls, [
+    { command: "node", args: ["../../dev/artifacts/verify-correctness-test-artifacts.mjs"] },
+  ]);
+});
+
+test("runs Vitest only after the artifact preflight succeeds", () => {
+  const calls = [];
+  const spawn = (command, args) => {
+    calls.push({ command, args });
+    return { status: 0 };
+  };
+  assert.equal(run(["tests/browser/alpha-public-flow-gate.test.ts"], spawn), 0);
+  assert.equal(calls[0].command, "node");
+  assert.equal(calls[1].command, "pnpm");
+  assert.deepEqual(calls[1].args.slice(0, 5), [
+    "exec",
+    "vitest",
+    "run",
+    "--config",
+    "vitest.config.browser.ts",
+  ]);
 });
 
 test("rejects missing, multiple, and unknown arguments with specific errors", () => {


### PR DESCRIPTION
🤖 This makes browser correctness tests fail closed when generated Rust bindings do not match the checkout they are about to load.

## What changed

- Verify the exact release-NAPI and fast-WASM profiles before full or focused browser tests.
- Include generated WASM JavaScript and declarations in artifact provenance, not only the WASM binary.
- Check worker-boundary binding arity and Rust/TypeScript wire-version agreement.
- Route every NAPI build entrypoint through one target-aware guard that requires the requested artifact to be regenerated and preserves unrelated platform binaries.
- Add contract tests for stale glue, wire drift, direct cross-target builds, foreign-artifact preservation, and preflight short-circuiting before Vitest.

## Why

During review of #1484, a clean worktree loaded stale ignored WASM glue and a stale cross-target NAPI binary. The existing manifests could be skipped by focused browser commands, and one NAPI entrypoint could bless pre-existing output after a successful no-op build.

## Validation

- Artifact/provenance contracts: 11 passed.
- Focused browser runner contracts: 8 passed.
- pnpm build:test-artifacts completed NAPI, fast WASM, and CLI generation with fresh provenance. Its final jazz-tools build encountered existing runtime fixture type drift on the integration base, unrelated to this change.
- Format and diff checks passed.
- Independent adversarial review approved after target-path and preflight-order fixes.