### PR TITLE
refactor: make Jazz a featureless semantic core by default

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -121,10 +121,10 @@ jobs:
       - name: Build native benchmark binaries
         run: |
           set -euo pipefail
-          cargo build --release -p jazz --features client,rocksdb --example realistic_bench
-          cargo build --release -p jazz --features client,sqlite --example realistic_bench
-          cargo bench -p jazz --features rocksdb --bench realistic_phase1 --no-run
-          cargo bench -p jazz --features sqlite --bench realistic_phase1 --no-run
+          cargo build --release -p jazz --features client,rocksdb,transport-compression-zstd --example realistic_bench
+          cargo build --release -p jazz --features client,sqlite,transport-compression-zstd --example realistic_bench
+          cargo bench -p jazz --features rocksdb,transport-compression-zstd --bench realistic_phase1 --no-run
+          cargo bench -p jazz --features sqlite,transport-compression-zstd --bench realistic_phase1 --no-run
           cargo bench -p jazz-sim --bench s2_canvas --no-run
 
       - name: Run native benchmark suite
@@ -349,7 +349,7 @@ jobs:
           uname -a > bench-out/browser/uname.txt
 
       - name: Build jazz-tools server binary
-        run: cargo build -p jazz --features cli
+        run: cargo build -p jazz-cli --bin jazz-tools
 
       - name: Build jazz-napi package
         run: pnpm --dir crates/jazz-napi run build

--- a/.github/workflows/build-jazz-packages.yml
+++ b/.github/workflows/build-jazz-packages.yml
@@ -62,7 +62,7 @@ jobs:
           tool: cargo-zigbuild
 
       - name: Build CLI binary
-        run: cargo zigbuild -p jazz-tools --bin jazz-tools --features cli,otel --release --target ${{ matrix.target }}
+        run: cargo zigbuild -p jazz-cli --bin jazz-tools --features otel --release --target ${{ matrix.target }}
 
       - name: Stage artifact
         run: |
@@ -100,7 +100,7 @@ jobs:
           setup-node: "false"
 
       - name: Build CLI binary
-        run: cargo build -p jazz-tools --bin jazz-tools --features cli,otel --release --target ${{ matrix.target }}
+        run: cargo build -p jazz-cli --bin jazz-tools --features otel --release --target ${{ matrix.target }}
 
       - name: Stage artifact
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test_binary="$(cargo test -p jazz --lib --no-run --message-format=json | node -e '
+          test_binary="$(cargo test -p jazz --lib --features test --no-run --message-format=json | node -e '
             const readline = require("node:readline");
             let executable;
             const lines = readline.createInterface({ input: process.stdin });

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -90,6 +90,7 @@ impl StorageDelta {
     }
 }
 
