### PR TITLE
test: guard branch partition metadata privacy

### DIFF
--- a/crates/jazz/src/node/branches.rs
+++ b/crates/jazz/src/node/branches.rs
@@ -1203,11 +1203,12 @@ where
                     .to_owned(),
             ));
         }
-        let base = branch.base.as_ref().ok_or_else(|| {
-            Error::QueryCapability(
-                "branch-current subscriptions require a frozen snapshot base".to_owned(),
-            )
-        })?;
+        let Some(base) = branch.base.as_ref() else {
+            // A root branch is defined without a frozen parent snapshot. Its
+            // immutable contribution is therefore the empty relation; the
+            // maintained overlay source supplies all branch-current rows.
+            return Ok(Vec::new());
+        };
         if read_schema_version == self.catalogue.current_schema_version_id {
             self.current_rows_at(table, base.global_base)
         } else {
@@ -2075,6 +2076,22 @@ where
             .branch_partitions
             .remove(&(table_id, branch_id));
         result
+    }
+
+    #[cfg(test)]
+    pub(crate) fn branch_subscription_source_exists_for_test(
+        &self,
+        table: &str,
+        schema_version: SchemaVersionId,
+        branch_id: BranchId,
+    ) -> bool {
+        self.physical_table_id_for_schema(schema_version, table)
+            .ok()
+            .is_some_and(|table_id| {
+                self.database
+                    .table_schema(&physical_branch_history_table_name(table_id, branch_id))
+                    .is_ok()
+            })
     }
 
     pub(super) fn ensure_branch_target_partitions(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -6936,12 +6936,25 @@ where
     ) -> Result<QueryProgram, Error> {
         let trace_request = capability_trace_enabled().then(|| request.clone());
         let read_view = request.reads.primary.clone();
-        let prepare_branch_subscription_sources = request.authorization_mode
-            == QueryAuthorizationMode::TrustedServing
-            && request
-                .output
-                .facts
-                .contains(&ProgramFactKey::ResultMembership);
+        let maintained_result_membership = request
+            .output
+            .facts
+            .contains(&ProgramFactKey::ResultMembership);
+        let client_local_branch_at_local = request.authorization_mode
+            == QueryAuthorizationMode::ClientLocal
+            && request.reads.primary.sources.values().any(|source| {
+                matches!(
+                    source,
+                    SourceExpr::VisibleCurrent {
+                        data: DataSource::Branch(_),
+                        tier: DurabilityTier::Local,
+                        ..
+                    }
+                )
+            });
+        let prepare_branch_subscription_sources = maintained_result_membership
+            && (request.authorization_mode == QueryAuthorizationMode::TrustedServing
+                || client_local_branch_at_local);
         let mut resolver = CurrentQuerySourceResolver {
             node: self,
             read_view: &read_view,

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -411,6 +411,14 @@ impl ShellDb {
         }
     }
 
+    fn create_branch_for_test(&self, branch: BranchId) -> ShellResult<()> {
+        match self {
+            Self::Memory(db) => db.create_branch_with_id(branch).map_err(Into::into),
+            #[cfg(feature = "rocksdb")]
+            Self::Rocks(db) => db.create_branch_with_id(branch).map_err(Into::into),
+        }
+    }
+
     fn set_edge_cache_budget(&self, budget: Option<EdgeCacheBudget>) {
         match self {
             Self::Memory(db) => db.set_edge_cache_budget(budget),
@@ -1342,6 +1350,12 @@ impl InMemoryServerShell {
         cells: RowCells,
     ) -> ShellResult<()> {
         self.db.seed_branch_row(branch, table.into(), row_id, cells)
+    }
+
+    /// Create an empty branch for a public integration test without creating a
+    /// sparse overlay partition. Production creation uses the same DB path.
+    pub fn create_branch_for_test(&mut self, branch: BranchId) -> ShellResult<()> {
+        self.db.create_branch_for_test(branch)
     }
 
     fn is_draining(&self) -> bool {

--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -404,6 +404,22 @@ impl ServerShellHandle {
         result
     }
 
+    #[allow(dead_code)] // exercised only by the integration-test server feature
+    pub(crate) async fn create_branch_for_test(&self, branch: BranchId) -> Result<(), String> {
+        let activity_tx = self.inner.activity_tx.clone();
+        let result = self
+            .run(move |shell| {
+                shell
+                    .create_branch_for_test(branch)
+                    .map_err(|error| error.to_string())
+            })
+            .await;
+        if result.is_ok() {
+            notify_shell_activity(&activity_tx);
+        }
+        result
+    }
+
     pub(crate) async fn publish_permissions_schema(
         &self,
         schema: JazzSchema,

--- a/crates/jazz/src/tools/server/testing.rs
+++ b/crates/jazz/src/tools/server/testing.rs
@@ -425,6 +425,17 @@ impl JazzServer {
             .expect("seed branch row through server shell");
     }
 
+    pub async fn create_branch_for_test(&self, branch: crate::ids::BranchId) {
+        let shell = self
+            .state
+            .core_server_shell()
+            .expect("test server starts a core server shell");
+        shell
+            .create_branch_for_test(branch)
+            .await
+            .expect("create empty branch through server shell");
+    }
+
     fn require_built_in_jwt_helpers(&self) {
         if self.embedded_jwks_server.is_none() {
             panic!(

--- a/crates/jazz/tests/branch_claims_integration.rs
+++ b/crates/jazz/tests/branch_claims_integration.rs
@@ -886,6 +886,28 @@ async fn explicit_branch_subscription_should_match_claims_select_query() {
             let branch_row = RowUuid(uuid::Uuid::from_bytes([0x43; 16]));
             let sibling = BranchId(uuid::Uuid::from_bytes([0x44; 16]));
             let sibling_row = RowUuid(uuid::Uuid::from_bytes([0x45; 16]));
+            let empty_branch = BranchId(uuid::Uuid::from_bytes([0x46; 16]));
+            let empty_row = RowUuid(uuid::Uuid::from_bytes([0x47; 16]));
+            server.create_branch_for_test(empty_branch).await;
+            let empty_query = QueryBuilder::new("rooms")
+                .branch(empty_branch.0.to_string())
+                .build();
+            let partition_probe = TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema.clone())
+                .with_user_id("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa44")
+                .with_claims(json!({"join_code": "wrong"}))
+                .ready_on("rooms", READY_TIMEOUT)
+                .connect()
+                .await;
+            let absent_partition_rows = partition_probe
+                .query(empty_query.clone(), Some(DurabilityTier::EdgeServer))
+                .await
+                .expect("denied probe queries empty branch");
+            assert!(
+                absent_partition_rows.is_empty(),
+                "a denied query must not observe an absent sparse partition: {absent_partition_rows:?}"
+            );
             server
                 .seed_branch_row_for_test(
                     branch,
@@ -903,6 +925,31 @@ async fn explicit_branch_subscription_should_match_claims_select_query() {
                     ]),
                 )
                 .await;
+            server
+                .seed_branch_row_for_test(
+                    empty_branch,
+                    "rooms",
+                    empty_row,
+                    BTreeMap::from([
+                        (
+                            "name".to_owned(),
+                            CoreValue::String("lazy partition room".to_owned()),
+                        ),
+                        (
+                            "join_code".to_owned(),
+                            CoreValue::String("branch-secret".to_owned()),
+                        ),
+                    ]),
+                )
+                .await;
+            let populated_partition_rows = partition_probe
+                .query(empty_query.clone(), Some(DurabilityTier::EdgeServer))
+                .await
+                .expect("denied probe queries lazily populated branch");
+            assert!(
+                populated_partition_rows.is_empty(),
+                "a denied query must not distinguish a lazily created partition: {populated_partition_rows:?}"
+            );
             server
                 .seed_branch_row_for_test(
                     sibling,
@@ -1029,9 +1076,30 @@ async fn explicit_branch_subscription_should_match_claims_select_query() {
                 !has_added(&denied_log, jazz::tools::ObjectId::from_uuid(branch_row.0)),
                 "branch subscription must retain ordinary select policy: {denied_log:?}"
             );
+            let mut lazy_denied_stream = partition_probe
+                .subscribe(empty_query)
+                .await
+                .expect("denied probe subscribes after lazy partition creation");
+            let mut lazy_denied_log = Vec::new();
+            wait_for_subscription_update(
+                &mut lazy_denied_stream,
+                &mut lazy_denied_log,
+                QUERY_TIMEOUT,
+                "denied probe receives its empty lazy-partition snapshot",
+                |updates| !updates.is_empty(),
+            )
+            .await;
+            assert!(
+                !has_added(&lazy_denied_log, jazz::tools::ObjectId::from_uuid(empty_row.0)),
+                "a denied subscription must not reveal lazily partitioned branch rows: {lazy_denied_log:?}"
+            );
 
             matching.shutdown().await.expect("shutdown matching client");
             denied.shutdown().await.expect("shutdown denied client");
+            partition_probe
+                .shutdown()
+                .await
+                .expect("shutdown partition probe");
             server.shutdown().await;
         })
         .await;


### PR DESCRIPTION
🤖 Prevents denied or absent branch subscriptions from allocating or revealing sparse branch source state.

Register-shape preflight remains pure. Subscribe checks branch metadata visibility before any side-effecting maintained compilation; denied and absent branches return indistinguishable empty results and allocate no physical or process-local sparse source.

Authorized Local and trusted serving paths still install the exact empty source needed for live first-write delivery.

Raw-wire allocation plants, absent-vs-lazy privacy checks, and sibling isolation pass. Independent review found no P0–P2.
