### PR TITLE
fix: preserve optimistic rows across stale worker view updates

### DIFF
--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1028,7 +1028,7 @@ where
 
 fn unsettled_transaction_row_keys_for_query<S>(
     node: &Rc<RefCell<NodeState<S>>>,
-    cache: &mut BTreeMap<(AuthorId, Option<GlobalSeq>), BTreeSet<(String, RowUuid)>>,
+    cache: &mut BTreeMap<(AuthorId, Option<GlobalTime>), BTreeSet<(String, RowUuid)>>,
     shape: &ValidatedQuery,
     binding: &Binding,
     author: AuthorId,

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1026,28 +1026,39 @@ where
     }
 }
 
-fn optimistic_transaction_row_keys_for_query<S>(
+fn unsettled_transaction_row_keys_for_query<S>(
     node: &Rc<RefCell<NodeState<S>>>,
-    cache: &mut BTreeMap<AuthorId, BTreeSet<(String, RowUuid)>>,
+    cache: &mut BTreeMap<(AuthorId, Option<GlobalSeq>), BTreeSet<(String, RowUuid)>>,
     shape: &ValidatedQuery,
+    binding: &Binding,
     author: AuthorId,
-) -> Result<BTreeSet<(String, RowUuid)>, Error>
+    binding_view: BindingViewKey,
+) -> Result<(BTreeSet<(String, RowUuid)>, BTreeSet<(String, RowUuid)>), Error>
 where
     S: OrderedKvStorage,
 {
-    let row_keys = match cache.entry(author) {
+    let settled_through = node.borrow().settled_through_for_binding_view(binding_view);
+    let row_keys = match cache.entry((author, settled_through)) {
         std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
         std::collections::btree_map::Entry::Vacant(entry) => {
             let transactions = node
                 .borrow_mut()
-                .unresolved_transaction_ids_for_author(author)?;
+                .transaction_ids_ahead_of_settled_through_for_author(author, settled_through)?;
             let row_keys = node.borrow_mut().transaction_row_keys(&transactions)?;
             entry.insert(row_keys)
         }
     };
-    Ok(node
+    let row_keys = node
         .borrow()
-        .transaction_row_keys_for_query(shape, row_keys))
+        .transaction_row_keys_for_query(shape, row_keys);
+    let present_row_keys = node
+        .borrow_mut()
+        .query_rows_for_client(shape, binding, DurabilityTier::Local, author)?
+        .into_iter()
+        .map(|row| (row.table().to_owned(), row.row_uuid()))
+        .collect::<BTreeSet<_>>();
+    let absent_row_keys = row_keys.difference(&present_row_keys).cloned().collect();
+    Ok((row_keys, absent_row_keys))
 }
 
 /// Re-evaluate every live subscription against the node and push a delta event
@@ -1198,22 +1209,28 @@ where
                         .then_some(settled_binding_view)
                 });
             let authoritative_binding_view = pending_binding_view.unwrap_or(settled_binding_view);
-            let local_overlay_row_keys = if authorization_mode
+            let (local_overlay_row_keys, local_overlay_absent_row_keys) = if authorization_mode
                 == QueryAuthorizationMode::ClientLocal
                 && read_tier == DurabilityTier::Local
-                && remote_read_tier.is_some_and(|tier| tier >= DurabilityTier::Edge)
+                // The browser main thread reconciles against its Local-tier
+                // durable worker before the worker relays authority receipts.
+                // Protect unsettled rows at that handoff as well as on a
+                // direct Edge/Global connection.
+                && remote_read_tier.is_some()
                 && node.borrow().authored_commit_durability() == DurabilityTier::None
                 && active_authority_view_receipts.borrow().is_some()
                 && supports_pending_overlay_reconciliation(shape.query())
             {
-                optimistic_transaction_row_keys_for_query(
+                unsettled_transaction_row_keys_for_query(
                     node,
                     &mut optimistic_row_keys_by_author,
                     &shape,
+                    &binding,
                     author,
+                    authoritative_binding_view,
                 )?
             } else {
-                BTreeSet::new()
+                (BTreeSet::new(), BTreeSet::new())
             };
             let has_conflicting_local_overlay = {
                 let state_ref = state.borrow();
@@ -1267,6 +1284,7 @@ where
                             maintained,
                             Some(binding_view),
                             &local_overlay_row_keys,
+                            &local_overlay_absent_row_keys,
                         )?;
                     debug_assert!(suppressed);
                     if let Some(update) = update {
@@ -1443,24 +1461,29 @@ where
                                 authoritative_reset_binding_view,
                             )
                         });
