### PR TITLE
(new core) Fix pending writes disappearing during subscription hydration

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1099,6 +1099,21 @@ fn effective_read_tier(opts: &ReadOpts) -> DurabilityTier {
     }
 }
 
+fn supports_pending_overlay_reconciliation(query: &Query) -> bool {
+    // ponytail: row-key reconciliation currently covers flat root results;
+    // add contributor provenance before enabling structured or aggregate shapes.
+    query.aggregate.is_none()
+        && query.flat_join.is_none()
+        && query.array_subqueries.is_empty()
+        && query.includes.is_empty()
+        && query.joins.is_empty()
+        && query.policy_branches.is_empty()
+        && query.inherits.is_empty()
+        && query.reachable.is_empty()
+        && query.limit.is_none()
+        && query.offset == 0
+}
+
 fn upstream_register_shape_options(
     tier: DurabilityTier,
     read_view: ReadViewSpec,

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1026,6 +1026,30 @@ where
     }
 }
 
+fn optimistic_transaction_row_keys_for_query<S>(
+    node: &Rc<RefCell<NodeState<S>>>,
+    cache: &mut BTreeMap<AuthorId, BTreeSet<(String, RowUuid)>>,
+    shape: &ValidatedQuery,
+    author: AuthorId,
+) -> Result<BTreeSet<(String, RowUuid)>, Error>
+where
+    S: OrderedKvStorage,
+{
+    let row_keys = match cache.entry(author) {
+        std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            let transactions = node
+                .borrow_mut()
+                .unresolved_transaction_ids_for_author(author)?;
+            let row_keys = node.borrow_mut().transaction_row_keys(&transactions)?;
+            entry.insert(row_keys)
+        }
+    };
+    Ok(node
+        .borrow()
+        .transaction_row_keys_for_query(shape, row_keys))
+}
+
 /// Re-evaluate every live subscription against the node and push a delta event
 /// for any whose rows changed. Shared by local writes
 /// ([`Db::refresh_subscriptions`]) and by inbound sync application
@@ -1040,6 +1064,7 @@ where
 {
     let mut retained = Vec::new();
     let mut changed = 0;
+    let mut optimistic_row_keys_by_author = BTreeMap::new();
     let pending_authoritative_resets = node
         .borrow_mut()
         .take_pending_authoritative_reset_binding_views();
@@ -1113,6 +1138,10 @@ where
                     author,
                     authorization_mode,
                 )?;
+            let (previous_snapshot, previous_snapshot_index) = {
+                let state_ref = state.borrow();
+                (state_ref.snapshot.clone(), state_ref.snapshot_index.clone())
+            };
             let (maintained, mut snapshot) = node
                 .borrow_mut()
                 .open_maintained_view_subscription_in_authorization_mode(
@@ -1160,6 +1189,47 @@ where
                 }
                 .read_view_key(),
             };
+            let pending_binding_view = pending_authoritative_resets
+                .contains(&delivered_binding_view)
+                .then_some(delivered_binding_view)
+                .or_else(|| {
+                    pending_authoritative_resets
+                        .contains(&settled_binding_view)
+                        .then_some(settled_binding_view)
+                });
+            let authoritative_binding_view = pending_binding_view.unwrap_or(settled_binding_view);
+            let local_overlay_row_keys = if authorization_mode
+                == QueryAuthorizationMode::ClientLocal
+                && read_tier == DurabilityTier::Local
+                && remote_read_tier.is_some_and(|tier| tier >= DurabilityTier::Edge)
+                && node.borrow().authored_commit_durability() == DurabilityTier::None
+                && active_authority_view_receipts.borrow().is_some()
+                && supports_pending_overlay_reconciliation(shape.query())
+            {
+                optimistic_transaction_row_keys_for_query(
+                    node,
+                    &mut optimistic_row_keys_by_author,
+                    &shape,
+                    author,
+                )?
+            } else {
+                BTreeSet::new()
+            };
+            let has_conflicting_local_overlay = {
+                let state_ref = state.borrow();
+                let SubscriptionKind::Prepared {
+                    maintained_subscription,
+                    ..
+                } = &state_ref.kind;
+                maintained_subscription.as_ref().is_some_and(|maintained| {
+                    node.borrow()
+                        .local_maintained_authority_reconciliation_conflicts(
+                            maintained,
+                            authoritative_binding_view,
+                            &local_overlay_row_keys,
+                        )
+                })
+            };
             if authorization_mode == QueryAuthorizationMode::ClientLocal
                 && remote_read_tier.is_some()
                 && shape.query().aggregate.is_none()
@@ -1171,25 +1241,18 @@ where
                 } = &mut state_ref.kind;
                 if let Some(maintained) = maintained_subscription.as_mut() {
                     node.borrow()
-                        .seed_local_maintained_authoritative_result_membership(
+                        .seed_local_maintained_authoritative_generation(
                             maintained,
-                            settled_binding_view,
+                            authoritative_binding_view,
                         );
+                    if has_conflicting_local_overlay {
+                        node.borrow()
+                            .defer_local_maintained_authority_reconciliation(maintained);
+                    }
                 }
             }
