### PR TITLE
fix(auth): invalidate stale claims and preserve EXISTS correlations

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -9687,7 +9687,11 @@ where
                 tier,
                 format!(
                     "client-local:{}",
-                    policy_plan_cache_signature(&binding, identity)
+                    policy_plan_cache_signature(
+                        &binding,
+                        identity,
+                        self.session_claim_revision(identity),
+                    )
                 ),
             );
             if let Some(plan) = self.query.query_shape_cache.get(&key) {
@@ -10457,7 +10461,7 @@ where
         let key = (
             shape.shape_id(),
             tier,
-            policy_plan_cache_signature(binding, identity),
+            policy_plan_cache_signature(binding, identity, self.session_claim_revision(identity)),
         );
         if let Some(plan) = self.query.query_shape_cache.get(&key)
             && !matches!(plan.as_ref(), PreparedQueryPlan::PeerMaintainedMarker)

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -17364,6 +17364,55 @@ mod tests {
     }
 
     #[test]
+    fn prepared_policy_plan_is_recompiled_after_same_identity_claim_revision_changes() {
+        let schema = JazzSchema::new([TableSchema::new(
+            "issues",
+            [
+                ColumnSchema::new("title", ColumnType::String),
+                ColumnSchema::new("state", ColumnType::String),
+                ColumnSchema::new("assignee", ColumnType::Uuid),
+                ColumnSchema::new("priority", ColumnType::U64),
+            ],
+        )
+        .with_read_policy(
+            Query::from("issues").filter(eq(col("assignee"), claim("selected_assignee"))),
+        )]);
+        let (_dir, mut node) =
+            open_node_with_uuid(NodeUuid::from_bytes([0x81; 16]), schema.clone());
+        let alice = author(0x82);
+        let bob = author(0x83);
+        commit_issue(&mut node, 1, "open", alice);
+        commit_issue(&mut node, 2, "open", bob);
+
+        let identity = author(0x84);
+        let shape = Query::from("issues").validate(&schema).unwrap();
+        let binding = shape.bind(BTreeMap::new()).unwrap();
+        let visible_for = |node: &mut NodeState<RocksDbStorage>| {
+            node.query_rows_for_link(&shape, &binding, DurabilityTier::Local, identity)
+                .unwrap()
+                .into_iter()
+                .map(|row| row.row_uuid())
+                .collect::<BTreeSet<_>>()
+        };
+
+        node.set_session_claims(
+            identity,
+            BTreeMap::from([("selected_assignee".to_owned(), Value::Uuid(alice.0))]),
+        );
+        assert_eq!(visible_for(&mut node), BTreeSet::from([row(1)]));
+
+        node.set_session_claims(
+            identity,
+            BTreeMap::from([("selected_assignee".to_owned(), Value::Uuid(bob.0))]),
+        );
+        assert_eq!(
+            visible_for(&mut node),
+            BTreeSet::from([row(2)]),
+            "the same prepared shape and identity must not reuse the plan compiled for prior claims",
+        );
+    }
+
+    #[test]
     fn text_range_predicates_use_lexicographic_row_comparison() {
         assert_eq!(
             compare_values(

--- a/crates/jazz/src/node/query_eval/prepared_bindings.rs
+++ b/crates/jazz/src/node/query_eval/prepared_bindings.rs
@@ -14,12 +14,16 @@ pub(super) fn query_binding_value_signature(binding: &Binding) -> String {
         .join(",")
 }
 
-pub(super) fn policy_plan_cache_signature(binding: &Binding, identity: AuthorId) -> String {
+pub(super) fn policy_plan_cache_signature(
+    binding: &Binding,
+    identity: AuthorId,
+    claims_revision: u64,
+) -> String {
     // Authorization lowering still embeds the permission subject in source
     // plans. Claim values are routed at bind time, but plans from different
     // subjects are not interchangeable until that subject is parameterized.
     format!(
-        "{}|subject={identity:?}",
+        "{}|subject={identity:?}|claims={claims_revision}",
         query_binding_value_signature(binding)
     )
 }

--- a/crates/jazz/src/query.rs
+++ b/crates/jazz/src/query.rs
@@ -1520,6 +1520,27 @@ impl Query {
         self
     }
 
+    /// Add a row-id traversal with extra source-row equality correlations.
+    pub fn join_via_row_id_with_correlations(
+        mut self,
+        table: impl Into<String>,
+        source_column: impl Into<String>,
+        correlated_filters: impl IntoIterator<Item = JoinCorrelation>,
+        filters: impl IntoIterator<Item = Predicate>,
+    ) -> Self {
+        self.joins.push(JoinVia {
+            table: table.into(),
+            on_column: "id".to_owned(),
+            target: JoinTarget::RowId,
+            source_column: Some(source_column.into()),
+            source_lookup: None,
+            correlated_filters: correlated_filters.into_iter().collect(),
+            filters: filters.into_iter().collect(),
+            nested_joins: Vec::new(),
+        });
+        self
+    }
+
     /// Add a recursive reachability traversal through an access table and edge table.
     #[allow(clippy::too_many_arguments)]
     pub fn reachable_via(

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -1215,7 +1215,12 @@ fn append_exists_policy_clause(
     let source_column = source_column.expect("join_column and source_column are set together");
 
     if join_column == "id" {
-        Ok(query.join_via_row_id(exists_table, source_column, filters))
+        Ok(query.join_via_row_id_with_correlations(
+            exists_table,
+            source_column,
+            correlated_filters,
+            filters,
+        ))
     } else if correlated_filters.is_empty() {
         Ok(query.join_via_column(exists_table, join_column, source_column, filters))
     } else {
@@ -3040,11 +3045,13 @@ mod tests {
             .table(
                 TableSchemaBuilder::new("chats")
                     .column("name", ColumnType::Text)
+                    .column("createdBy", ColumnType::Text)
                     .column("isPublic", ColumnType::Boolean),
             )
             .table(
                 TableSchemaBuilder::new("messages")
                     .fk_column("chatId", "chats")
+                    .column("createdBy", ColumnType::Text)
                     .column("text", ColumnType::Text)
                     .policies(TablePolicies::new().with_select(PolicyExpr::Exists {
                         table: "chats".to_owned(),
@@ -3061,6 +3068,14 @@ mod tests {
                                 column: "isPublic".to_owned(),
                                 op: CmpOp::Eq,
                                 value: PolicyValue::Literal(Value::Boolean(true)),
+                            },
+                            PolicyExpr::Cmp {
+                                column: "createdBy".to_owned(),
+                                op: CmpOp::Eq,
+                                value: PolicyValue::SessionRef(vec![
+                                    "__jazz_outer_row".to_owned(),
+                                    "createdBy".to_owned(),
+                                ]),
                             },
                         ])),
                     })),
@@ -3081,6 +3096,13 @@ mod tests {
         assert_eq!(join.on_column, "id");
         assert_eq!(join.target, JoinTarget::RowId);
         assert_eq!(join.source_column.as_deref(), Some("chatId"));
+        assert_eq!(
+            join.correlated_filters,
+            vec![JoinCorrelation {
+                join_column: "createdBy".to_owned(),
+                source_column: "createdBy".to_owned(),
+            }]
+        );
         assert_eq!(
             join.filters,
             vec![Predicate::Eq(

--- a/crates/jazz/src/tools/server/public_schema_convert.rs
+++ b/crates/jazz/src/tools/server/public_schema_convert.rs
@@ -1171,9 +1171,7 @@ fn append_exists_policy_clause(
         ));
     }
 
-    let mut join_column = None;
-    let mut source_column = None;
-    let mut correlated_filters = Vec::new();
+    let mut outer_correlations = Vec::new();
     let mut filters = Vec::new();
 
     let conditions = match condition {
@@ -1188,15 +1186,10 @@ fn append_exists_policy_clause(
                 op: CmpOp::Eq,
                 value: PolicyValue::SessionRef(path_segments),
             } if path_segments.len() == 2 && path_segments[0] == "__jazz_outer_row" => {
-                if join_column.is_none() {
-                    join_column = Some(column.clone());
-                    source_column = Some(path_segments[1].clone());
-                } else {
-                    correlated_filters.push(JoinCorrelation {
-                        join_column: column.clone(),
-                        source_column: path_segments[1].clone(),
-                    });
-                }
+                outer_correlations.push(JoinCorrelation {
+                    join_column: column.clone(),
+                    source_column: path_segments[1].clone(),
+                });
             }
             other => filters.push(convert_policy_predicate(
                 &exists_table_name,
@@ -1206,13 +1199,20 @@ fn append_exists_policy_clause(
         }
     }
 
-    let join_column = join_column.ok_or_else(|| {
-        err(
+    if outer_correlations.is_empty() {
+        return Err(err(
             format!("$.{}.{}", table.as_str(), path),
             "core schema policies require EXISTS to include an equality against __jazz_outer_row",
-        )
-    })?;
-    let source_column = source_column.expect("join_column and source_column are set together");
+        ));
+    }
+    let primary_index = outer_correlations
+        .iter()
+        .position(|correlation| correlation.join_column == "id")
+        .unwrap_or(0);
+    let primary = outer_correlations.remove(primary_index);
+    let join_column = primary.join_column;
+    let source_column = primary.source_column;
+    let correlated_filters = outer_correlations;
 
     if join_column == "id" {
         Ok(query.join_via_row_id_with_correlations(
@@ -3057,6 +3057,14 @@ mod tests {
                         table: "chats".to_owned(),
                         condition: Box::new(PolicyExpr::And(vec![
                             PolicyExpr::Cmp {
+                                column: "createdBy".to_owned(),
+                                op: CmpOp::Eq,
+                                value: PolicyValue::SessionRef(vec![
+                                    "__jazz_outer_row".to_owned(),
+                                    "createdBy".to_owned(),
+                                ]),
+                            },
+                            PolicyExpr::Cmp {
                                 column: "id".to_owned(),
                                 op: CmpOp::Eq,
                                 value: PolicyValue::SessionRef(vec![
@@ -3068,14 +3076,6 @@ mod tests {
                                 column: "isPublic".to_owned(),
                                 op: CmpOp::Eq,
                                 value: PolicyValue::Literal(Value::Boolean(true)),
-                            },
-                            PolicyExpr::Cmp {
-                                column: "createdBy".to_owned(),
-                                op: CmpOp::Eq,
-                                value: PolicyValue::SessionRef(vec![
-                                    "__jazz_outer_row".to_owned(),
-                                    "createdBy".to_owned(),
-                                ]),
                             },
                         ])),
                     })),

--- a/examples/chat-react/permissions.ts
+++ b/examples/chat-react/permissions.ts
@@ -17,8 +17,8 @@ export default definePermissions(app, ({ policy, session, allOf, anyOf, allowedT
       userIsChatMember(chat),
       // Users may update only non-protected fields. `createdBy` and `isPublic` cannot be updated.
       policy.chats.exists.where({
-        id: chat.id,
         createdBy: chat.createdBy,
+        id: chat.id,
         isPublic: chat.isPublic,
       }),
     ]),

--- a/examples/chat-react/src/components/chat/ChatMessage.tsx
+++ b/examples/chat-react/src/components/chat/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useAll } from "jazz-tools/react";
 import DOMPurify from "dompurify";
 import { TrashIcon } from "lucide-react";
 import { ChatMetadata } from "@/components/chat/ChatMetadata";

--- a/examples/chat-react/tests/browser/test-globals.d.ts
+++ b/examples/chat-react/tests/browser/test-globals.d.ts
@@ -1,0 +1,17 @@
+import "vitest";
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    jazzServerUrl: string;
+  }
+}
+
+declare global {
+  interface Window {
+    __jazz?: {
+      shutdown(): Promise<void>;
+    };
+  }
+}
+
+export {};

--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -15,20 +15,21 @@ afterEach(async () => {
 
 describe("chat permissions", () => {
   it("allows pre-authorized private chat reads via join_code claim", async () => {
-    const privateChat = testApp.seed((db) => {
-      const { value: privateChat } = db.insert(app.chats, {
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
         name: "Private room",
         isPublic: false,
         createdBy: "alice",
         joinCode: "invite-123",
-      });
+      }),
+    );
+    await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
         userId: "alice",
         joinCode: "invite-123",
-      });
-      return privateChat;
-    });
+      }),
+    );
 
     const bobWithoutClaim = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
     const bobWithClaim = testApp.as({
@@ -44,24 +45,27 @@ describe("chat permissions", () => {
   });
 
   it("allows chat name updates", async () => {
-    const privateChat = testApp.seed((db) => {
+    await testApp.seed((db) =>
       db.insert(app.profiles, {
         userId: "alice",
         name: "Alice",
-      });
-      const { value: privateChat } = db.insert(app.chats, {
+      }),
+    );
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
         name: "Members only",
         isPublic: false,
         createdBy: "alice",
         joinCode: "invite-456",
-      });
+      }),
+    );
+    await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
         userId: "alice",
         joinCode: "invite-456",
-      });
-      return privateChat;
-    });
+      }),
+    );
 
     const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
 
@@ -73,34 +77,37 @@ describe("chat permissions", () => {
   });
 
   it("does not allow chat creator and isPublic updates", async () => {
-    const privateChat = testApp.seed((db) => {
+    await testApp.seed((db) =>
       db.insert(app.profiles, {
         userId: "alice",
         name: "Alice",
-      });
-      const { value: privateChat } = db.insert(app.chats, {
+      }),
+    );
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
         name: "Members only",
         isPublic: false,
         createdBy: "alice",
         joinCode: "invite-456",
-      });
+      }),
+    );
+    await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
         userId: "alice",
         joinCode: "invite-456",
-      });
-      return privateChat;
-    });
+      }),
+    );
 
     const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
 
