### PR TITLE
fix: preserve authored schema for client writes

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1239,12 +1239,17 @@ where
     ) -> Result<WriteHandle<S>, Error> {
         let row = self.row_id_source.borrow_mut().next_row_id();
         let cells = self.apply_insert_defaults(table, cells)?;
-        let tx_id = self.node.node.borrow_mut().commit_mergeable_on_branch(
-            branch,
-            MergeableCommit::new(table, row, self.next_now_ms())
-                .made_by(self.identity.author)
-                .cells(cells),
-        )?;
+        let tx_id = self
+            .node
+            .node
+            .borrow_mut()
+            .commit_mergeable_on_branch_in_schema(
+                branch,
+                self.schema_version_id,
+                MergeableCommit::new(table, row, self.next_now_ms())
+                    .made_by(self.identity.author)
+                    .cells(cells),
+            )?;
         let local_tier = self.finalize_local_commit(tx_id)?;
         self.refresh_subscriptions()?;
         Ok(WriteHandle {
@@ -1269,7 +1274,8 @@ where
         cells: RowCells,
     ) -> Result<TxId, Error> {
         let cells = self.apply_insert_defaults(table, cells)?;
-        let tx_id = self.node.node.borrow_mut().commit_mergeable(
+        let tx_id = self.node.node.borrow_mut().commit_mergeable_in_schema(
+            self.schema_version_id,
             MergeableCommit::new(table, row, self.next_now_ms())
                 .made_by(made_by)
                 .cells(cells),
@@ -1302,8 +1308,9 @@ where
         if node.branch_record(branch).is_none() {
             node.create_branch(branch)?;
         }
-        let tx_id = node.commit_mergeable_on_branch(
+        let tx_id = node.commit_mergeable_on_branch_in_schema(
             branch,
+            self.schema_version_id,
             MergeableCommit::new(table, row, self.next_now_ms())
                 .made_by(made_by)
                 .cells(cells),
@@ -3892,17 +3899,24 @@ where
                 .collect::<Vec<_>>();
             (content_parents, deletion_parents)
         };
-        let tx_id = self.node.node.borrow_mut().commit_mergeable_many(vec![
-            MergeableCommit::new(table, row, self.next_now_ms())
-                .made_by(self.identity.author)
-                .parents(content_parents)
-                .cells(cells),
-            MergeableCommit::new(table, row, self.next_now_ms())
-                .made_by(self.identity.author)
-                .parents(deletion_parents)
-                .cells(BTreeMap::<String, Value>::new())
-                .deletion(DeletionEvent::Restored),
-        ])?;
+        let tx_id = self
+            .node
+            .node
+            .borrow_mut()
+            .commit_mergeable_many_in_schema(
+                self.schema_version_id,
+                vec![
+                    MergeableCommit::new(table, row, self.next_now_ms())
+                        .made_by(self.identity.author)
+                        .parents(content_parents)
+                        .cells(cells),
+                    MergeableCommit::new(table, row, self.next_now_ms())
+                        .made_by(self.identity.author)
+                        .parents(deletion_parents)
+                        .cells(BTreeMap::<String, Value>::new())
+                        .deletion(DeletionEvent::Restored),
+                ],
+            )?;
         let local_tier = self.finalize_local_commit(tx_id)?;
         self.refresh_subscriptions()?;
         Ok(WriteHandle {
@@ -3935,19 +3949,26 @@ where
                 .collect::<Vec<_>>();
             (content_parents, deletion_parents)
         };
-        let tx_id = self.node.node.borrow_mut().commit_mergeable_many(vec![
-            MergeableCommit::new(table, row, self.next_now_ms())
-                .made_by(identity)
-                .permission_subject(identity)
-                .parents(content_parents)
-                .cells(cells),
-            MergeableCommit::new(table, row, self.next_now_ms())
-                .made_by(identity)
-                .permission_subject(identity)
-                .parents(deletion_parents)
-                .cells(BTreeMap::<String, Value>::new())
-                .deletion(DeletionEvent::Restored),
-        ])?;
+        let tx_id = self
+            .node
+            .node
+            .borrow_mut()
+            .commit_mergeable_many_in_schema(
+                self.schema_version_id,
+                vec![
+                    MergeableCommit::new(table, row, self.next_now_ms())
+                        .made_by(identity)
+                        .permission_subject(identity)
+                        .parents(content_parents)
+                        .cells(cells),
+                    MergeableCommit::new(table, row, self.next_now_ms())
+                        .made_by(identity)
+                        .permission_subject(identity)
+                        .parents(deletion_parents)
+                        .cells(BTreeMap::<String, Value>::new())
+                        .deletion(DeletionEvent::Restored),
+                ],
+            )?;
         let local_tier = self.finalize_local_commit(tx_id)?;
         self.refresh_subscriptions()?;
         Ok(WriteHandle {
@@ -4013,17 +4034,24 @@ where
         let cells = self.apply_insert_defaults(table, cells)?;
         self.ensure_row_deleted(table, row, self.identity.author)?;
         let (content_parents, deletion_parents) = self.row_layer_parents(table, row)?;
-        let tx_id = self.node.node.borrow_mut().commit_mergeable_many(vec![
-            MergeableCommit::new(table, row, now_ms)
-                .made_by(self.identity.author)
-                .parents(content_parents)
-                .cells(cells),
-            MergeableCommit::new(table, row, now_ms)
-                .made_by(self.identity.author)
-                .parents(deletion_parents)
-                .cells(BTreeMap::<String, Value>::new())
-                .deletion(DeletionEvent::Restored),
-        ])?;
+        let tx_id = self
+            .node
+            .node
+            .borrow_mut()
+            .commit_mergeable_many_in_schema(
+                self.schema_version_id,
+                vec![
+                    MergeableCommit::new(table, row, now_ms)
+                        .made_by(self.identity.author)
+                        .parents(content_parents)
+                        .cells(cells),
+                    MergeableCommit::new(table, row, now_ms)
+                        .made_by(self.identity.author)
+                        .parents(deletion_parents)
+                        .cells(BTreeMap::<String, Value>::new())
+                        .deletion(DeletionEvent::Restored),
+                ],
+            )?;
         let local_tier = self.finalize_local_commit(tx_id)?;
         self.refresh_subscriptions()?;
         Ok(WriteHandle {
@@ -4046,19 +4074,26 @@ where
         let cells = self.apply_insert_defaults(table, cells)?;
         self.ensure_row_deleted(table, row, identity)?;
         let (content_parents, deletion_parents) = self.row_layer_parents(table, row)?;
-        let tx_id = self.node.node.borrow_mut().commit_mergeable_many(vec![
-            MergeableCommit::new(table, row, now_ms)
-                .made_by(identity)
-                .permission_subject(identity)
-                .parents(content_parents)
-                .cells(cells),
-            MergeableCommit::new(table, row, now_ms)
-                .made_by(identity)
-                .permission_subject(identity)
-                .parents(deletion_parents)
-                .cells(BTreeMap::<String, Value>::new())
-                .deletion(DeletionEvent::Restored),
-        ])?;
+        let tx_id = self
+            .node
+            .node
+            .borrow_mut()
+            .commit_mergeable_many_in_schema(
+                self.schema_version_id,
+                vec![
+                    MergeableCommit::new(table, row, now_ms)
+                        .made_by(identity)
+                        .permission_subject(identity)
+                        .parents(content_parents)
+                        .cells(cells),
+                    MergeableCommit::new(table, row, now_ms)
+                        .made_by(identity)
+                        .permission_subject(identity)
+                        .parents(deletion_parents)
+                        .cells(BTreeMap::<String, Value>::new())
+                        .deletion(DeletionEvent::Restored),
+                ],
+            )?;
         let local_tier = self.finalize_local_commit(tx_id)?;
         self.refresh_subscriptions()?;
         Ok(WriteHandle {
@@ -4178,7 +4213,11 @@ where
         }
         // Db is an untrusted client: structurally valid writes are staged and
         // sent optimistically. A serving authority assigns the policy fate.
-        let tx_id = self.node.node.borrow_mut().commit_mergeable(commit)?;
+        let tx_id = self
+            .node
+            .node
+            .borrow_mut()
+            .commit_mergeable_in_schema(self.schema_version_id, commit)?;
         let local_tier = self.finalize_local_commit(tx_id)?;
         self.refresh_subscriptions()?;
         Ok(WriteHandle {

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -9931,6 +9931,146 @@ fn offline_branch_creation_and_commit_sync_metadata_before_data() {
 }
 
 #[test]
+fn fixed_schema_db_branch_and_bootstrap_writes_retain_authored_schema() {
+    let base = schema();
+    let evolved_schema = JazzSchema::new([TableSchema::new(
+        "todos",
+        [
+            ColumnSchema::new("title", ColumnType::String),
+            ColumnSchema::new("done", ColumnType::Bool),
+            ColumnSchema::new("owner", ColumnType::Uuid),
+            ColumnSchema::new("body", ColumnType::String),
+        ],
+    )
+    .with_read_policy(Policy::public())
+    .with_write_policy(Policy::public())]);
+    let evolved = SchemaVersion::new(evolved_schema.clone());
+    let identity = AuthorId::from_bytes([0xc2; 16]);
+    let writer = open_db(0xc2, identity, &base);
+    let publication = SchemaLineagePublication::new(
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "body".to_owned(),
+                    default: Value::String("default-body".to_owned()),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    );
+    writer
+        .node
+        .node
+        .borrow_mut()
+        .apply_trusted_catalogue_message(SyncMessage::PublishSchemaWithLens {
+            author: AuthorId::SYSTEM,
+            catalogue_seq: 1,
+            publication: Box::new(publication),
+        })
+        .unwrap();
+    writer
+        .node
+        .node
+        .borrow_mut()
+        .apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+            author: AuthorId::SYSTEM,
+            pointer: CurrentWriteSchema {
+                revision: 1,
+                schema: evolved.id,
+            },
+        })
+        .unwrap();
+
+    let branch = BranchId::from_bytes([0x52; 16]);
+    writer.create_branch_with_id(branch).unwrap();
+    let write = writer
+        .insert_on_branch(branch, "todos", cells("authored-base", false, identity))
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = writer
+        .node
+        .node
+        .borrow_mut()
+        .commit_unit_for(write.mergeable_tx_id())
+        .unwrap()
+    else {
+        panic!("commit unit expected");
+    };
+    assert_eq!(versions[0].schema_version(), base.version_id());
+
+    let receiver = open_db(0xc3, identity, &evolved_schema);
+    receiver
+        .node
+        .node
+        .borrow_mut()
+        .apply_trusted_catalogue_snapshot(writer.node.node.borrow().catalogue_snapshot().unwrap())
+        .unwrap();
+    receiver.create_branch_with_id(branch).unwrap();
+    receiver
+        .node
+        .node
+        .borrow_mut()
+        .ingest_relay_commit_unit(tx, versions)
+        .unwrap();
+    let shape = Query::from("todos").validate(&evolved_schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let rows = receiver
+        .node
+        .node
+        .borrow_mut()
+        .query_rows_on_branch(branch, &shape, &binding)
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].cell_at(3),
+        Some(Value::String("default-body".to_owned()))
+    );
+
+    let seeded_row = RowUuid::from_bytes([0x53; 16]);
+    let seeded_tx = writer
+        .seed_settled_mergeable_for_bootstrap(
+            "todos",
+            seeded_row,
+            identity,
+            cells("seeded-base", true, identity),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = writer
+        .node
+        .node
+        .borrow_mut()
+        .commit_unit_for(seeded_tx)
+        .unwrap()
+    else {
+        panic!("commit unit expected");
+    };
+    assert_eq!(versions[0].schema_version(), base.version_id());
+    receiver
+        .node
+        .node
+        .borrow_mut()
+        .ingest_relay_commit_unit(tx, versions)
+        .unwrap();
+    let rows = receiver
+        .node
+        .node
+        .borrow_mut()
+        .query_rows(&shape, &binding, DurabilityTier::Local)
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].row_uuid(), seeded_row);
+    assert_eq!(
+        rows[0].cell_at(3),
+        Some(Value::String("default-body".to_owned()))
+    );
+}
+
+#[test]
 fn session_branch_metadata_rejects_creator_mismatch() {
     let schema = schema();
     let identity = AuthorId::from_bytes([0xc1; 16]);

--- a/crates/jazz/src/node/branches.rs
+++ b/crates/jazz/src/node/branches.rs
@@ -592,6 +592,19 @@ where
         self.commit_mergeable_many_on_branch(branch_id, vec![commit])
     }
 
+    /// Commit a branch-local write under an admitted authored schema.
+    pub(crate) fn commit_mergeable_on_branch_in_schema(
+        &mut self,
+        branch_id: BranchId,
+        schema_version: SchemaVersionId,
+        commit: MergeableCommit,
+    ) -> Result<TxId, Error>
+    where
+        S: ReopenableStorage,
+    {
+        self.commit_mergeable_many_on_branch_in_schema(branch_id, schema_version, vec![commit])
+    }
+
     /// Commit multiple ordinary mergeable writes atomically into one branch
     /// target. The resulting transaction differs from a root commit only in
     /// its explicit target lineage and the target-relative policy/storage view.
@@ -603,7 +616,30 @@ where
     where
         S: ReopenableStorage,
     {
+        let schema_version = self.catalogue.current_write_schema.schema;
+        self.commit_mergeable_many_on_branch_in_schema(branch_id, schema_version, commits)
+    }
+
+    /// Commit branch-local writes atomically under one admitted authored schema.
+    pub(crate) fn commit_mergeable_many_on_branch_in_schema(
+        &mut self,
+        branch_id: BranchId,
+        schema_version: SchemaVersionId,
+        commits: Vec<MergeableCommit>,
+    ) -> Result<TxId, Error>
+    where
+        S: ReopenableStorage,
+    {
         self.require_catalogue_ready()?;
+        if !self
+            .catalogue
+            .catalogue_schemas
+            .contains_key(&schema_version)
+        {
+            return Err(Error::InvalidMergeableCommit(
+                "authored schema version is not admitted",
+            ));
+        }
         if commits.is_empty() {
             return Err(Error::InvalidMergeableCommit(
                 "mergeable transaction requires at least one write",
@@ -627,21 +663,21 @@ where
                 self.merge_tx_time(parent.time);
             }
         }
-        let write_schema_version = self.catalogue.current_write_schema.schema;
         for table in commits
             .iter()
             .map(|commit| commit.table.clone())
             .collect::<BTreeSet<_>>()
         {
-            self.persist_branch_partition(table, write_schema_version, branch_id)?;
+            self.persist_branch_partition(table, schema_version, branch_id)?;
         }
         let made_at = self.mint_tx_time(commits[0].now_ms);
-        self.commit_mergeable_many_on_branch_at(branch_id, commits, made_at, None)
+        self.commit_mergeable_many_on_branch_at(branch_id, schema_version, commits, made_at, None)
     }
 
     fn commit_mergeable_many_on_branch_at(
         &mut self,
         branch_id: BranchId,
+        write_schema_version: SchemaVersionId,
         commits: Vec<MergeableCommit>,
         made_at: TxTime,
         branch_merge: Option<BranchMergeProvenance>,
@@ -649,7 +685,6 @@ where
     where
         S: ReopenableStorage,
     {
-        let write_schema_version = self.catalogue.current_write_schema.schema;
         let branch = self
             .branches
             .branches
@@ -1772,6 +1807,7 @@ where
                 let made_at = self.mint_tx_time(0);
                 self.commit_mergeable_many_on_branch_at(
                     branch_id,
+                    write_schema_version,
                     commits,
                     made_at,
                     Some(branch_merge),

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2083,6 +2083,20 @@ where
         self.commit_mergeable_at(commit, made_at)
     }
 
+    /// Commit one local mergeable write under an admitted authored schema.
+    ///
+    /// Client database handles retain the schema they were opened with even
+    /// when an authority later advances its separate current-write pointer.
+    /// Their canonical versions must retain that authored schema so receivers
+    /// can reconstruct through the ordered catalogue lineage.
+    pub(crate) fn commit_mergeable_in_schema(
+        &mut self,
+        schema_version: SchemaVersionId,
+        commit: MergeableCommit,
+    ) -> Result<TxId, Error> {
+        self.commit_mergeable_many_in_schema(schema_version, vec![commit])
+    }
+
     /// Commit multiple local mergeable writes as one transaction.
     pub fn commit_mergeable_many(&mut self, commits: Vec<MergeableCommit>) -> Result<TxId, Error> {
         if commits.is_empty() {
@@ -2101,6 +2115,47 @@ where
         self.merge_commit_parent_times(&commits)?;
         let made_at = self.mint_tx_time(commits[0].now_ms);
         self.commit_mergeable_many_at(commits, made_at)
+    }
+
+    /// Commit local mergeable writes under one admitted authored schema.
+    pub(crate) fn commit_mergeable_many_in_schema(
+        &mut self,
+        schema_version: SchemaVersionId,
+        commits: Vec<MergeableCommit>,
+    ) -> Result<TxId, Error> {
+        self.require_catalogue_ready()?;
+        if !self
+            .catalogue
+            .catalogue_schemas
+            .contains_key(&schema_version)
+        {
+            return Err(Error::InvalidMergeableCommit(
+                "authored schema version is not admitted",
+            ));
+        }
+        if commits.is_empty() {
+            return Err(Error::InvalidMergeableCommit(
+                "mergeable transaction requires at least one write",
+            ));
+        }
+        for commit in &commits {
+            commit.validate()?;
+            if commit.effective_permission_subject() != commits[0].effective_permission_subject() {
+                return Err(Error::InvalidMergeableCommit(
+                    "mergeable transaction permission subjects must match",
+                ));
+            }
+        }
+        self.merge_commit_parent_times(&commits)?;
+        let made_at = self.mint_tx_time(commits[0].now_ms);
+        self.commit_mergeable_many_at_with_schema_versions(
+            commits
+                .into_iter()
+                .map(|commit| (schema_version, commit))
+                .collect(),
+            made_at,
+            None,
+        )
     }
 
     fn merge_commit_parent_times(&mut self, commits: &[MergeableCommit]) -> Result<(), Error> {

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -162,7 +162,7 @@ fn catalogue_snapshot_preserves_active_schema_storage_identity() {
 }
 
 #[test]
-fn settled_view_projects_authored_row_into_clients_active_schema() {
+fn settled_view_projects_old_authored_row_into_clients_active_schema() {
     // Internal because settled result-set installation is a sync receiver
     // boundary; schema projection itself is asserted through the query API.
     let base = schema();
@@ -197,20 +197,27 @@ fn settled_view_projects_authored_row_into_clients_active_schema() {
         })
         .unwrap();
 
-    let (_writer_dir, mut writer) = open_node_with_schema(node(0x64), base);
-    let (tx_id, unit) = writer
-        .commit_mergeable_unit(
+    let snapshot = authority.catalogue_snapshot().unwrap();
+    let (_writer_dir, mut writer) = open_node_with_schema(node(0x64), base.clone());
+    writer
+        .apply_trusted_catalogue_snapshot(snapshot.clone())
+        .unwrap();
+    let tx_id = writer
+        .commit_mergeable_in_schema(
+            base.version_id(),
             MergeableCommit::new("todos", row(0x65), 10).cells(title_cells("authored-base")),
         )
         .unwrap();
+    let unit = writer.commit_unit_for(tx_id).unwrap();
     let SyncMessage::CommitUnit { tx, versions } = unit else {
         panic!("commit unit expected");
     };
+    assert_eq!(versions[0].schema_version(), base.version_id());
 
     let (_receiver_dir, mut receiver) =
         open_node_with_schema(node(0x66), evolved.schema.clone());
     receiver
-        .apply_trusted_catalogue_snapshot(authority.catalogue_snapshot().unwrap())
+        .apply_trusted_catalogue_snapshot(snapshot)
         .unwrap();
     receiver
         .ingest_known_transaction(
@@ -252,6 +259,41 @@ fn settled_view_projects_authored_row_into_clients_active_schema() {
             ]),
         )])
     );
+}
+
+#[test]
+fn mergeable_commit_rejects_unadmitted_authored_schema() {
+    // Internal because this verifies the node admission boundary underlying a
+    // public client's fixed-schema write contract.
+    let (_dir, mut writer) = open_node_with_schema(node(0x67), schema());
+    let unknown = SchemaVersionId(uuid::Uuid::from_bytes([0x67; 16]));
+    assert!(matches!(
+        writer.commit_mergeable_in_schema(
+            unknown,
+            MergeableCommit::new("todos", row(0x68), 10).cells(title_cells("forged")),
+        ),
+        Err(Error::InvalidMergeableCommit("authored schema version is not admitted"))
+    ));
+    assert!(writer.query_all_versions().unwrap().is_empty());
+}
+
+#[test]
+fn branch_commit_rejects_unadmitted_authored_schema_without_persistence() {
+    let (_dir, mut writer) = open_node_with_schema(node(0x69), schema());
+    let branch_id = branch(0x69);
+    writer.create_root_branch(branch_id).unwrap();
+    let unknown = SchemaVersionId(uuid::Uuid::from_bytes([0x69; 16]));
+    assert!(matches!(
+        writer.commit_mergeable_on_branch_in_schema(
+            branch_id,
+            unknown,
+            MergeableCommit::new("todos", row(0x6a), 10).cells(title_cells("forged")),
+        ),
+        Err(Error::InvalidMergeableCommit(
+            "authored schema version is not admitted"
+        ))
+    ));
+    assert!(writer.query_all_versions().unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
🤖 Preserves the schema that actually authored a client write instead of retagging its canonical version with the authority’s mutable current-write pointer.

A Db configured for v1 validates and defaults v1 cells. After the authority advances to v2, the old path stored that v1-shaped record as v2; receivers therefore saw authored==read==v2 and never ran the v1→v2 lens, producing a missing-column failure. Root writes, bootstrap/import seeds, and branch writes now thread the configured admitted schema through validation and persistence.

The authority-owned legacy APIs retain current-pointer semantics. Unknown or unadmitted authored schemas reject before any version or branch partition is persisted.

Worked behavior:
- Alice’s v1 Db writes users {id,name} after v2 people {id,name,email} is active;
- the canonical version remains tagged v1;
- Bob’s v2 receiver selects that authored winner and applies the ordered lens/default locally;
- no projected application-row carrier or raw descriptor relabel is introduced.

Evidence:
- the formerly quarantined add-column/new-client integration passes in 0.28s;
- root bootstrap and branch writes remain v1-tagged after v2 activation and reconstruct correctly on v2 receivers;
- root and branch unadmitted-schema negatives persist no versions;
- planted current-pointer retagging makes the exact regressions fail;
- independent adversarial review found no P0–P2.