### PR TITLE
fix(sync): preserve provisional openings safely

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1259,6 +1259,10 @@ where
         self.register_physical_current_variant_projections()?;
         self.groove_runtime_token = next_groove_runtime_token();
         self.invalidate_runtime_handles_after_database_rebuild();
+        // The rebuilt Groove registry invalidates runtime handles, not durable
+        // query facts. Rehydrate those facts (including conservative
+        // authority-opening markers) before returning to live traffic.
+        self.recover_known_state_facts()?;
         self.parking = parking;
         Ok(())
     }

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2696,6 +2696,18 @@ where
         Ok(())
     }
 
+    pub(crate) fn has_persisted_opening_pending(
+        &self,
+        binding_view_key: BindingViewKey,
+    ) -> Result<bool, Error> {
+        let store = self
+            .database
+            .direct_record_store(PENDING_OPENING_BINDING_VIEWS_STORE)?;
+        Ok(store
+            .get(&known_state_fact_key(binding_view_key))?
+            .is_some())
+    }
+
     pub(crate) fn load_known_state_fact(
         &mut self,
         binding_view_key: BindingViewKey,
@@ -2726,6 +2738,11 @@ where
     }
 
     pub(crate) fn clear_all_known_state_facts(&mut self) -> Result<(), Error> {
+        // A pending marker may be removed only after every piece of state that
+        // could otherwise make this view appear settled has been durably
+        // cleared. Keep all in-memory mirrors conservative until their durable
+        // counterpart has been removed successfully.
+        self.clear_all_settled_result_state()?;
         let store = self.database.direct_record_store(KNOWN_STATE_FACTS_STORE)?;
         let keys = store
             .prefix_entries(&[])?
@@ -2735,6 +2752,8 @@ where
         for key in keys {
             store.delete(&key)?;
         }
+        self.query.settled_through_by_binding_view.clear();
+        self.query.authorization_progress_by_binding_view.clear();
         let pending_store = self
             .database
             .direct_record_store(PENDING_OPENING_BINDING_VIEWS_STORE)?;
@@ -2746,10 +2765,7 @@ where
         for key in pending_keys {
             pending_store.delete(&key)?;
         }
-        self.query.settled_through_by_binding_view.clear();
-        self.query.authorization_progress_by_binding_view.clear();
         self.query.pending_opening_binding_views.clear();
-        self.clear_all_settled_result_state()?;
         Ok(())
     }
 

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -39,8 +39,9 @@ use crate::protocol::{
 };
 use crate::query::{Binding, BindingId, QueryError, ShapeId, ValidatedQuery};
 use crate::schema::{
-    JazzSchema, KNOWN_STATE_FACTS_STORE, MergeStrategy, SETTLED_PROGRAM_FACTS_STORE,
-    SETTLED_RESULT_MEMBERS_STORE, TableSchema, registered_column_transform,
+    JazzSchema, KNOWN_STATE_FACTS_STORE, MergeStrategy, PENDING_OPENING_BINDING_VIEWS_STORE,
+    SETTLED_PROGRAM_FACTS_STORE, SETTLED_RESULT_MEMBERS_STORE, TableSchema,
+    registered_column_transform,
 };
 use crate::time::{GlobalSeq, TxTime};
 use crate::tools::OpenBatchId;
@@ -2674,6 +2675,23 @@ where
         Ok(())
     }
 
