### PR TITLE
test(jazz): drive remote shared coverage subscription opens

### DIFF
--- a/crates/jazz/tests/shared_coverage_differential.rs
+++ b/crates/jazz/tests/shared_coverage_differential.rs
@@ -310,18 +310,14 @@ fn run_scenario(mode: CoverageMode) -> ScenarioReceipt {
         let prepared = client
             .prepare_query(&Query::from(table))
             .expect("prepare subscription query");
-        let mut stream =
+        let stream =
             block_on(client.subscribe(&prepared, global_read_opts())).expect("subscribe table");
-        traces
-            .get_mut(table)
-            .expect("trace bucket")
-            .push(event_trace(
-                &table_schemas,
-                block_on(stream.next_event()).expect("initial subscription event"),
-            ));
         streams.insert(table, stream);
     }
 
+    // A remote subscription has no autonomous executor: endpoint ticks carry
+    // its registration and reset.  Waiting for `next_event` before driving the
+    // endpoints spins forever because no endpoint can produce that event yet.
     drive(&server, &client, &mut streams, &table_schemas, &mut traces);
 
     server


### PR DESCRIPTION
🤖 **WIP harness correction; this does not retire the shared-coverage quarantine.**

The differential test deadlocked by awaiting its first remote event before ticking either endpoint. It now drives the endpoints before draining events and completes in ~0.2s.

The test remains ignored and its TEST_BURNDOWN row remains: `CoverageMode::ForcedGroupingHook` is currently a no-op, and the fixture uses distinct shapes, so unignoring it would falsely claim forced grouping coverage. This draft preserves the harness correction and makes the remaining product-design gap explicit.

Validation: focused ignored test passes; clippy, rustfmt, sensitive-data guard.