### PR TITLE
(new core) Tighten insert and authentication config types

### DIFF
--- a/.changeset/tidy-api-config-types.md
+++ b/.changeset/tidy-api-config-types.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Rename `CreateOptions` to `InsertOptions` and reject conflicting `secret`, `jwtToken`, and `cookieSession` values in `DbConfig` at compile time. After local-first authentication is resolved, `Db.getConfig()` now returns the minted JWT without also exposing the original secret.

--- a/.changeset/tidy-api-config-types.md
+++ b/.changeset/tidy-api-config-types.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Rename `CreateOptions` to `InsertOptions` and reject conflicting `secret`, `jwtToken`, and `cookieSession` values in `DbConfig` at compile time. After local-first authentication is resolved, `Db.getConfig()` now returns the minted JWT without also exposing the original secret.
+Breaking change: rename `CreateOptions` to `InsertOptions` and reject conflicting `secret`, `jwtToken`, and `cookieSession` values in `DbConfig` at compile time. After local-first authentication is resolved, `Db.getConfig()` returns the minted JWT without also exposing the original secret.

--- a/packages/jazz-tools/src/react-native/runtime-source.ts
+++ b/packages/jazz-tools/src/react-native/runtime-source.ts
@@ -9,7 +9,7 @@ import {
   REACT_NATIVE_SQLITE_STORAGE_REJECTED_ERROR,
 } from "./storage.js";
 
