### PR TITLE
feat: add ordinary-row mutable files

### DIFF
--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -39,3 +39,7 @@ harness = false
 [[bench]]
 name = "micro"
 harness = false
+
+[[bench]]
+name = "file_layout_storage"
+harness = false

--- a/crates/groove/benches/file_layout_storage.rs
+++ b/crates/groove/benches/file_layout_storage.rs
@@ -95,10 +95,17 @@ fn main() {
     let mut opts = Options::default();
     opts.create_if_missing(true);
     opts.create_missing_column_families(true);
-    opts.set_compression_type(DBCompressionType::Zstd);
+    opts.set_compression_type(DBCompressionType::Lz4);
+    opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+    let mut history = Options::default();
+    history.set_compression_type(DBCompressionType::Zstd);
+    history.set_bottommost_compression_type(DBCompressionType::Zstd);
+    let mut current_meta = Options::default();
+    current_meta.set_compression_type(DBCompressionType::Lz4);
+    current_meta.set_bottommost_compression_type(DBCompressionType::Zstd);
     let cfs = [
-        ColumnFamilyDescriptor::new("roots", Options::default()),
-        ColumnFamilyDescriptor::new("parts", Options::default()),
+        ColumnFamilyDescriptor::new("roots", current_meta),
+        ColumnFamilyDescriptor::new("parts", history),
     ];
     let db = DB::open_cf_descriptors(&opts, dir.path(), cfs).expect("rocksdb");
     let payload = vec![b'x'; append_bytes];
@@ -132,5 +139,5 @@ fn main() {
     db.compact_range::<&[u8], &[u8]>(None, None);
     let compacted = bytes(dir.path());
     let pct = |n: usize| times[(times.len() - 1) * n / 100];
-    println!("{}",serde_json::to_string(&Receipt{appends,append_bytes,logical_bytes:appends*append_bytes,p50_us:pct(50),p95_us:pct(95),root_rows:appends,part_rows:appends*payload.len().div_ceil(PART),compression:"zstd",before_flush:before,after_flush:flushed,after_compaction:compacted,caveat:"apparent/allocated bytes include RocksDB metadata and WAL; compaction timing is backend-dependent"}).unwrap());
+    println!("{}",serde_json::to_string(&Receipt{appends,append_bytes,logical_bytes:appends*append_bytes,p50_us:pct(50),p95_us:pct(95),root_rows:appends,part_rows:appends*payload.len().div_ceil(PART),compression:"roots_lz4_parts_zstd_bottommost_zstd",before_flush:before,after_flush:flushed,after_compaction:compacted,caveat:"apparent/allocated bytes include RocksDB metadata and WAL; compaction timing is backend-dependent"}).unwrap());
 }

--- a/crates/groove/benches/file_layout_storage.rs
+++ b/crates/groove/benches/file_layout_storage.rs
@@ -1,0 +1,136 @@
+//! Native RocksDB receipt for the ordinary-row file layout.
+//!
+//! `JAZZ_FILE_DISK_BENCH=1 cargo bench -p groove --bench file_layout_storage`
+//! reports logical bytes, append latency, and both apparent (`metadata.len`)
+//! and allocated (`st_blocks * 512`, Unix) directory bytes. RocksDB's WAL and
+//! memtables make pre-flush numbers deliberately non-final; use the reported
+//! post-flush and post-compaction receipts for comparisons.
+use rocksdb::{ColumnFamilyDescriptor, DB, DBCompressionType, Options, WriteBatch};
+use serde::Serialize;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+use std::{fs, path::Path, time::Instant};
+use tempfile::TempDir;
+
+const PART: usize = 256 * 1024;
+#[derive(Serialize)]
+struct Bytes {
+    apparent: u64,
+    allocated: Option<u64>,
+}
+#[derive(Serialize)]
+struct Receipt {
+    appends: usize,
+    append_bytes: usize,
+    logical_bytes: usize,
+    p50_us: u128,
+    p95_us: u128,
+    root_rows: usize,
+    part_rows: usize,
+    compression: &'static str,
+    before_flush: Bytes,
+    after_flush: Bytes,
+    after_compaction: Bytes,
+    caveat: &'static str,
+}
+fn bytes(path: &Path) -> Bytes {
+    fn walk(p: &Path, a: &mut u64, #[cfg(unix)] b: &mut u64) {
+        let Ok(rd) = fs::read_dir(p) else { return };
+        for e in rd.flatten() {
+            let Ok(m) = e.metadata() else { continue };
+            if m.is_dir() {
+                walk(
+                    &e.path(),
+                    a,
+                    #[cfg(unix)]
+                    b,
+                )
+            } else {
+                *a += m.len();
+                #[cfg(unix)]
+                {
+                    *b += m.blocks() * 512;
+                }
+            }
+        }
+    }
+    let mut a = 0;
+    #[cfg(unix)]
+    let mut b = 0;
+    walk(
+        path,
+        &mut a,
+        #[cfg(unix)]
+        &mut b,
+    );
+    Bytes {
+        apparent: a,
+        allocated: {
+            #[cfg(unix)]
+            {
+                Some(b)
+            }
+            #[cfg(not(unix))]
+            {
+                None
+            }
+        },
+    }
+}
+fn main() {
+    if std::env::var("JAZZ_FILE_DISK_BENCH").as_deref() != Ok("1") {
+        eprintln!("skipped; set JAZZ_FILE_DISK_BENCH=1");
+        return;
+    }
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    let appends = std::env::var("JAZZ_FILE_DISK_APPENDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(400);
+    let append_bytes = std::env::var("JAZZ_FILE_DISK_APPEND_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(PART);
+    let dir = TempDir::new().expect("tempdir");
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    opts.set_compression_type(DBCompressionType::Zstd);
+    let cfs = [
+        ColumnFamilyDescriptor::new("roots", Options::default()),
+        ColumnFamilyDescriptor::new("parts", Options::default()),
+    ];
+    let db = DB::open_cf_descriptors(&opts, dir.path(), cfs).expect("rocksdb");
+    let payload = vec![b'x'; append_bytes];
+    let mut times = Vec::with_capacity(appends);
+    for i in 0..appends {
+        let now = Instant::now();
+        let mut b = WriteBatch::default();
+        for (n, chunk) in payload.chunks(PART).enumerate() {
+            b.put_cf(
+                db.cf_handle("parts").unwrap(),
+                [(i as u64).to_be_bytes(), (n as u64).to_be_bytes()].concat(),
+                chunk,
+            );
+        }
+        b.put_cf(
+            db.cf_handle("roots").unwrap(),
+            (i as u64).to_be_bytes(),
+            [
+                (i as u64).to_be_bytes(),
+                (payload.len() as u64).to_be_bytes(),
+            ]
+            .concat(),
+        );
+        db.write(&b).expect("ordinary-row file transaction");
+        times.push(now.elapsed().as_micros());
+    }
+    times.sort_unstable();
+    let before = bytes(dir.path());
+    db.flush().expect("flush");
+    let flushed = bytes(dir.path());
+    db.compact_range::<&[u8], &[u8]>(None, None);
+    let compacted = bytes(dir.path());
+    let pct = |n: usize| times[(times.len() - 1) * n / 100];
+    println!("{}",serde_json::to_string(&Receipt{appends,append_bytes,logical_bytes:appends*append_bytes,p50_us:pct(50),p95_us:pct(95),root_rows:appends,part_rows:appends*payload.len().div_ceil(PART),compression:"zstd",before_flush:before,after_flush:flushed,after_compaction:compacted,caveat:"apparent/allocated bytes include RocksDB metadata and WAL; compaction timing is backend-dependent"}).unwrap());
+}

--- a/packages/jazz-tools/src/runtime/FILE_STORAGE.md
+++ b/packages/jazz-tools/src/runtime/FILE_STORAGE.md
@@ -31,7 +31,8 @@ benchmarked before claiming efficient arbitrary large-file insertion.
 A `FileRow` input is reloaded by id, so it always reads the current head. Only
 `FileSnapshot` is a historical object. Nodes and parts should be policy-locked
 to `select` plus `insert` (with the same owner/tenant isolation as the root),
-never update/delete. Current range reads validate and materialize the reachable
+and explicitly set both `update` and `delete` to `False`; omission is
+permissive. Current range reads validate and materialize the reachable
 file before slicing; that is correct but not the final large-range I/O path.
 
 ## Native RocksDB receipt

--- a/packages/jazz-tools/src/runtime/FILE_STORAGE.md
+++ b/packages/jazz-tools/src/runtime/FILE_STORAGE.md
@@ -40,8 +40,9 @@ file before slicing; that is correct but not the final large-range I/O path.
 JAZZ_FILE_DISK_APPEND_BYTES=4096 cargo bench -p groove --bench
 file_layout_storage` on the native lane reported p50 7 µs and p95 29 µs for
 32,768 logical bytes (eight ordinary root transactions and eight parts), with
-Zstd enabled. Directory bytes were 103,746 apparent / 78,102,528 allocated
-before and after flush, and 112,328 apparent / 78,110,720 allocated after full
+LZ4 current-root metadata, Zstd append parts, and Zstd bottommost compression.
+Directory bytes were 103,671 apparent / 78,102,528 allocated before and after
+flush, and 112,251 apparent / 78,110,720 allocated after full
 compaction. This deliberately small receipt is a correctness/lifecycle sample,
 not a capacity claim: allocated blocks include RocksDB's preallocation,
 metadata and WAL; compaction timing and space reuse are backend-dependent.

--- a/packages/jazz-tools/src/runtime/FILE_STORAGE.md
+++ b/packages/jazz-tools/src/runtime/FILE_STORAGE.md
@@ -23,7 +23,19 @@ permissions, transactions, branching, or rollback behavior.
    before yielding bytes.
 5. A root change and all newly referenced ordinary rows commit atomically.
 
-The current implementation makes bounded byte parts and immutable roots
-available first. Its tree rebuilds on overwrite/insert; right-spine path-copy
-optimization is the next performance slice and must be benchmarked before
-claiming efficient large-file editing.
+Equal-length overwrites path-copy only affected parts and their ancestor nodes.
+Insert still uses the conservative immutable splice/rebuild path; persistent
+tree concatenation/rebalancing is the next performance slice and must be
+benchmarked before claiming efficient arbitrary large-file insertion.
+
+## Native RocksDB receipt
+
+`JAZZ_FILE_DISK_BENCH=1 JAZZ_FILE_DISK_APPENDS=8
+JAZZ_FILE_DISK_APPEND_BYTES=4096 cargo bench -p groove --bench
+file_layout_storage` on the native lane reported p50 7 µs and p95 29 µs for
+32,768 logical bytes (eight ordinary root transactions and eight parts), with
+Zstd enabled. Directory bytes were 103,746 apparent / 78,102,528 allocated
+before and after flush, and 112,328 apparent / 78,110,720 allocated after full
+compaction. This deliberately small receipt is a correctness/lifecycle sample,
+not a capacity claim: allocated blocks include RocksDB's preallocation,
+metadata and WAL; compaction timing and space reuse are backend-dependent.

--- a/packages/jazz-tools/src/runtime/FILE_STORAGE.md
+++ b/packages/jazz-tools/src/runtime/FILE_STORAGE.md
@@ -1,0 +1,29 @@
+# Ordinary-row mutable files
+
+`createConventionalFileStorage` is a library convention, not a Jazz storage
+feature. A `files` row is the mutable logical root; immutable `file_parts`
+(at most 256 KiB each) and immutable `file_nodes` form a bounded-fanout extent
+tree. A saved root tuple is independently readable and never requires an
+ancestor-history scan.
+
+The first implementation uses ordinary `bytes` rows. Replacing part payloads
+with immutable blob-store pointers is deliberately a future extension: the
+root/tree contract does not change. Writers must have ordinary transaction
+permission to insert the referenced rows and update the file root; readers
+need permission to every reachable row. The helper does not bypass Jazz
+permissions, transactions, branching, or rollback behavior.
+
+## Invariants
+
+1. A file root's `byteLength` equals its immutable-tree bytes plus inline bytes.
+2. Node child ids and lengths have equal non-zero cardinality; child lengths
+   exactly match the referenced part/subtree.
+3. Nodes and parts are append-only immutable objects.
+4. Range reads validate the reachable tree (including cycles and heights)
+   before yielding bytes.
+5. A root change and all newly referenced ordinary rows commit atomically.
+
+The current implementation makes bounded byte parts and immutable roots
+available first. Its tree rebuilds on overwrite/insert; right-spine path-copy
+optimization is the next performance slice and must be benchmarked before
+claiming efficient large-file editing.

--- a/packages/jazz-tools/src/runtime/FILE_STORAGE.md
+++ b/packages/jazz-tools/src/runtime/FILE_STORAGE.md
@@ -28,6 +28,12 @@ Insert still uses the conservative immutable splice/rebuild path; persistent
 tree concatenation/rebalancing is the next performance slice and must be
 benchmarked before claiming efficient arbitrary large-file insertion.
 
+A `FileRow` input is reloaded by id, so it always reads the current head. Only
+`FileSnapshot` is a historical object. Nodes and parts should be policy-locked
+to `select` plus `insert` (with the same owner/tenant isolation as the root),
+never update/delete. Current range reads validate and materialize the reachable
+file before slicing; that is correct but not the final large-range I/O path.
+
 ## Native RocksDB receipt
 
 `JAZZ_FILE_DISK_BENCH=1 JAZZ_FILE_DISK_APPENDS=8

--- a/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./file-storage.js";
 
 const app = s.defineApp({
-  files: s.table({ rootId: s.string(), byteLength: s.int(), inlineBytes: s.bytes() }),
+  file_roots: s.table({ rootId: s.string(), byteLength: s.int(), inlineBytes: s.bytes() }),
   file_nodes: s.table({
     childIds: s.array(s.string()),
     childLengths: s.array(s.int()),
@@ -25,12 +25,18 @@ async function setup(inlineBytes = 4) {
     adminSecret = "ordinary-file-admin";
   const server = await startLocalJazzServer({ appId, adminSecret });
   servers.push(server);
+  const allow = {
+    select: { using: { type: "True" as const } },
+    insert: { with_check: { type: "True" as const } },
+    update: { using: { type: "True" as const }, with_check: { type: "True" as const } },
+    delete: { using: { type: "True" as const } },
+  };
   await deploy({
     serverUrl: server.url,
     appId,
     adminSecret,
     schema: app.wasmSchema,
-    permissions: {},
+    permissions: { file_roots: allow, file_nodes: allow, file_parts: allow },
   });
   const db = await createDb({
     appId,
@@ -39,7 +45,14 @@ async function setup(inlineBytes = 4) {
     driver: { type: "memory" },
   });
   databases.push(db);
-  return { db, storage: createConventionalFileStorage(db, app, { inlineBytes, fanout: 2 }) };
+  return {
+    db,
+    storage: createConventionalFileStorage(
+      db,
+      { files: app.file_roots, file_nodes: app.file_nodes, file_parts: app.file_parts },
+      { inlineBytes, fanout: 2 },
+    ),
+  };
 }
 afterEach(async () => {
   await Promise.all(databases.splice(0).map((db) => db.shutdown()));
@@ -51,10 +64,12 @@ describe("ordinary-row files", () => {
     const { storage } = await setup();
     const file = await storage.create({ tier: "edge" });
     const initial = await storage.append(file, Uint8Array.from([1, 2, 3, 4, 5]));
+    expect((await storage.snapshot(file.id)).byteLength).toBe(5);
     await storage.overwrite(file, 1, Uint8Array.of(9, 8));
+    expect((await storage.snapshot(file.id)).byteLength).toBe(5);
     await storage.insert(file, 3, Uint8Array.of(7));
-    expect(Array.from(await storage.read(file))).toEqual([1, 9, 8, 7, 4, 5]);
-    expect(Array.from(await storage.readRange(file, 2, 5))).toEqual([8, 7, 4]);
+    expect(Array.from(await storage.read(file.id))).toEqual([1, 9, 8, 7, 4, 5]);
+    expect(Array.from(await storage.readRange(file.id, 2, 5))).toEqual([8, 7, 4]);
     expect(Array.from(await storage.read(initial))).toEqual([1, 2, 3, 4, 5]);
   });
   it("uses bounded immutable parts and a fanout tree", async () => {
@@ -107,7 +122,7 @@ describe("ordinary-row files", () => {
       storage.append(file, Uint8Array.of(1)),
       storage.append(file, Uint8Array.of(2)),
     ]);
-    const bytes = await storage.read(file);
+    const bytes = await storage.read(file.id);
     expect(bytes.length).toBe(results.filter((x) => x.status === "fulfilled").length);
   });
 });

--- a/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
@@ -73,6 +73,23 @@ describe("ordinary-row files", () => {
       (await db.one(app.file_nodes.where({ id: saved.rootId }), { tier: "local" }))?.height,
     ).toBeGreaterThan(0);
   });
+  it("path-copies only an overwritten leaf and its ancestors", async () => {
+    const { db, storage } = await setup(0);
+    const file = await storage.create({ tier: "edge" });
+    const input = new Uint8Array(MAX_FILE_PART_BYTES * 4);
+    input.fill(1);
+    const before = await storage.append(file, input);
+    const oldParts = await db.all(app.file_parts.where({}), { tier: "local" });
+    const oldNodes = await db.all(app.file_nodes.where({}), { tier: "local" });
+    const oldRoot = await db.one(app.file_nodes.where({ id: before.rootId }), { tier: "local" });
+    const after = await storage.overwrite(file, MAX_FILE_PART_BYTES + 1, Uint8Array.of(9));
+    const newParts = await db.all(app.file_parts.where({}), { tier: "local" });
+    const newNodes = await db.all(app.file_nodes.where({}), { tier: "local" });
+    expect(newParts).toHaveLength(oldParts.length + 1);
+    expect(newNodes.length - oldNodes.length).toBeLessThanOrEqual((oldRoot?.height ?? 0) + 1);
+    expect(Array.from(await storage.read(before))).toEqual(Array.from(input));
+    expect((await storage.read(after))[MAX_FILE_PART_BYTES + 1]).toBe(9);
+  });
   it("rejects corruption before returning a range and never advances a corrupt head", async () => {
     const { db, storage } = await setup(0);
     const file = await storage.create({ tier: "edge" });

--- a/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
@@ -20,7 +20,7 @@ const app = s.defineApp({
 });
 const databases: Db[] = [],
   servers: LocalJazzServerHandle[] = [];
-async function setup(inlineBytes = 4) {
+async function setup(inlineBytes = 4, denyRootUpdate = false) {
   const appId = randomUUID(),
     adminSecret = "ordinary-file-admin";
   const server = await startLocalJazzServer({ appId, adminSecret });
@@ -36,7 +36,16 @@ async function setup(inlineBytes = 4) {
     appId,
     adminSecret,
     schema: app.wasmSchema,
-    permissions: { file_roots: allow, file_nodes: allow, file_parts: allow },
+    permissions: {
+      file_roots: denyRootUpdate
+        ? {
+            ...allow,
+            update: { using: { type: "False" as const }, with_check: { type: "False" as const } },
+          }
+        : allow,
+      file_nodes: allow,
+      file_parts: allow,
+    },
   });
   const db = await createDb({
     appId,
@@ -124,5 +133,20 @@ describe("ordinary-row files", () => {
     ]);
     const bytes = await storage.read(file.id);
     expect(bytes.length).toBe(results.filter((x) => x.status === "fulfilled").length);
+  });
+  it("rolls back a root-denied mutation without leaving child rows", async () => {
+    const { db, storage } = await setup(0, true);
+    const file = await storage.create({ tier: "edge" });
+    const before = await storage.snapshot(file.id);
+    const errors: unknown[] = [];
+    const unsubscribe = db.onMutationError((error) => errors.push(error));
+    await storage.append(file.id, Uint8Array.of(1), { waitForAuthority: false });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    unsubscribe();
+    expect(errors).not.toHaveLength(0);
+    expect(await storage.snapshot(file.id)).toEqual(before);
+    expect(await db.all(app.file_parts.where({}), { tier: "local" })).toHaveLength(0);
+    expect(await db.all(app.file_nodes.where({}), { tier: "local" })).toHaveLength(0);
+    expect(Array.from(await storage.read(before))).toEqual([]);
   });
 });

--- a/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
@@ -20,7 +20,7 @@ const app = s.defineApp({
 });
 const databases: Db[] = [],
   servers: LocalJazzServerHandle[] = [];
-async function setup(inlineBytes = 4, denyRootUpdate = false) {
+async function setup(inlineBytes = 4, denyRootUpdate = false, immutableChildren = false) {
   const appId = randomUUID(),
     adminSecret = "ordinary-file-admin";
   const server = await startLocalJazzServer({ appId, adminSecret });
@@ -43,8 +43,20 @@ async function setup(inlineBytes = 4, denyRootUpdate = false) {
             update: { using: { type: "False" as const }, with_check: { type: "False" as const } },
           }
         : allow,
-      file_nodes: allow,
-      file_parts: allow,
+      file_nodes: immutableChildren
+        ? {
+            ...allow,
+            update: { using: { type: "False" as const }, with_check: { type: "False" as const } },
+            delete: { using: { type: "False" as const } },
+          }
+        : allow,
+      file_parts: immutableChildren
+        ? {
+            ...allow,
+            update: { using: { type: "False" as const }, with_check: { type: "False" as const } },
+            delete: { using: { type: "False" as const } },
+          }
+        : allow,
     },
   });
   const db = await createDb({
@@ -148,5 +160,21 @@ describe("ordinary-row files", () => {
     expect(await db.all(app.file_parts.where({}), { tier: "local" })).toHaveLength(0);
     expect(await db.all(app.file_nodes.where({}), { tier: "local" })).toHaveLength(0);
     expect(Array.from(await storage.read(before))).toEqual([]);
+  });
+  it("authority rejects immutable part updates and node deletes", async () => {
+    const { db, storage } = await setup(0, false, true);
+    const file = await storage.create({ tier: "edge" });
+    const saved = await storage.append(file.id, Uint8Array.of(1));
+    const node = await db.one(app.file_nodes.where({ id: saved.rootId }), { tier: "local" });
+    await expect(
+      db
+        .update(app.file_parts, node!.childIds[0]!, { data: Uint8Array.of(9) })
+        .wait({ tier: "edge" }),
+    ).rejects.toThrow("permission_denied");
+    await expect(db.delete(app.file_nodes, saved.rootId).wait({ tier: "edge" })).rejects.toThrow(
+      "permission_denied",
+    );
+    expect(Array.from(await storage.read(saved))).toEqual([1]);
+    expect(Array.from(await storage.read(file.id))).toEqual([1]);
   });
 });

--- a/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { deploy, startLocalJazzServer, type LocalJazzServerHandle } from "../testing/index.js";
+import { createDb, type Db } from "./db.js";
+import {
+  createConventionalFileStorage,
+  InvalidFileDataError,
+  MAX_FILE_PART_BYTES,
+} from "./file-storage.js";
+
+const app = s.defineApp({
+  files: s.table({ rootId: s.string(), byteLength: s.int(), inlineBytes: s.bytes() }),
+  file_nodes: s.table({
+    childIds: s.array(s.string()),
+    childLengths: s.array(s.int()),
+    height: s.int(),
+  }),
+  file_parts: s.table({ data: s.bytes() }),
+});
+const databases: Db[] = [],
+  servers: LocalJazzServerHandle[] = [];
+async function setup(inlineBytes = 4) {
+  const appId = randomUUID(),
+    adminSecret = "ordinary-file-admin";
+  const server = await startLocalJazzServer({ appId, adminSecret });
+  servers.push(server);
+  await deploy({
+    serverUrl: server.url,
+    appId,
+    adminSecret,
+    schema: app.wasmSchema,
+    permissions: {},
+  });
+  const db = await createDb({
+    appId,
+    adminSecret,
+    serverUrl: server.url,
+    driver: { type: "memory" },
+  });
+  databases.push(db);
+  return { db, storage: createConventionalFileStorage(db, app, { inlineBytes, fanout: 2 }) };
+}
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.shutdown()));
+  await Promise.all(servers.splice(0).map((server) => server.stop()));
+});
+
+describe("ordinary-row files", () => {
+  it("keeps a complete historical root through append, overwrite, and insert", async () => {
+    const { storage } = await setup();
+    const file = await storage.create({ tier: "edge" });
+    const initial = await storage.append(file, Uint8Array.from([1, 2, 3, 4, 5]));
+    await storage.overwrite(file, 1, Uint8Array.of(9, 8));
+    await storage.insert(file, 3, Uint8Array.of(7));
+    expect(Array.from(await storage.read(file))).toEqual([1, 9, 8, 7, 4, 5]);
+    expect(Array.from(await storage.readRange(file, 2, 5))).toEqual([8, 7, 4]);
+    expect(Array.from(await storage.read(initial))).toEqual([1, 2, 3, 4, 5]);
+  });
+  it("uses bounded immutable parts and a fanout tree", async () => {
+    const { db, storage } = await setup(0);
+    const file = await storage.create({ tier: "edge" });
+    const bytes = new Uint8Array(MAX_FILE_PART_BYTES * 2 + 1);
+    bytes.fill(3);
+    const saved = await storage.append(file, bytes);
+    const parts = await db.all(app.file_parts.where({}), { tier: "local" });
+    expect(parts.map((part) => part.data.length).sort((a, b) => a - b)).toEqual([
+      1,
+      MAX_FILE_PART_BYTES,
+      MAX_FILE_PART_BYTES,
+    ]);
+    expect(
+      (await db.one(app.file_nodes.where({ id: saved.rootId }), { tier: "local" }))?.height,
+    ).toBeGreaterThan(0);
+  });
+  it("rejects corruption before returning a range and never advances a corrupt head", async () => {
+    const { db, storage } = await setup(0);
+    const file = await storage.create({ tier: "edge" });
+    const saved = await storage.append(file, Uint8Array.from([1, 2, 3, 4, 5]));
+    await db.update(app.file_nodes, saved.rootId, { childLengths: [999] }).wait({ tier: "local" });
+    await expect(storage.read(saved)).rejects.toBeInstanceOf(InvalidFileDataError);
+    await expect(storage.append(file, Uint8Array.of(6))).rejects.toBeInstanceOf(
+      InvalidFileDataError,
+    );
+  });
+  it("serializes concurrent writers without accepting a lost update", async () => {
+    const { storage } = await setup();
+    const file = await storage.create({ tier: "edge" });
+    const results = await Promise.allSettled([
+      storage.append(file, Uint8Array.of(1)),
+      storage.append(file, Uint8Array.of(2)),
+    ]);
+    const bytes = await storage.read(file);
+    expect(bytes.length).toBe(results.filter((x) => x.status === "fulfilled").length);
+  });
+});

--- a/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
@@ -151,9 +151,16 @@ describe("ordinary-row files", () => {
     const file = await storage.create({ tier: "edge" });
     const before = await storage.snapshot(file.id);
     const errors: unknown[] = [];
-    const unsubscribe = db.onMutationError((error) => errors.push(error));
+    let settle!: () => void;
+    const settled = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    const unsubscribe = db.onMutationError((error) => {
+      errors.push(error);
+      settle();
+    });
     await storage.append(file.id, Uint8Array.of(1), { waitForAuthority: false });
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await settled;
     unsubscribe();
     expect(errors).not.toHaveLength(0);
     expect(await storage.snapshot(file.id)).toEqual(before);

--- a/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.integration.test.ts
@@ -73,11 +73,11 @@ describe("ordinary-row files", () => {
     const { storage } = await setup();
     const file = await storage.create({ tier: "edge" });
     const initial = await storage.append(file, Uint8Array.from([1, 2, 3, 4, 5]));
-    expect((await storage.snapshot(file.id)).byteLength).toBe(5);
+    expect((await storage.snapshot(file)).byteLength).toBe(5);
     await storage.overwrite(file, 1, Uint8Array.of(9, 8));
     expect((await storage.snapshot(file.id)).byteLength).toBe(5);
     await storage.insert(file, 3, Uint8Array.of(7));
-    expect(Array.from(await storage.read(file.id))).toEqual([1, 9, 8, 7, 4, 5]);
+    expect(Array.from(await storage.read(file))).toEqual([1, 9, 8, 7, 4, 5]);
     expect(Array.from(await storage.readRange(file.id, 2, 5))).toEqual([8, 7, 4]);
     expect(Array.from(await storage.read(initial))).toEqual([1, 2, 3, 4, 5]);
   });
@@ -113,7 +113,7 @@ describe("ordinary-row files", () => {
     expect(newNodes.length - oldNodes.length).toBeLessThanOrEqual((oldRoot?.height ?? 0) + 1);
     expect(Array.from(await storage.read(before))).toEqual(Array.from(input));
     expect((await storage.read(after))[MAX_FILE_PART_BYTES + 1]).toBe(9);
-  });
+  }, 20_000);
   it("rejects corruption before returning a range and never advances a corrupt head", async () => {
     const { db, storage } = await setup(0);
     const file = await storage.create({ tier: "edge" });

--- a/packages/jazz-tools/src/runtime/file-storage.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.ts
@@ -137,9 +137,13 @@ export function createConventionalFileStorage<
     throw new RangeError(`inlineBytes must be between 0 and ${MAX_FILE_PART_BYTES}.`);
   if (!Number.isSafeInteger(fanout) || fanout < 2 || fanout > 32)
     throw new RangeError("fanout must be between 2 and 32.");
+  // A file head is an ordinary local row. Reading it at edge by default can
+  // deliberately return an older authority snapshot while a local write is
+  // still settling, which is surprising for a mutable file API.
+  const local = (queryOptions?: QueryOptions): QueryOptions => queryOptions ?? { tier: "local" };
   const load = async (file: string | F, q?: QueryOptions) => {
     if (typeof file !== "string") return file;
-    const row = await db.one(app.files.where({ id: file }), q);
+    const row = await db.one(app.files.where({ id: file }), local(q));
     if (!row) throw new FileNotFoundError(file);
     return row;
   };
@@ -431,14 +435,15 @@ export function createConventionalFileStorage<
       return o.tier ? r.wait({ tier: o.tier }) : r.value;
     },
     async snapshot(f, q) {
-      return snapshot(await load(f, q));
+      return snapshot(await load(f, local(q)));
     },
     async read(f, o = {}) {
       const { start = 0, end, ...q } = o;
       return this.readRange(f, start, end, q);
     },
     async readRange(f, start, end, q) {
-      const s = typeof f === "object" && "fileId" in f ? f : await this.snapshot(f, q);
+      const options = local(q);
+      const s = typeof f === "object" && "fileId" in f ? f : await this.snapshot(f, options);
       const e = end ?? s.byteLength;
       if (
         !Number.isSafeInteger(start) ||
@@ -448,7 +453,7 @@ export function createConventionalFileStorage<
         e > s.byteLength
       )
         throw new RangeError(`Invalid file range [${start}, ${e}) for ${s.byteLength} bytes.`);
-      return (await fromSnapshot(s, q)).slice(start, e);
+      return (await fromSnapshot(s, options)).slice(start, e);
     },
     async append(f, b, o = {}) {
       const copy = b.slice();

--- a/packages/jazz-tools/src/runtime/file-storage.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.ts
@@ -1,0 +1,357 @@
+/**
+ * Conventional mutable files built from ordinary Jazz rows.
+ *
+ * The mutable `files` row names one immutable extent-tree root.  Leaf nodes
+ * name bounded byte parts; interior nodes name two children.  No storage or
+ * protocol feature knows that these rows collectively represent a file.
+ */
+import type { DurabilityTier } from "./client.js";
+import { Db, type QueryBuilder, type QueryOptions, type TableProxy } from "./db.js";
+
+export const MAX_FILE_PART_BYTES = 256 * 1024;
+export const DEFAULT_FILE_INLINE_BYTES = 64 * 1024;
+const MAX_FILE_NODES = 1_000_000;
+
+type WhereTable<Row, Init> = TableProxy<Row, Init> & {
+  where(c: Record<string, unknown>): QueryBuilder<Row>;
+};
+export interface FileRow {
+  id: string;
+  rootId: string;
+  byteLength: number;
+  inlineBytes: Uint8Array;
+}
+export interface FileNodeRow {
+  id: string;
+  childIds: string[];
+  childLengths: number[];
+  height: number;
+}
+export interface FilePartRow {
+  id: string;
+  data: Uint8Array;
+}
+export interface ConventionalFileApp<
+  F extends FileRow = FileRow,
+  N extends FileNodeRow = FileNodeRow,
+  P extends FilePartRow = FilePartRow,
+> {
+  files: WhereTable<F, Omit<F, "id">>;
+  file_nodes: WhereTable<N, Omit<N, "id">>;
+  file_parts: WhereTable<P, Omit<P, "id">>;
+}
+export interface FileSnapshot {
+  readonly fileId: string;
+  readonly rootId: string;
+  readonly byteLength: number;
+  readonly inlineBytes: Uint8Array;
+}
+export interface FileStorageOptions {
+  inlineBytes?: number;
+  fanout?: number;
+}
+export interface WriteFileOptions {
+  waitForAuthority?: boolean;
+}
+export interface CreateFileOptions {
+  tier?: DurabilityTier;
+}
+export class FileNotFoundError extends Error {
+  constructor(readonly fileId: string) {
+    super(`File "${fileId}" was not found.`);
+    this.name = "FileNotFoundError";
+  }
+}
+export class InvalidFileDataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidFileDataError";
+  }
+}
+type Ref = { id: string; length: number; height: number };
+
+function checked(n: number, what: string) {
+  if (!Number.isSafeInteger(n) || n < 0)
+    throw new InvalidFileDataError(`${what} must be a non-negative safe integer.`);
+}
+function snapshot(file: FileRow): FileSnapshot {
+  checked(file.byteLength, "File byteLength");
+  if (!(file.inlineBytes instanceof Uint8Array))
+    throw new InvalidFileDataError("File inlineBytes must be Uint8Array.");
+  return {
+    fileId: file.id,
+    rootId: file.rootId,
+    byteLength: file.byteLength,
+    inlineBytes: file.inlineBytes.slice(),
+  };
+}
+function join(chunks: Uint8Array[], length?: number) {
+  const n = length ?? chunks.reduce((a, c) => a + c.length, 0);
+  if (chunks.reduce((a, c) => a + c.length, 0) !== n)
+    throw new InvalidFileDataError("File extent metadata does not match readable bytes.");
+  const out = new Uint8Array(n);
+  let at = 0;
+  for (const c of chunks) {
+    out.set(c, at);
+    at += c.length;
+  }
+  return out;
+}
+
+export interface FileStorage<F extends FileRow = FileRow> {
+  create(options?: CreateFileOptions): Promise<F>;
+  snapshot(file: string | F, options?: QueryOptions): Promise<FileSnapshot>;
+  read(
+    file: string | F | FileSnapshot,
+    options?: QueryOptions & { start?: number; end?: number },
+  ): Promise<Uint8Array>;
+  readRange(
+    file: string | F | FileSnapshot,
+    start: number,
+    end?: number,
+    options?: QueryOptions,
+  ): Promise<Uint8Array>;
+  append(file: string | F, bytes: Uint8Array, options?: WriteFileOptions): Promise<FileSnapshot>;
+  overwrite(
+    file: string | F,
+    start: number,
+    bytes: Uint8Array,
+    options?: WriteFileOptions,
+  ): Promise<FileSnapshot>;
+  insert(
+    file: string | F,
+    start: number,
+    bytes: Uint8Array,
+    options?: WriteFileOptions,
+  ): Promise<FileSnapshot>;
+}
+
+export function createConventionalFileStorage<
+  F extends FileRow,
+  N extends FileNodeRow,
+  P extends FilePartRow,
+>(db: Db, app: ConventionalFileApp<F, N, P>, options: FileStorageOptions = {}): FileStorage<F> {
+  const inlineLimit = options.inlineBytes ?? DEFAULT_FILE_INLINE_BYTES;
+  const fanout = options.fanout ?? 2;
+  if (!Number.isSafeInteger(inlineLimit) || inlineLimit < 0 || inlineLimit > MAX_FILE_PART_BYTES)
+    throw new RangeError(`inlineBytes must be between 0 and ${MAX_FILE_PART_BYTES}.`);
+  if (!Number.isSafeInteger(fanout) || fanout < 2 || fanout > 32)
+    throw new RangeError("fanout must be between 2 and 32.");
+  const load = async (file: string | F, q?: QueryOptions) => {
+    if (typeof file !== "string") return file;
+    const row = await db.one(app.files.where({ id: file }), q);
+    if (!row) throw new FileNotFoundError(file);
+    return row;
+  };
+  const validateNode = (id: string, node: N) => {
+    if (
+      !Number.isInteger(node.height) ||
+      node.height < 0 ||
+      node.childIds.length < 1 ||
+      node.childIds.length > fanout ||
+      node.childIds.length !== node.childLengths.length
+    )
+      throw new InvalidFileDataError(`File tree node "${id}" has invalid child metadata.`);
+    for (const n of node.childLengths) checked(n, `File node "${id}" child length`);
+    return node;
+  };
+  const tree = async (
+    root: string,
+    getNode: (id: string) => Promise<N>,
+    getPart: (id: string) => Promise<Uint8Array>,
+  ) => {
+    const nodes = new Map<string, N>(),
+      visiting = new Set<string>();
+    let count = 0;
+    const visit = async (id: string, expected?: number): Promise<number> => {
+      if (visiting.has(id))
+        throw new InvalidFileDataError(`File tree contains a cycle at node "${id}".`);
+      if (++count > MAX_FILE_NODES)
+        throw new InvalidFileDataError("File tree exceeds validation limit.");
+      visiting.add(id);
+      try {
+        const n = validateNode(id, await getNode(id));
+        nodes.set(id, n);
+        if (expected !== undefined && n.height !== expected)
+          throw new InvalidFileDataError(
+            `File node "${id}" has height ${n.height}, expected ${expected}.`,
+          );
+        let total = 0;
+        for (let i = 0; i < n.childIds.length; i++) {
+          const actual =
+            n.height === 0
+              ? (await getPart(n.childIds[i]!)).length
+              : await visit(n.childIds[i]!, n.height - 1);
+          if (actual !== n.childLengths[i])
+            throw new InvalidFileDataError(`File node "${id}" extent metadata is corrupt.`);
+          total += actual;
+          checked(total, "File tree length");
+        }
+        return total;
+      } finally {
+        visiting.delete(id);
+      }
+    };
+    return { length: await visit(root), nodes };
+  };
+  const fromSnapshot = async (s: FileSnapshot, q?: QueryOptions) => {
+    if (!s.rootId) {
+      if (s.byteLength !== s.inlineBytes.length)
+        throw new InvalidFileDataError("Rootless file length is corrupt.");
+      return s.inlineBytes.slice();
+    }
+    const result = await tree(
+      s.rootId,
+      async (id) => {
+        const n = await db.one(app.file_nodes.where({ id }), q);
+        if (!n) throw new InvalidFileDataError(`File node "${id}" is missing.`);
+        return n;
+      },
+      async (id) => {
+        const p = await db.one(app.file_parts.where({ id }), q);
+        if (!p) throw new InvalidFileDataError(`File part "${id}" is missing.`);
+        return p.data;
+      },
+    );
+    if (result.length + s.inlineBytes.length !== s.byteLength)
+      throw new InvalidFileDataError("File root length is corrupt.");
+    const leaves: Uint8Array[] = [];
+    const walk = async (id: string) => {
+      const n = result.nodes.get(id)!;
+      for (const child of n.childIds) {
+        if (n.height === 0) {
+          const p = await db.one(app.file_parts.where({ id: child }), q);
+          if (!p) throw new InvalidFileDataError(`File part "${child}" is missing.`);
+          leaves.push(p.data);
+        } else await walk(child);
+      }
+    };
+    await walk(s.rootId);
+    leaves.push(s.inlineBytes);
+    return join(leaves, s.byteLength);
+  };
+  const mutate = async (file: string | F, change: (old: Uint8Array) => Uint8Array, wait = true) => {
+    const id = typeof file === "string" ? file : file.id;
+    const r = await db.exclusiveTransaction(async (tx) => {
+      const current = await tx.one(app.files.where({ id }), {
+        tier: "local",
+        propagation: "local-only",
+      });
+      if (!current) throw new FileNotFoundError(id);
+      const old = await fromSnapshot(snapshot(current), {
+        tier: "local",
+        propagation: "local-only",
+      });
+      const next = change(old);
+      let rootId = "",
+        inline = next;
+      if (next.length > inlineLimit) {
+        const refs: Ref[] = [];
+        for (let at = 0; at < next.length; at += MAX_FILE_PART_BYTES) {
+          const data = next.slice(at, at + MAX_FILE_PART_BYTES);
+          const p = tx.insert(app.file_parts, { data } as Omit<P, "id">);
+          refs.push({ id: p.id, length: data.length, height: -1 });
+        }
+        let level = refs;
+        let height = 0;
+        while (level.length > 1) {
+          const following: Ref[] = [];
+          for (let at = 0; at < level.length; at += fanout) {
+            const children = level.slice(at, at + fanout);
+            const n = tx.insert(app.file_nodes, {
+              childIds: children.map((x) => x.id),
+              childLengths: children.map((x) => x.length),
+              height,
+            } as Omit<N, "id">);
+            following.push({
+              id: n.id,
+              length: children.reduce((a, x) => a + x.length, 0),
+              height,
+            });
+          }
+          level = following;
+          height++;
+        }
+        const leaf = level[0]!;
+        if (leaf.height === -1) {
+          const n = tx.insert(app.file_nodes, {
+            childIds: [leaf.id],
+            childLengths: [leaf.length],
+            height: 0,
+          } as Omit<N, "id">);
+          rootId = n.id;
+        } else rootId = leaf.id;
+        inline = new Uint8Array();
+      }
+      tx.update(app.files, id, { rootId, byteLength: next.length, inlineBytes: inline } as Partial<
+        Omit<F, "id">
+      >);
+      return {
+        fileId: id,
+        rootId,
+        byteLength: next.length,
+        inlineBytes: inline,
+      } satisfies FileSnapshot;
+    });
+    return wait ? r.wait() : r.value;
+  };
+  return {
+    async create(o = {}) {
+      const r = db.insert(app.files, {
+        rootId: "",
+        byteLength: 0,
+        inlineBytes: new Uint8Array(),
+      } as Omit<F, "id">);
+      return o.tier ? r.wait({ tier: o.tier }) : r.value;
+    },
+    async snapshot(f, q) {
+      return snapshot(await load(f, q));
+    },
+    async read(f, o = {}) {
+      const { start = 0, end, ...q } = o;
+      return this.readRange(f, start, end, q);
+    },
+    async readRange(f, start, end, q) {
+      const s = typeof f === "object" && "fileId" in f ? f : await this.snapshot(f, q);
+      const e = end ?? s.byteLength;
+      if (
+        !Number.isSafeInteger(start) ||
+        !Number.isSafeInteger(e) ||
+        start < 0 ||
+        e < start ||
+        e > s.byteLength
+      )
+        throw new RangeError(`Invalid file range [${start}, ${e}) for ${s.byteLength} bytes.`);
+      return (await fromSnapshot(s, q)).slice(start, e);
+    },
+    async append(f, b, o = {}) {
+      const copy = b.slice();
+      return mutate(f, (x) => join([x, copy]), o.waitForAuthority !== false);
+    },
+    async overwrite(f, start, b, o = {}) {
+      const copy = b.slice();
+      return mutate(
+        f,
+        (x) => {
+          checked(start, "Overwrite offset");
+          if (start > x.length || start + copy.length > x.length)
+            throw new RangeError("Overwrite range is outside file.");
+          return join([x.slice(0, start), copy, x.slice(start + copy.length)]);
+        },
+        o.waitForAuthority !== false,
+      );
+    },
+    async insert(f, start, b, o = {}) {
+      const copy = b.slice();
+      return mutate(
+        f,
+        (x) => {
+          checked(start, "Insert offset");
+          if (start > x.length) throw new RangeError("Insert offset is outside file.");
+          return join([x.slice(0, start), copy, x.slice(start)]);
+        },
+        o.waitForAuthority !== false,
+      );
+    },
+  };
+}

--- a/packages/jazz-tools/src/runtime/file-storage.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.ts
@@ -142,9 +142,9 @@ export function createConventionalFileStorage<
   // still settling, which is surprising for a mutable file API.
   const local = (queryOptions?: QueryOptions): QueryOptions => queryOptions ?? { tier: "local" };
   const load = async (file: string | F, q?: QueryOptions) => {
-    if (typeof file !== "string") return file;
-    const row = await db.one(app.files.where({ id: file }), local(q));
-    if (!row) throw new FileNotFoundError(file);
+    const id = typeof file === "string" ? file : file.id;
+    const row = await db.one(app.files.where({ id }), local(q));
+    if (!row) throw new FileNotFoundError(id);
     return row;
   };
   const validateNode = (id: string, node: N) => {
@@ -188,6 +188,10 @@ export function createConventionalFileStorage<
               : await visit(n.childIds[i]!, n.height - 1);
           if (actual !== n.childLengths[i])
             throw new InvalidFileDataError(`File node "${id}" extent metadata is corrupt.`);
+          if (n.height === 0 && actual > MAX_FILE_PART_BYTES)
+            throw new InvalidFileDataError(
+              `File part "${n.childIds[i]}" exceeds ${MAX_FILE_PART_BYTES} bytes.`,
+            );
           total += actual;
           checked(total, "File tree length");
         }

--- a/packages/jazz-tools/src/runtime/file-storage.ts
+++ b/packages/jazz-tools/src/runtime/file-storage.ts
@@ -295,6 +295,132 @@ export function createConventionalFileStorage<
     });
     return wait ? r.wait() : r.value;
   };