-    aliceDb.expectDenied((db) =>
+    await aliceDb.expectDenied((db) =>
       db.update(app.chats, privateChat.id, {
         createdBy: "bob",
       }),
     );
 
-    aliceDb.expectDenied((db) =>
+    await aliceDb.expectDenied((db) =>
       db.update(app.chats, privateChat.id, {
         isPublic: true,
       }),
@@ -108,28 +115,33 @@ describe("chat permissions", () => {
   });
 
   it("allows message inserts only for chat members", async () => {
-    const { aliceProfile, bobProfile, privateChat } = testApp.seed((db) => {
-      const { value: aliceProfile } = db.insert(app.profiles, {
+    const aliceProfile = await testApp.seed((db) =>
+      db.insert(app.profiles, {
         userId: "alice",
         name: "Alice",
-      });
-      const { value: bobProfile } = db.insert(app.profiles, {
+      }),
+    );
+    const bobProfile = await testApp.seed((db) =>
+      db.insert(app.profiles, {
         userId: "bob",
         name: "Bob",
-      });
-      const { value: privateChat } = db.insert(app.chats, {
+      }),
+    );
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
         name: "Members only",
         isPublic: false,
         createdBy: "alice",
         joinCode: "invite-456",
-      });
+      }),
+    );
+    await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
         userId: "alice",
         joinCode: "invite-456",
-      });
-      return { aliceProfile, bobProfile, privateChat };
-    });
+      }),
+    );
 
     const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
     const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
