### PR TITLE
feat(content): add persistent text manifests

### DIFF
--- a/crates/jazz/SPEC/12_text_content_adapter.md
+++ b/crates/jazz/SPEC/12_text_content_adapter.md
@@ -1,0 +1,139 @@
+# 12. Text content adapter
+
+## 12.1 Scope and foundation boundary
+
+This chapter specifies only the text adapter for the ordinary content-manifest
+foundation. The foundation owns the atomic-column contract, materializer
+registration, merge-strategy dispatch, and interior-query/index integration.
+This adapter supplies typed text roots, validates and materializes its own
+bounded tail, and produces the adapter value consumed by those foundation
+hooks. It MUST NOT introduce a text-specific mutable head or version table.
+
+An application column declared as `content.text()` holds one atomic manifest:
+
+```text
+TextManifest {
+  root: TextRootId
+  editTail: TextEdit[]
+}
+```
+
+The column's schema establishes that the manifest is text; the stored value
+does not repeat a runtime type tag. A version of the owning application row
+therefore names one exact text snapshot. Copying the manifest preserves that
+snapshot; following an application-row reference follows later row versions.
+
+`TextRootId` is distinct from arbitrary row IDs at the public TypeScript
+boundary. It identifies an immutable rope node/root row accepted by this
+adapter; it does not grant authority to read that row.
+
+## 12.2 Immutable rope rows
+
+The adapter stores a UTF-8 rope in immutable ordinary rows. A leaf contains
+bounded UTF-8 text and its Unicode scalar (code-point) length. A branch
+contains its ordered child IDs, the children’s subtree scalar lengths, and the
+height needed to validate balancing. The root is a complete snapshot: readers
+MUST NOT replay older manifests or Jazz row history to reconstruct it.
+
+Leaf and branch IDs are content-derived from a domain-scoped canonical encoding
+that includes the format version, node kind, all semantic metadata, and the
+full leaf bytes or child identity/length tuple. The domain/encryption scope is
+part of that encoding, so equal plaintext in different authority domains does
+not reveal equality through a shared ID. An immutable-row insert is
+idempotent only when an existing same-ID row has identical canonical contents;
+a differing row is a corruption/error, never an overwrite.
+
+## 12.3 Edit tail and Unicode contract
+
+The tail is a bounded, ordered list of insertion intents:
+
+```text
+TextEdit { atCodePoint: u64, textUtf8: string }
+```
+
+Each `atCodePoint` is evaluated against the text after all earlier tail edits.
+An edit MUST use an integer scalar offset in `0..=currentScalarLength`; adapters
+MUST reject invalid offsets before authoring a transaction. Splitting a UTF-8
+code unit or Unicode scalar is impossible because both validation and rope
+navigation use scalar offsets, not JavaScript UTF-16 indices or byte offsets.
+
+The persisted text format has hard limits of at most 64 edits and 16 KiB of
+canonical UTF-8 tail encoding. Every reader validates encoded byte length
+before parsing, validates count before materialization, and rejects malformed
+or semantically invalid entries. Local writer limits may be lower but never
+higher. An accepted writer may return an empty/no-op edit without rewriting
+the owning column.
+
+## 12.4 Materialization, merges, and interior access
+
+`materialize(TextManifest)` loads exactly the addressed rope snapshot, applies
+the ordered bounded tail, validates the resulting scalar length, and returns a
+text value plus enough stable provenance for the foundation to invoke text
+merge strategies and interior-query/index adapters. Missing, malformed, or
+out-of-domain nodes fail closed; there is no history fallback.
+
+Foundation merge strategies and query/index providers receive the materialized
+text value (or a requested text range when their declared operation permits a
+range). They MUST NOT compare only `root` and MUST NOT ignore `editTail`.
+Consequently a `contains`, equality, order, or text-specific index operation
+observes the same logical text as an ordinary application read.
+
+The initial implementation need only expose whole-value materialization and
+explicit range reads. Interior index pushdown may progressively use rope
+subtree lengths, but every optimized result MUST equal materializing the same
+manifest and applying its tail first.
+
+## 12.5 Writes and promotion
+
+A small insertion changes only the owning application row's atomic manifest:
+
+```text
+{ root: R7, editTail: [e1] }
+  -> { root: R7, editTail: [e1, e2] }
+```
+
+When appending the proposed edit would exceed either writer bound, the adapter
+synchronously materializes the current manifest, path-copies the affected rope
+path (or builds a smaller complete balanced tree if scattered edits make that
+cheaper), inserts only the reachable new immutable rows, and writes:
+
+```text
+{ root: R8, editTail: [] }
+```
+
+The immutable rows and owning-row manifest update belong to one ordinary Jazz
+transaction. A denied owning-row update rolls back every newly inserted
+immutable row. Untouched subtrees are reused by ID. A direct historical read
+of a manifest continues to use its original root plus original tail after a
+later promotion.
+
+## 12.6 Required black-box evidence
+
+- public `content.text()` schema declaration stores and reads a manifest as one
+  atomic content column, with no adapter-created head/version row;
+- inserting before, inside, and after non-ASCII scalars (including astral
+  scalars and combining sequences) never splits a scalar and reports scalar,
+  not UTF-16, offsets;
+- a tail-only edit changes the owning row manifest while reusing its root;
+- count and canonical-byte threshold crossings promote synchronously, clear
+  the tail, and retain unchanged subtree IDs where a localized path is cheaper;
+- a copied historical manifest reads exactly its old text after later edits and
+  promotions; deleting its root makes that read fail rather than replaying
+  history;
+- malformed/oversized replicated tails and inconsistent rope metadata fail
+  before observable content, and cannot poison an unrelated row update;
+- a permission denial rolls back new immutable rows and the owner manifest as
+  one transaction;
+- identical immutable canonical rows are idempotently accepted, while a
+  deliberately same-ID/different-content insert fails closed;
+- equality/contains/range access and any enabled text index observe root plus
+  tail, including an unpromoted edit; and
+- a competing update is passed to the registered materializing merge strategy
+  with both full logical values, never two unexamined manifest records.
+
+## 12.7 Open implementation dependencies
+
+The foundation PR must settle the exact public interfaces for atomic content
+columns, manifest codecs, content-row insertion, merge-provider inputs, and
+interior-query/index providers. The text PR will bind this contract to those
+interfaces after it is stacked. It must not recreate those mechanisms locally.

--- a/crates/jazz/SPEC/12_text_content_adapter.md
+++ b/crates/jazz/SPEC/12_text_content_adapter.md
@@ -29,11 +29,14 @@ adapter; it does not grant authority to read that row.
 
 ## 12.2 Immutable rope rows
 
-The adapter stores a UTF-8 rope in immutable ordinary rows. A leaf contains
-bounded UTF-8 text and its Unicode scalar (code-point) length. A branch
+The adapter stores a UTF-8 rope in immutable ordinary rows. A leaf contains at
+most 4 KiB of UTF-8 text and its Unicode scalar (code-point) length. A branch
 contains its ordered child IDs, the children’s subtree scalar lengths, and the
-height needed to validate balancing. The root is a complete snapshot: readers
-MUST NOT replay older manifests or Jazz row history to reconstruct it.
+height needed to validate balancing. Readers reject a root-to-leaf depth above
+64 and any branch whose child heights differ by more than one, even when every
+row has a valid content-derived ID and internally consistent metadata. The root
+is a complete snapshot: readers MUST NOT replay older manifests or Jazz row
+history to reconstruct it.
 
 Leaf and branch IDs are content-derived from a domain-scoped canonical encoding
 that includes the format version, node kind, all semantic metadata, and the

--- a/crates/jazz/src/content_manifest.rs
+++ b/crates/jazz/src/content_manifest.rs
@@ -333,14 +333,6 @@ pub trait ContentManifestAdapter: Send + Sync + 'static {
     /// Validate one already type-checked tail entry.  The concrete type comes
     /// from `ContentManifestSchema::tail_entry_type`, so adapters never need
     /// a shared byte envelope or a per-row discriminant.
