### PR TITLE
fix: retire dormant server coverage receivers

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -9406,7 +9406,17 @@ where
                                             binding_id: coverage.binding_id,
                                             read_view: coverage.opts.read_view_key(),
                                         };
-                                        peer.forget_subscription(group_subscription);
+                                        // A coverage group owns a maintained Groove receiver.
+                                        // Forgetting only the peer-side cursor leaves that
+                                        // receiver dormant in the shared runtime; a later
+                                        // re-open of the same logical coverage then races a
+                                        // stale source subscription instead of observing the
+                                        // current authority membership. Tear down both pieces
+                                        // together when the final usage site goes away.
+                                        peer.forget_subscription_with_node(
+                                            &mut self.node.borrow_mut(),
+                                            group_subscription,
+                                        );
                                         coverage_groups.remove(&coverage);
                                         if propagated_upstream {
                                             upstream_subscriptions.borrow_mut().push(

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -12851,6 +12851,88 @@ fn one_shot_propagated_query_attaches_fresh_usage_subscription_for_covered_bindi
     client.detach_query(second_attachment);
 }
 
+/// Ensures a dormant propagated query coverage group releases its maintained
+/// server runtime receiver before the same logical query opens again.
+///
+/// This is intentionally an internal lifecycle test: the public query API can
+/// observe the later re-open, but cannot expose the authority's receiver
+/// count. The count is the exact ownership boundary that prevents a dropped
+/// one-shot handle from retaining stale maintained source state.
+///
+/// ```text
+/// client ──open coverage──► server maintained receiver
+/// client ──drop last handle► server receiver removed
+/// client ──re-open────────► exactly one fresh receiver
+/// ```
+#[test]
+fn final_query_coverage_drop_releases_server_maintained_receiver_before_reopen() {
+    let schema = schema();
+    let owner = AuthorId::from_bytes([0xa1; 16]);
+    let client_author = AuthorId::from_bytes([0xc1; 16]);
+    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    let client = open_db(0xc1, client_author, &schema);
+    seed(&server, "todos", cells("initial", false, owner));
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = client.connect_upstream(client_transport);
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let query = Query::from("todos");
+    let prepared = prepared(&client, &query);
+    let baseline_receivers = server
+        .node()
+        .borrow()
+        .runtime_stats_for_test()
+        .active_subscriptions;
+
+    let attachment = client
+        .attach_query_with_opts(&prepared, global_subscribe_opts())
+        .expect("attach propagated one-shot coverage");
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert!(client.query_attachment_is_covered(&attachment));
+    assert_eq!(
+        server
+            .node()
+            .borrow()
+            .runtime_stats_for_test()
+            .active_subscriptions,
+        baseline_receivers + 1,
+        "the server owns one maintained receiver while coverage is live"
+    );
+
+    client.detach_query(attachment);
+    client.tick().unwrap();
+    server.tick().unwrap();
+    assert_eq!(
+        server
+            .node()
+            .borrow()
+            .runtime_stats_for_test()
+            .active_subscriptions,
+        baseline_receivers,
+        "dropping the final coverage handle must unregister its server receiver"
+    );
+
+    let reopened = client
+        .attach_query_with_opts(&prepared, global_subscribe_opts())
+        .expect("re-open propagated one-shot coverage");
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert!(client.query_attachment_is_covered(&reopened));
+    assert_eq!(
+        server
+            .node()
+            .borrow()
+            .runtime_stats_for_test()
+            .active_subscriptions,
+        baseline_receivers + 1,
+        "re-open installs exactly one fresh maintained receiver"
+    );
+    client.detach_query(reopened);
+}
+
 #[test]
 fn one_shot_borrowed_stream_coverage_stays_pinned_until_query_detach() {
     let schema = schema();


### PR DESCRIPTION
🤖 Retires maintained server receivers when the final coverage user leaves, while preserving shared users and reconnect behavior.

The previous unsubscribe path forgot only the PeerState cursor/cache. The owned Groove receiver stayed live, so a later reopen could coexist with dormant maintained state. Final coverage-group unsubscribe now uses the node-aware teardown path and releases both layers.

This is a lifecycle correctness fix; it does not claim that the remaining local-join E2E is resolved or retire its burndown row.

Evidence:
- open → final drop → reopen receiver count regression;
- duplicate usage and borrowed-stream coverage remain alive until their final owner leaves;
- two-client isolation probe preserves the surviving client;
- old forget-only and over-eager teardown plants both fail;
- burndown remains exact 6 active + 9 dormant;
- independent review found no P0–P2.
