### PR TITLE
refactor: remove stale Jazz shell dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,28 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,11 +1874,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "jazz"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "axum",
  "base64 0.22.1",
  "blake3",
- "bytes",
  "criterion",
  "ed25519-dalek",
  "futures",
@@ -1922,7 +1898,6 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest",
- "rusqlite",
  "rust-rocksdb",
  "serde",
  "serde_bytes",
@@ -1936,7 +1911,6 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "tungstenite",
  "uuid",
  "web-time",

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -11,7 +11,7 @@ autotests = true
 # storage, transport, compression, and server capabilities explicitly.
 default = []
 rocksdb = ["groove/rocksdb", "dep:rocksdb"]
-sqlite = ["dep:rusqlite"]
+sqlite = []
 native-websocket-transport = [
   "dep:reqwest",
   "dep:tokio",
@@ -19,14 +19,7 @@ native-websocket-transport = [
   "dep:tungstenite",
 ]
 client = ["native-websocket-transport"]
-server = [
-  "native-websocket-transport",
-  "dep:axum",
-  "dep:jsonwebtoken",
-  "dep:tracing-subscriber",
-  "dep:tower-http",
-  "dep:async-stream",
-]
+server = ["native-websocket-transport", "dep:axum", "dep:jsonwebtoken", "dep:tower-http"]
 sync-autopsy = []
 # Disabled-by-default counters for the cold-settle attribution bench. They do
 # not alter protocol behavior or production measurement paths.
@@ -67,7 +60,6 @@ rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = fal
   "lz4",
   "zstd",
 ], optional = true }
-rusqlite = { version = "0.34", features = ["bundled"], optional = true }
 axum = { version = "0.8.9", default-features = false, features = [
   "http1",
   "json",
@@ -78,13 +70,10 @@ axum = { version = "0.8.9", default-features = false, features = [
   "tracing",
   "ws",
 ], optional = true }
-bytes = { version = "1", optional = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 tower-http = { version = "0.6.8", default-features = false, features = [
   "cors",
   "trace",
 ], optional = true }
-async-stream = { version = "0.3", optional = true }
 tokio-tungstenite = { version = "0.29", default-features = false, features = [
   "connect",
   "rustls-tls-native-roots",
@@ -112,9 +101,7 @@ tempfile = "3.27.0"
 libc = "0.2"
 criterion = "0.5"
 insta = "1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-bytes = "1"
 jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
 futures = "0.3"
 tokio = { version = "1", features = [


### PR DESCRIPTION
🤖 Removes dependency declarations left behind by the recent server, telemetry, transport, and storage-boundary extractions.

Jazz no longer references `bytes`, `async-stream`, `tracing-subscriber`, or `rusqlite`, but they remained in its normal/dev dependency graph. This removes those declarations and the resulting lockfile-only packages.

The `sqlite` feature remains as a semantic/API configuration switch; it simply no longer pulls `rusqlite` into the Jazz crate. SQLite implementations belong in outward storage adapters rather than the common semantic library.

Examples:

- A featureless Jazz build no longer carries declarations for server streaming, telemetry subscriber setup, or SQLite's native library.
- A server build gets tracing subscriber setup from the extracted telemetry/server shell rather than Jazz core.
- Enabling `sqlite` still exposes the existing SQLite configuration surface, without pretending Jazz directly implements it through `rusqlite`.

Verified with featureless, `server`, and `embedded-server` Cargo checks; repository formatting; strict Jazz clippy; and the sensitive-data guard.
