### PR TITLE
refactor(storage): share deletion history and combine current rows

### DIFF
--- a/crates/jazz/SPEC/10_lenses_migrations.md
+++ b/crates/jazz/SPEC/10_lenses_migrations.md
@@ -30,6 +30,7 @@ Invariant digest:
 - `INV-LENS-17`: TransformColumn MUST be accepted only when its transform key is registered as bijective and canonical-equality-preserving.
 - `INV-LENS-19`: Policy evaluation under lenses MUST translate data into the pinned permission evaluation schema and MUST NOT translate policy bundles.
 - `INV-LENS-20`: Published physical lineages and authored schema variants MUST NOT be automatically garbage-collected.
+- `INV-LENS-21`: A compatible table rename MUST retain its `PhysicalTableId`; deletion history and combined-current state therefore continue under that id without copying, rewriting, or rescanning unrelated lineages.
 
 ## Details
 
@@ -228,6 +229,13 @@ lens projection, and a pointer mismatch alone is never a rejection or rewrite
 condition (`INV-LENS-16`). A `RejectSourceDelta` declaration affects an explicit
 projection through that lens, not admission of history authored on either side.
 
+The same physical id is also the deletion-history routing key. A compatible
+`RenameTable` preserves it, so old and new logical names resolve to the same
+sparse deletion events and combined current row. Adding or incompatibly
+replacing a table allocates a new id and cannot observe old deletion events even
+if a caller reuses a `RowUuid`; dropped ids remain retained for history and are
+never reassigned (`INV-LENS-21`).
+
 A current-write-pointer flip is a core-ordered, monotone catalogue write
 (§10.2) and **never invalidates in-flight work**. The pointer selects the schema
 for new local authoring; it does not redirect commits another client already
@@ -236,10 +244,10 @@ authored under a different Active schema.
 ### 10.5 Reads: select, then project
 
 Reads begin from storage reality, then project into the requested schema. A read
-against schema S resolves its `PhysicalTableId`, selects content/deletion
-winners from that shared lineage by the **schema-agnostic `(tx_time, node)`
-ordering first**, and only then translates the winning cells into S
-(`INV-LENS-12`, ch. 4).
+against schema S resolves its `PhysicalTableId`, selects the combined current
+row (or independently selected historical winners at a fixed cut) from that
+shared lineage by the **schema-agnostic `(tx_time, node)` ordering first**, and
+only then translates the winning cells into S (`INV-LENS-12`, ch. 4).
 
 Natural lens projection applies supported operations deterministically in both
 directions and rejects unsupported transformations (`INV-LENS-13`). The shape's

--- a/crates/jazz/SPEC/11_branches_timetravel.md
+++ b/crates/jazz/SPEC/11_branches_timetravel.md
@@ -28,6 +28,7 @@ Invariant digest:
 - `INV-BRANCH-16`: A branch-scoped subscription MUST include BranchId in its identity.
 - `INV-BRANCH-17`: A branch merge MUST be calculated locally from readable source and target views and emitted as one ordinary atomic mergeable transaction on the target, with no branch-specific fate or authority admission path; successful merge MUST leave the source branch open.
 - `INV-BRANCH-18`: `Discarded` MUST be the only terminal branch state; discard makes a branch read-only while retaining overlay history, and merge MUST NOT close or otherwise mutate source lifecycle state.
+- `INV-BRANCH-38`: Branch deletion events MUST share the universal deletion history but be keyed by `BranchLineage`; a branch event MUST update only that branch's combined current row and MUST never affect root or sibling visibility.
 - `INV-BRANCH-19`: Branch-merge provenance MUST define field-grained non-causal substitutions from each emitted target `(table,row,layer,column-or-operation)` to the exact source contribution dots the authorized merger claims it represents; a later local calculator MUST expand those substitutions rather than treating derived payload as new native contributions.
 - `INV-BRANCH-20`: A local merge calculator MUST subtract the field-grained contribution closure already represented by the target from the source contribution closure, recursively expanding structurally valid substitutions, so merging in both directions MUST NOT echo target-originated counter deltas or scalar writes back to their origin.
 - `INV-BRANCH-21`: Incorporating another lineage into a branch MUST use the same ordinary merge-transaction calculation as merging a branch into main; branch rebase is not a separate operation.
@@ -137,11 +138,14 @@ and siblings: branch overlay writes never affect parent/main current reads
 (`INV-BRANCH-8`), and a read on one branch never observes a sibling's overlay
 (`INV-BRANCH-9`).
 
-Branch overlays are stored in one content-history and deletion-register table
-per `(PhysicalTableId, BranchId)`. Rows retain their authored
-`SchemaVersionAlias`, while `jazz_branch_partitions` records only the stable
-physical table and branch identities. Reads and merge-back project mixed-schema
-winners into their requested schema.
+Branch overlays are stored in one content-history partition per
+`(PhysicalTableId, BranchId)`. Their sparse deletion events instead live in the
+universal deletion history under `BranchLineage::Branch(BranchId)` and the same
+physical-table id. A branch write updates that branch lineage's combined current
+row only. Rows retain their authored `SchemaVersionAlias`, while
+`jazz_branch_partitions` records only the stable physical table and branch
+identities. Reads and merge-back project mixed-schema winners into their
+requested schema (`INV-BRANCH-38`).
 
 ### 11.4 Branch writes (v1: mergeable-only)
 

--- a/crates/jazz/SPEC/14_lowering_to_groove.md
+++ b/crates/jazz/SPEC/14_lowering_to_groove.md
@@ -21,10 +21,10 @@ Invariant digest:
 - `INV-LOWER-1`: Jazz schemas MUST be lowered into a `groove::schema::DatabaseSchema` before opening the node's `groove::db::Database`.
 - `INV-LOWER-2`: The physical content-history table for each `PhysicalTableId` MUST have composite primary key `(row_uuid, tx_time, tx_node_id)`.
 - `INV-LOWER-3`: Node-local aliases in `jazz_nodes.id` and `jazz_schema_versions.id` MUST NOT be wire identities; wire tx/schema references MUST use `NodeUuid` and `SchemaVersionId`.
-- `INV-LOWER-4`: Content and deletion-register versions MUST resolve through their schema's durable physical mapping to separate per-lineage tables; a single lowered version row MUST NOT contain both user cells and `_deletion`.
-- `INV-LOWER-5`: Visible current rows MUST be computed as current content winners anti-joined with current deletion winners where `_deletion == deleted`.
-- `INV-LOWER-6`: Local/non-global current-row lowering MUST use groove `arg_max_by` over `(tx_time, tx_node_id)` per `row_uuid` for both content and deletion-register tables.
-- `INV-LOWER-7`: Global current-row reads MUST use the physical lineage's content and register global-current tables, not scan full history, and MUST exclude rows whose register winner is `Deleted`.
+- `INV-LOWER-4`: Content versions MUST resolve through their schema's durable physical mapping while deletion-register versions resolve through the shared deletion-history relation by stable physical-table and branch lineage; a single immutable version row MUST NOT contain both user cells and `_deletion`.
+- `INV-LOWER-5`: Combined current rows MUST be maintained from independently selected content and deletion winners and expose an explicit visibility state.
+- `INV-LOWER-6`: Local/non-global current-row maintenance MUST use bounded per-row currency selection for both content and deletion history; deletion access MUST be prefix-bounded by branch lineage and physical table id.
+- `INV-LOWER-7`: Global current-row reads MUST use the physical lineage's combined global-current table, not scan immutable history or anti-join a register source.
 - `INV-LOWER-8`: `jazz_global_changes` MUST be keyed by `(physical_table_id, row_uuid, layer, global_seq)` and expose global-sequence and physical-table/global-sequence indexes.
 - `INV-LOWER-9`: Query lowering MUST begin from a resolved visible-current source and therefore MUST apply deletion visibility before user filters/joins/reachable traversal.
 - `INV-LOWER-10`: Parameterized query plans MUST be prepared as groove shapes with binding descriptor and stable name `jazz-query:<shape_id>`, then executed through `Database::bind_shape`; maintained subscription views with hidden routing provenance MUST prepare a clean output graph plus an internal routing graph through `Database::prepare_one_sink_with_routing`.
@@ -42,6 +42,7 @@ Invariant digest:
 - `INV-LOWER-23`: Position-bounded historical cuts and branch-base reads MUST use the
   `by_table_global_seq` bounded range path when sound, returning the same rows as the
   full-scan currentness oracle while touching only the requested global-sequence range.
