### PR TITLE
ci: move core checks to Blacksmith

### DIFF
--- a/.github/actions/setup-blacksmith/action.yml
+++ b/.github/actions/setup-blacksmith/action.yml
@@ -1,0 +1,85 @@
+name: Set up Blacksmith CI
+description: Verify the immutable tool image and attach repository-scoped caches.
+
+inputs:
+  sccache-s3:
+    description: Enable the already-authenticated shared S3 cache tier.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Verify immutable toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "JAZZ_TEST_ARTIFACT_LOCK_PATH=${RUNNER_TEMP}/jazz-test-artifacts.lock" >> "${GITHUB_ENV}"
+        test "$(node --version)" = "v24.13.0"
+        test "$(pnpm --version)" = "10.14.0"
+        rustc --version | grep -F "1.93.1"
+        cargo clippy --version
+        cargo fmt --version
+        rustup target list --installed | grep -Fx "wasm32-unknown-unknown"
+        sccache --version | grep -F "0.15.0"
+        cargo-nextest --version | grep -F "0.9.143"
+        wasm-pack --version | grep -F "0.13.1"
+        wasm-bindgen --version | grep -F "0.2.117"
+        test -r /opt/jazz-ci/toolchains/v1/manifest.json
+        test -d "${PLAYWRIGHT_BROWSERS_PATH}"
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+        mkdir -p /github/home/.cache
+        if [[ ! -e /github/home/.cache/ms-playwright ]]; then
+          ln -s "${PLAYWRIGHT_BROWSERS_PATH}" /github/home/.cache/ms-playwright
+        fi
+        test "$(readlink -f /github/home/.cache/ms-playwright)" = "${PLAYWRIGHT_BROWSERS_PATH}"
+
+    - name: Restore pnpm store
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: /github/home/.local/share/pnpm/store
+        key: blacksmith-pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          blacksmith-pnpm-${{ runner.os }}-
+
+    - name: Install workspace dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Cache Rust build artifacts
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-on-failure: true
+        cache-bin: false
+        prefix-key: blacksmith-rocksdb-v1
+        key: repo-${{ env.CACHE_SCOPE_REPOSITORY_ID }}
+
+    - name: Start isolated sccache daemon
+      shell: bash
+      env:
+        ENABLE_S3: ${{ inputs.sccache-s3 }}
+      run: |
+        set -euo pipefail
+        socket="${RUNNER_TEMP}/sccache-server.sock"
+        cache_dir="${RUNNER_TEMP}/sccache-local"
+        mkdir -p "${cache_dir}"
+        echo "RUSTC_WRAPPER=sccache" >> "${GITHUB_ENV}"
+        echo "SCCACHE_BASEDIRS=${GITHUB_WORKSPACE}" >> "${GITHUB_ENV}"
+        echo "SCCACHE_DIR=${cache_dir}" >> "${GITHUB_ENV}"
+        echo "SCCACHE_SERVER_UDS=${socket}" >> "${GITHUB_ENV}"
+        echo "SCCACHE_CACHE_SIZE=5G" >> "${GITHUB_ENV}"
+        if [[ "${ENABLE_S3}" == "true" ]]; then
+          echo "SCCACHE_MULTILEVEL_CHAIN=disk,s3" >> "${GITHUB_ENV}"
+          echo "SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY=l0" >> "${GITHUB_ENV}"
+          SCCACHE_BASEDIRS="${GITHUB_WORKSPACE}" \
+            SCCACHE_MULTILEVEL_CHAIN=disk,s3 \
+            SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY=l0 \
+            SCCACHE_DIR="${cache_dir}" \
+            SCCACHE_SERVER_UDS="${socket}" \
+            sccache --start-server
+        else
+          SCCACHE_BASEDIRS="${GITHUB_WORKSPACE}" \
+            SCCACHE_DIR="${cache_dir}" \
+            SCCACHE_SERVER_UDS="${socket}" \
+            sccache --start-server
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,43 @@ concurrency:
 
 env:
   CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
+  SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+  SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
+  SCCACHE_S3_USE_SSL: "true"
+  SCCACHE_S3_KEY_PREFIX: jazz-ci/v1/production/blacksmith-v1
+  # The AWS roles enforce the cache boundary: PR credentials cannot PutObject,
+  # while trusted branch credentials can. sccache has no S3 read-only switch.
 
 jobs:
   lint:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-build
