### PR TITLE
fix(jazz): gate edge fate test on runtime

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -148,3 +148,7 @@ required-features = ["testing"]
 [[test]]
 name = "authorization_scope_reentry"
 required-features = ["testing"]
+
+[[test]]
+name = "edge_fate_authority"
+required-features = ["runtime"]


### PR DESCRIPTION
🤖 Declare the `edge_fate_authority` integration test as requiring Jazz’s `runtime` feature, matching its use of the runtime-gated `jazz::serving` API.

Validation:
- `cargo test -p jazz --no-run` passes and omits the runtime-only target
- `cargo test -p jazz --features runtime --test edge_fate_authority --no-run` passes
- runtime-enabled test passes 3/3
- pre-commit Clippy and sensitive-data gate pass