### PR TITLE
refactor: gate testkit scenario dependencies

### DIFF
--- a/crates/jazz-testkit/Cargo.toml
+++ b/crates/jazz-testkit/Cargo.toml
@@ -5,17 +5,32 @@ edition = "2024"
 
 [features]
 default = ["scenarios", "rocksdb", "transport-compression-zstd"]
-scenarios = ["jazz/test-utils"]
+scenarios = [
+  "jazz/test-utils",
+  "dep:jsonwebtoken",
+  "dep:reqwest",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:tempfile",
+  "dep:tokio",
+  "dep:uuid",
+]
 rocksdb = ["scenarios", "jazz/rocksdb"]
-transport-compression-zstd = ["jazz/transport-compression-zstd"]
+transport-compression-zstd = ["jazz/transport-compression-zstd", "dep:zstd"]
 
 [dependencies]
 jazz.workspace = true
-jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tempfile = "3.27.0"
-tokio = { version = "1", features = ["time"] }
-uuid = { version = "1", features = ["v5"] }
-zstd = "0.13.3"
+jsonwebtoken = { version = "10.4", default-features = false, features = [
+  "rust_crypto",
+  "use_pem",
+], optional = true }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
+tempfile = { version = "3.27.0", optional = true }
+tokio = { version = "1", features = ["time"], optional = true }
+uuid = { version = "1", features = ["v5"], optional = true }
+zstd = { version = "0.13.3", optional = true }

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -106,7 +106,8 @@ public client/server scenarios and their native adapters. Direct testkit runs
 default to the full scenario harness, RocksDB, and zstd as before, while Jazz's
 white-box dev-dependency disables those defaults. Its retained engine tests can
 use the duplex transport without re-enabling server, client, SQLite, RocksDB,
-or compression through feature unification.
+compression, HTTP/JWT, async-runtime, or fixture dependencies through feature
+unification. Those dependencies are optional and selected by `scenarios`.
 
 ### Tests
 


### PR DESCRIPTION
🤖 ## Summary

- make every public-scenario-only `jazz-testkit` dependency optional
- select JWT, HTTP, serialization, temporary-storage, Tokio, UUID, and zstd dependencies from the existing scenario/default features
- leave the featureless duplex-transport base with exactly one direct dependency: featureless Jazz
- retain the default testkit scenario configuration and behavior

## Why the previous module split was insufficient

Rust `cfg` gates stop scenario source from compiling, but Cargo still compiles unconditional dependencies even when no enabled module uses them. After #1625, `jazz-testkit --no-default-features` exposed only `duplex_transport` in Rust while its manifest still selected the JWT, HTTP, Tokio, fixture, and codec packages.

This PR aligns dependency selection with the source boundary:

```text
jazz-testkit --no-default-features
  └── jazz --no-default-features

jazz-testkit (defaults)
  ├── scenarios
  ├── JWT / HTTP / serde / tempfile / Tokio / UUID
  ├── RocksDB
  └── zstd
```

For example, a retained Jazz engine test using only `duplex_transport::duplex()` no longer builds reqwest or Tokio through testkit. Running the normal `gset_merge` or `transactions` scenario targets still selects the full public harness; 7 and 12 tests respectively pass unchanged, including the large compressed WebSocket import.

## Verification

- `cargo tree -p jazz-testkit --no-default-features --depth 1` shows only Jazz
- `cargo check -p jazz-testkit --no-default-features`
- `cargo clippy -p jazz-testkit --no-default-features -- -D warnings`
- `cargo check -p jazz-testkit` with defaults
- `cargo test -p jazz-testkit --test gset_merge --no-fail-fast` — 7 passed
- `cargo test -p jazz-testkit --test transactions --no-fail-fast` — 12 passed
- pre-commit clippy, sensitive-data, and oxfmt hooks
- `git diff --check`
