### PR TITLE
feat: maintain branch-current subscriptions

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1331,6 +1331,7 @@ where
                 .made_by(made_by)
                 .cells(cells),
         )?;
+        node.finalize_local_mergeable_commit(tx_id)?;
         drop(node);
         self.refresh_subscriptions()?;
         self.node.mark_subscriber_connections_dirty();
@@ -1697,12 +1698,26 @@ where
                             author,
                         )
                         .map_err(Into::into),
-                    QueryAuthorizationMode::ClientLocal => node
+                    QueryAuthorizationMode::ClientLocal if tier < DurabilityTier::Edge => node
                         .query_rows_on_branch_for_client(
                             crate::ids::BranchId(*branch),
                             &prepared.shape,
                             &prepared.binding,
                             author,
+                        )
+                        .map_err(Into::into),
+                    QueryAuthorizationMode::ClientLocal => node
+                        .query_rows_for_client_read_view(
+                            &prepared.shape,
+                            &prepared.binding,
+                            self.node
+                                .upstream_register_shape_options(
+                                    tier,
+                                    opts.read_view.clone(),
+                                    opts.propagation == Propagation::Full,
+                                )
+                                .tier,
+                            &opts.read_view,
                         )
                         .map_err(Into::into),
                 };
@@ -8866,7 +8881,17 @@ where
                                 }
                             };
                             if let Some(shape) = &shape {
-                                if shape.params().is_empty() {
+                                // Branch compilation may install an empty
+                                // process-local sparse source. Defer that
+                                // side-effecting preflight until Subscribe,
+                                // where the authenticated branch gate is
+                                // available.
+                                if shape.params().is_empty()
+                                    && !matches!(
+                                        opts.read_view.source,
+                                        ReadViewSourceSpec::Branch { .. }
+                                    )
+                                {
                                     let binding = shape.bind(BTreeMap::new()).map_err(Error::from);
                                     let binding = match binding {
                                         Ok(binding) => binding,
@@ -9107,6 +9132,34 @@ where
                                 && existing != purpose
                             {
                                 drop_peer_request(&self.node);
+                                continue;
+                            }
+                            if let ReadViewSourceSpec::Branch { branch } = &opts.read_view.source
+                                && !self.node.borrow_mut().branch_metadata_visible_to(
+                                    crate::ids::BranchId(*branch),
+                                    peer.link_identity(),
+                                )?
+                            {
+                                let update = SyncMessage::ViewUpdate {
+                                    subscription,
+                                    settled_through: self.node.borrow().applied_global_watermark(),
+                                    reset_result_set: true,
+                                    version_carriers: Vec::new(),
+                                    version_bundles: Vec::new(),
+                                    peer_payload_inventory:
+                                        crate::protocol::PeerPayloadInventory::default(),
+                                    result_member_adds: Vec::new(),
+                                    result_member_removes: Vec::new(),
+                                    terminal_operations: Vec::new(),
+                                    program_fact_adds: Vec::new(),
+                                    program_fact_removes: Vec::new(),
+                                };
+                                send_with_sync_context(
+                                    &self.node,
+                                    peer,
+                                    self.transport.as_mut(),
+                                    update,
+                                )?;
                                 continue;
                             }
                             let supported = self
@@ -10115,13 +10168,16 @@ where
             }
         }
     }
+    let updates = std::mem::take(pending)
+        .into_iter()
+        .map(|update| update.parts)
+        .collect::<Vec<_>>();
     let mut node_ref = node.borrow_mut();
-    node_ref.apply_view_updates_in_batch(
-        std::mem::take(pending)
-            .into_iter()
-            .map(|update| update.parts)
-            .collect(),
-    )?;
+    // Branch view payloads carry branch-target version witnesses. Provision
+    // their sparse physical partitions before staging the receiver batch, so
+    // a durable table exists before the selected result becomes observable.
+    node_ref.prepare_view_update_branch_partitions(&updates)?;
+    node_ref.apply_view_updates_in_batch(updates)?;
     drop(node_ref);
     if let Some(receipts) = active_authority_view_receipts.borrow_mut().as_mut()
         && receipts.connection_epoch == connection_epoch

--- a/crates/jazz/src/db/tests.rs
+++ b/crates/jazz/src/db/tests.rs
@@ -2202,6 +2202,34 @@ fn branch_read_view_relation_snapshot_uses_query_engine_relation_edges() {
     let schema = relation_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
     let branch = BranchId(uuid::Uuid::from_bytes([0x42; 16]));
+    let root_versions = [
+        MergeableCommit::new("users", row(0xa1), 10).cells(BTreeMap::from([(
+            "name".to_owned(),
+            Value::String("alice".to_owned()),
+        )])),
+        MergeableCommit::new("todos", row(0x11), 11).cells(BTreeMap::from([
+            ("title".to_owned(), Value::String("root todo".to_owned())),
+            ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
+        ])),
+    ];
+    for (sequence, commit) in root_versions.into_iter().enumerate() {
+        let tx = db
+            .node
+            .node
+            .borrow_mut()
+            .commit_mergeable(commit)
+            .expect("commit root relation row");
+        db.node
+            .node
+            .borrow_mut()
+            .apply_fate_update(
+                tx,
+                Fate::Accepted,
+                Some(GlobalSeq(sequence as u64 + 1)),
+                Some(DurabilityTier::Global),
+            )
+            .expect("globally accept root relation row");
+    }
     db.node
         .node
         .borrow_mut()
@@ -2214,21 +2242,10 @@ fn branch_read_view_relation_snapshot_uses_query_engine_relation_edges() {
             branch,
             MergeableCommit::new("users", row(0xa1), 10).cells(BTreeMap::from([(
                 "name".to_owned(),
-                Value::String("alice".to_owned()),
+                Value::String("branch alice".to_owned()),
             )])),
         )
-        .expect("commit branch user");
-    db.node
-        .node
-        .borrow_mut()
-        .commit_mergeable_on_branch(
-            branch,
-            MergeableCommit::new("todos", row(0x11), 11).cells(BTreeMap::from([
-                ("title".to_owned(), Value::String("branch todo".to_owned())),
-                ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
-            ])),
-        )
-        .expect("commit branch todo");
+        .expect("replace only the source row in the branch overlay");
 
     let query = Query::from("users").array_subquery(ArraySubquery::new(
         "todosViaOwner",
@@ -2245,7 +2262,28 @@ fn branch_read_view_relation_snapshot_uses_query_engine_relation_edges() {
     assert!(snapshot.edges.is_empty());
     assert_eq!(
         terminal_nested_text_values(&snapshot, row(0xa1), "todosViaOwner", "title"),
-        vec!["branch todo".to_owned()]
+        vec!["root todo".to_owned()]
+    );
+    let binding = prepared_query
+        .shape()
+        .bind(BTreeMap::new())
+        .expect("bind relation snapshot shape");
+    let discriminators = db
+        .node
+        .node
+        .borrow_mut()
+        .query_relation_branch_discriminators_for_test(
+            prepared_query.shape(),
+            &binding,
+            DurabilityTier::Local,
+            db.identity.author,
+            &branch_read_opts().read_view,
+        )
+        .expect("inspect production relation-edge witnesses");
+    assert_eq!(
+        discriminators,
+        vec![(Some(branch.0), None)],
+        "the overlay source keeps its branch witness while the frozen target retains root lineage"
     );
 }
 

--- a/crates/jazz/src/node/branches.rs
+++ b/crates/jazz/src/node/branches.rs
@@ -359,7 +359,9 @@ where
             .clone();
         let known_source_dots = self.validated_target_source_dots(source, target)?;
         for table in write_schema.tables.clone() {
-            let table_schema = self.table_in_schema(&table.name, write_schema_version)?;
+            let table_schema = self
+                .table_in_schema(&table.name, write_schema_version)?
+                .clone();
             let overlay_rows = self.lineage_row_ids(&table.name, source)?;
             if identity != AuthorId::SYSTEM && !overlay_rows.is_empty() {
                 let shape = crate::query::Query::from(table.name.as_str())
@@ -379,6 +381,63 @@ where
                 .into_iter()
                 .map(|row| row.row_uuid())
                 .collect::<BTreeSet<_>>();
+                let mut readable = readable;
+                if let Some(branch) = &source_branch {
+                    let unread = overlay_rows
+                        .difference(&readable)
+                        .copied()
+                        .collect::<Vec<_>>();
+                    for row_uuid in unread {
+                        let deleted = self
+                            .branch_overlay_layer_winner_for_schema(
+                                &table.name,
+                                row_uuid,
+                                VersionLayer::Deletion,
+                                branch.branch_id,
+                                write_schema_version,
+                            )?
+                            .is_some_and(|winner| {
+                                winner.deletion() == Some(DeletionEvent::Deleted)
+                            });
+                        if !deleted {
+                            continue;
+                        }
+                        let Some(subject) = self.branch_selected_content_witness(
+                            branch,
+                            &table_schema,
+                            row_uuid,
+                            write_schema_version,
+                        )?
+                        else {
+                            continue;
+                        };
+                        let allowed = if let Some(policy) = &table_schema.read_policy {
+                            let cells = table_schema
+                                .columns
+                                .iter()
+                                .filter_map(|column| {
+                                    subject
+                                        .cell(&table_schema, &column.name)
+                                        .map(|value| (column.name.clone(), value))
+                                })
+                                .collect();
+                            self.branch_write_policy_query_allows_candidate(
+                                branch.branch_id,
+                                &table_schema,
+                                policy,
+                                row_uuid,
+                                &cells,
+                                identity,
+                                false,
+                            )?
+                        } else {
+                            true
+                        };
+                        if allowed {
+                            readable.insert(row_uuid);
+                        }
+                    }
+                }
                 if !overlay_rows.is_subset(&readable) {
                     return Err(Error::AuthorizationDenied);
                 }
@@ -1043,6 +1102,45 @@ where
         Ok(None)
     }
 
+    fn branch_selected_content_witness(
+        &mut self,
+        branch: &BranchRecord,
+        table: &TableSchema,
+        row_uuid: RowUuid,
+        read_schema_version: SchemaVersionId,
+    ) -> Result<Option<CurrentRow>, Error> {
+        if let Some(content) = self.branch_overlay_layer_winner_for_schema(
+            &table.name,
+            row_uuid,
+            VersionLayer::Content,
+            branch.branch_id,
+            read_schema_version,
+        )? {
+            let source_schema = self
+                .schema_version_for_alias(content.schema_version_alias())
+                .ok_or(Error::InvalidStoredValue(
+                    "branch content witness schema version alias missing",
+                ))?;
+            let source_table = self
+                .table_in_schema(content.table(), source_schema)?
+                .clone();
+            let mut cells = self.materialized_cells_for_version(&source_table, &content)?;
+            let projected = self.translate_cells(
+                source_schema,
+                read_schema_version,
+                content.table(),
+                &mut cells,
+            )?;
+            if projected.as_deref() == Some(table.name.as_str()) {
+                return current_row_from_materialized_cells(table, &content, &cells).map(Some);
+            }
+        }
+        Ok(self
+            .branch_base_rows_for_schema(&table.name, branch, read_schema_version)?
+            .into_iter()
+            .find(|row| row.row_uuid() == row_uuid))
+    }
+
     #[cfg(test)]
     pub(crate) fn evaluate_branch_metadata_write_policy_for_test(
         &mut self,
@@ -1088,6 +1186,33 @@ where
         let mut rows = by_row.into_values().collect::<Vec<_>>();
         sort_current_rows(&mut rows);
         Ok(rows)
+    }
+
+    /// Resolve only the frozen root contribution of a parentless snapshot-base
+    /// branch.  Maintained branch-current reads keep this portion immutable
+    /// while an IVM graph follows the branch overlay in front of it.
+    pub(super) fn branch_base_rows_for_schema(
+        &mut self,
+        table: &str,
+        branch: &BranchRecord,
+        read_schema_version: SchemaVersionId,
+    ) -> Result<Vec<CurrentRow>, Error> {
+        if branch.parent.is_some() {
+            return Err(Error::QueryCapability(
+                "branch-current subscriptions support only parentless snapshot-base branches"
+                    .to_owned(),
+            ));
+        }
+        let base = branch.base.as_ref().ok_or_else(|| {
+            Error::QueryCapability(
+                "branch-current subscriptions require a frozen snapshot base".to_owned(),
+            )
+        })?;
+        if read_schema_version == self.catalogue.current_schema_version_id {
+            self.current_rows_at(table, base.global_base)
+        } else {
+            self.projected_historical_current_rows(table, read_schema_version, base.global_base)
+        }
     }
 
     #[cfg(test)]

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -992,7 +992,7 @@ where
     /// Prepare physical branch storage only after bounded structural checks and
     /// catalogue dependencies are known to be satisfiable. Missing catalogue
     /// schemas are left for the ordinary parking path.
-    fn prepare_branch_target_partitions_if_ready(
+    pub(super) fn prepare_branch_target_partitions_if_ready(
         &mut self,
         tx: &Transaction,
         versions: &[VersionRecord],

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -1575,6 +1575,44 @@ where
         ))
     }
 
+    /// The branch-overlay counterpart of [`Self::physical_history_source_graph`].
+    ///
+    /// Branch content history has the same variant layouts as root history;
+    /// only the physical partition differs.  Keeping that distinction here is
+    /// important: query lowering can keep an IVM source subscribed to the
+    /// durable overlay table instead of snapshotting branch rows into an inline
+    /// graph at subscription-open time.
+    pub(super) fn physical_branch_history_source_graph(
+        &self,
+        schema_version: SchemaVersionId,
+        logical_table: &str,
+        branch_id: BranchId,
+    ) -> Result<GraphBuilder, Error> {
+        let alias = self
+            .catalogue
+            .schema_version_aliases
+            .get(&schema_version)
+            .copied()
+            .ok_or(Error::InvalidStoredValue(
+                "physical branch history source schema alias missing",
+            ))?;
+        // Validate that the logical table has the same physical history
+        // binding as a root history source before selecting its branch
+        // partition.
+        let _ = physical_history_binding(
+            &self.catalogue.catalogue_schemas,
+            &self.catalogue.schema_version_aliases,
+            &self.catalogue.physical_mappings,
+            schema_version,
+            logical_table,
+        )?;
+        let table_id = self.physical_table_id_for_schema(schema_version, logical_table)?;
+        Ok(GraphBuilder::variant_source(
+            physical_branch_history_table_name(table_id, branch_id),
+            physical_history_projection_target(alias, logical_table),
+        ))
+    }
+
     pub(super) fn register_physical_history_variant_projections(&mut self) -> Result<(), Error> {
         let targets = self
             .catalogue
@@ -1596,19 +1634,10 @@ where
                     "physical projection target schema alias missing",
                 ))?;
             let target_table = self.table_in_schema(&target_table_name, target_schema)?;
-            let storage_table = physical_history_table_name(target_mapping.table_id);
             let projection_target =
                 physical_history_projection_target(target_alias, &target_table_name);
             let logical_output = target_table.history_storage_table().record_schema();
             let physical_names = physical_history_field_names(&target_table, &target_mapping)?;
-            let output = widened_projection_descriptor(
-                &logical_output,
-                &physical_names,
-                self.database.table_schema(&storage_table)?,
-            )?;
-            self.database
-                .define_variant_projection(&storage_table, &projection_target, output)?;
-
             let sources = self
                 .catalogue
                 .physical_mappings
@@ -1623,47 +1652,74 @@ where
                         })
                 })
                 .collect::<Vec<_>>();
