### PR TITLE
wip(jazz): add dynamic catalogue bootstrap state

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1070,7 +1070,7 @@ where
             if node.catalogue_schemas().contains_key(&target_id) {
                 return Ok(());
             }
-            let current = node.current_write_schema();
+            let current = node.current_write_schema().map_err(Error::from)?;
             let source = node
                 .catalogue_schemas()
                 .get(&current.schema)
@@ -3344,8 +3344,12 @@ where
     }
 
     /// Return the current write-schema pointer known to this database.
-    pub fn current_write_schema(&self) -> CurrentWriteSchema {
-        self.node.node.borrow().current_write_schema()
+    pub fn current_write_schema(&self) -> Result<CurrentWriteSchema, Error> {
+        self.node
+            .node
+            .borrow()
+            .current_write_schema()
+            .map_err(Into::into)
     }
 
     /// Return a published schema-version payload known to this database.
@@ -4147,7 +4151,7 @@ where
             return Ok((self.schema.clone(), self.schema_version_id));
         }
         let node = self.node.node.borrow();
-        let current = node.current_write_schema();
+        let current = node.current_write_schema().map_err(Error::from)?;
         if current.schema == self.schema_version_id {
             return Ok((self.schema.clone(), self.schema_version_id));
         }
@@ -10615,7 +10619,7 @@ fn send_with_sync_context<S>(
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
-    let snapshot = node.borrow().catalogue_snapshot();
+    let snapshot = node.borrow().catalogue_snapshot()?;
     let catalogue_fingerprint = *blake3::hash(
         &serde_json::to_vec(&snapshot).expect("catalogue snapshot serialization is infallible"),
     )

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -982,6 +982,78 @@ where
         })
     }
 
+    /// Open an edge whose durable store has no authority catalogue yet.
+    ///
+    /// This is deliberately narrower than [`Db::open`]: callers may only use
+    /// it to receive one connection-authenticated catalogue snapshot and then
+    /// select one of the snapshot's admitted schema views.  Until then the
+    /// node has no application schema and rejects ordinary data/sync work.
+    pub(crate) async fn open_catalogue_uninitialized_edge(
+        config: DbConfig<S>,
+    ) -> Result<Self, Error> {
+        let bootstrap_schema = JazzSchema::new([]);
+        let schema_version_id = bootstrap_schema.version_id();
+        let schema_views = Rc::new(RefCell::new(BTreeMap::from([(
+            SchemaViewId::for_schema(&bootstrap_schema),
+            bootstrap_schema.clone(),
+        )])));
+        let node = NodeState::new_catalogue_uninitialized(config.identity.node, config.storage)?;
+        let node = Node::new(node);
+        node.restore_pending_uploads(config.identity)?;
+        Ok(Self {
+            schema: bootstrap_schema,
+            schema_version_id,
+            schema_view_is_fixed: false,
+            schema_views,
+            identity: config.identity,
+            node: Rc::new(node),
+            row_id_source: Rc::new(RefCell::new(
+                config
+                    .id_source
+                    .unwrap_or_else(|| Box::new(ProductionRowIdSource)),
+            )),
+            next_now_ms: Rc::new(Cell::new(1)),
+        })
+    }
+
+    /// Install a complete catalogue received over the authenticated upstream
+    /// bootstrap link.  This is intentionally crate-private: ordinary wire
+    /// dispatch must never turn an arbitrary peer's snapshot into authority.
+    pub(crate) fn apply_trusted_catalogue_snapshot(
+        &self,
+        snapshot: crate::protocol::CatalogueSnapshot,
+    ) -> Result<(), Error> {
+        Ok(self
+            .node
+            .node
+            .borrow_mut()
+            .apply_trusted_catalogue_snapshot(snapshot)?)
+    }
+
+    /// Produce the authority's complete catalogue for the privileged
+    /// snapshot-only transport exchange.
+    pub(crate) fn trusted_catalogue_snapshot(
+        &self,
+    ) -> Result<crate::protocol::CatalogueSnapshot, Error> {
+        Ok(self.node.node.borrow().catalogue_snapshot()?)
+    }
+
+    /// Return the active authority-admitted schema, failing closed when this
+    /// dynamic edge still has no bootstrap receipt.
+    pub(crate) fn trusted_current_catalogue_schema(&self) -> Result<JazzSchema, Error> {
+        let node = self.node.node.borrow();
+        let pointer = node.current_write_schema()?;
+        node.catalogue_schemas()
+            .get(&pointer.schema)
+            .map(|schema| schema.schema.clone())
+            .ok_or_else(|| Error::new(ErrorCode::Schema, "active catalogue schema is missing"))
+    }
+
+    pub(crate) fn catalogue_bootstrap_is_ready(&self) -> bool {
+        self.node.node.borrow().catalogue_bootstrap_state()
+            == crate::node::CatalogueBootstrapState::Ready
+    }
+
     /// Register a typed schema view on this database owner.
     ///
     /// Registration is process-local and idempotent by the exact typed schema

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -7578,6 +7578,32 @@ fn logical_message_larger_than_frame_round_trips_reordered_and_duplicated() {
 }
 
 #[test]
+fn strict_bootstrap_receive_rejects_bad_physical_frame_before_later_valid_message() {
+    let (left, right) = byte_duplex_raw();
+    let staged = Rc::clone(&right.inbound);
+    let features =
+        FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS | FEATURE_MESSAGE_FRAGMENTATION;
+    let mut sender = WireTransportAdapter::new(left, WIRE_PROTOCOL_VERSION, features, None);
+    let mut receiver = WireTransportAdapter::new(right, WIRE_PROTOCOL_VERSION, features, None);
+    sender
+        .send(SyncMessage::SessionClaims {
+            identity: AuthorId::SYSTEM,
+            claims: BTreeMap::new(),
+        })
+        .expect("stage valid later message");
+    staged.borrow_mut().push_front(vec![0xff]);
+
+    let error = receiver
+        .try_recv_strict()
+        .expect_err("bootstrap must fail on the first malformed physical frame");
+    assert_eq!(error.code, crate::wire::WireErrorCode::MalformedFrame);
+    assert!(
+        !staged.borrow().is_empty(),
+        "later valid message must not erase the preceding bootstrap violation"
+    );
+}
+
+#[test]
 fn schema_lineage_publication_fragments_before_atomic_admission() {
     let base = schema();
     let mut evolved_schema = base.clone();

--- a/crates/jazz/src/db/wire_transport.rs
+++ b/crates/jazz/src/db/wire_transport.rs
@@ -369,6 +369,74 @@ where
             })?;
         Ok(message)
     }
+
+    /// Strict receive mode for bootstrap-only exchanges. Unlike a live peer,
+    /// bootstrap cannot safely skip a malformed physical frame and continue to
+    /// a later catalogue snapshot: that would make the authority boundary
+    /// depend on first-valid-message behavior.
+    pub(crate) fn try_recv_strict(&mut self) -> Result<Option<SyncMessage>, WireError> {
+        let _ = self.flush_pending_outbound();
+        while let Some(bytes) = self.inner.try_recv_frame() {
+            validate_wire_frame_len(bytes.len()).map_err(|message| {
+                WireError::new(WireErrorCode::MalformedFrame, WireRetry::Never, message)
+            })?;
+            let frame = decode_frame(&bytes).map_err(|error| {
+                WireError::new(
+                    WireErrorCode::MalformedFrame,
+                    WireRetry::Never,
+                    format!("failed to decode wire frame: {error}"),
+                )
+            })?;
+            match frame {
+                WireFrame::Message(envelope) => {
+                    return self.decode_inbound_envelope(envelope).map(Some);
+                }
+                WireFrame::MessageFragment(fragment) => {
+                    let fragment_message_id = fragment.message_id;
+                    let metadata = WireEnvelope {
+                        protocol_version: fragment.protocol_version,
+                        features: fragment.features,
+                        session: fragment.session.clone(),
+                        payload: Vec::new(),
+                    };
+                    self.validate_inbound_metadata(&metadata)?;
+                    self.validate_inbound_session(&metadata)?;
+                    if self.features & FEATURE_MESSAGE_FRAGMENTATION == 0
+                        || fragment.features & FEATURE_MESSAGE_FRAGMENTATION == 0
+                    {
+                        return Err(WireError::new(
+                            WireErrorCode::UnsupportedFeature,
+                            WireRetry::Never,
+                            "fragment does not declare logical-message fragmentation",
+                        ));
+                    }
+                    match self.reassembler.push(fragment) {
+                        Ok(Some(envelope)) => {
+                            return self.decode_inbound_envelope(envelope).map(Some);
+                        }
+                        Ok(None) => {}
+                        Err(message) => {
+                            self.reassembler.discard(fragment_message_id);
+                            return Err(WireError::new(
+                                WireErrorCode::MalformedFrame,
+                                WireRetry::AfterResume,
+                                message,
+                            ));
+                        }
+                    }
+                }
+                WireFrame::Hello(_) => {
+                    return Err(WireError::new(
+                        WireErrorCode::UnsupportedFeature,
+                        WireRetry::AfterResume,
+                        "hello frames must be handled before constructing a peer connection",
+                    ));
+                }
+                WireFrame::Error(error) => return Err(error),
+            }
+        }
+        Ok(None)
+    }
 }
 
 impl<T> Transport for WireTransportAdapter<T>

