### PR TITLE
Accept synchronous in-memory runtime close

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -81,9 +81,9 @@ type NativeDbConstructor = {
 };
 
 type NativeDb = {
-  // Browser WASM databases close asynchronously, while the in-memory WASM
-  // database closes synchronously and returns whether it changed state.
-  // `await` below intentionally accepts either implementation.
+  // Native runtime adapters may close synchronously or asynchronously and may
+  // report whether they transitioned state. The adapter awaits either form and
+  // owns idempotence, so callers never observe that implementation detail.
   close?(): void | boolean | Promise<void | boolean>;
   registerSchema(schema: Uint8Array): NativeDb;
   beginTransaction(openBatchId: string, kind: TransactionKind, author?: Uint8Array): void;

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -81,7 +81,10 @@ type NativeDbConstructor = {
 };
 
 type NativeDb = {
-  close?(): Promise<unknown>;
+  // Browser WASM databases close asynchronously, while the in-memory WASM
+  // database closes synchronously and returns whether it changed state.
+  // `await` below intentionally accepts either implementation.
+  close?(): void | boolean | Promise<void | boolean>;
   registerSchema(schema: Uint8Array): NativeDb;
   beginTransaction(openBatchId: string, kind: TransactionKind, author?: Uint8Array): void;
   commitTransaction(openBatchId: string, kind?: TransactionKind): Write;

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -104,6 +104,22 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(decodeSchemaSource(encoded).tables.docs?.columns[0]?.merge_strategy).toBe("GSet");
   });
 
+  it("accepts and ignores a synchronous native database close result", async () => {
+    const close = vi.fn(() => true);
+    const runtime = new NativeRuntimeAdapter(
+      { openMemory: () => fakeDb({ close }) },
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    await expect(runtime.close()).resolves.toBeUndefined();
+    await expect(runtime.close()).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
   it("resolves connect only after the owned native transport has pumped", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -32,6 +32,10 @@ import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
 import { encodeNativeNullValue, storageColumnValueType } from "./native-row-codec.js";
 import { type BatchId, type WriteReceipt } from "../client.js";
 
+type NativeDbForTest = ReturnType<
+  NonNullable<ConstructorParameters<typeof NativeRuntimeAdapter>[0]>["openMemory"]
+>;
+
 async function committedBatchId(receipt: WriteReceipt): Promise<BatchId> {
   if (receipt.kind !== "committed") throw new Error("expected committed write receipt");
   return await receipt.batchId;
@@ -5353,9 +5357,7 @@ function encodeArrayRows(): Uint8Array {
   return writer.finish();
 }
 
-function fakeDb<T extends object>(
-  db: T,
-): T & { setTickScheduler(callback: (urgency: "immediate" | "deferred") => void): void } {
+function fakeDb<T extends object>(db: T): T & NativeDbForTest {
   type FakeOpenBatch = {
     kind: "mergeable" | "exclusive";
     author?: Uint8Array;
@@ -5415,9 +5417,7 @@ function fakeDb<T extends object>(
       await upstream?.tick();
     };
   }
-  return result as T & {
-    setTickScheduler(callback: (urgency: "immediate" | "deferred") => void): void;
-  };
+  return result as T & NativeDbForTest;
 }
 
 function fakeTx(overrides: Partial<TxForTest> = {}): TxForTest {


### PR DESCRIPTION
🤖 Accept the actual close shapes exposed by both WASM database implementations. Browser storage closes asynchronously; the in-memory runtime closes synchronously and returns whether state changed. The adapter already awaits either shape, so this aligns the TypeScript contract with runtime behavior and restores React Native typechecking.\n\nVerified locally:\n- `pnpm --filter jazz-tools typecheck:react-native`\n- `pnpm --filter jazz-tools check`