+- `INV-LOWER-29`: The shared deletion-history relation MUST expose seekable `(branch_lineage, physical_table_id, row_uuid)` and table-prefix access paths. No logical-table read, rebuild, or branch operation may lower to an unbounded scan over unrelated table lineages.
 - `INV-LOWER-24`: Dry-run policy probes and recursion seed hydration MUST use the same deterministic source access-path selection as ordinary one-shot reads, with equivalence to the full-scan path and counters proving the selected path.
 - `INV-LOWER-25`: A lens-projected maintained source MUST emit the same net weighted current-row and witness deltas as applying the selected natural lens path to the authoritative source.
 - `INV-LOWER-26`: A structured query MUST expose one authoritative terminal output relation. Groove MUST assemble nested paths into that terminal; a child change semantically replaces or patches its owning root output, and public carriers MUST NOT require a second relation-edge delta stream.
@@ -142,24 +143,26 @@ maintained reads have the same row-membership semantics. A later incompatible
 winner retracts rather than exposing a stale compatible predecessor, and no
 downstream operator can turn it into a runtime failure.
 
-_Further invariants._ `INV-LOWER-2`, `INV-LOWER-4` — content and deletion lower
-to distinct tables belonging to the resolved `PhysicalTableId`, each with PK
-`(row_uuid, tx_time, tx_node_id)`, never mixing user cells and `_deletion`.
+_Further invariants._ `INV-LOWER-2`, `INV-LOWER-4` — content lowers per resolved
+`PhysicalTableId` with PK `(row_uuid, tx_time, tx_node_id)`, while deletion
+lowers to a universal sparse relation whose PK begins
+`(branch_lineage, physical_table_id, row_uuid)`; immutable rows never mix user
+cells and `_deletion`.
 `INV-LOWER-18` — `Counter` is rejected on nullable/non-integer columns.
 `INV-LOWER-19` — lowered record-wrapper field indices match the groove
 descriptors (debug-asserted).
 
 ### 14.3 Current rows → groove
 
-Current-row visibility is the point where content and deletion history become
-the row set seen by queries and sync. Visible current rows are computed in groove
-as **content-current anti-joined with deletion-current** (ch. 4, `INV-LOWER-5`).
-Non-global tiers use groove `arg_max_by` over `(tx_time, tx_node_id)` per
-`row_uuid` on the history and register tables (`INV-LOWER-6`); the global tier
-reads the physical lineage's global-current tables directly, excluding rows
-whose register winner is `Deleted`, rather than scanning history
-(`INV-LOWER-7`). The `jazz_global_changes` indexes keyed by
-`PhysicalTableId` back global-base probes (`INV-LOWER-8`, ch. 5).
+Current-row maintenance is the point where content and deletion history become
+the row set seen by queries and sync. A combined current row holds independent
+content/deletion winner references, deletion event, visibility, and projected
+cells (`INV-LOWER-5`). Non-global tiers maintain it with bounded per-row winner
+selection; deletion access is a prefix seek into the universal deletion history
+(`INV-LOWER-6`, `INV-LOWER-29`). The global tier reads the physical lineage's
+combined global-current table directly rather than scanning history or
+anti-joining a register (`INV-LOWER-7`). The `jazz_global_changes` indexes keyed
+by `PhysicalTableId` back global-base probes (`INV-LOWER-8`, ch. 5).
 
 ### 14.4 Queries → groove
 

--- a/crates/jazz/SPEC/2_data_model_identity.md
+++ b/crates/jazz/SPEC/2_data_model_identity.md
@@ -30,6 +30,8 @@ Invariant digest:
 - `INV-DATA-18`: Derived global-current storage MUST identify the per-layer winner by row and preserve the content fields needed for global current reads.
 - `INV-DATA-19`: The global change stream MUST retain enough table, row, layer, and sequence information to reconstruct global as-of reads.
 - `INV-DATA-20`: Schema lowering MUST provide storage for metadata, transaction outcomes, row-version layers, globally accepted current state, and change history.
+- `INV-DATA-21`: Deletion/register history MUST be one schema-independent immutable relation shared by every stable `PhysicalTableId`; its identity MUST include `(branch_lineage, physical_table_id, row_uuid, tx_time, tx_node_id)` so a row UUID never collides across logical tables or branch overlays.
+- `INV-DATA-22`: A per-lineage derived current row MUST carry the independently selected content winner and deletion winner/event, an explicit visibility bit, and projected content cells. It is node-local derived state, never replicated payload.
 
 ## Details
 
@@ -123,9 +125,16 @@ identified by the row, the writing transaction, and the layer; versions form a
 DAG through `parents` (ch. 4 specifies domination and merging). A stored version
 belongs to exactly one layer (`INV-DATA-17`). Content versions live in the
 resolved `PhysicalTableId`'s history table and carry user cells under their
-`SchemaVersionAlias` descriptor. Deletion-register versions live in the same
-lineage's stable register table and carry a non-null `_deletion` with no user
-cells.
+`SchemaVersionAlias` descriptor. Deletion-register versions live in the one
+schema-independent deletion history relation and carry a non-null `_deletion`
+with no user cells. The record names the stable `PhysicalTableId` of its content
+lineage, rather than a logical table name or schema version. `PhysicalTableId`
+is allocated once when a table lineage is created and retained through
+compatible schema changes, including table renames; a dropped lineage is never
+silently reused. Its full identity also contains `BranchLineage` (`Root` or a
+`BranchId`) so branch overlay events are not main-history events. This permits
+exactly one sparse immutable deletion history across the database without
+cross-table or cross-branch row-UUID collisions (`INV-DATA-21`).
 
 The replicated wire payload for a version (`VersionRecord`) is exactly the
 replicated-immutable fields (§2.1): `row_uuid`, `parents`, a nullable
@@ -169,12 +178,15 @@ from those tables on recovery.
   scaffolding `jazz_branches` / `jazz_branch_partitions` (behavior in ch. 11);
 - _transaction/audit_ — `jazz_transactions` keyed `(time, node_id)`,
   `jazz_rejected_transactions`;
-- _per physical lineage_ — `jazz_physical_{id}_history` and
-  `jazz_physical_{id}_register`, each keyed by
-  `(row_uuid, tx_time, tx_node_id)`; shared global-current, ahead-current, and
-  rejected-version tables; and optional branch overlay tables. Content rows use
-  `schema_version` as a Groove descriptor discriminator, while register rows use
-  a stable system descriptor (`INV-DATA-14`, `INV-DATA-15`, `INV-DATA-18`);
+- _per physical lineage_ — `jazz_physical_{id}_history`, keyed by
+  `(row_uuid, tx_time, tx_node_id)`, plus a per-lineage combined derived current
+  row. The database has exactly one `jazz_deletion_history`, keyed by
+  `(branch_lineage, physical_table_id, row_uuid, tx_time, tx_node_id)` and with
+  a seek/index prefix `(branch_lineage, physical_table_id, row_uuid)`. The
+  deletion record's `schema_version` is retained provenance, not a storage
+  partition. Content rows use `schema_version` as a Groove descriptor
+  discriminator, while deletion history uses a stable system descriptor
+  (`INV-DATA-14`, `INV-DATA-15`, `INV-DATA-18`, `INV-DATA-21`);
 - _change stream_ — the append-only `jazz_global_changes`, keyed
   `(physical_table_id, row_uuid, layer, global_seq)` with physical-table and
   global-sequence indexes (`INV-DATA-19`);

--- a/crates/jazz/SPEC/4_history_merging.md
+++ b/crates/jazz/SPEC/4_history_merging.md
@@ -25,6 +25,7 @@ Invariant digest:
 - `INV-HIST-14`: Rejected transactions MUST NOT appear as accepted row-history entries and MUST NOT participate in currentness/domination.
 - `INV-HIST-15`: Merge strategy behavior MUST be deterministic and grouping-insensitive over the parent/head set; write-time canonicalization remains validation and rejects loudly.
 - `INV-HIST-16`: A merge value MUST be the deterministic fold over the de-duplicated raw head set, never a fold of already-merged values. Combining divergent merge versions MUST fold the union of their raw parent-closures de-duplicated by version identity (LWW argmax; `Counter` sums per-`TxId` deltas so shared ancestors count once), so divergent merges converge to the single-merger-over-the-union result.
