### PR TITLE
feat: add ordinary-row text documents

### DIFF
--- a/.changeset/ordinary-row-text.md
+++ b/.changeset/ordinary-row-text.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Add an experimental ordinary-row `TextStore` with Unicode-safe inserts,
+bounded inline patch frontiers, immutable rope snapshots, and exact-version
+reads that do not replay ancestor history.

--- a/crates/jazz/SPEC/12_ordinary_row_text.md
+++ b/crates/jazz/SPEC/12_ordinary_row_text.md
@@ -1,0 +1,71 @@
+# 12. Ordinary-row text documents
+
+## 12.1 Contract
+
+Collaborative text is a library data structure built from ordinary Jazz tables
+and transactions. It is not a scalar type understood by the storage engine,
+wire protocol, sync path, or authority.
+
+A committed text version names a complete immutable snapshot:
+
+```text
+TextVersion {
+  document
+  base_root
+  patches[]       // bounded, ordered inserts against base_root
+  length
+  previous_version? // lineage metadata only
+}
+```
+
+Reading a version MUST load only that version's base root and bounded patch
+frontier. `previous_version` MUST NOT be followed to reconstruct content. This
+keeps historical read work independent of Jazz history depth.
+
+The document's current-version pointer and the new immutable version MUST be
+written in one ordinary Jazz transaction. Consequently text edits participate
+in the same durability, sync, authorization, branch, and history boundaries as
+other row writes.
+
+## 12.2 Bounded frontier
+
+Small inserts append to the version's patch frontier. The library MUST bound
+both patch count and encoded patch bytes. Crossing either bound synchronously
+materializes a new immutable rope root in the same transaction as the new
+version and document-pointer update. No application batching is required: one
+Unicode-safe insertion may be one durable Jazz transaction.
+
+Rope nodes are immutable ordinary rows. Leaves contain bounded UTF-8 text;
+branch nodes contain child references and subtree code-point lengths. A root is
+a complete snapshot, not a checkpoint that requires ancestor replay.
+
+## 12.3 Initial public scope
+
+The first API supports create, current read, exact-version read, and insertion
+at a Unicode code-point offset. It deliberately does not claim automatic
+semantic merging of concurrent document heads. Competing document-pointer
+writes use ordinary Jazz merge behavior, while both immutable versions remain
+in history for a future format-aware merge layer.
+
+Applications include the exported three-table definitions in their schema and
+define ordinary permissions for documents, versions, and nodes. The library
+does not add a privileged ownership or content protocol.
+
+## 12.4 Required evidence
+
+- inserts before, inside, and after non-ASCII text never split a scalar value;
+- threshold crossings keep patch count and bytes bounded;
+- sampled old versions remain readable after later consolidation;
+- deleting or corrupting lineage metadata cannot be necessary for a read;
+- a planted missing base node makes the read fail rather than fall back to
+  scanning prior versions;
+- representative durable edit, materialization, row-count, logical-byte, and
+  disk receipts remain reproducible beside the implementation.
+
+## 12.5 Open questions
+
+- automatic merge policy for rare competing heads (plain-text three-way merge
+  versus format-aware Markdown/HTML adapters);
+- transaction-created child authorization for least-privilege node insertion;
+- batched reachable-node hydration and content-addressed subtree reuse;
+- deletion and replacement operations beyond the initial insertion slice.

--- a/crates/jazz/SPEC/12_ordinary_row_text.md
+++ b/crates/jazz/SPEC/12_ordinary_row_text.md
@@ -30,7 +30,12 @@ other row writes.
 ## 12.2 Bounded frontier
 
 Small inserts append to the version's patch frontier. The library MUST bound
-both patch count and encoded patch bytes. Crossing either bound synchronously
+the persisted format to at most 64 patches and 16 KiB of UTF-8 encoded patch
+JSON. Every reader MUST reject encoded bytes above the byte cap before parsing
+and MUST reject decoded arrays above the count cap. These are format limits,
+not reader configuration: writer thresholds may be lower but never higher, and
+a conforming reader accepts every otherwise-valid frontier within both format
+limits. Crossing either configured writer bound synchronously
 materializes a new immutable rope root in the same transaction as the new
 version and document-pointer update. No application batching is required: one
 Unicode-safe insertion may be one durable Jazz transaction.
@@ -48,7 +53,10 @@ The first API supports create, current read, exact-version read, and insertion
 at a Unicode code-point offset. It deliberately does not claim automatic
 semantic merging of concurrent document heads. Competing document-pointer
 writes use ordinary Jazz merge behavior, while both immutable versions remain
-in history for a future format-aware merge layer.
+in history for a future format-aware merge layer. A writer configured for
+another Jazz branch still participates in that ordinary merged current-head
+behavior; the text library does not manufacture isolated per-branch head
+storage of its own.
 
 Applications include the exported three-table definitions in their schema and
 define ordinary permissions for documents, versions, and nodes. The library
@@ -66,12 +74,19 @@ snapshot = await text.insert(snapshot, 5, "!");
 
 Snapshots returned by the module are immutable capability objects. `insert`
 rejects fabricated snapshots so caller mutation cannot make persisted patch
-coordinates disagree with the materialized base.
+coordinates disagree with the materialized base. It also rejects non-string
+insertion payloads before the empty-string shortcut or any transaction begins.
 
 ## 12.4 Required evidence
 
 - inserts before, inside, and after non-ASCII text never split a scalar value;
 - threshold crossings keep patch count and bytes bounded;
+- oversized replicated patch encodings fail before parsing, and oversized
+  decoded patch arrays fail before materialization;
+- an authority-denied head update rolls back the complete ordinary-row edit
+  transaction, including its new immutable version and nodes;
+- independent clients and branch-configured writers observe the current head
+  through ordinary Jazz synchronization and merge behavior;
 - sampled old versions remain readable after later consolidation;
 - deleting or corrupting lineage metadata cannot be necessary for a read;
 - a planted missing base node makes the read fail rather than fall back to

--- a/crates/jazz/SPEC/12_ordinary_row_text.md
+++ b/crates/jazz/SPEC/12_ordinary_row_text.md
@@ -36,8 +36,11 @@ version and document-pointer update. No application batching is required: one
 Unicode-safe insertion may be one durable Jazz transaction.
 
 Rope nodes are immutable ordinary rows. Leaves contain bounded UTF-8 text;
-branch nodes contain child references and subtree code-point lengths. A root is
-a complete snapshot, not a checkpoint that requires ancestor replay.
+branch nodes contain child references, subtree code-point lengths, and balanced
+tree heights. A localized consolidation path-copies and shares untouched
+subtrees. If scattered edits would retain more new path nodes than a complete
+balanced tree, consolidation writes the smaller complete tree instead. A root
+is a complete snapshot, not a checkpoint that requires ancestor replay.
 
 ## 12.3 Initial public scope
 
@@ -50,6 +53,20 @@ in history for a future format-aware merge layer.
 Applications include the exported three-table definitions in their schema and
 define ordinary permissions for documents, versions, and nodes. The library
 does not add a privileged ownership or content protocol.
+
+```ts
+const app = schema.defineApp({
+  ...textTableDefinitions,
+  // application tables may reference jazz_text_documents normally
+});
+const text = createTextStore(db, textTablesFromApp(app));
+let snapshot = await text.create("hello");
+snapshot = await text.insert(snapshot, 5, "!");
+```
+
+Snapshots returned by the module are immutable capability objects. `insert`
+rejects fabricated snapshots so caller mutation cannot make persisted patch
+coordinates disagree with the materialized base.
 
 ## 12.4 Required evidence
 

--- a/dev/experiments/ordinary-row-text-production.md
+++ b/dev/experiments/ordinary-row-text-production.md
@@ -1,0 +1,70 @@
+# Ordinary-row text production receipt
+
+This receipt exercises the public `TextStore` implementation, not a synthetic
+row-count model. Every edit waits for local RocksDB durability. The bounded
+frontier is configured for 32 patches / 4 KiB encoded patches / 4 KiB UTF-8
+leaves. End and deterministic middle-heavy one-character inserts are measured
+separately.
+
+The structure uses ordinary document, explicit immutable version, and immutable
+rope-node rows. Consolidation path-copies localized edits and shares untouched
+subtrees. It instead emits a complete balanced root when scattered path copies
+would create more rows than rebuilding the full leaf tree.
+
+Environment: one Node 24 process using the freshly built release NAPI/RocksDB
+artifact. These are single-machine receipts and not stable release thresholds.
+
+## 100 KiB initial text, 300 edits
+
+| Workload | Representation   | durable p50 / p95 | row mutations/edit | logical bytes | RocksDB dir | consolidations p50 / p95 | exact-version materialization p50 |
+| -------- | ---------------- | ----------------: | -----------------: | ------------: | ----------: | -----------------------: | --------------------------------: |
+| end      | whole string     |  29.56 / 48.51 ms |               1.00 |      30.87 MB |    62.43 MB |                       -- |                       not exposed |
+| end      | bounded frontier |  13.18 / 32.26 ms |               2.15 |       ≥246 KB |     2.66 MB |        67.58 / 107.38 ms |                         171.96 ms |
+| middle   | whole string     |  30.06 / 56.11 ms |               1.00 |      30.87 MB |    62.43 MB |                       -- |                       not exposed |
+| middle   | bounded frontier |  12.70 / 24.17 ms |               3.53 |      ≥1.17 MB |     4.89 MB |       182.74 / 292.44 ms |                         578.91 ms |
+
+`logical bytes` for the frontier is deliberately marked as a lower bound: it
+counts encoded patch frontiers, ids, leaf text, and child references, but not
+the engine's ordinary transaction framing. Row mutations include the immutable
+version insert and document-head update plus amortized new rope nodes.
+
+## 4 KiB initial text, 1,000 edits
+
+| Workload | Representation   | durable p50 / p95 | row mutations/edit | logical bytes | RocksDB dir | consolidations p50 / p95 | exact-version materialization p50 |
+| -------- | ---------------- | ----------------: | -----------------: | ------------: | ----------: | -----------------------: | --------------------------------: |
+| end      | whole string     |    3.32 / 6.34 ms |               1.00 |       4.60 MB |    11.06 MB |                       -- |                       not exposed |
+| end      | bounded frontier |   9.39 / 19.58 ms |               2.06 |       ≥441 KB |    16.62 MB |         17.94 / 36.24 ms |                          13.70 ms |
+| middle   | whole string     |    3.21 / 6.57 ms |               1.00 |       4.60 MB |    11.04 MB |                       -- |                       not exposed |
+| middle   | bounded frontier |  10.02 / 17.43 ms |               2.09 |       ≥556 KB |    16.86 MB |         55.45 / 85.76 ms |                          12.70 ms |
+
+## Interpretation
+
+- At 100 KiB, avoiding the full-string cell rewrite wins clearly on ordinary
+  durable latency, logical payload, and disk footprint even while retaining an
+  explicit independently readable version row for every keystroke.
+- At 4 KiB, whole-string rewrite wins: the frontier pays two ordinary row
+  mutations per edit and explicit-version metadata dominates. A production API
+  should keep the representation choice visible or use a size crossover rather
+  than claiming the rope is universally cheaper.
+- Localized end edits share well (2.15 rows/edit at 100 KiB). Scattered edits
+  choose bounded full-tree rebuilding and cost 3.53 rows/edit, still avoiding a
+  100 KiB string rewrite on every keystroke.
+- Exact historical reads perform no Jazz-history replay, but the current public
+  implementation issues one ordinary point query per reachable rope node. The
+  100 KiB result makes batched/reachable child hydration the clearest next
+  general-purpose Jazz optimization.
+- Consolidation spikes, especially scattered edits, remain visible. The
+  frontier bounds their frequency rather than hiding their cost.
+
+## Reproduce
+
+```sh
+pnpm build:test-artifacts
+JAZZ_TEXT_BENCH=1 JAZZ_TEXT_BENCH_INITIAL_BYTES=102400 \
+JAZZ_TEXT_BENCH_EDITS=300 pnpm --dir packages/jazz-tools exec vitest run \
+src/text/text.bench.test.ts --reporter=verbose
+
+JAZZ_TEXT_BENCH=1 JAZZ_TEXT_BENCH_INITIAL_BYTES=4096 \
+JAZZ_TEXT_BENCH_EDITS=1000 pnpm --dir packages/jazz-tools exec vitest run \
+src/text/text.bench.test.ts --reporter=verbose
+```

