### PR TITLE
test: allow worker rejection callback to settle

### DIFF
--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1337,7 +1337,7 @@ describe("Worker Bridge with OPFS", () => {
     const batchId = await insertResult.transactionId;
     await waitForCondition(
       async () => mutationErrorSpy.mock.calls.length > 0,
-      1000,
+      5000,
       "onMutationError handler should be called",
     );
     expect(mutationErrorSpy).toHaveBeenCalledWith({


### PR DESCRIPTION
🤖 Stabilize the worker rejection callback regression test. The callback crosses worker, server, and browser scheduling boundaries; its former one-second deadline was shorter than normal focused executions and produced a single full-suite flake. This uses the existing five-second rejection/restart-test deadline while retaining exact permission_denied and transaction assertions. Focused 5×, the full 297-test browser suite, and a planted listener-suppression negative passed.