### PR TITLE
fix: preserve deltas during live membership reconciliation

### DIFF
--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -928,6 +928,15 @@ impl PeerState {
             .difference(&current_member_result_set)
             .cloned()
             .collect::<Vec<_>>();
+        // A live reconciliation is still a delta to the receiver's existing
+        // result set.  Rehydration used for an explicit reset is different:
+        // the receiver discards that set and needs the complete replacement.
+        // In particular, a deletion witness may force reconciliation alongside
+        // an ordinary result delta; do not resend retained window members as
+        // additions in that case.
+        if !reset_result_set {
+            result_member_adds.retain(|member| !previous_member_result_set.contains(member));
+        }
         // The downstream cursor tracks data progress, not authorization. A
         // removed prior member or newly visible pre-cursor member cannot be
         // reconstructed from that cursor, so it cannot safely suppress the


### PR DESCRIPTION
🤖 Fixes live maintained-view reconciliation after deletion witnesses.

The correctness fallback rehydrates authoritative membership when Groove emits deletion/replacement witness deltas, but a live non-reset update was forwarding the complete rehydrated window as adds. Retained members were therefore re-added, producing duplicate/out-of-window membership in ordered limit/offset views.

This change filters only emitted live adds against the previous member set. Explicit reset paths still carry the complete replacement, and removals remain derived from the full old/current difference.

Evidence:
- the six Rust workspace failures in maintained ordering/real-peer capture reproduce independently on the parent;
- all focused window tests and the M3 concurrent delete+insert oracle pass;
- planting the old unfiltered behavior makes the boundary, ordered-limit, and real-peer exact-delta tests fail;
- independent adversarial review found no P0–P2.