### PR TITLE
fix(ci): provide Windows libclang for NAPI builds

### DIFF
--- a/.github/workflows/build-jazz-packages.yml
+++ b/.github/workflows/build-jazz-packages.yml
@@ -182,6 +182,21 @@ jobs:
           sccache: ${{ matrix.use_sccache && 'true' || 'false' }}
           sccache-key: release-napi-sccache-${{ github.event.pull_request.head.repo.id || github.repository_id }}-${{ matrix.platform }}-v1
 
+      # The Windows runner image supplies the MSVC toolchain but not libclang.
+      # RocksDB's zstd-sys build uses bindgen, which must be pointed at the DLL
+      # before napi invokes Cargo.
+      - name: Install libclang for Windows bindgen
+        if: matrix.platform == 'win32-x64-msvc'
+        shell: pwsh
+        run: |
+          choco install llvm --version=21.1.8 --yes --no-progress --limit-output
+          $libclangPath = Join-Path $env:ProgramFiles "LLVM\bin"
+          if (-not (Test-Path (Join-Path $libclangPath "libclang.dll"))) {
+            throw "LLVM installation did not provide libclang.dll at $libclangPath"
+          }
+          "LIBCLANG_PATH=$libclangPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $libclangPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Build jazz-napi binding
         run: |
           node dev/artifacts/build.mjs napi release --target ${{ matrix.target }}

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -523,6 +523,17 @@ test("CI runs the workflow contract test through its package script", () => {
   assert.match(lint, /run: pnpm test:ci-workflow/);
 });
 
+test("Windows NAPI release builds provision libclang for RocksDB bindgen", () => {
+  const windowsNapiSetup =
+    /name: Install libclang for Windows bindgen[\s\S]*if: matrix\.platform == 'win32-x64-msvc'[\s\S]*choco install llvm --version=21\.1\.8 --yes --no-progress --limit-output[\s\S]*Test-Path \(Join-Path \$libclangPath "libclang\.dll"\)[\s\S]*LIBCLANG_PATH=\$libclangPath[\s\S]*\$env:GITHUB_PATH/;
+  assert.match(packageBuild, windowsNapiSetup);
+  assert.throws(
+    () =>
+      assert.match(packageBuild.replace('"LIBCLANG_PATH=$libclangPath" | ', ""), windowsNapiSetup),
+    /LIBCLANG_PATH/,
+  );
+});
+
 test("TypeScript CI overlaps independent Node and browser suites after one artifact build", () => {
   const typescript = job("test-ts");
   const runner = fs.readFileSync(path.join(root, "dev/gates/run-ts-tests.sh"), "utf8");


### PR DESCRIPTION
🤖 Fix the Windows preview NAPI build by provisioning pinned LLVM 21.1.8 before Cargo invokes RocksDB/zstd bindgen.

The Windows runner has MSVC but no libclang. This verifies the expected DLL and exports LIBCLANG_PATH and PATH for bindgen. A workflow contract test keeps the setup Windows-only and pinned.

Validation:
- CI workflow contract tests: 20 passed
- pnpm format:check
- independent adversarial review approved

The hosted Windows preview build remains the definitive end-to-end receipt.