### PR TITLE
docs: track atomic schema admin API launch work

### DIFF
--- a/LAUNCH-TODO.md
+++ b/LAUNCH-TODO.md
@@ -1,0 +1,29 @@
+# Launch TODOs
+
+## Public schema administration API
+
+Design a public schema administration API that makes the catalogue invariant
+explicit: activating a non-genesis schema and publishing its lineage-defining
+lens are one atomic operation.
+
+The current administrative surface still reflects an older schema-first model
+in which a schema may be uploaded as a draft and a migration supplied later.
+Before launch, decide whether that draft workflow should remain public, become
+an explicitly named staging API, or be replaced by a single atomic publication
+operation.
+
+The design must specify:
+
+- how callers submit and validate the target schema, source schema, lens, table
+  partition changes, and current-write-pointer transition;
+- whether drafts have durable public identities and how they are listed,
+  replaced, abandoned, and garbage-collected;
+- idempotency, optimistic concurrency, authorization, auditability, and error
+  behavior for retries and competing administrators;
+- how generated/client schema tooling obtains the lineage bundle it must
+  publish; and
+- how the existing administrative endpoints migrate without creating a path
+  that can expose a non-genesis schema before its lens is active.
+
+This item records an open API-design task. It does not reopen the runtime
+invariant: runtime activation remains atomic across schema and lens.


### PR DESCRIPTION
🤖 Adds a launch-level design TODO for replacing or explicitly reframing the schema-first administrative workflow around the runtime invariant that non-genesis schema activation and its lineage lens are atomic.

The note records the API questions around staging, identity, validation, retries, authorization, tooling, migration, and preventing premature runtime exposure. It deliberately does not choose the final public API shape.
