### PR TITLE
fix: preserve runtime migration projection defaults

### DIFF
--- a/TEST_BURNDOWN.md
+++ b/TEST_BURNDOWN.md
@@ -28,7 +28,7 @@ Focused browser receipts are produced with `pnpm --filter jazz-tools test:browse
 
 A future fix must remove both the matching visible skip marker and this entry, then include a focused green receipt. Never delete or weaken the test. New known reds require both a source annotation and one row. Executable gates enforce the active annotation/entry bijection.
 
-## Active Rust quarantine (74)
+## Active Rust quarantine (72)
 
 | Test                                                                                                                                              | Definition                                                                  | Current reason                                                                                                                                                                                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -104,7 +104,6 @@ A future fix must remove both the matching visible skip marker and this entry, t
 | `jazz-testkit::replica_settlement::relay_topology::detaching_the_upstream_settles_held_subscription_locally_exactly_once`                         | `crates/jazz-testkit/tests/replica_settlement.rs`                           | confirm desired semantics with adopters: current strict Edge/Global contract keeps authority-tier subscriptions pending through upstream disconnect or detach; it does not implicitly settle from local state                           |
 | `jazz-testkit::reconnect_write_durability::detaching_the_upstream_resolves_pending_global_wait`                                                   | `crates/jazz-testkit/tests/reconnect_write_durability.rs`                   | confirm desired semantics with adopters: current strict Edge/Global contract keeps durability waits pending through upstream disconnect or detach; it does not implicitly collapse to local-tier settlement                             |
 | `jazz-testkit::schema_migration_policies::v2_update_of_v1_document_preserves_untouched_columns`                                                   | `crates/jazz-testkit/tests/schema_migration_policies.rs`                    | alice's v2 update of her v1-authored row never settles at the edge (neither accepted nor rejected) when the published read policy is session-scoped; the same update settles under an allow-all head and a v2-authored row updates fine |
-| `jazz-testkit::mixed_generation_history::migration_published_at_runtime_still_converges_mixed_generation_row`                                     | `crates/jazz-testkit/tests/mixed_generation_history.rs`                     | after a runtime-published v1->v2 catalogue bundle the serving edge rejects the current-schema table shape with UnsupportedShapeCapability (gap: Source(SchemaProjection)), so post-migration writes never settle at the edge            |
 
 ## Pre-existing/dormant Rust ignores (10; separately registered)
 

--- a/crates/jazz-testkit/tests/mixed_generation_history.rs
+++ b/crates/jazz-testkit/tests/mixed_generation_history.rs
@@ -563,7 +563,6 @@ async fn read_paths_agree_on_newest_state_after_mixed_generation_writes_impl() {
 /// bob (v2) ──update tags/labels──► server ──► newest state converges
 /// ```
 #[tokio::test]
-#[ignore = "after a runtime-published v1->v2 catalogue bundle the serving edge rejects the current-schema table shape with UnsupportedShapeCapability (gap: Source(SchemaProjection)), so post-migration writes never settle at the edge"]
 async fn migration_published_at_runtime_still_converges_mixed_generation_row() {
     tokio::task::LocalSet::new()
         .run_until(migration_published_at_runtime_still_converges_mixed_generation_row_impl())

--- a/crates/jazz/src/node/physical/projections.rs
+++ b/crates/jazz/src/node/physical/projections.rs
@@ -496,21 +496,24 @@ where
                 let column_id = target_mapping.columns.get(&column.name).copied()?;
                 let has_enum_boundary =
                     physical_mapping_has_enum_boundary(&target_mapping, column_id)
-                    || matches!(
-                        column.column_type,
-                        records::ValueType::EnumTag(_) | records::ValueType::Enum(_)
-                    );
+                    || value_type_has_enum_boundary(&column.column_type);
                 has_enum_boundary.then_some(column_id)
             })
             .collect::<BTreeSet<_>>();