-            let pending_binding_view = pending_authoritative_resets
-                .contains(&delivered_binding_view)
-                .then_some(delivered_binding_view)
-                .or_else(|| {
-                    pending_authoritative_resets
-                        .contains(&settled_binding_view)
-                        .then_some(settled_binding_view)
-                });
             if let Some(binding_view) = pending_binding_view {
-                let authoritative = node
-                    .borrow_mut()
-                    .authoritative_reset_snapshot_for_binding_view(&shape, binding_view)?;
-                if let Some(authoritative) = authoritative {
+                if has_conflicting_local_overlay {
                     let mut state_ref = state.borrow_mut();
                     let SubscriptionKind::Prepared {
                         maintained_subscription,
@@ -1198,13 +1261,47 @@ where
                     let maintained = maintained_subscription
                         .as_mut()
                         .expect("replacement maintained subscription installed");
-                    node.borrow_mut()
-                        .reset_local_maintained_view_subscription_from_binding_view(
+                    let (update, suppressed) = node
+                        .borrow_mut()
+                        .drain_local_maintained_view_subscription_preserving_rows(
                             maintained,
-                            binding_view,
+                            Some(binding_view),
+                            &local_overlay_row_keys,
                         )?;
-                    snapshot = authoritative;
+                    debug_assert!(suppressed);
+                    if let Some(update) = update {
+                        let mut snapshot_index = RelationSnapshotIndex::from_snapshot(&snapshot);
+                        let _ = apply_maintained_update_to_snapshot(
+                            &mut snapshot,
+                            &mut snapshot_index,
+                            update,
+                            read_tier,
+                            previous_settled,
+                            terminal_rows,
+                        );
+                    }
                     consumed_authoritative_resets.insert(binding_view);
+                } else {
+                    let authoritative = node
+                        .borrow_mut()
+                        .authoritative_reset_snapshot_for_binding_view(&shape, binding_view)?;
+                    if let Some(authoritative) = authoritative {
+                        let mut state_ref = state.borrow_mut();
+                        let SubscriptionKind::Prepared {
+                            maintained_subscription,
+                            ..
+                        } = &mut state_ref.kind;
+                        let maintained = maintained_subscription
+                            .as_mut()
+                            .expect("replacement maintained subscription installed");
+                        node.borrow_mut()
+                            .reset_local_maintained_view_subscription_from_binding_view(
+                                maintained,
+                                binding_view,
+                            )?;
+                        snapshot = authoritative;
+                        consumed_authoritative_resets.insert(binding_view);
+                    }
                 }
             }
             let root_occurrence_ids = if shape.query().aggregate.is_some() {
@@ -1229,8 +1326,6 @@ where
                     .root_occurrence_ids()
                     .to_vec()
             };
-            let reset_outputs =
-                subscription_outputs_with_occurrence_sidecar(&snapshot, &root_occurrence_ids)?;
             let settled = subscription_is_settled(
                 &node.borrow(),
                 active_authority_view_receipts,
@@ -1241,28 +1336,35 @@ where
                 remote_propagate_upstream,
                 requires_authority_receipt,
             );
-            let mut state_ref = state.borrow_mut();
-            let removed = reset_removed_roots(
-                &state_ref.snapshot,
-                &state_ref.snapshot_index,
-                &root_occurrence_ids,
-            );
-            let event = SubscriptionEvent::Delta {
-                reset: true,
-                // Rebuilding a local maintained terminal during an Edge/Global
-                // opening must not leak a second provisional empty reset. The
-                // initial opener already suppressed it; runtime replacement
-                // follows the same authority boundary. Non-empty optimistic
-                // results and retractions remain observable as before.
-                publishable: settled || !reset_outputs.is_empty() || !removed.is_empty(),
-                added: reset_outputs,
-                updated: Vec::new(),
-                removed,
-                terminal_operations: Vec::new(),
-                terminal_layout: None,
+            let mut event = subscription_delta_event_with_reset(
+                read_tier,
                 settled,
-                tier: read_tier,
-            };
+                &previous_snapshot,
+                &snapshot,
+                false,
+                terminal_rows,
+            );
+            if let SubscriptionEvent::Delta {
+                reset,
+                publishable,
+                added,
+                updated,
+                removed,
+                ..
+            } = &mut event
+            {
+                *reset = true;
+                *added =
+                    subscription_outputs_with_occurrence_sidecar(&snapshot, &root_occurrence_ids)?;
+                updated.clear();
+                *removed = reset_removed_roots(
+                    &previous_snapshot,
+                    &previous_snapshot_index,
+                    &root_occurrence_ids,
+                );
+                *publishable = settled || !added.is_empty() || !removed.is_empty();
+            }
+            let mut state_ref = state.borrow_mut();
             state_ref.groove_runtime_token = groove_runtime_token;
             state_ref.snapshot = relation_snapshot_with_delta_slack(&snapshot);
             state_ref.snapshot_index = RelationSnapshotIndex::from_snapshot(&state_ref.snapshot);
@@ -1334,6 +1436,40 @@ where
                         };
                     let authoritative_reset_pending =
                         pending_authoritative_resets.contains(&authoritative_reset_binding_view);
+                    let authority_reconciliation_due = authoritative_reset_pending
+                        || maintained_subscription.as_ref().is_some_and(|maintained| {
+                            node.borrow().local_maintained_authority_reconciliation_due(
+                                maintained,
+                                authoritative_reset_binding_view,
+                            )
+                        });
+                    let local_overlay_row_keys = if authorization_mode
+                        == QueryAuthorizationMode::ClientLocal
+                        && read_tier == DurabilityTier::Local
+                        && remote_read_tier.is_some_and(|tier| tier >= DurabilityTier::Edge)
+                        && node.borrow().authored_commit_durability() == DurabilityTier::None
+                        && active_authority_view_receipts.borrow().is_some()
+                        && supports_pending_overlay_reconciliation(shape.query())
+                        && authority_reconciliation_due
+                    {
+                        optimistic_transaction_row_keys_for_query(
+                            node,
+                            &mut optimistic_row_keys_by_author,
+                            &shape,
+                            author,
+                        )?
+                    } else {
+                        BTreeSet::new()
+                    };
+                    let has_conflicting_local_overlay =
+                        maintained_subscription.as_ref().is_some_and(|maintained| {
+                            node.borrow()
+                                .local_maintained_authority_reconciliation_conflicts(
+                                    maintained,
+                                    authoritative_reset_binding_view,
+                                    &local_overlay_row_keys,
+                                )
+                        });
                     if authoritative_reset_pending {
                         consumed_authoritative_resets.insert(authoritative_reset_binding_view);
                     }
@@ -1364,24 +1500,19 @@ where
                     // cannot replace newer main-thread writes.
                     let reconciles_remote_authoritative_membership = authorization_mode
                         == QueryAuthorizationMode::ClientLocal
-                        && node.borrow().authored_commit_durability() == DurabilityTier::None
                         && remote_read_tier.is_some()
-                        && shape.query().aggregate.is_none();
-                    // A main-thread browser Db is an optimistic overlay, so
-                    // its worker's durable baseline must reconcile through
-                    // the maintained view. Fate bookkeeping can advance
-                    // before that worker has incorporated every overlay row;
-                    // using a pending-transaction scan here would therefore
-                    // allow a stale reset to reorder or erase live rows.
-                    // The first authority handoff still needs to be an
-                    // explicit relation replacement: there is no local
-                    // overlay to preserve, and consumers use the reset as the
-                    // boundary at which an initially provisional relation
-                    // becomes authoritative. Once a local relation exists,
-                    // reconcile the worker baseline through the maintained
-                    // view so it cannot erase an optimistic overlay.
+                        && supports_pending_overlay_reconciliation(shape.query())
+                        && (has_conflicting_local_overlay
+                            || (remote_read_tier.is_some_and(|tier| tier < DurabilityTier::Edge)
+                                && node.borrow().authored_commit_durability()
+                                    == DurabilityTier::None));
+                    // Preserve the reset boundary unless it would overwrite
+                    // an unsettled local row. A browser worker's Local handoff
+                    // is an internal baseline update, while Edge/Global
+                    // handoffs remain public authority boundaries.
                     let authoritative_reset = authoritative_reset_pending
-                        && (!reconciles_remote_authoritative_membership || local_snapshot_is_empty);
+                        && (!reconciles_remote_authoritative_membership
+                            || (local_snapshot_is_empty && !has_conflicting_local_overlay));
                     if authoritative_reset && terminal_rows {
                         let Some(maintained) = maintained_subscription.as_mut() else {
                             return Err(Error::new(
@@ -1582,40 +1713,42 @@ where
                             }
                             continue;
                         }
-                        let maintained_update = if let Some(maintained) =
-                            maintained_subscription.as_mut()
-                        {
-                            let mut node_ref = node.borrow_mut();
-                            // Every client-local remote subscription must
-                            // drain against the authority's binding view. The
-                            // non-durable browser runtime additionally uses
-                            // that same view to preserve its local overlay;
-                            // restricting the view to only that runtime makes
-                            // ordinary Local clients miss a later authority
-                            // revoke until a further refresh.
-                            let authoritative_binding_view = (authorization_mode
-                                == QueryAuthorizationMode::ClientLocal
-                                && remote_read_tier.is_some()
-                                && shape.query().aggregate.is_none())
-                            .then_some(settled_binding_view);
-                            match node_ref.drain_local_maintained_view_subscription(
-                                maintained,
-                                authoritative_binding_view,
-                            ) {
-                                Ok(update) => update,
-                                Err(crate::node::Error::MissingTransaction(_)) => {
-                                    node_ref.record_authoritative_reset_missing_payload_fallback();
-                                    node_ref.defer_authoritative_reset_for_binding_view(
-                                        authoritative_reset_binding_view,
-                                    );
-                                    retained.push(Rc::downgrade(&state));
-                                    continue;
+                        let (maintained_update, suppressed_authoritative_change) =
+                            if let Some(maintained) = maintained_subscription.as_mut() {
+                                let mut node_ref = node.borrow_mut();
+                                // Every client-local remote subscription must
+                                // drain against the authority's binding view. The
+                                // non-durable browser runtime additionally uses
+                                // that same view to preserve its local overlay;
+                                // restricting the view to only that runtime makes
+                                // ordinary Local clients miss a later authority
+                                // revoke until a further refresh.
+                                let authoritative_binding_view = (authorization_mode
+                                    == QueryAuthorizationMode::ClientLocal
+                                    && remote_read_tier.is_some()
+                                    && shape.query().aggregate.is_none())
+                                .then_some(settled_binding_view);
+                                match node_ref
+                                    .drain_local_maintained_view_subscription_preserving_rows(
+                                        maintained,
+                                        authoritative_binding_view,
+                                        &local_overlay_row_keys,
+                                    ) {
+                                    Ok(update) => update,
+                                    Err(crate::node::Error::MissingTransaction(_)) => {
+                                        node_ref
+                                            .record_authoritative_reset_missing_payload_fallback();
+                                        node_ref.defer_authoritative_reset_for_binding_view(
+                                            authoritative_reset_binding_view,
+                                        );
+                                        retained.push(Rc::downgrade(&state));
+                                        continue;
+                                    }
+                                    Err(error) => return Err(error.into()),
                                 }
-                                Err(error) => return Err(error.into()),
-                            }
-                        } else {
-                            None
-                        };
+                            } else {
+                                (None, false)
+                            };
                         if let Some(update) = maintained_update {
                             if terminal_rows {
                                 if !update.terminal_operations.is_empty() {
@@ -1770,11 +1903,14 @@ where
                                 continue;
                             }
                         }
+                        let preserve_local_overlay = suppressed_authoritative_change;
                         let (snapshot, snapshot_source) = if terminal_rows {
                             (
                                 state_ref.snapshot.clone(),
                                 SubscriptionSnapshotSource::LocalMaintained,
                             )
+                        } else if preserve_local_overlay {
+                            (state_ref.snapshot.clone(), previous_source)
                         } else if remote_settled_tier.is_some() {
                             let previous = state_ref.snapshot.clone();
                             if previous.root_count == 0
@@ -1854,16 +1990,7 @@ where
                                         Err(error) => return Err(error.into()),
                                     }
                                 };
-                                if has_maintained_subscription
-                                    && previous.root_count > 0
-                                    && previous_source
-                                        == SubscriptionSnapshotSource::LocalMaintained
-                                    && remote_snapshot.root_count == 0
-                                {
-                                    (previous.clone(), previous_source)
-                                } else {
-                                    (remote_snapshot, SubscriptionSnapshotSource::LinkSnapshot)
-                                }
+                                (remote_snapshot, SubscriptionSnapshotSource::LinkSnapshot)
                             }
                         } else if has_maintained_subscription {
                             let previous = state_ref.snapshot.clone();
@@ -1892,7 +2019,13 @@ where
                             remote_propagate_upstream,
                             requires_authority_receipt,
                         );
-                        (snapshot, snapshot_source, settled, snapshot_tier, false)
+                        (
+                            snapshot,
+                            snapshot_source,
+                            settled,
+                            snapshot_tier,
+                            preserve_local_overlay,
+                        )
                     }
                 }
             }

