### PR TITLE
Bound one-shot indexed first-page hydration

### DIFF
--- a/crates/groove/src/ivm/op_types.rs
+++ b/crates/groove/src/ivm/op_types.rs
@@ -71,6 +71,10 @@ pub struct IndexSourceOp {
 pub enum StaticScanSpec {
     Point(Vec<LiteralValue>),
     Prefix(Vec<LiteralValue>),
+    PrefixLimit {
+        prefix: Vec<LiteralValue>,
+        limit: u64,
+    },
     Range {
         start: Vec<LiteralValue>,
         end: Vec<LiteralValue>,

--- a/crates/groove/src/ivm/runtime/evaluation_session.rs
+++ b/crates/groove/src/ivm/runtime/evaluation_session.rs
@@ -29,6 +29,12 @@ pub(super) enum StorageRequestKey {
         index: String,
         prefix: Vec<u8>,
     },
+    IndexedRowsPrefixLimit {
+        table: String,
+        index: String,
+        prefix: Vec<u8>,
+        limit: u64,
+    },
     IndexedRowsRange {
         table: String,
         index: String,
@@ -146,6 +152,30 @@ impl<'a> StorageRequests<'a> {
                     .clone();
                 let index = index.clone();
                 let scan = storage.scan_prefix("indices".to_owned(), prefix.clone());
+                let storage = storage.clone();
+                Box::pin(async move {
+                    let entries = scan.await?;
+                    load_indexed_rows(storage, table_schema, index_schema, index, entries).await
+                })
+            }
+            StorageRequestKey::IndexedRowsPrefixLimit {
+                table,
+                index,
+                prefix,
+                limit,
+            } => {
+                let table_schema = schema
+                    .table(table)
+                    .expect("compiled indexed-row source table exists")
+                    .clone();
+                let index_schema = table_schema
+                    .indices
+                    .iter()
+                    .find(|candidate| candidate.name == *index)
+                    .expect("compiled indexed-row source index exists")
+                    .clone();
+                let index = index.clone();
+                let scan = storage.scan_prefix_limit("indices".to_owned(), prefix.clone(), *limit);
                 let storage = storage.clone();
                 Box::pin(async move {
                     let entries = scan.await?;

--- a/crates/groove/src/ivm/runtime/operator_updates.rs
+++ b/crates/groove/src/ivm/runtime/operator_updates.rs
@@ -28,12 +28,12 @@ impl NodeState {
                 family: input.table.clone(),
                 prefix: Vec::new(),
             }),
-            Some(StaticScanBounds::Prefix(prefix)) => {
-                Some(super::evaluation_session::StorageRequestKey::ScanPrefix {
-                    family: input.table.clone(),
-                    prefix,
-                })
-            }
+            Some(
+                StaticScanBounds::Prefix(prefix) | StaticScanBounds::PrefixLimit { prefix, .. },
+            ) => Some(super::evaluation_session::StorageRequestKey::ScanPrefix {
+                family: input.table.clone(),
+                prefix,
+            }),
             Some(StaticScanBounds::Range { start, end }) if start < end => {
                 Some(super::evaluation_session::StorageRequestKey::ScanRange {
                     family: input.table.clone(),
@@ -59,6 +59,14 @@ impl NodeState {
                             prefix,
                         }
                     }
+                    StaticScanBounds::PrefixLimit { prefix, limit } => {
+                        super::evaluation_session::StorageRequestKey::IndexedRowsPrefixLimit {
+                            table: input.table.clone(),
+                            index: input.index.clone(),
+                            prefix,
+                            limit,
+                        }
+                    }
                     StaticScanBounds::Range { start, end } => {
                         super::evaluation_session::StorageRequestKey::IndexedRowsRange {
                             table: input.table.clone(),
@@ -72,7 +80,7 @@ impl NodeState {
         }
         Ok(
             match persisted_index_scan_bounds(&input.table, &input.index, input.scan.as_ref())? {
-                StaticScanBounds::Prefix(prefix) => {
+                StaticScanBounds::Prefix(prefix) | StaticScanBounds::PrefixLimit { prefix, .. } => {
                     Some(super::evaluation_session::StorageRequestKey::ScanPrefix {
                         family: "indices".to_owned(),
                         prefix,
@@ -351,7 +359,10 @@ impl NodeState {
             let scan =
                 match persisted_index_scan_bounds(&input.table, &input.index, input.scan.as_ref())?
                 {
-                    StaticScanBounds::Prefix(prefix) => store.scan_prefix(&prefix).await?,
+                    StaticScanBounds::Prefix(prefix)
+                    | StaticScanBounds::PrefixLimit { prefix, .. } => {
+                        store.scan_prefix(&prefix).await?
+                    }
                     StaticScanBounds::Range { start, end } => {
                         if start < end {
                             store.scan_range(&start, &end).await?

--- a/crates/groove/src/ivm/runtime/record_projection.rs
+++ b/crates/groove/src/ivm/runtime/record_projection.rs
@@ -1401,6 +1401,7 @@ fn index_keys(
 
 pub(super) enum StaticScanBounds {
     Prefix(Vec<u8>),
+    PrefixLimit { prefix: Vec<u8>, limit: u64 },
     Range { start: Vec<u8>, end: Vec<u8> },
 }
 
@@ -1409,6 +1410,10 @@ pub(super) fn scan_bounds(scan: &StaticScanSpec) -> Result<StaticScanBounds, Ivm
         StaticScanSpec::Point(values) | StaticScanSpec::Prefix(values) => {
             Ok(StaticScanBounds::Prefix(static_scan_key(values)?))
         }
+        StaticScanSpec::PrefixLimit { prefix, limit } => Ok(StaticScanBounds::PrefixLimit {
+            prefix: static_scan_key(prefix)?,
+            limit: *limit,
+        }),
         StaticScanSpec::Range { start, end } => Ok(StaticScanBounds::Range {
             start: static_scan_key(start)?,
             end: static_scan_key(end)?,
@@ -1429,7 +1434,9 @@ pub(super) fn key_matches_static_scan(
     scan: &StaticScanSpec,
 ) -> Result<bool, IvmRuntimeError> {
     Ok(match scan_bounds(scan)? {
-        StaticScanBounds::Prefix(prefix) => key.starts_with(&prefix),
+        StaticScanBounds::Prefix(prefix) | StaticScanBounds::PrefixLimit { prefix, .. } => {
+            key.starts_with(&prefix)
+        }
         StaticScanBounds::Range { start, end } => start.as_slice() <= key && key < end.as_slice(),
     })
 }
@@ -1453,6 +1460,10 @@ pub(super) fn persisted_index_scan_bounds(
         Some(StaticScanSpec::Point(values) | StaticScanSpec::Prefix(values)) => {
             StaticScanBounds::Prefix(wrap_prefix(static_scan_key(values)?))
         }
+        Some(StaticScanSpec::PrefixLimit { prefix, limit }) => StaticScanBounds::PrefixLimit {
+            prefix: wrap_prefix(static_scan_key(prefix)?),
+            limit: *limit,
+        },
         Some(StaticScanSpec::Range { start, end }) => StaticScanBounds::Range {
             start: wrap_prefix(static_scan_key(start)?),
             end: wrap_prefix(static_scan_key(end)?),

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -470,7 +470,9 @@ pub(super) async fn snapshot_table_deltas(
         let mut cursor = match &source.scan {
             None => Some(store.scan_prefix(b"").await?),
             Some(scan) => match scan_bounds(scan)? {
-                StaticScanBounds::Prefix(prefix) => Some(store.scan_prefix(&prefix).await?),
+                StaticScanBounds::Prefix(prefix) | StaticScanBounds::PrefixLimit { prefix, .. } => {
+                    Some(store.scan_prefix(&prefix).await?)
+                }
                 StaticScanBounds::Range { start, end } if start < end => {
                     Some(store.scan_range(&start, &end).await?)
                 }

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -105,6 +105,19 @@ impl<'a> OwnedStorage<'a> {
             collect_scan(scan).await
         })
     }
+
+    pub(crate) fn scan_prefix_limit(
+        &self,
+        cf: String,
+        prefix: Vec<u8>,
+        limit: u64,
+    ) -> StorageFuture<'a, Result<Vec<KeyValue>, Error>> {
+        let storage = Rc::clone(&self.0);
+        Box::pin(async move {
+            let scan = storage.scan_prefix(cf, prefix).await?;
+            collect_scan_limit(scan, limit).await
+        })
+    }
 }
 
 /// Owned, executor-local cursor over an ordered scan.
@@ -140,6 +153,18 @@ async fn collect_scan(mut scan: StorageScan<'_>) -> Result<Vec<KeyValue>, Error>
     let mut values = Vec::new();
     while let Some(batch) = scan.next_batch().await? {
         values.extend(batch);
+    }
+    Ok(values)
+}
+
+async fn collect_scan_limit(mut scan: StorageScan<'_>, limit: u64) -> Result<Vec<KeyValue>, Error> {
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    let mut values = Vec::new();
+    while values.len() < limit
+        && let Some(batch) = scan.next_batch().await?
+    {
+        let remaining = limit - values.len();
+        values.extend(batch.into_iter().take(remaining));
     }
     Ok(values)
 }

--- a/crates/jazz/benches/owner_filter_diagnostic.rs
+++ b/crates/jazz/benches/owner_filter_diagnostic.rs
@@ -20,6 +20,7 @@ use jazz_storage_rocksdb::RocksDbStorage;
 use serde_json::{Map, json};
 
 const TABLE: &str = "documents";
+const PUBLIC_TABLE: &str = "public_documents";
 const AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000a1"));
 const OTHER_AUTHOR: AuthorId = AuthorId(uuid::uuid!("00000000-0000-0000-0000-0000000000b2"));
 
@@ -49,41 +50,78 @@ fn run_rung(table_rows: usize, owned_rows: usize, result_rows: usize, batch_rows
     drop(db);
 
     let cases = [
-        ("policy_only", policy_only_query(), owned_rows),
-        ("owner_predicate_all", owner_predicate_query(), owned_rows),
-        (
-            "owner_predicate_ordered_limit",
-            owner_predicate_query()
+        Case {
+            name: "policy_only",
+            query: policy_only_query(),
+            expected_rows: owned_rows,
+            mode: CaseMode::TrustedIdentity,
+            include_deleted: false,
+        },
+        Case {
+            name: "owner_predicate_all",
+            query: owner_predicate_query(),
+            expected_rows: owned_rows,
+            mode: CaseMode::TrustedIdentity,
+            include_deleted: false,
+        },
+        Case {
+            name: "public_owner_predicate_limit_include_deleted_system",
+            query: owner_predicate_limit_query(PUBLIC_TABLE, result_rows),
+            expected_rows: result_rows,
+            mode: CaseMode::SystemIdentity,
+            include_deleted: true,
+        },
+        Case {
+            name: "owner_predicate_ordered_limit",
+            query: owner_predicate_query()
                 .order_by("updated_at", OrderDirection::Desc)
                 .limit(result_rows),
-            result_rows,
-        ),
+            expected_rows: result_rows,
+            mode: CaseMode::TrustedIdentity,
+            include_deleted: false,
+        },
     ];
 
-    for (case, query, expected_rows) in cases {
+    for case in cases {
         let db = open_db(temp.path(), schema.clone());
         let open_metrics = db.take_storage_read_metrics_for_test();
         db.reset_storage_read_metrics_for_test();
         let prepare_started = Instant::now();
         let prepared = db
-            .prepare_query(&query)
+            .prepare_query(&case.query)
             .expect("prepare owner-filter query");
         let prepare_us = prepare_started.elapsed().as_micros();
         let prepare_metrics = db.take_storage_read_metrics_for_test();
 
         db.reset_storage_read_metrics_for_test();
         let query_started = Instant::now();
-        let rows = block_on(db.all_for_identity(&prepared, global_read_opts(), AUTHOR))
-            .expect("run owner-filter query");
+        let rows = match case.mode {
+            CaseMode::TrustedIdentity => block_on(db.all_for_identity(
+                &prepared,
+                global_read_opts(case.include_deleted),
+                AUTHOR,
+            )),
+            CaseMode::SystemIdentity => block_on(db.all_for_identity(
+                &prepared,
+                global_read_opts(case.include_deleted),
+                AuthorId::SYSTEM,
+            )),
+        }
+        .expect("run owner-filter query");
         let query_us = query_started.elapsed().as_micros();
         let query_metrics = db.take_storage_read_metrics_for_test();
 
-        assert_eq!(rows.len(), expected_rows, "{case} row count changed");
+        assert_eq!(
+            rows.len(),
+            case.expected_rows,
+            "{} row count changed",
+            case.name
+        );
         emit_case(
-            case,
+            case.name,
             table_rows,
             owned_rows,
-            expected_rows,
+            case.expected_rows,
             seed_us,
             prepare_us,
             query_us,
@@ -95,20 +133,43 @@ fn run_rung(table_rows: usize, owned_rows: usize, result_rows: usize, batch_rows
     }
 }
 
+struct Case {
+    name: &'static str,
+    query: Query,
+    expected_rows: usize,
+    mode: CaseMode,
+    include_deleted: bool,
+}
+
+#[derive(Clone, Copy)]
+enum CaseMode {
+    TrustedIdentity,
+    SystemIdentity,
+}
+
 fn schema() -> JazzSchema {
     schema_fixture::compile(
-        SchemaBuilder::new().table(
-            TableSchemaBuilder::new(TABLE)
-                .column("owner", ColumnType::Uuid)
-                .column("active", ColumnType::Boolean)
-                .column("updated_at", ColumnType::Timestamp)
-                .column("title", ColumnType::Text)
-                .policies(
-                    TablePolicies::new()
-                        .with_select(schema_fixture::session_user_id_column("owner")),
-                )
-                .index_only(["owner", "updated_at"]),
-        ),
+        SchemaBuilder::new()
+            .table(
+                TableSchemaBuilder::new(TABLE)
+                    .column("owner", ColumnType::Uuid)
+                    .column("active", ColumnType::Boolean)
+                    .column("updated_at", ColumnType::Timestamp)
+                    .column("title", ColumnType::Text)
+                    .policies(
+                        TablePolicies::new()
+                            .with_select(schema_fixture::session_user_id_column("owner")),
+                    )
+                    .index_only(["owner", "updated_at"]),
+            )
+            .table(
+                TableSchemaBuilder::new(PUBLIC_TABLE)
+                    .column("owner", ColumnType::Uuid)
+                    .column("active", ColumnType::Boolean)
+                    .column("updated_at", ColumnType::Timestamp)
+                    .column("title", ColumnType::Text)
+                    .index_only(["owner"]),
+            ),
     )
 }
 
@@ -158,6 +219,20 @@ fn seed_rows(db: &Db<RocksDbStorage>, table_rows: usize, owned_rows: usize, batc
                 ]),
             ))
             .expect("stage owner-filter row");
+            block_on(tx.insert_with_id(
+                PUBLIC_TABLE,
+                public_row(index),
+                BTreeMap::from([
+                    ("owner".to_owned(), Value::Uuid(owner.0)),
+                    ("active".to_owned(), Value::Bool(true)),
+                    ("updated_at".to_owned(), Value::U64(index as u64)),
+                    (
+                        "title".to_owned(),
+                        Value::String(format!("public-document-{index}")),
+                    ),
+                ]),
+            ))
+            .expect("stage public owner-filter row");
         }
 
         let tx_id = block_on(tx.commit()).expect("commit owner-filter seed tx");
@@ -167,8 +242,16 @@ fn seed_rows(db: &Db<RocksDbStorage>, table_rows: usize, owned_rows: usize, batc
 }
 
 fn row(index: usize) -> RowUuid {
+    row_with_prefix(0x61, index)
+}
+
+fn public_row(index: usize) -> RowUuid {
+    row_with_prefix(0x62, index)
+}
+
+fn row_with_prefix(prefix: u8, index: usize) -> RowUuid {
     let mut bytes = [0_u8; 16];
-    bytes[0] = 0x61;
+    bytes[0] = prefix;
     bytes[8..].copy_from_slice(&(index as u64).to_be_bytes());
     RowUuid::from_bytes(bytes)
 }
@@ -183,12 +266,18 @@ fn owner_predicate_query() -> Query {
         .filter(eq(col("active"), lit(true)))
 }
 
-fn global_read_opts() -> ReadOpts {
+fn owner_predicate_limit_query(table: &str, result_rows: usize) -> Query {
+    Query::from(table)
+        .filter(eq(col("owner"), lit(AUTHOR.0)))
+        .limit(result_rows)
+}
+
+fn global_read_opts(include_deleted: bool) -> ReadOpts {
     ReadOpts {
         tier: DurabilityTier::Global,
         local_updates: LocalUpdates::Deferred,
         propagation: Propagation::LocalOnly,
-        include_deleted: false,
+        include_deleted,
         ..ReadOpts::default()
     }
 }

--- a/crates/jazz/src/node/physical/projections.rs
+++ b/crates/jazz/src/node/physical/projections.rs
@@ -1401,6 +1401,10 @@ fn branch_scan(
         None => StaticScanSpec::Prefix(vec![branch]),
         Some(StaticScanSpec::Point(values)) => StaticScanSpec::Point(prepend(values)),
         Some(StaticScanSpec::Prefix(values)) => StaticScanSpec::Prefix(prepend(values)),
+        Some(StaticScanSpec::PrefixLimit { prefix, limit }) => StaticScanSpec::PrefixLimit {
+            prefix: prepend(prefix),
+            limit,
+        },
         Some(StaticScanSpec::Range { start, end }) => StaticScanSpec::Range {
             start: prepend(start),
             end: prepend(end),

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -550,7 +550,13 @@ where
             input,
             output: current_query_output_request(CurrentQueryProgramOutput::AppRows, shape.query()),
         };
-        self.compile_query_program_request(request).await
+        let root_source = root_source_id(&shape.query().table);
+        let mut access_paths = self.one_shot_access_paths(shape, binding, tier)?;
+        access_paths.retain(|source, access_path| {
+            *source == root_source && matches!(access_path, CurrentAccessPath::Index { .. })
+        });
+        self.compile_query_program_request_with_access_paths(request, access_paths)
+            .await
     }
 
     async fn compile_open_tx_query_program(

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -242,6 +242,65 @@ pub(super) fn literal_equalities_for_filters(
     Ok(equalities)
 }
 
+pub(super) fn root_filters_are_only_literal_equality_on(
+    query: &JazzQuery,
+    binding: &Binding,
+    column: &str,
+) -> Result<bool, Error> {
+    let mut saw_equality = false;
+    for predicate in &query.filters {
+        if !predicate_is_only_literal_equality_on(predicate, binding, column, &mut saw_equality)? {
+            return Ok(false);
+        }
+    }
+    Ok(saw_equality)
+}
+
+fn predicate_is_only_literal_equality_on(
+    predicate: &Predicate,
+    binding: &Binding,
+    column: &str,
+    saw_equality: &mut bool,
+) -> Result<bool, Error> {
+    match predicate {
+        Predicate::All(predicates) => {
+            for predicate in predicates {
+                if !predicate_is_only_literal_equality_on(predicate, binding, column, saw_equality)?
+                {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        Predicate::Eq(left, right) => {
+            let equality = match root_equality_literal(left, right, binding)? {
+                Some(equality) => Some(equality),
+                None => root_equality_literal(right, left, binding)?,
+            };
+            let Some((field, _)) = equality else {
+                return Ok(false);
+            };
+            if field == column {
+                *saw_equality = true;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        Predicate::Any(_)
+        | Predicate::Not(_)
+        | Predicate::Ne(_, _)
+        | Predicate::In(_, _)
+        | Predicate::Gt(_, _)
+        | Predicate::Gte(_, _)
+        | Predicate::Lt(_, _)
+        | Predicate::Lte(_, _)
+        | Predicate::Contains(_, _)
+        | Predicate::EnumMatch { .. }
+        | Predicate::IsNull(_) => Ok(false),
+    }
+}
+
 fn collect_root_literal_equalities(
     predicate: &Predicate,
     binding: &Binding,
@@ -308,6 +367,7 @@ pub(super) fn select_current_access_path(
             return Some(CurrentAccessPath::Index {
                 column,
                 prefix: vec![Value::Nullable(Some(Box::new(value)))],
+                limit: None,
             });
         }
     }

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -27,7 +27,11 @@ pub(super) struct CurrentSourceGraph {
 #[derive(Clone, Debug)]
 pub(super) enum CurrentAccessPath {
     PrimaryKey(Vec<Value>),
-    Index { column: String, prefix: Vec<Value> },
+    Index {
+        column: String,
+        prefix: Vec<Value>,
+        limit: Option<u64>,
+    },
 }
 
 impl<S> SourceGraphPreparer for JazzSourceGraphPreparer<'_, S>
@@ -981,7 +985,8 @@ where
                 (graph, source.descriptor, source.metadata, BTreeSet::new())
             }
         } else if request.visibility == RowVisibility::IncludeDeleted
-            && self.needs_projected_current_source(&request.source.table)
+            && (self.needs_projected_current_source(&request.source.table)
+                || self.access_paths.contains_key(&request.source))
         {
             let tier = graph_tier.expect("visible current source has a tier");
             let base = self
@@ -1391,10 +1396,17 @@ where
                     table, tier, prefix,
                 )))
             }
-            CurrentAccessPath::Index { column, prefix } => {
+            CurrentAccessPath::Index {
+                column,
+                prefix,
+                limit,
+            } => {
                 if tier != DurabilityTier::Global {
                     return Ok(None);
                 }
+                let limit = (request.visibility == RowVisibility::IncludeDeleted)
+                    .then_some(limit)
+                    .flatten();
                 let projection_target = self.current_projection_target(request, table)?;
                 let rows = self
                     .node
@@ -1403,6 +1415,7 @@ where
                         self.read_view.read_schema,
                         &column,
                         &prefix,
+                        limit,
                         &projection_target,
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
@@ -1687,7 +1700,12 @@ where
                             source_resolution_error(request, SourceGap::SchemaProjection)
                         })?
                 }
-                Some(CurrentAccessPath::Index { column, prefix }) => {
+                Some(CurrentAccessPath::Index {
+                    column,
+                    prefix,
+                    limit,
+                }) => {
+                    let limit = (!exclude_deleted).then_some(limit).flatten();
                     self.node.query_engine_read_metrics.source_index_probes += 1;
                     self.node
                         .physical_global_current_source_for_index_scan(
@@ -1695,6 +1713,7 @@ where
                             self.read_view.read_schema,
                             &column,
                             &prefix,
+                            limit,
                             &projection_target,
                         )
                         .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
@@ -1769,10 +1788,15 @@ where
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?
             }
-            Some(CurrentAccessPath::Index { column, prefix }) if tier == DurabilityTier::Global => {
+            Some(CurrentAccessPath::Index {
+                column,
+                prefix,
+                limit,
+            }) if tier == DurabilityTier::Global => {
                 // A Global index already selects from the canonical settled
                 // winner relation. Project those raw physical rows first, then
                 // apply the compatibility boundary below.
+                let limit = if exclude_deleted { None } else { *limit };
                 self.node.query_engine_read_metrics.source_index_probes += 1;
                 self.node
                     .physical_global_current_source_for_index_scan_with_output(
@@ -1780,6 +1804,7 @@ where
                         self.read_view.read_schema,
                         column,
                         prefix,
+                        limit,
                         &projection_target,
                         raw_global_output.clone(),
                     )
@@ -2860,9 +2885,23 @@ where
         let mut access_paths = self.current_query_primary_key_access_paths(shape, binding)?;
         let table = self.table_in_schema(&query.table, shape.schema_version())?;
         let equalities = root_literal_equalities(query, binding)?;
-        let Some(access_path) = select_current_access_path(&table, &equalities) else {
+        let Some(mut access_path) = select_current_access_path(&table, &equalities) else {
             return Ok(access_paths);
         };
+        if table.read_policy.is_none()
+            && access_edge_parent_reference(&table).is_none()
+            && let CurrentAccessPath::Index { column, limit, .. } = &mut access_path
+            && query.order_by.is_empty()
+            && query.offset == 0
+            && query.limit.is_some()
+            && query.reachable.is_empty()
+            && query.inherits.is_empty()
+            && query.includes.is_empty()
+            && query.flat_join.is_none()
+            && root_filters_are_only_literal_equality_on(query, binding, column)?
+        {
+            *limit = query.limit.map(|limit| limit.min(u64::MAX as usize) as u64);
+        }
         access_paths.insert(root_source_id(&query.table), access_path);
         self.add_reachable_access_paths(query, shape.schema_version(), binding, &mut access_paths)?;
         Ok(access_paths)
@@ -2955,6 +2994,7 @@ where
         schema_version: SchemaVersionId,
         column: &str,
         prefix: &[Value],
+        limit: Option<u64>,
         projection_target: &str,
     ) -> Result<GraphBuilder, Error> {
         self.physical_global_current_source_for_index_scan_with_output(
@@ -2962,6 +3002,7 @@ where
             schema_version,
             column,
             prefix,
+            limit,
             projection_target,
             table.global_current_storage_tables()[0].record_schema(),
         )
@@ -2973,6 +3014,7 @@ where
         schema_version: SchemaVersionId,
         column: &str,
         prefix: &[Value],
+        limit: Option<u64>,
         projection_target: &str,
         _output: RecordDescriptor,
     ) -> Result<GraphBuilder, Error> {
@@ -2996,7 +3038,15 @@ where
             storage_table,
             physical_current_index_name(column_id),
             projection_target,
-            StaticScanSpec::Prefix(prefix.iter().cloned().map(LiteralValue::from).collect()),
+            match limit {
+                Some(limit) => StaticScanSpec::PrefixLimit {
+                    prefix: prefix.iter().cloned().map(LiteralValue::from).collect(),
+                    limit,
+                },
+                None => {
+                    StaticScanSpec::Prefix(prefix.iter().cloned().map(LiteralValue::from).collect())
+                }
+            },
         ))
     }
 }

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -464,6 +464,115 @@ fn physical_index_backfills_existing_rows_and_read_cost_ignores_schema_variant_c
 }
 
 #[test]
+fn one_shot_include_deleted_indexed_first_page_hydrates_only_limited_rows() {
+    // Internal storage metrics are intentional here: the public rows match a
+    // full scan either way, but the regression is whether pagination hydrates
+    // every matching owner row before applying LIMIT.
+    let schema = access_path_schema();
+    let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let owner = user(0xa1);
+    let other = user(0xb2);
+    let mut expected = Vec::new();
+
+    for index in 0..40_u8 {
+        let row = row(index);
+        if index < 5 {
+            expected.push(row);
+        }
+        commit_mergeable_global(
+            &mut writer,
+            &mut core,
+            MergeableCommit::new("docs", row, u64::from(index) + 10).cells(
+                access_path_doc_cells(owner, "open", &format!("owned-{index}")),
+            ),
+        );
+    }
+    for index in 40..50_u8 {
+        commit_mergeable_global(
+            &mut writer,
+            &mut core,
+            MergeableCommit::new("docs", row(index), u64::from(index) + 10).cells(
+                access_path_doc_cells(other, "open", &format!("other-{index}")),
+            ),
+        );
+    }
+
+    let shape = Query::from("docs")
+        .filter(eq(col("owner"), lit(Value::Uuid(owner.0))))
+        .limit(5)
+        .validate(&core.catalogue.schema)
+        .expect("validate first-page query");
+    let binding = shape.bind(BTreeMap::new()).expect("bind first-page query");
+
+    core.reset_storage_read_metrics();
+    let rows = core
+        .query_rows_including_deleted_in_authorization_mode(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            None,
+            AuthorId::SYSTEM,
+            QueryAuthorizationMode::TrustedServing,
+        )
+        .expect("run indexed first-page query");
+    let metrics = core.take_storage_read_metrics();
+
+    assert_eq!(
+        rows.into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert_eq!(
+        metrics.global_current_rows.reads, 5,
+        "LIMIT should cap row hydration after the indexed owner prefix"
+    );
+}
+
+#[test]
+fn one_shot_visible_indexed_first_page_fills_past_deleted_rows() {
+    let schema = access_path_schema();
+    let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let owner = user(0xa1);
+    let deleted = row(0);
+
+    for index in 0..6_u8 {
+        commit_mergeable_global(
+            &mut writer,
+            &mut core,
+            MergeableCommit::new("docs", row(index), u64::from(index) + 10).cells(
+                access_path_doc_cells(owner, "open", &format!("owned-{index}")),
+            ),
+        );
+    }
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("docs", deleted, 100).deletion(DeletionEvent::Deleted),
+    );
+
+    let shape = Query::from("docs")
+        .filter(eq(col("owner"), lit(Value::Uuid(owner.0))))
+        .limit(5)
+        .validate(&core.catalogue.schema)
+        .expect("validate visible first-page query");
+    let binding = shape.bind(BTreeMap::new()).expect("bind first-page query");
+
+    let rows = core
+        .query_rows_for_link(&shape, &binding, DurabilityTier::Global, AuthorId::SYSTEM)
+        .expect("run visible indexed first-page query");
+
+    assert_eq!(
+        rows.into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>(),
+        (1..6).map(row).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn one_shot_filtered_read_keeps_residual_filters_after_pushdown() {
     let schema = access_path_schema();
     let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());


### PR DESCRIPTION
## Why this matters

This is the server/sync-node multi-tenant shape we have been testing:

- one physical table can contain millions of rows
- one user/org owns a much smaller slice
- the common read is "give me the first page of my rows"

Before this PR, a row-projected index scan could find the `owner = X` prefix, but it still had to hydrate every row in that prefix before the query-level `LIMIT` was applied. For a 500-row page over 10k owned rows, that meant 10k row hydrations.

## What changed

- Adds `StaticScanSpec::PrefixLimit` to Groove.
- Adds `OwnedStorage::scan_prefix_limit`.
- Adds an indexed-row storage request that scans only the bounded prefix entries and hydrates only those rows.
- Lets Jazz attach that source limit for a narrow safe query shape:
  - root indexed literal equality
  - `LIMIT`, no `OFFSET`
  - no explicit `ORDER BY`
  - no joins/includes/reachable/inherits/flat joins
  - no read policy
  - no access-edge implicit policy
- Carries root index access paths into include-deleted one-shot reads where the source limit is safe.
- Explicitly does **not** apply source limits before visible-row tombstone filtering or before read-policy filtering.

## Benchmark

Command:

```sh
JAZZ_BENCHMARK_DIRTY_OK=1 JAZZ_OWNER_FILTER_ROWS=100000 JAZZ_OWNER_FILTER_OWNED_ROWS=10000 JAZZ_OWNER_FILTER_RESULT_ROWS=500 cargo bench -p jazz --features testing --bench owner_filter_diagnostic --quiet
```

Data shape:

| Setting | Value |
| --- | ---: |
| total rows | 100,000 |
| rows owned by target user | 10,000 |
| requested page size | 500 |

Result:

| Case | What it represents | Result rows | Index reads | Row hydrations | Logical reads | Query time |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `owner_predicate_ordered_limit` | current protected, visible, ordered app-facing control | 500 | 10,000 | 10,000 | 20,000 | 215.905ms |
| `public_owner_predicate_limit_include_deleted_system` | new bounded exact-prefix source path | 500 | 512 | 500 | 1,012 | 8.638ms |

Source-level upside shown by the bounded path:

| Metric | Before/control | Bounded path | Change |
| --- | ---: | ---: | ---: |
| row hydrations | 10,000 | 500 | 20x fewer |
| logical reads | 20,000 | 1,012 | ~19.8x fewer |
| query time | 215.905ms | 8.638ms | ~25x faster |

The 512 index reads for a 500-row page are expected today because the storage cursor batches in chunks of 256. Row hydration is capped exactly at 500.

## Important scope note

This PR is **not** the full app-facing fix for:

```text
owner == current_user ORDER BY updated_at DESC LIMIT 500
```

under read policies and normal visible-row semantics.

That case is intentionally still shown in the benchmark as `owner_predicate_ordered_limit`, and it still reads/hydrates all 10k owned rows. Making that fast needs a follow-up visibility/policy-safe live-row or composite ordered index path, so we can bound the source without under-filling pages after tombstone filtering and without capping rows before policy filtering.

This PR is the lower-level piece that proves the engine/storage path can be page-sized once the planner has a safe source to use.

## Tests

- `cargo check -p jazz --features testing`
- `cargo test -p jazz one_shot_ --features testing`
- `cargo test -p groove --lib`
- `JAZZ_BENCHMARK_DIRTY_OK=1 JAZZ_OWNER_FILTER_ROWS=100000 JAZZ_OWNER_FILTER_OWNED_ROWS=10000 JAZZ_OWNER_FILTER_RESULT_ROWS=500 cargo bench -p jazz --features testing --bench owner_filter_diagnostic --quiet`

Pre-commit also ran:

- `cargo clippy --package groove --package jazz -- -D warnings`
- `rustfmt`

The sensitive-data guard was not available in this worktree because `jazz-private/dev/gates/no-sensitive-data.sh` was missing.
