### PR TITLE
fix(jazz): retain trusted catalogue lineages across reopen

### DIFF
--- a/crates/jazz/src/node/catalogue_ingest.rs
+++ b/crates/jazz/src/node/catalogue_ingest.rs
@@ -177,16 +177,11 @@ where
         }
 
         for (catalogue_seq, publication) in lineages {
-            self.validate_schema_lineage_publication_bounds(&publication)?;
-            if publication.id != publication.content_id()
-                || publication.schema.id != publication.schema.schema.version_id()
-                || publication.lens.id != publication.lens.content_id()
-                || publication.lens.target != publication.schema.id
-            {
-                return Err(Error::InvalidCatalogueUpdate(
+            Self::validate_schema_lineage_publication(&publication).map_err(|_| {
+                Error::InvalidCatalogueUpdate(
                     "trusted catalogue snapshot contains invalid lineage identity",
-                ));
-            }
+                )
+            })?;
             if let Some(existing) = planned
                 .active_lineages_by_target
                 .get(&publication.schema.id)
@@ -209,8 +204,8 @@ where
                 .ok_or(Error::InvalidCatalogueUpdate(
                     "trusted catalogue snapshot lineage source is missing",
                 ))?;
-            self.validate_migration_lens_between(&publication.lens, source, &publication.schema)?;
-            self.validate_lineage_table_partition(
+            Self::validate_migration_lens_between(&publication.lens, source, &publication.schema)?;
+            Self::validate_lineage_table_partition(
                 &source.schema,
                 &publication.schema.schema,
                 &publication.lens,

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -280,12 +280,7 @@ where
         S: ReopenableStorage,
     {
         self.require_catalogue_admin(author, ingest_context)?;
-        self.validate_schema_lineage_publication_bounds(&publication)?;
-        if publication.id != publication.content_id() {
-            return Err(Error::InvalidCatalogueUpdate(
-                "schema lineage publication id mismatch",
-            ));
-        }
+        Self::validate_schema_lineage_publication(&publication)?;
         if catalogue_seq == 0 {
             return Err(Error::InvalidCatalogueUpdate(
                 "schema lineage catalogue sequence must be nonzero",
@@ -293,21 +288,6 @@ where
         }
         let schema = &publication.schema;
         let lens = &publication.lens;
-        if schema.id != schema.schema.version_id() {
-            return Err(Error::InvalidCatalogueUpdate(
-                "schema id does not match schema payload",
-            ));
-        }
-        if lens.id != lens.content_id() {
-            return Err(Error::InvalidCatalogueUpdate(
-                "lens id does not match lens payload",
-            ));
-        }
-        if lens.target != schema.id {
-            return Err(Error::InvalidCatalogueUpdate(
-                "lineage lens target does not match schema",
-            ));
-        }
         if let Some(existing) = self.catalogue.active_lineages_by_target.get(&schema.id) {
             if existing.publication != publication || existing.catalogue_seq != catalogue_seq {
                 return Err(Error::InvalidCatalogueUpdate(
@@ -335,8 +315,8 @@ where
             }
         } else {
             if let Some(source) = self.catalogue.catalogue_schemas.get(&lens.source) {
-                self.validate_migration_lens_between(lens, source, schema)?;
-                self.validate_lineage_table_partition(
+                Self::validate_migration_lens_between(lens, source, schema)?;
+                Self::validate_lineage_table_partition(
                     &source.schema,
                     &schema.schema,
                     lens,
@@ -390,17 +370,20 @@ where
             else {
                 break;
             };
-            let validation = self
-                .validate_migration_lens_between(&publication.lens, &source, &publication.schema)
-                .and_then(|()| {
-                    self.validate_lineage_table_partition(
-                        &source.schema,
-                        &publication.schema.schema,
-                        &publication.lens,
-                        &publication.new_tables,
-                        &publication.dropped_tables,
-                    )
-                });
+            let validation = Self::validate_migration_lens_between(
+                &publication.lens,
+                &source,
+                &publication.schema,
+            )
+            .and_then(|()| {
+                Self::validate_lineage_table_partition(
+                    &source.schema,
+                    &publication.schema.schema,
+                    &publication.lens,
+                    &publication.new_tables,
+                    &publication.dropped_tables,
+                )
+            });
             if validation.is_err() {
                 self.remove_pending_schema_lineage(next, publication.id)?;
                 break;
@@ -720,11 +703,10 @@ where
             .catalogue_schemas
             .get(&lens.target)
             .ok_or(Error::InvalidCatalogueUpdate("lens endpoint is unknown"))?;
-        self.validate_migration_lens_between(lens, source, target)
+        Self::validate_migration_lens_between(lens, source, target)
     }
 
     pub(super) fn validate_migration_lens_between(
-        &self,
         lens: &MigrationLens,
         source: &SchemaVersion,
         target: &SchemaVersion,
@@ -860,7 +842,6 @@ where
     }
 
     pub(super) fn validate_lineage_table_partition(
-        &self,
         source: &JazzSchema,
         target: &JazzSchema,
         lens: &MigrationLens,
@@ -910,7 +891,6 @@ where
     }
 
     pub(super) fn validate_schema_lineage_publication_bounds(
-        &self,
         publication: &SchemaLineagePublication,
     ) -> Result<(), Error> {
         let declaration_count = publication
@@ -943,6 +923,33 @@ where
         {
             return Err(Error::InvalidCatalogueUpdate(
                 "schema lineage publication exceeds structural limits",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_schema_lineage_publication(
+        publication: &SchemaLineagePublication,
+    ) -> Result<(), Error> {
+        Self::validate_schema_lineage_publication_bounds(publication)?;
+        if publication.id != publication.content_id() {
+            return Err(Error::InvalidCatalogueUpdate(
+                "schema lineage publication id mismatch",
+            ));
+        }
+        if publication.schema.id != publication.schema.schema.version_id() {
+            return Err(Error::InvalidCatalogueUpdate(
+                "schema id does not match schema payload",
+            ));
+        }
+        if publication.lens.id != publication.lens.content_id() {
+            return Err(Error::InvalidCatalogueUpdate(
+                "lens id does not match lens payload",
+            ));
+        }
+        if publication.lens.target != publication.schema.id {
+            return Err(Error::InvalidCatalogueUpdate(
+                "lineage lens target does not match schema",
             ));
         }
         Ok(())

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1375,8 +1375,7 @@ where
         let mut catalogue_lenses = BTreeMap::new();
         let mut staged_lineages_by_id = BTreeMap::new();
         let mut pending_lineages = BTreeMap::new();
-        let mut active_lineage_ids = BTreeSet::new();
-        let mut active_catalogue_seq = 0;
+        let mut active_lineages_by_id = BTreeMap::new();
         let mut pending_write_pointers = BTreeMap::new();
         let mut genesis_schema = None;
         for raw in meta_database.primary_key_scan_raw("jazz_catalogue", &[])? {
@@ -1438,13 +1437,14 @@ where
                     let active: SchemaLineageActivation = serde_json::from_slice(
                         record.get_bytes(CatalogueRowRecord::FIELD_PAYLOAD_IDX)?,
                     )?;
-                    if active.id.0 != record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)? {
+                    if active.id.0 != record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)?
+                        || active.catalogue_seq == 0
+                        || active_lineages_by_id.insert(active.id, active).is_some()
+                    {
                         return Err(Error::InvalidStoredValue(
                             "active schema lineage id mismatch",
                         ));
                     }
-                    active_catalogue_seq = active_catalogue_seq.max(active.catalogue_seq);
-                    active_lineage_ids.insert(active.id);
                 }
                 b"write_pointer_pending" => {
                     let pointer: CurrentWriteSchema = serde_json::from_slice(
@@ -1466,9 +1466,41 @@ where
         }
         let mut staged_lineages = BTreeMap::new();
         let mut active_lineages_by_target = BTreeMap::new();
+        let mut lineage_targets = BTreeSet::new();
+        let mut active_lineages_by_seq = BTreeMap::new();
+        for active in active_lineages_by_id.values() {
+            if active_lineages_by_seq
+                .insert(active.catalogue_seq, active.id)
+                .is_some()
+            {
+                return Err(Error::InvalidStoredValue(
+                    "duplicate active catalogue sequence",
+                ));
+            }
+        }
         for staged in staged_lineages_by_id.into_values() {
-            if active_lineage_ids.contains(&staged.publication.id) {
+            Self::validate_durable_staged_lineage(&staged, &catalogue_schemas)?;
+            if staged.catalogue_seq == 0 {
+                return Err(Error::InvalidStoredValue(
+                    "staged schema lineage sequence must be nonzero",
+                ));
+            }
+            if !lineage_targets.insert(staged.publication.schema.id) {
+                return Err(Error::InvalidStoredValue(
+                    "duplicate durable schema lineage target",
+                ));
+            }
+            if let Some(active) = active_lineages_by_id.remove(&staged.publication.id) {
+                if active.catalogue_seq != staged.catalogue_seq {
+                    return Err(Error::InvalidStoredValue(
+                        "active schema lineage payload conflicts with marker",
+                    ));
+                }
                 active_lineages_by_target.insert(staged.publication.schema.id, staged);
+            } else if active_lineages_by_seq.contains_key(&staged.catalogue_seq) {
+                return Err(Error::InvalidStoredValue(
+                    "staged catalogue sequence conflicts with active lineage",
+                ));
             } else if staged_lineages
                 .insert(staged.catalogue_seq, staged)
                 .is_some()
@@ -1478,6 +1510,23 @@ where
                 ));
             }
         }
+        if !active_lineages_by_id.is_empty() {
+            return Err(Error::InvalidStoredValue(
+                "active schema lineage is missing canonical payload",
+            ));
+        }
+        for (expected, actual) in (1..).zip(active_lineages_by_seq.keys().copied()) {
+            if actual != expected {
+                return Err(Error::InvalidStoredValue(
+                    "active catalogue sequences are not contiguous",
+                ));
+            }
+        }
+        let active_catalogue_seq = active_lineages_by_seq
+            .keys()
+            .next_back()
+            .copied()
+            .unwrap_or(0);
         let mut schema_version_aliases = BTreeMap::new();
         let mut physical_mappings = BTreeMap::new();
         for raw in meta_database.primary_key_scan_raw("jazz_schema_versions", &[])? {
@@ -1644,6 +1693,39 @@ where
             current_write_schema,
             branch_partitions,
         })
+    }
+
+    fn validate_durable_staged_lineage(
+        staged: &StagedSchemaLineage,
+        catalogue_schemas: &BTreeMap<SchemaVersionId, SchemaVersion>,
+    ) -> Result<(), Error> {
+        Self::validate_schema_lineage_publication(&staged.publication).map_err(|_| {
+            Error::InvalidStoredValue(
+                "staged schema lineage violates trusted publication invariants",
+            )
+        })?;
+        let source = catalogue_schemas
+            .get(&staged.publication.lens.source)
+            .ok_or(Error::InvalidStoredValue(
+                "staged schema lineage source is missing",
+            ))?;
+        Self::validate_migration_lens_between(
+            &staged.publication.lens,
+            source,
+            &staged.publication.schema,
+        )
+        .map_err(|_| Error::InvalidStoredValue("staged schema lineage lens is invalid"))?;
+        Self::validate_lineage_table_partition(
+            &source.schema,
+            &staged.publication.schema.schema,
+            &staged.publication.lens,
+            &staged.publication.new_tables,
+            &staged.publication.dropped_tables,
+        )
+        .map_err(|_| {
+            Error::InvalidStoredValue("staged schema lineage table partition is invalid")
+        })?;
+        Ok(())
     }
 
     /// Commit a local mergeable write and leave its fate pending.
@@ -3925,6 +4007,17 @@ where
     ) -> Result<(), Error> {
         let schema = &staged.publication.schema;
         let lens = &staged.publication.lens;
+        // The active marker only carries an id and sequence. Persist its
+        // canonical payload in the same durable activation batch so recovery
+        // can prove both the prefix identity and its exact sequence.
+        batch.update(
+            "jazz_catalogue",
+            vec![
+                Value::Bytes(b"schema_lineage_staged".to_vec()),
+                Value::Uuid(staged.publication.id.0),
+                Value::Bytes(serde_json::to_vec(staged)?),
+            ],
+        );
         batch.update(
             "jazz_catalogue",
             vec![

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -254,6 +254,455 @@ fn settled_view_projects_authored_row_into_clients_active_schema() {
     );
 }
 
+#[test]
+fn trusted_catalogue_snapshot_reopen_retains_the_idempotent_lineage_prefix() {
+    // A trusted snapshot is a complete authoritative prefix, not a delta. Once
+    // its activation commits, reopening must retain enough canonical lineage
+    // identity to recognize that same prefix on the next upstream connection.
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x3f), base.clone());
+
+    receiver
+        .apply_trusted_catalogue_snapshot(snapshot.clone())
+        .unwrap();
+    assert_eq!(receiver.active_catalogue_seq(), 1);
+    drop(receiver);
+
+    let mut reopened = reopen_node_at(&dir, node(0x3f), base);
+    assert_eq!(reopened.active_catalogue_seq(), 1);
+    reopened.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    assert_eq!(reopened.active_catalogue_seq(), 1);
+}
+
+fn write_catalogue_record(
+    node: &mut NodeState<RocksDbStorage>,
+    kind: &[u8],
+    id: uuid::Uuid,
+    payload: Vec<u8>,
+) {
+    let mut batch = node.database.open_batch();
+    batch.update(
+        "jazz_catalogue",
+        vec![
+            Value::Bytes(kind.to_vec()),
+            Value::Uuid(id),
+            Value::Bytes(payload),
+        ],
+    );
+    node.database.commit_batch(batch).unwrap();
+}
+
+fn delete_catalogue_record(node: &mut NodeState<RocksDbStorage>, kind: &[u8], id: uuid::Uuid) {
+    let mut batch = node.database.open_batch();
+    batch.delete(
+        "jazz_catalogue",
+        groove::db::PrimaryKeyValue::Composite(vec![
+            groove::db::PrimaryKeyValue::Bytes(kind.to_vec()),
+            groove::db::PrimaryKeyValue::Uuid(id),
+        ]),
+    );
+    node.database.commit_batch(batch).unwrap();
+}
+
+fn write_active_lineage_record(node: &mut NodeState<RocksDbStorage>, staged: &StagedSchemaLineage) {
+    write_catalogue_record(
+        node,
+        b"schema_lineage_staged",
+        staged.publication.id.0,
+        serde_json::to_vec(staged).unwrap(),
+    );
+    write_catalogue_record(
+        node,
+        b"schema_lineage_active",
+        staged.publication.id.0,
+        serde_json::to_vec(&SchemaLineageActivation {
+            id: staged.publication.id,
+            catalogue_seq: staged.catalogue_seq,
+        })
+        .unwrap(),
+    );
+}
+
+fn duplicate_target_lineage(
+    base: &JazzSchema,
+    original: &StagedSchemaLineage,
+    catalogue_seq: u64,
+) -> StagedSchemaLineage {
+    let duplicate_publication = SchemaLineagePublication::new(
+        original.publication.schema.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            original.publication.schema.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "body".to_owned(),
+                    default: Value::String("different-default".to_owned()),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    );
+    assert_ne!(duplicate_publication.id, original.publication.id);
+    StagedSchemaLineage {
+        catalogue_seq,
+        publication: duplicate_publication,
+        alias: original.alias,
+        mapping: original.mapping.clone(),
+    }
+}
+
+fn assert_staged_corruption_rejected(
+    byte: u8,
+    expected: &'static str,
+    mutate: impl FnOnce(&mut StagedSchemaLineage),
+) {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(byte), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    let mut staged = receiver
+        .catalogue
+        .active_lineages_by_target
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    let original_id = staged.publication.id;
+    mutate(&mut staged);
+    delete_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_active",
+        original_id.0,
+    );
+    delete_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        original_id.0,
+    );
+    write_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        staged.publication.id.0,
+        serde_json::to_vec(&staged).unwrap(),
+    );
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(&dir, node(byte), base, expected);
+}
+
+fn assert_catalogue_reopen_rejected(
+    dir: &tempfile::TempDir,
+    node_uuid: NodeUuid,
+    schema: JazzSchema,
+    expected: &'static str,
+) {
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(dir.path(), &refs).unwrap();
+    assert!(matches!(
+        NodeState::new(node_uuid, schema, storage),
+        Err(Error::InvalidStoredValue(message)) if message == expected
+    ));
+}
+
+#[test]
+fn reopen_rejects_active_catalogue_marker_without_canonical_payload() {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x40), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    let publication_id = receiver
+        .catalogue
+        .active_lineages_by_target
+        .values()
+        .next()
+        .unwrap()
+        .publication
+        .id;
+    delete_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        publication_id.0,
+    );
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(
+        &dir,
+        node(0x40),
+        base,
+        "active schema lineage is missing canonical payload",
+    );
+}
+
+#[test]
+fn reopen_rejects_active_catalogue_marker_with_mismatched_payload_sequence() {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x41), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    let mut staged = receiver
+        .catalogue
+        .active_lineages_by_target
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    staged.catalogue_seq = 2;
+    write_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        staged.publication.id.0,
+        serde_json::to_vec(&staged).unwrap(),
+    );
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(
+        &dir,
+        node(0x41),
+        base,
+        "active schema lineage payload conflicts with marker",
+    );
+}
+
+#[test]
+fn reopen_rejects_gapped_active_catalogue_sequences() {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x42), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+
+    let v2 = SchemaVersion::new(catalogue_evolved_schema());
+    let v3 = SchemaVersion::new(JazzSchema::new([TableSchema::new(
+        "todos",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("body", ColumnType::String),
+            ColumnSchema::new("archived", ColumnType::Bool),
+        ],
+    )]));
+    publish_schema_lineage(
+        &mut receiver,
+        v3.clone(),
+        MigrationLens::new(
+            v2.id,
+            v3.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "archived".to_owned(),
+                    default: Value::Bool(false),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    let mut staged = receiver.catalogue.active_lineages_by_target[&v3.id].clone();
+    staged.catalogue_seq = 3;
+    write_active_lineage_record(&mut receiver, &staged);
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(
+        &dir,
+        node(0x42),
+        base,
+        "active catalogue sequences are not contiguous",
+    );
+}
+
+#[test]
+fn reopen_rejects_duplicate_active_catalogue_targets() {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x43), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    let original = receiver
+        .catalogue
+        .active_lineages_by_target
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    let duplicate = duplicate_target_lineage(&base, &original, 2);
+    write_active_lineage_record(&mut receiver, &duplicate);
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(
+        &dir,
+        node(0x43),
+        base,
+        "duplicate durable schema lineage target",
+    );
+}
+
+#[test]
+fn reopen_rejects_inactive_catalogue_target_already_active() {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x44), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    let original = receiver
+        .catalogue
+        .active_lineages_by_target
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    let duplicate = duplicate_target_lineage(&base, &original, 2);
+    write_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        duplicate.publication.id.0,
+        serde_json::to_vec(&duplicate).unwrap(),
+    );
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(
+        &dir,
+        node(0x44),
+        base,
+        "duplicate durable schema lineage target",
+    );
+}
+
+#[test]
+fn reopen_rejects_duplicate_inactive_catalogue_targets() {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x45), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    let mut first = receiver
+        .catalogue
+        .active_lineages_by_target
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    first.catalogue_seq = 1;
+    let duplicate = duplicate_target_lineage(&base, &first, 2);
+    delete_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_active",
+        first.publication.id.0,
+    );
+    write_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        first.publication.id.0,
+        serde_json::to_vec(&first).unwrap(),
+    );
+    write_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        duplicate.publication.id.0,
+        serde_json::to_vec(&duplicate).unwrap(),
+    );
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(
+        &dir,
+        node(0x45),
+        base,
+        "duplicate durable schema lineage target",
+    );
+}
+
+#[test]
+fn reopen_rejects_zero_sequence_staged_lineage() {
+    let base = schema();
+    let snapshot = catalogue_snapshot_fixture();
+    let (dir, mut receiver) = open_node_with_schema(node(0x46), base.clone());
+    receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    let mut staged = receiver
+        .catalogue
+        .active_lineages_by_target
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    staged.catalogue_seq = 0;
+    write_catalogue_record(
+        &mut receiver,
+        b"schema_lineage_staged",
+        staged.publication.id.0,
+        serde_json::to_vec(&staged).unwrap(),
+    );
+    drop(receiver);
+
+    assert_catalogue_reopen_rejected(
+        &dir,
+        node(0x46),
+        base,
+        "staged schema lineage sequence must be nonzero",
+    );
+}
+
+#[test]
+fn reopen_rejects_staged_schema_payload_identity_mismatch() {
+    let base_id = schema().version_id();
+    assert_staged_corruption_rejected(
+        0x47,
+        "staged schema lineage violates trusted publication invariants",
+        |staged| {
+            staged.publication.schema.id = base_id;
+            staged.publication.id = staged.publication.content_id();
+        },
+    );
+}
+
+#[test]
+fn reopen_rejects_staged_lens_content_identity_mismatch() {
+    assert_staged_corruption_rejected(
+        0x48,
+        "staged schema lineage violates trusted publication invariants",
+        |staged| {
+            staged.publication.lens.id = MigrationLensId(uuid::Uuid::nil());
+            staged.publication.id = staged.publication.content_id();
+        },
+    );
+}
+
+#[test]
+fn reopen_rejects_staged_lens_target_mismatch() {
+    let base_id = schema().version_id();
+    assert_staged_corruption_rejected(
+        0x49,
+        "staged schema lineage violates trusted publication invariants",
+        |staged| {
+            staged.publication.lens.target = base_id;
+            staged.publication.lens.id = staged.publication.lens.content_id();
+            staged.publication.id = staged.publication.content_id();
+        },
+    );
+}
+
+#[test]
+fn reopen_rejects_staged_lens_operation_mismatch() {
+    assert_staged_corruption_rejected(0x4a, "staged schema lineage lens is invalid", |staged| {
+        staged.publication.lens.table_lenses[0].ops.clear();
+        staged.publication.lens.id = staged.publication.lens.content_id();
+        staged.publication.id = staged.publication.content_id();
+    });
+}
+
+#[test]
+fn reopen_rejects_staged_table_partition_mismatch() {
+    assert_staged_corruption_rejected(
+        0x4b,
+        "staged schema lineage table partition is invalid",
+        |staged| {
+            staged.publication.new_tables.push("todos".to_owned());
+            staged.publication.id = staged.publication.content_id();
+        },
+    );
+}
+
 fn catalogue_snapshot_fixture() -> crate::protocol::CatalogueSnapshot {
     let base = schema();
     let evolved = SchemaVersion::new(catalogue_evolved_schema());


### PR DESCRIPTION
🤖 Fixes trusted catalogue snapshot recovery across storage reopen.

The active lineage marker now commits atomically with its canonical staged payload. Recovery fails closed on missing or mismatched payloads, non-contiguous active sequences, duplicate targets, zero sequence numbers, and malformed schema/lens/table-partition metadata. This does not relax ingress or add compatibility repair.

WIP follow-up: after this lands, rerun the quarantined persistent-worker browser case from #1512 before removing its test-burndown entry.

Validation: 13 focused corruption/reopen tests; 90 neighbouring catalogue tests; full Jazz lib suite (1320 passed); cargo fmt; clippy; sensitive-data guard. Independently reviewed with no P0–P2 findings.