--- a/crates/jazz/src/db/subscriptions.rs
+++ b/crates/jazz/src/db/subscriptions.rs
@@ -398,7 +398,16 @@ where
     ) -> Result<SubscriptionStream, Error> {
         ensure_supported_subscription_read_opts(&opts)?;
         self.validate_prepared_shape_for_registration(prepared)?;
-        let read_tier = effective_read_tier(&opts);
+        let requested_read_tier = effective_read_tier(&opts);
+        let read_tier = if opts.local_updates == LocalUpdates::Immediate
+            && opts.propagation == Propagation::Full
+            && supports_pending_overlay_reconciliation(prepared.shape.query())
+            && self.node.node.borrow().authored_commit_durability() == DurabilityTier::None
+        {
+            DurabilityTier::Local
+        } else {
+            requested_read_tier
+        };
         self.node
             .node
             .borrow_mut()
@@ -471,7 +480,7 @@ where
             || self.node.upstream_durability_floor.get() == DurabilityTier::Local;
         if propagates_upstream {
             let upstream_opts = self.node.upstream_register_shape_options(
-                effective_read_tier(&opts),
+                requested_read_tier,
                 opts.read_view.clone(),
                 remote_propagate_upstream,
             );
@@ -508,7 +517,7 @@ where
             upstream_subscription_handles = opened.handles;
             suppress_provisional_opening = authorization_mode
                 == QueryAuthorizationMode::ClientLocal
-                && read_tier >= DurabilityTier::Edge
+                && requested_read_tier >= DurabilityTier::Edge
                 && opened.awaits_initial_authority_response
                 && snapshot.root_count == 0
                 && snapshot.edges.is_empty();
@@ -532,10 +541,7 @@ where
                 self.node
                     .node
                     .borrow()
-                    .seed_local_maintained_authoritative_result_membership(
-                        maintained,
-                        binding_view_key,
-                    );
+                    .seed_local_maintained_authoritative_generation(maintained, binding_view_key);
             }
         }
         let settled = subscription_is_settled(
@@ -555,7 +561,7 @@ where
         // known while opening a fresh upstream handle, but an already-open
         // link has the same receipt requirement.
         suppress_provisional_opening |= authorization_mode == QueryAuthorizationMode::ClientLocal
-            && read_tier >= DurabilityTier::Edge
+            && requested_read_tier >= DurabilityTier::Edge
             && remote_read_tier.is_some()
             && !settled
             && snapshot.root_count == 0

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -1416,6 +1416,19 @@ where
         Some(tables)
     }
 
