### PR TITLE
fix: preserve live subscriptions across schema registry growth

### DIFF
--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -1842,6 +1842,16 @@ where
             .unwrap_or(false)
     }
 
+    /// Retire subscriptions whose receiving handles have already been
+    /// dropped, even when no later data delta exists to discover the closed
+    /// notification channel.
+    pub fn prune_dropped_subscriptions(&mut self) -> Result<usize, Error> {
+        self.ensure_not_poisoned()?;
+        self.ivm_runtime
+            .prune_dropped_subscriptions_with_storage(&self.storage)
+            .map_err(Error::IvmRuntime)
+    }
+
     /// Run one IVM tick without base-table writes.
     ///
     /// Commiting a batch ticks automatically; `flush` is useful after creating

--- a/crates/groove/src/db/tests.rs
+++ b/crates/groove/src/db/tests.rs
@@ -2999,6 +2999,23 @@ fn dropping_subscription_receiver_unsubscribes_on_next_message() {
 }
 
 #[test]
+fn dropped_subscription_receiver_can_be_pruned_without_a_later_message() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = RocksDbStorage::open(temp_dir.path(), &["albums"]).unwrap();
+    let mut database = Database::new(albums_schema(), storage).unwrap();
+    let subscription = database
+        .subscribe_one_sink(GraphBuilder::table("albums"))
+        .unwrap();
+    let subscription_id = subscription.id();
+    assert_eq!(database.runtime_stats().active_subscriptions, 1);
+    drop(subscription);
+
+    assert_eq!(database.prune_dropped_subscriptions().unwrap(), 1);
+    assert_eq!(database.runtime_stats().active_subscriptions, 0);
+    assert!(!database.unsubscribe(subscription_id));
+}
+
+#[test]
 fn subscribe_returns_current_rows_as_initial_message_then_future_deltas() {
     let temp_dir = tempfile::tempdir().unwrap();
     let storage = RocksDbStorage::open(temp_dir.path(), &["albums"]).unwrap();

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -15,7 +15,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::{
-    Arc,
+    Arc, Weak,
     mpsc::{self, Receiver, RecvError, Sender, TryRecvError},
 };
 
@@ -1583,6 +1583,7 @@ impl IvmRuntime {
         }
         let subscription_id = self.next_subscription_id();
         let (sender, receiver) = mpsc::channel();
+        let receiver_liveness = Arc::new(());
         for output in outputs.values() {
             self.retain_as_subscription(subscription_id, output.node);
         }
@@ -1590,6 +1591,7 @@ impl IvmRuntime {
             subscription_id,
             MultisinkSubscriptionState {
                 sender,
+                receiver_liveness: Arc::downgrade(&receiver_liveness),
                 outputs: outputs.clone(),
                 target: MultisinkSubscriptionTarget::Direct,
             },
@@ -1612,6 +1614,7 @@ impl IvmRuntime {
         Ok(MultisinkSubscription {
             id: subscription_id,
             receiver,
+            _receiver_liveness: receiver_liveness,
         })
     }
 
@@ -1774,10 +1777,12 @@ impl IvmRuntime {
             return Err(error);
         }
         let (sender, receiver) = mpsc::channel();
+        let receiver_liveness = Arc::new(());
         self.multisink_subscriptions.insert(
             subscription_id,
             MultisinkSubscriptionState {
                 sender,
+                receiver_liveness: Arc::downgrade(&receiver_liveness),
                 outputs: outputs.clone(),
                 target: MultisinkSubscriptionTarget::RoutedShape {
                     shape_id,
@@ -1803,6 +1808,7 @@ impl IvmRuntime {
         Ok(MultisinkSubscription {
             id: subscription_id,
             receiver,
+            _receiver_liveness: receiver_liveness,
         })
     }
 
@@ -1962,6 +1968,24 @@ impl IvmRuntime {
         }
 
         Ok(false)
+    }
+
+    pub(crate) fn prune_dropped_subscriptions_with_storage<S>(
+        &mut self,
+        storage: &S,
+    ) -> Result<usize, IvmRuntimeError>
+    where
+        S: OrderedKvStorage,
+    {
+        let dropped = self
+            .multisink_subscriptions
+            .iter()
+            .filter_map(|(id, state)| state.receiver_liveness.upgrade().is_none().then_some(*id))
+            .collect::<Vec<_>>();
+        for id in &dropped {
+            self.unsubscribe_with_storage(*id, storage)?;
+        }
+        Ok(dropped.len())
     }
 
     pub fn add_dedup_schema_indices(&mut self) -> Result<(), IvmRuntimeError> {
@@ -4072,6 +4096,7 @@ impl MultisinkDeltas {
 pub struct MultisinkSubscription {
     id: SubscriptionId,
     receiver: Receiver<QueuedMultisinkDeltas>,
+    _receiver_liveness: Arc<()>,
 }
 
 impl MultisinkSubscription {
@@ -4193,6 +4218,7 @@ impl RecordDelta {
 #[derive(Clone, Debug)]
 struct MultisinkSubscriptionState {
     sender: Sender<QueuedMultisinkDeltas>,
+    receiver_liveness: Weak<()>,
     outputs: BTreeMap<String, CompiledNode>,
     target: MultisinkSubscriptionTarget,
 }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -333,7 +333,7 @@ struct PendingBranchViewUpdate {
 }
 
 struct EdgeFateRoute {
-    authority: AuthorityContext,
+    authority: Option<AuthorityContext>,
     queue: Weak<RefCell<Vec<SyncMessage>>>,
 }
 type EdgeFateRoutes = Rc<RefCell<BTreeMap<TxId, Vec<EdgeFateRoute>>>>;
@@ -453,9 +453,10 @@ where
     Ok(())
 }
 
-/// A parked fate belongs to one admitted upstream epoch.  Drop routes for
-/// departed/replaced sessions (and dead subscriber queues) eagerly: retaining
-/// a weak queue alone would let arbitrary uploads grow this registry forever.
+/// A parked fate either awaits its first admitted upstream or belongs to one
+/// admitted upstream epoch. Drop routes for departed/replaced sessions (and
+/// dead subscriber queues) eagerly: retaining a weak queue alone would let
+/// arbitrary uploads grow this registry forever.
 fn prune_edge_fate_routes(
     routes: &mut BTreeMap<TxId, Vec<EdgeFateRoute>>,
     admitted: Option<AuthorityContext>,
@@ -463,7 +464,11 @@ fn prune_edge_fate_routes(
     routes.retain(|_, pending| {
         pending.retain(|route| {
             route.queue.upgrade().is_some()
-                && admitted.is_some_and(|ctx| ctx.same_admitted_link(route.authority))
+                && match (route.authority, admitted) {
+                    (None, _) => true,
+                    (Some(route), Some(admitted)) => admitted.same_admitted_link(route),
+                    (Some(_), None) => false,
+                }
         });
         !pending.is_empty()
     });
@@ -5625,7 +5630,7 @@ where
                 let routed_txs = routes.keys().copied().collect::<Vec<_>>();
                 for pending in routes.values_mut() {
                     for route in pending.iter_mut() {
-                        route.authority = context;
+                        route.authority = Some(context);
                     }
                 }
                 drop(routes);
@@ -5722,7 +5727,6 @@ where
             permission_advice_waiters: Rc::clone(&self.permission_advice_waiters),
             edge_fate_routes: Rc::clone(&self.edge_fate_routes),
             local_fate_routes: Rc::clone(&self.local_fate_routes),
-            admitted_upstream_authorities: Rc::clone(&self.admitted_upstream_authorities),
             admitted_upstream_authority: Rc::clone(&self.admitted_upstream_authority),
             downstream_fates: Rc::new(RefCell::new(Vec::new())),
             mutation_errors: Rc::clone(&self.mutation_errors),
@@ -5942,7 +5946,6 @@ where
             permission_advice_waiters: Rc::clone(&self.permission_advice_waiters),
             edge_fate_routes: Rc::clone(&self.edge_fate_routes),
             local_fate_routes: Rc::clone(&self.local_fate_routes),
-            admitted_upstream_authorities: Rc::clone(&self.admitted_upstream_authorities),
             admitted_upstream_authority: Rc::clone(&self.admitted_upstream_authority),
             downstream_fates,
             mutation_errors: Rc::clone(&self.mutation_errors),
@@ -6056,8 +6059,8 @@ where
                     routes.retain(|_, pending| {
                         pending.retain(|route| route.queue.upgrade().is_some());
                         for route in pending.iter_mut() {
-                            if route.authority == authority {
-                                route.authority = handoff;
+                            if route.authority == Some(authority) {
+                                route.authority = Some(handoff);
                             }
                         }
                         !pending.is_empty()
@@ -6099,6 +6102,11 @@ where
                     // after an Edge acceptance would strand the caller.
                     routes.retain(|_, pending| {
                         pending.retain(|route| route.queue.upgrade().is_some());
+                        for route in pending.iter_mut() {
+                            if route.authority == Some(authority) {
+                                route.authority = None;
+                            }
+                        }
                         !pending.is_empty()
                     });
                     self.schedule_tick(TickUrgency::Immediate);
@@ -6125,10 +6133,15 @@ where
             stats.remote_sync_applied += next.remote_sync_applied;
             remote_sync_applied |= next.remote_sync_applied > 0;
         }
-        if remote_sync_applied || self.subscriber_dirty_epoch.get() != subscriber_dirty_epoch_before
-        {
+        let subscriber_state_changed =
+            self.subscriber_dirty_epoch.get() != subscriber_dirty_epoch_before;
+        if remote_sync_applied || subscriber_state_changed {
             for connection in self.connections.borrow().iter() {
-                if connection.borrow_mut().mark_subscriber_dirty() {
+                let should_tick = {
+                    let mut connection = connection.borrow_mut();
+                    connection.mark_subscriber_dirty() || subscriber_state_changed
+                };
+                if should_tick {
                     let next = connection.borrow_mut().tick()?;
                     stats.subscription_events += next.subscription_events;
                     stats.remote_sync_applied += next.remote_sync_applied;
@@ -7212,7 +7225,6 @@ where
     permission_advice_waiters: PermissionAdviceWaiters,
     edge_fate_routes: EdgeFateRoutes,
     local_fate_routes: LocalFateRoutes,
-    admitted_upstream_authorities: AdmittedUpstreamAuthorities,
     admitted_upstream_authority: Rc<RefCell<Option<AuthorityContext>>>,
     downstream_fates: PendingDownstreamFates,
     mutation_errors: SharedMutationErrors,
@@ -8585,10 +8597,14 @@ where
                                 if let Some(pending) = routes.get_mut(&tx_id) {
                                     let mut remaining = Vec::new();
                                     for route in std::mem::take(pending) {
-                                        if authority.is_some_and(|authority| {
-                                            route.authority.same_admitted_link(authority)
-                                        }) {
-                                            if let Some(queue) = route.queue.upgrade() {
+                                        let authority_matches = matches!(
+                                            (route.authority, authority),
+                                            (Some(route), Some(authority))
+                                                if route.same_admitted_link(authority)
+                                        );
+                                        let queue = route.queue.upgrade();
+                                        if authority_matches {
+                                            if let Some(queue) = queue {
                                                 queue.borrow_mut().push(fate.clone());
                                             }
                                         } else {
@@ -9575,15 +9591,16 @@ where
                                             let pending = routes.get(&tx_id);
                                             let already_routed = pending.is_some_and(|pending| {
                                                 pending.iter().any(|route| {
-                                                    route.authority.same_admitted_link(authority)
-                                                        && route.queue.upgrade().is_some_and(
-                                                            |queue| {
-                                                                Rc::ptr_eq(
-                                                                    &queue,
-                                                                    &self.downstream_fates,
-                                                                )
-                                                            },
-                                                        )
+                                                    route.authority.is_some_and(|route| {
+                                                        route.same_admitted_link(authority)
+                                                    }) && route.queue.upgrade().is_some_and(
+                                                        |queue| {
+                                                            Rc::ptr_eq(
+                                                                &queue,
+                                                                &self.downstream_fates,
+                                                            )
+                                                        },
+                                                    )
                                                 })
                                             });
                                             if already_routed {
@@ -9592,7 +9609,7 @@ where
                                                 let pending = routes.entry(tx_id).or_default();
                                                 if pending.len() < MAX_EDGE_FATE_ROUTES_PER_TX {
                                                     pending.push(EdgeFateRoute {
-                                                        authority,
+                                                        authority: Some(authority),
                                                         queue: Rc::downgrade(
                                                             &self.downstream_fates,
                                                         ),
@@ -9605,14 +9622,44 @@ where
                                                 false
                                             }
                                         } else {
-                                            false
+                                            let mut routes = self.edge_fate_routes.borrow_mut();
+                                            prune_edge_fate_routes(&mut routes, None);
+                                            let already_routed =
+                                                routes.get(&tx_id).is_some_and(|pending| {
+                                                    pending.iter().any(|route| {
+                                                        route.authority.is_none()
+                                                            && route.queue.upgrade().is_some_and(
+                                                                |queue| {
+                                                                    Rc::ptr_eq(
+                                                                        &queue,
+                                                                        &self.downstream_fates,
+                                                                    )
+                                                                },
+                                                            )
+                                                    })
+                                                });
+                                            let route_count =
+                                                routes.values().map(Vec::len).sum::<usize>();
+                                            if already_routed {
+                                                true
+                                            } else if route_count >= MAX_EDGE_FATE_ROUTES {
+                                                false
+                                            } else {
+                                                let pending = routes.entry(tx_id).or_default();
+                                                if pending.len() >= MAX_EDGE_FATE_ROUTES_PER_TX {
+                                                    false
+                                                } else {
+                                                    pending.push(EdgeFateRoute {
+                                                        authority: None,
+                                                        queue: Rc::downgrade(
+                                                            &self.downstream_fates,
+                                                        ),
+                                                    });
+                                                    true
+                                                }
+                                            }
                                         };
-                                        let legacy_park = !route_registered
-                                            && self
-                                                .admitted_upstream_authorities
-                                                .borrow()
-                                                .is_empty();
-                                        if !route_registered && !legacy_park {
+                                        if !route_registered {
                                             // Do not claim Edge durability for
                                             // a write that lacks exactly one
                                             // authority route; otherwise its

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -6272,6 +6272,31 @@ fn duplex_with_server_outbound_tap() -> (
     )
 }
 
+/// In-memory transport pair with a read-only tap on client-to-server frames.
+/// The tap lets an Edge test inspect an upstream upload before Core applies it.
+fn duplex_with_client_outbound_tap() -> (
+    Box<dyn Transport>,
+    Box<dyn Transport>,
+    Rc<RefCell<std::collections::VecDeque<SyncMessage>>>,
+) {
+    use std::collections::VecDeque;
+    let client_to_server = Rc::new(RefCell::new(VecDeque::new()));
+    let server_to_client = Rc::new(RefCell::new(VecDeque::new()));
+    (
+        Box::new(DuplexTransport {
+            outbound: Rc::clone(&client_to_server),
+            inbound: Rc::clone(&server_to_client),
+            session_context: None,
+        }),
+        Box::new(DuplexTransport {
+            outbound: server_to_client,
+            inbound: Rc::clone(&client_to_server),
+            session_context: None,
+        }),
+        client_to_server,
+    )
+}
+
 /// In-memory handshake pairing needs an internal test because it verifies the
 /// transport/admission boundary before any user-visible sync payload exists.
 fn duplex_with_admitted_session_context(
@@ -6784,7 +6809,7 @@ fn concurrent_upstreams_keep_selected_owner_until_detach_handoff() {
     edge.server.edge_fate_routes.borrow_mut().insert(
         tx_id,
         vec![EdgeFateRoute {
-            authority: first.unwrap(),
+            authority: Some(first.unwrap()),
             queue: Rc::downgrade(&queue),
         }],
     );
@@ -6797,7 +6822,7 @@ fn concurrent_upstreams_keep_selected_owner_until_detach_handoff() {
     let handoff = edge.server.admitted_upstream_authority.borrow().unwrap();
     assert_eq!(
         edge.server.edge_fate_routes.borrow()[&tx_id][0].authority,
-        handoff,
+        Some(handoff),
         "an Edge-Accepted caller route must follow the selected handoff rather than vanish"
     );
 }
@@ -6846,7 +6871,7 @@ fn edge_route_capacity_rejects_instead_of_reporting_edge_acceptance() {
         write.mergeable_tx_id(),
         (0..MAX_EDGE_FATE_ROUTES_PER_TX)
             .map(|_| EdgeFateRoute {
-                authority: selected,
+                authority: Some(selected),
                 queue: Rc::downgrade(&queue),
             })
             .collect(),
@@ -6927,7 +6952,7 @@ fn admitted_edge_session_routes_selected_authority_fate_to_uploading_client() {
     let routes = edge.server.edge_fate_routes.borrow();
     let routes_for_tx = routes.get(&tx_id).expect("edge must park the upload route");
     assert_eq!(routes_for_tx.len(), 1);
-    assert_eq!(routes_for_tx[0].authority, expected_authority);
+    assert_eq!(routes_for_tx[0].authority, Some(expected_authority));
     drop(routes);
 
     // Scope receipts advance authorization metadata on the same physical
@@ -7096,7 +7121,7 @@ fn stale_upstream_epoch_cannot_settle_routed_local_fate_before_selected_epoch() 
     edge.server.edge_fate_routes.borrow_mut().insert(
         tx_id,
         vec![EdgeFateRoute {
-            authority: selected,
+            authority: Some(selected),
             queue: Rc::downgrade(&downstream),
         }],
     );
@@ -7332,6 +7357,11 @@ fn edge_parks_downstream_fate_until_a_later_authority_connects() {
 
     assert!(edge.server.detach_connection(&edge_a));
     assert_eq!(edge.server.edge_fate_routes.borrow().len(), 1);
+    assert_eq!(
+        edge.server.edge_fate_routes.borrow()[&write.mergeable_tx_id()][0].authority,
+        None,
+        "a route whose authority disconnected remains parked without stale authority claims"
+    );
 
     let authority_c = open_core(0xc2, AuthorId::SYSTEM, &schema);
     let (edge_c_transport, c_transport) = duplex_with_admitted_session_context(
@@ -7355,20 +7385,19 @@ fn edge_parks_downstream_fate_until_a_later_authority_connects() {
     assert!(edge.server.edge_fate_routes.borrow().is_empty());
 }
 
-/// The raw Edge ingestion path records no fate route when a client writes
+/// An offline-ready Edge retains a client's fate route when a write arrives
 /// before normal upstream admission.
 ///
-/// This is an internal lifecycle-boundary test: a public websocket race only
-/// exposes the symptom (a Global wait that never resolves), while the decisive
-/// contract is that Ready publication happens after this route can be bound;
-/// the dynamic-shell admission test enforces that boundary externally.
+/// A validated durable Edge may serve while its Core is offline. Its local
+/// acceptance therefore has to retain an unbound downstream obligation, bind
+/// it to the first authenticated authority, and redrive the canonical unit.
 ///
 /// ```text
 /// alice --write--> edge (no upstream yet) --later attach--> core
-///                    \-- no route is available for alice yet
+///                    \-- park(tx, alice) --bind(core)--> global fate
 /// ```
 #[test]
-fn edge_write_before_upstream_admission_has_no_fate_route() {
+fn edge_write_before_upstream_admission_binds_and_redrives_fate_route() {
     let schema = schema();
     let alice = AuthorId::from_bytes([0xa1; 16]);
     let edge_node = NodeUuid::from_bytes([0xe0; 16]);
@@ -7382,7 +7411,7 @@ fn edge_write_before_upstream_admission_has_no_fate_route() {
         edge_node,
         13,
     );
-    let _client_upstream = client.connect_upstream(client_transport);
+    let client_upstream = client.connect_upstream(client_transport);
     let edge_client = edge.server.accept_edge_authority_subscriber_with_claims(
         edge_transport,
         alice,
@@ -7390,10 +7419,7 @@ fn edge_write_before_upstream_admission_has_no_fate_route() {
     );
 
     let write = client
-        .insert(
-            "todos",
-            BTreeMap::from([("title".to_owned(), Value::String("startup race".to_owned()))]),
-        )
+        .insert("todos", cells("startup race", false, alice))
         .unwrap();
     let tx_id = write.mergeable_tx_id();
     client.tick().unwrap();
@@ -7403,27 +7429,68 @@ fn edge_write_before_upstream_admission_has_no_fate_route() {
         write.write_state().unwrap().durability,
         DurabilityTier::Edge
     );
-    assert!(
-        !edge.server.edge_fate_routes.borrow().contains_key(&tx_id),
-        "a shell published before upstream admission currently parks no authority route"
+    assert_eq!(
+        edge.server.edge_fate_routes.borrow()[&tx_id][0].authority,
+        None,
+        "an offline-ready edge retains the downstream obligation without inventing authority"
+    );
+    client_upstream
+        .borrow_mut()
+        .transport
+        .send(
+            client
+                .node
+                .node
+                .borrow_mut()
+                .commit_unit_for(tx_id)
+                .unwrap(),
+        )
+        .unwrap();
+    edge.tick().unwrap();
+    assert_eq!(
+        edge.server.edge_fate_routes.borrow()[&tx_id].len(),
+        1,
+        "a retransmitted pre-admission unit must reuse the same downstream route"
     );
 
     let (edge_upstream_transport, core_transport) =
         duplex_with_admitted_session_context(AuthorId::SYSTEM, edge_node, 41, core_node, 97);
     let _edge_upstream = edge.server.connect_upstream(edge_upstream_transport);
+    assert!(
+        edge.server.edge_fate_routes.borrow()[&tx_id][0]
+            .authority
+            .is_some(),
+        "the first authenticated authority binds the parked route"
+    );
     let core = open_core(0xc0, AuthorId::SYSTEM, &schema);
-    let _core_session = core.accept_subscriber(core_transport, AuthorId::SYSTEM);
+    let core_session = core.accept_subscriber(core_transport, AuthorId::SYSTEM);
     edge.tick().unwrap();
-    core.tick().unwrap();
+    let uploaded = std::iter::from_fn(|| core_session.borrow_mut().transport.try_recv())
+        .any(|message| matches!(message, SyncMessage::CommitUnit { tx, .. } if tx.tx_id == tx_id));
+    assert!(
+        uploaded,
+        "binding the first authority redrives the parked unit"
+    );
+    core_session
+        .borrow_mut()
+        .transport
+        .send(SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Accepted,
+            global_seq: Some(GlobalSeq(1)),
+            durability: Some(DurabilityTier::Global),
+        })
+        .unwrap();
     edge.tick().unwrap();
     edge_client.borrow_mut().tick().unwrap();
     client.tick().unwrap();
 
     assert_eq!(
         write.write_state().unwrap().durability,
-        DurabilityTier::Edge,
-        "a late Core fate cannot reach a client whose write was accepted before route admission"
+        DurabilityTier::Global,
+        "the late Core fate must discharge the offline client's parked route"
     );
+    assert!(edge.server.edge_fate_routes.borrow().is_empty());
 }
 
 #[test]
@@ -7484,7 +7551,7 @@ fn stale_same_authority_session_cannot_settle_or_forward_a_routed_fate() {
         .borrow_mut()
         .get_mut(&write.mergeable_tx_id())
         .expect("routed edge write")[0]
-        .authority = current_context;
+        .authority = Some(current_context);
     old.borrow_mut()
         .transport
         .send(SyncMessage::FateUpdate {
@@ -9795,6 +9862,64 @@ fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
     assert!(
         core_to_peer.borrow().is_empty(),
         "a post-cascade idle tick emits no unchanged peer update"
+    );
+}
+
+/// An Edge immediately flushes an upload queued by a later client connection
+/// through the upstream connection that was already visited in the same pass.
+///
+/// The upstream connection is deliberately installed first. One client tick
+/// places the commit on the Edge subscriber transport; one Edge tick must both
+/// ingest it and emit the corresponding Core-bound `CommitUnit`.
+#[test]
+fn edge_later_client_upload_flushes_earlier_upstream_in_same_tick() {
+    let schema = schema();
+    let alice = AuthorId::from_bytes([0xa1; 16]);
+    let edge = open_db(0xd1, AuthorId::SYSTEM, &schema);
+    let client = open_db(0xd2, alice, &schema);
+
+    let (edge_transport, _core_transport, edge_to_core) = duplex_with_client_outbound_tap();
+    let _edge_upstream = edge.connect_upstream(edge_transport);
+
+    let (client_transport, edge_client_transport) = duplex();
+    let _client_upstream = client.connect_upstream(client_transport);
+    let _edge_client = edge.accept_subscriber(edge_client_transport, alice);
+
+    let write = client
+        .insert_with_id("todos", row(0xd3), cells("later upload", false, alice))
+        .unwrap();
+    client.tick().unwrap();
+    edge.tick().unwrap();
+
+    let uploads = edge_to_core
+        .borrow()
+        .iter()
+        .filter(|message| {
+            matches!(
+                message,
+                SyncMessage::CommitUnit { tx, .. } if tx.tx_id == write.tx_id
+            )
+        })
+        .count();
+    assert_eq!(
+        uploads, 1,
+        "one Edge service pass flushes the later client upload through the earlier upstream link"
+    );
+
+    edge.tick().unwrap();
+    assert_eq!(
+        edge_to_core
+            .borrow()
+            .iter()
+            .filter(|message| {
+                matches!(
+                    message,
+                    SyncMessage::CommitUnit { tx, .. } if tx.tx_id == write.tx_id
+                )
+            })
+            .count(),
+        1,
+        "a quiet follow-up tick does not replay the same upload"
     );
 }
 

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -464,14 +464,37 @@ where
 
             self.install_staged_schema_lineage_in_memory(&staged);
             // A widened lineage adds new variant cases to existing physical
-            // current tables. Reopening the database installs those cases in
-            // Groove's projection registry; incremental table evolution only
-            // updates the stored table definitions, leaving a stale process
-            // unable to project a just-admitted v2 commit.
-            if self.rebuild_database_slot().is_err() {
+            // current tables. Install those cases in the live registry rather
+            // than reopening the database: a reopen drops active history and
+            // maintained-subscription receivers even when their output shape
+            // remains compatible.
+            if self.synchronize_physical_version_tables().is_err() {
                 self.remove_staged_schema_lineage_from_memory(&staged);
                 self.catalogue_activation_failed = true;
                 return Err(Error::CatalogueActivationFailed);
+            }
+            // Closed raw receivers can otherwise make a cold server look live
+            // until a later non-empty notification. Prune them explicitly;
+            // then rebuild only when no observable subscription handle would
+            // be disconnected. Live handles use the in-place cases above.
+            if self.database.prune_dropped_subscriptions().is_err() {
+                self.remove_staged_schema_lineage_from_memory(&staged);
+                self.catalogue_activation_failed = true;
+                return Err(Error::CatalogueActivationFailed);
+            }
+            let rebuild_cold_runtime = self.database.runtime_stats().active_subscriptions == 0;
+            if rebuild_cold_runtime && self.rebuild_database_slot().is_err() {
+                self.remove_staged_schema_lineage_from_memory(&staged);
+                self.catalogue_activation_failed = true;
+                return Err(Error::CatalogueActivationFailed);
+            }
+            if widens_shared_current_descriptor && !rebuild_cold_runtime {
+                // Peer-serving and maintained caches are compiled against the
+                // shared current-row descriptor too. Retire those handles now;
+                // their owners rebuild from the new runtime token below. Raw
+                // history subscriptions remain attached to the live Groove
+                // registry and keep receiving compatible projected rows.
+                self.invalidate_runtime_handles_after_database_rebuild();
             }
             #[cfg(test)]
             if self.catalogue_activation_failpoint

--- a/crates/jazz/src/node/tests/catalogue_lenses.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses.rs
@@ -2201,6 +2201,96 @@ fn active_history_projection_accepts_a_new_schema_variant_without_rebuild() {
     );
 }
 
+/// A cold runtime may rebuild its projection registry after pruning a dropped
+/// raw receiver, and the rebuilt registry must admit the new enum variant.
+///
+/// Actors: alice writes and drops a history stream; mallory then publishes an
+/// append-only enum case through the trusted catalogue lane.
+///
+/// ```text
+/// alice --drop history--> core --prune/rebuild--> v2 registry
+/// mallory --publish v2--------------------------> new v2 write
+/// ```
+#[test]
+fn dropped_history_receiver_allows_cold_registry_rebuild() {
+    let schema = |statuses: &[&str]| {
+        JazzSchema::new([TableSchema::new(
+            "items",
+            [
+                ColumnSchema::new("title", ColumnType::String),
+                ColumnSchema::new(
+                    "status",
+                    ColumnType::EnumTag(
+                        groove::records::ScalarEnumSchema::new(
+                            "status",
+                            statuses.iter().copied(),
+                        )
+                        .unwrap(),
+                    ),
+                ),
+            ],
+        )])
+    };
+    let base = schema(&["open"]);
+    let evolved = SchemaVersion::new(schema(&["open", "archived"]));
+    let evolved_id = evolved.id;
+    let (_dir, mut core) = open_node_with_schema(node(0x6c), base.clone());
+    core.commit_mergeable(
+        MergeableCommit::new("items", row(0x6c), 900).cells(BTreeMap::from([
+            ("title".to_owned(), Value::String("before".to_owned())),
+            ("status".to_owned(), Value::EnumTag(0)),
+        ])),
+    )
+    .unwrap();
+    let subscription = core.subscribe_history("items").unwrap();
+    assert_eq!(subscription.recv().unwrap().deltas.len(), 1);
+    drop(subscription);
+    assert_eq!(core.runtime_stats_for_test().active_subscriptions, 1);
+    let runtime = core.groove_runtime_token();
+
+    core.apply_trusted_catalogue_message(SyncMessage::PublishSchemaWithLens {
+        author: AuthorId::SYSTEM,
+        catalogue_seq: 1,
+        publication: Box::new(SchemaLineagePublication::new(
+            evolved,
+            MigrationLens::new(
+                base.version_id(),
+                evolved_id,
+                vec![TableLens {
+                    source_table: "items".to_owned(),
+                    target_table: "items".to_owned(),
+                    ops: vec![LensOp::TransformColumn {
+                        column: "status".to_owned(),
+                        transform: "jazz.identity".to_owned(),
+                    }],
+                }],
+            ),
+            Vec::<String>::new(),
+            Vec::<String>::new(),
+        )),
+    })
+    .unwrap();
+
+    assert_eq!(core.runtime_stats_for_test().active_subscriptions, 0);
+    assert_ne!(core.groove_runtime_token(), runtime);
+    core.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+        author: AuthorId::SYSTEM,
+        pointer: CurrentWriteSchema {
+            revision: 1,
+            schema: evolved_id,
+        },
+    })
+    .unwrap();
+    core.commit_mergeable(
+        MergeableCommit::new("items", row(0x6d), 1_000).cells(BTreeMap::from([
+            ("title".to_owned(), Value::String("after".to_owned())),
+            ("status".to_owned(), Value::EnumTag(1)),
+        ])),
+    )
+    .unwrap();
+    assert_eq!(core.query_table_versions("items").unwrap().len(), 2);
+}
+
 #[test]
 fn table_and_column_rename_reuses_the_existing_physical_identities() {
     let base = schema();

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -1025,7 +1025,8 @@ impl ClientDb {
 
     async fn wait_for_batch(&self, batch_id: BatchId, tier: DurabilityTier) -> Result<()> {
         self.ensure_tick_driver_running()?;
-        ClientDbInner::handle_wait_for_batch(&self.inner, batch_id, tier).await
+        ClientDbInner::handle_wait_for_batch(&self.inner, batch_id, tier, Duration::from_secs(25))
+            .await
     }
 
     fn disconnect_upstream(&self) -> bool {
@@ -1473,9 +1474,10 @@ impl ClientDbInner {
         inner: &Rc<RefCell<Self>>,
         batch_id: BatchId,
         tier: DurabilityTier,
+        timeout: Duration,
     ) -> Result<()> {
         let desired = core_tier(tier);
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(25);
+        let deadline = tokio::time::Instant::now() + timeout;
         loop {
             inner.borrow().ensure_tick_driver_running()?;
             let tx_id = {
@@ -3166,6 +3168,18 @@ impl JazzClient {
 
     pub(crate) fn disconnect_upstream_for_test(&self) -> bool {
         self.db.disconnect_upstream()
+    }
+
+    /// Wait for a durability tier using an exact timeout rather than the
+    /// load-tolerant test multiplier.
+    pub async fn wait_for_batch_with_timeout_for_test(
+        &self,
+        batch_id: BatchId,
+        tier: DurabilityTier,
+        timeout: Duration,
+    ) -> Result<()> {
+        self.db.ensure_tick_driver_running()?;
+        ClientDbInner::handle_wait_for_batch(&self.db.inner, batch_id, tier, timeout).await
     }
 
     pub(crate) async fn reconnect_upstream_for_test(&self) -> Result<bool> {

--- a/crates/jazz/tests/transactions.rs
+++ b/crates/jazz/tests/transactions.rs
@@ -717,7 +717,11 @@ async fn wait_for_batch_errors_for_unattainable_durability_tier() {
 
     assert!(
         client
-            .wait_for_batch(batch_id.expect("ordinary mutation commits immediately"), DurabilityTier::GlobalServer)
+            .wait_for_batch_with_timeout_for_test(
+                batch_id.expect("ordinary mutation commits immediately"),
+                DurabilityTier::GlobalServer,
+                Duration::from_millis(100),
+            )
             .await
             .is_err(),
         "serverless test client cannot reach GlobalServer durability"


### PR DESCRIPTION
🤖 Preserves live subscriptions while installing compatible schema-registry growth, without weakening cold stale-runtime reconstruction.

Dropped multisink receivers now have explicit Arc/Weak liveness leases and can be pruned without waiting for a later notification failure. When live receivers remain, new table/variant/projection cases are installed in place so their channels and runtime token survive. When pruning reaches zero, the runtime performs the full cold rebuild required by stale edge projection state.

All prune, synchronization, and rebuild failures remain inside the catalogue activation rollback/fail-closed boundary.

The cumulative reconnect race also exposed a pre-existing contradiction at the offline Edge boundary: a validated durable Edge may serve before its Core reconnects, but an Edge-accepted write previously retained no downstream fate route. Offline writes now retain a bounded, deduplicated, unbound client obligation. The first authenticated authority binds it and redrives the canonical commit; stale authority epochs remain unable to settle it. Public `wait_for_batch` keeps its fixed 25-second API deadline, while the dedicated negative test uses an explicit short timeout.

Evidence:
- both cumulative CI regressions pass (live history channel and enum/layout subscription);
- dropped-receiver cold rebuild test is mutation-sensitive to disabling rebuild;
- offline route regression proves bind, redrive, exact client delivery, retransmit deduplication, and route retirement;
- removing offline route registration fails at Local vs Edge durability; disabling deduplication fails with two routes instead of one;
- stale persisted-edge reconnect passes 50/50 sequential local stress runs at multiplier 1;
- Jazz lib suite passes 1,404/1,404, with 2 ignored;
- authority handoff, stale-epoch, route-capacity, formatting, clippy, sensitive-data, and commit hooks pass;
- independent adversarial review found no P0–P2.

Fresh CI for the amended SHA is in progress.