-            for (source_schema, source_table_name, source_mapping) in sources {
-                let source_alias = self
-                    .catalogue
-                    .schema_version_aliases
-                    .get(&source_schema)
-                    .copied()
-                    .ok_or(Error::InvalidStoredValue(
-                        "physical projection source schema alias missing",
-                    ))?;
-                let cases = if source_mapping.variant_cases.is_empty() {
-                    vec![(groove_variant_tag(source_alias)?, None)]
-                } else {
-                    source_mapping
-                        .variant_cases
-                        .iter()
-                        .map(|case| (case.tag, Some(&case.fields)))
-                        .collect()
-                };
-                for (tag, present) in cases {
-                    let Some(fields) = self.physical_history_projection_case(
-                        source_schema,
-                        &source_table_name,
-                        &source_mapping,
-                        target_schema,
-                        &target_table_name,
-                        present,
-                    )?
-                    else {
-                        self.database.register_variant_ignore_case(
+            let storage_tables =
+                std::iter::once(physical_history_table_name(target_mapping.table_id))
+                    .chain(
+                        self.branches
+                            .branch_partitions
+                            .iter()
+                            .filter(|(table_id, _)| *table_id == target_mapping.table_id)
+                            .map(|(_, branch_id)| {
+                                physical_branch_history_table_name(
+                                    target_mapping.table_id,
+                                    *branch_id,
+                                )
+                            }),
+                    )
+                    .collect::<Vec<_>>();
+            for storage_table in storage_tables {
+                let output = widened_projection_descriptor(
+                    &logical_output,
+                    &physical_names,
+                    self.database.table_schema(&storage_table)?,
+                )?;
+                self.database.define_variant_projection(
+                    &storage_table,
+                    &projection_target,
+                    output,
+                )?;
+                for (source_schema, source_table_name, source_mapping) in &sources {
+                    let source_alias = self
+                        .catalogue
+                        .schema_version_aliases
+                        .get(source_schema)
+                        .copied()
+                        .ok_or(Error::InvalidStoredValue(
+                            "physical projection source schema alias missing",
+                        ))?;
+                    let cases = if source_mapping.variant_cases.is_empty() {
+                        vec![(groove_variant_tag(source_alias)?, None)]
+                    } else {
+                        source_mapping
+                            .variant_cases
+                            .iter()
+                            .map(|case| (case.tag, Some(&case.fields)))
+                            .collect()
+                    };
+                    for (tag, present) in cases {
+                        let Some(fields) = self.physical_history_projection_case(
+                            *source_schema,
+                            source_table_name,
+                            source_mapping,
+                            target_schema,
+                            &target_table_name,
+                            present,
+                        )?
+                        else {
+                            self.database.register_variant_ignore_case(
+                                &storage_table,
+                                &projection_target,
+                                tag,
+                            )?;
+                            continue;
+                        };
+                        self.database.register_variant_case(
                             &storage_table,
                             &projection_target,
                             tag,
+                            fields,
                         )?;
-                        continue;
-                    };
-                    self.database.register_variant_case(
-                        &storage_table,
-                        &projection_target,
-                        tag,
-                        fields,
-                    )?;
+                    }
                 }
             }
         }

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -7286,6 +7286,9 @@ fn result_membership_fields(
         ProjectField::renamed(version.tx_time_field, "content_tx_time"),
         ProjectField::renamed(version.tx_node_field, "content_tx_node_id"),
     ];
+    if let Some(branch_or_prefix) = version.branch_or_prefix_field {
+        fields.push(ProjectField::named(branch_or_prefix));
+    }
     fields.extend(
         occurrence_id_fields
             .iter()
@@ -7593,6 +7596,14 @@ fn prefixed_version_witness_fields_for_tagged_rows(
             table_user_column_field(&source.table_schema.name, &column.name),
         )
     }));
