### PR TITLE
(new core) fix transaction overlays across tables

### DIFF
--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -272,6 +272,163 @@ fn exclusive_overlay_reserves_stable_provenance_for_insert_and_update() {
     assert_eq!(provenance(&committed, existing), updated_overlay);
 }
 
+/// This stays internal because transaction overlays are not sync-visible. The
+/// point, table, and prepared-query paths are separate overlay consumers, so
+/// exercise all three with the same row UUID present in two logical tables.
+#[test]
+fn exclusive_tx_overlay_scopes_same_row_uuid_by_table() {
+    fn table_schema(name: &str) -> TableSchema {
+        TableSchema::new(
+            name,
+            [
+                ColumnSchema::new("status", ColumnType::String),
+                ColumnSchema::new("value", ColumnType::String),
+            ],
+        )
+        .with_read_policy(Policy::public())
+        .with_write_policy(Policy::public())
+    }
+
+    fn cells(status: &str, value: &str) -> RowCells {
+        BTreeMap::from([
+            ("status".to_owned(), Value::String(status.to_owned())),
+            ("value".to_owned(), Value::String(value.to_owned())),
+        ])
+    }
+
+    fn visible_cells(
+        rows: Vec<CurrentRow>,
+        table_name: &str,
+        table: &TableSchema,
+    ) -> BTreeMap<RowUuid, RowCells> {
+        rows.into_iter()
+            .map(|row| {
+                assert_eq!(row.table(), table_name);
+                (
+                    row.row_uuid(),
+                    BTreeMap::from([
+                        (
+                            "status".to_owned(),
+                            row.cell(table, "status").expect("status cell"),
+                        ),
+                        (
+                            "value".to_owned(),
+                            row.cell(table, "value").expect("value cell"),
+                        ),
+                    ]),
+                )
+            })
+            .collect()
+    }
+
+    fn assert_reads<T>(
+        tx: &T,
+        table_name: &str,
+        table: &TableSchema,
+        filtered: &PreparedQuery,
+        shared_row: RowUuid,
+        expected_shared: &RowCells,
+        expected_all: BTreeMap<RowUuid, RowCells>,
+    ) where
+        T: ExclusiveTxOps<RocksDbStorage>,
+    {
+        assert_eq!(
+            tx.read(table_name, shared_row).unwrap().as_ref(),
+            Some(expected_shared)
+        );
+        assert_eq!(
+            visible_cells(tx.all(table_name).unwrap(), table_name, table),
+            expected_all
+        );
+        assert_eq!(
+            visible_cells(tx.all_prepared(filtered).unwrap(), table_name, table),
+            BTreeMap::from([(shared_row, expected_shared.clone())])
+        );
+    }
+
+    let schema = JazzSchema::new([table_schema("table_a"), table_schema("table_b")]);
+    let db = open_db(0x5e, AuthorId::SYSTEM, &schema);
+    let table_a = schema
+        .tables
+        .iter()
+        .find(|table| table.name == "table_a")
+        .unwrap();
+    let table_b = schema
+        .tables
+        .iter()
+        .find(|table| table.name == "table_b")
+        .unwrap();
+    let shared_row = row(0x44);
+    let other_a = row(0xa1);
+    let other_b = row(0xb1);
+    let current_a = cells("selected", "table A current");
+    let current_b = cells("selected", "table B current");
+    let nonmatching_a = cells("ignored", "table A nonmatching");
+    let nonmatching_b = cells("ignored", "table B nonmatching");
+
+    for (table, row_uuid, row_cells) in [
+        ("table_a", shared_row, current_a.clone()),
+        ("table_a", other_a, nonmatching_a.clone()),
+        ("table_b", shared_row, current_b.clone()),
+        ("table_b", other_b, nonmatching_b.clone()),
+    ] {
+        let write = db.insert_with_id(table, row_uuid, row_cells).unwrap();
+        block_on(write.wait(DurabilityTier::Local)).unwrap();
+    }
+
+    let filtered_a = db
+        .prepare_query(
+            &db.table("table_a")
+                .filter(eq(col("status"), lit("selected"))),
+        )
+        .unwrap();
+    let filtered_b = db
+        .prepare_query(
+            &db.table("table_b")
+                .filter(eq(col("status"), lit("selected"))),
+        )
+        .unwrap();
+    let tx = db.exclusive_tx().unwrap();
+    let pending_a = cells("selected", "table A pending");
+    tx.insert_with_id("table_a", shared_row, pending_a.clone())
+        .unwrap();
+
+    assert_reads(
+        &tx,
+        "table_b",
+        table_b,
+        &filtered_b,
+        shared_row,
+        &current_b,
+        BTreeMap::from([
+            (shared_row, current_b.clone()),
+            (other_b, nonmatching_b.clone()),
+        ]),
+    );
+
+    let pending_b = cells("selected", "table B pending");
+    tx.insert_with_id("table_b", shared_row, pending_b.clone())
+        .unwrap();
+    assert_reads(
+        &tx,
+        "table_a",
+        table_a,
+        &filtered_a,
+        shared_row,
+        &pending_a,
+        BTreeMap::from([(shared_row, pending_a.clone()), (other_a, nonmatching_a)]),
+    );
+    assert_reads(
+        &tx,
+        "table_b",
+        table_b,
+        &filtered_b,
+        shared_row,
+        &pending_b,
+        BTreeMap::from([(shared_row, pending_b.clone()), (other_b, nonmatching_b)]),
+    );
+}
+
 #[test]
 fn upsert_merges_existing_rows_but_writes_absent_rows_directly() {
     let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();


### PR DESCRIPTION
## What changed

Scope pending exclusive-transaction overlays by both table name and row UUID.

## Why

Two tables may legitimately contain the same row UUID. The overlay previously keyed pending rows only by UUID, so a write in one table could mask or replace the pending row in another table during the same transaction.

## Impact

Transactions now preserve independent pending values for identical UUIDs in different tables.

## Validation

- Added `exclusive_tx_overlay_scopes_same_row_uuid_by_table`
- Full Jazz library suite: 1285 passed, 0 failed, 2 ignored
- Pre-commit Clippy and rustfmt hooks passed

Stack base: `codex/jazz-core-engine-swap`.
