### PR TITLE
(new core) cover rejected ancestry and global read sync

### DIFF
--- a/crates/jazz/src/node/tests/sync/commit_causality.rs
+++ b/crates/jazz/src/node/tests/sync/commit_causality.rs
@@ -91,6 +91,67 @@ fn authority_rejects_later_child_of_rejected_parent_with_cascade() {
             .is_empty()
     );
 }
+
+#[test]
+fn rejected_update_does_not_silence_the_next_fresh_row_commit() {
+    let (_client_dir, mut client) = open_node_with_uuid(node(1));
+    let (_core_dir, mut core) = open_node_with_uuid(node(9));
+    let target = row(0x71);
+
+    let (_base, base_unit) = client
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", target, 10).cells(title_cells("base")),
+        )
+        .unwrap();
+    let [base_fate] = core.apply_sync_message(base_unit).unwrap().try_into().unwrap();
+    client.apply_sync_message(base_fate).unwrap();
+
+    let (_rejected, rejected_unit) = client
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", target, SKEW_TOLERANCE_MS + 1)
+                .cells(title_cells("rejected")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = rejected_unit else {
+        panic!("expected rejected update commit unit");
+    };
+    let [rejected_fate] = core
+        .ingest_commit_unit(tx, versions, 0)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    assert!(matches!(
+        rejected_fate,
+        SyncMessage::FateUpdate {
+            fate: Fate::Rejected(RejectionReason::ClientClockTooFarAhead),
+            ..
+        }
+    ));
+    client.apply_sync_message(rejected_fate).unwrap();
+
+    let (fresh, fresh_unit) = client
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", target, 20).cells(title_cells("fresh")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = fresh_unit else {
+        panic!("expected fresh update commit unit");
+    };
+    let [fresh_fate] = core
+        .ingest_commit_unit(tx, versions, u64::MAX - SKEW_TOLERANCE_MS)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    assert!(matches!(
+        fresh_fate,
+        SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Accepted,
+            durability: Some(DurabilityTier::Global),
+            ..
+        } if tx_id == fresh
+    ));
+}
 #[test]
 fn client_side_rejection_cascades_to_local_mergeable_descendant() {
     let (_client_dir, mut client) = open_node_with_uuid(node(1));

--- a/crates/jazz/src/node/tests/sync/commit_causality.rs
+++ b/crates/jazz/src/node/tests/sync/commit_causality.rs
@@ -106,7 +106,7 @@ fn rejected_update_does_not_silence_the_next_fresh_row_commit() {
     let [base_fate] = core.apply_sync_message(base_unit).unwrap().try_into().unwrap();
     client.apply_sync_message(base_fate).unwrap();
 
-    let (_rejected, rejected_unit) = client
+    let (rejected, rejected_unit) = client
         .commit_mergeable_unit(
             MergeableCommit::new("todos", target, SKEW_TOLERANCE_MS + 1)
                 .cells(title_cells("rejected")),
@@ -128,6 +128,21 @@ fn rejected_update_does_not_silence_the_next_fresh_row_commit() {
         }
     ));
     client.apply_sync_message(rejected_fate).unwrap();
+    assert_eq!(
+        client.transaction_state(rejected).unwrap().0,
+        Fate::Rejected(RejectionReason::ClientClockTooFarAhead)
+    );
+    // The rejected speculative version must be removed from the visible row,
+    // leaving the previously accepted base as the current value.
+    assert_eq!(
+        client
+            .current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(target, title_cells("base"))])
+    );
 
     let (fresh, fresh_unit) = client
         .commit_mergeable_unit(
@@ -142,15 +157,35 @@ fn rejected_update_does_not_silence_the_next_fresh_row_commit() {
         .unwrap()
         .try_into()
         .unwrap();
-    assert!(matches!(
-        fresh_fate,
-        SyncMessage::FateUpdate {
-            tx_id,
-            fate: Fate::Accepted,
-            durability: Some(DurabilityTier::Global),
-            ..
-        } if tx_id == fresh
-    ));
+    let SyncMessage::FateUpdate {
+        tx_id,
+        fate,
+        global_seq,
+        durability,
+    } = fresh_fate
+    else {
+        panic!("expected fresh fate update");
+    };
+    assert_eq!(tx_id, fresh);
+    assert_eq!(fate, Fate::Accepted);
+    assert_eq!(durability, Some(DurabilityTier::Global));
+    client
+        .apply_fate_update(tx_id, fate, global_seq, durability)
+        .unwrap();
+    assert_eq!(
+        client.transaction_state(fresh).unwrap().0,
+        Fate::Accepted
+    );
+    assert_eq!(ahead_current_row_count(&mut client, "todos"), 0);
+    assert_eq!(
+        client
+            .current_rows("todos", DurabilityTier::Global)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(target, title_cells("fresh"))])
+    );
 }
 #[test]
 fn client_side_rejection_cascades_to_local_mergeable_descendant() {

--- a/crates/jazz/src/node/tests/sync/view_delivery.rs
+++ b/crates/jazz/src/node/tests/sync/view_delivery.rs
@@ -77,6 +77,50 @@ fn view_updates_ship_current_versions_to_downstream_nodes() {
         BTreeMap::from([(row, title_cells("replicate me"))])
     );
 }
