### PR TITLE
feat: add ordinary-row persistent streams

### DIFF
--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -39,3 +39,7 @@ harness = false
 [[bench]]
 name = "micro"
 harness = false
+
+[[bench]]
+name = "stream_layout_storage"
+harness = false

--- a/crates/groove/benches/stream_layout_storage.rs
+++ b/crates/groove/benches/stream_layout_storage.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+use std::time::Instant;
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -17,7 +18,7 @@ const HISTORY: &str = "history";
 const PARTS: &str = "parts";
 const NODES: &str = "nodes";
 const FANOUT: usize = 32;
-const INLINE_TAIL_BYTES: usize = 64 * 1024;
+const INLINE_TAIL_CAPS: [usize; 6] = [64, 128, 256, 512, 1_024, 64 * 1_024];
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -46,9 +47,18 @@ struct DiskBytes {
     allocated: Option<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Serialize)]
+struct WriteLatencyMicros {
+    total: u64,
+    p50: u64,
+    p95: u64,
+    max: u64,
+}
+
 #[derive(Debug, Serialize)]
 struct Receipt {
     layout: Layout,
+    inline_tail_bytes: usize,
     payload_kind: PayloadKind,
     appends: usize,
     append_bytes: usize,
@@ -62,12 +72,16 @@ struct Receipt {
     empty_store: DiskBytes,
     before_memtable_flush: DiskBytes,
     after_memtable_flush: DiskBytes,
+    after_memtable_flush_increment: DiskBytes,
     after_full_compaction: DiskBytes,
+    after_full_compaction_increment: DiskBytes,
+    write_latency_micros: WriteLatencyMicros,
 }
 
 struct Writer<'a> {
     db: &'a DB,
     layout: Layout,
+    inline_tail_bytes: usize,
     nodes: BTreeMap<u64, Node>,
     next_id: u64,
     root: Option<u64>,
@@ -80,10 +94,11 @@ struct Writer<'a> {
 }
 
 impl<'a> Writer<'a> {
-    fn new(db: &'a DB, layout: Layout) -> Self {
+    fn new(db: &'a DB, layout: Layout, inline_tail_bytes: usize) -> Self {
         Self {
             db,
             layout,
+            inline_tail_bytes,
             nodes: BTreeMap::new(),
             next_id: 1,
             root: None,
@@ -109,7 +124,7 @@ impl<'a> Writer<'a> {
             }
             Layout::PersistentTreeInlineTail => {
                 self.tail.extend_from_slice(bytes);
-                if self.tail.len() > INLINE_TAIL_BYTES {
+                if self.tail.len() > self.inline_tail_bytes {
                     let consolidated = std::mem::take(&mut self.tail);
                     let length = consolidated.len() as u64;
                     let part = self.write_part(&mut batch, &consolidated);
@@ -257,15 +272,24 @@ fn main() {
             (short_appends, 1_024),
             (large_appends, 64 * 1024),
         ] {
-            for layout in [
-                Layout::Flat,
-                Layout::PersistentTree,
-                Layout::PersistentTreeInlineTail,
-            ] {
+            for (layout, inline_tail_bytes) in [(Layout::Flat, 0), (Layout::PersistentTree, 0)]
+                .into_iter()
+                .chain(
+                    INLINE_TAIL_CAPS
+                        .into_iter()
+                        .map(|cap| (Layout::PersistentTreeInlineTail, cap)),
+                )
+            {
                 println!(
                     "{}",
-                    serde_json::to_string(&measure(layout, payload_kind, appends, append_bytes))
-                        .expect("serialize receipt")
+                    serde_json::to_string(&measure(
+                        layout,
+                        inline_tail_bytes,
+                        payload_kind,
+                        appends,
+                        append_bytes,
+                    ))
+                    .expect("serialize receipt")
                 );
             }
         }
@@ -274,6 +298,7 @@ fn main() {
 
 fn measure(
     layout: Layout,
+    inline_tail_bytes: usize,
     payload_kind: PayloadKind,
     appends: usize,
     append_bytes: usize,
@@ -282,9 +307,13 @@ fn measure(
     let db = open_db(dir.path());
     flush_and_compact(&db);
     let empty_store = disk_bytes(dir.path());
-    let mut writer = Writer::new(&db, layout);
+    let mut writer = Writer::new(&db, layout, inline_tail_bytes);
+    let mut write_latencies = Vec::with_capacity(appends);
     for ordinal in 0..appends {
-        writer.append(ordinal, &payload(payload_kind, ordinal, append_bytes));
+        let bytes = payload(payload_kind, ordinal, append_bytes);
+        let started = Instant::now();
+        writer.append(ordinal, &bytes);
+        write_latencies.push(started.elapsed().as_micros() as u64);
     }
     db.flush_wal(true).expect("flush WAL before measuring");
     let before_memtable_flush = disk_bytes(dir.path());
@@ -298,6 +327,7 @@ fn measure(
         .unwrap_or(0);
     Receipt {
         layout,
+        inline_tail_bytes,
         payload_kind,
         appends,
         append_bytes,
@@ -311,8 +341,36 @@ fn measure(
         empty_store,
         before_memtable_flush,
         after_memtable_flush,
+        after_memtable_flush_increment: subtract_disk_bytes(after_memtable_flush, empty_store),
         after_full_compaction,
+        after_full_compaction_increment: subtract_disk_bytes(after_full_compaction, empty_store),
+        write_latency_micros: summarize_latencies(&mut write_latencies),
     }
+}
+
+fn subtract_disk_bytes(total: DiskBytes, baseline: DiskBytes) -> DiskBytes {
+    DiskBytes {
+        apparent: total.apparent.saturating_sub(baseline.apparent),
+        allocated: total
+            .allocated
+            .zip(baseline.allocated)
+            .map(|(total, baseline)| total.saturating_sub(baseline)),
+    }
+}
+
+fn summarize_latencies(latencies: &mut [u64]) -> WriteLatencyMicros {
+    latencies.sort_unstable();
+    WriteLatencyMicros {
+        total: latencies.iter().sum(),
+        p50: percentile(latencies, 50),
+        p95: percentile(latencies, 95),
+        max: latencies.last().copied().unwrap_or_default(),
+    }
+}
+
+fn percentile(sorted: &[u64], percentile: usize) -> u64 {
+    let index = sorted.len().saturating_sub(1).saturating_mul(percentile) / 100;
+    sorted.get(index).copied().unwrap_or_default()
 }
 
 fn open_db(path: &Path) -> DB {

--- a/crates/groove/benches/stream_layout_storage.rs
+++ b/crates/groove/benches/stream_layout_storage.rs
@@ -1,0 +1,429 @@
+//! Opt-in compressed RocksDB receipt for ordinary-row stream layouts.
+//!
+//! `JAZZ_STREAM_DISK_BENCH=1 cargo bench -p groove --bench stream_layout_storage`
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+use rocksdb::{ColumnFamilyDescriptor, DB, DBCompressionType, Options, WriteBatch};
+use serde::Serialize;
+use tempfile::TempDir;
+
+const HISTORY: &str = "history";
+const PARTS: &str = "parts";
+const NODES: &str = "nodes";
+const FANOUT: usize = 32;
+const INLINE_TAIL_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Layout {
+    Flat,
+    PersistentTree,
+    PersistentTreeInlineTail,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PayloadKind {
+    Binary,
+    Text,
+}
+
+#[derive(Clone, Debug)]
+struct Node {
+    height: u32,
+    children: Vec<(u64, u64)>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct DiskBytes {
+    apparent: u64,
+    allocated: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct Receipt {
+    layout: Layout,
+    payload_kind: PayloadKind,
+    appends: usize,
+    append_bytes: usize,
+    logical_payload_bytes: usize,
+    history_rows: usize,
+    part_rows: usize,
+    node_rows: usize,
+    consolidations: usize,
+    tree_depth: u32,
+    compression: &'static str,
+    empty_store: DiskBytes,
+    before_memtable_flush: DiskBytes,
+    after_memtable_flush: DiskBytes,
+    after_full_compaction: DiskBytes,
+}
+
+struct Writer<'a> {
+    db: &'a DB,
+    layout: Layout,
+    nodes: BTreeMap<u64, Node>,
+    next_id: u64,
+    root: Option<u64>,
+    prefix_bytes: u64,
+    tail: Vec<u8>,
+    part_ids: Vec<(u64, u64)>,
+    part_rows: usize,
+    node_rows: usize,
+    consolidations: usize,
+}
+
+impl<'a> Writer<'a> {
+    fn new(db: &'a DB, layout: Layout) -> Self {
+        Self {
+            db,
+            layout,
+            nodes: BTreeMap::new(),
+            next_id: 1,
+            root: None,
+            prefix_bytes: 0,
+            tail: Vec::new(),
+            part_ids: Vec::new(),
+            part_rows: 0,
+            node_rows: 0,
+            consolidations: 0,
+        }
+    }
+
+    fn append(&mut self, ordinal: usize, bytes: &[u8]) {
+        let mut batch = WriteBatch::default();
+        match self.layout {
+            Layout::Flat => {
+                let part = self.write_part(&mut batch, bytes);
+                self.part_ids.push((part, bytes.len() as u64));
+            }
+            Layout::PersistentTree => {
+                let part = self.write_part(&mut batch, bytes);
+                self.append_part(&mut batch, part, bytes.len() as u64);
+            }
+            Layout::PersistentTreeInlineTail => {
+                self.tail.extend_from_slice(bytes);
+                if self.tail.len() > INLINE_TAIL_BYTES {
+                    let consolidated = std::mem::take(&mut self.tail);
+                    let length = consolidated.len() as u64;
+                    let part = self.write_part(&mut batch, &consolidated);
+                    self.append_part(&mut batch, part, length);
+                    self.consolidations += 1;
+                }
+            }
+        }
+        let value = self.root_value();
+        batch.put_cf(
+            self.db.cf_handle(HISTORY).expect("history CF"),
+            history_key(ordinal),
+            value,
+        );
+        self.db.write(&batch).expect("append batch");
+    }
+
+    fn write_part(&mut self, batch: &mut WriteBatch, bytes: &[u8]) -> u64 {
+        let id = self.allocate_id();
+        batch.put_cf(
+            self.db.cf_handle(PARTS).expect("parts CF"),
+            id.to_be_bytes(),
+            bytes,
+        );
+        self.part_rows += 1;
+        id
+    }
+
+    fn append_part(&mut self, batch: &mut WriteBatch, part: u64, length: u64) {
+        self.prefix_bytes += length;
+        self.root = Some(match self.root {
+            None => self.write_node(
+                batch,
+                Node {
+                    height: 0,
+                    children: vec![(part, length)],
+                },
+            ),
+            Some(root) => {
+                let (updated, overflow) = self.append_to_node(batch, root, part, length);
+                if let Some(overflow) = overflow {
+                    let height = self.nodes[&updated].height + 1;
+                    let left_length = node_length(&self.nodes[&updated]);
+                    let right_length = node_length(&self.nodes[&overflow]);
+                    self.write_node(
+                        batch,
+                        Node {
+                            height,
+                            children: vec![(updated, left_length), (overflow, right_length)],
+                        },
+                    )
+                } else {
+                    updated
+                }
+            }
+        });
+    }
+
+    fn append_to_node(
+        &mut self,
+        batch: &mut WriteBatch,
+        node_id: u64,
+        part: u64,
+        length: u64,
+    ) -> (u64, Option<u64>) {
+        let mut node = self.nodes[&node_id].clone();
+        if node.height == 0 {
+            node.children.push((part, length));
+        } else {
+            let (right_id, _) = *node.children.last().expect("non-empty node");
+            let (updated, overflow) = self.append_to_node(batch, right_id, part, length);
+            let last = node.children.last_mut().expect("non-empty node");
+            *last = (updated, node_length(&self.nodes[&updated]));
+            if let Some(overflow) = overflow {
+                node.children
+                    .push((overflow, node_length(&self.nodes[&overflow])));
+            }
+        }
+        if node.children.len() <= FANOUT {
+            return (self.write_node(batch, node), None);
+        }
+        let right_children = node.children.split_off(FANOUT / 2);
+        let height = node.height;
+        let left = self.write_node(batch, node);
+        let right = self.write_node(
+            batch,
+            Node {
+                height,
+                children: right_children,
+            },
+        );
+        (left, Some(right))
+    }
+
+    fn write_node(&mut self, batch: &mut WriteBatch, node: Node) -> u64 {
+        let id = self.allocate_id();
+        batch.put_cf(
+            self.db.cf_handle(NODES).expect("nodes CF"),
+            id.to_be_bytes(),
+            encode_node(&node),
+        );
+        self.nodes.insert(id, node);
+        self.node_rows += 1;
+        id
+    }
+
+    fn root_value(&self) -> Vec<u8> {
+        let mut value = Vec::new();
+        match self.layout {
+            Layout::Flat => {
+                value.extend_from_slice(&(self.part_ids.len() as u64).to_le_bytes());
+                for (id, length) in &self.part_ids {
+                    value.extend_from_slice(&id.to_le_bytes());
+                    value.extend_from_slice(&length.to_le_bytes());
+                }
+            }
+            Layout::PersistentTree | Layout::PersistentTreeInlineTail => {
+                value.extend_from_slice(&self.root.unwrap_or_default().to_le_bytes());
+                value.extend_from_slice(&self.prefix_bytes.to_le_bytes());
+                value.extend_from_slice(&(self.tail.len() as u64).to_le_bytes());
+                value.extend_from_slice(&self.tail);
+            }
+        }
+        value
+    }
+
+    fn allocate_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}
+
+fn main() {
+    if std::env::var("JAZZ_STREAM_DISK_BENCH").as_deref() != Ok("1") {
+        eprintln!("skipped; set JAZZ_STREAM_DISK_BENCH=1");
+        return;
+    }
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    let short_appends = env_usize("JAZZ_STREAM_DISK_SHORT_APPENDS", 1_000);
+    let large_appends = env_usize("JAZZ_STREAM_DISK_LARGE_APPENDS", 256);
+    for payload_kind in [PayloadKind::Binary, PayloadKind::Text] {
+        for (appends, append_bytes) in [
+            (short_appends, 32),
+            (short_appends, 1_024),
+            (large_appends, 64 * 1024),
+        ] {
+            for layout in [
+                Layout::Flat,
+                Layout::PersistentTree,
+                Layout::PersistentTreeInlineTail,
+            ] {
+                println!(
+                    "{}",
+                    serde_json::to_string(&measure(layout, payload_kind, appends, append_bytes))
+                        .expect("serialize receipt")
+                );
+            }
+        }
+    }
+}
+
+fn measure(
+    layout: Layout,
+    payload_kind: PayloadKind,
+    appends: usize,
+    append_bytes: usize,
+) -> Receipt {
+    let dir = TempDir::new().expect("temporary RocksDB directory");
+    let db = open_db(dir.path());
+    flush_and_compact(&db);
+    let empty_store = disk_bytes(dir.path());
+    let mut writer = Writer::new(&db, layout);
+    for ordinal in 0..appends {
+        writer.append(ordinal, &payload(payload_kind, ordinal, append_bytes));
+    }
+    db.flush_wal(true).expect("flush WAL before measuring");
+    let before_memtable_flush = disk_bytes(dir.path());
+    flush_memtables(&db);
+    let after_memtable_flush = disk_bytes(dir.path());
+    compact(&db);
+    let after_full_compaction = disk_bytes(dir.path());
+    let tree_depth = writer
+        .root
+        .map(|root| writer.nodes[&root].height + 1)
+        .unwrap_or(0);
+    Receipt {
+        layout,
+        payload_kind,
+        appends,
+        append_bytes,
+        logical_payload_bytes: appends * append_bytes,
+        history_rows: appends,
+        part_rows: writer.part_rows,
+        node_rows: writer.node_rows,
+        consolidations: writer.consolidations,
+        tree_depth,
+        compression: "history=zstd; parts/nodes=lz4; bottommost=zstd",
+        empty_store,
+        before_memtable_flush,
+        after_memtable_flush,
+        after_full_compaction,
+    }
+}
+
+fn open_db(path: &Path) -> DB {
+    let mut db_options = Options::default();
+    db_options.create_if_missing(true);
+    db_options.create_missing_column_families(true);
+    let descriptors = [HISTORY, PARTS, NODES].map(|name| {
+        let mut options = Options::default();
+        options.set_compression_type(if name == HISTORY {
+            DBCompressionType::Zstd
+        } else {
+            DBCompressionType::Lz4
+        });
+        options.set_bottommost_compression_type(DBCompressionType::Zstd);
+        ColumnFamilyDescriptor::new(name, options)
+    });
+    DB::open_cf_descriptors(&db_options, path, descriptors).expect("open RocksDB")
+}
+
+fn flush_memtables(db: &DB) {
+    for cf in [HISTORY, PARTS, NODES] {
+        db.flush_cf(db.cf_handle(cf).expect("column family"))
+            .expect("flush memtable");
+    }
+}
+
+fn compact(db: &DB) {
+    for cf in [HISTORY, PARTS, NODES] {
+        db.compact_range_cf(
+            db.cf_handle(cf).expect("column family"),
+            None::<&[u8]>,
+            None::<&[u8]>,
+        );
+    }
+}
+
+fn flush_and_compact(db: &DB) {
+    flush_memtables(db);
+    compact(db);
+}
+
+fn payload(kind: PayloadKind, ordinal: usize, length: usize) -> Vec<u8> {
+    match kind {
+        PayloadKind::Text => (0..length)
+            .map(|index| b"The quick brown fox jumps over the lazy dog. "[(index + ordinal) % 45])
+            .collect(),
+        PayloadKind::Binary => {
+            let mut state = (ordinal as u64 + 1).wrapping_mul(0x9e37_79b9_7f4a_7c15);
+            (0..length)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    state as u8
+                })
+                .collect()
+        }
+    }
+}
+
+fn history_key(ordinal: usize) -> [u8; 16] {
+    let mut key = [0; 16];
+    key[..8].copy_from_slice(b"stream-0");
+    key[8..].copy_from_slice(&(ordinal as u64).to_be_bytes());
+    key
+}
+
+fn encode_node(node: &Node) -> Vec<u8> {
+    let mut value = Vec::with_capacity(8 + node.children.len() * 16);
+    value.extend_from_slice(&node.height.to_le_bytes());
+    value.extend_from_slice(&(node.children.len() as u32).to_le_bytes());
+    for (id, length) in &node.children {
+        value.extend_from_slice(&id.to_le_bytes());
+        value.extend_from_slice(&length.to_le_bytes());
+    }
+    value
+}
+
+fn node_length(node: &Node) -> u64 {
+    node.children.iter().map(|(_, length)| length).sum()
+}
+
+fn disk_bytes(path: &Path) -> DiskBytes {
+    let mut result = DiskBytes {
+        apparent: 0,
+        allocated: if cfg!(unix) { Some(0) } else { None },
+    };
+    for entry in fs::read_dir(path).expect("read RocksDB directory") {
+        let entry = entry.expect("directory entry");
+        let metadata = entry.metadata().expect("entry metadata");
+        if metadata.is_dir() {
+            let nested = disk_bytes(&entry.path());
+            result.apparent += nested.apparent;
+            result.allocated = result
+                .allocated
+                .zip(nested.allocated)
+                .map(|(left, right)| left + right);
+        } else {
+            result.apparent += metadata.len();
+            #[cfg(unix)]
+            if let Some(allocated) = result.allocated.as_mut() {
+                *allocated += metadata.blocks() * 512;
+            }
+        }
+    }
+    result
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}

--- a/dev/experiments/ordinary-row-stream-production.md
+++ b/dev/experiments/ordinary-row-stream-production.md
@@ -51,3 +51,64 @@ pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts \
 
 The append count, append size, tail threshold, and fanout are configurable. The
 benchmark is skipped in ordinary test runs.
+
+## Compressed RocksDB layout receipt
+
+`stream_layout_storage` writes the three candidate physical layouts to isolated
+fresh RocksDB databases. Each append is one atomic batch and writes a complete
+root history version. Immutable parts and persistent-tree nodes use ordinary
+separate column families. The receipt uses the production compression split:
+Zstd for append/history data, LZ4 for ordinary part/node data, and Zstd at the
+bottommost level. Payloads are swept as deterministic incompressible binary and
+highly repetitive text; those are useful sensitivity bounds, not claims about a
+specific application corpus.
+
+The most comparable number is the filesystem increment after explicit memtable
+flush and full compaction. It subtracts the same store's 87,080 apparent-byte /
+4,292,608 allocated-byte empty baseline:
+
+| payload         | workload      |     flat root array |         persistent tree |  tree + 64 KiB tail |
+| --------------- | ------------- | ------------------: | ----------------------: | ------------------: |
+| binary          | 1,000 × 32 B  |       660 / 648 KiB |       **180 / 188 KiB** | 15,604 / 15,604 KiB |
+| binary          | 1,000 × 1 KiB |   1,611 / 1,616 KiB |   **1,159 / 1,164 KiB** | 32,543 / 32,556 KiB |
+| binary          | 256 × 64 KiB  | 16,441 / 16,452 KiB | **16,438 / 16,444 KiB** | 24,626 / 24,632 KiB |
+| repetitive text | 1,000 × 32 B  |       605 / 608 KiB |       **151 / 156 KiB** |       446 / 448 KiB |
+| repetitive text | 1,000 × 1 KiB |       628 / 632 KiB |       **175 / 180 KiB** |       224 / 228 KiB |
+| repetitive text | 256 × 64 KiB  |       133 / 140 KiB |           131 / 136 KiB |   **123 / 128 KiB** |
+
+Each cell is `apparent / allocated` incremental storage. Full compaction changed
+the post-flush figures only slightly because each fresh column family already
+had a single small SST. Before memtable flush, every store reserved about 78 MiB
+of filesystem blocks for RocksDB/WAL machinery, so absolute allocated bytes at
+that phase are honest but not useful for comparing these small isolated stores.
+
+The result changes the recommendation. A 64 KiB inline tail is excellent only
+when repeated historical tails compress strongly. For incompressible data it
+stores the growing tail again in every independently readable history row:
+1,000 × 1 KiB appends consumed 32.5 MiB after compaction for 1 MiB of logical
+payload. The persistent tree consumed 1.16 MiB. Even 32-byte binary appends did
+not cross the threshold and therefore retained 15.6 MiB of historical tails for
+only 32 KiB of payload.
+
+So bounded inline tails should not be a universal stream representation. The
+persistent tree is the stable default for unknown or binary content. An inline
+tail remains plausible for compressible text or with a much smaller byte/history
+budget, an explicit content policy, or storage-level suffix sharing. Compression
+alone does not bound the worst case.
+
+This is a physical-layout receipt rather than a full Jazz-row storage receipt:
+it includes real keys, values, atomic batches, WAL, memtables, SST compression,
+flush, compaction, and filesystem allocation, but intentionally excludes the
+common Jazz row envelope and indices. Those shared costs would raise every
+layout and should not reverse the large binary-tail result.
+
+### Reproduction
+
+```sh
+JAZZ_STREAM_DISK_BENCH=1 \
+cargo bench -p groove --bench stream_layout_storage
+```
+
+Defaults are 1,000 appends for 32-byte and 1-KiB chunks and 256 appends for
+64-KiB chunks. `JAZZ_STREAM_DISK_SHORT_APPENDS` and
+`JAZZ_STREAM_DISK_LARGE_APPENDS` override those counts.

--- a/dev/experiments/ordinary-row-stream-production.md
+++ b/dev/experiments/ordinary-row-stream-production.md
@@ -64,37 +64,75 @@ highly repetitive text; those are useful sensitivity bounds, not claims about a
 specific application corpus.
 
 The most comparable number is the filesystem increment after explicit memtable
-flush and full compaction. It subtracts the same store's 87,080 apparent-byte /
-4,292,608 allocated-byte empty baseline:
+flush and full compaction. The harness now emits that baseline subtraction
+directly for both apparent and allocated bytes. Each configuration uses a fresh
+store; the empty baseline was about 85 KiB apparent / 4,192 KiB allocated. The
+tables below show `apparent / allocated` incremental KiB, tail consolidations,
+immutable part/node rows, total timed RocksDB write milliseconds, and p95 write
+microseconds. Every workload writes one history row per append; payload
+generation, flush, and compaction are outside the write timing.
 
-| payload         | workload      |     flat root array |         persistent tree |  tree + 64 KiB tail |
-| --------------- | ------------- | ------------------: | ----------------------: | ------------------: |
-| binary          | 1,000 × 32 B  |       660 / 648 KiB |       **180 / 188 KiB** | 15,604 / 15,604 KiB |
-| binary          | 1,000 × 1 KiB |   1,611 / 1,616 KiB |   **1,159 / 1,164 KiB** | 32,543 / 32,556 KiB |
-| binary          | 256 × 64 KiB  | 16,441 / 16,452 KiB | **16,438 / 16,444 KiB** | 24,626 / 24,632 KiB |
-| repetitive text | 1,000 × 32 B  |       605 / 608 KiB |       **151 / 156 KiB** |       446 / 448 KiB |
-| repetitive text | 1,000 × 1 KiB |       628 / 632 KiB |       **175 / 180 KiB** |       224 / 228 KiB |
-| repetitive text | 256 × 64 KiB  |       133 / 140 KiB |           131 / 136 KiB |   **123 / 128 KiB** |
+### 1,000 × 32-byte appends (1,000 history versions)
 
-Each cell is `apparent / allocated` incremental storage. Full compaction changed
-the post-flush figures only slightly because each fresh column family already
-had a single small SST. Before memtable flush, every store reserved about 78 MiB
-of filesystem blocks for RocksDB/WAL machinery, so absolute allocated bytes at
-that phase are honest but not useful for comparing these small isolated stores.
+| tail cap |      binary KiB |    text KiB | consolidations | parts / nodes | binary total / p95 | text total / p95 |
+| -------- | --------------: | ----------: | -------------: | ------------: | -----------------: | ---------------: |
+| tree (0) |       180 / 188 |   151 / 156 |              0 | 1,000 / 2,503 |      5.1 ms / 7 µs |    4.4 ms / 5 µs |
+| 64 B     |       116 / 120 |     69 / 72 |            333 |     333 / 653 |      2.6 ms / 4 µs |    2.6 ms / 4 µs |
+| 128 B    |   **109 / 112** |     58 / 60 |            200 |     200 / 379 |      2.6 ms / 3 µs |    2.6 ms / 3 µs |
+| 256 B    |       110 / 116 |     53 / 60 |            111 |     111 / 195 |      2.2 ms / 3 µs |    2.2 ms / 3 µs |
+| 512 B    |       126 / 132 | **52 / 60** |             58 |       58 / 86 |      2.7 ms / 3 µs |    3.0 ms / 3 µs |
+| 1 KiB    |       184 / 192 |     57 / 64 |             30 |       30 / 30 |      2.8 ms / 3 µs |    2.8 ms / 3 µs |
+| 64 KiB   | 15,604 / 15,608 |   446 / 448 |              0 |         0 / 0 |    23.6 ms / 41 µs |  23.1 ms / 41 µs |
 
-The result changes the recommendation. A 64 KiB inline tail is excellent only
-when repeated historical tails compress strongly. For incompressible data it
-stores the growing tail again in every independently readable history row:
-1,000 × 1 KiB appends consumed 32.5 MiB after compaction for 1 MiB of logical
-payload. The persistent tree consumed 1.16 MiB. Even 32-byte binary appends did
-not cross the threshold and therefore retained 15.6 MiB of historical tails for
-only 32 KiB of payload.
+### 1,000 × 1-KiB appends (1,000 history versions)
 
-So bounded inline tails should not be a universal stream representation. The
-persistent tree is the stable default for unknown or binary content. An inline
-tail remains plausible for compressible text or with a much smaller byte/history
-budget, an explicit content policy, or storage-level suffix sharing. Compression
-alone does not bound the worst case.
+| tail cap |        binary KiB |      text KiB | consolidations | parts / nodes | binary total / p95 | text total / p95 |
+| -------- | ----------------: | ------------: | -------------: | ------------: | -----------------: | ---------------: |
+| tree (0) | **1,159 / 1,164** |     175 / 180 |              0 | 1,000 / 2,503 |      5.5 ms / 6 µs |    5.6 ms / 6 µs |
+| 64 B     |     1,159 / 1,164 |     175 / 180 |          1,000 | 1,000 / 2,503 |      5.9 ms / 7 µs |    5.1 ms / 6 µs |
+| 128 B    |     1,159 / 1,164 |     175 / 180 |          1,000 | 1,000 / 2,503 |      5.0 ms / 6 µs |    5.3 ms / 6 µs |
+| 256 B    |     1,159 / 1,164 |     175 / 180 |          1,000 | 1,000 / 2,503 |      5.3 ms / 6 µs |    4.9 ms / 5 µs |
+| 512 B    |     1,159 / 1,164 |     175 / 180 |          1,000 | 1,000 / 2,503 |      4.9 ms / 6 µs |    5.3 ms / 5 µs |
+| 1 KiB    |     1,620 / 1,624 | **126 / 132** |            500 |     500 / 998 |      4.8 ms / 6 µs |    4.5 ms / 6 µs |
+| 64 KiB   |   32,543 / 32,556 |     224 / 228 |             15 |       15 / 15 |    46.2 ms / 84 µs |  45.9 ms / 89 µs |
+
+### 256 × 64-KiB appends (256 history versions)
+
+| tail cap |          binary KiB |      text KiB | consolidations | parts / nodes | binary total / p95 | text total / p95 |
+| -------- | ------------------: | ------------: | -------------: | ------------: | -----------------: | ---------------: |
+| tree (0) | **16,439 / 16,448** |     131 / 136 |              0 |     256 / 494 |    22.7 ms / 92 µs |  23.3 ms / 91 µs |
+| 64 B     |     16,439 / 16,448 |     131 / 136 |            256 |     256 / 494 |    22.7 ms / 91 µs |  23.1 ms / 92 µs |
+| 128 B    |     16,439 / 16,448 |     131 / 136 |            256 |     256 / 494 |    22.9 ms / 92 µs |  23.4 ms / 94 µs |
+| 256 B    |     16,439 / 16,448 |     131 / 136 |            256 |     256 / 494 |    23.8 ms / 93 µs |  23.3 ms / 92 µs |
+| 512 B    |     16,439 / 16,448 |     131 / 136 |            256 |     256 / 494 |    23.0 ms / 92 µs |  23.6 ms / 91 µs |
+| 1 KiB    |     16,439 / 16,448 |     131 / 136 |            256 |     256 / 494 |    23.2 ms / 93 µs |  23.2 ms / 93 µs |
+| 64 KiB   |     24,626 / 24,632 | **123 / 128** |            128 |     128 / 230 |   34.4 ms / 179 µs | 35.0 ms / 181 µs |
+
+Full compaction changed post-flush figures only slightly because each fresh
+column family already had a single small SST. Before memtable flush, every
+store reserved about 78 MiB of filesystem blocks for RocksDB/WAL machinery, so
+absolute allocated bytes at that phase remain honest but unhelpful for these
+small isolated stores. The flat-root-array reference remains in the raw JSONL
+output but is omitted above because the tail crossover is against the stable
+persistent-tree baseline.
+
+The recommendation is now narrower than either universal tree or universal
+64-KiB tail. For frequent 32-byte appends, a 128–256 B cap is the best binary
+storage point and 256–512 B is the best repetitive-text point. Those caps also
+reduce tree churn and total direct write time by grouping several appends per
+consolidation. At 1-KiB appends, a cap below the append size is effectively the
+tree baseline: it consolidates every append, with the same rows, storage, and
+write latency. A 1-KiB cap helps repetitive text by grouping pairs but costs
+about 40% more storage for incompressible binary. At 64-KiB appends, all smaller
+caps collapse to the tree baseline; the 64-KiB cap saves only 8 KiB of repetitive
+text while making p95 writes roughly twice as slow and adds about 8 MiB for
+binary.
+
+Therefore do not change the public default from this physical receipt alone.
+For unknown or binary content, tree baseline remains safest; if a default tail
+is introduced after end-to-end Jazz-row measurement, 128–256 B is the strongest
+current candidate for small appends. Content-aware text policy can justify a
+somewhat larger cap, but compression alone does not bound historical-tail cost.
 
 This is a physical-layout receipt rather than a full Jazz-row storage receipt:
 it includes real keys, values, atomic batches, WAL, memtables, SST compression,

--- a/dev/experiments/ordinary-row-stream-production.md
+++ b/dev/experiments/ordinary-row-stream-production.md
@@ -1,0 +1,53 @@
+# Ordinary-row stream production helper: early receipt
+
+The opt-in benchmark exercises `createConventionalStreamStorage` through the
+public `Db` API against a real local Jazz authority. Every append is one
+exclusive transaction and waits for authority acceptance. It records append
+latency, consolidation spikes, ordinary immutable node/part rows, a full read,
+and independently reads the first, middle, and last saved snapshot roots.
+
+## Initial receipt
+
+Environment: Node 24 client using the in-memory WASM runtime, local
+`jazz-server`, one process. Workload: 40 authority-accepted 32-byte appends,
+256-byte tail, fanout 4. The deliberately small tail forces four consolidations.
+
+| metric                   |                result |
+| ------------------------ | --------------------: |
+| append p50 / p95 / max   | 25.3 / 35.3 / 81.7 ms |
+| consolidation p50 / p95  |        28.3 / 35.3 ms |
+| immutable part rows      |                     4 |
+| immutable tree-node rows |                     4 |
+| full 1,280-byte read     |                254 ms |
+
+The receipt is directional, not a cross-machine benchmark. Its important early
+signal is structural: 40 small appends produced four parts and four tree nodes,
+instead of a part and copied tree path on every append. Consolidation was
+visible but remained inside the ordinary accepted-transaction latency band.
+
+The 254 ms full read exposes the current userland cost: the helper resolves
+ordinary referenced rows through individual public point queries. General
+reachable-row hydration/batching would improve documents, files, and other
+ordinary graph-shaped application data too.
+
+Node `createDb` currently uses the in-memory WASM runtime even when a native
+filesystem path is supplied, so this receipt deliberately does not claim a
+client disk delta. The earlier structural experiment measured a persistent
+backend, but backend trusted-serving exclusive transaction reads require the
+newer browser/runtime stack. A durable client disk receipt belongs after that
+parent is integrated rather than as a synthetic zero.
+
+## Reproduction
+
+```sh
+JAZZ_STREAM_BENCH=1 \
+JAZZ_STREAM_BENCH_APPENDS=40 \
+JAZZ_STREAM_BENCH_APPEND_BYTES=32 \
+JAZZ_STREAM_BENCH_TAIL_BYTES=256 \
+JAZZ_STREAM_BENCH_FANOUT=4 \
+pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts \
+  src/runtime/stream-storage.benchmark.test.ts --reporter=verbose
+```
+
+The append count, append size, tail threshold, and fanout are configurable. The
+benchmark is skipped in ordinary test runs.

--- a/packages/jazz-tools/src/package-root-public-api.test.ts
+++ b/packages/jazz-tools/src/package-root-public-api.test.ts
@@ -301,6 +301,7 @@ describe("package root public API", () => {
       "RowChangeKind",
       "Transaction",
       "createDb",
+      "createConventionalStreamStorage",
       "fetchSchemaHashes",
       "fetchStoredPermissions",
       "fetchStoredWasmSchema",

--- a/packages/jazz-tools/src/runtime/STREAM_STORAGE.md
+++ b/packages/jazz-tools/src/runtime/STREAM_STORAGE.md
@@ -1,0 +1,77 @@
+# Ordinary-row stream storage contract
+
+Jazz streams are a TypeScript library data structure built entirely from
+ordinary Jazz rows. The core, wire protocol, storage drivers, authorization,
+branching, and history have no stream-specific path.
+
+## Logical value
+
+Every stream row version is a complete, independently readable snapshot:
+
+```text
+StreamSnapshot {
+  rootId:        id of an immutable extent-tree root, or ""
+  prefixBytes:   logical bytes covered by rootId
+  inlineTail:    bounded recent bytes
+}
+```
+
+Reading a snapshot follows only its `rootId` and appends its `inlineTail`. It
+MUST NOT find or replay an earlier stream history version. Therefore historical
+and branch reads inherit ordinary Jazz row-version semantics rather than adding
+a second stream history.
+
+## Physical ordinary rows
+
+The conventional schema contains:
+
+- `streams(rootId, prefixBytes, inlineTail)` — one mutable logical root;
+- `stream_nodes(childIds, childLengths, height)` — immutable persistent tree
+  nodes; height zero children are segment ids, other children are node ids;
+- `stream_parts(data)` — immutable bounded byte segments.
+
+The tree has bounded fanout. An append copies only the right spine. Small
+appends update the bounded tail. The transaction that would cross the tail
+limit writes one or more bounded immutable parts, copies the tree path, clears
+the tail, and advances the root atomically.
+
+## Public behavior
+
+- `create()` creates an empty ordinary stream row.
+- `append()` is an exclusive transaction so concurrent appenders cannot silently
+  discard one another. Authority rejection is surfaced to the caller for retry.
+- `snapshot()` returns the complete root tuple.
+- `read()` and `readRange()` materialize only the addressed snapshot/tree and
+  requested segment ranges.
+- `subscribe()` subscribes to the ordinary stream row and emits complete root
+  tuples; consumers may range-read bytes after each root change.
+
+Parts are at most 1 MiB, matching the ordinary `BYTEA` cell limit. The default
+tail limit is 64 KiB and fanout is 32. These are library placement choices, not
+replicated-format constants.
+
+## Authorization and lifecycle
+
+The library does not bypass row authorization. Applications define permissions
+on all three conventional tables. A usable deployment MUST ensure that a writer
+authorized to advance a stream root may atomically insert the referenced nodes
+and parts; a reader authorized for a stream must also be able to read its
+reachable immutable rows. General transaction-created-child authorization is a
+separate Jazz policy capability and is not hidden inside this library.
+
+Ordinary history retaining a stream root keeps its referenced content logically
+live. Automatic reachability collection is not part of the first slice; deleting
+a stream does not claim to delete rows still reachable from retained history or
+branches.
+
+## Invariants
+
+1. `prefixBytes` equals the total length under `rootId`.
+2. `inlineTail.length <= tailLimit` after every committed append.
+3. Node `childIds` and `childLengths` have equal non-zero lengths; a node length
+   is the sum of its child lengths.
+4. Nodes and parts are immutable after insertion.
+5. A range result preserves append order and equals the corresponding slice of
+   a full read.
+6. A saved snapshot remains readable after later appends without consulting
+   stream-row history.

--- a/packages/jazz-tools/src/runtime/STREAM_STORAGE.md
+++ b/packages/jazz-tools/src/runtime/STREAM_STORAGE.md
@@ -39,7 +39,8 @@ the tail, and advances the root atomically.
 
 - `create()` creates an empty ordinary stream row.
 - `append()` is an exclusive transaction so concurrent appenders cannot silently
-  discard one another. Authority rejection is surfaced to the caller for retry.
+  discard one another. It waits for authority acceptance by default; conflict
+  rejection is surfaced to the caller for retry.
 - `snapshot()` returns the complete root tuple.
 - `read()` and `readRange()` materialize only the addressed snapshot/tree and
   requested segment ranges.

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -37,6 +37,24 @@ export {
 } from "./db.js";
 export type { AuthFailureReason, AuthState } from "./auth-state.js";
 export {
+  createConventionalStreamStorage,
+  DEFAULT_STREAM_INLINE_TAIL_BYTES,
+  DEFAULT_STREAM_TREE_FANOUT,
+  InvalidStreamDataError,
+  MAX_STREAM_PART_BYTES,
+  StreamNotFoundError,
+  type AppendStreamOptions,
+  type ConventionalStreamApp,
+  type CreateStreamOptions,
+  type ReadStreamOptions,
+  type StreamNodeRow,
+  type StreamPartRow,
+  type StreamRow,
+  type StreamSnapshot,
+  type StreamStorage,
+  type StreamStorageOptions,
+} from "./stream-storage.js";
+export {
   fetchStoredPermissions,
   fetchSchemaHashes,
   fetchStoredWasmSchema,

--- a/packages/jazz-tools/src/runtime/stream-storage.benchmark.test.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.benchmark.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Opt-in end-to-end benchmark for the production ordinary-row stream helper.
+ *
+ * JAZZ_STREAM_BENCH=1 JAZZ_STREAM_BENCH_APPENDS=100 \
+ *   pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts \
+ *   src/runtime/stream-storage.benchmark.test.ts --reporter=verbose
+ */
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { deploy, startLocalJazzServer } from "../testing/index.js";
+import { createDb } from "./db.js";
+import { createConventionalStreamStorage } from "./stream-storage.js";
+
+const app = s.defineApp({
+  streams: s.table({ rootId: s.string(), prefixBytes: s.int(), inlineTail: s.bytes() }),
+  stream_nodes: s.table({
+    childIds: s.array(s.string()),
+    childLengths: s.array(s.int()),
+    height: s.int(),
+  }),
+  stream_parts: s.table({ data: s.bytes() }),
+});
+
+const enabled = process.env.JAZZ_STREAM_BENCH === "1";
+const appends = Number(process.env.JAZZ_STREAM_BENCH_APPENDS ?? "100");
+const appendBytes = Number(process.env.JAZZ_STREAM_BENCH_APPEND_BYTES ?? "32");
+const tailBytes = Number(process.env.JAZZ_STREAM_BENCH_TAIL_BYTES ?? `${64 * 1024}`);
+const fanout = Number(process.env.JAZZ_STREAM_BENCH_FANOUT ?? "32");
+
+function percentile(values: number[], quantile: number) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * quantile))] ?? 0;
+}
+
+describe.skipIf(!enabled)("ordinary-row stream production benchmark", () => {
+  it("measures authority-accepted appends, consolidation, reads, and stored rows", async () => {
+    const appId = randomUUID();
+    const adminSecret = "stream-storage-benchmark-admin";
+    const server = await startLocalJazzServer({ appId, adminSecret });
+    const latencies: number[] = [];
+    const consolidationLatencies: number[] = [];
+    try {
+      await deploy({
+        serverUrl: server.url,
+        appId,
+        adminSecret,
+        schema: app.wasmSchema,
+        permissions: {},
+      });
+      const db = await createDb({
+        appId,
+        adminSecret,
+        serverUrl: server.url,
+        driver: { type: "memory" },
+      });
+      const storage = createConventionalStreamStorage(db, app, {
+        inlineTailBytes: tailBytes,
+        fanout,
+      });
+      try {
+        const stream = await storage.create({ tier: "edge" });
+        const snapshots = [];
+        let prefixBytes = 0;
+        for (let ordinal = 0; ordinal < appends; ordinal += 1) {
+          const chunk = new Uint8Array(appendBytes);
+          chunk.fill(ordinal & 255);
+          const started = performance.now();
+          const snapshot = await storage.append(stream.id, chunk);
+          const elapsed = performance.now() - started;
+          latencies.push(elapsed);
+          if (snapshot.prefixBytes !== prefixBytes) consolidationLatencies.push(elapsed);
+          prefixBytes = snapshot.prefixBytes;
+          snapshots.push(snapshot);
+        }
+
+        const readStarted = performance.now();
+        const current = await storage.read(stream.id);
+        const fullReadMs = performance.now() - readStarted;
+        expect(current).toHaveLength(appends * appendBytes);
+        for (const index of new Set([0, Math.floor(appends / 2), appends - 1])) {
+          expect(await storage.read(snapshots[index]!)).toHaveLength((index + 1) * appendBytes);
+        }
+        const [nodes, parts] = await Promise.all([
+          db.all(app.stream_nodes.where({}), { tier: "local" }),
+          db.all(app.stream_parts.where({}), { tier: "local" }),
+        ]);
+        console.info(
+          `[ordinary-stream-production] ${JSON.stringify({
+            appends,
+            appendBytes,
+            tailBytes,
+            fanout,
+            durableP50Ms: percentile(latencies, 0.5),
+            durableP95Ms: percentile(latencies, 0.95),
+            durableMaxMs: Math.max(...latencies),
+            consolidationCount: consolidationLatencies.length,
+            consolidationP50Ms: percentile(consolidationLatencies, 0.5),
+            consolidationP95Ms: percentile(consolidationLatencies, 0.95),
+            nodeRows: nodes.length,
+            partRows: parts.length,
+            fullReadMs,
+            clientStorage: "Node createDb uses in-memory WASM; disk delta not measured here",
+          })}`,
+        );
+      } finally {
+        await db.shutdown();
+      }
+    } finally {
+      await server.stop();
+    }
+  }, 180_000);
+});

--- a/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
@@ -1,0 +1,132 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { createDb, type Db } from "./db.js";
+import {
+  createConventionalStreamStorage,
+  InvalidStreamDataError,
+  MAX_STREAM_PART_BYTES,
+  type StreamSnapshot,
+} from "./stream-storage.js";
+
+const app = s.defineApp({
+  streams: s.table({
+    rootId: s.string(),
+    prefixBytes: s.int(),
+    inlineTail: s.bytes(),
+  }),
+  stream_nodes: s.table({
+    childIds: s.array(s.string()),
+    childLengths: s.array(s.int()),
+    height: s.int(),
+  }),
+  stream_parts: s.table({
+    data: s.bytes(),
+  }),
+});
+
+const paths: string[] = [];
+const databases: Db[] = [];
+
+async function setup(options: { inlineTailBytes?: number; fanout?: number } = {}) {
+  const path = mkdtempSync(join(tmpdir(), "jazz-stream-storage-"));
+  paths.push(path);
+  const db = await createDb({
+    appId: `stream-storage-${Date.now()}-${Math.random()}`,
+    driver: { type: "persistent", dataPath: path },
+    adminSecret: "stream-storage-integration-test",
+    serverUrl: "ws://stream-storage.invalid",
+  });
+  databases.push(db);
+  return { db, storage: createConventionalStreamStorage(db, app, options) };
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.shutdown()));
+  for (const path of paths.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("ordinary-row stream storage", () => {
+  it("atomically consolidates a bounded tail and preserves old snapshots", async () => {
+    const { db, storage } = await setup({ inlineTailBytes: 4, fanout: 4 });
+    const stream = await storage.create({ tier: "local" });
+    const first = await storage.append(stream, Uint8Array.from([1, 2]));
+    await storage.append(stream.id, Uint8Array.from([3, 4]));
+    const consolidated = await storage.append(stream.id, Uint8Array.from([5]));
+    await storage.append(stream.id, Uint8Array.from([6, 7]));
+
+    expect(Array.from(await storage.read(stream.id))).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(Array.from(await storage.readRange(stream.id, 3, 6))).toEqual([4, 5, 6]);
+
+    // Both snapshots are complete roots. Later stream-row history is irrelevant.
+    expect(Array.from(await storage.read(first))).toEqual([1, 2]);
+    expect(Array.from(await storage.read(consolidated))).toEqual([1, 2, 3, 4, 5]);
+    expect(consolidated.prefixBytes).toBe(5);
+    expect(consolidated.inlineTail).toHaveLength(0);
+
+    expect(await db.all(app.stream_parts.where({}), { tier: "local" })).toHaveLength(1);
+    expect(await db.all(app.stream_nodes.where({}), { tier: "local" })).toHaveLength(1);
+  });
+
+  it("splits oversized consolidation into bounded immutable parts and a persistent tree", async () => {
+    const { db, storage } = await setup({ inlineTailBytes: 8, fanout: 4 });
+    const stream = await storage.create({ tier: "local" });
+    const input = new Uint8Array(MAX_STREAM_PART_BYTES + 3);
+    input.fill(9);
+    input[MAX_STREAM_PART_BYTES] = 1;
+    input[MAX_STREAM_PART_BYTES + 1] = 2;
+    input[MAX_STREAM_PART_BYTES + 2] = 3;
+
+    const snapshot = await storage.append(stream, input);
+    const parts = await db.all(app.stream_parts.where({}), { tier: "local" });
+    expect(parts.map((part) => part.data.length).sort((a, b) => a - b)).toEqual([
+      3,
+      MAX_STREAM_PART_BYTES,
+    ]);
+    expect(Array.from(await storage.readRange(snapshot, MAX_STREAM_PART_BYTES - 1))).toEqual([
+      9, 1, 2, 3,
+    ]);
+  });
+
+  it("subscribes through the ordinary stream row", async () => {
+    const { storage } = await setup({ inlineTailBytes: 16 });
+    const stream = await storage.create({ tier: "local" });
+    const observed: StreamSnapshot[] = [];
+    const appended = new Promise<void>((resolve) => {
+      const unsubscribe = storage.subscribe(stream.id, (snapshot) => {
+        if (!snapshot) return;
+        observed.push(snapshot);
+        if (snapshot.length === 3) {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    await storage.append(stream, Uint8Array.from([4, 5, 6]));
+    await appended;
+    expect(observed.at(-1)?.inlineTail).toEqual(Uint8Array.from([4, 5, 6]));
+  });
+
+  it("detects corrupted child-length metadata before returning wrong bytes", async () => {
+    const { db, storage } = await setup({ inlineTailBytes: 0, fanout: 4 });
+    const stream = await storage.create({ tier: "local" });
+    const snapshot = await storage.append(stream, Uint8Array.from([1, 2, 3]));
+    const root = await db.one(app.stream_nodes.where({ id: snapshot.rootId }), { tier: "local" });
+    expect(root).toBeTruthy();
+
+    await db
+      .update(app.stream_nodes, snapshot.rootId, { childLengths: [2] })
+      .wait({ tier: "local" });
+    await expect(storage.read(snapshot)).rejects.toBeInstanceOf(InvalidStreamDataError);
+  });
+
+  it("rejects invalid ranges instead of silently truncating", async () => {
+    const { storage } = await setup();
+    const stream = await storage.create({ tier: "local" });
+    await storage.append(stream, Uint8Array.from([1, 2, 3]));
+    await expect(storage.readRange(stream.id, 2, 4)).rejects.toThrow("for 3 bytes");
+  });
+});

--- a/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
@@ -168,7 +168,31 @@ describe("ordinary-row stream storage", () => {
     await db
       .update(app.stream_nodes, snapshot!.rootId, { childLengths: [1, 4] })
       .wait({ tier: "local" });
-    await expect(storage.read(snapshot!)).rejects.toBeInstanceOf(InvalidStreamDataError);
+    await expect(storage.readRange(snapshot!, 0, 2)).rejects.toBeInstanceOf(InvalidStreamDataError);
+  });
+
+  it("rejects corrupted current-tree metadata instead of advancing the stream head", async () => {
+    const { db, storage } = await setup({ inlineTailBytes: 0, fanout: 4 });
+    const stream = await storage.create({ tier: "edge" });
+    let snapshot: StreamSnapshot | undefined;
+    for (let value = 0; value < 5; value += 1) {
+      snapshot = await storage.append(stream, Uint8Array.of(value), { waitForAuthority: true });
+    }
+    const root = await db.one(app.stream_nodes.where({ id: snapshot!.rootId }), { tier: "local" });
+    expect(root?.childLengths).toEqual([2, 3]);
+    await db
+      .update(app.stream_nodes, snapshot!.rootId, { childLengths: [1, 4] })
+      .wait({ tier: "edge" });
+    const before = await db.one(app.streams.where({ id: stream.id }), { tier: "local" });
+
+    await expect(storage.append(stream.id, Uint8Array.of(5))).rejects.toBeInstanceOf(
+      InvalidStreamDataError,
+    );
+
+    const after = await db.one(app.streams.where({ id: stream.id }), { tier: "local" });
+    expect(after?.rootId).toBe(before?.rootId);
+    expect(after?.prefixBytes).toBe(before?.prefixBytes);
+    expect(after?.inlineTail).toEqual(before?.inlineTail);
   });
 
   it("rejects malformed descendant heights before reading a stream", async () => {

--- a/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
@@ -1,8 +1,7 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
 import { schema as s } from "../index.js";
+import { deploy, startLocalJazzServer, type LocalJazzServerHandle } from "../testing/index.js";
 import { createDb, type Db } from "./db.js";
 import {
   createConventionalStreamStorage,
@@ -27,17 +26,26 @@ const app = s.defineApp({
   }),
 });
 
-const paths: string[] = [];
 const databases: Db[] = [];
+const adminSecret = "stream-storage-integration-admin";
+const servers: LocalJazzServerHandle[] = [];
 
 async function setup(options: { inlineTailBytes?: number; fanout?: number } = {}) {
-  const path = mkdtempSync(join(tmpdir(), "jazz-stream-storage-"));
-  paths.push(path);
+  const appId = randomUUID();
+  const server = await startLocalJazzServer({ appId, adminSecret });
+  servers.push(server);
+  await deploy({
+    serverUrl: server.url,
+    appId,
+    adminSecret,
+    schema: app.wasmSchema,
+    permissions: {},
+  });
   const db = await createDb({
-    appId: `stream-storage-${Date.now()}-${Math.random()}`,
-    driver: { type: "persistent", dataPath: path },
-    adminSecret: "stream-storage-integration-test",
-    serverUrl: "ws://stream-storage.invalid",
+    appId,
+    driver: { type: "memory" },
+    adminSecret,
+    serverUrl: server.url,
   });
   databases.push(db);
   return { db, storage: createConventionalStreamStorage(db, app, options) };
@@ -45,17 +53,19 @@ async function setup(options: { inlineTailBytes?: number; fanout?: number } = {}
 
 afterEach(async () => {
   await Promise.all(databases.splice(0).map((db) => db.shutdown()));
-  for (const path of paths.splice(0)) rmSync(path, { recursive: true, force: true });
+  await Promise.all(servers.splice(0).map((server) => server.stop()));
 });
 
 describe("ordinary-row stream storage", () => {
   it("atomically consolidates a bounded tail and preserves old snapshots", async () => {
     const { db, storage } = await setup({ inlineTailBytes: 4, fanout: 4 });
-    const stream = await storage.create({ tier: "local" });
-    const first = await storage.append(stream, Uint8Array.from([1, 2]));
-    await storage.append(stream.id, Uint8Array.from([3, 4]));
-    const consolidated = await storage.append(stream.id, Uint8Array.from([5]));
-    await storage.append(stream.id, Uint8Array.from([6, 7]));
+    const stream = await storage.create({ tier: "edge" });
+    const first = await storage.append(stream, Uint8Array.from([1, 2]), { waitForAuthority: true });
+    await storage.append(stream.id, Uint8Array.from([3, 4]), { waitForAuthority: true });
+    const consolidated = await storage.append(stream.id, Uint8Array.from([5]), {
+      waitForAuthority: true,
+    });
+    await storage.append(stream.id, Uint8Array.from([6, 7]), { waitForAuthority: true });
 
     expect(Array.from(await storage.read(stream.id))).toEqual([1, 2, 3, 4, 5, 6, 7]);
     expect(Array.from(await storage.readRange(stream.id, 3, 6))).toEqual([4, 5, 6]);
@@ -72,14 +82,14 @@ describe("ordinary-row stream storage", () => {
 
   it("splits oversized consolidation into bounded immutable parts and a persistent tree", async () => {
     const { db, storage } = await setup({ inlineTailBytes: 8, fanout: 4 });
-    const stream = await storage.create({ tier: "local" });
+    const stream = await storage.create({ tier: "edge" });
     const input = new Uint8Array(MAX_STREAM_PART_BYTES + 3);
     input.fill(9);
     input[MAX_STREAM_PART_BYTES] = 1;
     input[MAX_STREAM_PART_BYTES + 1] = 2;
     input[MAX_STREAM_PART_BYTES + 2] = 3;
 
-    const snapshot = await storage.append(stream, input);
+    const snapshot = await storage.append(stream, input, { waitForAuthority: true });
     const parts = await db.all(app.stream_parts.where({}), { tier: "local" });
     expect(parts.map((part) => part.data.length).sort((a, b) => a - b)).toEqual([
       3,
@@ -90,9 +100,44 @@ describe("ordinary-row stream storage", () => {
     ]);
   });
 
+  it("copies a bounded right spine while sampled old roots remain independently readable", async () => {
+    const { db, storage } = await setup({ inlineTailBytes: 0, fanout: 4 });
+    const stream = await storage.create({ tier: "edge" });
+    const snapshots: StreamSnapshot[] = [];
+    for (let value = 0; value < 20; value += 1) {
+      snapshots.push(await storage.append(stream.id, Uint8Array.of(value)));
+    }
+
+    const current = snapshots.at(-1)!;
+    const root = await db.one(app.stream_nodes.where({ id: current.rootId }), { tier: "local" });
+    expect(root?.height).toBeGreaterThan(0);
+    expect(Array.from(await storage.read(current))).toEqual(
+      Array.from({ length: 20 }, (_, index) => index),
+    );
+    for (const index of [0, 7, 19]) {
+      expect(Array.from(await storage.read(snapshots[index]!))).toEqual(
+        Array.from({ length: index + 1 }, (_, value) => value),
+      );
+    }
+  }, 20_000);
+
+  it("never reports two concurrent appends accepted while losing one", async () => {
+    const { storage } = await setup({ inlineTailBytes: 16 });
+    const stream = await storage.create({ tier: "edge" });
+    const results = await Promise.allSettled([
+      storage.append(stream.id, Uint8Array.of(1)),
+      storage.append(stream.id, Uint8Array.of(2)),
+    ]);
+    const accepted = results.filter((result) => result.status === "fulfilled").length;
+    const bytes = Array.from(await storage.read(stream.id));
+    expect(bytes).toHaveLength(accepted);
+    expect(bytes.every((value) => value === 1 || value === 2)).toBe(true);
+    expect(new Set(bytes).size).toBe(bytes.length);
+  });
+
   it("subscribes through the ordinary stream row", async () => {
     const { storage } = await setup({ inlineTailBytes: 16 });
-    const stream = await storage.create({ tier: "local" });
+    const stream = await storage.create({ tier: "edge" });
     const observed: StreamSnapshot[] = [];
     const appended = new Promise<void>((resolve) => {
       const unsubscribe = storage.subscribe(stream.id, (snapshot) => {
@@ -105,15 +150,17 @@ describe("ordinary-row stream storage", () => {
       });
     });
 
-    await storage.append(stream, Uint8Array.from([4, 5, 6]));
+    await storage.append(stream, Uint8Array.from([4, 5, 6]), { waitForAuthority: true });
     await appended;
     expect(observed.at(-1)?.inlineTail).toEqual(Uint8Array.from([4, 5, 6]));
   });
 
   it("detects corrupted child-length metadata before returning wrong bytes", async () => {
     const { db, storage } = await setup({ inlineTailBytes: 0, fanout: 4 });
-    const stream = await storage.create({ tier: "local" });
-    const snapshot = await storage.append(stream, Uint8Array.from([1, 2, 3]));
+    const stream = await storage.create({ tier: "edge" });
+    const snapshot = await storage.append(stream, Uint8Array.from([1, 2, 3]), {
+      waitForAuthority: true,
+    });
     const root = await db.one(app.stream_nodes.where({ id: snapshot.rootId }), { tier: "local" });
     expect(root).toBeTruthy();
 
@@ -125,8 +172,8 @@ describe("ordinary-row stream storage", () => {
 
   it("rejects invalid ranges instead of silently truncating", async () => {
     const { storage } = await setup();
-    const stream = await storage.create({ tier: "local" });
-    await storage.append(stream, Uint8Array.from([1, 2, 3]));
+    const stream = await storage.create({ tier: "edge" });
+    await storage.append(stream, Uint8Array.from([1, 2, 3]), { waitForAuthority: true });
     await expect(storage.readRange(stream.id, 2, 4)).rejects.toThrow("for 3 bytes");
   });
 });

--- a/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.integration.test.ts
@@ -155,19 +155,52 @@ describe("ordinary-row stream storage", () => {
     expect(observed.at(-1)?.inlineTail).toEqual(Uint8Array.from([4, 5, 6]));
   });
 
-  it("detects corrupted child-length metadata before returning wrong bytes", async () => {
+  it("rejects exact [2, 3] to [1, 4] child-length corruption before returning bytes", async () => {
     const { db, storage } = await setup({ inlineTailBytes: 0, fanout: 4 });
     const stream = await storage.create({ tier: "edge" });
-    const snapshot = await storage.append(stream, Uint8Array.from([1, 2, 3]), {
-      waitForAuthority: true,
-    });
-    const root = await db.one(app.stream_nodes.where({ id: snapshot.rootId }), { tier: "local" });
-    expect(root).toBeTruthy();
+    let snapshot: StreamSnapshot | undefined;
+    for (let value = 0; value < 5; value += 1) {
+      snapshot = await storage.append(stream, Uint8Array.of(value), { waitForAuthority: true });
+    }
+    const root = await db.one(app.stream_nodes.where({ id: snapshot!.rootId }), { tier: "local" });
+    expect(root?.childLengths).toEqual([2, 3]);
 
     await db
-      .update(app.stream_nodes, snapshot.rootId, { childLengths: [2] })
+      .update(app.stream_nodes, snapshot!.rootId, { childLengths: [1, 4] })
       .wait({ tier: "local" });
-    await expect(storage.read(snapshot)).rejects.toBeInstanceOf(InvalidStreamDataError);
+    await expect(storage.read(snapshot!)).rejects.toBeInstanceOf(InvalidStreamDataError);
+  });
+
+  it("rejects malformed descendant heights before reading a stream", async () => {
+    const { db, storage } = await setup({ inlineTailBytes: 0, fanout: 4 });
+    const stream = await storage.create({ tier: "edge" });
+    let snapshot: StreamSnapshot | undefined;
+    for (let value = 0; value < 5; value += 1) {
+      snapshot = await storage.append(stream, Uint8Array.of(value), { waitForAuthority: true });
+    }
+    const root = await db.one(app.stream_nodes.where({ id: snapshot!.rootId }), { tier: "local" });
+    expect(root?.height).toBe(1);
+
+    await db.update(app.stream_nodes, root!.childIds[0]!, { height: 1 }).wait({ tier: "local" });
+    await expect(storage.read(snapshot!)).rejects.toThrow("expected 0");
+  });
+
+  it("rejects cyclic stream trees without recursing indefinitely", async () => {
+    const { db, storage } = await setup({ inlineTailBytes: 0, fanout: 4 });
+    const stream = await storage.create({ tier: "edge" });
+    let snapshot: StreamSnapshot | undefined;
+    for (let value = 0; value < 5; value += 1) {
+      snapshot = await storage.append(stream, Uint8Array.of(value), { waitForAuthority: true });
+    }
+    const root = await db.one(app.stream_nodes.where({ id: snapshot!.rootId }), { tier: "local" });
+    expect(root?.height).toBe(1);
+
+    await db
+      .update(app.stream_nodes, snapshot!.rootId, {
+        childIds: [snapshot!.rootId, ...root!.childIds.slice(1)],
+      })
+      .wait({ tier: "local" });
+    await expect(storage.read(snapshot!)).rejects.toThrow("contains a cycle");
   });
 
   it("rejects invalid ranges instead of silently truncating", async () => {

--- a/packages/jazz-tools/src/runtime/stream-storage.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.ts
@@ -5,6 +5,8 @@ import type { SubscriptionDelta } from "./subscription-manager.js";
 export const DEFAULT_STREAM_INLINE_TAIL_BYTES = 64 * 1024;
 export const DEFAULT_STREAM_TREE_FANOUT = 32;
 export const MAX_STREAM_PART_BYTES = 1_048_576;
+const MAX_STREAM_TREE_FANOUT = 256;
+const MAX_STREAM_TREE_NODES = 1_000_000;
 
 type WhereTable<Row, Init> = TableProxy<Row, Init> & {
   where(conditions: Record<string, unknown>): QueryBuilder<Row>;
@@ -137,6 +139,12 @@ function asSnapshot(stream: StreamRow): StreamSnapshot {
   };
 }
 
+function validateLength(value: number, description: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new InvalidStreamDataError(`${description} must be a finite, non-negative integer.`);
+  }
+}
+
 function validateOptions(options: StreamStorageOptions) {
   const inlineTailBytes = options.inlineTailBytes ?? DEFAULT_STREAM_INLINE_TAIL_BYTES;
   const fanout = options.fanout ?? DEFAULT_STREAM_TREE_FANOUT;
@@ -149,7 +157,12 @@ function validateOptions(options: StreamStorageOptions) {
       `inlineTailBytes must be an integer between 0 and ${MAX_STREAM_PART_BYTES}.`,
     );
   }
-  if (!Number.isSafeInteger(fanout) || fanout < 4 || fanout > 256 || fanout % 2 !== 0) {
+  if (
+    !Number.isSafeInteger(fanout) ||
+    fanout < 4 ||
+    fanout > MAX_STREAM_TREE_FANOUT ||
+    fanout % 2 !== 0
+  ) {
     throw new RangeError("fanout must be an even integer between 4 and 256.");
   }
   return { inlineTailBytes, fanout };
@@ -176,9 +189,18 @@ export function createConventionalStreamStorage<
   const readNode = async (id: string, queryOptions?: QueryOptions): Promise<TNode> => {
     const node = await db.one(app.stream_nodes.where({ id }), queryOptions);
     if (!node) throw new InvalidStreamDataError(`Stream tree node "${id}" is missing.`);
-    if (node.childIds.length === 0 || node.childIds.length !== node.childLengths.length) {
+    if (
+      !Number.isSafeInteger(node.height) ||
+      node.height < 0 ||
+      node.childIds.length === 0 ||
+      node.childIds.length !== node.childLengths.length ||
+      node.childIds.length > MAX_STREAM_TREE_FANOUT
+    ) {
       throw new InvalidStreamDataError(`Stream tree node "${id}" has invalid child metadata.`);
     }
+    node.childLengths.forEach((length, index) =>
+      validateLength(length, `Stream tree node "${id}" child length ${index}`),
+    );
     return node;
   };
 
@@ -193,13 +215,64 @@ export function createConventionalStreamStorage<
     return part.data;
   };
 
+  const validateTree = async (
+    nodeId: string,
+    queryOptions?: QueryOptions,
+  ): Promise<{ length: number; nodes: Map<string, TNode> }> => {
+    const visiting = new Set<string>();
+    const nodes = new Map<string, TNode>();
+    let visitedNodes = 0;
+    const visit = async (id: string, expectedHeight?: number): Promise<number> => {
+      if (visiting.has(id)) {
+        throw new InvalidStreamDataError(`Stream tree contains a cycle at node "${id}".`);
+      }
+      visitedNodes += 1;
+      if (visitedNodes > MAX_STREAM_TREE_NODES) {
+        throw new InvalidStreamDataError(
+          `Stream tree exceeds the ${MAX_STREAM_TREE_NODES}-node validation limit.`,
+        );
+      }
+      visiting.add(id);
+      try {
+        const node = await readNode(id, queryOptions);
+        nodes.set(id, node);
+        if (expectedHeight !== undefined && node.height !== expectedHeight) {
+          throw new InvalidStreamDataError(
+            `Stream tree node "${id}" has height ${node.height}, expected ${expectedHeight}.`,
+          );
+        }
+        let length = 0;
+        for (let index = 0; index < node.childIds.length; index += 1) {
+          const childLength = node.childLengths[index]!;
+          const actualLength =
+            node.height === 0 ? childLength : await visit(node.childIds[index]!, node.height - 1);
+          if (childLength !== actualLength) {
+            throw new InvalidStreamDataError(
+              `Stream tree node "${id}" child ${index} promises ${childLength} bytes, but its subtree contains ${actualLength}.`,
+            );
+          }
+          length += childLength;
+          validateLength(length, `Stream tree node "${id}" extent`);
+        }
+        return length;
+      } finally {
+        visiting.delete(id);
+      }
+    };
+    return { length: await visit(nodeId), nodes };
+  };
+
   const readTreeRange = async (
     nodeId: string,
     start: number,
     end: number,
+    nodes: ReadonlyMap<string, TNode>,
     queryOptions?: QueryOptions,
   ): Promise<Uint8Array[]> => {
-    const node = await readNode(nodeId, queryOptions);
+    const node = nodes.get(nodeId);
+    if (!node) {
+      throw new InvalidStreamDataError(`Validated stream tree node "${nodeId}" is missing.`);
+    }
     const chunks: Uint8Array[] = [];
     let cursor = 0;
     for (let index = 0; index < node.childIds.length; index += 1) {
@@ -213,7 +286,13 @@ export function createConventionalStreamStorage<
           chunks.push(part.slice(localStart, localEnd));
         } else {
           chunks.push(
-            ...(await readTreeRange(node.childIds[index]!, localStart, localEnd, queryOptions)),
+            ...(await readTreeRange(
+              node.childIds[index]!,
+              localStart,
+              localEnd,
+              nodes,
+              queryOptions,
+            )),
           );
         }
       }
@@ -360,6 +439,19 @@ export function createConventionalStreamStorage<
         typeof streamOrSnapshot === "object" && "streamId" in streamOrSnapshot
           ? streamOrSnapshot
           : await this.snapshot(streamOrSnapshot, queryOptions);
+      validateLength(snapshot.prefixBytes, "Stream prefixBytes");
+      if (!(snapshot.inlineTail instanceof Uint8Array)) {
+        throw new InvalidStreamDataError("Stream inlineTail must be a Uint8Array.");
+      }
+      if (!snapshot.rootId && snapshot.prefixBytes !== 0) {
+        throw new InvalidStreamDataError("A stream without a root cannot have a non-zero prefix.");
+      }
+      if (!Number.isSafeInteger(snapshot.prefixBytes + snapshot.inlineTail.length)) {
+        throw new InvalidStreamDataError("Stream length exceeds the safe integer range.");
+      }
+      if (snapshot.length !== snapshot.prefixBytes + snapshot.inlineTail.length) {
+        throw new InvalidStreamDataError("Stream snapshot length does not match its root tuple.");
+      }
       const effectiveEnd = end ?? snapshot.length;
       if (
         !Number.isSafeInteger(start) ||
@@ -372,6 +464,14 @@ export function createConventionalStreamStorage<
           `Invalid stream range [${start}, ${effectiveEnd}) for ${snapshot.length} bytes.`,
         );
       }
+      const validatedRoot = snapshot.rootId
+        ? await validateTree(snapshot.rootId, queryOptions)
+        : undefined;
+      if (validatedRoot && validatedRoot.length !== snapshot.prefixBytes) {
+        throw new InvalidStreamDataError(
+          `Stream root "${snapshot.rootId}" contains ${validatedRoot.length} bytes, but prefixBytes is ${snapshot.prefixBytes}.`,
+        );
+      }
       const chunks: Uint8Array[] = [];
       if (start < snapshot.prefixBytes && snapshot.rootId) {
         chunks.push(
@@ -379,6 +479,7 @@ export function createConventionalStreamStorage<
             snapshot.rootId,
             start,
             Math.min(effectiveEnd, snapshot.prefixBytes),
+            validatedRoot!.nodes,
             queryOptions,
           )),
         );

--- a/packages/jazz-tools/src/runtime/stream-storage.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.ts
@@ -52,7 +52,7 @@ export interface CreateStreamOptions {
 }
 
 export interface AppendStreamOptions {
-  /** Wait for global authority acceptance. Off by default for offline clients. */
+  /** Wait for global authority acceptance. Defaults to true. */
   waitForAuthority?: boolean;
 }
 
@@ -111,6 +111,12 @@ function concat(
   chunks: Uint8Array[],
   length = chunks.reduce((sum, chunk) => sum + chunk.length, 0),
 ) {
+  const actualLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  if (actualLength !== length) {
+    throw new InvalidStreamDataError(
+      `Stream extent metadata promised ${length} bytes, but ${actualLength} bytes were readable.`,
+    );
+  }
   const output = new Uint8Array(length);
   let offset = 0;
   for (const chunk of chunks) {
@@ -234,14 +240,13 @@ export function createConventionalStreamStorage<
     async append(streamOrId, data, appendOptions = {}) {
       const streamId = typeof streamOrId === "string" ? streamOrId : streamOrId.id;
       const bytes = data.slice();
+      if (bytes.length === 0) return this.snapshot(streamId);
       const result = await db.exclusiveTransaction(async (tx) => {
         const current = await tx.one(app.streams.where({ id: streamId }), {
           tier: "local",
           propagation: "local-only",
         });
         if (!current) throw new StreamNotFoundError(streamId);
-        if (bytes.length === 0) return asSnapshot(current);
-
         const combinedTail = concat([current.inlineTail, bytes]);
         if (combinedTail.length <= inlineTailBytes) {
           tx.update(app.streams, streamId, { inlineTail: combinedTail } as Partial<
@@ -342,7 +347,7 @@ export function createConventionalStreamStorage<
           length: current.prefixBytes + combinedTail.length,
         } satisfies StreamSnapshot;
       });
-      return appendOptions.waitForAuthority ? result.wait() : result.value;
+      return appendOptions.waitForAuthority === false ? result.value : result.wait();
     },
 
     async read(streamOrSnapshot, readOptions = {}) {

--- a/packages/jazz-tools/src/runtime/stream-storage.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.ts
@@ -186,9 +186,7 @@ export function createConventionalStreamStorage<
     return stream;
   };
 
-  const readNode = async (id: string, queryOptions?: QueryOptions): Promise<TNode> => {
-    const node = await db.one(app.stream_nodes.where({ id }), queryOptions);
-    if (!node) throw new InvalidStreamDataError(`Stream tree node "${id}" is missing.`);
+  const validateNode = (id: string, node: TNode): TNode => {
     if (
       !Number.isSafeInteger(node.height) ||
       node.height < 0 ||
@@ -204,6 +202,12 @@ export function createConventionalStreamStorage<
     return node;
   };
 
+  const readNode = async (id: string, queryOptions?: QueryOptions): Promise<TNode> => {
+    const node = await db.one(app.stream_nodes.where({ id }), queryOptions);
+    if (!node) throw new InvalidStreamDataError(`Stream tree node "${id}" is missing.`);
+    return validateNode(id, node);
+  };
+
   const readPart = async (id: string, expectedLength: number, queryOptions?: QueryOptions) => {
     const part = await db.one(app.stream_parts.where({ id }), queryOptions);
     if (!part) throw new InvalidStreamDataError(`Stream part "${id}" is missing.`);
@@ -217,7 +221,8 @@ export function createConventionalStreamStorage<
 
   const validateTree = async (
     nodeId: string,
-    queryOptions?: QueryOptions,
+    loadNode: (id: string) => Promise<TNode>,
+    loadPartLength?: (id: string) => Promise<number>,
   ): Promise<{ length: number; nodes: Map<string, TNode> }> => {
     const visiting = new Set<string>();
     const nodes = new Map<string, TNode>();
@@ -234,7 +239,7 @@ export function createConventionalStreamStorage<
       }
       visiting.add(id);
       try {
-        const node = await readNode(id, queryOptions);
+        const node = await loadNode(id);
         nodes.set(id, node);
         if (expectedHeight !== undefined && node.height !== expectedHeight) {
           throw new InvalidStreamDataError(
@@ -245,7 +250,11 @@ export function createConventionalStreamStorage<
         for (let index = 0; index < node.childIds.length; index += 1) {
           const childLength = node.childLengths[index]!;
           const actualLength =
-            node.height === 0 ? childLength : await visit(node.childIds[index]!, node.height - 1);
+            node.height === 0
+              ? loadPartLength
+                ? await loadPartLength(node.childIds[index]!)
+                : childLength
+              : await visit(node.childIds[index]!, node.height - 1);
           if (childLength !== actualLength) {
             throw new InvalidStreamDataError(
               `Stream tree node "${id}" child ${index} promises ${childLength} bytes, but its subtree contains ${actualLength}.`,
@@ -326,6 +335,41 @@ export function createConventionalStreamStorage<
           propagation: "local-only",
         });
         if (!current) throw new StreamNotFoundError(streamId);
+        validateLength(current.prefixBytes, "Stream prefixBytes");
+        if (!(current.inlineTail instanceof Uint8Array)) {
+          throw new InvalidStreamDataError("Stream inlineTail must be a Uint8Array.");
+        }
+        if (!current.rootId && current.prefixBytes !== 0) {
+          throw new InvalidStreamDataError(
+            "A stream without a root cannot have a non-zero prefix.",
+          );
+        }
+        const validatedTree = current.rootId
+          ? await validateTree(
+              current.rootId,
+              async (id) => {
+                const node = await tx.one(app.stream_nodes.where({ id }), {
+                  tier: "local",
+                  propagation: "local-only",
+                });
+                if (!node) throw new InvalidStreamDataError(`Stream tree node "${id}" is missing.`);
+                return validateNode(id, node);
+              },
+              async (id) => {
+                const part = await tx.one(app.stream_parts.where({ id }), {
+                  tier: "local",
+                  propagation: "local-only",
+                });
+                if (!part) throw new InvalidStreamDataError(`Stream part "${id}" is missing.`);
+                return part.data.length;
+              },
+            )
+          : undefined;
+        if (validatedTree && validatedTree.length !== current.prefixBytes) {
+          throw new InvalidStreamDataError(
+            `Stream root "${current.rootId}" contains ${validatedTree.length} bytes, but prefixBytes is ${current.prefixBytes}.`,
+          );
+        }
         const combinedTail = concat([current.inlineTail, bytes]);
         if (combinedTail.length <= inlineTailBytes) {
           tx.update(app.streams, streamId, { inlineTail: combinedTail } as Partial<
@@ -341,11 +385,9 @@ export function createConventionalStreamStorage<
         const getNode = async (id: string) => {
           const inserted = insertedNodes.get(id);
           if (inserted) return inserted;
-          const node = await tx.one(app.stream_nodes.where({ id }), {
-            tier: "local",
-            propagation: "local-only",
-          });
-          if (!node) throw new InvalidStreamDataError(`Stream tree node "${id}" is missing.`);
+          const node = validatedTree?.nodes.get(id);
+          if (!node)
+            throw new InvalidStreamDataError(`Validated stream tree node "${id}" is missing.`);
           return { ...node, length: node.childLengths.reduce((sum, length) => sum + length, 0) };
         };
         const insertNode = (children: TreeRef[], height: number) => {
@@ -465,7 +507,7 @@ export function createConventionalStreamStorage<
         );
       }
       const validatedRoot = snapshot.rootId
-        ? await validateTree(snapshot.rootId, queryOptions)
+        ? await validateTree(snapshot.rootId, (id) => readNode(id, queryOptions))
         : undefined;
       if (validatedRoot && validatedRoot.length !== snapshot.prefixBytes) {
         throw new InvalidStreamDataError(

--- a/packages/jazz-tools/src/runtime/stream-storage.ts
+++ b/packages/jazz-tools/src/runtime/stream-storage.ts
@@ -1,0 +1,400 @@
+import type { DurabilityTier } from "./client.js";
+import { Db, type QueryBuilder, type QueryOptions, type TableProxy } from "./db.js";
+import type { SubscriptionDelta } from "./subscription-manager.js";
+
+export const DEFAULT_STREAM_INLINE_TAIL_BYTES = 64 * 1024;
+export const DEFAULT_STREAM_TREE_FANOUT = 32;
+export const MAX_STREAM_PART_BYTES = 1_048_576;
+
+type WhereTable<Row, Init> = TableProxy<Row, Init> & {
+  where(conditions: Record<string, unknown>): QueryBuilder<Row>;
+};
+
+export interface StreamRow {
+  id: string;
+  rootId: string;
+  prefixBytes: number;
+  inlineTail: Uint8Array;
+}
+
+export interface StreamNodeRow {
+  id: string;
+  childIds: string[];
+  childLengths: number[];
+  height: number;
+}
+
+export interface StreamPartRow {
+  id: string;
+  data: Uint8Array;
+}
+
+export interface ConventionalStreamApp<
+  TStream extends StreamRow = StreamRow,
+  TNode extends StreamNodeRow = StreamNodeRow,
+  TPart extends StreamPartRow = StreamPartRow,
+> {
+  streams: WhereTable<TStream, Omit<TStream, "id">>;
+  stream_nodes: WhereTable<TNode, Omit<TNode, "id">>;
+  stream_parts: WhereTable<TPart, Omit<TPart, "id">>;
+}
+
+export interface StreamSnapshot {
+  readonly streamId: string;
+  readonly rootId: string;
+  readonly prefixBytes: number;
+  readonly inlineTail: Uint8Array;
+  readonly length: number;
+}
+
+export interface CreateStreamOptions {
+  tier?: DurabilityTier;
+}
+
+export interface AppendStreamOptions {
+  /** Wait for global authority acceptance. Off by default for offline clients. */
+  waitForAuthority?: boolean;
+}
+
+export interface ReadStreamOptions extends QueryOptions {
+  start?: number;
+  end?: number;
+}
+
+export interface StreamStorageOptions {
+  inlineTailBytes?: number;
+  fanout?: number;
+}
+
+export class StreamNotFoundError extends Error {
+  constructor(readonly streamId: string) {
+    super(`Stream "${streamId}" was not found.`);
+    this.name = "StreamNotFoundError";
+  }
+}
+
+export class InvalidStreamDataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidStreamDataError";
+  }
+}
+
+type TreeRef = { id: string; length: number; height: number };
+
+export interface StreamStorage<TStream extends StreamRow = StreamRow> {
+  create(options?: CreateStreamOptions): Promise<TStream>;
+  snapshot(streamOrId: string | TStream, options?: QueryOptions): Promise<StreamSnapshot>;
+  append(
+    streamOrId: string | TStream,
+    data: Uint8Array,
+    options?: AppendStreamOptions,
+  ): Promise<StreamSnapshot>;
+  read(
+    streamOrSnapshot: string | TStream | StreamSnapshot,
+    options?: ReadStreamOptions,
+  ): Promise<Uint8Array>;
+  readRange(
+    streamOrSnapshot: string | TStream | StreamSnapshot,
+    start: number,
+    end?: number,
+    options?: QueryOptions,
+  ): Promise<Uint8Array>;
+  subscribe(
+    streamId: string,
+    callback: (snapshot: StreamSnapshot | null) => void,
+    options?: QueryOptions,
+  ): () => void;
+}
+
+function concat(
+  chunks: Uint8Array[],
+  length = chunks.reduce((sum, chunk) => sum + chunk.length, 0),
+) {
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+function asSnapshot(stream: StreamRow): StreamSnapshot {
+  const tail = stream.inlineTail.slice();
+  return {
+    streamId: stream.id,
+    rootId: stream.rootId,
+    prefixBytes: stream.prefixBytes,
+    inlineTail: tail,
+    length: stream.prefixBytes + tail.length,
+  };
+}
+
+function validateOptions(options: StreamStorageOptions) {
+  const inlineTailBytes = options.inlineTailBytes ?? DEFAULT_STREAM_INLINE_TAIL_BYTES;
+  const fanout = options.fanout ?? DEFAULT_STREAM_TREE_FANOUT;
+  if (
+    !Number.isSafeInteger(inlineTailBytes) ||
+    inlineTailBytes < 0 ||
+    inlineTailBytes > MAX_STREAM_PART_BYTES
+  ) {
+    throw new RangeError(
+      `inlineTailBytes must be an integer between 0 and ${MAX_STREAM_PART_BYTES}.`,
+    );
+  }
+  if (!Number.isSafeInteger(fanout) || fanout < 4 || fanout > 256 || fanout % 2 !== 0) {
+    throw new RangeError("fanout must be an even integer between 4 and 256.");
+  }
+  return { inlineTailBytes, fanout };
+}
+
+export function createConventionalStreamStorage<
+  TStream extends StreamRow,
+  TNode extends StreamNodeRow,
+  TPart extends StreamPartRow,
+>(
+  db: Db,
+  app: ConventionalStreamApp<TStream, TNode, TPart>,
+  options: StreamStorageOptions = {},
+): StreamStorage<TStream> {
+  const { inlineTailBytes, fanout } = validateOptions(options);
+
+  const loadStream = async (streamOrId: string | TStream, queryOptions?: QueryOptions) => {
+    if (typeof streamOrId !== "string") return streamOrId;
+    const stream = await db.one(app.streams.where({ id: streamOrId }), queryOptions);
+    if (!stream) throw new StreamNotFoundError(streamOrId);
+    return stream;
+  };
+
+  const readNode = async (id: string, queryOptions?: QueryOptions): Promise<TNode> => {
+    const node = await db.one(app.stream_nodes.where({ id }), queryOptions);
+    if (!node) throw new InvalidStreamDataError(`Stream tree node "${id}" is missing.`);
+    if (node.childIds.length === 0 || node.childIds.length !== node.childLengths.length) {
+      throw new InvalidStreamDataError(`Stream tree node "${id}" has invalid child metadata.`);
+    }
+    return node;
+  };
+
+  const readPart = async (id: string, expectedLength: number, queryOptions?: QueryOptions) => {
+    const part = await db.one(app.stream_parts.where({ id }), queryOptions);
+    if (!part) throw new InvalidStreamDataError(`Stream part "${id}" is missing.`);
+    if (part.data.length !== expectedLength) {
+      throw new InvalidStreamDataError(
+        `Stream part "${id}" expected ${expectedLength} bytes, got ${part.data.length}.`,
+      );
+    }
+    return part.data;
+  };
+
+  const readTreeRange = async (
+    nodeId: string,
+    start: number,
+    end: number,
+    queryOptions?: QueryOptions,
+  ): Promise<Uint8Array[]> => {
+    const node = await readNode(nodeId, queryOptions);
+    const chunks: Uint8Array[] = [];
+    let cursor = 0;
+    for (let index = 0; index < node.childIds.length; index += 1) {
+      const childLength = node.childLengths[index]!;
+      const childEnd = cursor + childLength;
+      if (childEnd > start && cursor < end) {
+        const localStart = Math.max(0, start - cursor);
+        const localEnd = Math.min(childLength, end - cursor);
+        if (node.height === 0) {
+          const part = await readPart(node.childIds[index]!, childLength, queryOptions);
+          chunks.push(part.slice(localStart, localEnd));
+        } else {
+          chunks.push(
+            ...(await readTreeRange(node.childIds[index]!, localStart, localEnd, queryOptions)),
+          );
+        }
+      }
+      cursor = childEnd;
+      if (cursor >= end) break;
+    }
+    return chunks;
+  };
+
+  return {
+    async create(createOptions = {}) {
+      const result = db.insert(app.streams, {
+        rootId: "",
+        prefixBytes: 0,
+        inlineTail: new Uint8Array(),
+      } as Omit<TStream, "id">);
+      return createOptions.tier ? result.wait({ tier: createOptions.tier }) : result.value;
+    },
+
+    async snapshot(streamOrId, queryOptions) {
+      return asSnapshot(await loadStream(streamOrId, queryOptions));
+    },
+
+    async append(streamOrId, data, appendOptions = {}) {
+      const streamId = typeof streamOrId === "string" ? streamOrId : streamOrId.id;
+      const bytes = data.slice();
+      const result = await db.exclusiveTransaction(async (tx) => {
+        const current = await tx.one(app.streams.where({ id: streamId }), {
+          tier: "local",
+          propagation: "local-only",
+        });
+        if (!current) throw new StreamNotFoundError(streamId);
+        if (bytes.length === 0) return asSnapshot(current);
+
+        const combinedTail = concat([current.inlineTail, bytes]);
+        if (combinedTail.length <= inlineTailBytes) {
+          tx.update(app.streams, streamId, { inlineTail: combinedTail } as Partial<
+            Omit<TStream, "id">
+          >);
+          return asSnapshot({ ...current, inlineTail: combinedTail });
+        }
+
+        const insertedNodes = new Map<
+          string,
+          TreeRef & { childIds: string[]; childLengths: number[] }
+        >();
+        const getNode = async (id: string) => {
+          const inserted = insertedNodes.get(id);
+          if (inserted) return inserted;
+          const node = await tx.one(app.stream_nodes.where({ id }), {
+            tier: "local",
+            propagation: "local-only",
+          });
+          if (!node) throw new InvalidStreamDataError(`Stream tree node "${id}" is missing.`);
+          return { ...node, length: node.childLengths.reduce((sum, length) => sum + length, 0) };
+        };
+        const insertNode = (children: TreeRef[], height: number) => {
+          const row = tx.insert(app.stream_nodes, {
+            childIds: children.map((child) => child.id),
+            childLengths: children.map((child) => child.length),
+            height,
+          } as Omit<TNode, "id">);
+          const node = {
+            id: row.id,
+            length: children.reduce((sum, child) => sum + child.length, 0),
+            height,
+            childIds: children.map((child) => child.id),
+            childLengths: children.map((child) => child.length),
+          };
+          insertedNodes.set(node.id, node);
+          return node;
+        };
+        const appendAt = async (node: Awaited<ReturnType<typeof getNode>>, leaf: TreeRef) => {
+          if (node.height === 0) {
+            const children = node.childIds.map((id, index) => ({
+              id,
+              length: node.childLengths[index]!,
+              height: -1,
+            }));
+            children.push(leaf);
+            if (children.length <= fanout) return [insertNode(children, 0)] as const;
+            const split = children.length / 2;
+            return [
+              insertNode(children.slice(0, split), 0),
+              insertNode(children.slice(split), 0),
+            ] as const;
+          }
+          const last = await getNode(node.childIds.at(-1)!);
+          const [replacement, split] = await appendAt(last, leaf);
+          const children = node.childIds.slice(0, -1).map((id, index) => ({
+            id,
+            length: node.childLengths[index]!,
+            height: node.height - 1,
+          }));
+          children.push(replacement);
+          if (split) children.push(split);
+          if (children.length <= fanout) return [insertNode(children, node.height)] as const;
+          const splitAt = children.length / 2;
+          return [
+            insertNode(children.slice(0, splitAt), node.height),
+            insertNode(children.slice(splitAt), node.height),
+          ] as const;
+        };
+        const appendLeaf = async (root: TreeRef | null, leaf: TreeRef): Promise<TreeRef> => {
+          if (!root) return insertNode([leaf], 0);
+          const [replacement, split] = await appendAt(await getNode(root.id), leaf);
+          return split ? insertNode([replacement, split], root.height + 1) : replacement;
+        };
+
+        let root: TreeRef | null = current.rootId
+          ? {
+              id: current.rootId,
+              length: current.prefixBytes,
+              height: (await getNode(current.rootId)).height,
+            }
+          : null;
+        for (let offset = 0; offset < combinedTail.length; offset += MAX_STREAM_PART_BYTES) {
+          const partData = combinedTail.slice(offset, offset + MAX_STREAM_PART_BYTES);
+          const part = tx.insert(app.stream_parts, { data: partData } as Omit<TPart, "id">);
+          root = await appendLeaf(root, { id: part.id, length: partData.length, height: -1 });
+        }
+        tx.update(app.streams, streamId, {
+          rootId: root!.id,
+          prefixBytes: current.prefixBytes + combinedTail.length,
+          inlineTail: new Uint8Array(),
+        } as Partial<Omit<TStream, "id">>);
+        return {
+          streamId,
+          rootId: root!.id,
+          prefixBytes: current.prefixBytes + combinedTail.length,
+          inlineTail: new Uint8Array(),
+          length: current.prefixBytes + combinedTail.length,
+        } satisfies StreamSnapshot;
+      });
+      return appendOptions.waitForAuthority ? result.wait() : result.value;
+    },
+
+    async read(streamOrSnapshot, readOptions = {}) {
+      const { start = 0, end, ...queryOptions } = readOptions;
+      return this.readRange(streamOrSnapshot, start, end, queryOptions);
+    },
+
+    async readRange(streamOrSnapshot, start, end, queryOptions) {
+      const snapshot =
+        typeof streamOrSnapshot === "object" && "streamId" in streamOrSnapshot
+          ? streamOrSnapshot
+          : await this.snapshot(streamOrSnapshot, queryOptions);
+      const effectiveEnd = end ?? snapshot.length;
+      if (
+        !Number.isSafeInteger(start) ||
+        !Number.isSafeInteger(effectiveEnd) ||
+        start < 0 ||
+        effectiveEnd < start ||
+        effectiveEnd > snapshot.length
+      ) {
+        throw new RangeError(
+          `Invalid stream range [${start}, ${effectiveEnd}) for ${snapshot.length} bytes.`,
+        );
+      }
+      const chunks: Uint8Array[] = [];
+      if (start < snapshot.prefixBytes && snapshot.rootId) {
+        chunks.push(
+          ...(await readTreeRange(
+            snapshot.rootId,
+            start,
+            Math.min(effectiveEnd, snapshot.prefixBytes),
+            queryOptions,
+          )),
+        );
+      }
+      if (effectiveEnd > snapshot.prefixBytes) {
+        const tailStart = Math.max(0, start - snapshot.prefixBytes);
+        const tailEnd = effectiveEnd - snapshot.prefixBytes;
+        chunks.push(snapshot.inlineTail.slice(tailStart, tailEnd));
+      }
+      return concat(chunks, effectiveEnd - start);
+    },
+
+    subscribe(streamId, callback, queryOptions) {
+      return db.subscribeAll(
+        app.streams.where({ id: streamId }),
+        (delta: SubscriptionDelta<TStream>) => {
+          const stream = delta.all?.[0];
+          callback(stream ? asSnapshot(stream) : null);
+        },
+        queryOptions,
+      );
+    },
+  };
+}


### PR DESCRIPTION
🤖 Reintroduces appendable streams as an ordinary-row persistent tree after the Large Value subtraction.

## Design

- mutable stream head plus immutable bounded byte parts and tree nodes
- append, full read, range read, subscription, and independent historical roots
- ordinary Jazz transactions, permissions, and synchronization only
- full fail-closed tree validation before reads and appends

## Correctness

- validates heights, extents, fanout, cycles, traversal bounds, and physical part lengths
- rejects corrupted roots before authority can advance the stream head
- covers concurrency, deep trees, corruption, and historical snapshots

## Measurements

The compressed RocksDB sweep shows a persistent tree is the safe binary default. A small inline tail is promising only for tiny appends: 128–256 bytes was best for repeated 32-byte binary appends, while 256–512 bytes was best for repetitive text. A 64 KiB tail remains prohibitively expensive for incompressible history. The public default is intentionally unchanged pending policy iteration.

Draft for design, API, and performance iteration.