### PR TITLE
test: stabilize starter persistence canaries

### DIFF
--- a/TEST_BURNDOWN.md
+++ b/TEST_BURNDOWN.md
@@ -58,3 +58,14 @@ The original measured TypeScript/browser failure set is burned down. The former
 catalogue-rehydration case is now an active browser receipt in
 `worker-bridge.test.ts`, with a fresh release-NAPI/fast-WASM run on the trusted
 catalogue-lineage persistence fix.
+
+## Manual starter E2E stabilization (not quarantine)
+
+- **Fresh-artifact starter matrix:** run the four local-first production-build
+  starters (`next-localfirst`, `sveltekit-localfirst`, `react-localfirst`, and
+  `ts-localfirst`) through `create-jazz-e2e` after `pnpm build:test-artifacts`.
+  The canary waits for each starter's accessible **Saved locally** acknowledgement
+  before reload, so it checks persistence after the documented Local-durability
+  boundary rather than an optimistic-render timing race. This manual/release
+  tracking item is explicitly excluded from the strict Rust and TypeScript
+  ignored-test accounting above: it adds no skip marker and no quarantined test.

--- a/dev/scripts/check-starters-parity.mjs
+++ b/dev/scripts/check-starters-parity.mjs
@@ -250,6 +250,43 @@ function checkSharedReadmeBlocks() {
   }
 }
 
