### PR TITLE
fix(ci): protect provisioned Rust state from cache cleanup

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -117,7 +117,12 @@ runs:
         components: ${{ inputs.rust-components }}
 
     - name: Cache Rust build artifacts
-      if: inputs.rust-toolchain != '' && inputs.rust-cache == 'true'
+      # The provisioned self-hosted runners already persist target artifacts
+      # and share sccache.  Swatinem/rust-cache's post-job cleanup mutates
+      # host-owned shared Cargo state on those runners, so one job can remove
+      # registry sources while another job is compiling.  Keep rust-cache
+      # confined to hosted jobs, whose mutable Rust homes are job-local.
+      if: inputs.rust-toolchain != '' && inputs.rust-cache == 'true' && steps.provisioned-tools.outputs.active != 'true'
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-on-failure: true

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -202,6 +202,11 @@ test("trusted runners consume the validated immutable tool bundle", () => {
     /echo "RUSTC=\/opt\/jazz-ci\/toolchains\/v1\/rustup\/toolchains\/1\.93\.1-x86_64-unknown-linux-gnu\/bin\/rustc" >> "\$\{GITHUB_ENV\}"/,
   );
   assert.match(setupBuildAction, /Jobs are clients only/);
+  assert.match(
+    setupBuildAction,
+    /name: Cache Rust build artifacts[\s\S]*if: inputs\.rust-toolchain != '' && inputs\.rust-cache == 'true' && steps\.provisioned-tools\.outputs\.active != 'true'[\s\S]*uses: Swatinem\/rust-cache@/,
+    "rust-cache cleanup must never mutate a provisioned runner's shared Rust homes",
+  );
   assert.doesNotMatch(
     setupBuildAction.match(
       /if \[\[ '\$\{\{ steps\.provisioned-tools\.outputs\.active \}\}' == 'true' \]\]; then[\s\S]*?else/,
@@ -209,6 +214,17 @@ test("trusted runners consume the validated immutable tool bundle", () => {
     /sccache --(?:start|stop)-server/,
   );
   assert.match(fallbackBranch, /sccache --start-server/);
+  assert.throws(
+    () =>
+      assert.match(
+        setupBuildAction.replace(
+          " && steps.provisioned-tools.outputs.active != 'true'\n      uses: Swatinem/rust-cache@",
+          "\n      uses: Swatinem/rust-cache@",
+        ),
+        /name: Cache Rust build artifacts[\s\S]*if: inputs\.rust-toolchain != '' && inputs\.rust-cache == 'true' && steps\.provisioned-tools\.outputs\.active != 'true'[\s\S]*uses: Swatinem\/rust-cache@/,
+      ),
+    /rust-cache/,
+  );
 });
 
 test("Rust CI does not rerun differential integration binaries selected by the workspace test gate", () => {


### PR DESCRIPTION
🤖 Prevents CI jobs on provisioned self-hosted runners from deleting Cargo state used by sibling jobs.

The provisioned runners already persist target artifacts and share sccache, but the generic Rust cache action still ran there. Its post-job cleanup removes Cargo registry/git/bin state. Because those paths are host-shared on provisioned runners, one completed job could remove registry sources while another was compiling, producing the observed missing-source and tool-execution failures across unrelated PRs.

The setup action now skips `Swatinem/rust-cache` only when the validated provisioned tool bundle is active. Hosted, fork, and Dependabot jobs retain their job-local Rust cache behavior.

Validation:

- Focused workflow contract: 18/18
- Full CI workflow contract: 39/39
- Reversible removal of the provisioned-runner guard failed the intended test
- Sensitive-data and diff checks passed
- Independent adversarial review found no P0/P1; its comment-accuracy P2 was corrected

This intentionally does not serialize the CI workflow. Remaining `EAGAIN` bursts indicate runner-level process-density limits and should be handled by runner configuration rather than masking them with repository-wide serialization.
