### PR TITLE
refactor: extract transport compression codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,18 +1913,17 @@ dependencies = [
  "insta",
  "internment",
  "jazz-benchmark-guard",
+ "jazz-compression",
  "jazz-testkit",
  "jsonschema",
  "jsonwebtoken",
  "libc",
- "lz4_flex 0.11.6",
  "postcard",
  "rand 0.8.5",
  "rcgen",
  "reqwest",
  "rusqlite",
  "rust-rocksdb",
- "ruzstd",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1941,7 +1940,6 @@ dependencies = [
  "tungstenite",
  "uuid",
  "web-time",
- "zstd",
 ]
 
 [[package]]
@@ -1974,6 +1972,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tungstenite",
+]
+
+[[package]]
+name = "jazz-compression"
+version = "0.1.0"
+dependencies = [
+ "lz4_flex 0.11.6",
+ "ruzstd",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/benchmark-guard",
   "crates/groove",
   "crates/jazz",
+  "crates/jazz-compression",
   "crates/jazz-native-transport",
   "crates/jazz-cli",
   "crates/jazz-server",
@@ -30,6 +31,7 @@ exclude = ["examples/todo-server-rs", "examples/docs/todo-server-rs"]
 [workspace.dependencies]
 groove = { path = "crates/groove", default-features = false }
 jazz = { path = "crates/jazz", default-features = false }
+jazz-compression = { path = "crates/jazz-compression", default-features = false }
 jazz-otel = { path = "crates/jazz-otel" }
 rustc-hash = "2.1.1"
 

--- a/crates/jazz-compression/Cargo.toml
+++ b/crates/jazz-compression/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "jazz-compression"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+default = []
+lz4 = ["dep:lz4_flex"]
+zstd = ["dep:zstd"]
+ruzstd = ["dep:ruzstd"]
+
+[dependencies]
+lz4_flex = { version = "0.11.5", default-features = false, features = ["frame"], optional = true }
+ruzstd = { version = "0.8.2", default-features = false, optional = true }
+zstd = { version = "0.13.3", optional = true }
+
+[dev-dependencies]
+zstd = "0.13.3"

--- a/crates/jazz-compression/src/lib.rs
+++ b/crates/jazz-compression/src/lib.rs
@@ -1,0 +1,121 @@
+//! Platform codec implementations used by Jazz transport envelopes.
+//!
+//! Wire negotiation, feature bits, and logical message limits remain owned by
+//! `jazz`; this crate owns only codec-specific dependencies and byte transforms.
+
+#[cfg(all(not(feature = "zstd"), feature = "ruzstd"))]
+use ruzstd::io::Read as _;
+
+#[cfg(feature = "lz4")]
+pub fn compress_lz4(payload: &[u8]) -> Result<Vec<u8>, String> {
+    Ok(lz4_flex::compress_prepend_size(payload))
+}
+
+#[cfg(not(feature = "lz4"))]
+pub fn compress_lz4(_payload: &[u8]) -> Result<Vec<u8>, String> {
+    Err("lz4 transport compression feature is not compiled in".to_owned())
+}
+
+#[cfg(feature = "lz4")]
+pub fn decompress_lz4(payload: &[u8], max_decoded_len: usize) -> Result<Vec<u8>, String> {
+    let advertised = payload
+        .get(..4)
+        .and_then(|bytes| bytes.try_into().ok())
+        .map(u32::from_le_bytes)
+        .ok_or_else(|| "lz4 payload is missing its decoded-length prefix".to_owned())?
+        as usize;
+    validate_decoded_len(advertised, max_decoded_len)?;
+    let decoded = lz4_flex::decompress_size_prepended(payload)
+        .map_err(|error| format!("failed to decompress lz4 payload: {error}"))?;
+    validate_decoded_len(decoded.len(), max_decoded_len)?;
+    Ok(decoded)
+}
+
+#[cfg(not(feature = "lz4"))]
+pub fn decompress_lz4(_payload: &[u8], _max_decoded_len: usize) -> Result<Vec<u8>, String> {
+    Err("lz4 transport compression feature is not compiled in".to_owned())
+}
+
+#[cfg(feature = "zstd")]
+pub fn compress_zstd(payload: &[u8]) -> Result<Vec<u8>, String> {
+    zstd::bulk::compress(payload, 3)
+        .map_err(|error| format!("failed to compress zstd payload: {error}"))
+}
+
+#[cfg(not(feature = "zstd"))]
+pub fn compress_zstd(_payload: &[u8]) -> Result<Vec<u8>, String> {
+    Err("zstd transport compression feature is not compiled in".to_owned())
+}
+
+#[cfg(feature = "zstd")]
+pub fn decompress_zstd(payload: &[u8], max_decoded_len: usize) -> Result<Vec<u8>, String> {
+    zstd::bulk::decompress(payload, max_decoded_len)
+        .map_err(|error| format!("failed to decompress zstd payload: {error}"))
+}
+
+#[cfg(all(not(feature = "zstd"), feature = "ruzstd"))]
+pub fn decompress_zstd(payload: &[u8], max_decoded_len: usize) -> Result<Vec<u8>, String> {
+    let decoder = ruzstd::decoding::StreamingDecoder::new(payload)
+        .map_err(|error| format!("failed to initialize ruzstd payload: {error}"))?;
+    let mut output = Vec::new();
+    decoder
+        .take(max_decoded_len.saturating_add(1) as u64)
+        .read_to_end(&mut output)
+        .map_err(|error| format!("failed to decompress ruzstd payload: {error}"))?;
+    validate_decoded_len(output.len(), max_decoded_len)?;
+    Ok(output)
+}
+
+#[cfg(not(any(feature = "zstd", feature = "ruzstd")))]
+pub fn decompress_zstd(_payload: &[u8], _max_decoded_len: usize) -> Result<Vec<u8>, String> {
+    Err("zstd transport compression feature is not compiled in".to_owned())
+}
+
+#[cfg(any(feature = "lz4", all(not(feature = "zstd"), feature = "ruzstd")))]
+fn validate_decoded_len(len: usize, max_decoded_len: usize) -> Result<(), String> {
+    if len > max_decoded_len {
+        return Err(format!(
+            "logical message payload size {len} exceeds max {max_decoded_len}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "lz4")]
+    #[test]
+    fn lz4_round_trips_with_a_decoded_size_limit() {
+        let payload = b"canonical transport payload".repeat(32);
+        let compressed = super::compress_lz4(&payload).expect("compress lz4");
+        assert_eq!(
+            super::decompress_lz4(&compressed, payload.len()).expect("decompress lz4"),
+            payload
+        );
+        assert!(super::decompress_lz4(&compressed, payload.len() - 1).is_err());
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn native_zstd_round_trips_with_a_decoded_size_limit() {
+        let payload = b"canonical transport payload".repeat(32);
+        let compressed = super::compress_zstd(&payload).expect("compress zstd");
+        assert_eq!(
+            super::decompress_zstd(&compressed, payload.len()).expect("decompress zstd"),
+            payload
+        );
+        assert!(super::decompress_zstd(&compressed, payload.len() - 1).is_err());
+    }
+
+    #[cfg(all(feature = "ruzstd", not(feature = "zstd")))]
+    #[test]
+    fn pure_rust_zstd_decoder_reads_native_zstd_frames() {
+        let payload = b"canonical transport payload".repeat(32);
+        let compressed = zstd::bulk::compress(&payload, 3).expect("compress fixture");
+        assert_eq!(
+            super::decompress_zstd(&compressed, payload.len()).expect("decompress ruzstd"),
+            payload
+        );
+        assert!(super::decompress_zstd(&compressed, payload.len() - 1).is_err());
+    }
+}

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -33,9 +33,9 @@ cold-settle-attribution = ["groove/cold-settle-attribution"]
 r3-open-attribution = ["rocksdb", "testing"]
 testing = []
 embedded-server = ["server", "client", "sqlite"]
-transport-compression-lz4 = ["dep:lz4_flex"]
-transport-compression-zstd = ["dep:zstd"]
-transport-compression-ruzstd = ["dep:ruzstd"]
+transport-compression-lz4 = ["jazz-compression/lz4"]
+transport-compression-zstd = ["jazz-compression/zstd"]
+transport-compression-ruzstd = ["jazz-compression/ruzstd"]
 test-utils = ["embedded-server", "sync-autopsy"]
 test = ["test-utils", "rocksdb", "transport-compression-zstd"]
 
@@ -46,15 +46,13 @@ futures = "0.3"
 futures-util = "0.3"
 blake3 = "1"
 groove = { workspace = true, default-features = false }
-lz4_flex = { version = "0.11.5", default-features = false, features = ["frame"], optional = true }
+jazz-compression.workspace = true
 postcard = { version = "1.1.3", features = ["alloc"] }
-ruzstd = { version = "0.8.2", default-features = false, optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
 uuid = { version = "1.18.1", features = ["serde", "v4", "v5", "v7"] }
 web-time = "1.1"
-zstd = { version = "0.13.3", optional = true }
 tracing = "0.1"
 hex = "0.4"
 rand = "0.8"

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -6,12 +6,6 @@
 //! server shells can adopt the envelope before the full [`crate::protocol::SyncMessage`]
 //! encoder is frozen.
 
-#[cfg(all(
-    not(feature = "transport-compression-zstd"),
-    feature = "transport-compression-ruzstd"
-))]
-use ruzstd::io::Read;
-
 use postcard::{from_bytes, to_allocvec};
 use serde::{Deserialize, Serialize};
 
@@ -528,80 +522,20 @@ pub fn decompress_sync_payload(
     }
 }
 
-#[cfg(feature = "transport-compression-lz4")]
 fn compress_lz4(payload: &[u8]) -> Result<Vec<u8>, String> {
-    Ok(lz4_flex::compress_prepend_size(payload))
+    jazz_compression::compress_lz4(payload)
 }
 
-#[cfg(not(feature = "transport-compression-lz4"))]
-fn compress_lz4(_payload: &[u8]) -> Result<Vec<u8>, String> {
-    Err("lz4 transport compression feature is not compiled in".to_owned())
-}
-
-#[cfg(feature = "transport-compression-lz4")]
 fn decompress_lz4(payload: &[u8]) -> Result<Vec<u8>, String> {
-    let advertised = payload
-        .get(..4)
-        .and_then(|bytes| bytes.try_into().ok())
-        .map(u32::from_le_bytes)
-        .ok_or_else(|| "lz4 payload is missing its decoded-length prefix".to_owned())?
-        as usize;
-    validate_logical_message_len(advertised)?;
-    let decoded = lz4_flex::decompress_size_prepended(payload)
-        .map_err(|error| format!("failed to decompress lz4 payload: {error}"))?;
-    validate_logical_message_len(decoded.len())?;
-    Ok(decoded)
+    jazz_compression::decompress_lz4(payload, crate::protocol_limits::MAX_LOGICAL_MESSAGE_BYTES)
 }
 
-#[cfg(not(feature = "transport-compression-lz4"))]
-fn decompress_lz4(_payload: &[u8]) -> Result<Vec<u8>, String> {
-    Err("lz4 transport compression feature is not compiled in".to_owned())
-}
-
-#[cfg(feature = "transport-compression-zstd")]
 fn compress_zstd(payload: &[u8]) -> Result<Vec<u8>, String> {
-    zstd::bulk::compress(payload, 3)
-        .map_err(|error| format!("failed to compress zstd payload: {error}"))
+    jazz_compression::compress_zstd(payload)
 }
 
-#[cfg(not(feature = "transport-compression-zstd"))]
-fn compress_zstd(_payload: &[u8]) -> Result<Vec<u8>, String> {
-    Err("zstd transport compression feature is not compiled in".to_owned())
-}
-
-#[cfg(any(
-    feature = "transport-compression-zstd",
-    feature = "transport-compression-ruzstd"
-))]
 fn decompress_zstd(payload: &[u8]) -> Result<Vec<u8>, String> {
-    #[cfg(feature = "transport-compression-zstd")]
-    {
-        zstd::bulk::decompress(payload, crate::protocol_limits::MAX_LOGICAL_MESSAGE_BYTES)
-            .map_err(|error| format!("failed to decompress zstd payload: {error}"))
-    }
-    #[cfg(all(
-        not(feature = "transport-compression-zstd"),
-        feature = "transport-compression-ruzstd"
-    ))]
-    {
-        let decoder = ruzstd::decoding::StreamingDecoder::new(payload)
-            .map_err(|error| format!("failed to initialize ruzstd payload: {error}"))?;
-        let mut output = Vec::new();
-        decoder
-            .take((crate::protocol_limits::MAX_LOGICAL_MESSAGE_BYTES + 1) as u64)
-            .read_to_end(&mut output)
-            .map_err(|error| format!("failed to decompress ruzstd payload: {error}"))?;
-        validate_logical_message_len(output.len())?;
-        Ok(output)
-    }
-}
-
-#[cfg(not(any(
-    feature = "transport-compression-zstd",
-    feature = "transport-compression-ruzstd"
-)))]
-fn decompress_zstd(_payload: &[u8]) -> Result<Vec<u8>, String> {
-    Err("zstd transport compression feature is not compiled in".to_owned())
+    jazz_compression::decompress_zstd(payload, crate::protocol_limits::MAX_LOGICAL_MESSAGE_BYTES)
 }
 
 /// Negotiated per-message compression for sync payloads.
