### PR TITLE
refactor: gate JWT verification behind server

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -22,6 +22,7 @@ client = ["native-websocket-transport"]
 server = [
   "native-websocket-transport",
   "dep:axum",
+  "dep:jsonwebtoken",
   "dep:tracing-subscriber",
   "dep:tower-http",
   "dep:async-stream",
@@ -92,7 +93,10 @@ tokio-tungstenite = { version = "0.29", default-features = false, features = [
 tungstenite = { version = "0.29", default-features = false, features = [
   "handshake",
 ], optional = true }
-jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
+jsonwebtoken = { version = "10.4", default-features = false, features = [
+  "rust_crypto",
+  "use_pem",
+], optional = true }
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/dev/COMPILE_BOUNDARY_PLAN.md
+++ b/dev/COMPILE_BOUNDARY_PLAN.md
@@ -69,6 +69,11 @@ access is valuable.
 - Move binaries, clap configuration, signals, allocator selection, and command
   presentation to `jazz-cli`.
 
+Progress: JWT verification is now selected by the server capability rather
+than compiled as an unconditional semantic-core dependency. Identity signing
+remains in core because it is part of client identity semantics, not the HTTP
+authentication adapter.
+
 ### Storage and compression
 
 - Make generic storage the only core contract.


### PR DESCRIPTION
🤖 ## Summary

- make `jsonwebtoken` an optional Jazz dependency selected by the existing `server` capability
- stop compiling JWT/JWK/PEM verification machinery in featureless semantic-core checks
- preserve server, embedded-server, test-utils, and test feature behavior through the existing feature graph
- document why Ed25519 identity signing remains in core while HTTP/JWT admission does not

## Boundary and examples

JWT verification is used only by the server admission surfaces: Axum authentication middleware, loopback WebSocket admission, and embedded test/dev servers. The featureless semantic runtime does not parse or verify bearer tokens.

Before:

```text
jazz --no-default-features
  └── jsonwebtoken + RSA/JWK/PEM verification dependencies
```

After:

```text
jazz --no-default-features
  └── no jsonwebtoken dependency

jazz --features server
  └── jsonwebtoken
```

For example, a featureless in-memory `Db` still signs and verifies Jazz's own Ed25519 identity material exactly as before. An Axum server accepting an external JWT still performs the same issuer, audience, expiry, JWK, and signature checks because `server` now explicitly selects `jsonwebtoken`.

`embedded-server`, `test-utils`, and the canonical `test` feature all transitively select `server`, so their existing JWT fixtures and APIs remain unchanged.

## Verification

- `cargo check -p jazz --no-default-features`
- normal featureless dependency graph contains no `jsonwebtoken`
- `cargo check -p jazz --no-default-features --features server`
- `cargo test -p jazz --lib --features test tools::middleware::auth::tests --no-fail-fast` — 23 passed
- pre-commit Jazz clippy with `-D warnings`, sensitive-data, and oxfmt hooks
- `pnpm format:check`
- `git diff --check`

The server-only check continues to report pre-existing dead-code warnings in the legacy admin catalogue row decoder; this PR neither suppresses nor expands them.