--- a/dev/experiments/ordinary-row-text-production.md
+++ b/dev/experiments/ordinary-row-text-production.md
@@ -12,16 +12,18 @@ subtrees. It instead emits a complete balanced root when scattered path copies
 would create more rows than rebuilding the full leaf tree.
 
 Environment: one Node 24 process using the freshly built release NAPI/RocksDB
-artifact. These are single-machine receipts and not stable release thresholds.
+artifact. The production RocksDB profile uses Zstd for append/history column
+families, LZ4 for current/index/meta, and Zstd for bottommost compression. These
+are single-machine receipts and not stable release thresholds.
 
 ## 100 KiB initial text, 300 edits
 
-| Workload | Representation   | durable p50 / p95 | row mutations/edit | logical bytes | RocksDB dir | consolidations p50 / p95 | exact-version materialization p50 |
-| -------- | ---------------- | ----------------: | -----------------: | ------------: | ----------: | -----------------------: | --------------------------------: |
-| end      | whole string     |  15.50 / 27.21 ms |               1.00 |      30.87 MB |    62.43 MB |                       -- |                       not exposed |
-| end      | bounded frontier |   6.82 / 13.24 ms |               2.21 |       ≥248 KB |     2.67 MB |         26.29 / 28.51 ms |                          85.37 ms |
-| middle   | whole string     |  16.43 / 26.26 ms |               1.00 |      30.87 MB |    62.41 MB |                       -- |                       not exposed |
-| middle   | bounded frontier |   6.52 / 11.40 ms |               3.53 |      ≥1.17 MB |     4.89 MB |         66.36 / 74.83 ms |                         237.01 ms |
+| Workload | Representation   | durable p50 / p95 | row mutations/edit | logical bytes | closed apparent / allocated | reopened apparent / allocated | consolidations p50 / p95 | exact-version materialization p50 |
+| -------- | ---------------- | ----------------: | -----------------: | ------------: | --------------------------: | ----------------------------: | -----------------------: | --------------------------------: |
+| end      | whole string     |  15.46 / 25.94 ms |               1.00 |      30.87 MB |            62.43 / 62.46 MB |                0.62 / 0.66 MB |                       -- |                       not exposed |
+| end      | bounded frontier |   6.45 / 13.18 ms |               2.21 |       ≥248 KB |             2.67 / 78.18 MB |                0.50 / 0.53 MB |         25.21 / 27.72 ms |                          83.12 ms |
+| middle   | whole string     |  16.29 / 26.59 ms |               1.00 |      30.87 MB |            62.41 / 62.43 MB |                0.96 / 1.00 MB |                       -- |                       not exposed |
+| middle   | bounded frontier |   6.62 / 12.05 ms |               3.53 |      ≥1.17 MB |             4.89 / 78.18 MB |                0.64 / 0.68 MB |         65.45 / 83.93 ms |                         230.76 ms |
 
 `logical bytes` for the frontier is deliberately marked as a lower bound: it
 counts encoded patch frontiers, ids, leaf text, and child references, but not
@@ -30,12 +32,35 @@ version insert and document-head update plus amortized new rope nodes.
 
 ## 4 KiB initial text, 1,000 edits
 
-| Workload | Representation   | durable p50 / p95 | row mutations/edit | logical bytes | RocksDB dir | consolidations p50 / p95 | exact-version materialization p50 |
-| -------- | ---------------- | ----------------: | -----------------: | ------------: | ----------: | -----------------------: | --------------------------------: |
-| end      | whole string     |    3.32 / 6.34 ms |               1.00 |       4.60 MB |    11.06 MB |                       -- |                       not exposed |
-| end      | bounded frontier |   9.39 / 19.58 ms |               2.06 |       ≥441 KB |    16.62 MB |         17.94 / 36.24 ms |                          13.70 ms |
-| middle   | whole string     |    3.21 / 6.57 ms |               1.00 |       4.60 MB |    11.04 MB |                       -- |                       not exposed |
-| middle   | bounded frontier |  10.02 / 17.43 ms |               2.09 |       ≥556 KB |    16.86 MB |         55.45 / 85.76 ms |                          12.70 ms |
+| Workload | Representation   | durable p50 / p95 | row mutations/edit | logical bytes | closed apparent / allocated | reopened apparent / allocated | consolidations p50 / p95 | exact-version materialization p50 |
+| -------- | ---------------- | ----------------: | -----------------: | ------------: | --------------------------: | ----------------------------: | -----------------------: | --------------------------------: |
+| end      | whole string     |    2.51 / 4.35 ms |               1.00 |       4.60 MB |            11.06 / 11.08 MB |                0.57 / 0.61 MB |                       -- |                       not exposed |
+| end      | bounded frontier |   8.21 / 15.05 ms |               2.06 |       ≥441 KB |            16.60 / 78.18 MB |                0.88 / 0.91 MB |         12.91 / 22.96 ms |                          10.14 ms |
+| middle   | whole string     |    2.41 / 4.93 ms |               1.00 |       4.60 MB |            11.04 / 11.06 MB |                1.51 / 1.54 MB |                       -- |                       not exposed |
+| middle   | bounded frontier |   8.44 / 15.56 ms |               2.09 |       ≥556 KB |            16.86 / 78.18 MB |                0.96 / 1.00 MB |         39.05 / 46.04 ms |                          10.92 ms |
+
+## Storage measurement method
+
+Each representation/workload uses a fresh isolated database and the same
+deterministic edit offsets. `apparent` recursively sums file lengths;
+`allocated` sums `stat.blocks * 512`, equivalent to the data portion of `du`.
+The live and just-closed stores are WAL-dominated. RocksDB can preallocate WAL
+blocks, which explains the 78.18 MB allocated figure even when apparent bytes
+are much lower.
+
+To prove recovery without relying on the original process releasing every DB
+wrapper, the benchmark copies the exact closed directory, reopens that copy,
+reads and verifies the final value, and shuts it down before measuring again.
+Normal recovery turns almost all of the WAL into compressed SSTs: reopened WAL
+is below 1 KB in every receipt, while SST apparent bytes range from 0.19 MB to
+1.20 MB. The reopened columns above therefore show a useful compressed
+post-recovery footprint, not merely the logical payload or a live WAL size.
+They are not a claim about fully compacted bottommost-level size.
+
+No public production API currently exposes RocksDB memtable flush or manual
+compaction. `JazzContext.flush()` flushes the query runtime, not RocksDB. The
+receipt records live-after-runtime-flush, close, and reopen in its JSON output,
+but deliberately does not label any number as a forced-compaction result.
 
 ## Interpretation
 

--- a/dev/experiments/ordinary-row-text-production.md
+++ b/dev/experiments/ordinary-row-text-production.md
@@ -18,10 +18,10 @@ artifact. These are single-machine receipts and not stable release thresholds.
 
 | Workload | Representation   | durable p50 / p95 | row mutations/edit | logical bytes | RocksDB dir | consolidations p50 / p95 | exact-version materialization p50 |
 | -------- | ---------------- | ----------------: | -----------------: | ------------: | ----------: | -----------------------: | --------------------------------: |
-| end      | whole string     |  29.56 / 48.51 ms |               1.00 |      30.87 MB |    62.43 MB |                       -- |                       not exposed |
-| end      | bounded frontier |  13.18 / 32.26 ms |               2.15 |       ≥246 KB |     2.66 MB |        67.58 / 107.38 ms |                         171.96 ms |
-| middle   | whole string     |  30.06 / 56.11 ms |               1.00 |      30.87 MB |    62.43 MB |                       -- |                       not exposed |
-| middle   | bounded frontier |  12.70 / 24.17 ms |               3.53 |      ≥1.17 MB |     4.89 MB |       182.74 / 292.44 ms |                         578.91 ms |
+| end      | whole string     |  15.50 / 27.21 ms |               1.00 |      30.87 MB |    62.43 MB |                       -- |                       not exposed |
+| end      | bounded frontier |   6.82 / 13.24 ms |               2.21 |       ≥248 KB |     2.67 MB |         26.29 / 28.51 ms |                          85.37 ms |
+| middle   | whole string     |  16.43 / 26.26 ms |               1.00 |      30.87 MB |    62.41 MB |                       -- |                       not exposed |
+| middle   | bounded frontier |   6.52 / 11.40 ms |               3.53 |      ≥1.17 MB |     4.89 MB |         66.36 / 74.83 ms |                         237.01 ms |
 
 `logical bytes` for the frontier is deliberately marked as a lower bound: it
 counts encoded patch frontiers, ids, leaf text, and child references, but not
@@ -46,7 +46,7 @@ version insert and document-head update plus amortized new rope nodes.
   mutations per edit and explicit-version metadata dominates. A production API
   should keep the representation choice visible or use a size crossover rather
   than claiming the rope is universally cheaper.
-- Localized end edits share well (2.15 rows/edit at 100 KiB). Scattered edits
+- Localized end edits share well (2.21 rows/edit at 100 KiB). Scattered edits
   choose bounded full-tree rebuilding and cost 3.53 rows/edit, still avoiding a
   100 KiB string rewrite on every keystroke.
 - Exact historical reads perform no Jazz-history replay, but the current public

--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -220,6 +220,7 @@ export * from "./drivers/index.js";
 
 // Runtime client
 export * from "./runtime/index.js";
+export * from "./text/index.js";
 
 // Permissions DSL
 export * from "./permissions/index.js";

--- a/packages/jazz-tools/src/package-root-public-api.test.ts
+++ b/packages/jazz-tools/src/package-root-public-api.test.ts
@@ -314,6 +314,15 @@ describe("package root public API", () => {
       );
     }
 
