### PR TITLE
fix premature browser edge subscription seeding

### DIFF
--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -20,6 +20,13 @@ fn schema() -> JazzSchema {
     )])
 }
 
+fn filtered_membership_schema() -> JazzSchema {
+    JazzSchema::new([TableSchema::new(
+        "deposits",
+        [ColumnSchema::new("collected", ColumnType::Bool)],
+    )])
+}
+
 fn included_relation_schema() -> JazzSchema {
     JazzSchema::new([
         TableSchema::new("profiles", [ColumnSchema::new("name", ColumnType::String)]),
@@ -798,6 +805,148 @@ fn browser_relay_publishes_an_explicit_settled_empty_handoff() {
             } if added.is_empty()
         )),
         "expected explicit settled-empty handoff, got {settled:?}"
+    );
+}
+
+/// Native isolation test for incremental filtered membership across two browser relays.
+/// Bob subscribes through one worker while Alice writes through another; after the
+/// authority confirms Bob's initial empty result, matching and non-matching changes must
+/// reach Bob as membership additions and removals.
+///
+/// ```text
+/// alice main ──insert/update──► alice worker ──► server
+///                                                   │
+/// bob main ◄──add/remove──── bob worker ◄───────────┘
+/// ```
+#[test]
+fn browser_relays_propagate_incremental_filtered_membership_add_and_remove() {
+    let schema = filtered_membership_schema();
+    let alice = AuthorId::from_bytes([0xc1; 16]);
+    let bob = alice;
+    let alice_main = open_db(0x41, alice, &schema);
+    let alice_worker = open_db(0x42, AuthorId::SYSTEM, &schema);
+    let bob_main = open_db(0x43, bob, &schema);
+    let bob_worker = open_db(0x44, AuthorId::SYSTEM, &schema);
+    let core = open_core(0x45, &schema);
+    alice_main.set_non_durable_client();
+    bob_main.set_non_durable_client();
+
+    let (alice_main_transport, alice_worker_transport) = duplex();
+    let _alice_main_connection = alice_main.connect_upstream(alice_main_transport);
+    let _alice_worker_subscriber = alice_worker.accept_subscriber(alice_worker_transport, alice);
+    let (alice_upstream_transport, alice_core_transport) = duplex();
+    let _alice_upstream = alice_worker.connect_upstream(alice_upstream_transport);
+    let _alice_core_subscriber = core.accept_subscriber(alice_core_transport, alice);
+
+    let (bob_main_transport, bob_worker_transport) = duplex();
+    let _bob_main_connection = bob_main.connect_upstream(bob_main_transport);
+    let _bob_worker_subscriber = bob_worker.accept_subscriber(bob_worker_transport, bob);
+    let (bob_upstream_transport, bob_core_transport) = duplex();
+    let _bob_upstream = bob_worker.connect_upstream(bob_upstream_transport);
+    let _bob_core_subscriber = core.accept_subscriber(bob_core_transport, bob);
+
+    let uncollected = bob_main
+        .prepare_query(
+            &bob_main
+                .table("deposits")
+                .filter(eq(col("collected"), lit(false))),
+        )
+        .expect("prepare Bob's filtered query");
+    let mut subscription = block_on(bob_main.subscribe(
+        &uncollected,
+        ReadOpts {
+            tier: DurabilityTier::Edge,
+            ..ReadOpts::default()
+        },
+    ))
+    .expect("subscribe through Bob's worker");
+
+    bob_main.tick().expect("register Bob's coverage");
+    bob_worker.tick().expect("forward Bob's coverage");
+
+    let first_insert = alice_main
+        .insert(
+            "deposits",
+            BTreeMap::from([("collected".to_owned(), Value::Bool(false))]),
+        )
+        .expect("Alice inserts a matching deposit");
+    let row = first_insert.row_uuid();
+    let mut remaining_rows = Vec::new();
+    for _ in 1..22 {
+        remaining_rows.push(
+            alice_main
+                .insert(
+                    "deposits",
+                    BTreeMap::from([("collected".to_owned(), Value::Bool(false))]),
+                )
+                .expect("Alice inserts another matching deposit")
+                .row_uuid(),
+        );
+    }
+    alice_main.tick().expect("upload Alice's seed batch");
+    alice_worker.tick().expect("relay Alice's seed batch");
+
+    // The authority observes Bob's registration and Alice's seed batch in the
+    // same turn, while Bob's initial empty result is still being established.
+    for _ in 0..4 {
+        core.tick()
+            .expect("serve Bob and accept Alice's seed batch");
+        alice_worker
+            .tick()
+            .expect("receive Alice's acknowledgement");
+        bob_worker.tick().expect("receive matching membership");
+        bob_main.tick().expect("apply matching membership");
+    }
+    let entered = std::iter::from_fn(|| subscription.try_next_event()).collect::<Vec<_>>();
+    assert!(
+        entered
+            .iter()
+            .any(|event| matches!(event, SubscriptionEvent::Delta { settled: true, .. }))
+    );
+    assert!(
+        entered.iter().any(|event| matches!(
+            event,
+            SubscriptionEvent::Delta { added, .. }
+                if added.iter().any(|item| item.row.row_uuid() == row)
+        )),
+        "matching insert must enter Bob's filtered result: {entered:?}"
+    );
+    for expected in remaining_rows {
+        assert!(
+            entered.iter().any(|event| matches!(
+                event,
+                SubscriptionEvent::Delta { added, .. }
+                    if added.iter().any(|item| item.row.row_uuid() == expected)
+            )),
+            "every matching insert must enter Bob's filtered result: {entered:?}"
+        );
+    }
+
+    alice_main
+        .update(
+            "deposits",
+            row,
+            BTreeMap::from([("collected".to_owned(), Value::Bool(true))]),
+        )
+        .expect("Alice moves the deposit out of the filter");
+    for _ in 0..4 {
+        alice_main.tick().expect("upload Alice's update");
+        alice_worker.tick().expect("relay Alice's update");
+        core.tick().expect("accept Alice's update");
+        alice_worker
+            .tick()
+            .expect("receive Alice's acknowledgement");
+        bob_worker.tick().expect("receive removed membership");
+        bob_main.tick().expect("apply removed membership");
+    }
+    let exited = std::iter::from_fn(|| subscription.try_next_event()).collect::<Vec<_>>();
+    assert!(
+        exited.iter().any(|event| matches!(
+            event,
+            SubscriptionEvent::Delta { removed, .. }
+                if removed.iter().any(|item| item.row_uuid == row)
+        )),
+        "non-matching update must exit Bob's filtered result: {exited:?}"
     );
 }
 

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -53,6 +53,7 @@ export class BrowserConnectionManager extends ConnectionManager {
   private resolveFollowerReady: (() => void) | null = null;
   private rejectFollowerReady: ((error: Error) => void) | null = null;
   private followerReadyResolved = false;
+  private explicitlyDisconnected = false;
   private durablePathError: Error | null = null;
   private brokerSchemaFingerprint: string | null = null;
   private brokerResetSchema: WasmSchema | null = null;
@@ -161,6 +162,7 @@ export class BrowserConnectionManager extends ConnectionManager {
       throw new Error("Db.disconnect() requires an active browser connection.");
     }
     await roleBridge.disconnect();
+    this.explicitlyDisconnected = true;
   }
 
   async reconnect(): Promise<void> {
@@ -173,6 +175,7 @@ export class BrowserConnectionManager extends ConnectionManager {
       throw new Error("Db.reconnect() requires an active browser connection.");
     }
     await roleBridge.reconnect();
+    this.explicitlyDisconnected = false;
     this.brokerClient?.replayAuthRefresh();
   }
 