+
+#[test]
+fn global_read_drops_its_pending_local_replica_and_accepts_the_authoritative_winner() {
+    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
+    let (_other_dir, mut other) = open_node_with_uuid(node(2));
+    let (_core_dir, mut core) = open_node_with_uuid(node(9));
+    let target = row(0x72);
+
+    let (_pending, pending_unit) = writer
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", target, 10).cells(title_cells("pending local")),
+        )
+        .unwrap();
+    assert_eq!(writer.current_rows("todos", DurabilityTier::Local).unwrap().len(), 1);
+    assert!(writer
+        .current_rows("todos", DurabilityTier::Global)
+        .unwrap()
+        .is_empty());
+
+    let [pending_fate] = core
+        .apply_sync_message(pending_unit)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    writer.apply_sync_message(pending_fate).unwrap();
+
+    let (_, authoritative_unit) = other
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", target, 20).cells(title_cells("authoritative remote")),
+        )
+        .unwrap();
+    core.apply_sync_message(authoritative_unit).unwrap();
+
+    let mut link = PeerState::client_link(AuthorId::SYSTEM);
+    let update = link.current_rows_update(&mut core, "todos").unwrap();
+    writer.apply_sync_message(update).unwrap();
+
+    let rows = writer.current_rows("todos", DurabilityTier::Global).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].cell(writer.table("todos").unwrap(), "title"),
+        Some(Value::String("authoritative remote".to_owned()))
+    );
+}
 #[test]
 fn view_updates_use_peer_payload_inventory_refs_for_previously_shipped_complete_payloads() {
     let (_writer_dir, mut writer) = open_node_with_uuid(node(1));

--- a/crates/jazz/src/node/tests/sync/view_delivery.rs
+++ b/crates/jazz/src/node/tests/sync/view_delivery.rs
@@ -79,46 +79,83 @@ fn view_updates_ship_current_versions_to_downstream_nodes() {
 }
 
 #[test]
-fn global_read_drops_its_pending_local_replica_and_accepts_the_authoritative_winner() {
-    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
+/// A global whole-table rehydration ignores a newer, unacknowledged local write.
+///
+/// `other` publishes the globally accepted value to `core`; `core` then makes a
+/// higher-HLC local-only write for the same row. `reader` must receive the
+/// authoritative global value and the global settled position, rather than the
+/// local speculative value.
+///
+/// other ──accepted──► core ──Global view──► reader
+///                         ▲
+///                    local pending write
+fn global_read_ignores_a_newer_unacknowledged_local_write() {
     let (_other_dir, mut other) = open_node_with_uuid(node(2));
     let (_core_dir, mut core) = open_node_with_uuid(node(9));
+    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
     let target = row(0x72);
-
-    let (_pending, pending_unit) = writer
-        .commit_mergeable_unit(
-            MergeableCommit::new("todos", target, 10).cells(title_cells("pending local")),
-        )
-        .unwrap();
-    assert_eq!(writer.current_rows("todos", DurabilityTier::Local).unwrap().len(), 1);
-    assert!(writer
-        .current_rows("todos", DurabilityTier::Global)
-        .unwrap()
-        .is_empty());
-
-    let [pending_fate] = core
-        .apply_sync_message(pending_unit)
-        .unwrap()
-        .try_into()
-        .unwrap();
-    writer.apply_sync_message(pending_fate).unwrap();
 
     let (_, authoritative_unit) = other
         .commit_mergeable_unit(
-            MergeableCommit::new("todos", target, 20).cells(title_cells("authoritative remote")),
+            MergeableCommit::new("todos", target, 20)
+                .cells(title_cells("authoritative remote")),
         )
         .unwrap();
-    core.apply_sync_message(authoritative_unit).unwrap();
+    let [authoritative_fate] = core
+        .apply_sync_message(authoritative_unit)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let SyncMessage::FateUpdate {
+        global_seq: Some(authoritative_seq),
+        ..
+    } = authoritative_fate
+    else {
+        panic!("expected globally accepted authoritative fate");
+    };
+
+    let (pending_tx, _pending_unit) = core
+        .commit_mergeable_unit(
+            MergeableCommit::new("todos", target, 30).cells(title_cells("pending local")),
+        )
+        .unwrap();
+    assert_eq!(core.transaction_state(pending_tx).unwrap().0, Fate::Pending);
+    assert_eq!(
+        core.current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(target, title_cells("pending local"))])
+    );
+    assert_eq!(
+        core.current_rows("todos", DurabilityTier::Global)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(target, title_cells("authoritative remote"))])
+    );
 
     let mut link = PeerState::client_link(AuthorId::SYSTEM);
     let update = link.current_rows_update(&mut core, "todos").unwrap();
-    writer.apply_sync_message(update).unwrap();
+    let SyncMessage::ViewUpdate {
+        settled_through, ..
+    } = &update
+    else {
+        panic!("expected view update");
+    };
+    assert_eq!(*settled_through, authoritative_seq);
+    reader.apply_sync_message(update).unwrap();
 
-    let rows = writer.current_rows("todos", DurabilityTier::Global).unwrap();
-    assert_eq!(rows.len(), 1);
     assert_eq!(
-        rows[0].cell(writer.table("todos").unwrap(), "title"),
-        Some(Value::String("authoritative remote".to_owned()))
+        reader
+            .subscription_current_rows("todos", DurabilityTier::Local)
+            .unwrap()
+            .into_iter()
+            .map(current_row_pair)
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([(target, title_cells("authoritative remote"))])
     );
 }
 #[test]


### PR DESCRIPTION
## What changed

Add executable coverage for two synchronization guarantees from the upstream-defect audit.

## Why

The new core rearchitected both problem areas, but lacked focused regressions proving the old failures cannot recur.

## Covered guarantees

- A rejected update does not silence the next fresh commit for that row; the fresh commit reaches authority and is accepted.
- A pending local write appears at local tier but not global tier, and a later authoritative remote winner is used by global reads.

No production behavior changes are included in this layer.

## Validation

- Both new focused regressions pass
- Full Jazz library suite: 1285 passed, 0 failed, 2 ignored
- Pre-commit Clippy and rustfmt hooks passed

Stacked on #1652.