+    for (const textExport of [
+      "TextStore",
+      "createTextStore",
+      "textTableDefinitions",
+      "textTablesFromApp",
+    ]) {
+      expect(packageRoot, `ordinary text export ${textExport}`).toHaveProperty(textExport);
+    }
+
     for (const internalRuntimeExport of internalRuntimeExports) {
       expect(runtime, `runtime internal export ${internalRuntimeExport}`).not.toHaveProperty(
         internalRuntimeExport,

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -137,6 +137,24 @@ describe("ordinary-row text", () => {
     }
   });
 
+  it("rejects a current-version pointer transplanted from another document", async () => {
+    const { context, db, text } = setup();
+    try {
+      const first = await text.create("first");
+      const second = await text.create("second");
+      const tampered = db.update(app.jazz_text_documents, first.documentId, {
+        current_version: second.versionId,
+      });
+      await tampered.wait({ tier: "local" });
+
+      await expect(text.read(first.documentId)).rejects.toThrow(
+        "points to another document's version",
+      );
+    } finally {
+      await context.shutdown();
+    }
+  });
+
   it("enforces both frontier bounds", async () => {
     const { context, text } = setup({ maxPatches: 100, maxPatchBytes: 40 });
     try {

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -12,6 +12,8 @@ import {
   TEXT_FRONTIER_MAX_PATCHES,
   textTableDefinitions,
   textTablesFromApp,
+  type TextSnapshot,
+  type TextStore,
 } from "./index.js";
 
 const app = s.defineApp({ ...textTableDefinitions });
@@ -35,6 +37,27 @@ const readWritePermissions = s.definePermissions(app, ({ policy }) => [
   policy.jazz_text_nodes.allowRead.always(),
   policy.jazz_text_nodes.allowInsert.always(),
 ]);
+
+async function waitForTextSnapshot(
+  text: TextStore,
+  documentId: string,
+  accept: (snapshot: TextSnapshot) => boolean,
+  description: string,
+): Promise<TextSnapshot> {
+  const deadline = performance.now() + 5_000;
+  let lastError: unknown;
+  while (performance.now() < deadline) {
+    try {
+      const snapshot = await text.read(documentId);
+      if (accept(snapshot)) return snapshot;
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes("was not found")) throw error;
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for ${description}`, { cause: lastError });
+}
 
 function setup(options: Parameters<typeof createTextStore>[2] = {}) {
   const dataPath = mkdtempSync(join(tmpdir(), "jazz-ordinary-text-test-"));
@@ -203,18 +226,42 @@ describe("ordinary-row text", () => {
     const draft = makeClient("draft");
     try {
       const initial = await first.text.create("shared");
-      const mainBase = await second.text.read(initial.documentId);
-      const draftBase = await draft.text.read(initial.documentId);
+      const mainBase = await waitForTextSnapshot(
+        second.text,
+        initial.documentId,
+        (snapshot) => snapshot.versionId === initial.versionId,
+        "the initial main-client text head",
+      );
+      const draftBase = await waitForTextSnapshot(
+        draft.text,
+        initial.documentId,
+        (snapshot) => snapshot.versionId === initial.versionId,
+        "the initial branch-writer text head",
+      );
       expect(mainBase.versionId).toBe(initial.versionId);
       expect(draftBase.versionId).toBe(initial.versionId);
 
       const mainEdit = await second.text.insert(mainBase, mainBase.length, "!");
       const draftEdit = await draft.text.insert(draftBase, draftBase.length, "?");
-      await expect(first.text.read(initial.documentId)).resolves.toMatchObject({
+      await expect(
+        waitForTextSnapshot(
+          first.text,
+          initial.documentId,
+          (snapshot) => snapshot.versionId === draftEdit.versionId,
+          "the merged current text head on the first client",
+        ),
+      ).resolves.toMatchObject({
         versionId: draftEdit.versionId,
         text: "shared?",
       });
-      await expect(second.text.read(initial.documentId)).resolves.toMatchObject({
+      await expect(
+        waitForTextSnapshot(
+          second.text,
+          initial.documentId,
+          (snapshot) => snapshot.versionId === draftEdit.versionId,
+          "the merged current text head on the second client",
+        ),
+      ).resolves.toMatchObject({
         versionId: draftEdit.versionId,
         text: "shared?",
       });

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createJazzContext } from "../backend/create-jazz-context.js";
 import { schema as s } from "../index.js";
-import { createTextStore, textTableDefinitions } from "./index.js";
+import { createTextStore, textTableDefinitions, textTablesFromApp } from "./index.js";
 
 const app = s.defineApp({ ...textTableDefinitions });
 
@@ -15,15 +15,7 @@ function setup(options: Parameters<typeof createTextStore>[2] = {}) {
     tier: "local",
   });
   const db = context.asBackend();
-  const text = createTextStore(
-    db,
-    {
-      documents: app.jazz_text_documents,
-      versions: app.jazz_text_versions,
-      nodes: app.jazz_text_nodes,
-    },
-    options,
-  );
+  const text = createTextStore(db, textTablesFromApp(app), options);
   return { context, db, text };
 }
 
@@ -82,6 +74,35 @@ describe("ordinary-row text", () => {
     }
   });
 
+  it("path-copies consolidation and retains untouched ordinary rope rows", async () => {
+    const { context, db, text } = setup({ maxPatches: 2, maxPatchBytes: 1024, leafBytes: 4 });
+    try {
+      const initialText = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+      const initial = await text.create(initialText);
+      const initialNodes = await db.all(app.jazz_text_nodes, { tier: "local" });
+      const initialIds = new Set(initialNodes.map((node) => node.id));
+      let snapshot = await text.insert(initial, 0, "X");
+      snapshot = await text.insert(snapshot, 0, "Y");
+      snapshot = await text.insert(snapshot, 0, "Z");
+      expect(snapshot.patchCount).toBe(0);
+
+      const reachable = new Set<string>();
+      const visit = async (id: string): Promise<void> => {
+        if (reachable.has(id)) return;
+        reachable.add(id);
+        const node = await db.one(app.jazz_text_nodes.where({ id }), { tier: "local" });
+        if (node?.left) await visit(node.left);
+        if (node?.right) await visit(node.right);
+      };
+      await visit(snapshot.baseRoot);
+
+      expect([...reachable].some((id) => initialIds.has(id))).toBe(true);
+      expect((await text.readVersion(snapshot.versionId)).text).toBe(`ZYX${initialText}`);
+    } finally {
+      await context.shutdown();
+    }
+  });
+
   it("fails closed on a missing base node instead of replaying version ancestry", async () => {
     const { context, db, text } = setup();
     try {
@@ -108,6 +129,19 @@ describe("ordinary-row text", () => {
       expect(second.patchCount).toBe(0);
       expect(second.patchBytes).toBe(2);
       expect(second.text).toBe("1234567890123456789012345678901234567890");
+    } finally {
+      await context.shutdown();
+    }
+  });
+
+  it("rejects fabricated snapshots before they can author inconsistent patches", async () => {
+    const { context, text } = setup();
+    try {
+      const snapshot = await text.create("safe");
+      expect(Object.isFrozen(snapshot)).toBe(true);
+      await expect(text.insert({ ...snapshot, text: "forged" }, 1, "x")).rejects.toThrow(
+        "snapshot returned by this module",
+      );
     } finally {
       await context.shutdown();
     }

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { createJazzContext } from "../backend/create-jazz-context.js";
 import { deploy } from "../dev/catalogue.js";
 import { schema as s } from "../index.js";
@@ -34,16 +37,21 @@ const readWritePermissions = s.definePermissions(app, ({ policy }) => [
 ]);
 
 function setup(options: Parameters<typeof createTextStore>[2] = {}) {
+  const dataPath = mkdtempSync(join(tmpdir(), "jazz-ordinary-text-test-"));
   const context = createJazzContext({
     appId: `ordinary-text-${crypto.randomUUID()}`,
     app,
     permissions: {},
-    driver: { type: "in-memory" },
+    driver: { type: "persistent", dataPath },
     adminSecret: "ordinary-text-test",
     tier: "local",
   });
   const db = context.asBackend();
   const text = createTextStore(db, textTablesFromApp(app), options);
+  onTestFinished(async () => {
+    await context.shutdown();
+    rmSync(dataPath, { recursive: true, force: true });
+  });
   return { context, db, text };
 }
 

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { createJazzContext } from "../backend/create-jazz-context.js";
+import { schema as s } from "../index.js";
+import { createTextStore, textTableDefinitions } from "./index.js";
+
+const app = s.defineApp({ ...textTableDefinitions });
+
+function setup(options: Parameters<typeof createTextStore>[2] = {}) {
+  const context = createJazzContext({
+    appId: `ordinary-text-${crypto.randomUUID()}`,
+    app,
+    permissions: {},
+    driver: { type: "in-memory" },
+    adminSecret: "ordinary-text-test",
+    tier: "local",
+  });
+  const db = context.asBackend();
+  const text = createTextStore(
+    db,
+    {
+      documents: app.jazz_text_documents,
+      versions: app.jazz_text_versions,
+      nodes: app.jazz_text_nodes,
+    },
+    options,
+  );
+  return { context, db, text };
+}
+
+describe("ordinary-row text", () => {
+  it("inserts at Unicode code-point positions without splitting scalars", async () => {
+    const { context, text } = setup();
+    try {
+      let snapshot = await text.create("A😀C");
+      snapshot = await text.insert(snapshot, 2, "é");
+      snapshot = await text.insert(snapshot, 0, "🙂");
+      snapshot = await text.insert(snapshot, snapshot.length, "!");
+
+      expect(snapshot.text).toBe("🙂A😀éC!");
+      expect(snapshot.length).toBe(6);
+      await expect(text.read(snapshot.documentId)).resolves.toEqual(snapshot);
+      await expect(text.insert(snapshot, 7, "x")).rejects.toThrow("outside 0..6");
+    } finally {
+      await context.shutdown();
+    }
+  });
+
+  it("consolidates synchronously while old versions remain independently readable", async () => {
+    const { context, db, text } = setup({ maxPatches: 2, maxPatchBytes: 1024, leafBytes: 4 });
+    try {
+      const initial = await text.create("abcdefgh");
+      const first = await text.insert(initial, 4, "X");
+      const second = await text.insert(first, 5, "Y");
+      const consolidated = await text.insert(second, 6, "Z");
+
+      expect(first.patchCount).toBe(1);
+      expect(second.patchCount).toBe(2);
+      expect(consolidated.patchCount).toBe(0);
+      expect(consolidated.baseRoot).not.toBe(initial.baseRoot);
+      await expect(text.readVersion(initial.versionId)).resolves.toMatchObject({
+        text: "abcdefgh",
+      });
+      await expect(text.readVersion(first.versionId)).resolves.toMatchObject({ text: "abcdXefgh" });
+      await expect(text.readVersion(second.versionId)).resolves.toMatchObject({
+        text: "abcdXYefgh",
+      });
+      await expect(text.readVersion(consolidated.versionId)).resolves.toMatchObject({
+        text: "abcdXYZefgh",
+      });
+
+      const document = await db.one(
+        app.jazz_text_documents.where({ id: consolidated.documentId }),
+        { tier: "local" },
+      );
+      const version = await db.one(app.jazz_text_versions.where({ id: consolidated.versionId }), {
+        tier: "local",
+      });
+      expect(document?.current_version).toBe(consolidated.versionId);
+      expect(version?.previous_version).toBe(second.versionId);
+    } finally {
+      await context.shutdown();
+    }
+  });
+
+  it("fails closed on a missing base node instead of replaying version ancestry", async () => {
+    const { context, db, text } = setup();
+    try {
+      const initial = await text.create("base");
+      const edited = await text.insert(initial, 4, "!");
+      const removed = db.delete(app.jazz_text_nodes, edited.baseRoot);
+      await removed.wait({ tier: "local" });
+
+      await expect(text.readVersion(edited.versionId)).rejects.toThrow(
+        `Text rope node ${edited.baseRoot} was not found`,
+      );
+    } finally {
+      await context.shutdown();
+    }
+  });
+
+  it("enforces both frontier bounds", async () => {
+    const { context, text } = setup({ maxPatches: 100, maxPatchBytes: 40 });
+    try {
+      const initial = await text.create("");
+      const first = await text.insert(initial, 0, "12345678901234567890");
+      const second = await text.insert(first, first.length, "12345678901234567890");
+      expect(first.patchCount).toBe(1);
+      expect(second.patchCount).toBe(0);
+      expect(second.patchBytes).toBe(2);
+      expect(second.text).toBe("1234567890123456789012345678901234567890");
+    } finally {
+      await context.shutdown();
+    }
+  });
+});

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -164,4 +164,30 @@ describe("ordinary-row text", () => {
       await context.shutdown();
     }
   });
+
+  it("matches a plain-string oracle across localized and scattered consolidations", async () => {
+    const { context, text } = setup({ maxPatches: 7, maxPatchBytes: 120, leafBytes: 16 });
+    try {
+      let expected = "start🙂end";
+      let snapshot = await text.create(expected);
+      const retained = [{ versionId: snapshot.versionId, expected }];
+      for (let edit = 0; edit < 80; edit += 1) {
+        const at = (edit * 48271 + 17) % (Array.from(expected).length + 1);
+        const inserted = edit % 9 === 0 ? "é" : edit % 13 === 0 ? "🚀" : "x";
+        const points = Array.from(expected);
+        points.splice(at, 0, inserted);
+        expected = points.join("");
+        snapshot = await text.insert(snapshot, at, inserted);
+        expect(snapshot.text).toBe(expected);
+        if (edit % 10 === 0) retained.push({ versionId: snapshot.versionId, expected });
+      }
+      for (const version of retained) {
+        await expect(text.readVersion(version.versionId)).resolves.toMatchObject({
+          text: version.expected,
+        });
+      }
+    } finally {
+      await context.shutdown();
+    }
+  });
 });

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -1,9 +1,37 @@
 import { describe, expect, it } from "vitest";
 import { createJazzContext } from "../backend/create-jazz-context.js";
+import { deploy } from "../dev/catalogue.js";
 import { schema as s } from "../index.js";
-import { createTextStore, textTableDefinitions, textTablesFromApp } from "./index.js";
+import { startLocalJazzServer } from "../testing/index.js";
+import {
+  createTextStore,
+  TEXT_FRONTIER_MAX_BYTES,
+  TEXT_FRONTIER_MAX_PATCHES,
+  textTableDefinitions,
+  textTablesFromApp,
+} from "./index.js";
 
 const app = s.defineApp({ ...textTableDefinitions });
+
+const readInsertOnlyPermissions = s.definePermissions(app, ({ policy }) => [
+  policy.jazz_text_documents.allowRead.always(),
+  policy.jazz_text_documents.allowInsert.always(),
+  policy.jazz_text_documents.allowUpdate.never(),
+  policy.jazz_text_versions.allowRead.always(),
+  policy.jazz_text_versions.allowInsert.always(),
+  policy.jazz_text_nodes.allowRead.always(),
+  policy.jazz_text_nodes.allowInsert.always(),
+]);
+
+const readWritePermissions = s.definePermissions(app, ({ policy }) => [
+  policy.jazz_text_documents.allowRead.always(),
+  policy.jazz_text_documents.allowInsert.always(),
+  policy.jazz_text_documents.allowUpdate.always(),
+  policy.jazz_text_versions.allowRead.always(),
+  policy.jazz_text_versions.allowInsert.always(),
+  policy.jazz_text_nodes.allowRead.always(),
+  policy.jazz_text_nodes.allowInsert.always(),
+]);
 
 function setup(options: Parameters<typeof createTextStore>[2] = {}) {
   const context = createJazzContext({
@@ -36,6 +64,161 @@ describe("ordinary-row text", () => {
       await context.shutdown();
     }
   });
+
+  it("rejects a non-string insert without poisoning the document transaction", async () => {
+    const { context, db, text } = setup();
+    try {
+      const snapshot = await text.create("safe");
+      const before = await Promise.all([
+        db.all(app.jazz_text_documents, { tier: "local" }),
+        db.all(app.jazz_text_versions, { tier: "local" }),
+        db.all(app.jazz_text_nodes, { tier: "local" }),
+      ]);
+
+      await expect(text.insert(snapshot, 0, 0 as unknown as string)).rejects.toThrow(
+        "Text insertion must be a string",
+      );
+
+      const after = await Promise.all([
+        db.all(app.jazz_text_documents, { tier: "local" }),
+        db.all(app.jazz_text_versions, { tier: "local" }),
+        db.all(app.jazz_text_nodes, { tier: "local" }),
+      ]);
+      expect(after).toEqual(before);
+      await expect(text.read(snapshot.documentId)).resolves.toEqual(snapshot);
+    } finally {
+      await context.shutdown();
+    }
+  });
+
+  it("rolls back the complete edit when ordinary row permissions deny the head update", async () => {
+    const appId = crypto.randomUUID();
+    const adminSecret = `ordinary-text-permission-${appId}`;
+    const backendSecret = `ordinary-text-backend-${appId}`;
+    const server = await startLocalJazzServer({
+      appId,
+      adminSecret,
+      backendSecret,
+      inMemory: true,
+    });
+    await deploy({
+      appId,
+      serverUrl: server.url,
+      adminSecret,
+      schema: app,
+      permissions: readInsertOnlyPermissions,
+    });
+    const context = createJazzContext({
+      appId,
+      app,
+      permissions: readInsertOnlyPermissions,
+      driver: { type: "memory" },
+      serverUrl: server.url,
+      backendSecret,
+      tier: "global",
+    });
+    const db = context.forSession({
+      user_id: "ordinary-text-writer",
+      claims: {},
+      authMode: "external",
+    });
+    const text = createTextStore(db, textTablesFromApp(app), { durability: "global" });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const initial = await text.create("safe");
+      const before = await Promise.all([
+        db.all(app.jazz_text_documents, { tier: "global" }),
+        db.all(app.jazz_text_versions, { tier: "global" }),
+        db.all(app.jazz_text_nodes, { tier: "global" }),
+      ]);
+
+      await expect(text.insert(initial, 4, "!")).rejects.toMatchObject({
+        code: "permission_denied",
+      });
+
+      const after = await Promise.all([
+        db.all(app.jazz_text_documents, { tier: "global" }),
+        db.all(app.jazz_text_versions, { tier: "global" }),
+        db.all(app.jazz_text_nodes, { tier: "global" }),
+      ]);
+      expect(after).toEqual(before);
+      await expect(text.read(initial.documentId)).resolves.toEqual(initial);
+    } finally {
+      await context.shutdown();
+      await server.stop();
+    }
+  }, 20_000);
+
+  it("syncs the ordinary current head across clients and branch writers", async () => {
+    const appId = crypto.randomUUID();
+    const adminSecret = `ordinary-text-branches-${appId}`;
+    const backendSecret = `ordinary-text-branches-backend-${appId}`;
+    const server = await startLocalJazzServer({
+      appId,
+      adminSecret,
+      backendSecret,
+      inMemory: true,
+    });
+    await deploy({
+      appId,
+      serverUrl: server.url,
+      adminSecret,
+      schema: app,
+      permissions: readWritePermissions,
+    });
+    const makeClient = (userBranch: string) => {
+      const context = createJazzContext({
+        appId,
+        app,
+        permissions: readWritePermissions,
+        driver: { type: "memory" },
+        serverUrl: server.url,
+        backendSecret,
+        userBranch,
+        tier: "global",
+      });
+      const db = context.forSession({
+        user_id: "ordinary-text-writer",
+        claims: {},
+        authMode: "external",
+      });
+      return {
+        context,
+        text: createTextStore(db, textTablesFromApp(app), { durability: "global" }),
+      };
+    };
+    const first = makeClient("main");
+    const second = makeClient("main");
+    const draft = makeClient("draft");
+    try {
+      const initial = await first.text.create("shared");
+      const observed = await second.text.read(initial.documentId);
+      expect(observed.text).toBe("shared");
+      const mainEdit = await second.text.insert(observed, observed.length, "!");
+      await expect(first.text.read(initial.documentId)).resolves.toMatchObject({
+        versionId: mainEdit.versionId,
+        text: "shared!",
+      });
+
+      const draftBase = await draft.text.read(initial.documentId);
+      const draftEdit = await draft.text.insert(draftBase, draftBase.length, "?");
+      await expect(draft.text.read(initial.documentId)).resolves.toMatchObject({
+        versionId: draftEdit.versionId,
+        text: "shared!?",
+      });
+      await expect(first.text.read(initial.documentId)).resolves.toMatchObject({
+        versionId: draftEdit.versionId,
+        text: "shared!?",
+      });
+    } finally {
+      await Promise.all([
+        first.context.shutdown(),
+        second.context.shutdown(),
+        draft.context.shutdown(),
+      ]);
+      await server.stop();
+    }
+  }, 20_000);
 
   it("consolidates synchronously while old versions remain independently readable", async () => {
     const { context, db, text } = setup({ maxPatches: 2, maxPatchBytes: 1024, leafBytes: 4 });
@@ -156,7 +339,10 @@ describe("ordinary-row text", () => {
   });
 
   it("enforces both frontier bounds", async () => {
-    const { context, text } = setup({ maxPatches: 100, maxPatchBytes: 40 });
+    const { context, text } = setup({
+      maxPatches: TEXT_FRONTIER_MAX_PATCHES,
+      maxPatchBytes: 40,
+    });
     try {
       const initial = await text.create("");
       const first = await text.insert(initial, 0, "12345678901234567890");
@@ -165,6 +351,63 @@ describe("ordinary-row text", () => {
       expect(second.patchCount).toBe(0);
       expect(second.patchBytes).toBe(2);
       expect(second.text).toBe("1234567890123456789012345678901234567890");
+    } finally {
+      await context.shutdown();
+    }
+  });
+
+  it("enforces format-level frontier limits on replicated rows", async () => {
+    const { context, db, text } = setup({ maxPatches: 4, maxPatchBytes: 128 });
+    try {
+      expect(() =>
+        createTextStore(db, textTablesFromApp(app), {
+          maxPatches: TEXT_FRONTIER_MAX_PATCHES + 1,
+        }),
+      ).toThrow(`maxPatches cannot exceed ${TEXT_FRONTIER_MAX_PATCHES}`);
+      expect(() =>
+        createTextStore(db, textTablesFromApp(app), {
+          maxPatchBytes: TEXT_FRONTIER_MAX_BYTES + 1,
+        }),
+      ).toThrow(`maxPatchBytes cannot exceed ${TEXT_FRONTIER_MAX_BYTES}`);
+
+      const snapshot = await text.create("safe");
+      const oversizedBytes = db.update(app.jazz_text_versions, snapshot.versionId, {
+        patches: " ".repeat(TEXT_FRONTIER_MAX_BYTES + 1),
+      });
+      await oversizedBytes.wait({ tier: "local" });
+      await expect(text.readVersion(snapshot.versionId)).rejects.toThrow(
+        "exceeds the persisted byte limit",
+      );
+
+      const oversizedCount = db.update(app.jazz_text_versions, snapshot.versionId, {
+        patches: JSON.stringify(
+          Array.from({ length: TEXT_FRONTIER_MAX_PATCHES + 1 }, () => ({ at: 0, text: "" })),
+        ),
+      });
+      await oversizedCount.wait({ tier: "local" });
+      await expect(text.readVersion(snapshot.versionId)).rejects.toThrow(
+        "exceeds the persisted count limit",
+      );
+    } finally {
+      await context.shutdown();
+    }
+  });
+
+  it("reads valid frontiers independently of local writer thresholds", async () => {
+    const { context, db, text: writer } = setup({ maxPatches: 4, maxPatchBytes: 128 });
+    try {
+      const initial = await writer.create("base");
+      const first = await writer.insert(initial, 4, "1");
+      const second = await writer.insert(first, 5, "2");
+      const stricterReader = createTextStore(db, textTablesFromApp(app), {
+        maxPatches: 1,
+        maxPatchBytes: 16,
+      });
+
+      await expect(stricterReader.readVersion(second.versionId)).resolves.toMatchObject({
+        text: "base12",
+        patchCount: 2,
+      });
     } finally {
       await context.shutdown();
     }

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -75,6 +75,9 @@ describe("ordinary-row text", () => {
         db.all(app.jazz_text_nodes, { tier: "local" }),
       ]);
 
+      await expect(text.insert(snapshot, 0, 7 as unknown as string)).rejects.toThrow(
+        "Text insertion must be a string",
+      );
       await expect(text.insert(snapshot, 0, 0 as unknown as string)).rejects.toThrow(
         "Text insertion must be a string",
       );
@@ -192,23 +195,26 @@ describe("ordinary-row text", () => {
     const draft = makeClient("draft");
     try {
       const initial = await first.text.create("shared");
-      const observed = await second.text.read(initial.documentId);
-      expect(observed.text).toBe("shared");
-      const mainEdit = await second.text.insert(observed, observed.length, "!");
+      const mainBase = await second.text.read(initial.documentId);
+      const draftBase = await draft.text.read(initial.documentId);
+      expect(mainBase.versionId).toBe(initial.versionId);
+      expect(draftBase.versionId).toBe(initial.versionId);
+
+      const mainEdit = await second.text.insert(mainBase, mainBase.length, "!");
+      const draftEdit = await draft.text.insert(draftBase, draftBase.length, "?");
       await expect(first.text.read(initial.documentId)).resolves.toMatchObject({
-        versionId: mainEdit.versionId,
+        versionId: draftEdit.versionId,
+        text: "shared?",
+      });
+      await expect(second.text.read(initial.documentId)).resolves.toMatchObject({
+        versionId: draftEdit.versionId,
+        text: "shared?",
+      });
+      await expect(first.text.readVersion(mainEdit.versionId)).resolves.toMatchObject({
         text: "shared!",
       });
-
-      const draftBase = await draft.text.read(initial.documentId);
-      const draftEdit = await draft.text.insert(draftBase, draftBase.length, "?");
-      await expect(draft.text.read(initial.documentId)).resolves.toMatchObject({
-        versionId: draftEdit.versionId,
-        text: "shared!?",
-      });
-      await expect(first.text.read(initial.documentId)).resolves.toMatchObject({
-        versionId: draftEdit.versionId,
-        text: "shared!?",
+      await expect(draft.text.readVersion(draftEdit.versionId)).resolves.toMatchObject({
+        text: "shared?",
       });
     } finally {
       await Promise.all([

--- a/packages/jazz-tools/src/text/index.test.ts
+++ b/packages/jazz-tools/src/text/index.test.ts
@@ -119,6 +119,24 @@ describe("ordinary-row text", () => {
     }
   });
 
+  it("rejects a root transplanted from another document", async () => {
+    const { context, db, text } = setup();
+    try {
+      const first = await text.create("first");
+      const second = await text.create("second");
+      const tampered = db.update(app.jazz_text_versions, first.versionId, {
+        base_root: second.baseRoot,
+      });
+      await tampered.wait({ tier: "local" });
+
+      await expect(text.readVersion(first.versionId)).rejects.toThrow(
+        "belongs to a different document",
+      );
+    } finally {
+      await context.shutdown();
+    }
+  });
+
   it("enforces both frontier bounds", async () => {
     const { context, text } = setup({ maxPatches: 100, maxPatchBytes: 40 });
     try {

--- a/packages/jazz-tools/src/text/index.ts
+++ b/packages/jazz-tools/src/text/index.ts
@@ -119,6 +119,10 @@ type RopeBranch = {
 type RopeNode = RopeLeaf | RopeBranch;
 
 const encoder = new TextEncoder();
+/** Hard format limit applied by every reader, independent of writer tuning. */
+export const TEXT_FRONTIER_MAX_PATCHES = 64;
+/** Hard UTF-8 format limit applied before parsing a persisted frontier. */
+export const TEXT_FRONTIER_MAX_BYTES = 16 * 1024;
 const snapshotPatches = new WeakMap<TextSnapshot, readonly TextPatch[]>();
 const snapshotRoots = new WeakMap<TextSnapshot, RopeNode>();
 
@@ -145,8 +149,14 @@ function encodePatches(patches: readonly TextPatch[]): string {
 }
 
 function decodePatches(encoded: string): TextPatch[] {
+  if (byteLength(encoded) > TEXT_FRONTIER_MAX_BYTES) {
+    throw new Error("Text patch frontier exceeds the persisted byte limit");
+  }
   const value: unknown = JSON.parse(encoded);
   if (!Array.isArray(value)) throw new Error("Invalid text patch frontier");
+  if (value.length > TEXT_FRONTIER_MAX_PATCHES) {
+    throw new Error("Text patch frontier exceeds the persisted count limit");
+  }
   return value.map((entry) => {
     if (
       typeof entry !== "object" ||
@@ -335,8 +345,14 @@ export class TextStore {
     if (!Number.isInteger(this.maxPatches) || this.maxPatches < 1) {
       throw new RangeError("maxPatches must be a positive integer");
     }
+    if (this.maxPatches > TEXT_FRONTIER_MAX_PATCHES) {
+      throw new RangeError(`maxPatches cannot exceed ${TEXT_FRONTIER_MAX_PATCHES}`);
+    }
     if (!Number.isInteger(this.maxPatchBytes) || this.maxPatchBytes < 2) {
       throw new RangeError("maxPatchBytes must be an integer of at least 2");
+    }
+    if (this.maxPatchBytes > TEXT_FRONTIER_MAX_BYTES) {
+      throw new RangeError(`maxPatchBytes cannot exceed ${TEXT_FRONTIER_MAX_BYTES}`);
     }
     if (!Number.isInteger(this.leafBytes) || this.leafBytes < 4) {
       throw new RangeError("leafBytes must be an integer of at least 4");
@@ -398,6 +414,7 @@ export class TextStore {
   }
 
   async insert(snapshot: TextSnapshot, at: number, inserted: string): Promise<TextSnapshot> {
+    if (typeof inserted !== "string") throw new TypeError("Text insertion must be a string");
     if (!inserted) return snapshot;
     const text = insertAtCodePoint(snapshot.text, at, inserted);
     let root = snapshot.baseRoot;

--- a/packages/jazz-tools/src/text/index.ts
+++ b/packages/jazz-tools/src/text/index.ts
@@ -239,21 +239,13 @@ function balance(left: RopeNode, right: RopeNode, created: Map<string, RopeNode>
 }
 
 function buildBalanced(nodes: RopeNode[], created: Map<string, RopeNode>): RopeNode {
-  let level = nodes;
-  while (level.length > 1) {
-    const next: typeof level = [];
-    for (let index = 0; index < level.length; index += 2) {
-      const left = level[index]!;
-      const right = level[index + 1];
-      if (!right) {
-        next.push(left);
-        continue;
-      }
-      next.push(makeBranch(left, right, created));
-    }
-    level = next;
-  }
-  return level[0]!;
+  if (nodes.length === 1) return nodes[0]!;
+  const middle = Math.floor(nodes.length / 2);
+  return makeBranch(
+    buildBalanced(nodes.slice(0, middle), created),
+    buildBalanced(nodes.slice(middle), created),
+    created,
+  );
 }
 
 function buildRope(value: string, leafBytes: number): { root: RopeNode; nodes: RopeNode[] } {

--- a/packages/jazz-tools/src/text/index.ts
+++ b/packages/jazz-tools/src/text/index.ts
@@ -12,7 +12,7 @@ const NODE_TABLE = "jazz_text_nodes";
 /** Ordinary table definitions required by {@link createTextStore}. */
 export const textTableDefinitions = {
   [DOCUMENT_TABLE]: s.table({
-    current_version: s.string(),
+    current_version: s.ref(VERSION_TABLE),
     text_length: s.int(),
   }),
   [VERSION_TABLE]: s.table({
@@ -25,8 +25,11 @@ export const textTableDefinitions = {
   [NODE_TABLE]: s.table({
     document: s.ref(DOCUMENT_TABLE),
     kind: s.string(),
-    payload: s.string(),
+    text: s.string().optional(),
+    left: s.ref(NODE_TABLE).optional(),
+    right: s.ref(NODE_TABLE).optional(),
     text_length: s.int(),
+    height: s.int(),
   }),
 } as const;
 
@@ -49,8 +52,11 @@ export type TextNodeRow = {
   id: string;
   document: string;
   kind: string;
-  payload: string;
+  text: string | null;
+  left: string | null;
+  right: string | null;
   text_length: number;
+  height: number;
 };
 
 type TextTable<Row, Init> = TableProxy<Row, Init> & {
@@ -63,7 +69,20 @@ export interface TextTables {
     TextVersionRow,
     Omit<TextVersionRow, "id" | "previous_version"> & { previous_version?: string | null }
   >;
-  nodes: TextTable<TextNodeRow, Omit<TextNodeRow, "id">>;
+  nodes: TextTable<
+    TextNodeRow,
+    Omit<TextNodeRow, "id" | "text" | "left" | "right"> & {
+      text?: string | null;
+      left?: string | null;
+      right?: string | null;
+    }
+  >;
+}
+
+export interface TextAppTables {
+  jazz_text_documents: TextTables["documents"];
+  jazz_text_versions: TextTables["versions"];
+  jazz_text_nodes: TextTables["nodes"];
 }
 
 export interface TextStoreOptions {
@@ -78,22 +97,30 @@ export interface TextStoreOptions {
 }
 
 export interface TextSnapshot {
-  documentId: string;
-  versionId: string;
-  text: string;
-  length: number;
-  baseRoot: string;
-  patchCount: number;
-  patchBytes: number;
+  readonly documentId: string;
+  readonly versionId: string;
+  readonly text: string;
+  readonly length: number;
+  readonly baseRoot: string;
+  readonly patchCount: number;
+  readonly patchBytes: number;
 }
 
 type TextPatch = { at: number; text: string };
-type PendingNode = Omit<TextNodeRow, "document">;
-type LeafPayload = { text: string };
-type BranchPayload = { left: string; right: string };
+type RopeLeaf = { id: string; kind: "leaf"; text: string; length: number; height: number };
+type RopeBranch = {
+  id: string;
+  kind: "branch";
+  left: RopeNode;
+  right: RopeNode;
+  length: number;
+  height: number;
+};
+type RopeNode = RopeLeaf | RopeBranch;
 
 const encoder = new TextEncoder();
 const snapshotPatches = new WeakMap<TextSnapshot, readonly TextPatch[]>();
+const snapshotRoots = new WeakMap<TextSnapshot, RopeNode>();
 
 function byteLength(value: string): number {
   return encoder.encode(value).byteLength;
@@ -158,14 +185,61 @@ function splitUtf8(value: string, maximumBytes: number): string[] {
   return leaves;
 }
 
-function buildRope(value: string, leafBytes: number): { root: string; nodes: PendingNode[] } {
-  const nodes: PendingNode[] = splitUtf8(value, leafBytes).map((text) => ({
+function makeLeaf(text: string, created: Map<string, RopeNode>): RopeLeaf {
+  const node: RopeLeaf = {
     id: crypto.randomUUID(),
     kind: "leaf",
-    payload: JSON.stringify({ text } satisfies LeafPayload),
-    text_length: codePointLength(text),
-  }));
-  let level = nodes.map((node) => ({ id: node.id, length: node.text_length }));
+    text,
+    length: codePointLength(text),
+    height: 1,
+  };
+  created.set(node.id, node);
+  return node;
+}
+
+function makeBranch(left: RopeNode, right: RopeNode, created: Map<string, RopeNode>): RopeBranch {
+  const node: RopeBranch = {
+    id: crypto.randomUUID(),
+    kind: "branch",
+    left,
+    right,
+    length: left.length + right.length,
+    height: Math.max(left.height, right.height) + 1,
+  };
+  created.set(node.id, node);
+  return node;
+}
+
+function balance(left: RopeNode, right: RopeNode, created: Map<string, RopeNode>): RopeNode {
+  if (left.height > right.height + 1 && left.kind === "branch") {
+    if (left.left.height >= left.right.height) {
+      return makeBranch(left.left, makeBranch(left.right, right, created), created);
+    }
+    if (left.right.kind === "branch") {
+      return makeBranch(
+        makeBranch(left.left, left.right.left, created),
+        makeBranch(left.right.right, right, created),
+        created,
+      );
+    }
+  }
+  if (right.height > left.height + 1 && right.kind === "branch") {
+    if (right.right.height >= right.left.height) {
+      return makeBranch(makeBranch(left, right.left, created), right.right, created);
+    }
+    if (right.left.kind === "branch") {
+      return makeBranch(
+        makeBranch(left, right.left.left, created),
+        makeBranch(right.left.right, right.right, created),
+        created,
+      );
+    }
+  }
+  return makeBranch(left, right, created);
+}
+
+function buildBalanced(nodes: RopeNode[], created: Map<string, RopeNode>): RopeNode {
+  let level = nodes;
   while (level.length > 1) {
     const next: typeof level = [];
     for (let index = 0; index < level.length; index += 2) {
@@ -175,18 +249,80 @@ function buildRope(value: string, leafBytes: number): { root: string; nodes: Pen
         next.push(left);
         continue;
       }
-      const node: PendingNode = {
-        id: crypto.randomUUID(),
-        kind: "branch",
-        payload: JSON.stringify({ left: left.id, right: right.id } satisfies BranchPayload),
-        text_length: left.length + right.length,
-      };
-      nodes.push(node);
-      next.push({ id: node.id, length: node.text_length });
+      next.push(makeBranch(left, right, created));
     }
     level = next;
   }
-  return { root: level[0]!.id, nodes };
+  return level[0]!;
+}
+
+function buildRope(value: string, leafBytes: number): { root: RopeNode; nodes: RopeNode[] } {
+  const created = new Map<string, RopeNode>();
+  const leaves = splitUtf8(value, leafBytes).map((text) => makeLeaf(text, created));
+  const root = buildBalanced(leaves, created);
+  return { root, nodes: [...created.values()] };
+}
+
+function insertIntoRope(
+  node: RopeNode,
+  at: number,
+  inserted: string,
+  leafBytes: number,
+  created: Map<string, RopeNode>,
+): RopeNode {
+  if (node.kind === "leaf") {
+    const value = insertAtCodePoint(node.text, at, inserted);
+    const leaves = splitUtf8(value, leafBytes).map((text) => makeLeaf(text, created));
+    return buildBalanced(leaves, created);
+  }
+  if (at <= node.left.length) {
+    return balance(
+      insertIntoRope(node.left, at, inserted, leafBytes, created),
+      node.right,
+      created,
+    );
+  }
+  return balance(
+    node.left,
+    insertIntoRope(node.right, at - node.left.length, inserted, leafBytes, created),
+    created,
+  );
+}
+
+function reachableCreatedNodes(root: RopeNode, created: Map<string, RopeNode>): RopeNode[] {
+  const reachable: RopeNode[] = [];
+  const visit = (node: RopeNode) => {
+    if (!created.has(node.id)) return;
+    reachable.push(node);
+    if (node.kind === "branch") {
+      visit(node.left);
+      visit(node.right);
+    }
+  };
+  visit(root);
+  return reachable;
+}
+
+function nodeInsert(node: RopeNode, document: string): Omit<TextNodeRow, "id"> {
+  return node.kind === "leaf"
+    ? {
+        document,
+        kind: "leaf",
+        text: node.text,
+        left: null,
+        right: null,
+        text_length: node.length,
+        height: node.height,
+      }
+    : {
+        document,
+        kind: "branch",
+        text: null,
+        left: node.left.id,
+        right: node.right.id,
+        text_length: node.length,
+        height: node.height,
+      };
 }
 
 export class TextStore {
@@ -226,13 +362,13 @@ export class TextStore {
         { id: documentId },
       );
       for (const node of rope.nodes) {
-        tx.insert(this.tables.nodes, { ...node, document: documentId }, { id: node.id });
+        tx.insert(this.tables.nodes, nodeInsert(node, documentId), { id: node.id });
       }
       tx.insert(
         this.tables.versions,
         {
           document: documentId,
-          base_root: rope.root,
+          base_root: rope.root.id,
           patches: "[]",
           text_length: codePointLength(initialText),
         },
@@ -257,33 +393,50 @@ export class TextStore {
     });
     if (!version) throw new Error(`Text version ${versionId} was not found`);
     const patches = decodePatches(version.patches);
-    const text = applyPatches(await this.readNode(version.base_root), patches);
+    const root = await this.readNode(version.base_root);
+    const text = applyPatches(this.materialize(root), patches);
     if (codePointLength(text) !== version.text_length) {
       throw new Error(`Text version ${versionId} length does not match its content`);
     }
-    return this.snapshot(version.document, version.id, text, version.base_root, patches);
+    return this.snapshot(version.document, version.id, text, root, patches);
   }
 
   async insert(snapshot: TextSnapshot, at: number, inserted: string): Promise<TextSnapshot> {
     if (!inserted) return snapshot;
     const text = insertAtCodePoint(snapshot.text, at, inserted);
     let root = snapshot.baseRoot;
-    const retainedPatches = snapshotPatches.get(snapshot) ?? (await this.loadPatches(snapshot));
+    let rootNode = snapshotRoots.get(snapshot);
+    const retainedPatches = snapshotPatches.get(snapshot);
+    if (!retainedPatches) {
+      throw new Error("Text insert requires a snapshot returned by this module");
+    }
     let patches = [...retainedPatches, { at, text: inserted }];
     const encoded = encodePatches(patches);
     const consolidate =
       patches.length > this.maxPatches || byteLength(encoded) > this.maxPatchBytes;
-    const rope = consolidate ? buildRope(text, this.leafBytes) : null;
-    if (rope) {
-      root = rope.root;
+    let createdNodes: RopeNode[] = [];
+    if (consolidate) {
+      rootNode ??= await this.readNode(snapshot.baseRoot);
+      const created = new Map<string, RopeNode>();
+      for (const patch of patches) {
+        rootNode = insertIntoRope(rootNode, patch.at, patch.text, this.leafBytes, created);
+      }
+      createdNodes = reachableCreatedNodes(rootNode, created);
+      // A scattered frontier can retain O(patches * depth) path-copied nodes.
+      // Rebuilding a balanced root is cheaper once that exceeds the complete
+      // leaf tree; localized typing still keeps the structurally shared path.
+      const rebuilt = buildRope(text, this.leafBytes);
+      if (rebuilt.nodes.length < createdNodes.length) {
+        rootNode = rebuilt.root;
+        createdNodes = rebuilt.nodes;
+      }
+      root = rootNode.id;
       patches = [];
     }
     const versionId = crypto.randomUUID();
     const result = await this.db.transaction((tx) => {
-      if (rope) {
-        for (const node of rope.nodes) {
-          tx.insert(this.tables.nodes, { ...node, document: snapshot.documentId }, { id: node.id });
-        }
+      for (const node of createdNodes) {
+        tx.insert(this.tables.nodes, nodeInsert(node, snapshot.documentId), { id: node.id });
       }
       tx.insert(
         this.tables.versions,
@@ -302,17 +455,18 @@ export class TextStore {
       });
     });
     await result.wait({ tier: this.durability });
-    return this.snapshot(snapshot.documentId, versionId, text, root, patches);
+    return this.snapshot(snapshot.documentId, versionId, text, rootNode ?? root, patches);
   }
 
   private snapshot(
     documentId: string,
     versionId: string,
     text: string,
-    baseRoot: string,
+    root: RopeNode | string,
     patches: readonly TextPatch[],
   ): TextSnapshot {
-    const snapshot = {
+    const baseRoot = typeof root === "string" ? root : root.id;
+    const snapshot: TextSnapshot = {
       documentId,
       versionId,
       text,
@@ -322,42 +476,57 @@ export class TextStore {
       patchBytes: byteLength(encodePatches(patches)),
     };
     snapshotPatches.set(snapshot, [...patches]);
-    return snapshot;
+    if (typeof root !== "string") snapshotRoots.set(snapshot, root);
+    return Object.freeze(snapshot);
   }
 
-  private async loadPatches(snapshot: TextSnapshot): Promise<TextPatch[]> {
-    const version = await this.db.one(this.tables.versions.where({ id: snapshot.versionId }), {
-      tier: this.durability,
-    });
-    if (!version) throw new Error(`Text version ${snapshot.versionId} was not found`);
-    return decodePatches(version.patches);
-  }
-
-  private async readNode(id: string): Promise<string> {
+  private async readNode(id: string): Promise<RopeNode> {
     const node = await this.db.one(this.tables.nodes.where({ id }), {
       tier: this.durability,
     });
     if (!node) throw new Error(`Text rope node ${id} was not found`);
     if (node.kind === "leaf") {
-      const payload = JSON.parse(node.payload) as LeafPayload;
-      if (typeof payload.text !== "string") throw new Error(`Invalid text leaf ${id}`);
-      return payload.text;
+      if (typeof node.text !== "string") throw new Error(`Invalid text leaf ${id}`);
+      if (node.text_length !== codePointLength(node.text) || node.height !== 1) {
+        throw new Error(`Text leaf ${id} metadata does not match its content`);
+      }
+      return { id, kind: "leaf", text: node.text, length: node.text_length, height: node.height };
     }
     if (node.kind === "branch") {
-      const payload = JSON.parse(node.payload) as BranchPayload;
-      if (typeof payload.left !== "string" || typeof payload.right !== "string") {
+      if (typeof node.left !== "string" || typeof node.right !== "string") {
         throw new Error(`Invalid text branch ${id}`);
       }
       const [left, right] = await Promise.all([
-        this.readNode(payload.left),
-        this.readNode(payload.right),
+        this.readNode(node.left),
+        this.readNode(node.right),
       ]);
-      return left + right;
+      if (node.text_length !== left.length + right.length) {
+        throw new Error(`Text branch ${id} length does not match its children`);
+      }
+      if (node.height !== Math.max(left.height, right.height) + 1) {
+        throw new Error(`Text branch ${id} height does not match its children`);
+      }
+      return { id, kind: "branch", left, right, length: node.text_length, height: node.height };
     }
     throw new Error(`Unknown text rope node kind ${node.kind}`);
+  }
+
+  private materialize(node: RopeNode): string {
+    return node.kind === "leaf"
+      ? node.text
+      : this.materialize(node.left) + this.materialize(node.right);
   }
 }
 
 export function createTextStore(db: Db, tables: TextTables, options?: TextStoreOptions): TextStore {
   return new TextStore(db, tables, options);
+}
+
+/** Select the text table handles from an app containing {@link textTableDefinitions}. */
+export function textTablesFromApp(app: TextAppTables): TextTables {
+  return {
+    documents: app.jazz_text_documents,
+    versions: app.jazz_text_versions,
+    nodes: app.jazz_text_nodes,
+  };
 }

--- a/packages/jazz-tools/src/text/index.ts
+++ b/packages/jazz-tools/src/text/index.ts
@@ -1,0 +1,363 @@
+import { col } from "../dsl.js";
+import type { DurabilityTier } from "../runtime/client.js";
+import type { Db, QueryBuilder, TableProxy } from "../runtime/db.js";
+import { defineTable } from "../typed-app.js";
+
+const s = Object.assign({}, col, { table: defineTable });
+
+const DOCUMENT_TABLE = "jazz_text_documents";
+const VERSION_TABLE = "jazz_text_versions";
+const NODE_TABLE = "jazz_text_nodes";
+
+/** Ordinary table definitions required by {@link createTextStore}. */
+export const textTableDefinitions = {
+  [DOCUMENT_TABLE]: s.table({
+    current_version: s.string(),
+    text_length: s.int(),
+  }),
+  [VERSION_TABLE]: s.table({
+    document: s.ref(DOCUMENT_TABLE),
+    base_root: s.ref(NODE_TABLE),
+    patches: s.string(),
+    text_length: s.int(),
+    previous_version: s.ref(VERSION_TABLE).optional(),
+  }),
+  [NODE_TABLE]: s.table({
+    document: s.ref(DOCUMENT_TABLE),
+    kind: s.string(),
+    payload: s.string(),
+    text_length: s.int(),
+  }),
+} as const;
+
+export type TextDocumentRow = {
+  id: string;
+  current_version: string;
+  text_length: number;
+};
+
+export type TextVersionRow = {
+  id: string;
+  document: string;
+  base_root: string;
+  patches: string;
+  text_length: number;
+  previous_version: string | null;
+};
+
+export type TextNodeRow = {
+  id: string;
+  document: string;
+  kind: string;
+  payload: string;
+  text_length: number;
+};
+
+type TextTable<Row, Init> = TableProxy<Row, Init> & {
+  where(input: unknown): QueryBuilder<Row>;
+};
+
+export interface TextTables {
+  documents: TextTable<TextDocumentRow, Omit<TextDocumentRow, "id">>;
+  versions: TextTable<
+    TextVersionRow,
+    Omit<TextVersionRow, "id" | "previous_version"> & { previous_version?: string | null }
+  >;
+  nodes: TextTable<TextNodeRow, Omit<TextNodeRow, "id">>;
+}
+
+export interface TextStoreOptions {
+  /** Maximum number of inline inserts retained by one independently readable version. */
+  maxPatches?: number;
+  /** Maximum UTF-8 byte length of the encoded patch frontier. */
+  maxPatchBytes?: number;
+  /** Maximum UTF-8 byte length of a rope leaf. */
+  leafBytes?: number;
+  /** Durability awaited by create/insert. Defaults to local. */
+  durability?: DurabilityTier;
+}
+
+export interface TextSnapshot {
+  documentId: string;
+  versionId: string;
+  text: string;
+  length: number;
+  baseRoot: string;
+  patchCount: number;
+  patchBytes: number;
+}
+
+type TextPatch = { at: number; text: string };
+type PendingNode = Omit<TextNodeRow, "document">;
+type LeafPayload = { text: string };
+type BranchPayload = { left: string; right: string };
+
+const encoder = new TextEncoder();
+const snapshotPatches = new WeakMap<TextSnapshot, readonly TextPatch[]>();
+
+function byteLength(value: string): number {
+  return encoder.encode(value).byteLength;
+}
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function insertAtCodePoint(value: string, at: number, inserted: string): string {
+  if (!Number.isInteger(at)) throw new RangeError("Text insertion offset must be an integer");
+  const points = Array.from(value);
+  if (at < 0 || at > points.length) {
+    throw new RangeError(`Text insertion offset ${at} is outside 0..${points.length}`);
+  }
+  points.splice(at, 0, inserted);
+  return points.join("");
+}
+
+function encodePatches(patches: readonly TextPatch[]): string {
+  return JSON.stringify(patches);
+}
+
+function decodePatches(encoded: string): TextPatch[] {
+  const value: unknown = JSON.parse(encoded);
+  if (!Array.isArray(value)) throw new Error("Invalid text patch frontier");
+  return value.map((entry) => {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      !Number.isInteger((entry as TextPatch).at) ||
+      typeof (entry as TextPatch).text !== "string"
+    ) {
+      throw new Error("Invalid text patch frontier entry");
+    }
+    return entry as TextPatch;
+  });
+}
+
+function applyPatches(base: string, patches: readonly TextPatch[]): string {
+  return patches.reduce((value, patch) => insertAtCodePoint(value, patch.at, patch.text), base);
+}
+
+function splitUtf8(value: string, maximumBytes: number): string[] {
+  const leaves: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+  for (const point of value) {
+    const pointBytes = byteLength(point);
+    if (pointBytes > maximumBytes) {
+      throw new Error("leafBytes cannot hold one Unicode scalar value");
+    }
+    if (current && currentBytes + pointBytes > maximumBytes) {
+      leaves.push(current);
+      current = "";
+      currentBytes = 0;
+    }
+    current += point;
+    currentBytes += pointBytes;
+  }
+  if (current || leaves.length === 0) leaves.push(current);
+  return leaves;
+}
+
+function buildRope(value: string, leafBytes: number): { root: string; nodes: PendingNode[] } {
+  const nodes: PendingNode[] = splitUtf8(value, leafBytes).map((text) => ({
+    id: crypto.randomUUID(),
+    kind: "leaf",
+    payload: JSON.stringify({ text } satisfies LeafPayload),
+    text_length: codePointLength(text),
+  }));
+  let level = nodes.map((node) => ({ id: node.id, length: node.text_length }));
+  while (level.length > 1) {
+    const next: typeof level = [];
+    for (let index = 0; index < level.length; index += 2) {
+      const left = level[index]!;
+      const right = level[index + 1];
+      if (!right) {
+        next.push(left);
+        continue;
+      }
+      const node: PendingNode = {
+        id: crypto.randomUUID(),
+        kind: "branch",
+        payload: JSON.stringify({ left: left.id, right: right.id } satisfies BranchPayload),
+        text_length: left.length + right.length,
+      };
+      nodes.push(node);
+      next.push({ id: node.id, length: node.text_length });
+    }
+    level = next;
+  }
+  return { root: level[0]!.id, nodes };
+}
+
+export class TextStore {
+  private readonly maxPatches: number;
+  private readonly maxPatchBytes: number;
+  private readonly leafBytes: number;
+  private readonly durability: DurabilityTier;
+
+  constructor(
+    private readonly db: Db,
+    private readonly tables: TextTables,
+    options: TextStoreOptions = {},
+  ) {
+    this.maxPatches = options.maxPatches ?? 32;
+    this.maxPatchBytes = options.maxPatchBytes ?? 4096;
+    this.leafBytes = options.leafBytes ?? 4096;
+    this.durability = options.durability ?? "local";
+    if (!Number.isInteger(this.maxPatches) || this.maxPatches < 1) {
+      throw new RangeError("maxPatches must be a positive integer");
+    }
+    if (!Number.isInteger(this.maxPatchBytes) || this.maxPatchBytes < 2) {
+      throw new RangeError("maxPatchBytes must be an integer of at least 2");
+    }
+    if (!Number.isInteger(this.leafBytes) || this.leafBytes < 4) {
+      throw new RangeError("leafBytes must be an integer of at least 4");
+    }
+  }
+
+  async create(initialText = ""): Promise<TextSnapshot> {
+    const documentId = crypto.randomUUID();
+    const versionId = crypto.randomUUID();
+    const rope = buildRope(initialText, this.leafBytes);
+    const result = await this.db.transaction((tx) => {
+      tx.insert(
+        this.tables.documents,
+        { current_version: versionId, text_length: codePointLength(initialText) },
+        { id: documentId },
+      );
+      for (const node of rope.nodes) {
+        tx.insert(this.tables.nodes, { ...node, document: documentId }, { id: node.id });
+      }
+      tx.insert(
+        this.tables.versions,
+        {
+          document: documentId,
+          base_root: rope.root,
+          patches: "[]",
+          text_length: codePointLength(initialText),
+        },
+        { id: versionId },
+      );
+    });
+    await result.wait({ tier: this.durability });
+    return this.snapshot(documentId, versionId, initialText, rope.root, []);
+  }
+
+  async read(documentId: string): Promise<TextSnapshot> {
+    const document = await this.db.one(this.tables.documents.where({ id: documentId }), {
+      tier: this.durability,
+    });
+    if (!document) throw new Error(`Text document ${documentId} was not found`);
+    return this.readVersion(document.current_version);
+  }
+
+  async readVersion(versionId: string): Promise<TextSnapshot> {
+    const version = await this.db.one(this.tables.versions.where({ id: versionId }), {
+      tier: this.durability,
+    });
+    if (!version) throw new Error(`Text version ${versionId} was not found`);
+    const patches = decodePatches(version.patches);
+    const text = applyPatches(await this.readNode(version.base_root), patches);
+    if (codePointLength(text) !== version.text_length) {
+      throw new Error(`Text version ${versionId} length does not match its content`);
+    }
+    return this.snapshot(version.document, version.id, text, version.base_root, patches);
+  }
+
+  async insert(snapshot: TextSnapshot, at: number, inserted: string): Promise<TextSnapshot> {
+    if (!inserted) return snapshot;
+    const text = insertAtCodePoint(snapshot.text, at, inserted);
+    let root = snapshot.baseRoot;
+    const retainedPatches = snapshotPatches.get(snapshot) ?? (await this.loadPatches(snapshot));
+    let patches = [...retainedPatches, { at, text: inserted }];
+    const encoded = encodePatches(patches);
+    const consolidate =
+      patches.length > this.maxPatches || byteLength(encoded) > this.maxPatchBytes;
+    const rope = consolidate ? buildRope(text, this.leafBytes) : null;
+    if (rope) {
+      root = rope.root;
+      patches = [];
+    }
+    const versionId = crypto.randomUUID();
+    const result = await this.db.transaction((tx) => {
+      if (rope) {
+        for (const node of rope.nodes) {
+          tx.insert(this.tables.nodes, { ...node, document: snapshot.documentId }, { id: node.id });
+        }
+      }
+      tx.insert(
+        this.tables.versions,
+        {
+          document: snapshot.documentId,
+          base_root: root,
+          patches: encodePatches(patches),
+          text_length: codePointLength(text),
+          previous_version: snapshot.versionId,
+        },
+        { id: versionId },
+      );
+      tx.update(this.tables.documents, snapshot.documentId, {
+        current_version: versionId,
+        text_length: codePointLength(text),
+      });
+    });
+    await result.wait({ tier: this.durability });
+    return this.snapshot(snapshot.documentId, versionId, text, root, patches);
+  }
+
+  private snapshot(
+    documentId: string,
+    versionId: string,
+    text: string,
+    baseRoot: string,
+    patches: readonly TextPatch[],
+  ): TextSnapshot {
+    const snapshot = {
+      documentId,
+      versionId,
+      text,
+      length: codePointLength(text),
+      baseRoot,
+      patchCount: patches.length,
+      patchBytes: byteLength(encodePatches(patches)),
+    };
+    snapshotPatches.set(snapshot, [...patches]);
+    return snapshot;
+  }
+
+  private async loadPatches(snapshot: TextSnapshot): Promise<TextPatch[]> {
+    const version = await this.db.one(this.tables.versions.where({ id: snapshot.versionId }), {
+      tier: this.durability,
+    });
+    if (!version) throw new Error(`Text version ${snapshot.versionId} was not found`);
+    return decodePatches(version.patches);
+  }
+
+  private async readNode(id: string): Promise<string> {
+    const node = await this.db.one(this.tables.nodes.where({ id }), {
+      tier: this.durability,
+    });
+    if (!node) throw new Error(`Text rope node ${id} was not found`);
+    if (node.kind === "leaf") {
+      const payload = JSON.parse(node.payload) as LeafPayload;
+      if (typeof payload.text !== "string") throw new Error(`Invalid text leaf ${id}`);
+      return payload.text;
+    }
+    if (node.kind === "branch") {
+      const payload = JSON.parse(node.payload) as BranchPayload;
+      if (typeof payload.left !== "string" || typeof payload.right !== "string") {
+        throw new Error(`Invalid text branch ${id}`);
+      }
+      const [left, right] = await Promise.all([
+        this.readNode(payload.left),
+        this.readNode(payload.right),
+      ]);
+      return left + right;
+    }
+    throw new Error(`Unknown text rope node kind ${node.kind}`);
+  }
+}
+
+export function createTextStore(db: Db, tables: TextTables, options?: TextStoreOptions): TextStore {
+  return new TextStore(db, tables, options);
+}

--- a/packages/jazz-tools/src/text/index.ts
+++ b/packages/jazz-tools/src/text/index.ts
@@ -393,7 +393,7 @@ export class TextStore {
     });
     if (!version) throw new Error(`Text version ${versionId} was not found`);
     const patches = decodePatches(version.patches);
-    const root = await this.readNode(version.base_root);
+    const root = await this.readNode(version.base_root, version.document);
     const text = applyPatches(this.materialize(root), patches);
     if (codePointLength(text) !== version.text_length) {
       throw new Error(`Text version ${versionId} length does not match its content`);
@@ -416,7 +416,7 @@ export class TextStore {
       patches.length > this.maxPatches || byteLength(encoded) > this.maxPatchBytes;
     let createdNodes: RopeNode[] = [];
     if (consolidate) {
-      rootNode ??= await this.readNode(snapshot.baseRoot);
+      rootNode ??= await this.readNode(snapshot.baseRoot, snapshot.documentId);
       const created = new Map<string, RopeNode>();
       for (const patch of patches) {
         rootNode = insertIntoRope(rootNode, patch.at, patch.text, this.leafBytes, created);
@@ -480,11 +480,20 @@ export class TextStore {
     return Object.freeze(snapshot);
   }
 
-  private async readNode(id: string): Promise<RopeNode> {
+  private async readNode(
+    id: string,
+    expectedDocument: string,
+    ancestors: ReadonlySet<string> = new Set(),
+  ): Promise<RopeNode> {
+    if (ancestors.has(id)) throw new Error(`Text rope contains a cycle at node ${id}`);
+    const nextAncestors = new Set(ancestors).add(id);
     const node = await this.db.one(this.tables.nodes.where({ id }), {
       tier: this.durability,
     });
     if (!node) throw new Error(`Text rope node ${id} was not found`);
+    if (node.document !== expectedDocument) {
+      throw new Error(`Text rope node ${id} belongs to a different document`);
+    }
     if (node.kind === "leaf") {
       if (typeof node.text !== "string") throw new Error(`Invalid text leaf ${id}`);
       if (node.text_length !== codePointLength(node.text) || node.height !== 1) {
@@ -497,14 +506,17 @@ export class TextStore {
         throw new Error(`Invalid text branch ${id}`);
       }
       const [left, right] = await Promise.all([
-        this.readNode(node.left),
-        this.readNode(node.right),
+        this.readNode(node.left, expectedDocument, nextAncestors),
+        this.readNode(node.right, expectedDocument, nextAncestors),
       ]);
       if (node.text_length !== left.length + right.length) {
         throw new Error(`Text branch ${id} length does not match its children`);
       }
       if (node.height !== Math.max(left.height, right.height) + 1) {
         throw new Error(`Text branch ${id} height does not match its children`);
+      }
+      if (Math.abs(left.height - right.height) > 1) {
+        throw new Error(`Text branch ${id} is not balanced`);
       }
       return { id, kind: "branch", left, right, length: node.text_length, height: node.height };
     }

--- a/packages/jazz-tools/src/text/index.ts
+++ b/packages/jazz-tools/src/text/index.ts
@@ -376,7 +376,11 @@ export class TextStore {
       tier: this.durability,
     });
     if (!document) throw new Error(`Text document ${documentId} was not found`);
-    return this.readVersion(document.current_version);
+    const snapshot = await this.readVersion(document.current_version);
+    if (snapshot.documentId !== documentId) {
+      throw new Error(`Text document ${documentId} points to another document's version`);
+    }
+    return snapshot;
   }
 
   async readVersion(versionId: string): Promise<TextSnapshot> {

--- a/packages/jazz-tools/src/text/text.bench.test.ts
+++ b/packages/jazz-tools/src/text/text.bench.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Opt-in durable receipt for the production ordinary-row text API.
+ *
+ * JAZZ_TEXT_BENCH=1 JAZZ_TEXT_BENCH_INITIAL_BYTES=102400 \
+ * JAZZ_TEXT_BENCH_EDITS=300 pnpm --dir packages/jazz-tools exec vitest run \
+ * src/text/text.bench.test.ts --reporter=verbose
+ */
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createJazzContext } from "../backend/create-jazz-context.js";
+import { schema as s } from "../index.js";
+import {
+  createTextStore,
+  textTableDefinitions,
+  textTablesFromApp,
+  type TextSnapshot,
+} from "./index.js";
+
+const app = s.defineApp({
+  ...textTableDefinitions,
+  text_benchmark_whole: s.table({ value: s.string() }),
+});
+const enabled = process.env.JAZZ_TEXT_BENCH === "1";
+const editCount = Number(process.env.JAZZ_TEXT_BENCH_EDITS ?? "300");
+const initialBytes = Number(process.env.JAZZ_TEXT_BENCH_INITIAL_BYTES ?? "102400");
+
+function percentile(values: readonly number[], quantile: number): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * quantile))] ?? 0;
+}
+
+function directorySize(path: string): number {
+  const stat = statSync(path);
+  return stat.isDirectory()
+    ? readdirSync(path).reduce((total, child) => total + directorySize(join(path, child)), 0)
+    : stat.size;
+}
+
+function insertionOffset(length: number, edit: number, workload: "end" | "middle"): number {
+  return workload === "end" ? length : (edit * 48271 + 17) % (length + 1);
+}
+
+async function wholeStringReceipt(initial: string, workload: "end" | "middle") {
+  const path = mkdtempSync(join(tmpdir(), "jazz-text-whole-"));
+  const context = createJazzContext({
+    appId: `text-whole-${crypto.randomUUID()}`,
+    app,
+    permissions: {},
+    driver: { type: "persistent", dataPath: path },
+    adminSecret: "ordinary-text-benchmark",
+    tier: "local",
+  });
+  const db = context.asBackend();
+  let value = initial;
+  let logicalBytes = value.length;
+  const latencies: number[] = [];
+  try {
+    const document = db.insert(app.text_benchmark_whole, { value });
+    await document.wait({ tier: "local" });
+    for (let edit = 0; edit < editCount; edit += 1) {
+      const at = insertionOffset(value.length, edit, workload);
+      value = value.slice(0, at) + "x" + value.slice(at);
+      const started = performance.now();
+      const write = db.update(app.text_benchmark_whole, document.value.id, { value });
+      await write.wait({ tier: "local" });
+      latencies.push(performance.now() - started);
+      logicalBytes += value.length;
+    }
+    const readStarted = performance.now();
+    expect(
+      (await db.one(app.text_benchmark_whole.where({ id: document.value.id }), { tier: "local" }))
+        ?.value,
+    ).toBe(value);
+    const materializationMs = performance.now() - readStarted;
+    await context.shutdown();
+    return {
+      label: `whole-${workload}`,
+      editCount,
+      p50Ms: percentile(latencies, 0.5),
+      p95Ms: percentile(latencies, 0.95),
+      ordinaryRowsPerEdit: 1,
+      retainedVersionRows: 0,
+      logicalWriteBytes: logicalBytes,
+      diskBytes: directorySize(path),
+      currentReadMs: materializationMs,
+    };
+  } finally {
+    await context.shutdown().catch(() => undefined);
+    rmSync(path, { recursive: true, force: true });
+  }
+}
+
+async function textReceipt(initial: string, workload: "end" | "middle") {
+  const path = mkdtempSync(join(tmpdir(), "jazz-text-frontier-"));
+  const context = createJazzContext({
+    appId: `text-frontier-${crypto.randomUUID()}`,
+    app,
+    permissions: {},
+    driver: { type: "persistent", dataPath: path },
+    adminSecret: "ordinary-text-benchmark",
+    tier: "local",
+  });
+  const db = context.asBackend();
+  const store = createTextStore(db, textTablesFromApp(app), {
+    maxPatches: 32,
+    maxPatchBytes: 4096,
+    leafBytes: 4096,
+  });
+  const latencies: number[] = [];
+  const consolidationLatencies: number[] = [];
+  const samples: TextSnapshot[] = [];
+  let logicalFrontierBytes = 0;
+  try {
+    let snapshot = await store.create(initial);
+    const initialNodeCount = (await db.all(app.jazz_text_nodes, { tier: "local" })).length;
+    samples.push(snapshot);
+    for (let edit = 0; edit < editCount; edit += 1) {
+      const before = snapshot;
+      const at = insertionOffset(snapshot.length, edit, workload);
+      const started = performance.now();
+      snapshot = await store.insert(snapshot, at, "x");
+      const elapsed = performance.now() - started;
+      latencies.push(elapsed);
+      logicalFrontierBytes += snapshot.patchBytes + 16 * 3 + 1;
+      if (snapshot.patchCount === 0 && before.patchCount > 0) {
+        consolidationLatencies.push(elapsed);
+      }
+      if (edit === Math.floor(editCount / 2) || edit === editCount - 1) samples.push(snapshot);
+    }
+    const historicalReads: number[] = [];
+    for (const sample of samples) {
+      const started = performance.now();
+      const loaded = await store.readVersion(sample.versionId);
+      historicalReads.push(performance.now() - started);
+      expect(loaded.text).toBe(sample.text);
+    }
+    const [nodes, versions] = await Promise.all([
+      db.all(app.jazz_text_nodes, { tier: "local" }),
+      db.all(app.jazz_text_versions, { tier: "local" }),
+    ]);
+    const nodePayloadBytes = nodes.reduce(
+      (total, node) =>
+        total + (node.text?.length ?? 0) + (node.left?.length ?? 0) + (node.right?.length ?? 0),
+      0,
+    );
+    await context.shutdown();
+    return {
+      label: `frontier-${workload}`,
+      editCount,
+      p50Ms: percentile(latencies, 0.5),
+      p95Ms: percentile(latencies, 0.95),
+      ordinaryRowsPerEdit: 2 + (nodes.length - initialNodeCount) / editCount,
+      retainedVersionRows: versions.length,
+      consolidationCount: consolidationLatencies.length,
+      consolidationP50Ms: percentile(consolidationLatencies, 0.5),
+      consolidationP95Ms: percentile(consolidationLatencies, 0.95),
+      logicalWriteBytesLowerBound: logicalFrontierBytes + nodePayloadBytes,
+      diskBytes: directorySize(path),
+      historicalMaterializationP50Ms: percentile(historicalReads, 0.5),
+      finalPatchCount: snapshot.patchCount,
+    };
+  } finally {
+    await context.shutdown().catch(() => undefined);
+    rmSync(path, { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(!enabled)("ordinary-row text durable receipt", () => {
+  it("compares whole strings with the bounded patch frontier", async () => {
+    const initial = "a".repeat(initialBytes);
+    const receipts = [];
+    for (const workload of ["end", "middle"] as const) {
+      receipts.push(await wholeStringReceipt(initial, workload));
+      receipts.push(await textReceipt(initial, workload));
+    }
+    for (const receipt of receipts) console.info(`[ordinary-text] ${JSON.stringify(receipt)}`);
+    expect(receipts).toHaveLength(4);
+  }, 600_000);
+});

--- a/packages/jazz-tools/src/text/text.bench.test.ts
+++ b/packages/jazz-tools/src/text/text.bench.test.ts
@@ -5,7 +5,7 @@
  * JAZZ_TEXT_BENCH_EDITS=300 pnpm --dir packages/jazz-tools exec vitest run \
  * src/text/text.bench.test.ts --reporter=verbose
  */
-import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { cpSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -31,21 +31,69 @@ function percentile(values: readonly number[], quantile: number): number {
   return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * quantile))] ?? 0;
 }
 
-function directorySize(path: string): number {
+type DiskUsage = {
+  apparentBytes: number;
+  allocatedBytes: number;
+  walApparentBytes: number;
+  sstApparentBytes: number;
+};
+
+function diskUsage(path: string): DiskUsage {
   const stat = statSync(path);
-  return stat.isDirectory()
-    ? readdirSync(path).reduce((total, child) => total + directorySize(join(path, child)), 0)
-    : stat.size;
+  if (!stat.isDirectory()) {
+    return {
+      apparentBytes: stat.size,
+      allocatedBytes: stat.blocks * 512,
+      walApparentBytes: path.endsWith(".log") ? stat.size : 0,
+      sstApparentBytes: path.endsWith(".sst") ? stat.size : 0,
+    };
+  }
+  return readdirSync(path).reduce<DiskUsage>(
+    (total, child) => {
+      const usage = diskUsage(join(path, child));
+      total.apparentBytes += usage.apparentBytes;
+      total.allocatedBytes += usage.allocatedBytes;
+      total.walApparentBytes += usage.walApparentBytes;
+      total.sstApparentBytes += usage.sstApparentBytes;
+      return total;
+    },
+    { apparentBytes: 0, allocatedBytes: 0, walApparentBytes: 0, sstApparentBytes: 0 },
+  );
 }
 
 function insertionOffset(length: number, edit: number, workload: "end" | "middle"): number {
   return workload === "end" ? length : (edit * 48271 + 17) % (length + 1);
 }
 
+async function reopenContext(appId: string, path: string) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      const context = createJazzContext({
+        appId,
+        app,
+        permissions: {},
+        driver: { type: "persistent", dataPath: path },
+        adminSecret: "ordinary-text-benchmark",
+        tier: "local",
+      });
+      // Force the lazy runtime open while it is still covered by the retry.
+      context.asBackend();
+      return context;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw lastError;
+}
+
 async function wholeStringReceipt(initial: string, workload: "end" | "middle") {
   const path = mkdtempSync(join(tmpdir(), "jazz-text-whole-"));
+  const restartPath = `${path}-restart`;
+  const appId = `text-whole-${crypto.randomUUID()}`;
   const context = createJazzContext({
-    appId: `text-whole-${crypto.randomUUID()}`,
+    appId,
     app,
     permissions: {},
     driver: { type: "persistent", dataPath: path },
@@ -74,7 +122,21 @@ async function wholeStringReceipt(initial: string, workload: "end" | "middle") {
         ?.value,
     ).toBe(value);
     const materializationMs = performance.now() - readStarted;
+    context.flush();
+    const liveDisk = diskUsage(path);
     await context.shutdown();
+    const closedDisk = diskUsage(path);
+    cpSync(path, restartPath, { recursive: true });
+    const reopened = await reopenContext(appId, restartPath);
+    expect(
+      (
+        await reopened
+          .asBackend()
+          .one(app.text_benchmark_whole.where({ id: document.value.id }), { tier: "local" })
+      )?.value,
+    ).toBe(value);
+    await reopened.shutdown();
+    const reopenedDisk = diskUsage(restartPath);
     return {
       label: `whole-${workload}`,
       editCount,
@@ -83,19 +145,22 @@ async function wholeStringReceipt(initial: string, workload: "end" | "middle") {
       ordinaryRowsPerEdit: 1,
       retainedVersionRows: 0,
       logicalWriteBytes: logicalBytes,
-      diskBytes: directorySize(path),
+      disk: { liveAfterRuntimeFlush: liveDisk, afterClose: closedDisk, afterReopen: reopenedDisk },
       currentReadMs: materializationMs,
     };
   } finally {
     await context.shutdown().catch(() => undefined);
     rmSync(path, { recursive: true, force: true });
+    rmSync(restartPath, { recursive: true, force: true });
   }
 }
 
 async function textReceipt(initial: string, workload: "end" | "middle") {
   const path = mkdtempSync(join(tmpdir(), "jazz-text-frontier-"));
+  const restartPath = `${path}-restart`;
+  const appId = `text-frontier-${crypto.randomUUID()}`;
   const context = createJazzContext({
-    appId: `text-frontier-${crypto.randomUUID()}`,
+    appId,
     app,
     permissions: {},
     driver: { type: "persistent", dataPath: path },
@@ -145,7 +210,20 @@ async function textReceipt(initial: string, workload: "end" | "middle") {
         total + (node.text?.length ?? 0) + (node.left?.length ?? 0) + (node.right?.length ?? 0),
       0,
     );
+    context.flush();
+    const liveDisk = diskUsage(path);
     await context.shutdown();
+    const closedDisk = diskUsage(path);
+    cpSync(path, restartPath, { recursive: true });
+    const reopened = await reopenContext(appId, restartPath);
+    const reopenedStore = createTextStore(reopened.asBackend(), textTablesFromApp(app), {
+      maxPatches: 32,
+      maxPatchBytes: 4096,
+      leafBytes: 4096,
+    });
+    expect((await reopenedStore.read(snapshot.documentId)).text).toBe(snapshot.text);
+    await reopened.shutdown();
+    const reopenedDisk = diskUsage(restartPath);
     return {
       label: `frontier-${workload}`,
       editCount,
@@ -157,13 +235,14 @@ async function textReceipt(initial: string, workload: "end" | "middle") {
       consolidationP50Ms: percentile(consolidationLatencies, 0.5),
       consolidationP95Ms: percentile(consolidationLatencies, 0.95),
       logicalWriteBytesLowerBound: logicalFrontierBytes + nodePayloadBytes,
-      diskBytes: directorySize(path),
+      disk: { liveAfterRuntimeFlush: liveDisk, afterClose: closedDisk, afterReopen: reopenedDisk },
       historicalMaterializationP50Ms: percentile(historicalReads, 0.5),
       finalPatchCount: snapshot.patchCount,
     };
   } finally {
     await context.shutdown().catch(() => undefined);
     rmSync(path, { recursive: true, force: true });
+    rmSync(restartPath, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
🤖 Reintroduces rich plain text as an ordinary-row feature after the Large Value subtraction.

## Design

- mutable document head plus immutable balanced rope nodes and version roots
- bounded patch frontier for keystroke-level inserts
- flat-string behavior remains preferable for small documents
- historical versions load directly from their root without ancestor-history replay
- ordinary Jazz transactions, permissions, branches, and synchronization only

## Correctness

- Unicode-safe insertion and consolidation
- format-level frontier caps: 64 patches / 16 KiB
- fail-closed ownership, cycle, height, balance, and malformed-frontier validation
- permission-denied rollback and competing-head coverage

## Measurements

For a 100 KiB document with 300 edits, the frontier measured roughly 6.5–6.8 ms p50 versus 15.5–16.4 ms for whole-string rewrites. Closed compressed RocksDB storage was 0.50–0.64 MB versus 0.62–0.96 MB. For 4 KiB end-heavy text the flat string remains faster and smaller, so the receipt recommends a hybrid threshold.

Draft for design and API iteration.