### PR TITLE
fix(subscriptions): preserve stable root ordering

### DIFF
--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -4522,12 +4522,25 @@ fn flat_subscription_updates_with_nullable_sort_payload() {
     )
     .unwrap();
     db.tick().unwrap();
-    let event = block_on(subscription.next_raw()).unwrap();
-    assert!(matches!(
-        event,
-        SubscriptionEvent::Delta { terminal_operations, .. }
-            if terminal_operations.iter().any(|operation| matches!(operation.edit, groove::ivm::TerminalEdit::Update { .. }))
-    ));
+    let SubscriptionEvent::Delta {
+        terminal_operations,
+        ..
+    } = block_on(subscription.next_raw()).unwrap()
+    else {
+        panic!("title-only update must emit a terminal delta");
+    };
+    assert!(
+        terminal_operations
+            .iter()
+            .any(|operation| matches!(operation.edit, groove::ivm::TerminalEdit::Update { .. })),
+        "title-only update must retain its root payload"
+    );
+    assert!(
+        !terminal_operations
+            .iter()
+            .any(|operation| matches!(operation.edit, groove::ivm::TerminalEdit::Move { .. })),
+        "unchanged nullable sort key must not produce a root move"
+    );
 }
 
 #[test]

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1811,6 +1811,7 @@ export class NativeRuntimeAdapter implements Runtime {
             this.schema,
             chunk.reset === true,
             subscription.outputColumns,
+            chunk.terminalOperations,
           );
         } catch (error) {
           const buffered = applySubscriptionDeltaToState(
@@ -1820,6 +1821,7 @@ export class NativeRuntimeAdapter implements Runtime {
             this.schema,
             chunk.reset === true,
             subscription.outputColumns,
+            chunk.terminalOperations,
           );
           if (
             subscriptionRowsRequireBufferedPublication(
@@ -3848,6 +3850,7 @@ export function applySubscriptionDeltaWithWireDelta(
   schema: WasmSchema,
   reset = false,
   outputColumns: SubscriptionOutputColumns | null = null,
+  terminalOperations?: readonly NativeTerminalOperation[],
 ): { rows: RowState[]; rowIndexByKey: Map<string, number>; wireDelta: NativeRowDelta } {
   const { addedRows, updatedRows, removedEntries, rows, rowIndexByKey } =
     applySubscriptionDeltaToState(
@@ -3857,6 +3860,7 @@ export function applySubscriptionDeltaWithWireDelta(
       schema,
       reset,
       outputColumns,
+      terminalOperations,
     );
   return {
     rows,
@@ -3896,6 +3900,7 @@ function applySubscriptionDeltaToState(
   schema: WasmSchema,
   reset = false,
   outputColumns: SubscriptionOutputColumns | null = null,
+  terminalOperations?: readonly NativeTerminalOperation[],
 ): {
   addedRows: RowState[];
   updatedRows: RowState[];
@@ -3913,12 +3918,29 @@ function applySubscriptionDeltaToState(
     resultKeyBytes?: Uint8Array;
   }> = [];
 
+  const addedRows = rowsFromSubscriptionBatches(delta.added, schema, outputColumns, "full-record");
+  const updatedRows = rowsFromSubscriptionBatches(
+    delta.updated,
+    schema,
+    outputColumns,
+    "full-record",
+  );
+  attachOccurrenceKeys(addedRows, delta.addedOccurrenceKeys);
+  attachOccurrenceKeys(updatedRows, delta.updatedOccurrenceKeys);
+
+  // A changed row can arrive as a remove/add pair because relational record
+  // bytes include the changed value. It remains the same public occurrence,
+  // though, and must retain its slot until an explicit terminal Move says
+  // otherwise. Deleting it first makes Map insertion order spuriously turn a
+  // title-only edit into a sort reorder.
+  const replacementKeys = new Set(addedRows.concat(updatedRows).map((row) => rowStateKey(row)));
   for (const [removedIndex, removed] of delta.removed.entries()) {
     const id = formatUuid(removed.rowId);
     const resultKeyBytes = delta.removedOccurrenceKeys[removedIndex];
     const key = resultKeyBytes
       ? occurrenceStateKey(resultKeyBytes, removed.table, id)
       : rowKey(removed.table, id);
+    if (replacementKeys.has(key)) continue;
     removedEntries.push({
       table: removed.table,
       id,
@@ -3928,26 +3950,12 @@ function applySubscriptionDeltaToState(
     rowsByKey.delete(key);
   }
 
-  const nestedRowCarrier: NestedRowCarrier = "full-record";
-  const addedRows = rowsFromSubscriptionBatches(
-    delta.added,
-    schema,
-    outputColumns,
-    nestedRowCarrier,
-  );
-  const updatedRows = rowsFromSubscriptionBatches(
-    delta.updated,
-    schema,
-    outputColumns,
-    nestedRowCarrier,
-  );
-  attachOccurrenceKeys(addedRows, delta.addedOccurrenceKeys);
-  attachOccurrenceKeys(updatedRows, delta.updatedOccurrenceKeys);
   for (const row of addedRows.concat(updatedRows)) {
     rowsByKey.set(rowStateKey(row), row);
   }
 
   const rows = Array.from(rowsByKey.values());
+  applyTerminalRootOrdering(rows, terminalOperations, outputColumns?.rootTable);
   const rowIndexByKey = indexRowsByKey(rows);
   return {
     addedRows,
@@ -3956,6 +3964,40 @@ function applySubscriptionDeltaToState(
     rows,
     rowIndexByKey,
   };
+}
+
+/**
+ * Relation deltas describe row membership while terminal edits own public
+ * root positions. Root Remove edits therefore do not delete adapter state: a
+ * changed sort key is represented as Remove followed by Insert for the same
+ * occurrence, and the relation replacement already supplies its new payload.
+ * Apply only unambiguous flat-root Insert/Move positions here; composite
+ * occurrence keys intentionally remain opaque rather than guessing which
+ * duplicate physical row they address.
+ */
+function applyTerminalRootOrdering(
+  rows: RowState[],
+  operations: readonly NativeTerminalOperation[] | undefined,
+  rootTable: string | undefined,
+): void {
+  for (const operation of operations ?? []) {
+    if (operation.path.length !== 0) continue;
+    const rootEdit = operation.edit;
+    if (!("Insert" in rootEdit) && !("Move" in rootEdit)) continue;
+    const key = "Insert" in rootEdit ? rootEdit.Insert.key : rootEdit.Move.key;
+    if (key.length !== 17 || key[0] !== 10) continue;
+    const id = formatUuid(Uint8Array.from(key.slice(1)));
+    const matches = rows
+      .map((row, index) =>
+        row.id === id && (rootTable === undefined || row.table === rootTable) ? index : -1,
+      )
+      .filter((index) => index !== -1);
+    if (matches.length !== 1) continue;
+    const index = matches[0]!;
+    const target = "Insert" in rootEdit ? rootEdit.Insert.index : rootEdit.Move.index;
+    const [row] = rows.splice(index, 1);
+    rows.splice(Math.max(0, Math.min(target, rows.length)), 0, row!);
+  }
 }
 
 function rowsFromSubscriptionBatches(

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -4908,6 +4908,110 @@ it("keeps same-row union occurrences distinct through apply, removal, and reopen
   );
 });
 
+it("keeps a remove/add root replacement in place without a terminal move", () => {
+  const ids = [1, 2, 3].map((value) => {
+    const bytes = new Uint8Array(16);
+    bytes[15] = value;
+    return bytes;
+  });
+  const decode = (bytes: Uint8Array) => readNativeSubscriptionDelta(new PostcardReader(bytes));
+  const initial = applySubscriptionDeltaWithWireDelta(
+    [],
+    new Map(),
+    decode(
+      encodeSubscriptionDelta({
+        added: ids.map((rowId, index) => ({ table: "todos", rowId, title: `todo-${index}` })),
+        updated: [],
+        removed: [],
+      }),
+    ),
+    testSchema,
+  );
+  const replaced = ids[0]!;
+  const afterTitleOnlyReplacement = applySubscriptionDeltaWithWireDelta(
+    initial.rows,
+    initial.rowIndexByKey,
+    decode(
+      encodeSubscriptionDelta({
+        added: [{ table: "todos", rowId: replaced, title: "renamed" }],
+        updated: [],
+        removed: [{ table: "todos", rowId: replaced }],
+      }),
+    ),
+    testSchema,
+    false,
+    null,
+    [
+      {
+        root_key: [10, ...replaced],
+        path: [],
+        edit: { Update: { key: [10, ...replaced], value: [] } },
+      },
+    ],
+  );
+
+  expect(afterTitleOnlyReplacement.rows.map((row) => row.id)).toEqual(
+    ids.map((id) => formatUuid(id)),
+  );
+  expect(decodeNativeDelta(afterTitleOnlyReplacement.wireDelta, testSchema.todos.columns)).toEqual([
+    expect.objectContaining({ id: formatUuid(replaced), index: 0 }),
+  ]);
+
+  const afterSortReplacement = applySubscriptionDeltaWithWireDelta(
+    afterTitleOnlyReplacement.rows,
+    afterTitleOnlyReplacement.rowIndexByKey,
+    decode(
+      encodeSubscriptionDelta({
+        added: [{ table: "todos", rowId: replaced, title: "renamed and moved" }],
+        updated: [],
+        removed: [{ table: "todos", rowId: replaced }],
+      }),
+    ),
+    testSchema,
+    false,
+    null,
+    [
+      {
+        root_key: [10, ...replaced],
+        path: [],
+        edit: { Remove: { key: [10, ...replaced] } },
+      },
+      {
+        root_key: [10, ...replaced],
+        path: [],
+        edit: { Insert: { key: [10, ...replaced], index: 2, value: [] } },
+      },
+    ],
+  );
+  expect(afterSortReplacement.rows.map((row) => row.id)).toEqual([
+    formatUuid(ids[1]!),
+    formatUuid(ids[2]!),
+    formatUuid(replaced),
+  ]);
+
+  const moved = ids[2]!;
+  const afterExplicitMove = applySubscriptionDeltaWithWireDelta(
+    afterSortReplacement.rows,
+    afterSortReplacement.rowIndexByKey,
+    decode(encodeSubscriptionDelta({ added: [], updated: [], removed: [] })),
+    testSchema,
+    false,
+    null,
+    [
+      {
+        root_key: [10, ...moved],
+        path: [],
+        edit: { Move: { key: [10, ...moved], index: 0 } },
+      },
+    ],
+  );
+  expect(afterExplicitMove.rows.map((row) => row.id)).toEqual([
+    formatUuid(moved),
+    formatUuid(ids[1]!),
+    formatUuid(replaced),
+  ]);
+});
+
 function encodeUserWrappedSubscriptionDelta(row: {
   table: string;
   rowId: Uint8Array;


### PR DESCRIPTION
🤖 Fixes maintained-query rows being spuriously repositioned after updates that do not change their sort value.

Rust correctly emits a terminal `Update` with no `Move` for a title-only update. The native TypeScript adapter previously implemented the accompanying remove/add record replacement by deleting and reinserting the occurrence into a `Map`, fabricating a new end index. That made null/undefined sort rows move nondeterministically and caused recurring browser failures on unrelated PRs.

Relation deltas now remain the sole authority for membership. Terminal root `Insert`/`Move` operations are the sole authority for explicit positional changes; root `Remove`/`Update` no longer delete an already-retained replacement occurrence.

Validation:

- exact same-occurrence stable replacement regression
- exact same-UUID `Remove` → `Insert` reorder regression
- explicit `Move` regression
- Rust nullable-sort `Update`/no-`Move` contract
- Rust structured terminal reorder contract
- native runtime suite: 77 passed, 1 skipped
- full browser sort suite: 18/18, plus maintained and restart/reload repetitions
- reversible old-behavior and row-loss plants failed as expected
- independent adversarial review: no P0/P1; one nonblocking composite deferred-publication coverage note