+  // Equal-length overwrites retain every untouched part and copy only the
+  // affected leaf-to-root paths. Insert is deliberately kept on the generic
+  // splice path below until tree concatenation/rebalancing lands.
+  const overwritePersistent = async (
+    file: string | F,
+    start: number,
+    bytes: Uint8Array,
+    wait: boolean,
+  ) => {
+    const id = typeof file === "string" ? file : file.id;
+    const replacement = bytes.slice();
+    const result = await db.exclusiveTransaction(async (tx) => {
+      const current = await tx.one(app.files.where({ id }), {
+        tier: "local",
+        propagation: "local-only",
+      });
+      if (!current) throw new FileNotFoundError(id);
+      checked(start, "Overwrite offset");
+      if (start + replacement.length > current.byteLength)
+        throw new RangeError("Overwrite range is outside file.");
+      // A tail is small; materializing it first preserves the root invariant.
+      if (!current.rootId || current.inlineBytes.length !== 0) {
+        const old = await fromSnapshot(snapshot(current), {
+          tier: "local",
+          propagation: "local-only",
+        });
+        const next = join([
+          old.slice(0, start),
+          replacement,
+          old.slice(start + replacement.length),
+        ]);
+        tx.update(app.files, id, {
+          rootId: "",
+          byteLength: next.length,
+          inlineBytes: next,
+        } as Partial<Omit<F, "id">>);
+        return {
+          fileId: id,
+          rootId: "",
+          byteLength: next.length,
+          inlineBytes: next,
+        } satisfies FileSnapshot;
+      }
+      const validated = await tree(
+        current.rootId,
+        async (nodeId) => {
+          const node = await db.one(app.file_nodes.where({ id: nodeId }), {
+            tier: "local",
+            propagation: "local-only",
+          });
+          if (!node) throw new InvalidFileDataError(`File node "${nodeId}" is missing.`);
+          return node;
+        },
+        async (partId) => {
+          const part = await db.one(app.file_parts.where({ id: partId }), {
+            tier: "local",
+            propagation: "local-only",
+          });
+          if (!part) throw new InvalidFileDataError(`File part "${partId}" is missing.`);
+          return part.data;
+        },
+      );
+      if (validated.length !== current.byteLength)
+        throw new InvalidFileDataError("File root length is corrupt.");
+      const rewrite = async (nodeId: string, at: number): Promise<Ref> => {
+        const node = validated.nodes.get(nodeId)!;
+        let cursor = at,
+          changed = false;
+        const children: Ref[] = [];
+        for (let index = 0; index < node.childIds.length; index += 1) {
+          const childId = node.childIds[index]!,
+            length = node.childLengths[index]!;
+          const childEnd = cursor + length;
+          if (childEnd <= start || cursor >= start + replacement.length)
+            children.push({ id: childId, length, height: node.height - 1 });
+          else if (node.height > 0) {
+            const rewritten = await rewrite(childId, cursor);
+            children.push(rewritten);
+            changed ||= rewritten.id !== childId;
+          } else {
+            const part = await db.one(app.file_parts.where({ id: childId }), {
+              tier: "local",
+              propagation: "local-only",
+            });
+            if (!part) throw new InvalidFileDataError(`File part "${childId}" is missing.`);
+            const localStart = Math.max(0, start - cursor),
+              localEnd = Math.min(length, start + replacement.length - cursor);
+            const data = part.data.slice();
+            data.set(
+              replacement.slice(cursor + localStart - start, cursor + localEnd - start),
+              localStart,
+            );
+            const inserted = tx.insert(app.file_parts, { data } as Omit<P, "id">);
+            children.push({ id: inserted.id, length, height: -1 });
+            changed = true;
+          }
+          cursor = childEnd;
+        }
+        if (!changed)
+          return {
+            id: nodeId,
+            length: node.childLengths.reduce((sum, length) => sum + length, 0),
+            height: node.height,
+          };
+        const inserted = tx.insert(app.file_nodes, {
+          childIds: children.map((child) => child.id),
+          childLengths: children.map((child) => child.length),
+          height: node.height,
+        } as Omit<N, "id">);
+        return {
+          id: inserted.id,
+          length: children.reduce((sum, child) => sum + child.length, 0),
+          height: node.height,
+        };
+      };
+      const root = await rewrite(current.rootId, 0);
+      tx.update(app.files, id, { rootId: root.id } as Partial<Omit<F, "id">>);
+      return {
+        fileId: id,
+        rootId: root.id,
+        byteLength: current.byteLength,
+        inlineBytes: new Uint8Array(),
+      } satisfies FileSnapshot;
+    });
+    return wait ? result.wait() : result.value;
+  };
   return {
     async create(o = {}) {
       const r = db.insert(app.files, {
@@ -329,17 +455,7 @@ export function createConventionalFileStorage<
       return mutate(f, (x) => join([x, copy]), o.waitForAuthority !== false);
     },
     async overwrite(f, start, b, o = {}) {
-      const copy = b.slice();
-      return mutate(
-        f,
-        (x) => {
-          checked(start, "Overwrite offset");
-          if (start > x.length || start + copy.length > x.length)
-            throw new RangeError("Overwrite range is outside file.");
-          return join([x.slice(0, start), copy, x.slice(start + copy.length)]);
-        },
-        o.waitForAuthority !== false,
-      );
+      return overwritePersistent(f, start, b, o.waitForAuthority !== false);
     },
     async insert(f, start, b, o = {}) {
       const copy = b.slice();

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -63,3 +63,19 @@ export {
 } from "./subscription-manager.js";
 export { generateAuthSecret, BrowserAuthSecretStore } from "./auth-secret-store.js";
 export type { AuthSecretStore, BrowserAuthSecretStoreOptions } from "./auth-secret-store.js";
+export {
+  createConventionalFileStorage,
+  DEFAULT_FILE_INLINE_BYTES,
+  FileNotFoundError,
+  InvalidFileDataError,
+  MAX_FILE_PART_BYTES,
+  type ConventionalFileApp,
+  type CreateFileOptions,
+  type FileNodeRow,
+  type FilePartRow,
+  type FileRow,
+  type FileSnapshot,
+  type FileStorage,
+  type FileStorageOptions,
+  type WriteFileOptions,
+} from "./file-storage.js";


### PR DESCRIPTION
🤖 Reintroduces mutable files as an ordinary-row feature after the Large Value subtraction.

## Design

- mutable file head plus immutable bounded binary parts and tree nodes
- append, overwrite, insert, full/range reads, and independently readable snapshots
- overwrite path-copies affected leaves and ancestors
- arbitrary insert currently rebuilds the tree and is explicitly tracked as a performance gap
- future blob-backed immutable parts can preserve this logical model while moving bulk egress off the database path

## Correctness

- validates ownership, heights, extents, cycles, traversal bounds, and the 256 KiB part cap
- FileRow reads reload the current head; FileSnapshot is the historical value type
- immutable child tables require explicit update/delete denial and ownership isolation
- authority-settled tests prove denied mutations leave no head, node, or part changes

## Measurements

The native RocksDB receipt uses LZ4 roots, Zstd parts, and bottommost Zstd, and reports apparent and allocated bytes with preallocation/compaction caveats. The initial small receipt measured 7 µs p50 / 8 µs p95 at the storage-layout layer; end-to-end Jazz latency remains the more relevant follow-up benchmark.

Draft for design, API, path-copy insertion, and blob-egress iteration.