-    /// Verify that replicated schema bounds are within the adapter's intrinsic
-    /// format limits. The default accepts any positive foundation-valid bounds.
-    fn validate_schema(&self, schema: &ContentManifestSchema) -> Result<(), ManifestError> {
-        if schema.adapter_kind != self.adapter_kind() {
-            return Err(ManifestError::InvalidSchema);
-        }
-        Ok(())
-    }
     fn validate_operation(&self, operation: &Value) -> Result<(), ManifestError>;
     fn materialize(
         &self,

--- a/crates/jazz/src/content_manifest.rs
+++ b/crates/jazz/src/content_manifest.rs
@@ -411,7 +411,13 @@ impl ContentManifestAdapterRegistry {
 /// races with node/query worker threads.
 pub fn global_content_manifest_adapters() -> &'static ContentManifestAdapterRegistry {
     static REGISTRY: OnceLock<ContentManifestAdapterRegistry> = OnceLock::new();
-    REGISTRY.get_or_init(ContentManifestAdapterRegistry::default)
+    REGISTRY.get_or_init(|| {
+        let registry = ContentManifestAdapterRegistry::default();
+        registry
+            .register(Arc::new(crate::text_content::TextContentAdapter::default()))
+            .expect("built-in text content adapter registers exactly once");
+        registry
+    })
 }
 
 /// Validate adapter-specific schema limits when the adapter is built in or has

--- a/crates/jazz/src/content_manifest.rs
+++ b/crates/jazz/src/content_manifest.rs
@@ -333,6 +333,14 @@ pub trait ContentManifestAdapter: Send + Sync + 'static {
     /// Validate one already type-checked tail entry.  The concrete type comes
     /// from `ContentManifestSchema::tail_entry_type`, so adapters never need
     /// a shared byte envelope or a per-row discriminant.
+    /// Verify that replicated schema bounds are within the adapter's intrinsic
+    /// format limits. The default accepts any positive foundation-valid bounds.
+    fn validate_schema(&self, schema: &ContentManifestSchema) -> Result<(), ManifestError> {
+        if schema.adapter_kind != self.adapter_kind() {
+            return Err(ManifestError::InvalidSchema);
+        }
+        Ok(())
+    }
     fn validate_operation(&self, operation: &Value) -> Result<(), ManifestError>;
     fn materialize(
         &self,

--- a/crates/jazz/src/lib.rs
+++ b/crates/jazz/src/lib.rs
@@ -103,6 +103,8 @@ pub mod authorization_scope;
 pub mod binding_codec;
 /// Atomic embedded manifests for content backed by immutable graphs.
 pub mod content_manifest;
+/// Text adapter for embedded manifests backed by immutable UTF-8 ropes.
+pub mod text_content;
 
 /// Disabled-by-default counters used by the native cold-settle attribution bench.
 #[cfg(feature = "cold-settle-attribution")]

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -931,6 +931,13 @@ where
     where
         S: ReopenableStorage,
     {
+        for table in &schema.tables {
+            for column in &table.columns {
+                if let Some(manifest) = &column.content_manifest {
+                    crate::content_manifest::validate_content_manifest_schema(manifest)?;
+                }
+            }
+        }
         let current_schema_version_id = schema.version_id();
         #[cfg(feature = "testing")]
         let started = receipt.as_ref().map(|_| Instant::now());

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -298,6 +298,18 @@ impl JazzSchema {
         assign_content_manifests(&mut schema, manifests, |column, manifest| {
             column.column_type == manifest.cell_type()
         })?;
+        for table in &schema.tables {
+            for column in &table.columns {
+                if let Some(manifest) = &column.content_manifest {
+                    crate::content_manifest::validate_content_manifest_schema(manifest).map_err(
+                        |_| SchemaWireError::InvalidManifestMetadata {
+                            table: table.name.clone(),
+                            column: column.name.clone(),
+                        },
+                    )?;
+                }
+            }
+        }
         Ok(schema)
     }
 }

--- a/crates/jazz/src/text_content.rs
+++ b/crates/jazz/src/text_content.rs
@@ -6,7 +6,10 @@
 //! mutable identity and every historical row version already retains a complete
 //! text snapshot.
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, OnceLock},
+};
 
 use crate::content_manifest::{
     ContentAddress, ContentDomainId, ContentId, ContentManifest, ContentManifestAdapter,
@@ -20,6 +23,10 @@ pub const TEXT_ADAPTER_KIND: &str = "text-v1";
 pub const TEXT_MAX_TAIL_ENTRIES: u32 = 64;
 /// Format, rather than tuning, limit: every reader applies this bound.
 pub const TEXT_MAX_TAIL_BYTES: u32 = 16 * 1024;
+/// Maximum canonical bytes in a remotely supplied immutable leaf.
+pub const TEXT_MAX_LEAF_BYTES: usize = 4096;
+/// Maximum accepted root-to-leaf depth for a remotely supplied rope.
+pub const TEXT_MAX_ROPE_DEPTH: u32 = 64;
 
 const LEAF_TAG: &[u8; 5] = b"TXT1L";
 const NODE_TAG: &[u8; 5] = b"TXT1N";
@@ -147,9 +154,19 @@ impl TextContentAdapter {
         if text.is_empty() {
             return Ok(manifest.clone());
         }
-        let current = self.materialize(manifest, &MaterializationRequest::Full, context, store)?;
-        let current = std::str::from_utf8(&current).map_err(|_| ManifestError::Malformed)?;
-        let updated = insert_at_code_point(current, at_code_point, text)?;
+        manifest.validate(&self.schema)?;
+        let root = self.load_root(manifest.root, context, store)?;
+        let mut logical_length = root.length();
+        for operation in &manifest.edit_tail {
+            let edit = decode_edit(operation)?;
+            validate_edit_offset(logical_length, &edit)?;
+            logical_length = logical_length
+                .checked_add(scalar_len(&edit.text))
+                .ok_or(ManifestError::Malformed)?;
+        }
+        if at_code_point > logical_length {
+            return Err(ManifestError::Malformed);
+        }
         let encoded = encode_edit(&TextEdit {
             at_code_point,
             text: text.to_owned(),
@@ -163,7 +180,26 @@ impl TextContentAdapter {
         if candidate.validate(&self.schema).is_ok() {
             return Ok(candidate);
         }
-        let root = self.build_root(&updated, context.domain, store)?;
+        let mut promoted = root;
+        for operation in &candidate.edit_tail {
+            let edit = decode_edit(operation)?;
+            promoted = self.insert_into_rope(
+                promoted,
+                edit.at_code_point,
+                &edit.text,
+                context.domain,
+                store,
+            )?;
+        }
+        let payload = root_payload(promoted.id(), promoted.length(), promoted.height());
+        let root = store.put_if_absent_or_identical(
+            ContentAddress {
+                domain: context.domain,
+                adapter_kind: TEXT_ADAPTER_KIND,
+                kind: ImmutableContentKind::Root,
+            },
+            payload,
+        )?;
         Ok(ContentManifest {
             root,
             edit_tail: Vec::new(),
@@ -181,7 +217,7 @@ impl TextContentAdapter {
         domain: ContentDomainId,
         store: &mut dyn ImmutableContentStore,
     ) -> Result<ContentId, ManifestError> {
-        let leaves = split_utf8(text, 4096)?
+        let leaves = split_utf8(text, TEXT_MAX_LEAF_BYTES)?
             .into_iter()
             .map(|part| self.store_leaf(&part, domain, store))
             .collect::<Result<Vec<_>, _>>()?;
@@ -256,6 +292,9 @@ impl TextContentAdapter {
             .max(right.height())
             .checked_add(1)
             .ok_or(ManifestError::Malformed)?;
+        if height > TEXT_MAX_ROPE_DEPTH {
+            return Err(ManifestError::Malformed);
+        }
         let id = store.put_if_absent_or_identical(
             ContentAddress {
                 domain,
@@ -273,6 +312,100 @@ impl TextContentAdapter {
         })
     }
 
+    fn insert_into_rope(
+        &self,
+        rope: Rope,
+        at: u64,
+        inserted: &str,
+        domain: ContentDomainId,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<Rope, ManifestError> {
+        if at > rope.length() {
+            return Err(ManifestError::Malformed);
+        }
+        match rope {
+            Rope::Leaf { text, .. } => {
+                let updated = insert_at_code_point(&text, at, inserted)?;
+                let leaves = split_utf8(&updated, TEXT_MAX_LEAF_BYTES)?
+                    .into_iter()
+                    .map(|part| self.store_leaf(part, domain, store))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.build_balanced(leaves, domain, store)
+            }
+            Rope::Branch { left, right, .. } if at <= left.length() => {
+                let left = self.insert_into_rope(*left, at, inserted, domain, store)?;
+                self.balance(left, *right, domain, store)
+            }
+            Rope::Branch { left, right, .. } => {
+                let offset = at
+                    .checked_sub(left.length())
+                    .ok_or(ManifestError::Malformed)?;
+                let right = self.insert_into_rope(*right, offset, inserted, domain, store)?;
+                self.balance(*left, right, domain, store)
+            }
+        }
+    }
+
+    fn balance(
+        &self,
+        left: Rope,
+        right: Rope,
+        domain: ContentDomainId,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<Rope, ManifestError> {
+        if left.height() > right.height().saturating_add(1) {
+            let Rope::Branch {
+                left: ll,
+                right: lr,
+                ..
+            } = left
+            else {
+                return Err(ManifestError::Malformed);
+            };
+            if ll.height() >= lr.height() {
+                let new_right = self.store_branch(*lr, right, domain, store)?;
+                return self.store_branch(*ll, new_right, domain, store);
+            }
+            let Rope::Branch {
+                left: lrl,
+                right: lrr,
+                ..
+            } = *lr
+            else {
+                return Err(ManifestError::Malformed);
+            };
+            let new_left = self.store_branch(*ll, *lrl, domain, store)?;
+            let new_right = self.store_branch(*lrr, right, domain, store)?;
+            return self.store_branch(new_left, new_right, domain, store);
+        }
+        if right.height() > left.height().saturating_add(1) {
+            let Rope::Branch {
+                left: rl,
+                right: rr,
+                ..
+            } = right
+            else {
+                return Err(ManifestError::Malformed);
+            };
+            if rr.height() >= rl.height() {
+                let new_left = self.store_branch(left, *rl, domain, store)?;
+                return self.store_branch(new_left, *rr, domain, store);
+            }
+            let Rope::Branch {
+                left: rll,
+                right: rlr,
+                ..
+            } = *rl
+            else {
+                return Err(ManifestError::Malformed);
+            };
+            let new_left = self.store_branch(left, *rll, domain, store)?;
+            let new_right = self.store_branch(*rlr, *rr, domain, store)?;
+            return self.store_branch(new_left, new_right, domain, store);
+        }
+        self.store_branch(left, right, domain, store)
+    }
+
     fn load_root(
         &self,
         root: ContentId,
@@ -281,7 +414,10 @@ impl TextContentAdapter {
     ) -> Result<Rope, ManifestError> {
         let payload = checked_get(store, context, root, ImmutableContentKind::Root)?;
         let (child, length, height) = parse_root(payload)?;
-        let tree = self.load_tree(child, context, store)?;
+        if height == 0 || height > TEXT_MAX_ROPE_DEPTH {
+            return Err(ManifestError::Malformed);
+        }
+        let tree = self.load_tree(child, 1, context, store)?;
         if tree.length() != length || tree.height() != height {
             return Err(ManifestError::Malformed);
         }
@@ -291,9 +427,13 @@ impl TextContentAdapter {
     fn load_tree(
         &self,
         id: ContentId,
+        depth: u32,
         context: ContentReadContext,
         store: &dyn ImmutableContentStore,
     ) -> Result<Rope, ManifestError> {
+        if depth == 0 || depth > TEXT_MAX_ROPE_DEPTH {
+            return Err(ManifestError::Malformed);
+        }
         let bytes = store.get(context, id).ok_or(ManifestError::Malformed)?;
         if bytes.starts_with(LEAF_TAG) {
             let payload = checked_get(store, context, id, ImmutableContentKind::Leaf)?;
@@ -302,13 +442,18 @@ impl TextContentAdapter {
         }
         let payload = checked_get(store, context, id, ImmutableContentKind::Node)?;
         let (left_id, right_id, length, height) = parse_branch(payload)?;
-        let left = self.load_tree(left_id, context, store)?;
-        let right = self.load_tree(right_id, context, store)?;
+        if height <= 1 || height > TEXT_MAX_ROPE_DEPTH {
+            return Err(ManifestError::Malformed);
+        }
+        let next_depth = depth.checked_add(1).ok_or(ManifestError::Malformed)?;
+        let left = self.load_tree(left_id, next_depth, context, store)?;
+        let right = self.load_tree(right_id, next_depth, context, store)?;
         if length
             != left
                 .length()
                 .checked_add(right.length())
                 .ok_or(ManifestError::Malformed)?
+            || left.height().abs_diff(right.height()) > 1
             || height
                 != left
                     .height()
@@ -336,6 +481,17 @@ impl TextContentAdapter {
         }
         Ok(text)
     }
+}
+
+/// Register the production `text-v1` adapter through the process-wide
+/// foundation registry. Registration is append-only and idempotent.
+pub fn register_text_content_adapter() -> Result<Arc<TextContentAdapter>, ManifestError> {
+    static ADAPTER: OnceLock<Arc<TextContentAdapter>> = OnceLock::new();
+    let adapter = ADAPTER
+        .get_or_init(|| Arc::new(TextContentAdapter::default()))
+        .clone();
+    crate::content_manifest::global_content_manifest_adapters().register(adapter.clone())?;
+    Ok(adapter)
 }
 
 impl Default for TextContentAdapter {
@@ -484,6 +640,13 @@ fn insert_at_code_point(base: &str, at: u64, inserted: &str) -> Result<String, M
     Ok(output)
 }
 
+fn validate_edit_offset(current_length: u64, edit: &TextEdit) -> Result<(), ManifestError> {
+    if edit.at_code_point > current_length {
+        return Err(ManifestError::Malformed);
+    }
+    Ok(())
+}
+
 fn range_at_code_points(text: &str, offset: u64, length: u64) -> Result<String, ManifestError> {
     let total = scalar_len(text);
     let end = offset.checked_add(length).ok_or(ManifestError::Malformed)?;
@@ -556,7 +719,7 @@ fn parse_leaf(bytes: &[u8]) -> Result<(String, u64), ManifestError> {
             .try_into()
             .map_err(|_| ManifestError::Malformed)?,
     ) as usize;
-    if bytes.len() != 17 + byte_len {
+    if byte_len > TEXT_MAX_LEAF_BYTES || bytes.len() != 17 + byte_len {
         return Err(ManifestError::Malformed);
     }
     let text = std::str::from_utf8(&bytes[17..])
@@ -637,7 +800,39 @@ mod tests {
     // adapter/store seam, not a public client-level adapter registry. They are
     // black-box tests of that public seam and use no rope internals.
     use super::*;
-    use crate::content_manifest::MemoryImmutableContentStore;
+    use crate::content_manifest::{
+        ContentManifestRuntime, ContentManifestRuntimeProvider, MemoryImmutableContentStore,
+        global_content_manifest_adapters,
+    };
+    use crate::{
+        ids::NodeUuid,
+        node::NodeState,
+        schema::{ColumnSchema, JazzSchema, TableSchema},
+    };
+    use groove::{records::Value, schema::ColumnType, storage::MemoryStorage};
+    use std::collections::BTreeSet;
+
+    #[derive(Default)]
+    struct CountingStore {
+        inner: MemoryImmutableContentStore,
+        puts: usize,
+        ids: BTreeSet<ContentId>,
+    }
+    impl ImmutableContentStore for CountingStore {
+        fn get(&self, context: ContentReadContext, id: ContentId) -> Option<&[u8]> {
+            self.inner.get(context, id)
+        }
+        fn put_if_absent_or_identical(
+            &mut self,
+            address: ContentAddress<'_>,
+            bytes: Vec<u8>,
+        ) -> Result<ContentId, ManifestError> {
+            self.puts += 1;
+            let id = self.inner.put_if_absent_or_identical(address, bytes)?;
+            self.ids.insert(id);
+            Ok(id)
+        }
+    }
 
     fn context() -> ContentReadContext {
         ContentReadContext {
@@ -781,6 +976,243 @@ mod tests {
             adapter
                 .merge(&[promoted, stale], context(), &store)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn promotion_path_copies_only_the_edited_path_and_reuses_untouched_subtrees() {
+        let adapter = TextContentAdapter::new(64, 1).unwrap();
+        let mut store = CountingStore::default();
+        let initial = format!("{}{}tail", "a".repeat(4096), "b".repeat(4096));
+        let base = adapter.create(&initial, context(), &mut store).unwrap();
+        let old = adapter.load_root(base.root, context(), &store).unwrap();
+        let old_left = match old {
+            Rope::Branch { left, .. } => left.id(),
+            Rope::Leaf { .. } => panic!("fixture must have multiple leaves"),
+        };
+        store.puts = 0;
+        store.ids.clear();
+
+        let promoted = adapter
+            .insert(&base, scalar_len(&initial), "!", context(), &mut store)
+            .unwrap();
+        assert!(promoted.edit_tail.is_empty());
+        assert_eq!(
+            text(&adapter, &promoted, &store.inner),
+            format!("{initial}!")
+        );
+        let new = adapter.load_root(promoted.root, context(), &store).unwrap();
+        let new_left = match new {
+            Rope::Branch { left, .. } => left.id(),
+            Rope::Leaf { .. } => panic!("fixture must remain multi-leaf"),
+        };
+        assert_eq!(new_left, old_left, "untouched left subtree must be reused");
+        assert_eq!(store.puts, 3, "one leaf, one path node, and one root");
+        assert_eq!(store.ids.len(), 3);
+    }
+
+    fn store_raw(
+        store: &mut MemoryImmutableContentStore,
+        kind: ImmutableContentKind,
+        payload: Vec<u8>,
+    ) -> ContentId {
+        store
+            .put_if_absent_or_identical(
+                ContentAddress {
+                    domain: context().domain,
+                    adapter_kind: TEXT_ADAPTER_KIND,
+                    kind,
+                },
+                payload,
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn content_valid_oversize_skewed_and_deep_remote_ropes_fail_closed() {
+        let adapter = TextContentAdapter::default();
+
+        let mut oversized_store = MemoryImmutableContentStore::default();
+        let oversized_text = "x".repeat(TEXT_MAX_LEAF_BYTES + 1);
+        let leaf = store_raw(
+            &mut oversized_store,
+            ImmutableContentKind::Leaf,
+            leaf_payload(&oversized_text, scalar_len(&oversized_text)),
+        );
+        let root = store_raw(
+            &mut oversized_store,
+            ImmutableContentKind::Root,
+            root_payload(leaf, scalar_len(&oversized_text), 1),
+        );
+        assert!(
+            adapter
+                .materialize(
+                    &ContentManifest {
+                        root,
+                        edit_tail: vec![]
+                    },
+                    &MaterializationRequest::Full,
+                    context(),
+                    &oversized_store
+                )
+                .is_err()
+        );
+
+        let mut skewed_store = MemoryImmutableContentStore::default();
+        let leaf = store_raw(
+            &mut skewed_store,
+            ImmutableContentKind::Leaf,
+            leaf_payload("x", 1),
+        );
+        let pair = store_raw(
+            &mut skewed_store,
+            ImmutableContentKind::Node,
+            branch_payload(leaf, leaf, 2, 2),
+        );
+        let balanced = store_raw(
+            &mut skewed_store,
+            ImmutableContentKind::Node,
+            branch_payload(pair, leaf, 3, 3),
+        );
+        let skewed = store_raw(
+            &mut skewed_store,
+            ImmutableContentKind::Node,
+            branch_payload(balanced, leaf, 4, 4),
+        );
+        let root = store_raw(
+            &mut skewed_store,
+            ImmutableContentKind::Root,
+            root_payload(skewed, 4, 4),
+        );
+        assert!(
+            adapter
+                .materialize(
+                    &ContentManifest {
+                        root,
+                        edit_tail: vec![]
+                    },
+                    &MaterializationRequest::Full,
+                    context(),
+                    &skewed_store
+                )
+                .is_err()
+        );
+
+        let mut deep_store = MemoryImmutableContentStore::default();
+        let leaf = store_raw(
+            &mut deep_store,
+            ImmutableContentKind::Leaf,
+            leaf_payload("x", 1),
+        );
+        let mut child = leaf;
+        let mut length = 1;
+        for height in 2..=TEXT_MAX_ROPE_DEPTH + 1 {
+            length += 1;
+            child = store_raw(
+                &mut deep_store,
+                ImmutableContentKind::Node,
+                branch_payload(child, leaf, length, height),
+            );
+        }
+        let root = store_raw(
+            &mut deep_store,
+            ImmutableContentKind::Root,
+            root_payload(child, length, TEXT_MAX_ROPE_DEPTH + 1),
+        );
+        assert!(
+            adapter
+                .materialize(
+                    &ContentManifest {
+                        root,
+                        edit_tail: vec![]
+                    },
+                    &MaterializationRequest::Full,
+                    context(),
+                    &deep_store
+                )
+                .is_err()
+        );
+    }
+
+    struct Provider(MemoryImmutableContentStore);
+    impl ContentManifestRuntimeProvider for Provider {
+        fn read_context(&self, _: NodeUuid) -> ContentReadContext {
+            context()
+        }
+        fn immutable_store(&self) -> &dyn ImmutableContentStore {
+            &self.0
+        }
+    }
+
+    #[test]
+    fn registered_text_schema_runs_through_node_materialize_merge_and_index_seams() {
+        let registered = register_text_content_adapter().unwrap();
+        let manifest_schema = registered.schema().clone();
+        let column = ColumnSchema::content_manifest("body", manifest_schema.clone());
+        let schema = JazzSchema::new([TableSchema::new(
+            "documents",
+            [
+                ColumnSchema::new("title", ColumnType::String),
+                column.clone(),
+            ],
+        )]);
+        let mut store = MemoryImmutableContentStore::default();
+        let base = registered.create("root", context(), &mut store).unwrap();
+        let tailed = registered
+            .insert(&base, 4, " tail", context(), &mut store)
+            .unwrap();
+        let equivalent = registered
+            .create("root tail", context(), &mut store)
+            .unwrap();
+        let tailed_value = Value::Bytes(tailed.encode(&manifest_schema).unwrap());
+        let equivalent_value = Value::Bytes(equivalent.encode(&manifest_schema).unwrap());
+
+        crate::node::codec::validate_cell_value(&column, &tailed_value).unwrap();
+        let refs = schema.column_families();
+        let refs = refs.iter().map(String::as_str).collect::<Vec<_>>();
+        let provider = Arc::new(Provider(store));
+        let node = NodeState::new_with_content_manifest_provider(
+            NodeUuid(uuid::Uuid::from_bytes([99; 16])),
+            schema,
+            MemoryStorage::new(&refs),
+            provider.clone(),
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            node.materialize_content_manifest(
+                "documents",
+                "body",
+                &tailed_value,
+                &MaterializationRequest::Full
+            )
+            .unwrap(),
+            b"root tail"
+        );
+        assert_eq!(
+            node.content_manifest_index_values(
+                "documents",
+                "body",
+                &tailed_value,
+                &["text".into()]
+            )
+            .unwrap()["text"],
+            b"root tail"
+        );
+
+        let runtime = ContentManifestRuntime::new(
+            global_content_manifest_adapters(),
+            context(),
+            provider.immutable_store(),
+        );
+        let merged = runtime
+            .merge_cells(&manifest_schema, &[tailed_value, equivalent_value])
+            .unwrap();
+        assert_eq!(
+            runtime
+                .materialize_cell(&manifest_schema, &merged, &MaterializationRequest::Full)
+                .unwrap(),
+            b"root tail"
         );
     }
 }

--- a/crates/jazz/src/text_content.rs
+++ b/crates/jazz/src/text_content.rs
@@ -8,6 +8,8 @@
 
 use std::collections::BTreeMap;
 
+use groove::records::{Value, ValueType};
+
 use crate::content_manifest::{
     ContentAddress, ContentDomainId, ContentId, ContentManifest, ContentManifestAdapter,
     ContentManifestSchema, ContentReadContext, ImmutableContentKind, ImmutableContentStore,
@@ -104,8 +106,9 @@ impl TextContentAdapter {
             return Err(ManifestError::InvalidSchema);
         }
         Ok(Self {
-            schema: ContentManifestSchema::new(
+            schema: ContentManifestSchema::with_tail_entry_type(
                 TEXT_ADAPTER_KIND,
+                ValueType::Bytes,
                 max_tail_entries,
                 max_tail_bytes,
             )?,
@@ -155,7 +158,7 @@ impl TextContentAdapter {
         let root = self.load_root(manifest.root, context, store)?;
         let mut logical_length = root.length();
         for operation in &manifest.edit_tail {
-            let edit = decode_edit(operation)?;
+            let edit = decode_edit(value_bytes(operation)?)?;
             validate_edit_offset(logical_length, &edit)?;
             logical_length = logical_length
                 .checked_add(scalar_len(&edit.text))
@@ -169,7 +172,7 @@ impl TextContentAdapter {
             text: text.to_owned(),
         });
         let mut tail = manifest.edit_tail.clone();
-        tail.push(encoded);
+        tail.push(Value::Bytes(encoded));
         let candidate = ContentManifest {
             root: manifest.root,
             edit_tail: tail,
@@ -179,7 +182,7 @@ impl TextContentAdapter {
         }
         let mut promoted = root;
         for operation in &candidate.edit_tail {
-            let edit = decode_edit(operation)?;
+            let edit = decode_edit(value_bytes(operation)?)?;
             promoted = self.insert_into_rope(
                 promoted,
                 edit.at_code_point,
@@ -204,8 +207,8 @@ impl TextContentAdapter {
     }
 
     /// Decodes a text operation for callers that need to inspect a tail.
-    pub fn decode_edit(operation: &[u8]) -> Result<TextEdit, ManifestError> {
-        decode_edit(operation)
+    pub fn decode_edit(operation: &Value) -> Result<TextEdit, ManifestError> {
+        decode_edit(value_bytes(operation)?)
     }
 
     fn build_root(
@@ -470,11 +473,11 @@ impl TextContentAdapter {
         })
     }
 
-    fn apply_tail(&self, root: Rope, tail: &[Vec<u8>]) -> Result<String, ManifestError> {
+    fn apply_tail(&self, root: Rope, tail: &[Value]) -> Result<String, ManifestError> {
         let mut text = String::new();
         root.text(&mut text);
         for operation in tail {
-            let edit = decode_edit(operation)?;
+            let edit = decode_edit(value_bytes(operation)?)?;
             text = insert_at_code_point(&text, edit.at_code_point, &edit.text)?;
         }
         Ok(text)
@@ -492,8 +495,18 @@ impl ContentManifestAdapter for TextContentAdapter {
         TEXT_ADAPTER_KIND
     }
 
-    fn validate_operation(&self, operation: &[u8]) -> Result<(), ManifestError> {
-        decode_edit(operation).map(|_| ())
+    fn validate_schema(&self, schema: &ContentManifestSchema) -> Result<(), ManifestError> {
+        if schema.adapter_kind != TEXT_ADAPTER_KIND
+            || schema.max_tail_entries > TEXT_MAX_TAIL_ENTRIES
+            || schema.max_tail_bytes > TEXT_MAX_TAIL_BYTES
+        {
+            return Err(ManifestError::InvalidSchema);
+        }
+        Ok(())
+    }
+
+    fn validate_operation(&self, operation: &Value) -> Result<(), ManifestError> {
+        Self::decode_edit(operation).map(|_| ())
     }
 
     fn materialize(
@@ -565,6 +578,13 @@ impl ContentManifestAdapter for TextContentAdapter {
             }
         }
         Ok(values)
+    }
+}
+
+fn value_bytes(value: &Value) -> Result<&[u8], ManifestError> {
+    match value {
+        Value::Bytes(bytes) => Ok(bytes),
+        _ => Err(ManifestError::Malformed),
     }
 }
 
@@ -922,7 +942,7 @@ mod tests {
         let base = adapter.create("safe", context(), &mut store).unwrap();
         let malformed = ContentManifest {
             root: base.root,
-            edit_tail: vec![b"not an edit".to_vec()],
+            edit_tail: vec![Value::Bytes(b"not an edit".to_vec())],
         };
         assert!(
             adapter
@@ -1229,5 +1249,39 @@ mod tests {
                 .unwrap(),
             b"root tail"
         );
+    }
+
+    #[test]
+    fn public_text_schema_rejects_bounds_above_intrinsic_format_before_cell_admission() {
+        let schema_with = |entries, bytes| {
+            JazzSchema::new([TableSchema::new(
+                "documents",
+                [ColumnSchema::content_manifest(
+                    "body",
+                    ContentManifestSchema::new(TEXT_ADAPTER_KIND, entries, bytes).unwrap(),
+                )],
+            )])
+        };
+        assert!(
+            std::panic::catch_unwind(|| schema_with(TEXT_MAX_TAIL_ENTRIES + 1, 1024)).is_err(),
+            "65 operations must be rejected during public schema construction"
+        );
+        assert!(
+            std::panic::catch_unwind(|| schema_with(8, 20_000)).is_err(),
+            "20,000 tail bytes must be rejected during public schema construction"
+        );
+
+        let schema = schema_with(TEXT_MAX_TAIL_ENTRIES, TEXT_MAX_TAIL_BYTES);
+        let column = &schema.tables[0].columns[0];
+        let manifest_schema = column.content_manifest.as_ref().unwrap();
+        let value = Value::Bytes(
+            ContentManifest {
+                root: ContentId([0; 32]),
+                edit_tail: vec![],
+            }
+            .encode(manifest_schema)
+            .unwrap(),
+        );
+        crate::node::codec::validate_cell_value(column, &value).unwrap();
     }
 }

--- a/crates/jazz/src/text_content.rs
+++ b/crates/jazz/src/text_content.rs
@@ -6,10 +6,7 @@
 //! mutable identity and every historical row version already retains a complete
 //! text snapshot.
 
-use std::{
-    collections::BTreeMap,
-    sync::{Arc, OnceLock},
-};
+use std::collections::BTreeMap;
 
 use crate::content_manifest::{
     ContentAddress, ContentDomainId, ContentId, ContentManifest, ContentManifestAdapter,
@@ -235,23 +232,24 @@ impl TextContentAdapter {
 
     fn build_balanced(
         &self,
-        mut level: Vec<Rope>,
+        mut nodes: Vec<Rope>,
         domain: ContentDomainId,
         store: &mut dyn ImmutableContentStore,
     ) -> Result<Rope, ManifestError> {
-        debug_assert!(!level.is_empty());
-        while level.len() > 1 {
-            let mut next = Vec::with_capacity(level.len().div_ceil(2));
-            let mut entries = level.into_iter();
-            while let Some(left) = entries.next() {
-                match entries.next() {
-                    Some(right) => next.push(self.store_branch(left, right, domain, store)?),
-                    None => next.push(left),
-                }
-            }
-            level = next;
+        if nodes.is_empty() {
+            return Err(ManifestError::Malformed);
         }
-        Ok(level.pop().expect("nonempty text rope"))
+        if nodes.len() == 1 {
+            return Ok(nodes.pop().expect("one text rope node"));
+        }
+        // Splitting by count, recursively, guarantees the two child heights
+        // differ by at most one for every leaf count. Pairing successive levels
+        // leaves a five-leaf tree as [height 3, height 1], which its own reader
+        // correctly rejects.
+        let right = nodes.split_off(nodes.len() / 2);
+        let left = self.build_balanced(nodes, domain, store)?;
+        let right = self.build_balanced(right, domain, store)?;
+        self.store_branch(left, right, domain, store)
     }
 
     fn store_leaf(
@@ -481,17 +479,6 @@ impl TextContentAdapter {
         }
         Ok(text)
     }
-}
-
-/// Register the production `text-v1` adapter through the process-wide
-/// foundation registry. Registration is append-only and idempotent.
-pub fn register_text_content_adapter() -> Result<Arc<TextContentAdapter>, ManifestError> {
-    static ADAPTER: OnceLock<Arc<TextContentAdapter>> = OnceLock::new();
-    let adapter = ADAPTER
-        .get_or_init(|| Arc::new(TextContentAdapter::default()))
-        .clone();
-    crate::content_manifest::global_content_manifest_adapters().register(adapter.clone())?;
-    Ok(adapter)
 }
 
 impl Default for TextContentAdapter {
@@ -810,7 +797,7 @@ mod tests {
         schema::{ColumnSchema, JazzSchema, TableSchema},
     };
     use groove::{records::Value, schema::ColumnType, storage::MemoryStorage};
-    use std::collections::BTreeSet;
+    use std::{collections::BTreeSet, sync::Arc};
 
     #[derive(Default)]
     struct CountingStore {
@@ -1007,8 +994,31 @@ mod tests {
             Rope::Leaf { .. } => panic!("fixture must remain multi-leaf"),
         };
         assert_eq!(new_left, old_left, "untouched left subtree must be reused");
-        assert_eq!(store.puts, 3, "one leaf, one path node, and one root");
-        assert_eq!(store.ids.len(), 3);
+        assert_eq!(
+            store.puts, 4,
+            "one leaf, two path nodes, and one root wrapper"
+        );
+        assert_eq!(store.ids.len(), 4);
+    }
+
+    #[test]
+    fn balanced_builder_round_trips_adversarial_leaf_counts() {
+        let adapter = TextContentAdapter::default();
+        let mut store = MemoryImmutableContentStore::default();
+        for leaf_count in [1usize, 2, 3, 4, 5, 6, 7, 9, 10, 17, 31, 33, 65] {
+            let byte_length = if leaf_count == 1 {
+                1
+            } else {
+                (leaf_count - 1) * TEXT_MAX_LEAF_BYTES + 1
+            };
+            let value = "x".repeat(byte_length);
+            let manifest = adapter.create(&value, context(), &mut store).unwrap();
+            assert_eq!(
+                text(&adapter, &manifest, &store),
+                value,
+                "leaf count {leaf_count} must create a reader-valid AVL rope"
+            );
+        }
     }
 
     fn store_raw(
@@ -1146,8 +1156,15 @@ mod tests {
 
     #[test]
     fn registered_text_schema_runs_through_node_materialize_merge_and_index_seams() {
-        let registered = register_text_content_adapter().unwrap();
-        let manifest_schema = registered.schema().clone();
+        let writer = TextContentAdapter::default();
+        let manifest_schema = writer.schema().clone();
+        // No adapter registration call precedes this lookup: `text-v1` is a
+        // production built-in installed while the global registry is created.
+        assert!(
+            global_content_manifest_adapters()
+                .get(TEXT_ADAPTER_KIND)
+                .is_ok()
+        );
         let column = ColumnSchema::content_manifest("body", manifest_schema.clone());
         let schema = JazzSchema::new([TableSchema::new(
             "documents",
@@ -1157,13 +1174,11 @@ mod tests {
             ],
         )]);
         let mut store = MemoryImmutableContentStore::default();
-        let base = registered.create("root", context(), &mut store).unwrap();
-        let tailed = registered
+        let base = writer.create("root", context(), &mut store).unwrap();
+        let tailed = writer
             .insert(&base, 4, " tail", context(), &mut store)
             .unwrap();
-        let equivalent = registered
-            .create("root tail", context(), &mut store)
-            .unwrap();
+        let equivalent = writer.create("root tail", context(), &mut store).unwrap();
         let tailed_value = Value::Bytes(tailed.encode(&manifest_schema).unwrap());
         let equivalent_value = Value::Bytes(equivalent.encode(&manifest_schema).unwrap());
 

--- a/crates/jazz/src/text_content.rs
+++ b/crates/jazz/src/text_content.rs
@@ -497,6 +497,7 @@ impl ContentManifestAdapter for TextContentAdapter {
 
     fn validate_schema(&self, schema: &ContentManifestSchema) -> Result<(), ManifestError> {
         if schema.adapter_kind != TEXT_ADAPTER_KIND
+            || schema.tail_entry_type != ValueType::Bytes
             || schema.max_tail_entries > TEXT_MAX_TAIL_ENTRIES
             || schema.max_tail_bytes > TEXT_MAX_TAIL_BYTES
         {
@@ -1199,8 +1200,8 @@ mod tests {
             .insert(&base, 4, " tail", context(), &mut store)
             .unwrap();
         let equivalent = writer.create("root tail", context(), &mut store).unwrap();
-        let tailed_value = Value::Bytes(tailed.encode(&manifest_schema).unwrap());
-        let equivalent_value = Value::Bytes(equivalent.encode(&manifest_schema).unwrap());
+        let tailed_value = tailed.into_value(&manifest_schema).unwrap();
+        let equivalent_value = equivalent.into_value(&manifest_schema).unwrap();
 
         crate::node::codec::validate_cell_value(&column, &tailed_value).unwrap();
         let refs = schema.column_families();
@@ -1253,35 +1254,46 @@ mod tests {
 
     #[test]
     fn public_text_schema_rejects_bounds_above_intrinsic_format_before_cell_admission() {
-        let schema_with = |entries, bytes| {
+        let schema_with = |tail_entry_type, entries, bytes| {
             JazzSchema::new([TableSchema::new(
                 "documents",
                 [ColumnSchema::content_manifest(
                     "body",
-                    ContentManifestSchema::new(TEXT_ADAPTER_KIND, entries, bytes).unwrap(),
+                    ContentManifestSchema::with_tail_entry_type(
+                        TEXT_ADAPTER_KIND,
+                        tail_entry_type,
+                        entries,
+                        bytes,
+                    )
+                    .unwrap(),
                 )],
             )])
         };
         assert!(
-            std::panic::catch_unwind(|| schema_with(TEXT_MAX_TAIL_ENTRIES + 1, 1024)).is_err(),
+            std::panic::catch_unwind(|| {
+                schema_with(ValueType::Bytes, TEXT_MAX_TAIL_ENTRIES + 1, 1024)
+            })
+            .is_err(),
             "65 operations must be rejected during public schema construction"
         );
         assert!(
-            std::panic::catch_unwind(|| schema_with(8, 20_000)).is_err(),
+            std::panic::catch_unwind(|| schema_with(ValueType::Bytes, 8, 20_000)).is_err(),
             "20,000 tail bytes must be rejected during public schema construction"
         );
+        assert!(
+            std::panic::catch_unwind(|| schema_with(ValueType::String, 8, 1024)).is_err(),
+            "text manifests must reject a non-byte typed tail during schema construction"
+        );
 
-        let schema = schema_with(TEXT_MAX_TAIL_ENTRIES, TEXT_MAX_TAIL_BYTES);
+        let schema = schema_with(ValueType::Bytes, TEXT_MAX_TAIL_ENTRIES, TEXT_MAX_TAIL_BYTES);
         let column = &schema.tables[0].columns[0];
         let manifest_schema = column.content_manifest.as_ref().unwrap();
-        let value = Value::Bytes(
-            ContentManifest {
-                root: ContentId([0; 32]),
-                edit_tail: vec![],
-            }
-            .encode(manifest_schema)
-            .unwrap(),
-        );
+        let value = ContentManifest {
+            root: ContentId([0; 32]),
+            edit_tail: vec![],
+        }
+        .into_value(manifest_schema)
+        .unwrap();
         crate::node::codec::validate_cell_value(column, &value).unwrap();
     }
 }

--- a/crates/jazz/src/text_content.rs
+++ b/crates/jazz/src/text_content.rs
@@ -1,0 +1,786 @@
+//! The `text-v1` embedded-content adapter.
+//!
+//! The public seam is [`TextContentAdapter`].  It is intentionally expressed
+//! through `content_manifest` rather than through a second mutable document or
+//! version table: the application cell containing a [`ContentManifest`] is the
+//! mutable identity and every historical row version already retains a complete
+//! text snapshot.
+
+use std::collections::BTreeMap;
+
+use crate::content_manifest::{
+    ContentAddress, ContentDomainId, ContentId, ContentManifest, ContentManifestAdapter,
+    ContentManifestSchema, ContentReadContext, ImmutableContentKind, ImmutableContentStore,
+    ManifestError, MaterializationRequest, content_id,
+};
+
+/// Stable adapter metadata used by `ColumnSchema::content_manifest`.
+pub const TEXT_ADAPTER_KIND: &str = "text-v1";
+/// Format, rather than tuning, limit: every reader applies this bound.
+pub const TEXT_MAX_TAIL_ENTRIES: u32 = 64;
+/// Format, rather than tuning, limit: every reader applies this bound.
+pub const TEXT_MAX_TAIL_BYTES: u32 = 16 * 1024;
+
+const LEAF_TAG: &[u8; 5] = b"TXT1L";
+const NODE_TAG: &[u8; 5] = b"TXT1N";
+const ROOT_TAG: &[u8; 5] = b"TXT1R";
+const EDIT_TAG: &[u8; 5] = b"TXT1E";
+
+/// A UTF-8 insertion intent, addressed in Unicode scalar positions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextEdit {
+    /// Insertion position measured in Unicode scalar values, not UTF-16 units.
+    pub at_code_point: u64,
+    /// Well-formed UTF-8 text inserted at that position.
+    pub text: String,
+}
+
+/// Strongly typed view of a root stored in a text manifest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TextRootId(pub ContentId);
+
+/// The text adapter and its writer consolidation thresholds.
+#[derive(Clone, Debug)]
+pub struct TextContentAdapter {
+    schema: ContentManifestSchema,
+}
+
+#[derive(Clone, Debug)]
+enum Rope {
+    Leaf {
+        id: ContentId,
+        text: String,
+        length: u64,
+    },
+    Branch {
+        id: ContentId,
+        left: Box<Rope>,
+        right: Box<Rope>,
+        length: u64,
+        height: u32,
+    },
+}
+
+impl Rope {
+    fn id(&self) -> ContentId {
+        match self {
+            Self::Leaf { id, .. } | Self::Branch { id, .. } => *id,
+        }
+    }
+    fn length(&self) -> u64 {
+        match self {
+            Self::Leaf { length, .. } | Self::Branch { length, .. } => *length,
+        }
+    }
+    fn height(&self) -> u32 {
+        match self {
+            Self::Leaf { .. } => 1,
+            Self::Branch { height, .. } => *height,
+        }
+    }
+    fn text(&self, output: &mut String) {
+        match self {
+            Self::Leaf { text, .. } => output.push_str(text),
+            Self::Branch { left, right, .. } => {
+                left.text(output);
+                right.text(output);
+            }
+        }
+    }
+}
+
+impl TextContentAdapter {
+    /// Creates an adapter whose writer bounds are also valid persisted bounds.
+    pub fn new(max_tail_entries: u32, max_tail_bytes: u32) -> Result<Self, ManifestError> {
+        if max_tail_entries == 0
+            || max_tail_entries > TEXT_MAX_TAIL_ENTRIES
+            || max_tail_bytes == 0
+            || max_tail_bytes > TEXT_MAX_TAIL_BYTES
+        {
+            return Err(ManifestError::InvalidSchema);
+        }
+        Ok(Self {
+            schema: ContentManifestSchema::new(
+                TEXT_ADAPTER_KIND,
+                max_tail_entries,
+                max_tail_bytes,
+            )?,
+        })
+    }
+
+    /// Default text format limits. Callers can select lower writer thresholds.
+    pub fn schema(&self) -> &ContentManifestSchema {
+        &self.schema
+    }
+
+    /// Returns the manifest root at the typed text-adapter boundary.
+    pub fn root_id(&self, manifest: &ContentManifest) -> TextRootId {
+        TextRootId(manifest.root)
+    }
+
+    /// Stores a complete initial immutable rope and returns its empty-tail manifest.
+    pub fn create(
+        &self,
+        text: &str,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<ContentManifest, ManifestError> {
+        let root = self.build_root(text, context.domain, store)?;
+        Ok(ContentManifest {
+            root,
+            edit_tail: Vec::new(),
+        })
+    }
+
+    /// Adds an insertion to the tail or synchronously promotes it into a new root.
+    ///
+    /// This is deliberately a foreground operation: it never performs a
+    /// background root rewrite that could race an ordinary owning-row update.
+    pub fn insert(
+        &self,
+        manifest: &ContentManifest,
+        at_code_point: u64,
+        text: &str,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<ContentManifest, ManifestError> {
+        if text.is_empty() {
+            return Ok(manifest.clone());
+        }
+        let current = self.materialize(manifest, &MaterializationRequest::Full, context, store)?;
+        let current = std::str::from_utf8(&current).map_err(|_| ManifestError::Malformed)?;
+        let updated = insert_at_code_point(current, at_code_point, text)?;
+        let encoded = encode_edit(&TextEdit {
+            at_code_point,
+            text: text.to_owned(),
+        });
+        let mut tail = manifest.edit_tail.clone();
+        tail.push(encoded);
+        let candidate = ContentManifest {
+            root: manifest.root,
+            edit_tail: tail,
+        };
+        if candidate.validate(&self.schema).is_ok() {
+            return Ok(candidate);
+        }
+        let root = self.build_root(&updated, context.domain, store)?;
+        Ok(ContentManifest {
+            root,
+            edit_tail: Vec::new(),
+        })
+    }
+
+    /// Decodes a text operation for callers that need to inspect a tail.
+    pub fn decode_edit(operation: &[u8]) -> Result<TextEdit, ManifestError> {
+        decode_edit(operation)
+    }
+
+    fn build_root(
+        &self,
+        text: &str,
+        domain: ContentDomainId,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<ContentId, ManifestError> {
+        let leaves = split_utf8(text, 4096)?
+            .into_iter()
+            .map(|part| self.store_leaf(&part, domain, store))
+            .collect::<Result<Vec<_>, _>>()?;
+        let tree = self.build_balanced(leaves, domain, store)?;
+        let payload = root_payload(tree.id(), tree.length(), tree.height());
+        store.put_if_absent_or_identical(
+            ContentAddress {
+                domain,
+                adapter_kind: TEXT_ADAPTER_KIND,
+                kind: ImmutableContentKind::Root,
+            },
+            payload,
+        )
+    }
+
+    fn build_balanced(
+        &self,
+        mut level: Vec<Rope>,
+        domain: ContentDomainId,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<Rope, ManifestError> {
+        debug_assert!(!level.is_empty());
+        while level.len() > 1 {
+            let mut next = Vec::with_capacity(level.len().div_ceil(2));
+            let mut entries = level.into_iter();
+            while let Some(left) = entries.next() {
+                match entries.next() {
+                    Some(right) => next.push(self.store_branch(left, right, domain, store)?),
+                    None => next.push(left),
+                }
+            }
+            level = next;
+        }
+        Ok(level.pop().expect("nonempty text rope"))
+    }
+
+    fn store_leaf(
+        &self,
+        text: &str,
+        domain: ContentDomainId,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<Rope, ManifestError> {
+        let length = scalar_len(text);
+        let id = store.put_if_absent_or_identical(
+            ContentAddress {
+                domain,
+                adapter_kind: TEXT_ADAPTER_KIND,
+                kind: ImmutableContentKind::Leaf,
+            },
+            leaf_payload(text, length),
+        )?;
+        Ok(Rope::Leaf {
+            id,
+            text: text.to_owned(),
+            length,
+        })
+    }
+
+    fn store_branch(
+        &self,
+        left: Rope,
+        right: Rope,
+        domain: ContentDomainId,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<Rope, ManifestError> {
+        let length = left
+            .length()
+            .checked_add(right.length())
+            .ok_or(ManifestError::Malformed)?;
+        let height = left
+            .height()
+            .max(right.height())
+            .checked_add(1)
+            .ok_or(ManifestError::Malformed)?;
+        let id = store.put_if_absent_or_identical(
+            ContentAddress {
+                domain,
+                adapter_kind: TEXT_ADAPTER_KIND,
+                kind: ImmutableContentKind::Node,
+            },
+            branch_payload(left.id(), right.id(), length, height),
+        )?;
+        Ok(Rope::Branch {
+            id,
+            left: Box::new(left),
+            right: Box::new(right),
+            length,
+            height,
+        })
+    }
+
+    fn load_root(
+        &self,
+        root: ContentId,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<Rope, ManifestError> {
+        let payload = checked_get(store, context, root, ImmutableContentKind::Root)?;
+        let (child, length, height) = parse_root(payload)?;
+        let tree = self.load_tree(child, context, store)?;
+        if tree.length() != length || tree.height() != height {
+            return Err(ManifestError::Malformed);
+        }
+        Ok(tree)
+    }
+
+    fn load_tree(
+        &self,
+        id: ContentId,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<Rope, ManifestError> {
+        let bytes = store.get(context, id).ok_or(ManifestError::Malformed)?;
+        if bytes.starts_with(LEAF_TAG) {
+            let payload = checked_get(store, context, id, ImmutableContentKind::Leaf)?;
+            let (text, length) = parse_leaf(payload)?;
+            return Ok(Rope::Leaf { id, text, length });
+        }
+        let payload = checked_get(store, context, id, ImmutableContentKind::Node)?;
+        let (left_id, right_id, length, height) = parse_branch(payload)?;
+        let left = self.load_tree(left_id, context, store)?;
+        let right = self.load_tree(right_id, context, store)?;
+        if length
+            != left
+                .length()
+                .checked_add(right.length())
+                .ok_or(ManifestError::Malformed)?
+            || height
+                != left
+                    .height()
+                    .max(right.height())
+                    .checked_add(1)
+                    .ok_or(ManifestError::Malformed)?
+        {
+            return Err(ManifestError::Malformed);
+        }
+        Ok(Rope::Branch {
+            id,
+            left: Box::new(left),
+            right: Box::new(right),
+            length,
+            height,
+        })
+    }
+
+    fn apply_tail(&self, root: Rope, tail: &[Vec<u8>]) -> Result<String, ManifestError> {
+        let mut text = String::new();
+        root.text(&mut text);
+        for operation in tail {
+            let edit = decode_edit(operation)?;
+            text = insert_at_code_point(&text, edit.at_code_point, &edit.text)?;
+        }
+        Ok(text)
+    }
+}
+
+impl Default for TextContentAdapter {
+    fn default() -> Self {
+        Self::new(TEXT_MAX_TAIL_ENTRIES, TEXT_MAX_TAIL_BYTES).expect("valid text defaults")
+    }
+}
+
+impl ContentManifestAdapter for TextContentAdapter {
+    fn adapter_kind(&self) -> &str {
+        TEXT_ADAPTER_KIND
+    }
+
+    fn validate_operation(&self, operation: &[u8]) -> Result<(), ManifestError> {
+        decode_edit(operation).map(|_| ())
+    }
+
+    fn materialize(
+        &self,
+        manifest: &ContentManifest,
+        request: &MaterializationRequest,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<Vec<u8>, ManifestError> {
+        manifest.validate(&self.schema)?;
+        for operation in &manifest.edit_tail {
+            self.validate_operation(operation)?;
+        }
+        let full = self.apply_tail(
+            self.load_root(manifest.root, context, store)?,
+            &manifest.edit_tail,
+        )?;
+        match request {
+            MaterializationRequest::Full | MaterializationRequest::Projection(_) => {
+                Ok(full.into_bytes())
+            }
+            MaterializationRequest::Range { offset, length } => {
+                range_at_code_points(&full, *offset, *length).map(String::into_bytes)
+            }
+        }
+    }
+
+    fn merge(
+        &self,
+        manifests: &[ContentManifest],
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<ContentManifest, ManifestError> {
+        let Some(first) = manifests.first() else {
+            return Err(ManifestError::Conflict("no text candidates"));
+        };
+        let first_value = self.materialize(first, &MaterializationRequest::Full, context, store)?;
+        for candidate in &manifests[1..] {
+            if self.materialize(candidate, &MaterializationRequest::Full, context, store)?
+                != first_value
+            {
+                return Err(ManifestError::Conflict(
+                    "different text values require normal atomic LWW",
+                ));
+            }
+        }
+        Ok(first.clone())
+    }
+
+    fn index_values(
+        &self,
+        manifest: &ContentManifest,
+        requested: &[String],
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<BTreeMap<String, Vec<u8>>, ManifestError> {
+        let text = self.materialize(manifest, &MaterializationRequest::Full, context, store)?;
+        let text = std::str::from_utf8(&text).map_err(|_| ManifestError::Malformed)?;
+        let mut values = BTreeMap::new();
+        for key in requested {
+            match key.as_str() {
+                "text" => {
+                    values.insert(key.clone(), text.as_bytes().to_vec());
+                }
+                "length" => {
+                    values.insert(key.clone(), scalar_len(text).to_le_bytes().to_vec());
+                }
+                _ => return Err(ManifestError::Conflict("unknown text index")),
+            }
+        }
+        Ok(values)
+    }
+}
+
+fn checked_get(
+    store: &dyn ImmutableContentStore,
+    context: ContentReadContext,
+    id: ContentId,
+    kind: ImmutableContentKind,
+) -> Result<&[u8], ManifestError> {
+    let bytes = store.get(context, id).ok_or(ManifestError::Malformed)?;
+    if content_id(context.domain, TEXT_ADAPTER_KIND, kind, bytes) != id {
+        return Err(ManifestError::Malformed);
+    }
+    Ok(bytes)
+}
+
+fn scalar_len(text: &str) -> u64 {
+    text.chars().count() as u64
+}
+
+fn split_utf8(text: &str, max_bytes: usize) -> Result<Vec<&str>, ManifestError> {
+    let mut out = Vec::new();
+    let mut start = 0;
+    let mut bytes = 0;
+    for (index, ch) in text.char_indices() {
+        let width = ch.len_utf8();
+        if width > max_bytes {
+            return Err(ManifestError::Malformed);
+        }
+        if bytes != 0 && bytes + width > max_bytes {
+            out.push(&text[start..index]);
+            start = index;
+            bytes = 0;
+        }
+        bytes += width;
+    }
+    if start < text.len() || text.is_empty() {
+        out.push(&text[start..]);
+    }
+    Ok(out)
+}
+
+fn insert_at_code_point(base: &str, at: u64, inserted: &str) -> Result<String, ManifestError> {
+    let length = scalar_len(base);
+    if at > length {
+        return Err(ManifestError::Malformed);
+    }
+    let byte = if at == length {
+        base.len()
+    } else {
+        base.char_indices()
+            .nth(at as usize)
+            .ok_or(ManifestError::Malformed)?
+            .0
+    };
+    let mut output = String::with_capacity(base.len() + inserted.len());
+    output.push_str(&base[..byte]);
+    output.push_str(inserted);
+    output.push_str(&base[byte..]);
+    Ok(output)
+}
+
+fn range_at_code_points(text: &str, offset: u64, length: u64) -> Result<String, ManifestError> {
+    let total = scalar_len(text);
+    let end = offset.checked_add(length).ok_or(ManifestError::Malformed)?;
+    if offset > total || end > total {
+        return Err(ManifestError::Malformed);
+    }
+    let start_byte = if offset == total {
+        text.len()
+    } else {
+        text.char_indices()
+            .nth(offset as usize)
+            .ok_or(ManifestError::Malformed)?
+            .0
+    };
+    let end_byte = if end == total {
+        text.len()
+    } else {
+        text.char_indices()
+            .nth(end as usize)
+            .ok_or(ManifestError::Malformed)?
+            .0
+    };
+    Ok(text[start_byte..end_byte].to_owned())
+}
+
+fn leaf_payload(text: &str, length: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(17 + text.len());
+    out.extend_from_slice(LEAF_TAG);
+    out.extend_from_slice(&length.to_le_bytes());
+    out.extend_from_slice(&(text.len() as u32).to_le_bytes());
+    out.extend_from_slice(text.as_bytes());
+    out
+}
+fn branch_payload(left: ContentId, right: ContentId, length: u64, height: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity(81);
+    out.extend_from_slice(NODE_TAG);
+    out.extend_from_slice(&left.0);
+    out.extend_from_slice(&right.0);
+    out.extend_from_slice(&length.to_le_bytes());
+    out.extend_from_slice(&height.to_le_bytes());
+    out
+}
+fn root_payload(child: ContentId, length: u64, height: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity(49);
+    out.extend_from_slice(ROOT_TAG);
+    out.extend_from_slice(&child.0);
+    out.extend_from_slice(&length.to_le_bytes());
+    out.extend_from_slice(&height.to_le_bytes());
+    out
+}
+fn encode_edit(edit: &TextEdit) -> Vec<u8> {
+    let mut out = Vec::with_capacity(17 + edit.text.len());
+    out.extend_from_slice(EDIT_TAG);
+    out.extend_from_slice(&edit.at_code_point.to_le_bytes());
+    out.extend_from_slice(&(edit.text.len() as u32).to_le_bytes());
+    out.extend_from_slice(edit.text.as_bytes());
+    out
+}
+fn parse_leaf(bytes: &[u8]) -> Result<(String, u64), ManifestError> {
+    if bytes.len() < 17 || !bytes.starts_with(LEAF_TAG) {
+        return Err(ManifestError::Malformed);
+    }
+    let length = u64::from_le_bytes(
+        bytes[5..13]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    let byte_len = u32::from_le_bytes(
+        bytes[13..17]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    ) as usize;
+    if bytes.len() != 17 + byte_len {
+        return Err(ManifestError::Malformed);
+    }
+    let text = std::str::from_utf8(&bytes[17..])
+        .map_err(|_| ManifestError::Malformed)?
+        .to_owned();
+    if scalar_len(&text) != length {
+        return Err(ManifestError::Malformed);
+    }
+    Ok((text, length))
+}
+fn parse_branch(bytes: &[u8]) -> Result<(ContentId, ContentId, u64, u32), ManifestError> {
+    if bytes.len() != 81 || !bytes.starts_with(NODE_TAG) {
+        return Err(ManifestError::Malformed);
+    }
+    let mut left = [0; 32];
+    left.copy_from_slice(&bytes[5..37]);
+    let mut right = [0; 32];
+    right.copy_from_slice(&bytes[37..69]);
+    let length = u64::from_le_bytes(
+        bytes[69..77]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    let height = u32::from_le_bytes(
+        bytes[77..81]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    Ok((ContentId(left), ContentId(right), length, height))
+}
+fn parse_root(bytes: &[u8]) -> Result<(ContentId, u64, u32), ManifestError> {
+    if bytes.len() != 49 || !bytes.starts_with(ROOT_TAG) {
+        return Err(ManifestError::Malformed);
+    }
+    let mut child = [0; 32];
+    child.copy_from_slice(&bytes[5..37]);
+    let length = u64::from_le_bytes(
+        bytes[37..45]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    let height = u32::from_le_bytes(
+        bytes[45..49]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    Ok((ContentId(child), length, height))
+}
+fn decode_edit(bytes: &[u8]) -> Result<TextEdit, ManifestError> {
+    if bytes.len() < 17 || !bytes.starts_with(EDIT_TAG) {
+        return Err(ManifestError::Malformed);
+    }
+    let at_code_point = u64::from_le_bytes(
+        bytes[5..13]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    let byte_len = u32::from_le_bytes(
+        bytes[13..17]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    ) as usize;
+    if bytes.len() != 17 + byte_len {
+        return Err(ManifestError::Malformed);
+    }
+    let text = std::str::from_utf8(&bytes[17..])
+        .map_err(|_| ManifestError::Malformed)?
+        .to_owned();
+    Ok(TextEdit {
+        at_code_point,
+        text,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    // These are internal only because the foundation currently exposes an
+    // adapter/store seam, not a public client-level adapter registry. They are
+    // black-box tests of that public seam and use no rope internals.
+    use super::*;
+    use crate::content_manifest::MemoryImmutableContentStore;
+
+    fn context() -> ContentReadContext {
+        ContentReadContext {
+            domain: ContentDomainId(uuid::Uuid::from_bytes([7; 16])),
+        }
+    }
+    fn text(
+        adapter: &TextContentAdapter,
+        manifest: &ContentManifest,
+        store: &MemoryImmutableContentStore,
+    ) -> String {
+        String::from_utf8(
+            adapter
+                .materialize(manifest, &MaterializationRequest::Full, context(), store)
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn manifests_materialize_unicode_root_plus_tail_and_range() {
+        let adapter = TextContentAdapter::new(4, 1024).unwrap();
+        let mut store = MemoryImmutableContentStore::default();
+        let base = adapter.create("A😀C", context(), &mut store).unwrap();
+        let edited = adapter
+            .insert(&base, 2, "é", context(), &mut store)
+            .unwrap();
+        assert_eq!(edited.root, base.root, "tail-only edit reuses root");
+        assert_eq!(text(&adapter, &edited, &store), "A😀éC");
+        assert_eq!(
+            adapter
+                .materialize(
+                    &edited,
+                    &MaterializationRequest::Range {
+                        offset: 1,
+                        length: 2
+                    },
+                    context(),
+                    &store
+                )
+                .unwrap(),
+            "😀é".as_bytes()
+        );
+        assert!(
+            adapter
+                .insert(&edited, 5, "x", context(), &mut store)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn promotion_retains_direct_historical_manifest() {
+        let adapter = TextContentAdapter::new(1, 1024).unwrap();
+        let mut store = MemoryImmutableContentStore::default();
+        let base = adapter.create("base", context(), &mut store).unwrap();
+        let tail = adapter
+            .insert(&base, 4, "!", context(), &mut store)
+            .unwrap();
+        let promoted = adapter
+            .insert(&tail, 5, "?", context(), &mut store)
+            .unwrap();
+        assert_ne!(promoted.root, base.root);
+        assert!(promoted.edit_tail.is_empty());
+        assert_eq!(text(&adapter, &tail, &store), "base!");
+        assert_eq!(text(&adapter, &promoted, &store), "base!?");
+    }
+
+    #[test]
+    fn materializers_and_indices_observe_unpromoted_tail() {
+        let adapter = TextContentAdapter::default();
+        let mut store = MemoryImmutableContentStore::default();
+        let base = adapter.create("old", context(), &mut store).unwrap();
+        let edited = adapter
+            .insert(&base, 3, " tail", context(), &mut store)
+            .unwrap();
+        assert_eq!(
+            adapter
+                .index_values(
+                    &edited,
+                    &["text".into(), "length".into()],
+                    context(),
+                    &store
+                )
+                .unwrap()
+                .get("text"),
+            Some(&b"old tail".to_vec())
+        );
+        assert_eq!(
+            adapter.merge(&[base, edited], context(), &store),
+            Err(ManifestError::Conflict(
+                "different text values require normal atomic LWW"
+            ))
+        );
+    }
+
+    #[test]
+    fn malformed_or_cross_domain_content_fails_closed() {
+        let adapter = TextContentAdapter::default();
+        let mut store = MemoryImmutableContentStore::default();
+        let base = adapter.create("safe", context(), &mut store).unwrap();
+        let malformed = ContentManifest {
+            root: base.root,
+            edit_tail: vec![b"not an edit".to_vec()],
+        };
+        assert!(
+            adapter
+                .materialize(&malformed, &MaterializationRequest::Full, context(), &store)
+                .is_err()
+        );
+        let other = ContentReadContext {
+            domain: ContentDomainId(uuid::Uuid::from_bytes([8; 16])),
+        };
+        assert!(
+            adapter
+                .materialize(&base, &MaterializationRequest::Full, other, &store)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn equal_text_is_domain_scoped_content_addressed_and_stale_promotion_is_not_merged() {
+        let adapter = TextContentAdapter::new(1, 1024).unwrap();
+        let mut store = MemoryImmutableContentStore::default();
+        let base = adapter.create("same", context(), &mut store).unwrap();
+        let repeated = adapter.create("same", context(), &mut store).unwrap();
+        assert_eq!(adapter.root_id(&base), adapter.root_id(&repeated));
+
+        let first = adapter
+            .insert(&base, 4, "!", context(), &mut store)
+            .unwrap();
+        let promoted = adapter
+            .insert(&first, 5, "?", context(), &mut store)
+            .unwrap();
+        let stale = adapter
+            .insert(&base, 4, ".", context(), &mut store)
+            .unwrap();
+        assert!(promoted.edit_tail.is_empty());
+        assert_eq!(text(&adapter, &promoted, &store), "same!?");
+        assert_eq!(text(&adapter, &stale, &store), "same.");
+        assert!(
+            adapter
+                .merge(&[promoted, stale], context(), &store)
+                .is_err()
+        );
+    }
+}

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -522,20 +522,27 @@ fn convert_column(
 ) -> Result<CoreColumnSchema, SchemaConversionError> {
     if let Some(manifest) = &column.content_manifest {
         let tail_entry_type = validate_content_manifest_column(table, column)?;
+        let manifest = ContentManifestSchema::with_tail_entry_type(
+            &manifest.adapter_kind,
+            tail_entry_type,
+            manifest.max_tail_entries,
+            manifest.max_tail_bytes,
+        )
+        .map_err(|error| {
+            err(
+                format!("$.{}.{}", table.as_str(), column.name.as_str()),
+                error.to_string(),
+            )
+        })?;
+        crate::content_manifest::validate_content_manifest_schema(&manifest).map_err(|error| {
+            err(
+                format!("$.{}.{}", table.as_str(), column.name.as_str()),
+                error.to_string(),
+            )
+        })?;
         return Ok(CoreColumnSchema::content_manifest(
             column.name.as_str(),
-            ContentManifestSchema::with_tail_entry_type(
-                &manifest.adapter_kind,
-                tail_entry_type,
-                manifest.max_tail_entries,
-                manifest.max_tail_bytes,
-            )
-            .map_err(|error| {
-                err(
-                    format!("$.{}.{}", table.as_str(), column.name.as_str()),
-                    error.to_string(),
-                )
-            })?,
+            manifest,
         ));
     }
     let mut column_type = convert_column_type(table, column.name.as_str(), &column.column_type)?;

--- a/docs/content/docs/content/meta.json
+++ b/docs/content/docs/content/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Content",
-  "pages": ["overview"]
+  "pages": ["overview", "text"]
 }

--- a/docs/content/docs/content/text.mdx
+++ b/docs/content/docs/content/text.mdx
@@ -1,0 +1,23 @@
+---
+title: Text content
+description: Edit and materialize a typed text content column.
+---
+
+`text-v1` stores UTF-8 text in an immutable rope and a bounded `Bytes` tail.
+
+```rust
+use jazz::{content_manifest::{global_content_manifest_adapters, ContentDomainId, ContentManifestRuntime, ContentReadContext, MaterializationRequest, MemoryImmutableContentStore}, text_content::TextContentAdapter};
+
+fn text_example() -> Result<(), Box<dyn std::error::Error>> {
+    let context = ContentReadContext { domain: ContentDomainId(uuid::Uuid::new_v4()) };
+    let mut store = MemoryImmutableContentStore::default();
+    let adapter = TextContentAdapter::default();
+    let schema = adapter.schema().clone();
+    let base = adapter.create("Hello", context, &mut store)?;
+    let manifest = adapter.insert(&base, 5, " Jazz", context, &mut store)?;
+    let cell = manifest.into_value(&schema)?;
+    let runtime = ContentManifestRuntime::new(global_content_manifest_adapters(), context, &store);
+    assert_eq!(runtime.materialize_cell(&schema, &cell, &MaterializationRequest::Full)?, b"Hello Jazz");
+    Ok(())
+}
+```


### PR DESCRIPTION
🤖 Adds the persistent text implementation on top of the shared typed-content foundation.

## What changed

- Adds content-addressed immutable UTF-8 rope nodes and leaves.
- Applies Unicode-scalar edit tails and materializes full or ranged text from `root + editTail`.
- Promotes bounded tails with localized path copying and AVL rebalancing while preserving old roots.
- Registers `text-v1`, requires byte-tail metadata, derives tail-aware index values, and enforces intrinsic 64-entry / 16 KiB limits at schema activation.
- Adds a complete public text API chapter with runnable setup, publication, editing, materialization, and indexing examples.

## Validation

- Focused text/schema tests and real Node runtime coverage.
- Docs typecheck/build; the public example was compiled and executed against the current Rust API.
- Independent adversarial review of balancing, integrity, registry startup, schema bounds, and tail typing.

This is PR 2 of 5 and depends on the foundation PR.
