### PR TITLE
fix(jazz): preserve authored witness through table rename

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -5482,7 +5482,7 @@ where
         // Result-member ordering is for identity and deduplication, not public
         // query rank. Membership/windowing is already lowered; only restore the
         // selected roots to their advertised order before sending a reset.
-        self.apply_query_order(shape.query(), &mut rows)?;
+        self.apply_query_order_in_schema(shape.query(), shape.schema_version(), &mut rows)?;
         if shape.query().flat_join.is_none() {
             self.apply_projection_in_schema(shape.query(), shape.schema_version(), &mut rows)?;
         }
@@ -7581,7 +7581,7 @@ where
                 authorization_mode,
             )?;
             let query = shape.query();
-            self.finish_engine_query_rows(query, &mut rows)?;
+            self.finish_engine_query_rows_in_schema(query, shape.schema_version(), &mut rows)?;
             self.apply_projection_in_schema(query, shape.schema_version(), &mut rows)?;
             return Ok(rows);
         }
@@ -7740,7 +7740,7 @@ where
             normalize_public_current_rows(&table_schema, &mut rows)?;
         }
         let query = shape.query();
-        self.finish_engine_query_rows(query, &mut rows)?;
+        self.finish_engine_query_rows_in_schema(query, shape.schema_version(), &mut rows)?;
         if query.flat_join.is_none() && query.array_subqueries.is_empty() {
             self.apply_projection_in_schema(query, shape.schema_version(), &mut rows)?;
         }
@@ -7887,7 +7887,7 @@ where
 
         let query = shape.query();
         let phase_started = Instant::now();
-        self.finish_engine_query_rows(query, &mut rows)?;
+        self.finish_engine_query_rows_in_schema(query, shape.schema_version(), &mut rows)?;
         profile.finish_rows = phase_started.elapsed();
 
         let phase_started = Instant::now();
@@ -8150,7 +8150,7 @@ where
     ) -> Result<Vec<CurrentRow>, Error> {
         let mut rows = self.query_rows_at_with_query_engine(shape, binding, position, identity)?;
         let query = shape.query();
-        self.finish_engine_query_rows(query, &mut rows)?;
+        self.finish_engine_query_rows_in_schema(query, shape.schema_version(), &mut rows)?;
         Ok(rows)
     }
 
@@ -9772,7 +9772,7 @@ where
             self.materialize_inline_current_query_rows(&table, deltas)?
         };
         let query = shape.query();
-        self.finish_engine_query_rows(query, &mut rows)?;
+        self.finish_engine_query_rows_in_schema(query, shape.schema_version(), &mut rows)?;
         Ok(rows)
     }
 
@@ -10072,7 +10072,7 @@ where
         }
         // Multisink records are transport-key ordered. Restore public root rank
         // while retaining the lowered program's membership and window.
-        self.apply_query_order(shape.query(), &mut rows)?;
+        self.apply_query_order_in_schema(shape.query(), shape.schema_version(), &mut rows)?;
         Ok(rows)
     }
 
