### PR TITLE
fix(query): enforce canonical default row ordering

### DIFF
--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -6,9 +6,13 @@ const app = s.defineApp({
   users: s.table({
     name: s.string(),
   }),
+  projects: s.table({
+    name: s.string(),
+  }),
   todos: s.table({
     title: s.string(),
     done: s.boolean(),
+    projectId: s.ref("projects"),
     ownerId: s.ref("users").optional(),
   }),
   events: s.table({
@@ -155,5 +159,19 @@ describe("translateQuery", () => {
     // the public relation field directly.
     expect(translated.array_subqueries).toMatchObject([{ column_name: "owner" }]);
     expect(translated.array_subqueries[0]).not.toHaveProperty("public_name");
+  });
+
+  it("leaves required-include pagination at the core query boundary", () => {
+    const translated = JSON.parse(
+      translateQuery(
+        app.todos.include({ project: true }).requireIncludes().offset(2).limit(1)._build(),
+        app.wasmSchema,
+      ),
+    );
+
+    expect(translated).toMatchObject({ limit: 1, offset: 2 });
+    expect(translated.array_subqueries).toMatchObject([{ requirement: "AtLeastOne" }]);
+    expect(translated).not.toHaveProperty("__jazz_client_limit");
+    expect(translated).not.toHaveProperty("__jazz_client_offset");
   });
 });

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -205,19 +205,6 @@ function visibleSelectColumns(resolvedSelect: readonly string[]): string[] | nul
   return resolvedSelect.length > 0 ? [...resolvedSelect] : null;
 }
 
-function hasRequiredArraySubquery(subqueries: readonly object[]): boolean {
-  return subqueries.some((subquery) => {
-    const record = subquery as { requirement?: unknown; nested_arrays?: unknown };
-    if (
-      record.requirement === "AtLeastOne" ||
-      record.requirement === "MatchCorrelationCardinality"
-    ) {
-      return true;
-    }
-    return Array.isArray(record.nested_arrays) && hasRequiredArraySubquery(record.nested_arrays);
-  });
-}
-
 function validateIncludeBuilderSpec(
   relation: Relation,
   spec: NormalizedIncludeEntry,
@@ -935,12 +922,6 @@ export function translateQuery(builderJson: string, schema: WasmSchema): string 
   }
 
   const orderBy = toRuntimeOrderBy(builder.orderBy, schema, builder.table);
-  const clientPagesAfterRequiredIncludes =
-    arraySubqueries.length > 0 &&
-    hasRequiredArraySubquery(arraySubqueries) &&
-    typeof builder.limit === "number" &&
-    typeof builder.offset === "number" &&
-    builder.offset > 0;
   const clientLimit = typeof builder.limit === "number" ? builder.limit : undefined;
   const clientOffset = typeof builder.offset === "number" ? builder.offset : undefined;
   const query = {
@@ -950,17 +931,8 @@ export function translateQuery(builderJson: string, schema: WasmSchema): string 
     ...(builder.includeDeleted ? { include_deleted: true } : {}),
     ...(projectedColumns ? { select_columns: projectedColumns } : {}),
     ...(orderBy.length > 0 ? { order_by: orderBy } : {}),
-    ...(clientPagesAfterRequiredIncludes
-      ? {
-          limit: clientLimit! + clientOffset!,
-          offset: 0,
-          __jazz_client_limit: clientLimit,
-          __jazz_client_offset: clientOffset,
-        }
-      : {
-          ...(clientLimit !== undefined ? { limit: clientLimit } : {}),
-          ...(clientOffset !== undefined ? { offset: clientOffset } : {}),
-        }),
+    ...(clientLimit !== undefined ? { limit: clientLimit } : {}),
+    ...(clientOffset !== undefined ? { offset: clientOffset } : {}),
   };
 
   return JSON.stringify(query);

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
@@ -311,6 +311,26 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
 
         expect(latestIds(snapshots)).toEqual(expectedById);
+
+        await db.delete(todos, expectedById[1]!);
+        await waitForCondition(
+          () => latestRows(snapshots).length === 2,
+          10_000,
+          "expected default-order deletion",
+        );
+        expect(latestIds(snapshots)).toEqual([expectedById[0]!, expectedById[2]!]);
+
+        const {
+          value: { id: insertedId },
+        } = await db.insert(todos, { title: "Inserted", rank: 0, done: false });
+        await waitForCondition(
+          () => latestRows(snapshots).some((row) => row.id === insertedId),
+          10_000,
+          "expected default-order insertion",
+        );
+        expect(latestIds(snapshots)).toEqual(
+          [expectedById[0]!, expectedById[2]!, insertedId].toSorted((a, b) => a.localeCompare(b)),
+        );
       } finally {
         unsubscribe();
       }