+      - name: Authenticate read-only PR sccache
+        if: github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
-          rust-targets: wasm32-unknown-unknown
-          rust-components: clippy,rustfmt
-          sccache: "true"
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache writer
+        if: github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
 
       - run: pnpm format:check
       - run: pnpm lint
@@ -35,24 +59,39 @@ jobs:
       - run: pnpm test:ci-workflow
       - name: Verify Turbo artifact cache inputs
         run: pnpm test:turbo-cache-inputs
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats
 
   test-rust:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-build
+      - name: Authenticate read-only PR sccache
+        if: github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
-          rust-targets: wasm32-unknown-unknown
-          sccache: "true"
-
-      - name: Install bounded Rust test runner
-        uses: ./.github/actions/install-rust-tool
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache writer
+        if: github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
-          # Download the release asset rather than compiling the runner in
-          # every job. Keep this explicit so test selection is reproducible.
-          tool: cargo-nextest@0.9.143
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
       - name: Workspace Rust tests (bounded, sharded, receipted)
         run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features test
       - name: Verify Nextest partition coverage
@@ -64,6 +103,9 @@ jobs:
           name: rust-test-receipt
           path: target/test-receipts/*.json
           if-no-files-found: error
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats
       # The correctness story of the engine-swap PR, first-class in CI
       # (Anselm-approved 2026-07-19): mechanism canaries, differential
       # harnesses, and the maintained-vs-one-shot oracle at a CI-sized seed
@@ -76,20 +118,47 @@ jobs:
           JAZZ_SEED_COUNT=50 cargo test -p jazz m3_maintained_one_shot_differential_oracle
 
   test-ts:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     # JAZZ_NAPI_RELEASE=0 (debug builds) removed 2026-07-19: debug-profile
     # jazz-napi .node files fail dlopen on the Linux runners deterministically
     # (root cause TBD; see dev/CI_NOTES.md). Release builds load fine.
 
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-build
+      - name: Authenticate read-only PR sccache
+        if: github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
-          rust-targets: wasm32-unknown-unknown
-          sccache: "true"
-          sccache-sticky-disk: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'true' || 'false' }}
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache writer
+        if: github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Set up signed Turbo Remote Cache
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: garden-co
+          policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c
+          audience: https://github.com/garden-co
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
 
       # Keep the integration-branch compile gate, but run it as the first
       # phase of this trusted-runner job. Keeping it here avoids a separate
@@ -101,36 +170,20 @@ jobs:
       - name: Check integration workspace
         run: cargo check --workspace --all-targets
 
-      - name: Install WASM packager
-        # Only this job builds jazz-wasm. Other Rust jobs receive their target
-        # through setup-build but do not pay to install the packager.
-        uses: ./.github/actions/install-rust-tool
-        with:
-          tool: wasm-pack@0.13.1
-
-      - name: Mount Turbo sticky disk
-        if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]')
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
-        with:
-          key: turbo-cache-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
-          path: ${{ github.workspace }}/.turbo/cache
-
       # Correctness tests use an unoptimised, provenance-checked WASM build.
       # Package/publish workflows continue to use jazz-wasm's release build.
-      # The script reuses the restored default Cargo target, runs NAPI alone on
-      # the 4-vCPU runner, then overlaps CLI with fast WASM. It only repairs
-      # NAPI if its first load check proves the artifact unusable.
+      # The script reuses the restored default Cargo target, runs NAPI alone,
+      # then overlaps CLI with fast WASM. Each deterministic build is a signed
+      # Turbo task; the nondeterministic test suites below remain uncached.
       - name: Build correctness-test artifacts
         run: pnpm build:test-artifacts
-      - name: Mount Playwright sticky disk
-        if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]')
-        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1
-        with:
-          key: playwright-browsers-${{ env.CACHE_SCOPE_REPOSITORY_ID }}-${{ runner.os }}-v1
-          path: /home/runner/.cache/ms-playwright
-      - run: pnpm exec playwright install chromium
+      - name: Verify preinstalled Chromium
+        run: pnpm exec playwright install --dry-run chromium
       # Both suites consume the already-built artifacts and do not write shared
       # outputs. Running them together avoids extending the PR critical path
       # while retaining the complete Node and browser coverage in this gate.
       - name: Run Node and browser test suites in parallel
         run: dev/gates/run-ts-tests.sh
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats

--- a/dev/gates/build-test-artifacts.mjs
+++ b/dev/gates/build-test-artifacts.mjs
@@ -338,16 +338,40 @@ export async function buildTestArtifacts(run = command, scope = createBuildScope
   // CPUs. NAPI is the long pole and benefits most from running alone. Once it
   // is complete, CLI and fast WASM can share the remaining compile window;
   // jazz-tools then consumes both generated prerequisites.
-  await guardedRun("pnpm", ["--filter", "jazz-napi", "build"], "release NAPI");
-  const cli = guardedRun("pnpm", ["--filter", "@jazz/rust", "build:crates"], "CLI");
-  const wasm = guardedRun("pnpm", ["--filter", "jazz-wasm", "build:fast"], "fast WASM");
+  await guardedRun(
+    "pnpm",
+    ["exec", "turbo", "run", "build", "--filter=jazz-napi", "--only"],
+    "release NAPI",
+  );
+  const cli = guardedRun(
+    "pnpm",
+    ["exec", "turbo", "run", "build:crates", "--filter=@jazz/rust", "--only"],
+    "CLI",
+  );
+  const wasm = guardedRun(
+    "pnpm",
+    ["exec", "turbo", "run", "build:fast", "--filter=jazz-wasm", "--only"],
+    "fast WASM",
+  );
   try {
     await Promise.all([cli, wasm]);
   } catch (error) {
     await scope.drain();
     throw firstBuildError ?? error;
   }
-  await guardedRun("pnpm", ["--filter", "jazz-tools", "build"], "jazz-tools");
+  // The parallel CLI Cargo process can overlap the WASM build's first receipt.
+  // Seal the completed (or signed-cache-restored) artifact against the stable
+  // post-build checkout before any consumer uses it.
+  await guardedRun(
+    "node",
+    ["dev/artifacts/provenance.mjs", "write", "wasm", "fast"],
+    "seal fast WASM provenance",
+  );
+  await guardedRun(
+    "pnpm",
+    ["exec", "turbo", "run", "build", "--filter=jazz-tools", "--only"],
+    "jazz-tools",
+  );
 
   // A manifest is the contract that makes a cached/generated artifact safe to
   // consume. NAPI is built release because that is the loadable Linux mode;
@@ -356,6 +380,11 @@ export async function buildTestArtifacts(run = command, scope = createBuildScope
     "node",
     ["dev/artifacts/provenance.mjs", "verify", "wasm", "fast"],
     "verify fast WASM provenance",
+  );
+  await guardedRun(
+    "node",
+    ["dev/artifacts/provenance.mjs", "write", "napi", "release"],
+    "seal release NAPI provenance",
   );
 
   try {
@@ -370,7 +399,11 @@ export async function buildTestArtifacts(run = command, scope = createBuildScope
     // A damaged native artifact must not make every run pay a second build.
     // Repair only after the first load proves it necessary, then prove repair.
     console.warn(`test-artifacts: release NAPI did not load; repairing (${error.message})`);
-    await guardedRun("pnpm", ["--filter", "jazz-napi", "build"], "repair release NAPI");
+    await guardedRun(
+      "pnpm",
+      ["exec", "turbo", "run", "build", "--filter=jazz-napi", "--only", "--force"],
+      "repair release NAPI",
+    );
     await guardedRun("node", ["-e", "require('./crates/jazz-napi')"], "load repaired release NAPI");
   }
   await guardedRun(

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -9,6 +9,9 @@ node_tests_command=${JAZZ_NODE_TEST_COMMAND:-"pnpm test --filter=!moon-lander-re
 browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --filter jazz-tools test:browser"}
 node_tests_pid=""
 browser_tests_pid=""
+log_dir=${RUNNER_TEMP:-/tmp}
+node_tests_log="${log_dir}/jazz-node-tests-$$.log"
+browser_tests_log="${log_dir}/jazz-browser-tests-$$.log"
 
 terminate_children() {
   trap - INT TERM
@@ -32,9 +35,9 @@ interrupt() {
 trap 'interrupt 130' INT
 trap 'interrupt 143' TERM
 
-setsid bash -c "${node_tests_command}" &
+setsid bash -c "${node_tests_command}" >"${node_tests_log}" 2>&1 &
 node_tests_pid=$!
-setsid bash -c "${browser_tests_command}" &
+setsid bash -c "${browser_tests_command}" >"${browser_tests_log}" 2>&1 &
 browser_tests_pid=$!
 
 wait "${node_tests_pid}"
@@ -42,6 +45,14 @@ node_tests_status=$?
 wait "${browser_tests_pid}"
 browser_tests_status=$?
 trap - INT TERM
+
+# GitHub's live log pipe can be nonblocking. Two concurrent Turbo/Vitest trees
+# writing directly to it can fail with EAGAIN even though the tests themselves
+# are healthy. Give each suite a blocking regular file, then replay both logs
+# after both process trees have terminated.
+cat "${node_tests_log}"
+cat "${browser_tests_log}"
+rm -f "${node_tests_log}" "${browser_tests_log}"
 
 echo "Node test suite exit status: ${node_tests_status}"
 echo "Browser test suite exit status: ${browser_tests_status}"

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -11,6 +11,10 @@ const setupBuildAction = fs.readFileSync(
   path.join(root, ".github/actions/setup-build/action.yml"),
   "utf8",
 );
+const setupBlacksmithAction = fs.readFileSync(
+  path.join(root, ".github/actions/setup-blacksmith/action.yml"),
+  "utf8",
+);
 const installRustTool = fs.readFileSync(
   path.join(root, ".github/actions/install-rust-tool/action.yml"),
   "utf8",
@@ -19,6 +23,10 @@ const packageBuild = fs.readFileSync(
   path.join(root, ".github/workflows/build-jazz-packages.yml"),
   "utf8",
 );
+const otherWorkflows = fs
+  .readdirSync(path.join(root, ".github/workflows"))
+  .filter((name) => name.endsWith(".yml") && name !== "ci.yml")
+  .map((name) => fs.readFileSync(path.join(root, ".github/workflows", name), "utf8"));
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 const toolBundleValidator = fs.readFileSync(
   path.join(root, "dev/ci/validate-tool-bundle.mjs"),
@@ -44,26 +52,11 @@ const job = (name) => {
   assert.notEqual(source, undefined, `missing ${name} job`);
   return source;
 };
-const trustedRunnerExpression =
-  "${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'blacksmith-4vcpu-ubuntu-2404' || 'jazz-ci' }}";
-const untrustedPullRequestPredicate =
-  "github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]')";
-const assertUsesTrustedRunnerPool = (jobName, jobSource) => {
-  assert.ok(
-    jobSource.includes(`runs-on: ${trustedRunnerExpression}`),
-    `${jobName} must use jazz-ci for pushes and trusted PRs, while fork PRs use Blacksmith`,
-  );
-  assert.doesNotMatch(
-    jobSource,
-    /^    runs-on: jazz-ci$/m,
-    `${jobName} must not run fork or Dependabot PRs unconditionally on jazz-ci`,
-  );
+const assertUsesBlacksmithRunner = (jobName, jobSource) => {
+  const cpu = jobName === "test-ts" ? 16 : 4;
+  assert.match(jobSource, new RegExp(`runs-on: blacksmith-${cpu}vcpu-ubuntu-2404`));
+  assert.doesNotMatch(jobSource, /^    runs-on: jazz-ci$/m);
 };
-const expectedRunner = ({ eventName, headRepository, repository, pullRequestUser }) =>
-  eventName === "pull_request" &&
-  (headRepository !== repository || pullRequestUser === "dependabot[bot]")
-    ? "blacksmith-4vcpu-ubuntu-2404"
-    : "jazz-ci";
 const integrationCheckStep = (typescriptJob) => {
   const start = typescriptJob.indexOf("name: Check integration workspace");
   assert.notEqual(start, -1, "missing integration workspace check");
@@ -92,11 +85,14 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
   const typescript = job("test-ts");
 
   assert.doesNotMatch(workflow, /cargo install cargo-nextest/);
-  assert.match(rust, /tool: cargo-nextest@0\.9\.143/);
-  assert.doesNotMatch(rust, /ensure:rust-toolchain|wasm-pack/);
+  assert.match(setupBlacksmithAction, /cargo-nextest --version \| grep -F "0\.9\.143"/);
+  assert.match(setupBlacksmithAction, /wasm-pack --version \| grep -F "0\.13\.1"/);
+  assert.doesNotMatch(rust, /install-rust-tool|ensure:rust-toolchain|wasm-pack/);
   assert.doesNotMatch(rust, /rust-components:/);
-  assert.doesNotMatch(lint, /ensure:rust-toolchain|wasm-pack/);
-  assert.match(typescript, /tool: wasm-pack@0\.13\.1/);
+  assert.doesNotMatch(lint, /install-rust-tool|ensure:rust-toolchain|wasm-pack/);
+  assert.doesNotMatch(typescript, /install-rust-tool/);
+  for (const source of [lint, rust, typescript])
+    assert.match(source, /uses: \.\/\.github\/actions\/setup-blacksmith/);
 });
 
 test("build setup scopes mutable pnpm and sccache state to the agent temp directory", () => {
@@ -269,7 +265,7 @@ test("the TypeScript CI job checks the integration workspace before TypeScript a
   const typescript = job("test-ts");
 
   assert.match(
-    setupBuildAction,
+    setupBlacksmithAction,
     /echo "JAZZ_TEST_ARTIFACT_LOCK_PATH=\$\{RUNNER_TEMP\}\/jazz-test-artifacts\.lock" >> "\$\{GITHUB_ENV\}"/,
   );
 
@@ -285,66 +281,65 @@ test("the TypeScript CI job checks the integration workspace before TypeScript a
       typescript.indexOf("name: Build correctness-test artifacts"),
     "workspace check must fail before the expensive correctness artifact build",
   );
-  assertUsesTrustedRunnerPool("test-ts", typescript);
+  assertUsesBlacksmithRunner("test-ts", typescript);
 });
 
-test("every CI job uses jazz-ci only for trusted work and Blacksmith for untrusted PRs", () => {
+test("every CI job uses an independently sized Blacksmith runner", () => {
   for (const [name, source] of jobs) {
-    assertUsesTrustedRunnerPool(name, source);
+    assertUsesBlacksmithRunner(name, source);
   }
 });
 
-test("trusted-runner policy keeps forks and same-repository Dependabot PRs hosted", () => {
-  const repository = "gardencmp/jazz";
-  assert.equal(expectedRunner({ eventName: "push", repository }), "jazz-ci");
-  assert.equal(
-    expectedRunner({ eventName: "pull_request", headRepository: repository, repository }),
-    "jazz-ci",
-  );
-  assert.equal(
-    expectedRunner({ eventName: "pull_request", headRepository: "fork/jazz", repository }),
-    "blacksmith-4vcpu-ubuntu-2404",
-  );
-  assert.equal(
-    expectedRunner({
-      eventName: "pull_request",
-      headRepository: repository,
-      repository,
-      pullRequestUser: "dependabot[bot]",
-    }),
-    "blacksmith-4vcpu-ubuntu-2404",
-  );
-  assert.match(workflow, /github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'/);
-  assert.doesNotMatch(workflow, /github\.actor/);
-});
-
-test("TypeScript cache mounts use the same untrusted-PR predicate as the runner", () => {
+test("Turbo cache uses pinned OIDC policy, signing, and excludes fork PRs", () => {
   const typescript = job("test-ts");
-  assert.ok(
-    typescript.includes(
-      `sccache-sticky-disk: \${{ ${untrustedPullRequestPredicate} && 'true' || 'false' }}`,
-    ),
+  assert.match(
+    typescript,
+    /if: github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
   );
-  assert.equal(
-    typescript.split(`if: ${untrustedPullRequestPredicate}`).length - 1,
-    2,
-    "Turbo and Playwright sticky-disk mounts must both follow the runner trust boundary",
+  assert.match(typescript, /policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c/);
+  assert.match(typescript, /audience: https:\/\/github\.com\/garden-co/);
+  assert.match(typescript, /team: garden-co/);
+  assert.match(
+    typescript,
+    /TURBO_REMOTE_CACHE_SIGNATURE_KEY: \$\{\{ secrets\.TURBO_REMOTE_CACHE_SIGNATURE_KEY \}\}/,
   );
+  assert.match(fs.readFileSync(path.join(root, "turbo.json"), "utf8"), /"signature": true/);
+  for (const releaseWorkflow of otherWorkflows)
+    assert.doesNotMatch(
+      releaseWorkflow,
+      /setup-turborepo-remote-cache-action|TURBO_REMOTE_CACHE_SIGNATURE_KEY/,
+      "release/deployment workflows must not consume the PR-populated CI cache",
+    );
 });
 
-test("trusted-runner contract rejects planted unsafe runner changes", () => {
-  const lint = job("lint");
-  assert.throws(
-    () => assertUsesTrustedRunnerPool("lint", lint.replace(trustedRunnerExpression, "jazz-ci")),
-    /must use jazz-ci for pushes and trusted PRs, while fork PRs use Blacksmith/,
+test("shared Rust cache separates read-only PRs from trusted writers", () => {
+  for (const name of ["lint", "test-rust", "test-ts"]) {
+    const source = job(name);
+    assert.match(source, /role-to-assume: \$\{\{ vars\.SCCACHE_PR_READER_AWS_ROLE_ARN \}\}/);
+    assert.match(source, /role-to-assume: \$\{\{ vars\.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN \}\}/);
+  }
+  assert.match(workflow, /SCCACHE_S3_KEY_PREFIX: jazz-ci\/v1\/production\/blacksmith-v1/);
+  assert.doesNotMatch(
+    workflow,
+    /SCCACHE_S3_RW_MODE/,
+    "sccache has no S3 read-only switch; the distinct IAM roles enforce this boundary",
   );
+  assert.match(setupBlacksmithAction, /SCCACHE_MULTILEVEL_CHAIN=disk,s3/);
+  assert.match(setupBlacksmithAction, /SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY=l0/);
+});
+
+test("Blacksmith and cache trust contracts reject planted unsafe changes", () => {
+  const typescript = job("test-ts");
   assert.throws(
-    () =>
-      assertUsesTrustedRunnerPool(
-        "lint",
-        lint.replace(" || github.event.pull_request.user.login == 'dependabot[bot]'", ""),
-      ),
-    /must use jazz-ci for pushes and trusted PRs, while fork PRs use Blacksmith/,
+    () => assertUsesBlacksmithRunner("test-ts", typescript.replace("blacksmith-16vcpu", "jazz-ci")),
+    /blacksmith-16vcpu/,
+  );
+  assert.doesNotMatch(
+    typescript.replace(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+      "true",
+    ),
+    /if: github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
   );
 });
 
@@ -397,8 +392,11 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(typescript, /name: Run Node and browser test suites in parallel/);
   assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
   assert.match(runner, /--concurrency=2/);
-  assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" &/);
-  assert.match(runner, /setsid bash -c "\$\{browser_tests_command\}" &/);
+  assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
+  assert.match(
+    runner,
+    /setsid bash -c "\$\{browser_tests_command\}" >"\$\{browser_tests_log\}" 2>&1 &/,
+  );
   assert.match(runner, /trap 'interrupt 130' INT/);
   assert.match(runner, /trap 'interrupt 143' TERM/);
   assert.match(runner, /kill -TERM -- "-\$\{child_pid\}"/);
@@ -406,6 +404,8 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(runner, /node_tests_status=\$\?/);
   assert.match(runner, /wait "\$\{browser_tests_pid\}"/);
   assert.match(runner, /browser_tests_status=\$\?/);
+  assert.match(runner, /cat "\$\{node_tests_log\}"/);
+  assert.match(runner, /cat "\$\{browser_tests_log\}"/);
   assert.match(runner, /Node test suite exit status:/);
   assert.match(runner, /Browser test suite exit status:/);
   assert.match(runner, /node_tests_status.*-ne 0 \|\|.*browser_tests_status.*-ne 0/);

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -300,7 +300,13 @@ test("test artifact pipeline overlaps independent bindings and repairs NAPI only
   });
 
   const labels = calls.map((call) => call.label);
-  assert.deepEqual(labels.slice(0, 4), ["release NAPI", "CLI", "fast WASM", "jazz-tools"]);
+  assert.deepEqual(labels.slice(0, 5), [
+    "release NAPI",
+    "CLI",
+    "fast WASM",
+    "seal fast WASM provenance",
+    "jazz-tools",
+  ]);
   assert.equal(labels.filter((label) => label === "release NAPI").length, 1);
   assert.equal(labels.filter((label) => label === "repair release NAPI").length, 1);
   assert.ok(labels.indexOf("jazz-tools") > labels.indexOf("fast WASM"));
@@ -438,26 +444,44 @@ test("CI uses the correctness artifact path while package builds keep release WA
   );
   assert.doesNotMatch(workflow, /CARGO_TARGET_DIR/);
   assert.doesNotMatch(pipeline, /target\/test-artifacts-(?:wasm|napi)/);
+  for (const task of ["build", "build:crates", "build:fast"])
+    assert.match(
+      pipeline,
+      new RegExp(`"exec", "turbo", "run", "${task.replace(":", "\\:")}"`),
+      `${task} correctness artifact must run through Turbo`,
+    );
 });
 
 test("Turbo invalidates each native artifact only for its Cargo closure", () => {
   const turbo = JSON.parse(readFileSync(new URL("../../../turbo.json", import.meta.url), "utf8"));
   const napi = turbo.tasks["jazz-napi#build"];
   const wasm = turbo.tasks["jazz-wasm#build"];
+  const fastWasm = turbo.tasks["jazz-wasm#build:fast"];
+  const jazzTools = turbo.tasks["jazz-tools#build"];
   const cli = turbo.tasks["build:crates"];
   assert.equal(napi.dependsOn, undefined);
   assert.equal(wasm.dependsOn, undefined);
   for (const [task, inputs] of [
     [
       napi,
-      ["jazz-napi", "jazz", "groove", "opfs-btree"].map(
-        (crate) => `$TURBO_ROOT$/crates/${crate}/**`,
-      ),
+      [
+        "$TURBO_ROOT$/crates/jazz-napi/package.json",
+        "$TURBO_ROOT$/crates/jazz-napi/Cargo.toml",
+        "$TURBO_ROOT$/crates/jazz-napi/build.rs",
+        "$TURBO_ROOT$/crates/jazz-napi/scripts/**",
+        "$TURBO_ROOT$/crates/jazz-napi/src/**/*.rs",
+      ].concat(["jazz", "groove", "opfs-btree"].map((crate) => `$TURBO_ROOT$/crates/${crate}/**`)),
     ],
     [
       wasm,
-      ["jazz-wasm", "jazz", "groove", "opfs-btree"].map(
-        (crate) => `$TURBO_ROOT$/crates/${crate}/**`,
+      ["package.json", "Cargo.toml", "src/**/*.rs"].concat(
+        ["jazz", "groove", "opfs-btree"].map((crate) => `$TURBO_ROOT$/crates/${crate}/**`),
+      ),
+    ],
+    [
+      fastWasm,
+      ["package.json", "Cargo.toml", "src/**/*.rs"].concat(
+        ["jazz", "groove", "opfs-btree"].map((crate) => `$TURBO_ROOT$/crates/${crate}/**`),
       ),
     ],
     [
@@ -471,4 +495,13 @@ test("Turbo invalidates each native artifact only for its Cargo closure", () => 
     for (const input of inputs) assert.ok(task.inputs.includes(input), input);
     assert.equal(task.inputs.includes("$TURBO_ROOT$/crates/**/*.rs"), false);
   }
+  for (const generatedInput of [
+    "$TURBO_ROOT$/crates/jazz-napi/*.node",
+    "$TURBO_ROOT$/crates/jazz-napi/.jazz-artifact-manifest.json",
+    "$TURBO_ROOT$/crates/jazz-wasm/pkg/**",
+  ])
+    assert.ok(
+      jazzTools.inputs.includes(generatedInput),
+      `jazz-tools build hash omits ${generatedInput}`,
+    );
 });