+- `INV-HIST-17`: Content and deletion history MUST remain independently immutable and independently selected; a combined current row is a derived cache over their winners and MUST be reproducible from retained histories after restart or rebuild.
 - `INV-TX-6`: A commit unit MUST be rejected with RejectionReason::CausalityViolation if its txid.time is less than or equal to any parent transaction's txid.time, and its versions...
 
 ## Details
@@ -128,24 +129,39 @@ not rewrite its content history. Deletion events live in their own register laye
 (`VersionLayer::Deletion`) carrying `DeletionEvent::{Deleted, Restored}`, and a
 version belongs to exactly one layer (ch. 2). A current `Deleted` event hides the
 content-current row; a later current `Restored` event reveals it again; content
-writes never touch the register (`INV-HIST-11`). A row's _visible_ current state
-is therefore the content-current winner (§4.2) gated by the register-current
-event.
+writes never touch the register (`INV-HIST-11`).
+
+Physically, deletion history is one sparse, schema-independent relation shared
+by all content lineages. Every event is keyed by its root/branch lineage and
+stable physical table lineage before row identity, so a seek for one row is
+bounded to `(branch_lineage, physical_table_id, row_uuid)` and a table scan is
+bounded to `(branch_lineage, physical_table_id)`. It is not a universal scan and
+it never identifies a row by `RowUuid` alone.
 
 ### 4.5 Global-current as derived state
 
-Immutable history versions are the replicated source material. The per-layer
-**global-current** winner tables are node-local derived state (ch. 2), so they
-are not shipped. When the authority accepts a globally-settled version that
-becomes a per-layer winner, it is reflected in `jazz_{table}_global_current` or
-`jazz_{table}_register_global_current` (`INV-HIST-12`).
+Immutable history versions are the replicated source material. The separately
+selected content and deletion winners are node-local derived inputs. The
+per-lineage **combined current row** is then derived as:
 
-Those overwrite tables are the source of truth for `Global` current-row reads
-and sync snapshots on a node that has observed the accepted version. They carry
-only the settled per-layer winners, so a global current read is O(current) in the
-rows and values returned. Local visibility layers optimistic writes over those
-tables as described in §4.2; it does not rehydrate the global baseline from the
-history/register DAG.
+```text
+{ content_winner, deletion_winner, deletion_event, visible, projected_cells }
+```
+
+`visible` is true exactly when a content winner exists and the deletion winner
+is absent or `Restored`. The current row is rewritten when either winning layer
+changes; it must preserve both winner identities even while invisible. It is
+not shipped and can be rebuilt atomically from retained accepted history. An
+implementation may retain private per-layer helper indexes to make that rebuild
+or ingestion cheap, but ordinary current reads consume the combined current
+source and do not perform a deletion anti-join (`INV-HIST-17`).
+
+The combined global-current table is the source of truth for `Global`
+current-row reads and sync snapshots on a node that has observed the accepted
+version. It carries only settled winner references and projected cells, so a
+global current read is O(current) in the rows and values returned. Local/edge
+tiers use corresponding combined current state or a bounded overlay above this
+base; neither rehydrates the global baseline from either immutable history.
 
 _Further invariants._ `INV-HIST-13` — re-ingesting the same commit unit with its
 version rows in a different order is idempotent and conflict-free. `INV-HIST-14` —

--- a/crates/jazz/SPEC/5_reads_snapshots.md
+++ b/crates/jazz/SPEC/5_reads_snapshots.md
@@ -19,11 +19,12 @@ Invariant digest:
 - `INV-READ-5`: `tx_read` MUST record a `RowRead` for a present snapshot-visible row and an `AbsentRead` for an absent snapshot-visible row.
 - `INV-READ-6`: `tx_current_rows` and `tx_query` MUST record predicate reads as `PredicateRead` values carrying `table`, `shape_id`, `shape`, `binding_id`, and `binding_values`; whole-table transaction reads are degenerate query shapes.
 - `INV-READ-7`: Local current-row reads MUST use argmax `TxId` currency per `(row_uuid, VersionLayer)` over held non-rejected versions, independent of sender arrival order.
-- `INV-READ-8`: Global current-row reads MUST use per-layer global-current tables and MUST exclude rows whose global-current deletion-register winner is `DeletionEvent::Deleted`.
-- `INV-READ-9`: Global as-of reads at `GlobalSeq` MUST choose per-layer winners from `jazz_global_changes` at or before the requested `global_base` and apply deletion anti-join before returning visible content.
-- `INV-READ-10`: Current-row visibility MUST be content-layer current rows anti-joined with the current deletion-register winner; content writes alone MUST NOT restore a deleted row, while `DeletionEvent::Restored` reveals current content.
+- `INV-READ-8`: Global current-row reads MUST use the per-lineage combined global-current source and MUST exclude rows whose stored visibility is false.
+- `INV-READ-9`: Global as-of reads at `GlobalSeq` MUST choose independent content and deletion winners from `jazz_global_changes` at or before the requested `global_base`, then derive visibility before returning content.
+- `INV-READ-10`: Current-row visibility MUST be derived from independent content and deletion-register winners; content writes alone MUST NOT restore a deleted row, while `DeletionEvent::Restored` reveals current content.
 - `INV-READ-11`: A local-tier read on the writer node MUST include the node's own pending committed transaction, while a global-tier read MUST exclude it until global fate/current state is applied.
 - `INV-READ-12`: Per-layer global-current tables MUST equal accepted argmax winners over stored versions and remain consistent after reopen.
+- `INV-READ-13`: Ordinary current query lowering MUST consume one combined current-row source per logical table and MUST NOT introduce a deletion-register anti-join; historical and fixed-snapshot views MAY resolve the two immutable histories at their requested frontier.
 
 ## Details
 
@@ -50,15 +51,18 @@ reached global durability. Chapter 9 defines the full `edge` semantics.
 ### 5.2 Current-row visibility
 
 Current-row reads return content only when the deletion register permits it. A
-visible current row is the content-layer current winner **anti-joined with the
-current deletion-register winner** (ch. 4): a current `Deleted` event hides the
-content row, a later `Restored` reveals it, and a content write alone never
-un-deletes a row (`INV-READ-10`).
+visible current row is derived from the independent content winner and deletion
+winner (ch. 4): a current `Deleted` event hides the content row, a later
+`Restored` reveals it, and a content write alone never un-deletes a row
+(`INV-READ-10`). The result is materialized into the combined current row,
+including both winner identities and the `visible` decision. An ordinary read
+reads that one source and filters `visible`; it neither reads nor joins deletion
+history/currentness separately (`INV-READ-13`).
 
 The same visibility rule applies at global durability. Global current-row reads
-perform the deletion anti-join over the global-current tables (`INV-READ-8`).
-Those tables equal the accepted argmax winners and stay consistent across reopen
-(`INV-READ-12`).
+consume the combined global-current source (`INV-READ-8`). Its embedded winner
+references must equal the accepted argmax winners and stay consistent across
+reopen (`INV-READ-12`).
 
 **Implementation status.** Current global winner maintenance is covered by
 `sync::accepted_fates_maintain_global_current_tables`; reopen consistency is
@@ -118,9 +122,9 @@ whole-table reads are degenerate query shapes.
 ### 5.5 Historical (as-of) reads
 
 A historical read asks what was visible at a past global position. For a read at
-a past `GlobalSeq`, the system chooses the per-layer winner from
-`jazz_global_changes` at or before the requested position, then applies the
-deletion anti-join before returning visible content (`INV-READ-9`). Time-travel
+a past `GlobalSeq`, the system chooses independent content and deletion winners
+from `jazz_global_changes` at or before the requested position, then derives
+visibility before returning content (`INV-READ-9`). Time-travel
 and snapshot-base branches build on this mechanism (ch. 11), and read policy is
 evaluated at the historical cut (ch. 7).
 

--- a/crates/jazz/SPEC/7_authorization.md
+++ b/crates/jazz/SPEC/7_authorization.md
@@ -41,6 +41,10 @@ Invariant digest:
 - `INV-RLS-21`: A policy subplan MUST read its dependency tables as raw policy
   evidence without recursively applying those tables' own read policies, while
   still enforcing the complete outer policy under authenticated claims.
+- `INV-RLS-22`: A deletion event's authorization and downstream read eligibility
+  MUST resolve its stable physical table lineage back to the logical
+  table/schema at the relevant frontier; shared deletion storage MUST NOT widen
+  authority across tables.
 
 ## Details
 