@@ -143,7 +155,7 @@ describe("chat permissions", () => {
       }),
     );
 
-    bobDb.expectDenied((db) =>
+    await bobDb.expectDenied((db) =>
       db.insert(app.messages, {
         chatId: privateChat.id,
         text: "hello from bob",
@@ -152,13 +164,13 @@ describe("chat permissions", () => {
       }),
     );
 
-    testApp.seed((db) => {
+    await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
         userId: "bob",
         joinCode: "invite-456",
-      });
-    });
+      }),
+    );
 
     bobDb.expectAllowed((db) =>
       db.insert(app.messages, {
@@ -171,40 +183,49 @@ describe("chat permissions", () => {
   });
 
   it("inherits reaction reads from the parent message/chat chain", async () => {
-    const reaction = testApp.seed((db) => {
-      const { value: aliceProfile } = db.insert(app.profiles, {
+    const aliceProfile = await testApp.seed((db) =>
+      db.insert(app.profiles, {
         userId: "alice",
         name: "Alice",
-      });
-      const { value: privateChat } = db.insert(app.chats, {
+      }),
+    );
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
         name: "Uploads",
         isPublic: false,
         createdBy: "alice",
         joinCode: "invite-789",
-      });
+      }),
+    );
+    await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
         userId: "alice",
         joinCode: "invite-789",
-      });
+      }),
+    );
+    await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
         userId: "bob",
         joinCode: "invite-789",