+function checkSaveLifecycleContracts() {
+  for (const [framework, dirs] of Object.entries(STARTERS)) {
+    const widgetPath = {
+      next: "components/todo-widget.tsx",
+      sveltekit: "src/lib/TodoWidget.svelte",
+      react: "src/todo-widget.tsx",
+      ts: "src/todo-widget.ts",
+    }[framework];
+    for (const dir of dirs) {
+      const path = `${dir}/${widgetPath}`;
+      const content = read(path);
+      if (content === null) continue;
+      for (const [description, pattern] of [
+        ["a save generation guard", /latestSaveGeneration/],
+        ["a pending local-save counter", /pending(?:Local)?SaveCount/],
+        ["a local failure acknowledgement", /Save failed locally/],
+        ["a lifecycle-state renderer", /renderLocalSaveState/],
+      ]) {
+        if (!pattern.test(content)) {
+          errors.push(`${path}: missing ${description}`);
+        }
+      }
+      if (framework === "ts") {
+        for (const [description, pattern] of [
+          ["an edge durability wait after local acknowledgement", /wait\(\{ tier: "edge" \}\)/],
+          ["an edge failure acknowledgement", /Saved locally; sync failed/],
+          ["a generation-guarded reset", /generation === latestSaveGeneration\) form\.reset/],
+        ]) {
+          if (!pattern.test(content)) {
+            errors.push(`${path}: missing ${description}`);
+          }
+        }
+      }
+    }
+  }
+}
+
 function checkAllStartersParity() {
   const allDirs = Object.values(STARTERS).flat();
   for (const rel of ALL_STARTERS_FILES) {
@@ -279,6 +316,7 @@ checkAllStartersParity();
 checkHonoServerPairs();
 checkReadmeStructure();
 checkSharedReadmeBlocks();
+checkSaveLifecycleContracts();
 
 if (errors.length > 0) {
   console.error("Starters parity check FAILED:\n");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1863,12 +1863,18 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
       typescript:
         specifier: catalog:default
         version: 6.0.2
       vite:
         specifier: catalog:default
         version: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -24854,6 +24860,38 @@ snapshots:
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 20.8.4
       jsdom: 28.1.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.6.0
+      '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      '@vitest/ui': 4.1.0(vitest@4.1.0)
+      happy-dom: 20.8.4
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 

--- a/starters/next-betterauth/components/todo-widget.tsx
+++ b/starters/next-betterauth/components/todo-widget.tsx
@@ -1,17 +1,45 @@
 "use client";
 
+import { useRef, useState } from "react";
 import { useDb, useAll } from "jazz-tools/react";
 import { app } from "@/schema";
 
 export function TodoWidget() {
   const db = useDb();
   const { data: todos = [] } = useAll(app.todos);
+  const [localSaveState, setLocalSaveState] = useState("Ready to save locally");
+  const latestSaveGeneration = useRef(0);
+  const pendingSaveCount = useRef(0);
+  const latestSaveFailed = useRef(false);
 
-  function add(formData: FormData) {
+  function renderLocalSaveState() {
+    setLocalSaveState(
+      latestSaveFailed.current
+        ? "Save failed locally"
+        : pendingSaveCount.current > 0
+          ? "Saving locally…"
+          : "Saved locally",
+    );
+  }
+
+  async function add(formData: FormData) {
     const title = formData.get("title") as string;
     const trimmed = title.trim();
     if (!trimmed) return;
-    db.insert(app.todos, { title: trimmed, done: false });
+    const generation = ++latestSaveGeneration.current;
+    pendingSaveCount.current += 1;
+    latestSaveFailed.current = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title: trimmed, done: false });
+      await write.wait({ tier: "local" });
+    } catch {
+      if (generation === latestSaveGeneration.current) latestSaveFailed.current = true;
+    } finally {
+      pendingSaveCount.current -= 1;
+      if (generation === latestSaveGeneration.current || pendingSaveCount.current === 0)
+        renderLocalSaveState();
+    }
   }
 
   return (
@@ -21,6 +49,9 @@ export function TodoWidget() {
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">
+        {localSaveState}
+      </p>
       <ul>
         {todos.map((t) => (
           <li key={t.id} className={t.done ? "done" : ""}>

--- a/starters/next-hybrid/components/todo-widget.tsx
+++ b/starters/next-hybrid/components/todo-widget.tsx
@@ -1,17 +1,45 @@
 "use client";
 
+import { useRef, useState } from "react";
 import { useDb, useAll } from "jazz-tools/react";
 import { app } from "@/schema";
 
 export function TodoWidget() {
   const db = useDb();
   const { data: todos = [] } = useAll(app.todos);
+  const [localSaveState, setLocalSaveState] = useState("Ready to save locally");
+  const latestSaveGeneration = useRef(0);
+  const pendingSaveCount = useRef(0);
+  const latestSaveFailed = useRef(false);
 
-  function add(formData: FormData) {
+  function renderLocalSaveState() {
+    setLocalSaveState(
+      latestSaveFailed.current
+        ? "Save failed locally"
+        : pendingSaveCount.current > 0
+          ? "Saving locally…"
+          : "Saved locally",
+    );
+  }
+
+  async function add(formData: FormData) {
     const title = formData.get("title") as string;
     const trimmed = title.trim();
     if (!trimmed) return;
-    db.insert(app.todos, { title: trimmed, done: false });
+    const generation = ++latestSaveGeneration.current;
+    pendingSaveCount.current += 1;
+    latestSaveFailed.current = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title: trimmed, done: false });
+      await write.wait({ tier: "local" });
+    } catch {
+      if (generation === latestSaveGeneration.current) latestSaveFailed.current = true;
+    } finally {
+      pendingSaveCount.current -= 1;
+      if (generation === latestSaveGeneration.current || pendingSaveCount.current === 0)
+        renderLocalSaveState();
+    }
   }
 
   return (
@@ -21,6 +49,9 @@ export function TodoWidget() {
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">
+        {localSaveState}
+      </p>
       <ul>
         {todos.map((t) => (
           <li key={t.id} className={t.done ? "done" : ""}>

--- a/starters/next-localfirst/components/todo-widget.tsx
+++ b/starters/next-localfirst/components/todo-widget.tsx
@@ -1,17 +1,45 @@
 "use client";
 
+import { useRef, useState } from "react";
 import { useDb, useAll } from "jazz-tools/react";
 import { app } from "@/schema";
 
 export function TodoWidget() {
   const db = useDb();
   const { data: todos = [] } = useAll(app.todos);
+  const [localSaveState, setLocalSaveState] = useState("Ready to save locally");
+  const latestSaveGeneration = useRef(0);
+  const pendingSaveCount = useRef(0);
+  const latestSaveFailed = useRef(false);
 
-  function add(formData: FormData) {
+  function renderLocalSaveState() {
+    setLocalSaveState(
+      latestSaveFailed.current
+        ? "Save failed locally"
+        : pendingSaveCount.current > 0
+          ? "Saving locally…"
+          : "Saved locally",
+    );
+  }
+
+  async function add(formData: FormData) {
     const title = formData.get("title") as string;
     const trimmed = title.trim();
     if (!trimmed) return;
-    db.insert(app.todos, { title: trimmed, done: false });
+    const generation = ++latestSaveGeneration.current;
+    pendingSaveCount.current += 1;
+    latestSaveFailed.current = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title: trimmed, done: false });
+      await write.wait({ tier: "local" });
+    } catch {
+      if (generation === latestSaveGeneration.current) latestSaveFailed.current = true;
+    } finally {
+      pendingSaveCount.current -= 1;
+      if (generation === latestSaveGeneration.current || pendingSaveCount.current === 0)
+        renderLocalSaveState();
+    }
   }
 
   return (
@@ -21,6 +49,9 @@ export function TodoWidget() {
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">
+        {localSaveState}
+      </p>
       <ul>
         {todos.map((t) => (
           <li key={t.id} className={t.done ? "done" : ""}>

--- a/starters/next-localfirst/e2e/auth-backup.spec.ts
+++ b/starters/next-localfirst/e2e/auth-backup.spec.ts
@@ -13,6 +13,7 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  await expect(page.getByRole("status")).toHaveText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("recovery phrase round-trips the local-first identity", async ({ page }) => {

--- a/starters/next-localfirst/e2e/todo-flow.spec.ts
+++ b/starters/next-localfirst/e2e/todo-flow.spec.ts
@@ -13,6 +13,7 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  await expect(page.getByRole("status")).toHaveText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("todo persists across reload in pure local-first mode", async ({ page }) => {

--- a/starters/react-betterauth/src/todo-widget.tsx
+++ b/starters/react-betterauth/src/todo-widget.tsx
@@ -1,15 +1,44 @@
+import { useRef, useState } from "react";
 import { useDb, useAll } from "jazz-tools/react";
 import { app } from "../schema";
 
 export function TodoWidget() {
   const db = useDb();
   const { data: todos = [] } = useAll(app.todos);
+  const [localSaveState, setLocalSaveState] = useState("Ready to save locally");
+  const latestSaveGeneration = useRef(0);
+  const pendingSaveCount = useRef(0);
+  const latestSaveFailed = useRef(false);
 
-  function add(formData: FormData) {
+  function renderLocalSaveState() {
+    setLocalSaveState(
+      latestSaveFailed.current
+        ? "Save failed locally"
+        : pendingSaveCount.current > 0
+          ? "Saving locally…"
+          : "Saved locally",
+    );
+  }
+
+  async function add(formData: FormData) {
     const title = formData.get("title") as string;
     const trimmed = title.trim();
     if (!trimmed) return;
-    db.insert(app.todos, { title: trimmed, done: false });
+    const generation = ++latestSaveGeneration.current;
+    pendingSaveCount.current += 1;
+    latestSaveFailed.current = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title: trimmed, done: false });
+      await write.wait({ tier: "local" });
+    } catch {
+      if (generation === latestSaveGeneration.current) latestSaveFailed.current = true;
+    } finally {
+      pendingSaveCount.current -= 1;
+      if (generation === latestSaveGeneration.current || pendingSaveCount.current === 0) {
+        renderLocalSaveState();
+      }
+    }
   }
 
   return (
@@ -19,6 +48,9 @@ export function TodoWidget() {
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">
+        {localSaveState}
+      </p>
       <ul>
         {todos.map((t) => (
           <li key={t.id} className={t.done ? "done" : ""}>

--- a/starters/react-hybrid/src/todo-widget.tsx
+++ b/starters/react-hybrid/src/todo-widget.tsx
@@ -1,15 +1,44 @@
+import { useRef, useState } from "react";
 import { useDb, useAll } from "jazz-tools/react";
 import { app } from "../schema";
 
 export function TodoWidget() {
   const db = useDb();
   const { data: todos = [] } = useAll(app.todos);
+  const [localSaveState, setLocalSaveState] = useState("Ready to save locally");
+  const latestSaveGeneration = useRef(0);
+  const pendingSaveCount = useRef(0);
+  const latestSaveFailed = useRef(false);
 
-  function add(formData: FormData) {
+  function renderLocalSaveState() {
+    setLocalSaveState(
+      latestSaveFailed.current
+        ? "Save failed locally"
+        : pendingSaveCount.current > 0
+          ? "Saving locally…"
+          : "Saved locally",
+    );
+  }
+
+  async function add(formData: FormData) {
     const title = formData.get("title") as string;
     const trimmed = title.trim();
     if (!trimmed) return;
-    db.insert(app.todos, { title: trimmed, done: false });
+    const generation = ++latestSaveGeneration.current;
+    pendingSaveCount.current += 1;
+    latestSaveFailed.current = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title: trimmed, done: false });
+      await write.wait({ tier: "local" });
+    } catch {
+      if (generation === latestSaveGeneration.current) latestSaveFailed.current = true;
+    } finally {
+      pendingSaveCount.current -= 1;
+      if (generation === latestSaveGeneration.current || pendingSaveCount.current === 0) {
+        renderLocalSaveState();
+      }
+    }
   }
 
   return (
@@ -19,6 +48,9 @@ export function TodoWidget() {
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">
+        {localSaveState}
+      </p>
       <ul>
         {todos.map((t) => (
           <li key={t.id} className={t.done ? "done" : ""}>

--- a/starters/react-localfirst/e2e/auth-backup.spec.ts
+++ b/starters/react-localfirst/e2e/auth-backup.spec.ts
@@ -13,6 +13,7 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  await expect(page.getByRole("status")).toHaveText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("recovery phrase round-trips the local-first identity", async ({ page }) => {

--- a/starters/react-localfirst/e2e/todo-flow.spec.ts
+++ b/starters/react-localfirst/e2e/todo-flow.spec.ts
@@ -13,6 +13,7 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  await expect(page.getByRole("status")).toHaveText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("todo persists across reload in pure local-first mode", async ({ page }) => {

--- a/starters/react-localfirst/src/todo-widget.tsx
+++ b/starters/react-localfirst/src/todo-widget.tsx
@@ -1,15 +1,44 @@
+import { useRef, useState } from "react";
 import { useDb, useAll } from "jazz-tools/react";
 import { app } from "../schema";
 
 export function TodoWidget() {
   const db = useDb();
   const { data: todos = [] } = useAll(app.todos);
+  const [localSaveState, setLocalSaveState] = useState("Ready to save locally");
+  const latestSaveGeneration = useRef(0);
+  const pendingSaveCount = useRef(0);
+  const latestSaveFailed = useRef(false);
 
-  function add(formData: FormData) {
+  function renderLocalSaveState() {
+    setLocalSaveState(
+      latestSaveFailed.current
+        ? "Save failed locally"
+        : pendingSaveCount.current > 0
+          ? "Saving locally…"
+          : "Saved locally",
+    );
+  }
+
+  async function add(formData: FormData) {
     const title = formData.get("title") as string;
     const trimmed = title.trim();
     if (!trimmed) return;
-    db.insert(app.todos, { title: trimmed, done: false });
+    const generation = ++latestSaveGeneration.current;
+    pendingSaveCount.current += 1;
+    latestSaveFailed.current = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title: trimmed, done: false });
+      await write.wait({ tier: "local" });
+    } catch {
+      if (generation === latestSaveGeneration.current) latestSaveFailed.current = true;
+    } finally {
+      pendingSaveCount.current -= 1;
+      if (generation === latestSaveGeneration.current || pendingSaveCount.current === 0) {
+        renderLocalSaveState();
+      }
+    }
   }
 
   return (
@@ -19,6 +48,9 @@ export function TodoWidget() {
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">
+        {localSaveState}
+      </p>
       <ul>
         {todos.map((t) => (
           <li key={t.id} className={t.done ? "done" : ""}>

--- a/starters/sveltekit-betterauth/src/lib/TodoWidget.svelte
+++ b/starters/sveltekit-betterauth/src/lib/TodoWidget.svelte
@@ -4,14 +4,38 @@
 
   const db = getDb();
   const todos = new QuerySubscription(app.todos);
+  let localSaveState = "Ready to save locally";
+  let latestSaveGeneration = 0;
+  let pendingSaveCount = 0;
+  let latestSaveFailed = false;
 
-  function add(e: SubmitEvent) {
+  function renderLocalSaveState() {
+    localSaveState = latestSaveFailed
+      ? "Save failed locally"
+      : pendingSaveCount > 0
+        ? "Saving locally…"
+        : "Saved locally";
+  }
+
+  async function add(e: SubmitEvent) {
     e.preventDefault();
     const form = e.currentTarget as HTMLFormElement;
     const title = (new FormData(form).get("title") as string).trim();
     if (!title) return;
-    db.insert(app.todos, { title, done: false });
-    form.reset();
+    const generation = ++latestSaveGeneration;
+    pendingSaveCount += 1;
+    latestSaveFailed = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title, done: false });
+      await write.wait({ tier: "local" });
+      if (generation === latestSaveGeneration) form.reset();
+    } catch {
+      if (generation === latestSaveGeneration) latestSaveFailed = true;
+    } finally {
+      pendingSaveCount -= 1;
+      if (generation === latestSaveGeneration || pendingSaveCount === 0) renderLocalSaveState();
+    }
   }
 </script>
 
@@ -26,6 +50,7 @@
     />
     <button type="submit">Add</button>
   </form>
+  <p role="status" aria-live="polite">{localSaveState}</p>
   <ul>
     {#each todos.current ?? [] as todo (todo.id)}
       <li class={todo.done ? "done" : ""}>

--- a/starters/sveltekit-hybrid/src/lib/TodoWidget.svelte
+++ b/starters/sveltekit-hybrid/src/lib/TodoWidget.svelte
@@ -4,14 +4,38 @@
 
   const db = getDb();
   const todos = new QuerySubscription(app.todos);
+  let localSaveState = "Ready to save locally";
+  let latestSaveGeneration = 0;
+  let pendingSaveCount = 0;
+  let latestSaveFailed = false;
 
-  function add(e: SubmitEvent) {
+  function renderLocalSaveState() {
+    localSaveState = latestSaveFailed
+      ? "Save failed locally"
+      : pendingSaveCount > 0
+        ? "Saving locally…"
+        : "Saved locally";
+  }
+
+  async function add(e: SubmitEvent) {
     e.preventDefault();
     const form = e.currentTarget as HTMLFormElement;
     const title = (new FormData(form).get("title") as string).trim();
     if (!title) return;
-    db.insert(app.todos, { title, done: false });
-    form.reset();
+    const generation = ++latestSaveGeneration;
+    pendingSaveCount += 1;
+    latestSaveFailed = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title, done: false });
+      await write.wait({ tier: "local" });
+      if (generation === latestSaveGeneration) form.reset();
+    } catch {
+      if (generation === latestSaveGeneration) latestSaveFailed = true;
+    } finally {
+      pendingSaveCount -= 1;
+      if (generation === latestSaveGeneration || pendingSaveCount === 0) renderLocalSaveState();
+    }
   }
 </script>
 
@@ -26,6 +50,7 @@
     />
     <button type="submit">Add</button>
   </form>
+  <p role="status" aria-live="polite">{localSaveState}</p>
   <ul>
     {#each todos.current ?? [] as todo (todo.id)}
       <li class={todo.done ? "done" : ""}>

--- a/starters/sveltekit-localfirst/e2e/auth-backup.spec.ts
+++ b/starters/sveltekit-localfirst/e2e/auth-backup.spec.ts
@@ -13,6 +13,7 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  await expect(page.getByRole("status")).toHaveText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("recovery phrase round-trips the local-first identity", async ({ page }) => {

--- a/starters/sveltekit-localfirst/e2e/todo-flow.spec.ts
+++ b/starters/sveltekit-localfirst/e2e/todo-flow.spec.ts
@@ -13,6 +13,7 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  await expect(page.getByRole("status")).toHaveText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("todo persists across reload in pure local-first mode", async ({ page }) => {

--- a/starters/sveltekit-localfirst/src/lib/TodoWidget.svelte
+++ b/starters/sveltekit-localfirst/src/lib/TodoWidget.svelte
@@ -4,14 +4,38 @@
 
   const db = getDb();
   const todos = new QuerySubscription(app.todos);
+  let localSaveState = "Ready to save locally";
+  let latestSaveGeneration = 0;
+  let pendingSaveCount = 0;
+  let latestSaveFailed = false;
 
-  function add(e: SubmitEvent) {
+  function renderLocalSaveState() {
+    localSaveState = latestSaveFailed
+      ? "Save failed locally"
+      : pendingSaveCount > 0
+        ? "Saving locally…"
+        : "Saved locally";
+  }
+
+  async function add(e: SubmitEvent) {
     e.preventDefault();
     const form = e.currentTarget as HTMLFormElement;
     const title = (new FormData(form).get("title") as string).trim();
     if (!title) return;
-    db.insert(app.todos, { title, done: false });
-    form.reset();
+    const generation = ++latestSaveGeneration;
+    pendingSaveCount += 1;
+    latestSaveFailed = false;
+    renderLocalSaveState();
+    try {
+      const write = db.insert(app.todos, { title, done: false });
+      await write.wait({ tier: "local" });
+      if (generation === latestSaveGeneration) form.reset();
+    } catch {
+      if (generation === latestSaveGeneration) latestSaveFailed = true;
+    } finally {
+      pendingSaveCount -= 1;
+      if (generation === latestSaveGeneration || pendingSaveCount === 0) renderLocalSaveState();
+    }
   }
 </script>
 
@@ -26,6 +50,7 @@
     />
     <button type="submit">Add</button>
   </form>
+  <p role="status" aria-live="polite">{localSaveState}</p>
   <ul>
     {#each todos.current ?? [] as todo (todo.id)}
       <li class={todo.done ? "done" : ""}>

--- a/starters/ts-betterauth/src/todo-widget.ts
+++ b/starters/ts-betterauth/src/todo-widget.ts
@@ -58,12 +58,28 @@ export function mountTodoWidget(
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">Ready to save locally</p>
       <ul></ul>
     </section>
   `;
   const form = parent.querySelector<HTMLFormElement>("form")!;
   const input = form.querySelector<HTMLInputElement>("input[name='title']")!;
   const list = parent.querySelector<HTMLUListElement>("ul")!;
+  const localSaveStatus = parent.querySelector<HTMLElement>("[role='status']")!;
+  let latestSaveGeneration = 0;
+  let pendingLocalSaveCount = 0;
+  let latestLocalSaveState: "saving" | "saved" | "failed" | "sync-failed" = "saved";
+
+  function renderLocalSaveState() {
+    localSaveStatus.textContent =
+      latestLocalSaveState === "failed"
+        ? "Save failed locally"
+        : latestLocalSaveState === "sync-failed"
+          ? "Saved locally; sync failed"
+          : pendingLocalSaveCount > 0
+            ? "Saving locally…"
+            : "Saved locally";
+  }
 
   function renderTodos(todos: Todo[]) {
     list.replaceChildren(...todos.map(renderRow));
@@ -73,9 +89,32 @@ export function mountTodoWidget(
     event.preventDefault();
     const title = input.value.trim();
     if (!title) return;
-    const write = await db.insert(app.todos, { title, done: false });
-    await write.wait({ tier: "edge" });
-    form.reset();
+    const generation = ++latestSaveGeneration;
+    pendingLocalSaveCount += 1;
+    latestLocalSaveState = "saving";
+    renderLocalSaveState();
+    let savedLocally = false;
+    try {
+      const write = await db.insert(app.todos, { title, done: false });
+      await write.wait({ tier: "local" });
+      savedLocally = true;
+      if (generation === latestSaveGeneration) latestLocalSaveState = "saved";
+      pendingLocalSaveCount -= 1;
+      renderLocalSaveState();
+      await write.wait({ tier: "edge" });
+      if (generation === latestSaveGeneration) form.reset();
+    } catch {
+      if (generation === latestSaveGeneration) {
+        latestLocalSaveState = savedLocally ? "sync-failed" : "failed";
+        renderLocalSaveState();
+      }
+    } finally {
+      if (!savedLocally) {
+        pendingLocalSaveCount -= 1;
+        if (generation === latestSaveGeneration) latestLocalSaveState = "failed";
+        renderLocalSaveState();
+      }
+    }
   });
 
   list.addEventListener("click", (event) => {

--- a/starters/ts-hybrid/src/todo-widget.ts
+++ b/starters/ts-hybrid/src/todo-widget.ts
@@ -58,12 +58,28 @@ export function mountTodoWidget(
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">Ready to save locally</p>
       <ul></ul>
     </section>
   `;
   const form = parent.querySelector<HTMLFormElement>("form")!;
   const input = form.querySelector<HTMLInputElement>("input[name='title']")!;
   const list = parent.querySelector<HTMLUListElement>("ul")!;
+  const localSaveStatus = parent.querySelector<HTMLElement>("[role='status']")!;
+  let latestSaveGeneration = 0;
+  let pendingLocalSaveCount = 0;
+  let latestLocalSaveState: "saving" | "saved" | "failed" | "sync-failed" = "saved";
+
+  function renderLocalSaveState() {
+    localSaveStatus.textContent =
+      latestLocalSaveState === "failed"
+        ? "Save failed locally"
+        : latestLocalSaveState === "sync-failed"
+          ? "Saved locally; sync failed"
+          : pendingLocalSaveCount > 0
+            ? "Saving locally…"
+            : "Saved locally";
+  }
 
   function renderTodos(todos: Todo[]) {
     list.replaceChildren(...todos.map(renderRow));
@@ -73,9 +89,32 @@ export function mountTodoWidget(
     event.preventDefault();
     const title = input.value.trim();
     if (!title) return;
-    const write = await db.insert(app.todos, { title, done: false });
-    await write.wait({ tier: "edge" });
-    form.reset();
+    const generation = ++latestSaveGeneration;
+    pendingLocalSaveCount += 1;
+    latestLocalSaveState = "saving";
+    renderLocalSaveState();
+    let savedLocally = false;
+    try {
+      const write = await db.insert(app.todos, { title, done: false });
+      await write.wait({ tier: "local" });
+      savedLocally = true;
+      if (generation === latestSaveGeneration) latestLocalSaveState = "saved";
+      pendingLocalSaveCount -= 1;
+      renderLocalSaveState();
+      await write.wait({ tier: "edge" });
+      if (generation === latestSaveGeneration) form.reset();
+    } catch {
+      if (generation === latestSaveGeneration) {
+        latestLocalSaveState = savedLocally ? "sync-failed" : "failed";
+        renderLocalSaveState();
+      }
+    } finally {
+      if (!savedLocally) {
+        pendingLocalSaveCount -= 1;
+        if (generation === latestSaveGeneration) latestLocalSaveState = "failed";
+        renderLocalSaveState();
+      }
+    }
   });
 
   list.addEventListener("click", (event) => {

--- a/starters/ts-localfirst/e2e/auth-backup.spec.ts
+++ b/starters/ts-localfirst/e2e/auth-backup.spec.ts
@@ -13,6 +13,8 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  // Edge sync may fail after Local durability; either terminal status is safe to reload.
+  await expect(page.getByRole("status")).toContainText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("recovery phrase round-trips the local-first identity", async ({ page }) => {

--- a/starters/ts-localfirst/e2e/todo-flow.spec.ts
+++ b/starters/ts-localfirst/e2e/todo-flow.spec.ts
@@ -13,6 +13,8 @@ async function addTodo(page: Page, title: string) {
   await page.getByLabel(TODO_INPUT_LABEL).fill(title);
   await page.getByRole("button", { name: "Add" }).click();
   await expect(page.getByText(title)).toBeVisible({ timeout: TIMEOUT });
+  // Edge sync may fail after Local durability; either terminal status is safe to reload.
+  await expect(page.getByRole("status")).toContainText("Saved locally", { timeout: TIMEOUT });
 }
 
 test("todo persists across reload in pure local-first mode", async ({ page }) => {

--- a/starters/ts-localfirst/package.json
+++ b/starters/ts-localfirst/package.json
@@ -7,14 +7,17 @@
     "dev": "vite",
     "build": "tsc -p tsconfig.json && vite build",
     "preview": "vite preview",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "jsdom": "^26.0.0",
     "typescript": "catalog:default",
-    "vite": "catalog:default"
+    "vite": "catalog:default",
+    "vitest": "catalog:default"
   }
 }

--- a/starters/ts-localfirst/src/todo-widget.test.ts
+++ b/starters/ts-localfirst/src/todo-widget.test.ts
@@ -1,0 +1,159 @@
+import { expect, test } from "vitest";
+import type { SubscriptionDelta } from "jazz-tools/client";
+import { mountTodoWidget, type TodoDb, type TodoSubscribeAll } from "./todo-widget.js";
+
+type TestTodo = { id: string; title: string; done: boolean };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function localAndEdgeWrites() {
+  const local = deferred<void>();
+  const edge = deferred<void>();
+  const write = {
+    wait({ tier }: { tier?: "local" | "edge" | "global" } = {}) {
+      return tier === "edge" ? edge.promise : local.promise;
+    },
+  };
+  return { local, edge, write };
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function mount(db: TodoDb) {
+  const parent = document.createElement("div");
+  let publishTodos: (todos: TestTodo[]) => void = () => {};
+  const subscribeAll: TodoSubscribeAll = (_query, callback) => {
+    callback({ all: [], delta: [] });
+    const publishTestTodos = callback as unknown as (delta: SubscriptionDelta<TestTodo>) => void;
+    publishTodos = (all) => publishTestTodos({ all, delta: [] });
+    return () => {};
+  };
+  mountTodoWidget(parent, db, subscribeAll);
+  return {
+    form: parent.querySelector<HTMLFormElement>("form")!,
+    input: parent.querySelector<HTMLInputElement>("input")!,
+    status: parent.querySelector<HTMLElement>("[role='status']")!,
+    publishTodos,
+  };
+}
+
+function submit(form: HTMLFormElement, input: HTMLInputElement, title: string) {
+  input.value = title;
+  form.requestSubmit();
+}
+
+test("a rejected local write reports failure without leaking its rejection", async () => {
+  const local = deferred<void>();
+  const { form, input, status } = mount({
+    insert: () => ({ wait: () => local.promise }),
+    update: () => ({ wait: async () => {} }),
+    delete: () => ({ wait: async () => {} }),
+  });
+
+  submit(form, input, "will fail");
+  local.reject(new Error("disk unavailable"));
+  await flush();
+
+  expect(status.textContent).toBe("Save failed locally");
+  expect(input.value).toBe("will fail");
+});
+
+test("overlapping adds do not let an older completion announce local durability", async () => {
+  const first = localAndEdgeWrites();
+  const second = localAndEdgeWrites();
+  const writes = [first.write, second.write];
+  const { form, input, status } = mount({
+    insert: () => writes.shift()!,
+    update: () => ({ wait: async () => {} }),
+    delete: () => ({ wait: async () => {} }),
+  });
+
+  submit(form, input, "A");
+  submit(form, input, "B");
+  first.local.resolve();
+  await flush();
+  expect(status.textContent).toBe("Saving locally…");
+
+  second.local.resolve();
+  await flush();
+  expect(status.textContent).toBe("Saved locally");
+
+  first.edge.resolve();
+  second.edge.resolve();
+  await flush();
+});
+
+test("the local marker precedes edge durability, which alone resets the form", async () => {
+  const write = localAndEdgeWrites();
+  const { form, input, status, publishTodos } = mount({
+    insert: () => write.write,
+    update: () => ({ wait: async () => {} }),
+    delete: () => ({ wait: async () => {} }),
+  });
+
+  submit(form, input, "wait for edge");
+  publishTodos([{ id: "optimistic", title: "wait for edge", done: false }]);
+  expect(form.parentElement?.textContent).toContain("wait for edge");
+  write.local.resolve();
+  await flush();
+  expect(status.textContent).toBe("Saved locally");
+  expect(input.value).toBe("wait for edge");
+
+  write.edge.resolve();
+  await flush();
+  expect(input.value).toBe("");
+});
+
+test("an older edge completion cannot reset a newer pending add", async () => {
+  const first = localAndEdgeWrites();
+  const second = localAndEdgeWrites();
+  const writes = [first.write, second.write];
+  const { form, input } = mount({
+    insert: () => writes.shift()!,
+    update: () => ({ wait: async () => {} }),
+    delete: () => ({ wait: async () => {} }),
+  });
+
+  submit(form, input, "A");
+  first.local.resolve();
+  await flush();
+  submit(form, input, "B");
+
+  first.edge.resolve();
+  await flush();
+  expect(input.value).toBe("B");
+
+  second.local.resolve();
+  second.edge.resolve();
+  await flush();
+  expect(input.value).toBe("");
+});
+
+test("an edge rejection keeps the local acknowledgement and reports sync failure", async () => {
+  const write = localAndEdgeWrites();
+  const { form, input, status } = mount({
+    insert: () => write.write,
+    update: () => ({ wait: async () => {} }),
+    delete: () => ({ wait: async () => {} }),
+  });
+
+  submit(form, input, "edge failure");
+  write.local.resolve();
+  await flush();
+  write.edge.reject(new Error("edge unavailable"));
+  await flush();
+
+  expect(status.textContent).toBe("Saved locally; sync failed");
+  expect(input.value).toBe("edge failure");
+});

--- a/starters/ts-localfirst/src/todo-widget.ts
+++ b/starters/ts-localfirst/src/todo-widget.ts
@@ -58,12 +58,28 @@ export function mountTodoWidget(
         <input type="text" name="title" placeholder="Add a task" aria-label="New todo" />
         <button type="submit">Add</button>
       </form>
+      <p role="status" aria-live="polite">Ready to save locally</p>
       <ul></ul>
     </section>
   `;
   const form = parent.querySelector<HTMLFormElement>("form")!;
   const input = form.querySelector<HTMLInputElement>("input[name='title']")!;
   const list = parent.querySelector<HTMLUListElement>("ul")!;
+  const localSaveStatus = parent.querySelector<HTMLElement>("[role='status']")!;
+  let latestSaveGeneration = 0;
+  let pendingLocalSaveCount = 0;
+  let latestLocalSaveState: "saving" | "saved" | "failed" | "sync-failed" = "saved";
+
+  function renderLocalSaveState() {
+    localSaveStatus.textContent =
+      latestLocalSaveState === "failed"
+        ? "Save failed locally"
+        : latestLocalSaveState === "sync-failed"
+          ? "Saved locally; sync failed"
+          : pendingLocalSaveCount > 0
+            ? "Saving locally…"
+            : "Saved locally";
+  }
 
   function renderTodos(todos: Todo[]) {
     list.replaceChildren(...todos.map(renderRow));
@@ -73,9 +89,32 @@ export function mountTodoWidget(
     event.preventDefault();
     const title = input.value.trim();
     if (!title) return;
-    const write = await db.insert(app.todos, { title, done: false });
-    await write.wait({ tier: "edge" });
-    form.reset();
+    const generation = ++latestSaveGeneration;
+    pendingLocalSaveCount += 1;
+    latestLocalSaveState = "saving";
+    renderLocalSaveState();
+    let savedLocally = false;
+    try {
+      const write = await db.insert(app.todos, { title, done: false });
+      await write.wait({ tier: "local" });
+      savedLocally = true;
+      if (generation === latestSaveGeneration) latestLocalSaveState = "saved";
+      pendingLocalSaveCount -= 1;
+      renderLocalSaveState();
+      await write.wait({ tier: "edge" });
+      if (generation === latestSaveGeneration) form.reset();
+    } catch {
+      if (generation === latestSaveGeneration) {
+        latestLocalSaveState = savedLocally ? "sync-failed" : "failed";
+        renderLocalSaveState();
+      }
+    } finally {
+      if (!savedLocally) {
+        pendingLocalSaveCount -= 1;
+        if (generation === latestSaveGeneration) latestLocalSaveState = "failed";
+        renderLocalSaveState();
+      }
+    }
   });
 
   list.addEventListener("click", (event) => {

--- a/starters/ts-localfirst/vite.config.ts
+++ b/starters/ts-localfirst/vite.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
 export default defineConfig({
-  plugins: [jazzPlugin()],
+  test: {
+    environment: "jsdom",
+    include: ["src/**/*.test.ts"],
+  },
+  plugins: process.env.VITEST ? [] : [jazzPlugin()],
   worker: {
     format: "es",
   },


### PR DESCRIPTION
🤖 Stabilizes the manual create-jazz persistence canaries around the actual durability contract.

All 12 starter widgets preserve optimistic rendering but expose an ARIA lifecycle:
- Saving locally… while the write is pending;
- Saved locally only after wait({tier: local});
- local and Edge failures are caught and reported;
- overlapping submissions are generation-guarded so an older completion cannot reset or overwrite newer input.

The TS starters retain their stronger Edge sequencing: Local durability publishes the saved marker, Edge settlement still gates form reset, and Edge rejection reports Saved locally; sync failed.

The four local-first E2E helpers now wait for the explicit Local-durable marker before reload. This tests INV-API-30 rather than racing an optimistic DOM render against abrupt page termination. The suite remains manual/non-CI and is tracked separately from strict quarantine accounting.

Evidence:
- TS lifecycle unit suite 5/5; unconditional stale-A reset plant fails exactly;
- starter parity 12/12, all four production builds, lint/format, fresh artifact verifier;
- packaged matrix passes: Next, SvelteKit, React, TS;
- independent adversarial review found no P0–P2.