### PR TITLE
refactor: extract Jazz telemetry adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@ For ordinary Rust/core work, the full gate set is:
   tests. The binary names are stable, but their Cargo package is `jazz-cli`;
   build them with `cargo build -p jazz-cli --bin jazz-tools` or
   `cargo build -p jazz-cli --bin jazz-server`.
+- `cargo test -p jazz-otel` covers exporter/provider construction. Its ignored
+  `sync_telemetry_otel` target is a manual receipt because it does not
+  programmatically assert collector delivery.
 - `cargo check -p jazz-sim --benches` (always; it is cheap enough and catches bench API rot)
 - `dev/gates/ts-wire-codec.sh` for TypeScript/native-runtime wire-codec coverage
   (Anselm-approved 2026-07-07)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,12 +1212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,25 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,7 +1623,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1675,19 +1649,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1956,11 +1917,6 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "lz4_flex 0.11.6",
- "opentelemetry",
- "opentelemetry-appender-tracing",
- "opentelemetry-otlp",
- "opentelemetry-stdout",
- "opentelemetry_sdk",
  "postcard",
  "rand 0.8.5",
  "rcgen",
@@ -1980,7 +1936,6 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "tungstenite",
  "uuid",
@@ -2001,6 +1956,7 @@ dependencies = [
  "clap",
  "futures-util",
  "jazz",
+ "jazz-otel",
  "jsonwebtoken",
  "libc",
  "mimalloc",
@@ -2023,6 +1979,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "jazz",
+ "jazz-otel",
  "mimalloc-safe",
  "napi",
  "napi-build",
@@ -2033,6 +1990,27 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "jazz-otel"
+version = "0.1.0"
+dependencies = [
+ "jazz",
+ "jsonwebtoken",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -2754,8 +2732,6 @@ dependencies = [
  "reqwest",
  "serde_json",
  "thiserror",
- "tokio",
- "tonic",
  "tracing",
 ]
 
@@ -4255,19 +4231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,15 +4259,10 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
  "percent-encoding",
  "pin-project",
  "sync_wrapper",
- "tokio",
  "tokio-stream",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4329,15 +4287,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/groove",
   "crates/jazz",
   "crates/jazz-cli",
+  "crates/jazz-otel",
   "crates/jazz-sim",
   "crates/opfs-btree",
   "crates/jazz-wasm",
@@ -26,6 +27,7 @@ exclude = ["examples/todo-server-rs", "examples/docs/todo-server-rs"]
 [workspace.dependencies]
 groove = { path = "crates/groove", default-features = false }
 jazz = { path = "crates/jazz", default-features = false }
+jazz-otel = { path = "crates/jazz-otel" }
 rustc-hash = "2.1.1"
 
 [patch.crates-io]

--- a/crates/jazz-cli/Cargo.toml
+++ b/crates/jazz-cli/Cargo.toml
@@ -12,11 +12,12 @@ sqlite = ["jazz/sqlite"]
 transport-compression-lz4 = ["jazz/transport-compression-lz4"]
 transport-compression-zstd = ["jazz/transport-compression-zstd"]
 transport-compression-ruzstd = ["jazz/transport-compression-ruzstd"]
-otel = ["jazz/otel-core", "dep:opentelemetry", "dep:opentelemetry_sdk"]
+otel = ["dep:jazz-otel", "dep:opentelemetry", "dep:opentelemetry_sdk"]
 test = ["jazz/test"]
 
 [dependencies]
 jazz = { workspace = true, default-features = false, features = ["server"] }
+jazz-otel = { workspace = true, optional = true }
 axum = { version = "0.8.9", default-features = false, features = ["http1", "json", "tokio"] }
 clap = { version = "4", features = ["derive", "env"] }
 mimalloc = { version = "0.1", default-features = false }

--- a/crates/jazz-cli/src/bin/jazz-tools.rs
+++ b/crates/jazz-cli/src/bin/jazz-tools.rs
@@ -16,9 +16,9 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use clap::{Parser, Subcommand};
 use jazz::tools::middleware::AuthConfig;
-#[cfg(feature = "otel")]
-use jazz::tools::otel;
 use jazz_cli::commands;
+#[cfg(feature = "otel")]
+use jazz_otel as otel;
 
 const DEFAULT_SHUTDOWN_TIMEOUT_SECS: u64 = 30;
 const MAX_SHUTDOWN_TIMEOUT_SECS: u64 = 60 * 60;

--- a/crates/jazz-cli/src/commands/server.rs
+++ b/crates/jazz-cli/src/commands/server.rs
@@ -97,7 +97,7 @@ pub async fn run(
         .then(|| {
             let meter = opentelemetry::global::meter("jazz-server");
             let shutdown = state.shutdown.clone();
-            jazz::tools::otel::register_active_websockets_gauge(&meter, move || {
+            jazz_otel::register_active_websockets_gauge(&meter, move || {
                 shutdown.active_websockets() as u64
             })
         });

--- a/crates/jazz-napi/Cargo.toml
+++ b/crates/jazz-napi/Cargo.toml
@@ -11,7 +11,8 @@ rocksdb = ["jazz/rocksdb"]
 crate-type = ["cdylib"]
 
 [dependencies]
-jazz = { path = "../jazz", default-features = false, features = ["test-utils", "otel-core"] }
+jazz = { path = "../jazz", default-features = false, features = ["test-utils"] }
+jazz-otel.workspace = true
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 base64 = "0.22"
 napi = { version = "3", features = ["napi6", "serde-json", "async"] }

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2719,10 +2719,10 @@ fn init_jazz_server_telemetry(collector_url: Option<&str>) {
     JAZZ_SERVER_TELEMETRY_INIT.get_or_init(|| {
         use tracing_subscriber::layer::SubscriberExt as _;
 
-        let endpoint = jazz::tools::otel::normalize_otlp_traces_endpoint(collector_url);
+        let endpoint = jazz_otel::normalize_otlp_traces_endpoint(collector_url);
         let provider =
-            jazz::tools::otel::init_tracer_provider_with_endpoint("jazz-server", Some(&endpoint));
-        let otel_layer = jazz::tools::otel::layer(&provider);
+            jazz_otel::init_tracer_provider_with_endpoint("jazz-server", Some(&endpoint));
+        let otel_layer = jazz_otel::layer(&provider);
         let filter = tracing_subscriber::EnvFilter::from_default_env()
             .add_directive("jazz_tools=trace".parse().expect("valid tracing directive"))
             .add_directive("tower_http=debug".parse().expect("valid tracing directive"));

--- a/crates/jazz-otel/Cargo.toml
+++ b/crates/jazz-otel/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "jazz-otel"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+opentelemetry = "0.31"
+opentelemetry_sdk = { version = "0.31", features = ["logs", "metrics"] }
+opentelemetry-otlp = { version = "0.31", features = [
+  "http-json",
+  "reqwest-blocking-client",
+  "logs",
+  "metrics",
+] }
+opentelemetry-stdout = "0.31"
+opentelemetry-appender-tracing = "0.31"
+tracing = "0.1"
+tracing-opentelemetry = "0.32"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+jazz = { workspace = true, default-features = false, features = ["test"] }
+jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
+opentelemetry_sdk = { version = "0.31", features = ["testing"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
+tokio = { version = "1", features = ["macros", "rt", "time"] }
+uuid = { version = "1", features = ["v5"] }

--- a/crates/jazz-otel/src/lib.rs
+++ b/crates/jazz-otel/src/lib.rs
@@ -1,4 +1,4 @@
-//! OpenTelemetry tracer initialization.
+//! OpenTelemetry exporter and runtime integration for Jazz process shells.
 //!
 //! Activated by the `otel` feature + `OTEL_EXPORTER_OTLP_ENDPOINT` being set
 //! at runtime in the CLI, or by explicit dev-server telemetry configuration

--- a/crates/jazz-otel/tests/sync_telemetry_otel.rs
+++ b/crates/jazz-otel/tests/sync_telemetry_otel.rs
@@ -1,15 +1,14 @@
-#![cfg(all(feature = "test", feature = "otel-core"))]
-
+#[path = "../../jazz/tests/support/mod.rs"]
 mod support;
 
 use std::collections::HashMap;
 use std::time::Duration;
 
-use jazz::tools::otel;
 use jazz::tools::server::JazzServer;
 use jazz::tools::{
     ColumnType, DurabilityTier, QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
 };
+use jazz_otel as otel;
 use support::{TestingClient, has_row, wait_for_query};
 use tracing_subscriber::{EnvFilter, prelude::*};
 

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -32,15 +32,6 @@ transport-compression-zstd = ["dep:zstd"]
 transport-compression-ruzstd = ["dep:ruzstd"]
 test-utils = ["server", "client", "sqlite", "sync-autopsy"]
 test = ["test-utils", "transport-compression-zstd"]
-otel-core = [
-  "server",
-  "dep:opentelemetry",
-  "dep:opentelemetry_sdk",
-  "dep:opentelemetry-otlp",
-  "dep:opentelemetry-stdout",
-  "dep:opentelemetry-appender-tracing",
-  "dep:tracing-opentelemetry",
-]
 
 [dependencies]
 futures-core = "0.3.31"
@@ -104,28 +95,11 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls",
 ], optional = true }
-opentelemetry = { version = "0.31", optional = true }
-opentelemetry_sdk = { version = "0.31", features = [
-  "rt-tokio",
-  "logs",
-  "metrics",
-], optional = true }
-opentelemetry-otlp = { version = "0.31", features = [
-  "grpc-tonic",
-  "http-json",
-  "reqwest-blocking-client",
-  "logs",
-  "metrics",
-], optional = true }
-opentelemetry-stdout = { version = "0.31", optional = true }
-opentelemetry-appender-tracing = { version = "0.31", optional = true }
-tracing-opentelemetry = { version = "0.32", optional = true }
 
 [dev-dependencies]
 jazz-benchmark-guard = { path = "../benchmark-guard" }
 hdrhistogram = "7.5.4"
 tempfile = "3.27.0"
-opentelemetry_sdk = { version = "0.31", features = ["testing"] }
 libc = "0.2"
 criterion = "0.5"
 insta = "1"
@@ -291,10 +265,6 @@ required-features = ["test"]
 [[test]]
 name = "claims_merge_integration"
 required-features = ["test"]
-
-[[test]]
-name = "sync_telemetry_otel"
-required-features = ["test", "otel-core"]
 
 [[example]]
 name = "realistic_bench"

--- a/crates/jazz/src/tools/mod.rs
+++ b/crates/jazz/src/tools/mod.rs
@@ -7,8 +7,6 @@ pub mod metadata;
 #[cfg(feature = "server")]
 pub mod middleware;
 mod object;
-#[cfg(feature = "otel-core")]
-pub mod otel;
 pub mod policy_claims;
 pub(crate) mod public_api;
 pub mod public_schema;

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -88,7 +88,9 @@ integration. Executable and binding shells opt into it.
 
 - Move `TestingClient`, `TestJwtIssuer`, reusable fixtures, simulation helpers,
   and the semantic oracle to `jazz-testkit`.
-- Stop enabling `test-utils` and `otel-core` as NAPI production features.
+- Make NAPI depend directly on `jazz-otel`; stop enabling telemetry support in
+  the semantic crate. Its remaining `test-utils` dependency belongs to the
+  later testkit slice.
 - Keep focused private white-box tests in `jazz`.
 - Move large public/scenario harnesses to `jazz-testkit` or dedicated integration
   packages so a focused core unit test does not compile every scenario fixture.
@@ -127,8 +129,9 @@ rocksdb = ["jazz-storage-rocksdb"]
 otel = ["jazz-otel"]
 ```
 
-Remove the umbrella `test`, `test-utils`, `client`, `server`, `cli`,
-`otel-core`, and `testing` features from semantic core after callers migrate.
+Remove the remaining umbrella `test`, `test-utils`, `client`, `server`, and
+`testing` features from semantic core after callers migrate. The executable
+and telemetry slices remove `cli` and `otel-core` first.
 
 ## Canonical build matrix
 

--- a/dev/gates/artifacts-fresh.sh
+++ b/dev/gates/artifacts-fresh.sh
@@ -82,7 +82,7 @@ check_layer \
   target/debug/jazz-tools
 
 # index.js and index.d.ts are outputs of napi build, not inputs.
-source_roots=(crates/jazz-napi/src crates/jazz-napi/build.rs crates/jazz-napi/Cargo.toml crates/jazz-napi/package.json crates/jazz-napi/scripts crates/jazz/src crates/groove/src crates/jazz/Cargo.toml crates/groove/Cargo.toml Cargo.toml Cargo.lock)
+source_roots=(crates/jazz-napi/src crates/jazz-napi/build.rs crates/jazz-napi/Cargo.toml crates/jazz-napi/package.json crates/jazz-napi/scripts crates/jazz-otel/src crates/jazz-otel/Cargo.toml crates/jazz/src crates/groove/src crates/jazz/Cargo.toml crates/groove/Cargo.toml Cargo.toml Cargo.lock)
 shopt -s nullglob
 napi_artifacts=(crates/jazz-napi/*.node)
 shopt -u nullglob

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -470,7 +470,11 @@ test("Turbo invalidates each native artifact only for its Cargo closure", () => 
         "$TURBO_ROOT$/crates/jazz-napi/build.rs",
         "$TURBO_ROOT$/crates/jazz-napi/scripts/**",
         "$TURBO_ROOT$/crates/jazz-napi/src/**/*.rs",
-      ].concat(["jazz", "groove", "opfs-btree"].map((crate) => `$TURBO_ROOT$/crates/${crate}/**`)),
+      ].concat(
+        ["jazz-otel", "jazz", "groove", "opfs-btree"].map(
+          (crate) => `$TURBO_ROOT$/crates/${crate}/**`,
+        ),
+      ),
     ],
     [
       wasm,

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,7 @@
         "$TURBO_ROOT$/crates/jazz-napi/build.rs",
         "$TURBO_ROOT$/crates/jazz-napi/scripts/**",
         "$TURBO_ROOT$/crates/jazz-napi/src/**/*.rs",
+        "$TURBO_ROOT$/crates/jazz-otel/**",
         "$TURBO_ROOT$/crates/jazz/**",
         "$TURBO_ROOT$/crates/groove/**",
         "$TURBO_ROOT$/crates/opfs-btree/**",


### PR DESCRIPTION
🤖 Extract OpenTelemetry exporter/runtime setup into a dedicated adapter crate.

## Boundary

- moves tracer, logger, meter, panic-hook, endpoint normalization, and server gauge setup from `jazz` to `jazz-otel`
- removes the `otel-core` feature and all OpenTelemetry SDK/exporter dependencies from semantic `jazz`
- makes `jazz-cli` opt into `jazz-otel` through its `otel` feature
- makes NAPI depend directly on `jazz-otel` instead of enabling telemetry in `jazz`
- moves the telemetry integration receipt with its adapter
- updates Turbo and artifact-freshness dependency closures so telemetry changes invalidate NAPI artifacts

## Verification

- `cargo check --workspace`
- `cargo check -p jazz-otel --all-targets`
- `cargo check -p jazz-cli --all-targets --features test,otel`
- `cargo check -p jazz-napi`
- `cargo check -p jazz --no-default-features`
- `cargo test -p jazz-otel --lib --no-fail-fast`
- `cargo test -p jazz-otel --test sync_telemetry_otel sync_layers_emit_otel_spans -- --ignored --exact`
- `cargo tree -p jazz` contains no OpenTelemetry package
- focused Turbo artifact-pipeline tests
- pre-commit workspace Clippy, formatting, and sensitive-data guard
