### PR TITLE
fix(groove): order nullable window keys deterministically

### DIFF
--- a/crates/groove/src/db/tests/queries/windows.rs
+++ b/crates/groove/src/db/tests/queries/windows.rs
@@ -430,7 +430,10 @@ fn top_by_orders_nullable_sort_keys_null_first() {
     batch.insert(
         "scores",
         vec![
-            Value::U64(2),
+            // The non-null row deliberately has the earlier tie key: this
+            // verifies NULL ordering rather than accidentally passing through
+            // the id tie-breaker.
+            Value::U64(1),
             Value::Nullable(Some(Box::new(Value::U64(10)))),
             Value::String("ten".to_owned()),
         ],
@@ -438,7 +441,7 @@ fn top_by_orders_nullable_sort_keys_null_first() {
     batch.insert(
         "scores",
         vec![
-            Value::U64(1),
+            Value::U64(2),
             Value::Nullable(None),
             Value::String("null".to_owned()),
         ],
@@ -459,7 +462,7 @@ fn top_by_orders_nullable_sort_keys_null_first() {
         subscription.recv().unwrap().to_values().unwrap(),
         [(
             vec![
-                Value::U64(1),
+                Value::U64(2),
                 Value::Nullable(None),
                 Value::String("null".to_owned()),
             ],

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -13,9 +13,7 @@ pub(super) struct TopBySortPart {
 
 impl PartialEq for TopBySortPart {
     fn eq(&self, other: &Self) -> bool {
-        self.direction == other.direction
-            && compare_values_sql(&self.key, &other.key, ValueComparison::Exact)
-                == Some(std::cmp::Ordering::Equal)
+        self.direction == other.direction && self.cmp(other) == std::cmp::Ordering::Equal
     }
 }
 
@@ -23,15 +21,19 @@ impl Eq for TopBySortPart {}
 
 impl Ord for TopBySortPart {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let ordering = match (is_sql_null_value(&self.key), is_sql_null_value(&other.key)) {
+            // Windows need a total order, unlike SQL predicates where any
+            // comparison involving NULL is unknown. Keep NULL first for the
+            // canonical ascending order, then apply the declared direction.
+            (true, true) => std::cmp::Ordering::Equal,
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            (false, false) => compare_values_sql(&self.key, &other.key, ValueComparison::Exact)
+                .expect("non-null TopBy values must be comparable"),
+        };
         match self.direction {
-            TopByDirection::Asc => {
-                compare_values_sql(&self.key, &other.key, ValueComparison::Exact)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            }
-            TopByDirection::Desc => {
-                compare_values_sql(&other.key, &self.key, ValueComparison::Exact)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            }
+            TopByDirection::Asc => ordering,
+            TopByDirection::Desc => ordering.reverse(),
         }
     }
 }

--- a/crates/jazz/src/db/tests/subscriptions/structured.rs
+++ b/crates/jazz/src/db/tests/subscriptions/structured.rs
@@ -594,13 +594,24 @@ fn flat_subscription_updates_with_nullable_sort_payload() {
         row(0xa1),
         BTreeMap::from([
             ("name".to_owned(), Value::String("before".to_owned())),
-            (
-                "rank".to_owned(),
-                Value::Nullable(Some(Box::new(Value::I32(1)))),
-            ),
+            ("rank".to_owned(), Value::Nullable(None)),
         ]),
     )
     .unwrap();
+    for (id, rank) in [(0xb1, 1), (0xc1, 2)] {
+        db.insert_with_id(
+            "users",
+            row(id),
+            BTreeMap::from([
+                ("name".to_owned(), Value::String(format!("rank-{rank}"))),
+                (
+                    "rank".to_owned(),
+                    Value::Nullable(Some(Box::new(Value::I32(rank)))),
+                ),
+            ]),
+        )
+        .unwrap();
+    }
     let query = Query::from("users").order_by("rank", OrderDirection::Asc);
     let prepared_query = prepared(&db, &query);
     let mut subscription = block_on(db.subscribe(&prepared_query, ReadOpts::default())).unwrap();
@@ -627,10 +638,13 @@ fn flat_subscription_updates_with_nullable_sort_payload() {
         "title-only update must retain its root payload"
     );
     assert!(
-        !terminal_operations
-            .iter()
-            .any(|operation| matches!(operation.edit, groove::ivm::TerminalEdit::Move { .. })),
-        "unchanged nullable sort key must not produce a root move"
+        !terminal_operations.iter().any(|operation| matches!(
+            operation.edit,
+            groove::ivm::TerminalEdit::Move { .. }
+                | groove::ivm::TerminalEdit::Remove { .. }
+                | groove::ivm::TerminalEdit::Insert { .. }
+        )),
+        "unchanged nullable sort key must not reposition the root"
     );
 }
 

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
@@ -6,7 +6,7 @@ import type { WasmSchema } from "../../src/drivers/types.js";
 interface Todo {
   id: string;
   title: string;
-  rank?: number;
+  rank: number | null;
   done: boolean;
 }
 
@@ -722,17 +722,25 @@ describe("db.subscribeAll sorting browser integration", () => {
     }
   });
 
-  it("keeps null/undefined sort-value ordering stable", async () => {
+  it("keeps an explicit null sort value ordering stable", async () => {
     await withDb("null-sort-values", async (db) => {
       const snapshots: Todo[][] = [];
+      let sawInitialReset = false;
       const unsubscribe = db.subscribeAll(sortedByRankAscQuery, (delta) => {
+        sawInitialReset ||= delta.reset === true;
         snapshots.push(delta.all);
       });
 
       try {
+        await waitForCondition(
+          () => sawInitialReset,
+          SUBSCRIPTION_CONVERGENCE_TIMEOUT_MS,
+          "expected initial empty subscription reset",
+        );
+
         const {
           value: { id: idNull },
-        } = await db.insert(todos, { title: "N", rank: undefined, done: false });
+        } = await db.insert(todos, { title: "N", rank: null, done: false });
         const {
           value: { id: idOne },
         } = await db.insert(todos, { title: "A", rank: 1, done: false });


### PR DESCRIPTION
🤖 Make nullable window sort keys deterministic so unrelated field updates cannot reposition a row whose sort key is NULL.

Previously SQL comparison returned no ordering for NULL versus non-NULL, which TopBy converted to equality; encoded full-record bytes then became an accidental tiebreaker. The comparator now orders NULL first ascending and last descending before applying stable ties. Browser setup also waits for its initial reset and writes an explicit NULL.

Validation:
- focused Rust NULL-order and structured subscription regressions pass
- browser sort suite: 18 passed
- planted old comparator fails the strengthened ascending test
- independent descending NULL-last planted probe passes current and fails old behavior
- independent adversarial review approved