--- a/crates/jazz/src/node/branches.rs
+++ b/crates/jazz/src/node/branches.rs
@@ -57,6 +57,7 @@ where
         branch_id: BranchId,
         created_by: AuthorId,
     ) -> Result<BranchRecord, Error> {
+        self.require_catalogue_ready()?;
         if let Some(existing) = self.branches.branches.get(&branch_id) {
             if existing.created_by == created_by
                 && existing.parent.is_none()
@@ -89,6 +90,7 @@ where
 
     /// Declare a root branch with no parent fallback.
     pub fn create_root_branch(&mut self, branch_id: BranchId) -> Result<BranchRecord, Error> {
+        self.require_catalogue_ready()?;
         let record = BranchRecord {
             branch_id,
             created_by: AuthorId(uuid::Uuid::nil()),
@@ -124,6 +126,7 @@ where
         &mut self,
         metadata: &crate::protocol::BranchMetadata,
     ) -> Result<(), Error> {
+        self.require_catalogue_ready()?;
         if !self
             .branches
             .pending_metadata_uploads
@@ -152,6 +155,7 @@ where
         &mut self,
         metadata: crate::protocol::BranchMetadata,
     ) -> Result<(), Error> {
+        self.require_catalogue_ready()?;
         self.admit_branch_metadata_with_upstream_relay(metadata, false)
     }
 
@@ -201,6 +205,7 @@ where
         metadata: crate::protocol::BranchMetadata,
         identity: AuthorId,
     ) -> Result<bool, Error> {
+        self.require_catalogue_ready()?;
         if metadata.created_by != identity {
             return Err(Error::InvalidStoredValue(
                 "branch metadata creator does not match authenticated session",
@@ -242,6 +247,7 @@ where
 
     /// Discard an open branch without deleting its overlay history.
     pub fn discard_branch(&mut self, branch_id: BranchId) -> Result<(), Error> {
+        self.require_catalogue_ready()?;
         let mut record = self
             .branches
             .branches
@@ -305,6 +311,7 @@ where
     where
         S: ReopenableStorage,
     {
+        self.require_catalogue_ready()?;
         if source == target {
             return Err(Error::BranchMergeCalculation(
                 "source and target lineage must differ",
@@ -569,6 +576,7 @@ where
 
     /// Branch-scoped exclusives are intentionally not implemented in v1.
     pub fn open_exclusive_on_branch(&mut self, _branch_id: BranchId) -> Result<OpenBatchId, Error> {
+        self.require_catalogue_ready()?;
         Err(Error::UnsupportedBranchExclusive)
     }
 
@@ -595,6 +603,7 @@ where
     where
         S: ReopenableStorage,
     {
+        self.require_catalogue_ready()?;
         if commits.is_empty() {
             return Err(Error::InvalidMergeableCommit(
                 "mergeable transaction requires at least one write",
@@ -761,6 +770,7 @@ where
         binding: &Binding,
         identity: AuthorId,
     ) -> Result<Vec<CurrentRow>, Error> {
+        self.require_catalogue_ready()?;
         let Some(branch) = self.branches.branches.get(&branch_id).cloned() else {
             // Remote/session branch reads deliberately conflate an unknown
             // lineage with a lineage the caller is not allowed to enumerate.
@@ -787,6 +797,7 @@ where
         binding: &Binding,
         identity: AuthorId,
     ) -> Result<Vec<CurrentRow>, Error> {
+        self.require_catalogue_ready()?;
         if !self.branches.branches.contains_key(&branch_id) {
             return Ok(Vec::new());
         }

--- a/crates/jazz/src/node/catalogue_ingest.rs
+++ b/crates/jazz/src/node/catalogue_ingest.rs
@@ -33,6 +33,8 @@ where
     where
         S: ReopenableStorage,
     {
+        let bootstrap_uninitialized =
+            self.catalogue_bootstrap_state == CatalogueBootstrapState::Uninitialized;
         let plan = self.plan_trusted_catalogue_snapshot(snapshot)?;
         let runtime_semantics_changed = self.catalogue.schema != plan.catalogue.schema
             || self.catalogue.catalogue_schemas != plan.catalogue.catalogue_schemas
@@ -57,6 +59,36 @@ where
         }
 
         let mut batch = self.database.open_batch();
+        if bootstrap_uninitialized || self.catalogue_bootstrap_marker {
+            // This is intentionally in the same batch as every imported
+            // schema, physical mapping, lineage activation, and write
+            // pointer.  A dynamic edge must never recover an empty local
+            // schema as a durable genesis if it crashes before the first
+            // authority snapshot completes.  Existing bootstrap markers are
+            // refreshed on every later trusted snapshot so a fresh process
+            // can verify the exact durable pointer and catalogue high-water.
+            batch.update(
+                "jazz_catalogue",
+                vec![
+                    Value::Bytes(b"genesis".to_vec()),
+                    Value::Uuid(plan.catalogue.current_schema_version_id.0),
+                    Value::Bytes(Vec::new()),
+                ],
+            );
+            let ready = CatalogueBootstrapReady {
+                genesis: plan.catalogue.current_schema_version_id,
+                current_write_schema: plan.catalogue.current_write_schema,
+                active_catalogue_seq: plan.catalogue.active_catalogue_seq,
+            };
+            batch.update(
+                "jazz_catalogue",
+                vec![
+                    Value::Bytes(b"bootstrap_ready".to_vec()),
+                    Value::Uuid(ready.genesis.0),
+                    Value::Bytes(serde_json::to_vec(&ready)?),
+                ],
+            );
+        }
         for schema in plan.catalogue.catalogue_schemas.values() {
             batch.update(
                 "jazz_catalogue",
@@ -103,6 +135,8 @@ where
         self.query.query_shape_cache.clear();
         self.query.read_policy_authorization_request_cache.clear();
         self.query.policy_authorization_graph_cache.clear();
+        self.catalogue_bootstrap_state = CatalogueBootstrapState::Ready;
+        self.catalogue_bootstrap_marker |= bootstrap_uninitialized;
         if runtime_semantics_changed {
             self.groove_runtime_token = next_groove_runtime_token();
         }
@@ -145,19 +179,87 @@ where
             .iter()
             .map(|(_, publication)| publication.schema.id)
             .collect::<BTreeSet<_>>();
-        let local_schema_storage_anchor = self
-            .catalogue
-            .schema_version_aliases
-            .get(&self.catalogue.current_schema_version_id)
+        // §10.2 has one durable genesis and every other schema enters through
+        // its lineage-defining bundle.  A snapshot is a complete authority
+        // catalogue, not an opportunity to smuggle a dormant standalone
+        // schema into a receiver's read/write surface.
+        let genesis_ids = schemas
+            .keys()
+            .filter(|schema_id| !lineage_targets.contains(schema_id))
             .copied()
-            .zip(
-                self.catalogue
-                    .physical_mappings
-                    .get(&self.catalogue.current_schema_version_id)
-                    .cloned(),
-            );
+            .collect::<Vec<_>>();
+        let [genesis_id] = genesis_ids.as_slice() else {
+            return Err(Error::InvalidCatalogueUpdate(
+                "trusted catalogue snapshot must contain exactly one genesis schema",
+            ));
+        };
+        let bootstrap_genesis =
+            if self.catalogue_bootstrap_state == CatalogueBootstrapState::Uninitialized {
+                Some(
+                    schemas
+                        .get(genesis_id)
+                        .cloned()
+                        .ok_or(Error::InvalidCatalogueUpdate(
+                            "trusted bootstrap snapshot omits genesis payload",
+                        ))?,
+                )
+            } else {
+                None
+            };
 
-        let mut planned = self.catalogue.clone();
+        let local_schema_storage_anchor = (!matches!(
+            self.catalogue_bootstrap_state,
+            CatalogueBootstrapState::Uninitialized
+        ))
+        .then(|| {
+            self.catalogue
+                .schema_version_aliases
+                .get(&self.catalogue.current_schema_version_id)
+                .copied()
+                .zip(
+                    self.catalogue
+                        .physical_mappings
+                        .get(&self.catalogue.current_schema_version_id)
+                        .cloned(),
+                )
+        })
+        .flatten();
+
+        let mut planned = match bootstrap_genesis {
+            Some(genesis) => {
+                let mut next_physical_table_id = 1;
+                let mut next_physical_column_id = 1;
+                let mapping = allocate_provisional_physical_mapping(
+                    &genesis.schema,
+                    &mut next_physical_table_id,
+                    &mut next_physical_column_id,
+                )?;
+                let genesis_id = genesis.id;
+                SchemaCatalogue {
+                    current_schema_version_id: genesis_id,
+                    current_schema_version_alias: Some(SchemaVersionAlias(1)),
+                    schema: genesis.schema.clone(),
+                    schema_version_aliases: BTreeMap::from([(genesis_id, SchemaVersionAlias(1))]),
+                    catalogue_schemas: BTreeMap::from([(genesis_id, genesis)]),
+                    catalogue_lenses: BTreeMap::new(),
+                    physical_mappings: BTreeMap::from([(genesis_id, mapping)]),
+                    staged_lineages: BTreeMap::new(),
+                    pending_lineages: BTreeMap::new(),
+                    active_lineages_by_target: BTreeMap::new(),
+                    active_catalogue_seq: 0,
+                    pending_write_pointers: BTreeMap::new(),
+                    next_physical_table_id,
+                    next_physical_column_id,
+                    lens_path_cache: BTreeMap::new(),
+                    compiled_lens_cache: BTreeMap::new(),
+                    current_write_schema: CurrentWriteSchema {
+                        revision: 0,
+                        schema: genesis_id,
+                    },
+                }
+            }
+            None => self.catalogue.clone(),
+        };
         let mut activated_lineages = Vec::new();
         for schema in schemas.values() {
             if lineage_targets.contains(&schema.id)

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -74,6 +74,12 @@ where
     where
         S: ReopenableStorage,
     {
+        // A dynamic edge has exactly one admissible pre-ready transition: the
+        // authenticated upstream invokes `apply_trusted_catalogue_snapshot`
+        // directly.  Incremental catalogue/data/branch traffic has no
+        // authority lineage to validate against and must not leave durable
+        // pending rows that poison a later reopen.
+        self.require_catalogue_ready()?;
         if self.catalogue_activation_failed {
             return Err(Error::CatalogueActivationFailed);
         }
@@ -993,6 +999,7 @@ where
     where
         S: ReopenableStorage,
     {
+        self.require_catalogue_ready()?;
         self.ingest_commit_unit_with_context(tx, versions, now_ms, None)
     }
 
@@ -1009,6 +1016,7 @@ where
     where
         S: ReopenableStorage,
     {
+        self.require_catalogue_ready()?;
         if let Some(reason) = commit_unit_limit_violation(&versions) {
             let fate = Fate::Rejected(RejectionReason::MalformedCommit(reason));
             self.ingest_rejected_transaction(tx.clone(), fate.clone())?;
@@ -1046,6 +1054,7 @@ where
     where
         S: ReopenableStorage,
     {
+        self.require_catalogue_ready()?;
         if commit_unit_limit_violation(&versions).is_none()
             && commit_unit_write_count_matches(&tx, versions.len())
             && let Some(reason) = self.malformed_authored_version_reason(&versions)
@@ -1075,6 +1084,7 @@ where
     where
         S: ReopenableStorage,
     {
+        self.require_catalogue_ready()?;
         if commit_unit_limit_violation(&versions).is_none()
             && commit_unit_write_count_matches(&tx, versions.len())
             && let Some(reason) = self.malformed_authored_version_reason(&versions)
@@ -1111,6 +1121,7 @@ where
     /// authority validation the node already performed when it authored the
     /// commit. Idempotent: a non-pending transaction is left untouched.
     pub fn finalize_local_mergeable_commit(&mut self, tx_id: TxId) -> Result<(), Error> {
+        self.require_catalogue_ready()?;
         let stored = self
             .query_transaction(tx_id)?
             .ok_or(Error::MissingTransaction(tx_id))?;
@@ -1172,6 +1183,7 @@ where
         tx: Transaction,
         versions: Vec<VersionRecord>,
     ) -> Result<Fate, Error> {
+        self.require_catalogue_ready()?;
         let tx_id = tx.tx_id;
         if tx.kind != TxKind::Exclusive {
             return Err(Error::UnsupportedCommitUnit(
@@ -1384,6 +1396,7 @@ where
     where
         S: ReopenableStorage,
     {
+        self.require_catalogue_ready()?;
         if commit_unit_limit_violation(&versions).is_some()
             || !commit_unit_write_count_matches(&tx, versions.len())
         {
@@ -1823,6 +1836,7 @@ where
         global_seq: Option<GlobalSeq>,
         durability: DurabilityTier,
     ) -> Result<(), Error> {
+        self.require_catalogue_ready()?;
         debug_assert!(
             global_seq.is_none() || durability == DurabilityTier::Global,
             "a global sequence requires Global durability"
@@ -2140,6 +2154,7 @@ where
         global_seq: Option<GlobalSeq>,
         durability: Option<DurabilityTier>,
     ) -> Result<(), Error> {
+        self.require_catalogue_ready()?;
         debug_assert!(
             global_seq.is_none() || durability == Some(DurabilityTier::Global),
             "a global sequence requires Global durability"

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -515,6 +515,17 @@ pub struct NodeState<S> {
     self_node_alias: Option<NodeAlias>,
     /// Schema catalogue, migration lenses, and logical-to-physical mappings.
     catalogue: SchemaCatalogue,
+    /// Whether this runtime has an authoritative catalogue lineage that may
+    /// safely describe application data.  A dynamic edge starts
+    /// `Uninitialized`: its temporary system-only runtime schema is never a
+    /// database genesis and no query or write may use it.  The first trusted
+    /// catalogue snapshot installs the authority's exact genesis together
+    /// with its mappings and write pointer in one durable batch.
+    catalogue_bootstrap_state: CatalogueBootstrapState,
+    /// Whether this durable catalogue was installed through the dynamic-edge
+    /// bootstrap snapshot boundary and therefore carries a completion record
+    /// that must be refreshed with later trusted snapshots.
+    catalogue_bootstrap_marker: bool,
     /// In-memory branch records and branch-specific storage partitions.
     branches: Branches,
     /// Local logical time and global-application progress counters.
@@ -610,6 +621,22 @@ struct SchemaCatalogue {
     compiled_lens_cache: BTreeMap<CompiledLensCacheKey, Option<CompiledLensPath>>,
     /// Schema version currently used for newly authored writes.
     current_write_schema: CurrentWriteSchema,
+}
+
+/// Readiness of a dynamically catalogued node.
+///
+/// This is deliberately separate from the catalogue's current-write pointer.
+/// A pointer is meaningful only after a durable authority lineage exists;
+/// treating an empty constructor schema as that lineage manufactures a false
+/// genesis on an edge that has not yet heard from its core.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CatalogueBootstrapState {
+    /// No authority catalogue has been installed.  Application state must
+    /// fail closed until [`NodeState::apply_trusted_catalogue_snapshot`] is
+    /// called on the authenticated upstream path.
+    Uninitialized,
+    /// A durable genesis, mappings, and pointer have been installed.
+    Ready,
 }
 
 /// Branch metadata and branch-partition layout known by the node.
@@ -814,6 +841,266 @@ where
         Self::new_with_history_complete(node_uuid, schema, storage, false)
     }
 
+    /// Open an edge-local runtime before it has received an authenticated
+    /// authority catalogue.
+    ///
+    /// Unlike [`NodeState::new`], this deliberately does *not* create a
+    /// durable genesis from `JazzSchema::new([])`.  Its only valid transition
+    /// is installation of a trusted catalogue snapshot; application reads,
+    /// writes, and current-schema access fail closed beforehand.
+    pub(crate) fn new_catalogue_uninitialized(
+        node_uuid: NodeUuid,
+        storage: S,
+    ) -> Result<Self, Error>
+    where
+        S: ReopenableStorage,
+    {
+        let (storage, durable_genesis) = Self::discover_durable_catalogue_genesis(storage)?;
+        if let Some(schema) = durable_genesis {
+            // A fresh process cannot assume the temporary empty schema it
+            // would use for an uninitialized edge.  Recover the authority
+            // genesis from the durable catalogue first, then use the normal
+            // ready open path so all physical layouts are reconstructed from
+            // the real lineage.
+            return Self::new_with_options_inner(
+                node_uuid,
+                schema,
+                storage,
+                false,
+                CatalogueBootstrapState::Ready,
+                #[cfg(feature = "testing")]
+                None,
+            );
+        }
+        Self::new_with_options_inner(
+            node_uuid,
+            JazzSchema::new([]),
+            storage,
+            false,
+            CatalogueBootstrapState::Uninitialized,
+            #[cfg(feature = "testing")]
+            None,
+        )
+    }
+
+    /// Read only the fixed catalogue metadata layout to discover an already
+    /// durable authority genesis before choosing an application schema for a
+    /// fresh process.  This is the inverse of the uninitialized constructor:
+    /// it never uses `JazzSchema::new([])` as a genesis candidate.
+    fn discover_durable_catalogue_genesis(storage: S) -> Result<(S, Option<JazzSchema>), Error> {
+        let bootstrap_schema = JazzSchema::new([]);
+        // Dynamic discovery must inspect the fixed history/branch/fate stores
+        // too: an empty catalogue does not make an existing Jazz store safe to
+        // repurpose as an uninitialized edge.
+        let meta_schema = bootstrap_schema.lower_to_groove();
+        let meta_database = Database::new_with_storage_layout(
+            meta_schema,
+            storage,
+            StorageLayout::jazz_class_v1(),
+        )?;
+        let mut genesis = None;
+        let mut schemas = BTreeMap::new();
+        let mut bootstrap_ready = None;
+        let mut staged_lineages = BTreeMap::new();
+        let mut active_lineages = BTreeMap::new();
+        let mut has_catalogue_residue = false;
+        for raw in meta_database.primary_key_scan_raw("jazz_catalogue", &[])? {
+            has_catalogue_residue = true;
+            let record = raw.record();
+            match record.get_bytes(CatalogueRowRecord::FIELD_KIND_IDX)? {
+                b"genesis" => {
+                    let schema =
+                        SchemaVersionId(record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)?);
+                    if genesis.replace(schema).is_some() {
+                        return Err(Error::InvalidStoredValue(
+                            "duplicate catalogue genesis marker",
+                        ));
+                    }
+                }
+                b"schema" => {
+                    let schema: SchemaVersion = serde_json::from_slice(
+                        record.get_bytes(CatalogueRowRecord::FIELD_PAYLOAD_IDX)?,
+                    )?;
+                    if schema.id
+                        != SchemaVersionId(record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)?)
+                        || schemas.insert(schema.id, schema).is_some()
+                    {
+                        return Err(Error::InvalidStoredValue("catalogue schema id mismatch"));
+                    }
+                }
+                b"schema_lineage_active" => {
+                    let active: SchemaLineageActivation = serde_json::from_slice(
+                        record.get_bytes(CatalogueRowRecord::FIELD_PAYLOAD_IDX)?,
+                    )?;
+                    if active.id.0 != record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)?
+                        || active.catalogue_seq == 0
+                        || active_lineages
+                            .insert(active.id, active.catalogue_seq)
+                            .is_some()
+                    {
+                        return Err(Error::InvalidStoredValue(
+                            "catalogue bootstrap active lineage marker is malformed",
+                        ));
+                    }
+                }
+                b"schema_lineage_staged" => {
+                    let staged: StagedSchemaLineage = serde_json::from_slice(
+                        record.get_bytes(CatalogueRowRecord::FIELD_PAYLOAD_IDX)?,
+                    )?;
+                    if staged.publication.id.0
+                        != record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)?
+                        || staged.catalogue_seq == 0
+                        || staged_lineages
+                            .insert(staged.publication.id, staged)
+                            .is_some()
+                    {
+                        return Err(Error::InvalidStoredValue(
+                            "catalogue bootstrap staged lineage marker is malformed",
+                        ));
+                    }
+                }
+                b"bootstrap_ready" => {
+                    let ready: CatalogueBootstrapReady = serde_json::from_slice(
+                        record.get_bytes(CatalogueRowRecord::FIELD_PAYLOAD_IDX)?,
+                    )?;
+                    if ready.genesis.0 != record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)?
+                        || bootstrap_ready.replace(ready).is_some()
+                    {
+                        return Err(Error::InvalidStoredValue(
+                            "duplicate or malformed catalogue bootstrap marker",
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mapping_ids = meta_database
+            .primary_key_scan_raw("jazz_schema_versions", &[])?
+            .into_iter()
+            .map(|raw| {
+                Ok(SchemaVersionId(
+                    raw.record()
+                        .get_uuid(SchemaVersionAliasRowRecord::FIELD_UUID_IDX)?,
+                ))
+            })
+            .collect::<Result<BTreeSet<_>, Error>>()?;
+        let durable_pointer = meta_database
+            .primary_key_last_raw("jazz_catalogue_pointer", &[])?
+            .map(|raw| {
+                let record = raw.record();
+                Ok::<CurrentWriteSchema, Error>(CurrentWriteSchema {
+                    revision: record.get_u64(CataloguePointerRowRecord::FIELD_REVISION_IDX)?,
+                    schema: SchemaVersionId(
+                        record.get_uuid(CataloguePointerRowRecord::FIELD_SCHEMA_IDX)?,
+                    ),
+                })
+            })
+            .transpose()?;
+        let mut has_non_catalogue_residue = false;
+        for table in [
+            "jazz_transactions",
+            "jazz_branches",
+            "jazz_branch_partitions",
+            "jazz_rejected_transactions",
+            "jazz_pending_edges",
+            "jazz_merge_heads",
+            "jazz_global_changes",
+            "jazz_deletion_history",
+        ] {
+            if !meta_database.primary_key_scan_raw(table, &[])?.is_empty() {
+                has_non_catalogue_residue = true;
+                break;
+            }
+        }
+        let has_residue = has_catalogue_residue
+            || !mapping_ids.is_empty()
+            || durable_pointer.is_some()
+            || has_non_catalogue_residue;
+        let schema = match bootstrap_ready {
+            None if !has_residue => None,
+            None if has_non_catalogue_residue => {
+                return Err(Error::InvalidStoredValue(
+                    "dynamic catalogue state cannot initialize over durable history",
+                ));
+            }
+            None => {
+                return Err(Error::InvalidStoredValue(
+                    "dynamic catalogue state has no bootstrap completion marker",
+                ));
+            }
+            Some(ready) => {
+                let mut active_lineage_targets = BTreeSet::new();
+                let mut active_catalogue_sequences = BTreeSet::new();
+                for staged in staged_lineages.values() {
+                    Self::validate_durable_staged_lineage(staged, &schemas)?;
+                    match active_lineages.remove(&staged.publication.id) {
+                        Some(sequence) if sequence == staged.catalogue_seq => {
+                            if schemas.get(&staged.publication.schema.id)
+                                != Some(&staged.publication.schema)
+                                || !active_lineage_targets.insert(staged.publication.schema.id)
+                            {
+                                return Err(Error::InvalidStoredValue(
+                                    "catalogue bootstrap active lineage does not own its schema",
+                                ));
+                            }
+                            if !active_catalogue_sequences.insert(sequence) {
+                                return Err(Error::InvalidStoredValue(
+                                    "catalogue bootstrap active lineage marker is malformed",
+                                ));
+                            }
+                        }
+                        Some(_) => {
+                            return Err(Error::InvalidStoredValue(
+                                "catalogue bootstrap active lineage marker conflicts with payload",
+                            ));
+                        }
+                        None if schemas.contains_key(&staged.publication.schema.id)
+                            || mapping_ids.contains(&staged.publication.schema.id) =>
+                        {
+                            return Err(Error::InvalidStoredValue(
+                                "catalogue bootstrap inactive lineage has durable target state",
+                            ));
+                        }
+                        None => {}
+                    }
+                }
+                if !active_lineages.is_empty() {
+                    return Err(Error::InvalidStoredValue(
+                        "catalogue bootstrap active lineage is missing canonical payload",
+                    ));
+                }
+                let expected_schema_ids = std::iter::once(ready.genesis)
+                    .chain(active_lineage_targets)
+                    .collect::<BTreeSet<_>>();
+                if genesis != Some(ready.genesis)
+                    || durable_pointer != Some(ready.current_write_schema)
+                    || !schemas.contains_key(&ready.genesis)
+                    || schemas.keys().copied().collect::<BTreeSet<_>>() != expected_schema_ids
+                    || mapping_ids != expected_schema_ids
+                    || active_catalogue_sequences.len()
+                        != usize::try_from(ready.active_catalogue_seq).map_err(|_| {
+                            Error::InvalidStoredValue("catalogue bootstrap sequence exceeds usize")
+                        })?
+                    || active_catalogue_sequences
+                        .iter()
+                        .copied()
+                        .ne(1..=ready.active_catalogue_seq)
+                {
+                    return Err(Error::InvalidStoredValue(
+                        "catalogue bootstrap completion marker does not match durable catalogue",
+                    ));
+                }
+                Some(
+                    schemas
+                        .remove(&ready.genesis)
+                        .expect("validated durable genesis schema must exist")
+                        .schema,
+                )
+            }
+        };
+        Ok((meta_database.into_storage(), schema))
+    }
+
     /// Open or create a node that is known to hold complete settled history.
     ///
     /// This is the authority/local-complete constructor for historical reads.
@@ -839,17 +1126,23 @@ where
         let NodeState {
             node_uuid,
             catalogue,
+            catalogue_bootstrap_state,
             database,
             history_complete,
             ..
         } = self;
         let storage = database.into_inner().into_storage();
-        let reopened = Self::new_with_history_complete(
-            node_uuid,
-            catalogue.schema,
-            storage,
-            history_complete,
-        )?;
+        let reopened = match catalogue_bootstrap_state {
+            CatalogueBootstrapState::Uninitialized => {
+                Self::new_catalogue_uninitialized(node_uuid, storage)?
+            }
+            CatalogueBootstrapState::Ready => Self::new_with_history_complete(
+                node_uuid,
+                catalogue.schema,
+                storage,
+                history_complete,
+            )?,
+        };
         Ok(reopened)
     }
 
@@ -879,6 +1172,7 @@ where
             schema,
             storage,
             history_complete,
+            CatalogueBootstrapState::Ready,
             #[cfg(feature = "testing")]
             None,
         )
@@ -901,6 +1195,7 @@ where
             schema,
             storage,
             history_complete,
+            CatalogueBootstrapState::Ready,
             Some(&mut receipt),
         )?;
         Ok((node, receipt))
@@ -911,6 +1206,7 @@ where
         schema: JazzSchema,
         storage: S,
         history_complete: bool,
+        catalogue_bootstrap_state: CatalogueBootstrapState,
         #[cfg(feature = "testing")] mut receipt: Option<&mut NodeOpenReceipt>,
     ) -> Result<Self, Error>
     where
@@ -934,7 +1230,8 @@ where
             next_physical_column_id,
             current_write_schema,
             branch_partitions,
-        } = Self::open_catalogue_stage(schema.clone(), storage)?;
+            catalogue_bootstrap_marker,
+        } = Self::open_catalogue_stage(schema.clone(), storage, catalogue_bootstrap_state)?;
         #[cfg(feature = "testing")]
         if let (Some(receipt), Some(started)) = (&mut receipt, started) {
             receipt.catalogue_open = started.elapsed();
@@ -974,6 +1271,21 @@ where
             }
             let mut batch = database.open_batch();
             Self::write_active_schema_lineage_to_batch(&mut batch, &staged)?;
+            if catalogue_bootstrap_marker {
+                let ready = CatalogueBootstrapReady {
+                    genesis: current_schema_version_id,
+                    current_write_schema,
+                    active_catalogue_seq: next,
+                };
+                batch.update(
+                    "jazz_catalogue",
+                    vec![
+                        Value::Bytes(b"bootstrap_ready".to_vec()),
+                        Value::Uuid(ready.genesis.0),
+                        Value::Bytes(serde_json::to_vec(&ready)?),
+                    ],
+                );
+            }
             database.commit_batch(batch)?;
             schemas.insert(
                 staged.publication.schema.id,
@@ -1022,6 +1334,8 @@ where
                 compiled_lens_cache: BTreeMap::new(),
                 current_write_schema,
             },
+            catalogue_bootstrap_state,
+            catalogue_bootstrap_marker,
             branches: Branches {
                 branches: BTreeMap::new(),
                 branch_partitions,
@@ -1363,6 +1677,7 @@ where
     fn open_catalogue_stage(
         schema: JazzSchema,
         storage: S,
+        catalogue_bootstrap_state: CatalogueBootstrapState,
     ) -> Result<CatalogueOpenState<S>, Error> {
         let current_schema_version_id = schema.version_id();
         let meta_schema = schema.lower_catalogue_meta_to_groove();
@@ -1378,6 +1693,7 @@ where
         let mut active_lineages_by_id = BTreeMap::new();
         let mut pending_write_pointers = BTreeMap::new();
         let mut genesis_schema = None;
+        let mut catalogue_bootstrap_ready = None;
         for raw in meta_database.primary_key_scan_raw("jazz_catalogue", &[])? {
             let record = raw.record();
             match record.get_bytes(CatalogueRowRecord::FIELD_KIND_IDX)? {
@@ -1458,6 +1774,18 @@ where
                     if genesis_schema.replace(schema).is_some() {
                         return Err(Error::InvalidStoredValue(
                             "duplicate catalogue genesis marker",
+                        ));
+                    }
+                }
+                b"bootstrap_ready" => {
+                    let ready: CatalogueBootstrapReady = serde_json::from_slice(
+                        record.get_bytes(CatalogueRowRecord::FIELD_PAYLOAD_IDX)?,
+                    )?;
+                    if ready.genesis.0 != record.get_uuid(CatalogueRowRecord::FIELD_ID_IDX)?
+                        || catalogue_bootstrap_ready.replace(ready).is_some()
+                    {
+                        return Err(Error::InvalidStoredValue(
+                            "duplicate or malformed catalogue bootstrap marker",
                         ));
                     }
                 }
@@ -1593,6 +1921,22 @@ where
             }
             _ => {}
         }
+        if catalogue_bootstrap_state == CatalogueBootstrapState::Uninitialized
+            && (genesis_schema.is_some()
+                || !catalogue_schemas.is_empty()
+                || !catalogue_lenses.is_empty()
+                || !physical_mappings.is_empty()
+                || !schema_version_aliases.is_empty()
+                || active_catalogue_seq != 0
+                || !staged_lineages.is_empty()
+                || !pending_lineages.is_empty()
+                || !active_lineages_by_target.is_empty()
+                || !pending_write_pointers.is_empty())
+        {
+            return Err(Error::InvalidStoredValue(
+                "uninitialized catalogue open requires empty durable catalogue state",
+            ));
+        }
         let had_current_schema = catalogue_schemas.contains_key(&current_schema_version_id);
         if !had_current_schema {
             catalogue_schemas.insert(
@@ -1623,34 +1967,36 @@ where
                         .checked_add(1)
                         .ok_or(Error::InvalidStoredValue("schema version alias exhausted"))?,
                 ));
-            let mut batch = meta_database.open_batch();
-            if genesis_schema.is_none() {
-                batch.update(
-                    "jazz_catalogue",
-                    vec![
-                        Value::Bytes(b"genesis".to_vec()),
-                        Value::Uuid(current_schema_version_id.0),
-                        Value::Bytes(Vec::new()),
-                    ],
-                );
+            if catalogue_bootstrap_state == CatalogueBootstrapState::Ready {
+                let mut batch = meta_database.open_batch();
+                if genesis_schema.is_none() {
+                    batch.update(
+                        "jazz_catalogue",
+                        vec![
+                            Value::Bytes(b"genesis".to_vec()),
+                            Value::Uuid(current_schema_version_id.0),
+                            Value::Bytes(Vec::new()),
+                        ],
+                    );
+                }
+                if !had_current_schema {
+                    batch.update(
+                        "jazz_catalogue",
+                        vec![
+                            Value::Bytes(b"schema".to_vec()),
+                            Value::Uuid(current_schema_version_id.0),
+                            Value::Bytes(serde_json::to_vec(&SchemaVersion::new(schema.clone()))?),
+                        ],
+                    );
+                }
+                Self::write_schema_version_mapping_to_batch(
+                    &mut batch,
+                    alias,
+                    current_schema_version_id,
+                    &mapping,
+                )?;
+                meta_database.commit_batch(batch)?;
             }
-            if !had_current_schema {
-                batch.update(
-                    "jazz_catalogue",
-                    vec![
-                        Value::Bytes(b"schema".to_vec()),
-                        Value::Uuid(current_schema_version_id.0),
-                        Value::Bytes(serde_json::to_vec(&SchemaVersion::new(schema.clone()))?),
-                    ],
-                );
-            }
-            Self::write_schema_version_mapping_to_batch(
-                &mut batch,
-                alias,
-                current_schema_version_id,
-                &mapping,
-            )?;
-            meta_database.commit_batch(batch)?;
             schema_version_aliases.insert(current_schema_version_id, alias);
             physical_mappings.insert(current_schema_version_id, mapping);
         }
@@ -1692,6 +2038,7 @@ where
             next_physical_column_id,
             current_write_schema,
             branch_partitions,
+            catalogue_bootstrap_marker: catalogue_bootstrap_ready.is_some(),
         })
     }
 
@@ -1789,6 +2136,7 @@ where
         made_at: TxTime,
         branch_merge: Option<BranchMergeProvenance>,
     ) -> Result<TxId, Error> {
+        self.require_catalogue_ready()?;
         let write_schema_version = self.catalogue.current_write_schema.schema;
         let commits = commits
             .into_iter()
@@ -2006,6 +2354,7 @@ where
         table: &str,
         settled: DurabilityTier,
     ) -> Result<Vec<CurrentRow>, Error> {
+        self.require_catalogue_ready()?;
         let shape = crate::query::Query::from(table).validate(&self.catalogue.schema)?;
         let binding = shape.bind(BTreeMap::new())?;
         self.query_rows(&shape, &binding, settled)
@@ -2494,12 +2843,46 @@ where
         &self.catalogue.catalogue_lenses
     }
 
-    /// Current write-schema pointer known to this node.
-    pub fn current_write_schema(&self) -> CurrentWriteSchema {
-        self.catalogue.current_write_schema
+    /// Current dynamic-catalogue bootstrap state.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn catalogue_bootstrap_state(&self) -> CatalogueBootstrapState {
+        self.catalogue_bootstrap_state
     }
 
-    pub(crate) fn catalogue_snapshot(&self) -> crate::protocol::CatalogueSnapshot {
+    /// Return the authoritative current-write pointer, or fail closed before
+    /// an edge has adopted its first trusted catalogue snapshot.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn try_current_write_schema(&self) -> Result<CurrentWriteSchema, Error> {
+        self.require_catalogue_ready()?;
+        Ok(self.catalogue.current_write_schema)
+    }
+
+    /// Return the active read-schema only after an authority catalogue has
+    /// been durably adopted.  Dynamic-edge callers must use this instead of
+    /// treating the temporary system schema as an application schema.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn try_current_schema(&self) -> Result<&JazzSchema, Error> {
+        self.require_catalogue_ready()?;
+        Ok(&self.catalogue.schema)
+    }
+
+    pub(crate) fn require_catalogue_ready(&self) -> Result<(), Error> {
+        if self.catalogue_bootstrap_state == CatalogueBootstrapState::Uninitialized {
+            return Err(Error::CatalogueUninitialized);
+        }
+        Ok(())
+    }
+
+    /// Current write-schema pointer known to this node.
+    ///
+    /// An uninitialized dynamic edge has no current application schema; the
+    /// temporary system-only layout must not leak through this API.
+    pub fn current_write_schema(&self) -> Result<CurrentWriteSchema, Error> {
+        self.try_current_write_schema()
+    }
+
+    pub(crate) fn catalogue_snapshot(&self) -> Result<crate::protocol::CatalogueSnapshot, Error> {
+        self.require_catalogue_ready()?;
         let mut schemas = self
             .catalogue
             .catalogue_schemas
@@ -2514,11 +2897,11 @@ where
             .map(|lineage| (lineage.catalogue_seq, lineage.publication.clone()))
             .collect::<Vec<_>>();
         lineages.sort_by_key(|(catalogue_seq, _)| *catalogue_seq);
-        crate::protocol::CatalogueSnapshot {
+        Ok(crate::protocol::CatalogueSnapshot {
             schemas,
             lineages,
             current_write_schema: self.catalogue.current_write_schema,
-        }
+        })
     }
 
     /// Return a historical read handle at an exact global settle position.
@@ -5355,6 +5738,7 @@ struct CatalogueOpenState<S> {
     next_physical_column_id: u64,
     current_write_schema: CurrentWriteSchema,
     branch_partitions: BTreeSet<(PhysicalTableId, BranchId)>,
+    catalogue_bootstrap_marker: bool,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -5375,6 +5759,16 @@ struct PendingSchemaLineage {
 struct SchemaLineageActivation {
     id: SchemaLineagePublicationId,
     catalogue_seq: u64,
+}
+
+/// Durable completion receipt for an authority snapshot installed by an
+/// initially unconfigured dynamic edge.  Its record is the atomic boundary:
+/// discovery never repairs a prefix that lacks this exact join.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+struct CatalogueBootstrapReady {
+    genesis: SchemaVersionId,
+    current_write_schema: CurrentWriteSchema,
+    active_catalogue_seq: u64,
 }
 
 #[cfg(test)]
@@ -5592,6 +5986,10 @@ pub enum Error {
     /// Durable staged catalogue activation failed and requires node reopen.
     #[error("catalogue activation failed; reopen required")]
     CatalogueActivationFailed,
+    /// A dynamically catalogued runtime has not yet received the trusted
+    /// authority snapshot that establishes its genesis, mappings, and pointer.
+    #[error("catalogue bootstrap is not ready")]
+    CatalogueUninitialized,
     /// Durable catalogue payload could not be encoded or decoded.
     #[error(transparent)]
     CatalogueCodec(#[from] serde_json::Error),

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -47,6 +47,7 @@ where
         kind: OpenTransactionKind,
         provisional_author: AuthorId,
     ) -> Result<(), Error> {
+        self.require_catalogue_ready()?;
         if self.open_tx.open_transactions.contains_key(&id)
             || self.open_tx.closed_batches.contains(&id)
         {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -7450,6 +7450,7 @@ where
         binding: &Binding,
         tier: DurabilityTier,
     ) -> Result<Vec<CurrentRow>, Error> {
+        self.require_catalogue_ready()?;
         self.query_rows_with_prepared_plan(shape, binding, tier, None)
     }
 
@@ -8138,6 +8139,7 @@ where
         binding: &Binding,
         position: GlobalSeq,
     ) -> Result<Vec<CurrentRow>, Error> {
+        self.require_catalogue_ready()?;
         self.query_rows_at_for_identity(shape, binding, position, AuthorId::SYSTEM)
     }
 

--- a/crates/jazz/src/node/tests/branching.rs
+++ b/crates/jazz/src/node/tests/branching.rs
@@ -572,7 +572,7 @@ fn branch_creation_persists_no_overlay_partition_until_first_write() {
     )
     .unwrap();
     let table_id = core
-        .physical_table_id_for_schema(core.current_write_schema().schema, "todos")
+        .physical_table_id_for_schema(core.current_write_schema().unwrap().schema, "todos")
         .unwrap();
     assert!(
         core.branches
@@ -607,7 +607,7 @@ fn branch_overlay_partition_creation_rebuilds_live_database_without_storage_reop
         BTreeMap::from([(row(0x22), title_cells("branch partition write"))])
     );
     let table_id = core
-        .physical_table_id_for_schema(core.current_write_schema().schema, "todos")
+        .physical_table_id_for_schema(core.current_write_schema().unwrap().schema, "todos")
         .unwrap();
     assert!(
         core.branches

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -78,7 +78,7 @@ fn trusted_catalogue_snapshot_installs_lineage_before_authored_payloads() {
         .unwrap();
 
     let (_receiver_dir, mut receiver) = open_node_with_schema(node(0x37), base);
-    let snapshot = authority.catalogue_snapshot();
+    let snapshot = authority.catalogue_snapshot().unwrap();
     assert!(matches!(
         receiver.apply_sync_message(SyncMessage::CatalogueSnapshot(Box::new(snapshot.clone()))),
         Err(Error::UnsupportedSyncMessage(
@@ -86,7 +86,7 @@ fn trusted_catalogue_snapshot_installs_lineage_before_authored_payloads() {
         ))
     ));
     receiver.apply_trusted_catalogue_snapshot(snapshot).unwrap();
-    assert_eq!(receiver.current_write_schema().schema, evolved.id);
+    assert_eq!(receiver.current_write_schema().unwrap().schema, evolved.id);
     receiver.apply_sync_message(authored).unwrap();
     let versions = receiver.query_all_versions().unwrap();
     assert_eq!(versions.len(), 1);
@@ -147,7 +147,7 @@ fn catalogue_snapshot_preserves_active_schema_storage_identity() {
         )
         .unwrap();
     receiver
-        .apply_trusted_catalogue_snapshot(authority.catalogue_snapshot())
+        .apply_trusted_catalogue_snapshot(authority.catalogue_snapshot().unwrap())
         .unwrap();
 
     assert_eq!(
@@ -210,7 +210,7 @@ fn settled_view_projects_authored_row_into_clients_active_schema() {
     let (_receiver_dir, mut receiver) =
         open_node_with_schema(node(0x66), evolved.schema.clone());
     receiver
-        .apply_trusted_catalogue_snapshot(authority.catalogue_snapshot())
+        .apply_trusted_catalogue_snapshot(authority.catalogue_snapshot().unwrap())
         .unwrap();
     receiver
         .ingest_known_transaction(
@@ -303,6 +303,49 @@ fn delete_catalogue_record(node: &mut NodeState<RocksDbStorage>, kind: &[u8], id
         ]),
     );
     node.database.commit_batch(batch).unwrap();
+}
+
+fn delete_catalogue_pointer(node: &mut NodeState<RocksDbStorage>, revision: u64) {
+    let mut batch = node.database.open_batch();
+    batch.delete(
+        "jazz_catalogue_pointer",
+        groove::db::PrimaryKeyValue::U64(revision),
+    );
+    node.database.commit_batch(batch).unwrap();
+}
+
+fn write_schema_mapping_record(
+    node: &mut NodeState<RocksDbStorage>,
+    alias: SchemaVersionAlias,
+    schema: SchemaVersionId,
+    mapping: &SchemaPhysicalMapping,
+) {
+    let mut batch = node.database.open_batch();
+    NodeState::<RocksDbStorage>::write_schema_version_mapping_to_batch(
+        &mut batch, alias, schema, mapping,
+    )
+    .unwrap();
+    node.database.commit_batch(batch).unwrap();
+}
+
+fn delete_schema_mapping_record(node: &mut NodeState<RocksDbStorage>, alias: SchemaVersionAlias) {
+    let mut batch = node.database.open_batch();
+    batch.delete(
+        "jazz_schema_versions",
+        groove::db::PrimaryKeyValue::U64(alias.0),
+    );
+    node.database.commit_batch(batch).unwrap();
+}
+
+fn fresh_dynamic_edge_open(
+    path: &std::path::Path,
+    node_uuid: NodeUuid,
+) -> Result<NodeState<RocksDbStorage>, Error> {
+    let empty_schema = JazzSchema::new([]);
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(path, &refs)?;
+    NodeState::new_catalogue_uninitialized(node_uuid, storage)
 }
 
 fn write_active_lineage_record(node: &mut NodeState<RocksDbStorage>, staged: &StagedSchemaLineage) {
@@ -703,6 +746,571 @@ fn reopen_rejects_staged_table_partition_mismatch() {
     );
 }
 
+/// A dynamic edge without a local catalogue must not manufacture the empty
+/// constructor schema as durable genesis; after its trusted core snapshot it
+/// atomically adopts the core lineage and survives reopen.
+///
+/// ```text
+/// core catalogue snapshot ──trusted install──► edge(Uninitialized -> Ready)
+///                                                        │
+///                                                        └──reopen──► exact core genesis
+/// ```
+#[test]
+fn dynamic_edge_bootstrap_adopts_authority_genesis_atomically_and_reopens_ready() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x91), storage)
+        .expect("open explicit uninitialized edge");
+
+    assert_eq!(
+        edge.catalogue_bootstrap_state(),
+        CatalogueBootstrapState::Uninitialized
+    );
+    assert!(matches!(
+        edge.try_current_write_schema(),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.current_write_schema(),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.try_current_schema(),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.catalogue_snapshot(),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(
+        edge.database
+            .primary_key_scan_raw("jazz_catalogue", &[])
+            .expect("scan empty durable catalogue")
+            .is_empty(),
+        "uninitialized edge must not persist an empty-schema genesis marker"
+    );
+    assert!(
+        edge.database
+            .primary_key_scan_raw("jazz_schema_versions", &[])
+            .expect("scan empty durable physical mappings")
+            .is_empty(),
+        "uninitialized edge must not persist a provisional physical mapping"
+    );
+    assert!(matches!(
+        edge.current_rows("todos", DurabilityTier::Local),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.commit_mergeable(MergeableCommit::new("todos", row(0x92), 1).cells(BTreeMap::from([
+            ("title".to_owned(), v("must not write before catalogue bootstrap")),
+        ]))),
+        Err(Error::CatalogueUninitialized)
+    ));
+
+    let snapshot = catalogue_snapshot_fixture();
+    let authority_genesis = schema().version_id();
+    edge.apply_trusted_catalogue_snapshot(snapshot.clone())
+        .expect("install exact trusted core catalogue");
+    assert_eq!(edge.catalogue_bootstrap_state(), CatalogueBootstrapState::Ready);
+    assert_eq!(edge.catalogue.current_schema_version_id, authority_genesis);
+    assert_eq!(edge.catalogue.schema, schema());
+    assert_eq!(edge.current_write_schema().unwrap(), snapshot.current_write_schema);
+    assert_eq!(edge.active_catalogue_seq(), 1);
+    assert_eq!(edge.catalogue_schemas().len(), 2);
+
+    drop(edge);
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("reopen edge store");
+    let reopened = NodeState::new_catalogue_uninitialized(node(0x91), storage)
+        .expect("fresh process discovers durable authority genesis");
+    assert_eq!(reopened.catalogue_bootstrap_state(), CatalogueBootstrapState::Ready);
+    assert_eq!(
+        reopened.catalogue.current_schema_version_id,
+        authority_genesis,
+        "reopen must use the authority genesis, never the empty temporary schema"
+    );
+    assert_eq!(
+        reopened.current_write_schema().unwrap(),
+        snapshot.current_write_schema
+    );
+    assert_eq!(reopened.active_catalogue_seq(), 1);
+    assert_eq!(reopened.catalogue_schemas().len(), 2);
+}
+
+/// A failed first trusted snapshot leaves a dynamic edge uninitialized, so a
+/// later reopen cannot observe a partially installed genesis or pointer.
+///
+/// ```text
+/// core snapshot ──durable failpoint──► edge(Uninitialized) ──reopen──► Uninitialized
+/// ```
+#[test]
+fn dynamic_edge_bootstrap_failure_never_persists_a_partial_authority_catalogue() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x93), storage)
+        .expect("open explicit uninitialized edge");
+    edge.set_catalogue_activation_failpoint(
+        CatalogueActivationFailpoint::BeforeSnapshotActivationCommit,
+    );
+
+    assert!(matches!(
+        edge.apply_trusted_catalogue_snapshot(catalogue_snapshot_fixture()),
+        Err(Error::CatalogueActivationFailed)
+    ));
+    assert_eq!(
+        edge.catalogue_bootstrap_state(),
+        CatalogueBootstrapState::Uninitialized
+    );
+    assert!(matches!(
+        edge.try_current_write_schema(),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(
+        edge.database
+            .primary_key_scan_raw("jazz_catalogue", &[])
+            .expect("scan failed bootstrap catalogue")
+            .is_empty(),
+        "failed bootstrap must not leave a genesis, pointer, or lineage prefix"
+    );
+    assert!(
+        edge.database
+            .primary_key_scan_raw("jazz_schema_versions", &[])
+            .expect("scan failed bootstrap mappings")
+            .is_empty(),
+        "failed bootstrap must not leave a physical mapping prefix"
+    );
+
+    drop(edge);
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("reopen empty edge store");
+    let reopened = NodeState::new_catalogue_uninitialized(node(0x93), storage)
+        .expect("fresh process retains no failed bootstrap state");
+    assert_eq!(
+        reopened.catalogue_bootstrap_state(),
+        CatalogueBootstrapState::Uninitialized
+    );
+    assert!(matches!(
+        reopened.try_current_write_schema(),
+        Err(Error::CatalogueUninitialized)
+    ));
+}
+
+/// A fresh dynamic-edge open treats every durable catalogue row as a completed
+/// bootstrap only when its atomic completion record is present.  A raw
+/// genesis/schema prefix is corrupt, not an invitation to repair it using an
+/// empty local schema.
+#[test]
+fn dynamic_edge_reopen_rejects_catalogue_prefix_without_bootstrap_marker() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x9a), storage)
+        .expect("open explicit uninitialized edge");
+    let snapshot = catalogue_snapshot_fixture();
+    edge.apply_trusted_catalogue_snapshot(snapshot).unwrap();
+    delete_catalogue_record(
+        &mut edge,
+        b"bootstrap_ready",
+        schema().version_id().0,
+    );
+    drop(edge);
+
+    for attempt in 0..2 {
+        assert!(matches!(
+            fresh_dynamic_edge_open(temp_dir.path(), node(0x9a)),
+            Err(Error::InvalidStoredValue(
+                "dynamic catalogue state has no bootstrap completion marker"
+            ))
+        ), "open attempt {attempt} must reject rather than repair the prefix");
+    }
+}
+
+/// Removing a normal node's catalogue cannot turn its remaining transaction
+/// history into a blank dynamic edge.  Discovery must fail before an
+/// uninitialized constructor can adopt a new authority over stale data.
+#[test]
+fn dynamic_edge_reopen_rejects_catalogue_stripped_history() {
+    let base = schema();
+    let (temp_dir, mut durable_node) = open_node_with_schema(node(0x9e), base.clone());
+    durable_node.commit_mergeable(
+        MergeableCommit::new("todos", row(0x9f), 10).cells(title_cells("durable history")),
+    )
+    .unwrap();
+    let alias = durable_node.catalogue.current_schema_version_alias.unwrap();
+    delete_catalogue_record(&mut durable_node, b"genesis", base.version_id().0);
+    delete_catalogue_record(&mut durable_node, b"schema", base.version_id().0);
+    delete_schema_mapping_record(&mut durable_node, alias);
+    drop(durable_node);
+
+    for attempt in 0..2 {
+        assert!(matches!(
+            fresh_dynamic_edge_open(temp_dir.path(), node(0x9e)),
+            Err(Error::InvalidStoredValue(
+                "dynamic catalogue state cannot initialize over durable history"
+            ))
+        ), "open attempt {attempt} must reject rather than adopt over history");
+    }
+}
+
+/// The completion record joins the exact write pointer and active lineage
+/// high-water.  Removing either side, or changing the receipt, must reject a
+/// fresh recovery before normal catalogue open can repair missing metadata.
+#[test]
+fn dynamic_edge_reopen_rejects_truncated_or_mismatched_bootstrap_marker() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x9b), storage)
+        .expect("open explicit uninitialized edge");
+    let snapshot = catalogue_snapshot_fixture();
+    edge.apply_trusted_catalogue_snapshot(snapshot.clone()).unwrap();
+    delete_catalogue_pointer(&mut edge, snapshot.current_write_schema.revision);
+    drop(edge);
+
+    assert!(matches!(
+        fresh_dynamic_edge_open(temp_dir.path(), node(0x9b)),
+        Err(Error::InvalidStoredValue(
+            "catalogue bootstrap completion marker does not match durable catalogue"
+        ))
+    ));
+
+    let temp_dir = tempfile::tempdir().expect("create second edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open second edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x9c), storage)
+        .expect("open explicit uninitialized edge");
+    edge.apply_trusted_catalogue_snapshot(snapshot.clone()).unwrap();
+    write_catalogue_record(
+        &mut edge,
+        b"bootstrap_ready",
+        schema().version_id().0,
+        serde_json::to_vec(&CatalogueBootstrapReady {
+            genesis: schema().version_id(),
+            current_write_schema: snapshot.current_write_schema,
+            active_catalogue_seq: 0,
+        })
+        .unwrap(),
+    );
+    drop(edge);
+
+    assert!(matches!(
+        fresh_dynamic_edge_open(temp_dir.path(), node(0x9c)),
+        Err(Error::InvalidStoredValue(
+            "catalogue bootstrap completion marker does not match durable catalogue"
+        ))
+    ));
+}
+
+/// The bootstrap receipt does not bless arbitrary catalogue rows.  Every
+/// durable schema and mapping must be the genesis or the target of a canonical
+/// staged lineage payload; a raw-added standalone schema remains corrupt even
+/// when it carries an otherwise valid physical mapping.
+#[test]
+fn dynamic_edge_reopen_rejects_smuggled_schema_and_mapping() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x9d), storage)
+        .expect("open explicit uninitialized edge");
+    edge.apply_trusted_catalogue_snapshot(catalogue_snapshot_fixture())
+        .unwrap();
+
+    let smuggled = SchemaVersion::new(JazzSchema::new([TableSchema::new(
+        "unrelated",
+        [ColumnSchema::new("title", ColumnType::String)],
+    )]));
+    let mut next_table_id = 100;
+    let mut next_column_id = 100;
+    let mapping = allocate_provisional_physical_mapping(
+        &smuggled.schema,
+        &mut next_table_id,
+        &mut next_column_id,
+    )
+    .unwrap();
+    write_catalogue_record(
+        &mut edge,
+        b"schema",
+        smuggled.id.0,
+        serde_json::to_vec(&smuggled).unwrap(),
+    );
+    write_schema_mapping_record(&mut edge, SchemaVersionAlias(99), smuggled.id, &mapping);
+    drop(edge);
+
+    for attempt in 0..2 {
+        assert!(matches!(
+            fresh_dynamic_edge_open(temp_dir.path(), node(0x9d)),
+            Err(Error::InvalidStoredValue(
+                "catalogue bootstrap completion marker does not match durable catalogue"
+            ))
+        ), "open attempt {attempt} must reject rather than repair smuggled state");
+    }
+}
+
+/// A crash after canonical lineage staging but before activation leaves no
+/// target schema or mapping.  A fresh dynamic edge must accept that exact
+/// durable seam, drain it into one atomic activation, and refresh its
+/// bootstrap receipt for the next process open.
+#[test]
+fn dynamic_edge_reopen_drains_after_staged_lineage_crash() {
+    let base = schema();
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0xa1), storage)
+        .expect("open explicit uninitialized edge");
+    edge.apply_trusted_catalogue_snapshot(crate::protocol::CatalogueSnapshot {
+        schemas: vec![SchemaVersion::new(base.clone())],
+        lineages: Vec::new(),
+        current_write_schema: CurrentWriteSchema {
+            revision: 0,
+            schema: base.version_id(),
+        },
+    })
+    .unwrap();
+
+    let target = SchemaVersion::new(catalogue_evolved_schema());
+    let publication = SchemaLineagePublication::new(
+        target.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            target.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "body".to_owned(),
+                    default: v(""),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    );
+    edge.set_catalogue_activation_failpoint(CatalogueActivationFailpoint::AfterStaged);
+    assert!(matches!(
+        edge.apply_trusted_catalogue_message(SyncMessage::PublishSchemaWithLens {
+            author: AuthorId::SYSTEM,
+            catalogue_seq: 1,
+            publication: Box::new(publication),
+        }),
+        Err(Error::CatalogueActivationFailed)
+    ));
+    assert!(
+        edge.database
+            .primary_key_scan_raw("jazz_schema_versions", &[])
+            .unwrap()
+            .iter()
+            .all(|raw| raw.record().get_uuid(SchemaVersionAliasRowRecord::FIELD_UUID_IDX).unwrap()
+                != target.id.0),
+        "AfterStaged must not persist the inactive target mapping"
+    );
+    drop(edge);
+
+    let reopened = fresh_dynamic_edge_open(temp_dir.path(), node(0xa1))
+        .expect("fresh discovery accepts canonical inactive staging");
+    assert_eq!(reopened.active_catalogue_seq(), 1);
+    assert!(reopened.catalogue_schemas().contains_key(&target.id));
+    drop(reopened);
+
+    let reopened = fresh_dynamic_edge_open(temp_dir.path(), node(0xa1))
+        .expect("activation refreshes the dynamic bootstrap receipt");
+    assert_eq!(reopened.active_catalogue_seq(), 1);
+    assert!(reopened.catalogue_schemas().contains_key(&target.id));
+}
+
+/// A bootstrap snapshot has exactly one non-lineage schema: the authority's
+/// genesis.  Mallory cannot make an edge choose among multiple roots.
+///
+/// ```text
+/// malformed snapshot(two roots) ──► edge(Uninitialized) ──reject──► no durable state
+/// ```
+#[test]
+fn dynamic_edge_bootstrap_rejects_snapshot_with_ambiguous_genesis() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x94), storage)
+        .expect("open explicit uninitialized edge");
+    let mut snapshot = catalogue_snapshot_fixture();
+    snapshot.schemas.push(SchemaVersion::new(JazzSchema::new([
+        TableSchema::new(
+            "other",
+            [ColumnSchema::new("title", ColumnType::String)],
+        ),
+    ])));
+
+    assert!(matches!(
+        edge.apply_trusted_catalogue_snapshot(snapshot),
+        Err(Error::InvalidCatalogueUpdate(
+            "trusted catalogue snapshot must contain exactly one genesis schema"
+        ))
+    ));
+    assert_eq!(
+        edge.catalogue_bootstrap_state(),
+        CatalogueBootstrapState::Uninitialized
+    );
+    let reopened = edge.reopen_in_place().expect("no malformed bootstrap state persisted");
+    assert_eq!(
+        reopened.catalogue_bootstrap_state(),
+        CatalogueBootstrapState::Uninitialized
+    );
+}
+
+/// Incremental protocol traffic cannot establish a dynamic edge's catalogue;
+/// only one complete trusted snapshot may cross the bootstrap boundary.
+///
+/// ```text
+/// stale incremental pointer ──► edge(Uninitialized) ──reject──► no pending pointer row
+/// ```
+#[test]
+fn dynamic_edge_bootstrap_rejects_incremental_catalogue_messages_without_residue() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x95), storage)
+        .expect("open explicit uninitialized edge");
+
+    assert!(matches!(
+        edge.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+            author: AuthorId::SYSTEM,
+            pointer: CurrentWriteSchema {
+                revision: 1,
+                schema: schema().version_id(),
+            },
+        }),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(
+        edge.database
+            .primary_key_scan_raw("jazz_catalogue", &[])
+            .expect("scan rejected incremental message")
+            .is_empty(),
+        "incremental pointer must not leave a durable pending catalogue row"
+    );
+}
+
+/// Direct public mutation APIs are the same catalogue admission boundary as
+/// sync dispatch.  An uninitialized edge must reject a structurally valid
+/// commit unit and fate update before either can create transaction or parked
+/// durable residue.
+#[test]
+fn dynamic_edge_bootstrap_rejects_direct_ingest_and_fate_without_residue() {
+    let (_source_dir, mut source) = open_node_with_schema(node(0x97), schema());
+    let (_tx_id, unit) = source
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", row(0x98), 10).cells(title_cells("valid source unit")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = unit else {
+        panic!("commit unit expected");
+    };
+
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x99), storage)
+        .expect("open explicit uninitialized edge");
+
+    assert!(matches!(
+        edge.open_exclusive(OpenBatchId::new()),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.ingest_commit_unit(tx.clone(), versions.clone(), 20),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.ingest_edge_authority_mergeable_commit_unit(tx.clone(), versions.clone(), 20),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.ingest_edge_authority_mergeable_commit_unit_with_identity(
+            tx.clone(),
+            versions.clone(),
+            20,
+            AuthorId::SYSTEM,
+        ),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.ingest_relay_commit_unit(tx.clone(), versions),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.apply_fate_update(tx.tx_id, Fate::Accepted, None, Some(DurabilityTier::Edge)),
+        Err(Error::CatalogueUninitialized)
+    ));
+    for table in [
+        "jazz_catalogue",
+        "jazz_schema_versions",
+        "jazz_transactions",
+    ] {
+        assert!(
+            edge.database
+                .primary_key_scan_raw(table, &[])
+                .expect("scan rejected direct mutation")
+                .is_empty(),
+            "uninitialized direct mutation must not persist {table}"
+        );
+    }
+}
+
+/// Branch metadata depends on a real catalogue and must not create durable
+/// branch state while an edge has no trusted authority lineage.
+///
+/// ```text
+/// alice branch create ──► edge(Uninitialized) ──reject──► no branch metadata
+/// ```
+#[test]
+fn dynamic_edge_bootstrap_rejects_branch_creation_without_residue() {
+    let empty_schema = JazzSchema::new([]);
+    let temp_dir = tempfile::tempdir().expect("create edge store");
+    let cfs = empty_schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = RocksDbStorage::open(temp_dir.path(), &refs).expect("open empty edge store");
+    let mut edge = NodeState::new_catalogue_uninitialized(node(0x96), storage)
+        .expect("open explicit uninitialized edge");
+
+    assert!(matches!(
+        edge.create_branch(BranchId(uuid::Uuid::from_bytes([0x96; 16]))),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(matches!(
+        edge.create_root_branch(BranchId(uuid::Uuid::from_bytes([0x97; 16]))),
+        Err(Error::CatalogueUninitialized)
+    ));
+    assert!(
+        edge.database
+            .primary_key_scan_raw("jazz_branches", &[])
+            .expect("scan rejected branch creates")
+            .is_empty(),
+        "uninitialized edge must not persist branch metadata"
+    );
+}
+
 fn catalogue_snapshot_fixture() -> crate::protocol::CatalogueSnapshot {
     let base = schema();
     let evolved = SchemaVersion::new(catalogue_evolved_schema());
@@ -746,13 +1354,13 @@ fn trusted_catalogue_snapshot_rejects_invalid_later_lineage_without_prefix_activ
     ));
     assert_eq!(core.active_catalogue_seq(), 0);
     assert_eq!(core.catalogue_schemas().len(), 1);
-    assert_eq!(core.current_write_schema().revision, 0);
+    assert_eq!(core.current_write_schema().unwrap().revision, 0);
     drop(core);
 
     let reopened = reopen_node_at(&dir, node(0x38), base);
     assert_eq!(reopened.active_catalogue_seq(), 0);
     assert_eq!(reopened.catalogue_schemas().len(), 1);
-    assert_eq!(reopened.current_write_schema().revision, 0);
+    assert_eq!(reopened.current_write_schema().unwrap().revision, 0);
 }
 
 #[test]
@@ -773,7 +1381,7 @@ fn trusted_catalogue_snapshot_rejects_pointer_conflict_without_lineage_activatio
     let reopened = reopen_node_at(&dir, node(0x39), base);
     assert_eq!(reopened.active_catalogue_seq(), 0);
     assert_eq!(reopened.catalogue_schemas().len(), 1);
-    assert_eq!(reopened.current_write_schema().revision, 0);
+    assert_eq!(reopened.current_write_schema().unwrap().revision, 0);
 }
 
 #[test]
@@ -790,7 +1398,7 @@ fn trusted_catalogue_snapshot_activation_failure_never_exposes_a_prefix_and_reop
     ));
     assert_eq!(core.active_catalogue_seq(), 0);
     assert_eq!(core.catalogue_schemas().len(), 1);
-    assert_eq!(core.current_write_schema().revision, 0);
+    assert_eq!(core.current_write_schema().unwrap().revision, 0);
     assert!(matches!(
         core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
             author: AuthorId::SYSTEM,
@@ -806,13 +1414,13 @@ fn trusted_catalogue_snapshot_activation_failure_never_exposes_a_prefix_and_reop
     let mut reopened = reopen_node_at(&dir, node(0x3a), base);
     assert_eq!(reopened.active_catalogue_seq(), 0);
     assert_eq!(reopened.catalogue_schemas().len(), 1);
-    assert_eq!(reopened.current_write_schema().revision, 0);
+    assert_eq!(reopened.current_write_schema().unwrap().revision, 0);
     reopened
         .apply_trusted_catalogue_snapshot(catalogue_snapshot_fixture())
         .unwrap();
     assert_eq!(reopened.active_catalogue_seq(), 1);
     assert_eq!(reopened.catalogue_schemas().len(), 2);
-    assert_eq!(reopened.current_write_schema().revision, 1);
+    assert_eq!(reopened.current_write_schema().unwrap().revision, 1);
 }
 
 #[test]
@@ -3163,7 +3771,7 @@ fn commit_arrival_preserves_known_noncurrent_authored_variant() {
         Vec::<String>::new(),
     )
     .unwrap();
-    assert_eq!(core.current_write_schema().schema, base.version_id());
+    assert_eq!(core.current_write_schema().unwrap().schema, base.version_id());
 
     let row = row(0x5c);
     let (_tx_id, unit) = writer
@@ -3176,7 +3784,7 @@ fn commit_arrival_preserves_known_noncurrent_authored_variant() {
         .unwrap();
     core.apply_sync_message(unit).unwrap();
 
-    assert_eq!(core.current_write_schema().schema, base.version_id());
+    assert_eq!(core.current_write_schema().unwrap().schema, base.version_id());
     let stored = core.query_table_versions("todos").unwrap();
     assert_eq!(stored.len(), 1);
     let stored_wire = core.version_record_from_row(&stored[0]).unwrap();
@@ -3222,8 +3830,8 @@ fn catalogue_current_write_schema_revision_is_core_ordered() {
         },
     })
     .unwrap();
-    assert_eq!(core.current_write_schema().revision, 2);
-    assert_eq!(core.current_write_schema().schema, evolved_payload.id);
+    assert_eq!(core.current_write_schema().unwrap().revision, 2);
+    assert_eq!(core.current_write_schema().unwrap().schema, evolved_payload.id);
 
     let stale = core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
         author: AuthorId::SYSTEM,
@@ -3240,7 +3848,7 @@ fn catalogue_current_write_schema_revision_is_core_ordered() {
             ..
         })]
     ));
