### PR TITLE
test: make direct subscription fixtures local-only

### DIFF
--- a/crates/jazz-sim/benches/s1_saas.rs
+++ b/crates/jazz-sim/benches/s1_saas.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 
 use hdrhistogram::Histogram;
 use jazz::db::{
-    Db, DbConfig, DbIdentity, ReadOpts, RowCells, SeededRowIdSource, SubscriptionEvent,
-    SubscriptionStream,
+    Db, DbConfig, DbIdentity, Propagation, ReadOpts, RowCells, SeededRowIdSource,
+    SubscriptionEvent, SubscriptionStream,
 };
 use jazz::groove::records::Value;
 use jazz::groove::schema::{ColumnSchema, ColumnType};
@@ -224,10 +224,18 @@ pub fn db_surface_smoke() {
     let query2 = db_query2(&plan);
     let prepared_query1 = db.prepare_query(&query1).expect("db prepare q1");
     let prepared_query2 = db.prepare_query(&query2).expect("db prepare q2");
+    // The database-surface fixture has no authority peer. Its opening state is
+    // intentionally the immediately observable local terminal, not a remote
+    // Full-propagation request awaiting an authority receipt.
+    let local_subscription_opts = ReadOpts {
+        propagation: Propagation::LocalOnly,
+        ..ReadOpts::default()
+    };
     let mut subscription1 =
-        block_on(db.subscribe(&prepared_query1, ReadOpts::default())).expect("db subscribe q1");
+        block_on(db.subscribe(&prepared_query1, local_subscription_opts.clone()))
+            .expect("db subscribe q1");
     let mut subscription2 =
-        block_on(db.subscribe(&prepared_query2, ReadOpts::default())).expect("db subscribe q2");
+        block_on(db.subscribe(&prepared_query2, local_subscription_opts)).expect("db subscribe q2");
     let mut subscription1_rows = subscription_snapshot_row_set(&mut subscription1);
     let mut subscription2_rows = subscription_snapshot_row_set(&mut subscription2);
     assert!(subscription1_rows.is_empty());

--- a/crates/jazz-sim/benches/s2_canvas.rs
+++ b/crates/jazz-sim/benches/s2_canvas.rs
@@ -8,7 +8,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use hdrhistogram::Histogram;
-use jazz::db::{Db, DbConfig, DbIdentity, ReadOpts, SeededRowIdSource, SubscriptionEvent};
+use jazz::db::{
+    Db, DbConfig, DbIdentity, Propagation, ReadOpts, SeededRowIdSource, SubscriptionEvent,
+};
 use jazz::groove::records::{ScalarEnumSchema, Value};
 use jazz::groove::schema::{ColumnSchema, ColumnType};
 use jazz::groove::storage::{Durability, RocksDbStorage};
@@ -1803,9 +1805,16 @@ fn run_db_surface(config: &Config, coalesced: bool) -> DbSurfaceSummary {
 
     let query = db_canvas_query(canvas);
     let prepared_query = db.prepare_query(&query).expect("db prepare query");
+    // This direct-Db benchmark is intentionally local-only: it has no
+    // authority peer whose receipt could settle a Full-propagation opening.
+    let local_subscription_opts = ReadOpts {
+        propagation: Propagation::LocalOnly,
+        ..ReadOpts::default()
+    };
     let mut watches = (0..(config.active + config.passive))
         .map(|_| {
-            block_on(db.subscribe(&prepared_query, ReadOpts::default())).expect("db subscribe")
+            block_on(db.subscribe(&prepared_query, local_subscription_opts.clone()))
+                .expect("db subscribe")
         })
         .collect::<Vec<_>>();
     let mut watch_rows = Vec::with_capacity(watches.len());
@@ -1821,7 +1830,7 @@ fn run_db_surface(config: &Config, coalesced: bool) -> DbSurfaceSummary {
     let spy_query = db_canvas_query(row(99_999));
     let prepared_spy_query = db.prepare_query(&spy_query).expect("db prepare spy query");
     let mut spy_watch =
-        block_on(db.subscribe(&prepared_spy_query, ReadOpts::default())).expect("db spy watch");
+        block_on(db.subscribe(&prepared_spy_query, local_subscription_opts)).expect("db spy watch");
     let mut spy_rows = BTreeMap::new();
     apply_db_subscription_event(
         &mut spy_rows,

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -2650,7 +2650,17 @@ fn relation_query_subscription_multi_hop_scalar_fk_uses_nested_join_path() {
     let schema = relation_hop_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
     let query = users_to_orgs_relation_query();
-    let mut stream = block_on(db.subscribe_relation_query(&query, ReadOpts::default())).unwrap();
+    // This fixture exercises only the local maintained-query program. It does
+    // not model an authority receipt, so request the immediate local terminal
+    // explicitly rather than relying on a provisional Full-propagation empty.
+    let mut stream = block_on(db.subscribe_relation_query(
+        &query,
+        ReadOpts {
+            propagation: Propagation::LocalOnly,
+            ..ReadOpts::default()
+        },
+    ))
+    .unwrap();
     assert!(opened_rows(stream.try_next_event().expect("opened event")).is_empty());
 
     db.insert_with_id(
@@ -2769,7 +2779,17 @@ fn relation_query_gather_uses_unified_reachable_lowering_for_reads_and_subscript
     .with_write_policy(Policy::public())]);
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
     let query = teams_gather_relation_query();
-    let mut stream = block_on(db.subscribe_relation_query(&query, ReadOpts::default())).unwrap();
+    // This fixture exercises only the local maintained-query program. It does
+    // not model an authority receipt, so request the immediate local terminal
+    // explicitly rather than relying on a provisional Full-propagation empty.
+    let mut stream = block_on(db.subscribe_relation_query(
+        &query,
+        ReadOpts {
+            propagation: Propagation::LocalOnly,
+            ..ReadOpts::default()
+        },
+    ))
+    .unwrap();
     assert!(opened_rows(stream.try_next_event().expect("opened event")).is_empty());
 
     let root = row(0x01);

--- a/crates/jazz/tests/catalogue_sync_integration.rs
+++ b/crates/jazz/tests/catalogue_sync_integration.rs
@@ -1682,24 +1682,11 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
         .subscribe(query.clone())
         .await
         .expect("subscribe reader before permissions");
+    // A Full-propagation subscription must not publish a local empty opening
+    // before the authority has evaluated it. The first observable update below
+    // is therefore deliberately awaited only after the permissions head and
+    // the matching authority-side write have settled.
     let mut log = Vec::new();
-
-    wait_for_subscription_update(
-        &mut stream,
-        &mut log,
-        Duration::from_secs(10),
-        "initial empty local subscription snapshot before permissions",
-        |updates| !updates.is_empty(),
-    )
-    .await;
-    assert!(
-        log[0].is_empty(),
-        "plain local subscription should fail closed as an empty local delta before permissions"
-    );
-    assert!(
-        log[0].pending,
-        "the fail-closed opening snapshot must remain visibly provisional before permissions"
-    );
 
     let allow_head = publish_allow_all_permissions(
         &server.base_url(),

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -17,6 +17,11 @@ import type { WasmRow } from "../drivers/types.js";
 import { createOpenBatchId, type BatchId, type OpenBatchId, type WriteReceipt } from "./client.js";
 
 const require = createRequire(import.meta.url);
+// These direct-memory subscription fixtures exercise only the local NAPI
+// delivery boundary.  An unqualified subscription propagates upstream by
+// default, so an initially empty full-propagation view is deliberately
+// withheld until its authority has settled it.
+const LOCAL_ONLY_SUBSCRIPTION_OPTIONS = JSON.stringify({ propagation: "local-only" });
 const debugSubscriptionEventFixture = hasJazzNapiBuild()
   ? (
       require("jazz-napi") as typeof import("jazz-napi") & {
@@ -498,7 +503,12 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
     const manager = new SubscriptionManager<WasmRow>();
     const updates: ReturnType<SubscriptionManager<WasmRow>["handleDelta"]>[] = [];
-    const handle = runtime.createSubscription(JSON.stringify({ table: "todos" }), null, "local");
+    const handle = runtime.createSubscription(
+      JSON.stringify({ table: "todos" }),
+      null,
+      "local",
+      LOCAL_ONLY_SUBSCRIPTION_OPTIONS,
+    );
     runtime.executeSubscription(handle, (delta: unknown) => {
       updates.push(
         manager.handleDelta(
@@ -553,6 +563,41 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     ]);
 
     runtime.unsubscribe(handle);
+  });
+
+  it("withholds a default full-propagation empty opening but publishes a local-only one", async () => {
+    const { NapiDb } = await loadNapiModule();
+    const runtime = new NativeRuntimeAdapter(
+      { openMemory: (schema, config) => NapiDb.openMemory(schema, config) as never },
+      TEST_SCHEMA,
+      deterministicBytes("jazz-napi-native-runtime-provisional-empty:node"),
+      deterministicBytes("jazz-napi-native-runtime-provisional-empty:author"),
+      25,
+      true,
+    );
+    runtimes.push(runtime);
+
+    const defaultFullUpdates: unknown[] = [];
+    const defaultFull = runtime.createSubscription(
+      JSON.stringify({ table: "todos" }),
+      null,
+      "local",
+    );
+    runtime.executeSubscription(defaultFull, (delta: unknown) => defaultFullUpdates.push(delta));
+    expect(defaultFullUpdates).toEqual([]);
+
+    const localOnlyUpdates: unknown[] = [];
+    const localOnly = runtime.createSubscription(
+      JSON.stringify({ table: "todos" }),
+      null,
+      "local",
+      LOCAL_ONLY_SUBSCRIPTION_OPTIONS,
+    );
+    runtime.executeSubscription(localOnly, (delta: unknown) => localOnlyUpdates.push(delta));
+    expect(localOnlyUpdates).toHaveLength(1);
+
+    runtime.unsubscribe(defaultFull);
+    runtime.unsubscribe(localOnly);
   });
 
   it("returns raw NAPI subscription payloads as Uint8Array with registered terminal layouts", async () => {
@@ -622,7 +667,12 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
     const manager = new SubscriptionManager<WasmRow>();
     const updates: ReturnType<SubscriptionManager<WasmRow>["handleDelta"]>[] = [];
-    const handle = runtime.createSubscription(JSON.stringify({ table: "blobs" }), null, "local");
+    const handle = runtime.createSubscription(
+      JSON.stringify({ table: "blobs" }),
+      null,
+      "local",
+      LOCAL_ONLY_SUBSCRIPTION_OPTIONS,
+    );
     runtime.executeSubscription(handle, (delta: unknown) => {
       updates.push(
         manager.handleDelta(
@@ -774,6 +824,7 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
           JSON.stringify({ table: "todos" }),
           null,
           "local",
+          LOCAL_ONLY_SUBSCRIPTION_OPTIONS,
         );
         runtime.executeSubscription(handle, (...args: unknown[]) => notifications.push(args));
         expect(notifications).toHaveLength(1);
@@ -846,7 +897,12 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
     const manager = new SubscriptionManager<WasmRow>();
     const updates: ReturnType<SubscriptionManager<WasmRow>["handleDelta"]>[] = [];
-    const handle = runtime.createSubscription(JSON.stringify({ table: "todos" }), null, "local");
+    const handle = runtime.createSubscription(
+      JSON.stringify({ table: "todos" }),
+      null,
+      "local",
+      LOCAL_ONLY_SUBSCRIPTION_OPTIONS,
+    );
     runtime.executeSubscription(handle, (delta: unknown) => {
       updates.push(
         manager.handleDelta(
@@ -1014,7 +1070,12 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
       );
     const aliceDecodedUpdates: ReturnType<SubscriptionManager<WasmRow>["handleDelta"]>[] = [];
 
-    const aliceHandle = runtime.createSubscription(query, aliceSession, "local");
+    const aliceHandle = runtime.createSubscription(
+      query,
+      aliceSession,
+      "local",
+      LOCAL_ONLY_SUBSCRIPTION_OPTIONS,
+    );
     runtime.executeSubscription(aliceHandle, (delta: unknown) => {
       aliceUpdates.push(delta);
       aliceDecodedUpdates.push(decodeAliceDelta(delta));


### PR DESCRIPTION
🤖 Makes direct local subscription fixtures state their local-only propagation contract after provisional remote empty openings became authority-gated.

Five failures on the combined stack were stale assumptions, not product regressions:
- two in-process relation tests requested full propagation despite having no authority peer;
- the dynamic server test expected the provisional fail-closed empty event that is intentionally no longer public;
- S1 and S2 direct-Db smokes opened full subscriptions without an authority and blocked until CI timeout.

The direct fixtures now use explicit LocalOnly propagation. The dynamic server test waits for the first authority-admitted add after permissions and Edge settlement, then still proves retightening removes it. No sleeps or remote-settlement weakening were added.

The S2 historical implicit-include QueryCapability diagnostic remains intact and visible.

Evidence:
- both relation tests, dynamic integration, S1, and S2 pass;
- restoring Full propagation makes the local fixtures fail at the missing initial event;
- planting allow-all instead of retightening makes the removal assertion time out;
- independent adversarial review found no P0–P2;
- Rust burndown remains exactly 9 active + 9 dormant.