+    pub(crate) fn transaction_row_keys_for_query(
+        &self,
+        shape: &ValidatedQuery,
+        row_keys: &BTreeSet<(String, RowUuid)>,
+    ) -> BTreeSet<(String, RowUuid)> {
+        let query_tables = self.query_storage_read_tables(shape);
+        let mut row_keys = row_keys.clone();
+        if let Some(query_tables) = query_tables {
+            row_keys.retain(|(table, _)| query_tables.contains(table));
+        }
+        row_keys
+    }
+
     fn collect_include_read_tables(
         &self,
         root_table: &str,

--- a/crates/jazz/src/node/query_eval/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/maintained_views.rs
@@ -19,8 +19,9 @@ pub(crate) struct LocalMaintainedViewSubscription {
     pub(super) binding_view_key: BindingViewKey,
     pub(super) result_select: Option<Vec<String>>,
     pub(super) result_set: BTreeSet<ResultMemberEntry>,
-    pub(super) authoritative_result_set: BTreeSet<ResultMemberEntry>,
     pub(super) authoritative_result_generation: u64,
+    pub(super) authoritative_reconciliation_deferred: bool,
+    pub(super) deferred_authoritative_row_keys: BTreeSet<(String, RowUuid)>,
     pub(super) result_payloads: BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
     pub(super) program_facts: BTreeSet<ProgramFactEntry>,
     pub(super) root_occurrence_ids: Vec<OutputOccurrenceId>,
@@ -89,16 +90,6 @@ impl LocalMaintainedViewSubscription {
             })
             .sum::<usize>()
             + self.result_set.len() * 64;
-        let authoritative_result_set_bytes = self
-            .authoritative_result_set
-            .iter()
-            .map(|member| {
-                postcard::to_allocvec(member)
-                    .map(|bytes| bytes.len())
-                    .unwrap_or(0)
-            })
-            .sum::<usize>()
-            + self.authoritative_result_set.len() * 64;
         let result_payloads_bytes = self
             .result_payloads
             .iter()
@@ -122,6 +113,12 @@ impl LocalMaintainedViewSubscription {
             })
             .sum::<usize>()
             + self.program_facts.len() * 64;
+        let deferred_authoritative_row_keys_bytes = self
+            .deferred_authoritative_row_keys
+            .iter()
+            .map(|(table, _)| table.len() + std::mem::size_of::<RowUuid>())
+            .sum::<usize>()
+            + self.deferred_authoritative_row_keys.len() * 64;
         let control_state_bytes = terminal_schemas.terminal_schemas_bytes
             + tables_bytes
             + self.result_table.len()
@@ -131,9 +128,9 @@ impl LocalMaintainedViewSubscription {
                 .map(|columns| columns.iter().map(String::len).sum::<usize>())
                 .unwrap_or_default()
             + result_set_bytes
-            + authoritative_result_set_bytes
             + result_payloads_bytes
-            + program_facts_bytes;
+            + program_facts_bytes
+            + deferred_authoritative_row_keys_bytes;
         LocalMaintainedViewSubscriptionFootprint {
             maintained,
             terminal_schemas,
@@ -155,6 +152,22 @@ pub(crate) struct LocalMaintainedViewSubscriptionUpdate {
     pub(crate) removed_edges: Vec<RelationEdge>,
     pub(crate) terminal_operations: Vec<groove::ivm::TerminalOperation>,
     pub(crate) terminal_layout: Option<crate::db::TerminalRootLayout>,
+}
+
+fn result_member_matches_row_keys(
+    member: &ResultMemberEntry,
+    row_keys: &BTreeSet<(String, RowUuid)>,
+) -> bool {
+    result_member_matching_row_key(member, row_keys).is_some()
+}
+
+fn result_member_matching_row_key(
+    member: &ResultMemberEntry,
+    row_keys: &BTreeSet<(String, RowUuid)>,
+) -> Option<(String, RowUuid)> {
+    let row = member.as_real_row()?;
+    let row_key = (row.table.to_string(), row.row_uuid);
+    row_keys.contains(&row_key).then_some(row_key)
 }
 
 impl<S> NodeState<S>
@@ -218,8 +231,9 @@ where
             }),
             result_select: shape.query().select.clone(),
             result_set: BTreeSet::new(),
