### PR TITLE
refactor: move policy scenarios into Jazz testkit

### DIFF
--- a/crates/jazz-testkit/tests/branch_claims_integration.rs
+++ b/crates/jazz-testkit/tests/branch_claims_integration.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test")]
-
 use jazz_testkit as support;
 
 use std::collections::BTreeMap;

--- a/crates/jazz-testkit/tests/claims_merge_integration.rs
+++ b/crates/jazz-testkit/tests/claims_merge_integration.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test")]
-
 //! Integration test for ephemeral payload claims merging into the server session.
 //!
 //! Verifies the fix from 094a5626: when a JWT-authenticated client supplies

--- a/crates/jazz-testkit/tests/inherited_policies.rs
+++ b/crates/jazz-testkit/tests/inherited_policies.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test")]
-
 use jazz_testkit as support;
 
 use std::time::Duration;
@@ -197,7 +195,7 @@ async fn publish_schema(server: &JazzServer, schema: &jazz::tools::Schema) {
         server.app_id(),
         "dev",
         "main",
-        &[schema.clone()],
+        std::slice::from_ref(schema),
         &[],
     )
     .await
@@ -741,7 +739,7 @@ async fn inherited_update_policy_allows_update_through_parent() {
                 server.app_id(),
                 "dev",
                 "main",
-                &[schema.clone()],
+                std::slice::from_ref(&schema),
                 &[],
             )
             .await
@@ -874,7 +872,7 @@ async fn inherited_update_policy_allows_multi_hop_update_chain() {
                 server.app_id(),
                 "dev",
                 "main",
-                &[schema.clone()],
+                std::slice::from_ref(&schema),
                 &[],
             )
             .await
@@ -992,7 +990,7 @@ async fn inherited_update_policy_allows_reparenting_when_old_and_new_parents_gra
                 server.app_id(),
                 "dev",
                 "main",
-                &[schema.clone()],
+                std::slice::from_ref(&schema),
                 &[],
             )
             .await

--- a/crates/jazz-testkit/tests/local_first_auth_integration.rs
+++ b/crates/jazz-testkit/tests/local_first_auth_integration.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test")]
-
 //! End-to-end integration coverage for local-first (Ed25519 seed) auth.
 //!
 //! These tests prove that a `JazzClient` carrying an Ed25519-minted Bearer

--- a/crates/jazz-testkit/tests/policy_branch_closure.rs
+++ b/crates/jazz-testkit/tests/policy_branch_closure.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test")]
-
 use jazz_testkit as support;
 
 use std::time::Duration;

--- a/crates/jazz-testkit/tests/rename_write_authorization.rs
+++ b/crates/jazz-testkit/tests/rename_write_authorization.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test")]
-
 use jazz_testkit as support;
 
 use std::collections::BTreeMap;

--- a/crates/jazz-testkit/tests/scope_revocation.rs
+++ b/crates/jazz-testkit/tests/scope_revocation.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "test")]
-
 use jazz_testkit as support;
 
 use std::collections::HashMap;
@@ -70,7 +68,7 @@ async fn scope_revocation_removes_edge_results_without_redacting_local_copy() {
                 server.app_id(),
                 "dev",
                 "main",
-                &[schema.clone()],
+                std::slice::from_ref(&schema),
                 &[],
             )
             .await

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -193,18 +193,6 @@ harness = false
 required-features = ["testing"]
 
 [[test]]
-name = "branch_claims_integration"
-required-features = ["test"]
-
-[[test]]
-name = "inherited_policies"
-required-features = ["test"]
-
-[[test]]
-name = "scope_revocation"
-required-features = ["test"]
-
-[[test]]
 name = "aggregate_subscriptions"
 required-features = ["test-utils"]
 
@@ -225,19 +213,11 @@ name = "nullable_writes"
 required-features = ["test-utils"]
 
 [[test]]
-name = "policy_branch_closure"
-required-features = ["test"]
-
-[[test]]
 name = "query_membership_filters"
 required-features = ["test"]
 
 [[test]]
 name = "flush_once_per_refresh"
-required-features = ["test"]
-
-[[test]]
-name = "rename_write_authorization"
 required-features = ["test"]
 
 [[test]]
@@ -261,15 +241,7 @@ name = "clients_sync"
 required-features = ["test"]
 
 [[test]]
-name = "local_first_auth_integration"
-required-features = ["test"]
-
-[[test]]
 name = "gset_merge"
-required-features = ["test"]
-
-[[test]]
-name = "claims_merge_integration"
 required-features = ["test"]
 
 [[example]]

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -100,7 +100,10 @@ Progress: reusable scenario-client, JWT, permissions-publication, query-wait,
 and in-memory duplex helpers now live in `jazz-testkit`. Existing Jazz
 integration targets consume that package through a dev-dependency, so helper
 changes compile as one independently cached unit while the scenario targets
-are migrated outward incrementally.
+are migrated outward incrementally. The first outward cluster covers public
+claims, inherited policies, policy-aware branches, authorization across schema
+renames, scope revocation, and local-first authentication; these seven binaries
+now compile and run under `jazz-testkit` rather than Jazz's core test inventory.
 
 ## Proposed feature model
 


### PR DESCRIPTION
🤖 Move the first coherent public scenario cluster from Jazz core's integration-test inventory into `jazz-testkit`.

The migrated scenarios cover:

- claims-based query, subscription, branch, and numeric authorization;
- ephemeral claim merging and same-identity session isolation;
- inherited select/update policies and multi-hop parent chains;
- policy-aware branch closure;
- write authorization across schema/table renames;
- scope revocation across Local and Edge views;
- local-first principal derivation, persistence, JWT coexistence, and queued-write reconnect.

This is ownership-only: the scenario bodies and assertions move intact. The only source adjustments remove the old Jazz feature guard and satisfy the stricter all-targets clippy boundary now applied to `jazz-testkit`.

Example boundary:

```text
jazz
  private unit/white-box tests

jazz-testkit
  public multi-process scenarios
  ├── branch_claims_integration
  ├── inherited_policies
  ├── rename_write_authorization
  └── local_first_auth_integration
```

This removes seven binaries and their explicit feature declarations from Jazz's package inventory. They now compile together against the package-owned testkit helpers extracted in #1619.

Verification:

- all seven migrated targets compile under `jazz-testkit`;
- complete migrated suite: 27 tests passed;
- `cargo clippy -p jazz-testkit --all-targets -- -D warnings` passes;
- format, diff, workspace hooks, and sensitive-data guard pass.

The compile-boundary plan records this first completed outward scenario cluster.