--- a/dev/gates/test/turbo-cache-inputs.test.mjs
+++ b/dev/gates/test/turbo-cache-inputs.test.mjs
@@ -10,7 +10,12 @@ import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const root = resolve(import.meta.dirname, "../../..");
-const tasks = ["@jazz/rust#build:crates", "jazz-wasm#build", "jazz-napi#build"];
+const tasks = [
+  "@jazz/rust#build:crates",
+  "jazz-wasm#build",
+  "jazz-wasm#build:fast",
+  "jazz-napi#build",
+];
 
 function dryGraph() {
   const output = execFileSync(
@@ -21,6 +26,7 @@ function dryGraph() {
       "run",
       "build:crates",
       "build",
+      "build:fast",
       "--filter=@jazz/rust",
       "--filter=jazz-wasm",
       "--filter=jazz-napi",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "signature": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -32,7 +35,11 @@
         "scripts/build.js",
         "src/**/*.rs",
         "$TURBO_ROOT$/dev/artifacts/**",
-        "$TURBO_ROOT$/crates/jazz-napi/**",
+        "$TURBO_ROOT$/crates/jazz-napi/package.json",
+        "$TURBO_ROOT$/crates/jazz-napi/Cargo.toml",
+        "$TURBO_ROOT$/crates/jazz-napi/build.rs",
+        "$TURBO_ROOT$/crates/jazz-napi/scripts/**",
+        "$TURBO_ROOT$/crates/jazz-napi/src/**/*.rs",
         "$TURBO_ROOT$/crates/jazz/**",
         "$TURBO_ROOT$/crates/groove/**",
         "$TURBO_ROOT$/crates/opfs-btree/**",
@@ -53,7 +60,6 @@
         "Cargo.toml",
         "src/**/*.rs",
         "$TURBO_ROOT$/dev/artifacts/**",
-        "$TURBO_ROOT$/crates/jazz-wasm/**",
         "$TURBO_ROOT$/crates/jazz/**",
         "$TURBO_ROOT$/crates/groove/**",
         "$TURBO_ROOT$/crates/opfs-btree/**",
@@ -68,6 +74,43 @@
         "$TURBO_ROOT$/turbo.json"
       ],
       "outputs": ["pkg/**"]
+    },
+    "jazz-wasm#build:fast": {
+      "inputs": [
+        "package.json",
+        "Cargo.toml",
+        "src/**/*.rs",
+        "$TURBO_ROOT$/dev/artifacts/**",
+        "$TURBO_ROOT$/crates/jazz/**",
+        "$TURBO_ROOT$/crates/groove/**",
+        "$TURBO_ROOT$/crates/opfs-btree/**",
+        "$TURBO_ROOT$/crates/wasm-tracing/**",
+        "$TURBO_ROOT$/Cargo.toml",
+        "$TURBO_ROOT$/Cargo.lock",
+        "$TURBO_ROOT$/rust-toolchain.toml",
+        "$TURBO_ROOT$/.cargo/**",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/pnpm-lock.yaml",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/turbo.json"
+      ],
+      "outputs": ["pkg/**"]
+    },
+    "jazz-tools#build": {
+      "inputs": [
+        "package.json",
+        "src/**",
+        "$TURBO_ROOT$/crates/jazz-napi/*.node",
+        "$TURBO_ROOT$/crates/jazz-napi/index.js",
+        "$TURBO_ROOT$/crates/jazz-napi/index.d.ts",
+        "$TURBO_ROOT$/crates/jazz-napi/.jazz-artifact-manifest.json",
+        "$TURBO_ROOT$/crates/jazz-wasm/pkg/**",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/pnpm-lock.yaml",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/turbo.json"
+      ],
+      "outputs": ["dist/**"]
     },
     "build:crates": {
       "dependsOn": ["^build:crates"],


### PR DESCRIPTION
🤖 Moves the three core CI jobs to independent Blacksmith VMs and the immutable prebuilt toolchain image.

Key changes:

- lint and Rust tests use 4-vCPU Blacksmith runners; TypeScript/browser tests use 16 vCPUs
- PR jobs assume the production read-only sccache role; trusted branch pushes assume the writer role; both are restricted to `jazz-ci/v1/production/blacksmith-v1`
- each job uses an isolated local sccache L0 plus shared S3 L1
- TypeScript uses Vercel OIDC for signed Turbo Remote Cache, without a long-lived token; fork PRs do not receive cache credentials
- deterministic NAPI, CLI, fast-WASM, and jazz-tools builds now run through explicit Turbo tasks with tested input/output closures
- nondeterministic Node, browser, and Rust tests remain uncached
- generated native artifacts are resealed and provenance-verified after concurrent/cache-restored builds
- release/deployment workflows are statically prevented from consuming this PR-populated Turbo cache

Local receipts:

- `pnpm test:ci-workflow` — 39/39 plus exact TS burndown
- `pnpm test:turbo-cache-inputs` — green
- `pnpm build:test-artifacts` — green, then immediate repeat with 4/4 Turbo task hits and fresh NAPI/WASM provenance
- `pnpm format:check` — green
- `pnpm lint` — green
- pre-commit sensitive-data and formatting guards — green

This PR's first CI run is the fresh-VM/read-only-cache receipt. After it passes, I will rerun the TypeScript job on another fresh VM to verify signed remote Turbo hits before merging.