-            authoritative_result_set: BTreeSet::new(),
             authoritative_result_generation: 0,
+            authoritative_reconciliation_deferred: false,
+            deferred_authoritative_row_keys: BTreeSet::new(),
             result_payloads: BTreeMap::new(),
             program_facts: BTreeSet::new(),
             root_occurrence_ids: Vec::new(),
@@ -237,15 +251,31 @@ where
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
     ) -> Result<Option<LocalMaintainedViewSubscriptionUpdate>, Error> {
-        let Some(transitions) = self.drain_local_maintained_view_subscription_transitions(
+        self.drain_local_maintained_view_subscription_preserving_rows(
             local,
             authoritative_binding_view,
-        )?
-        else {
-            return Ok(None);
+            &BTreeSet::new(),
+        )
+        .map(|(update, _)| update)
+    }
+
+    pub(crate) fn drain_local_maintained_view_subscription_preserving_rows(
+        &mut self,
+        local: &mut LocalMaintainedViewSubscription,
+        authoritative_binding_view: Option<BindingViewKey>,
+        preserved_row_keys: &BTreeSet<(String, RowUuid)>,
+    ) -> Result<(Option<LocalMaintainedViewSubscriptionUpdate>, bool), Error> {
+        let (transitions, suppressed_authoritative_change) = self
+            .drain_local_maintained_view_subscription_transitions(
+                local,
+                authoritative_binding_view,
+                preserved_row_keys,
+            )?;
+        let Some(transitions) = transitions else {
+            return Ok((None, suppressed_authoritative_change));
         };
         let update = self.apply_local_maintained_view_transitions(local, transitions)?;
-        Ok(Some(update))
+        Ok((Some(update), suppressed_authoritative_change))
     }
 
     pub(crate) fn drain_local_maintained_view_subscription_state(
@@ -253,9 +283,10 @@ where
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
     ) -> Result<bool, Error> {
-        let Some(transitions) = self.drain_local_maintained_view_subscription_transitions(
+        let (Some(transitions), _) = self.drain_local_maintained_view_subscription_transitions(
             local,
             authoritative_binding_view,
+            &BTreeSet::new(),
         )?
         else {
             return Ok(false);
@@ -290,9 +321,10 @@ where
                     .collect()
             })
             .unwrap_or_default();
-        local.authoritative_result_set = local.result_set.clone();
         local.authoritative_result_generation =
             self.applied_view_update_generation(binding_view_key);
+        local.authoritative_reconciliation_deferred = false;
+        local.deferred_authoritative_row_keys.clear();
         local.program_facts = self
             .query
             .settled_program_facts
@@ -331,26 +363,62 @@ where
         Ok(())
     }
 
-    pub(crate) fn seed_local_maintained_authoritative_result_membership(
+    pub(crate) fn seed_local_maintained_authoritative_generation(
         &self,
         local: &mut LocalMaintainedViewSubscription,
         binding_view_key: BindingViewKey,
     ) {
-        local.authoritative_result_set = self
+        local.authoritative_result_generation =
+            self.applied_view_update_generation(binding_view_key);
+    }
+
+    pub(crate) fn defer_local_maintained_authority_reconciliation(
+        &self,
+        local: &mut LocalMaintainedViewSubscription,
+    ) {
+        local.authoritative_reconciliation_deferred = true;
+    }
+
+    pub(crate) fn local_maintained_authority_reconciliation_conflicts(
+        &self,
+        local: &LocalMaintainedViewSubscription,
+        binding_view_key: BindingViewKey,
+        preserved_row_keys: &BTreeSet<(String, RowUuid)>,
+    ) -> bool {
+        let remote_members = self
             .query
             .settled_result_sets
             .get(&binding_view_key)
             .cloned()
             .unwrap_or_default();
-        local.authoritative_result_generation =
-            self.applied_view_update_generation(binding_view_key);
+        local
+            .result_set
+            .symmetric_difference(&remote_members)
+            .any(|member| result_member_matches_row_keys(member, preserved_row_keys))
+    }
+
+    pub(crate) fn local_maintained_authority_reconciliation_due(
+        &self,
+        local: &LocalMaintainedViewSubscription,
+        binding_view_key: BindingViewKey,
+    ) -> bool {
+        local.authoritative_reconciliation_deferred
+            || self.applied_view_update_generation(binding_view_key)
+                != local.authoritative_result_generation
     }
 
     fn drain_local_maintained_view_subscription_transitions(
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
-    ) -> Result<Option<super::maintained_subscription_view::ResultTransitions>, Error> {
+        preserved_row_keys: &BTreeSet<(String, RowUuid)>,
+    ) -> Result<
+        (
+            Option<super::maintained_subscription_view::ResultTransitions>,
+            bool,
+        ),
+        Error,
+    > {
         if local.result_query.aggregate.is_some()
             && let Some(remote_members) =
                 self.query.settled_result_sets.get(&local.binding_view_key)
@@ -422,7 +490,7 @@ where
                         _ => None,
                     })
                     .collect();
-                return Ok(Some(transitions));
+                return Ok((Some(transitions), false));
             }
         }
         let mut states = BTreeMap::<ResultMemberEntry, (bool, bool)>::new();
@@ -438,12 +506,21 @@ where
         let mut terminal_operations = Vec::new();
         let mut authoritative_membership_changed = false;
         let mut authoritative_member_adds = BTreeSet::new();
