### PR TITLE
fix: admit canonical flat tuple contributors

### DIFF
--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -404,6 +404,38 @@ impl MaintainedSubscriptionView {
         self.versions.versions_by_tx(tx_id)
     }
 
+    /// Source records whose row identities occur in visible flat tuples.
+    /// The caller resolves each maintained record back to its authored history
+    /// version before publishing the result-to-contributor admission fact.
+    pub(crate) fn tuple_source_versions_for_members(
+        &self,
+        members: &[ResultMemberEntry],
+    ) -> Vec<(ResultMemberEntry, VersionRow)> {
+        let mut tuples = Vec::new();
+        for member in members {
+            let Some(occurrence) = member.output_occurrence_id() else {
+                continue;
+            };
+            let joined_rows = occurrence
+                .joined_sources()
+                .iter()
+                .map(|id| RowUuid(*id.uuid()))
+                .collect::<BTreeSet<_>>();
+            if joined_rows.is_empty() {
+                continue;
+            }
+            for weighted in self.versions.by_identity.values() {
+                if weighted.weight > 0
+                    && weighted.row.deletion().is_none()
+                    && joined_rows.contains(&weighted.row.row_uuid())
+                {
+                    tuples.push((member.clone(), weighted.row.clone()));
+                }
+            }
+        }
+        tuples
+    }
+
     pub(crate) fn replacement_for(
         &self,
         table: &str,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -8678,6 +8678,34 @@ where
                     )
                 })
             }));
