### PR TITLE
(new core) fix Better Auth session compatibility

### DIFF
--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -324,9 +324,7 @@ fn ws_peer_identity(identity: &str) -> Result<AuthorId, String> {
 }
 
 fn ws_validate_session_identity(user_id: &str, peer_identity: AuthorId) -> Result<(), String> {
-    let session_identity = uuid::Uuid::parse_str(user_id.trim())
-        .map(|uuid| AuthorId::from_bytes(*uuid.as_bytes()))
-        .map_err(|_| "websocket session user_id must be a UUID".to_owned())?;
+    let session_identity = jazz::tools::identity::author_id_from_principal(user_id);
     if session_identity != peer_identity {
         return Err("websocket peer_identity must match authenticated session user_id".to_owned());
     }
@@ -1046,10 +1044,15 @@ mod tests {
         let peer = AuthorId::from_bytes([1; 16]);
         let matching = uuid::Uuid::from_bytes([1; 16]).to_string();
         let mismatching = uuid::Uuid::from_bytes([2; 16]).to_string();
+        let external_subject = "better-auth-user";
+        let external_peer = AuthorId::from_bytes(
+            *uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, external_subject.as_bytes()).as_bytes(),
+        );
 
         assert!(ws_validate_session_identity(&matching, peer).is_ok());
         assert!(ws_validate_session_identity(&mismatching, peer).is_err());
-        assert!(ws_validate_session_identity("not-a-uuid", peer).is_err());
+        assert!(ws_validate_session_identity(external_subject, external_peer).is_ok());
+        assert!(ws_validate_session_identity(external_subject, peer).is_err());
     }
 
     #[test]

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -1488,10 +1488,7 @@ fn core_identity(context: &AppContext, default_session: Option<&Session>) -> Cor
         .map(|id| id.0)
         .unwrap_or_else(Uuid::now_v7);
     let author_uuid = default_session
-        .map(|session| {
-            Uuid::parse_str(session.user_id.trim())
-                .unwrap_or_else(|_| Uuid::new_v5(&Uuid::NAMESPACE_URL, session.user_id.as_bytes()))
-        })
+        .map(|session| crate::tools::identity::author_id_from_principal(&session.user_id).0)
         .unwrap_or(node_uuid);
     CoreDbIdentity {
         node: CoreNodeUuid(node_uuid),
@@ -1500,10 +1497,7 @@ fn core_identity(context: &AppContext, default_session: Option<&Session>) -> Cor
 }
 
 fn core_author_from_principal(principal: &str) -> CoreAuthorId {
-    CoreAuthorId(
-        Uuid::parse_str(principal.trim())
-            .unwrap_or_else(|_| Uuid::new_v5(&Uuid::NAMESPACE_URL, principal.as_bytes())),
-    )
+    crate::tools::identity::author_id_from_principal(principal)
 }
 
 fn core_storage(schema: &crate::schema::JazzSchema, context: &AppContext) -> Result<StorageBundle> {
@@ -1579,6 +1573,9 @@ fn session_claims_to_core_claims(session: &Session) -> Result<HashMap<String, Co
         ));
     };
     let mut core_claims = HashMap::new();
+    for (name, value) in claims {
+        core_claims.insert(name, json_claim_to_core_value(value)?);
+    }
     core_claims.insert("sub".to_owned(), CoreValue::String(session.user_id.clone()));
     core_claims.insert(
         "user_id".to_owned(),
@@ -1588,9 +1585,6 @@ fn session_claims_to_core_claims(session: &Session) -> Result<HashMap<String, Co
         "authMode".to_owned(),
         CoreValue::String(auth_mode_claim_value(session.auth_mode).to_owned()),
     );
-    for (name, value) in claims {
-        core_claims.insert(name, json_claim_to_core_value(value)?);
-    }
     Ok(core_claims)
 }
 
@@ -3180,6 +3174,31 @@ mod tests {
             CoreValue::U64(9_007_199_254_740_992)
         );
         assert!(json_claim_to_core_value(json!({ "role": "admin" })).is_err());