@@ -10127,18 +10127,6 @@ where
 
     pub(crate) fn uses_schema_projected_read(&self, shape: &ValidatedQuery) -> bool {
         shape.schema_version() != self.catalogue.current_schema_version_id
-    }
-
-    fn finish_engine_query_rows(
-        &self,
-        query: &crate::query::Query,
-        rows: &mut Vec<CurrentRow>,
-    ) -> Result<(), Error> {
-        self.finish_engine_query_rows_in_schema(
-            query,
-            self.catalogue.current_write_schema.schema,
-            rows,
-        )
     }
 
     fn finish_engine_query_rows_in_schema(

--- a/crates/jazz/src/node/tests/lens_projected_maintained.rs
+++ b/crates/jazz/src/node/tests/lens_projected_maintained.rs
@@ -130,3 +130,79 @@ fn maintained_projected_current_picks_winner_before_lens_projection() {
     assert_eq!(shipped.cell_at(0), Some(v("new-name")));
     assert_eq!(shipped.cell_at(1), Some(v("new-body")));
 }
+
+/// A maintained `tasks` view may read an old `todos` row through a table-rename
+/// lens, but its wire witness remains the complete `todos` history version.
+#[test]
+fn maintained_renamed_table_witness_reloads_the_authored_history_row() {
+    let base = schema();
+    let evolved = JazzSchema::new([TableSchema::new(
+        "tasks",
+        [ColumnSchema::new("title", ColumnType::String)],
+    )]);
+    let evolved_payload = SchemaVersion::new(evolved.clone());
+    let (_dir, mut core) = open_node_with_schema(node(0x5d), base.clone());
+    let shared_row = row(0x5e);
+
+    let old_tx = core
+        .commit_mergeable(MergeableCommit::new("todos", shared_row, 10).cells(BTreeMap::from([
+            ("title".to_owned(), v("old-title")),
+        ])))
+        .unwrap();
+    core.apply_fate_update(
+        old_tx,
+        Fate::Accepted,
+        Some(core.clock.next_global_seq),
+        Some(DurabilityTier::Global),
+    )
+    .unwrap();
+    publish_schema_lineage(
+        &mut core,
+        evolved_payload.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved_payload.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "tasks".to_owned(),
+                ops: vec![LensOp::RenameTable {
+                    from: "todos".to_owned(),
+                    to: "tasks".to_owned(),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved_payload.id,
+        },
+    })
+    .unwrap();
+
+    let shape = Query::from("tasks")
+        .validate_with_schema_version(&evolved, evolved_payload.id)
+        .unwrap();
+    let rows = core
+        .query_rows(
+            &shape,
+            &shape.bind(BTreeMap::new()).unwrap(),
+            DurabilityTier::Global,
+        )
+        .unwrap();
+    assert_eq!(rows.len(), 1, "the renamed view sees the old row");
+
+    let mut peer = PeerState::new();
+    let update = peer.current_rows_update(&mut core, "tasks").unwrap();
+    let bundles = version_bundles_for_update(&update);
+    assert_eq!(bundles.len(), 1);
+    assert_eq!(bundles[0].versions.len(), 1);
+    let shipped = &bundles[0].versions[0];
+    assert_eq!(shipped.schema_version(), base.version_id());
+    assert_eq!(shipped.table(), "todos");
+    assert_eq!(shipped.cell_at(0), Some(v("old-title")));
+}

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1332,25 +1332,10 @@ where
         &mut self,
         version: &VersionRow,
     ) -> Result<VersionRow, Error> {
-        let authored_schema = self
-            .schema_version_for_alias(version.schema_version_alias())
-            .ok_or(Error::InvalidStoredValue(
-                "maintained witness schema version alias must exist",
-            ))?;
-        let authored_table = self
-            .table_in_schema(version.table(), authored_schema)?
-            .clone();
-        let authored_descriptor = if version.layer() == VersionLayer::Deletion {
-            authored_table.register_storage_table().record_schema()
-        } else {
-            authored_table.history_storage_table().record_schema()
-        };
-        let has_authored_layout = version.record.descriptor() == &authored_descriptor;
-
         // A maintained witness is decoded from the current-query graph. Its
-        // descriptor can be identical to history storage while selected-out
-        // cells are still typed nulls, so first prefer its immutable stored
-        // history identity even when the descriptors match.
+        // logical table can therefore be the read-schema projection while its
+        // schema alias still names the authored schema. Reload the immutable
+        // history row before interpreting that projected table as authored.
         for storage_table in
             self.version_storage_sources_for_layer(version.table(), version.layer())?
         {
@@ -1368,6 +1353,23 @@ where
                 return Ok(canonical);
             }
         }
+
+        let authored_schema = self
+            .schema_version_for_alias(version.schema_version_alias())
+            .ok_or(Error::InvalidStoredValue(
+                "maintained witness schema version alias must exist",
+            ))?;
+        let Ok(authored_table) = self.table_in_schema(version.table(), authored_schema) else {
+            return Err(Error::MaintainedViewMissingBundleWitness(
+                "maintained witness is a projection without its canonical history row",
+            ));
+        };
+        let authored_descriptor = if version.layer() == VersionLayer::Deletion {
+            authored_table.register_storage_table().record_schema()
+        } else {
+            authored_table.history_storage_table().record_schema()
+        };
+        let has_authored_layout = version.record.descriptor() == &authored_descriptor;
 
         // Some maintained rows are legitimate materialized/synthetic versions
         // (for example, synthesized merge output) and therefore have no persisted


### PR DESCRIPTION
🤖 **WIP prerequisite for the lens-evolution burndown.**

Projected maintained rows can carry a logical table name from a newer schema while their witness points at an older authored row. The old path interpreted that projected alias before reloading canonical history, producing `TableNotFound` during table-rename evolution.

This change reloads the immutable canonical authored history row first, then interprets and validates its original schema/table alias. Policy filtering and provenance are unchanged; only the witness serialization source is corrected. Query finalization and ordering use the schema version stamped on the maintained shape.

It adds a focused black-box table-rename witness regression. Restoring the old lookup order makes that test fail deterministically with `TableNotFound("tasks")`.

This does **not** retire any test-burndown row. The broader old-branch rename test now advances beyond the witness error, but still exposes a separate maintained-subscription delivery gap after the write reaches EdgeServer. The obsolete standalone non-genesis lens publication test also remains quarantined pending explicit retirement/replacement under `INV-LENS-1`.

Validation:

- focused maintained rename witness test
- existing policy/projection canonical-byte test
- clippy, rustfmt, and sensitive-data guard
- independent adversarial review: no P0/P1/P2 findings
