### PR TITLE
test: restore browser catalogue reopen coverage

### DIFF
--- a/TEST_BURNDOWN.md
+++ b/TEST_BURNDOWN.md
@@ -82,10 +82,9 @@ A future fix must remove both the matching visible skip marker and this entry, t
 | `groove::db::tests::indexed_batch_commit_timing_receipt_20k_and_single_row`                      | `crates/groove/src/db/tests.rs`               | timing receipt             |
 | `jazz::node::tests::harness::policy_graph_perf_dropdown_entry_reset_ingest_timing_receipt`       | `crates/jazz/src/node/tests/sync.rs`          | timing receipt             |
 
-## Active TypeScript/browser quarantine (1)
+## Active TypeScript/browser quarantine (0)
 
-The original measured TypeScript/browser failure set has been burned down. One browser catalogue-rehydration failure remains tracked below.
-
-| Test                                                                                                          | Definition                                                | Status | Category                      | Failure signature / theory                                                                                                                                    | Owner  |
-| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `Worker Bridge with OPFS > rehydrates current catalogue schema and lens state after persistent worker reopen` | `packages/jazz-tools/tests/browser/worker-bridge.test.ts` | FAIL   | Browser catalogue rehydration | Reopened worker rejects catalogue snapshots as non-contiguous and never receives a current-schema row written through an independent server-connected client. | Anselm |
+The original measured TypeScript/browser failure set is burned down. The former
+catalogue-rehydration case is now an active browser receipt in
+`worker-bridge.test.ts`, with a fresh release-NAPI/fast-WASM run on the trusted
+catalogue-lineage persistence fix.

--- a/dev/gates/test-burndown-ts.mjs
+++ b/dev/gates/test-burndown-ts.mjs
@@ -23,7 +23,7 @@ function documentedRows(doc) {
     if (identities.has(identity)) fail(`duplicate documented TS/browser test: ${identity}`);
     identities.add(identity);
   }
-  if (active.length !== 1) fail(`expected 1 active TS/browser row, got ${active.length}`);
+  if (active.length !== 0) fail(`expected 0 active TS/browser rows, got ${active.length}`);
   return { active, identities };
 }
 function sourceMarkers() {
@@ -87,4 +87,4 @@ for (const row of active)
   if (!fs.existsSync(row.path)) fail(`documented path does not exist: ${row.path}`);
 const source = sourceMarkers();
 if (!same(documented, source)) fail("TS/browser source markers differ from documented active set");
-console.log("TS/browser burndown: exact 1 active identity bijection.");
+console.log("TS/browser burndown: exact 0 active identity bijection.");

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -885,9 +885,7 @@ describe("Worker Bridge with OPFS", () => {
     expect(rows).toEqual([]);
   });
 
-  // TEST_BURNDOWN_TS: Worker Bridge with OPFS > rehydrates current catalogue schema and lens state after persistent worker reopen
-  // known red; tracked in TEST_BURNDOWN.md — reopen rejects non-contiguous catalogue snapshots, then never receives an authoritative remote row.
-  it.skip("rehydrates current catalogue schema and lens state after persistent worker reopen", async () => {
+  it("rehydrates current catalogue schema and lens state after persistent worker reopen", async () => {
     const protocolErrors: string[] = [];
     const recordProtocolError = (event: ErrorEvent) => {
       const message = event.error instanceof Error ? event.error.message : event.message;


### PR DESCRIPTION
🤖 Stacked on #1518. Restores the sole quarantined TypeScript/browser contract: current catalogue schema and lens state survive OPFS worker shutdown/reopen and continue accepting current-schema rows from an independent server-connected client.

Removes the exact marker and TEST_BURNDOWN row; TypeScript/browser active quarantine becomes zero.

Validation on exact commit with fresh release NAPI + fast WASM artifacts: focused Chromium 1/1; complete worker-bridge file 52 passed / 1 expected failure; exact-zero TypeScript burndown gate. Sensitivity: removing #1518’s staged-lineage durable write made the same reopened-worker test fail after 15s with no local rows; restored. Independently reviewed with no P0–P2 findings.