### PR TITLE
Assert stale worker views preserve optimistic rows

### DIFF
--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -306,6 +306,14 @@ fn browser_worker_initial_view_preserves_newer_optimistic_membership() {
             .any(|event| matches!(event, SubscriptionEvent::Delta { reset: true, .. })),
         "the worker's internal hydration must not reset the main subscription: {after_ack:?}"
     );
+    assert_eq!(
+        main_thread
+            .read(&open_todos)
+            .expect("read after stale worker view")
+            .len(),
+        1,
+        "the stale worker view must not retract the optimistic row"
+    );
 
     main_thread
         .update(


### PR DESCRIPTION
🤖 Strengthen the deterministic browser-relay regression for stale worker hydration. Current `main` already preserves optimistic membership during the handoff; this adds the missing end-state assertion that the row remains queryable after the stale worker view arrives, rather than checking only emitted delta shapes.\n\nThe focused test passes, and a planted mutation disabling remote-authoritative reconciliation fails deterministically with the stale hydration reset.\n\nVerified: `cargo test -p jazz --test browser_relay_durability browser_worker_initial_view_preserves_newer_optimistic_membership -- --exact --nocapture`.