### PR TITLE
refactor: make Groove featureless by default

### DIFF
--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = ["rocksdb"]
+default = []
 rocksdb = ["dep:rocksdb"]
+# Canonical Groove tests retain durable-backend coverage explicitly rather
+# than relying on a production default feature.
+test = ["rocksdb"]
 cold-settle-attribution = []
 
 [dependencies]

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -200,6 +200,12 @@ Actual shells select storage, compression, client, and server capabilities
 explicitly; the remaining work is extracting the Axum/server implementation
 without widening its private state into a public compatibility API.
 
+Groove is also featureless by default. Canonical tests and native Jazz shells
+select its existing RocksDB adapter explicitly, so checking the semantic
+storage/query core no longer compiles RocksDB or its native C++ dependency.
+The implementation remains at its established public path until a source-
+compatible adapter/facade split can replace it without a dependency cycle.
+
 ### Lane 4: storage, compression, and telemetry adapters
 
 Move RocksDB, compression implementations, and OTLP exporters to shell-selected


### PR DESCRIPTION
🤖 Makes `groove` a featureless semantic storage/query core by default. RocksDB remains available at its existing API path, but native consumers and canonical tests now select it explicitly.

## Behavior change

Before:

```toml
groove = { path = "../groove" }
```

implicitly compiled RocksDB and its native C++ dependency, even for consumers using only memory, OPFS, schema, query, or IVM semantics.

After:

```toml
# Semantic core only
groove = { path = "../groove" }

# Existing durable adapter
groove = { path = "../groove", features = ["rocksdb"] }
```

The canonical `test` feature explicitly includes `rocksdb`, preserving the full durable test matrix without making RocksDB a production default. Jazz already selects `groove/rocksdb` through its own explicit RocksDB feature, so CLI, server, NAPI, and simulation behavior is unchanged.

## Why this precedes a separate adapter crate

`RocksDbStorage` currently has a stable nested path at `groove::storage::RocksDbStorage`. Moving it directly into a crate that depends on Groove would prevent re-exporting it back through that module without a dependency cycle. This PR captures the immediate compile-boundary benefit while retaining compatibility; a later core/facade split can move the implementation without breaking the path.

## Verification

- `cargo clippy -p groove --no-default-features -- -D warnings`
- featureless dependency tree contains no RocksDB, `librocksdb-sys`, or `zstd-sys`
- `cargo test -p groove --features test --no-run`
- `cargo check -p jazz`
- `cargo check -p jazz-cli`
- `cargo check -p jazz-server`
- `cargo check -p jazz-napi`
- `cargo fmt --all -- --check`
- `git diff --check`

Sensitivity plant: removing `rocksdb` from Groove's `test` feature makes the canonical test compilation fail across the durable storage integration tests, proving that the explicit test selection—not residual defaults—retains coverage.
