### PR TITLE
feat(content): add persistent stream manifests

### DIFF
--- a/crates/jazz/SPEC/20_stream_content_adapter.md
+++ b/crates/jazz/SPEC/20_stream_content_adapter.md
@@ -1,0 +1,17 @@
+# jazz — Specification · 20. Stream content adapter
+
+`stream-v1` is declared as one required content-manifest record with a
+`Bytes` tail entry type. It represents an immutable byte prefix plus at most
+one inline suffix. Construct the column with
+`ContentManifestSchema::with_tail_entry_type("stream-v1", ValueType::Bytes, entries, bytes)`
+and `ColumnSchema::content_manifest`.
+
+Use `StreamManifestAdapter::empty_manifest` and `append` to produce the next
+complete manifest. Store it with `ContentManifest::into_value`; materialize a
+full value or a byte range through `ContentManifestRuntime`. The adapter's
+`length` index is available through `index_values_for_cell`.
+
+The tail is bounded inline data. An append beyond its adapter limit is
+consolidated into immutable stream tree objects and returns an empty tail. A
+merge receives complete candidate manifests and rejects incompatible roots or
+tails rather than joining independent fields.

--- a/crates/jazz/src/content_manifest.rs
+++ b/crates/jazz/src/content_manifest.rs
@@ -417,6 +417,11 @@ pub fn global_content_manifest_adapters() -> &'static ContentManifestAdapterRegi
             .register(Arc::new(crate::text_content::TextContentAdapter::default()))
             .expect("built-in text content adapter registers exactly once");
         registry
+            .register(Arc::new(
+                crate::stream_manifest::StreamManifestAdapter::default(),
+            ))
+            .expect("built-in stream manifest adapter must register once");
+        registry
     })
 }
 

--- a/crates/jazz/src/lib.rs
+++ b/crates/jazz/src/lib.rs
@@ -134,6 +134,7 @@ pub mod result_tree;
 pub mod schema;
 /// Operational server-shell APIs formerly provided by jazz-server.
 pub mod serving;
+pub mod stream_manifest;
 /// Logical time and sequence counters.
 pub mod time;
 /// Public client, server, and CLI support APIs formerly provided by jazz-tools.

