### PR TITLE
(new core) resolve declared id columns before row ids

### DIFF
--- a/crates/jazz/src/node/policy.rs
+++ b/crates/jazz/src/node/policy.rs
@@ -278,15 +278,19 @@ where
                 ))?
                 .schema
         };
+        // `id` resolves to a declared user column when a table has one, so an
+        // internal physical-row probe must use the dedicated access-path API.
         let shape = crate::query::Query::from(table_name)
-            .filter(crate::query::eq(
-                crate::query::col("id"),
-                crate::query::lit(Value::Uuid(row_uuid.0)),
-            ))
             .validate_with_schema_version(schema, schema_version)?;
         let binding = shape.bind(BTreeMap::new())?;
-        self.query_rows_for_link(&shape, &binding, DurabilityTier::Local, identity)
-            .map(|rows| !rows.is_empty())
+        self.query_rows_for_link_physical_row(
+            &shape,
+            &binding,
+            DurabilityTier::Local,
+            identity,
+            row_uuid,
+        )
+        .map(|rows| rows.into_iter().any(|row| row.row_uuid() == row_uuid))
     }
 
     #[cfg(test)]

--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -2288,6 +2288,15 @@ fn lower_join_key_ref(
         && value_source == source_id
         && field == "id"
     {
+        let declared_id = user_column_field(field);
+        if source
+            .row_shape
+            .descriptor
+            .field_index(&declared_id)
+            .is_some()
+        {
+            return require_source_field(source, &declared_id);
+        }
         return require_source_field(source, &source.row_shape.row_uuid_field);
     }
     match lower_value_ref(value, source_id, source, request)? {
@@ -2973,10 +2982,18 @@ fn lower_value_ref(
             source: value_source,
             field,
         } if value_source == source_id => {
-            let field = if source.row_shape.descriptor.field_index(field).is_some() {
+            let user_field = user_column_field(field);
+            let field = if source
+                .row_shape
+                .descriptor
+                .field_index(&user_field)
+                .is_some()
+            {
+                user_field
+            } else if source.row_shape.descriptor.field_index(field).is_some() {
                 field.clone()
             } else {
-                user_column_field(field)
+                user_field
             };
             Ok(LoweredValueRef::Field(require_source_field(
                 source, &field,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -2862,7 +2862,7 @@ fn compare_values(left: &Value, right: &Value) -> Option<std::cmp::Ordering> {
 }
 
 fn query_order_value(row: &CurrentRow, table: &TableSchema, column: &str) -> Option<Value> {
-    if column == "id" {
+    if column == "id" && !table.columns.iter().any(|candidate| candidate.name == "id") {
         return Some(Value::Uuid(row.row_uuid().0));
     }
     if is_magic_current_column(column) {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -396,6 +396,7 @@ where
             settled_binding_view,
             authorization_mode,
             prepared_claim_binding_mode,
+            false,
         )?;
         self.compile_query_program_request(request)
     }
@@ -423,23 +424,22 @@ where
         self.compile_query_program_request_with_access_paths(request, access_paths)
     }
 
-    fn compile_current_query_program_with_selected_access_paths(
+    fn compile_current_query_program_with_access_paths(
         &mut self,
         shape: &ValidatedQuery,
         binding: &Binding,
         tier: DurabilityTier,
         identity: AuthorId,
         output: CurrentQueryProgramOutput,
+        access_paths: BTreeMap<SourceId, CurrentAccessPath>,
     ) -> Result<QueryProgram, Error> {
-        let access_paths = self.current_query_primary_key_access_paths(shape, binding)?;
-        let request = self.current_query_program_request(
+        let request = self.current_query_program_request_with_inline_binding_source(
             shape,
             binding,
             tier,
             identity,
             output,
             &ReadViewSpec::default(),
-            None,
             QueryAuthorizationMode::TrustedServing,
         )?;
         self.compile_query_program_request_with_access_paths(request, access_paths)
@@ -703,6 +703,31 @@ where
             settled_binding_view,
             authorization_mode,
             PreparedClaimBindingMode::Strict,
+            false,
+        )
+    }
+
+    fn current_query_program_request_with_inline_binding_source(
+        &self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        identity: AuthorId,
+        output: CurrentQueryProgramOutput,
+        read_view: &ReadViewSpec,
+        authorization_mode: QueryAuthorizationMode,
+    ) -> Result<QueryProgramRequest, Error> {
+        self.current_query_program_request_with_prepared_claim_mode(
+            shape,
+            binding,
+            tier,
+            identity,
+            output,
+            read_view,
+            None,
+            authorization_mode,
+            PreparedClaimBindingMode::Strict,
+            true,
         )
     }
 
@@ -717,6 +742,7 @@ where
         settled_binding_view: Option<BindingViewKey>,
         authorization_mode: QueryAuthorizationMode,
         prepared_claim_binding_mode: PreparedClaimBindingMode,
+        force_inline_binding_source: bool,
     ) -> Result<QueryProgramRequest, Error> {
         let lowered_shape;
         let lowered_binding;
@@ -726,6 +752,7 @@ where
         // than trying to evaluate a server-maintained binding graph.
         let use_prepared_binding_source = authorization_mode
             == QueryAuthorizationMode::TrustedServing
+            && !force_inline_binding_source
             && self.can_use_prepared_current_query_plan(shape)
             && settled_binding_view.is_none()
             && !matches!(output, CurrentQueryProgramOutput::RelationSnapshot);
@@ -2016,6 +2043,41 @@ where
         identity: AuthorId,
     ) -> Result<Vec<CurrentRow>, Error> {
         self.query_rows_with_prepared_plan_for_identity(shape, binding, tier, None, identity)
+    }
+
+    /// Execute a serving query with its root constrained to a physical row
+    /// UUID. This is for internal authorization probes: public `id` may be a
+    /// declared user column and must not be used as the storage-row selector.
+    pub(in crate::node) fn query_rows_for_link_physical_row(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        identity: AuthorId,
+        row_uuid: RowUuid,
+    ) -> Result<Vec<CurrentRow>, Error> {
+        let table = self
+            .table_in_schema(&shape.query().table, shape.schema_version())?
+            .clone();
+        let access_paths = BTreeMap::from([(
+            root_source_id(&shape.query().table),
+            CurrentAccessPath::PrimaryKey(vec![Value::Uuid(row_uuid.0)]),
+        )]);
+        let program = self.compile_current_query_program_with_access_paths(
+            shape,
+            binding,
+            tier,
+            identity,
+            CurrentQueryProgramOutput::AppRows,
+            access_paths,
+        )?;
+        let deltas = self
+            .database
+            .query_graph(lowered_materialization_app_rows_graph(&program)?)
+            .map_err(Error::Groove)?;
+        let mut rows = self.materialize_inline_current_query_rows(&table, deltas)?;
+        self.finish_engine_query_rows_in_schema(shape.query(), shape.schema_version(), &mut rows)?;
+        Ok(rows)
     }
 
     #[cfg(test)]

--- a/crates/jazz/src/node/query_eval/authorization.rs
+++ b/crates/jazz/src/node/query_eval/authorization.rs
@@ -343,12 +343,7 @@ where
         row_uuid: RowUuid,
         identity: AuthorId,
     ) -> Result<bool, Error> {
-        let mut query = policy.clone();
-        query.filters.push(crate::query::eq(
-            crate::query::col("id"),
-            crate::query::lit(Value::Uuid(row_uuid.0)),
-        ));
-        let policy_shape = query.validate(&self.catalogue.schema)?;
+        let policy_shape = policy.validate(&self.catalogue.schema)?;
         let policy_binding = policy_shape.bind(BTreeMap::new())?;
         let policy_shape = bind_query_params_with_mode(
             &policy_shape,
@@ -357,12 +352,19 @@ where
             ParamBindingMode::InlineAllReachableSeeds,
         )?;
         let binding = policy_shape.bind(BTreeMap::new())?;
-        let program = self.compile_current_query_program_with_selected_access_paths(
+        // A primary-key access path addresses the physical row UUID without
+        // overloading public `id`, which may be a declared user column.
+        let access_paths = BTreeMap::from([(
+            root_source_id(&policy.table),
+            CurrentAccessPath::PrimaryKey(vec![Value::Uuid(row_uuid.0)]),
+        )]);
+        let program = self.compile_current_query_program_with_access_paths(
             &policy_shape,
             &binding,
             DurabilityTier::Local,
             identity,
             CurrentQueryProgramOutput::AppRows,
+            access_paths,
         )?;
         self.write_policy_query_program_allows(&program, &policy_shape, &binding)
     }

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -1322,7 +1322,7 @@ fn normalize_reachable(
     ))
 }
 
-fn source_column_value(
+pub(super) fn source_column_value(
     schema: &JazzSchema,
     source: &SourceId,
     column: &str,

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -260,7 +260,8 @@ pub(super) fn select_current_access_path(
     table: &TableSchema,
     equalities: &BTreeMap<String, Value>,
 ) -> Option<CurrentAccessPath> {
-    if let Some(value) = equalities.get("id").cloned() {
+    let has_declared_id = table.columns.iter().any(|column| column.name == "id");
+    if !has_declared_id && let Some(value) = equalities.get("id").cloned() {
         return Some(CurrentAccessPath::PrimaryKey(vec![value]));
     }
     for column in table.global_current_indexed_columns() {
@@ -592,10 +593,25 @@ fn normalize_compare(
 ) -> Result<NormalizedPredicateExpr, Error> {
     let left_type = operand_column_type(schema, source, left)?;
     let right_type = operand_column_type(schema, source, right)?;
+    let has_declared_id = schema
+        .tables
+        .iter()
+        .find(|table| table.name == source.table)
+        .is_some_and(|table| table.columns.iter().any(|column| column.name == "id"));
     Ok(NormalizedPredicateExpr::Compare {
-        left: normalize_operand_with_target_type(source, left, right_type.as_ref())?,
+        left: normalize_operand_with_target_type_and_declared_id(
+            source,
+            left,
+            right_type.as_ref(),
+            has_declared_id,
+        )?,
         op,
-        right: normalize_operand_with_target_type(source, right, left_type.as_ref())?,
+        right: normalize_operand_with_target_type_and_declared_id(
+            source,
+            right,
+            left_type.as_ref(),
+            has_declared_id,
+        )?,
     })
 }
 
@@ -608,8 +624,17 @@ fn normalize_operand_with_target_type(
     operand: &Operand,
     target_type: Option<&ColumnType>,
 ) -> Result<NormalizedValueRef, Error> {
+    normalize_operand_with_target_type_and_declared_id(source, operand, target_type, false)
+}
+
+fn normalize_operand_with_target_type_and_declared_id(
+    source: &SourceId,
+    operand: &Operand,
+    target_type: Option<&ColumnType>,
+    has_declared_id: bool,
+) -> Result<NormalizedValueRef, Error> {
     Ok(match operand {
-        Operand::Column(column) if column == "id" => {
+        Operand::Column(column) if column == "id" && !has_declared_id => {
             NormalizedValueRef::RowId(RowIdRef::Source(source.clone()))
         }
         Operand::Column(column) => match provenance_field(column) {
@@ -647,21 +672,29 @@ pub(super) fn operand_column_type(
     let Operand::Column(column) = operand else {
         return Ok(None);
     };
-    if column == "id" {
-        return Ok(Some(ColumnType::Uuid));
-    }
     if let Some(field) = provenance_field(column) {
         return Ok(Some(match field {
             ProvenanceField::CreatedAt | ProvenanceField::UpdatedAt => ColumnType::U64,
             ProvenanceField::CreatedBy | ProvenanceField::UpdatedBy => ColumnType::Uuid,
         }));
     }
-    let table = table_schema(schema, &source.table)?;
-    Ok(table
+    let table = match table_schema(schema, &source.table) {
+        Ok(table) => table,
+        Err(_) if column == "id" => return Ok(Some(ColumnType::Uuid)),
+        Err(error) => return Err(error),
+    };
+    let declared = table
         .columns
         .iter()
         .find(|candidate| candidate.name == *column)
-        .map(|column| column.column_type.clone()))
+        .map(|column| column.column_type.clone());
+    if declared.is_some() {
+        return Ok(declared);
+    }
+    if column == "id" {
+        return Ok(Some(ColumnType::Uuid));
+    }
+    Ok(None)
 }
 
 pub(super) fn contains_needle_type(

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -790,11 +790,16 @@ fn provenance_field(column: &str) -> Option<ProvenanceField> {
 }
 
 fn normalize_order_key(
+    schema: &JazzSchema,
     source: &SourceId,
     order: &crate::query::OrderBy,
 ) -> Result<NormalizedOrderKey, Error> {
     Ok(NormalizedOrderKey {
-        value: normalize_operand(source, &Operand::Column(order.column.clone()))?,
+        value: normalize_operand_for_schema(
+            schema,
+            source,
+            &Operand::Column(order.column.clone()),
+        )?,
         direction: match order.direction {
             OrderDirection::Asc => NormalizedSortDirection::Asc,
             OrderDirection::Desc => NormalizedSortDirection::Desc,
@@ -803,17 +808,21 @@ fn normalize_order_key(
 }
 
 fn normalized_aggregate_group_by(
+    schema: &JazzSchema,
     source: &SourceId,
     aggregate: &AggregateQuery,
 ) -> Result<Vec<NormalizedValueRef>, Error> {
     aggregate
         .group_by
         .iter()
-        .map(|column| normalize_operand(source, &Operand::Column(column.clone())))
+        .map(|column| {
+            normalize_operand_for_schema(schema, source, &Operand::Column(column.clone()))
+        })
         .collect()
 }
 
 fn normalized_aggregate_outputs(
+    schema: &JazzSchema,
     source: &SourceId,
     aggregate: &AggregateQuery,
 ) -> Result<Vec<NormalizedAggregateExpr>, Error> {
@@ -830,7 +839,13 @@ fn normalized_aggregate_outputs(
                 input: aggregate
                     .column
                     .as_ref()
-                    .map(|column| normalize_operand(source, &Operand::Column(column.clone())))
+                    .map(|column| {
+                        normalize_operand_for_schema(
+                            schema,
+                            source,
+                            &Operand::Column(column.clone()),
+                        )
+                    })
                     .transpose()?,
             })
         })
@@ -1026,7 +1041,7 @@ fn normalize_array_subquery(
                 keys: subquery
                     .order_by
                     .iter()
-                    .map(|order| normalize_order_key(&child_source, order))
+                    .map(|order| normalize_order_key(schema, &child_source, order))
                     .collect::<Result<Vec<_>, Error>>()
                     .map_err(|err| normalization_gap(err.to_string()))?,
             },
@@ -1040,10 +1055,12 @@ fn normalize_array_subquery(
             slice_node.clone(),
             RowSetExpr::Slice {
                 input: child_current,
-                partition_by: vec![NormalizedValueRef::SourceField {
-                    source: child_source.clone(),
-                    field: subquery.inner_column.clone(),
-                }],
+                partition_by: vec![source_column_value(
+                    schema,
+                    &child_source,
+                    &subquery.inner_column,
+                    JoinTarget::Column,
+                )],
                 limit: subquery
                     .limit
                     .map(|limit| limit.min(u32::MAX as usize) as u32),
@@ -1074,7 +1091,8 @@ fn normalize_array_subquery(
                     field: subquery.inner_column.clone(),
                 },
                 op: NormalizedComparisonOp::Eq,
-                right: normalize_operand(
+                right: normalize_operand_for_schema(
+                    schema,
                     owner_source,
                     &Operand::Column(subquery.outer_column.clone()),
                 )
@@ -1167,14 +1185,12 @@ fn normalize_reachable(
                     field: "reachable_team".to_owned(),
                 },
                 op: NormalizedComparisonOp::Eq,
-                right: if reachable.edge_member_column == "id" {
-                    NormalizedValueRef::RowId(RowIdRef::Source(edge_source.clone()))
-                } else {
-                    NormalizedValueRef::SourceField {
-                        source: edge_source.clone(),
-                        field: reachable.edge_member_column.clone(),
-                    }
-                },
+                right: source_column_value(
+                    schema,
+                    &edge_source,
+                    &reachable.edge_member_column,
+                    JoinTarget::Column,
+                ),
             },
         },
     );
@@ -1262,6 +1278,7 @@ fn normalize_reachable(
             mode: NormalizedJoinMode::Inner,
             on: NormalizedPredicateExpr::Compare {
                 left: reachable_access_key(
+                    schema,
                     &access_source,
                     &reachable.access_team_column,
                     reachable.access_team_target,
@@ -1283,9 +1300,10 @@ fn normalize_reachable(
             right: access_join_node.clone(),
             mode: NormalizedJoinMode::Inner,
             on: NormalizedPredicateExpr::Compare {
-                left: NormalizedValueRef::RowId(RowIdRef::Source(root_source.clone())),
+                left: source_column_value(schema, root_source, "id", JoinTarget::Column),
                 op: NormalizedComparisonOp::Eq,
                 right: reachable_access_key(
+                    schema,
                     &access_source,
                     &reachable.access_row_column,
                     JoinTarget::Column,
@@ -1304,19 +1322,29 @@ fn normalize_reachable(
     ))
 }
 
+fn source_column_value(
+    schema: &JazzSchema,
+    source: &SourceId,
+    column: &str,
+    target: JoinTarget,
+) -> NormalizedValueRef {
+    if target == JoinTarget::RowId || (column == "id" && !source_has_declared_id(schema, source)) {
+        NormalizedValueRef::RowId(RowIdRef::Source(source.clone()))
+    } else {
+        NormalizedValueRef::SourceField {
+            source: source.clone(),
+            field: column.to_owned(),
+        }
+    }
+}
+
 fn reachable_access_key(
+    schema: &JazzSchema,
     access_source: &SourceId,
     column: &str,
     target: JoinTarget,
 ) -> NormalizedValueRef {
-    if column == "id" || target == JoinTarget::RowId {
-        NormalizedValueRef::RowId(RowIdRef::Source(access_source.clone()))
-    } else {
-        NormalizedValueRef::SourceField {
-            source: access_source.clone(),
-            field: column.to_owned(),
-        }
-    }
+    source_column_value(schema, access_source, column, target)
 }
 
 fn normalize_join_via_right(
@@ -1371,14 +1399,12 @@ fn normalize_join_via_right(
                 on: NormalizedPredicateExpr::Compare {
                     left: join_via_target_key(&join_source, join),
                     op: NormalizedComparisonOp::Eq,
-                    right: if lookup.value_column == "id" {
-                        NormalizedValueRef::RowId(RowIdRef::Source(lookup_source.clone()))
-                    } else {
-                        NormalizedValueRef::SourceField {
-                            source: lookup_source.clone(),
-                            field: lookup.value_column.clone(),
-                        }
-                    },
+                    right: source_column_value(
+                        schema,
+                        &lookup_source,
+                        &lookup.value_column,
+                        JoinTarget::Column,
+                    ),
                 },
             },
         );
@@ -1517,14 +1543,8 @@ fn normalize_reachable_seed(
             seed_current = seed_filter_node;
         }
         let seed_project_node = RowSetNodeId(format!("{reachable_id}:seed_project"));
-        let seed_team_value = if seed.team_column == "id" {
-            NormalizedValueRef::RowId(RowIdRef::Source(seed_source.clone()))
-        } else {
-            NormalizedValueRef::SourceField {
-                source: seed_source.clone(),
-                field: seed.team_column.clone(),
-            }
-        };
+        let seed_team_value =
+            source_column_value(schema, &seed_source, &seed.team_column, JoinTarget::Column);
         let mut seed_columns = vec![
             RowProjection {
                 output: typed_output_field("team", ColumnType::Uuid),
@@ -1607,14 +1627,7 @@ fn reachable_seed_frontier_columns(
             seed.table, seed.team_column, team_column_ty
         )));
     }
-    let value = if seed.team_column == "id" {
-        NormalizedValueRef::RowId(RowIdRef::Source(source.clone()))
-    } else {
-        NormalizedValueRef::SourceField {
-            source: source.clone(),
-            field: seed.team_column.clone(),
-        }
-    };
+    let value = source_column_value(schema, source, &seed.team_column, JoinTarget::Column);
     let mut columns = vec![
         ValueSourceColumn {
             name: "team".to_owned(),
@@ -2675,13 +2688,10 @@ where
                     let source = sources.get(scope).ok_or_else(|| {
                         Error::QueryCapability(format!("unknown flat join source {scope}"))
                     })?;
-                    Ok(if column == "id" || column == "_id" {
+                    Ok(if column == "_id" {
                         NormalizedValueRef::RowId(RowIdRef::Source(source.clone()))
                     } else {
-                        NormalizedValueRef::SourceField {
-                            source: source.clone(),
-                            field: column.to_owned(),
-                        }
+                        source_column_value(schema, source, column, JoinTarget::Column)
                     })
                 };
                 let (_, right_column) = join.on.right.rsplit_once('.').ok_or_else(|| {
@@ -2700,13 +2710,15 @@ where
                         on: NormalizedPredicateExpr::Compare {
                             left: value_ref(&join.on.left)?,
                             op: NormalizedComparisonOp::Eq,
-                            right: if right_column == "id" || right_column == "_id" {
+                            right: if right_column == "_id" {
                                 NormalizedValueRef::RowId(RowIdRef::Source(source.clone()))
                             } else {
-                                NormalizedValueRef::SourceField {
-                                    source: source.clone(),
-                                    field: right_column.to_owned(),
-                                }
+                                source_column_value(
+                                    schema,
+                                    &source,
+                                    right_column,
+                                    JoinTarget::Column,
+                                )
                             },
                         },
                     },
@@ -2802,7 +2814,7 @@ where
                     keys: query
                         .order_by
                         .iter()
-                        .map(|order| normalize_order_key(&root_source, order))
+                        .map(|order| normalize_order_key(schema, &root_source, order))
                         .collect::<Result<Vec<_>, Error>>()?,
                 },
             );
@@ -2844,8 +2856,8 @@ where
                 aggregate_node.clone(),
                 RowSetExpr::Aggregate {
                     input: current,
-                    group_by: normalized_aggregate_group_by(&root_source, aggregate)?,
-                    outputs: normalized_aggregate_outputs(&root_source, aggregate)?,
+                    group_by: normalized_aggregate_group_by(schema, &root_source, aggregate)?,
+                    outputs: normalized_aggregate_outputs(schema, &root_source, aggregate)?,
                 },
             );
             current = aggregate_node;

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -327,11 +327,12 @@ fn normalize_predicate(
             normalize_compare(schema, source, left, NormalizedComparisonOp::Lte, right)?
         }
         Predicate::In(value, options) => NormalizedPredicateExpr::In {
-            value: normalize_operand(source, value)?,
+            value: normalize_operand_for_schema(schema, source, value)?,
             options: options
                 .iter()
                 .map(|operand| {
-                    normalize_operand_with_target_type(
+                    normalize_operand_with_target_type_for_schema(
+                        schema,
                         source,
                         operand,
                         operand_column_type(schema, source, value)?.as_ref(),
@@ -340,15 +341,16 @@ fn normalize_predicate(
                 .collect::<Result<Vec<_>, Error>>()?,
         },
         Predicate::Contains(value, needle) => NormalizedPredicateExpr::ArrayContains {
-            value: normalize_operand(source, value)?,
-            needle: normalize_operand_with_target_type(
+            value: normalize_operand_for_schema(schema, source, value)?,
+            needle: normalize_operand_with_target_type_for_schema(
+                schema,
                 source,
                 needle,
                 contains_needle_type(schema, source, value)?.as_ref(),
             )?,
         },
         Predicate::IsNull(value) => {
-            NormalizedPredicateExpr::IsNull(normalize_operand(source, value)?)
+            NormalizedPredicateExpr::IsNull(normalize_operand_for_schema(schema, source, value)?)
         }
         Predicate::EnumMatch {
             column,
@@ -593,11 +595,7 @@ fn normalize_compare(
 ) -> Result<NormalizedPredicateExpr, Error> {
     let left_type = operand_column_type(schema, source, left)?;
     let right_type = operand_column_type(schema, source, right)?;
-    let has_declared_id = schema
-        .tables
-        .iter()
-        .find(|table| table.name == source.table)
-        .is_some_and(|table| table.columns.iter().any(|column| column.name == "id"));
+    let has_declared_id = source_has_declared_id(schema, source);
     Ok(NormalizedPredicateExpr::Compare {
         left: normalize_operand_with_target_type_and_declared_id(
             source,
@@ -617,6 +615,41 @@ fn normalize_compare(
 
 fn normalize_operand(source: &SourceId, operand: &Operand) -> Result<NormalizedValueRef, Error> {
     normalize_operand_with_target_type(source, operand, None)
+}
+
+fn source_has_declared_id(schema: &JazzSchema, source: &SourceId) -> bool {
+    schema
+        .tables
+        .iter()
+        .find(|table| table.name == source.table)
+        .is_some_and(|table| table.columns.iter().any(|column| column.name == "id"))
+}
+
+fn normalize_operand_for_schema(
+    schema: &JazzSchema,
+    source: &SourceId,
+    operand: &Operand,
+) -> Result<NormalizedValueRef, Error> {
+    normalize_operand_with_target_type_and_declared_id(
+        source,
+        operand,
+        None,
+        source_has_declared_id(schema, source),
+    )
+}
+
+fn normalize_operand_with_target_type_for_schema(
+    schema: &JazzSchema,
+    source: &SourceId,
+    operand: &Operand,
+    target_type: Option<&ColumnType>,
+) -> Result<NormalizedValueRef, Error> {
+    normalize_operand_with_target_type_and_declared_id(
+        source,
+        operand,
+        target_type,
+        source_has_declared_id(schema, source),
+    )
 }
 
 fn normalize_operand_with_target_type(
@@ -1376,7 +1409,7 @@ fn normalize_join_via_right(
                 left: current,
                 right: nested_right,
                 mode: NormalizedJoinMode::Inner,
-                on: join_via_predicate(&join_source, &nested_source, nested),
+                on: join_via_predicate(schema, &join_source, &nested_source, nested),
             },
         );
         let project_node = RowSetNodeId(format!("{nested_path}:parent_project"));
@@ -1715,15 +1748,20 @@ pub(super) fn table_schema<'a>(
 }
 
 fn schema_column_type(schema: &JazzSchema, table: &str, column: &str) -> Result<ColumnType, Error> {
-    if column == "id" {
-        return Ok(ColumnType::Uuid);
-    }
-    table_schema(schema, table)?
+    let schema_table = table_schema(schema, table)?;
+    if let Some(column) = schema_table
         .columns
         .iter()
         .find(|candidate| candidate.name == column)
-        .map(|column| column.column_type.clone())
-        .ok_or_else(|| Error::QueryLowering(format!("unknown query column {table}.{column}")))
+    {
+        return Ok(column.column_type.clone());
+    }
+    if column == "id" {
+        return Ok(ColumnType::Uuid);
+    }
+    Err(Error::QueryLowering(format!(
+        "unknown query column {table}.{column}"
+    )))
 }
 
 fn row_id_output_field() -> TypedOutputField {
@@ -1745,11 +1783,15 @@ fn source_public_field_projections(table: &TableSchema, source: &SourceId) -> Ve
     .collect()
 }
 
-fn join_via_root_key(root_source: &SourceId, join: &JoinVia) -> NormalizedValueRef {
+fn join_via_root_key(
+    schema: &JazzSchema,
+    root_source: &SourceId,
+    join: &JoinVia,
+) -> NormalizedValueRef {
     join.source_column
         .as_ref()
         .map(|field| {
-            if field == "id" {
+            if field == "id" && !source_has_declared_id(schema, root_source) {
                 NormalizedValueRef::RowId(RowIdRef::Source(root_source.clone()))
             } else {
                 NormalizedValueRef::SourceField {
@@ -1772,6 +1814,7 @@ fn join_via_target_key(join_source: &SourceId, join: &JoinVia) -> NormalizedValu
 }
 
 fn join_via_predicate(
+    schema: &JazzSchema,
     left_source: &SourceId,
     right_source: &SourceId,
     join: &JoinVia,
@@ -1789,7 +1832,7 @@ fn join_via_predicate(
         )
     } else {
         (
-            join_via_root_key(left_source, join),
+            join_via_root_key(schema, left_source, join),
             join_via_target_key(right_source, join),
         )
     }];
@@ -1982,7 +2025,7 @@ fn normalize_filter_join_chain(
         };
         let (right, join_source) =
             normalize_join_via_right(nodes, auxiliary_sources, schema, join, &path)?;
-        let join_predicate = join_via_predicate(root_source, &join_source, join);
+        let join_predicate = join_via_predicate(schema, root_source, &join_source, join);
         if record_join_contributions {
             join_contributions.push(JoinContribution {
                 id: path.clone(),

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -2200,7 +2200,9 @@ where
         let query = shape.query();
         let mut access_paths = BTreeMap::new();
         let equalities = root_literal_equalities(query, binding)?;
-        if let Some(value) = equalities.get("id").cloned() {
+        let table = self.table_in_schema(&query.table, shape.schema_version())?;
+        let has_declared_id = table.columns.iter().any(|column| column.name == "id");
+        if !has_declared_id && let Some(value) = equalities.get("id").cloned() {
             access_paths.insert(
                 root_source_id(&query.table),
                 CurrentAccessPath::PrimaryKey(vec![value]),

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -2265,9 +2265,7 @@ where
     ) -> Result<(), Error> {
         let table = self.table_in_schema(table_name, schema_version)?;
         let equalities = literal_equalities_for_filters(filters, binding)?;
-        if let Some(value) = equalities.get("id").cloned() {
-            access_paths.insert(source.clone(), CurrentAccessPath::PrimaryKey(vec![value]));
-        } else if let Some(access_path) = select_current_access_path(&table, &equalities)
+        if let Some(access_path) = select_current_access_path(&table, &equalities)
             && matches!(access_path, CurrentAccessPath::PrimaryKey(_))
         {
             access_paths.insert(source.clone(), access_path);
@@ -3062,4 +3060,35 @@ pub(super) fn maintained_view_history_storage_field_names(table: &TableSchema) -
     );
     fields.push("authored_columns".to_owned());
     fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// This is an internal planner assertion because the selected physical
+    /// access path is not observable through the public query result. A
+    /// declared `id` must never be mistaken for the storage row UUID.
+    #[test]
+    fn declared_id_filter_does_not_select_the_physical_primary_key() {
+        let table = TableSchema::new("things", [ColumnSchema::new("id", ColumnType::Uuid)]);
+        let declared_id = uuid::Uuid::from_u128(0x99);
+        let equalities = BTreeMap::from([("id".to_owned(), Value::Uuid(declared_id))]);
+
+        assert!(select_current_access_path(&table, &equalities).is_none());
+    }
+
+    /// A table without a declared `id` retains the legacy physical row-id
+    /// primary-key access path.
+    #[test]
+    fn missing_declared_id_filter_selects_the_physical_primary_key() {
+        let table = TableSchema::new("things", [ColumnSchema::new("label", ColumnType::String)]);
+        let row_id = uuid::Uuid::from_u128(0x9a);
+        let equalities = BTreeMap::from([("id".to_owned(), Value::Uuid(row_id))]);
+
+        assert!(matches!(
+            select_current_access_path(&table, &equalities),
+            Some(CurrentAccessPath::PrimaryKey(values)) if values == vec![Value::Uuid(row_id)]
+        ));
+    }
 }

--- a/crates/jazz/src/node/query_eval/tests/materialization.rs
+++ b/crates/jazz/src/node/query_eval/tests/materialization.rs
@@ -714,7 +714,7 @@ fn flat_join_correlates_projected_v1_sources_across_table_rename() {
             alias: None,
             on: FlatJoinOn {
                 left: "posts.author_id".to_owned(),
-                right: "people.id".to_owned(),
+                right: "people._id".to_owned(),
             },
         }],
     });
@@ -726,7 +726,7 @@ fn flat_join_correlates_projected_v1_sources_across_table_rename() {
     assert_eq!(
         rows.len(),
         1,
-        "flat joins must use the source row identity for `id`, not an arbitrary stored id cell"
+        "flat joins must use the explicit source row identity alias, not an arbitrary stored id cell"
     );
 
     let opts = RegisterShapeOptions {

--- a/crates/jazz/src/node/query_eval/tests/normalization.rs
+++ b/crates/jazz/src/node/query_eval/tests/normalization.rs
@@ -1,6 +1,7 @@
 //! normalization query-evaluation tests.
 
 use super::*;
+use crate::node::query_eval::normalization::source_column_value;
 
 #[test]
 fn payload_enum_normalization_uses_case_local_field_types() {
@@ -100,6 +101,32 @@ fn declared_id_order_and_aggregate_lower_as_source_fields() {
         Some(RowSetExpr::Aggregate { group_by, .. })
             if matches!(group_by.as_slice(), [NormalizedValueRef::SourceField { source: key_source, field }]
                 if key_source == &source && field == "id")
+    ));
+}
+
+/// The shared source-key resolver is used by lookup joins, reachability seeds
+/// and access joins, array correlations, and flat joins. Declared `id` must
+/// select the authored field while legacy tables keep their physical row id.
+#[test]
+fn source_key_resolution_distinguishes_declared_and_physical_ids() {
+    let schema = JazzSchema::new([
+        TableSchema::new("declared", [ColumnSchema::new("id", ColumnType::Uuid)]),
+        TableSchema::new("legacy", [ColumnSchema::new("label", ColumnType::String)]),
+    ]);
+    let declared = root_source_id("declared");
+    let legacy = root_source_id("legacy");
+
+    assert!(matches!(
+        source_column_value(&schema, &declared, "id", JoinTarget::Column),
+        NormalizedValueRef::SourceField { source, field } if source == declared && field == "id"
+    ));
+    assert!(matches!(
+        source_column_value(&schema, &legacy, "id", JoinTarget::Column),
+        NormalizedValueRef::RowId(RowIdRef::Source(source)) if source == legacy
+    ));
+    assert!(matches!(
+        source_column_value(&schema, &declared, "id", JoinTarget::RowId),
+        NormalizedValueRef::RowId(RowIdRef::Source(source)) if source == declared
     ));
 }
 

--- a/crates/jazz/src/node/query_eval/tests/normalization.rs
+++ b/crates/jazz/src/node/query_eval/tests/normalization.rs
@@ -59,6 +59,50 @@ fn predicate_params_collects_every_operand_position_and_operator() {
     );
 }
 
+/// A declared `id` remains a user field in order and aggregate lowering;
+/// the physical row UUID is retained only for tables that do not declare it.
+#[test]
+fn declared_id_order_and_aggregate_lower_as_source_fields() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "things",
+        [
+            ColumnSchema::new("id", ColumnType::Uuid),
+            ColumnSchema::new("label", ColumnType::String),
+        ],
+    )]);
+    let (_dir, node) = open_node_with_uuid(NodeUuid::from_bytes([7; 16]), schema.clone());
+    let source = root_source_id("things");
+
+    let ordered = Query::from("things")
+        .order_by("id", OrderDirection::Asc)
+        .validate(&schema)
+        .unwrap();
+    let ordered = node
+        .normalized_row_set_shape(&ordered, &ordered.bind(BTreeMap::new()).unwrap())
+        .unwrap();
+    assert!(matches!(
+        ordered.nodes.get(&RowSetNodeId("order".to_owned())),
+        Some(RowSetExpr::OrderBy { keys, .. })
+            if matches!(keys.as_slice(), [NormalizedOrderKey { value: NormalizedValueRef::SourceField { source: key_source, field }, .. }]
+                if key_source == &source && field == "id")
+    ));
+
+    let grouped = Query::from("things")
+        .count()
+        .group_by("id")
+        .validate(&schema)
+        .unwrap();
+    let grouped = node
+        .normalized_row_set_shape(&grouped, &grouped.bind(BTreeMap::new()).unwrap())
+        .unwrap();
+    assert!(matches!(
+        grouped.nodes.get(&RowSetNodeId("aggregate".to_owned())),
+        Some(RowSetExpr::Aggregate { group_by, .. })
+            if matches!(group_by.as_slice(), [NormalizedValueRef::SourceField { source: key_source, field }]
+                if key_source == &source && field == "id")
+    ));
+}
+
 #[test]
 fn join_read_tables_include_source_lookups_and_nested_joins() {
     let nested = crate::query::JoinVia {

--- a/crates/jazz/src/node/query_eval/tests/normalization.rs
+++ b/crates/jazz/src/node/query_eval/tests/normalization.rs
@@ -237,6 +237,65 @@ fn declared_id_lookup_and_reachable_types_validate() {
     );
 }
 
+/// A same-table reachability seed may use `id` only when its effective
+/// frontier value is a non-null UUID; string and nullable declared IDs cannot
+/// drive UUID edge traversal.
+#[test]
+fn reachable_self_seed_id_requires_non_nullable_uuid() {
+    let schema = |team_id_type| {
+        JazzSchema::new([
+            TableSchema::new("roots", [ColumnSchema::new("label", ColumnType::String)]),
+            TableSchema::new(
+                "access",
+                [
+                    ColumnSchema::new("root", ColumnType::Uuid),
+                    ColumnSchema::new("team", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("root", "roots")
+            .with_reference("team", "teams"),
+            TableSchema::new(
+                "teams",
+                [
+                    ColumnSchema::new("id", team_id_type),
+                    ColumnSchema::new("identity", ColumnType::Uuid),
+                ],
+            ),
+            TableSchema::new(
+                "edges",
+                [
+                    ColumnSchema::new("member", ColumnType::Uuid),
+                    ColumnSchema::new("parent", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("member", "teams")
+            .with_reference("parent", "teams"),
+        ])
+    };
+    let query = || {
+        Query::from("roots")
+            .reachable_via(
+                "access",
+                "root",
+                "team",
+                lit(Value::Uuid(uuid::Uuid::nil())),
+                "edges",
+                "member",
+                "parent",
+                [],
+            )
+            .seeded_by("teams", "identity", "sub", "id")
+    };
+
+    assert!(query().validate(&schema(ColumnType::Uuid)).is_ok());
+    assert!(query().validate(&schema(ColumnType::String)).is_err());
+    assert!(
+        query()
+            .validate(&schema(ColumnType::Uuid.nullable()))
+            .is_err()
+    );
+}
+
 #[test]
 fn join_read_tables_include_source_lookups_and_nested_joins() {
     let nested = crate::query::JoinVia {

--- a/crates/jazz/src/node/query_eval/tests/normalization.rs
+++ b/crates/jazz/src/node/query_eval/tests/normalization.rs
@@ -161,6 +161,82 @@ fn declared_id_join_types_and_flat_join_physical_alias_validate() {
     assert!(flat.validate(&schema).is_ok());
 }
 
+/// Lookup and reachability policies must reject declared ID joins whose
+/// authored types disagree, while a matching declared-ID reachability path
+/// remains valid.
+#[test]
+fn declared_id_lookup_and_reachable_types_validate() {
+    let lookup_schema = JazzSchema::new([
+        TableSchema::new("roots", [ColumnSchema::new("lookup", ColumnType::Uuid)])
+            .with_reference("lookup", "lookups"),
+        TableSchema::new("lookups", [ColumnSchema::new("id", ColumnType::String)]),
+        TableSchema::new("children", [ColumnSchema::new("lookup", ColumnType::Uuid)])
+            .with_reference("lookup", "lookups"),
+    ]);
+    assert!(
+        Query::from("roots")
+            .join_via_source_lookup(
+                "children",
+                "lookup",
+                JoinSourceLookup {
+                    table: "lookups".to_owned(),
+                    row_id_source_column: "lookup".to_owned(),
+                    value_column: "id".to_owned(),
+                },
+                [],
+            )
+            .validate(&lookup_schema)
+            .is_err()
+    );
+
+    let reachable_schema = |root_id_type| {
+        JazzSchema::new([
+            TableSchema::new("roots", [ColumnSchema::new("id", root_id_type)]),
+            TableSchema::new(
+                "access",
+                [
+                    ColumnSchema::new("id", ColumnType::String),
+                    ColumnSchema::new("team", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("id", "roots")
+            .with_reference("team", "teams"),
+            TableSchema::new("teams", [ColumnSchema::new("label", ColumnType::String)]),
+            TableSchema::new(
+                "edges",
+                [
+                    ColumnSchema::new("member", ColumnType::Uuid),
+                    ColumnSchema::new("parent", ColumnType::Uuid),
+                ],
+            )
+            .with_reference("member", "teams")
+            .with_reference("parent", "teams"),
+        ])
+    };
+    let reachable = || {
+        Query::from("roots").reachable_via(
+            "access",
+            "id",
+            "team",
+            lit(Value::Uuid(uuid::Uuid::nil())),
+            "edges",
+            "member",
+            "parent",
+            [],
+        )
+    };
+    assert!(
+        reachable()
+            .validate(&reachable_schema(ColumnType::Uuid))
+            .is_err()
+    );
+    assert!(
+        reachable()
+            .validate(&reachable_schema(ColumnType::String))
+            .is_ok()
+    );
+}
+
 #[test]
 fn join_read_tables_include_source_lookups_and_nested_joins() {
     let nested = crate::query::JoinVia {

--- a/crates/jazz/src/node/query_eval/tests/normalization.rs
+++ b/crates/jazz/src/node/query_eval/tests/normalization.rs
@@ -130,6 +130,37 @@ fn source_key_resolution_distinguishes_declared_and_physical_ids() {
     ));
 }
 
+/// A declared string `id` cannot be used as a UUID foreign-key join source,
+/// while FlatJoin's explicit `_id` alias remains the physical UUID row key.
+#[test]
+fn declared_id_join_types_and_flat_join_physical_alias_validate() {
+    let schema = JazzSchema::new([
+        TableSchema::new("parents", [ColumnSchema::new("id", ColumnType::String)]),
+        TableSchema::new("children", [ColumnSchema::new("parent", ColumnType::Uuid)])
+            .with_reference("parent", "parents"),
+    ]);
+    assert!(
+        Query::from("parents")
+            .join_via_column("children", "parent", "id", [])
+            .validate(&schema)
+            .is_err()
+    );
+
+    let mut flat = Query::from("parents");
+    flat.flat_join = Some(FlatJoin {
+        root_alias: None,
+        sources: vec![FlatJoinSource {
+            table: "children".to_owned(),
+            alias: None,
+            on: FlatJoinOn {
+                left: "parents._id".to_owned(),
+                right: "children.parent".to_owned(),
+            },
+        }],
+    });
+    assert!(flat.validate(&schema).is_ok());
+}
+
 #[test]
 fn join_read_tables_include_source_lookups_and_nested_joins() {
     let nested = crate::query::JoinVia {

--- a/crates/jazz/src/node/tests/policies_rls/includes.rs
+++ b/crates/jazz/src/node/tests/policies_rls/includes.rs
@@ -78,6 +78,56 @@ fn parent_ref_join_matches_a_declared_id_column_instead_of_the_physical_row_uuid
 
 }
 
+/// A serving authority's internal point-read authorization must select the
+/// physical target row even when `id` is declared user data. Alice owns the
+/// row, while its declared id deliberately differs from its storage identity.
+#[test]
+fn point_read_authorization_keeps_using_physical_row_uuid_with_declared_id() {
+    let alice = user(0xa1);
+    let schema = JazzSchema::new([TableSchema::new(
+        "documents",
+        [
+            ColumnSchema::new("id", ColumnType::Uuid),
+            ColumnSchema::new("owner", ColumnType::Uuid),
+        ],
+    )
+    .with_read_policy(Policy::owner_only("documents", "owner"))
+    .with_write_policy(Some(Query::from("documents")))]);
+    let (_core_dir, mut core) = open_node_with_schema(node(0xa9), schema);
+    let physical_row = row(0xc1);
+    let declared_id = row(0xd1);
+    let tx = core
+        .commit_mergeable_unit(
+            MergeableCommit::new("documents", physical_row, 10).cells(BTreeMap::from([
+                ("id".to_owned(), Value::Uuid(declared_id.0)),
+                ("owner".to_owned(), Value::Uuid(alice.0)),
+            ])),
+        )
+        .unwrap();
+    core.apply_fate_update(
+        tx.0,
+        Fate::Accepted,
+        Some(core.clock.next_global_seq),
+        Some(DurabilityTier::Global),
+    )
+    .unwrap();
+
+    core.reset_query_engine_read_metrics();
+    assert!(
+        core.dry_run_read_current_allows("documents", physical_row, alice)
+            .unwrap()
+    );
+    assert_eq!(
+        core.query_engine_read_metrics().source_primary_key_scans,
+        1,
+        "the authorization probe must point-scan the physical row"
+    );
+    assert!(
+        core.dry_run_write_current_allows("documents", physical_row, alice)
+            .unwrap()
+    );
+}
+
 fn required_include_shape(core: &NodeState<RocksDbStorage>, include: Include) -> ValidatedQuery {
     Query::from("roots")
         .include_with(include)

--- a/crates/jazz/src/node/tests/policies_rls/includes.rs
+++ b/crates/jazz/src/node/tests/policies_rls/includes.rs
@@ -21,6 +21,63 @@ fn required_include_rls_schema() -> JazzSchema {
     ])
 }
 
+#[test]
+fn parent_ref_join_matches_a_declared_id_column_instead_of_the_physical_row_uuid() {
+    let schema = JazzSchema::new([
+        TableSchema::new(
+            "memberships",
+            [
+                ColumnSchema::new("chat", ColumnType::Uuid),
+                ColumnSchema::new("label", ColumnType::String),
+            ],
+        )
+        .with_reference("chat", "chats"),
+        TableSchema::new(
+            "chats",
+            [
+                ColumnSchema::new("id", ColumnType::Uuid),
+                ColumnSchema::new("title", ColumnType::String),
+            ],
+        ),
+    ]);
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let physical_chat = row(0xc1);
+    let declared_chat_id = row(0xaa);
+    let membership = row(0xd1);
+    let tx = core
+        .commit_mergeable_many(vec![
+            MergeableCommit::new("chats", physical_chat, 10).cells(BTreeMap::from([
+                ("id".to_owned(), Value::Uuid(declared_chat_id.0)),
+                ("title".to_owned(), v("declared-id chat")),
+            ])),
+            MergeableCommit::new("memberships", membership, 11).cells(BTreeMap::from([
+                ("chat".to_owned(), Value::Uuid(declared_chat_id.0)),
+                ("label".to_owned(), v("membership")),
+            ])),
+        ])
+        .unwrap();
+    core.apply_fate_update(
+        tx,
+        Fate::Accepted,
+        Some(core.clock.next_global_seq),
+        Some(DurabilityTier::Global),
+    )
+    .unwrap();
+
+    // This is the core query shape emitted by a binding-layer parent include:
+    // correlate the child's foreign-key value with the parent's declared `id`.
+    let shape = Query::from("memberships")
+        .join_via_column("chats", "id", "chat", [])
+        .validate(&core.catalogue.schema)
+        .unwrap();
+    let rows = required_include_rows(&mut core, &shape, AuthorId::SYSTEM);
+    assert_eq!(
+        rows.into_iter().map(|row| row.row_uuid()).collect::<Vec<_>>(),
+        vec![membership]
+    );
+
+}
+
 fn required_include_shape(core: &NodeState<RocksDbStorage>, include: Include) -> ValidatedQuery {
     Query::from("roots")
         .include_with(include)
@@ -654,4 +711,3 @@ fn system_identity_required_include_uses_existence_only_resolvability() {
         BTreeSet::from([row(0xd1), row(0xd2)])
     );
 }
-

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -79,6 +79,34 @@ fn one_shot_filtered_read_uses_primary_key_scan_for_id_equality() {
 }
 
 #[test]
+fn declared_id_column_filter_uses_declared_value_not_physical_row_uuid() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "things",
+        [
+            ColumnSchema::new("id", ColumnType::Uuid),
+            ColumnSchema::new("label", ColumnType::String),
+        ],
+    )]);
+    let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let physical_row = row(0x11);
+    let declared_id = row(0xaa);
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("things", physical_row, 10).cells(BTreeMap::from([
+            ("id".to_owned(), Value::Uuid(declared_id.0)),
+            ("label".to_owned(), Value::String("declared id".to_owned())),
+        ])),
+    );
+
+    let query = Query::from("things").filter(eq(col("id"), lit(Value::Uuid(declared_id.0))));
+    let (selected, _) = query_rows_by_uuid(&mut core, query, DurabilityTier::Global);
+
+    assert_eq!(selected, vec![physical_row]);
+}
+
+#[test]
 fn one_shot_filtered_read_uses_declared_index_for_indexed_column_equality() {
     let schema = access_path_schema();
     let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -221,8 +221,8 @@ fn inverse_join_via_column_uses_root_declared_id() {
     assert_eq!(rows, vec![parent]);
 }
 
-/// Alice's declared IDs control final one-shot ordering and pagination, even
-/// when their physical row UUID order is the opposite.
+/// Alice's declared IDs control final one-shot ordering and multi-row
+/// pagination, even when their physical row UUID order is the opposite.
 #[test]
 fn declared_id_order_and_pagination_use_declared_values() {
     let schema = JazzSchema::new([TableSchema::new(
@@ -236,12 +236,21 @@ fn declared_id_order_and_pagination_use_declared_values() {
     let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
     let physically_first = row(0x31);
     let physically_second = row(0x32);
+    let physically_third = row(0x33);
     commit_mergeable_global(
         &mut writer,
         &mut core,
         MergeableCommit::new("things", physically_first, 10).cells(BTreeMap::from([
             ("id".to_owned(), Value::Uuid(row(0xf1).0)),
             ("label".to_owned(), Value::String("later".to_owned())),
+        ])),
+    );
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("things", physically_third, 12).cells(BTreeMap::from([
+            ("id".to_owned(), Value::Uuid(row(0x80).0)),
+            ("label".to_owned(), Value::String("middle".to_owned())),
         ])),
     );
     commit_mergeable_global(
@@ -257,10 +266,11 @@ fn declared_id_order_and_pagination_use_declared_values() {
         &mut core,
         Query::from("things")
             .order_by("id", OrderDirection::Asc)
-            .limit(1),
+            .offset(1)
+            .limit(2),
         DurabilityTier::Global,
     );
-    assert_eq!(rows, vec![physically_second]);
+    assert_eq!(rows, vec![physically_third, physically_first]);
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -1,3 +1,5 @@
+use crate::query::{in_list, is_null};
+
 fn access_path_schema() -> JazzSchema {
     JazzSchema::new([TableSchema::new(
         "docs",
@@ -104,6 +106,119 @@ fn declared_id_column_filter_uses_declared_value_not_physical_row_uuid() {
     let (selected, _) = query_rows_by_uuid(&mut core, query, DurabilityTier::Global);
 
     assert_eq!(selected, vec![physical_row]);
+}
+
+/// A declared `id` is an ordinary user column for IN and NULL predicates;
+/// Alice's physical row UUID must not leak into either predicate evaluation.
+#[test]
+fn declared_id_column_in_and_is_null_use_declared_values() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "things",
+        [
+            ColumnSchema::new("id", ColumnType::Nullable(Box::new(ColumnType::Uuid))),
+            ColumnSchema::new("label", ColumnType::String),
+        ],
+    )]);
+    let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let matching_row = row(0x12);
+    let null_row = row(0x13);
+    let declared_id = row(0xab);
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("things", matching_row, 10).cells(BTreeMap::from([
+            (
+                "id".to_owned(),
+                Value::Nullable(Some(Box::new(Value::Uuid(declared_id.0)))),
+            ),
+            ("label".to_owned(), Value::String("matching".to_owned())),
+        ])),
+    );
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("things", null_row, 11).cells(BTreeMap::from([
+            ("id".to_owned(), Value::Nullable(None)),
+            ("label".to_owned(), Value::String("null".to_owned())),
+        ])),
+    );
+
+    let (in_rows, _) = query_rows_by_uuid(
+        &mut core,
+        Query::from("things").filter(in_list(
+            col("id"),
+            [lit(Value::Nullable(Some(Box::new(Value::Uuid(declared_id.0)))) )],
+        )),
+        DurabilityTier::Global,
+    );
+    let (null_rows, _) = query_rows_by_uuid(
+        &mut core,
+        Query::from("things").filter(is_null(col("id"))),
+        DurabilityTier::Global,
+    );
+    assert_eq!(in_rows, vec![matching_row]);
+    assert_eq!(null_rows, vec![null_row]);
+
+    let missing_id_schema = JazzSchema::new([TableSchema::new(
+        "without_declared_id",
+        [ColumnSchema::new("label", ColumnType::String)],
+    )]);
+    assert!(Query::from("without_declared_id")
+        .filter(is_null(col("id")))
+        .validate(&missing_id_schema)
+        .is_err());
+}
+
+/// Alice joins a child back to a parent through the parent's declared `id`,
+/// rather than accidentally comparing the child FK with the physical row UUID.
+#[test]
+fn inverse_join_via_column_uses_root_declared_id() {
+    let schema = JazzSchema::new([
+        TableSchema::new(
+            "parents",
+            [
+                ColumnSchema::new("id", ColumnType::Uuid),
+                ColumnSchema::new("label", ColumnType::String),
+            ],
+        ),
+        TableSchema::new(
+            "children",
+            [
+                ColumnSchema::new("parent", ColumnType::Uuid),
+                ColumnSchema::new("label", ColumnType::String),
+            ],
+        )
+        .with_reference("parent", "parents"),
+    ]);
+    let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let parent = row(0x21);
+    let child = row(0x22);
+    let declared_parent_id = row(0xac);
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("parents", parent, 10).cells(BTreeMap::from([
+            ("id".to_owned(), Value::Uuid(declared_parent_id.0)),
+            ("label".to_owned(), Value::String("parent".to_owned())),
+        ])),
+    );
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("children", child, 11).cells(BTreeMap::from([
+            ("parent".to_owned(), Value::Uuid(declared_parent_id.0)),
+            ("label".to_owned(), Value::String("child".to_owned())),
+        ])),
+    );
+
+    let (rows, _) = query_rows_by_uuid(
+        &mut core,
+        Query::from("parents").join_via_column("children", "parent", "id", []),
+        DurabilityTier::Global,
+    );
+    assert_eq!(rows, vec![parent]);
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -221,6 +221,48 @@ fn inverse_join_via_column_uses_root_declared_id() {
     assert_eq!(rows, vec![parent]);
 }
 
+/// Alice's declared IDs control final one-shot ordering and pagination, even
+/// when their physical row UUID order is the opposite.
+#[test]
+fn declared_id_order_and_pagination_use_declared_values() {
+    let schema = JazzSchema::new([TableSchema::new(
+        "things",
+        [
+            ColumnSchema::new("id", ColumnType::Uuid),
+            ColumnSchema::new("label", ColumnType::String),
+        ],
+    )]);
+    let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let physically_first = row(0x31);
+    let physically_second = row(0x32);
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("things", physically_first, 10).cells(BTreeMap::from([
+            ("id".to_owned(), Value::Uuid(row(0xf1).0)),
+            ("label".to_owned(), Value::String("later".to_owned())),
+        ])),
+    );
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("things", physically_second, 11).cells(BTreeMap::from([
+            ("id".to_owned(), Value::Uuid(row(0x01).0)),
+            ("label".to_owned(), Value::String("earlier".to_owned())),
+        ])),
+    );
+
+    let (rows, _) = query_rows_by_uuid(
+        &mut core,
+        Query::from("things")
+            .order_by("id", OrderDirection::Asc)
+            .limit(1),
+        DurabilityTier::Global,
+    );
+    assert_eq!(rows, vec![physically_second]);
+}
+
 #[test]
 fn one_shot_filtered_read_uses_declared_index_for_indexed_column_equality() {
     let schema = access_path_schema();

--- a/crates/jazz/src/query/validation.rs
+++ b/crates/jazz/src/query/validation.rs
@@ -390,9 +390,7 @@ fn validate_join(
                 });
             }
         }
-        if lookup.value_column != "id" {
-            planner_column_type(&lookup_table, &lookup.value_column)?;
-        }
+        planner_column_type(&lookup_table, &lookup.value_column)?;
         if join.source_column.as_deref() != Some(lookup.value_column.as_str()) {
             return Err(QueryError::JoinNotRefCompatible {
                 join_table: lookup.table.clone(),
@@ -581,6 +579,10 @@ fn planner_column_type<'a>(
     Ok(&column_schema(table, column)?.column_type)
 }
 
+fn has_declared_id(table: &TableSchema) -> bool {
+    table.columns.iter().any(|column| column.name == "id")
+}
+
 fn executable_magic_column_type(column: &str) -> Result<Option<&'static ColumnType>, QueryError> {
     if is_permission_introspection_magic_column(column) {
         return Err(QueryError::UnsupportedMagicColumn {
@@ -678,7 +680,7 @@ fn validate_reachable(
     let access = table(schema, &reachable.access_table)?;
     planner_column_type(&access, &reachable.access_row_column)?;
     planner_column_type(&access, &reachable.access_team_column)?;
-    if reachable.access_row_column == "id" {
+    if reachable.access_row_column == "id" && !has_declared_id(&access) {
         if access.name != root.name {
             return Err(QueryError::JoinNotRefCompatible {
                 join_table: reachable.access_table.clone(),
@@ -731,7 +733,7 @@ fn validate_reachable(
     let edge = table(schema, &reachable.edge_table)?;
     for column in [&reachable.edge_member_column, &reachable.edge_parent_column] {
         planner_column_type(&edge, column)?;
-        if *column == "id" && edge.name == *team_table {
+        if *column == "id" && !has_declared_id(&edge) && edge.name == *team_table {
             continue;
         }
         match edge.references.get(column) {
@@ -751,7 +753,7 @@ fn validate_reachable(
         if let Some(user_column) = &seed.user_column {
             planner_column_type(&seed_table, user_column)?;
         }
-        let seed_projects_team = if seed.team_column == "id" {
+        let seed_projects_team = if seed.team_column == "id" && !has_declared_id(&seed_table) {
             seed_table.name == *team_table
         } else {
             matches!(

--- a/crates/jazz/src/query/validation.rs
+++ b/crates/jazz/src/query/validation.rs
@@ -569,6 +569,9 @@ fn planner_column_type<'a>(
     table: &'a TableSchema,
     column: &str,
 ) -> Result<&'a ColumnType, QueryError> {
+    if let Ok(column_schema) = column_schema(table, column) {
+        return Ok(&column_schema.column_type);
+    }
     if column == "id" {
         return Ok(&ColumnType::Uuid);
     }

--- a/crates/jazz/src/query/validation.rs
+++ b/crates/jazz/src/query/validation.rs
@@ -402,6 +402,13 @@ fn validate_join(
             }
         }
         planner_column_type(&lookup_table, &lookup.value_column)?;
+        if lookup.value_column == "id"
+            && has_declared_id(&lookup_table)
+            && planner_column_type(&lookup_table, &lookup.value_column)?
+                != planner_column_type(&join_table, &join.on_column)?
+        {
+            return Err(QueryError::OperandTypeMismatch);
+        }
         if join.source_column.as_deref() != Some(lookup.value_column.as_str()) {
             return Err(QueryError::JoinNotRefCompatible {
                 join_table: lookup.table.clone(),
@@ -697,6 +704,11 @@ fn validate_reachable(
     let access = table(schema, &reachable.access_table)?;
     planner_column_type(&access, &reachable.access_row_column)?;
     planner_column_type(&access, &reachable.access_team_column)?;
+    let root_key_type = if has_declared_id(root) {
+        planner_column_type(root, "id")?
+    } else {
+        &ColumnType::Uuid
+    };
     if reachable.access_row_column == "id" && !has_declared_id(&access) {
         if access.name != root.name {
             return Err(QueryError::JoinNotRefCompatible {
@@ -707,8 +719,7 @@ fn validate_reachable(
         }
     } else if access.name == root.name {
         let access_column_type = planner_column_type(&access, &reachable.access_row_column)?;
-        let root_column_type = planner_column_type(root, &reachable.access_row_column)?;
-        if !column_types_comparable(access_column_type, root_column_type) {
+        if !column_types_comparable(access_column_type, root_key_type) {
             return Err(QueryError::JoinNotRefCompatible {
                 join_table: reachable.access_table.clone(),
                 column: reachable.access_row_column.clone(),
@@ -725,6 +736,12 @@ fn validate_reachable(
                     target_table: root.name.clone(),
                 });
             }
+        }
+        if !column_types_comparable(
+            planner_column_type(&access, &reachable.access_row_column)?,
+            root_key_type,
+        ) {
+            return Err(QueryError::OperandTypeMismatch);
         }
     }
     let team_table = match reachable.access_team_target {

--- a/crates/jazz/src/query/validation.rs
+++ b/crates/jazz/src/query/validation.rs
@@ -783,11 +783,13 @@ fn validate_reachable(
     }
     if let Some(seed) = &reachable.seed {
         let seed_table = table(schema, &seed.table)?;
-        planner_column_type(&seed_table, &seed.team_column)?;
+        if planner_column_type(&seed_table, &seed.team_column)? != &ColumnType::Uuid {
+            return Err(QueryError::OperandTypeMismatch);
+        }
         if let Some(user_column) = &seed.user_column {
             planner_column_type(&seed_table, user_column)?;
         }
-        let seed_projects_team = if seed.team_column == "id" && !has_declared_id(&seed_table) {
+        let seed_projects_team = if seed.team_column == "id" {
             seed_table.name == *team_table
         } else {
             matches!(

--- a/crates/jazz/src/query/validation.rs
+++ b/crates/jazz/src/query/validation.rs
@@ -312,6 +312,17 @@ fn flat_join_qualified_field(field: &str) -> Result<(&str, &str), QueryError> {
         })
 }
 
+fn flat_join_column_type<'a>(
+    table: &'a TableSchema,
+    column: &str,
+) -> Result<&'a ColumnType, QueryError> {
+    if column == "_id" {
+        Ok(&ColumnType::Uuid)
+    } else {
+        planner_column_type(table, column)
+    }
+}
+
 fn validate_flat_join(
     schema: &JazzSchema,
     root_table: &str,
@@ -346,8 +357,8 @@ fn validate_flat_join(
         }
         let left_schema = table(schema, left_table)?;
         let right_schema = table(schema, &source.table)?;
-        if planner_column_type(&left_schema, left_column)?
-            != planner_column_type(&right_schema, right_column)?
+        if flat_join_column_type(&left_schema, left_column)?
+            != flat_join_column_type(&right_schema, right_column)?
         {
             return Err(QueryError::OperandTypeMismatch);
         }
@@ -413,6 +424,12 @@ fn validate_join(
         }
     } else if let Some(source_column) = &join.source_column {
         if source_column == "id" {
+            if has_declared_id(root)
+                && planner_column_type(root, source_column)?
+                    != planner_column_type(&join_table, &join.on_column)?
+            {
+                return Err(QueryError::OperandTypeMismatch);
+            }
             root_table.to_owned()
         } else {
             planner_column_type(root, source_column)?;


### PR DESCRIPTION
## What changed

Resolve a schema-declared `id` column before falling back to Jazz's physical row UUID in predicate normalization, access-path selection, and join-key lowering.

## Why

Several query paths treated every column named `id` as the hidden physical row identity. Queries returned no rows when an application declared its own `id` whose value differed from the physical UUID. The primary-key optimizer could also incorrectly narrow the scan using the declared value.

## Impact

Filters and parent-reference join shapes use the application column when it exists. Tables without a declared `id` retain the existing physical-row-ID behavior.

## Validation

- Added direct declared-ID filter regression
- Added parent-reference join regression
- Full Jazz library suite: 1285 passed, 0 failed, 2 ignored
- Pre-commit Clippy and rustfmt hooks passed

Stacked on #1649.