+        let mut suppressed_authoritative_change = false;
+        let mut suppressed_authoritative_row_keys = BTreeSet::new();
         if let Some(binding_view) = authoritative_binding_view {
             let authoritative_generation = self.applied_view_update_generation(binding_view);
             // Local optimistic changes can advance the maintained graph
             // without any newer serving-peer membership decision. Keep them
             // visible until an authoritative generation advances.
-            if authoritative_generation != local.authoritative_result_generation {
+            if authoritative_generation != local.authoritative_result_generation
+                || local.authoritative_reconciliation_deferred
+            {
+                let mut protected_row_keys = preserved_row_keys.clone();
+                if authoritative_generation == local.authoritative_result_generation {
+                    protected_row_keys
+                        .extend(local.deferred_authoritative_row_keys.iter().cloned());
+                }
                 let remote_members = self
                     .query
                     .settled_result_sets
@@ -470,7 +547,14 @@ where
                 // decision for that frontier.  Import members newly admitted
                 // there so a row promoted across a TopBy boundary is delivered
                 // even though none of its locally-visible source facts changed.
-                for entry in remote_members.difference(&local.authoritative_result_set) {
+                for entry in remote_members.difference(&local.result_set) {
+                    if let Some(row_key) =
+                        result_member_matching_row_key(entry, &protected_row_keys)
+                    {
+                        suppressed_authoritative_change = true;
+                        suppressed_authoritative_row_keys.insert(row_key);
+                        continue;
+                    }
                     if !local.result_set.contains(entry) {
                         let materializable = if remote_payloads.contains_key(entry) {
                             true
@@ -508,7 +592,14 @@ where
                         }
                     }
                 }
-                for entry in local.authoritative_result_set.difference(&remote_members) {
+                for entry in local.result_set.difference(&remote_members) {
+                    if let Some(row_key) =
+                        result_member_matching_row_key(entry, &protected_row_keys)
+                    {
+                        suppressed_authoritative_change = true;
+                        suppressed_authoritative_row_keys.insert(row_key);
+                        continue;
+                    }
                     // Replace the exact prior member even when its output
                     // occurrence remains visible through a new content
                     // version. The snapshot reducer coalesces the matching
@@ -524,8 +615,13 @@ where
                         }
                     }
                 }
-                local.authoritative_result_set = remote_members;
                 local.authoritative_result_generation = authoritative_generation;
+                local.authoritative_reconciliation_deferred = suppressed_authoritative_change;
+                if suppressed_authoritative_change {
+                    local.deferred_authoritative_row_keys = suppressed_authoritative_row_keys;
+                } else {
+                    local.deferred_authoritative_row_keys.clear();
+                }
             }
         }
         loop {
@@ -594,7 +690,7 @@ where
             && structured_app_row_changes.is_empty()
             && terminal_operations.is_empty()
         {
-            return Ok(None);
+            return Ok((None, suppressed_authoritative_change));
         }
         let mut transitions = super::maintained_subscription_view::ResultTransitions {
             authoritative_membership_changed,
@@ -652,7 +748,7 @@ where
                 })
                 .collect();
         }