+            row_entries.extend(program_facts.iter().filter_map(|fact| {
+                let ProgramFactEntry::ContributingMembers(contribution) = fact else {
+                    return None;
+                };
+                if contribution.role.as_deref() != Some("flat_tuple_source")
+                    || !row_result_set.contains(&contribution.result)
+                {
+                    return None;
+                }
+                contribution
+                    .contributor
+                    .as_real_row()
+                    .and_then(|contributor| {
+                        contributor.row_projection().map(|(table, row, tx)| {
+                            (
+                                (table.to_string(), row, tx),
+                                Some(RowVersionRefEntry {
+                                    tx,
+                                    schema_version: contributor.schema_version,
+                                    layer: contributor.layer,
+                                    batch: contributor.batch,
+                                    branch_or_prefix: contributor.branch_or_prefix.clone(),
+                                    row_digest: contributor.row_digest.clone(),
+                                }),
+                            )
+                        })
+                    })
+            }));
         }
         let mut rows = Vec::with_capacity(row_entries.len());
         for ((canonical_table, row_uuid, tx_id), relation_version) in row_entries {

--- a/crates/jazz/src/node/tests/view_update_capture.rs
+++ b/crates/jazz/src/node/tests/view_update_capture.rs
@@ -443,6 +443,7 @@ impl MaintainedSubscriptionViewSubscription {
                 known_state: None,
                 complete_exclusive_payloads: false,
                 previous_result_set,
+                previous_program_facts: BTreeSet::new(),
                 result_member_adds: result_member_adds
                     .into_iter()
                     .map(crate::protocol::ResultMemberEntry::from)

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -12,9 +12,9 @@ use super::*;
 use crate::ids::SchemaVersionId;
 use crate::node::maintained_subscription_view::MaintainedSubscriptionView;
 use crate::protocol::{
-    KnownStateDeclaration, PeerPayloadInventory, ProgramFactEntry, ResultMemberEntry,
-    RowVersionRef, VersionBundle, VersionBundleRef, VersionCarrier, VersionRecord,
-    build_version_carriers_from_singletons,
+    ContributingMembersEntry, KnownStateDeclaration, PeerPayloadInventory, ProgramFactEntry,
+    RealRowMemberEntry, ResultMemberEntry, ResultRowSource, RowVersionRef, VersionBundle,
+    VersionBundleRef, VersionCarrier, VersionRecord, build_version_carriers_from_singletons,
 };
 
 fn maintained_view_tx_versions_contain_winner(
@@ -145,6 +145,25 @@ fn relation_edge_version_rows_for_bundle(
         .collect()
 }
 
+fn contributing_member_version_rows_for_bundle(
+    facts: &[ProgramFactEntry],
+) -> BTreeSet<(String, RowUuid, TxId)> {
+    facts
+        .iter()
+        .filter_map(|fact| match fact {
+            ProgramFactEntry::ContributingMembers(contribution)
+                if contribution.role.as_deref() == Some("flat_tuple_source") =>
+            {
+                contribution
+                    .contributor
+                    .as_row()
+                    .map(|(table, row, tx)| (table.to_string(), row, tx))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
 pub(crate) struct MaintainedViewBundleInputs<'a> {
     pub(crate) subscription: SubscriptionKey,
     /// Peer inventory of transactions whose full row-version payload has
@@ -157,6 +176,10 @@ pub(crate) struct MaintainedViewBundleInputs<'a> {
     /// use refreshed rows as a write base for later exclusive transactions.
     pub(crate) complete_exclusive_payloads: bool,
     pub(crate) previous_result_set: BTreeSet<TxId>,
+    /// Facts previously admitted on this subscription. Result-to-contributor
+    /// admissions are retired with their result member, rather than becoming
+    /// a durable general-history grant.
+    pub(crate) previous_program_facts: BTreeSet<ProgramFactEntry>,
     pub(crate) result_member_adds: Vec<ResultMemberEntry>,
     pub(crate) result_member_removes: Vec<ResultMemberEntry>,
     pub(crate) program_fact_adds: Vec<ProgramFactEntry>,
@@ -332,6 +355,7 @@ where
             known_state: None,
             complete_exclusive_payloads: false,
             previous_result_set,
+            previous_program_facts: BTreeSet::new(),
             identity,
             tier,
             maintained_facts: &maintained,
@@ -354,13 +378,55 @@ where
             result_member_adds,
             result_member_removes,
             mut program_fact_adds,
-            program_fact_removes,
+            mut program_fact_removes,
+            previous_program_facts,
             identity: _identity,
             tier: _tier,
             maintained_facts,
             allow_storage_witness_fallback,
         } = inputs;
         program_fact_adds.extend(maintained_facts.payload_facts_for_members(&result_member_adds));
+        for (result, maintained_version) in
+            maintained_facts.tuple_source_versions_for_members(&result_member_adds)
+        {
+            let canonical =
+                self.canonical_history_version_for_maintained_witness(&maintained_version)?;
+            let tx = self.version_tx_id(&canonical)?;
+            let schema_version = self
+                .schema_version_for_alias(canonical.schema_version_alias())
+                .ok_or(Error::InvalidStoredValue(
+                    "flat tuple source witness schema version alias must exist",
+                ))?;
+            let stored_tx = self
+                .query_transaction(tx)?
+                .ok_or(Error::MissingTransaction(tx))?;
+            let mut contributor = RealRowMemberEntry::current_content((
+                canonical.table.clone(),
+                canonical.row_uuid(),
+                tx,
+            ));
+            contributor.schema_version = Some(schema_version);
+            if let BranchLineage::Branch(branch) = stored_tx.tx.target_lineage {
+                contributor.branch_or_prefix = Some(branch.to_bytes());
+                contributor.source = ResultRowSource::Branch { branch: branch.0 };
+            }
+            program_fact_adds.push(ProgramFactEntry::ContributingMembers(
+                ContributingMembersEntry {
+                    result,
+                    contributor: contributor.into(),
+                    batch: Some(tx),
+                    role: Some("flat_tuple_source".to_owned()),
+                },
+            ));
+        }
+        program_fact_removes.extend(previous_program_facts.into_iter().filter(|fact| {
+            matches!(
+                fact,
+                ProgramFactEntry::ContributingMembers(contribution)
+                    if contribution.role.as_deref() == Some("flat_tuple_source")
+                        && result_member_removes.iter().any(|member| member == &contribution.result)
+            )
+        }));
         let program_fact_adds = program_fact_adds
             .into_iter()
             .collect::<BTreeSet<_>>()
@@ -417,12 +483,28 @@ where
                 }
                 None
             })
+            .chain(program_fact_adds.iter().filter_map(|fact| {
+                let ProgramFactEntry::ContributingMembers(contribution) = fact else {
+                    return None;
+                };
+                if contribution.role.as_deref() != Some("flat_tuple_source") {
+                    return None;
+                }
+                let contributor = contribution.contributor.as_real_row()?;
+                let (table, row, tx) = contributor.row_projection()?;
+                let version_ref = RowVersionRef::new(table.to_string(), row, tx);
+                known_state_exact_refs
+                    .contains(&version_ref)
+                    .then_some((table.to_string(), row))
+            }))
             .collect::<BTreeSet<_>>();
         let relation_edge_add_rows = relation_edge_version_rows_for_bundle(&program_fact_adds);
+        let contributing_add_rows = contributing_member_version_rows_for_bundle(&program_fact_adds);
         let wanted_add_rows_by_tx = row_result_adds
             .iter()
             .map(|(table, row_uuid, tx_id)| (table.to_string(), *row_uuid, *tx_id))
             .chain(relation_edge_add_rows)
+            .chain(contributing_add_rows)
             .fold(
                 BTreeMap::<TxId, BTreeSet<(String, RowUuid)>>::new(),
                 |mut by_tx, (table, row_uuid, tx_id)| {

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -581,6 +581,11 @@ impl PeerState {
             .subscriptions
             .get(&subscription)
             .and_then(|state| state.known_state.clone());
+        let previous_program_facts = self
+            .subscriptions
+            .get(&subscription)
+            .map(PeerSubscriptionState::program_fact_set)
+            .unwrap_or_default();
         let bundle_start = Instant::now();
         if trace_rehydrate {
             node.reset_storage_read_metrics();
@@ -601,6 +606,7 @@ impl PeerState {
                     known_state,
                     complete_exclusive_payloads: self.ship_complete_exclusive_payloads,
                     previous_result_set: previous_result_tx_ids,
+                    previous_program_facts,
                     result_member_adds,
                     result_member_removes,
                     program_fact_adds,
@@ -1010,6 +1016,7 @@ impl PeerState {
                 known_state: bundle_known_state,
                 complete_exclusive_payloads: self.ship_complete_exclusive_payloads,
                 previous_result_set: BTreeSet::new(),
+                previous_program_facts: BTreeSet::new(),
                 result_member_adds,
                 result_member_removes,
                 program_fact_adds,
@@ -1357,6 +1364,7 @@ impl PeerState {
                     known_state,
                     complete_exclusive_payloads: self.ship_complete_exclusive_payloads,
                     previous_result_set: BTreeSet::new(),
+                    previous_program_facts: BTreeSet::new(),
                     result_member_adds,
                     result_member_removes: Vec::new(),
                     program_fact_adds: Vec::new(),

--- a/crates/jazz/src/tools/object.rs
+++ b/crates/jazz/src/tools/object.rs
@@ -132,6 +132,11 @@ impl OutputOccurrenceId {
         }
     }
 
+    /// Source rows contributed after the root, in declared join order.
+    pub(crate) fn joined_sources(&self) -> &[ObjectId] {
+        &self.joined
+    }
+
     /// Canonical positional bytes for terminal-state keys and consolidation.
     ///
     /// Each component is a fixed-width UUID, so concatenating root followed by


### PR DESCRIPTION
🤖 Admits exact canonical source contributors for flat tuple results so receivers can reconstruct joins locally.

Each flat result member now carries member-scoped `ContributingMembers` facts pointing to exact canonical source versions, including authored schema and branch lineage. Source bodies are bundled or repaired through known-state; receivers lens those admitted versions into the requested read schema.

This does not use ResultPayload/projected tuple rows as IVM input and does not alter existing wire structs.

Contributor closure is diffed against the peer fact set, so removal, replacement, and same-member re-entry retire stale sources.

Independent review found no P0–P2. Broader non-flat auxiliary-source admission remains separate, and the original join E2Es remain quarantined.