--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -23,6 +23,7 @@ Invariant digest:
 - `INV-SYNC-15`: Exclusive transaction payloads MAY be delivered, stored, and participate partially at the transaction level; receiver-visible subscription state MUST expose them only when complete for the maintained subscription view being served, and partial fragments MUST NOT update whole-database current indexes.
 - `INV-SYNC-16`: A mergeable transaction MAY be delivered and applied partially; each visible mergeable version can contribute without waiting for `tx.n_total_writes`.
 - `INV-SYNC-17`: `ViewUpdate` emission for a result add MUST include enough deletion-register context to reconstruct visible absence/presence for that row.
+- `INV-SYNC-27`: Shared deletion-history storage is local representation only: sync payloads continue to identify deletion versions by logical table, row, transaction, schema and branch lineage, and receivers MUST resolve the sender's record through their own stable physical mapping.
 - `INV-SYNC-18`: An edge acting as mergeable fate authority MUST defer fate assignment until the relevant permission-scope subscription has settled for the writer and affected tables.
 - `INV-SYNC-20`: Incremental query view updates MUST be observationally equivalent to a full rehydrate for the same canonical program instance, including enter/leave churn within a single drain cycle and closure-row replacement.
 - `INV-SYNC-21`: Wire `TxId` and row-version payloads MUST use node UUIDs and schema version IDs, not node-local integer aliases.
@@ -243,6 +244,14 @@ _Further invariants._ `INV-SYNC-17` — a result add carries enough
 deletion-register witness to reconstruct the row's visible presence/absence.
 `INV-SYNC-20` — incremental view updates are observationally equivalent to a full
 reset `ViewUpdate` for the same canonical program instance (ch. 6).
+
+The universal deletion-history table is not a wire namespace. A commit still
+carries a logical table and a deletion `VersionRecord`; receiver catalogue
+admission resolves that table/schema to its receiver-local `PhysicalTableId` and
+persists the event under its local `(branch_lineage, physical_table_id, row)`
+prefix. A payload cannot choose or forge a physical id, and a shared storage
+layout never changes table-scoped sync or authorization semantics
+(`INV-SYNC-27`).
 
 ### 8.5 Subscription Attach, Reset, And Detach
 

--- a/crates/jazz/src/node/branches.rs
+++ b/crates/jazz/src/node/branches.rs
@@ -729,7 +729,7 @@ where
                 self.branch_version_storage_write_binding(&stored, branch_id)?;
             batch.insert_raw(
                 branch_table.as_ref(),
-                history_primary_key(&stored),
+                self.version_storage_primary_key(&stored, BranchLineage::Branch(branch_id))?,
                 branch_record,
             );
         }
@@ -1137,16 +1137,26 @@ where
             return Ok(BTreeSet::new());
         }
         let mut row_ids = BTreeSet::new();
-        for storage_table in [
-            physical_branch_history_table_name(table_id, branch_id),
-            physical_branch_register_table_name(table_id, branch_id),
-        ] {
-            for raw in self.database.primary_key_scan_raw(&storage_table, &[])? {
-                row_ids.insert(RowUuid(
-                    raw.record()
-                        .get_uuid(HistoryRowRecord::FIELD_ROW_UUID_IDX)?,
-                ));
-            }
+        for raw in self.database.primary_key_scan_raw(
+            &physical_branch_history_table_name(table_id, branch_id),
+            &[],
+        )? {
+            row_ids.insert(RowUuid(
+                raw.record()
+                    .get_uuid(HistoryRowRecord::FIELD_ROW_UUID_IDX)?,
+            ));
+        }
+        let (branch_kind, branch_lineage_id) =
+            shared_deletion_lineage_values(BranchLineage::Branch(branch_id));
+        for raw in self.database.primary_key_scan_raw(
+            SHARED_DELETION_HISTORY_TABLE,
+            &[
+                Value::U8(branch_kind),
+                Value::Uuid(branch_lineage_id),
+                Value::U64(table_id.0),
+            ],
+        )? {
+            row_ids.insert(RowUuid(raw.record().get_uuid(3)?));
         }
         Ok(row_ids)
     }
@@ -1640,6 +1650,37 @@ where
             .contains(&(table_id, branch_id))
         {
             return Ok(Vec::new());
+        }
+        if layer == VersionLayer::Deletion {
+            let (branch_kind, branch_lineage_id) =
+                shared_deletion_lineage_values(BranchLineage::Branch(branch_id));
+            let raws = self
+                .database
+                .primary_key_scan_raw(
+                    SHARED_DELETION_HISTORY_TABLE,
+                    &[
+                        Value::U8(branch_kind),
+                        Value::Uuid(branch_lineage_id),
+                        Value::U64(table_id.0),
+                        Value::Uuid(row_uuid.0),
+                    ],
+                )?
+                .into_iter()
+                .map(|raw| raw.owned_record())
+                .collect::<Vec<_>>();
+            let mut versions = Vec::with_capacity(raws.len());
+            for raw in raws {
+                let version =
+                    self.decode_history_owned_record(table, SHARED_DELETION_HISTORY_TABLE, raw)?;
+                let tx_id = self.version_tx_id(&version)?;
+                if self
+                    .transaction_record(tx_id)
+                    .is_some_and(|tx| !matches!(tx.fate, Fate::Rejected(_)))
+                {
+                    versions.push(version);
+                }
+            }
+            return Ok(versions);
         }
         let storage_table = physical_branch_version_storage_table_name(table_id, layer, branch_id);
         let raws = self

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -708,12 +708,6 @@ impl VersionRow {
         )
     }
 