-        Ok(Some(transitions))
+        Ok((Some(transitions), suppressed_authoritative_change))
     }
 
     fn apply_local_maintained_view_transitions(

--- a/crates/jazz/src/node/query_eval/tests/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/tests/maintained_views.rs
@@ -59,7 +59,7 @@ fn settled_edge_authority_preserves_an_ordinary_local_content_update() {
         )
         .expect("open client-local maintained issues query");
     assert_eq!(initial_snapshot.root_count, 1);
-    client.seed_local_maintained_authoritative_result_membership(&mut local, binding_view);
+    client.seed_local_maintained_authoritative_generation(&mut local, binding_view);
 
     let updated_tx = client
         .commit_mergeable(

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -241,6 +241,21 @@ where
         &mut self,
         author: AuthorId,
     ) -> Result<Vec<TxId>, Error> {
+        self.below_global_transaction_ids_for_author(author, true)
+    }
+
+    pub(crate) fn unresolved_transaction_ids_for_author(
+        &mut self,
+        author: AuthorId,
+    ) -> Result<Vec<TxId>, Error> {
+        self.below_global_transaction_ids_for_author(author, false)
+    }
+
+    fn below_global_transaction_ids_for_author(
+        &mut self,
+        author: AuthorId,
+        include_accepted: bool,
+    ) -> Result<Vec<TxId>, Error> {
         let mut candidates = Vec::new();
         for raw in self.database.index_scan_raw(
             "jazz_transactions",
@@ -248,11 +263,9 @@ where
             &[Value::Nullable(None)],
         )? {
             let record = raw.record();
+            let fate = record.get_enum(TransactionRowRecord::FIELD_FATE_IDX)?;
             if AuthorId(record.get_uuid(TransactionRowRecord::FIELD_MADE_BY_IDX)?) != author
-                || !matches!(
-                    record.get_enum(TransactionRowRecord::FIELD_FATE_IDX)?,
-                    0 | 1
-                )
+                || !(fate == 0 || (include_accepted && fate == 1))
                 || durability_from_discriminant(
                     record.get_enum(TransactionRowRecord::FIELD_DURABILITY_IDX)?,
                 )? >= DurabilityTier::Global
@@ -274,6 +287,21 @@ where
         tx_ids.sort();
         tx_ids.dedup();
         Ok(tx_ids)
+    }
+
+    pub(crate) fn transaction_row_keys(
+        &mut self,
+        tx_ids: &[TxId],
+    ) -> Result<BTreeSet<(String, RowUuid)>, Error> {
+        let mut row_keys = BTreeSet::new();
+        for tx_id in tx_ids {
+            row_keys.extend(
+                self.query_versions_for_tx(*tx_id)?
+                    .into_iter()
+                    .map(|version| (version.table().to_owned(), version.row_uuid())),
+            );
+        }
+        Ok(row_keys)
     }
 
     /// Find replayable local transactions in the null slice of

--- a/packages/jazz-tools/tests/browser/db.disconnect.test.ts
+++ b/packages/jazz-tools/tests/browser/db.disconnect.test.ts
@@ -3,7 +3,14 @@ import { schema as s } from "../../src/";
 import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import { deploy } from "../../src/dev/catalogue.js";
-import { TestCleanup, sleep, uniqueDbName, waitForQuery, withTimeout } from "./support.js";
+import {
+  TestCleanup,
+  sleep,
+  uniqueDbName,
+  waitForCondition,
+  waitForQuery,
+  withTimeout,
+} from "./support.js";
 import { getJazzServerInfo, type JazzServerInfo } from "./testing-server.js";
 
 const schema = {
@@ -53,7 +60,317 @@ describe("Db disconnect/reconnect", () => {
     await ctx.cleanup();
   });
 
-  describe("direct server connection", () => {
+  describe("server-backed subscriptions", () => {
+    it("preserves an unresolved local write while the edge subscription hydrates", async () => {
+      const { db, peer } = await createDbPair(ctx, createWorkerDb, createDirectDb);
+      const serverTitle = "existing server row";
+      await withTimeout(
+        peer.insert(todos, { title: serverTitle, done: true }).wait({ tier: "edge" }),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "server row did not reach edge",
+      );
+      await waitForTodos(
+        db,
+        (rows) => rows.some((row) => row.title === serverTitle),
+        "db did not receive the existing server row",
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge",
+      );
+      await db.disconnect();
+
+      const title = "pending optimistic write";
+      const snapshots: Array<{
+        rows: Todo[];
+        edgeSettled: boolean;
+        afterReconnect: boolean;
+      }> = [];
+      let edgeSettled = false;
+      let reconnectRequested = false;
+      const unsubscribe = ctx.trackSubscription(
+        db.subscribeAll(
+          app.todos,
+          (delta) => {
+            if (delta.all === undefined) return;
+            snapshots.push({
+              rows: [...delta.all],
+              edgeSettled,
+              afterReconnect: reconnectRequested,
+            });
+          },
+          { tier: "edge", localUpdates: "immediate" },
+        ),
+      );
+
+      const write = db.insert(todos, { title, done: false });
+      const edgeWait = write.wait({ tier: "edge" }).then(() => {
+        edgeSettled = true;
+      });
+      await withTimeout(
+        write.wait({ tier: "local" }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "local write did not become visible",
+      );
+      await waitForCondition(
+        async () => snapshots.some(({ rows }) => rows.some((row) => row.title === title)),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "edge subscription did not publish the immediate local write",
+      );
+
+      const firstVisibleSnapshot = snapshots.findIndex(({ rows }) =>
+        rows.some((row) => row.title === title),
+      );
+      await expectStillPending(
+        write.wait({ tier: "edge" }),
+        PENDING_ASSERTION_MS,
+        "write settled before the delayed server snapshot was allowed to arrive",
+      );
+      const snapshotsBeforeReconnect = snapshots.length;
+      reconnectRequested = true;
+      await db.reconnect();
+      await waitForCondition(
+        async () =>
+          snapshots
+            .slice(snapshotsBeforeReconnect)
+            .some(({ afterReconnect, edgeSettled }) => afterReconnect && !edgeSettled),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "edge hydration did not publish a follow-up subscription result",
+      );
+      const beforeAcceptance = snapshots.at(-1)!.rows;
+      await withTimeout(
+        edgeWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "local write did not settle at edge after reconnect",
+      );
+
+      expect(snapshots.at(-1)!.rows).toEqual(beforeAcceptance);
+      expect(
+        snapshots
+          .slice(firstVisibleSnapshot)
+          .every(({ rows }) => rows.some((row) => row.title === title)),
+      ).toBe(true);
+      unsubscribe();
+    }, 60_000);
+
+    it("preserves an unresolved local update while the edge subscription hydrates", async () => {
+      const { db, peer } = await createDbPair(ctx, createWorkerDb, createDirectDb);
+      const title = "pending optimistic update";
+      const serverRow = await withTimeout(
+        peer.insert(todos, { title, done: false }).wait({ tier: "edge" }),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "server row did not reach edge",
+      );
+      await waitForTodos(
+        db,
+        (rows) => rows.some((row) => row.id === serverRow.id),
+        "db did not receive the row to update",
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge",
+      );
+      await db.disconnect();
+
+      const snapshots: Array<{
+        rows: Todo[];
+        edgeSettled: boolean;
+        afterReconnect: boolean;
+      }> = [];
+      let edgeSettled = false;
+      let reconnectRequested = false;
+      const unsubscribe = ctx.trackSubscription(
+        db.subscribeAll(
+          todoByTitle(title),
+          (delta) => {
+            if (delta.all === undefined) return;
+            snapshots.push({
+              rows: [...delta.all],
+              edgeSettled,
+              afterReconnect: reconnectRequested,
+            });
+          },
+          { tier: "edge", localUpdates: "immediate" },
+        ),
+      );
+
+      const update = db.update(todos, serverRow.id, { done: true });
+      const edgeWait = update.wait({ tier: "edge" }).then(() => {
+        edgeSettled = true;
+      });
+      await withTimeout(
+        update.wait({ tier: "local" }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "local update did not become visible",
+      );
+      await waitForCondition(
+        async () => snapshots.some(({ rows }) => rows.some((row) => row.done)),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "edge subscription did not publish the immediate local update",
+      );
+
+      const firstUpdatedSnapshot = snapshots.findIndex(({ rows }) => rows.some((row) => row.done));
+      await expectStillPending(
+        update.wait({ tier: "edge" }),
+        PENDING_ASSERTION_MS,
+        "update settled before the delayed server snapshot was allowed to arrive",
+      );
+      const snapshotsBeforeReconnect = snapshots.length;
+      reconnectRequested = true;
+      await db.reconnect();
+      await waitForCondition(
+        async () =>
+          snapshots
+            .slice(snapshotsBeforeReconnect)
+            .some(({ afterReconnect, edgeSettled }) => afterReconnect && !edgeSettled),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "edge hydration did not publish a follow-up subscription result",
+      );
+      const beforeAcceptance = snapshots.at(-1)!.rows;
+      await withTimeout(
+        edgeWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "local update did not settle at edge after reconnect",
+      );
+
+      expect(snapshots.at(-1)!.rows).toEqual(beforeAcceptance);
+      expect(
+        snapshots
+          .slice(firstUpdatedSnapshot)
+          .every(({ rows }) => rows.some((row) => row.id === serverRow.id && row.done)),
+      ).toBe(true);
+      unsubscribe();
+    }, 60_000);
+
+    it("preserves an unresolved local delete while the edge subscription hydrates", async () => {
+      const { db, peer } = await createDbPair(ctx, createWorkerDb, createDirectDb);
+      const title = "pending optimistic delete";
+      const serverRow = await withTimeout(
+        peer.insert(todos, { title, done: false }).wait({ tier: "edge" }),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "server row did not reach edge",
+      );
+      await waitForTodos(
+        db,
+        (rows) => rows.some((row) => row.id === serverRow.id),
+        "db did not receive the row to delete",
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge",
+      );
+      await db.disconnect();
+
+      const deletion = db.delete(todos, serverRow.id);
+      await withTimeout(
+        deletion.wait({ tier: "local" }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "local delete did not become visible",
+      );
+      const localRows = await withTimeout(
+        db.all(todoByTitle(title), {
+          tier: "local",
+          localUpdates: "immediate",
+          propagation: "local-only",
+        }),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "local read did not reflect the delete",
+      );
+      expect(localRows).toEqual([]);
+
+      const snapshots: Array<{
+        rows: Todo[];
+        edgeSettled: boolean;
+        afterReconnect: boolean;
+      }> = [];
+      let edgeSettled = false;
+      let reconnectRequested = false;
+      const edgeWait = deletion.wait({ tier: "edge" }).then(() => {
+        edgeSettled = true;
+      });
+      const unsubscribe = ctx.trackSubscription(
+        db.subscribeAll(
+          todoByTitle(title),
+          (delta) => {
+            if (delta.all === undefined) return;
+            snapshots.push({
+              rows: [...delta.all],
+              edgeSettled,
+              afterReconnect: reconnectRequested,
+            });
+          },
+          { tier: "edge", localUpdates: "immediate" },
+        ),
+      );
+      await waitForCondition(
+        async () => snapshots.some(({ rows }) => rows.length === 0),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "edge subscription did not publish the immediate local delete",
+      );
+
+      const firstDeletedSnapshot = snapshots.findIndex(({ rows }) => rows.length === 0);
+      await expectStillPending(
+        deletion.wait({ tier: "edge" }),
+        PENDING_ASSERTION_MS,
+        "delete settled before the delayed server snapshot was allowed to arrive",
+      );
+      const snapshotsBeforeReconnect = snapshots.length;
+      reconnectRequested = true;
+      await db.reconnect();
+      await waitForCondition(
+        async () =>
+          snapshots
+            .slice(snapshotsBeforeReconnect)
+            .some(({ afterReconnect, edgeSettled }) => afterReconnect && !edgeSettled),
+        LOCAL_OPERATION_TIMEOUT_MS,
+        "edge hydration did not publish a follow-up subscription result",
+      );
+      const beforeAcceptance = snapshots.at(-1)!.rows;
+      await withTimeout(
+        edgeWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "local delete did not settle at edge after reconnect",
+      );
+
+      expect(snapshots.at(-1)!.rows).toEqual(beforeAcceptance);
+      expect(snapshots.slice(firstDeletedSnapshot).every(({ rows }) => rows.length === 0)).toBe(
+        true,
+      );
+      unsubscribe();
+    }, 60_000);
+
+    it("publishes server deletions through an edge subscription", async () => {
+      const { db, peer } = await createDbPair(ctx, createDirectDb);
+      const deletedTitle = "server row deleted live";
+      const serverRow = await withTimeout(
+        peer.insert(todos, { title: deletedTitle, done: false }).wait({ tier: "edge" }),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "server row did not reach edge",
+      );
+      const snapshots: Todo[][] = [];
+      const unsubscribe = ctx.trackSubscription(
+        db.subscribeAll(
+          todoByTitle(deletedTitle),
+          (delta) => {
+            if (delta.all === undefined) return;
+            snapshots.push([...delta.all]);
+          },
+          { tier: "edge", localUpdates: "immediate" },
+        ),
+      );
+
+      await waitForCondition(
+        async () => snapshots.some((rows) => rows.some((row) => row.title === deletedTitle)),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge subscription did not show the server row",
+      );
+      await withTimeout(
+        peer.delete(todos, serverRow.id).wait({ tier: "edge" }),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "server deletion did not reach edge",
+      );
+      await waitForCondition(
+        async () => snapshots.some((rows) => rows.length === 0),
+        SYNC_OPERATION_TIMEOUT_MS,
+        "edge subscription did not publish the server deletion",
+      );
+      unsubscribe();
+    }, 60_000);
+
     it("syncs writes made while disconnected after reconnect", async () => {
       const { db, peer } = await createDbPair(ctx, createDirectDb);
 
@@ -389,12 +706,16 @@ async function createWorkerDb(
   );
 }
 
-async function createDbPair(ctx: TestCleanup, createDbForMode: DbFactory): Promise<ConnectedPair> {
+async function createDbPair(
+  ctx: TestCleanup,
+  createDbForMode: DbFactory,
+  createPeerDb: DbFactory = createDbForMode,
+): Promise<ConnectedPair> {
   const label = uniqueDbName("db-disconnect-pair");
   const server = await publishSyncServerSchemaAndPermissions(label);
   const sharedSecret = generateAuthSecret();
   const db = await createDbForMode(ctx, `${label}-a`, sharedSecret, server);
-  const peer = await createDbForMode(ctx, `${label}-peer`, sharedSecret, server);
+  const peer = await createPeerDb(ctx, `${label}-peer`, sharedSecret, server);
 
   return { db, peer };
 }


### PR DESCRIPTION
## Summary

- Keep unresolved local inserts, updates and deletes visible when an edge subscription applies a server snapshot.
- Reconcile only rows from transactions that are still pending. Accepted writes, rejected writes and real server deletions continue to update the result normally.
- Add server-backed tests covering pending writes during hydration and legitimate server deletion.

## Testing

- `pnpm exec vitest run --config vitest.config.browser.ts tests/browser/db.disconnect.test.ts --reporter=verbose` — passed, 13 tests
- `pnpm --filter jazz-tools check` — passed
- `cargo test -q -p jazz --no-default-features --features test` — passed with no failures
