### PR TITLE
Use read-policy indexes for owner-filtered reads

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -106,6 +106,11 @@ harness = false
 required-features = ["testing"]
 
 [[bench]]
+name = "owner_filter_diagnostic"
+harness = false
+required-features = ["testing"]
+
+[[bench]]
 name = "observer_write_path"
 harness = false
 

--- a/crates/jazz/benches/owner_filter_diagnostic.rs
+++ b/crates/jazz/benches/owner_filter_diagnostic.rs
@@ -1,0 +1,245 @@
+mod schema_fixture;
+mod support;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Instant;
+
+use jazz::db::{
+    Db, DbConfig, DbIdentity, LocalUpdates, MergeableTxOps, Propagation, ReadOpts,
+    SeededRowIdSource, block_on,
+};
+use jazz::groove::db::StorageReadMetrics;
+use jazz::groove::records::Value;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, col, eq, lit};
+use jazz::schema::JazzSchema;
+use jazz::tools::{ColumnType, SchemaBuilder, TablePolicies, TableSchemaBuilder};
+use jazz::tx::DurabilityTier;
+use jazz_storage_rocksdb::RocksDbStorage;
+use serde_json::{Map, json};
+
+const TABLE: &str = "documents";
+const AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000a1"));
+const OTHER_AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000b2"));
+
+fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+
+    let table_rows = support::csv_usizes("JAZZ_OWNER_FILTER_ROWS", "10000,100000");
+    let owned_rows = support::env_usize("JAZZ_OWNER_FILTER_OWNED_ROWS", 500);
+    let result_rows = support::env_usize("JAZZ_OWNER_FILTER_RESULT_ROWS", 500);
+    let batch_rows = support::env_usize("JAZZ_OWNER_FILTER_BATCH_ROWS", 1000);
+
+    for rows in table_rows {
+        assert!(rows >= owned_rows);
+        run_rung(rows, owned_rows, result_rows, batch_rows);
+    }
+}
+
+fn run_rung(table_rows: usize, owned_rows: usize, result_rows: usize, batch_rows: usize) {
+    let temp = tempfile::tempdir().expect("create owner-filter RocksDB directory");
+    let schema = schema();
+    let db = open_db(temp.path(), schema.clone());
+
+    let seed_started = Instant::now();
+    seed_rows(&db, table_rows, owned_rows, batch_rows);
+    let seed_us = seed_started.elapsed().as_micros();
+    db.close().expect("close seeded owner-filter db");
+    drop(db);
+
+    let cases = [
+        ("policy_only", policy_only_query(), owned_rows),
+        ("owner_predicate_all", owner_predicate_query(), owned_rows),
+        (
+            "owner_predicate_ordered_limit",
+            owner_predicate_query()
+                .order_by("updated_at", OrderDirection::Desc)
+                .limit(result_rows),
+            result_rows,
+        ),
+    ];
+
+    for (case, query, expected_rows) in cases {
+        let db = open_db(temp.path(), schema.clone());
+        let open_metrics = db.take_storage_read_metrics_for_test();
+        db.reset_storage_read_metrics_for_test();
+        let prepare_started = Instant::now();
+        let prepared = db
+            .prepare_query(&query)
+            .expect("prepare owner-filter query");
+        let prepare_us = prepare_started.elapsed().as_micros();
+        let prepare_metrics = db.take_storage_read_metrics_for_test();
+
+        db.reset_storage_read_metrics_for_test();
+        let query_started = Instant::now();
+        let rows = block_on(db.all_for_identity(&prepared, global_read_opts(), AUTHOR))
+            .expect("run owner-filter query");
+        let query_us = query_started.elapsed().as_micros();
+        let query_metrics = db.take_storage_read_metrics_for_test();
+
+        assert_eq!(rows.len(), expected_rows, "{case} row count changed");
+        emit_case(
+            case,
+            table_rows,
+            owned_rows,
+            expected_rows,
+            seed_us,
+            prepare_us,
+            query_us,
+            &open_metrics,
+            &prepare_metrics,
+            &query_metrics,
+        );
+        db.close().expect("close owner-filter db");
+    }
+}
+
+fn schema() -> JazzSchema {
+    schema_fixture::compile(
+        SchemaBuilder::new().table(
+            TableSchemaBuilder::new(TABLE)
+                .column("owner", ColumnType::Uuid)
+                .column("active", ColumnType::Boolean)
+                .column("updated_at", ColumnType::Timestamp)
+                .column("title", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(schema_fixture::session_user_id_column("owner")),
+                )
+                .index_only(["owner", "updated_at"]),
+        ),
+    )
+}
+
+fn open_db(path: &Path, schema: JazzSchema) -> Db<RocksDbStorage> {
+    let column_families = schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+
+    block_on(Db::open_history_complete(
+        DbConfig::new(
+            schema,
+            RocksDbStorage::open(path, &refs).expect("open owner-filter RocksDB"),
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x51; 16]),
+                author: AUTHOR,
+            },
+        )
+        .with_id_source(SeededRowIdSource::new(0x51)),
+    ))
+    .expect("open owner-filter Jazz db")
+}
+
+fn seed_rows(db: &Db<RocksDbStorage>, table_rows: usize, owned_rows: usize, batch_rows: usize) {
+    for batch_start in (0..table_rows).step_by(batch_rows) {
+        let batch_end = table_rows.min(batch_start + batch_rows);
+        let tx = block_on(db.mergeable_tx()).expect("open owner-filter seed tx");
+
+        for index in batch_start..batch_end {
+            let owner = if index < owned_rows {
+                AUTHOR
+            } else {
+                OTHER_AUTHOR
+            };
+            block_on(tx.insert_with_id(
+                TABLE,
+                row(index),
+                BTreeMap::from([
+                    ("owner".to_owned(), Value::Uuid(owner.0)),
+                    ("active".to_owned(), Value::Bool(true)),
+                    ("updated_at".to_owned(), Value::U64(index as u64)),
+                    (
+                        "title".to_owned(),
+                        Value::String(format!("document-{index}")),
+                    ),
+                ]),
+            ))
+            .expect("stage owner-filter row");
+        }
+
+        let tx_id = block_on(tx.commit()).expect("commit owner-filter seed tx");
+        db.finalize_local_mergeable_commit_for_test(tx_id)
+            .expect("settle owner-filter seed tx");
+    }
+}
+
+fn row(index: usize) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[0] = 0x61;
+    bytes[8..].copy_from_slice(&(index as u64).to_be_bytes());
+    RowUuid::from_bytes(bytes)
+}
+
+fn policy_only_query() -> Query {
+    Query::from(TABLE)
+}
+
+fn owner_predicate_query() -> Query {
+    Query::from(TABLE)
+        .filter(eq(col("owner"), lit(AUTHOR.0)))
+        .filter(eq(col("active"), lit(true)))
+}
+
+fn global_read_opts() -> ReadOpts {
+    ReadOpts {
+        tier: DurabilityTier::Global,
+        local_updates: LocalUpdates::Deferred,
+        propagation: Propagation::LocalOnly,
+        include_deleted: false,
+        ..ReadOpts::default()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_case(
+    case: &str,
+    table_rows: usize,
+    owned_rows: usize,
+    result_rows: usize,
+    seed_us: u128,
+    prepare_us: u128,
+    query_us: u128,
+    open_metrics: &StorageReadMetrics,
+    prepare_metrics: &StorageReadMetrics,
+    query_metrics: &StorageReadMetrics,
+) {
+    let mut fields = Map::new();
+    fields.insert("phase".to_owned(), json!("owner_filter_diagnostic"));
+    fields.insert("case".to_owned(), json!(case));
+    fields.insert("table_rows".to_owned(), json!(table_rows));
+    fields.insert("owned_rows".to_owned(), json!(owned_rows));
+    fields.insert("result_rows".to_owned(), json!(result_rows));
+    fields.insert("seed_us".to_owned(), json!(seed_us));
+    fields.insert("prepare_us".to_owned(), json!(prepare_us));
+    fields.insert("query_us".to_owned(), json!(query_us));
+    insert_metrics(&mut fields, "open", open_metrics);
+    insert_metrics(&mut fields, "prepare", prepare_metrics);
+    insert_metrics(&mut fields, "query", query_metrics);
+    support::emit_json_line("owner_filter_diagnostic", fields);
+}
+
+fn insert_metrics(
+    fields: &mut Map<String, serde_json::Value>,
+    prefix: &str,
+    metrics: &StorageReadMetrics,
+) {
+    fields.insert(
+        format!("{prefix}_logical_reads"),
+        json!(metrics.total.reads),
+    );
+    fields.insert(
+        format!("{prefix}_logical_ranges"),
+        json!(metrics.total.ranges),
+    );
+    fields.insert(
+        format!("{prefix}_global_current_row_reads"),
+        json!(metrics.global_current_rows.reads),
+    );
+    fields.insert(
+        format!("{prefix}_global_current_index_reads"),
+        json!(metrics.global_current_indexes.reads),
+    );
+}

--- a/crates/jazz/src/node/query_eval/authorization.rs
+++ b/crates/jazz/src/node/query_eval/authorization.rs
@@ -196,7 +196,11 @@ where
         }
 
         let result = async {
-            let program = Box::pin(self.compile_query_program_request(request)).await?;
+            let access_paths = self.policy_authorization_access_paths(&request)?;
+            let program = Box::pin(
+                self.compile_query_program_request_with_access_paths(request, access_paths),
+            )
+            .await?;
             let graph = lowered_terminal_graph(&program, "policy.authorized_rows")?;
             let route_fields = program
                 .lowered

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -904,13 +904,30 @@ where
                 )
                 .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
             } else {
-                let source = self
-                    .projected_visible_current_source_graph(
+                let tier = graph_tier.expect("visible current source has a tier");
+                let selected_policy_base = if self.access_paths.contains_key(&request.source) {
+                    None
+                } else {
+                    self.selected_policy_filtered_global_current_source_graph(
                         request,
                         &table,
-                        graph_tier.expect("visible current source has a tier"),
+                        tier,
+                        &authorization,
                     )
-                    .await?;
+                    .await?
+                };
+                let source = if let Some(graph) = selected_policy_base {
+                    CurrentSourceGraph {
+                        graph: graph.project_fields(storage_to_canonical_current_source_fields(
+                            &table, true, false,
+                        )),
+                        descriptor: current_row_descriptor(&table),
+                        metadata: BTreeMap::new(),
+                    }
+                } else {
+                    self.projected_visible_current_source_graph(request, &table, tier)
+                        .await?
+                };
                 let graph = match &authorization {
                     SourceAuthorizationRequest::System => source.graph,
                     SourceAuthorizationRequest::PolicyFiltered {
@@ -1064,20 +1081,29 @@ where
                 BTreeSet::new(),
             )
         } else {
+            let tier = graph_tier.expect("visible current source has a tier");
             let selected_base = self
-                .selected_global_current_source_graph(
-                    request,
-                    &table,
-                    graph_tier.expect("visible current source has a tier"),
-                )
+                .selected_global_current_source_graph(request, &table, tier)
                 .await?;
+            let selected_base = match selected_base {
+                Some(selected_base) => Some(selected_base),
+                None => {
+                    self.selected_policy_filtered_global_current_source_graph(
+                        request,
+                        &table,
+                        tier,
+                        &authorization,
+                    )
+                    .await?
+                }
+            };
             if selected_base.is_none() {
                 self.node.query_engine_read_metrics.source_full_scans += 1;
             }
             resolved_current_source_graph(
                 self.node,
                 &table,
-                graph_tier.expect("visible current source has a tier"),
+                tier,
                 &request.requirements,
                 &authorization,
                 self.read_view.policy_schema,
@@ -1277,6 +1303,87 @@ where
         let Some(access_path) = self.access_paths.get(&request.source).cloned() else {
             return Ok(None);
         };
+        self.selected_global_current_source_graph_for_access_path(request, table, tier, access_path)
+            .await
+    }
+
+    async fn selected_policy_filtered_global_current_source_graph(
+        &mut self,
+        request: &SourceRequest,
+        table: &TableSchema,
+        tier: DurabilityTier,
+        authorization: &SourceAuthorizationRequest,
+    ) -> Result<Option<GraphBuilder>, SourceResolutionError> {
+        let (permission_subject, plan) = match authorization {
+            SourceAuthorizationRequest::PolicyFiltered {
+                permission_subject,
+                plan,
+            }
+            | SourceAuthorizationRequest::PolicyProof {
+                permission_subject,
+                plan,
+            } => (permission_subject, plan),
+            SourceAuthorizationRequest::System => return Ok(None),
+        };
+        if plan.protected_source.table != table.name
+            || plan.role != PolicyDecisionRole::Read
+            || plan.protected_row_field != "row_uuid"
+        {
+            return Err(source_resolution_error(request, SourceGap::Coverage));
+        }
+        let param_binding_mode = if plan.binding_source_shape.is_some() {
+            ParamBindingMode::RetainAllParams
+        } else {
+            ParamBindingMode::InlineAllReachableSeeds
+        };
+        let policy_request = self.node.table_read_policy_authorization_request(
+            self.read_view.policy_schema,
+            &table.name,
+            *permission_subject,
+            param_binding_mode,
+            tier,
+            plan.binding_source_shape.clone(),
+            plan.binding_user_params.clone(),
+            plan.binding_claim_params.clone(),
+        );
+        let policy_request = policy_request.map(|mut policy_request| {
+            policy_request.reads.primary =
+                policy_read_view_projected_through(&policy_request.reads.primary, self.read_view);
+            policy_request
+        });
+        let policy_request = match policy_request {
+            Ok(policy_request) => policy_request,
+            Err(Error::QueryCapability(error)) if error.contains("PolicyProofCycle") => {
+                return Err(source_resolution_error_from_policy_proof(
+                    request,
+                    Error::QueryCapability(error),
+                ));
+            }
+            Err(Error::QueryCapability(_)) => return Ok(None),
+            Err(error) => return Err(source_resolution_error_from_policy_proof(request, error)),
+        };
+        let access_paths = self
+            .node
+            .policy_authorization_access_paths(&policy_request)
+            .map_err(|error| source_resolution_error_from_policy_proof(request, error))?;
+        let Some(access_path) = access_paths
+            .get(&plan.protected_source)
+            .cloned()
+            .or_else(|| access_paths.values().next().cloned())
+        else {
+            return Ok(None);
+        };
+        self.selected_global_current_source_graph_for_access_path(request, table, tier, access_path)
+            .await
+    }
+
+    async fn selected_global_current_source_graph_for_access_path(
+        &mut self,
+        request: &SourceRequest,
+        table: &TableSchema,
+        tier: DurabilityTier,
+        access_path: CurrentAccessPath,
+    ) -> Result<Option<GraphBuilder>, SourceResolutionError> {
         match access_path {
             CurrentAccessPath::PrimaryKey(prefix) => {
                 self.node.query_engine_read_metrics.source_primary_key_scans += 1;
@@ -2688,6 +2795,42 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
+    pub(super) fn policy_authorization_access_paths(
+        &self,
+        request: &QueryProgramRequest,
+    ) -> Result<BTreeMap<SourceId, CurrentAccessPath>, Error> {
+        let target = match &request.policy {
+            PolicyContext::AuthorizationSubplan {
+                protected_source,
+                role,
+                ..
+            } if *role == PolicyDecisionRole::Read => protected_source,
+            _ => return Ok(BTreeMap::new()),
+        };
+        if request.reads.primary.source_current_tier(target) != Some(DurabilityTier::Global) {
+            return Ok(BTreeMap::new());
+        }
+
+        let mut equalities = BTreeMap::new();
+        let reaches_target = normalized_source_equalities_from_node(
+            &request.input.shape,
+            &request.input.shape.root,
+            target,
+            &request.input.binding,
+            &request.policy,
+            &mut equalities,
+        )?;
+        if !reaches_target {
+            return Ok(BTreeMap::new());
+        }
+
+        let table = self.table_in_schema(&target.table, request.reads.primary.read_schema)?;
+        let Some(access_path) = select_current_access_path(&table, &equalities) else {
+            return Ok(BTreeMap::new());
+        };
+        Ok(BTreeMap::from([(target.clone(), access_path)]))
+    }
+
     pub(super) fn one_shot_access_paths(
         &self,
         shape: &ValidatedQuery,
@@ -2855,6 +2998,129 @@ where
             projection_target,
             StaticScanSpec::Prefix(prefix.iter().cloned().map(LiteralValue::from).collect()),
         ))
+    }
+}
+
+fn normalized_source_equalities_from_node(
+    shape: &NormalizedRowSetShape,
+    node_id: &RowSetNodeId,
+    target: &SourceId,
+    binding: &ProgramBinding,
+    policy: &PolicyContext,
+    equalities: &mut BTreeMap<String, Value>,
+) -> Result<bool, Error> {
+    let node = shape.nodes.get(node_id).ok_or(Error::InvalidStoredValue(
+        "normalized access-path node missing",
+    ))?;
+    match node {
+        RowSetExpr::Filter { input, predicate } => {
+            collect_normalized_source_equalities(predicate, target, binding, policy, equalities)?;
+            normalized_source_equalities_from_node(
+                shape, input, target, binding, policy, equalities,
+            )
+        }
+        RowSetExpr::Distinct { input, .. }
+        | RowSetExpr::OrderBy { input, .. }
+        | RowSetExpr::Project { input, .. }
+        | RowSetExpr::Slice { input, .. } => normalized_source_equalities_from_node(
+            shape, input, target, binding, policy, equalities,
+        ),
+        RowSetExpr::Source { source, .. } => Ok(source == target),
+        RowSetExpr::Aggregate { .. }
+        | RowSetExpr::CorrelatedPathProjection { .. }
+        | RowSetExpr::FrontierSource { .. }
+        | RowSetExpr::Join { .. }
+        | RowSetExpr::RecursiveRelation { .. }
+        | RowSetExpr::Union { .. }
+        | RowSetExpr::ValueSource { .. } => Ok(false),
+    }
+}
+
+fn collect_normalized_source_equalities(
+    predicate: &NormalizedPredicateExpr,
+    target: &SourceId,
+    binding: &ProgramBinding,
+    policy: &PolicyContext,
+    equalities: &mut BTreeMap<String, Value>,
+) -> Result<(), Error> {
+    match predicate {
+        NormalizedPredicateExpr::And(predicates) => {
+            for predicate in predicates {
+                collect_normalized_source_equalities(
+                    predicate, target, binding, policy, equalities,
+                )?;
+            }
+        }
+        NormalizedPredicateExpr::Compare {
+            left,
+            op: NormalizedComparisonOp::Eq,
+            right,
+        } => {
+            if let Some((field, value)) =
+                normalized_source_equality(left, right, target, binding, policy)?
+            {
+                equalities.entry(field).or_insert(value);
+            } else if let Some((field, value)) =
+                normalized_source_equality(right, left, target, binding, policy)?
+            {
+                equalities.entry(field).or_insert(value);
+            }
+        }
+        NormalizedPredicateExpr::ArrayContains { .. }
+        | NormalizedPredicateExpr::Compare { .. }
+        | NormalizedPredicateExpr::EnumMatch { .. }
+        | NormalizedPredicateExpr::False
+        | NormalizedPredicateExpr::In { .. }
+        | NormalizedPredicateExpr::IsNotNull(_)
+        | NormalizedPredicateExpr::IsNull(_)
+        | NormalizedPredicateExpr::Not(_)
+        | NormalizedPredicateExpr::Or(_)
+        | NormalizedPredicateExpr::TextContains { .. }
+        | NormalizedPredicateExpr::True => {}
+    }
+    Ok(())
+}
+
+fn normalized_source_equality(
+    field: &NormalizedValueRef,
+    value: &NormalizedValueRef,
+    target: &SourceId,
+    binding: &ProgramBinding,
+    policy: &PolicyContext,
+) -> Result<Option<(String, Value)>, Error> {
+    let Some(field) = normalized_source_field(field, target) else {
+        return Ok(None);
+    };
+    let Some(value) = normalized_bound_value(value, binding, policy)? else {
+        return Ok(None);
+    };
+    Ok(Some((field, value)))
+}
+
+fn normalized_source_field(value: &NormalizedValueRef, target: &SourceId) -> Option<String> {
+    match value {
+        NormalizedValueRef::SourceField { source, field } if source == target => {
+            Some(field.clone())
+        }
+        NormalizedValueRef::RowId(RowIdRef::Source(source)) if source == target => {
+            Some("id".to_owned())
+        }
+        _ => None,
+    }
+}
+
+fn normalized_bound_value(
+    value: &NormalizedValueRef,
+    binding: &ProgramBinding,
+    policy: &PolicyContext,
+) -> Result<Option<Value>, Error> {
+    match value {
+        NormalizedValueRef::Param(name) => Ok(binding.values.get(name).cloned()),
+        NormalizedValueRef::Literal(bytes) => postcard::from_bytes::<Value>(bytes)
+            .map(Some)
+            .map_err(|err| Error::QueryLowering(format!("literal decoding failed: {err}"))),
+        NormalizedValueRef::Claim(path) => prepared_claim_value(path, policy),
+        _ => Ok(None),
     }
 }
 


### PR DESCRIPTION
## Why

Large multi-tenant tables need `get my/org documents` to scale with the tenant-owned slice, not with the whole server table. Before this change, the read-policy authorization path could still scan every Global current row and then join authorized row ids, so a user owning 500 rows in a 1M-row table paid the 1M-row cost. That is exactly the hot path for sync nodes serving user/org document lists.

This PR lets simple indexed read policies, such as `owner == session.user_id`, drive the physical read path. Both the authorization proof and the protected base source can now use the declared owner index, keeping the work proportional to authorized candidates.

## What changed

- Derive Global current access paths from normalized read-policy authorization subplans.
- Compile policy authorization graphs with the access-path-aware compiler.
- Reuse the policy-selected access path for the protected visible-current base source when the user query itself has no narrower path.
- Add `owner_filter_diagnostic` to cover the multi-tenant owner-policy benchmark directly.

## Performance

Baseline from `codex/async-ordered-storage-v2` at 100k total / 500 owned rows:

| case | query time | Global current row reads |
| --- | ---: | ---: |
| policy only | ~914 ms | 100,000 |
| owner predicate | ~843 ms | 100,000 |
| owner + order/limit | ~841 ms | 100,000 |

This PR:

| total rows / owned rows | policy only | owner predicate | owner + order/limit | row reads | index reads |
| --- | ---: | ---: | ---: | ---: | ---: |
| 10k / 500 | 15.9 ms | 14.7 ms | 17.6 ms | 500 | 500 |
| 100k / 500 | 14.5 ms | 14.9 ms | 17.2 ms | 500 | 500 |
| 1M / 500 | 17.8 ms | 15.1 ms | 18.0 ms | 500 | 500 |

So the owner-policy path is now flat across 10k -> 1M total rows in this benchmark.

## Verification

- `cargo check -p jazz --benches --features testing`
- `JAZZ_OWNER_FILTER_ROWS=10000,100000 JAZZ_OWNER_FILTER_OWNED_ROWS=500 JAZZ_OWNER_FILTER_RESULT_ROWS=500 cargo bench -p jazz --features testing --bench owner_filter_diagnostic --quiet`
- `JAZZ_OWNER_FILTER_ROWS=1000000 JAZZ_OWNER_FILTER_OWNED_ROWS=500 JAZZ_OWNER_FILTER_RESULT_ROWS=500 JAZZ_OWNER_FILTER_BATCH_ROWS=10000 cargo bench -p jazz --features testing --bench owner_filter_diagnostic --quiet`
- Pre-commit ran `cargo clippy --package jazz -- -D warnings` and `rustfmt`. The sensitive-data guard warned it was unavailable because `jazz-private` is not present in this temp worktree.

## Known boundary

This PR fixes the owner/read-policy path. The generic non-policy `selective_global_hydration` benchmark still fails, so arbitrary prepared-query index selection remains separate follow-up work.

Tooling-friction: the 1M receipt spent ~660s seeding; a reusable persisted fixture would save nearly all benchmark wall-clock.