@@ -188,6 +191,10 @@ export class BrowserConnectionManager extends ConnectionManager {
 
   shouldDeferSubscriptionStart(tier?: DurabilityTier): boolean {
     return tier === "edge" || tier === "global";
+  }
+
+  shouldSeedDeferredSubscription(tier?: DurabilityTier): boolean {
+    return (tier === "edge" || tier === "global") && this.explicitlyDisconnected;
   }
 
   async deleteClientStorage(): Promise<void> {

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
@@ -48,6 +48,10 @@ export class DirectConnectionManager extends ConnectionManager {
     return false;
   }
 
+  shouldSeedDeferredSubscription(_tier?: DurabilityTier): boolean {
+    return false;
+  }
+
   async disconnect(): Promise<void> {
     if (!this.host.config.serverUrl) {
       throw new Error("Db.disconnect() requires a configured serverUrl.");

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -119,6 +119,8 @@ export abstract class ConnectionManager {
 
   abstract shouldDeferSubscriptionStart(tier?: DurabilityTier): boolean;
 
+  abstract shouldSeedDeferredSubscription(tier?: DurabilityTier): boolean;
+
   abstract disconnect(): Promise<void>;
 
   abstract reconnect(): Promise<void>;

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1635,11 +1635,15 @@ export class Db {
     if (queryOptions.tier == null || queryOptions.tier === "local") {
       callback(manager.seed([]));
     }
-    if (this.connection.shouldDeferSubscriptionStart(queryOptions.tier)) {
+    const deferSubscriptionStart = this.connection.shouldDeferSubscriptionStart(queryOptions.tier);
+    const seedDeferredSubscription =
+      deferSubscriptionStart && this.connection.shouldSeedDeferredSubscription(queryOptions.tier);
+    if (deferSubscriptionStart) {
       // The worker can only classify the initial authority-tier snapshot as
       // settled after its own server transport is attached. Delay native
       // subscription creation until that topology is ready; the native stream
-      // then owns the settled-snapshot gate and remains the sole data source.
+      // then owns the settled-snapshot gate. An explicitly disconnected client
+      // may still publish its local optimistic seed while it waits to reconnect.
       void this.ensureReady(queryOptions.tier)
         .then(startNativeSubscription)
         .catch((error: unknown) => {
@@ -1653,6 +1657,7 @@ export class Db {
     }
     if (
       this.config.serverUrl &&
+      (!deferSubscriptionStart || seedDeferredSubscription) &&
       queryOptions.propagation !== "local-only" &&
       queryOptions.tier !== "global" &&
       !queryUsesRelationTraversal(builtQuery)

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -33,7 +33,7 @@ import {
   createRemoteBrowserDb,
   waitForRemoteBrowserDbTitle,
 } from "./remote-browser-db.js";
-import { CompiledPermissions, schema as s } from "../../src/";
+import { CompiledPermissions, RowChangeKind, schema as s } from "../../src/";
 import { deploy } from "../../src/dev/catalogue.js";
 
 // ---------------------------------------------------------------------------
@@ -1076,69 +1076,73 @@ describe("Worker Bridge with OPFS", () => {
     unsub();
   });
 
-  it("tiered subscriptions gate the first callback until the worker's settled snapshot content is local", async () => {
-    const syncServer = await publishSyncServerSchemaAndPermissions("subscribe-global-gated");
-    const sharedLocalAuthToken = generateAuthSecret();
-    const seeder = track(
-      await createDb({
-        appId: syncServer.appId,
-        driver: {
-          type: "persistent",
-          dbName: uniqueDbName("subscribe-global-gated-seeder"),
-        },
-        serverUrl: syncServer.serverUrl,
-        secret: sharedLocalAuthToken,
-      }),
-    );
+  it.each(["edge", "global"] as const)(
+    "%s subscriptions gate the first callback until the worker's settled snapshot content is local",
+    async (tier) => {
+      const syncServer = await publishSyncServerSchemaAndPermissions(`subscribe-${tier}-gated`);
+      const sharedLocalAuthToken = generateAuthSecret();
+      const seeder = track(
+        await createDb({
+          appId: syncServer.appId,
+          driver: {
+            type: "persistent",
+            dbName: uniqueDbName(`subscribe-${tier}-gated-seeder`),
+          },
+          serverUrl: syncServer.serverUrl,
+          secret: sharedLocalAuthToken,
+        }),
+      );
 
-    const {
-      value: { id: projectId },
-    } = seeder.insert(projects, { name: `server-project-${Date.now()}` });
-    await seeder.all(app.projects.where({ id: projectId }), { tier: "global" });
+      const {
+        value: { id: projectId },
+      } = seeder.insert(projects, { name: `server-project-${Date.now()}` });
+      await seeder.all(app.projects.where({ id: projectId }), { tier });
 
-    const expectedTitles: string[] = [];
-    for (let i = 0; i < 12; i += 1) {
-      const title = `server-seeded-${i}`;
-      expectedTitles.push(title);
-      await seeder.insert(todos, { title, done: i % 2 === 0, projectId }).wait({ tier: "global" });
-    }
-    await seeder.shutdown();
-    ctx.untrack(seeder);
+      const expectedTitles: string[] = [];
+      for (let i = 0; i < 12; i += 1) {
+        const title = `server-seeded-${i}`;
+        expectedTitles.push(title);
+        await seeder.insert(todos, { title, done: i % 2 === 0, projectId }).wait({ tier });
+      }
+      await seeder.shutdown();
+      ctx.untrack(seeder);
 
-    const fresh = track(
-      await createDb({
-        appId: syncServer.appId,
-        driver: {
-          type: "persistent",
-          dbName: uniqueDbName("subscribe-global-gated-fresh"),
-        },
-        serverUrl: syncServer.serverUrl,
-        secret: sharedLocalAuthToken,
-      }),
-    );
-    const snapshots: Todo[][] = [];
-    const unsubscribe = trackSubscription(
-      fresh.subscribeAll(
-        todosByProject(projectId),
-        (delta) => {
-          snapshots.push([...(delta.all ?? [])]);
-        },
-        { tier: "global" },
-      ),
-    );
+      const fresh = track(
+        await createDb({
+          appId: syncServer.appId,
+          driver: {
+            type: "persistent",
+            dbName: uniqueDbName(`subscribe-${tier}-gated-fresh`),
+          },
+          serverUrl: syncServer.serverUrl,
+          secret: sharedLocalAuthToken,
+        }),
+      );
+      const snapshots: Todo[][] = [];
+      const unsubscribe = trackSubscription(
+        fresh.subscribeAll(
+          todosByProject(projectId),
+          (delta) => {
+            snapshots.push([...(delta.all ?? [])]);
+          },
+          { tier },
+        ),
+      );
 
-    await waitForCondition(
-      async () => snapshots.some((snapshot) => snapshot.length === expectedTitles.length),
-      15000,
-      "global tier subscription should deliver the settled snapshot",
-    );
+      await waitForCondition(
+        async () => snapshots.some((snapshot) => snapshot.length === expectedTitles.length),
+        15000,
+        `${tier} tier subscription should deliver the settled snapshot`,
+      );
 
-    const firstSnapshot = snapshots[0];
-    expect(firstSnapshot).toHaveLength(expectedTitles.length);
-    expect(firstSnapshot.map((row) => row.title).sort()).toEqual([...expectedTitles].sort());
+      const firstSnapshot = snapshots[0];
+      expect(firstSnapshot).toHaveLength(expectedTitles.length);
+      expect(firstSnapshot.map((row) => row.title).sort()).toEqual([...expectedTitles].sort());
 
-    unsubscribe();
-  }, 90000);
+      unsubscribe();
+    },
+    90000,
+  );
 
   it("delivers an initial scoped subscription snapshot after seeding many synced rows", async () => {
     const sharedLocalAuthToken = generateAuthSecret();
@@ -1320,6 +1324,84 @@ describe("Worker Bridge with OPFS", () => {
     const todosAfterRevert = await db.all(allTodos, { tier: "local" });
     expect(todosAfterRevert.length).toBe(0);
   });
+
+  it("relays incremental filtered membership between independent browser workers", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("filtered-membership-workers");
+    const sharedSecret = generateAuthSecret();
+    const dbA = ctx.track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent", dbName: uniqueDbName("filtered-membership-a") },
+        serverUrl: syncServer.serverUrl,
+        adminSecret: syncServer.adminSecret,
+        secret: sharedSecret,
+      }),
+    );
+    const openTodos = todos.where({ done: false });
+    await dbA.all(openTodos, { tier: "local" });
+    const dbB = ctx.track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: { type: "persistent", dbName: uniqueDbName("filtered-membership-b") },
+        serverUrl: syncServer.serverUrl,
+        adminSecret: syncServer.adminSecret,
+        secret: sharedSecret,
+      }),
+    );
+    const snapshots: Todo[][] = [];
+    const publicChanges: Array<{ kind: number; id: string }> = [];
+    const writes: Array<ReturnType<Db["insert"]>> = [];
+    const competingWrites: Array<ReturnType<Db["insert"]>> = [];
+    trackSubscription(
+      dbB.subscribeAll(
+        openTodos,
+        (delta) => {
+          snapshots.push([...(delta.all ?? [])]);
+          publicChanges.push(...delta.delta.map(({ kind, id }) => ({ kind, id })));
+          if (delta.all?.length === 0 && writes.length === 0) {
+            for (let index = 0; index < 22; index += 1) {
+              writes.push(
+                dbA.insert(todos, { title: `remote worker entry ${index}`, done: false }),
+              );
+              competingWrites.push(
+                dbB.insert(todos, { title: `local worker entry ${index}`, done: false }),
+              );
+            }
+          }
+        },
+        { tier: "edge" },
+      ),
+    );
+    trackSubscription(dbA.subscribeAll(openTodos, () => {}, { tier: "edge" }));
+    trackSubscription(dbA.subscribeAll(todos.where({ done: true }), () => {}));
+    trackSubscription(dbB.subscribeAll(todos.where({ done: true }), () => {}));
+
+    await waitForCondition(
+      async () => snapshots.length > 0 && snapshots.at(-1)?.length === 0,
+      10_000,
+      "B receives the authoritative empty filtered snapshot",
+    );
+    await Promise.all([...writes, ...competingWrites].map((write) => write.wait({ tier: "edge" })));
+    await waitForCondition(
+      async () => snapshots.at(-1)?.length === writes.length + competingWrites.length,
+      10_000,
+      "B receives every membership entry",
+    );
+    for (const write of writes) {
+      expect(publicChanges).toContainEqual({ kind: RowChangeKind.Added, id: write.value.id });
+    }
+
+    await dbA.update(todos, writes[0]!.value.id, { done: true }).wait({ tier: "edge" });
+    await waitForCondition(
+      async () => snapshots.at(-1)?.length === writes.length + competingWrites.length - 1,
+      10_000,
+      "B receives membership exit",
+    );
+    expect(publicChanges).toContainEqual({
+      kind: RowChangeKind.Removed,
+      id: writes[0]!.value.id,
+    });
+  }, 60_000);
 
   it("server permissions check rejects client optimistic insert - onMutationError notification", async () => {
     const syncServer = await publishSyncServerSchemaAndPermissions(


### PR DESCRIPTION
## Summary

- make server-backed browser subscriptions wait for the worker's confirmed initial result instead of reporting local-storage data too early
- preserve local optimistic state for apps that explicitly call `Db.disconnect()`, with server-backed updates resuming after reconnect
- add regression tests covering initial-result timing and rows entering and leaving filtered queries across two independent browser workers

## Root cause

Browser `edge` and `global` subscriptions deliberately defer native subscription creation until the worker's durable path is ready. The separate JavaScript local-storage seed path could still complete during that wait and invoke the public callback with a provisional empty result. Consumers treated that callback as the fulfilled initial result and could issue writes before remote coverage existed, causing later filtered-query membership changes to be missed.

An explicitly disconnected client is the intentional exception: it continues to show unresolved local inserts, updates, and deletes while offline, and starts its server-backed subscription after reconnecting.

## Validation

- `cargo test -p jazz --test browser_relay_durability` — 13 passed
- full `packages/jazz-tools/tests/browser/db.disconnect.test.ts` and `worker-bridge.test.ts` — 67 passed, 1 expected failure
- full `examples/moon-lander-react/tests/browser/multiplayer.test.tsx` — 4 passed
- TypeScript type-check, oxfmt, oxlint, and sensitive-data checks passed locally
- all GitHub CI checks passed
