### PR TITLE
Define the server runtime facade

### DIFF
--- a/crates/jazz-server/src/lib.rs
+++ b/crates/jazz-server/src/lib.rs
@@ -279,4 +279,12 @@ mod tests {
             "admin secret must not appear in logged link"
         );
     }
+
+    #[test]
+    fn semantic_runtime_facade_is_consumable_without_core_state_access() {
+        let _boundary = |runtime: &jazz::tools::server::ServerRuntimeHandle| {
+            let _activity = runtime.subscribe_activity();
+            runtime.notify_activity();
+        };
+    }
 }

--- a/crates/jazz/src/tools/server/builder.rs
+++ b/crates/jazz/src/tools/server/builder.rs
@@ -293,7 +293,7 @@ impl ServerBuilder {
         latest_catalogue_schema: Option<Schema>,
         storage_config: Result<StorageConfig, String>,
         topology: ServerTopology,
-    ) -> Result<Option<crate::tools::server::core_server_shell::ServerShellHandle>, String> {
+    ) -> Result<Option<crate::tools::server::core_server_shell::ServerRuntimeHandle>, String> {
         let role = match topology {
             ServerTopology::Core => NodeRole::Core,
             ServerTopology::Edge => NodeRole::Edge,
@@ -301,7 +301,7 @@ impl ServerBuilder {
         if let Some(schema) = &self.core_server_shell_schema {
             let storage_config = storage_config?;
             return Ok(Some(
-                crate::tools::server::core_server_shell::ServerShellHandle::start_with_storage_config(
+                crate::tools::server::core_server_shell::ServerRuntimeHandle::start_with_storage_config(
                     schema.clone(),
                     storage_config,
                     self.storage_factory.clone(),
@@ -317,7 +317,7 @@ impl ServerBuilder {
         };
         let Some(schema) = schema else {
             if topology == ServerTopology::Edge {
-                return crate::tools::server::core_server_shell::ServerShellHandle::try_start_dynamic_edge_from_storage(
+                return crate::tools::server::core_server_shell::ServerRuntimeHandle::try_start_dynamic_edge_from_storage(
                     storage_config?,
                     self.storage_factory.clone(),
                     self.edge_cache_budget,
@@ -329,7 +329,7 @@ impl ServerBuilder {
         let schema = crate::tools::public_schema_convert::convert_public_schema(&schema)
             .map_err(|error| format!("failed to build server shell schema: {error}"))?;
         Ok(Some(
-            crate::tools::server::core_server_shell::ServerShellHandle::start_with_storage_config(
+            crate::tools::server::core_server_shell::ServerRuntimeHandle::start_with_storage_config(
                 schema,
                 storage_config,
                 self.storage_factory.clone(),
@@ -440,7 +440,7 @@ fn spawn_edge_upstream_connector(
                     continue;
                 }
             };
-            let shell = match state.core_server_shell() {
+            let shell = match state.runtime() {
                 Some(shell) => match state.refresh_dynamic_edge_catalogue(&shell, snapshot).await {
                     Ok(()) => shell,
                     Err(error) => {
@@ -653,7 +653,7 @@ mod tests {
             .expect("build authority core");
         let snapshot = core
             .state
-            .core_server_shell()
+            .runtime()
             .expect("core has shell")
             .trusted_catalogue_snapshot_for_test()
             .await
@@ -679,7 +679,7 @@ mod tests {
                 .is_err()
         );
         assert!(
-            edge.state.core_server_shell().is_none(),
+            edge.state.runtime().is_none(),
             "failed adoption must not publish a shell to downstream clients"
         );
         assert!(
@@ -687,10 +687,7 @@ mod tests {
                 .start_dynamic_edge_shell(snapshot.clone(), None)
                 .is_ok()
         );
-        let first_shell = edge
-            .state
-            .core_server_shell()
-            .expect("retry publishes ready shell");
+        let first_shell = edge.state.runtime().expect("retry publishes ready shell");
         let second_shell = edge
             .state
             .start_dynamic_edge_shell(snapshot, None)
@@ -725,7 +722,7 @@ mod tests {
             .expect("build authority core");
         let snapshot = core
             .state
-            .core_server_shell()
+            .runtime()
             .expect("core has shell")
             .trusted_catalogue_snapshot_for_test()
             .await
@@ -738,12 +735,9 @@ mod tests {
             .build()
             .await
             .expect("build edge with a validated durable generation");
-        let shell = edge
-            .state
-            .core_server_shell()
-            .expect("edge has ready shell");
+        let shell = edge.state.runtime().expect("edge has ready shell");
         assert!(
-            edge.state.core_server_shell_for_client().is_some(),
+            edge.state.runtime_for_client().is_some(),
             "validated catalogue is usable while the upstream is offline"
         );
 
@@ -762,7 +756,7 @@ mod tests {
                 .is_err()
         );
         assert!(
-            edge.state.core_server_shell_for_client().is_none(),
+            edge.state.runtime_for_client().is_none(),
             "failed validation/install must not advance the ready generation"
         );
 
@@ -771,7 +765,7 @@ mod tests {
             .await
             .expect("later complete refresh installs successfully");
         assert!(
-            edge.state.core_server_shell_for_client().is_some(),
+            edge.state.runtime_for_client().is_some(),
             "readiness advances only after the complete install returns"
         );
 
@@ -830,7 +824,7 @@ mod tests {
             "v1-to-v2 activation fails after registry reconstruction at the planted boundary"
         );
         assert!(
-            edge.state.core_server_shell_for_client().is_none(),
+            edge.state.runtime_for_client().is_none(),
             "a post-registry activation failure must not publish the new ready generation"
         );
     }
@@ -978,7 +972,7 @@ mod tests {
                 .build()
                 .await
                 .expect("build fixed schema server");
-            assert!(built.state.core_server_shell().is_some());
+            assert!(built.state.runtime().is_some());
             built
                 .state
                 .catalogue_store
@@ -1000,7 +994,7 @@ mod tests {
             .await
             .expect("build dynamic server from rehydrated catalogue");
 
-        assert!(rebuilt.state.core_server_shell().is_some());
+        assert!(rebuilt.state.runtime().is_some());
     }
 
     #[tokio::test]
@@ -1026,7 +1020,7 @@ mod tests {
                 .await
                 .expect("build RocksDB server with server shell");
 
-            assert!(built.state.core_server_shell().is_some());
+            assert!(built.state.runtime().is_some());
             assert!(data_dir.path().join(CATALOGUE_ROCKSDB_DIR).exists());
             assert!(data_dir.path().join(SERVER_SHELL_ROCKSDB_DIR).exists());
             assert_eq!(
@@ -1037,7 +1031,7 @@ mod tests {
             Arc::clone(&built.state)
         };
         assert!(
-            retained_state.core_server_shell().is_none(),
+            retained_state.runtime().is_none(),
             "shutdown must retire the shell even if request/router state outlives BuiltServer"
         );
 
@@ -1051,7 +1045,7 @@ mod tests {
             .await
             .expect("rebuild RocksDB server with server shell");
 
-        assert!(rebuilt.state.core_server_shell().is_some());
+        assert!(rebuilt.state.runtime().is_some());
         assert!(data_dir.path().join(SERVER_SHELL_ROCKSDB_DIR).exists());
         rebuilt.shutdown().await;
 
@@ -1069,7 +1063,7 @@ mod tests {
                 .build()
                 .await
                 .expect("build RocksDB server for direct-drop lifecycle");
-            assert!(dropped.state.core_server_shell().is_some());
+            assert!(dropped.state.runtime().is_some());
         }
 
         let reopened_after_drop = ServerBuilder::new(app_id)
@@ -1081,7 +1075,7 @@ mod tests {
             .build()
             .await
             .expect("reopen RocksDB server after direct builder drop");
-        assert!(reopened_after_drop.state.core_server_shell().is_some());
+        assert!(reopened_after_drop.state.runtime().is_some());
         assert_eq!(
             reopened_after_drop.shutdown().await,
             crate::tools::server::ShutdownPhase::StorageClosed
@@ -1211,7 +1205,7 @@ mod tests {
                     .expect("later runtime reaches durable-close barrier"),
                 crate::tools::server::ShutdownPhase::StorageClosed
             );
-            assert!(state.core_server_shell().is_none());
+            assert!(state.runtime().is_none());
             ServerBuilder::new(app_id)
                 .with_schema(schema)
                 .with_storage_factory(Arc::new(jazz_storage_rocksdb::RocksDbStorageFactory))

--- a/crates/jazz/src/tools/server/core_server_shell.rs
+++ b/crates/jazz/src/tools/server/core_server_shell.rs
@@ -26,8 +26,35 @@ use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 /// joins the owner before its surrounding server storage lifecycle completes.
 /// This ensures native RocksDB resources are destroyed on their owner thread.
 #[derive(Clone)]
-pub(crate) struct ServerShellHandle {
+pub struct ServerRuntimeHandle {
     inner: Arc<ServerShellInner>,
+}
+
+/// Opaque activity subscription for a server runtime.
+pub struct ServerRuntimeActivity {
+    receiver: watch::Receiver<u64>,
+}
+
+impl ServerRuntimeActivity {
+    /// Wait until runtime work may have produced outbound frames.
+    pub async fn changed(&mut self) -> Result<(), String> {
+        self.receiver
+            .changed()
+            .await
+            .map_err(|_| "server runtime activity channel closed".to_owned())
+    }
+}
+
+/// Opaque stream of per-tick outbound frame batches.
+pub struct ServerRuntimeFrameStream {
+    receiver: tokio_mpsc::UnboundedReceiver<Result<Vec<AbiBytes>, String>>,
+}
+
+impl ServerRuntimeFrameStream {
+    /// Receive the next completed tick's outbound frames.
+    pub async fn recv(&mut self) -> Option<Result<Vec<AbiBytes>, String>> {
+        self.receiver.recv().await
+    }
 }
 
 struct ServerShellInner {
@@ -43,7 +70,7 @@ impl Drop for ServerShellInner {
         // direct builder use that is simply dropped: without it, dropping the
         // last sender merely asks the owner thread to exit and a caller can
         // race a reopen of the same RocksDB path before that exit completes.
-        // There can be no remaining `ServerShellHandle` when this runs, so no
+        // There can be no remaining `ServerRuntimeHandle` when this runs, so no
         // public operation can be waiting for an owner-thread reply.
         let _ = shutdown_blocking(self);
     }
@@ -56,7 +83,7 @@ enum ServerShellCommand {
     Shutdown(mpsc::Sender<()>),
 }
 
-impl ServerShellHandle {
+impl ServerRuntimeHandle {
     /// Reopen an already bootstrapped dynamic edge. A blank store returns
     /// `None` so its owner can run the authenticated bootstrap exchange.
     pub(crate) fn try_start_dynamic_edge_from_storage(
@@ -349,11 +376,15 @@ impl ServerShellHandle {
         })
     }
 
-    pub(crate) fn subscribe_activity(&self) -> watch::Receiver<u64> {
-        self.inner.activity_tx.subscribe()
+    /// Subscribe to runtime activity that may make outbound session frames available.
+    pub fn subscribe_activity(&self) -> ServerRuntimeActivity {
+        ServerRuntimeActivity {
+            receiver: self.inner.activity_tx.subscribe(),
+        }
     }
 
-    pub(crate) async fn open_with_session_context(
+    /// Admit an authenticated session into the semantic runtime.
+    pub async fn open_with_session_context(
         &self,
         identity: AuthorId,
         claims: BTreeMap<String, Value>,
@@ -375,7 +406,8 @@ impl ServerShellHandle {
         .await
     }
 
-    pub(crate) async fn publish_schema_with_lens(
+    /// Publish a validated schema and optional migration lens to the runtime.
+    pub async fn publish_schema_with_lens(
         &self,
         schema: JazzSchema,
         lens: MigrationLens,
@@ -434,7 +466,8 @@ impl ServerShellHandle {
         result
     }
 
-    pub(crate) async fn publish_permissions_schema(
+    /// Publish the permissions schema selected by the catalogue shell.
+    pub async fn publish_permissions_schema(
         &self,
         schema: JazzSchema,
         lineage_source: SchemaVersionId,
@@ -459,11 +492,12 @@ impl ServerShellHandle {
     /// shell thread keeps ingesting later frames. This is intentionally a
     /// streaming operation rather than one large `run` job so a route can
     /// publish a durability fate as soon as it is true.
-    pub(crate) fn receive_tick_stream(
+    /// Apply an inbound frame batch and stream every immediately available response.
+    pub fn receive_tick_stream(
         &self,
         session: ServerSession,
         frames: Vec<AbiBytes>,
-    ) -> Result<tokio_mpsc::UnboundedReceiver<Result<Vec<AbiBytes>, String>>, String> {
+    ) -> Result<ServerRuntimeFrameStream, String> {
         let activity_tx = self.inner.activity_tx.clone();
         let (outbound_tx, outbound_rx) = tokio_mpsc::unbounded_channel();
         self.send(ServerShellCommand::Run(Box::new(move |shell| {
@@ -492,10 +526,13 @@ impl ServerShellHandle {
                 notify_shell_activity(&activity_tx);
             }
         })))?;
-        Ok(outbound_rx)
+        Ok(ServerRuntimeFrameStream {
+            receiver: outbound_rx,
+        })
     }
 
-    pub(crate) async fn tick_take(&self, session: ServerSession) -> Result<Vec<AbiBytes>, String> {
+    /// Tick the runtime once and return pending frames for one session.
+    pub async fn tick_take(&self, session: ServerSession) -> Result<Vec<AbiBytes>, String> {
         let activity_tx = self.inner.activity_tx.clone();
         self.run(move |shell| {
             let result = shell
@@ -518,7 +555,8 @@ impl ServerShellHandle {
         .await
     }
 
-    pub(crate) async fn connect_upstream(
+    /// Attach a negotiated upstream transport to an edge runtime.
+    pub async fn connect_upstream(
         &self,
         transport: Box<dyn Transport + Send>,
     ) -> Result<(), String> {
@@ -535,11 +573,13 @@ impl ServerShellHandle {
         .await
     }
 
-    pub(crate) fn notify_activity(&self) {
+    /// Wake shell tasks after an adapter stages inbound work.
+    pub fn notify_activity(&self) {
         notify_shell_activity(&self.inner.activity_tx);
     }
 
-    pub(crate) fn close(&self, session: ServerSession) {
+    /// Close a semantic session without exposing runtime storage or peer state.
+    pub fn close(&self, session: ServerSession) {
         let _ = self.send(ServerShellCommand::Run(Box::new(move |shell| {
             let _ = shell.close_session(session);
         })));
@@ -547,7 +587,8 @@ impl ServerShellHandle {
 
     /// Retire the job sender, then wait until the owner has dropped the shell
     /// and its storage. It is safe for multiple shutdown paths to call this.
-    pub(crate) async fn shutdown(&self) -> Result<(), String> {
+    /// Stop and join the runtime owner thread.
+    pub async fn shutdown(&self) -> Result<(), String> {
         let inner = Arc::clone(&self.inner);
         tokio::task::spawn_blocking(move || shutdown_blocking(&inner))
             .await

--- a/crates/jazz/src/tools/server/mod.rs
+++ b/crates/jazz/src/tools/server/mod.rs
@@ -12,6 +12,7 @@ mod catalogue;
 mod catalogue_entry;
 mod catalogue_storage;
 mod core_server_shell;
+pub use core_server_shell::{ServerRuntimeActivity, ServerRuntimeFrameStream, ServerRuntimeHandle};
 pub mod routes;
 pub(crate) mod runtime_catalogue;
 mod shutdown;
@@ -71,7 +72,7 @@ pub struct ServerState {
     /// Configured verifier for external JWTs.
     pub jwt_verifier: Option<Arc<JwtVerifier>>,
     /// Sendable handle to the local-owner server shell for the websocket route.
-    pub(crate) core_server_shell: StdRwLock<Option<core_server_shell::ServerShellHandle>>,
+    pub(crate) core_server_shell: StdRwLock<Option<core_server_shell::ServerRuntimeHandle>>,
     pub(crate) core_server_shell_storage_config: Option<StorageConfig>,
     pub(crate) storage_factory: Option<Arc<dyn crate::groove::storage::StorageFactory>>,
     /// Whether the current Edge shell generation has a fully installed,
@@ -142,14 +143,14 @@ impl ServerState {
     #[cfg(feature = "test")]
     #[doc(hidden)]
     pub fn has_core_server_shell_for_test(&self) -> bool {
-        self.core_server_shell().is_some()
+        self.runtime().is_some()
     }
 
     /// Test-only observation of whether an edge is ready for downstream clients.
     #[cfg(feature = "test")]
     #[doc(hidden)]
     pub fn has_core_server_shell_for_client_for_test(&self) -> bool {
-        self.core_server_shell_for_client().is_some()
+        self.runtime_for_client().is_some()
     }
 
     /// Test-only adoption hook for exercising the interval between catalogue
@@ -171,22 +172,21 @@ impl ServerState {
     pub async fn trusted_catalogue_snapshot_for_test(
         &self,
     ) -> Result<crate::protocol::CatalogueSnapshot, String> {
-        self.core_server_shell()
+        self.runtime()
             .ok_or_else(|| "server has no runtime shell".to_owned())?
             .trusted_catalogue_snapshot_for_test()
             .await
     }
 
-    pub(crate) fn core_server_shell(&self) -> Option<core_server_shell::ServerShellHandle> {
+    /// Return the installed semantic runtime, including bootstrap-only access.
+    pub fn runtime(&self) -> Option<ServerRuntimeHandle> {
         self.core_server_shell.read().unwrap().clone()
     }
 
-    /// Shell eligible for an ordinary downstream websocket session. Bootstrap
-    /// code may inspect the raw shell, but a blank or refreshing dynamic Edge
+    /// Return the runtime eligible for an ordinary downstream client session.
+    /// Bootstrap code may inspect [`Self::runtime`], but a blank or refreshing dynamic Edge
     /// remains RetryLater until a complete catalogue generation is installed.
-    pub(crate) fn core_server_shell_for_client(
-        &self,
-    ) -> Option<core_server_shell::ServerShellHandle> {
+    pub fn runtime_for_client(&self) -> Option<ServerRuntimeHandle> {
         client_shell_snapshot(
             self.topology,
             &self.core_server_shell,
@@ -214,7 +214,7 @@ impl ServerState {
 
     pub(crate) async fn refresh_dynamic_edge_catalogue(
         &self,
-        shell: &core_server_shell::ServerShellHandle,
+        shell: &core_server_shell::ServerRuntimeHandle,
         snapshot: crate::protocol::CatalogueSnapshot,
     ) -> Result<(), String> {
         self.mark_dynamic_edge_catalogue_refreshing();
@@ -230,8 +230,8 @@ impl ServerState {
     pub(crate) fn start_core_server_shell(
         &self,
         schema: crate::schema::JazzSchema,
-    ) -> Result<core_server_shell::ServerShellHandle, String> {
-        if let Some(core_server_shell) = self.core_server_shell() {
+    ) -> Result<core_server_shell::ServerRuntimeHandle, String> {
+        if let Some(core_server_shell) = self.runtime() {
             return Ok(core_server_shell);
         }
 
@@ -243,7 +243,7 @@ impl ServerState {
         if let Some(existing) = core_server_shell.clone() {
             return Ok(existing);
         }
-        let started = core_server_shell::ServerShellHandle::start_with_storage(
+        let started = core_server_shell::ServerRuntimeHandle::start_with_storage(
             schema,
             storage_config,
             self.storage_factory.clone(),
@@ -260,7 +260,7 @@ impl ServerState {
         &self,
         snapshot: crate::protocol::CatalogueSnapshot,
         edge_cache_budget: Option<crate::node::EdgeCacheBudget>,
-    ) -> Result<core_server_shell::ServerShellHandle, String> {
+    ) -> Result<core_server_shell::ServerRuntimeHandle, String> {
         if self.topology != ServerTopology::Edge {
             return Err("dynamic catalogue bootstrap is only valid for edge topology".to_owned());
         }
@@ -273,7 +273,7 @@ impl ServerState {
             return Ok(existing);
         }
         let started =
-            core_server_shell::ServerShellHandle::start_dynamic_edge_with_catalogue_snapshot(
+            core_server_shell::ServerRuntimeHandle::start_dynamic_edge_with_catalogue_snapshot(
                 storage_config,
                 self.storage_factory.clone(),
                 edge_cache_budget,

--- a/crates/jazz/src/tools/server/routes/http.rs
+++ b/crates/jazz/src/tools/server/routes/http.rs
@@ -585,7 +585,7 @@ pub(super) async fn publish_schema_handler(
             .into_response();
     }
 
-    if (state.core_server_shell().is_some() || state.core_server_shell_storage_config.is_some())
+    if (state.runtime().is_some() || state.core_server_shell_storage_config.is_some())
         && let Err(err) =
             crate::tools::public_schema_convert::convert_public_schema(&request.schema)
     {
@@ -859,7 +859,7 @@ pub(super) async fn publish_permissions_handler(
         table.policies = policies.clone();
     }
 
-    if (state.core_server_shell().is_some() || state.core_server_shell_storage_config.is_some())
+    if (state.runtime().is_some() || state.core_server_shell_storage_config.is_some())
         && let Err(err) =
             crate::tools::public_schema_convert::convert_public_schema(&schema_with_permissions)
     {

--- a/crates/jazz/src/tools/server/routes/mod.rs
+++ b/crates/jazz/src/tools/server/routes/mod.rs
@@ -1403,7 +1403,7 @@ mod tests {
                 }],
             }],
         );
-        let runtime_shell = state.core_server_shell().expect("runtime shell started");
+        let runtime_shell = state.runtime().expect("runtime shell started");
         assert_eq!(
             runtime_shell
                 .runtime_catalogue_contains(runtime_v2.version_id(), expected_runtime_lens.id)
@@ -1654,7 +1654,7 @@ mod tests {
                 }],
             }],
         );
-        let runtime_shell = state.core_server_shell().expect("runtime shell started");
+        let runtime_shell = state.runtime().expect("runtime shell started");
         assert_eq!(
             runtime_shell
                 .runtime_catalogue_contains(runtime_v2.version_id(), expected_runtime_lens.id)

--- a/crates/jazz/src/tools/server/routes/websocket.rs
+++ b/crates/jazz/src/tools/server/routes/websocket.rs
@@ -588,7 +588,7 @@ async fn handle_ws_connection(
             let _ = socket.close().await;
             return;
         }
-        let Some(core_server_shell) = state.core_server_shell() else {
+        let Some(core_server_shell) = state.runtime() else {
             send_ws_error(
                 &mut socket,
                 WireError::new(
@@ -647,7 +647,7 @@ async fn handle_ws_connection(
         return;
     }
 
-    let Some(core_server_shell) = state.core_server_shell_for_client() else {
+    let Some(core_server_shell) = state.runtime_for_client() else {
         send_ws_error(
             &mut socket,
             WireError::new(
@@ -867,7 +867,7 @@ async fn handle_ws_connection(
 
 async fn drain_ws_outbound(
     socket: &mut WebSocket,
-    core_server_shell: &crate::tools::server::core_server_shell::ServerShellHandle,
+    core_server_shell: &crate::tools::server::core_server_shell::ServerRuntimeHandle,
     session: crate::serving::ServerSession,
 ) -> Result<(), String> {
     let outbound = core_server_shell.tick_take(session).await?;
@@ -1253,7 +1253,7 @@ mod tests {
     // Internal admission-boundary test: server-shell policy reads are not yet
     // observable through a public websocket client helper, so this pins
     // the security invariant at the route admission point that feeds
-    // ServerShellHandle::open(identity, claims, trust).
+    // ServerRuntimeHandle::open(identity, claims, trust).
     #[tokio::test]
     async fn ws_backend_session_admits_session_claims_for_policy_reads() {
         let state = make_ws_test_state().await;

--- a/crates/jazz/src/tools/server/runtime_catalogue.rs
+++ b/crates/jazz/src/tools/server/runtime_catalogue.rs
@@ -8,7 +8,7 @@ use crate::protocol::{LensOp as CoreLensOp, MigrationLens, TableLens};
 use crate::tools::public_api::types::{Schema, SchemaHash, TableName, Value};
 use crate::tools::schema_lens::{Lens, LensOp};
 
-use super::{ServerState, core_server_shell::ServerShellHandle};
+use super::{ServerState, core_server_shell::ServerRuntimeHandle};
 use crate::tools::public_schema_convert;
 
 /// Publish newly admitted catalogue entries into the active runtime shell.
@@ -22,11 +22,11 @@ pub(crate) async fn publish_runtime_catalogue(
     schemas: &[Schema],
     lenses: &[Lens],
 ) -> Result<(), String> {
-    if state.core_server_shell().is_none() && state.core_server_shell_storage_config.is_none() {
+    if state.runtime().is_none() && state.core_server_shell_storage_config.is_none() {
         return Ok(());
     }
 
-    let mut shell = state.core_server_shell();
+    let mut shell = state.runtime();
     let supplied_schemas = schemas
         .iter()
         .cloned()
@@ -104,9 +104,9 @@ pub(crate) async fn publish_runtime_catalogue(
 
 fn runtime_shell(
     state: &ServerState,
-    shell: &mut Option<ServerShellHandle>,
+    shell: &mut Option<ServerRuntimeHandle>,
     initial_schema: crate::schema::JazzSchema,
-) -> Result<ServerShellHandle, String> {
+) -> Result<ServerRuntimeHandle, String> {
     if let Some(shell) = shell.clone() {
         return Ok(shell);
     }

--- a/crates/jazz/src/tools/server/testing.rs
+++ b/crates/jazz/src/tools/server/testing.rs
@@ -432,7 +432,7 @@ impl JazzServer {
     ) {
         let shell = self
             .state
-            .core_server_shell()
+            .runtime()
             .expect("test server starts a core server shell");
         shell
             .seed_branch_row_for_test(branch, table.into(), row_id, cells)
@@ -443,7 +443,7 @@ impl JazzServer {
     pub async fn create_branch_for_test(&self, branch: crate::ids::BranchId) {
         let shell = self
             .state
-            .core_server_shell()
+            .runtime()
             .expect("test server starts a core server shell");
         shell
             .create_branch_for_test(branch)


### PR DESCRIPTION
🤖 This defines the narrow semantic runtime facade that lets the native server shell operate Jazz without owning or exposing raw `Db`/`Node` implementation state.

The facade names the server's actual semantic operations—connection admission, catalogue installation, schema conversion, shutdown, and inspection—while keeping HTTP, Axum, JWT/JWK verification, and process lifecycle outside the semantic crate.

Worked examples:

- An Axum WebSocket route asks the facade to admit and drive a connection; it does not reach into peer maps or Groove internals.
- Catalogue HTTP code hands a validated catalogue snapshot to the facade for atomic semantic adoption.
- Shutdown code requests semantic drain/close through the handle rather than coordinating raw storage and Node fields itself.

This is intentionally a boundary-only PR before moving the implementation, making the dependency direction reviewable on its own.

Verification includes server/runtime focused tests, formatting, clippy, and the sensitive-data guard.
