### PR TITLE
Release native callbacks before owner shutdown

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2459,8 +2459,19 @@ impl NapiDb {
             Ok(())
         } else if let Some(inner) = inner {
             match inner {
-                NapiDbInnerStorage::Memory(db) => core_block_on(db.close()),
-                NapiDbInnerStorage::Persistent(db) => core_block_on(db.close()),
+                NapiDbInnerStorage::Memory(db) => {
+                    // Schema views retain this core through their own Rc. Release every
+                    // N-API-owned callback before the fallible async close so a retained
+                    // view cannot keep Node's event loop alive after its owner closes.
+                    db.set_tick_scheduler(None);
+                    db.clear_mutation_error_callback();
+                    core_block_on(db.close())
+                }
+                NapiDbInnerStorage::Persistent(db) => {
+                    db.set_tick_scheduler(None);
+                    db.clear_mutation_error_callback();
+                    core_block_on(db.close())
+                }
             }
         } else {
             Ok(())

--- a/packages/jazz-tools/src/runtime/__fixtures__/napi-close-retained-schema-view.mjs
+++ b/packages/jazz-tools/src/runtime/__fixtures__/napi-close-retained-schema-view.mjs
@@ -1,0 +1,26 @@
+import { NapiDb } from "jazz-napi";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const decode = (value) => Uint8Array.from(Buffer.from(value, "base64"));
+const [storage, encodedSchema, encodedConfig] = process.argv.slice(2);
+const schema = decode(encodedSchema);
+const config = decode(encodedConfig);
+
+const directory =
+  storage === "persistent" ? await mkdtemp(join(tmpdir(), "jazz-napi-close-")) : null;
+const owner =
+  directory === null
+    ? NapiDb.openMemory(schema, config)
+    : NapiDb.openPersistent(directory, schema, config);
+// A registered view intentionally outlives its owner. It shares the core and
+// previously retained host callbacks after owner shutdown.
+const retainedView = owner.registerSchema(schema);
+owner.setTickScheduler(() => undefined);
+owner.onMutationError(() => undefined);
+await owner.close();
+if (directory !== null) await rm(directory, { force: true, recursive: true });
+void retainedView;
+
+console.log(`owner closed with ${storage} schema view retained`);

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -1,7 +1,10 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
 import { WebSocket } from "undici";
 import { afterEach, describe, expect, it } from "vitest";
 import type { SubscriptionEvent as NapiSubscriptionEvent } from "jazz-napi";
@@ -17,6 +20,8 @@ import type { WasmRow } from "../drivers/types.js";
 import { createOpenBatchId, type BatchId, type OpenBatchId, type WriteReceipt } from "./client.js";
 
 const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
 const debugSubscriptionEventFixture = hasJazzNapiBuild()
   ? (
       require("jazz-napi") as typeof import("jazz-napi") & {
@@ -24,6 +29,13 @@ const debugSubscriptionEventFixture = hasJazzNapiBuild()
       }
     ).__testSubscriptionEvents
   : undefined;
+
+async function runNapiFixture(name: string, args: string[] = []) {
+  return await execFileAsync(process.execPath, [join(here, "__fixtures__", name), ...args], {
+    encoding: "utf8",
+    timeout: 9_000,
+  });
+}
 
 function beginTestBatch(runtime: NativeRuntimeAdapter): OpenBatchId {
   const id = createOpenBatchId();
@@ -344,6 +356,29 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
     db.close?.();
   }, 20_000);
+
+  it("releases N-API callbacks when the owner closes with a schema view retained", async () => {
+    const schema = Buffer.from(encodeSchema(TEST_SCHEMA)).toString("base64");
+    const config = Buffer.from(
+      openConfig(
+        deterministicBytes("jazz-napi-native-runtime:retained-view-node"),
+        deterministicBytes("jazz-napi-native-runtime:retained-view-author"),
+        1,
+        true,
+      ),
+    ).toString("base64");
+
+    for (const storage of ["memory", "persistent"]) {
+      const result = await runNapiFixture("napi-close-retained-schema-view.mjs", [
+        storage,
+        schema,
+        config,
+      ]);
+
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe(`owner closed with ${storage} schema view retained\n`);
+    }
+  }, 10_000);
 
   it("emits core tick scheduler wakes through the NAPI bridge", async () => {
     const { NapiDb } = await loadNapiModule();


### PR DESCRIPTION
🤖 Ports the still-relevant shutdown fix to the current N-API runtime. Owner close clears scheduler and mutation-error ThreadsafeFunctions before fallible core close, so retained schema views cannot keep Node alive.

Coverage retains a schema view and installs both callback types for memory and persistent owners. Independently removing either cleanup makes the child process time out; the restored implementation exits cleanly.