### PR TITLE
test(browser): await final alpha subscription state

### DIFF
--- a/packages/jazz-tools/tests/browser/alpha-public-flow-gate.test.ts
+++ b/packages/jazz-tools/tests/browser/alpha-public-flow-gate.test.ts
@@ -122,7 +122,6 @@ describe("alpha public package flow", () => {
       list: "launch",
     });
     await expectTodoSummaries(db, ["Adopt alpha public flow:done", "Prove public imports:open"]);
-
     await db.delete(app.todos, second.id).wait({ tier: "local" });
     await expectTodoSummaries(db, ["Adopt alpha public flow:done"]);
     expect(await db.one(app.todos.where({ id: second.id }))).toBeNull();
@@ -688,6 +687,11 @@ describe("alpha public package flow", () => {
       list: "launch",
     });
     await expectTodoSummaries(db, ["Adopt alpha public flow:done", "Prove public imports:open"]);
+    await waitForSnapshotSummaries(
+      snapshots,
+      ["Adopt alpha public flow:done", "Prove public imports:open"],
+      "pre-delete subscribed todos",
+    );
 
     await withTimeout(
       db.delete(app.todos, secondRow.id).wait({ tier: "edge" }),
@@ -702,6 +706,15 @@ describe("alpha public package flow", () => {
       }),
     ).toBeNull();
 
+    // Edge settlement proves the committed read frontier, not that the
+    // independently scheduled application subscription callback has already
+    // consumed that frontier. Before releasing the subscription, wait for its
+    // required delivery of the post-delete view.
+    await waitForSnapshotSummaries(
+      snapshots,
+      ["Adopt alpha public flow:done"],
+      "post-delete retained todo",
+    );
     unsubscribe();
     expect(
       snapshots.some(


### PR DESCRIPTION
🤖 Makes the alpha public-flow browser gate observe the causally relevant subscription delivery before teardown.

The state-convergence waits in this test establish the committed Edge read frontier, but they do not promise that the independently scheduled application subscription callback has already run. Under CI contention, the test unsubscribed immediately after the final delete and then asserted that its callback history already contained the retained post-delete row.

The test now fences the exact pre-delete subscribed state, performs the delete and Edge convergence check, then waits for the exact post-delete subscribed state before unsubscribing. The expected public state is unchanged; no sleep or timeout was added.

Validation:

- fresh correctness artifacts and focused browser test: 5/5
- suppressing only the final exact callback fails at the new post-delete wait before unsubscribe
- formatter, linter, and sensitive-data guard
- independent adversarial review: no P0/P1/P2 findings

This addresses the repeated `alpha-public-flow-gate` CI failure observed on #1516; #1516 itself has no browser-source delta.
