### PR TITLE
fix: exclude generated NAPI staging from provenance

### DIFF
--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -65,6 +65,23 @@ function wasmPackToolVersion(root, name) {
   return toolVersion(root, candidates[0]);
 }
 
+// build.mjs temporarily renames the current target binding while napi-rs
+// produces its replacement.  The suffix intentionally does not end in
+// `.node`, so the ordinary generated-artifact exclusion below would otherwise
+// mistake it for a source input.  Keep this exact to the build wrapper's
+// ephemeral filename contract: real NAPI sources and any other generated
+// inputs remain provenance inputs.
+const isStagedNapiBinding = (repoPath) =>
+  /^crates\/jazz-napi\/jazz-napi\.(?:linux-x64-gnu|win32-x64-msvc|darwin-x64|darwin-arm64)\.node\.staged-\d+-\d+$/.test(
+    repoPath,
+  );
+
+// Turbo writes its task receipt after the package's build command returns.
+// The NAPI wrapper seals provenance inside that command, so this local output
+// directory must not be part of the inputs it validates.  This is deliberately
+// scoped to the NAPI package; root turbo.json remains an input.
+const isNapiTurboOutputDirectory = (repoPath) => repoPath === "crates/jazz-napi/.turbo";
+
 function files(root, paths) {
   const found = [];
   const visit = (path) => {
@@ -73,11 +90,18 @@ function files(root, paths) {
     if (stat.isDirectory())
       for (const name of readdirSync(path).sort()) {
         if (["pkg", "target", "node_modules"].includes(name)) continue;
-        visit(join(path, name));
+        const child = join(path, name);
+        if (isNapiTurboOutputDirectory(relative(root, child))) continue;
+        visit(child);
       }
     else if (stat.isFile()) {
       const repoPath = relative(root, path);
-      if (repoPath.endsWith(".node") || repoPath.endsWith(".jazz-artifact-manifest.json")) return;
+      if (
+        repoPath.endsWith(".node") ||
+        repoPath.endsWith(".jazz-artifact-manifest.json") ||
+        isStagedNapiBinding(repoPath)
+      )
+        return;
       found.push(repoPath);
     }
   };

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -77,6 +77,46 @@ test("dirty source changes invalidate the manifest", () => {
   );
 });
 
+test("NAPI provenance excludes only the wrapper's ephemeral staged binding", () => {
+  const root = fixture();
+  writeManifest(root, "napi", "release");
+  const before = expectedManifest(root, "napi", "release").packageInputs;
+
+  // build.mjs uses this exact name while replacing a target binding.  Its
+  // presence must not make a manifest stale immediately after the build.
+  writeFileSync(
+    join(root, "crates/jazz-napi/jazz-napi.linux-x64-gnu.node.staged-123-456"),
+    "previous native binding",
+  );
+  assert.equal(expectedManifest(root, "napi", "release").packageInputs, before);
+  assert.equal(verifyManifest(root, "napi", "release"), null);
+  rmSync(join(root, "crates/jazz-napi/jazz-napi.linux-x64-gnu.node.staged-123-456"));
+
+  // Turbo writes this receipt after the inner NAPI build wrapper seals its
+  // manifest. It is a package-local build output, not a build input.
+  mkdirSync(join(root, "crates/jazz-napi/.turbo"));
+  writeFileSync(join(root, "crates/jazz-napi/.turbo/turbo-build.log"), "outer task receipt");
+  assert.equal(expectedManifest(root, "napi", "release").packageInputs, before);
+  assert.equal(verifyManifest(root, "napi", "release"), null);
+
+  // Near misses are ordinary inputs: accepting any made-up binding name,
+  // suffix, or appended extension would let generated source evade freshness.
+  for (const path of [
+    "jazz-napi.linux-x64-gnu.node.staged-123-456.rs",
+    "jazz-napi.attacker.node.staged-123-456",
+    "jazz-napi.linux-x64-gnu.node.staged-not-a-wrapper",
+  ]) {
+    const file = join(root, "crates/jazz-napi", path);
+    writeFileSync(file, "must remain an input");
+    assert.notEqual(expectedManifest(root, "napi", "release").packageInputs, before, path);
+    rmSync(file);
+  }
+
+  // Planted positive: an actual NAPI source remains a provenance input.
+  writeFileSync(join(root, "crates/jazz-napi/src/lib.rs"), "// changed native source\n");
+  assert.match(verifyManifest(root, "napi", "release"), /packageInputs differs/);
+});
+
 test("WASM provenance covers generated glue and declarations, not only the binary", () => {
   const root = fixture();
   for (const file of [


### PR DESCRIPTION
🤖 Keep NAPI artifact provenance stable across build-wrapper staging and Turbo receipt writes without weakening source freshness checks.

The wrapper briefly creates target-specific staged native bindings, and outer Turbo writes its package-local receipt after the inner build seals provenance. Both are generated build machinery rather than inputs. This excludes only the four exact supported staged-binding forms and the exact NAPI package `.turbo` directory; source files and near-miss names remain hashed.

Validation:
- provenance tests: 8 passed
- direct release NAPI and fast WASM builds
- combined correctness-artifact verifier reports both fresh
- independent adversarial review approved