-    assert_eq!(core.current_write_schema().revision, 2);
+    assert_eq!(core.current_write_schema().unwrap().revision, 2);
 
     core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
         author: AuthorId::SYSTEM,
@@ -3250,8 +3858,8 @@ fn catalogue_current_write_schema_revision_is_core_ordered() {
         },
     })
     .unwrap();
-    assert_eq!(core.current_write_schema().revision, 3);
-    assert_eq!(core.current_write_schema().schema, base.version_id());
+    assert_eq!(core.current_write_schema().unwrap().revision, 3);
+    assert_eq!(core.current_write_schema().unwrap().schema, base.version_id());
 }
 #[test]
 fn durable_catalogue_values_pointer_and_physical_mappings_survive_restart() {
@@ -3304,7 +3912,7 @@ fn durable_catalogue_values_pointer_and_physical_mappings_survive_restart() {
     );
     assert_eq!(reopened.catalogue_lenses().get(&lens.id), Some(&lens));
     assert_eq!(
-        reopened.current_write_schema(),
+        reopened.current_write_schema().unwrap(),
         CurrentWriteSchema {
             revision: 4,
             schema: evolved_payload.id,

--- a/crates/jazz/src/node/tests/exclusive_transactions.rs
+++ b/crates/jazz/src/node/tests/exclusive_transactions.rs
@@ -238,7 +238,7 @@ fn tx_read_parent_cache_is_invalidated_by_same_row_write_without_changing_read_s
             .unwrap()
             .base_snapshot_rows
             .contains_key(&(
-                node.current_write_schema().schema,
+                node.current_write_schema().unwrap().schema,
                 "todos".to_owned(),
                 row
             ))
@@ -252,7 +252,7 @@ fn tx_read_parent_cache_is_invalidated_by_same_row_write_without_changing_read_s
             .unwrap()
             .base_snapshot_rows
             .contains_key(&(
-                node.current_write_schema().schema,
+                node.current_write_schema().unwrap().schema,
                 "todos".to_owned(),
                 row
             ))

--- a/crates/jazz/src/protocol_limits.rs
+++ b/crates/jazz/src/protocol_limits.rs
@@ -13,6 +13,15 @@ use crate::protocol::{KnownStateDeclaration, RowVersionRef, ShapeAst, VersionRec
 /// envelope overhead while forcing large batches to split by bytes.
 pub const MAX_WIRE_FRAME_BYTES: usize = 2 * 1024 * 1024;
 
+/// Maximum raw wire frames carried by one postcard WebSocket batch.
+///
+/// Carrier encoders split above this count. It is deliberately the same as
+/// the maximum atomic commit-unit cardinality; meanwhile the 512 KiB
+/// fragmentation extent means even a maximum legal 256 MiB logical message
+/// needs only 512 physical frames. This keeps a tiny-frame flood from being
+/// retained or staged beyond a bounded cardinality at the WebSocket boundary.
+pub const MAX_WIRE_BATCH_FRAMES: usize = MAX_COMMIT_UNIT_VERSIONS;
+
 /// Resource ceiling for one decoded logical message, independent of framing.
 ///
 /// This prevents allocation bombs while allowing normal database payloads to

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -272,6 +272,101 @@ impl fmt::Debug for ServerSessionState {
 }
 
 impl ShellDb {
+    fn open_catalogue_uninitialized_edge(
+        identity: DbIdentity,
+        storage_config: StorageConfig,
+        row_id_seed: Option<u64>,
+    ) -> ShellResult<Self> {
+        let schema = JazzSchema::new([]);
+        match storage_config {
+            StorageConfig::InMemory => {
+                let refs = schema.column_families();
+                let refs = refs.iter().map(String::as_str).collect::<Vec<_>>();
+                let mut config = DbConfig::new(schema, MemoryStorage::new(&refs), identity);
+                if let Some(seed) = row_id_seed {
+                    config = config.with_id_source(SeededRowIdSource::new(seed));
+                }
+                Ok(Self::Memory(crate::db::block_on(
+                    Db::open_catalogue_uninitialized_edge(config),
+                )?))
+            }
+            #[cfg(feature = "rocksdb")]
+            StorageConfig::RocksDb { path } => {
+                let refs = schema.column_families();
+                let refs = refs.iter().map(String::as_str).collect::<Vec<_>>();
+                let mut config = DbConfig::new(
+                    schema,
+                    RocksDbStorage::open(path, &refs).map_err(db_storage_error)?,
+                    identity,
+                );
+                if let Some(seed) = row_id_seed {
+                    config = config.with_id_source(SeededRowIdSource::new(seed));
+                }
+                Ok(Self::Rocks(crate::db::block_on(
+                    Db::open_catalogue_uninitialized_edge(config),
+                )?))
+            }
+            #[cfg(not(feature = "rocksdb"))]
+            StorageConfig::RocksDb { .. } | StorageConfig::SQLite { .. } => {
+                Err(ShellError::UnsupportedStorage {
+                    storage: storage_config,
+                })
+            }
+            #[cfg(feature = "rocksdb")]
+            StorageConfig::SQLite { .. } => Err(ShellError::UnsupportedStorage {
+                storage: storage_config,
+            }),
+        }
+    }
+
+    fn apply_trusted_catalogue_snapshot(
+        &self,
+        snapshot: crate::protocol::CatalogueSnapshot,
+    ) -> ShellResult<()> {
+        match self {
+            Self::Memory(db) => db
+                .apply_trusted_catalogue_snapshot(snapshot)
+                .map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db
+                .apply_trusted_catalogue_snapshot(snapshot)
+                .map_err(Into::into),
+        }
+    }
+
+    fn trusted_catalogue_snapshot(&self) -> ShellResult<crate::protocol::CatalogueSnapshot> {
+        match self {
+            Self::Memory(db) => db.trusted_catalogue_snapshot().map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db.trusted_catalogue_snapshot().map_err(Into::into),
+        }
+    }
+
+    fn trusted_current_catalogue_schema(&self) -> ShellResult<JazzSchema> {
+        match self {
+            Self::Memory(db) => db.trusted_current_catalogue_schema().map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db.trusted_current_catalogue_schema().map_err(Into::into),
+        }
+    }
+
+    fn catalogue_bootstrap_is_ready(&self) -> bool {
+        match self {
+            Self::Memory(db) => db.catalogue_bootstrap_is_ready(),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db.catalogue_bootstrap_is_ready(),
+        }
+    }
+
+    fn select_schema_view(&mut self, schema: JazzSchema) -> ShellResult<()> {
+        match self {
+            Self::Memory(db) => *db = db.register_schema_view(schema)?,
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => *db = db.register_schema_view(schema)?,
+        }
+        Ok(())
+    }
+
     fn seed_branch_row(
         &self,
         branch: BranchId,
@@ -592,6 +687,93 @@ impl InMemoryServerShell {
             shell.bootstrap_runtime_schema(bootstrap_schema)?;
         }
         Ok(shell)
+    }
+
+    /// Start from a blank dynamic-edge store, atomically adopt the supplied
+    /// authenticated authority snapshot, then expose the ordinary ready shell.
+    /// No application session can be admitted during this construction.
+    pub fn start_dynamic_edge_with_catalogue_snapshot(
+        identity: DbIdentity,
+        storage_config: StorageConfig,
+        edge_cache_budget: Option<EdgeCacheBudget>,
+        snapshot: crate::protocol::CatalogueSnapshot,
+    ) -> ShellResult<Self> {
+        let active_schema = snapshot.current_write_schema.schema;
+        let active_schema_payload = snapshot
+            .schemas
+            .iter()
+            .find(|schema| schema.id == active_schema)
+            .map(|schema| schema.schema.clone())
+            .ok_or(ShellError::MissingEvent("trusted snapshot active schema"))?;
+        let db = ShellDb::open_catalogue_uninitialized_edge(identity, storage_config, Some(0x5e))?;
+        db.apply_trusted_catalogue_snapshot(snapshot)?;
+        let mut db = db;
+        db.select_schema_view(active_schema_payload)?;
+        db.set_edge_cache_budget(edge_cache_budget);
+        Ok(Self {
+            db,
+            role: NodeRole::Edge,
+            sessions: Vec::new(),
+            resume_cursors: BTreeMap::new(),
+            next_resume_token: 1,
+            runtime_schema_state: RuntimeSchemaState::default(),
+            metrics: InMemoryServerShellMetrics::default(),
+            drain_state: DrainState::Running,
+        })
+    }
+
+    /// Reopen an already-adopted dynamic edge without contacting upstream.
+    /// Returns `None` for a genuinely blank store so the owner can run the
+    /// authenticated bootstrap driver; malformed durable state remains an
+    /// error and is never treated as blank.
+    pub fn try_start_dynamic_edge_from_storage(
+        identity: DbIdentity,
+        storage_config: StorageConfig,
+        edge_cache_budget: Option<EdgeCacheBudget>,
+    ) -> ShellResult<Option<Self>> {
+        let db = ShellDb::open_catalogue_uninitialized_edge(identity, storage_config, Some(0x5e))?;
+        if !db.catalogue_bootstrap_is_ready() {
+            return Ok(None);
+        }
+        let schema = db.trusted_current_catalogue_schema()?;
+        let mut db = db;
+        db.select_schema_view(schema)?;
+        db.set_edge_cache_budget(edge_cache_budget);
+        Ok(Some(Self {
+            db,
+            role: NodeRole::Edge,
+            sessions: Vec::new(),
+            resume_cursors: BTreeMap::new(),
+            next_resume_token: 1,
+            runtime_schema_state: RuntimeSchemaState::default(),
+            metrics: InMemoryServerShellMetrics::default(),
+            drain_state: DrainState::Running,
+        }))
+    }
+
+    /// Return the complete authority catalogue for the authenticated
+    /// snapshot-only websocket exchange.
+    pub(crate) fn trusted_catalogue_snapshot(
+        &self,
+    ) -> ShellResult<crate::protocol::CatalogueSnapshot> {
+        self.db.trusted_catalogue_snapshot()
+    }
+
+    /// Encode the snapshot through the ordinary negotiated wire codec so
+    /// large catalogues retain the protocol's fragmentation and feature rules.
+    pub(crate) fn encoded_trusted_catalogue_snapshot(
+        &self,
+        protocol_version: u16,
+        features: crate::wire::WireFeatures,
+    ) -> ShellResult<Vec<AbiBytes>> {
+        let transport = SharedWireTransport::default();
+        let mut wire =
+            WireTransportAdapter::new(transport.clone(), protocol_version, features, None);
+        wire.send(SyncMessage::CatalogueSnapshot(Box::new(
+            self.trusted_catalogue_snapshot()?,
+        )))
+        .map_err(|error| ShellError::Transport(format!("{error:?}")))?;
+        Ok(transport.queues.borrow_mut().outbound.drain(..).collect())
     }
 
     /// Return the shell's ABI runtime handle for diagnostics in unit tests.

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -312,11 +312,11 @@ impl ShellDb {
         }
     }
 
-    fn current_write_schema(&self) -> CurrentWriteSchema {
+    fn current_write_schema(&self) -> ShellResult<CurrentWriteSchema> {
         match self {
-            Self::Memory(db) => db.current_write_schema(),
+            Self::Memory(db) => db.current_write_schema().map_err(Into::into),
             #[cfg(feature = "rocksdb")]
-            Self::Rocks(db) => db.current_write_schema(),
+            Self::Rocks(db) => db.current_write_schema().map_err(Into::into),
         }
     }
 
@@ -630,7 +630,7 @@ impl InMemoryServerShell {
 
     fn bootstrap_runtime_schema(&mut self, schema: JazzSchema) -> ShellResult<()> {
         let schema_id = schema.version_id();
-        let current = self.db.current_write_schema();
+        let current = self.db.current_write_schema()?;
         if current.schema == schema_id
             && current.revision > 0
             && self.db.catalogue_schema(schema_id).is_some()
@@ -650,7 +650,7 @@ impl InMemoryServerShell {
         let schema_version = SchemaVersion::new(schema);
         let schema_id = schema_version.id;
         let expected_schema = schema_version.schema.clone();
-        let current = self.db.current_write_schema();
+        let current = self.db.current_write_schema()?;
         if current.schema == schema_id
             && current.revision > 0
             && self.db.catalogue_schema(schema_id).as_ref() == Some(&expected_schema)
@@ -673,7 +673,7 @@ impl InMemoryServerShell {
             return Err(ShellError::MissingEvent("CatalogueAck"));
         }
 
-        let current = self.db.current_write_schema();
+        let current = self.db.current_write_schema()?;
         if current.schema == schema_id && current.revision > 0 {
             self.runtime_schema_state.current_write_revision = current.revision;
             self.runtime_schema_state.last_published_schema = Some(schema_id);
@@ -689,7 +689,7 @@ impl InMemoryServerShell {
         let set_current_applied = set_current_acks.iter().any(|ack| {
             ack.applied && ack.revision == Some(revision) && ack.schema == Some(schema_id)
         });
-        let current = self.db.current_write_schema();
+        let current = self.db.current_write_schema()?;
         if !(set_current_applied || current.schema == schema_id && current.revision > 0) {
             return Err(ShellError::MissingEvent("CatalogueAck"));
         }
@@ -781,7 +781,7 @@ impl InMemoryServerShell {
             self.publish_runtime_schema_with_lens(schema, lens, Vec::new(), Vec::new())?;
         }
 
-        let current = self.db.current_write_schema();
+        let current = self.db.current_write_schema()?;
         if current.schema != schema_id {
             let revision = current.revision.saturating_add(1);
             let acks = catalogue_acks_from_messages(self.db.set_current_write_schema(
@@ -796,7 +796,7 @@ impl InMemoryServerShell {
                 return Err(ShellError::MissingEvent("CatalogueAck"));
             }
         }
-        let current = self.db.current_write_schema();
+        let current = self.db.current_write_schema()?;
         self.runtime_schema_state.current_write_revision = current.revision;
         self.runtime_schema_state.last_published_schema = Some(schema_id);
         self.db.set_permissions_ready(true)?;
@@ -1808,7 +1808,7 @@ mod tests {
             .publish_permissions_schema(second.clone(), schema_id)
             .unwrap();
         assert_eq!(shell.db.catalogue_schema(schema_id), Some(second.clone()));
-        assert_eq!(shell.db.current_write_schema().schema, schema_id);
+        assert_eq!(shell.db.current_write_schema().unwrap().schema, schema_id);
         drop(shell);
 
         let reopened = InMemoryServerShell::start_with_storage(
@@ -1819,7 +1819,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(reopened.db.catalogue_schema(schema_id), Some(second));
-        assert_eq!(reopened.db.current_write_schema().schema, schema_id);
+        assert_eq!(
+            reopened.db.current_write_schema().unwrap().schema,
+            schema_id
+        );
     }
 
     #[test]

--- a/crates/jazz/src/tools/server/builder.rs
+++ b/crates/jazz/src/tools/server/builder.rs
@@ -19,6 +19,7 @@ use crate::tools::public_schema::Schema;
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 use crate::tools::server::CatalogueRocksDbStorage;
 use crate::tools::server::core_websocket_transport::WebSocketTransport;
+use crate::tools::server::core_websocket_transport::validate_catalogue_bootstrap_upstream_url;
 use crate::tools::server::routes;
 use crate::tools::server::{
     CatalogueMemoryStorage, DynCatalogueStorage, ServerState, ServerTopology, StoredCatalogue,
@@ -167,6 +168,14 @@ impl ServerBuilder {
             None => None,
         };
         validate_server_config(&auth_config, topology)?;
+        if topology == ServerTopology::Edge {
+            validate_catalogue_bootstrap_upstream_url(
+                self.upstream_url
+                    .as_deref()
+                    .expect("edge topology has an upstream URL"),
+                self.app_id,
+            )?;
+        }
         let jwt_verifier = build_jwt_verifier(&auth_config).await?;
         log_auth_config(&auth_config, topology);
 
@@ -181,7 +190,6 @@ impl ServerBuilder {
             core_server_shell_storage_config.clone(),
             topology,
         )?;
-        let edge_upstream_shell = core_server_shell.clone();
         let core_server_shell_storage_config = core_server_shell_storage_config.ok();
 
         let state = Arc::new(ServerState {
@@ -198,18 +206,17 @@ impl ServerBuilder {
             shutdown: crate::tools::server::ShutdownController::new(self.shutdown_timeout),
         });
 
-        if let (ServerTopology::Edge, Some(upstream_url), Some(shell), Some(admin_secret)) = (
+        if let (ServerTopology::Edge, Some(upstream_url), Some(admin_secret)) = (
             topology,
             self.upstream_url.clone(),
-            edge_upstream_shell,
             state.auth_config.admin_secret.clone(),
         ) {
             spawn_edge_upstream_connector(
                 state.clone(),
-                shell,
                 upstream_url,
                 self.app_id,
                 admin_secret,
+                self.edge_cache_budget,
             );
         }
 
@@ -275,6 +282,12 @@ impl ServerBuilder {
             ServerSchemaMode::Dynamic => latest_catalogue_schema,
         };
         let Some(schema) = schema else {
+            if topology == ServerTopology::Edge {
+                return crate::tools::server::core_server_shell::ServerShellHandle::try_start_dynamic_edge_from_storage(
+                    storage_config?,
+                    self.edge_cache_budget,
+                );
+            }
             return Ok(None);
         };
         let storage_config = storage_config?;
@@ -395,10 +408,10 @@ fn test_schema_branches(schema: Option<&Schema>) -> Vec<String> {
 
 fn spawn_edge_upstream_connector(
     state: Arc<ServerState>,
-    shell: crate::tools::server::core_server_shell::ServerShellHandle,
     upstream_url: String,
     app_id: AppId,
     admin_secret: String,
+    edge_cache_budget: Option<EdgeCacheBudget>,
 ) {
     tokio::spawn(async move {
         let retry_delay = Duration::from_millis(100);
@@ -406,12 +419,39 @@ fn spawn_edge_upstream_connector(
             if state.shutdown.is_shutting_down() {
                 return;
             }
-            let wake_shell = shell.clone();
-            let wake = Arc::new(move || wake_shell.notify_activity());
             let auth = crate::tools::websocket_prelude_auth::AuthConfig {
                 admin_secret: Some(admin_secret.clone()),
                 ..Default::default()
             };
+            let shell = match state.core_server_shell() {
+                Some(shell) => shell,
+                None => match WebSocketTransport::connect_catalogue_bootstrap(
+                    &upstream_url,
+                    app_id,
+                    AuthorId::SYSTEM,
+                    auth.clone(),
+                )
+                .await
+                {
+                    Ok(snapshot) => {
+                        match state.start_dynamic_edge_shell(snapshot, edge_cache_budget) {
+                            Ok(shell) => shell,
+                            Err(error) => {
+                                info!("edge catalogue bootstrap pending: {}", error);
+                                tokio::time::sleep(retry_delay).await;
+                                continue;
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        info!("edge catalogue bootstrap pending: {}", error);
+                        tokio::time::sleep(retry_delay).await;
+                        continue;
+                    }
+                },
+            };
+            let wake_shell = shell.clone();
+            let wake = Arc::new(move || wake_shell.notify_activity());
             match WebSocketTransport::connect_with_wake(
                 &upstream_url,
                 app_id,
@@ -579,6 +619,307 @@ mod tests {
     use crate::tools::AppId;
     use crate::tools::server::catalogue::CatalogueStore;
 
+    async fn serve_for_dynamic_bootstrap(
+        built: BuiltServer,
+    ) -> (String, Arc<ServerState>, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let address = listener.local_addr().expect("test listener address");
+        let state = built.state.clone();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, built.app)
+                .await
+                .expect("serve test server");
+        });
+        (format!("ws://{address}"), state, task)
+    }
+
+    fn dynamic_bootstrap_schema() -> crate::tools::public_schema::Schema {
+        crate::tools::public_schema::SchemaBuilder::new()
+            .table(
+                crate::tools::public_schema::TableSchema::builder("notes")
+                    .column("id", crate::tools::public_schema::ColumnType::Uuid)
+                    .column("body", crate::tools::public_schema::ColumnType::Text),
+            )
+            .build()
+    }
+
+    #[tokio::test]
+    async fn dynamic_edge_bootstraps_authenticated_catalogue_before_first_client() {
+        let app_id = AppId::from_name("dynamic-edge-bootstrap-first-client");
+        let auth = AuthConfig {
+            admin_secret: Some("bootstrap-secret".to_owned()),
+            ..Default::default()
+        };
+        let core = ServerBuilder::new(app_id)
+            .with_schema(dynamic_bootstrap_schema())
+            .with_auth_config(auth.clone())
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build authority core");
+        let (core_url, core_state, core_task) = serve_for_dynamic_bootstrap(core).await;
+        let expected = core_state
+            .core_server_shell()
+            .expect("core has runtime shell")
+            .trusted_catalogue_snapshot_for_test()
+            .await
+            .expect("read authority catalogue");
+
+        // This uses the separate snapshot-only wire exchange: no downstream
+        // edge session or application schema exists before it succeeds.
+        let edge = ServerBuilder::new(app_id)
+            .with_auth_config(auth.clone())
+            .with_storage(StorageBackend::InMemory)
+            .with_upstream_url(core_url.clone())
+            .build()
+            .await
+            .expect("build blank dynamic edge");
+        assert!(edge.state.core_server_shell().is_none());
+        let (edge_url, edge_state, edge_task) = serve_for_dynamic_bootstrap(edge).await;
+
+        let ready_shell = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if let Some(shell) = edge_state.core_server_shell() {
+                    return shell;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("edge becomes ready from idle bootstrap");
+        assert_eq!(
+            ready_shell
+                .trusted_catalogue_snapshot_for_test()
+                .await
+                .expect("read adopted edge catalogue"),
+            expected,
+            "edge must adopt the authority genesis, lineage, and policy-bearing schema exactly"
+        );
+
+        // The first normal downstream connection is admitted only after Ready;
+        // it is deliberately a separate connection from bootstrap.
+        let client = WebSocketTransport::connect(
+            &edge_url,
+            app_id,
+            AuthorId::from_bytes([0x44; 16]),
+            crate::tools::websocket_prelude_auth::AuthConfig {
+                admin_secret: Some("bootstrap-secret".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await;
+        assert!(
+            client.is_ok(),
+            "ready edge admits first normal client: {client:?}"
+        );
+
+        edge_task.abort();
+        core_task.abort();
+    }
+
+    #[tokio::test]
+    async fn dynamic_catalogue_bootstrap_rejects_wrong_authority_credential() {
+        let app_id = AppId::from_name("dynamic-edge-bootstrap-auth-denial");
+        let core = ServerBuilder::new(app_id)
+            .with_schema(dynamic_bootstrap_schema())
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("right-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build authority core");
+        let (core_url, _core_state, core_task) = serve_for_dynamic_bootstrap(core).await;
+        let error = WebSocketTransport::connect_catalogue_bootstrap(
+            core_url,
+            app_id,
+            AuthorId::SYSTEM,
+            crate::tools::websocket_prelude_auth::AuthConfig {
+                admin_secret: Some("wrong-secret".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("wrong bootstrap credential must not obtain a catalogue");
+        assert!(
+            matches!(error, crate::tools::server::core_websocket_transport::WebSocketClientError::ServerRejected(ref message) if message.contains("AuthFailed")),
+            "unexpected bootstrap auth result: {error}"
+        );
+        core_task.abort();
+    }
+
+    #[tokio::test]
+    async fn dynamic_catalogue_bootstrap_requires_the_reserved_edge_identity() {
+        let app_id = AppId::from_name("dynamic-edge-bootstrap-identity-denial");
+        let core = ServerBuilder::new(app_id)
+            .with_schema(dynamic_bootstrap_schema())
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("bootstrap-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build authority core");
+        let (core_url, _core_state, core_task) = serve_for_dynamic_bootstrap(core).await;
+        let error = WebSocketTransport::connect_catalogue_bootstrap(
+            core_url,
+            app_id,
+            AuthorId::from_bytes([0x46; 16]),
+            crate::tools::websocket_prelude_auth::AuthConfig {
+                admin_secret: Some("bootstrap-secret".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("normal privileged client identity must not request bootstrap");
+        assert!(
+            matches!(error, crate::tools::server::core_websocket_transport::WebSocketClientError::ServerRejected(ref message) if message.contains("AuthFailed")),
+            "bootstrap identity boundary returned {error}"
+        );
+        core_task.abort();
+    }
+
+    #[tokio::test]
+    async fn dynamic_catalogue_bootstrap_rejects_generic_backend_credential() {
+        let app_id = AppId::from_name("dynamic-edge-bootstrap-backend-denial");
+        let core = ServerBuilder::new(app_id)
+            .with_schema(dynamic_bootstrap_schema())
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("bootstrap-admin-secret".to_owned()),
+                backend_secret: Some("ordinary-backend-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build authority core");
+        let (core_url, _core_state, core_task) = serve_for_dynamic_bootstrap(core).await;
+        let error = WebSocketTransport::connect_catalogue_bootstrap(
+            core_url,
+            app_id,
+            AuthorId::SYSTEM,
+            crate::tools::websocket_prelude_auth::AuthConfig {
+                backend_secret: Some("ordinary-backend-secret".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("backend credential must not read an authority catalogue");
+        assert!(
+            matches!(error, crate::tools::server::core_websocket_transport::WebSocketClientError::ServerRejected(ref message) if message.contains("AuthFailed")),
+            "generic backend credential crossed bootstrap boundary: {error}"
+        );
+        core_task.abort();
+    }
+
+    #[tokio::test]
+    async fn dynamic_edge_keeps_unready_after_malformed_snapshot_then_accepts_retry() {
+        let app_id = AppId::from_name("dynamic-edge-bootstrap-malformed-retry");
+        let auth = AuthConfig {
+            admin_secret: Some("bootstrap-secret".to_owned()),
+            ..Default::default()
+        };
+        let core = ServerBuilder::new(app_id)
+            .with_schema(dynamic_bootstrap_schema())
+            .with_auth_config(auth.clone())
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build authority core");
+        let snapshot = core
+            .state
+            .core_server_shell()
+            .expect("core has shell")
+            .trusted_catalogue_snapshot_for_test()
+            .await
+            .expect("read authority snapshot");
+        let edge = ServerBuilder::new(app_id)
+            .with_auth_config(auth)
+            .with_storage(StorageBackend::InMemory)
+            .with_upstream_url("ws://127.0.0.1:9")
+            .build()
+            .await
+            .expect("build blank edge");
+        let mut malformed = snapshot.clone();
+        malformed.schemas.push(
+            malformed
+                .schemas
+                .first()
+                .expect("authority has genesis")
+                .clone(),
+        );
+        assert!(
+            edge.state
+                .start_dynamic_edge_shell(malformed, None)
+                .is_err()
+        );
+        assert!(
+            edge.state.core_server_shell().is_none(),
+            "failed adoption must not publish a shell to downstream clients"
+        );
+        assert!(
+            edge.state
+                .start_dynamic_edge_shell(snapshot.clone(), None)
+                .is_ok()
+        );
+        let first_shell = edge
+            .state
+            .core_server_shell()
+            .expect("retry publishes ready shell");
+        let second_shell = edge
+            .state
+            .start_dynamic_edge_shell(snapshot, None)
+            .expect("duplicate driver wake is idempotent");
+        assert_eq!(
+            first_shell
+                .trusted_catalogue_snapshot_for_test()
+                .await
+                .expect("read first ready shell"),
+            second_shell
+                .trusted_catalogue_snapshot_for_test()
+                .await
+                .expect("read duplicate-ready shell"),
+            "a duplicate bootstrap wake reuses the already-published shell"
+        );
+    }
+
+    #[tokio::test]
+    async fn blank_dynamic_edge_rejects_downstream_with_retry_later_until_ready() {
+        let app_id = AppId::from_name("dynamic-edge-unready-downstream");
+        let edge = ServerBuilder::new(app_id)
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("edge-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_storage(StorageBackend::InMemory)
+            .with_upstream_url("ws://127.0.0.1:9")
+            .build()
+            .await
+            .expect("build blank edge");
+        assert!(edge.state.core_server_shell().is_none());
+        let (edge_url, _edge_state, edge_task) = serve_for_dynamic_bootstrap(edge).await;
+        let error = WebSocketTransport::connect(
+            edge_url,
+            app_id,
+            AuthorId::from_bytes([0x45; 16]),
+            crate::tools::websocket_prelude_auth::AuthConfig {
+                admin_secret: Some("edge-secret".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("unready edge must not admit a downstream session");
+        assert!(
+            matches!(error, crate::tools::server::core_websocket_transport::WebSocketClientError::ServerRejected(ref message) if message.contains("bootstrapping") && message.contains("retry shortly")),
+            "unready edge must return an explicit retry-later diagnosis: {error}"
+        );
+        edge_task.abort();
+    }
+
     #[tokio::test]
     async fn edge_upstream_mode_builds_with_admin_secret() {
         let app_id =
@@ -596,6 +937,27 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn edge_builder_rejects_remote_plaintext_bootstrap_upstream() {
+        let result = ServerBuilder::new(AppId::from_name("edge-plaintext-bootstrap-rejected"))
+            .with_storage(StorageBackend::InMemory)
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("admin-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_upstream_url("http://core.example.test")
+            .build()
+            .await;
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("remote plaintext bootstrap must fail configuration"),
+        };
+        assert!(
+            error.contains("plaintext ws:// bootstrap"),
+            "error: {error}"
+        );
     }
 
     #[test]

--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -56,6 +56,147 @@ enum ServerShellCommand {
 }
 
 impl ServerShellHandle {
+    /// Reopen an already bootstrapped dynamic edge. A blank store returns
+    /// `None` so its owner can run the authenticated bootstrap exchange.
+    pub(crate) fn try_start_dynamic_edge_from_storage(
+        storage_config: StorageConfig,
+        edge_cache_budget: Option<EdgeCacheBudget>,
+    ) -> Result<Option<Self>, String> {
+        let (jobs, receiver) = mpsc::channel::<ServerShellCommand>();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (activity_tx, _) = watch::channel(0_u64);
+        let join = thread::Builder::new()
+            .name("jazz-server-shell".to_owned())
+            .spawn(move || {
+                let shell = match InMemoryServerShell::try_start_dynamic_edge_from_storage(
+                    DbIdentity {
+                        node: NodeUuid::from_bytes([0x5e; 16]),
+                        author: AuthorId::SYSTEM,
+                    },
+                    storage_config,
+                    edge_cache_budget,
+                ) {
+                    Ok(Some(shell)) => {
+                        let _ = started_tx.send(Ok(true));
+                        shell
+                    }
+                    Ok(None) => {
+                        let _ = started_tx.send(Ok(false));
+                        return;
+                    }
+                    Err(error) => {
+                        let _ = started_tx.send(Err(error.to_string()));
+                        return;
+                    }
+                };
+                let mut shell = shell;
+                while let Ok(command) = receiver.recv() {
+                    match command {
+                        ServerShellCommand::Run(job) => job(&mut shell),
+                        ServerShellCommand::Shutdown(stopped) => {
+                            drop(shell);
+                            let _ = stopped.send(());
+                            return;
+                        }
+                    }
+                }
+            })
+            .map_err(|error| format!("failed to spawn server shell thread: {error}"))?;
+        let started = started_rx
+            .recv()
+            .map_err(|_| "server shell thread exited before dynamic reopen".to_owned())??;
+        Ok(started.then_some(Self {
+            inner: Arc::new(ServerShellInner {
+                jobs: Mutex::new(Some(jobs)),
+                join: Mutex::new(Some(join)),
+                activity_tx,
+            }),
+        }))
+    }
+
+    /// Construct a ready edge shell only after an authenticated bootstrap
+    /// snapshot has been durably adopted. The owner thread is not published to
+    /// downstream routes until this returns successfully.
+    pub(crate) fn start_dynamic_edge_with_catalogue_snapshot(
+        storage_config: StorageConfig,
+        edge_cache_budget: Option<EdgeCacheBudget>,
+        snapshot: crate::protocol::CatalogueSnapshot,
+    ) -> Result<Self, String> {
+        let (jobs, receiver) = mpsc::channel::<ServerShellCommand>();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (activity_tx, _) = watch::channel(0_u64);
+
+        let join = thread::Builder::new()
+            .name("jazz-server-shell".to_owned())
+            .spawn(move || {
+                let shell = match InMemoryServerShell::start_dynamic_edge_with_catalogue_snapshot(
+                    DbIdentity {
+                        node: NodeUuid::from_bytes([0x5e; 16]),
+                        author: AuthorId::SYSTEM,
+                    },
+                    storage_config,
+                    edge_cache_budget,
+                    snapshot,
+                ) {
+                    Ok(shell) => {
+                        let _ = started_tx.send(Ok(()));
+                        shell
+                    }
+                    Err(error) => {
+                        let _ = started_tx.send(Err(error.to_string()));
+                        return;
+                    }
+                };
+                let mut shell = shell;
+                while let Ok(command) = receiver.recv() {
+                    match command {
+                        ServerShellCommand::Run(job) => job(&mut shell),
+                        ServerShellCommand::Shutdown(stopped) => {
+                            drop(shell);
+                            let _ = stopped.send(());
+                            return;
+                        }
+                    }
+                }
+            })
+            .map_err(|error| format!("failed to spawn server shell thread: {error}"))?;
+
+        started_rx
+            .recv()
+            .map_err(|_| "server shell thread exited before dynamic bootstrap".to_owned())??;
+        Ok(Self {
+            inner: Arc::new(ServerShellInner {
+                jobs: Mutex::new(Some(jobs)),
+                join: Mutex::new(Some(join)),
+                activity_tx,
+            }),
+        })
+    }
+
+    pub(crate) async fn encoded_trusted_catalogue_snapshot(
+        &self,
+        protocol_version: u16,
+        features: crate::wire::WireFeatures,
+    ) -> Result<Vec<AbiBytes>, String> {
+        self.run(move |shell| {
+            shell
+                .encoded_trusted_catalogue_snapshot(protocol_version, features)
+                .map_err(|error| error.to_string())
+        })
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn trusted_catalogue_snapshot_for_test(
+        &self,
+    ) -> Result<crate::protocol::CatalogueSnapshot, String> {
+        self.run(move |shell| {
+            shell
+                .trusted_catalogue_snapshot()
+                .map_err(|error| error.to_string())
+        })
+        .await
+    }
     #[cfg(test)]
     pub(crate) async fn runtime_catalogue_contains(
         &self,

--- a/crates/jazz/src/tools/server/core_websocket_transport.rs
+++ b/crates/jazz/src/tools/server/core_websocket_transport.rs
@@ -1,10 +1,12 @@
-use std::collections::VecDeque;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crate::db::ConnectionSessionContext;
+use crate::db::{ConnectionSessionContext, WireTransportAdapter};
 use crate::ids::{AuthorId, NodeUuid};
+use crate::protocol_limits::{
+    MAX_WIRE_BATCH_FRAMES, MAX_WIRE_FRAME_BYTES, validate_wire_frame_len,
+};
 use crate::wire::{
     FEATURE_SYNC_MESSAGE_PAYLOAD, TransportError, WIRE_PROTOCOL_VERSION, WireAuthorityEndpoint,
     WireError, WireFrame, WireHello, WirePeerRole, WireTransport, current_wire_features,
@@ -12,21 +14,28 @@ use crate::wire::{
 };
 use futures::{SinkExt as _, StreamExt as _};
 use std::sync::atomic::{AtomicU64, Ordering};
-use tokio::sync::mpsc;
-use tokio_tungstenite::connect_async;
+use tokio::sync::{Notify, Semaphore, mpsc};
+use tokio_tungstenite::connect_async_with_config;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 
 use crate::tools::AppId;
 use crate::tools::websocket_prelude_auth::AuthConfig;
 
 const WS_CLIENT_REQUIRED_FEATURES: u64 = FEATURE_SYNC_MESSAGE_PAYLOAD;
 const WS_CLIENT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
-// The serving route caps each WebSocket message at one MiB. Keep a small
-// postcard framing reserve so a burst of individually-valid wire frames never
-// becomes an invalid WebSocket message.
-const WS_CLIENT_BATCH_BYTES: usize = 1 << 20;
+// The serving route caps client-to-server WebSocket messages at one MiB. Keep
+// a small postcard framing reserve so a burst of individually-valid wire
+// frames never becomes an invalid request message.
+const WS_CLIENT_OUTBOUND_BATCH_BYTES: usize = 1 << 20;
 const POSTCARD_FRAME_LENGTH_RESERVE: usize = 5;
 const POSTCARD_BATCH_LENGTH_RESERVE: usize = 5;
+/// Bound a malicious upstream before the wire reassembler gets a chance to
+/// retain fragments. This applies equally to normal and bootstrap links. The
+/// sender waits when full, so a valid fragmented maximum-size catalogue is
+/// streamed through as its consumer drains rather than rejected mid-message.
+const WS_CLIENT_INBOUND_FRAME_SLOTS: usize = 64;
+const WS_CLIENT_MAX_QUEUED_BYTES: usize = 8 << 20;
 static NEXT_CLIENT_CONNECTION_EPOCH: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug)]
@@ -71,7 +80,9 @@ impl fmt::Display for WebSocketClientError {
 impl std::error::Error for WebSocketClientError {}
 
 pub struct WebSocketTransport {
-    inbound: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    inbound: Arc<Mutex<mpsc::Receiver<InboundFrame>>>,
+    inbound_error: Arc<Mutex<Option<String>>>,
+    inbound_notify: Arc<Notify>,
     outbound: mpsc::UnboundedSender<Vec<u8>>,
     wake: Arc<dyn Fn() + Send + Sync>,
     task: tokio::task::JoinHandle<()>,
@@ -80,10 +91,17 @@ pub struct WebSocketTransport {
     session_context: Option<ConnectionSessionContext>,
 }
 
+struct InboundFrame {
+    bytes: Vec<u8>,
+    // Keeping the permit with the queued frame makes the byte bound apply
+    // until the synchronous wire consumer has actually removed the frame.
+    _budget: tokio::sync::OwnedSemaphorePermit,
+}
+
 impl fmt::Debug for WebSocketTransport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WebSocketTransport")
-            .field("inbound", &self.inbound)
+            .field("inbound", &"bounded streaming channel")
             .field("outbound", &self.outbound)
             .field("task", &self.task)
             .finish_non_exhaustive()
@@ -107,14 +125,91 @@ impl WebSocketTransport {
         auth: AuthConfig,
         wake: Arc<dyn Fn() + Send + Sync>,
     ) -> Result<Self, WebSocketClientError> {
+        Self::connect_with_wake_and_bootstrap(base_url, app_id, peer_identity, auth, wake, false)
+            .await
+    }
+
+    /// Open the authenticated snapshot-only bootstrap exchange.  The returned
+    /// transport is deliberately short-lived: after adoption the edge opens a
+    /// fresh ordinary peer connection against the now-ready runtime.
+    pub(crate) async fn connect_catalogue_bootstrap(
+        base_url: impl AsRef<str>,
+        app_id: AppId,
+        peer_identity: AuthorId,
+        auth: AuthConfig,
+    ) -> Result<crate::protocol::CatalogueSnapshot, WebSocketClientError> {
+        validate_catalogue_bootstrap_upstream_url(base_url.as_ref(), app_id)
+            .map_err(WebSocketClientError::ServerRejected)?;
+        let transport = Self::connect_with_wake_and_bootstrap(
+            base_url,
+            app_id,
+            peer_identity,
+            auth,
+            Arc::new(|| {}),
+            true,
+        )
+        .await?;
+        let (protocol_version, features, session_context) =
+            transport.negotiated_transport_metadata();
+        let inbound_error = Arc::clone(&transport.inbound_error);
+        let inbound_notify = Arc::clone(&transport.inbound_notify);
+        let mut wire = WireTransportAdapter::new_with_session_context(
+            transport,
+            protocol_version,
+            features,
+            None,
+            session_context,
+        );
+        let deadline = tokio::time::Instant::now() + WS_CLIENT_HANDSHAKE_TIMEOUT;
+        loop {
+            let notified = inbound_notify.notified();
+            match wire.try_recv_strict() {
+                Ok(Some(message)) => {
+                    return match message {
+                        crate::protocol::SyncMessage::CatalogueSnapshot(snapshot) => Ok(*snapshot),
+                        _ => Err(WebSocketClientError::ServerRejected(
+                            "bootstrap peer sent application traffic instead of a catalogue snapshot"
+                                .to_owned(),
+                        )),
+                    };
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return Err(WebSocketClientError::ServerRejected(format!(
+                        "bootstrap wire validation failed: {:?}: {}",
+                        error.code, error.message
+                    )));
+                }
+            }
+            if let Some(error) = inbound_error.lock().ok().and_then(|error| error.clone()) {
+                return Err(WebSocketClientError::ServerRejected(error));
+            }
+            tokio::select! {
+                _ = notified => {}
+                _ = tokio::time::sleep_until(deadline) => {
+                    return Err(WebSocketClientError::HandshakeTimeout);
+                }
+            }
+        }
+    }
+
+    async fn connect_with_wake_and_bootstrap(
+        base_url: impl AsRef<str>,
+        app_id: AppId,
+        peer_identity: AuthorId,
+        auth: AuthConfig,
+        wake: Arc<dyn Fn() + Send + Sync>,
+        bootstrap_catalogue: bool,
+    ) -> Result<Self, WebSocketClientError> {
         let url = ws_url(base_url.as_ref(), app_id);
-        let (mut ws, _) = connect_async(url)
+        let (mut ws, _) = connect_async_with_config(url, Some(client_websocket_config()), false)
             .await
             .map_err(WebSocketClientError::Connect)?;
 
         let prelude = serde_json::to_vec(&WebSocketClientPrelude {
             peer_identity: hex::encode(peer_identity.as_bytes()),
             auth,
+            bootstrap_catalogue,
         })
         .map_err(WebSocketClientError::EncodePrelude)?;
         ws.send(Message::Binary(prelude.into()))
@@ -175,17 +270,27 @@ impl WebSocketTransport {
             None
         };
 
-        let inbound = Arc::new(Mutex::new(VecDeque::new()));
+        let (inbound_tx, inbound_rx) = mpsc::channel(WS_CLIENT_INBOUND_FRAME_SLOTS);
+        let inbound = Arc::new(Mutex::new(inbound_rx));
+        let inbound_error = Arc::new(Mutex::new(None));
+        let inbound_notify = Arc::new(Notify::new());
+        let inbound_budget = Arc::new(Semaphore::new(WS_CLIENT_MAX_QUEUED_BYTES));
         let (outbound, outbound_rx) = mpsc::unbounded_channel();
         let task = tokio::spawn(run_ws_pump(
             ws,
-            inbound.clone(),
+            inbound_tx,
+            inbound_budget,
+            Arc::clone(&inbound_error),
+            Arc::clone(&inbound_notify),
             outbound_rx,
             Arc::clone(&wake),
+            bootstrap_catalogue,
         ));
 
         Ok(Self {
             inbound,
+            inbound_error,
+            inbound_notify,
             outbound,
             wake,
             task,
@@ -225,18 +330,15 @@ impl WireTransport for WebSocketTransport {
 
     fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
         let mut inbound = self.inbound.lock().ok()?;
-        #[cfg(feature = "sync-autopsy")]
-        let before = inbound.len();
-        let frame = inbound.pop_front();
+        let frame = inbound.try_recv().ok();
         #[cfg(feature = "sync-autopsy")]
         if let Some(frame) = &frame {
             crate::db::sync_autopsy::record(format!(
-                "client websocket pop inbound before={before} after={} bytes={}",
-                inbound.len(),
-                frame.len()
+                "client websocket pop inbound bytes={}",
+                frame.bytes.len()
             ));
         }
-        frame
+        frame.map(|frame| frame.bytes)
     }
 }
 
@@ -244,6 +346,12 @@ impl WireTransport for WebSocketTransport {
 struct WebSocketClientPrelude {
     peer_identity: String,
     auth: AuthConfig,
+    #[serde(default, skip_serializing_if = "is_false")]
+    bootstrap_catalogue: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 fn ws_url(base_url: &str, app_id: AppId) -> String {
@@ -253,6 +361,65 @@ fn ws_url(base_url: &str, app_id: AppId) -> String {
         .trim_end_matches('/')
         .to_owned();
     format!("{base}/apps/{app_id}/ws")
+}
+
+fn client_websocket_config() -> WebSocketConfig {
+    WebSocketConfig::default()
+        // The server can batch raw wire frames up to this protocol boundary;
+        // logical catalogue snapshots still span many such WebSocket messages.
+        .max_message_size(Some(MAX_WIRE_FRAME_BYTES))
+        .max_frame_size(Some(MAX_WIRE_FRAME_BYTES))
+}
+
+pub(crate) fn validate_catalogue_bootstrap_upstream_url(
+    base_url: &str,
+    app_id: AppId,
+) -> Result<(), String> {
+    validate_bootstrap_upstream_url(&ws_url(base_url, app_id)).map_err(|error| error.to_string())
+}
+
+/// Bootstrap relies on the configured upstream transport for server identity:
+/// `wss://` gets the existing WebSocket/TLS validation, while plaintext is
+/// deliberately limited to loopback by default.  This is not mutual TLS or a
+/// new cryptographic authority proof; operators must configure a trusted WSS
+/// endpoint for remote edges.
+fn validate_bootstrap_upstream_url(base_url: &str) -> Result<(), WebSocketClientError> {
+    let url = reqwest::Url::parse(base_url).map_err(|error| {
+        WebSocketClientError::ServerRejected(format!("invalid bootstrap upstream URL: {error}"))
+    })?;
+    if url.scheme() != "ws" {
+        return Ok(());
+    }
+    let loopback = url.host_str().is_some_and(|host| {
+        let host = host.trim_matches(['[', ']']);
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    });
+    let explicitly_allowed = std::env::var("JAZZ_ALLOW_INSECURE_EDGE_BOOTSTRAP_WS")
+        .ok()
+        .as_deref()
+        == Some("1");
+    if loopback || explicitly_allowed {
+        Ok(())
+    } else {
+        Err(WebSocketClientError::ServerRejected(
+            "plaintext ws:// bootstrap is allowed only for loopback; configure wss:// or set JAZZ_ALLOW_INSECURE_EDGE_BOOTSTRAP_WS=1 for an explicit development override"
+                .to_owned(),
+        ))
+    }
+}
+
+fn fail_inbound(
+    error_slot: &Arc<Mutex<Option<String>>>,
+    notify: &Notify,
+    error: impl Into<String>,
+) {
+    if let Ok(mut slot) = error_slot.lock() {
+        *slot = Some(error.into());
+    }
+    notify.notify_waiters();
 }
 
 async fn receive_server_hello(
@@ -294,9 +461,13 @@ async fn run_ws_pump(
     mut ws: tokio_tungstenite::WebSocketStream<
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
-    inbound: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    inbound: mpsc::Sender<InboundFrame>,
+    inbound_budget: Arc<Semaphore>,
+    inbound_error: Arc<Mutex<Option<String>>>,
+    inbound_notify: Arc<Notify>,
     mut outbound: mpsc::UnboundedReceiver<Vec<u8>>,
     wake: Arc<dyn Fn() + Send + Sync>,
+    bootstrap_catalogue: bool,
 ) {
     loop {
         tokio::select! {
@@ -311,7 +482,9 @@ async fn run_ws_pump(
                     + POSTCARD_FRAME_LENGTH_RESERVE;
                 while let Ok(frame) = outbound.try_recv() {
                     let frame_bytes = frame.len() + POSTCARD_FRAME_LENGTH_RESERVE;
-                    if batch_bytes.saturating_add(frame_bytes) > WS_CLIENT_BATCH_BYTES {
+                    if batch.len() >= MAX_WIRE_BATCH_FRAMES
+                        || batch_bytes.saturating_add(frame_bytes) > WS_CLIENT_OUTBOUND_BATCH_BYTES
+                    {
                         let Ok(bytes) = postcard::to_allocvec(&batch) else {
                             return;
                         };
@@ -344,29 +517,214 @@ async fn run_ws_pump(
                 }
             }
             message = ws.next() => {
-                let Some(Ok(Message::Binary(bytes))) = message else {
-                    return;
+                let bytes = match message {
+                    Some(Ok(Message::Binary(bytes))) => bytes,
+                    Some(Ok(_)) => {
+                        fail_inbound(&inbound_error, &inbound_notify, "websocket peer sent a non-binary wire batch");
+                        let _ = ws.close(None).await;
+                        return;
+                    }
+                    Some(Err(error)) => {
+                        fail_inbound(&inbound_error, &inbound_notify, format!("websocket receive failed: {error}"));
+                        return;
+                    }
+                    None => {
+                        fail_inbound(&inbound_error, &inbound_notify, "websocket peer closed before completing wire exchange");
+                        return;
+                    }
                 };
-                let Ok(frames) = postcard::from_bytes::<Vec<Vec<u8>>>(&bytes) else {
-                    return;
+                let frames = match decode_inbound_batch(&bytes, bootstrap_catalogue) {
+                    Ok(frames) => frames,
+                    Err(error) => {
+                        fail_inbound(&inbound_error, &inbound_notify, error);
+                        let _ = ws.close(None).await;
+                        return;
+                    }
                 };
-                let Ok(mut queue) = inbound.lock() else {
-                    return;
-                };
-                #[cfg(feature = "sync-autopsy")]
-                let before = queue.len();
                 #[cfg(feature = "sync-autopsy")]
                 let frame_count = frames.len();
-                queue.extend(frames);
+                for frame in frames {
+                    if let Err(error) = validate_wire_frame_len(frame.len()) {
+                        fail_inbound(&inbound_error, &inbound_notify, error);
+                        let _ = ws.close(None).await;
+                        return;
+                    }
+                    let permits = u32::try_from(frame.len()).expect("wire frame limit fits u32");
+                    let Ok(budget) = Arc::clone(&inbound_budget).acquire_many_owned(permits).await else {
+                        return;
+                    };
+                    if inbound.send(InboundFrame { bytes: frame, _budget: budget }).await.is_err() {
+                        return;
+                    }
+                    // A maximum logical message can exceed the bounded
+                    // channel. Wake on every frame so its consumer drains
+                    // before the producer blocks on a later fragment.
+                    inbound_notify.notify_one();
+                    wake();
+                }
                 #[cfg(feature = "sync-autopsy")]
                 crate::db::sync_autopsy::record(format!(
-                    "client websocket received batch frames={frame_count} inbound_before={before} inbound_after={} bytes={}",
-                    queue.len(),
+                    "client websocket received batch frames={frame_count} bytes={}",
                     bytes.len()
                 ));
-                drop(queue);
-                wake();
             }
         }
+    }
+}
+
+fn decode_inbound_batch(bytes: &[u8], bootstrap_catalogue: bool) -> Result<Vec<Vec<u8>>, String> {
+    let frames = postcard::from_bytes::<Vec<Vec<u8>>>(bytes)
+        .map_err(|_| "websocket peer sent malformed wire batch".to_owned())?;
+    if frames.len() > MAX_WIRE_BATCH_FRAMES {
+        return Err(format!(
+            "websocket inbound batch exceeds frame-count limit of {MAX_WIRE_BATCH_FRAMES}"
+        ));
+    }
+    if bootstrap_catalogue && frames.is_empty() {
+        return Err("bootstrap peer sent an empty wire batch".to_owned());
+    }
+    Ok(frames)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Transport;
+    use std::collections::{BTreeMap, VecDeque};
+
+    #[derive(Clone)]
+    struct FrameSink(Arc<Mutex<VecDeque<Vec<u8>>>>);
+
+    impl WireTransport for FrameSink {
+        fn send_frame(&mut self, frame: Vec<u8>) -> Result<(), TransportError> {
+            self.0.lock().expect("frame sink lock").push_back(frame);
+            Ok(())
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    fn valid_fragmented_wire_message_larger_than_ingress_budget() -> Vec<Vec<u8>> {
+        let frames = Arc::new(Mutex::new(VecDeque::new()));
+        let sink = FrameSink(Arc::clone(&frames));
+        let features = FEATURE_SYNC_MESSAGE_PAYLOAD | crate::wire::FEATURE_MESSAGE_FRAGMENTATION;
+        let mut sender = WireTransportAdapter::new(sink, WIRE_PROTOCOL_VERSION, features, None);
+        let body = (0..(WS_CLIENT_MAX_QUEUED_BYTES + 1))
+            .map(|index| char::from((index % 251) as u8))
+            .collect::<String>();
+        sender
+            .send(crate::protocol::SyncMessage::SessionClaims {
+                identity: AuthorId::SYSTEM,
+                claims: BTreeMap::from([(
+                    "catalogue_fixture".to_owned(),
+                    crate::groove::records::Value::String(body),
+                )]),
+            })
+            .expect("encode valid fragmented logical message");
+        let frames = frames
+            .lock()
+            .expect("frame sink lock")
+            .drain(..)
+            .collect::<Vec<_>>();
+        assert!(frames.len() > 1, "message must be wire fragmented");
+        assert!(frames.iter().map(Vec::len).sum::<usize>() > WS_CLIENT_MAX_QUEUED_BYTES);
+        frames
+    }
+
+    #[test]
+    fn bootstrap_ingress_budget_is_finite() {
+        let budget = Arc::new(Semaphore::new(WS_CLIENT_MAX_QUEUED_BYTES));
+        let held = Arc::clone(&budget)
+            .try_acquire_many_owned(WS_CLIENT_MAX_QUEUED_BYTES as u32)
+            .expect("fill finite ingress byte budget");
+        assert!(
+            budget.try_acquire().is_err(),
+            "cap+1 byte is backpressured rather than allocated"
+        );
+        drop(held);
+    }
+
+    #[test]
+    fn websocket_rejects_oversized_physical_messages_before_batch_decode() {
+        let config = client_websocket_config();
+        assert_eq!(config.max_message_size, Some(MAX_WIRE_FRAME_BYTES));
+        assert_eq!(config.max_frame_size, Some(MAX_WIRE_FRAME_BYTES));
+    }
+
+    #[tokio::test]
+    async fn fragmented_bootstrap_larger_than_ingress_budget_streams_with_backpressure() {
+        let (sender, mut receiver) = mpsc::channel::<InboundFrame>(1);
+        let budget = Arc::new(Semaphore::new(WS_CLIENT_MAX_QUEUED_BYTES));
+        let consumer = tokio::spawn(async move {
+            let mut received = 0_usize;
+            while let Some(frame) = receiver.recv().await {
+                received += frame.bytes.len();
+            }
+            received
+        });
+        let frames = valid_fragmented_wire_message_larger_than_ingress_budget();
+        let expected = frames.iter().map(Vec::len).sum::<usize>();
+        for frame in frames {
+            let budget_permit = Arc::clone(&budget)
+                .acquire_many_owned(frame.len() as u32)
+                .await
+                .expect("consumer makes progress under ingress backpressure");
+            sender
+                .send(InboundFrame {
+                    bytes: frame,
+                    _budget: budget_permit,
+                })
+                .await
+                .expect("stream frame");
+        }
+        drop(sender);
+        assert_eq!(consumer.await.expect("consumer task"), expected);
+    }
+
+    #[test]
+    fn malformed_or_truncated_batch_wakes_bootstrap_with_a_terminal_error() {
+        let error = Arc::new(Mutex::new(None));
+        let notify = Notify::new();
+        fail_inbound(&error, &notify, "websocket peer sent malformed wire batch");
+        assert_eq!(
+            error.lock().expect("queue lock").as_deref(),
+            Some("websocket peer sent malformed wire batch")
+        );
+    }
+
+    #[test]
+    fn bootstrap_count_flood_or_empty_batch_is_rejected_before_ingress_staging() {
+        let empty = postcard::to_allocvec(&Vec::<Vec<u8>>::new()).expect("encode empty batch");
+        assert!(
+            decode_inbound_batch(&empty, true)
+                .expect_err("bootstrap must reject empty batches")
+                .contains("empty")
+        );
+
+        let flood = postcard::to_allocvec(&vec![Vec::<u8>::new(); MAX_WIRE_BATCH_FRAMES + 1])
+            .expect("encode count flood below physical byte cap");
+        assert!(flood.len() <= MAX_WIRE_FRAME_BYTES);
+        assert!(
+            decode_inbound_batch(&flood, false)
+                .expect_err("count flood must be rejected before channel staging")
+                .contains("frame-count limit")
+        );
+    }
+
+    #[test]
+    fn remote_plaintext_bootstrap_requires_explicit_override() {
+        assert!(validate_bootstrap_upstream_url("ws://127.0.0.1:4200").is_ok());
+        assert!(validate_bootstrap_upstream_url("ws://[::1]:4200").is_ok());
+        assert!(validate_bootstrap_upstream_url("wss://core.example.test").is_ok());
+        assert!(validate_bootstrap_upstream_url("ws://[::2]:4200").is_err());
+        assert!(validate_bootstrap_upstream_url("ws://core.example.test").is_err());
+        assert!(
+            validate_bootstrap_upstream_url("ws://core.example.test")
+                .expect_err("remote plaintext bootstrap must fail")
+                .to_string()
+                .contains("plaintext ws:// bootstrap")
+        );
     }
 }

--- a/crates/jazz/src/tools/server/mod.rs
+++ b/crates/jazz/src/tools/server/mod.rs
@@ -104,6 +104,36 @@ impl ServerState {
         Ok(started)
     }
 
+    /// Atomically publish a normal edge runtime after its independent
+    /// authenticated catalogue bootstrap completed. Holding the state lock
+    /// across construction makes downstream admission observe either no shell
+    /// (retry later) or the fully adopted ready shell, never a half-ready one.
+    pub(crate) fn start_dynamic_edge_shell(
+        &self,
+        snapshot: crate::protocol::CatalogueSnapshot,
+        edge_cache_budget: Option<crate::node::EdgeCacheBudget>,
+    ) -> Result<core_server_shell::ServerShellHandle, String> {
+        if self.topology != ServerTopology::Edge {
+            return Err("dynamic catalogue bootstrap is only valid for edge topology".to_owned());
+        }
+        let storage_config = self
+            .core_server_shell_storage_config
+            .clone()
+            .ok_or_else(|| "server shell storage is not configured".to_owned())?;
+        let mut core_server_shell = self.core_server_shell.write().unwrap();
+        if let Some(existing) = core_server_shell.clone() {
+            return Ok(existing);
+        }
+        let started =
+            core_server_shell::ServerShellHandle::start_dynamic_edge_with_catalogue_snapshot(
+                storage_config,
+                edge_cache_budget,
+                snapshot,
+            )?;
+        *core_server_shell = Some(started.clone());
+        Ok(started)
+    }
+
     /// Start (once) and await the server-wide teardown barrier.
     ///
     /// The first caller only launches the owned finalizer; it does not own the

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -13,7 +13,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::db::{CommitUnitTrust, ConnectionSessionContext};
 use crate::groove::records::Value as CoreValue;
 use crate::ids::{AuthorId, NodeUuid};
-use crate::protocol_limits::{MAX_WIRE_FRAME_BYTES, validate_wire_frame_len};
+use crate::protocol_limits::{
+    MAX_WIRE_BATCH_FRAMES, MAX_WIRE_FRAME_BYTES, validate_wire_frame_len,
+};
 use crate::wire::{
     FEATURE_SYNC_MESSAGE_PAYLOAD, WIRE_PROTOCOL_VERSION, WireAuthorityEndpoint, WireError,
     WireErrorCode, WireFrame, WireHello, WirePeerRole, WireRetry, current_wire_features,
@@ -72,6 +74,17 @@ struct WebSocketAdmission {
     identity: AuthorId,
     claims: BTreeMap<String, CoreValue>,
     trust: CommitUnitTrust,
+    credential: WebSocketCredential,
+}
+
+/// Authentication class selected by the prelude.  `TrustedBackend` is still
+/// the normal commit-ingest trust level for both machine credentials, but the
+/// privileged catalogue bootstrap has a narrower authority boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WebSocketCredential {
+    Admin,
+    Backend,
+    Session,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -151,6 +164,10 @@ fn ws_live_admissions_for(key: WebSocketAdmissionKey) -> usize {
 struct WebSocketPrelude {
     peer_identity: String,
     auth: crate::tools::websocket_prelude_auth::AuthConfig,
+    /// A one-shot authenticated authority-catalogue transfer. This is not a
+    /// subscriber session and never admits application frames.
+    #[serde(default)]
+    bootstrap_catalogue: bool,
 }
 
 async fn ws_admission(
@@ -171,6 +188,7 @@ async fn ws_admission(
             identity: peer_identity,
             claims: BTreeMap::new(),
             trust: CommitUnitTrust::TrustedBackend,
+            credential: WebSocketCredential::Admin,
         });
     }
 
@@ -207,6 +225,7 @@ async fn ws_admission(
             identity: peer_identity,
             claims: BTreeMap::new(),
             trust: CommitUnitTrust::TrustedBackend,
+            credential: WebSocketCredential::Backend,
         });
     }
 
@@ -237,6 +256,7 @@ async fn ws_admission(
         identity: peer_identity,
         claims: session_claims(session)?,
         trust: CommitUnitTrust::Session,
+        credential: WebSocketCredential::Session,
     })
 }
 
@@ -483,6 +503,7 @@ async fn handle_ws_connection(
             return;
         }
     };
+    let bootstrap_catalogue = prelude.bootstrap_catalogue;
     let admission = match ws_admission(prelude, &request_headers, &state).await {
         Ok(admission) => admission,
         Err(error) => {
@@ -550,13 +571,89 @@ async fn handle_ws_connection(
     // endpoint (below), so this directional capability advertisement does not
     // turn a client self-assertion into authority proof.
 
+    if bootstrap_catalogue {
+        if admission.credential != WebSocketCredential::Admin
+            || admission.identity != AuthorId::SYSTEM
+            || state.topology != crate::tools::server::ServerTopology::Core
+        {
+            send_ws_error(
+                &mut socket,
+                WireError::new(
+                    WireErrorCode::AuthFailed,
+                    WireRetry::Never,
+                    "catalogue bootstrap requires the authenticated core authority",
+                ),
+            )
+            .await;
+            let _ = socket.close().await;
+            return;
+        }
+        let Some(core_server_shell) = state.core_server_shell() else {
+            send_ws_error(
+                &mut socket,
+                WireError::new(
+                    WireErrorCode::Internal,
+                    WireRetry::Later,
+                    "authority runtime is not ready to provide its catalogue",
+                ),
+            )
+            .await;
+            let _ = socket.close().await;
+            return;
+        };
+        let server_endpoint = WireAuthorityEndpoint {
+            node: NodeUuid::from_bytes([0x5e; 16]),
+            epoch: WS_NEXT_CONNECTION_EPOCH.fetch_add(1, Ordering::Relaxed),
+        };
+        let hello = match encode_frame(&WireFrame::Hello(
+            WireHello::current(WirePeerRole::Core, negotiated.features)
+                .with_authority(server_endpoint.node, server_endpoint.epoch),
+        )) {
+            Ok(frame) => frame,
+            Err(error) => {
+                send_ws_error(
+                    &mut socket,
+                    WireError::new(
+                        WireErrorCode::Internal,
+                        WireRetry::Never,
+                        format!("failed to encode bootstrap hello: {error}"),
+                    ),
+                )
+                .await;
+                let _ = socket.close().await;
+                return;
+            }
+        };
+        if send_ws_encoded_frames(&mut socket, &[hello]).await.is_err() {
+            return;
+        }
+        let frames = match core_server_shell
+            .encoded_trusted_catalogue_snapshot(negotiated.protocol_version, negotiated.features)
+            .await
+        {
+            Ok(frames) => frames,
+            Err(error) => {
+                send_ws_error(
+                    &mut socket,
+                    WireError::new(WireErrorCode::Internal, WireRetry::Later, error),
+                )
+                .await;
+                let _ = socket.close().await;
+                return;
+            }
+        };
+        let _ = send_ws_encoded_frames(&mut socket, &frames).await;
+        let _ = socket.close().await;
+        return;
+    }
+
     let Some(core_server_shell) = state.core_server_shell() else {
         send_ws_error(
             &mut socket,
             WireError::new(
                 WireErrorCode::Internal,
-                WireRetry::Never,
-                "websocket requires a published schema",
+                WireRetry::Later,
+                "edge runtime is bootstrapping its authoritative catalogue; retry shortly",
             ),
         )
         .await;
@@ -805,9 +902,11 @@ fn decode_ws_encoded_frame_batch(bytes: &[u8]) -> Result<Vec<Vec<u8>>, postcard:
         return Err(postcard::Error::DeserializeUnexpectedEnd);
     }
     let frames = postcard::from_bytes::<Vec<Vec<u8>>>(bytes)?;
-    if frames
-        .iter()
-        .any(|frame| validate_wire_frame_len(frame.len()).is_err())
+    if frames.is_empty()
+        || frames.len() > MAX_WIRE_BATCH_FRAMES
+        || frames
+            .iter()
+            .any(|frame| validate_wire_frame_len(frame.len()).is_err())
     {
         return Err(postcard::Error::DeserializeUnexpectedEnd);
     }
@@ -852,7 +951,9 @@ fn encode_ws_frame_batches(frames: &[Vec<u8>]) -> Result<Vec<Vec<u8>>, postcard:
         let mut candidate = current.clone();
         candidate.push(frame.clone());
         let encoded = postcard::to_allocvec(&candidate)?;
-        if encoded.len() > MAX_WIRE_FRAME_BYTES && !current.is_empty() {
+        if (current.len() >= MAX_WIRE_BATCH_FRAMES || encoded.len() > MAX_WIRE_FRAME_BYTES)
+            && !current.is_empty()
+        {
             batches.push(postcard::to_allocvec(&current)?);
             current.clear();
         } else if encoded.len() > MAX_WIRE_FRAME_BYTES {
@@ -1127,6 +1228,7 @@ mod tests {
         let forged_peer = AuthorId::from_bytes([0x52; 16]);
         let prelude = WebSocketPrelude {
             peer_identity: hex::encode(forged_peer.as_bytes()),
+            bootstrap_catalogue: false,
             auth: crate::tools::websocket_prelude_auth::AuthConfig {
                 backend_secret: Some("backend-secret".to_owned()),
                 backend_session: Some(serde_json::json!({
@@ -1159,6 +1261,7 @@ mod tests {
         let user_id = uuid::Uuid::from_bytes(*identity.as_bytes()).to_string();
         let prelude = WebSocketPrelude {
             peer_identity: hex::encode(identity.as_bytes()),
+            bootstrap_catalogue: false,
             auth: crate::tools::websocket_prelude_auth::AuthConfig {
                 backend_secret: Some("backend-secret".to_owned()),
                 backend_session: Some(serde_json::json!({
@@ -1337,6 +1440,37 @@ mod tests {
             let decoded = decode_ws_encoded_frame_batch(&batch).expect("decode bounded batch");
             assert_eq!(decoded.len(), 1);
         }
+    }
+
+    #[test]
+    fn websocket_frame_batches_split_at_protocol_frame_count_cap() {
+        let frames = vec![vec![0x42]; MAX_WIRE_BATCH_FRAMES + 1];
+        let batches = encode_ws_frame_batches(&frames).expect("split bounded frame count");
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(
+            decode_ws_encoded_frame_batch(&batches[0])
+                .expect("decode first bounded batch")
+                .len(),
+            MAX_WIRE_BATCH_FRAMES
+        );
+        assert_eq!(
+            decode_ws_encoded_frame_batch(&batches[1])
+                .expect("decode remaining bounded batch")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn websocket_frame_batch_decoder_rejects_empty_and_count_floods() {
+        let empty = postcard::to_allocvec(&Vec::<Vec<u8>>::new()).expect("encode empty batch");
+        assert!(decode_ws_encoded_frame_batch(&empty).is_err());
+
+        let flood = postcard::to_allocvec(&vec![Vec::<u8>::new(); MAX_WIRE_BATCH_FRAMES + 1])
+            .expect("encode count flood below physical byte cap");
+        assert!(flood.len() <= MAX_WIRE_FRAME_BYTES);
+        assert!(decode_ws_encoded_frame_batch(&flood).is_err());
     }
 
     #[test]


### PR DESCRIPTION
🤖 WIP implementation of persistent dynamic-edge catalogue bootstrap on top of #1518.

This draft now contains the reviewed durable state seam and the reviewed authenticated wire/bootstrap driver. It deliberately keeps the three dynamic/stale-edge burndown rows quarantined until persistent server restart is tested with the #1525/#1545 teardown stack.

## What changed

- adds explicit `Uninitialized → Ready` catalogue state instead of constructing `JazzSchema::new([])`
- persists no local genesis/schema/mapping/application residue before bootstrap
- atomically adopts the authority's exact snapshot plus a durable completeness receipt
- validates fresh-process recovery, active/inactive staged lineage state, exact schema/mapping ownership, and rejects truncated/smuggled/stale stores
- gates every direct ingest, Fate, branch, transaction, and current-schema entrypoint until Ready
- adds a schema-independent `bootstrap_catalogue` WebSocket prelude before normal `Db`/peer construction
- requires explicit Admin capability, reserved SYSTEM edge identity, and Core topology; backend/session credentials cannot fetch the snapshot
- drives bootstrap while idle, publishes the normal shell only after atomic adoption, then opens the existing upstream peer
- returns retry-later to downstream clients until Ready
- retries malformed/failed adoption without publishing partial state
- streams large fragmented snapshots through bounded backpressure and uses strict fail-closed decoding
- enforces symmetric physical-message and batch-cardinality limits on client and server
- rejects non-loopback plaintext bootstrap synchronously unless the explicit development override is set

## Validation

- 7 focused durable bootstrap/recovery/corruption tests
- successful bootstrap → fresh RocksDB reopen Ready
- injected failure → fresh reopen Uninitialized without partial state
- real `AfterStaged` crash → fresh reopen drains activation → second reopen Ready
- markerless/truncated/mismatched, smuggled schema, and stripped-history plants reject without repair
- direct CommitUnit/edge/relay/Fate/branch/transaction paths reject while Uninitialized
- idle Core → blank edge bootstrap → first normal client passes
- wrong admin, valid backend credential, and spoofed identity deny snapshot access
- malformed snapshot remains unready then retries successfully
- >8 MiB fragmented logical stream passes under bounded backpressure
- malformed frame/fragment before later valid traffic rejects terminally
- client/server empty and >4096-frame batch floods reject
- remote plaintext configuration rejects during builder construction; loopback IPv4/IPv6 and WSS pass
- full Jazz test compilation (`--no-run`), cargo check, clippy with warnings denied, rustfmt, sensitive-data guard

Independent adversarial review found no remaining P0–P2 issues in either commit.

## Remaining work before row retirement

Stack the shutdown lifecycle work (#1525/#1545), add a persistent server restart/reconnect receipt that proves the shell releases RocksDB and reuses the durable Ready catalogue, then rerun:

- `edge_catalogue_publish_reaches_peer_edge_through_core_sync`
- `persisted_stale_edge_reconnect_replays_catalogue_before_client_work`
- `core_permission_retightening_reaches_subscribed_clients_on_every_edge`

No quarantine marker or burndown entry is removed here.