-export interface ReactNativeDbConfig extends DbConfig {
+export type ReactNativeDbConfig = DbConfig & {
   /**
    * Proposal-only SQLite storage hook for a future native v2 runtime.
    *
@@ -21,7 +21,7 @@ export interface ReactNativeDbConfig extends DbConfig {
    * native ordered-KV runtime exists.
    */
   sqliteStorage?: ReactNativeSqliteStorageDriver;
-}
+};
 
 function shouldRequireSqliteDriver(config: ReactNativeDbConfig): boolean {
   return (config.driver?.type ?? "persistent") === "persistent";

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -289,7 +289,7 @@ export interface MutationErrorEvent {
   transaction: LocalTransactionRecord;
 }
 
-export interface CreateOptions extends TimestampOverrideOptions {
+export interface InsertOptions extends TimestampOverrideOptions {
   id?: string;
 }
 
@@ -794,7 +794,7 @@ export class JazzClient {
   insert(
     table: string,
     values: InsertValues,
-    options?: CreateOptions,
+    options?: InsertOptions,
     session?: Session,
     attribution?: string,
   ): WriteResult<Row> {
@@ -808,7 +808,7 @@ export class JazzClient {
   insertInternal(
     table: string,
     values: InsertValues,
-    options?: CreateOptions,
+    options?: InsertOptions,
     session?: Session,
     attribution?: string,
     openBatchId?: OpenBatchId,

--- a/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
+++ b/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
@@ -31,6 +31,17 @@ describe("DbConfig auth validation", () => {
     await expect(createDb(config)).rejects.toThrow("mutually exclusive");
   });
 
+  it("rejects setting both secret and cookieSession from untyped callers", async () => {
+    const { createDb } = await import("./db.js");
+    const config = {
+      appId: "test-app",
+      secret: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      cookieSession,
+    } as unknown as DbConfig;
+
+    await expect(createDb(config)).rejects.toThrow("mutually exclusive");
+  });
+
   it("accepts flat secret field", async () => {
     const { createDb } = await import("./db.js");
     const db = await createDb({

--- a/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
+++ b/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect } from "vitest";
 import type { DbConfig } from "./db.js";
+import type { Session } from "./context.js";
+
+const cookieSession: Session = {
+  user_id: "alice",
+  claims: { role: "reader" },
+  authMode: "external",
+};
 
 describe("DbConfig auth validation", () => {
   it("rejects setting both secret and jwtToken", async () => {
     const { createDb } = await import("./db.js");
+    // @ts-expect-error Exercise the runtime guard for untyped JavaScript callers.
     const config: DbConfig = {
       appId: "test-app",
       secret: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -14,14 +22,11 @@ describe("DbConfig auth validation", () => {
 
   it("rejects setting both jwtToken and cookieSession", async () => {
     const { createDb } = await import("./db.js");
+    // @ts-expect-error Exercise the runtime guard for untyped JavaScript callers.
     const config: DbConfig = {
       appId: "test-app",
       jwtToken: "some-jwt",
-      cookieSession: {
-        user_id: "alice",
-        claims: { role: "reader" },
-        authMode: "external",
-      },
+      cookieSession,
     };
     await expect(createDb(config)).rejects.toThrow("mutually exclusive");
   });
@@ -33,6 +38,8 @@ describe("DbConfig auth validation", () => {
       secret: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     });
     expect(db).toBeDefined();
+    expect(db.getConfig()).toMatchObject({ jwtToken: expect.any(String) });
+    expect(db.getConfig().secret).toBeUndefined();
     await db.shutdown();
   });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -26,7 +26,7 @@ import {
   type MutationErrorEvent,
   WriteHandle,
   type TransactionKind,
-  type CreateOptions,
+  type InsertOptions,
   type RestoreOptions,
   type UpdateOptions,
   type UpsertOptions,
@@ -72,7 +72,7 @@ type WriteOperationName = "Insert" | "Update" | "Upsert" | "Restore";
 /**
  * Configuration for creating a Db instance.
  */
-export interface DbConfig {
+export type DbConfig = {
   /** Application identifier (used for isolation) */
   appId: string;
   /** Storage driver mode (defaults to persistent). */
@@ -85,10 +85,6 @@ export interface DbConfig {
   env?: string;
   /** User branch name (default: "main") */
   userBranch?: string;
-  /** JWT token for server authentication */
-  jwtToken?: string;
-  /** Mirrored session for local permission evaluation when sync auth uses cookies. */
-  cookieSession?: Session;
   /** Admin secret for catalogue sync */
   adminSecret?: string;
   /** Backend secret for backend-scoped sync auth with cookieSession. */
@@ -107,9 +103,26 @@ export interface DbConfig {
   telemetryCollectorUrl?: string;
   /** Enable runtime tracing for DevTools-only diagnostics. */
   devMode?: boolean;
-  /** Local-first auth via a local seed. Mutually exclusive with jwtToken. */
-  secret?: string;
-}
+} & (
+  | {
+      /** Local-first auth via a local seed. */
+      secret?: string;
+      jwtToken?: never;
+      cookieSession?: never;
+    }
+  | {
+      secret?: never;
+      /** JWT token for server authentication. */
+      jwtToken?: string;
+      cookieSession?: never;
+    }
+  | {
+      secret?: never;
+      jwtToken?: never;
+      /** Mirrored session for local permission evaluation when sync auth uses cookies. */
+      cookieSession?: Session;
+    }
+);
 
 function resolveStorageDriver(driver?: StorageDriver): StorageDriver {
   return driver ?? { type: "persistent" };
@@ -697,7 +710,7 @@ export class Transaction<TKind extends TransactionKind = TransactionKind> {
    * The insert is scoped to this transaction, and will only be globally visible
    * once it's committed.
    */
-  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
+  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: InsertOptions): T {
     this.bindTable(table);
     const transformedData = transformInputColumns(table, data);
     const values = toWriteRecordForOperation(
@@ -1216,7 +1229,7 @@ export class Db {
    * @param data Init object with column values
    * @returns Write result containing the inserted row
    */
-  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): WriteResult<T> {
+  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: InsertOptions): WriteResult<T> {
     const client = this.getClient(table._schema);
     const transformedData = transformInputColumns(table, data);
     const values = toWriteRecordForOperation(
@@ -1832,8 +1845,14 @@ export async function createDbWithRuntimeSource<RuntimeConfig extends DbConfig>(
     throw new Error("DbConfig error: jwtToken and cookieSession are mutually exclusive");
   }
 
-  let resolvedConfig = { ...config };
+  let resolvedConfig: DbConfig = { ...config };
   await runtimeSource.load(config);
+  const {
+    secret: _secret,
+    jwtToken: _jwtToken,
+    cookieSession: _cookieSession,
+    ...configWithoutAuth
+  } = config;
 
   // Local-first auth: resolve seed and mint a JWT
   let localFirstSecret: string | null = null;
@@ -1845,7 +1864,7 @@ export async function createDbWithRuntimeSource<RuntimeConfig extends DbConfig>(
       const jwtToken = runtimeSource.mintLocalFirstToken(
         createRuntimeTokenOptions(secret, config.appId, 3600),
       );
-      resolvedConfig = { ...resolvedConfig, jwtToken };
+      resolvedConfig = { ...configWithoutAuth, jwtToken };
     }
   } else if (!config.jwtToken && !config.cookieSession && !config.adminSecret) {
     // Anonymous: mint an ephemeral keypair + anonymous JWT.
@@ -1855,7 +1874,7 @@ export async function createDbWithRuntimeSource<RuntimeConfig extends DbConfig>(
     const jwtToken = runtimeSource.mintAnonymousToken(
       createRuntimeTokenOptions(ephemeralSeed, config.appId, 3600),
     );
-    resolvedConfig = { ...resolvedConfig, jwtToken };
+    resolvedConfig = { ...configWithoutAuth, jwtToken };
   }
 
   const driver = resolveStorageDriver(resolvedConfig.driver);

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -1,5 +1,5 @@
 export {
-  type CreateOptions,
+  type InsertOptions,
   type AuthConfig,
   type LocalTransactionRecord,
   type MutationErrorEvent,

--- a/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
+++ b/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
@@ -1,0 +1,64 @@
+import type {
+  DbConfig as PackageDbConfig,
+  InsertOptions as PackageInsertOptions,
+} from "../index.js";
+import type {
+  DbConfig as RuntimeDbConfig,
+  InsertOptions as RuntimeInsertOptions,
+} from "./index.js";
+
+// @ts-expect-error CreateOptions was renamed to InsertOptions.
+import type { CreateOptions as PackageCreateOptions } from "../index.js";
+// @ts-expect-error CreateOptions was renamed to InsertOptions.
+import type { CreateOptions as RuntimeCreateOptions } from "./index.js";
+
+const packageInsertOptions: PackageInsertOptions = { id: "row-1", updatedAt: 1 };
+const runtimeInsertOptions: RuntimeInsertOptions = { id: "row-1", updatedAt: 1 };
+
+const unauthenticated: PackageDbConfig = { appId: "app" };
+const localFirst: PackageDbConfig = { appId: "app", secret: "secret" };
+const jwt: RuntimeDbConfig = { appId: "app", jwtToken: "jwt" };
+const cookie: RuntimeDbConfig = {
+  appId: "app",
+  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+};
+const admin: PackageDbConfig = { appId: "app", adminSecret: "admin" };
+const backend: PackageDbConfig = {
+  appId: "app",
+  backendSecret: "backend",
+  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+};
+const optionalJwt: PackageDbConfig = {
+  appId: "app",
+  jwtToken: undefined as string | undefined,
+};
+
+// @ts-expect-error Local-first and JWT authentication are mutually exclusive.
+const localFirstWithJwt: PackageDbConfig = { appId: "app", secret: "secret", jwtToken: "jwt" };
+// @ts-expect-error Local-first and cookie authentication are mutually exclusive.
+const localFirstWithCookie: PackageDbConfig = {
+  appId: "app",
+  secret: "secret",
+  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+};
+// @ts-expect-error JWT and cookie authentication are mutually exclusive.
+const jwtWithCookie: RuntimeDbConfig = {
+  appId: "app",
+  jwtToken: "jwt",
+  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+};
+
+void packageInsertOptions;
+void runtimeInsertOptions;
+void unauthenticated;
+void localFirst;
+void jwt;
+void cookie;
+void admin;
+void backend;
+void optionalJwt;
+void localFirstWithJwt;
+void localFirstWithCookie;
+void jwtWithCookie;
+void (null as unknown as PackageCreateOptions);
+void (null as unknown as RuntimeCreateOptions);

--- a/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
+++ b/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
@@ -1,6 +1,7 @@
 import type {
   DbConfig as PackageDbConfig,
   InsertOptions as PackageInsertOptions,
+  Session,
 } from "../index.js";
 import type {
   DbConfig as RuntimeDbConfig,
@@ -14,19 +15,20 @@ import type { CreateOptions as RuntimeCreateOptions } from "./index.js";
 
 const packageInsertOptions: PackageInsertOptions = { id: "row-1", updatedAt: 1 };
 const runtimeInsertOptions: RuntimeInsertOptions = { id: "row-1", updatedAt: 1 };
+const session: Session = { user_id: "user", claims: {}, authMode: "external" };
 
 const unauthenticated: PackageDbConfig = { appId: "app" };
 const localFirst: PackageDbConfig = { appId: "app", secret: "secret" };
 const jwt: RuntimeDbConfig = { appId: "app", jwtToken: "jwt" };
 const cookie: RuntimeDbConfig = {
   appId: "app",
-  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+  cookieSession: session,
 };
 const admin: PackageDbConfig = { appId: "app", adminSecret: "admin" };
 const backend: PackageDbConfig = {
   appId: "app",
   backendSecret: "backend",
-  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+  cookieSession: session,
 };
 const optionalJwt: PackageDbConfig = {
   appId: "app",
@@ -39,13 +41,13 @@ const localFirstWithJwt: PackageDbConfig = { appId: "app", secret: "secret", jwt
 const localFirstWithCookie: PackageDbConfig = {
   appId: "app",
   secret: "secret",
-  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+  cookieSession: session,
 };
 // @ts-expect-error JWT and cookie authentication are mutually exclusive.
 const jwtWithCookie: RuntimeDbConfig = {
   appId: "app",
   jwtToken: "jwt",
-  cookieSession: { user_id: "user", claims: {}, authMode: "external" },
+  cookieSession: session,
 };
 
 void packageInsertOptions;

--- a/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
+++ b/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
@@ -8,11 +8,6 @@ import type {
   InsertOptions as RuntimeInsertOptions,
 } from "./index.js";
 
-// @ts-expect-error CreateOptions was renamed to InsertOptions.
-import type { CreateOptions as PackageCreateOptions } from "../index.js";
-// @ts-expect-error CreateOptions was renamed to InsertOptions.
-import type { CreateOptions as RuntimeCreateOptions } from "./index.js";
-
 const packageInsertOptions: PackageInsertOptions = { id: "row-1", updatedAt: 1 };
 const runtimeInsertOptions: RuntimeInsertOptions = { id: "row-1", updatedAt: 1 };
 const session: Session = { user_id: "user", claims: {}, authMode: "external" };
@@ -62,5 +57,3 @@ void optionalJwt;
 void localFirstWithJwt;
 void localFirstWithCookie;
 void jwtWithCookie;
-void (null as unknown as PackageCreateOptions);
-void (null as unknown as RuntimeCreateOptions);

--- a/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
+++ b/packages/jazz-tools/src/runtime/public-api-types.typecheck.ts
@@ -8,6 +8,11 @@ import type {
   InsertOptions as RuntimeInsertOptions,
 } from "./index.js";
 
+// @ts-expect-error CreateOptions was renamed to InsertOptions.
+import type { CreateOptions as PackageCreateOptions } from "../index.js";
+// @ts-expect-error CreateOptions was renamed to InsertOptions.
+import type { CreateOptions as RuntimeCreateOptions } from "./index.js";
+
 const packageInsertOptions: PackageInsertOptions = { id: "row-1", updatedAt: 1 };
 const runtimeInsertOptions: RuntimeInsertOptions = { id: "row-1", updatedAt: 1 };
 const session: Session = { user_id: "user", claims: {}, authMode: "external" };
@@ -57,3 +62,5 @@ void optionalJwt;
 void localFirstWithJwt;
 void localFirstWithCookie;
 void jwtWithCookie;
+void (null as unknown as PackageCreateOptions);
+void (null as unknown as RuntimeCreateOptions);


### PR DESCRIPTION
## Summary

- Rename `CreateOptions` to `InsertOptions` so the public type matches `db.insert`.
- Make `secret`, `jwtToken` and `cookieSession` mutually exclusive in `DbConfig`.
- After local-first authentication resolves, return the minted JWT from `db.getConfig()` without exposing the original secret.

## Testing

- `pnpm --filter jazz-tools build` — passed
- `pnpm --filter jazz-wasm build:fast` — passed
