### PR TITLE
refactor: add the native transport connector boundary

### DIFF
--- a/crates/jazz/src/tools/mod.rs
+++ b/crates/jazz/src/tools/mod.rs
@@ -6,6 +6,8 @@ pub mod identity;
 pub mod metadata;
 #[cfg(feature = "server")]
 pub mod middleware;
+/// Target-shell factory boundary for native peer transports.
+pub mod native_transport_connector;
 #[cfg(any(feature = "client", feature = "server"))]
 pub mod native_websocket_transport;
 mod object;

--- a/crates/jazz/src/tools/native_transport_connector.rs
+++ b/crates/jazz/src/tools/native_transport_connector.rs
@@ -1,0 +1,170 @@
+//! Native transport adapter boundary.
+//!
+//! A socket implementation belongs to a target shell, not to the semantic
+//! crate. This contract uses the core's already-buffered
+//! [`WireTransport`](crate::wire::WireTransport): an adapter owns DNS, TLS,
+//! WebSocket framing and its async pump, while `jazz` owns wire negotiation
+//! and peer state. Do not add an adapter dependency back to `jazz` merely to
+//! construct a client or an edge upstream connection.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::db::ConnectionSessionContext;
+use crate::ids::AuthorId;
+use crate::tools::AppId;
+use crate::tools::websocket_prelude_auth::AuthConfig;
+use crate::wire::WireTransport;
+
+/// Inputs shared by the public client and an edge server when opening a native
+/// peer link. The wake callback is only for newly staged inbound work: waking
+/// for outbound sends creates an empty-tick feedback loop in the synchronous
+/// database owner.
+#[derive(Clone)]
+pub struct NativeTransportRequest {
+    pub server_url: String,
+    pub app_id: AppId,
+    pub peer_identity: AuthorId,
+    pub auth: AuthConfig,
+    pub wake: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl std::fmt::Debug for NativeTransportRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NativeTransportRequest")
+            .field("server_url", &self.server_url)
+            .field("app_id", &self.app_id)
+            .field("peer_identity", &self.peer_identity)
+            // Authentication can contain JWTs, backend/admin credentials, and
+            // an impersonated session. Requests are routinely included in
+            // connection diagnostics, so no auth detail is safe to expose.
+            .field("auth", &"<redacted>")
+            .field("wake", &"inbound-only callback")
+            .finish()
+    }
+}
+
+/// A negotiated byte transport returned by a target-specific connector.
+///
+/// `session_context` is authenticated during the adapter handshake. Keeping it
+/// with the transport prevents an adapter from asserting identity in semantic
+/// messages or requiring server-private admission APIs.
+pub struct ConnectedNativeTransport {
+    pub transport: Box<dyn WireTransport>,
+    pub protocol_version: u16,
+    pub features: u64,
+    pub session_context: Option<ConnectionSessionContext>,
+}
+
+/// Future returned by a target-specific native connector.
+pub type NativeTransportFuture =
+    Pin<Box<dyn Future<Output = Result<ConnectedNativeTransport, NativeTransportError>> + 'static>>;
+
+/// Error at the target/socket boundary, before a core peer has been attached.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeTransportError(pub String);
+
+impl std::fmt::Display for NativeTransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for NativeTransportError {}
+
+/// Factory implemented by `jazz-native-transport` (or another native shell).
+///
+/// The factory is passed at consumer composition points rather than registered
+/// globally. CLI/server/NAPI therefore choose an adapter explicitly, and tests
+/// can use an in-memory transport without compiling Tokio or TLS into core.
+pub trait NativeTransportConnector {
+    fn connect(&self, request: NativeTransportRequest) -> NativeTransportFuture;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::TransportError;
+    use std::sync::Mutex;
+
+    struct NoopTransport;
+
+    impl WireTransport for NoopTransport {
+        fn send_frame(&mut self, _frame: Vec<u8>) -> Result<(), TransportError> {
+            Ok(())
+        }
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    struct RecordingConnector(Mutex<Option<NativeTransportRequest>>);
+
+    impl NativeTransportConnector for RecordingConnector {
+        fn connect(&self, request: NativeTransportRequest) -> NativeTransportFuture {
+            *self.0.lock().expect("record request") = Some(request);
+            Box::pin(async {
+                Ok(ConnectedNativeTransport {
+                    transport: Box::new(NoopTransport),
+                    protocol_version: 1,
+                    features: 0,
+                    session_context: None,
+                })
+            })
+        }
+    }
+
+    #[test]
+    // This internal test is necessary because the contract's observable effect
+    // is handing composition inputs to an adapter; opening a real socket would
+    // test Tokio/TLS rather than this featureless-core boundary.
+    fn connector_receives_composition_inputs_without_a_socket_dependency() {
+        let connector = RecordingConnector(Mutex::new(None));
+        let app_id = AppId::random();
+        let peer_identity = AuthorId::SYSTEM;
+        let connected = futures::executor::block_on(connector.connect(NativeTransportRequest {
+            server_url: "https://example.invalid".to_owned(),
+            app_id,
+            peer_identity,
+            auth: AuthConfig::default(),
+            wake: Arc::new(|| {}),
+        }))
+        .expect("connector result");
+
+        assert_eq!(connected.protocol_version, 1);
+        let request = connector
+            .0
+            .lock()
+            .expect("recorded request")
+            .take()
+            .unwrap();
+        assert_eq!(request.server_url, "https://example.invalid");
+        assert_eq!(request.app_id, app_id);
+        assert_eq!(request.peer_identity, peer_identity);
+    }
+
+    #[test]
+    // This internal test is necessary because redaction is a diagnostic
+    // boundary on this core-owned request type, before any public client can
+    // observe the socket adapter.
+    fn request_debug_redacts_all_authentication_material() {
+        let marker = "native-connector-credential-marker-9af1";
+        let request = NativeTransportRequest {
+            server_url: "https://example.invalid".to_owned(),
+            app_id: AppId::random(),
+            peer_identity: AuthorId::SYSTEM,
+            auth: AuthConfig {
+                jwt_token: Some(marker.to_owned()),
+                backend_secret: Some(marker.to_owned()),
+                admin_secret: Some(marker.to_owned()),
+                backend_session: Some(serde_json::json!({ "credential": marker })),
+            },
+            wake: Arc::new(|| {}),
+        };
+
+        let rendered = format!("{request:?}");
+        assert!(rendered.contains("auth: \"<redacted>\""));
+        assert!(!rendered.contains(marker));
+    }
+}


### PR DESCRIPTION
🤖 Adds the featureless-core connector contract needed to move native WebSocket networking into a target-owned adapter crate.

## Boundary

Today both the Rust client and edge-server builder directly construct `WebSocketTransport` inside `jazz`. Moving that implementation first would create a dependency cycle:

```text
jazz → native adapter → jazz
```

This PR introduces the composition seam that gives the final graph the correct direction:

```text
CLI / server / NAPI → jazz-native-transport → jazz
```

`NativeTransportConnector` receives target-owned connection inputs and asynchronously returns:

- a buffered core `WireTransport`;
- negotiated protocol version and feature bits;
- the authenticated connection session context.

The wake callback is explicitly inbound-only. Waking for outbound sends would create empty synchronous database tick loops.

The connector is passed at composition points rather than globally registered, so tests can inject an in-memory adapter and separate native shells can select different transport implementations.

## Security boundary

`NativeTransportRequest` can carry JWT, backend/admin credentials, and session content. Its `Debug` implementation always prints authentication as `<redacted>` and never delegates to `AuthConfig::Debug`. A focused regression populates every credential form with a distinctive marker and proves it is absent from diagnostics.

## Scope

This is the prerequisite contract only. It does not duplicate or partially move the existing WebSocket implementation. The next slice will move `native_websocket_transport.rs` into `jazz-native-transport` and migrate client/edge construction through this seam.

## Verification

- `cargo check -p jazz --no-default-features`
- `cargo check -p jazz --features client,server`
- `cargo clippy -p jazz --no-default-features --lib -- -D warnings`
- focused connector handoff test
- focused credential-redaction test
- `cargo fmt --check`
- pre-commit clippy, rustfmt, and sensitive-data guard

Independent review found and closed the authentication-debug leak before publication.