@@ -1232,6 +1166,7 @@ mod tests {
                     result_member_removes: Vec::new(),
                     program_fact_adds: Vec::new(),
                     program_fact_removes: Vec::new(),
+                    terminal_operations: Vec::new(),
                 }
             })
             .collect::<Vec<_>>();

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -78,6 +78,13 @@ access is valuable.
 - Define uncompressed semantic framing plus a codec seam in core.
 - Let shells select zstd, lz4, or ruzstd without recompiling semantic core.
 
+Progress: codec implementations and their native/pure-Rust dependencies now
+live in featureless-by-default `jazz-compression`. Jazz retains wire feature
+negotiation, envelope semantics, and logical message limits; its compatibility
+features forward codec selection to the adapter crate. This is the first half
+of the boundary: shells still select the established Jazz features until codec
+choice can be injected without weakening wire negotiation.
+
 ### Telemetry
 
 Core depends only on lightweight instrumentation vocabulary such as `tracing`.


### PR DESCRIPTION
🤖 ## Summary

- add featureless-by-default `jazz-compression` as the inward codec implementation crate
- move LZ4, native zstd, and pure-Rust ruzstd dependencies and byte transforms out of semantic Jazz
- retain wire negotiation, feature bits, codec precedence, envelope semantics, and logical message limits in Jazz
- preserve the existing Jazz and shell feature names by forwarding them to the adapter crate

