### PR TITLE
fix: failing chat-react tests

### DIFF
--- a/examples/chat-react/src/components/chat-view/ChatView.tsx
+++ b/examples/chat-react/src/components/chat-view/ChatView.tsx
@@ -29,7 +29,10 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
 
   const [showNLastMessages, setShowNLastMessages] = useState(INITIAL_MESSAGES_TO_SHOW);
 
-  const chatRowsResult = useAll(app.chats.where({ id: chatId }));
+  // Wait for the authority-tier snapshot before treating an empty result as an
+  // access denial. A local empty snapshot can merely mean the chat has not
+  // synced to this client yet.
+  const chatRowsResult = useAll(app.chats.where({ id: chatId }), sharedWriteOptions);
   const chatRows = chatRowsResult.data ?? [];
   const chat = chatRows[0];
   const chatKnown = chatRows.length > 0;
@@ -55,13 +58,11 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
   // joined in a previous session); otherwise becomes true only after the
   // auto-join insert is durably persisted at edge tier.
   const [membershipReady, setMembershipReady] = useState(false);
-  const [autoJoinFailed, setAutoJoinFailed] = useState(false);
 
   useEffect(() => {
     autoJoined.current = false;
     autoJoinPending.current = false;
     setMembershipReady(false);
-    setAutoJoinFailed(false);
   }, [chatId]);
 
   useEffect(() => {
@@ -79,7 +80,6 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
       return;
     autoJoined.current = true;
     autoJoinPending.current = true;
-    setAutoJoinFailed(false);
 
     waitForWrite(db.insert(app.chatMembers, { chatId, userId }), sharedWriteOptions)
       .then(() => {
@@ -90,7 +90,6 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
         console.error("auto-join failed", error);
         autoJoined.current = false;
         autoJoinPending.current = false;
-        setAutoJoinFailed(true);
       });
   }, [
     userId,
@@ -137,7 +136,7 @@ export const ChatView = ({ chatId }: ChatViewProps) => {
     fireAndReport(db.delete(app.messages, messageId), "failed to delete message");
   };
 
-  if (chatRowsResult !== undefined && !chatKnown && userId && autoJoinFailed) {
+  if (!chatRowsResult.isLoading && !chatKnown && userId) {
     return (
       <div className="flex-1 flex items-center justify-center p-8 text-center text-muted-foreground">
         <p>You don't have permission to access this chat.</p>

--- a/examples/chat-react/src/components/composer/MessageComposer.tsx
+++ b/examples/chat-react/src/components/composer/MessageComposer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { SendIcon } from "lucide-react";
 import { useDb, useSession } from "jazz-tools/react";
+import { ActionMenu } from "@/components/composer/ActionMenu";
 import { Editor, type EditorHandle } from "@/components/editor/Editor";
 import { Button } from "@/components/ui/button";
 import { useMyProfile } from "@/hooks/useMyProfile";
@@ -61,6 +62,8 @@ export function MessageComposer({ chatId, disabled = false }: MessageComposerPro
       data-testid="message-composer"
       data-pending-sends={pendingSends}
     >
+      <ActionMenu chatId={chatId} disabled={!composerReady} />
+
       <Editor ref={editorRef} onSend={handleSend} disabled={!composerReady} />
 
       <Button

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -303,7 +303,7 @@ describe("Chat App E2E", () => {
   // 4. Delete a message
   // -------------------------------------------------------------------------
 
-  it.fails("deletes a message via the dropdown menu", async () => {
+  it("deletes a message via the dropdown menu", async () => {
     const el = await mountApp();
 
     await waitFor(

--- a/examples/chat-react/tests/browser/chat-app.test.tsx
+++ b/examples/chat-react/tests/browser/chat-app.test.tsx
@@ -649,7 +649,7 @@ describe("Chat App E2E", () => {
     // and would look like "019c…" or "false" — the above assertion covers both.
   });
 
-  it.fails("denies access and hides messages for non-members of a private chat", async () => {
+  it("denies access and hides messages for non-members of a private chat", async () => {
     const { bobContainer } = await setupPrivateChatAccess();
 
     // The secret message should NOT be visible to a non-member

--- a/packages/jazz-tools/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.test.ts
@@ -191,6 +191,12 @@ function nativeAddedRawRecord(id: string, index: number, data: Uint8Array): Uint
   return Uint8Array.from(bytes);
 }
 
+function nativeRemovedRecord(id: string, index: number): Uint8Array {
+  const bytes: number[] = [...uuidBytes(id)];
+  pushU32(bytes, index);
+  return Uint8Array.from(bytes);
+}
+
 describe("SubscriptionManager", () => {
   it("transforms wire deltas into typed deltas", () => {
     const manager = new SubscriptionManager<TestItem>();
@@ -396,6 +402,54 @@ describe("SubscriptionManager", () => {
     expect(result.delta[0]?.id).toBe(
       `result:01${Array.from(uuidBytes(id), (byte) => byte.toString(16).padStart(2, "0")).join("")}${Array.from(uuidBytes(joinedId), (byte) => byte.toString(16).padStart(2, "0")).join("")}`,
     );
+  });
+
+  it("removes a legacy physical root before a packed composite terminal update", () => {
+    const manager = new SubscriptionManager<TestItem>();
+    const id = "00000000-0000-4000-8000-000000000001";
+    const joinedId = "00000000-0000-4000-8000-000000000002";
+    const key = [10, ...uuidBytes(id), 10, ...uuidBytes(joinedId)];
+    const occurrence = Uint8Array.from([1, ...uuidBytes(id), ...uuidBytes(joinedId)]);
+
+    manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: nativeAddedRecord(id, 0, "before", 6),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 1,
+        removedCount: 0,
+        updatedCount: 0,
+      },
+      transform,
+      nativeColumns,
+    );
+
+    const result = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: nativeRemovedRecord(id, 0),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 1,
+        updatedCount: 0,
+        removedOccurrenceKeys: [occurrence],
+        terminalOperations: [
+          {
+            root_key: key,
+            rootDescriptor: currentRowTerminalDescriptor(nativeColumns),
+            path: [],
+            edit: { Update: { key, value: [...terminalRowData(id, "after", 7)] } },
+          },
+        ],
+      },
+      transform,
+      nativeColumns,
+    );
+
+    expect(result.all).toEqual([]);
+    expect(manager.all()).toEqual([]);
   });
 
   it("does not collapse malformed or typed terminal root keys to their leading UUID", () => {
@@ -1636,6 +1690,213 @@ describe("SubscriptionManager", () => {
     expect(result.all).toEqual([
       { id: rootId, title: "root", children: [{ id: childId, name: "child" }] },
     ]);
+  });
+
+  it("discards descendant teardown after a packed removal of its exact root occurrence", () => {
+    type IncludedRoot = {
+      id: string;
+      title: string;
+      children: Array<{ id: string; name: string }>;
+    };
+    const manager = new SubscriptionManager<IncludedRoot>();
+    const rootId = "00000000-0000-4000-8000-000000000001";
+    const childId = "00000000-0000-4000-8000-000000000002";
+    const rootKey = [10, ...uuidBytes(rootId)];
+    const childKey = [10, ...uuidBytes(childId)];
+    const childColumns: ColumnDescriptor[] = [
+      { name: "name", column_type: { type: "Text" }, nullable: false },
+    ];
+    const rootColumns: ColumnDescriptor[] = [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      {
+        name: "children",
+        column_type: { type: "Array", element: { type: "Row", columns: childColumns } },
+        nullable: false,
+      },
+    ];
+    const transformIncluded = (row: WasmRow): IncludedRoot => {
+      const byName = (row as WasmRow & { valuesByColumn: Map<string, Value> }).valuesByColumn;
+      const children = byName.get("children");
+      return {
+        id: row.id,
+        title: (byName.get("title") as { type: "Text"; value: string }).value,
+        children:
+          children?.type === "Array"
+            ? children.value.map((value) => {
+                if (value.type !== "Row") throw new Error("expected child row");
+                return {
+                  id: value.value.id!,
+                  name: (value.value.values[0] as { type: "Text"; value: string }).value,
+                };
+              })
+            : [],
+      };
+    };
+
+    manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: nativeAddedRawRecord(rootId, 0, nativeRootWithEmptyChildren("original")),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 1,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: rootKey,
+            path: [{ Collection: "children" }],
+            edit: {
+              Insert: { index: 0, key: childKey, value: [...terminalTextChild(childId, "child")] },
+            },
+          },
+        ],
+      },
+      transformIncluded,
+      rootColumns,
+    );
+
+    const removed = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: nativeRemovedRecord(rootId, 0),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 1,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: rootKey,
+            path: [{ Collection: "children" }],
+            edit: { Remove: { key: childKey } },
+          },
+        ],
+      },
+      transformIncluded,
+      rootColumns,
+    );
+    expect(removed.all).toEqual([]);
+
+    // A later root insertion must not replay the prior frame's teardown.
+    const reopened = manager.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: new Uint8Array(),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 0,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: rootKey,
+            rootDescriptor: currentRowTerminalDescriptor(rootColumns),
+            path: [],
+            edit: {
+              Insert: {
+                index: 0,
+                key: rootKey,
+                value: [...terminalRootWithEmptyChildren(rootId, "reopened")],
+              },
+            },
+          },
+        ],
+      },
+      transformIncluded,
+      rootColumns,
+    );
+    expect(reopened.all).toEqual([{ id: rootId, title: "reopened", children: [] }]);
+
+    // Only teardown removals are subsumed. A child insert after the packed root
+    // removal is invalid and rolls the whole frame back.
+    expect(() =>
+      manager.handleDelta(
+        {
+          __jazzNativeRowDelta: true,
+          added: new Uint8Array(),
+          removed: nativeRemovedRecord(rootId, 0),
+          updated: new Uint8Array(),
+          addedCount: 0,
+          removedCount: 1,
+          updatedCount: 0,
+          terminalOperations: [
+            {
+              root_key: rootKey,
+              path: [{ Collection: "children" }],
+              edit: {
+                Insert: {
+                  index: 0,
+                  key: childKey,
+                  value: [...terminalTextChild(childId, "rejected")],
+                },
+              },
+            },
+          ],
+        },
+        transformIncluded,
+        rootColumns,
+      ),
+    ).toThrow(/terminal child edit addressed a root removed in the same packed frame/);
+    expect(manager.all()).toEqual([{ id: rootId, title: "reopened", children: [] }]);
+
+    // The packed removal must not broadly suppress a teardown for another
+    // occurrence: it remains pending and fails once that unrelated root arrives
+    // without the addressed child.
+    const unrelated = new SubscriptionManager<IncludedRoot>();
+    const otherRootId = "00000000-0000-4000-8000-000000000003";
+    const otherChildId = "00000000-0000-4000-8000-000000000004";
+    const otherRootKey = [10, ...uuidBytes(otherRootId)];
+    const otherChildKey = [10, ...uuidBytes(otherChildId)];
+    unrelated.handleDelta(
+      {
+        __jazzNativeRowDelta: true,
+        added: new Uint8Array(),
+        removed: nativeRemovedRecord(rootId, 0),
+        updated: new Uint8Array(),
+        addedCount: 0,
+        removedCount: 1,
+        updatedCount: 0,
+        terminalOperations: [
+          {
+            root_key: otherRootKey,
+            path: [{ Collection: "children" }],
+            edit: { Remove: { key: otherChildKey } },
+          },
+        ],
+      },
+      transformIncluded,
+      rootColumns,
+    );
+    expect(() =>
+      unrelated.handleDelta(
+        {
+          __jazzNativeRowDelta: true,
+          added: new Uint8Array(),
+          removed: new Uint8Array(),
+          updated: new Uint8Array(),
+          addedCount: 0,
+          removedCount: 0,
+          updatedCount: 0,
+          terminalOperations: [
+            {
+              root_key: otherRootKey,
+              rootDescriptor: currentRowTerminalDescriptor(rootColumns),
+              path: [],
+              edit: {
+                Insert: {
+                  index: 0,
+                  key: otherRootKey,
+                  value: [...terminalRootWithEmptyChildren(otherRootId, "other")],
+                },
+              },
+            },
+          ],
+        },
+        transformIncluded,
+        rootColumns,
+      ),
+    ).toThrow(/terminal child removal addressed missing key/);
   });
 
   it("clears tracked state before applying native reset frames", () => {

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -458,6 +458,7 @@ export class SubscriptionManager<T extends { id: string }> {
   ): SubscriptionDelta<T> {
     const beforeIndices = new Map(this.orderedIdIndex);
     const affectedRoots = new Set<string>();
+    const removedRoots = new Set<string>();
     // Pre-establish only newly inserted root payloads so child-before-root
     // batches are addressable. Positional insertion remains in producer order:
     // applying its index before an earlier root Remove makes the outcome depend
@@ -510,6 +511,7 @@ export class SubscriptionManager<T extends { id: string }> {
             if (isUuidOnlyTerminalKey(operation.root_key)) continue;
             throw new Error(`terminal root removal addressed missing root ${rootId}`);
           }
+          removedRoots.add(rootId);
           this.currentResults.delete(rootId);
           this.removeId(rootId);
         } else if ("Move" in edit) {
@@ -524,6 +526,10 @@ export class SubscriptionManager<T extends { id: string }> {
       }
 
       const root = this.terminalRows.get(rootId);
+      // A root removal subsumes any descendant removals emitted later in the
+      // same producer frame. Missing roots without that explicit removal still
+      // fail closed below.
+      if (!root && removedRoots.has(rootId)) continue;
       if (!root) throw new Error(`terminal child edit addressed missing root ${rootId}`);
       assertTerminalPathEditKey(operation.path, edit);
       const target = terminalCollection(root, rootColumns, operation.path);

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -314,9 +314,27 @@ export class SubscriptionManager<T extends { id: string }> {
         // record layout. Only Groove terminal edit payloads retain the outer
         // sparse current-row carrier described by `sparse`.
         const decoded = decodeNativeDelta(delta, logicalStorageColumns(nativeColumns));
+        // Packed row removals are applied before terminal operations. Keep their
+        // full public occurrence identities so a later descendant teardown in
+        // this frame can be recognized as subsumed by its root removal.
+        const packedRemovedRoots = new Set<string>();
+        for (const [index, change] of decoded
+          .filter((change) => change.kind === RowChangeKind.Removed)
+          .entries()) {
+          packedRemovedRoots.add(change.id);
+          const terminalKey = terminalKeyForPackedOccurrence(delta.removedOccurrenceKeys?.[index]);
+          if (!terminalKey) continue;
+          const bridgedRootId = this.terminalRootId(Array.from(terminalKey));
+          packedRemovedRoots.add(bridgedRootId);
+          // Legacy snapshots key their visible and terminal root state by the
+          // physical UUID. Retarget this packed removal before ordinary row
+          // reduction so it removes that legacy state as well as the sidecar
+          // occurrence address used by current snapshots.
+          change.id = bridgedRootId;
+        }
         for (const change of decoded) {
           if (change.kind === RowChangeKind.Removed) {
-            this.terminalRows.delete(change.id);
+            for (const rootId of packedRemovedRoots) this.terminalRows.delete(rootId);
           } else if (change.row) {
             // The plain native decoder exposes both positional values and a
             // name map, but decodes them independently. Terminal edits mutate
@@ -326,12 +344,16 @@ export class SubscriptionManager<T extends { id: string }> {
           }
         }
         const wireResult = this.handleWireDelta(decoded, transform, reset);
-        const terminalOperations = this.readyTerminalOperations(delta.terminalOperations ?? []);
+        const terminalOperations = this.readyTerminalOperations(
+          delta.terminalOperations ?? [],
+          packedRemovedRoots,
+        );
         if (terminalOperations.length > 0) {
           const terminalResult = this.handleTerminalOperations(
             terminalOperations,
             transform,
             nativeColumns,
+            packedRemovedRoots,
           );
           return reset
             ? { delta: terminalResult.delta, all: terminalResult.all ?? this.all(), reset: true }
@@ -425,7 +447,10 @@ export class SubscriptionManager<T extends { id: string }> {
    * A root insert in this same frame satisfies the dependency because the
    * terminal reducer pre-establishes such roots before applying children.
    */
-  private readyTerminalOperations(incoming: NativeTerminalOperation[]): NativeTerminalOperation[] {
+  private readyTerminalOperations(
+    incoming: NativeTerminalOperation[],
+    packedRemovedRoots: ReadonlySet<string>,
+  ): NativeTerminalOperation[] {
     const operations = [...this.deferredTerminalOperations, ...incoming];
     this.deferredTerminalOperations = [];
     const insertedRoots = new Set(
@@ -435,9 +460,18 @@ export class SubscriptionManager<T extends { id: string }> {
     );
     const ready: NativeTerminalOperation[] = [];
     for (const operation of operations) {
+      const rootAddress = this.terminalAddress(operation.root_key);
       if (
         operation.path.length > 0 &&
-        !insertedRoots.has(this.terminalAddress(operation.root_key)) &&
+        packedRemovedRoots.has(rootAddress) &&
+        !("Remove" in operation.edit)
+      ) {
+        throw new Error("terminal child edit addressed a root removed in the same packed frame");
+      }
+      if (
+        operation.path.length > 0 &&
+        !insertedRoots.has(rootAddress) &&
+        !packedRemovedRoots.has(rootAddress) &&
         !this.terminalRows.has(this.terminalRootId(operation.root_key))
       ) {
         this.deferredTerminalOperations.push(operation);
@@ -455,10 +489,11 @@ export class SubscriptionManager<T extends { id: string }> {
     operations: NativeTerminalOperation[],
     transform: (row: WasmRow) => T,
     rootColumns: readonly ColumnDescriptor[],
+    packedRemovedRoots: ReadonlySet<string>,
   ): SubscriptionDelta<T> {
     const beforeIndices = new Map(this.orderedIdIndex);
     const affectedRoots = new Set<string>();
-    const removedRoots = new Set<string>();
+    const removedRoots = new Set(packedRemovedRoots);
     // Pre-establish only newly inserted root payloads so child-before-root
     // batches are addressable. Positional insertion remains in producer order:
     // applying its index before an earlier root Remove makes the outcome depend
@@ -526,10 +561,10 @@ export class SubscriptionManager<T extends { id: string }> {
       }
 
       const root = this.terminalRows.get(rootId);
-      // A root removal subsumes any descendant removals emitted later in the
-      // same producer frame. Missing roots without that explicit removal still
-      // fail closed below.
-      if (!root && removedRoots.has(rootId)) continue;
+      // A root removal subsumes only descendant removals emitted later in the
+      // same producer frame. Other child edits against that absent root fail
+      // closed below.
+      if (!root && removedRoots.has(rootId) && "Remove" in edit) continue;
       if (!root) throw new Error(`terminal child edit addressed missing root ${rootId}`);
       assertTerminalPathEditKey(operation.path, edit);
       const target = terminalCollection(root, rootColumns, operation.path);
@@ -908,6 +943,21 @@ function orderedTerminalKeyForTypedOccurrence(sidecar: Uint8Array): Uint8Array |
     ordered.push(10, ...uuid);
   }
   return Uint8Array.from(ordered);
+}
+
+/** Reconstruct a terminal key for either supported packed occurrence carrier. */
+function terminalKeyForPackedOccurrence(sidecar: Uint8Array | undefined): Uint8Array | undefined {
+  if (!sidecar) return undefined;
+  const typed = orderedTerminalKeyForTypedOccurrence(sidecar);
+  if (typed) return typed;
+  if (sidecar[0] !== 1 || sidecar.byteLength < 17 || (sidecar.byteLength - 1) % 16 !== 0) {
+    return undefined;
+  }
+  const key: number[] = [];
+  for (let offset = 1; offset < sidecar.byteLength; offset += 16) {
+    key.push(10, ...sidecar.subarray(offset, offset + 16));
+  }
+  return Uint8Array.from(key);
 }
 
 function readU32Be(bytes: Uint8Array, offset: number): number {


### PR DESCRIPTION
## Description

Fixes failing tests in the chat-react example.

All three failures were straightforward:
- Deletion: the subscription reducer processed `Remove(root)` then errored on the redundant child removal. It now ignores descendant edits after an explicit same-frame root removal.
- Canvas: the canvas-only `ActionMenu` was accidentally disconnected during large-value cleanup. It is restored now.
- Private access: the UI interpreted an empty local snapshot as settled without displaying denial. It now waits for the authority-tier result before deciding access is denied.