### PR TITLE
(new core) quiet React Todo test warnings

### DIFF
--- a/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
@@ -29,7 +29,9 @@ async function waitFor(check: () => boolean, timeoutMs: number, message: string)
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (check()) return;
-    await new Promise((r) => setTimeout(r, 50));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
   }
   throw new Error(`Timeout: ${message}`);
 }
@@ -72,7 +74,9 @@ async function addTodoAndWaitForLocalDurability(el: HTMLDivElement, title: strin
   });
 
   await addTodo(el, title);
-  await localWriteDurable;
+  await act(async () => {
+    await localWriteDurable;
+  });
 }
 
 function EdgeReadinessProbe({ onSettled }: { onSettled: (error: Error | null) => void }) {
@@ -168,7 +172,9 @@ describe("React Todo App core browser canary", () => {
       secret: "VDOGX2nez-5T9Lgk4VfYMT33Qsa6J4loRAoKLZpvxBg",
     });
 
-    await new Promise((r) => setTimeout(r, 750));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 750));
+    });
 
     await addTodo(writer, "Core writer todo");
     await waitFor(
@@ -273,7 +279,9 @@ describe("React Todo App core browser canary", () => {
       secret: readerSecret,
     });
 
-    await new Promise((r) => setTimeout(r, 750));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 750));
+    });
 
     await addTodo(writer, onlineTitle);
     await waitFor(

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
@@ -140,7 +140,9 @@ describe("React Todo App core browser canary", () => {
     await act(async () => root.unmount());
     el.remove();
     mounts.splice(idx, 1);
-    await new Promise((r) => setTimeout(r, 200));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
   }
 
   afterEach(async () => {

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
@@ -134,7 +134,9 @@ describe("React Todo App core browser canary", () => {
     if (idx === -1) return;
 
     const { root } = mounts[idx];
-    await (window as TestWindow).__jazz?.shutdown(dbName);
+    await act(async () => {
+      await (window as TestWindow).__jazz?.shutdown(dbName);
+    });
     await act(async () => root.unmount());
     el.remove();
     mounts.splice(idx, 1);

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -95,7 +95,9 @@ describe("React Todo App E2E", () => {
     el.remove();
     mounts.splice(idx, 1);
     // Give OPFS handles time to release
-    await new Promise((r) => setTimeout(r, 200));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
   }
 
   afterEach(async () => {

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -20,7 +20,9 @@ async function waitFor(check: () => boolean, timeoutMs: number, message: string)
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (check()) return;
-    await new Promise((r) => setTimeout(r, 50));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
   }
   throw new Error(`Timeout: ${message}`);
 }
@@ -301,7 +303,9 @@ describe("React Todo App E2E", () => {
     });
 
     // Let both app instances finish server/event-stream setup before mutating.
-    await new Promise((r) => setTimeout(r, 750));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 750));
+    });
 
     // Add a todo in app 1 via the form
     const input1 = el1.querySelector<HTMLInputElement>("input[type='text']")!;
@@ -344,7 +348,9 @@ describe("React Todo App E2E", () => {
     });
 
     // Let both app instances finish server/event-stream setup before mutating.
-    await new Promise((r) => setTimeout(r, 750));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 750));
+    });
 
     // Add a todo in app 1 via the form
     const input1 = el1.querySelector<HTMLInputElement>("input[type='text']")!;

--- a/examples/todo-client-localfirst-react/vitest.config.browser.ts
+++ b/examples/todo-client-localfirst-react/vitest.config.browser.ts
@@ -19,7 +19,6 @@ export default defineConfig({
     globalSetup: ["tests/browser/global-setup.ts"],
     setupFiles: ["tests/browser/setup-react.ts"],
     testTimeout: 30000,
-    fileParallelism: false,
     sequence: {
       concurrent: false,
     },

--- a/examples/todo-client-localfirst-react/vitest.config.browser.ts
+++ b/examples/todo-client-localfirst-react/vitest.config.browser.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     globalSetup: ["tests/browser/global-setup.ts"],
     setupFiles: ["tests/browser/setup-react.ts"],
     testTimeout: 30000,
+    fileParallelism: false,
     sequence: {
       concurrent: false,
     },


### PR DESCRIPTION
## Summary

- wrap asynchronous Jazz polling and readiness waits in React `act()`
- run the two browser test files serially because they share asynchronous server state

## Why

Jazz subscription updates were arriving while the test harness was polling outside an `act()` boundary. Running both browser files together also allowed their shared asynchronous state to produce a final intermittent warning. The tests passed, but emitted a large amount of misleading React test output.

## Validation

- `pnpm --filter todo-client-localfirst-react test` (11/11 passing, no `act()` warnings)
- pre-commit `oxfmt`, `oxlint`, and sensitive-data checks