@@ -666,6 +686,36 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       expect(latestIds(snapshots)).toEqual([idB, idC, idA]);
+    } finally {
+      unsubscribe();
+      await db2.shutdown();
+    }
+  });
+
+  it("restores canonical id order across restart when orderBy is omitted", async () => {
+    const appId = uniqueDbName("default-restart");
+    const dbName = uniqueDbName("default-restart");
+
+    const db1 = await createDb({ appId, driver: { type: "persistent", dbName } });
+    const ids = [] as string[];
+    ids.push((await db1.insert(todos, { title: "First", rank: 3, done: false })).value.id);
+    ids.push((await db1.insert(todos, { title: "Second", rank: 1, done: false })).value.id);
+    ids.push((await db1.insert(todos, { title: "Third", rank: 2, done: false })).value.id);
+    await db1.shutdown();
+
+    const db2 = await createDb({ appId, driver: { type: "persistent", dbName } });
+    const snapshots: Todo[][] = [];
+    const unsubscribe = db2.subscribeAll(makeTodosQuery({}), (delta) => {
+      snapshots.push(delta.all);
+    });
+
+    try {
+      await waitForCondition(
+        () => latestRows(snapshots).length === 3,
+        10_000,
+        "expected default-ordered snapshot after restart",
+      );
+      expect(latestIds(snapshots)).toEqual(ids.toSorted((a, b) => a.localeCompare(b)));
     } finally {
       unsubscribe();
       await db2.shutdown();

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -19,6 +19,12 @@ function makeFriends(db: Db, user1: User, user2: User) {
 const readModes = ["direct", "mergeable-tx", "exclusive-tx"] as const;
 type ReadMode = (typeof readModes)[number];
 
+const orderedIds = {
+  low: "00000000-0000-4000-8000-000000000101",
+  middle: "00000000-0000-4000-8000-000000000102",
+  high: "00000000-0000-4000-8000-000000000103",
+} as const;
+
 describe.each(readModes)("TS Query API (%s reads)", (readMode: ReadMode) => {
   let db: Db;
 
@@ -58,6 +64,92 @@ describe.each(readModes)("TS Query API (%s reads)", (readMode: ReadMode) => {
       tx.rollback();
     }
   }
+
+  describe("default ordering", () => {
+    it("orders one-shot roots and pagination by canonical row id, not insertion order", async () => {
+      db.upsert(app.projects, { name: "High" }, { id: orderedIds.high });
+      db.upsert(app.projects, { name: "Low" }, { id: orderedIds.low });
+      db.upsert(app.projects, { name: "Middle" }, { id: orderedIds.middle });
+
+      const all = await readAll(app.projects);
+      expect(all.map((project) => project.id)).toEqual([
+        orderedIds.low,
+        orderedIds.middle,
+        orderedIds.high,
+      ]);
+
+      const window = await readAll(app.projects.offset(1).limit(1));
+      expect(window.map((project) => project.id)).toEqual([orderedIds.middle]);
+    });
+
+    it("uses canonical row id as the implicit tie-break for explicit ordering", async () => {
+      db.upsert(app.projects, { name: "Same" }, { id: orderedIds.high });
+      db.upsert(app.projects, { name: "Same" }, { id: orderedIds.low });
+      db.upsert(app.projects, { name: "Same" }, { id: orderedIds.middle });
+
+      const results = await readAll(app.projects.orderBy("name", "asc"));
+      expect(results.map((project) => project.id)).toEqual([
+        orderedIds.low,
+        orderedIds.middle,
+        orderedIds.high,
+      ]);
+    });
+
+    it("orders forward-array and reverse-relation payloads by child row id", async () => {
+      db.upsert(app.users, { name: "High", friendsIds: [] }, { id: orderedIds.high });
+      db.upsert(app.users, { name: "Low", friendsIds: [] }, { id: orderedIds.low });
+      db.upsert(app.users, { name: "Middle", friendsIds: [] }, { id: orderedIds.middle });
+      const project = insertProject(db, "Relations");
+      const todoIds = {
+        low: "00000000-0000-4000-8000-000000000201",
+        high: "00000000-0000-4000-8000-000000000203",
+      } as const;
+      db.upsert(
+        app.todos,
+        {
+          title: "High",
+          done: false,
+          tags: [],
+          projectId: project.id,
+          ownerId: null,
+          assigneesIds: [orderedIds.high, orderedIds.low, orderedIds.middle],
+        },
+        { id: todoIds.high },
+      );
+      db.upsert(
+        app.todos,
+        {
+          title: "Low",
+          done: false,
+          tags: [],
+          projectId: project.id,
+          ownerId: null,
+          assigneesIds: [],
+        },
+        { id: todoIds.low },
+      );
+
+      const todo = await readOne(
+        app.todos
+          .where({ id: { eq: todoIds.high } })
+          .include({ assignees: app.users.select("id") }),
+      );
+      assert(todo, "Todo is not defined");
+      expect(todo.assignees.map((user) => user.id)).toEqual([
+        orderedIds.low,
+        orderedIds.middle,
+        orderedIds.high,
+      ]);
+
+      const parent = await readOne(
+        app.projects
+          .where({ id: { eq: project.id } })
+          .include({ todosViaProject: app.todos.select("id") }),
+      );
+      assert(parent, "Project is not defined");
+      expect(parent.todosViaProject.map((child) => child.id)).toEqual([todoIds.low, todoIds.high]);
+    });
+  });
 
   describe("filtering", () => {
     it("queries by id", async () => {
@@ -134,11 +226,7 @@ describe.each(readModes)("TS Query API (%s reads)", (readMode: ReadMode) => {
       expect(resultsEqNull.map((todo) => todo.id)).toEqual([todoWithoutOwner.id]);
     });
 
-    // Order-sensitive assertion over unordered default results; default
-    // ordering (ascending id) is specced in crates/jazz/SPEC/6_queries.md
-    // (2026-07-18) with implementation scheduled — unskip and assert ordered
-    // equality once it lands.
-    it.skip("filters with explicit undefined values are no-ops", async () => {
+    it("filters with explicit undefined values are no-ops", async () => {
       const todoWithoutOwner = insertTodo(db, {
         title: "Todo without owner",
         ownerId: null,
@@ -149,7 +237,9 @@ describe.each(readModes)("TS Query API (%s reads)", (readMode: ReadMode) => {
       });
 
       const results = await readAll(app.todos.where({ ownerId: undefined }));
-      expect(results.map((todo) => todo.id)).toEqual([todoWithoutOwner.id, todoWithOwner.id]);
+      expect(results.map((todo) => todo.id)).toEqual(
+        [todoWithoutOwner.id, todoWithOwner.id].sort(),
+      );
     });
 
     describe("in operator", () => {
@@ -734,11 +824,7 @@ describe.each(readModes)("TS Query API (%s reads)", (readMode: ReadMode) => {
         expect(aliceFriend.friends.map((f) => f.id)).toEqual([alice.id]);
       });
 
-      // Order-sensitive over unordered default results (deterministically red since
-      // the policy-union lowering fix changed evaluation order); default ordering
-      // (ascending id) is specced in crates/jazz/SPEC/6_queries.md — unskip with
-      // ordered assertions when the implementation lands.
-      it.skip("rows skipped by requireIncludes affect limit-offset pagination", async () => {
+      it("rows skipped by requireIncludes affect limit-offset pagination", async () => {
         const alice = insertUser(db);
         const bob = insertUser(db);
         const deletedUser = insertUser(db);
@@ -749,7 +835,7 @@ describe.each(readModes)("TS Query API (%s reads)", (readMode: ReadMode) => {
         const results = await readAll(
           app.users.include({ friends: true }).requireIncludes().limit(1).offset(1),
         );
-        expect(results.map((u) => u.id)).toEqual([bob.id]);
+        expect(results.map((u) => u.id)).toEqual([[alice.id, bob.id, deletedUser.id].sort()[1]]);
 
         await db.delete(app.users, deletedUser.id);
 


### PR DESCRIPTION
🤖 Makes the documented default query-order contract executable across the public TypeScript, browser, and native-core boundaries.

## Contract

Without an explicit ordering clause, query results are ordered by canonical `RowUuid` ascending. Explicit ordering uses ascending row ID as the deterministic tie-break. The same ordering applies to one-shot reads, maintained subscriptions, pagination, relation materialization, resets, and reloads.

## What changed

- Unskips the two stale TS DSL ordering/pagination tests.
- Adds deterministic caller-supplied UUID fixtures covering direct, mergeable, and exclusive reads.
- Covers maintained insert/delete/update behavior and browser persistence/reload.
- Covers root pagination, required-includes pagination, forward arrays, reverse relations, and explicit-order ties.
- Removes a dead TypeScript `limit + offset` rewrite whose `__jazz_client_*` metadata had no consumer; native core now owns required-include filtering and pagination consistently.

## Why

The specification already guarantees canonical row-ID ordering, but skipped public tests allowed the TypeScript adapter to drift. Unskipping them exposed real overfetch/incorrect pagination when `requireIncludes` and `offset` were combined.

## Validation

- Query adapter + full query API: 160 passed.
- Browser maintained-order suite: 18 passed.
- Focused Rust default-order, bounded-child, maintained-hydration, and required-include pagination tests passed.
- Fresh release NAPI and fast WASM test artifacts built and verified.
- Reversed-order and offset off-by-one plants failed the intended tests and were restored.
- Independent review found no P0–P2 issues.
