### PR TITLE
docs: record policy replacement evolution question

### DIFF
--- a/crates/jazz/SPEC/7_authorization.md
+++ b/crates/jazz/SPEC/7_authorization.md
@@ -345,6 +345,21 @@ client-supplied values must not widen those facts.
   composition. Range/null predicates remain fail-closed. Decide whether to add
   direct support for the remaining query predicates or reject them earlier in
   policy-specific validation.
+- 🔶 **Policy replacement across schema evolution.** The current implementation
+  selects the active policy-owning schema independently for each operation: a
+  newer schema replaces a read, insert, update, or delete policy only when it
+  declares the applicable clause; otherwise that operation can continue using
+  the preceding active policy definition. Decide whether this is the intended
+  migration model, or whether every newly activated schema must instead provide
+  a complete replacement policy bundle for every surviving table. A
+  policy-complete model must define whether an omitted clause means public,
+  inherited, or invalid, and catalogue validation must reject ambiguous partial
+  replacements. It must also define what replacement means when a table is
+  renamed, split, copied, or dropped: whether the old table's policy disappears,
+  remains available only for historical/old-schema operations, or must be
+  explicitly mapped or tombstoned by the lineage publication. The decision must
+  preserve deterministic authorization for old authored versions, live clients
+  on older schemas, historical reads, and operation-specific permission advice.
 - 🔶 **History visibility rule.** Decide whether current-row readability should
   imply visibility for all historical versions of that row, or whether history
   sync/read must evaluate read policy per historical cut.


### PR DESCRIPTION
🤖 Records an explicit authorization-design question exposed by schema evolution.

The current implementation selects the active policy-owning schema independently for each operation. A newer schema replaces a read or operation-specific write policy only when it declares the applicable clause; otherwise the preceding active policy definition can remain applicable.

This documentation-only change asks whether that inheritance model is intended, or whether activating a schema must provide a complete replacement policy bundle for every surviving table. It identifies the decisions a policy-complete model would require:

- whether omission means public, inherited, or invalid;
- how catalogue validation rejects ambiguous partial replacements;
- what happens to policy identity when tables are renamed, copied, split, or dropped;
- how old authored versions, old-schema clients, historical reads, and permission advice remain deterministic.

No runtime behavior or accepted #1538 implementation is changed.

Validation: `oxfmt`, `git diff --check`, and the public sensitive-data guard.