+#[cfg(feature = "rocksdb")]
 pub(crate) fn compact_storage_delta_operand(
     template_operand: &[u8],
     merged_record: Vec<u8>,

--- a/crates/jazz-sim/Cargo.toml
+++ b/crates/jazz-sim/Cargo.toml
@@ -17,7 +17,11 @@ automerge = "0.10.0"
 backtrace = { version = "0.3", optional = true }
 diamond-types = "1.0.0"
 hdrhistogram = "7.5.4"
-jazz = { path = "../jazz", features = ["testing"] }
+jazz = { path = "../jazz", default-features = false, features = [
+  "rocksdb",
+  "testing",
+  "transport-compression-zstd",
+] }
 libc = "0.2"
 pprof = { version = "0.15.0", features = ["flamegraph"], optional = true }
 postcard = { version = "1.1.3", features = ["alloc"] }

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -7,7 +7,9 @@ autobenches = false
 autotests = true
 
 [features]
-default = ["rocksdb", "server", "transport-compression-zstd"]
+# Jazz is the common semantic library. Process and target shells select
+# storage, transport, compression, and server capabilities explicitly.
+default = []
 rocksdb = ["groove/rocksdb", "dep:rocksdb"]
 sqlite = ["dep:rusqlite"]
 native-websocket-transport = [
@@ -34,7 +36,7 @@ transport-compression-lz4 = ["dep:lz4_flex"]
 transport-compression-zstd = ["dep:zstd"]
 transport-compression-ruzstd = ["dep:ruzstd"]
 test-utils = ["server", "client", "sqlite", "sync-autopsy"]
-test = ["test-utils", "transport-compression-zstd"]
+test = ["test-utils", "rocksdb", "transport-compression-zstd"]
 
 [dependencies]
 futures-core = "0.3.31"

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -126,6 +126,7 @@ where
     /// it to receive one connection-authenticated catalogue snapshot and then
     /// select one of the snapshot's admitted schema views.  Until then the
     /// node has no application schema and rejects ordinary data/sync work.
+    #[cfg(any(feature = "server", test))]
     pub(crate) async fn open_catalogue_uninitialized_edge(
         config: DbConfig<S>,
     ) -> Result<Self, Error> {
@@ -157,6 +158,7 @@ where
     /// Install a complete catalogue received over the authenticated upstream
     /// bootstrap link.  This is intentionally crate-private: ordinary wire
     /// dispatch must never turn an arbitrary peer's snapshot into authority.
+    #[cfg(any(feature = "server", test))]
     pub(crate) fn apply_trusted_catalogue_snapshot(
         &self,
         snapshot: crate::protocol::CatalogueSnapshot,
@@ -181,6 +183,7 @@ where
 
     /// Produce the authority's complete catalogue for the privileged
     /// snapshot-only transport exchange.
+    #[cfg(any(feature = "server", test))]
     pub(crate) fn trusted_catalogue_snapshot(
         &self,
     ) -> Result<crate::protocol::CatalogueSnapshot, Error> {
@@ -189,6 +192,7 @@ where
 
     /// Return the active authority-admitted schema, failing closed when this
     /// dynamic edge still has no bootstrap receipt.
+    #[cfg(any(feature = "server", test))]
     pub(crate) fn trusted_current_catalogue_schema(&self) -> Result<JazzSchema, Error> {
         let node = self.node.node.borrow();
         let pointer = node.current_write_schema()?;
@@ -198,6 +202,7 @@ where
             .ok_or_else(|| Error::new(ErrorCode::Schema, "active catalogue schema is missing"))
     }
 
+    #[cfg(any(feature = "server", test))]
     pub(crate) fn catalogue_bootstrap_is_ready(&self) -> bool {
         self.node.node.borrow().catalogue_bootstrap_state()
             == crate::node::CatalogueBootstrapState::Ready

--- a/crates/jazz/src/db/wire_transport.rs
+++ b/crates/jazz/src/db/wire_transport.rs
@@ -374,6 +374,7 @@ where
     /// bootstrap cannot safely skip a malformed physical frame and continue to
     /// a later catalogue snapshot: that would make the authority boundary
     /// depend on first-valid-message behavior.
+    #[cfg(any(feature = "server", test))]
     pub(crate) fn try_recv_strict(&mut self) -> Result<Option<SyncMessage>, WireError> {
         let _ = self.flush_pending_outbound();
         while let Some(bytes) = self.inner.try_recv_frame() {

--- a/crates/jazz/src/lib.rs
+++ b/crates/jazz/src/lib.rs
@@ -129,6 +129,7 @@ pub mod result_tree;
 /// Jazz schema and storage lowering.
 pub mod schema;
 /// Operational server-shell APIs formerly provided by jazz-server.
+#[cfg(feature = "server")]
 pub mod serving;
 /// Logical time and sequence counters.
 pub mod time;

--- a/crates/jazz/src/tools/admin_catalogue_row_format.rs
+++ b/crates/jazz/src/tools/admin_catalogue_row_format.rs
@@ -11,7 +11,7 @@ const INVALID_UUID_TEXT_SENTINEL: [u8; 16] = [0xff; 16];
 
 macro_rules! cfg_decode {
     ($item:item) => {
-        #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+        #[cfg(any(test, feature = "server"))]
         $item
     };
 }
@@ -30,7 +30,7 @@ pub enum EncodingError {
     /// Null value for non-nullable column.
     NullNotAllowed { column: String },
     /// Binary data is malformed or too short.
-    #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+    #[cfg(any(test, feature = "server"))]
     MalformedData { message: String },
     /// BYTEA payload exceeds the configured per-cell limit.
     ByteaTooLarge {
@@ -39,7 +39,7 @@ pub enum EncodingError {
         max: usize,
     },
     /// Column index out of bounds.
-    #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+    #[cfg(any(test, feature = "server"))]
     ColumnIndexOutOfBounds { index: usize, max: usize },
 }
 
@@ -65,7 +65,7 @@ impl std::fmt::Display for EncodingError {
             EncodingError::NullNotAllowed { column } => {
                 write!(f, "null not allowed for column '{column}'")
             }
-            #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+            #[cfg(any(test, feature = "server"))]
             EncodingError::MalformedData { message } => {
                 write!(f, "malformed data: {message}")
             }
@@ -79,7 +79,7 @@ impl std::fmt::Display for EncodingError {
                     "bytea payload too large for column '{column}': {actual} bytes exceeds limit {max}"
                 )
             }
-            #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+            #[cfg(any(test, feature = "server"))]
             EncodingError::ColumnIndexOutOfBounds { index, max } => {
                 write!(f, "column index {index} out of bounds (max {max})")
             }
@@ -89,7 +89,7 @@ impl std::fmt::Display for EncodingError {
 
 impl std::error::Error for EncodingError {}
 
-#[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+#[cfg(any(test, feature = "server"))]
 #[derive(Debug, Clone)]
 struct CompiledColumnLayout {
     fixed_offset: Option<usize>,
@@ -101,7 +101,7 @@ struct CompiledColumnLayout {
 
 #[derive(Debug, Clone)]
 struct CompiledRowLayout {
-    #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+    #[cfg(any(test, feature = "server"))]
     columns: Vec<CompiledColumnLayout>,
     fixed_section_size: usize,
     variable_column_count: usize,
@@ -113,16 +113,16 @@ fn compiled_row_layout_cache() -> &'static Mutex<HashMap<[u8; 32], Arc<CompiledR
 }
 
 fn compile_row_layout(descriptor: &RowDescriptor) -> CompiledRowLayout {
-    #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+    #[cfg(any(test, feature = "server"))]
     let mut columns = Vec::with_capacity(descriptor.columns.len());
     let mut fixed_offset = 0usize;
     let mut variable_index = 0usize;
 
     for column in &descriptor.columns {
         if let Some(fixed_value_size) = column.column_type.fixed_size() {
-            #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+            #[cfg(any(test, feature = "server"))]
             let fixed_total_size = fixed_value_size + usize::from(column.nullable);
-            #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+            #[cfg(any(test, feature = "server"))]
             columns.push(CompiledColumnLayout {
                 fixed_offset: Some(fixed_offset),
                 fixed_total_size: Some(fixed_total_size),
@@ -132,7 +132,7 @@ fn compile_row_layout(descriptor: &RowDescriptor) -> CompiledRowLayout {
             });
             fixed_offset += fixed_value_size + usize::from(column.nullable);
         } else {
-            #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+            #[cfg(any(test, feature = "server"))]
             columns.push(CompiledColumnLayout {
                 fixed_offset: None,
                 fixed_total_size: None,
@@ -145,7 +145,7 @@ fn compile_row_layout(descriptor: &RowDescriptor) -> CompiledRowLayout {
     }
 
     CompiledRowLayout {
-        #[cfg(any(test, all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+        #[cfg(any(test, feature = "server"))]
         columns,
         fixed_section_size: fixed_offset,
         variable_column_count: variable_index,

--- a/crates/jazz/src/tools/public_schema.rs
+++ b/crates/jazz/src/tools/public_schema.rs
@@ -21,6 +21,7 @@ pub use crate::tools::transaction::{BatchId, OpenBatchId};
 /// This is shared by schema-default admission and every facade write path so a
 /// JSON default cannot bypass the same syntax/schema contract as an explicit
 /// value. Arrays recurse because `ColumnType::Array` permits JSON elements.
+#[cfg(any(feature = "client", feature = "server", test))]
 pub(crate) fn validate_json_value(
     value: &Value,
     column_type: &ColumnType,
@@ -72,6 +73,7 @@ pub(crate) fn validate_json_value(
 ///
 /// Instance validation stays at writes, but a bad declaration is a schema
 /// error even when a nullable column has no value or default yet.
+#[cfg(any(feature = "client", feature = "server", test))]
 pub(crate) fn validate_json_schemas(column_type: &ColumnType, path: &str) -> Result<(), String> {
     match column_type {
         ColumnType::Json {

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -194,6 +194,12 @@ Measure focused core-test compilation and NAPI checks before and after.
 Separate Axum/server, native client networking, and CLI dependencies. Remove the
 `client -> server` edge. Measure minimal core, NAPI, and WASM builds.
 
+Progress: executable binaries now live in `jazz-cli`, native client networking
+no longer selects the server module, and `jazz` is featureless by default.
+Actual shells select storage, compression, client, and server capabilities
+explicitly; the remaining work is extracting the Axum/server implementation
+without widening its private state into a public compatibility API.
+
 ### Lane 4: storage, compression, and telemetry adapters
 
 Move RocksDB, compression implementations, and OTLP exporters to shell-selected

--- a/dev/NATIVE_SELECT_INHERITS.md
+++ b/dev/NATIVE_SELECT_INHERITS.md
@@ -28,6 +28,6 @@
 | `cargo test -p jazz --test incremental_delivery_canary -j 2`                             | 0         |
 | `cargo fmt -p jazz-tools --check`                                                        | 0         |
 | `cargo check -p jazz-sim --benches -j 2`                                                 | 0         |
-| `cargo build --release -p jazz-tools --bin jazz-tools --features cli -j 2`               | 0         |
+| `cargo build --release -p jazz-cli --bin jazz-tools -j 2`                                | 0         |
 
 Release binary: `target/release/jazz-tools`.

--- a/dev/benchmarks/realistic/README.md
+++ b/dev/benchmarks/realistic/README.md
@@ -33,7 +33,7 @@ artifact/history plan.
 Run from workspace root:
 
 ```bash
-RUST_LOG=warn cargo run -p jazz --features client,rocksdb --example realistic_bench -- \
+RUST_LOG=warn cargo run -p jazz --features client,rocksdb,transport-compression-zstd --example realistic_bench -- \
   --profile dev/benchmarks/realistic/profiles/s.json \
   --scenario dev/benchmarks/realistic/scenarios/w1_interactive.json
 ```
@@ -41,7 +41,7 @@ RUST_LOG=warn cargo run -p jazz --features client,rocksdb --example realistic_be
 `W3` requires a running server and `--server-url`:
 
 ```bash
-RUST_LOG=warn cargo run -p jazz --features client,rocksdb --example realistic_bench -- \
+RUST_LOG=warn cargo run -p jazz --features client,rocksdb,transport-compression-zstd --example realistic_bench -- \
   --profile dev/benchmarks/realistic/profiles/s.json \
   --scenario dev/benchmarks/realistic/scenarios/w3_offline_reconnect.json \
   --server-url http://127.0.0.1:1625

--- a/dev/benchmarks/realistic/ci_benchmarks.test.mjs
+++ b/dev/benchmarks/realistic/ci_benchmarks.test.mjs
@@ -422,17 +422,20 @@ test("benchmark workflow prebuilds the RocksDB-backed and SQLite-backed native b
 
   assert.match(
     workflow,
-    /cargo build --release -p jazz --features client,rocksdb --example realistic_bench/,
+    /cargo build --release -p jazz --features client,rocksdb,transport-compression-zstd --example realistic_bench/,
   );
   assert.match(
     workflow,
-    /cargo build --release -p jazz --features client,sqlite --example realistic_bench/,
+    /cargo build --release -p jazz --features client,sqlite,transport-compression-zstd --example realistic_bench/,
   );
   assert.match(
     workflow,
-    /cargo bench -p jazz --features rocksdb --bench realistic_phase1 --no-run/,
+    /cargo bench -p jazz --features rocksdb,transport-compression-zstd --bench realistic_phase1 --no-run/,
   );
-  assert.match(workflow, /cargo bench -p jazz --features sqlite --bench realistic_phase1 --no-run/);
+  assert.match(
+    workflow,
+    /cargo bench -p jazz --features sqlite,transport-compression-zstd --bench realistic_phase1 --no-run/,
+  );
   assert.doesNotMatch(workflow, /-p jazz-tools\b/);
 });
 

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -275,7 +275,10 @@ test("Rust CI splits a bounded real differential-oracle smoke behind a stable ag
   ]) {
     assert.doesNotMatch(workspace, new RegExp(`cargo test -p jazz --test ${testTarget}`));
   }
-  assert.match(differential, /cargo test -p jazz --lib --no-run --message-format=json/);
+  assert.match(
+    differential,
+    /cargo test -p jazz --lib --features test --no-run --message-format=json/,
+  );
   assert.match(differential, /message\.target\.name === "jazz"/);
   assert.match(
     differential,
@@ -312,10 +315,10 @@ test("Rust CI splits a bounded real differential-oracle smoke behind a stable ag
     () =>
       assert.match(
         differential.replace(
-          "cargo test -p jazz --lib --no-run --message-format=json",
+          "cargo test -p jazz --lib --features test --no-run --message-format=json",
           "cargo test -p jazz --no-run --message-format=json",
         ),
-        /cargo test -p jazz --lib --no-run --message-format=json/,
+        /cargo test -p jazz --lib --features test --no-run --message-format=json/,
       ),
     /--lib/,
   );
@@ -347,8 +350,8 @@ test("Rust CI splits a bounded real differential-oracle smoke behind a stable ag
     () =>
       assertM3CompileThenRun(
         differential.replace(
-          "cargo test -p jazz --lib --no-run --message-format=json",
-          "timeout 60s cargo test -p jazz --lib --no-run --message-format=json",
+          "cargo test -p jazz --lib --features test --no-run --message-format=json",
+          "timeout 60s cargo test -p jazz --lib --features test --no-run --message-format=json",
         ),
       ),
     /cold compilation must not consume the semantic-execution timeout/,


### PR DESCRIPTION
🤖 Makes the `jazz` crate a featureless semantic core by default. Process and target shells now opt into storage, transport, compression, and server capabilities explicitly.

## Behavior change

Before this PR, a plain dependency on `jazz` silently enabled RocksDB, the Axum server shell, and zstd transport compression:

```toml
jazz = { path = "../jazz" }
```

After this PR, the same declaration builds only the common Jazz semantics. Consumers state the runtime they need:

```toml
# Native simulation with durable storage and compressed wire canaries
jazz = { path = "../jazz", default-features = false, features = [
  "rocksdb",
  "testing",
  "transport-compression-zstd",
] }
```

The existing shells already follow this model:

- `jazz-cli` selects the server capability.
- `jazz-napi` selects its client/server test utility surface explicitly.
- `jazz-wasm` remains free of native server and storage adapters.
- `jazz-sim` now explicitly selects RocksDB, testing helpers, and zstd rather than inheriting them accidentally.

This also tightens compile boundaries inside `jazz`: operational serving, bootstrap-only receive paths, server catalogue decoding, and facade JSON admission helpers compile only for the capabilities that use them. There are no blanket dead-code allowances.

## Build and workflow repairs

- Native benchmark commands explicitly opt into zstd.
- Release workflows now build the post-split `jazz-cli` package/bin instead of stale `jazz --features cli` commands.
- Benchmark documentation and command-contract tests match the explicit feature selection.
- The compile-boundary plan records progress through executable, telemetry, client/server, and default-feature separation.

## Verification

- `cargo clippy -p jazz -p jazz-sim -- -D warnings`
- `cargo check -p jazz`
- `cargo check -p jazz-cli`
- `cargo check -p jazz-napi`
- `cargo check -p jazz-sim --benches`
- benchmark command contracts: 21/21
- CI workflow contracts: 40/40; TS burndown exact 0
- `pnpm format:check`
- `git diff --check`
