### PR TITLE
Bound create-jazz package manifest receipt

### DIFF
--- a/packages/create-jazz/src/package-contents.test.ts
+++ b/packages/create-jazz/src/package-contents.test.ts
@@ -23,5 +23,5 @@ describe("create-jazz package contents", () => {
     for (const file of bundledSkillFiles) {
       expect(paths).toContain(file);
     }
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
🤖 Gives the real npm-pack manifest receipt a bounded 15-second Vitest timeout. It takes 6–7 seconds on CI despite passing, exceeding the default 5 seconds and making post-#1723 main red.