## Boundary and behavior

This changes dependency ownership, not the wire format.

```text
shell feature selection
        ↓
jazz wire negotiation and message-size policy
        ↓
jazz-compression codec byte transforms
        ↓
lz4_flex / zstd / ruzstd
```

Examples:

- A native CLI built with `transport-compression-zstd` still advertises and emits the same zstd payload feature, using compression level 3.
- The WASM default still decodes those zstd frames through ruzstd without linking the native zstd implementation.
- An LZ4 frame still has its decoded-length prefix checked before allocation and is rejected when it exceeds Jazz's logical-message limit.
- A featureless Jazz core can call the same internal seam, but unavailable codecs fail with the same “feature is not compiled in” errors and are never advertised.
- If both native zstd and ruzstd are enabled, native zstd retains precedence exactly as before.

Jazz intentionally still owns `MAX_LOGICAL_MESSAGE_BYTES` and passes the bound into the codec adapter. The adapter therefore cannot silently choose protocol policy, and no projected or pre-decoded payload crosses this boundary.

## Verification

- `cargo test -p jazz-compression --no-default-features --features lz4 --no-fail-fast`
- `cargo test -p jazz-compression --no-default-features --features zstd --no-fail-fast`
- `cargo test -p jazz-compression --no-default-features --features ruzstd --no-fail-fast`
- `cargo clippy -p jazz-compression --all-features --all-targets -- -D warnings`
- `cargo test -p jazz --lib --features test wire::tests --no-fail-fast` — 23 passed
- exact LZ4 stream round trip passed under the LZ4 feature
- `cargo check -p jazz --no-default-features --features transport-compression-ruzstd`
- `cargo check -p jazz-wasm`
- workspace pre-commit clippy, sensitive-data, oxfmt, and rustfmt hooks
- `git diff --check`

The LZ4-only broad wire-test compile exposed and repaired one stale `ViewUpdate` fixture that omitted the required `terminal_operations` field. The unrelated manual compression-ratio receipt currently expects stateful zstd savings even though the production encoder is per-message; it was not changed or used as correctness evidence here.