--- a/crates/jazz/src/stream_manifest.rs
+++ b/crates/jazz/src/stream_manifest.rs
@@ -1,0 +1,791 @@
+//! Ordinary byte streams backed by an embedded content manifest.
+//!
+//! The owning application row holds the mutable `{ root, editTail }` cell.
+//! This module owns only the stream-specific immutable byte tree and the
+//! materializer used by manifest-aware consumers.
+#![allow(missing_docs)]
+
+use std::collections::BTreeMap;
+
+use crate::content_manifest::{
+    ContentAddress, ContentId, ContentManifest, ContentManifestAdapter, ContentReadContext,
+    ImmutableContentKind, ImmutableContentStore, ManifestError, MaterializationRequest, content_id,
+};
+
+pub const DEFAULT_STREAM_INLINE_TAIL_BYTES: usize = 256;
+pub const DEFAULT_STREAM_TREE_FANOUT: usize = 32;
+pub const MAX_STREAM_PART_BYTES: usize = 1_048_576;
+const ADAPTER_KIND: &str = "stream-v1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TreeRef {
+    id: ContentId,
+    length: u64,
+    height: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct StreamNode {
+    height: u32,
+    children: Vec<TreeRef>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StreamRoot {
+    tree: Option<TreeRef>,
+    prefix_bytes: u64,
+}
+
+/// A byte-stream adapter.  Its tail is exactly zero or one byte operation: a
+/// bounded logical inline suffix, not one mutable tail per tree node.
+#[derive(Clone, Debug)]
+pub struct StreamManifestAdapter {
+    inline_tail_bytes: usize,
+    fanout: usize,
+}
+
+impl Default for StreamManifestAdapter {
+    fn default() -> Self {
+        Self {
+            inline_tail_bytes: DEFAULT_STREAM_INLINE_TAIL_BYTES,
+            fanout: DEFAULT_STREAM_TREE_FANOUT,
+        }
+    }
+}
+
+impl StreamManifestAdapter {
+    pub fn new(inline_tail_bytes: usize, fanout: usize) -> Result<Self, ManifestError> {
+        if inline_tail_bytes == 0 || inline_tail_bytes > MAX_STREAM_PART_BYTES {
+            return Err(ManifestError::Conflict(
+                "stream inline tail bound is invalid",
+            ));
+        }
+        if !(4..=256).contains(&fanout) || !fanout.is_multiple_of(2) {
+            return Err(ManifestError::Conflict("stream tree fanout is invalid"));
+        }
+        Ok(Self {
+            inline_tail_bytes,
+            fanout,
+        })
+    }
+
+    /// Create an empty immutable root and the manifest stored in an owner row.
+    pub fn empty_manifest(
+        &self,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<ContentManifest, ManifestError> {
+        Ok(ContentManifest {
+            root: self.put_root(
+                context,
+                store,
+                StreamRoot {
+                    tree: None,
+                    prefix_bytes: 0,
+                },
+            )?,
+            edit_tail: Vec::new(),
+        })
+    }
+
+    /// Produce the next owner-row manifest for an append.  Promotion and the
+    /// owner-row replacement must be committed by the caller as one transaction.
+    pub fn append(
+        &self,
+        manifest: &ContentManifest,
+        bytes: &[u8],
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<ContentManifest, ManifestError> {
+        let old_tail = self.tail(manifest)?;
+        if bytes.is_empty() {
+            return Ok(manifest.clone());
+        }
+        let mut combined = Vec::with_capacity(old_tail.len() + bytes.len());
+        combined.extend_from_slice(old_tail);
+        combined.extend_from_slice(bytes);
+        if combined.len() <= self.inline_tail_bytes {
+            return Ok(ContentManifest {
+                root: manifest.root,
+                edit_tail: vec![combined],
+            });
+        }
+
+        let old_root = self.get_root(manifest.root, context, store)?;
+        let mut tree = old_root.tree;
+        for part in combined.chunks(MAX_STREAM_PART_BYTES) {
+            let id = self.put_part(context, store, part)?;
+            tree = Some(self.append_leaf(
+                tree,
+                TreeRef {
+                    id,
+                    length: part.len() as u64,
+                    height: 0,
+                },
+                context,
+                store,
+            )?);
+        }
+        let prefix_bytes = old_root
+            .prefix_bytes
+            .checked_add(combined.len() as u64)
+            .ok_or(ManifestError::Conflict("stream length overflow"))?;
+        Ok(ContentManifest {
+            root: self.put_root(context, store, StreamRoot { tree, prefix_bytes })?,
+            edit_tail: Vec::new(),
+        })
+    }
+
+    fn tail<'a>(&self, manifest: &'a ContentManifest) -> Result<&'a [u8], ManifestError> {
+        match manifest.edit_tail.as_slice() {
+            [] => Ok(&[]),
+            [tail] if tail.len() <= self.inline_tail_bytes => Ok(tail),
+            [_] => Err(ManifestError::TailTooLarge {
+                actual: manifest.edit_tail[0].len(),
+                maximum: self.inline_tail_bytes as u32,
+            }),
+            _ => Err(ManifestError::Conflict(
+                "stream manifests have one logical tail",
+            )),
+        }
+    }
+
+    fn put_part(
+        &self,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+        bytes: &[u8],
+    ) -> Result<ContentId, ManifestError> {
+        store.put_if_absent_or_identical(
+            ContentAddress {
+                domain: context.domain,
+                adapter_kind: ADAPTER_KIND,
+                kind: ImmutableContentKind::Leaf,
+            },
+            bytes.to_vec(),
+        )
+    }
+
+    fn put_node(
+        &self,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+        node: StreamNode,
+    ) -> Result<ContentId, ManifestError> {
+        if node.children.is_empty() || node.children.len() > self.fanout {
+            return Err(ManifestError::Malformed);
+        }
+        if node
+            .children
+            .iter()
+            .any(|child| child.height != node.height)
+        {
+            return Err(ManifestError::Malformed);
+        }
+        store.put_if_absent_or_identical(
+            ContentAddress {
+                domain: context.domain,
+                adapter_kind: ADAPTER_KIND,
+                kind: ImmutableContentKind::Node,
+            },
+            encode_node(&node),
+        )
+    }
+
+    fn put_root(
+        &self,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+        root: StreamRoot,
+    ) -> Result<ContentId, ManifestError> {
+        if root.tree.map(|tree| tree.length) != Some(root.prefix_bytes) && root.tree.is_some() {
+            return Err(ManifestError::Malformed);
+        }
+        if root.tree.is_none() && root.prefix_bytes != 0 {
+            return Err(ManifestError::Malformed);
+        }
+        store.put_if_absent_or_identical(
+            ContentAddress {
+                domain: context.domain,
+                adapter_kind: ADAPTER_KIND,
+                kind: ImmutableContentKind::Root,
+            },
+            encode_root(root),
+        )
+    }
+
+    fn get_root(
+        &self,
+        id: ContentId,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<StreamRoot, ManifestError> {
+        decode_root(self.get_object(context, id, ImmutableContentKind::Root, store)?)
+    }
+
+    fn get_node(
+        &self,
+        id: ContentId,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<StreamNode, ManifestError> {
+        decode_node(self.get_object(context, id, ImmutableContentKind::Node, store)?)
+    }
+
+    fn get_object<'a>(
+        &self,
+        context: ContentReadContext,
+        id: ContentId,
+        kind: ImmutableContentKind,
+        store: &'a dyn ImmutableContentStore,
+    ) -> Result<&'a [u8], ManifestError> {
+        let bytes = store.get(context, id).ok_or(ManifestError::Malformed)?;
+        if content_id(context.domain, ADAPTER_KIND, kind, bytes) != id {
+            return Err(ManifestError::Malformed);
+        }
+        Ok(bytes)
+    }
+
+    fn append_leaf(
+        &self,
+        tree: Option<TreeRef>,
+        leaf: TreeRef,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<TreeRef, ManifestError> {
+        let Some(tree) = tree else {
+            let node = StreamNode {
+                height: 0,
+                children: vec![leaf],
+            };
+            return Ok(TreeRef {
+                id: self.put_node(context, store, node)?,
+                length: leaf.length,
+                height: 1,
+            });
+        };
+        let (replacement, split) = self.append_at(tree, leaf, context, store)?;
+        if let Some(split) = split {
+            let node = StreamNode {
+                height: replacement.height,
+                children: vec![replacement, split],
+            };
+            let length = replacement.length + split.length;
+            return Ok(TreeRef {
+                id: self.put_node(context, store, node)?,
+                length,
+                height: replacement.height + 1,
+            });
+        }
+        Ok(replacement)
+    }
+
+    fn append_at(
+        &self,
+        tree: TreeRef,
+        leaf: TreeRef,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<(TreeRef, Option<TreeRef>), ManifestError> {
+        let node = self.get_node(tree.id, context, store)?;
+        if tree.height != node.height + 1 || node.children.is_empty() {
+            return Err(ManifestError::Malformed);
+        }
+        let mut children = node.children;
+        if node.height == 0 {
+            if leaf.height != 0 {
+                return Err(ManifestError::Malformed);
+            }
+            children.push(leaf);
+        } else {
+            let last = children.pop().ok_or(ManifestError::Malformed)?;
+            let (replacement, split) = self.append_at(last, leaf, context, store)?;
+            children.push(replacement);
+            if let Some(split) = split {
+                children.push(split);
+            }
+        }
+        self.split_or_store_node(node.height, children, context, store)
+    }
+
+    fn split_or_store_node(
+        &self,
+        height: u32,
+        children: Vec<TreeRef>,
+        context: ContentReadContext,
+        store: &mut dyn ImmutableContentStore,
+    ) -> Result<(TreeRef, Option<TreeRef>), ManifestError> {
+        if children.len() <= self.fanout {
+            let length = children.iter().map(|child| child.length).sum();
+            return Ok((
+                TreeRef {
+                    id: self.put_node(context, store, StreamNode { height, children })?,
+                    length,
+                    height: height + 1,
+                },
+                None,
+            ));
+        }
+        let split_at = children.len() / 2;
+        let right_children = children[split_at..].to_vec();
+        let left_children = children[..split_at].to_vec();
+        let left_length = left_children.iter().map(|child| child.length).sum();
+        let right_length = right_children.iter().map(|child| child.length).sum();
+        let left = TreeRef {
+            id: self.put_node(
+                context,
+                store,
+                StreamNode {
+                    height,
+                    children: left_children,
+                },
+            )?,
+            length: left_length,
+            height: height + 1,
+        };
+        let right = TreeRef {
+            id: self.put_node(
+                context,
+                store,
+                StreamNode {
+                    height,
+                    children: right_children,
+                },
+            )?,
+            length: right_length,
+            height: height + 1,
+        };
+        Ok((left, Some(right)))
+    }
+
+    fn tree_range(
+        &self,
+        tree: TreeRef,
+        start: u64,
+        end: u64,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+        out: &mut Vec<u8>,
+    ) -> Result<(), ManifestError> {
+        if end > tree.length || start > end {
+            return Err(ManifestError::Malformed);
+        }
+        let node = self.get_node(tree.id, context, store)?;
+        if tree.height != node.height + 1 {
+            return Err(ManifestError::Malformed);
+        }
+        let mut offset = 0;
+        for child in node.children {
+            let child_end = offset + child.length;
+            if child_end > start && offset < end {
+                let child_start = start.saturating_sub(offset);
+                let child_limit = end.min(child_end) - offset;
+                if node.height == 0 {
+                    let bytes =
+                        self.get_object(context, child.id, ImmutableContentKind::Leaf, store)?;
+                    if bytes.len() as u64 != child.length {
+                        return Err(ManifestError::Malformed);
+                    }
+                    out.extend_from_slice(&bytes[child_start as usize..child_limit as usize]);
+                } else {
+                    self.tree_range(child, child_start, child_limit, context, store, out)?;
+                }
+            }
+            offset = child_end;
+        }
+        if offset != tree.length {
+            return Err(ManifestError::Malformed);
+        }
+        Ok(())
+    }
+
+    fn materialize_range(
+        &self,
+        manifest: &ContentManifest,
+        start: u64,
+        end: u64,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<Vec<u8>, ManifestError> {
+        let root = self.get_root(manifest.root, context, store)?;
+        let tail = self.tail(manifest)?;
+        let total = root.prefix_bytes + tail.len() as u64;
+        if start > end || end > total {
+            return Err(ManifestError::Conflict("stream range is out of bounds"));
+        }
+        let mut out = Vec::with_capacity((end - start) as usize);
+        if let Some(tree) = root.tree {
+            if start < root.prefix_bytes {
+                self.tree_range(
+                    tree,
+                    start,
+                    end.min(root.prefix_bytes),
+                    context,
+                    store,
+                    &mut out,
+                )?;
+            }
+        }
+        if end > root.prefix_bytes {
+            let tail_start = start.saturating_sub(root.prefix_bytes) as usize;
+            let tail_end = (end - root.prefix_bytes) as usize;
+            out.extend_from_slice(&tail[tail_start..tail_end]);
+        }
+        Ok(out)
+    }
+}
+
+impl ContentManifestAdapter for StreamManifestAdapter {
+    fn adapter_kind(&self) -> &str {
+        ADAPTER_KIND
+    }
+
+    fn validate_operation(&self, operation: &[u8]) -> Result<(), ManifestError> {
+        if operation.len() > self.inline_tail_bytes {
+            return Err(ManifestError::TailTooLarge {
+                actual: operation.len(),
+                maximum: self.inline_tail_bytes as u32,
+            });
+        }
+        Ok(())
+    }
+
+    fn materialize(
+        &self,
+        manifest: &ContentManifest,
+        request: &MaterializationRequest,
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<Vec<u8>, ManifestError> {
+        let root = self.get_root(manifest.root, context, store)?;
+        let total = root.prefix_bytes + self.tail(manifest)?.len() as u64;
+        match request {
+            MaterializationRequest::Full => {
+                self.materialize_range(manifest, 0, total, context, store)
+            }
+            MaterializationRequest::Range { offset, length } => self.materialize_range(
+                manifest,
+                *offset,
+                offset
+                    .checked_add(*length)
+                    .ok_or(ManifestError::Conflict("stream range overflow"))?,
+                context,
+                store,
+            ),
+            MaterializationRequest::Projection(_) => {
+                Err(ManifestError::Conflict("streams have no projections"))
+            }
+        }
+    }
+
+    fn merge(
+        &self,
+        manifests: &[ContentManifest],
+        _context: ContentReadContext,
+        _store: &dyn ImmutableContentStore,
+    ) -> Result<ContentManifest, ManifestError> {
+        let Some(first) = manifests.first() else {
+            return Err(ManifestError::Conflict("stream merge needs a manifest"));
+        };
+        if manifests.iter().all(|manifest| manifest == first) {
+            Ok(first.clone())
+        } else {
+            Err(ManifestError::Conflict(
+                "concurrent stream manifests need an append merge",
+            ))
+        }
+    }
+
+    fn index_values(
+        &self,
+        manifest: &ContentManifest,
+        requested: &[String],
+        context: ContentReadContext,
+        store: &dyn ImmutableContentStore,
+    ) -> Result<BTreeMap<String, Vec<u8>>, ManifestError> {
+        let root = self.get_root(manifest.root, context, store)?;
+        let length = root.prefix_bytes + self.tail(manifest)?.len() as u64;
+        let mut values = BTreeMap::new();
+        for name in requested {
+            match name.as_str() {
+                "length" => {
+                    values.insert(name.clone(), length.to_le_bytes().to_vec());
+                }
+                _ => return Err(ManifestError::Conflict("unknown stream index value")),
+            }
+        }
+        Ok(values)
+    }
+}
+
+fn encode_root(root: StreamRoot) -> Vec<u8> {
+    let mut out = Vec::with_capacity(45);
+    out.extend_from_slice(b"JSR1");
+    match root.tree {
+        Some(tree) => {
+            out.push(1);
+            out.extend_from_slice(&tree.id.0);
+            out.extend_from_slice(&tree.length.to_le_bytes());
+            out.extend_from_slice(&tree.height.to_le_bytes());
+        }
+        None => out.push(0),
+    }
+    out.extend_from_slice(&root.prefix_bytes.to_le_bytes());
+    out
+}
+
+fn decode_root(bytes: &[u8]) -> Result<StreamRoot, ManifestError> {
+    if bytes.len() < 13 || &bytes[..4] != b"JSR1" {
+        return Err(ManifestError::Malformed);
+    }
+    let (tree, cursor) = match bytes[4] {
+        0 => (None, 5),
+        1 if bytes.len() >= 49 => {
+            let mut id = [0; 32];
+            id.copy_from_slice(&bytes[5..37]);
+            let length = u64::from_le_bytes(
+                bytes[37..45]
+                    .try_into()
+                    .map_err(|_| ManifestError::Malformed)?,
+            );
+            let height = u32::from_le_bytes(
+                bytes[45..49]
+                    .try_into()
+                    .map_err(|_| ManifestError::Malformed)?,
+            );
+            (
+                Some(TreeRef {
+                    id: ContentId(id),
+                    length,
+                    height,
+                }),
+                49,
+            )
+        }
+        _ => return Err(ManifestError::Malformed),
+    };
+    if bytes.len() != cursor + 8 {
+        return Err(ManifestError::Malformed);
+    }
+    let prefix_bytes = u64::from_le_bytes(
+        bytes[cursor..]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    if tree.map(|tree| tree.length) != Some(prefix_bytes) && tree.is_some() {
+        return Err(ManifestError::Malformed);
+    }
+    if tree.is_none() && prefix_bytes != 0 {
+        return Err(ManifestError::Malformed);
+    }
+    Ok(StreamRoot { tree, prefix_bytes })
+}
+
+fn encode_node(node: &StreamNode) -> Vec<u8> {
+    let mut out = Vec::with_capacity(12 + node.children.len() * 44);
+    out.extend_from_slice(b"JSN1");
+    out.extend_from_slice(&node.height.to_le_bytes());
+    out.extend_from_slice(&(node.children.len() as u32).to_le_bytes());
+    for child in &node.children {
+        out.extend_from_slice(&child.id.0);
+        out.extend_from_slice(&child.length.to_le_bytes());
+        out.extend_from_slice(&child.height.to_le_bytes());
+    }
+    out
+}
+
+fn decode_node(bytes: &[u8]) -> Result<StreamNode, ManifestError> {
+    if bytes.len() < 12 || &bytes[..4] != b"JSN1" {
+        return Err(ManifestError::Malformed);
+    }
+    let height = u32::from_le_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    );
+    let count = u32::from_le_bytes(
+        bytes[8..12]
+            .try_into()
+            .map_err(|_| ManifestError::Malformed)?,
+    ) as usize;
+    if count == 0 || bytes.len() != 12 + count * 44 {
+        return Err(ManifestError::Malformed);
+    }
+    let mut children = Vec::with_capacity(count);
+    for chunk in bytes[12..].chunks_exact(44) {
+        let mut id = [0; 32];
+        id.copy_from_slice(&chunk[..32]);
+        let length = u64::from_le_bytes(
+            chunk[32..40]
+                .try_into()
+                .map_err(|_| ManifestError::Malformed)?,
+        );
+        let child_height = u32::from_le_bytes(
+            chunk[40..]
+                .try_into()
+                .map_err(|_| ManifestError::Malformed)?,
+        );
+        if child_height != height {
+            return Err(ManifestError::Malformed);
+        }
+        children.push(TreeRef {
+            id: ContentId(id),
+            length,
+            height: child_height,
+        });
+    }
+    Ok(StreamNode { height, children })
+}
+
+#[cfg(test)]
+mod tests {
+    // Internal because the foundation's adapter/store seam is not yet exposed
+    // through a public client API. These tests exercise the canonical content
+    // codec and corruption boundary directly until that public vertical slice exists.
+    use super::*;
+    use crate::content_manifest::{ContentDomainId, MemoryImmutableContentStore};
+
+    fn context() -> ContentReadContext {
+        ContentReadContext {
+            domain: ContentDomainId(uuid::Uuid::from_bytes([7; 16])),
+        }
+    }
+
+    #[test]
+    fn tail_is_part_of_every_materialized_owner_snapshot() {
+        let adapter = StreamManifestAdapter::new(4, 4).unwrap();
+        let mut store = MemoryImmutableContentStore::default();
+        let empty = adapter.empty_manifest(context(), &mut store).unwrap();
+        let first = adapter
+            .append(&empty, b"ab", context(), &mut store)
+            .unwrap();
+        let promoted = adapter
+            .append(&first, b"cde", context(), &mut store)
+            .unwrap();
+        let current = adapter
+            .append(&promoted, b"fg", context(), &mut store)
+            .unwrap();
+        assert_eq!(
+            adapter
+                .materialize(&first, &MaterializationRequest::Full, context(), &store)
+                .unwrap(),
+            b"ab"
+        );
+        assert_eq!(
+            adapter
+                .materialize(&promoted, &MaterializationRequest::Full, context(), &store)
+                .unwrap(),
+            b"abcde"
+        );
+        assert_eq!(
+            adapter
+                .materialize(
+                    &current,
+                    &MaterializationRequest::Range {
+                        offset: 3,
+                        length: 4
+                    },
+                    context(),
+                    &store
+                )
+                .unwrap(),
+            b"defg"
+        );
+    }
+
+    #[test]
+    fn promotion_is_content_addressed_and_keeps_one_logical_tail() {
+        let adapter = StreamManifestAdapter::new(3, 4).unwrap();
+        let mut store = MemoryImmutableContentStore::default();
+        let empty = adapter.empty_manifest(context(), &mut store).unwrap();
+        let tail = adapter
+            .append(&empty, b"abc", context(), &mut store)
+            .unwrap();
+        let promoted = adapter.append(&tail, b"d", context(), &mut store).unwrap();
+        assert_eq!(tail.edit_tail, vec![b"abc".to_vec()]);
+        assert!(promoted.edit_tail.is_empty());
+        let repeated = adapter
+            .append(&empty, b"abcd", context(), &mut store)
+            .unwrap();
+        assert_eq!(
+            promoted.root, repeated.root,
+            "identical immutable stream roots deduplicate"
+        );
+    }
+
+    #[test]
+    fn merge_and_index_see_the_complete_manifest_not_only_its_root() {
+        let adapter = StreamManifestAdapter::new(8, 4).unwrap();
+        let mut store = MemoryImmutableContentStore::default();
+        let empty = adapter.empty_manifest(context(), &mut store).unwrap();
+        let tail = adapter
+            .append(&empty, b"tail", context(), &mut store)
+            .unwrap();
+        assert_eq!(
+            adapter.merge(&[empty.clone(), tail.clone()], context(), &store),
+            Err(ManifestError::Conflict(
+                "concurrent stream manifests need an append merge"
+            ))
+        );
+        let index = adapter
+            .index_values(&tail, &["length".into()], context(), &store)
+            .unwrap();
+        assert_eq!(
+            u64::from_le_bytes(index["length"].as_slice().try_into().unwrap()),
+            4
+        );
+    }
+
+    #[test]
+    fn corrupted_tree_cannot_return_bytes() {
+        let adapter = StreamManifestAdapter::new(1, 4).unwrap();
+        let mut store = MemoryImmutableContentStore::default();
+        let empty = adapter.empty_manifest(context(), &mut store).unwrap();
+        let manifest = adapter
+            .append(&empty, b"ab", context(), &mut store)
+            .unwrap();
+        let root = adapter.get_root(manifest.root, context(), &store).unwrap();
+        let node = root.tree.unwrap();
+        let bad = StreamNode {
+            height: 0,
+            children: vec![TreeRef {
+                id: ContentId([9; 32]),
+                length: 2,
+                height: 0,
+            }],
+        };
+        let bad_id = store
+            .put_if_absent_or_identical(
+                ContentAddress {
+                    domain: context().domain,
+                    adapter_kind: ADAPTER_KIND,
+                    kind: ImmutableContentKind::Node,
+                },
+                encode_node(&bad),
+            )
+            .unwrap();
+        let bad_root = adapter
+            .put_root(
+                context(),
+                &mut store,
+                StreamRoot {
+                    tree: Some(TreeRef { id: bad_id, ..node }),
+                    prefix_bytes: 2,
+                },
+            )
+            .unwrap();
+        assert!(
+            adapter
+                .materialize(
+                    &ContentManifest {
+                        root: bad_root,
+                        edit_tail: vec![]
+                    },
+                    &MaterializationRequest::Full,
+                    context(),
+                    &store
+                )
+                .is_err()
+        );
+    }
+}

--- a/crates/jazz/src/stream_manifest.rs
+++ b/crates/jazz/src/stream_manifest.rs
@@ -7,9 +7,12 @@
 
 use std::collections::BTreeMap;
 
+use groove::records::{Value, ValueType};
+
 use crate::content_manifest::{
-    ContentAddress, ContentId, ContentManifest, ContentManifestAdapter, ContentReadContext,
-    ImmutableContentKind, ImmutableContentStore, ManifestError, MaterializationRequest, content_id,
+    ContentAddress, ContentId, ContentManifest, ContentManifestAdapter, ContentManifestSchema,
+    ContentReadContext, ImmutableContentKind, ImmutableContentStore, ManifestError,
+    MaterializationRequest, content_id,
 };
 
 pub const DEFAULT_STREAM_INLINE_TAIL_BYTES: usize = 256;
@@ -96,13 +99,20 @@ impl StreamManifestAdapter {
         if bytes.is_empty() {
             return Ok(manifest.clone());
         }
-        let mut combined = Vec::with_capacity(old_tail.len() + bytes.len());
+        let combined_len = old_tail
+            .len()
+            .checked_add(bytes.len())
+            .ok_or(ManifestError::Malformed)?;
+        let mut combined = Vec::new();
+        combined
+            .try_reserve_exact(combined_len)
+            .map_err(|_| ManifestError::Malformed)?;
         combined.extend_from_slice(old_tail);
         combined.extend_from_slice(bytes);
         if combined.len() <= self.inline_tail_bytes {
             return Ok(ContentManifest {
                 root: manifest.root,
-                edit_tail: vec![combined],
+                edit_tail: vec![Value::Bytes(combined)],
             });
         }
 
@@ -114,7 +124,7 @@ impl StreamManifestAdapter {
                 tree,
                 TreeRef {
                     id,
-                    length: part.len() as u64,
+                    length: u64::try_from(part.len()).map_err(|_| ManifestError::Malformed)?,
                     height: 0,
                 },
                 context,
@@ -123,8 +133,8 @@ impl StreamManifestAdapter {
         }
         let prefix_bytes = old_root
             .prefix_bytes
-            .checked_add(combined.len() as u64)
-            .ok_or(ManifestError::Conflict("stream length overflow"))?;
+            .checked_add(u64::try_from(combined.len()).map_err(|_| ManifestError::Malformed)?)
+            .ok_or(ManifestError::Malformed)?;
         Ok(ContentManifest {
             root: self.put_root(context, store, StreamRoot { tree, prefix_bytes })?,
             edit_tail: Vec::new(),
@@ -134,11 +144,12 @@ impl StreamManifestAdapter {
     fn tail<'a>(&self, manifest: &'a ContentManifest) -> Result<&'a [u8], ManifestError> {
         match manifest.edit_tail.as_slice() {
             [] => Ok(&[]),
-            [tail] if tail.len() <= self.inline_tail_bytes => Ok(tail),
-            [_] => Err(ManifestError::TailTooLarge {
-                actual: manifest.edit_tail[0].len(),
+            [Value::Bytes(tail)] if tail.len() <= self.inline_tail_bytes => Ok(tail),
+            [Value::Bytes(tail)] => Err(ManifestError::TailTooLarge {
+                actual: tail.len(),
                 maximum: self.inline_tail_bytes as u32,
             }),
+            [_] => Err(ManifestError::Malformed),
             _ => Err(ManifestError::Conflict(
                 "stream manifests have one logical tail",
             )),
@@ -269,11 +280,18 @@ impl StreamManifestAdapter {
                 height: replacement.height,
                 children: vec![replacement, split],
             };
-            let length = replacement.length + split.length;
+            let length = replacement
+                .length
+                .checked_add(split.length)
+                .ok_or(ManifestError::Malformed)?;
+            let height = replacement
+                .height
+                .checked_add(1)
+                .ok_or(ManifestError::Malformed)?;
             return Ok(TreeRef {
                 id: self.put_node(context, store, node)?,
                 length,
-                height: replacement.height + 1,
+                height,
             });
         }
         Ok(replacement)
@@ -287,7 +305,7 @@ impl StreamManifestAdapter {
         store: &mut dyn ImmutableContentStore,
     ) -> Result<(TreeRef, Option<TreeRef>), ManifestError> {
         let node = self.get_node(tree.id, context, store)?;
-        if tree.height != node.height + 1 || node.children.is_empty() {
+        if node.height.checked_add(1) != Some(tree.height) || node.children.is_empty() {
             return Err(ManifestError::Malformed);
         }
         let mut children = node.children;
@@ -315,12 +333,13 @@ impl StreamManifestAdapter {
         store: &mut dyn ImmutableContentStore,
     ) -> Result<(TreeRef, Option<TreeRef>), ManifestError> {
         if children.len() <= self.fanout {
-            let length = children.iter().map(|child| child.length).sum();
+            let length = checked_tree_length(&children)?;
+            let tree_height = height.checked_add(1).ok_or(ManifestError::Malformed)?;
             return Ok((
                 TreeRef {
                     id: self.put_node(context, store, StreamNode { height, children })?,
                     length,
-                    height: height + 1,
+                    height: tree_height,
                 },
                 None,
             ));
@@ -328,8 +347,9 @@ impl StreamManifestAdapter {
         let split_at = children.len() / 2;
         let right_children = children[split_at..].to_vec();
         let left_children = children[..split_at].to_vec();
-        let left_length = left_children.iter().map(|child| child.length).sum();
-        let right_length = right_children.iter().map(|child| child.length).sum();
+        let left_length = checked_tree_length(&left_children)?;
+        let right_length = checked_tree_length(&right_children)?;
+        let tree_height = height.checked_add(1).ok_or(ManifestError::Malformed)?;
         let left = TreeRef {
             id: self.put_node(
                 context,
@@ -340,7 +360,7 @@ impl StreamManifestAdapter {
                 },
             )?,
             length: left_length,
-            height: height + 1,
+            height: tree_height,
         };
         let right = TreeRef {
             id: self.put_node(
@@ -352,7 +372,7 @@ impl StreamManifestAdapter {
                 },
             )?,
             length: right_length,
-            height: height + 1,
+            height: tree_height,
         };
         Ok((left, Some(right)))
     }
@@ -370,22 +390,33 @@ impl StreamManifestAdapter {
             return Err(ManifestError::Malformed);
         }
         let node = self.get_node(tree.id, context, store)?;
-        if tree.height != node.height + 1 {
+        if node.height.checked_add(1) != Some(tree.height) {
             return Err(ManifestError::Malformed);
         }
-        let mut offset = 0;
+        let mut offset = 0_u64;
         for child in node.children {
-            let child_end = offset + child.length;
+            let child_end = offset
+                .checked_add(child.length)
+                .ok_or(ManifestError::Malformed)?;
             if child_end > start && offset < end {
                 let child_start = start.saturating_sub(offset);
                 let child_limit = end.min(child_end) - offset;
                 if node.height == 0 {
                     let bytes =
                         self.get_object(context, child.id, ImmutableContentKind::Leaf, store)?;
-                    if bytes.len() as u64 != child.length {
+                    if u64::try_from(bytes.len()).map_err(|_| ManifestError::Malformed)?
+                        != child.length
+                    {
                         return Err(ManifestError::Malformed);
                     }
-                    out.extend_from_slice(&bytes[child_start as usize..child_limit as usize]);
+                    let child_start =
+                        usize::try_from(child_start).map_err(|_| ManifestError::Malformed)?;
+                    let child_limit =
+                        usize::try_from(child_limit).map_err(|_| ManifestError::Malformed)?;
+                    let range = bytes
+                        .get(child_start..child_limit)
+                        .ok_or(ManifestError::Malformed)?;
+                    out.extend_from_slice(range);
                 } else {
                     self.tree_range(child, child_start, child_limit, context, store, out)?;
                 }
@@ -408,11 +439,14 @@ impl StreamManifestAdapter {
     ) -> Result<Vec<u8>, ManifestError> {
         let root = self.get_root(manifest.root, context, store)?;
         let tail = self.tail(manifest)?;
-        let total = root.prefix_bytes + tail.len() as u64;
+        let total = checked_total_length(root.prefix_bytes, tail.len())?;
         if start > end || end > total {
             return Err(ManifestError::Conflict("stream range is out of bounds"));
         }
-        let mut out = Vec::with_capacity((end - start) as usize);
+        let requested_len = usize::try_from(end - start).map_err(|_| ManifestError::Malformed)?;
+        let mut out = Vec::new();
+        out.try_reserve_exact(requested_len)
+            .map_err(|_| ManifestError::Malformed)?;
         if let Some(tree) = root.tree {
             if start < root.prefix_bytes {
                 self.tree_range(
@@ -426,9 +460,14 @@ impl StreamManifestAdapter {
             }
         }
         if end > root.prefix_bytes {
-            let tail_start = start.saturating_sub(root.prefix_bytes) as usize;
-            let tail_end = (end - root.prefix_bytes) as usize;
-            out.extend_from_slice(&tail[tail_start..tail_end]);
+            let tail_start = usize::try_from(start.saturating_sub(root.prefix_bytes))
+                .map_err(|_| ManifestError::Malformed)?;
+            let tail_end =
+                usize::try_from(end - root.prefix_bytes).map_err(|_| ManifestError::Malformed)?;
+            let range = tail
+                .get(tail_start..tail_end)
+                .ok_or(ManifestError::Malformed)?;
+            out.extend_from_slice(range);
         }
         Ok(out)
     }
@@ -439,7 +478,17 @@ impl ContentManifestAdapter for StreamManifestAdapter {
         ADAPTER_KIND
     }
 
-    fn validate_operation(&self, operation: &[u8]) -> Result<(), ManifestError> {
+    fn validate_schema(&self, schema: &ContentManifestSchema) -> Result<(), ManifestError> {
+        if schema.adapter_kind != ADAPTER_KIND || schema.tail_entry_type != ValueType::Bytes {
+            return Err(ManifestError::InvalidSchema);
+        }
+        Ok(())
+    }
+
+    fn validate_operation(&self, operation: &Value) -> Result<(), ManifestError> {
+        let Value::Bytes(operation) = operation else {
+            return Err(ManifestError::Malformed);
+        };
         if operation.len() > self.inline_tail_bytes {
             return Err(ManifestError::TailTooLarge {
                 actual: operation.len(),
@@ -457,7 +506,7 @@ impl ContentManifestAdapter for StreamManifestAdapter {
         store: &dyn ImmutableContentStore,
     ) -> Result<Vec<u8>, ManifestError> {
         let root = self.get_root(manifest.root, context, store)?;
-        let total = root.prefix_bytes + self.tail(manifest)?.len() as u64;
+        let total = checked_total_length(root.prefix_bytes, self.tail(manifest)?.len())?;
         match request {
             MaterializationRequest::Full => {
                 self.materialize_range(manifest, 0, total, context, store)
@@ -467,7 +516,7 @@ impl ContentManifestAdapter for StreamManifestAdapter {
                 *offset,
                 offset
                     .checked_add(*length)
-                    .ok_or(ManifestError::Conflict("stream range overflow"))?,
+                    .ok_or(ManifestError::Malformed)?,
                 context,
                 store,
             ),
@@ -503,7 +552,7 @@ impl ContentManifestAdapter for StreamManifestAdapter {
         store: &dyn ImmutableContentStore,
     ) -> Result<BTreeMap<String, Vec<u8>>, ManifestError> {
         let root = self.get_root(manifest.root, context, store)?;
-        let length = root.prefix_bytes + self.tail(manifest)?.len() as u64;
+        let length = checked_total_length(root.prefix_bytes, self.tail(manifest)?.len())?;
         let mut values = BTreeMap::new();
         for name in requested {
             match name.as_str() {
@@ -533,12 +582,26 @@ fn encode_root(root: StreamRoot) -> Vec<u8> {
     out
 }
 
+fn checked_tree_length(children: &[TreeRef]) -> Result<u64, ManifestError> {
+    children.iter().try_fold(0_u64, |total, child| {
+        total
+            .checked_add(child.length)
+            .ok_or(ManifestError::Malformed)
+    })
+}
+
+fn checked_total_length(prefix_bytes: u64, tail_bytes: usize) -> Result<u64, ManifestError> {
+    prefix_bytes
+        .checked_add(u64::try_from(tail_bytes).map_err(|_| ManifestError::Malformed)?)
+        .ok_or(ManifestError::Malformed)
+}
+
 fn decode_root(bytes: &[u8]) -> Result<StreamRoot, ManifestError> {
     if bytes.len() < 13 || &bytes[..4] != b"JSR1" {
         return Err(ManifestError::Malformed);
     }
     let (tree, cursor) = match bytes[4] {
-        0 => (None, 5),
+        0 => (None, 5_usize),
         1 if bytes.len() >= 49 => {
             let mut id = [0; 32];
             id.copy_from_slice(&bytes[5..37]);
@@ -558,12 +621,13 @@ fn decode_root(bytes: &[u8]) -> Result<StreamRoot, ManifestError> {
                     length,
                     height,
                 }),
-                49,
+                49_usize,
             )
         }
         _ => return Err(ManifestError::Malformed),
     };
-    if bytes.len() != cursor + 8 {
+    let expected_len = cursor.checked_add(8).ok_or(ManifestError::Malformed)?;
+    if bytes.len() != expected_len {
         return Err(ManifestError::Malformed);
     }
     let prefix_bytes = u64::from_le_bytes(
@@ -581,7 +645,13 @@ fn decode_root(bytes: &[u8]) -> Result<StreamRoot, ManifestError> {
 }
 
 fn encode_node(node: &StreamNode) -> Vec<u8> {
-    let mut out = Vec::with_capacity(12 + node.children.len() * 44);
+    let encoded_len = node
+        .children
+        .len()
+        .checked_mul(44)
+        .and_then(|children_len| 12_usize.checked_add(children_len))
+        .expect("bounded stream node encoding length");
+    let mut out = Vec::with_capacity(encoded_len);
     out.extend_from_slice(b"JSN1");
     out.extend_from_slice(&node.height.to_le_bytes());
     out.extend_from_slice(&(node.children.len() as u32).to_le_bytes());
@@ -602,15 +672,23 @@ fn decode_node(bytes: &[u8]) -> Result<StreamNode, ManifestError> {
             .try_into()
             .map_err(|_| ManifestError::Malformed)?,
     );
-    let count = u32::from_le_bytes(
+    let count = usize::try_from(u32::from_le_bytes(
         bytes[8..12]
             .try_into()
             .map_err(|_| ManifestError::Malformed)?,
-    ) as usize;
-    if count == 0 || bytes.len() != 12 + count * 44 {
+    ))
+    .map_err(|_| ManifestError::Malformed)?;
+    let encoded_len = count
+        .checked_mul(44)
+        .and_then(|children_len| 12_usize.checked_add(children_len))
+        .ok_or(ManifestError::Malformed)?;
+    if count == 0 || bytes.len() != encoded_len {
         return Err(ManifestError::Malformed);
     }
-    let mut children = Vec::with_capacity(count);
+    let mut children = Vec::new();
+    children
+        .try_reserve_exact(count)
+        .map_err(|_| ManifestError::Malformed)?;
     for chunk in bytes[12..].chunks_exact(44) {
         let mut id = [0; 32];
         id.copy_from_slice(&chunk[..32]);
@@ -701,7 +779,7 @@ mod tests {
             .append(&empty, b"abc", context(), &mut store)
             .unwrap();
         let promoted = adapter.append(&tail, b"d", context(), &mut store).unwrap();
-        assert_eq!(tail.edit_tail, vec![b"abc".to_vec()]);
+        assert_eq!(tail.edit_tail, vec![Value::Bytes(b"abc".to_vec())]);
         assert!(promoted.edit_tail.is_empty());
         let repeated = adapter
             .append(&empty, b"abcd", context(), &mut store)
@@ -856,6 +934,120 @@ mod tests {
                 Err(ManifestError::Malformed),
             ),
             "full reads, ranges, and later appends must all enforce the fetched-node fanout"
+        );
+    }
+
+    #[test]
+    fn extreme_declared_lengths_fail_closed_without_panicking() {
+        let adapter = StreamManifestAdapter::with_layout_for_test(256, 4);
+        let mut store = MemoryImmutableContentStore::default();
+        let children = [u64::MAX, 1, 1, 1]
+            .into_iter()
+            .map(|length| TreeRef {
+                id: ContentId([3; 32]),
+                length,
+                height: 0,
+            })
+            .collect::<Vec<_>>();
+        let node_bytes = encode_node(&StreamNode {
+            height: 0,
+            children,
+        });
+        let node_id = store
+            .put_if_absent_or_identical(
+                ContentAddress {
+                    domain: context().domain,
+                    adapter_kind: ADAPTER_KIND,
+                    kind: ImmutableContentKind::Node,
+                },
+                node_bytes,
+            )
+            .unwrap();
+        let root_bytes = encode_root(StreamRoot {
+            tree: Some(TreeRef {
+                id: node_id,
+                length: u64::MAX,
+                height: 1,
+            }),
+            prefix_bytes: u64::MAX,
+        });
+        let root = store
+            .put_if_absent_or_identical(
+                ContentAddress {
+                    domain: context().domain,
+                    adapter_kind: ADAPTER_KIND,
+                    kind: ImmutableContentKind::Root,
+                },
+                root_bytes,
+            )
+            .unwrap();
+        let without_tail = ContentManifest {
+            root,
+            edit_tail: Vec::new(),
+        };
+        let with_tail = ContentManifest {
+            root,
+            edit_tail: vec![Value::Bytes(vec![1])],
+        };
+
+        let outcomes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let full =
+                adapter.materialize(&with_tail, &MaterializationRequest::Full, context(), &store);
+            let request_overflow = adapter.materialize(
+                &without_tail,
+                &MaterializationRequest::Range {
+                    offset: u64::MAX,
+                    length: 1,
+                },
+                context(),
+                &store,
+            );
+            let empty_boundary_range = adapter.materialize(
+                &without_tail,
+                &MaterializationRequest::Range {
+                    offset: u64::MAX,
+                    length: 0,
+                },
+                context(),
+                &store,
+            );
+            let mut traversal_bytes = Vec::new();
+            let traversal_overflow = adapter.tree_range(
+                TreeRef {
+                    id: node_id,
+                    length: u64::MAX,
+                    height: 1,
+                },
+                u64::MAX,
+                u64::MAX,
+                context(),
+                &store,
+                &mut traversal_bytes,
+            );
+            let index = adapter.index_values(&with_tail, &["length".into()], context(), &store);
+            let append = adapter.append(&without_tail, &[9; 257], context(), &mut store);
+            (
+                full,
+                request_overflow,
+                empty_boundary_range,
+                traversal_overflow,
+                index,
+                append,
+            )
+        }))
+        .expect("untrusted stream lengths must never panic");
+
+        assert_eq!(
+            outcomes,
+            (
+                Err(ManifestError::Malformed),
+                Err(ManifestError::Malformed),
+                Ok(Vec::new()),
+                Err(ManifestError::Malformed),
+                Err(ManifestError::Malformed),
+                Err(ManifestError::Malformed),
+            ),
+            "full/range/index/append/promotion paths reject extreme metadata"
         );
     }
 

--- a/crates/jazz/src/stream_manifest.rs
+++ b/crates/jazz/src/stream_manifest.rs
@@ -54,19 +54,14 @@ impl Default for StreamManifestAdapter {
 }
 
 impl StreamManifestAdapter {
-    pub fn new(inline_tail_bytes: usize, fanout: usize) -> Result<Self, ManifestError> {
-        if inline_tail_bytes == 0 || inline_tail_bytes > MAX_STREAM_PART_BYTES {
-            return Err(ManifestError::Conflict(
-                "stream inline tail bound is invalid",
-            ));
-        }
-        if !(4..=256).contains(&fanout) || !fanout.is_multiple_of(2) {
-            return Err(ManifestError::Conflict("stream tree fanout is invalid"));
-        }
-        Ok(Self {
+    #[cfg(test)]
+    fn with_layout_for_test(inline_tail_bytes: usize, fanout: usize) -> Self {
+        assert!((1..=MAX_STREAM_PART_BYTES).contains(&inline_tail_bytes));
+        assert!((4..=256).contains(&fanout) && fanout.is_multiple_of(2));
+        Self {
             inline_tail_bytes,
             fanout,
-        })
+        }
     }
 
     /// Create an empty immutable root and the manifest stored in an owner row.
@@ -229,7 +224,11 @@ impl StreamManifestAdapter {
         context: ContentReadContext,
         store: &dyn ImmutableContentStore,
     ) -> Result<StreamNode, ManifestError> {
-        decode_node(self.get_object(context, id, ImmutableContentKind::Node, store)?)
+        let node = decode_node(self.get_object(context, id, ImmutableContentKind::Node, store)?)?;
+        if node.children.len() > self.fanout {
+            return Err(ManifestError::Malformed);
+        }
+        Ok(node)
     }
 
     fn get_object<'a>(
@@ -653,7 +652,7 @@ mod tests {
 
     #[test]
     fn tail_is_part_of_every_materialized_owner_snapshot() {
-        let adapter = StreamManifestAdapter::new(4, 4).unwrap();
+        let adapter = StreamManifestAdapter::with_layout_for_test(4, 4);
         let mut store = MemoryImmutableContentStore::default();
         let empty = adapter.empty_manifest(context(), &mut store).unwrap();
         let first = adapter
@@ -695,7 +694,7 @@ mod tests {
 
     #[test]
     fn promotion_is_content_addressed_and_keeps_one_logical_tail() {
-        let adapter = StreamManifestAdapter::new(3, 4).unwrap();
+        let adapter = StreamManifestAdapter::with_layout_for_test(3, 4);
         let mut store = MemoryImmutableContentStore::default();
         let empty = adapter.empty_manifest(context(), &mut store).unwrap();
         let tail = adapter
@@ -715,7 +714,7 @@ mod tests {
 
     #[test]
     fn merge_and_index_see_the_complete_manifest_not_only_its_root() {
-        let adapter = StreamManifestAdapter::new(8, 4).unwrap();
+        let adapter = StreamManifestAdapter::with_layout_for_test(8, 4);
         let mut store = MemoryImmutableContentStore::default();
         let empty = adapter.empty_manifest(context(), &mut store).unwrap();
         let tail = adapter
@@ -738,7 +737,7 @@ mod tests {
 
     #[test]
     fn corrupted_tree_cannot_return_bytes() {
-        let adapter = StreamManifestAdapter::new(1, 4).unwrap();
+        let adapter = StreamManifestAdapter::with_layout_for_test(1, 4);
         let mut store = MemoryImmutableContentStore::default();
         let empty = adapter.empty_manifest(context(), &mut store).unwrap();
         let manifest = adapter
@@ -786,6 +785,156 @@ mod tests {
                     &store
                 )
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn correctly_hashed_oversized_node_is_rejected_by_every_read_path() {
+        let adapter = StreamManifestAdapter::with_layout_for_test(1, 4);
+        let mut store = MemoryImmutableContentStore::default();
+        let children = (0..5)
+            .map(|byte| {
+                Ok(TreeRef {
+                    id: adapter.put_part(context(), &mut store, &[byte])?,
+                    length: 1,
+                    height: 0,
+                })
+            })
+            .collect::<Result<Vec<_>, ManifestError>>()
+            .unwrap();
+        let oversized = StreamNode {
+            height: 0,
+            children,
+        };
+        // Bypass the writer-side guard to model a correctly content-addressed
+        // node received from an untrusted or differently configured writer.
+        let node_id = store
+            .put_if_absent_or_identical(
+                ContentAddress {
+                    domain: context().domain,
+                    adapter_kind: ADAPTER_KIND,
+                    kind: ImmutableContentKind::Node,
+                },
+                encode_node(&oversized),
+            )
+            .unwrap();
+        let root = adapter
+            .put_root(
+                context(),
+                &mut store,
+                StreamRoot {
+                    tree: Some(TreeRef {
+                        id: node_id,
+                        length: 5,
+                        height: 1,
+                    }),
+                    prefix_bytes: 5,
+                },
+            )
+            .unwrap();
+        let manifest = ContentManifest {
+            root,
+            edit_tail: Vec::new(),
+        };
+
+        let full = adapter.materialize(&manifest, &MaterializationRequest::Full, context(), &store);
+        let range = adapter.materialize(
+            &manifest,
+            &MaterializationRequest::Range {
+                offset: 1,
+                length: 2,
+            },
+            context(),
+            &store,
+        );
+        let append = adapter.append(&manifest, b"xy", context(), &mut store);
+        assert_eq!(
+            (full, range, append),
+            (
+                Err(ManifestError::Malformed),
+                Err(ManifestError::Malformed),
+                Err(ManifestError::Malformed),
+            ),
+            "full reads, ranges, and later appends must all enforce the fetched-node fanout"
+        );
+    }
+
+    #[test]
+    fn multi_leaf_split_reuses_unchanged_spine_and_ranges_across_parts() {
+        let adapter = StreamManifestAdapter::with_layout_for_test(1, 4);
+        let mut store = MemoryImmutableContentStore::default();
+        let mut manifest = adapter.empty_manifest(context(), &mut store).unwrap();
+        let mut after_five = None;
+        for byte in 1..=6 {
+            manifest = adapter
+                .append(
+                    &manifest,
+                    &vec![byte; MAX_STREAM_PART_BYTES],
+                    context(),
+                    &mut store,
+                )
+                .unwrap();
+            if byte == 5 {
+                after_five = Some(manifest.clone());
+            }
+        }
+
+        let after_five = after_five.unwrap();
+        let five_root = adapter
+            .get_root(after_five.root, context(), &store)
+            .unwrap()
+            .tree
+            .unwrap();
+        let six_root = adapter
+            .get_root(manifest.root, context(), &store)
+            .unwrap()
+            .tree
+            .unwrap();
+        assert_eq!(five_root.height, 2, "the fifth leaf must split fanout four");
+        assert_eq!(six_root.height, 2);
+        let five_children = adapter
+            .get_node(five_root.id, context(), &store)
+            .unwrap()
+            .children;
+        let six_children = adapter
+            .get_node(six_root.id, context(), &store)
+            .unwrap()
+            .children;
+        assert_eq!(five_children.len(), 2);
+        assert_eq!(six_children.len(), 2);
+        assert_eq!(
+            five_children[0].id, six_children[0].id,
+            "appending on the right must reuse the untouched left subtree"
+        );
+
+        assert_eq!(
+            adapter
+                .materialize(
+                    &manifest,
+                    &MaterializationRequest::Range {
+                        offset: MAX_STREAM_PART_BYTES as u64 - 2,
+                        length: 4,
+                    },
+                    context(),
+                    &store,
+                )
+                .unwrap(),
+            [1, 1, 2, 2]
+        );
+        assert_eq!(
+            adapter
+                .materialize(
+                    &after_five,
+                    &MaterializationRequest::Range {
+                        offset: 5 * MAX_STREAM_PART_BYTES as u64 - 2,
+                        length: 2,
+                    },
+                    context(),
+                    &store,
+                )
+                .unwrap(),
+            [5, 5],
+            "the older root remains directly readable after right-spine copying"
         );
     }
 }

--- a/crates/jazz/tests/stream_content_manifest.rs
+++ b/crates/jazz/tests/stream_content_manifest.rs
@@ -5,7 +5,7 @@ use jazz::content_manifest::{
     ContentDomainId, ContentManifest, ContentManifestRuntimeProvider, ContentManifestSchema,
     ContentReadContext, ImmutableContentStore, MaterializationRequest, MemoryImmutableContentStore,
 };
-use jazz::groove::records::Value;
+use jazz::groove::records::{Value, ValueType};
 use jazz::groove::storage::RocksDbStorage;
 use jazz::ids::{NodeUuid, RowUuid};
 use jazz::node::{MergeableCommit, NodeState};
@@ -30,7 +30,7 @@ impl ContentManifestRuntimeProvider for Provider {
 }
 
 fn cell(manifest: &ContentManifest, schema: &ContentManifestSchema) -> Value {
-    Value::Bytes(manifest.encode(schema).unwrap())
+    manifest.into_value(schema).unwrap()
 }
 
 /// Black-boxes the public schema and Node seams. Adapter codec tests remain
@@ -60,7 +60,8 @@ fn registered_stream_manifest_runs_through_a_real_node() {
 
     // The schema bound is deliberately wider than stream-v1's production
     // bound so row admission proves the registered adapter also validates it.
-    let manifest_schema = ContentManifestSchema::new("stream-v1", 1, 512).unwrap();
+    let manifest_schema =
+        ContentManifestSchema::with_tail_entry_type("stream-v1", ValueType::Bytes, 1, 512).unwrap();
     let schema = JazzSchema::new([TableSchema::new(
         "documents",
         [ColumnSchema::content_manifest(
@@ -170,7 +171,7 @@ fn registered_stream_manifest_runs_through_a_real_node() {
 
     let maximum_tail = ContentManifest {
         root: current.root,
-        edit_tail: vec![vec![0; 256]],
+        edit_tail: vec![Value::Bytes(vec![0; 256])],
     };
     let boundary = node
         .commit_mergeable(
@@ -183,7 +184,7 @@ fn registered_stream_manifest_runs_through_a_real_node() {
 
     let invalid = ContentManifest {
         root: current.root,
-        edit_tail: vec![vec![0; 257]],
+        edit_tail: vec![Value::Bytes(vec![0; 257])],
     };
     assert!(
         node.commit_mergeable(

--- a/crates/jazz/tests/stream_content_manifest.rs
+++ b/crates/jazz/tests/stream_content_manifest.rs
@@ -42,16 +42,21 @@ fn registered_stream_manifest_runs_through_a_real_node() {
     let node_uuid = NodeUuid::from_bytes([0x51; 16]);
     let domain = ContentDomainId(node_uuid.0);
     let context = ContentReadContext { domain };
-    let adapter = StreamManifestAdapter::new(4, 4).unwrap();
+    let adapter = StreamManifestAdapter::default();
     let mut store = MemoryImmutableContentStore::default();
 
     let empty = adapter.empty_manifest(context, &mut store).unwrap();
+    let immutable_bytes = (0..257)
+        .map(|index| (index % 251) as u8)
+        .collect::<Vec<_>>();
     let immutable_history = adapter
-        .append(&empty, b"abcde", context, &mut store)
+        .append(&empty, &immutable_bytes, context, &mut store)
         .unwrap();
     let current = adapter
         .append(&immutable_history, b"fg", context, &mut store)
         .unwrap();
+    let mut current_bytes = immutable_bytes.clone();
+    current_bytes.extend_from_slice(b"fg");
 
     // The schema bound is deliberately wider than stream-v1's production
     // bound so row admission proves the registered adapter also validates it.
@@ -129,7 +134,7 @@ fn registered_stream_manifest_runs_through_a_real_node() {
             &MaterializationRequest::Full,
         )
         .unwrap(),
-        b"abcdefg"
+        current_bytes
     );
     assert_eq!(
         node.materialize_content_manifest(
@@ -137,12 +142,12 @@ fn registered_stream_manifest_runs_through_a_real_node() {
             "attachment",
             visible_cell,
             &MaterializationRequest::Range {
-                offset: 3,
+                offset: 255,
                 length: 4,
             },
         )
         .unwrap(),
-        b"defg"
+        [4, 5, b'f', b'g']
     );
     assert_eq!(
         node.materialize_content_manifest(
@@ -152,7 +157,7 @@ fn registered_stream_manifest_runs_through_a_real_node() {
             &MaterializationRequest::Full,
         )
         .unwrap(),
-        b"abcde",
+        immutable_bytes,
         "a direct historical manifest must not consult current row history"
     );
     let index = node
@@ -160,7 +165,7 @@ fn registered_stream_manifest_runs_through_a_real_node() {
         .unwrap();
     assert_eq!(
         u64::from_le_bytes(index["length"].as_slice().try_into().unwrap()),
-        7
+        259
     );
 
     let maximum_tail = ContentManifest {

--- a/crates/jazz/tests/stream_content_manifest.rs
+++ b/crates/jazz/tests/stream_content_manifest.rs
@@ -163,13 +163,26 @@ fn registered_stream_manifest_runs_through_a_real_node() {
         7
     );
 
+    let maximum_tail = ContentManifest {
+        root: current.root,
+        edit_tail: vec![vec![0; 256]],
+    };
+    let boundary = node
+        .commit_mergeable(
+            MergeableCommit::new("documents", RowUuid::from_bytes([0x53; 16]), 30).cells(
+                BTreeMap::from([("attachment".into(), cell(&maximum_tail, &manifest_schema))]),
+            ),
+        )
+        .expect("stream-v1's exact 256-byte operation bound must be admitted");
+    node.finalize_local_mergeable_commit(boundary).unwrap();
+
     let invalid = ContentManifest {
         root: current.root,
         edit_tail: vec![vec![0; 257]],
     };
     assert!(
         node.commit_mergeable(
-            MergeableCommit::new("documents", RowUuid::from_bytes([0x53; 16]), 30).cells(
+            MergeableCommit::new("documents", RowUuid::from_bytes([0x54; 16]), 31).cells(
                 BTreeMap::from([("attachment".into(), cell(&invalid, &manifest_schema))]),
             ),
         )

--- a/crates/jazz/tests/stream_content_manifest.rs
+++ b/crates/jazz/tests/stream_content_manifest.rs
@@ -1,0 +1,179 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use jazz::content_manifest::{
+    ContentDomainId, ContentManifest, ContentManifestRuntimeProvider, ContentManifestSchema,
+    ContentReadContext, ImmutableContentStore, MaterializationRequest, MemoryImmutableContentStore,
+};
+use jazz::groove::records::Value;
+use jazz::groove::storage::RocksDbStorage;
+use jazz::ids::{NodeUuid, RowUuid};
+use jazz::node::{MergeableCommit, NodeState};
+use jazz::schema::{ColumnSchema, JazzSchema, TableSchema};
+use jazz::stream_manifest::StreamManifestAdapter;
+
+struct Provider {
+    domain: ContentDomainId,
+    store: MemoryImmutableContentStore,
+}
+
+impl ContentManifestRuntimeProvider for Provider {
+    fn read_context(&self, _: NodeUuid) -> ContentReadContext {
+        ContentReadContext {
+            domain: self.domain,
+        }
+    }
+
+    fn immutable_store(&self) -> &dyn ImmutableContentStore {
+        &self.store
+    }
+}
+
+fn cell(manifest: &ContentManifest, schema: &ContentManifestSchema) -> Value {
+    Value::Bytes(manifest.encode(schema).unwrap())
+}
+
+/// Black-boxes the public schema and Node seams. Adapter codec tests remain
+/// internal, but admission, merge, materialization, range reads, historical
+/// manifests, and interior index values must all traverse the production
+/// registry/provider path here.
+#[test]
+fn registered_stream_manifest_runs_through_a_real_node() {
+    let node_uuid = NodeUuid::from_bytes([0x51; 16]);
+    let domain = ContentDomainId(node_uuid.0);
+    let context = ContentReadContext { domain };
+    let adapter = StreamManifestAdapter::new(4, 4).unwrap();
+    let mut store = MemoryImmutableContentStore::default();
+
+    let empty = adapter.empty_manifest(context, &mut store).unwrap();
+    let immutable_history = adapter
+        .append(&empty, b"abcde", context, &mut store)
+        .unwrap();
+    let current = adapter
+        .append(&immutable_history, b"fg", context, &mut store)
+        .unwrap();
+
+    // The schema bound is deliberately wider than stream-v1's production
+    // bound so row admission proves the registered adapter also validates it.
+    let manifest_schema = ContentManifestSchema::new("stream-v1", 1, 512).unwrap();
+    let schema = JazzSchema::new([TableSchema::new(
+        "documents",
+        [ColumnSchema::content_manifest(
+            "attachment",
+            manifest_schema.clone(),
+        )],
+    )]);
+    let dir = tempfile::tempdir().unwrap();
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    let mut node = NodeState::new_with_content_manifest_provider(
+        node_uuid,
+        schema,
+        storage,
+        Arc::new(Provider { domain, store }),
+        true,
+    )
+    .unwrap();
+    let row = RowUuid::from_bytes([0x52; 16]);
+
+    let base = node
+        .commit_mergeable(
+            MergeableCommit::new("documents", row, 10).cells(BTreeMap::from([(
+                "attachment".into(),
+                cell(&immutable_history, &manifest_schema),
+            )])),
+        )
+        .unwrap();
+    node.finalize_local_mergeable_commit(base).unwrap();
+
+    // Two concurrent heads carrying the same complete snapshot force the
+    // production manifest merge path without inventing ordering for distinct
+    // concurrent stream appends, which stream-v1 deliberately rejects.
+    let left = node
+        .commit_mergeable(
+            MergeableCommit::new("documents", row, 20)
+                .parents(vec![base])
+                .cells(BTreeMap::from([(
+                    "attachment".into(),
+                    cell(&current, &manifest_schema),
+                )])),
+        )
+        .unwrap();
+    node.finalize_local_mergeable_commit(left).unwrap();
+    let right = node
+        .commit_mergeable(
+            MergeableCommit::new("documents", row, 21)
+                .parents(vec![base])
+                .cells(BTreeMap::from([(
+                    "attachment".into(),
+                    cell(&current, &manifest_schema),
+                )])),
+        )
+        .unwrap();
+    node.finalize_local_mergeable_commit(right).unwrap();
+
+    let visible = node
+        .visible_current_cells("documents", row)
+        .unwrap()
+        .unwrap();
+    let visible_cell = &visible["attachment"];
+    assert_eq!(
+        node.materialize_content_manifest(
+            "documents",
+            "attachment",
+            visible_cell,
+            &MaterializationRequest::Full,
+        )
+        .unwrap(),
+        b"abcdefg"
+    );
+    assert_eq!(
+        node.materialize_content_manifest(
+            "documents",
+            "attachment",
+            visible_cell,
+            &MaterializationRequest::Range {
+                offset: 3,
+                length: 4,
+            },
+        )
+        .unwrap(),
+        b"defg"
+    );
+    assert_eq!(
+        node.materialize_content_manifest(
+            "documents",
+            "attachment",
+            &cell(&immutable_history, &manifest_schema),
+            &MaterializationRequest::Full,
+        )
+        .unwrap(),
+        b"abcde",
+        "a direct historical manifest must not consult current row history"
+    );
+    let index = node
+        .content_manifest_index_values("documents", "attachment", visible_cell, &["length".into()])
+        .unwrap();
+    assert_eq!(
+        u64::from_le_bytes(index["length"].as_slice().try_into().unwrap()),
+        7
+    );
+
+    let invalid = ContentManifest {
+        root: current.root,
+        edit_tail: vec![vec![0; 257]],
+    };
+    assert!(
+        node.commit_mergeable(
+            MergeableCommit::new("documents", RowUuid::from_bytes([0x53; 16]), 30).cells(
+                BTreeMap::from([("attachment".into(), cell(&invalid, &manifest_schema))]),
+            ),
+        )
+        .is_err(),
+        "Node row admission must call stream-v1 operation validation"
+    );
+}

--- a/docs/content/docs/content/meta.json
+++ b/docs/content/docs/content/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Content",
-  "pages": ["overview", "text"]
+  "pages": ["overview", "text", "stream"]
 }

--- a/docs/content/docs/content/stream.mdx
+++ b/docs/content/docs/content/stream.mdx
@@ -1,0 +1,45 @@
+---
+title: Stream content
+description: Append and range-read a byte stream.
+---
+
+`stream-v1` has a `Bytes` tail containing one inline suffix. This standalone
+example declares the column, appends data, publishes the complete cell, and
+range-reads it.
+
+```rust
+use groove::records::ValueType;
+use jazz::{
+    content_manifest::{
+        global_content_manifest_adapters, ContentDomainId, ContentManifestRuntime,
+        ContentManifestSchema, ContentReadContext, MaterializationRequest,
+        MemoryImmutableContentStore,
+    },
+    schema::ColumnSchema,
+    stream_manifest::StreamManifestAdapter,
+};
+
+fn stream_example() -> Result<(), Box<dyn std::error::Error>> {
+    let context = ContentReadContext { domain: ContentDomainId(uuid::Uuid::new_v4()) };
+    let mut store = MemoryImmutableContentStore::default();
+    let schema = ContentManifestSchema::with_tail_entry_type(
+        "stream-v1", ValueType::Bytes, 1, 256,
+    )?;
+    let column = ColumnSchema::content_manifest("attachment", schema.clone());
+    let adapter = StreamManifestAdapter::default();
+    let manifest = adapter.empty_manifest(context, &mut store)?;
+    let manifest = adapter.append(&manifest, b"chunk", context, &mut store)?;
+    let cell = manifest.into_value(&schema)?;
+
+    let runtime = ContentManifestRuntime::new(global_content_manifest_adapters(), context, &store);
+    let bytes = runtime.materialize_cell(
+        &schema, &cell, &MaterializationRequest::Range { offset: 0, length: 5 },
+    )?;
+    assert_eq!(bytes, b"chunk");
+    let _ = column;
+    Ok(())
+}
+```
+
+Large suffixes become immutable tree objects. The adapter exposes `length` as
+an index and rejects incompatible stream candidates during merge.

--- a/packages/jazz-tools/src/runtime/STREAM_MANIFEST_ADAPTER.md
+++ b/packages/jazz-tools/src/runtime/STREAM_MANIFEST_ADAPTER.md
@@ -1,0 +1,131 @@
+# Stream adapter on an embedded content manifest
+
+This document scopes the stream-specific layer of the ordinary-content stack.
+It deliberately assumes, but does not define, the foundation's atomic embedded
+content-manifest column and its materializer hooks.
+
+## Value carried by an owning Jazz row
+
+For a column declared as a stream, one version of its owning row carries one
+complete stream snapshot:
+
+```text
+StreamManifest {
+  root:      StreamRootId | null
+  editTail:  Uint8Array
+}
+```
+
+`root` identifies an immutable byte-tree root. `editTail` is one bounded,
+append-only byte suffix. The pair is one atomic column value: a merge strategy
+or index implementation must materialize the pair before making a decision;
+it must never select `root` and `editTail` from independent candidates.
+
+The owning row is the mutable identity. Copying a manifest produces an exact
+historical snapshot. A separate stream-head row is neither required nor
+created by this adapter.
+
+## Immutable rows
+
+The adapter owns these content-addressed immutable row shapes, all scoped to
+the foundation's authorization/encryption domain and canonical encoding
+version:
+
+```text
+StreamPart {
+  id: hash("jazz.stream.part.v1", domain, bytes)
+  bytes: Uint8Array                 // at most 1 MiB
+}
+
+StreamNode {
+  id: hash("jazz.stream.node.v1", domain, height, childIds, childByteLengths)
+  height: integer
+  childIds: StreamPartId[] | StreamNodeId[]
+  childByteLengths: integer[]
+}
+
+StreamRoot {
+  id: hash("jazz.stream.root.v1", domain, treeRoot, prefixBytes)
+  treeRoot: StreamNodeId | null
+  prefixBytes: integer
+}
+```
+
+All lengths and ordered child IDs participate in canonical hashing. An
+existing derived ID is idempotent only if its complete canonical payload is
+identical; a conflicting payload is corruption, not an ordinary insert
+conflict. `prefixBytes` is the immutable-byte count represented by `root` and
+does not include `editTail`.
+
+## Operations
+
+- **append(owner, bytes):** materialize the current manifest. If the appended
+  tail remains within the configured cap, replace only the owning row's
+  manifest with the same `root` and a new immutable byte tail. If it crosses
+  the cap, promote the old tail plus append into bounded content-addressed
+  parts, path-copy the right tree spine, insert a new root, and replace the
+  manifest with that root and an empty tail in the same owning-row transaction.
+- **materialize(manifest):** range-read `root`'s persistent byte tree, then
+  append `editTail`. It follows only rows reachable from that manifest and
+  never replays owning-row history.
+- **range(manifest, start, end):** descend only overlapping immutable-tree
+  paths, then include the overlapping portion of `editTail`. Bounds are over
+  `root.prefixBytes + editTail.length`.
+- **subscribe(owner):** subscribe to the owning row/column. Each observed
+  version supplies a full manifest that can be materialized independently.
+
+The initial cap should be selected for common appends, not as a universal
+constant. Existing physical receipts make 128--256 B a good initial
+small-append candidate; the foundation should allow the stream codec to state
+its cap so the public default remains revisable.
+
+## Foundation hooks consumed by this adapter
+
+The foundation needs to expose a column codec/materializer registration that
+lets the stream adapter:
+
+1. decode and validate the complete `{ root, editTail }` column value;
+2. materialize the complete value, or a requested byte range, for merge
+   strategies and interior query/index evaluation;
+3. report typed immutable references reachable from `root` and validate they
+   are in the same domain;
+4. publish the manifest as one maintained/subscription value; and
+5. atomically write the owner-row replacement plus newly reachable immutable
+   rows.
+
+The stream adapter must not reimplement generic column atomicity, reachability,
+conditional update, index maintenance, or authorization validation.
+
+## Required behavioral tests
+
+The adapter's integration suite should use public schema and Db APIs and cover:
+
+1. A short append retains one `editTail` and changes only the owner manifest;
+   an old owner-row version still materializes its former tail.
+2. An append crossing the cap promotes exactly the prior tail plus appended
+   bytes, clears the new tail, and leaves the prior manifest readable.
+3. Repeated common-size appends produce one bounded tail, not one mutable tail
+   per tree node or per history version.
+4. Full and range materialization agree at boundaries spanning the immutable
+   prefix/tail boundary and a persistent-tree-node boundary.
+5. A saved/copied manifest remains readable after subsequent appends without
+   consulting owner history.
+6. Subscription notifications expose complete manifests from the owning row.
+7. Re-inserting a content-addressed part/node/root is idempotent when identical
+   and rejects a mismatched payload for the same ID.
+8. Merge and indexed/interior-query paths receive the materialized stream value
+   rather than raw `root` or `editTail` fields.
+
+For sensitivity, the suite will temporarily plant (and restore) a defect that
+either omits the tail during materialization or treats its root and tail as
+independent merge fields. The affected historical/range or merge test must
+fail for the planted change. This is a test procedure, not committed product
+code.
+
+## Deliberate non-goals of this PR
+
+This adapter does not define text splice semantics, file extent patches, or
+JSON node/order operations. It also does not make a stream's byte payload
+directly queryable as a scalar index; the foundation only guarantees that an
+interior query/index consumer can request the materialized typed value needed
+by its declared operation.

--- a/packages/jazz-tools/src/runtime/STREAM_MANIFEST_ADAPTER.md
+++ b/packages/jazz-tools/src/runtime/STREAM_MANIFEST_ADAPTER.md
@@ -74,10 +74,12 @@ does not include `editTail`.
 - **subscribe(owner):** subscribe to the owning row/column. Each observed
   version supplies a full manifest that can be materialized independently.
 
-The initial cap should be selected for common appends, not as a universal
-constant. Existing physical receipts make 128--256 B a good initial
-small-append candidate; the foundation should allow the stream codec to state
-its cap so the public default remains revisable.
+`stream-v1` fixes the inline-tail cap at 256 B and tree fanout at 32. These are
+part of that adapter kind's replicated meaning even though they are not repeated
+in each payload. A different cap or fanout requires a new adapter kind/version;
+allowing runtime configuration under `stream-v1` would let equal logical input
+canonicalize to different roots. Existing physical receipts place 256 B in the
+best observed range for common small appends.
 
 ## Foundation hooks consumed by this adapter
 


### PR DESCRIPTION
🤖 Adds the append-oriented stream implementation on top of text and the shared foundation.

## What changed

- Adds content-addressed immutable stream parts and fanout-32 tree nodes.
- Keeps one bounded 256-byte logical append tail and promotes via right-spine path copying.
- Supports full/range/historical materialization, tail-aware length indexing, and conservative merge behavior.
- Fails closed on malformed fanout, height, aggregate-length, conversion, and overflow metadata.
- Adds the stream contract and a complete public API chapter with runnable append/read/index setup.

## Validation

- Focused stream tests plus real Node integration.
- Multi-leaf split/reuse/range/history coverage and extreme-length mutation-sensitivity plants.
- Docs typecheck/build; the public example was compiled and executed against the current Rust API.
- Independent adversarial review; Clippy and formatting pass.

This is PR 3 of 5 and depends on the text PR.
