### PR TITLE
refactor: centralize NAPI telemetry setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,13 +1988,11 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "opentelemetry_sdk",
  "postcard",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/jazz-napi/Cargo.toml
+++ b/crates/jazz-napi/Cargo.toml
@@ -18,12 +18,10 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 base64 = "0.22"
 napi = { version = "3", features = ["napi6", "serde-json", "async"] }
 napi-derive = "3"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 postcard = { version = "1.1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v7"] }
 # local_dynamic_tls: a dlopen'd cdylib with mimalloc's default initial-exec
 # TLS exhausts glibc's static TLS reserve ("cannot allocate memory in static

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -36,7 +36,7 @@ use serde_json::Value as JsonValue;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::rc::Rc;
-use std::sync::{Mutex, OnceLock};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use base64::Engine;
@@ -2707,34 +2707,15 @@ fn parse_jazz_server_start_options(options: JsonValue) -> napi::Result<JazzServe
         .map_err(|error| napi::Error::from_reason(format!("Invalid JazzServer options: {error}")))
 }
 
-static JAZZ_SERVER_OTEL_PROVIDER: OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
-    OnceLock::new();
-static JAZZ_SERVER_TELEMETRY_INIT: OnceLock<()> = OnceLock::new();
-
 fn init_jazz_server_telemetry(collector_url: Option<&str>) {
     let Some(collector_url) = collector_url else {
         return;
     };
-
-    JAZZ_SERVER_TELEMETRY_INIT.get_or_init(|| {
-        use tracing_subscriber::layer::SubscriberExt as _;
-
-        let endpoint = jazz_otel::normalize_otlp_traces_endpoint(collector_url);
-        let provider =
-            jazz_otel::init_tracer_provider_with_endpoint("jazz-server", Some(&endpoint));
-        let otel_layer = jazz_otel::layer(&provider);
-        let filter = tracing_subscriber::EnvFilter::from_default_env()
-            .add_directive("jazz_tools=trace".parse().expect("valid tracing directive"))
-            .add_directive("tower_http=debug".parse().expect("valid tracing directive"));
-
-        if tracing::subscriber::set_global_default(
-            tracing_subscriber::registry().with(filter).with(otel_layer),
-        )
-        .is_ok()
-        {
-            let _ = JAZZ_SERVER_OTEL_PROVIDER.set(provider);
-        }
-    });
+    jazz_otel::init_process_tracing_with_endpoint_once(
+        "jazz-server",
+        collector_url,
+        &["jazz_tools=trace", "tower_http=debug"],
+    );
 }
 
 #[napi]

--- a/crates/jazz-otel/src/lib.rs
+++ b/crates/jazz-otel/src/lib.rs
@@ -11,8 +11,48 @@ use opentelemetry_otlp::{Protocol, WithExportConfig};
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
+use std::sync::OnceLock;
+use tracing_subscriber::layer::SubscriberExt as _;
 
 const DEFAULT_SERVICE_NAME: &str = "jazz-server";
+
+// A process-global tracing subscriber must retain its provider for the life of
+// the process. Keep both the one-time installation boundary and that ownership
+// in the telemetry adapter rather than duplicating OTel SDK types in shells.
+static PROCESS_TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+static PROCESS_TRACING_INIT: OnceLock<()> = OnceLock::new();
+
+/// Installs process-global OTLP tracing once, retaining the provider for the
+/// process lifetime. Later calls are intentionally no-ops: Rust permits only
+/// one global tracing subscriber.
+///
+/// `directives` lets a thin process shell add its own default targets without
+/// depending directly on `opentelemetry_sdk` or assembling subscriber layers.
+pub fn init_process_tracing_with_endpoint_once(
+    service_name: &str,
+    collector_url: &str,
+    directives: &[&str],
+) {
+    PROCESS_TRACING_INIT.get_or_init(|| {
+        let endpoint = normalize_otlp_traces_endpoint(collector_url);
+        let provider = init_tracer_provider_with_endpoint(service_name, Some(&endpoint));
+        let otel_layer = layer(&provider);
+        let mut filter = tracing_subscriber::EnvFilter::from_default_env();
+        for directive in directives {
+            filter = filter.add_directive(directive.parse().unwrap_or_else(|error| {
+                panic!("invalid tracing directive {directive:?}: {error}")
+            }));
+        }
+
+        if tracing::subscriber::set_global_default(
+            tracing_subscriber::registry().with(filter).with(otel_layer),
+        )
+        .is_ok()
+        {
+            let _ = PROCESS_TRACER_PROVIDER.set(provider);
+        }
+    });
+}
 
 /// Resolve the service name from `OTEL_SERVICE_NAME`, falling back to
 /// `DEFAULT_SERVICE_NAME`. Used by the env-driven provider builders. The

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -84,6 +84,11 @@ Core depends only on lightweight instrumentation vocabulary such as `tracing`.
 `jazz-otel` owns OpenTelemetry SDKs, exporters, subscribers, and Tokio runtime
 integration. Executable and binding shells opt into it.
 
+Progress: the NAPI shell now delegates process-global subscriber assembly and
+tracer-provider lifetime ownership to `jazz-otel`; it no longer depends
+directly on `opentelemetry_sdk` or `tracing-subscriber`. Shell-specific default
+filter directives remain explicit inputs to the adapter boundary.
+
 ### Tests
 
 - Move `TestingClient`, `TestJwtIssuer`, reusable fixtures, simulation helpers,


### PR DESCRIPTION
🤖 ## Summary

- move process-global tracing subscriber assembly and tracer-provider lifetime ownership into `jazz-otel`
- let thin shells supply only a service name, collector URL, and shell-specific default filter directives
- remove NAPI's direct `opentelemetry_sdk` and `tracing-subscriber` dependencies
- record the completed boundary in the compile-boundary plan

## Behavior

This is an ownership refactor; telemetry behavior is unchanged.

For example, when the NAPI dev server starts with a collector URL it still:

1. normalizes `http://collector:4318` to `http://collector:4318/v1/traces`;
2. installs one process-global subscriber;
3. enables `jazz_tools=trace` and `tower_http=debug` unless overridden by the environment; and
4. retains the SDK tracer provider for the process lifetime.

The difference is architectural: NAPI now expresses that configuration through one `jazz-otel` API instead of knowing how to compose OTel SDK providers and tracing layers itself. Repeated initialization remains a no-op because Rust permits only one global subscriber.

## Verification

- `cargo check -p jazz-otel -p jazz-napi`
- `cargo test -p jazz-otel --lib --no-fail-fast`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-commit clippy, sensitive-data, oxfmt, and rustfmt hooks