+    if let Some(branch_or_prefix) =
+        version_witness_fields(&source.row_shape)?.branch_or_prefix_field
+    {
+        fields.push(ProjectField::renamed(
+            format!("{prefix}{branch_or_prefix}"),
+            branch_or_prefix,
+        ));
+    }
     Ok(fields)
 }
 
@@ -7627,6 +7638,9 @@ fn inline_version_witness_fields_for_tagged_rows(
             table_user_column_field(&source.table_schema.name, &column.name),
         )
     }));
+    if let Some(branch_or_prefix) = version.branch_or_prefix_field {
+        fields.push(ProjectField::named(branch_or_prefix));
+    }
     Ok(fields)
 }
 
@@ -7663,6 +7677,11 @@ fn deletion_witness_fields_for_tagged_rows(
             ValueType::Nullable(Box::new(column.column_type.clone())),
         )
     }));
+    if let Some(branch_or_prefix) =
+        version_witness_fields(&source.row_shape)?.branch_or_prefix_field
+    {
+        fields.push(ProjectField::named(branch_or_prefix));
+    }
     Ok(fields)
 }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1079,69 +1079,16 @@ where
                 .get(&branch_id)
                 .cloned()
                 .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
-            let rows = self
-                .node
-                .branch_current_rows_for_schema(
-                    &request.source.table,
-                    &branch,
-                    self.read_view.read_schema,
-                )
-                .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
-            let rows = rows
-                .into_iter()
-                .map(|row| {
-                    let tx_id = if let Some((time, alias)) = row.projected_tx_alias() {
-                        let node = self
-                            .node
-                            .node_aliases
-                            .iter()
-                            .find_map(|(node, candidate)| (*candidate == alias).then_some(*node))
-                            .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
-                        TxId::new(time, node)
-                    } else {
-                        let base = branch
-                            .base
-                            .as_ref()
-                            .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
-                        self.node
-                            .historical_content_witness_at(
-                                &request.source.table,
-                                self.read_view.read_schema,
-                                row.row_uuid(),
-                                base.global_base,
-                            )
-                            .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
-                            .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?
-                    };
-                    let tx = self
-                        .node
-                        .query_transaction(tx_id)
-                        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
-                        .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
-                    let lineage = match tx.tx.target_lineage {
-                        BranchLineage::Root => None,
-                        BranchLineage::Branch(branch) => Some(branch),
-                    };
-                    let alias = self
-                        .node
-                        .node_aliases
-                        .get(&tx_id.node)
-                        .copied()
-                        .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
-                    Ok((row, tx_id.time, alias, lineage))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let schema_version_alias = self
-                .node
-                .ensure_schema_version_alias(self.read_view.read_schema)
-                .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
-            let (base, descriptor, metadata) = inline_branch_current_graph(
+            let source = self.branch_current_source_graph(
+                request,
                 &table,
-                rows,
-                schema_version_alias,
-                &request.requirements,
-            )
-            .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+                &branch,
+                branch_id,
+                graph_tier.expect("branch-current source has a tier"),
+            )?;
+            let base = source.graph;
+            let descriptor = source.descriptor;
+            let metadata = source.metadata;
             let graph = match &authorization {
                 SourceAuthorizationRequest::System => base,
                 SourceAuthorizationRequest::PolicyFiltered {
@@ -1554,8 +1501,12 @@ where
         {
             return Err(source_resolution_error(request, SourceGap::Coverage));
         }
-        if branch_data.is_some() {
-            return Err(source_resolution_error(request, SourceGap::BranchOverlay));
+        if let Some(branch_id) = branch_data {
+            return Ok(Some(DeletionRegisterSource {
+                graph: self
+                    .branch_overlay_deletion_current_graph(request, table, branch_id, tier)?,
+                row_uuid_field: "row_uuid".to_owned(),
+            }));
         }
         if self.needs_projected_current_source(&request.source.table) {
             return Ok(Some(DeletionRegisterSource {
@@ -1603,7 +1554,12 @@ where
             return Err(source_resolution_error(request, SourceGap::Coverage));
         }
         if branch_data.is_some() {
-            return Err(source_resolution_error(request, SourceGap::BranchOverlay));
+            // The branch-current membership graph already carries the exact
+            // selected content witness (including its branch discriminator).
+            // Let the generic witness lowering consume that graph directly:
+            // a separate root-current sidecar would be both stale at the
+            // frozen base and capable of crossing branch identities.
+            return Ok(None);
         }
         if self.needs_projected_current_source(&request.source.table) {
             return Ok(Some(ContentVersionSource {
@@ -1646,6 +1602,242 @@ where
             .map_err(|_| source_resolution_error(request, SourceGap::HistoricalStorageCut))?;
         inline_current_graph(table, rows)
             .map_err(|_| source_resolution_error(request, SourceGap::HistoricalStorageCut))
+    }
+
+    /// Build the maintained input for one v1 branch-current source.
+    ///
+    /// The frozen root base is intentionally inline: no later root write may
+    /// move a branch's base.  The branch overlay, in contrast, stays wired to
+    /// its durable history and sparse deletion register so add/replace/delete/
+    /// restore events flow through the existing IVM subscription.  An overlay
+    /// content winner or a currently-deleted overlay row masks the frozen base;
+    /// a restored deletion without overlay content exposes that base again.
+    fn branch_current_source_graph(
+        &mut self,
+        request: &SourceRequest,
+        table: &TableSchema,
+        branch: &BranchRecord,
+        branch_id: BranchId,
+        tier: DurabilityTier,
+    ) -> Result<CurrentSourceGraph, SourceResolutionError> {
+        let base_rows = self
+            .node
+            .branch_base_rows_for_schema(&request.source.table, branch, self.read_view.read_schema)
+            .map_err(|_| source_resolution_error(request, SourceGap::BranchOverlay))?;
+        let base_rows = base_rows
+            .into_iter()
+            .map(|row| {
+                let tx_id = if let Some((time, alias)) = row.projected_tx_alias() {
+                    let node = self
+                        .node
+                        .node_aliases
+                        .iter()
+                        .find_map(|(node, candidate)| (*candidate == alias).then_some(*node))
+                        .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
+                    TxId::new(time, node)
+                } else {
+                    let base = branch
+                        .base
+                        .as_ref()
+                        .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
+                    self.node
+                        .historical_content_witness_at(
+                            &request.source.table,
+                            self.read_view.read_schema,
+                            row.row_uuid(),
+                            base.global_base,
+                        )
+                        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
+                        .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?
+                };
+                let alias = self
+                    .node
+                    .node_aliases
+                    .get(&tx_id.node)
+                    .copied()
+                    .ok_or_else(|| source_resolution_error(request, SourceGap::Coverage))?;
+                Ok((row, tx_id.time, alias, None))
+            })
+            .collect::<Result<Vec<_>, SourceResolutionError>>()?;
+        let schema_version_alias = self
+            .node
+            .ensure_schema_version_alias(self.read_view.read_schema)
+            .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+        let (frozen_base, descriptor, metadata) = inline_branch_current_graph(
+            table,
+            base_rows,
+            schema_version_alias,
+            &request.requirements,
+        )
+        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+
+        let table_id = self
+            .node
+            .physical_table_id_for_schema(self.read_view.read_schema, &request.source.table)
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        // The graph can name a sparse branch source before it has rows. The
+        // receiving ViewUpdate path provisions that physical partition before
+        // staging its first witness. A metadata-only receiver, however, has
+        // no such table and must expose its frozen base without creating a
+        // branch-content existence oracle; the rebuild on first witness
+        // reopens its maintained view against the live source.
+        if !self
+            .node
+            .branches
+            .branch_partitions
+            .contains(&(table_id, branch_id))
+        {
+            return Ok(CurrentSourceGraph {
+                graph: frozen_base,
+                descriptor,
+                metadata,
+            });
+        }
+        let history_fields = maintained_view_history_storage_field_names(table);
+        let overlay_content = GraphBuilder::arg_max_by(
+            tier_visible_branch_history_graph(
+                self.node
+                    .physical_branch_history_source_graph(
+                        self.read_view.read_schema,
+                        &request.source.table,
+                        branch_id,
+                    )
+                    .map_err(|_| source_resolution_error(request, SourceGap::BranchOverlay))?,
+                history_fields,
+                tier,
+            ),
+            ["row_uuid"],
+            ["tx_time", "tx_node_id"],
+        );
+        let overlay_deletion_winner =
+            self.branch_overlay_deletion_current_graph_for_table(table_id, branch_id, tier);
+        let deleted_overlay_rows = overlay_deletion_winner
+            .clone()
+            .filter(PredicateExpr::eq("_deletion", Value::EnumTag(0)))
+            .project(["row_uuid"]);
+        let overlay_visible = GraphBuilder::anti_join(
+            overlay_content.clone(),
+            deleted_overlay_rows.clone(),
+            ["row_uuid"],
+            ["row_uuid"],
+        );
+        let overlay_masks_base = GraphBuilder::union([
+            overlay_content.clone().project(["row_uuid"]),
+            deleted_overlay_rows,
+        ]);
+        let frozen_base =
+            GraphBuilder::anti_join(frozen_base, overlay_masks_base, ["row_uuid"], ["row_uuid"]);
+
+        // The durable content carrier uses storage names; normalize it to the
+        // same descriptor as the frozen-base records before their union.
+        let mut normalized = vec![ProjectField::named("row_uuid")];
+        normalized.extend(
+            table
+                .columns
+                .iter()
+                .map(|column| ProjectField::named(user_column_field(&column.name))),
+        );
+        normalized.extend([
+            ProjectField::renamed("created_by", "$createdBy"),
+            ProjectField::renamed("created_at", "$createdAt"),
+            ProjectField::renamed("updated_by", "$updatedBy"),
+            ProjectField::renamed("updated_at", "$updatedAt"),
+            ProjectField::named("tx_time"),
+            ProjectField::named("tx_node_id"),
+        ]);
+        if metadata.contains_key(&SourceMetadataRequirement::VersionWitnesses) {
+            normalized.extend([
+                ProjectField::literal("table", Value::String(table.name.clone())),
+                ProjectField::literal("layer", Value::String("content".to_owned())),
+                ProjectField::named("schema_version"),
+                ProjectField::named("parents"),
+                ProjectField::renamed("created_by", "created_by"),
+                ProjectField::renamed("created_at", "created_at"),
+                ProjectField::renamed("updated_by", "updated_by"),
+                ProjectField::renamed("updated_at", "updated_at"),
+                ProjectField::named("authored_columns"),
+                ProjectField::literal(
+                    "branch_id",
+                    Value::Nullable(Some(Box::new(Value::Uuid(branch_id.0)))),
+                ),
+            ]);
+        }
+        if metadata.contains_key(&SourceMetadataRequirement::Coverage) {
+            normalized.push(ProjectField::literal(
+                "coverage",
+                Value::String("branch-current".to_owned()),
+            ));
+        }
+        if metadata.contains_key(&SourceMetadataRequirement::SettlePosition) {
+            normalized.push(ProjectField::null_typed(
+                "settle_position",
+                ValueType::Nullable(Box::new(ValueType::U64)),
+            ));
+        }
+        // Keep this assertion close to the union: a metadata expansion must
+        // update both branches together instead of silently stripping a
+        // witness from live overlay rows.
+        debug_assert_eq!(
+            descriptor
+                .fields()
+                .iter()
+                .map(|field| field.name.as_deref())
+                .collect::<Vec<_>>(),
+            normalized
+                .iter()
+                .map(|field| Some(field.output_name.as_str()))
+                .collect::<Vec<_>>(),
+        );
+        let overlay_visible = overlay_visible.project_fields(normalized);
+        Ok(CurrentSourceGraph {
+            graph: GraphBuilder::union([frozen_base, overlay_visible]),
+            descriptor,
+            metadata,
+        })
+    }
+
+    fn branch_overlay_deletion_current_graph(
+        &mut self,
+        request: &SourceRequest,
+        table: &TableSchema,
+        branch_id: BranchId,
+        tier: DurabilityTier,
+    ) -> Result<GraphBuilder, SourceResolutionError> {
+        let table_id = self
+            .node
+            .physical_table_id_for_schema(self.read_view.read_schema, &request.source.table)
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        let _ = table;
+        Ok(self.branch_overlay_deletion_current_graph_for_table(table_id, branch_id, tier))
+    }
+
+    fn branch_overlay_deletion_current_graph_for_table(
+        &self,
+        table_id: PhysicalTableId,
+        branch_id: BranchId,
+        tier: DurabilityTier,
+    ) -> GraphBuilder {
+        GraphBuilder::arg_max_by(
+            tier_visible_branch_history_graph(
+                GraphBuilder::table(SHARED_DELETION_HISTORY_TABLE).filter(
+                    PredicateExpr::And(vec![
+                        PredicateExpr::eq("branch_kind", Value::U8(1)),
+                        PredicateExpr::eq("branch_id", Value::Uuid(branch_id.0)),
+                        PredicateExpr::eq("physical_table_id", Value::U64(table_id.0)),
+                    ])
+                    .canonicalize(),
+                ),
+                register_storage_field_names(),
+                tier,
+            ),
+            ["row_uuid"],
+            ["tx_time", "tx_node_id"],
+        )
+        .project_fields(
+            register_storage_fields_for_query_engine("")
+                .into_iter()
+                .chain([ProjectField::literal("branch_id", Value::Uuid(branch_id.0))]),
+        )
     }
 
     fn projected_maintained_visible_current_source_graph(
@@ -1961,6 +2153,52 @@ fn edge_visible_ahead_current_source_graph(
                 ])
                 .canonicalize(),
             )
+            .project(["time", "node_id"]),
+        ["tx_time", "tx_node_id"],
+        ["time", "node_id"],
+    )
+    .project_fields(
+        fields
+            .into_iter()
+            .map(|field| ProjectField::renamed(left_field(&field), field)),
+    )
+}
+
+/// Select branch overlay history by the same fate/durability contract as a
+/// root current read before choosing the row winner. Branch partitions retain
+/// raw history after rejection, so winner selection over the unfiltered table
+/// would expose pending rows at Edge/Global and let a rejected latest version
+/// continue masking an earlier accepted winner.
+fn tier_visible_branch_history_graph(
+    source: GraphBuilder,
+    fields: Vec<String>,
+    tier: DurabilityTier,
+) -> GraphBuilder {
+    let eligible = match tier {
+        DurabilityTier::None | DurabilityTier::Local => PredicateExpr::Or(vec![
+            PredicateExpr::eq("fate", Value::EnumTag(FateTag::Pending as u8)),
+            PredicateExpr::eq("fate", Value::EnumTag(FateTag::Accepted as u8)),
+        ])
+        .canonicalize(),
+        DurabilityTier::Edge => PredicateExpr::And(vec![
+            PredicateExpr::eq("fate", Value::EnumTag(FateTag::Accepted as u8)),
+            PredicateExpr::Or(vec![
+                PredicateExpr::eq("durability", Value::EnumTag(2)),
+                PredicateExpr::eq("durability", Value::EnumTag(3)),
+            ])
+            .canonicalize(),
+        ])
+        .canonicalize(),
+        DurabilityTier::Global => PredicateExpr::And(vec![
+            PredicateExpr::eq("fate", Value::EnumTag(FateTag::Accepted as u8)),
+            PredicateExpr::eq("durability", Value::EnumTag(3)),
+        ])
+        .canonicalize(),
+    };
+    GraphBuilder::join(
+        source.project(fields.clone()),
+        GraphBuilder::table("jazz_transactions")
+            .filter(eligible)
             .project(["time", "node_id"]),
         ["tx_time", "tx_node_id"],
         ["time", "node_id"],
@@ -7808,6 +8046,30 @@ where
         )
     }
 
+    pub(crate) fn query_rows_for_client_read_view(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        read_view: &ReadViewSpec,
+    ) -> Result<Vec<CurrentRow>, Error> {
+        let Some(binding_view) =
+            self.client_settled_binding_view_key_for_query(shape, binding, tier, read_view)
+        else {
+            return Ok(Vec::new());
+        };
+        let Some(snapshot) =
+            self.authoritative_reset_snapshot_for_binding_view(shape, binding_view)?
+        else {
+            return Ok(Vec::new());
+        };
+        Ok(snapshot
+            .rows
+            .into_iter()
+            .take(snapshot.root_count)
+            .collect())
+    }
+
     pub(crate) fn query_rows_local_preview(
         &mut self,
         shape: &ValidatedQuery,
@@ -10237,6 +10499,60 @@ where
             read_view,
             QueryAuthorizationMode::ClientLocal,
         )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn query_relation_branch_discriminators_for_test(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        identity: AuthorId,
+        read_view: &ReadViewSpec,
+    ) -> Result<Vec<(Option<uuid::Uuid>, Option<uuid::Uuid>)>, Error> {
+        let program = self.compile_current_query_program_for_read_view_in_authorization_mode(
+            shape,
+            binding,
+            tier,
+            identity,
+            CurrentQueryProgramOutput::RelationSnapshot,
+            read_view,
+            QueryAuthorizationMode::ClientLocal,
+        )?;
+        let snapshots = self
+            .database
+            .query_graphs(lowered_program_sinks(&program))
+            .map_err(Error::Groove)?;
+        let Some(edges) = snapshots.get("maintained.relation_edges") else {
+            return Ok(Vec::new());
+        };
+        let decode =
+            |record: &BorrowedRecord<'_>, field: &str| -> Result<Option<uuid::Uuid>, Error> {
+                let index = required_field_idx(&edges.descriptor, field)?;
+                match record.get_idx(index)? {
+                    Value::Uuid(value) => Ok(Some(value)),
+                    Value::Nullable(Some(value)) => match *value {
+                        Value::Uuid(value) => Ok(Some(value)),
+                        _ => Err(Error::InvalidStoredValue(
+                            "branch discriminator must be UUID",
+                        )),
+                    },
+                    Value::Nullable(None) => Ok(None),
+                    _ => Err(Error::InvalidStoredValue(
+                        "branch discriminator must be UUID",
+                    )),
+                }
+            };
+        edges
+            .iter()
+            .filter(|(_, weight)| *weight > 0)
+            .map(|(record, _)| {
+                Ok((
+                    decode(&record, "source_branch_or_prefix")?,
+                    decode(&record, "target_branch_or_prefix")?,
+                ))
+            })
+            .collect()
     }
 
     fn query_relation_snapshot_in_authorization_mode(

--- a/crates/jazz/src/node/query_eval/query_read_sets.rs
+++ b/crates/jazz/src/node/query_eval/query_read_sets.rs
@@ -178,6 +178,22 @@ pub(super) fn query_read_set_for_read_view(
     // the public row. Its authoritative result is materialized directly by
     // the subscription facade instead.
     let settled_binding_view = (!aggregate_query).then_some(settled_binding_view).flatten();
+    // Branch-current v1 deliberately remains an overlay-first source graph at
+    // every peer. A selected result may belong to a detached usage site,
+    // whereas durable branch history must continue to drive live writes,
+    // deletion, and restoration. BranchId remains in the binding/read-view
+    // key; this only chooses its live data source.
+    if let ReadViewSourceSpec::Branch { branch } = &read_view.source
+        && read_view.schema == Default::default()
+        && read_view.overlays.is_empty()
+    {
+        return Ok(branch_query_read_set(
+            shape,
+            read_schema,
+            tier,
+            BranchId(*branch),
+        ));
+    }
     if settled_binding_view.is_some() {
         if !read_view.is_default() {
             return Err(Error::QueryCapability(

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -741,6 +741,29 @@ where
         Ok(())
     }
 
+    /// Materialize sparse branch storage before a trusted receiver batch can
+    /// stage its branch-target versions. The branch metadata gate runs before
+    /// this path, so a receiver only provisions a partition for content it is
+    /// already allowed to name. Keeping this before the batch is essential:
+    /// the physical history table must be durable before a ViewUpdate can make
+    /// its version witness public to a maintained subscription.
+    pub(crate) fn prepare_view_update_branch_partitions(
+        &mut self,
+        updates: &[ViewUpdateParts],
+    ) -> Result<(), Error>
+    where
+        S: ReopenableStorage,
+    {
+        for update in updates {
+            for bundle in
+                version_bundle_refs_for_carriers(&update.version_bundles, &update.version_carriers)?
+            {
+                self.prepare_branch_target_partitions_if_ready(&bundle.tx, bundle.versions)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Validate all row bundles carried by a receiver frame without changing
     /// storage or in-memory receiver state.
     fn validate_view_update_payloads(&self, updates: &[ViewUpdateParts]) -> Result<(), Error> {

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -2969,15 +2969,19 @@ impl JazzClient {
                         author,
                     )?
                 } else {
+                    let opts = Self::core_read_opts(&query, durability_tier)?;
+                    let requires_branch_coverage =
+                        matches!(opts.read_view.source, CoreReadViewSourceSpec::Branch { .. });
                     self.db
                         .query_rows(
                             core_query,
-                            Self::core_read_opts(&query, durability_tier)?,
+                            opts,
                             table,
-                            matches!(
-                                durability_tier,
-                                Some(DurabilityTier::EdgeServer | DurabilityTier::GlobalServer)
-                            ),
+                            requires_branch_coverage
+                                || matches!(
+                                    durability_tier,
+                                    Some(DurabilityTier::EdgeServer | DurabilityTier::GlobalServer)
+                                ),
                         )
                         .await?
                 };

--- a/crates/jazz/tests/branch_claims_integration.rs
+++ b/crates/jazz/tests/branch_claims_integration.rs
@@ -959,7 +959,7 @@ async fn explicit_branch_subscription_should_match_claims_select_query() {
                 .connect()
                 .await;
             let denied_rows = denied
-                .query(branch_query, Some(DurabilityTier::EdgeServer))
+                .query(branch_query.clone(), Some(DurabilityTier::EdgeServer))
                 .await
                 .expect("nonmatching claim queries branch");
             assert!(
@@ -967,6 +967,23 @@ async fn explicit_branch_subscription_should_match_claims_select_query() {
                     .iter()
                     .all(|(id, _)| *id != jazz::tools::ObjectId::from_uuid(branch_row.0)),
                 "branch query must retain ordinary select policy: {denied_rows:?}"
+            );
+            let mut denied_stream = denied
+                .subscribe(branch_query)
+                .await
+                .expect("nonmatching claim subscribes to branch");
+            let mut denied_log = Vec::new();
+            wait_for_subscription_update(
+                &mut denied_stream,
+                &mut denied_log,
+                QUERY_TIMEOUT,
+                "nonmatching branch subscription receives its empty snapshot",
+                |updates| !updates.is_empty(),
+            )
+            .await;
+            assert!(
+                !has_added(&denied_log, jazz::tools::ObjectId::from_uuid(branch_row.0)),
+                "branch subscription must retain ordinary select policy: {denied_log:?}"
             );
 
             matching.shutdown().await.expect("shutdown matching client");


### PR DESCRIPTION
🤖 Enables branch-current one-shot and maintained subscriptions with root-equivalent tier semantics.

Local reads reconstruct canonical pending branch state. Edge and Global reads consume the exact BranchId-keyed authoritative snapshot, so unsent local overlays cannot leak upward and siblings cannot share cache identity. Branch overlay and frozen-base sources preserve exact root-or-branch witness lineage through relation terminals.

Sparse branch sources are installed live without rebuilding Groove; a subscription can survive the first overlay partition write.

Evidence includes Local pending insert/delete/restore, Edge/Global authority isolation, sibling identity, first-write survival, relation witness lineage, and planted boundary regressions. Independent review found no P0–P2.
