### PR TITLE
test: cover canonical flat join contributor closure

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -6445,7 +6445,7 @@ where
             retained.push(Rc::downgrade(&state));
             continue;
         }
-        let (snapshot, snapshot_source, settled, snapshot_tier, force_reset_event) = {
+        let (mut snapshot, mut snapshot_source, settled, snapshot_tier, force_reset_event) = {
             let mut state_ref = state.borrow_mut();
             let local_snapshot_is_empty =
                 state_ref.snapshot.root_count == 0 && state_ref.snapshot.edges.is_empty();
@@ -7062,7 +7062,44 @@ where
                 }
             }
         };
-        let previous = state.borrow().snapshot.clone();
+        let (previous, previous_source, has_maintained_subscription) = {
+            let state = state.borrow();
+            (
+                state.snapshot.clone(),
+                state.snapshot_source,
+                matches!(
+                    &state.kind,
+                    SubscriptionKind::Prepared {
+                        maintained_subscription: Some(_),
+                        ..
+                    }
+                ),
+            )
+        };
+        // A link snapshot is a relation facade without the terminal's flat
+        // tuple occurrence sidecar. Once a maintained terminal owns this
+        // stream, replace it from the terminal rather than installing an
+        // unaddressable facade snapshot.
+        if !force_reset_event
+            && has_maintained_subscription
+            && previous_source == SubscriptionSnapshotSource::LocalMaintained
+            && snapshot_source == SubscriptionSnapshotSource::LinkSnapshot
+        {
+            let materialized = {
+                let state = state.borrow();
+                let SubscriptionKind::Prepared {
+                    maintained_subscription: Some(maintained),
+                    ..
+                } = &state.kind
+                else {
+                    unreachable!("checked maintained subscription above");
+                };
+                node.borrow_mut()
+                    .materialize_local_maintained_relation_snapshot_with_occurrences(maintained)?
+            };
+            snapshot = materialized.snapshot;
+            snapshot_source = SubscriptionSnapshotSource::LocalMaintained;
+        }
         if force_reset_event || snapshot != previous || settled != previous_settled {
             let mut state = state.borrow_mut();
             let event = if force_reset_event {
@@ -7084,7 +7121,11 @@ where
                 )
             };
             state.snapshot = relation_snapshot_with_delta_slack(&snapshot);
-            state.snapshot_index = RelationSnapshotIndex::from_snapshot(&state.snapshot);
+            state.snapshot_index = maintained_snapshot_index_or_row_index(
+                &mut node.borrow_mut(),
+                &state.kind,
+                &state.snapshot,
+            )?;
             state.snapshot_source = snapshot_source;
             state.settled = settled;
             if state.sender.unbounded_send(event).is_ok() {
@@ -13154,6 +13195,36 @@ fn relation_snapshot_index_with_root_occurrences(
         ));
     }
     Ok(index)
+}
+
+/// Flat tuple identity is carried by the maintained terminal sidecar, not the
+/// public row: an external reset may omit hidden joined-row fields. Preserve
+/// that sidecar whenever its materialized snapshot is the replacement being
+/// installed; ordinary link-only snapshots retain row-derived indexing.
+fn maintained_snapshot_index_or_row_index<S>(
+    node: &mut NodeState<S>,
+    kind: &SubscriptionKind,
+    snapshot: &RelationSnapshot,
+) -> Result<RelationSnapshotIndex, Error>
+where
+    S: OrderedKvStorage,
+{
+    let SubscriptionKind::Prepared {
+        maintained_subscription: Some(maintained),
+        ..
+    } = kind
+    else {
+        return Ok(RelationSnapshotIndex::from_snapshot(snapshot));
+    };
+    let materialized =
+        node.materialize_local_maintained_relation_snapshot_with_occurrences(maintained)?;
+    if materialized.snapshot.root_count == snapshot.root_count {
+        return relation_snapshot_index_with_root_occurrences(
+            snapshot,
+            &materialized.root_occurrence_ids,
+        );
+    }
+    Ok(RelationSnapshotIndex::from_snapshot(snapshot))
 }
 
 fn relation_snapshot_with_delta_slack(snapshot: &RelationSnapshot) -> RelationSnapshot {

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -3743,13 +3743,32 @@ where
     }
 
     #[cfg(test)]