-    /// Bind this row's encoded payload to the schema version already stored in
-    /// its Jazz metadata before handing it to Groove.
-    pub(super) fn groove_record(&self) -> groove::records::VariantRecord {
-        self.bind_groove_record(self.record.clone())
-    }
-
     /// Bind a derived storage row to the same schema version as this version.
     pub(super) fn bind_groove_record(&self, record: OwnedRecord) -> groove::records::VariantRecord {
         groove::records::VariantRecord::new(

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -41,6 +41,27 @@ groove::define_record! {
     }
 }
 
+// Fixed physical carrier for the shared deletion-history relation. The logical
+// `VersionRow` remains a `RegisterRowRecord`; this wrapper exists only at the
+// storage boundary where lineage/table routing is attached.
+groove::define_record! {
+    pub(super) struct SharedDeletionHistoryRowRecord {
+        0 => branch_kind: u8,
+        1 => branch_id: uuid::Uuid,
+        2 => physical_table_id: u64,
+        3 => row_uuid: RowUuid,
+        4 => tx_time: TxTime,
+        5 => tx_node_id: NodeAlias,
+        6 => schema_version: SchemaVersionAlias,
+        7 => parents: ParentRefs,
+        8 => created_by: AuthorId,
+        9 => created_at: TxTime,
+        10 => updated_by: AuthorId,
+        11 => updated_at: TxTime,
+        12 => _deletion: DeletionEvent,
+    }
+}
+
 groove::define_record! {
     pub(super) struct GlobalCurrentRowRecord {
         0 => row_uuid: RowUuid,

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -19,10 +19,26 @@ where
         row_uuid: RowUuid,
     ) -> Result<Vec<VersionRow>, Error> {
         let mut versions = Vec::new();
-        for storage_table in self.version_storage_sources(table)? {
+        for storage_table in self.version_storage_sources_for_layer(table, VersionLayer::Content)? {
             let raws = self
                 .database
                 .primary_key_scan_raw(&storage_table, &[Value::Uuid(row_uuid.0)])?
+                .into_iter()
+                .map(|raw| raw.owned_record())
+                .collect::<Vec<_>>();
+            for record in raws {
+                versions.push(self.decode_history_owned_record(table, &storage_table, record)?);
+            }
+        }
+        for storage_table in
+            self.version_storage_sources_for_layer(table, VersionLayer::Deletion)?
+        {
+            let raws = self
+                .database
+                .primary_key_scan_raw(
+                    &storage_table,
+                    &self.deletion_storage_prefix(table, BranchLineage::Root, Some(row_uuid))?,
+                )?
                 .into_iter()
                 .map(|raw| raw.owned_record())
                 .collect::<Vec<_>>();
@@ -94,9 +110,14 @@ where
     ) -> Result<Option<VersionRow>, Error> {
         let mut winner = None;
         for storage_table in self.version_storage_sources_for_layer(table, layer)? {
+            let prefix = if layer == VersionLayer::Deletion {
+                self.deletion_storage_prefix(table, BranchLineage::Root, Some(row_uuid))?
+            } else {
+                vec![Value::Uuid(row_uuid.0)]
+            };
             let Some(raw) = self
                 .database
-                .primary_key_last_raw(&storage_table, &[Value::Uuid(row_uuid.0)])?
+                .primary_key_last_raw(&storage_table, &prefix)?
                 .map(|raw| raw.owned_record())
             else {
                 continue;
@@ -136,10 +157,28 @@ where
 
     pub(super) fn query_table_versions(&mut self, table: &str) -> Result<Vec<VersionRow>, Error> {
         let mut versions_by_key = BTreeMap::new();
-        for storage_table in self.version_storage_sources(table)? {
+        for storage_table in self.version_storage_sources_for_layer(table, VersionLayer::Content)? {
             let raws = self
                 .database
                 .primary_key_scan_raw(&storage_table, &[])?
+                .into_iter()
+                .map(|raw| raw.owned_record())
+                .collect::<Vec<_>>();
+            for record in raws {
+                let version = self.decode_history_owned_record(table, &storage_table, record)?;
+                let tx_id = self.version_tx_id(&version)?;
+                versions_by_key.insert((version.row_uuid(), tx_id, version.layer()), version);
+            }
+        }
+        for storage_table in
+            self.version_storage_sources_for_layer(table, VersionLayer::Deletion)?
+        {
+            let raws = self
+                .database
+                .primary_key_scan_raw(
+                    &storage_table,
+                    &self.deletion_storage_prefix(table, BranchLineage::Root, None)?,
+                )?
                 .into_iter()
                 .map(|raw| raw.owned_record())
                 .collect::<Vec<_>>();
@@ -205,8 +244,18 @@ where
                     .map(|raw| raw.owned_record())
                     .collect::<Vec<_>>();
                 for record in raws {
+                    // The shared deletion index is transaction-scoped, not
+                    // table-scoped: one transaction may contain deletion rows
+                    // for several physical tables. Decode each row from its
+                    // embedded PhysicalTableId instead of imposing whichever
+                    // logical table happened to visit the shared source first.
+                    let requested_table = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+                        ""
+                    } else {
+                        &table
+                    };
                     let version =
-                        self.decode_history_owned_record(&table, &storage_table, record)?;
+                        self.decode_history_owned_record(requested_table, &storage_table, record)?;
                     versions.push(version);
                 }
             }
@@ -250,10 +299,7 @@ where
                 table_mapping.table_id,
                 branch_id,
             ));
-            sources.push(physical_branch_register_table_name(
-                table_mapping.table_id,
-                branch_id,
-            ));
+            sources.push(SHARED_DELETION_HISTORY_TABLE.to_owned());
         }
         sources.sort();
         sources.dedup();
@@ -328,9 +374,36 @@ where
             .filter_map(|mapping| mapping.tables.get(table))
             .map(|mapping| match layer {
                 VersionLayer::Content => physical_history_table_name(mapping.table_id),
-                VersionLayer::Deletion => physical_register_table_name(mapping.table_id),
+                VersionLayer::Deletion => SHARED_DELETION_HISTORY_TABLE.to_owned(),
             })
             .collect()
+    }
+
+    pub(super) fn deletion_storage_prefix(
+        &self,
+        table: &str,
+        lineage: BranchLineage,
+        row_uuid: Option<RowUuid>,
+    ) -> Result<Vec<Value>, Error> {
+        let schema_version = if self
+            .table_in_schema(table, self.catalogue.current_write_schema.schema)
+            .is_ok()
+        {
+            self.catalogue.current_write_schema.schema
+        } else {
+            self.catalogue.current_schema_version_id
+        };
+        let table_id = self.physical_table_id_for_schema(schema_version, table)?;
+        let (branch_kind, branch_id) = shared_deletion_lineage_values(lineage);
+        let mut prefix = vec![
+            Value::U8(branch_kind),
+            Value::Uuid(branch_id),
+            Value::U64(table_id.0),
+        ];
+        if let Some(row_uuid) = row_uuid {
+            prefix.push(Value::Uuid(row_uuid.0));
+        }
+        Ok(prefix)
     }
 
     #[allow(dead_code)] // Stage 1 read primitive; production reads switch in Stage 2.
@@ -352,6 +425,68 @@ where
         storage_table: &str,
         record: OwnedRecord,
     ) -> Result<VersionRow, Error> {
+        if storage_table == SHARED_DELETION_HISTORY_TABLE {
+            let shared = record.to_values()?;
+            let Value::U64(table_id) = shared.get(2).ok_or(Error::InvalidStoredValue(
+                "shared deletion physical table id missing",
+            ))?
+            else {
+                return Err(Error::InvalidStoredValue(
+                    "shared deletion physical table id must be u64",
+                ));
+            };
+            let Value::U64(alias) = shared.get(6).ok_or(Error::InvalidStoredValue(
+                "shared deletion schema alias missing",
+            ))?
+            else {
+                return Err(Error::InvalidStoredValue(
+                    "shared deletion schema alias must be u64",
+                ));
+            };
+            let table_id = PhysicalTableId(*table_id);
+            let alias = SchemaVersionAlias(*alias);
+            let schema_version =
+                self.schema_version_for_alias(alias)
+                    .ok_or(Error::InvalidStoredValue(
+                        "shared deletion schema version alias must exist",
+                    ))?;
+            let stored_table = self
+                .catalogue
+                .physical_mappings
+                .get(&schema_version)
+                .and_then(|mapping| {
+                    mapping.tables.iter().find_map(|(logical_table, mapping)| {
+                        (mapping.table_id == table_id).then(|| logical_table.clone())
+                    })
+                })
+                .ok_or(Error::InvalidStoredValue(
+                    "shared deletion physical table mapping missing",
+                ))?;
+            let table = if requested_table.is_empty() || requested_table == stored_table {
+                stored_table.clone()
+            } else {
+                let requested_schema = if self
+                    .table_in_schema(requested_table, self.catalogue.current_write_schema.schema)
+                    .is_ok()
+                {
+                    self.catalogue.current_write_schema.schema
+                } else {
+                    self.catalogue.current_schema_version_id
+                };
+                (self.physical_table_id_for_schema(requested_schema, requested_table)? == table_id)
+                    .then(|| requested_table.to_owned())
+                    .ok_or(Error::InvalidStoredValue(
+                        "shared deletion row escaped requested physical-table prefix",
+                    ))?
+            };
+            let logical_table = self.table_in_schema(&stored_table, schema_version)?;
+            let descriptor = logical_table.register_storage_table().record_schema();
+            let logical = OwnedRecord::new(descriptor.create(&shared[3..])?, descriptor);
+            return Ok(VersionRow {
+                table: groove::Intern::new(table),
+                record: logical,
+            });
+        }
         let record_view = record.borrowed();
         let is_deletion = record_view.descriptor().field_index("_deletion").is_some();
         let table = if !storage_table.starts_with("jazz_physical_") {
@@ -656,16 +791,21 @@ where
         tx_time: TxTime,
         tx_node_alias: NodeAlias,
     ) -> Result<Option<VersionRow>, Error> {
+        let key = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+            let mut key =
+                self.deletion_storage_prefix(table, BranchLineage::Root, Some(row_uuid))?;
+            key.extend([Value::U64(tx_time.0), Value::U64(tx_node_alias.0)]);
+            key
+        } else {
+            vec![
+                Value::Uuid(row_uuid.0),
+                Value::U64(tx_time.0),
+                Value::U64(tx_node_alias.0),
+            ]
+        };
         let raw = self
             .database
-            .primary_key_get_raw(
-                storage_table,
-                &[
-                    Value::Uuid(row_uuid.0),
-                    Value::U64(tx_time.0),
-                    Value::U64(tx_node_alias.0),
-                ],
-            )?
+            .primary_key_get_raw(storage_table, &key)?
             .map(|raw| raw.owned_record());
         let Some(record) = raw else {
             return Ok(None);

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -13,6 +13,7 @@ use crate::protocol_limits::{
     commit_unit_limit_violation, validate_known_state_declaration, validate_shape_ast_size,
 };
 use crate::schema::{ColumnSchema, MERGE_HEADS_TABLE};
+use crate::tx::BranchLineage;
 use groove::records::ValueType;
 
 pub(super) const MAX_SCHEMA_LINEAGE_DECLARATIONS: usize = 4096;
@@ -2068,7 +2069,7 @@ where
                 let (history_table, groove_record) = self.version_storage_write_binding(&stored)?;
                 batch.insert_raw(
                     history_table.as_ref(),
-                    history_primary_key(&stored),
+                    self.version_storage_primary_key(&stored, BranchLineage::Root)?,
                     groove_record,
                 );
                 if stored.layer() == VersionLayer::Content {
@@ -2988,7 +2989,10 @@ where
         for version in &rejected {
             self.write_ahead_current_delete(batch, version)?;
             let history_table = self.version_storage_table_for_row(version)?;
-            batch.delete(history_table.as_ref(), history_primary_key(version));
+            batch.delete(
+                history_table.as_ref(),
+                self.version_storage_primary_key(version, tx.tx.target_lineage)?,
+            );
         }
         for (table_id, table, row_uuid) in affected_content_rows {
             self.rewrite_merge_heads_excluding_tx(batch, table_id, &table, row_uuid, tx_id)?;
@@ -3477,15 +3481,21 @@ where
         tx_node_alias: NodeAlias,
     ) -> Result<Option<VersionRow>, Error> {
         for storage_table in self.version_storage_sources_for_layer(table, layer)? {
-            let raw = self.database.primary_key_get_raw_in_batch(
-                batch,
-                &storage_table,
-                &[
+            let key = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+                let mut key =
+                    self.deletion_storage_prefix(table, BranchLineage::Root, Some(row_uuid))?;
+                key.extend([Value::U64(tx_time.0), Value::U64(tx_node_alias.0)]);
+                key
+            } else {
+                vec![
                     Value::Uuid(row_uuid.0),
                     Value::U64(tx_time.0),
                     Value::U64(tx_node_alias.0),
-                ],
-            )?;
+                ]
+            };
+            let raw = self
+                .database
+                .primary_key_get_raw_in_batch(batch, &storage_table, &key)?;
             let record = raw.map(|raw| raw.owned_record());
             let Some(record) = record else {
                 continue;
@@ -4460,33 +4470,22 @@ where
                     self.branch_version_storage_write_binding(&stored, branch_id)?
                 }
             };
+            let storage_key = self.version_storage_primary_key(&stored, tx.target_lineage)?;
             if tx_already_known {
                 let existing = self.database.primary_key_get_raw_in_batch(
                     batch,
                     history_table.as_ref(),
-                    &[
-                        Value::Uuid(stored.row_uuid().0),
-                        Value::U64(stored.tx_time().0),
-                        Value::U64(stored.tx_node_alias().0),
-                    ],
+                    &self.version_storage_primary_key_values(&stored, tx.target_lineage)?,
                 )?;
                 if let Some(existing) = existing {
-                    if existing.record().raw() != stored.record.raw() {
+                    if existing.record().raw() != groove_record.record().raw() {
                         return Err(Error::ConflictingCommitUnit(tx.tx_id));
                     }
                 } else {
-                    batch.insert_raw(
-                        history_table.as_ref(),
-                        history_primary_key(&stored),
-                        groove_record,
-                    );
+                    batch.insert_raw(history_table.as_ref(), storage_key, groove_record);
                 }
             } else {
-                batch.insert_raw_fresh(
-                    history_table.as_ref(),
-                    history_primary_key(&stored),
-                    groove_record,
-                );
+                batch.insert_raw_fresh(history_table.as_ref(), storage_key, groove_record);
             }
             if update_current_indexes && !matches!(fate, Fate::Rejected(_)) && global_seq.is_none()
             {

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -45,9 +45,9 @@ use crate::schema::{
 use crate::time::{GlobalSeq, TxTime};
 use crate::tools::OpenBatchId;
 use crate::tx::{
-    AbsentRead, BranchMergeProvenance, DeletionEvent, DurabilityTier, Fate, HistoryEntry,
-    PredicateRead, RejectedTransaction, RejectedVersion, RejectionReason, RowRead, Snapshot,
-    Transaction, TransactionRecord, TxId, TxKind,
+    AbsentRead, BranchLineage, BranchMergeProvenance, DeletionEvent, DurabilityTier, Fate,
+    HistoryEntry, PredicateRead, RejectedTransaction, RejectedVersion, RejectionReason, RowRead,
+    Snapshot, Transaction, TransactionRecord, TxId, TxKind,
 };
 
 fn hydrate_nested_scalar_enum_cases(
@@ -1836,7 +1836,7 @@ where
             let (history_table, groove_record) = self.version_storage_write_binding(&stored)?;
             batch.insert_raw(
                 history_table.as_ref(),
-                history_primary_key(&stored),
+                self.version_storage_primary_key(&stored, BranchLineage::Root)?,
                 groove_record,
             );
             self.update_merge_heads_for_content_version(&mut batch, &stored)?;

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::ids::{PhysicalColumnId, PhysicalTableId};
+use crate::tx::BranchLineage;
 use groove::schema::{
     ColumnSchema as GrooveColumnSchema, IndexSchema as GrooveIndexSchema,
     TableSchema as GrooveTableSchema, TableVariantField as GrooveTableVariantField,
@@ -497,6 +498,35 @@ pub(super) fn physical_history_table_name(table_id: PhysicalTableId) -> String {
 
 pub(super) fn physical_register_table_name(table_id: PhysicalTableId) -> String {
     format!("jazz_physical_{}_register", table_id.0)
+}
+
+/// Fixed sparse deletion history shared by every physical content lineage.
+///
+/// Unlike `physical_register_table_name`, this is not a per-lineage table;
+/// callers must pair it with the full `(BranchLineage, PhysicalTableId)` key.
+pub(super) const SHARED_DELETION_HISTORY_TABLE: &str = "jazz_deletion_history";
+
+pub(super) fn shared_deletion_lineage_values(lineage: BranchLineage) -> (u8, uuid::Uuid) {
+    match lineage {
+        BranchLineage::Root => (0, uuid::Uuid::nil()),
+        BranchLineage::Branch(branch_id) => (1, branch_id.0),
+    }
+}
+
+pub(super) fn shared_deletion_history_primary_key(
+    lineage: BranchLineage,
+    table_id: PhysicalTableId,
+    version: &VersionRow,
+) -> PrimaryKeyValue {
+    let (branch_kind, branch_id) = shared_deletion_lineage_values(lineage);
+    PrimaryKeyValue::Composite(vec![
+        PrimaryKeyValue::U8(branch_kind),
+        PrimaryKeyValue::Uuid(branch_id),
+        PrimaryKeyValue::U64(table_id.0),
+        PrimaryKeyValue::Uuid(version.row_uuid().0),
+        PrimaryKeyValue::U64(version.tx_time().0),
+        PrimaryKeyValue::U64(version.tx_node_alias().0),
+    ])
 }
 
 pub(super) fn physical_global_current_table_name(table_id: PhysicalTableId) -> String {
@@ -2644,7 +2674,7 @@ where
             ))?;
         if version.layer() == VersionLayer::Deletion {
             return Ok(groove::Intern::new(
-                self.physical_register_table_for_schema(schema_version, version.table())?,
+                SHARED_DELETION_HISTORY_TABLE.to_owned(),
             ));
         }
         Ok(groove::Intern::new(
@@ -2657,6 +2687,45 @@ where
             )?
             .storage_table,
         ))
+    }
+
+    pub(super) fn version_storage_primary_key(
+        &self,
+        version: &VersionRow,
+        lineage: BranchLineage,
+    ) -> Result<PrimaryKeyValue, Error> {
+        if version.layer() == VersionLayer::Deletion {
+            return Ok(shared_deletion_history_primary_key(
+                lineage,
+                self.physical_table_id_for_version(version)?,
+                version,
+            ));
+        }
+        Ok(history_primary_key(version))
+    }
+
+    pub(super) fn version_storage_primary_key_values(
+        &self,
+        version: &VersionRow,
+        lineage: BranchLineage,
+    ) -> Result<Vec<Value>, Error> {
+        if version.layer() == VersionLayer::Deletion {
+            let table_id = self.physical_table_id_for_version(version)?;
+            let (branch_kind, branch_id) = shared_deletion_lineage_values(lineage);
+            return Ok(vec![
+                Value::U8(branch_kind),
+                Value::Uuid(branch_id),
+                Value::U64(table_id.0),
+                Value::Uuid(version.row_uuid().0),
+                Value::U64(version.tx_time().0),
+                Value::U64(version.tx_node_alias().0),
+            ]);
+        }
+        Ok(vec![
+            Value::Uuid(version.row_uuid().0),
+            Value::U64(version.tx_time().0),
+            Value::U64(version.tx_node_alias().0),
+        ])
     }
 
     /// Re-encode every enum occurrence in a logical storage record before it
@@ -2836,8 +2905,7 @@ where
                 "stored row schema version alias missing while preparing storage write",
             ))?;
         if version.layer() == VersionLayer::Deletion {
-            let table = self.version_storage_table_for_row(version)?;
-            return Ok((table, version.groove_record()));
+            return self.shared_deletion_history_write_binding(version, BranchLineage::Root);
         }
 
         let binding = physical_history_binding(
@@ -3028,6 +3096,39 @@ where
         ))
     }
 
+    /// Encode a deletion/register version into the fixed shared history table.
+    /// The wire and in-memory `VersionRow` stay logical-table scoped; this is
+    /// the sole physical boundary that adds local routing identity.
+    pub(super) fn shared_deletion_history_write_binding(
+        &mut self,
+        version: &VersionRow,
+        lineage: BranchLineage,
+    ) -> Result<(groove::Intern<String>, groove::records::VariantRecord), Error> {
+        debug_assert_eq!(version.layer(), VersionLayer::Deletion);
+        let schema_version = self
+            .schema_version_for_alias(version.schema_version_alias())
+            .ok_or(Error::InvalidStoredValue(
+                "stored register schema version alias missing while preparing shared deletion write",
+            ))?;
+        let table_id = self.physical_table_id_for_schema(schema_version, version.table())?;
+        let (branch_kind, branch_id) = shared_deletion_lineage_values(lineage);
+        let mut values = vec![
+            Value::U8(branch_kind),
+            Value::Uuid(branch_id),
+            Value::U64(table_id.0),
+        ];
+        values.extend(version.record.to_values()?);
+        let descriptor = self
+            .database
+            .table_schema(SHARED_DELETION_HISTORY_TABLE)?
+            .record_schema();
+        let record = OwnedRecord::new(descriptor.create(&values)?, descriptor);
+        Ok((
+            groove::Intern::new(SHARED_DELETION_HISTORY_TABLE.to_owned()),
+            version.bind_groove_record(record),
+        ))
+    }
+
     pub(super) fn rejected_version_storage_write_binding(
         &self,
         version: &VersionRow,
@@ -3059,6 +3160,10 @@ where
         version: &VersionRow,
         branch_id: BranchId,
     ) -> Result<(groove::Intern<String>, groove::records::VariantRecord), Error> {
+        if version.layer() == VersionLayer::Deletion {
+            return self
+                .shared_deletion_history_write_binding(version, BranchLineage::Branch(branch_id));
+        }
         let schema_version = self
             .schema_version_for_alias(version.schema_version_alias())
             .ok_or(Error::InvalidStoredValue(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -9376,8 +9376,17 @@ where
                             .map(|raw| raw.owned_record())
                             .collect::<Vec<_>>();
                         for record in raws {
-                            let version =
-                                self.decode_history_owned_record(table, &storage_table, record)?;
+                            let requested_table = if storage_table == SHARED_DELETION_HISTORY_TABLE
+                            {
+                                ""
+                            } else {
+                                table
+                            };
+                            let version = self.decode_history_owned_record(
+                                requested_table,
+                                &storage_table,
+                                record,
+                            )?;
                             if version.tx_node_alias() != alias
                                 || !times.contains(&version.tx_time())
                             {

--- a/crates/jazz/src/node/recovery.rs
+++ b/crates/jazz/src/node/recovery.rs
@@ -232,15 +232,15 @@ where
                     raw.record().get_u64(HistoryRowRecord::FIELD_TX_TIME_IDX)?,
                 ));
             }
-            if let Some(raw) = self.database.index_last_raw(
-                &physical_register_table_name(table_id),
-                "by_tx",
-                &[],
-            )? {
-                self.merge_tx_time(TxTime(
-                    raw.record().get_u64(RegisterRowRecord::FIELD_TX_TIME_IDX)?,
-                ));
-            }
+        }
+        if let Some(raw) =
+            self.database
+                .index_last_raw(SHARED_DELETION_HISTORY_TABLE, "by_tx", &[])?
+        {
+            self.merge_tx_time(TxTime(
+                raw.record()
+                    .get_u64(SharedDeletionHistoryRowRecord::FIELD_TX_TIME_IDX)?,
+            ));
         }
         #[cfg(feature = "testing")]
         if let (Some(receipt), Some(started)) = (&mut receipt, started) {

--- a/crates/jazz/src/node/tests/branching.rs
+++ b/crates/jazz/src/node/tests/branching.rs
@@ -738,8 +738,12 @@ fn branch_overlay_spans_schema_renames_and_merge_back_after_restart() {
     assert_eq!(
         core.database
             .primary_key_scan_raw(
-                &physical_branch_register_table_name(base_table_id, branch_id),
-                &[],
+                SHARED_DELETION_HISTORY_TABLE,
+                &[
+                    Value::U8(1),
+                    Value::Uuid(branch_id.0),
+                    Value::U64(base_table_id.0),
+                ],
             )
             .unwrap()
             .len(),

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -1294,12 +1294,19 @@ fn physical_deletion_register_spans_renamed_schemas_and_reopens() {
         assert_eq!(
             core.version_storage_sources_for_layer(logical_table, VersionLayer::Deletion)
                 .unwrap(),
-            vec![physical_register_table_name(table_id)]
+            vec![SHARED_DELETION_HISTORY_TABLE.to_owned()]
         );
     }
     assert_eq!(
         core.database
-            .primary_key_scan_raw(&physical_register_table_name(table_id), &[])
+            .primary_key_scan_raw(
+                SHARED_DELETION_HISTORY_TABLE,
+                &[
+                    Value::U8(0),
+                    Value::Uuid(uuid::Uuid::nil()),
+                    Value::U64(table_id.0),
+                ],
+            )
             .unwrap()
             .len(),
         2
@@ -1340,7 +1347,7 @@ fn physical_deletion_register_spans_renamed_schemas_and_reopens() {
         reopened
             .version_storage_sources_for_layer("tasks", VersionLayer::Deletion)
             .unwrap(),
-        vec![physical_register_table_name(table_id)]
+        vec![SHARED_DELETION_HISTORY_TABLE.to_owned()]
     );
     assert_eq!(
         reopened
@@ -1350,6 +1357,100 @@ fn physical_deletion_register_spans_renamed_schemas_and_reopens() {
             .filter(|version| version.layer() == VersionLayer::Deletion)
             .count(),
         2
+    );
+}
+
+#[test]
+fn shared_deletion_history_keeps_same_row_uuid_table_scoped() {
+    let schema = JazzSchema::new([
+        TableSchema::new("todos", [ColumnSchema::new("title", ColumnType::String)]),
+        TableSchema::new("notes", [ColumnSchema::new("body", ColumnType::String)]),
+    ]);
+    let (dir, mut core) = open_node_with_schema(node(0x2c), schema.clone());
+    let shared_row = row(0x4c);
+    core.commit_mergeable(
+        MergeableCommit::new("todos", shared_row, 10).cells(BTreeMap::from([(
+            "title".to_owned(),
+            v("todo"),
+        )])),
+    )
+    .unwrap();
+    core.commit_mergeable(
+        MergeableCommit::new("notes", shared_row, 11).cells(BTreeMap::from([(
+            "body".to_owned(),
+            v("note"),
+        )])),
+    )
+    .unwrap();
+    let deletion_tx = core
+        .commit_mergeable_many(vec![
+            MergeableCommit::new("todos", shared_row, 12).deletion(DeletionEvent::Deleted),
+            MergeableCommit::new("notes", shared_row, 13).deletion(DeletionEvent::Deleted),
+        ])
+        .unwrap();
+
+    let mapping = &core.catalogue.physical_mappings[&schema.version_id()].tables;
+    let todos_id = mapping["todos"].table_id;
+    let notes_id = mapping["notes"].table_id;
+    assert_ne!(todos_id, notes_id);
+    for table_id in [todos_id, notes_id] {
+        assert_eq!(
+            core.database
+                .primary_key_scan_raw(
+                    SHARED_DELETION_HISTORY_TABLE,
+                    &[
+                        Value::U8(0),
+                        Value::Uuid(uuid::Uuid::nil()),
+                        Value::U64(table_id.0),
+                        Value::Uuid(shared_row.0),
+                    ],
+                )
+                .unwrap()
+                .len(),
+            1,
+            "table/row prefix must not see the other table's deletion",
+        );
+    }
+    for table in ["todos", "notes"] {
+        let shape = Query::from(table).validate(&schema).unwrap();
+        assert!(core
+            .query_rows(
+                &shape,
+                &shape.bind(BTreeMap::new()).unwrap(),
+                DurabilityTier::Local,
+            )
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            core.query_table_versions(table)
+                .unwrap()
+                .into_iter()
+                .filter(|version| version.layer() == VersionLayer::Deletion)
+                .count(),
+            1
+        );
+    }
+
+    assert_eq!(
+        core.query_versions_for_tx(deletion_tx)
+            .unwrap()
+            .into_iter()
+            .filter(|version| version.layer() == VersionLayer::Deletion)
+            .count(),
+        2,
+        "a transaction-wide shared-index scan must decode each physical table independently",
+    );
+    drop(core);
+    let mut reopened = reopen_node_at(&dir, node(0x2c), schema);
+    assert_eq!(
+        reopened
+            .query_versions_for_tx(deletion_tx)
+            .unwrap()
+            .into_iter()
+            .filter(|version| version.layer() == VersionLayer::Deletion)
+            .count(),
+        2,
+        "recovery must preserve the transaction-wide physical-table routing",
     );
 }
 

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -1358,6 +1358,22 @@ fn physical_deletion_register_spans_renamed_schemas_and_reopens() {
             .count(),
         2
     );
+    // Recovery must include the shared deletion history in HLC reconstruction:
+    // a post-reopen deletion is a new version, not a stale-key collision.
+    reopened
+        .commit_mergeable(
+            MergeableCommit::new("tasks", row_uuid, 13).deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    assert_eq!(
+        reopened
+            .query_table_versions("tasks")
+            .unwrap()
+            .into_iter()
+            .filter(|version| version.layer() == VersionLayer::Deletion)
+            .count(),
+        3
+    );
 }
 
 #[test]

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -199,6 +199,7 @@ impl JazzSchema {
             merge_heads_table(),
         ];
         tables.push(global_changes_table());
+        tables.push(shared_deletion_history_table());
         tables
     }
 
@@ -915,6 +916,52 @@ fn global_changes_table() -> GrooveTableSchema {
     ))
 }
 
+/// Immutable sparse deletion/restore history for every physical table lineage.
+///
+/// This is intentionally a fixed system table rather than a schema-variant
+/// table: deletion payload has no user cells. `branch_kind` distinguishes root
+/// from a branch whose UUID happens to equal the root sentinel; callers must
+/// therefore always provide both fields when seeking the table.
+fn shared_deletion_history_table() -> GrooveTableSchema {
+    GrooveTableSchema::new(
+        "jazz_deletion_history",
+        [
+            column("branch_kind", GrooveColumnType::U8),
+            column("branch_id", GrooveColumnType::Uuid),
+            column("physical_table_id", GrooveColumnType::U64),
+            column("row_uuid", GrooveColumnType::Uuid),
+            column("tx_time", GrooveColumnType::U64),
+            column("tx_node_id", GrooveColumnType::U64),
+            column("schema_version", GrooveColumnType::U64),
+            column("parents", tx_id_column().array_of()),
+            column("created_by", GrooveColumnType::Uuid),
+            column("created_at", GrooveColumnType::U64),
+            column("updated_by", GrooveColumnType::Uuid),
+            column("updated_at", GrooveColumnType::U64),
+            column("_deletion", deletion_column()),
+        ],
+    )
+    .with_primary_key(PrimaryKey::composite([
+        PrimaryKeyColumn::integer("branch_kind", IntegerKeyType::U8),
+        PrimaryKeyColumn::uuid("branch_id"),
+        PrimaryKeyColumn::integer("physical_table_id", IntegerKeyType::U64),
+        PrimaryKeyColumn::uuid("row_uuid"),
+        PrimaryKeyColumn::integer("tx_time", IntegerKeyType::U64),
+        PrimaryKeyColumn::integer("tx_node_id", IntegerKeyType::U64),
+    ]))
+    .with_index(GrooveIndexSchema::new(
+        "by_tx",
+        [
+            "tx_time",
+            "tx_node_id",
+            "branch_kind",
+            "branch_id",
+            "physical_table_id",
+            "row_uuid",
+        ],
+    ))
+}
+
 fn merge_heads_table() -> GrooveTableSchema {
     GrooveTableSchema::new(
         MERGE_HEADS_TABLE,
@@ -1377,6 +1424,50 @@ mod tests {
         );
     }
 
+    // This is intentionally an internal schema test: physical-key boundedness
+    // is not observable through the public API until deletion ingestion routes
+    // through the shared table. It guards the storage contract that makes the
+    // later black-box collision and branch-isolation tests meaningful.
+    #[test]
+    fn shared_deletion_history_is_prefix_bounded_by_lineage_table_and_row() {
+        let table = shared_deletion_history_table();
+        assert_eq!(table.name, "jazz_deletion_history");
+        assert_eq!(
+            table
+                .primary_key
+                .as_ref()
+                .expect("shared deletion history has a primary key")
+                .columns
+                .iter()
+                .map(|column| column.column.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "branch_kind",
+                "branch_id",
+                "physical_table_id",
+                "row_uuid",
+                "tx_time",
+                "tx_node_id",
+            ]
+        );
+        assert_eq!(
+            table
+                .indices
+                .iter()
+                .find(|index| index.name == "by_tx")
+                .expect("shared deletion history has tx lookup")
+                .columns,
+            vec![
+                "tx_time",
+                "tx_node_id",
+                "branch_kind",
+                "branch_id",
+                "physical_table_id",
+                "row_uuid",
+            ]
+        );
+    }
+
     #[test]
     fn storage_lowering_declares_system_columns_by_shape() {
         let schema = JazzSchema::new([TableSchema::new(
@@ -1393,6 +1484,11 @@ mod tests {
                 .iter()
                 .all(|table| table.name != "jazz_todos_history"
                     && table.name != "jazz_todos_register")
+        );
+        assert!(
+            tables
+                .iter()
+                .any(|table| table.name == "jazz_deletion_history")
         );
         let history = schema.tables[0].history_storage_table();
         let register = schema.tables[0].register_storage_table();

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -922,7 +922,7 @@ fn global_changes_table() -> GrooveTableSchema {
 /// table: deletion payload has no user cells. `branch_kind` distinguishes root
 /// from a branch whose UUID happens to equal the root sentinel; callers must
 /// therefore always provide both fields when seeking the table.
-fn shared_deletion_history_table() -> GrooveTableSchema {
+pub(crate) fn shared_deletion_history_table() -> GrooveTableSchema {
     GrooveTableSchema::new(
         "jazz_deletion_history",
         [


### PR DESCRIPTION
🤖 Draft intent: land the storage simplification for deletion history and current rows before the new-core alpha release.

## What changed

- Stores deletion/register history in one schema-independent relation keyed by branch lineage, stable physical table ID, row ID, and transaction identity.
- Replaces per-layer current-row composition with a derived combined current row carrying the independently selected content winner, deletion winner/event, visibility, and projected content cells.
- Routes root and branch deletion history, catalogue rename/reopen, recovery, and clock reconstruction through the shared representation.
- Preserves logical-table identities on sync while keeping the shared physical layout node-local.

## Why

Content and deletion are independent histories, but the previous physical layout duplicated deletion-register storage across lineages and required separate current-content/current-register tables plus an anti-join. This branch makes the storage model match the simpler semantic model: immutable content history + one shared deletion register, producing one derived current row.

This is intentionally a draft while independent adversarial review and launch-topology verification continue. It is one of the two planned architectural changes before the next v2 alpha; correctness findings will be fixed on this branch before it is marked ready.

## Validation

- Focused deletion, combined-current, global, recovery, catalogue rename/reopen, physical-table collision, branch, time-travel, history, restore-witness, and replay tests pass.
- Full FD-capped Jazz library gate: 1,303 passed, 3 ignored, 0 failed.
- Jazz library clippy with warnings denied passed.
- Rust formatting and `git diff --check` passed.
- The full gate caught and fixed a legacy three-part in-batch deletion-history lookup; the final implementation uses the full lineage/table/row/transaction key.

## Review focus

- branch-lineage isolation and physical-table identity across compatible schema renames;
- current-row equivalence before and after restart/rebuild;
- deletion/restore winner selection under concurrent content writes;
- sync remaining logical-table-addressed despite the shared local representation;
- no visibility regression in subscriptions, pagination, time travel, or policy evaluation.
