### PR TITLE
(new core) Remove the legacy query propagation option

### DIFF
--- a/.changeset/query-propagation-option.md
+++ b/.changeset/query-propagation-option.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Remove the legacy `propagate` query option. Use `propagation: "local-only"` to prevent upstream forwarding.
+Breaking change: remove the legacy `propagate` query option. Use `propagation: "local-only"` to prevent upstream forwarding.

--- a/.changeset/query-propagation-option.md
+++ b/.changeset/query-propagation-option.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Remove the legacy `propagate` query option. Use `propagation: "local-only"` to prevent upstream forwarding.

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2353,9 +2353,6 @@ fn core_read_opts_from_json(value: Option<JsonValue>) -> napi::Result<CoreReadOp
             }
         };
     }
-    if optional_json_bool_prop(&value, "propagate")? == Some(false) {
-        opts.propagation = CorePropagation::LocalOnly;
-    }
     if let Some(propagation) = optional_json_string_prop(&value, "propagation")? {
         opts.propagation = match propagation.as_str() {
             "Full" | "full" => CorePropagation::Full,
@@ -3235,6 +3232,14 @@ mod tests {
             .expect("parse read opts");
 
         assert_eq!(opts.propagation, CorePropagation::LocalOnly);
+    }
+
+    #[test]
+    fn core_read_opts_ignore_removed_propagate_field() {
+        let opts =
+            core_read_opts_from_json(Some(json!({ "propagate": false }))).expect("parse read opts");
+
+        assert_eq!(opts.propagation, CorePropagation::Full);
     }
 
     #[test]

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -2609,9 +2609,6 @@ fn read_opts_from_js(value: JsValue) -> Result<ReadOpts, JsValue> {
             other => return Err(JsValue::from_str(&format!("unknown local_updates {other}"))),
         };
     }
-    if optional_bool_prop(&value, "propagate")? == Some(false) {
-        opts.propagation = Propagation::LocalOnly;
-    }
     if let Some(propagation) = optional_string_prop(&value, "propagation")? {
         opts.propagation = match propagation.as_str() {
             "Full" | "full" => Propagation::Full,
@@ -2923,6 +2920,18 @@ mod dynamic_schema_view_tests {
     use jazz::db::{DbConfig, DbIdentity, ExclusiveTxOps};
     use jazz::groove::schema::ColumnType;
     use jazz::schema::{ColumnSchema, Policy, TableSchema};
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn removed_propagate_option_does_not_select_local_only() {
+        let value = js_sys::Object::new();
+        js_sys::Reflect::set(&value, &JsValue::from_str("propagate"), &JsValue::FALSE)
+            .expect("set legacy option");
+
+        let opts = read_opts_from_js(value.into()).expect("parse read options");
+
+        assert_eq!(opts.propagation, Propagation::Full);
+    }
 
     #[test]
     fn javascript_numeric_claims_preserve_safe_integers_and_fail_closed_when_lossy() {

--- a/packages/jazz-tools/src/package-root-public-api.test.ts
+++ b/packages/jazz-tools/src/package-root-public-api.test.ts
@@ -5,6 +5,18 @@ import { fileURLToPath } from "node:url";
 
 import * as packageRoot from "./index.js";
 import * as runtime from "./runtime/index.js";
+import type { QueryExecutionOptions } from "./runtime/index.js";
+
+const canonicalQueryExecutionOptions: QueryExecutionOptions = {
+  propagation: "local-only",
+};
+const removedQueryExecutionOptions: QueryExecutionOptions = {
+  // @ts-expect-error propagate was removed; use propagation instead.
+  propagate: false,
+};
+
+void canonicalQueryExecutionOptions;
+void removedQueryExecutionOptions;
 
 // @ts-expect-error NativeRuntimeAdapter is intentionally not part of the public runtime surface.
 import type { NativeRuntimeAdapter as InternalNativeRuntimeAdapterExport } from "./runtime/index.js";

--- a/packages/jazz-tools/src/runtime/client-tests/for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client-tests/for-request.test.ts
@@ -227,23 +227,6 @@ describe("JazzClient runtime helpers", () => {
     expect(createSubscriptionCalls[0]![3]).toBe(JSON.stringify({ propagation: "local-only" }));
   });
 
-  it("maps propagate false to local-only runtime subscriptions", () => {
-    const { client, createSubscriptionCalls } = makeClient();
-    client.subscribe('{"table":"todos"}', () => {}, {
-      propagate: false,
-    });
-    expect(createSubscriptionCalls[0]![3]).toBe(JSON.stringify({ propagation: "local-only" }));
-  });
-
-  it("lets explicit propagation override propagate shorthand", () => {
-    const { client, createSubscriptionCalls } = makeClient();
-    client.subscribe('{"table":"todos"}', () => {}, {
-      propagate: false,
-      propagation: "full",
-    });
-    expect(createSubscriptionCalls[0]![3]).toBeUndefined();
-  });
-
   // =========================================================================
   // 2-phase subscribe lifecycle
   // =========================================================================

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -213,13 +213,6 @@ export type QueryVisibility = "public" | "hidden_from_live_query_list";
 export interface QueryExecutionOptions {
   tier?: DurabilityTier;
   localUpdates?: LocalUpdatesMode;
-  /**
-   * Whether this subscription should cause upstream forwarding.
-   *
-   * Defaults to true. Set to false for inspector/helper subscriptions that
-   * should observe local state without opening remote coverage.
-   */
-  propagate?: boolean;
   propagation?: QueryPropagation;
   visibility?: QueryVisibility;
 }
@@ -363,7 +356,7 @@ export function resolveEffectiveQueryExecutionOptions(
   return {
     tier: options?.tier ?? resolveDefaultDurabilityTier(context),
     localUpdates: options?.localUpdates ?? "immediate",
-    propagation: options?.propagation ?? (options?.propagate === false ? "local-only" : "full"),
+    propagation: options?.propagation ?? "full",
     visibility: options?.visibility ?? "public",
   };
 }

--- a/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
+++ b/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
@@ -97,7 +97,7 @@ describe("Db devMode active query tracing", () => {
     const db = await makeDb(true);
     const unsubscribe = db.subscribeAll(makeQuery(), () => undefined, {
       tier: "edge",
-      propagate: false,
+      propagation: "local-only",
     });
 
     expect(db.getActiveQuerySubscriptions()[0]?.tier).toBe("edge");

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2318,9 +2318,6 @@ function readOptions(
   const options = optionsJson == null ? ({} as Record<string, unknown>) : JSON.parse(optionsJson);
   const readOptions: Record<string, unknown> = { tier: tier ?? "local" };
   if (includeDeleted) readOptions.include_deleted = true;
-  if (options.propagate === false && options.propagation == null) {
-    readOptions.propagation = "local_only";
-  }
   if (options.propagation === "local-only") readOptions.propagation = "local_only";
   if (options.propagation === "full") readOptions.propagation = "full";
   return readOptions;
@@ -2329,9 +2326,8 @@ function readOptions(
 function readPropagationIsFull(optionsJson?: string | null): boolean {
   if (optionsJson == null) return true;
   try {
-    const options = JSON.parse(optionsJson) as { propagation?: unknown; propagate?: unknown };
-    if (options.propagation != null) return options.propagation === "full";
-    return options.propagate !== false;
+    const options = JSON.parse(optionsJson) as { propagation?: unknown };
+    return options.propagation == null || options.propagation === "full";
   } catch {
     return true;
   }
@@ -2389,10 +2385,6 @@ function readSupportedReadOptions(optionsJson: string): void {
     throw new Error(
       `Native runtime does not support read propagation '${String(propagation)}' yet`,
     );
-  }
-  const propagate = parsed.propagate;
-  if (propagate != null && typeof propagate !== "boolean") {
-    throw new Error(`Native runtime does not support read propagate '${String(propagate)}' yet`);
   }
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -2090,6 +2090,45 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(detached).toEqual([]);
   });
 
+  it("ignores the removed propagate read option", async () => {
+    const readOptions: unknown[] = [];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: (_query: unknown, opts: unknown) => {
+              readOptions.push(opts);
+              return new Uint8Array([0]);
+            },
+            attachQuery: () => ({}),
+            queryAttachmentIsCovered: () => true,
+            detachQuery: () => undefined,
+            prepareQuery: () => ({}),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    await expect(
+      runtime.query(
+        JSON.stringify({ table: "todos" }),
+        null,
+        "edge",
+        JSON.stringify({ propagate: false }),
+      ),
+    ).resolves.toEqual([]);
+
+    expect(readOptions).toEqual([{ tier: "edge" }]);
+  });
+
   it("keeps concurrent client coverage attachments on the raw client path", async () => {
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     const attachedSubjects: string[] = [];


### PR DESCRIPTION
## Summary

- Remove the legacy `propagate` query option and keep `propagation` as the single public API.
- Mark the removal as a breaking alpha change. Use `propagation: "local-only"` to prevent upstream forwarding.

## Testing

- `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json` — passed
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/client-tests/for-request.test.ts src/runtime/db.dev-mode.test.ts src/package-root-public-api.test.ts` — 28 tests passed
- `pnpm build:core` — passed

The repository-wide format check only reported the unrelated ignored `.tokensave/config.json`; every changed file passes formatting.