+    pub(crate) fn persist_opening_pending(
+        &self,
+        binding_view_key: BindingViewKey,
+        opening_pending: bool,
+    ) -> Result<(), Error> {
+        let store = self
+            .database
+            .direct_record_store(PENDING_OPENING_BINDING_VIEWS_STORE)?;
+        let key = known_state_fact_key(binding_view_key);
+        if opening_pending {
+            store.set(&key, &[Value::U64(1)])?;
+        } else {
+            store.delete(&key)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn load_known_state_fact(
         &mut self,
         binding_view_key: BindingViewKey,
@@ -2713,8 +2731,20 @@ where
         for key in keys {
             store.delete(&key)?;
         }
+        let pending_store = self
+            .database
+            .direct_record_store(PENDING_OPENING_BINDING_VIEWS_STORE)?;
+        let pending_keys = pending_store
+            .prefix_entries(&[])?
+            .into_iter()
+            .map(|entry| entry.key)
+            .collect::<Vec<_>>();
+        for key in pending_keys {
+            pending_store.delete(&key)?;
+        }
         self.query.settled_through_by_binding_view.clear();
         self.query.authorization_progress_by_binding_view.clear();
+        self.query.pending_opening_binding_views.clear();
         self.clear_all_settled_result_state()?;
         Ok(())
     }
@@ -2896,6 +2926,7 @@ where
         self.query.settled_result_sets.clear();
         self.query.settled_result_row_index.clear();
         self.query.settled_program_facts.clear();
+        self.query.pending_opening_binding_views.clear();
         let store = self.database.direct_record_store(KNOWN_STATE_FACTS_STORE)?;
         for entry in store.prefix_entries(&[])? {
             if entry.key.len() != 3 {
@@ -2949,6 +2980,27 @@ where
                 _ => {
                     return Err(Error::InvalidStoredValue(
                         "known-state authorization progress must be u64",
+                    ));
+                }
+            }
+        }
+        let pending_store = self
+            .database
+            .direct_record_store(PENDING_OPENING_BINDING_VIEWS_STORE)?;
+        for entry in pending_store.prefix_entries(&[])? {
+            let binding_view_key = binding_view_key_from_store_key(
+                &entry.key,
+                "pending opening binding key must be valid",
+            )?;
+            match entry.value.get_idx(0)? {
+                Value::U64(1) => {
+                    self.query
+                        .pending_opening_binding_views
+                        .insert(binding_view_key);
+                }
+                _ => {
+                    return Err(Error::InvalidStoredValue(
+                        "pending opening marker must be one",
                     ));
                 }
             }

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2703,9 +2703,15 @@ where
         let store = self
             .database
             .direct_record_store(PENDING_OPENING_BINDING_VIEWS_STORE)?;
-        Ok(store
-            .get(&known_state_fact_key(binding_view_key))?
-            .is_some())
+        let Some(record) = store.get(&known_state_fact_key(binding_view_key))? else {
+            return Ok(false);
+        };
+        match record.get_idx(0)? {
+            Value::U64(1) => Ok(true),
+            _ => Err(Error::InvalidStoredValue(
+                "pending opening marker must be one",
+            )),
+        }
     }
 
     pub(crate) fn load_known_state_fact(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -5203,9 +5203,10 @@ where
             self.query
                 .initial_hydration_binding_views
                 .remove(&binding_view_key);
-            self.query
-                .pending_opening_binding_views
-                .remove(&binding_view_key);
+            // Authority opening state is durable and conservative: detaching
+            // the last local subscriber does not prove that the authority has
+            // completed its opening snapshot. Retain it until an
+            // authoritative non-pending update clears both memory and disk.
         }
     }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -5184,11 +5184,17 @@ where
     }
 
     pub(crate) fn apply_unsubscribe(&mut self, subscription: SubscriptionKey) {
-        let binding_view_key = self.binding_view_key_for_subscription(subscription).ok();
+        let binding_view_key = self
+            .binding_view_key_for_subscription(subscription)
+            .ok()
+            .filter(|binding_view_key| binding_view_key.read_view == subscription.read_view);
         if let Some(bindings) = self
             .query
             .registered_bindings
             .get_mut(&subscription.shape_id)
+            && bindings
+                .get(&subscription.binding_id)
+                .is_some_and(|binding| binding.read_view == subscription.read_view)
         {
             bindings.remove(&subscription.binding_id);
         }
@@ -14973,7 +14979,7 @@ mod tests {
         .expect("one-shot nested policy claim routes must bind against the root descriptor");
 
         let mut edge = PeerState::edge_client(identity);
-        let update = edge
+        let mut update = edge
             .rehydrate_query_with_opts(
                 &mut node,
                 &shape,
@@ -14984,6 +14990,14 @@ mod tests {
                 },
             )
             .expect("the serving maintained view must retain the invite claim route");
+        let SyncMessage::ViewUpdate { subscription, .. } = &mut update else {
+            panic!("invite rehydrate must produce a view update");
+        };
+        *subscription = SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: binding.binding_id(),
+            read_view: Default::default(),
+        };
         client
             .apply_sync_message(update)
             .expect("the client must materialize the invited chat update");
@@ -15065,12 +15079,17 @@ mod tests {
             BTreeMap::from([("user_id".to_owned(), Value::String(identity.0.to_string()))]),
         );
         let mut normal_membership_peer = PeerState::edge_client(identity);
+        let mut membership_update = normal_membership_peer
+            .current_rows_update(&mut node, "chatMembers")
+            .expect("serve the accepted membership to the normal client");
+        let SyncMessage::ViewUpdate { subscription, .. } = &mut membership_update else {
+            panic!("current rows update must produce a view update");
+        };
+        *subscription = normal_client
+            .whole_table_subscription_key("chatMembers")
+            .expect("normal client has canonical chatMembers coverage");
         normal_client
-            .apply_sync_message(
-                normal_membership_peer
-                    .current_rows_update(&mut node, "chatMembers")
-                    .expect("serve the accepted membership to the normal client"),
-            )
+            .apply_sync_message(membership_update)
             .expect("normal client applies its accepted membership before querying messages");
         let simple_message_shape = Query::from("messages")
             .filter(eq(col("chatId"), param("chat_id")))
@@ -15096,20 +15115,27 @@ mod tests {
             &simple_message_binding,
         );
         let mut normal_simple_peer = PeerState::edge_client(identity);
-        normal_client
-            .apply_sync_message(
-                normal_simple_peer
-                    .rehydrate_query_with_opts(
-                        &mut node,
-                        &simple_message_shape,
-                        &simple_message_binding,
-                        RegisterShapeOptions {
-                            tier: DurabilityTier::Edge,
-                            ..RegisterShapeOptions::default()
-                        },
-                    )
-                    .expect("serve normal-member message snapshot without include"),
+        let mut simple_update = normal_simple_peer
+            .rehydrate_query_with_opts(
+                &mut node,
+                &simple_message_shape,
+                &simple_message_binding,
+                RegisterShapeOptions {
+                    tier: DurabilityTier::Edge,
+                    ..RegisterShapeOptions::default()
+                },
             )
+            .expect("serve normal-member message snapshot without include");
+        let SyncMessage::ViewUpdate { subscription, .. } = &mut simple_update else {
+            panic!("message rehydrate must produce a view update");
+        };
+        *subscription = SubscriptionKey {
+            shape_id: simple_message_shape.shape_id(),
+            binding_id: simple_message_binding.binding_id(),
+            read_view: Default::default(),
+        };
+        normal_client
+            .apply_sync_message(simple_update)
             .expect("client applies normal-member message snapshot without include");
         assert_eq!(
             normal_client
@@ -15147,9 +15173,17 @@ mod tests {
                 },
             )
             .expect("serve normal-member message include/order snapshot");
-        let normal_versions = normal_update
+        let mut normal_versions = normal_update
             .expand_version_carriers_for_receive()
             .expect("expand normal-member message include/order payloads");
+        let SyncMessage::ViewUpdate { subscription, .. } = &mut normal_versions else {
+            panic!("expanded relation snapshot must remain a view update");
+        };
+        *subscription = SubscriptionKey {
+            shape_id: message_shape.shape_id(),
+            binding_id: message_binding.binding_id(),
+            read_view: Default::default(),
+        };
         if let SyncMessage::ViewUpdate {
             version_bundles, ..
         } = &normal_versions

--- a/crates/jazz/src/node/tests/branching.rs
+++ b/crates/jazz/src/node/tests/branching.rs
@@ -618,6 +618,43 @@ fn branch_overlay_partition_creation_rebuilds_live_database_without_storage_reop
 }
 
 #[test]
+fn branch_database_rebuild_recovers_pending_authority_opening() {
+    let mut core = open_history_complete_reopen_refusing_node_with_schema(node(0x23), schema());
+    let subscription = core.whole_table_subscription_key("todos").unwrap();
+    let binding_view = BindingViewKey::from_canonical_subscription_key(subscription);
+    core.apply_sync_message(SyncMessage::ViewUpdate {
+        subscription,
+        settled_through: GlobalSeq(7),
+        reset_result_set: true,
+        version_carriers: Vec::new(),
+        version_bundles: Vec::new(),
+        peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+            opening_pending: true,
+            ..Default::default()
+        },
+        result_member_adds: Vec::new(),
+        result_member_removes: Vec::new(),
+        terminal_operations: Vec::new(),
+        program_fact_adds: Vec::new(),
+        program_fact_removes: Vec::new(),
+    })
+    .unwrap();
+
+    let branch_id = branch(0x23);
+    core.create_branch(branch_id).unwrap();
+    core.commit_mergeable_on_branch(
+        branch_id,
+        MergeableCommit::new("todos", row(0x23), 10).cells(title_cells("rebuild marker")),
+    )
+    .unwrap();
+
+    assert!(
+        core.opening_pending_for_binding_view(binding_view),
+        "a live database-slot rebuild must recover durable authority-opening state"
+    );
+}
+
+#[test]
 fn branch_overlay_spans_schema_renames_and_merge_back_after_restart() {
     // Physical branch partition identity is internal storage topology; the
     // branch read and merge-back assertions cover its user-visible semantics.

--- a/crates/jazz/src/node/tests/support.rs
+++ b/crates/jazz/src/node/tests/support.rs
@@ -517,6 +517,7 @@ fn open_history_complete_reopen_refusing_node_with_schema(
 struct FailAfterWritesMemoryStorage {
     inner: MemoryStorage,
     successful_writes_before_failure: Rc<Cell<Option<usize>>>,
+    total_writes: Rc<Cell<usize>>,
 }
 
 impl FailAfterWritesMemoryStorage {
@@ -524,6 +525,7 @@ impl FailAfterWritesMemoryStorage {
         Self {
             inner: MemoryStorage::new(column_families),
             successful_writes_before_failure: Rc::new(Cell::new(None)),
+            total_writes: Rc::new(Cell::new(0)),
         }
     }
 
@@ -546,6 +548,10 @@ impl FailAfterWritesMemoryStorage {
             .set(Some(remaining - 1));
         Ok(())
     }
+
+    fn total_writes(&self) -> usize {
+        self.total_writes.get()
+    }
 }
 
 impl OrderedKvStorage for FailAfterWritesMemoryStorage {
@@ -564,11 +570,13 @@ impl OrderedKvStorage for FailAfterWritesMemoryStorage {
         value: &[u8],
     ) -> Result<(), groove::storage::Error> {
         self.before_write()?;
+        self.total_writes.set(self.total_writes.get() + 1);
         self.inner.set(cf, key, value)
     }
 
     fn delete(&self, cf: &ColumnFamilyName, key: &Key) -> Result<(), groove::storage::Error> {
         self.before_write()?;
+        self.total_writes.set(self.total_writes.get() + 1);
         self.inner.delete(cf, key)
     }
 
@@ -619,6 +627,7 @@ impl OrderedKvStorage for FailAfterWritesMemoryStorage {
 
     fn write_many(&self, operations: &[WriteOperation<'_>]) -> Result<(), groove::storage::Error> {
         self.before_write()?;
+        self.total_writes.set(self.total_writes.get() + 1);
         self.inner.write_many(operations)
     }
 

--- a/crates/jazz/src/node/tests/support.rs
+++ b/crates/jazz/src/node/tests/support.rs
@@ -513,6 +513,127 @@ fn open_history_complete_reopen_refusing_node_with_schema(
     NodeState::new_history_complete(node_uuid, schema, storage).unwrap()
 }
 
+#[derive(Clone)]
+struct FailAfterWritesMemoryStorage {
+    inner: MemoryStorage,
+    successful_writes_before_failure: Rc<Cell<Option<usize>>>,
+}
+
+impl FailAfterWritesMemoryStorage {
+    fn new(column_families: &[&str]) -> Self {
+        Self {
+            inner: MemoryStorage::new(column_families),
+            successful_writes_before_failure: Rc::new(Cell::new(None)),
+        }
+    }
+
+    fn fail_after_successful_writes(&self, successful_writes: usize) {
+        self.successful_writes_before_failure
+            .set(Some(successful_writes));
+    }
+
+    fn before_write(&self) -> Result<(), groove::storage::Error> {
+        let Some(remaining) = self.successful_writes_before_failure.get() else {
+            return Ok(());
+        };
+        if remaining == 0 {
+            self.successful_writes_before_failure.set(None);
+            return Err(groove::storage::Error::InvalidStorageLayout(
+                "injected write failure after pending-opening marker".to_owned(),
+            ));
+        }
+        self.successful_writes_before_failure
+            .set(Some(remaining - 1));
+        Ok(())
+    }
+}
+
+impl OrderedKvStorage for FailAfterWritesMemoryStorage {
+    fn get(
+        &self,
+        cf: &ColumnFamilyName,
+        key: &Key,
+    ) -> Result<Option<StorageValue>, groove::storage::Error> {
+        self.inner.get(cf, key)
+    }
+
+    fn set(
+        &self,
+        cf: &ColumnFamilyName,
+        key: &Key,
+        value: &[u8],
+    ) -> Result<(), groove::storage::Error> {
+        self.before_write()?;
+        self.inner.set(cf, key, value)
+    }
+
+    fn delete(&self, cf: &ColumnFamilyName, key: &Key) -> Result<(), groove::storage::Error> {
+        self.before_write()?;
+        self.inner.delete(cf, key)
+    }
+
+    fn scan_range(
+        &self,
+        cf: &ColumnFamilyName,
+        start: &Key,
+        end: &Key,
+        visit: &mut ScanVisitor<'_>,
+    ) -> Result<(), groove::storage::Error> {
+        self.inner.scan_range(cf, start, end, visit)
+    }
+
+    fn scan_prefix(
+        &self,
+        cf: &ColumnFamilyName,
+        prefix: &Key,
+        visit: &mut ScanVisitor<'_>,
+    ) -> Result<(), groove::storage::Error> {
+        self.inner.scan_prefix(cf, prefix, visit)
+    }
+
+    fn scan_prefix_reverse(
+        &self,
+        cf: &ColumnFamilyName,
+        prefix: &Key,
+        visit: &mut ScanVisitor<'_>,
+    ) -> Result<(), groove::storage::Error> {
+        self.inner.scan_prefix_reverse(cf, prefix, visit)
+    }
+
+    fn last_with_prefix(
+        &self,
+        cf: &ColumnFamilyName,
+        prefix: &Key,
+    ) -> Result<Option<groove::storage::KeyValue>, groove::storage::Error> {
+        self.inner.last_with_prefix(cf, prefix)
+    }
+
+    fn last_with_prefix_before_or_at(
+        &self,
+        cf: &ColumnFamilyName,
+        prefix: &Key,
+        upper: &Key,
+    ) -> Result<Option<groove::storage::KeyValue>, groove::storage::Error> {
+        self.inner.last_with_prefix_before_or_at(cf, prefix, upper)
+    }
+
+    fn write_many(&self, operations: &[WriteOperation<'_>]) -> Result<(), groove::storage::Error> {
+        self.before_write()?;
+        self.inner.write_many(operations)
+    }
+
+    fn column_family_names(&self) -> Option<Vec<String>> {
+        self.inner.column_family_names()
+    }
+}
+
+impl ReopenableStorage for FailAfterWritesMemoryStorage {
+    fn reopen(mut self, column_families: &[&str]) -> Result<Self, groove::storage::Error> {
+        self.inner = self.inner.reopen(column_families)?;
+        Ok(self)
+    }
+}
+
 fn open_node() -> (tempfile::TempDir, NodeState<RocksDbStorage>) {
     let schema = schema();
     let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -425,11 +425,35 @@ fn reused_binding_keeps_old_and_current_read_view_markers_isolated() {
     }
 
     // B now owns the reused shape/binding registration. A's late authoritative
-    // false must route through exact detached cleanup, never through B.
+    // true must be dropped rather than applied to B.
     reader
         .apply_sync_message(SyncMessage::ViewUpdate {
             subscription: subscription_a,
             settled_through: GlobalSeq(8),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                opening_pending: true,
+                ..Default::default()
+            },
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    let binding_view_a = BindingViewKey::from_canonical_subscription_key(subscription_a);
+    let binding_view_b = BindingViewKey::from_canonical_subscription_key(subscription_b);
+    assert!(reader.opening_pending_for_binding_view(binding_view_a));
+    assert!(reader.opening_pending_for_binding_view(binding_view_b));
+
+    // A's late authoritative false may clean up A exactly, never B.
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription: subscription_a,
+            settled_through: GlobalSeq(9),
             reset_result_set: true,
             version_carriers: Vec::new(),
             version_bundles: Vec::new(),
@@ -441,13 +465,30 @@ fn reused_binding_keeps_old_and_current_read_view_markers_isolated() {
             program_fact_removes: Vec::new(),
         })
         .unwrap();
-    let binding_view_a = BindingViewKey::from_canonical_subscription_key(subscription_a);
-    let binding_view_b = BindingViewKey::from_canonical_subscription_key(subscription_b);
     assert!(!reader.opening_pending_for_binding_view(binding_view_a));
+    assert!(reader.opening_pending_for_binding_view(binding_view_b));
+
+    // Once A is gone, duplicate false remains detached and cannot fall through
+    // to B merely because the shape/binding registration was reused.
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription: subscription_a,
+            settled_through: GlobalSeq(10),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
     assert!(reader.opening_pending_for_binding_view(binding_view_b));
     assert_eq!(
         reader.sync_metrics().dropped_detached_subscription_messages,
-        1
+        3
     );
     reader.close().unwrap();
     drop(reader);
@@ -455,6 +496,52 @@ fn reused_binding_keeps_old_and_current_read_view_markers_isolated() {
     let reopened = reopen_node_at(&dir, node(3), schema());
     assert!(!reopened.opening_pending_for_binding_view(binding_view_a));
     assert!(reopened.opening_pending_for_binding_view(binding_view_b));
+}
+
+#[test]
+fn stale_unsubscribe_cannot_detach_reused_read_view_binding() {
+    let (_dir, mut reader) = open_node_with_uuid(node(3));
+    let (shape, binding) = reader.whole_table_shape_binding("todos").unwrap();
+    reader
+        .apply_sync_message(SyncMessage::RegisterShape {
+            shape_id: shape.shape_id(),
+            ast: crate::protocol::ShapeAst::from_validated(&shape),
+            opts: crate::protocol::RegisterShapeOptions::default(),
+        })
+        .unwrap();
+    let subscription_for = |ordinal| SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: binding.binding_id(),
+        read_view: ReadViewKey {
+            id: uuid::Uuid::from_u128(ordinal),
+        },
+    };
+    let subscription_a = subscription_for(0xa1);
+    let subscription_b = subscription_for(0xb1);
+    for subscription in [subscription_a, subscription_b] {
+        reader
+            .apply_sync_message(SyncMessage::Subscribe(crate::protocol::Subscribe {
+                shape_id: shape.shape_id(),
+                subscription,
+                values: Vec::new(),
+                known_state: None,
+            }))
+            .unwrap();
+    }
+
+    reader.apply_unsubscribe(subscription_a);
+    assert_eq!(
+        reader
+            .binding_view_key_for_subscription(subscription_b)
+            .unwrap()
+            .read_view,
+        subscription_b.read_view,
+        "stale unsubscribe A must not remove the reused current registration B"
+    );
+    reader.apply_unsubscribe(subscription_b);
+    assert!(reader
+        .binding_view_key_for_subscription(subscription_b)
+        .is_err());
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -157,6 +157,286 @@ fn unsubscribe_and_resubscribe_retain_pending_authority_opening() {
 }
 
 #[test]
+fn detached_authoritative_false_clears_exact_pending_marker_across_reopen() {
+    let (dir, mut reader) = open_node_with_uuid(node(3));
+    let (shape, binding) = reader.whole_table_shape_binding("todos").unwrap();
+    let subscription = SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: binding.binding_id(),
+        read_view: ReadViewKey {
+            id: uuid::Uuid::from_u128(0xd37ac4),
+        },
+    };
+    reader
+        .apply_sync_message(SyncMessage::RegisterShape {
+            shape_id: shape.shape_id(),
+            ast: crate::protocol::ShapeAst::from_validated(&shape),
+            opts: crate::protocol::RegisterShapeOptions::default(),
+        })
+        .unwrap();
+    reader
+        .apply_sync_message(SyncMessage::Subscribe(crate::protocol::Subscribe {
+            shape_id: shape.shape_id(),
+            subscription,
+            values: Vec::new(),
+            known_state: None,
+        }))
+        .unwrap();
+    let binding_view = BindingViewKey::from_canonical_subscription_key(subscription);
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(7),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                opening_pending: true,
+                ..Default::default()
+            },
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    reader.apply_unsubscribe(subscription);
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(8),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    assert_eq!(
+        reader.sync_metrics().dropped_detached_subscription_messages,
+        1
+    );
+    assert!(!reader.opening_pending_for_binding_view(binding_view));
+    reader.close().unwrap();
+    drop(reader);
+
+    let reopened = reopen_node_at(&dir, node(3), schema());
+    assert!(!reopened.opening_pending_for_binding_view(binding_view));
+}
+
+#[test]
+fn detached_false_delete_failure_keeps_pending_marker_conservative() {
+    let schema = schema();
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailAfterWritesMemoryStorage::new(&refs);
+    let mut reader = NodeState::new(node(3), schema.clone(), storage.clone()).unwrap();
+    let (shape, binding) = reader.whole_table_shape_binding("todos").unwrap();
+    let subscription = SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: binding.binding_id(),
+        read_view: ReadViewKey {
+            id: uuid::Uuid::from_u128(0xfa11ed),
+        },
+    };
+    reader
+        .apply_sync_message(SyncMessage::RegisterShape {
+            shape_id: shape.shape_id(),
+            ast: crate::protocol::ShapeAst::from_validated(&shape),
+            opts: crate::protocol::RegisterShapeOptions::default(),
+        })
+        .unwrap();
+    reader
+        .apply_sync_message(SyncMessage::Subscribe(crate::protocol::Subscribe {
+            shape_id: shape.shape_id(),
+            subscription,
+            values: Vec::new(),
+            known_state: None,
+        }))
+        .unwrap();
+    let binding_view = BindingViewKey::from_canonical_subscription_key(subscription);
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(7),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                opening_pending: true,
+                ..Default::default()
+            },
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    reader.apply_unsubscribe(subscription);
+    storage.fail_after_successful_writes(0);
+    let error = reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(8),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .expect_err("the exact pending-marker delete must hit the planted failure");
+    assert!(error.to_string().contains("injected write failure"));
+    assert_eq!(
+        reader.sync_metrics().dropped_detached_subscription_messages,
+        1
+    );
+    assert!(reader.opening_pending_for_binding_view(binding_view));
+    drop(reader);
+
+    let reopened = NodeState::new(node(3), schema, storage).unwrap();
+    assert!(reopened.opening_pending_for_binding_view(binding_view));
+}
+
+#[test]
+fn detached_false_cleanup_bounds_unique_read_view_marker_churn() {
+    let (dir, mut reader) = open_node_with_uuid(node(3));
+    let (shape, binding) = reader.whole_table_shape_binding("todos").unwrap();
+    reader
+        .apply_sync_message(SyncMessage::RegisterShape {
+            shape_id: shape.shape_id(),
+            ast: crate::protocol::ShapeAst::from_validated(&shape),
+            opts: crate::protocol::RegisterShapeOptions::default(),
+        })
+        .unwrap();
+
+    for ordinal in 1..=32u128 {
+        let subscription = SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: binding.binding_id(),
+            read_view: ReadViewKey {
+                id: uuid::Uuid::from_u128(ordinal),
+            },
+        };
+        reader
+            .apply_sync_message(SyncMessage::Subscribe(crate::protocol::Subscribe {
+                shape_id: shape.shape_id(),
+                subscription,
+                values: Vec::new(),
+                known_state: None,
+            }))
+            .unwrap();
+        for opening_pending in [true, false] {
+            if !opening_pending {
+                reader.apply_unsubscribe(subscription);
+            }
+            reader
+                .apply_sync_message(SyncMessage::ViewUpdate {
+                    subscription,
+                    settled_through: GlobalSeq(ordinal as u64),
+                    reset_result_set: true,
+                    version_carriers: Vec::new(),
+                    version_bundles: Vec::new(),
+                    peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                        opening_pending,
+                        ..Default::default()
+                    },
+                    result_member_adds: Vec::new(),
+                    result_member_removes: Vec::new(),
+                    terminal_operations: Vec::new(),
+                    program_fact_adds: Vec::new(),
+                    program_fact_removes: Vec::new(),
+                })
+                .unwrap();
+        }
+    }
+    assert!(reader.query.pending_opening_binding_views.is_empty());
+    reader.close().unwrap();
+    drop(reader);
+
+    let reopened = reopen_node_at(&dir, node(3), schema());
+    assert!(reopened.query.pending_opening_binding_views.is_empty());
+}
+
+#[test]
+fn known_state_eviction_deletes_pending_marker_last() {
+    for (successful_writes, pending_after_reopen) in
+        [(0, true), (1, true), (2, true), (3, false)]
+    {
+        let schema = schema();
+        let column_families = schema.column_families();
+        let refs = column_families
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        let storage = FailAfterWritesMemoryStorage::new(&refs);
+        let mut reader = NodeState::new(node(3), schema.clone(), storage.clone()).unwrap();
+        let subscription = reader.whole_table_subscription_key("todos").unwrap();
+        let binding_view = BindingViewKey::from_canonical_subscription_key(subscription);
+        reader
+            .apply_sync_message(SyncMessage::ViewUpdate {
+                subscription,
+                settled_through: GlobalSeq(7),
+                reset_result_set: true,
+                version_carriers: Vec::new(),
+                version_bundles: Vec::new(),
+                peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                    opening_pending: true,
+                    ..Default::default()
+                },
+                result_member_adds: Vec::new(),
+                result_member_removes: Vec::new(),
+                terminal_operations: Vec::new(),
+                program_fact_adds: Vec::new(),
+                program_fact_removes: Vec::new(),
+            })
+            .unwrap();
+        reader
+            .persist_settled_result_state_delta(
+                binding_view,
+                false,
+                &[crate::protocol::ResultMemberEntry::row((
+                    groove::Intern::from("todos".to_owned()),
+                    row(9),
+                    TxId::new(TxTime(9), node(9)),
+                ))],
+                &[],
+                None,
+                &[],
+                &[],
+                None,
+            )
+            .unwrap();
+        storage.fail_after_successful_writes(successful_writes);
+        let result = reader.clear_all_known_state_facts();
+        assert_eq!(result.is_ok(), successful_writes == 3);
+        if pending_after_reopen {
+            assert!(reader.opening_pending_for_binding_view(binding_view));
+        }
+        drop(reader);
+
+        let reopened = NodeState::new(node(3), schema, storage).unwrap();
+        assert_eq!(
+            reopened.opening_pending_for_binding_view(binding_view),
+            pending_after_reopen,
+            "unexpected marker after {successful_writes} successful eviction writes"
+        );
+    }
+}
+
+#[test]
 fn observed_global_seq_advances_authority_allocator() {
     let (_core_dir, mut core) = open_node_with_uuid(node(9));
     let (_writer_dir, mut writer) = open_node_with_uuid(node(1));

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -1,4 +1,62 @@
 #[test]
+fn opening_pending_survives_storage_reopen() {
+    let (dir, mut reader) = open_node_with_uuid(node(3));
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let binding_view = BindingViewKey::from_canonical_subscription_key(subscription);
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(7),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                opening_pending: true,
+                ..Default::default()
+            },
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    assert!(reader.opening_pending_for_binding_view(binding_view));
+    reader.close().unwrap();
+    drop(reader);
+
+    let mut reopened = reopen_node_at(&dir, node(3), schema());
+    assert!(
+        reopened.opening_pending_for_binding_view(binding_view),
+        "a provisional authority opening must not become settled merely because the client restarted"
+    );
+    reopened
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(8),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    assert!(!reopened.opening_pending_for_binding_view(binding_view));
+    reopened.close().unwrap();
+    drop(reopened);
+
+    let settled_reopen = reopen_node_at(&dir, node(3), schema());
+    assert!(
+        !settled_reopen.opening_pending_for_binding_view(binding_view),
+        "an authoritative reset must durably clear the provisional opening marker"
+    );
+}
+
+#[test]
 fn observed_global_seq_advances_authority_allocator() {
     let (_core_dir, mut core) = open_node_with_uuid(node(9));
     let (_writer_dir, mut writer) = open_node_with_uuid(node(1));

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -371,6 +371,136 @@ fn detached_false_cleanup_bounds_unique_read_view_marker_churn() {
 }
 
 #[test]
+fn reused_binding_keeps_old_and_current_read_view_markers_isolated() {
+    let (dir, mut reader) = open_node_with_uuid(node(3));
+    let (shape, binding) = reader.whole_table_shape_binding("todos").unwrap();
+    reader
+        .apply_sync_message(SyncMessage::RegisterShape {
+            shape_id: shape.shape_id(),
+            ast: crate::protocol::ShapeAst::from_validated(&shape),
+            opts: crate::protocol::RegisterShapeOptions::default(),
+        })
+        .unwrap();
+    let subscription_for = |read_view| SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: binding.binding_id(),
+        read_view,
+    };
+    let read_view_a = ReadViewKey {
+        id: uuid::Uuid::from_u128(0xa),
+    };
+    let read_view_b = ReadViewKey {
+        id: uuid::Uuid::from_u128(0xb),
+    };
+    let subscription_a = subscription_for(read_view_a);
+    let subscription_b = subscription_for(read_view_b);
+
+    for subscription in [subscription_a, subscription_b] {
+        reader
+            .apply_sync_message(SyncMessage::Subscribe(crate::protocol::Subscribe {
+                shape_id: shape.shape_id(),
+                subscription,
+                values: Vec::new(),
+                known_state: None,
+            }))
+            .unwrap();
+        reader
+            .apply_sync_message(SyncMessage::ViewUpdate {
+                subscription,
+                settled_through: GlobalSeq(7),
+                reset_result_set: true,
+                version_carriers: Vec::new(),
+                version_bundles: Vec::new(),
+                peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                    opening_pending: true,
+                    ..Default::default()
+                },
+                result_member_adds: Vec::new(),
+                result_member_removes: Vec::new(),
+                terminal_operations: Vec::new(),
+                program_fact_adds: Vec::new(),
+                program_fact_removes: Vec::new(),
+            })
+            .unwrap();
+    }
+
+    // B now owns the reused shape/binding registration. A's late authoritative
+    // false must route through exact detached cleanup, never through B.
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription: subscription_a,
+            settled_through: GlobalSeq(8),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    let binding_view_a = BindingViewKey::from_canonical_subscription_key(subscription_a);
+    let binding_view_b = BindingViewKey::from_canonical_subscription_key(subscription_b);
+    assert!(!reader.opening_pending_for_binding_view(binding_view_a));
+    assert!(reader.opening_pending_for_binding_view(binding_view_b));
+    assert_eq!(
+        reader.sync_metrics().dropped_detached_subscription_messages,
+        1
+    );
+    reader.close().unwrap();
+    drop(reader);
+
+    let reopened = reopen_node_at(&dir, node(3), schema());
+    assert!(!reopened.opening_pending_for_binding_view(binding_view_a));
+    assert!(reopened.opening_pending_for_binding_view(binding_view_b));
+}
+
+#[test]
+fn repeated_pending_true_does_not_rewrite_the_same_marker() {
+    let schema = schema();
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailAfterWritesMemoryStorage::new(&refs);
+    let mut reader = NodeState::new(node(3), schema, storage.clone()).unwrap();
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let writes_before_updates = storage.total_writes();
+    let mut writes_after_updates = Vec::new();
+
+    for settled_through in [GlobalSeq(7), GlobalSeq(8)] {
+        reader
+            .apply_sync_message(SyncMessage::ViewUpdate {
+                subscription,
+                settled_through,
+                reset_result_set: true,
+                version_carriers: Vec::new(),
+                version_bundles: Vec::new(),
+                peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                    opening_pending: true,
+                    ..Default::default()
+                },
+                result_member_adds: Vec::new(),
+                result_member_removes: Vec::new(),
+                terminal_operations: Vec::new(),
+                program_fact_adds: Vec::new(),
+                program_fact_removes: Vec::new(),
+            })
+            .unwrap();
+        writes_after_updates.push(storage.total_writes());
+    }
+
+    assert_eq!(
+        writes_after_updates[0] - writes_before_updates,
+        writes_after_updates[1] - writes_after_updates[0] + 1,
+        "the first update must perform exactly one marker write that the repeated true skips"
+    );
+}
+
+#[test]
 fn known_state_eviction_deletes_pending_marker_last() {
     for (successful_writes, pending_after_reopen) in
         [(0, true), (1, true), (2, true), (3, false)]

--- a/crates/jazz/src/node/tests/sync.rs
+++ b/crates/jazz/src/node/tests/sync.rs
@@ -57,6 +57,106 @@ fn opening_pending_survives_storage_reopen() {
 }
 
 #[test]
+fn opening_pending_is_written_before_later_view_state() {
+    let schema = schema();
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailAfterWritesMemoryStorage::new(&refs);
+    let mut reader = NodeState::new(node(3), schema.clone(), storage.clone()).unwrap();
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let binding_view = BindingViewKey::from_canonical_subscription_key(subscription);
+
+    // The first write is the conservative pending marker. The injected second
+    // write failure simulates a crash while later settled-result state is
+    // advancing.
+    storage.fail_after_successful_writes(1);
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(7),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                opening_pending: true,
+                ..Default::default()
+            },
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .expect_err("later view-state persistence must hit the planted failure");
+    drop(reader);
+
+    let reopened = NodeState::new(node(3), schema, storage).unwrap();
+    assert!(
+        reopened.opening_pending_for_binding_view(binding_view),
+        "a crash after the marker but before settled state must reopen conservatively"
+    );
+}
+
+#[test]
+fn unsubscribe_and_resubscribe_retain_pending_authority_opening() {
+    let (_dir, mut reader) = open_node_with_uuid(node(3));
+    let (shape, binding) = reader.whole_table_shape_binding("todos").unwrap();
+    register_shape_binding(&mut reader, &shape, &binding);
+    let subscription = crate::protocol::SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: binding.binding_id(),
+        read_view: Default::default(),
+    };
+    let binding_view = BindingViewKey::from_canonical_subscription_key(subscription);
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(7),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                opening_pending: true,
+                ..Default::default()
+            },
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+
+    reader.apply_unsubscribe(subscription);
+    assert!(reader.opening_pending_for_binding_view(binding_view));
+    register_shape_binding(&mut reader, &shape, &binding);
+    assert!(
+        reader.opening_pending_for_binding_view(binding_view),
+        "resubscription must not turn a detached provisional opening into settled state"
+    );
+
+    reader
+        .apply_sync_message(SyncMessage::ViewUpdate {
+            subscription,
+            settled_through: GlobalSeq(8),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+        .unwrap();
+    assert!(!reader.opening_pending_for_binding_view(binding_view));
+}
+
+#[test]
 fn observed_global_seq_advances_authority_allocator() {
     let (_core_dir, mut core) = open_node_with_uuid(node(9));
     let (_writer_dir, mut writer) = open_node_with_uuid(node(1));

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -792,6 +792,19 @@ where
         let version_bundle_refs =
             version_bundle_refs_for_carriers(&version_bundles, &version_carriers)?;
         let binding_view_key = match self.binding_view_key_for_subscription(subscription) {
+            Ok(binding_view_key) if binding_view_key.read_view != subscription.read_view => {
+                let wire_binding_view_key =
+                    BindingViewKey::from_canonical_subscription_key(subscription);
+                if !opening_pending && self.has_persisted_opening_pending(wire_binding_view_key)? {
+                    self.sync_metrics.dropped_detached_subscription_messages += 1;
+                    self.persist_opening_pending(wire_binding_view_key, false)?;
+                    self.query
+                        .pending_opening_binding_views
+                        .remove(&wire_binding_view_key);
+                    return Ok(());
+                }
+                binding_view_key
+            }
             Ok(binding_view_key) => binding_view_key,
             Err(Error::InvalidStoredValue(
                 "subscription referenced unregistered shape"
@@ -826,7 +839,9 @@ where
         // provisional snapshot as settled.  The false transition remains the
         // final durable mutation in this method.
         if opening_pending {
-            self.persist_opening_pending(binding_view_key, true)?;
+            if !self.has_persisted_opening_pending(binding_view_key)? {
+                self.persist_opening_pending(binding_view_key, true)?;
+            }
             self.query
                 .pending_opening_binding_views
                 .insert(binding_view_key);

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1047,6 +1047,7 @@ where
                 .authorization_progress_by_binding_view
                 .insert(binding_view_key, progress);
         }
+        self.persist_opening_pending(binding_view_key, opening_pending)?;
         if opening_pending {
             self.query
                 .pending_opening_binding_views

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -807,6 +807,17 @@ where
             }
             Err(error) => return Err(error),
         };
+        // `opening_pending` is a conservative authority-safety marker.  Make
+        // the true transition durable before any result or known-state
+        // advancement below, so a crash cannot reopen a partially applied
+        // provisional snapshot as settled.  The false transition remains the
+        // final durable mutation in this method.
+        if opening_pending {
+            self.persist_opening_pending(binding_view_key, true)?;
+            self.query
+                .pending_opening_binding_views
+                .insert(binding_view_key);
+        }
         if reset_result_set {
             self.query
                 .pending_terminal_operations_by_binding_view
@@ -1047,12 +1058,8 @@ where
                 .authorization_progress_by_binding_view
                 .insert(binding_view_key, progress);
         }
-        self.persist_opening_pending(binding_view_key, opening_pending)?;
-        if opening_pending {
-            self.query
-                .pending_opening_binding_views
-                .insert(binding_view_key);
-        } else {
+        if !opening_pending {
+            self.persist_opening_pending(binding_view_key, false)?;
             self.query
                 .pending_opening_binding_views
                 .remove(&binding_view_key);

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -795,15 +795,14 @@ where
             Ok(binding_view_key) if binding_view_key.read_view != subscription.read_view => {
                 let wire_binding_view_key =
                     BindingViewKey::from_canonical_subscription_key(subscription);
+                self.sync_metrics.dropped_detached_subscription_messages += 1;
                 if !opening_pending && self.has_persisted_opening_pending(wire_binding_view_key)? {
-                    self.sync_metrics.dropped_detached_subscription_messages += 1;
                     self.persist_opening_pending(wire_binding_view_key, false)?;
                     self.query
                         .pending_opening_binding_views
                         .remove(&wire_binding_view_key);
-                    return Ok(());
                 }
-                binding_view_key
+                return Ok(());
             }
             Ok(binding_view_key) => binding_view_key,
             Err(Error::InvalidStoredValue(

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -803,6 +803,19 @@ where
                 // corruption. The receiver cannot distinguish late-detached
                 // from never-registered keys, so both are benign drops.
                 self.sync_metrics.dropped_detached_subscription_messages += 1;
+                if !opening_pending {
+                    let binding_view_key =
+                        BindingViewKey::from_canonical_subscription_key(subscription);
+                    // A detached authoritative `false` may clean up only the
+                    // exact durable tombstone named by the wire key. It cannot
+                    // install state or affect another canonical binding.
+                    if self.has_persisted_opening_pending(binding_view_key)? {
+                        self.persist_opening_pending(binding_view_key, false)?;
+                        self.query
+                            .pending_opening_binding_views
+                            .remove(&binding_view_key);
+                    }
+                }
                 return Ok(());
             }
             Err(error) => return Err(error),

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -27,6 +27,9 @@ pub const SCHEMA_VERSION_NAMESPACE: uuid::Uuid =
 
 /// Direct groove record store used for persisted fast known-state facts.
 pub const KNOWN_STATE_FACTS_STORE: &str = "jazz_known_state_facts";
+/// Direct groove record store used for provisional authority openings that
+/// must continue blocking publication across process restart.
+pub const PENDING_OPENING_BINDING_VIEWS_STORE: &str = "jazz_pending_opening_binding_views";
 /// Direct groove record store used for persisted settled result memberships.
 pub const SETTLED_RESULT_MEMBERS_STORE: &str = "jazz_settled_result_members";
 /// Direct groove record store used for persisted settled program facts.
@@ -240,6 +243,15 @@ impl JazzSchema {
                     ("settled_through", ValueType::U64),
                     ("authorization_progress", ValueType::U64),
                 ]),
+            ))
+            .with_direct_record_store(DirectRecordStoreSchema::new(
+                PENDING_OPENING_BINDING_VIEWS_STORE,
+                RecordDescriptor::new([
+                    ("shape_id", ValueType::Uuid),
+                    ("binding_id", ValueType::Uuid),
+                    ("read_view_id", ValueType::Uuid),
+                ]),
+                RecordDescriptor::new([("present", ValueType::U64)]),
             ))
             .with_direct_record_store(DirectRecordStoreSchema::new(
                 SETTLED_RESULT_MEMBERS_STORE,


### PR DESCRIPTION
🤖 Preserves provisional opening state across restart and prevents stale read-view traffic from publishing or clearing the wrong snapshot.

- persists opening markers before result/cursor advancement
- clears them only after authoritative non-pending state
- orders eviction cleanup conservatively across crash boundaries
- recovers markers on reopen and database-slot rebuild
- cleans detached exact-key tombstones without installing state
- rejects stale read-view true/false/unsubscribe traffic after binding reuse
- avoids redundant durable true-marker rewrites
- validates marker records strictly

Coverage includes injected write failures, reopen at each eviction phase, A/B read-view reuse, late true/false/duplicate false, stale unsubscribe, detached cleanup, marker churn, and sensitivity plants.

Verified with focused tests, the full Jazz library suite modulo two host file-descriptor failures that passed serially, Clippy, formatting, hooks, and independent adversarial review.