+    fn physical_table_id_for_authored_test_table(
+        &self,
+        table: &str,
+    ) -> Result<PhysicalTableId, Error> {
+        let candidates = self
+            .catalogue
+            .physical_mappings
+            .values()
+            .filter_map(|mapping| mapping.tables.get(table).map(|table| table.table_id))
+            .collect::<BTreeSet<_>>();
+        match candidates.iter().copied().collect::<Vec<_>>().as_slice() {
+            [table_id] => Ok(*table_id),
+            [] => Err(Error::TableNotFound(table.to_owned())),
+            _ => Err(Error::InvalidStoredValue(
+                "authored test table name maps to multiple physical lineages",
+            )),
+        }
+    }
+
+    #[cfg(test)]
     fn recomputed_merge_heads_from_history_for_test(
         &mut self,
         table: &str,
         row_uuid: RowUuid,
     ) -> Result<BTreeSet<TxId>, Error> {
-        let table_id =
-            self.physical_table_id_for_schema(self.catalogue.current_write_schema.schema, table)?;
+        let table_id = self.physical_table_id_for_authored_test_table(table)?;
         let versions = self.query_physical_content_row_versions(table_id, table, row_uuid)?;
         let mut candidate_indices = Vec::new();
         for (idx, version) in versions.iter().enumerate() {
@@ -3779,8 +3798,7 @@ where
         row_uuid: RowUuid,
     ) -> Result<(), Error> {
         let heads = self.recomputed_merge_heads_from_history_for_test(table, row_uuid)?;
-        let table_id =
-            self.physical_table_id_for_schema(self.catalogue.current_write_schema.schema, table)?;
+        let table_id = self.physical_table_id_for_authored_test_table(table)?;
         let mut batch = self.database.open_batch();
         Self::write_merge_heads(&mut batch, table_id, row_uuid, &heads)?;
         self.database.commit_batch(batch)?;
@@ -3794,8 +3812,7 @@ where
         row_uuid: RowUuid,
     ) -> Result<(), Error> {
         let expected = self.recomputed_merge_heads_from_history_for_test(table, row_uuid)?;
-        let table_id =
-            self.physical_table_id_for_schema(self.catalogue.current_write_schema.schema, table)?;
+        let table_id = self.physical_table_id_for_authored_test_table(table)?;
         let actual = self.require_merge_heads(table_id, row_uuid)?;
         if actual != expected {
             let versions = self

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -410,26 +410,26 @@ impl MaintainedSubscriptionView {
     pub(crate) fn tuple_source_versions_for_members(
         &self,
         members: &[ResultMemberEntry],
-    ) -> Vec<(ResultMemberEntry, VersionRow)> {
+        source_tables: &[String],
+    ) -> Vec<(ResultMemberEntry, usize, VersionRow)> {
         let mut tuples = Vec::new();
         for member in members {
             let Some(occurrence) = member.output_occurrence_id() else {
                 continue;
             };
-            let joined_rows = occurrence
-                .joined_sources()
-                .iter()
-                .map(|id| RowUuid(*id.uuid()))
-                .collect::<BTreeSet<_>>();
-            if joined_rows.is_empty() {
-                continue;
-            }
-            for weighted in self.versions.by_identity.values() {
-                if weighted.weight > 0
-                    && weighted.row.deletion().is_none()
-                    && joined_rows.contains(&weighted.row.row_uuid())
-                {
-                    tuples.push((member.clone(), weighted.row.clone()));
+            for (source_index, source) in occurrence.joined_sources().iter().enumerate() {
+                let Some(source_table) = source_tables.get(source_index) else {
+                    continue;
+                };
+                let source_row = RowUuid(*source.uuid());
+                for weighted in self.versions.by_identity.values() {
+                    if weighted.weight > 0
+                        && weighted.row.deletion().is_none()
+                        && weighted.row.table() == source_table
+                        && weighted.row.row_uuid() == source_row
+                    {
+                        tuples.push((member.clone(), source_index, weighted.row.clone()));
+                    }
                 }
             }
         }
@@ -517,6 +517,17 @@ impl MaintainedSubscriptionView {
             .filter_map(|member| self.result_payloads.get(member))
             .cloned()
             .map(ProgramFactEntry::ResultPayload)
+            .collect()
+    }
+
+    /// Current positive result memberships, including unchanged members during
+    /// a non-reset rehydrate. Tuple-source admissions are a closure over this
+    /// set, not merely over the membership delta.
+    pub(crate) fn active_result_members(&self) -> Vec<ResultMemberEntry> {
+        self.result_weights
+            .iter()
+            .filter(|(_, weight)| **weight > 0)
+            .map(|(member, _)| member.clone())
             .collect()
     }
 

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -33,9 +33,9 @@ use crate::ids::{
 };
 use crate::protocol::{
     BindingViewKey, CurrentWriteSchema, LensOp, MigrationLens, ProgramFactEntry, ReadViewKey,
-    ResultMemberEntry, ResultRowEntry, RowVersionRef, SchemaLineagePublication, SchemaVersion,
-    ShapeAst, Subscribe, SubscriptionKey, SyncMessage, VersionBundle, VersionCarrier,
-    VersionRecord, ViewFactEntry, expand_version_carriers,
+    RealRowMemberEntry, ResultMemberEntry, ResultRowEntry, RowVersionRef, SchemaLineagePublication,
+    SchemaVersion, ShapeAst, Subscribe, SubscriptionKey, SyncMessage, VersionBundle,
+    VersionCarrier, VersionRecord, ViewFactEntry, expand_version_carriers,
 };
 use crate::query::{Binding, BindingId, QueryError, ShapeId, ValidatedQuery};
 use crate::schema::{
@@ -5197,19 +5197,30 @@ where
         }
         for (table, row_uuid, tx_id) in program_fact_adds
             .iter()
-            .filter_map(|fact| match fact {
-                ProgramFactEntry::RelationEdge(edge) => Some(edge),
-                _ => None,
-            })
-            .flat_map(|edge| {
-                [
+            .flat_map(|fact| match fact {
+                ProgramFactEntry::RelationEdge(edge) => vec![
                     edge.source_version.as_ref().map(|version| {
                         (edge.source_table.to_string(), edge.source_row, version.tx)
                     }),
                     edge.target_version.as_ref().map(|version| {
                         (edge.target_table.to_string(), edge.target_row, version.tx)
                     }),
-                ]
+                ],
+                ProgramFactEntry::ContributingMembers(contribution)
+                    if contribution
+                        .role
+                        .as_deref()
+                        .is_some_and(|role| role.starts_with("flat_tuple_source:")) =>
+                {
+                    vec![
+                        contribution
+                            .contributor
+                            .as_real_row()
+                            .and_then(RealRowMemberEntry::row_projection)
+                            .map(|(table, row, tx)| (table.to_string(), row, tx)),
+                    ]
+                }
+                _ => Vec::new(),
             })
             .flatten()
         {
@@ -5250,7 +5261,34 @@ where
         // is carried by a registered subscription whose schema version makes
         // a reused logical table name unambiguous.
         let requested_table_id =
-            self.physical_table_id_for_schema(result_schema_version, &request.table)?;
+            match self.physical_table_id_for_schema(result_schema_version, &request.table) {
+                Ok(table_id) => table_id,
+                Err(Error::TableNotFound(_)) => {
+                    // Contributor facts deliberately name their authored table,
+                    // which may have been renamed out of the current result
+                    // schema. An inline body can cover it only when that old name
+                    // still has a unique physical lineage across the catalogue.
+                    let candidates = self
+                        .catalogue
+                        .physical_mappings
+                        .values()
+                        .filter_map(|mapping| {
+                            mapping
+                                .tables
+                                .get(request.table.as_str())
+                                .map(|table| table.table_id)
+                        })
+                        .collect::<BTreeSet<_>>();
+                    if candidates.is_empty() {
+                        return Err(Error::TableNotFound(request.table.to_string()));
+                    }
+                    if candidates.len() != 1 {
+                        return Ok(false);
+                    }
+                    *candidates.iter().next().expect("unique candidate")
+                }
+                Err(error) => return Err(error),
+            };
         Ok(incoming_versions.iter().any(|(incoming_tx, version)| {
             *incoming_tx == request.tx_id()
                 && version.row_uuid() == request.row_uuid

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -1521,6 +1521,7 @@ fn supported_current_storage_projection(
         | SourceExpr::SettledBindingView {
             projection,
             binding_view: _,
+            rows: _,
         } => Some(projection),
         SourceExpr::WithOverlays { input, overlays } => {
             if overlays

--- a/crates/jazz/src/node/query_engine/read.rs
+++ b/crates/jazz/src/node/query_engine/read.rs
@@ -97,6 +97,15 @@ pub(crate) type ResolvedSourceExpr = SourceExpr<ResolvedSourceStage>;
 /// Canonical source-expression set at a particular resolution stage.
 pub(crate) type SourceGraph<R> = BTreeMap<SourceId, SourceExpr<R>>;
 
+/// Which admitted rows a settled binding source exposes to one source node.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum SettledBindingRows {
+    /// Authoritative root/result members for the binding view.
+    ResultMembers,
+    /// Canonical source versions admitted for one flat-join input position.
+    FlatTupleContributor { source_index: usize },
+}
+
 /// Source expression algebra. Branches, snapshots, overlays, transactions, and
 /// schema projections compose here instead of selecting a separate query path.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -137,6 +146,9 @@ pub(crate) enum SourceExpr<R: SourceResolution> {
         projection: SchemaProjection<R>,
         /// Canonical registered binding/view result-set identity.
         binding_view: BindingViewKey,
+        /// Partition result members from admitted tuple sources so a
+        /// self-join cannot feed the same table-wide union into both sides.
+        rows: SettledBindingRows,
     },
     /// Overlay local/branch/transactional writes on top of another source.
     WithOverlays {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -36,7 +36,7 @@ use super::query_engine::{
     ReachableContribution, ReadView, RequestedReadSet, RequestedSourceStage, ResolvedSource,
     ResultId, ResultMembershipVersionSchema, ResultRowRef, RowIdRef, RowProjection,
     RowRefSchema as QueryEngineRowRefSchema, RowSetExpr, RowSetNodeId, RowSetOutputRequest,
-    RowSetProgramInput, RowVisibility, SchemaFamilySelection, SchemaProjection,
+    RowSetProgramInput, RowVisibility, SchemaFamilySelection, SchemaProjection, SettledBindingRows,
     SortDirection as NormalizedSortDirection, SourceAuthorizationRequest, SourceExpr, SourceGap,
     SourceId, SourceMetadataFields, SourceMetadataRequirement, SourcePath, SourceRequest,
     SourceRequirements, SourceResolutionError, SourceResolver, SourceRole, SourceRowShape,
@@ -830,6 +830,7 @@ where
             SourceExpr::SettledBindingView {
                 projection,
                 binding_view,
+                rows,
             } => {
                 if request.visibility != RowVisibility::Visible {
                     return Err(source_resolution_error(request, SourceGap::Coverage));
@@ -847,6 +848,7 @@ where
                     &request.source.table,
                     self.read_view.read_schema,
                     *binding_view,
+                    *rows,
                 ) {
                     Ok(rows) => {
                         let table = self
@@ -8655,18 +8657,40 @@ where
         table: &str,
         read_schema: SchemaVersionId,
         binding_view: BindingViewKey,
+        rows: SettledBindingRows,
     ) -> Result<Vec<CurrentRow>, Error> {
         let Some(row_result_set) = self.query.settled_result_sets.get(&binding_view) else {
             return Ok(Vec::new());
         };
-        let mut row_entries = row_result_set
-            .iter()
-            .filter_map(ResultMemberEntry::as_row)
-            .map(|(entry_table, row_uuid, tx_id)| {
-                ((entry_table.to_string(), row_uuid, tx_id), None)
+        let mut row_entries = matches!(rows, SettledBindingRows::ResultMembers)
+            .then(|| {
+                row_result_set
+                    .iter()
+                    .filter_map(ResultMemberEntry::as_row)
+                    .map(|(entry_table, row_uuid, tx_id)| {
+                        ((entry_table.to_string(), row_uuid, tx_id), None)
+                    })
+                    .collect::<BTreeMap<_, Option<RowVersionRefEntry>>>()
             })
-            .collect::<BTreeMap<_, Option<RowVersionRefEntry>>>();
-        if let Some(program_facts) = self.query.settled_program_facts.get(&binding_view) {
+            .unwrap_or_default();
+        if let Some(program_facts) = self.query.settled_program_facts.get(&binding_view)
+            && matches!(rows, SettledBindingRows::ResultMembers)
+        {
+            row_entries.extend(program_facts.iter().filter_map(|fact| {
+                let ProgramFactEntry::RelationEdge(edge) = fact else {
+                    return None;
+                };
+                edge.target_version.as_ref().map(|version| {
+                    (
+                        (edge.target_table.to_string(), edge.target_row, version.tx),
+                        Some(version.clone()),
+                    )
+                })
+            }));
+        }
+        if let Some(program_facts) = self.query.settled_program_facts.get(&binding_view)
+            && matches!(rows, SettledBindingRows::FlatTupleContributor { .. })
+        {
             row_entries.extend(program_facts.iter().filter_map(|fact| {
                 let ProgramFactEntry::RelationEdge(edge) = fact else {
                     return None;
@@ -8682,8 +8706,12 @@ where
                 let ProgramFactEntry::ContributingMembers(contribution) = fact else {
                     return None;
                 };
-                if contribution.role.as_deref() != Some("flat_tuple_source")
-                    || !row_result_set.contains(&contribution.result)
+                if !matches!(
+                    rows,
+                    SettledBindingRows::FlatTupleContributor { source_index }
+                        if contribution.role.as_deref()
+                            == Some(&format!("flat_tuple_source:{source_index}"))
+                ) || !row_result_set.contains(&contribution.result)
                 {
                     return None;
                 }
@@ -15162,13 +15190,14 @@ mod tests {
     use crate::node::{MergeableCommit, NodeState};
     use crate::peer::PeerState;
     use crate::protocol::{
-        CurrentWriteSchema, MigrationLens, ReadViewSourceSpec, ReadViewSpec, RegisterShapeOptions,
-        RelationEdgeEntry, ResultRowLayer, RowVersionRefEntry, SchemaVersion, ShapeAst, Subscribe,
-        SyncMessage, TableLens,
+        CurrentWriteSchema, MigrationLens, ReadViewSourceSpec, ReadViewSpec, RealRowMemberEntry,
+        RegisterShapeOptions, RelationEdgeEntry, ResultRowLayer, RowVersionRefEntry, SchemaVersion,
+        ShapeAst, Subscribe, SyncMessage, TableLens,
     };
     use crate::query::{
-        Aggregate, ArraySubquery, JoinSourceLookup, OrderDirection, PolicyBranch, Query, claim,
-        col, contains, eq, gt, in_list, lit, lte, param,
+        Aggregate, ArraySubquery, FlatJoin, FlatJoinOn, FlatJoinSource, JoinSourceLookup,
+        OrderDirection, PolicyBranch, Query, claim, col, contains, eq, gt, in_list, lit, lte,
+        param,
     };
     use crate::schema::{JazzSchema, Policy, TableSchema};
 
@@ -16966,6 +16995,15 @@ mod tests {
         shape: &ValidatedQuery,
         binding: &Binding,
     ) {
+        subscribe_query_binding_with_opts(node, shape, binding, RegisterShapeOptions::default());
+    }
+
+    fn subscribe_query_binding_with_opts(
+        node: &mut NodeState<RocksDbStorage>,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        opts: RegisterShapeOptions,
+    ) {
         let values = shape
             .params()
             .keys()
@@ -16976,7 +17014,7 @@ mod tests {
             subscription: SubscriptionKey {
                 shape_id: shape.shape_id(),
                 binding_id: binding.binding_id(),
-                read_view: Default::default(),
+                read_view: opts.read_view_key(),
             },
             values,
             known_state: None,
@@ -17661,7 +17699,12 @@ mod tests {
             BTreeSet::from([ProgramFactEntry::RelationEdge(edge.clone())]),
         );
         let settled_rows = node
-            .settled_binding_view_source_rows("members", v3.id, binding_view)
+            .settled_binding_view_source_rows(
+                "members",
+                v3.id,
+                binding_view,
+                SettledBindingRows::ResultMembers,
+            )
             .expect("project canonical settled relation source through both lenses");
         assert_eq!(settled_rows.len(), 1);
         assert_eq!(settled_rows[0].table(), "members");
@@ -17683,6 +17726,425 @@ mod tests {
         assert_eq!(
             row.cell(&members, "origin"),
             Some(Value::String("v1".to_owned()))
+        );
+    }
+
+    /// A v2 flat join must correlate the lens-projected v1 post and author
+    /// cells, rather than only materializing each source independently.
+    ///
+    /// alice ──v1 users/posts──► node ──users→people lens──► v2 flat join
+    #[test]
+    fn flat_join_correlates_projected_v1_sources_across_table_rename() {
+        let v1 = JazzSchema::new([
+            TableSchema::new(
+                "users",
+                [
+                    ColumnSchema::new("id", ColumnType::Uuid),
+                    ColumnSchema::new("name", ColumnType::String),
+                ],
+            ),
+            TableSchema::new(
+                "posts",
+                [
+                    ColumnSchema::new("id", ColumnType::Uuid),
+                    ColumnSchema::new("author_id", ColumnType::Uuid),
+                    ColumnSchema::new("title", ColumnType::String),
+                ],
+            ),
+        ]);
+        let people = TableSchema::new(
+            "people",
+            [
+                ColumnSchema::new("id", ColumnType::Uuid),
+                ColumnSchema::new("name", ColumnType::String),
+            ],
+        );
+        let v2 = SchemaVersion::new(JazzSchema::new([
+            people,
+            TableSchema::new(
+                "posts",
+                [
+                    ColumnSchema::new("id", ColumnType::Uuid),
+                    ColumnSchema::new("author_id", ColumnType::Uuid),
+                    ColumnSchema::new("title", ColumnType::String),
+                ],
+            ),
+        ]));
+        let (_dir, mut node) = open_node_with_uuid(NodeUuid::from_bytes([0xf6; 16]), v1.clone());
+        let (_client_dir, mut client) =
+            open_node_with_uuid(NodeUuid::from_bytes([0xf9; 16]), v1.clone());
+        let author = row(0xf7);
+        let post = row(0xf8);
+        let author_tx = node
+            .commit_mergeable(
+                MergeableCommit::new("users", author, 1).cells(BTreeMap::from([
+                    ("id".to_owned(), Value::Uuid(author.0)),
+                    ("name".to_owned(), Value::String("alice".to_owned())),
+                ])),
+            )
+            .expect("commit v1 author");
+        node.apply_fate_update(
+            author_tx,
+            Fate::Accepted,
+            Some(GlobalSeq(1)),
+            Some(DurabilityTier::Global),
+        )
+        .expect("settle v1 author");
+        let post_tx = node
+            .commit_mergeable(
+                MergeableCommit::new("posts", post, 2).cells(BTreeMap::from([
+                    ("id".to_owned(), Value::Uuid(post.0)),
+                    ("author_id".to_owned(), Value::Uuid(author.0)),
+                    ("title".to_owned(), Value::String("hello".to_owned())),
+                ])),
+            )
+            .expect("commit v1 post");
+        node.apply_fate_update(
+            post_tx,
+            Fate::Accepted,
+            Some(GlobalSeq(2)),
+            Some(DurabilityTier::Global),
+        )
+        .expect("settle v1 post");
+        node.apply_trusted_catalogue_message(SyncMessage::PublishSchemaWithLens {
+            author: AuthorId::SYSTEM,
+            catalogue_seq: 1,
+            publication: Box::new(SchemaLineagePublication::new(
+                v2.clone(),
+                MigrationLens::new(
+                    v1.version_id(),
+                    v2.id,
+                    vec![
+                        TableLens {
+                            source_table: "users".to_owned(),
+                            target_table: "people".to_owned(),
+                            ops: vec![LensOp::RenameTable {
+                                from: "users".to_owned(),
+                                to: "people".to_owned(),
+                            }],
+                        },
+                        TableLens {
+                            source_table: "posts".to_owned(),
+                            target_table: "posts".to_owned(),
+                            ops: Vec::new(),
+                        },
+                    ],
+                ),
+                Vec::<String>::new(),
+                Vec::<String>::new(),
+            )),
+        })
+        .expect("publish users to people lens");
+        client
+            .apply_trusted_catalogue_message(SyncMessage::PublishSchemaWithLens {
+                author: AuthorId::SYSTEM,
+                catalogue_seq: 1,
+                publication: Box::new(SchemaLineagePublication::new(
+                    v2.clone(),
+                    MigrationLens::new(
+                        v1.version_id(),
+                        v2.id,
+                        vec![
+                            TableLens {
+                                source_table: "users".to_owned(),
+                                target_table: "people".to_owned(),
+                                ops: vec![LensOp::RenameTable {
+                                    from: "users".to_owned(),
+                                    to: "people".to_owned(),
+                                }],
+                            },
+                            TableLens {
+                                source_table: "posts".to_owned(),
+                                target_table: "posts".to_owned(),
+                                ops: Vec::new(),
+                            },
+                        ],
+                    ),
+                    Vec::<String>::new(),
+                    Vec::<String>::new(),
+                )),
+            })
+            .expect("publish users to people lens to client");
+        node.apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+            author: AuthorId::SYSTEM,
+            pointer: CurrentWriteSchema {
+                revision: 1,
+                schema: v2.id,
+            },
+        })
+        .expect("activate v2 read schema");
+        client
+            .apply_trusted_catalogue_message(SyncMessage::SetCurrentWriteSchema {
+                author: AuthorId::SYSTEM,
+                pointer: CurrentWriteSchema {
+                    revision: 1,
+                    schema: v2.id,
+                },
+            })
+            .expect("activate v2 client read schema");
+
+        for table in ["people", "posts"] {
+            let shape = Query::from(table)
+                .validate(&v2.schema)
+                .expect("validate source");
+            let binding = shape.bind(BTreeMap::new()).expect("bind source");
+            assert_eq!(
+                node.query_rows_at(&shape, &binding, GlobalSeq(2))
+                    .expect("read projected source")
+                    .len(),
+                1,
+                "{table} must independently project its v1 row"
+            );
+        }
+        let mut query = Query::from("posts");
+        query.flat_join = Some(FlatJoin {
+            root_alias: None,
+            sources: vec![FlatJoinSource {
+                table: "people".to_owned(),
+                alias: None,
+                on: FlatJoinOn {
+                    left: "posts.author_id".to_owned(),
+                    right: "people.id".to_owned(),
+                },
+            }],
+        });
+        let shape = query.validate(&v2.schema).expect("validate v2 flat join");
+        let binding = shape.bind(BTreeMap::new()).expect("bind v2 flat join");
+        let rows = node
+            .query_rows_at(&shape, &binding, GlobalSeq(2))
+            .expect("evaluate v2 flat join");
+        assert_eq!(rows.len(), 1, "projected v1 sources must still correlate");
+
+        let opts = RegisterShapeOptions {
+            tier: DurabilityTier::Global,
+            ..RegisterShapeOptions::default()
+        };
+        register_query_shape(&mut node, &shape, opts.clone());
+        subscribe_query_binding_with_opts(&mut node, &shape, &binding, opts.clone());
+        register_query_shape(&mut client, &shape, opts.clone());
+        subscribe_query_binding_with_opts(&mut client, &shape, &binding, opts.clone());
+        let binding_view =
+            BindingViewKey::new(shape.shape_id(), binding.binding_id(), opts.read_view_key());
+        let subscription = SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: binding.binding_id(),
+            read_view: opts.read_view_key(),
+        };
+        let mut peer = PeerState::edge_client(AuthorId::SYSTEM);
+        let known_author = RowVersionRef::new("users", author, author_tx);
+        peer.declare_known_state(
+            subscription,
+            Some(KnownStateDeclaration::ExactVersionSet {
+                versions: vec![known_author.clone()],
+            }),
+        );
+        let update = peer
+            .rehydrate_query_with_opts(&mut node, &shape, &binding, opts.clone())
+            .expect("rehydrate maintained v2 flat join");
+        let missing = client
+            .missing_known_state_row_version_refs(&update)
+            .expect("detect omitted canonical contributor body");
+        assert_eq!(missing, vec![known_author]);
+        let repair = peer
+            .handle_row_versions_fetch(
+                &mut node,
+                SyncMessage::FetchRowVersions {
+                    requests: missing.clone(),
+                },
+            )
+            .expect("serve canonical contributor repair");
+        let [SyncMessage::RowVersionPayloads { version_bundles }] = repair.as_slice() else {
+            panic!("known contributor repair must carry row-version payloads");
+        };
+        client
+            .apply_row_version_payloads_for_requests(&missing, version_bundles.clone())
+            .expect("apply canonical contributor repair");
+        client
+            .apply_sync_message(update.clone())
+            .expect("apply maintained v2 flat join on client");
+        let SyncMessage::ViewUpdate {
+            reset_result_set,
+            result_member_adds,
+            ..
+        } = update
+        else {
+            panic!("flat join rehydrate must emit a view update");
+        };
+        assert!(reset_result_set);
+        assert_eq!(
+            result_member_adds.len(),
+            1,
+            "maintained v2 flat join must retain the projected source tuple"
+        );
+        let snapshot = client
+            .authoritative_reset_snapshot_for_binding_view(&shape, binding_view)
+            .expect("materialize applied flat-join authority snapshot")
+            .expect("applied flat-join authority snapshot");
+        assert_eq!(snapshot.root_count, 1);
+        // The authority payload can render this tuple, but the receiver's
+        // local IVM must instead rebuild it from canonical source versions.
+        assert_eq!(
+            client
+                .query_rows_for_client(&shape, &binding, DurabilityTier::Global, AuthorId::SYSTEM)
+                .expect("read applied v2 flat join on client")
+                .len(),
+            1,
+            "the client must retain the authority-maintained flat join tuple"
+        );
+
+        let updated_author_tx = node
+            .commit_mergeable(
+                MergeableCommit::new("people", author, 3).cells(BTreeMap::from([
+                    ("id".to_owned(), Value::Uuid(author.0)),
+                    ("name".to_owned(), Value::String("alice".to_owned())),
+                ])),
+            )
+            .expect("update renamed author");
+        node.apply_fate_update(
+            updated_author_tx,
+            Fate::Accepted,
+            Some(GlobalSeq(3)),
+            Some(DurabilityTier::Global),
+        )
+        .expect("settle renamed author update");
+        let replacement = peer
+            .query_update_for_subscription_with_opts(
+                &mut node,
+                subscription,
+                &shape,
+                &binding,
+                opts.clone(),
+            )
+            .expect("publish flat tuple replacement");
+        let SyncMessage::ViewUpdate {
+            reset_result_set,
+            version_carriers,
+            version_bundles,
+            result_member_adds,
+            result_member_removes,
+            program_fact_adds,
+            program_fact_removes,
+            ..
+        } = &replacement
+        else {
+            panic!("flat tuple replacement must emit a view update");
+        };
+        assert!(
+            !reset_result_set,
+            "unchanged result membership must take the non-reset rehydrate path"
+        );
+        assert!(
+            result_member_adds.is_empty() && result_member_removes.is_empty(),
+            "a no-op source version must retain the same result member"
+        );
+        let outgoing_contributor_adds = program_fact_adds
+            .iter()
+            .filter(|fact| {
+                matches!(
+                    fact,
+                    ProgramFactEntry::ContributingMembers(contribution)
+                        if contribution
+                            .role
+                            .as_deref()
+                            .is_some_and(|role| role.starts_with("flat_tuple_source:"))
+                )
+            })
+            .count();
+        let outgoing_contributor_removes = program_fact_removes
+            .iter()
+            .filter(|fact| {
+                matches!(
+                    fact,
+                    ProgramFactEntry::ContributingMembers(contribution)
+                        if contribution
+                            .role
+                            .as_deref()
+                            .is_some_and(|role| role.starts_with("flat_tuple_source:"))
+                )
+            })
+            .count();
+        assert_eq!(outgoing_contributor_adds, 1);
+        assert_eq!(outgoing_contributor_removes, 1);
+        let mut replacement_bundles = version_bundles.clone();
+        replacement_bundles.extend(
+            crate::protocol::expand_version_carriers(version_carriers)
+                .expect("expand replacement contributor bundles"),
+        );
+        assert_eq!(
+            replacement_bundles
+                .iter()
+                .filter(|bundle| bundle.tx.tx_id == updated_author_tx)
+                .flat_map(|bundle| &bundle.versions)
+                .count(),
+            1,
+            "the changed canonical contributor must ship exactly one body"
+        );
+        assert!(program_fact_removes.iter().any(|fact| {
+            matches!(
+                fact,
+                ProgramFactEntry::ContributingMembers(contribution)
+                    if contribution
+                        .role
+                        .as_deref()
+                        .is_some_and(|role| role.starts_with("flat_tuple_source:"))
+                        && contribution
+                            .contributor
+                            .as_real_row()
+                            .and_then(RealRowMemberEntry::row_projection)
+                            .is_some_and(|(table, row, tx)| table.to_string() == "users" && row == author && tx == author_tx)
+            )
+        }));
+        assert!(program_fact_adds.iter().any(|fact| {
+            matches!(
+                fact,
+                ProgramFactEntry::ContributingMembers(contribution)
+                    if contribution
+                        .role
+                        .as_deref()
+                        .is_some_and(|role| role.starts_with("flat_tuple_source:"))
+                        && contribution
+                            .contributor
+                            .as_real_row()
+                            .and_then(RealRowMemberEntry::row_projection)
+                            .is_some_and(|(table, row, tx)| table.to_string() == "people" && row == author && tx == updated_author_tx)
+            )
+        }));
+        client
+            .apply_sync_message(replacement)
+            .expect("apply flat tuple replacement");
+        let active_contributors = client
+            .query
+            .settled_program_facts
+            .get(&binding_view)
+            .expect("flat tuple facts remain scoped to the binding view")
+            .iter()
+            .filter(|fact| {
+                matches!(
+                    fact,
+                    ProgramFactEntry::ContributingMembers(contribution)
+                        if contribution
+                            .role
+                            .as_deref()
+                            .is_some_and(|role| role.starts_with("flat_tuple_source:"))
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(active_contributors.len(), 1);
+        assert!(matches!(
+            active_contributors[0],
+            ProgramFactEntry::ContributingMembers(contribution)
+                if contribution
+                    .contributor
+                    .as_real_row()
+                    .and_then(RealRowMemberEntry::row_projection)
+                    .is_some_and(|(table, row, tx)| table.to_string() == "people" && row == author && tx == updated_author_tx)
+        ));
+        assert_eq!(
+            client
+                .query_rows_for_client(&shape, &binding, DurabilityTier::Global, AuthorId::SYSTEM)
+                .expect("read retained flat tuple after no-op source version")
+                .len(),
+            1
         );
     }
 

--- a/crates/jazz/src/node/query_eval/query_read_sets.rs
+++ b/crates/jazz/src/node/query_eval/query_read_sets.rs
@@ -24,6 +24,7 @@ pub(super) fn current_query_read_set(
                     SourceExpr::SettledBindingView {
                         projection: projection.clone(),
                         binding_view,
+                        rows: SettledBindingRows::ResultMembers,
                     }
                 } else {
                     SourceExpr::VisibleCurrent {
@@ -37,11 +38,19 @@ pub(super) fn current_query_read_set(
         })
         .collect::<BTreeMap<_, _>>();
     for source in &shape.auxiliary_sources {
-        // Auxiliary closure sources are not result members of the settled binding
-        // view. Keep the result/root source pinned to the settled view, but read
-        // implicit reference targets from current storage so serving can resolve
-        // their rows instead of treating missing result-set entries as coverage
-        // gaps.
+        if let Some(binding_view) = settled_binding_view
+            && let Some(source_index) = flat_tuple_source_index(source)
+        {
+            sources.insert(
+                source.clone(),
+                SourceExpr::SettledBindingView {
+                    projection: projection.clone(),
+                    binding_view,
+                    rows: SettledBindingRows::FlatTupleContributor { source_index },
+                },
+            );
+            continue;
+        }
         sources.insert(
             source.clone(),
             SourceExpr::VisibleCurrent {
@@ -56,6 +65,18 @@ pub(super) fn current_query_read_set(
         policy_schema,
         sources,
     })
+}
+
+fn flat_tuple_source_index(source: &SourceId) -> Option<usize> {
+    let [SourceRole::Alias(alias)] = source.path.components.as_slice() else {
+        return None;
+    };
+    alias
+        .strip_prefix("flat_join:")?
+        .split_once(':')?
+        .0
+        .parse()
+        .ok()
 }
 
 pub(super) fn historical_query_read_set(

--- a/crates/jazz/src/node/tests/view_update_capture.rs
+++ b/crates/jazz/src/node/tests/view_update_capture.rs
@@ -444,6 +444,7 @@ impl MaintainedSubscriptionViewSubscription {
                 complete_exclusive_payloads: false,
                 previous_result_set,
                 previous_program_facts: BTreeSet::new(),
+                flat_tuple_source_tables: Vec::new(),
                 result_member_adds: result_member_adds
                     .into_iter()
                     .map(crate::protocol::ResultMemberEntry::from)

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -145,25 +145,6 @@ fn relation_edge_version_rows_for_bundle(
         .collect()
 }
 
-fn contributing_member_version_rows_for_bundle(
-    facts: &[ProgramFactEntry],
-) -> BTreeSet<(String, RowUuid, TxId)> {
-    facts
-        .iter()
-        .filter_map(|fact| match fact {
-            ProgramFactEntry::ContributingMembers(contribution)
-                if contribution.role.as_deref() == Some("flat_tuple_source") =>
-            {
-                contribution
-                    .contributor
-                    .as_row()
-                    .map(|(table, row, tx)| (table.to_string(), row, tx))
-            }
-            _ => None,
-        })
-        .collect()
-}
-
 pub(crate) struct MaintainedViewBundleInputs<'a> {
     pub(crate) subscription: SubscriptionKey,
     /// Peer inventory of transactions whose full row-version payload has
@@ -180,6 +161,8 @@ pub(crate) struct MaintainedViewBundleInputs<'a> {
     /// admissions are retired with their result member, rather than becoming
     /// a durable general-history grant.
     pub(crate) previous_program_facts: BTreeSet<ProgramFactEntry>,
+    /// Declared flat-join source table for each contributor position.
+    pub(crate) flat_tuple_source_tables: Vec<String>,
     pub(crate) result_member_adds: Vec<ResultMemberEntry>,
     pub(crate) result_member_removes: Vec<ResultMemberEntry>,
     pub(crate) program_fact_adds: Vec<ProgramFactEntry>,
@@ -356,6 +339,7 @@ where
             complete_exclusive_payloads: false,
             previous_result_set,
             previous_program_facts: BTreeSet::new(),
+            flat_tuple_source_tables: Vec::new(),
             identity,
             tier,
             maintained_facts: &maintained,
@@ -380,15 +364,19 @@ where
             mut program_fact_adds,
             mut program_fact_removes,
             previous_program_facts,
+            flat_tuple_source_tables,
             identity: _identity,
             tier: _tier,
             maintained_facts,
             allow_storage_witness_fallback,
         } = inputs;
         program_fact_adds.extend(maintained_facts.payload_facts_for_members(&result_member_adds));
-        for (result, maintained_version) in
-            maintained_facts.tuple_source_versions_for_members(&result_member_adds)
-        {
+        let tuple_source_versions = maintained_facts.tuple_source_versions_for_members(
+            &maintained_facts.active_result_members(),
+            &flat_tuple_source_tables,
+        );
+        let mut desired_tuple_source_facts = BTreeMap::new();
+        for (result, source_index, maintained_version) in &tuple_source_versions {
             let canonical =
                 self.canonical_history_version_for_maintained_witness(&maintained_version)?;
             let tx = self.version_tx_id(&canonical)?;
@@ -410,23 +398,49 @@ where
                 contributor.branch_or_prefix = Some(branch.to_bytes());
                 contributor.source = ResultRowSource::Branch { branch: branch.0 };
             }
-            program_fact_adds.push(ProgramFactEntry::ContributingMembers(
-                ContributingMembersEntry {
-                    result,
-                    contributor: contributor.into(),
-                    batch: Some(tx),
-                    role: Some("flat_tuple_source".to_owned()),
-                },
-            ));
+            let fact = ProgramFactEntry::ContributingMembers(ContributingMembersEntry {
+                result: result.clone(),
+                contributor: contributor.into(),
+                batch: Some(tx),
+                role: Some(format!("flat_tuple_source:{source_index}")),
+            });
+            desired_tuple_source_facts.insert(fact, maintained_version.clone());
         }
-        program_fact_removes.extend(previous_program_facts.into_iter().filter(|fact| {
-            matches!(
-                fact,
-                ProgramFactEntry::ContributingMembers(contribution)
-                    if contribution.role.as_deref() == Some("flat_tuple_source")
-                        && result_member_removes.iter().any(|member| member == &contribution.result)
-            )
-        }));
+        let previous_tuple_source_facts = previous_program_facts
+            .into_iter()
+            .filter(|fact| {
+                matches!(
+                    fact,
+                    ProgramFactEntry::ContributingMembers(contribution)
+                        if contribution
+                            .role
+                            .as_deref()
+                            .is_some_and(|role| role.starts_with("flat_tuple_source:"))
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        let tuple_source_bundle_rows = desired_tuple_source_facts
+            .iter()
+            .filter(|(fact, _)| !previous_tuple_source_facts.contains(*fact))
+            .map(|(_, version)| {
+                Ok((
+                    version.table().to_owned(),
+                    version.row_uuid(),
+                    self.version_tx_id(version)?,
+                ))
+            })
+            .collect::<Result<BTreeSet<_>, Error>>()?;
+        program_fact_adds.extend(
+            desired_tuple_source_facts
+                .keys()
+                .filter(|fact| !previous_tuple_source_facts.contains(*fact))
+                .cloned(),
+        );
+        program_fact_removes.extend(
+            previous_tuple_source_facts
+                .into_iter()
+                .filter(|fact| !desired_tuple_source_facts.contains_key(fact)),
+        );
         let program_fact_adds = program_fact_adds
             .into_iter()
             .collect::<BTreeSet<_>>()
@@ -464,6 +478,26 @@ where
             )
             | None => BTreeSet::new(),
         };
+        // Exact-known declarations name canonical authored versions, while the
+        // maintained source index is keyed by its read-schema table label.
+        // Translate that declaration back to the source label used to select
+        // bundle bodies (e.g. canonical `users` -> maintained `people`).
+        let mut known_tuple_source_bundle_rows = BTreeSet::new();
+        for (_, _, maintained_version) in &tuple_source_versions {
+            let canonical =
+                self.canonical_history_version_for_maintained_witness(maintained_version)?;
+            let tx = self.version_tx_id(&canonical)?;
+            if known_state_exact_refs.contains(&RowVersionRef::new(
+                canonical.table().to_owned(),
+                canonical.row_uuid(),
+                tx,
+            )) {
+                known_tuple_source_bundle_rows.insert((
+                    maintained_version.table().to_owned(),
+                    maintained_version.row_uuid(),
+                ));
+            }
+        }
         let skipped_known_state_rows = result_member_adds
             .iter()
             .filter_map(|member| {
@@ -483,28 +517,18 @@ where
                 }
                 None
             })
-            .chain(program_fact_adds.iter().filter_map(|fact| {
-                let ProgramFactEntry::ContributingMembers(contribution) = fact else {
-                    return None;
-                };
-                if contribution.role.as_deref() != Some("flat_tuple_source") {
-                    return None;
-                }
-                let contributor = contribution.contributor.as_real_row()?;
-                let (table, row, tx) = contributor.row_projection()?;
-                let version_ref = RowVersionRef::new(table.to_string(), row, tx);
-                known_state_exact_refs
-                    .contains(&version_ref)
-                    .then_some((table.to_string(), row))
-            }))
+            .chain(known_tuple_source_bundle_rows)
             .collect::<BTreeSet<_>>();
         let relation_edge_add_rows = relation_edge_version_rows_for_bundle(&program_fact_adds);
-        let contributing_add_rows = contributing_member_version_rows_for_bundle(&program_fact_adds);
         let wanted_add_rows_by_tx = row_result_adds
             .iter()
             .map(|(table, row_uuid, tx_id)| (table.to_string(), *row_uuid, *tx_id))
             .chain(relation_edge_add_rows)
-            .chain(contributing_add_rows)
+            // The contributor fact names canonical authored history; the
+            // maintained index is keyed by the source graph's read-schema
+            // label. Ship that exact retained witness and normalize it to
+            // canonical history only at the wire boundary below.
+            .chain(tuple_source_bundle_rows)
             .fold(
                 BTreeMap::<TxId, BTreeSet<(String, RowUuid)>>::new(),
                 |mut by_tx, (table, row_uuid, tx_id)| {

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -607,6 +607,7 @@ impl PeerState {
                     complete_exclusive_payloads: self.ship_complete_exclusive_payloads,
                     previous_result_set: previous_result_tx_ids,
                     previous_program_facts,
+                    flat_tuple_source_tables: flat_tuple_source_tables(shape),
                     result_member_adds,
                     result_member_removes,
                     program_fact_adds,
@@ -909,6 +910,11 @@ impl PeerState {
             .subscriptions
             .get(&subscription)
             .and_then(|state| state.known_state.clone());
+        let previous_program_facts = self
+            .subscriptions
+            .get(&subscription)
+            .map(PeerSubscriptionState::program_fact_set)
+            .unwrap_or_default();
         let known_membership_position = fast_current_membership_position(&known_state);
         let authorization_matches =
             self.fast_cursor_authorization_matches(subscription, &known_state);
@@ -1016,7 +1022,15 @@ impl PeerState {
                 known_state: bundle_known_state,
                 complete_exclusive_payloads: self.ship_complete_exclusive_payloads,
                 previous_result_set: BTreeSet::new(),
-                previous_program_facts: BTreeSet::new(),
+                // A non-reset rehydrate retains the receiver's existing fact
+                // set, so tuple-source closure must be diffed against it.
+                // A reset clears that receiver set before additions apply.
+                previous_program_facts: if reset_result_set {
+                    BTreeSet::new()
+                } else {
+                    previous_program_facts
+                },
+                flat_tuple_source_tables: flat_tuple_source_tables(shape),
                 result_member_adds,
                 result_member_removes,
                 program_fact_adds,
@@ -1365,6 +1379,7 @@ impl PeerState {
                     complete_exclusive_payloads: self.ship_complete_exclusive_payloads,
                     previous_result_set: BTreeSet::new(),
                     previous_program_facts: BTreeSet::new(),
+                    flat_tuple_source_tables: Vec::new(),
                     result_member_adds,
                     result_member_removes: Vec::new(),
                     program_fact_adds: Vec::new(),
@@ -2136,6 +2151,21 @@ impl From<MaintainedSubscriptionViewIndexFootprint> for MaintainedSubscriptionVi
             total_heap_bytes: footprint.total_heap_bytes,
         }
     }
+}
+
+fn flat_tuple_source_tables(shape: &ValidatedQuery) -> Vec<String> {
+    shape
+        .query()
+        .flat_join
+        .as_ref()
+        .map(|flat_join| {
+            flat_join
+                .sources
+                .iter()
+                .map(|source| source.table.clone())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🤖 Covers canonical flat-join contributor closure across rename, repair, source-version rotation, and occurrence identity.

The focused regressions prove:
- v1 `users` canonical sources reconstruct a v2 `people` flat join locally;
- omitted exact-known contributor bodies trigger `FetchRowVersions` repair;
- a no-op new source transaction with unchanged tuple membership produces one contributor remove and one add;
- receiver state retains exactly one current contribution, body, and tuple;
- settled sources are partitioned by exact tuple position, preserving occurrence sidecars for self/two-hop joins;
- contributor matching requires the declared source table, so equal UUIDs across tables fail closed.

Restoring the broken non-reset empty-prior-fact behavior fails the removal assertion. The implementation uses existing wire-safe `ContributingMembers`; no projected tuple payload becomes IVM input.

All output-occurrence tests, maintained/protocol tests, cargo check, formatting, burndown 3+9, hooks, and independent review pass. The slow table-rename join row remains active.