+    }
+
+    #[test]
+    fn client_session_reserved_claims_override_application_claims() {
+        let session = Session::new("trusted-user")
+            .with_auth_mode(crate::tools::public_api::session::AuthMode::LocalFirst)
+            .with_claims(json!({
+                "sub": "spoofed-subject",
+                "user_id": "spoofed-user",
+                "authMode": "external",
+            }));
+
+        let claims = session_claims_to_core_claims(&session).unwrap();
+        assert_eq!(
+            claims.get("sub"),
+            Some(&CoreValue::String("trusted-user".to_owned()))
+        );
+        assert_eq!(
+            claims.get("user_id"),
+            Some(&CoreValue::String("trusted-user".to_owned()))
+        );
+        assert_eq!(
+            claims.get("authMode"),
+            Some(&CoreValue::String("local-first".to_owned()))
+        );
     }
 
     // This narrow internal test is necessary because the wire crossing is an

--- a/crates/jazz/src/tools/identity.rs
+++ b/crates/jazz/src/tools/identity.rs
@@ -5,6 +5,8 @@ use sha2::{Digest, Sha512};
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
+use crate::ids::AuthorId;
+
 const KEY_NAMESPACE: Uuid = Uuid::from_bytes([
     0x6a, 0x61, 0x7a, 0x7a, 0x2d, 0x61, 0x75, 0x74, 0x68, 0x2d, 0x6b, 0x65, 0x79, 0x2d, 0x76, 0x31,
 ]);
@@ -302,6 +304,15 @@ pub fn derive_verifying_key(seed: &[u8; 32]) -> VerifyingKey {
 pub fn derive_user_id(seed: &[u8; 32]) -> Uuid {
     let verifying_key = derive_verifying_key(seed);
     user_id_from_public_key(verifying_key.as_bytes())
+}
+
+/// Convert a public session principal into the UUID-shaped core author identity.
+/// UUID principals retain their value; other external subjects are mapped
+/// deterministically so clients and servers derive the same identity.
+pub fn author_id_from_principal(principal: &str) -> AuthorId {
+    let uuid = Uuid::parse_str(principal.trim())
+        .unwrap_or_else(|_| Uuid::new_v5(&Uuid::NAMESPACE_URL, principal.as_bytes()));
+    AuthorId::from_bytes(*uuid.as_bytes())
 }
 
 /// Deterministically derive a UUIDv5 user id from Ed25519 public key bytes.

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -27,6 +27,8 @@ use crate::tools::public_schema::{
 
 const DIRECT_USER_ID_CLAIM: &str = "user_id";
 const PUBLIC_USER_ID_SESSION_PATHS: &[&str] = &["user_id", "userId"];
+const DIRECT_AUTH_MODE_CLAIM: &str = "authMode";
+const PUBLIC_AUTH_MODE_SESSION_PATHS: &[&str] = &["authMode", "auth_mode"];
 const RESERVED_AGGREGATE_OUTPUT_PREFIX: &str = "__jazz_aggregate_";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2330,13 +2332,18 @@ fn convert_session_path_operand(
     {
         return Ok(Operand::Claim(DIRECT_USER_ID_CLAIM.to_owned()));
     }
+    if path_segments.len() == 1
+        && PUBLIC_AUTH_MODE_SESSION_PATHS.contains(&path_segments[0].as_str())
+    {
+        return Ok(Operand::Claim(DIRECT_AUTH_MODE_CLAIM.to_owned()));
+    }
     if path_segments.len() == 2 && path_segments[0] == "claims" {
         return Ok(Operand::Claim(path_segments[1].clone()));
     }
     Err(err(
         format!("$.{}.{}", table.as_str(), path),
         format!(
-            "core schema policies only support session.user_id and session.claims.* references, got session.{}",
+            "core schema policies only support session.user_id, session.authMode, and session.claims.* references, got session.{}",
             path_segments.join(".")
         ),
     ))
@@ -3034,6 +3041,36 @@ mod tests {
             vec![Predicate::Eq(
                 Operand::Column("token_id".to_owned()),
                 Operand::Literal(GrooveValue::Uuid(Uuid::nil())),
+            )]
+        );
+    }
+
+    #[test]
+    fn converts_auth_mode_session_comparison_to_reserved_claim() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchemaBuilder::new("messages")
+                    .column("body", ColumnType::Text)
+                    .policies(TablePolicies::new().with_select(PolicyExpr::SessionCmp {
+                        path: vec!["authMode".to_owned()],
+                        op: CmpOp::Eq,
+                        value: Value::Text("external".to_owned()),
+                    })),
+            )
+            .build();
+
+        let converted = convert_public_schema(&schema).expect("authMode policy should convert");
+        let messages = converted
+            .tables
+            .iter()
+            .find(|table| table.name == "messages")
+            .unwrap();
+
+        assert_eq!(
+            messages.read_policy.as_ref().unwrap().filters,
+            vec![Predicate::Eq(
+                Operand::Claim("authMode".to_owned()),
+                Operand::Literal(GrooveValue::String("external".to_owned())),
             )]
         );
     }