-                    let local_overlay_row_keys = if authorization_mode
-                        == QueryAuthorizationMode::ClientLocal
-                        && read_tier == DurabilityTier::Local
-                        && remote_read_tier.is_some_and(|tier| tier >= DurabilityTier::Edge)
-                        && node.borrow().authored_commit_durability() == DurabilityTier::None
-                        && active_authority_view_receipts.borrow().is_some()
-                        && supports_pending_overlay_reconciliation(shape.query())
-                        && authority_reconciliation_due
-                    {
-                        optimistic_transaction_row_keys_for_query(
-                            node,
-                            &mut optimistic_row_keys_by_author,
-                            &shape,
-                            author,
-                        )?
-                    } else {
-                        BTreeSet::new()
-                    };
+                    let (local_overlay_row_keys, local_overlay_absent_row_keys) =
+                        if authorization_mode == QueryAuthorizationMode::ClientLocal
+                            && read_tier == DurabilityTier::Local
+                            // A Local-tier browser worker can advance the view
+                            // generation before its maintained membership contains
+                            // the main thread's unsettled optimistic row.
+                            && remote_read_tier.is_some()
+                            && node.borrow().authored_commit_durability() == DurabilityTier::None
+                            && active_authority_view_receipts.borrow().is_some()
+                            && supports_pending_overlay_reconciliation(shape.query())
+                            && authority_reconciliation_due
+                        {
+                            unsettled_transaction_row_keys_for_query(
+                                node,
+                                &mut optimistic_row_keys_by_author,
+                                &shape,
+                                &binding,
+                                author,
+                                authoritative_reset_binding_view,
+                            )?
+                        } else {
+                            (BTreeSet::new(), BTreeSet::new())
+                        };
                     let has_conflicting_local_overlay =
                         maintained_subscription.as_ref().is_some_and(|maintained| {
                             node.borrow()
@@ -1733,6 +1756,7 @@ where
                                         maintained,
                                         authoritative_binding_view,
                                         &local_overlay_row_keys,
+                                        &local_overlay_absent_row_keys,
                                     ) {
                                     Ok(update) => update,
                                     Err(crate::node::Error::MissingTransaction(_)) => {

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -743,6 +743,10 @@ struct QueryServing {
     /// updates. Attachments capture the current receipt and require a later
     /// one; this remains logical binding-view state, never a wire nonce.
     applied_view_update_generations: BTreeMap<BindingViewKey, u64>,
+    /// Monotonically increasing generations for authoritative result-membership
+    /// changes. Maintained local views use this to avoid reconciling optimistic
+    /// membership against progress-only authoritative updates.
+    applied_result_membership_generations: BTreeMap<BindingViewKey, u64>,
     /// Subscriber-side settled result-member/completeness state by canonical query binding/view.
     settled_result_sets: BTreeMap<BindingViewKey, BTreeSet<ResultMemberEntry>>,
     /// Point index for settled real-row output occurrences.

--- a/crates/jazz/src/node/query_eval/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/maintained_views.rs
@@ -255,6 +255,7 @@ where
             local,
             authoritative_binding_view,
             &BTreeSet::new(),
+            &BTreeSet::new(),
         )
         .map(|(update, _)| update)
     }
@@ -264,12 +265,14 @@ where
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
         preserved_row_keys: &BTreeSet<(String, RowUuid)>,
+        preserved_absent_row_keys: &BTreeSet<(String, RowUuid)>,
     ) -> Result<(Option<LocalMaintainedViewSubscriptionUpdate>, bool), Error> {
         let (transitions, suppressed_authoritative_change) = self
             .drain_local_maintained_view_subscription_transitions(
                 local,
                 authoritative_binding_view,
                 preserved_row_keys,
+                preserved_absent_row_keys,
             )?;
         let Some(transitions) = transitions else {
             return Ok((None, suppressed_authoritative_change));
@@ -286,6 +289,7 @@ where
         let (Some(transitions), _) = self.drain_local_maintained_view_subscription_transitions(
             local,
             authoritative_binding_view,
+            &BTreeSet::new(),
             &BTreeSet::new(),
         )?
         else {
@@ -322,7 +326,7 @@ where
             })
             .unwrap_or_default();
         local.authoritative_result_generation =
-            self.applied_view_update_generation(binding_view_key);
+            self.applied_result_membership_generation(binding_view_key);
         local.authoritative_reconciliation_deferred = false;
         local.deferred_authoritative_row_keys.clear();
         local.program_facts = self
@@ -369,7 +373,7 @@ where
         binding_view_key: BindingViewKey,
     ) {
         local.authoritative_result_generation =
-            self.applied_view_update_generation(binding_view_key);
+            self.applied_result_membership_generation(binding_view_key);
     }
 
     pub(crate) fn defer_local_maintained_authority_reconciliation(
@@ -403,7 +407,7 @@ where
         binding_view_key: BindingViewKey,
     ) -> bool {
         local.authoritative_reconciliation_deferred
-            || self.applied_view_update_generation(binding_view_key)
+            || self.applied_result_membership_generation(binding_view_key)
                 != local.authoritative_result_generation
     }
 
@@ -412,6 +416,7 @@ where
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
         preserved_row_keys: &BTreeSet<(String, RowUuid)>,
+        preserved_absent_row_keys: &BTreeSet<(String, RowUuid)>,
     ) -> Result<
         (
             Option<super::maintained_subscription_view::ResultTransitions>,
@@ -509,18 +514,53 @@ where
         let mut suppressed_authoritative_change = false;
         let mut suppressed_authoritative_row_keys = BTreeSet::new();
         if let Some(binding_view) = authoritative_binding_view {
-            let authoritative_generation = self.applied_view_update_generation(binding_view);
+            let authoritative_generation = self.applied_result_membership_generation(binding_view);
             // Local optimistic changes can advance the maintained graph
             // without any newer serving-peer membership decision. Keep them
             // visible until an authoritative generation advances.
             if authoritative_generation != local.authoritative_result_generation
                 || local.authoritative_reconciliation_deferred
             {
-                let mut protected_row_keys = preserved_row_keys.clone();
+                let mut protected_addition_row_keys = preserved_row_keys.clone();
                 if authoritative_generation == local.authoritative_result_generation {
-                    protected_row_keys
+                    protected_addition_row_keys
                         .extend(local.deferred_authoritative_row_keys.iter().cloned());
                 }
+                let mut protected_removal_row_keys = protected_addition_row_keys.clone();
+                protected_removal_row_keys
+                    .retain(|row_key| !preserved_absent_row_keys.contains(row_key));
+                let authoritative_settled_through =
+                    self.settled_through_for_binding_view(binding_view);
+                // A single-source member's settle position establishes whether
+                // this authority frontier could have decided its membership.
+                // A flat tuple has several source versions but only one carried
+                // settle position, so it cannot safely protect the whole tuple;
+                // those use the explicit/deferred row-key path above.
+                let unsettled_present_row_keys = local
+                    .result_set
+                    .iter()
+                    .filter_map(|member| {
+                        let row = member.as_real_row()?;
+                        let row_key = (row.table.to_string(), row.row_uuid);
+                        if preserved_absent_row_keys.contains(&row_key) {
+                            return None;
+                        }
+                        let occurrence = member.output_occurrence_id()?;
+                        if !occurrence.joined_sources().is_empty() {
+                            return None;
+                        }
+                        let is_ahead_of_authority =
+                            match (row.settle_position, authoritative_settled_through) {
+                                (Some(position), Some(settled_through)) => {
+                                    position > settled_through
+                                }
+                                (Some(_), None) | (None, _) => true,
+                            };
+                        is_ahead_of_authority.then_some(row_key)
+                    })
+                    .collect::<BTreeSet<_>>();
+                protected_addition_row_keys.extend(unsettled_present_row_keys.iter().cloned());
+                protected_removal_row_keys.extend(unsettled_present_row_keys);
                 let remote_members = self
                     .query
                     .settled_result_sets
@@ -549,7 +589,7 @@ where
                 // even though none of its locally-visible source facts changed.
                 for entry in remote_members.difference(&local.result_set) {
                     if let Some(row_key) =
-                        result_member_matching_row_key(entry, &protected_row_keys)
+                        result_member_matching_row_key(entry, &protected_addition_row_keys)
                     {
                         suppressed_authoritative_change = true;
                         suppressed_authoritative_row_keys.insert(row_key);
@@ -594,7 +634,7 @@ where
                 }
                 for entry in local.result_set.difference(&remote_members) {
                     if let Some(row_key) =
-                        result_member_matching_row_key(entry, &protected_row_keys)
+                        result_member_matching_row_key(entry, &protected_removal_row_keys)
                     {
                         suppressed_authoritative_change = true;
                         suppressed_authoritative_row_keys.insert(row_key);

--- a/crates/jazz/src/node/query_eval/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/subscriptions.rs
@@ -238,6 +238,17 @@ where
             .unwrap_or_default()
     }
 
+    pub(crate) fn applied_result_membership_generation(
+        &self,
+        binding_view_key: BindingViewKey,
+    ) -> u64 {
+        self.query
+            .applied_result_membership_generations
+            .get(&binding_view_key)
+            .copied()
+            .unwrap_or_default()
+    }
+
     #[cfg(test)]
     pub(crate) fn reset_subscription_snapshot_for_link_call_count(&mut self) {
         SUBSCRIPTION_SNAPSHOT_FOR_LINK_CALLS.with(|calls| calls.set(0));

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -300,20 +300,20 @@ where
     pub(crate) fn transaction_ids_ahead_of_settled_through_for_author(
         &mut self,
         author: AuthorId,
-        settled_through: Option<GlobalSeq>,
+        settled_through: Option<GlobalTime>,
     ) -> Result<Vec<TxId>, Error> {
         let mut tx_ids = self.pending_transaction_ids_for_author(author)?;
-        let first_global_seq = match settled_through {
-            Some(GlobalSeq(u64::MAX)) => return Ok(tx_ids),
-            Some(GlobalSeq(position)) => position + 1,
+        let first_global_time = match settled_through {
+            Some(GlobalTime(u64::MAX)) => return Ok(tx_ids),
+            Some(GlobalTime(position)) => position + 1,
             None => 0,
         };
-        let first_key = Value::Nullable(Some(Box::new(Value::U64(first_global_seq))));
+        let first_key = Value::Nullable(Some(Box::new(Value::U64(first_global_time))));
         let last_key = Value::Nullable(Some(Box::new(Value::U64(u64::MAX))));
-        let mut sequenced = if first_global_seq < u64::MAX {
+        let mut sequenced = if first_global_time < u64::MAX {
             self.database.index_scan_range_raw(
                 "jazz_transactions",
-                "by_global_seq",
+                "by_global_time",
                 std::slice::from_ref(&first_key),
                 std::slice::from_ref(&last_key),
             )?
@@ -322,7 +322,7 @@ where
         };
         sequenced.extend(self.database.index_scan_raw(
             "jazz_transactions",
-            "by_global_seq",
+            "by_global_time",
             std::slice::from_ref(&last_key),
         )?);
 

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -259,21 +259,6 @@ where
         &mut self,
         author: AuthorId,
     ) -> Result<Vec<TxId>, Error> {
-        self.below_global_transaction_ids_for_author(author, true)
-    }
-
-    pub(crate) fn unresolved_transaction_ids_for_author(
-        &mut self,
-        author: AuthorId,
-    ) -> Result<Vec<TxId>, Error> {
-        self.below_global_transaction_ids_for_author(author, false)
-    }
-
-    fn below_global_transaction_ids_for_author(
-        &mut self,
-        author: AuthorId,
-        include_accepted: bool,
-    ) -> Result<Vec<TxId>, Error> {
         let mut candidates = Vec::new();
         for raw in self.database.index_scan_raw(
             "jazz_transactions",
@@ -283,7 +268,7 @@ where
             let record = raw.record();
             let fate = record.get_enum(TransactionRowRecord::FIELD_FATE_IDX)?;
             if AuthorId(record.get_uuid(TransactionRowRecord::FIELD_MADE_BY_IDX)?) != author
-                || !(fate == 0 || (include_accepted && fate == 1))
+                || !matches!(fate, 0 | 1)
                 || durability_from_discriminant(
                     record.get_enum(TransactionRowRecord::FIELD_DURABILITY_IDX)?,
                 )? >= DurabilityTier::Global
@@ -296,6 +281,65 @@ where
             ));
         }
         let mut tx_ids = Vec::with_capacity(candidates.len());
+        for (alias, time) in candidates {
+            let Some(node) = self.resolve_node_alias(alias)? else {
+                continue;
+            };
+            tx_ids.push(TxId::new(time, node));
+        }
+        tx_ids.sort();
+        tx_ids.dedup();
+        Ok(tx_ids)
+    }
+
+    /// Return locally visible transactions by `author` that a binding view at
+    /// `settled_through` cannot yet have incorporated. This includes both
+    /// unsequenced transactions and globally sequenced transactions beyond the
+    /// view frontier so deleted rows retain causal provenance after their
+    /// current result member disappears.
+    pub(crate) fn transaction_ids_ahead_of_settled_through_for_author(
+        &mut self,
+        author: AuthorId,
+        settled_through: Option<GlobalSeq>,
+    ) -> Result<Vec<TxId>, Error> {
+        let mut tx_ids = self.pending_transaction_ids_for_author(author)?;
+        let first_global_seq = match settled_through {
+            Some(GlobalSeq(u64::MAX)) => return Ok(tx_ids),
+            Some(GlobalSeq(position)) => position + 1,
+            None => 0,
+        };
+        let first_key = Value::Nullable(Some(Box::new(Value::U64(first_global_seq))));
+        let last_key = Value::Nullable(Some(Box::new(Value::U64(u64::MAX))));
+        let mut sequenced = if first_global_seq < u64::MAX {
+            self.database.index_scan_range_raw(
+                "jazz_transactions",
+                "by_global_seq",
+                std::slice::from_ref(&first_key),
+                std::slice::from_ref(&last_key),
+            )?
+        } else {
+            Vec::new()
+        };
+        sequenced.extend(self.database.index_scan_raw(
+            "jazz_transactions",
+            "by_global_seq",
+            std::slice::from_ref(&last_key),
+        )?);
+
+        let mut candidates = Vec::new();
+        for raw in sequenced {
+            let record = raw.record();
+            let fate = record.get_enum(TransactionRowRecord::FIELD_FATE_IDX)?;
+            if AuthorId(record.get_uuid(TransactionRowRecord::FIELD_MADE_BY_IDX)?) != author
+                || !matches!(fate, 0 | 1)
+            {
+                continue;
+            }
+            candidates.push((
+                NodeAlias(record.get_u64(TransactionRowRecord::FIELD_NODE_ID_IDX)?),
+                TxTime(record.get_u64(TransactionRowRecord::FIELD_TIME_IDX)?),
+            ));
+        }
         for (alias, time) in candidates {
             let Some(node) = self.resolve_node_alias(alias)? else {
                 continue;

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -531,6 +531,7 @@ where
                 registered_shapes: BTreeMap::new(),
                 registered_bindings: BTreeMap::new(),
                 applied_view_update_generations: BTreeMap::new(),
+                applied_result_membership_generations: BTreeMap::new(),
                 settled_result_sets: BTreeMap::new(),
                 settled_result_row_index: BTreeMap::new(),
                 settled_program_facts: BTreeMap::new(),

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -918,6 +918,12 @@ where
                             if matches!(payload.member, ResultMemberEntry::Synthetic { .. })
                     )
                 });
+        // Maintained local views only reconcile optimistic membership when the
+        // authority actually changed result membership. ViewUpdate also carries
+        // payload and settlement progress, so receiving one does not by itself
+        // mean the authority made a newer membership decision.
+        let authoritative_membership_changed =
+            reset_result_set || !result_member_adds.is_empty() || !result_member_removes.is_empty();
         let version_bundle_refs =
             version_bundle_refs_for_carriers(&version_bundles, &version_carriers)?;
         let binding_view_key = match self.binding_view_key_for_subscription(subscription) {
@@ -1185,12 +1191,20 @@ where
                 .pending_opening_binding_views
                 .remove(&binding_view_key);
         }
-        let generation = self
+        let view_update_generation = self
             .query
             .applied_view_update_generations
             .entry(binding_view_key)
             .or_default();
-        *generation = generation.wrapping_add(1);
+        *view_update_generation = view_update_generation.wrapping_add(1);
+        if authoritative_membership_changed {
+            let membership_generation = self
+                .query
+                .applied_result_membership_generations
+                .entry(binding_view_key)
+                .or_default();
+            *membership_generation = membership_generation.wrapping_add(1);
+        }
         Ok(())
     }
 

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -2217,6 +2217,170 @@ describe("Worker Bridge with OPFS", () => {
     unsubscribe();
   });
 
+  it("does not retract a synced insert when two clients share a persistent database", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("synced-insert-shared-worker");
+    const dbName = uniqueDbName("synced-insert-shared-worker");
+    const secret = generateAuthSecret();
+    const config = {
+      appId: syncServer.appId,
+      serverUrl: syncServer.serverUrl,
+      secret,
+      driver: { type: "persistent" as const, dbName },
+    };
+    const remoteSeeder = track(
+      await createDb({
+        ...config,
+        driver: { type: "persistent", dbName: uniqueDbName("synced-insert-remote-seed") },
+      }),
+    );
+    const existingTitles = Array.from({ length: 10 }, (_, index) => `Existing ${index + 1}`);
+    for (const title of existingTitles) {
+      await remoteSeeder.insert(todos, { title, done: false }).wait({ tier: "global" });
+    }
+    await remoteSeeder.shutdown();
+    untrack(remoteSeeder);
+
+    const host = track(await createDb(config));
+    const hostSnapshots: Todo[][] = [];
+    const unsubscribeHost = trackSubscription(
+      host.subscribeAll(allTodos, (delta) => {
+        hostSnapshots.push([...(delta.all ?? [])]);
+      }),
+    );
+
+    await waitForCondition(
+      async () => (hostSnapshots[hostSnapshots.length - 1] ?? []).length === existingTitles.length,
+      15000,
+      "The first client should receive its settled rows before the second client opens",
+    );
+
+    await waitForCondition(
+      async () => getTabRole(host) === "leader",
+      12000,
+      "The first client should become broker leader before the second client opens",
+    );
+
+    const secondClient = track(await createDb(config));
+    await waitForLeaderAndFollower(host, secondClient);
+    const unsubscribeSecondClient = trackSubscription(
+      secondClient.subscribeAll(projects.orderBy("id", "asc").limit(101), () => {}, {
+        propagation: "local-only",
+      }),
+    );
+
+    for (const title of ["Synced host first", "Synced host second", "Synced host third"]) {
+      const firstNewSnapshot = hostSnapshots.length;
+      await host.insert(todos, { title, done: false }).wait({ tier: "local" });
+      await waitForCondition(
+        async () =>
+          (hostSnapshots[hostSnapshots.length - 1] ?? []).some((row) => row.title === title),
+        8000,
+        `The optimistic host snapshot should include ${title}`,
+      );
+      await sleep(750);
+
+      const snapshotsAfterInsert = hostSnapshots
+        .slice(firstNewSnapshot)
+        .map((rows) => rows.map((row) => row.title));
+      const firstSnapshotWithInsert = snapshotsAfterInsert.findIndex((titles) =>
+        titles.includes(title),
+      );
+      expect(firstSnapshotWithInsert).toBeGreaterThanOrEqual(0);
+      expect(
+        snapshotsAfterInsert
+          .slice(firstSnapshotWithInsert)
+          .every((snapshotTitles) => snapshotTitles.includes(title)),
+        `Host retracted ${title}; snapshots=${JSON.stringify(snapshotsAfterInsert)}`,
+      ).toBe(true);
+    }
+
+    unsubscribeSecondClient();
+    unsubscribeHost();
+  }, 90000);
+
+  it("does not resurrect an Edge-accepted delete when two clients share a persistent database", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("synced-delete-shared-worker");
+    const dbName = uniqueDbName("synced-delete-shared-worker");
+    const secret = generateAuthSecret();
+    const config = {
+      appId: syncServer.appId,
+      serverUrl: syncServer.serverUrl,
+      secret,
+      driver: { type: "persistent" as const, dbName },
+    };
+    const host = track(await createDb(config));
+    const hostSnapshots: Todo[][] = [];
+    const unsubscribeHost = trackSubscription(
+      host.subscribeAll(todos.orderBy("title"), (delta) => {
+        hostSnapshots.push([...(delta.all ?? [])]);
+      }),
+    );
+
+    await waitForCondition(
+      async () => getTabRole(host) === "leader",
+      12000,
+      "The first client should become broker leader before the second client opens",
+    );
+
+    const secondClient = track(await createDb(config));
+    await waitForLeaderAndFollower(host, secondClient);
+    const unsubscribeSecondClient = trackSubscription(
+      secondClient.subscribeAll(projects.orderBy("id", "asc").limit(101), () => {}, {
+        propagation: "local-only",
+      }),
+    );
+
+    const first = await host
+      .insert(todos, { title: "Keep after delete", done: false })
+      .wait({ tier: "edge" });
+    const second = await host
+      .insert(todos, { title: "Delete after second client opens", done: false })
+      .wait({ tier: "edge" });
+    await host.update(todos, first.id, { done: true }).wait({ tier: "edge" });
+    await waitForCondition(
+      async () => {
+        const rows = hostSnapshots[hostSnapshots.length - 1] ?? [];
+        return (
+          rows.length === 2 &&
+          rows.some((row) => row.id === first.id && row.done) &&
+          rows.some((row) => row.id === second.id)
+        );
+      },
+      8000,
+      "The host subscription should publish both rows before the delete",
+    );
+
+    const firstNewSnapshot = hostSnapshots.length;
+    await host.delete(todos, second.id).wait({ tier: "edge" });
+    await waitForCondition(
+      async () =>
+        hostSnapshots
+          .slice(firstNewSnapshot)
+          .some((rows) => rows.length === 1 && rows[0]?.id === first.id && rows[0].done),
+      8000,
+      "The host subscription should publish the accepted delete",
+    );
+    await sleep(750);
+
+    const snapshotsAfterDelete = hostSnapshots
+      .slice(firstNewSnapshot)
+      .map((rows) => rows.map((row) => row.id));
+    const firstSnapshotWithoutDeletedRow = snapshotsAfterDelete.findIndex(
+      (rowIds) => !rowIds.includes(second.id),
+    );
+    expect(firstSnapshotWithoutDeletedRow).toBeGreaterThanOrEqual(0);
+    expect(
+      snapshotsAfterDelete
+        .slice(firstSnapshotWithoutDeletedRow)
+        .every((rowIds) => !rowIds.includes(second.id)),
+      `Host resurrected the deleted row; snapshots=${JSON.stringify(snapshotsAfterDelete)}`,
+    ).toBe(true);
+    expect(await host.one(todos.where({ id: second.id }), { tier: "edge" })).toBeNull();
+
+    unsubscribeSecondClient();
+    unsubscribeHost();
+  }, 90000);
+
   it("syncs a follower opened after the leader is already ready", async () => {
     const dbName = uniqueDbName("late-follower-route");
     const leader = track(


### PR DESCRIPTION
### Bug

Opening more than one tab at the same time or mounting the Jazz inspector exposed an ordering race between optimistic writes and worker view updates. When issuing multiple writes, the main thread could receive a worker membership snapshot that included previous writes but had not yet incorporated the latest one. It treated that snapshot as fully authoritative and temporarily retracted the newest optimistic row, leaving the UI one row behind.

### Fix

Reconciliation now:

- Advances the authoritative generation only for actual membership changes.
- Preserves local rows whose settle position is newer than the worker view’s frontier.
- Applies this protection to the browser’s Local-tier worker handoff.

A browser regression test covers a host app sharing its broker with an inspector client and verifies that consecutive inserts never disappear.