-        // The durable projection is already complete for ordinary scalar
-        // columns and is refreshed whenever a compatible schema variant is
-        // admitted.  Only real enum boundaries need a query-local target so
-        // an unselected, unrepresentable enum can omit its row rather than
-        // fail the whole source.  In particular, an empty nested-enum
-        // registry is bookkeeping for every physical column, not evidence of
-        // an enum boundary.
-        if required_enum_columns.is_empty() {
+        let target_has_any_enum_boundary = target_table.columns.iter().any(|column| {
+            target_mapping
+                .columns
+                .get(&column.name)
+                .is_some_and(|column_id| {
+                    physical_mapping_has_enum_boundary(&target_mapping, *column_id)
+                })
+                || value_type_has_enum_boundary(&column.column_type)
+        });
+        // A schema with no enum boundary can use its durable target directly.
+        // For an enum-bearing table, an empty requirement set is itself a
+        // query-local compatibility boundary: unrequested enum cells must be
+        // typed-null before an old reader decodes the row.
+        if required_enum_columns.is_empty() && !target_has_any_enum_boundary {
             return Ok(physical_current_projection_target(
                 target_alias,
                 target_table_name,
@@ -636,14 +639,20 @@ where
                 let column_id = target_mapping.columns.get(&column.name).copied()?;
                 let has_enum_boundary =
                     physical_mapping_has_enum_boundary(&target_mapping, column_id)
-                    || matches!(
-                        column.column_type,
-                        records::ValueType::EnumTag(_) | records::ValueType::Enum(_)
-                    );
+                    || value_type_has_enum_boundary(&column.column_type);
                 has_enum_boundary.then_some(column_id)
             })
             .collect::<BTreeSet<_>>();
-        if required_enum_columns.is_empty() {
+        let target_has_any_enum_boundary = target_table.columns.iter().any(|column| {
+            target_mapping
+                .columns
+                .get(&column.name)
+                .is_some_and(|column_id| {
+                    physical_mapping_has_enum_boundary(&target_mapping, *column_id)
+                })
+                || value_type_has_enum_boundary(&column.column_type)
+        });
+        if required_enum_columns.is_empty() && !target_has_any_enum_boundary {
             return Ok(physical_history_projection_target(
                 target_alias,
                 target_table_name,

--- a/crates/jazz/src/node/physical/projections.rs
+++ b/crates/jazz/src/node/physical/projections.rs
@@ -494,14 +494,8 @@ where
             .filter(|column| required_fields.contains(&column.name))
             .filter_map(|column| {
                 let column_id = target_mapping.columns.get(&column.name).copied()?;
-                let has_enum_boundary = target_mapping.scalar_enum_cases.contains_key(&column_id)
-                    || target_mapping.payload_enum_cases.contains_key(&column_id)
-                    || target_mapping
-                        .nested_scalar_enum_cases
-                        .contains_key(&column_id)
-                    || target_mapping
-                        .nested_payload_enum_cases
-                        .contains_key(&column_id)
+                let has_enum_boundary =
+                    physical_mapping_has_enum_boundary(&target_mapping, column_id)
                     || matches!(
                         column.column_type,
                         records::ValueType::EnumTag(_) | records::ValueType::Enum(_)
@@ -509,6 +503,19 @@ where
                 has_enum_boundary.then_some(column_id)
             })
             .collect::<BTreeSet<_>>();
+        // The durable projection is already complete for ordinary scalar
+        // columns and is refreshed whenever a compatible schema variant is
+        // admitted.  Only real enum boundaries need a query-local target so
+        // an unselected, unrepresentable enum can omit its row rather than
+        // fail the whole source.  In particular, an empty nested-enum
+        // registry is bookkeeping for every physical column, not evidence of
+        // an enum boundary.
+        if required_enum_columns.is_empty() {
+            return Ok(physical_current_projection_target(
+                target_alias,
+                target_table_name,
+            ));
+        }
         let projection_target = physical_current_projection_target_for_enum_columns(
             target_alias,
             target_table_name,
@@ -627,14 +634,8 @@ where
             .filter(|column| required_fields.contains(&column.name))
             .filter_map(|column| {
                 let column_id = target_mapping.columns.get(&column.name).copied()?;
-                let has_enum_boundary = target_mapping.scalar_enum_cases.contains_key(&column_id)
-                    || target_mapping.payload_enum_cases.contains_key(&column_id)
-                    || target_mapping
-                        .nested_scalar_enum_cases
-                        .contains_key(&column_id)
-                    || target_mapping
-                        .nested_payload_enum_cases
-                        .contains_key(&column_id)
+                let has_enum_boundary =
+                    physical_mapping_has_enum_boundary(&target_mapping, column_id)
                     || matches!(
                         column.column_type,
                         records::ValueType::EnumTag(_) | records::ValueType::Enum(_)
@@ -642,6 +643,12 @@ where
                 has_enum_boundary.then_some(column_id)
             })
             .collect::<BTreeSet<_>>();
+        if required_enum_columns.is_empty() {
+            return Ok(physical_history_projection_target(
+                target_alias,
+                target_table_name,
+            ));
+        }
         let projection_target = physical_history_projection_target_for_enum_columns(
             target_alias,
             target_table_name,
@@ -1009,9 +1016,12 @@ where
                     }
                 }
                 Some(CurrentWinnerCellProjection::Literal(default)) => {
-                    let default = if matches!(output_type, records::ValueType::Nullable(_))
-                        && !matches!(default, Value::Nullable(_))
-                    {
+                    let default = if matches!(output_type, records::ValueType::Nullable(_)) {
+                        // A current-winner cell has one outer nullable layer
+                        // for source-field presence.  A nullable lens default
+                        // is its *inner* logical value, so it must be wrapped
+                        // too; otherwise a default null is indistinguishable
+                        // from an absent field and is lost by a partial write.
                         Value::Nullable(Some(Box::new(default)))
                     } else {
                         default
@@ -1242,6 +1252,11 @@ where
         #[derive(Clone)]
         enum CellProjection {
             Field(String),
+            /// The source variant did not author this cell, so it remains
+            /// absent in the target descriptor.
+            Missing,
+            /// A lens supplied this cell.  Its value (including a nullable
+            /// null) is a present logical value and must retain that fact.
             Literal(Value),
         }
 
@@ -1302,7 +1317,6 @@ where
                 }
             }
         }
-
         let target_storage = match shape {
             ContentProjectionShape::History => target_table.history_storage_table(),
             ContentProjectionShape::Current => {
@@ -1370,7 +1384,7 @@ where
             let output = user_column_field(&column.name);
             let projection = match cells.remove(&column.name) {
                 Some(projection) => projection,
-                None if present.is_some() => CellProjection::Literal(Value::Nullable(None)),
+                None if present.is_some() => CellProjection::Missing,
                 None => return Ok(None),
             };
             match projection {
@@ -1379,14 +1393,7 @@ where
                         Error::InvalidStoredValue("target enum physical column mapping missing"),
                     )?;
                     let has_enum_boundary =
-                        target_mapping.scalar_enum_cases.contains_key(&column_id)
-                            || target_mapping.payload_enum_cases.contains_key(&column_id)
-                            || target_mapping
-                                .nested_scalar_enum_cases
-                                .contains_key(&column_id)
-                            || target_mapping
-                                .nested_payload_enum_cases
-                                .contains_key(&column_id);
+                        physical_mapping_has_enum_boundary(target_mapping, column_id);
                     let direct_enum = matches!(
                         column.column_type,
                         records::ValueType::EnumTag(_) | records::ValueType::Enum(_)
@@ -1464,7 +1471,7 @@ where
                         fields.push(ProjectField::renamed(source, output));
                     }
                 }
-                CellProjection::Literal(Value::Nullable(None)) => {
+                CellProjection::Missing => {
                     fields.push(ProjectField::literal_typed(
                         output,
                         Value::Nullable(None),

--- a/dev/gates/test-burndown-rust.mjs
+++ b/dev/gates/test-burndown-rust.mjs
@@ -98,8 +98,8 @@ if (process.argv.includes("--self-test")) {
 }
 const doc = fs.readFileSync("TEST_BURNDOWN.md", "utf8");
 const { active, dormant, documented } = parse(doc);
-if (active.length !== 73 || dormant.length !== 10) fail("expected 73 active + 10 dormant rows");
+if (active.length !== 72 || dormant.length !== 10) fail("expected 72 active + 10 dormant rows");
 const ignored = compiledIgnored();
 if (!same(ignored, documented)) fail("compiled ignored set differs from documented set");
 verifyMarkers(active);
-console.log("Rust burndown: exact 73 active + 10 dormant identity bijection.");
+console.log("Rust burndown: exact 72 active + 10 dormant identity bijection.");


### PR DESCRIPTION
🤖 Fix runtime migration publication across schema generations.

Ordinary projected columns no longer acquire query-local enum targets merely because their nested-enum bookkeeping is empty. This lets stale-generation subscriptions drain after a schema update while retaining query-local omission behavior for actual enum boundaries.

The projection path also preserves a lens-supplied nullable default as a present logical null, distinct from a physically absent source cell.

Verification:
- mixed_generation_history: 7/7 passed
- schema_migration_policies: 8 enabled passed, 1 unrelated ignore
- Rust burndown: exact 72 active + 10 dormant
- fmt, scoped clippy, pre-commit, and sensitive-data guard passed

The newly enabled regression proves a v1 runtime subscription converges after publishing v2.