### PR TITLE
(new core) use point reads for write policy checks

### DIFF
--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -487,6 +487,16 @@ where
             .unwrap_or(false)
     }
 
+    /// Retire a prepared graph after all bindings have been unsubscribed.
+    /// Long-lived callers should retain and reuse their shapes; one-shot
+    /// callers must retire dynamically compiled shapes to release graph nodes.
+    pub fn retire_prepared_shape(&mut self, shape: PreparedShapeId) -> Result<(), Error> {
+        self.ensure_not_poisoned()?;
+        self.ivm_runtime
+            .retire_prepared_shape(shape)
+            .map_err(Error::IvmRuntime)
+    }
+
     /// Retire subscriptions whose receiving handles have already been
     /// dropped, even when no later data delta exists to discover the closed
     /// notification channel.

--- a/crates/groove/src/db/tests/subscriptions/parameters.rs
+++ b/crates/groove/src/db/tests/subscriptions/parameters.rs
@@ -574,6 +574,115 @@ fn prepared_shapes_retain_output_graph_nodes_without_subscribers() {
 }
 
 #[test]
+fn retiring_prepared_shape_releases_only_its_own_graph_after_unsubscribe() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = TestStorage::open(
+        temp_dir.path().join("groove-test.btree"),
+        &["albums", "artists"],
+    )
+    .unwrap();
+    let mut database = Database::new(albums_artists_schema(), storage).unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![
+            Value::U64(1),
+            Value::U64(7),
+            Value::String("Blue Train".to_owned()),
+        ],
+    );
+    database.commit_batch(batch).unwrap();
+    let baseline = database.runtime_stats();
+
+    // These deliberately share an identical binding source and graph. Retiring
+    // the first must not remove the descriptor or retained graph used by its
+    // sibling.
+    let first = database
+        .prepare_one_sink(
+            artist_album_shape_graph(),
+            "artist_params",
+            artist_binding_descriptor(),
+            ["artist_id"],
+        )
+        .unwrap();
+    let second = database
+        .prepare_one_sink(
+            artist_album_shape_graph(),
+            "artist_params",
+            artist_binding_descriptor(),
+            ["artist_id"],
+        )
+        .unwrap();
+    let first_id = first.id();
+    let second_id = second.id();
+    let first_subscription = database
+        .bind_shape_one_sink(first_id, &[Value::U64(7)])
+        .unwrap();
+    assert!(matches!(
+        database.retire_prepared_shape(first_id),
+        Err(Error::IvmRuntime(IvmRuntimeError::PreparedShapeHasActiveBindings(id))) if id == first_id
+    ));
+    assert_eq!(
+        expect_try_recv_vals(&first_subscription),
+        vec![(
+            vec![
+                Value::U64(7),
+                Value::U64(1),
+                Value::String("Blue Train".to_owned())
+            ],
+            1,
+        )]
+    );
+    database.unsubscribe(first_subscription.id());
+    database.retire_prepared_shape(first_id).unwrap();
+
+    assert!(matches!(
+        database.bind_shape_one_sink(first_id, &[Value::U64(7)]),
+        Err(Error::IvmRuntime(IvmRuntimeError::PreparedShapeNotFound(id))) if id == first_id
+    ));
+    let second_subscription = database
+        .bind_shape_one_sink(second_id, &[Value::U64(7)])
+        .expect("retiring a sibling must preserve its shared binding source");
+    assert_eq!(
+        expect_try_recv_vals(&second_subscription),
+        vec![(
+            vec![
+                Value::U64(7),
+                Value::U64(1),
+                Value::String("Blue Train".to_owned())
+            ],
+            1,
+        )]
+    );
+    database.unsubscribe(second_subscription.id());
+    database.retire_prepared_shape(second_id).unwrap();
+
+    assert!(matches!(
+        database.retire_prepared_shape(second_id),
+        Err(Error::IvmRuntime(IvmRuntimeError::PreparedShapeNotFound(id))) if id == second_id
+    ));
+    assert!(matches!(
+        database.bind_shape_one_sink(second_id, &[Value::U64(7)]),
+        Err(Error::IvmRuntime(IvmRuntimeError::PreparedShapeNotFound(id))) if id == second_id
+    ));
+    let final_stats = database.runtime_stats();
+    assert_eq!(
+        final_stats.active_subscriptions,
+        baseline.active_subscriptions
+    );
+    assert_eq!(
+        final_stats.active_prepared_shapes,
+        baseline.active_prepared_shapes
+    );
+    assert_eq!(
+        final_stats.active_shape_params,
+        baseline.active_shape_params
+    );
+    assert_eq!(final_stats.graph_nodes, baseline.graph_nodes);
+    assert_eq!(final_stats.arrangement_count, baseline.arrangement_count);
+}
+
+#[test]
 fn prepared_subscription_matches_literal_subscription_without_param_columns() {
     let temp_dir = tempfile::tempdir().unwrap();
     let storage = TestStorage::open(

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -354,6 +354,8 @@ pub enum IvmRuntimeError {
     StorageUnavailable,
     #[error("subscription shape not found: {0:?}")]
     PreparedShapeNotFound(PreparedShapeId),
+    #[error("cannot retire prepared shape {0:?} while it has active bindings")]
+    PreparedShapeHasActiveBindings(PreparedShapeId),
     #[error("runtime state is stale: expected={expected}, actual={actual:?}")]
     StaleRuntimeState {
         expected: String,

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -2016,6 +2016,43 @@ impl IvmRuntime {
         Ok(false)
     }
 
+    /// Remove a caller-owned prepared shape after all of its bindings have
+    /// been unsubscribed. Binding-source entries are intentionally retained:
+    /// multiple prepared shapes may share the same source descriptor, while
+    /// their graph retainers are owned by this exact shape id.
+    pub fn retire_prepared_shape(
+        &mut self,
+        shape_id: PreparedShapeId,
+    ) -> Result<(), IvmRuntimeError> {
+        if self.multisink_subscriptions.values().any(|subscription| {
+            matches!(
+                subscription.target,
+                MultisinkSubscriptionTarget::RoutedShape { shape_id: active, .. } if active == shape_id
+            )
+        }) {
+            return Err(IvmRuntimeError::PreparedShapeHasActiveBindings(shape_id));
+        }
+        let shape = self
+            .prepared_shapes
+            .remove(&shape_id)
+            .ok_or(IvmRuntimeError::PreparedShapeNotFound(shape_id))?;
+        for output_node in shape
+            .terminals
+            .values()
+            .map(|terminal| terminal.output.node)
+        {
+            self.remove_retainer(
+                output_node,
+                &Retainer::PreparedShape(shape_id.retainer_key()),
+            );
+        }
+        for node in self.gc_ephemeral_nodes(0) {
+            self.remove_node_runtime(node);
+        }
+        self.prune_unreferenced_arrangements();
+        Ok(())
+    }
+
     pub(crate) fn prune_dropped_subscriptions_with_storage<S>(
         &mut self,
         storage: &S,

--- a/crates/jazz/src/node/policy.rs
+++ b/crates/jazz/src/node/policy.rs
@@ -304,11 +304,7 @@ where
             return Ok(true);
         }
         let table = self.table(table_name)?.clone();
-        let Some(row) = self
-            .current_rows(table_name, DurabilityTier::Local)?
-            .into_iter()
-            .find(|row| row.row_uuid() == row_uuid)
-        else {
+        let Some(row) = self.local_current_row(table_name, row_uuid)? else {
             return Ok(false);
         };
         let Some(policy) = table.write_policies.update_using.clone() else {
@@ -327,11 +323,7 @@ where
             return Ok(true);
         }
         let table = self.table(table_name)?.clone();
-        let Some(row) = self
-            .current_rows(table_name, DurabilityTier::Local)?
-            .into_iter()
-            .find(|row| row.row_uuid() == row_uuid)
-        else {
+        let Some(row) = self.local_current_row(table_name, row_uuid)? else {
             return Ok(false);
         };
         let Some(policy) = table.write_policies.delete_using.clone() else {

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -2071,10 +2071,30 @@ where
             CurrentQueryProgramOutput::AppRows,
             access_paths,
         )?;
-        let deltas = self
-            .database
-            .query_graph(lowered_materialization_app_rows_graph(&program)?)
-            .map_err(Error::Groove)?;
+        // A policy can introduce claim parameters even though this physical
+        // row lookup has no public query parameters. Those programs must go
+        // through Groove's prepare/bind boundary just like ordinary serving
+        // reads; executing the lowered graph directly leaves its binding
+        // source unprepared and fails instead of representing a denied read.
+        let plan = self.prepared_query_plan_from_program(&program, shape, binding)?;
+        let policy = self.query_program_policy_context(identity);
+        let deltas = match plan {
+            PreparedQueryPlan::Prepared { shape, params } => {
+                let values = binding_values_for_plan(
+                    binding,
+                    &params,
+                    &policy,
+                    PreparedClaimBindingMode::Strict,
+                )?;
+                self.bind_disposable_shape_snapshot(shape, &values)?
+            }
+            PreparedQueryPlan::Graph(graph) => {
+                self.database.query_graph(graph).map_err(Error::Groove)?
+            }
+            PreparedQueryPlan::PeerMaintainedMarker => {
+                unreachable!("point reads never use peer-maintained plans")
+            }
+        };
         let mut rows = self.materialize_inline_current_query_rows(&table, deltas)?;
         self.finish_engine_query_rows_in_schema(shape.query(), shape.schema_version(), &mut rows)?;
         Ok(rows)
@@ -2695,6 +2715,37 @@ where
         let snapshot = subscription.recv().map_err(|_| Error::SubscriptionClosed);
         self.database.unsubscribe(subscription_id);
         snapshot
+    }
+
+    /// Bind and immediately retire a one-shot prepared graph. Point reads
+    /// compile a physical-row access path, so their graph cannot be safely
+    /// shared with later rows; retaining it would leak one shape per advice or
+    /// repair request.
+    fn bind_disposable_shape_snapshot(
+        &mut self,
+        shape: PreparedShapeId,
+        values: &[groove::records::Value],
+    ) -> Result<RecordDeltas, Error> {
+        let subscription = match self
+            .database
+            .bind_shape(shape, values)
+            .map_err(Error::Groove)
+        {
+            Ok(subscription) => subscription,
+            Err(error) => {
+                self.database
+                    .retire_prepared_shape(shape)
+                    .map_err(Error::Groove)?;
+                return Err(error);
+            }
+        };
+        let subscription_id = subscription.id();
+        let snapshot = subscription.recv().map_err(|_| Error::SubscriptionClosed);
+        self.database.unsubscribe(subscription_id);
+        self.database
+            .retire_prepared_shape(shape)
+            .map_err(Error::Groove)?;
+        snapshot.and_then(|deltas| take_required_sink_deltas(deltas, JAZZ_APP_ROWS_SINK))
     }
 }
 

--- a/crates/jazz/src/node/query_eval/tests/authorization.rs
+++ b/crates/jazz/src/node/query_eval/tests/authorization.rs
@@ -876,6 +876,104 @@ fn missing_policy_relation_seed_claim_fails_closed_without_breaking_prepared_bin
 }
 
 #[test]
+fn declared_id_point_read_prepares_claim_policy_bindings() {
+    // This deliberately exercises the internal point-read helper because it
+    // is the authorization-support path used by PermissionAdvice and repair,
+    // rather than a public client query. A declared `id` forces that helper to
+    // select by physical row UUID while the read policy requires a claim
+    // binding. The owner and denied reader must see the policy result, not a
+    // Groove binding-source execution error; changing ownership must reverse
+    // those results.
+    let schema = JazzSchema::new([TableSchema::new(
+        "documents",
+        [
+            ColumnSchema::new("id", ColumnType::Uuid),
+            ColumnSchema::new("owner", ColumnType::Uuid),
+            ColumnSchema::new("title", ColumnType::String),
+        ],
+    )
+    .with_read_policy(Policy::shape(
+        Query::from("documents").filter(eq(col("owner"), claim("user_id"))),
+    ))
+    .with_write_policy(Policy::public())]);
+    let (_dir, mut node) = open_node_with_uuid(NodeUuid::from_bytes([0xd1; 16]), schema);
+    let alice = author(0xd2);
+    let bob = author(0xd3);
+    let document = row(0xd4);
+
+    node.set_session_claims(
+        alice,
+        BTreeMap::from([("user_id".to_owned(), Value::Uuid(alice.0))]),
+    );
+    node.set_session_claims(
+        bob,
+        BTreeMap::from([("user_id".to_owned(), Value::Uuid(bob.0))]),
+    );
+    commit_global_cells(
+        &mut node,
+        "documents",
+        document,
+        BTreeMap::from([
+            ("id".to_owned(), Value::Uuid(row(0xd5).0)),
+            ("owner".to_owned(), Value::Uuid(alice.0)),
+            ("title".to_owned(), Value::String("private".to_owned())),
+        ]),
+        1,
+        1,
+    );
+    let prepared_shape_baseline = node.runtime_stats_for_test().active_prepared_shapes;
+
+    assert!(
+        node.dry_run_read_current_allows("documents", document, alice)
+            .expect("owner point read must bind policy claims")
+    );
+    assert_eq!(
+        node.runtime_stats_for_test().active_prepared_shapes,
+        prepared_shape_baseline,
+        "the one-shot owner point read must retire its prepared graph"
+    );
+    assert!(
+        !node
+            .dry_run_read_current_allows("documents", document, bob)
+            .expect("denied point read must be an empty result, not a binding error")
+    );
+    assert_eq!(
+        node.runtime_stats_for_test().active_prepared_shapes,
+        prepared_shape_baseline,
+        "the one-shot denied point read must retire its prepared graph"
+    );
+
+    commit_global_cells(
+        &mut node,
+        "documents",
+        document,
+        BTreeMap::from([("owner".to_owned(), Value::Uuid(bob.0))]),
+        2,
+        2,
+    );
+
+    assert!(
+        !node
+            .dry_run_read_current_allows("documents", document, alice)
+            .expect("former owner must lose access after ownership changes")
+    );
+    assert_eq!(
+        node.runtime_stats_for_test().active_prepared_shapes,
+        prepared_shape_baseline,
+        "ownership changes must not retain point-read graphs"
+    );
+    assert!(
+        node.dry_run_read_current_allows("documents", document, bob)
+            .expect("new owner must gain access after ownership changes")
+    );
+    assert_eq!(
+        node.runtime_stats_for_test().active_prepared_shapes,
+        prepared_shape_baseline,
+        "repeated point reads must retain no prepared graph"
+    );
+}
+
+#[test]
 fn missing_policy_seed_claim_denies_authorization_support_rehydration() {
     // Terminal CommitUnit admission rehydrates a compiled read-policy
     // support subscription. This is distinct from the one-shot policy

--- a/crates/jazz/src/node/tests/policies_rls/recursive.rs
+++ b/crates/jazz/src/node/tests/policies_rls/recursive.rs
@@ -124,6 +124,43 @@ fn recursive_reachable_write_policy_allows_direct_and_closure_docs() {
 }
 
 #[test]
+fn update_policy_point_check_does_not_scan_unrelated_current_rows() {
+    // Internal storage metrics are required because the defect is cost-only:
+    // the public authorization answer is correct while its work is O(table).
+    let schema = JazzSchema::new([TableSchema::new(
+        "docs",
+        [ColumnSchema::new("title", ColumnType::String)],
+    )
+    .with_read_policy(Policy::public())
+    .with_write_policy(Policy::public())]);
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let target = row(0x20);
+    for index in 0..40_u8 {
+        accept_global(
+            &mut core,
+            MergeableCommit::new("docs", row(index), u64::from(index) + 1).cells(
+                BTreeMap::from([(
+                    "title".to_owned(),
+                    Value::String(format!("doc {index}")),
+                )]),
+            ),
+        );
+    }
+
+    core.reset_storage_read_metrics();
+    let _allowed = core
+        .dry_run_write_current_allows("docs", target, user(0xb2))
+        .unwrap();
+    let reads = core.take_storage_read_metrics();
+
+    assert!(
+        reads.global_current_rows.reads <= 2,
+        "one point authorization read touched {} current rows",
+        reads.global_current_rows.reads
+    );
+}
+
+#[test]
 fn recursive_reachable_insert_policy_allows_direct_and_closure_docs() {
     // Internal node coverage is intentional here: this pins sync-unit admission
     // fates for proposed insert rows before the public client layer has a
@@ -430,5 +467,3 @@ fn missing_read_or_write_policy_is_public_for_that_operation() {
         BTreeSet::from([row(0x85)]),
     );
 }
-
-


### PR DESCRIPTION
## What changed

Use the existing local point-read path when checking update and delete policies for one row.

## Why

Authorization previously materialized every current row in the table and searched the result for the requested UUID. The cost therefore grew with unrelated table contents.

## Impact

Single-row update/delete policy checks now perform bounded lookup work.

## Validation

- Added a storage-read-metrics regression with 40 unrelated rows
- Full Jazz library suite: 1285 passed, 0 failed, 2 ignored
- Pre-commit Clippy and rustfmt hooks passed

Stacked on #1650.