-      });
-      const { value: message } = db.insert(app.messages, {
+      }),
+    );
+    const message = await testApp.seed((db) =>
+      db.insert(app.messages, {
         chatId: privateChat.id,
         text: "see attachment",
         senderId: aliceProfile.id,
         createdAt: new Date("2026-01-01T00:00:03.000Z"),
-      });
-      const { value: reaction } = db.insert(app.reactions, {
+      }),
+    );
+    const reaction = await testApp.seed((db) =>
+      db.insert(app.reactions, {
         messageId: message.id,
         userId: "alice",
         emoji: "fire",
-      });
-      return reaction;
-    });
+      }),
+    );
 
     const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
     const carolDb = testApp.as({ user_id: "carol", claims: {}, authMode: "local-first" });


### PR DESCRIPTION
🤖 Fixes two authorization bugs found by the chat-react black-box suite.

- includes session claim revision in prepared-plan cache keys for the same identity
- chooses row-ID EXISTS correlation independent of predicate order
- preserves all remaining outer-row correlations
- adds same-identity claim-change and reversed-correlation regressions
- proves ordinary updates remain allowed while protected-field mismatches remain denied

Verified with fresh NAPI/WASM artifacts, the full chat permission suite, focused Rust lowering/cache tests, sensitivity plants, Clippy, formatting, and independent adversarial review.