--- a/packages/jazz-tools/src/runtime/author-id.test.ts
+++ b/packages/jazz-tools/src/runtime/author-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { authorBytesForSubject } from "./author-id.js";
+
+describe("authorBytesForSubject", () => {
+  test("preserves UUID subjects", () => {
+    expect(Array.from(authorBytesForSubject("123e4567-e89b-12d3-a456-426614174000"))).toEqual([
+      0x12, 0x3e, 0x45, 0x67, 0xe8, 0x9b, 0x12, 0xd3, 0xa4, 0x56, 0x42, 0x66, 0x14, 0x17, 0x40,
+      0x00,
+    ]);
+  });
+
+  test("maps non-UUID subjects to UUIDv5 in the URL namespace", () => {
+    expect(Array.from(authorBytesForSubject("better-auth-user"))).toEqual([
+      0x07, 0x96, 0x0c, 0x5e, 0x28, 0xbb, 0x5e, 0xd4, 0xb4, 0x3a, 0x06, 0xf5, 0x9a, 0x65, 0xe1,
+      0x1c,
+    ]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/author-id.ts
+++ b/packages/jazz-tools/src/runtime/author-id.ts
@@ -1,0 +1,28 @@
+import { sha1 } from "@noble/hashes/legacy.js";
+
+const URL_NAMESPACE = Uint8Array.from([
+  0x6b, 0xa7, 0xb8, 0x11, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
+]);
+
+function uuidBytes(value: string): Uint8Array | null {
+  const hex = value.replaceAll("-", "");
+  if (!/^[0-9a-fA-F]{32}$/.test(hex)) return null;
+
+  return Uint8Array.from({ length: 16 }, (_, index) =>
+    Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16),
+  );
+}
+
+export function authorBytesForSubject(subject: string): Uint8Array {
+  const uuid = uuidBytes(subject);
+  if (uuid) return uuid;
+
+  const subjectBytes = new TextEncoder().encode(subject);
+  const input = new Uint8Array(URL_NAMESPACE.length + subjectBytes.length);
+  input.set(URL_NAMESPACE);
+  input.set(subjectBytes, URL_NAMESPACE.length);
+  const author = sha1(input).slice(0, 16);
+  author[6] = (author[6]! & 0x0f) | 0x50;
+  author[8] = (author[8]! & 0x3f) | 0x80;
+  return author;
+}

--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -22,6 +22,7 @@ import { installWasmTelemetry } from "./sync-telemetry.js";
 import { parseJwtPayload, resolveClientSessionSync } from "./client-session.js";
 import type { WasmSchema } from "../drivers/types.js";
 import { httpUrlToWs } from "./url.js";
+import { authorBytesForSubject } from "./author-id.js";
 
 const DEFAULT_WASM_LOG_LEVEL = "warn";
 
@@ -52,18 +53,6 @@ function randomBytes(): Uint8Array {
   return deterministicBytes(`${Date.now()}:${Math.random()}`);
 }
 
-function uuidBytes(value: string): Uint8Array | null {
-  const hex = value.replaceAll("-", "");
-  if (!/^[0-9a-fA-F]{32}$/.test(hex)) {
-    return null;
-  }
-  const bytes = new Uint8Array(16);
-  for (let index = 0; index < 16; index += 1) {
-    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
-  }
-  return bytes;
-}
-
 function subjectFromConfig(config: DbConfig): string | null {
   if (config.cookieSession?.user_id) return config.cookieSession.user_id;
   const payload = parseJwtPayload(config.jwtToken ?? "");
@@ -72,10 +61,6 @@ function subjectFromConfig(config: DbConfig): string | null {
 
 function persistentIdentitySeed(config: DbConfig, subject: string | null): string {
   return `${config.appId}:${config.env ?? "dev"}:${config.userBranch ?? "main"}:${subject ?? "anonymous"}`;
-}
-
-function authorBytesForSubject(subject: string, fallbackSeed: string): Uint8Array {
-  return uuidBytes(subject) ?? deterministicBytes(`${fallbackSeed}:author`);
 }
 
 function initialSyncFlushEvery(config: DbConfig): number {
@@ -123,7 +108,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
       ? deterministicBytes(`${identitySeed}:${resolveDefaultPersistentDbName(config)}:main-node`)
       : randomBytes();
     const author = subject
-      ? authorBytesForSubject(subject, identitySeed)
+      ? authorBytesForSubject(subject)
       : deterministicBytes(`${identitySeed}:author`);
     const flushEvery = initialSyncFlushEvery(config);
     const browserMode = isPersistentBrowserConfig(config);
@@ -176,7 +161,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     const identitySeed = persistentIdentitySeed(config, subject);
     const dbName = resolveDefaultPersistentDbName(config);
     const author = subject
-      ? authorBytesForSubject(subject, identitySeed)
+      ? authorBytesForSubject(subject)
       : deterministicBytes(`${identitySeed}:author`);
     return new DedicatedBrowserWorkerConnection(
       runtime,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -22,6 +22,7 @@ import type {
 } from "../client.js";
 import type { Session } from "../context.js";
 import { SYSTEM_AUTHOR_ID } from "../system-identity.js";
+import { authorBytesForSubject } from "../author-id.js";
 import {
   PostcardReader,
   PostcardWriter,
@@ -4829,32 +4830,6 @@ export function parseUuid(value: string): Uint8Array {
   const bytes = new Uint8Array(16);
   for (let i = 0; i < 16; i += 1) {
     bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
-}
-
-function uuidBytes(value: string): Uint8Array | null {
-  try {
-    return parseUuid(value);
-  } catch {
-    return null;
-  }
-}
-
-function authorBytesForSubject(subject: string): Uint8Array {
-  return uuidBytes(subject) ?? deterministicBytes(`session:${subject}:author`);
-}
-
-function deterministicBytes(seed: string): Uint8Array {
-  let hash = 0x811c9dc5;
-  const bytes = new Uint8Array(16);
-  const view = new DataView(bytes.buffer);
-  for (let round = 0; round < 4; round += 1) {
-    for (let i = 0; i < seed.length; i += 1) {
-      hash ^= seed.charCodeAt(i) + round;
-      hash = Math.imul(hash, 0x01000193);
-    }
-    view.setUint32(round * 4, hash >>> 0, true);
   }
   return bytes;
 }


### PR DESCRIPTION
## What changed

- support `session.authMode` in public permission-schema conversion
- prevent application claims from overriding reserved session claims
- derive the same author identity from non-UUID external subjects in Rust and browser runtimes
- validate WebSocket peer identities using that shared deterministic mapping

## Why

Better Auth uses opaque string user IDs rather than requiring UUIDs. The new core rejected `session.authMode` policies and then rejected or mismatched authenticated WebSocket identities for those subjects. Browser runtime paths also used different fallback hashes, so clients and servers could derive different identities for the same user.

UUID subjects remain unchanged. Other subjects now map deterministically with UUIDv5 using the URL namespace, while the original subject remains available as `session.user_id`.

## Validation

- `pnpm build:core`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/author-id.test.ts`
- focused `jazz` tests for `session.authMode` conversion and reserved claims
- focused `jazz-server` WebSocket identity test
- `pnpm --filter auth-betterauth-chat test` (2/2 passing)
