### PR TITLE
Bound recursive policy lowering

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -395,6 +395,69 @@ pub(super) fn lower_relation_input(
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
     request: &QueryProgramRequest,
 ) -> Result<LoweredRelationInput, UnsupportedReason> {
+    let mut lowered = BTreeMap::new();
+    for input in relation_input_postorder(plan) {
+        let output = lower_relation_input_cached(input, resolved_sources, request, &lowered)?;
+        lowered.insert(relation_input_key(input), output);
+    }
+    lowered
+        .remove(&relation_input_key(plan))
+        .ok_or_else(|| UnsupportedReason::Runtime("relation input was not lowered".to_owned()))
+}
+
+/// Relation inputs are nested by policy joins.  Lower them in postorder so a
+/// recursive policy graph is compiled iteratively rather than consuming the
+/// server shell stack through nested `lower_relation_input` calls.
+fn relation_input_postorder(root: &RelationInputPlan) -> Vec<&RelationInputPlan> {
+    let mut pending = vec![(root, false)];
+    let mut ordered = Vec::new();
+    while let Some((plan, visited)) = pending.pop() {
+        if visited {
+            ordered.push(plan);
+            continue;
+        }
+        pending.push((plan, true));
+        match plan {
+            RelationInputPlan::Linear(linear) => {
+                for step in linear.steps.iter().rev() {
+                    if let LinearStep::Join { right, .. } = step {
+                        pending.push((right, false));
+                    }
+                }
+            }
+            RelationInputPlan::Union(union) => {
+                for branch in union.branches.iter().rev() {
+                    pending.push((&branch.plan, false));
+                }
+            }
+            RelationInputPlan::Recursive(relation) => {
+                for step in relation
+                    .step
+                    .steps
+                    .iter()
+                    .rev()
+                    .chain(relation.seed.steps.iter().rev())
+                {
+                    if let LinearStep::Join { right, .. } = step {
+                        pending.push((right, false));
+                    }
+                }
+            }
+        }
+    }
+    ordered
+}
+
+fn relation_input_key(plan: &RelationInputPlan) -> usize {
+    std::ptr::from_ref(plan).addr()
+}
+
+fn lower_relation_input_cached(
+    plan: &RelationInputPlan,
+    resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
+    lowered: &BTreeMap<usize, LoweredRelationInput>,
+) -> Result<LoweredRelationInput, UnsupportedReason> {
     match plan {
         RelationInputPlan::Linear(linear) => {
             let source_id = linear.root.source().ok_or_else(|| {
@@ -403,16 +466,18 @@ pub(super) fn lower_relation_input(
             let source = resolved_sources.get(source_id).cloned().ok_or_else(|| {
                 UnsupportedReason::Runtime(format!("join source {:?} was not resolved", source_id))
             })?;
-            lower_linear_plan_steps(
+            lower_linear_plan_steps_cached(
                 source.graph.clone(),
                 linear,
                 &source,
                 resolved_sources,
                 request,
+                Some(lowered),
+                Some(linear),
             )
         }
         RelationInputPlan::Union(union) => {
-            lower_union_relation_input(union, resolved_sources, request)
+            lower_union_relation_input_cached(union, resolved_sources, request, lowered)
         }
         RelationInputPlan::Recursive(relation) => {
             let source_id = relation.root_source().ok_or_else(|| {
@@ -426,7 +491,14 @@ pub(super) fn lower_relation_input(
                     source_id
                 ))
             })?;
-            lower_recursive_relation(None, relation, &source, resolved_sources, request)
+            lower_recursive_relation_cached(
+                None,
+                relation,
+                &source,
+                resolved_sources,
+                request,
+                Some(lowered),
+            )
         }
     }
 }
@@ -439,29 +511,42 @@ fn lower_union_relation_input(
     lower_union_relation_input_with_prefix(union, resolved_sources, request, None)
 }
 
+fn lower_union_relation_input_cached(
+    union: &UnionPlan,
+    resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
+    lowered: &BTreeMap<usize, LoweredRelationInput>,
+) -> Result<LoweredRelationInput, UnsupportedReason> {
+    lower_union_relation_input_with_prefix_cached(
+        union,
+        resolved_sources,
+        request,
+        None,
+        Some(lowered),
+    )
+}
+
 fn lower_union_relation_input_with_prefix(
     union: &UnionPlan,
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
     request: &QueryProgramRequest,
     prefix: Option<&str>,
 ) -> Result<LoweredRelationInput, UnsupportedReason> {
-    let mut lowered = Vec::new();
-    for branch in &union.branches {
-        let label = prefix.map_or_else(
-            || branch.label.clone(),
-            |prefix| format!("{prefix}\u{0}{}", branch.label),
-        );
-        let linear = match &branch.plan {
+    lower_union_relation_input_with_prefix_cached(union, resolved_sources, request, prefix, None)
+}
+
+fn lower_union_relation_input_with_prefix_cached(
+    union: &UnionPlan,
+    resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
+    prefix: Option<&str>,
+    lowered: Option<&BTreeMap<usize, LoweredRelationInput>>,
+) -> Result<LoweredRelationInput, UnsupportedReason> {
+    let mut outputs = Vec::new();
+    for (plan, label) in union_branch_plans_with_labels(union, prefix) {
+        let linear = match plan {
             RelationInputPlan::Linear(linear) => linear,
-            RelationInputPlan::Union(nested) => {
-                lowered.push(lower_union_relation_input_with_prefix(
-                    nested,
-                    resolved_sources,
-                    request,
-                    Some(&label),
-                )?);
-                continue;
-            }
+            RelationInputPlan::Union(_) => unreachable!("nested unions are flattened above"),
             RelationInputPlan::Recursive(_) => {
                 return Err(UnsupportedReason::Operator(
                     "recursive UNION ALL join arms lack a stable finite occurrence carrier"
@@ -487,12 +572,14 @@ fn lower_union_relation_input_with_prefix(
                 value: NormalizedValueRef::RowId(RowIdRef::Source(source_id.clone())),
             });
         }
-        let mut output = lower_linear_plan_steps(
+        let mut output = lower_linear_plan_steps_cached(
             source.graph.clone(),
             &retained,
             source,
             resolved_sources,
             request,
+            lowered,
+            Some(linear),
         )?;
         if !output.fields.contains("__union_occurrence_row") {
             let row_field = &source.row_shape.row_uuid_field;
@@ -523,9 +610,45 @@ fn lower_union_relation_input_with_prefix(
             "__union_occurrence_arm".to_owned(),
             "__union_occurrence_row".to_owned(),
         ));
-        lowered.push(output);
+        outputs.push(output);
     }
-    lower_union_inputs(lowered, request)
+    lower_union_inputs(outputs, request)
+}
+
+/// Flatten nested UNION ALL inputs without using the call stack.  The complete
+/// path label remains the occurrence carrier for each leaf arm.
+fn union_branch_plans_with_labels<'a>(
+    union: &'a UnionPlan,
+    prefix: Option<&str>,
+) -> Vec<(&'a RelationInputPlan, String)> {
+    let mut leaves = Vec::new();
+    let mut pending = union
+        .branches
+        .iter()
+        .rev()
+        .map(|branch| {
+            let label = prefix.map_or_else(
+                || branch.label.clone(),
+                |prefix| format!("{prefix}\u{0}{}", branch.label),
+            );
+            (&branch.plan, label)
+        })
+        .collect::<Vec<_>>();
+    while let Some((plan, label)) = pending.pop() {
+        match plan {
+            RelationInputPlan::Union(nested) => pending.extend(
+                nested
+                    .branches
+                    .iter()
+                    .rev()
+                    .map(|branch| (&branch.plan, format!("{label}\u{0}{}", branch.label))),
+            ),
+            RelationInputPlan::Linear(_) | RelationInputPlan::Recursive(_) => {
+                leaves.push((plan, label))
+            }
+        }
+    }
+    leaves
 }
 
 fn lower_union_plan(
@@ -753,6 +876,24 @@ fn lower_recursive_relation(
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
     request: &QueryProgramRequest,
 ) -> Result<LoweredRelationInput, UnsupportedReason> {
+    lower_recursive_relation_cached(
+        root_graph,
+        relation,
+        root_source,
+        resolved_sources,
+        request,
+        None,
+    )
+}
+
+fn lower_recursive_relation_cached(
+    root_graph: Option<GraphBuilder>,
+    relation: &RecursiveRelationPlan,
+    root_source: &ResolvedSource,
+    resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
+    lowered: Option<&BTreeMap<usize, LoweredRelationInput>>,
+) -> Result<LoweredRelationInput, UnsupportedReason> {
     let seed_root_source = relation
         .seed_source()
         .and_then(|source| resolved_sources.get(source));
@@ -760,12 +901,14 @@ fn lower_recursive_relation(
     let seed_graph = seed_root
         .or(root_graph)
         .unwrap_or_else(|| root_source.graph.clone());
-    let seed = lower_linear_plan_steps(
+    let seed = lower_linear_plan_steps_cached(
         seed_graph,
         &relation.seed,
         seed_root_source.unwrap_or(root_source),
         resolved_sources,
         request,
+        lowered,
+        None,
     )?;
     let step_source_id = relation.step_source().ok_or_else(|| {
         UnsupportedReason::Operator("recursive step must include a table source".to_owned())
@@ -776,12 +919,14 @@ fn lower_recursive_relation(
             step_source_id
         ))
     })?;
-    let step = lower_linear_plan_steps(
+    let step = lower_linear_plan_steps_cached(
         step_source.graph.clone(),
         &relation.step,
         step_source,
         resolved_sources,
         request,
+        lowered,
+        None,
     )?;
     let max_iters = match relation.bound {
         RecursionBound::Fixpoint => FIXPOINT_MAX_ITERS,
@@ -814,6 +959,26 @@ fn lower_linear_plan_steps(
     root_source: &ResolvedSource,
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
     request: &QueryProgramRequest,
+) -> Result<LoweredRelationInput, UnsupportedReason> {
+    lower_linear_plan_steps_cached(
+        graph,
+        plan,
+        root_source,
+        resolved_sources,
+        request,
+        None,
+        None,
+    )
+}
+
+fn lower_linear_plan_steps_cached(
+    graph: GraphBuilder,
+    plan: &LinearCurrentRoot,
+    root_source: &ResolvedSource,
+    resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
+    lowered: Option<&BTreeMap<usize, LoweredRelationInput>>,
+    cache_plan: Option<&LinearCurrentRoot>,
 ) -> Result<LoweredRelationInput, UnsupportedReason> {
     let mut graph = match &plan.root {
         LinearRoot::Source { .. } => graph,
@@ -896,7 +1061,25 @@ fn lower_linear_plan_steps(
                         "join_via only lowers inner/semi joins".to_owned(),
                     ));
                 }
-                let lowered_right = lower_relation_input(right, resolved_sources, request)?;
+                let lowered_right = match lowered {
+                    Some(lowered) => lowered
+                        .get(&relation_input_key(
+                            cache_plan
+                                .and_then(|plan| plan.steps.get(step_index))
+                                .and_then(|step| match step {
+                                    LinearStep::Join { right, .. } => Some(right.as_ref()),
+                                    _ => None,
+                                })
+                                .unwrap_or(right),
+                        ))
+                        .cloned()
+                        .ok_or_else(|| {
+                            UnsupportedReason::Runtime(
+                                "join relation input was not lowered".to_owned(),
+                            )
+                        })?,
+                    None => lower_relation_input(right, resolved_sources, request)?,
+                };
                 let (left_keys, right_keys) = lower_linear_join_key_pairs(
                     on,
                     &plan.root,

--- a/crates/jazz/src/node/query_engine/lowering/planning.rs
+++ b/crates/jazz/src/node/query_engine/lowering/planning.rs
@@ -6,6 +6,11 @@
 
 use super::*;
 
+/// Bound the normalized row-set tree before recursive analysis constructs an
+/// owned plan.  This keeps malformed or adversarial query/policy programs
+/// from exhausting the server stack in analysis, traversal, or destruction.
+pub(super) const MAX_ROW_SET_NESTING_DEPTH: usize = 256;
+
 #[derive(Clone, Debug)]
 pub(super) struct LinearCurrentRoot {
     pub(super) root: LinearRoot,
@@ -204,6 +209,12 @@ pub(super) fn analyze_query_plan(
 ) -> Result<AnalyzedQueryPlan, Vec<UnsupportedReason>> {
     let mut gaps = Vec::new();
 
+    if let Err(gap) =
+        validate_row_set_nesting(&request.input.shape.root, &request.input.shape.nodes)
+    {
+        return Err(vec![gap]);
+    }
+
     if !request.reads.fact_reads.is_empty() {
         gaps.push(UnsupportedReason::Source(SourceGap::TransactionReadOverlay));
     }
@@ -233,6 +244,73 @@ pub(super) fn analyze_query_plan(
     }
 
     if gaps.is_empty() { Ok(plan) } else { Err(gaps) }
+}
+
+fn validate_row_set_nesting(
+    root: &RowSetNodeId,
+    nodes: &BTreeMap<RowSetNodeId, RowSetExpr>,
+) -> Result<(), UnsupportedReason> {
+    let mut pending = vec![(root.clone(), false)];
+    let mut active = BTreeSet::new();
+    let mut heights = BTreeMap::<RowSetNodeId, usize>::new();
+    while let Some((node_id, expanded)) = pending.pop() {
+        if heights.contains_key(&node_id) {
+            continue;
+        }
+        let node = nodes.get(&node_id).ok_or_else(|| {
+            UnsupportedReason::Operator(format!("row-set node {node_id:?} is missing"))
+        })?;
+        let children: Vec<RowSetNodeId> = match node {
+            RowSetExpr::Source { .. }
+            | RowSetExpr::ValueSource { .. }
+            | RowSetExpr::FrontierSource { .. } => Vec::new(),
+            RowSetExpr::Filter { input, .. }
+            | RowSetExpr::Distinct { input, .. }
+            | RowSetExpr::Project { input, .. }
+            | RowSetExpr::OrderBy { input, .. }
+            | RowSetExpr::Slice { input, .. }
+            | RowSetExpr::Aggregate { input, .. } => vec![input.clone()],
+            RowSetExpr::Join { left, right, .. } => vec![left.clone(), right.clone()],
+            RowSetExpr::RecursiveRelation { seed, step, .. } => vec![seed.clone(), step.clone()],
+            RowSetExpr::Union { inputs } => inputs.iter().map(|input| input.node.clone()).collect(),
+            RowSetExpr::CorrelatedPathProjection {
+                input, child_input, ..
+            } => vec![input.clone(), child_input.clone()],
+        };
+        if expanded {
+            active.remove(&node_id);
+            let height = 1 + children
+                .iter()
+                .filter_map(|child| heights.get(child))
+                .copied()
+                .max()
+                .unwrap_or(0);
+            if height > MAX_ROW_SET_NESTING_DEPTH {
+                return Err(UnsupportedReason::Operator(format!(
+                    "row-set nesting depth exceeds MAX_ROW_SET_NESTING_DEPTH ({MAX_ROW_SET_NESTING_DEPTH})"
+                )));
+            }
+            heights.insert(node_id, height);
+            continue;
+        }
+        if !active.insert(node_id.clone()) {
+            return Err(UnsupportedReason::Operator(format!(
+                "row-set nesting contains a cycle at node {node_id:?}"
+            )));
+        }
+        pending.push((node_id, true));
+        for child in children.into_iter().rev() {
+            if active.contains(&child) {
+                return Err(UnsupportedReason::Operator(format!(
+                    "row-set nesting contains a cycle at node {child:?}"
+                )));
+            }
+            if !heights.contains_key(&child) {
+                pending.push((child, false));
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn validate_output_capabilities(
@@ -944,12 +1022,7 @@ fn analyze_current_node(
     nodes: &BTreeMap<RowSetNodeId, RowSetExpr>,
     visited: &mut BTreeSet<RowSetNodeId>,
 ) -> Result<(LinearRoot, Vec<LinearStep>), UnsupportedReason> {
-    if !visited.insert(node_id.clone()) {
-        return Err(UnsupportedReason::Operator(format!(
-            "shared row-set subgraphs are not lowered yet (node revisited): {:?}",
-            node_id
-        )));
-    }
+    visited.insert(node_id.clone());
     let Some(node) = nodes.get(node_id) else {
         return Err(UnsupportedReason::Operator(format!(
             "row-set node {:?} is missing",
@@ -1065,6 +1138,7 @@ pub(super) fn analyze_relation_input_node(
     nodes: &BTreeMap<RowSetNodeId, RowSetExpr>,
     visited: &mut BTreeSet<RowSetNodeId>,
 ) -> Result<RelationInputPlan, UnsupportedReason> {
+    validate_row_set_nesting(node_id, nodes)?;
     let Some(node) = nodes.get(node_id) else {
         return Err(UnsupportedReason::Operator(format!(
             "row-set node {:?} is missing",
@@ -1074,12 +1148,7 @@ pub(super) fn analyze_relation_input_node(
 
     match node {
         RowSetExpr::Union { inputs } => {
-            if !visited.insert(node_id.clone()) {
-                return Err(UnsupportedReason::Operator(format!(
-                    "shared row-set subgraphs are not lowered yet (node revisited): {:?}",
-                    node_id
-                )));
-            }
+            visited.insert(node_id.clone());
             analyze_union(inputs, nodes, visited).map(RelationInputPlan::Union)
         }
         RowSetExpr::RecursiveRelation {
@@ -1090,12 +1159,7 @@ pub(super) fn analyze_relation_input_node(
             dedupe_keys,
             bound,
         } => {
-            if !visited.insert(node_id.clone()) {
-                return Err(UnsupportedReason::Operator(format!(
-                    "shared row-set subgraphs are not lowered yet (node revisited): {:?}",
-                    node_id
-                )));
-            }
+            visited.insert(node_id.clone());
             let seed = analyze_linear_subplan(seed, nodes, visited)?;
             let step = analyze_linear_subplan(step, nodes, visited)?;
             Ok(RelationInputPlan::Recursive(RecursiveRelationPlan {
@@ -1269,5 +1333,134 @@ fn validate_step_order(steps: &[LinearStep], gaps: &mut Vec<UnsupportedReason>) 
                 seen_aggregate = true;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod nesting_tests {
+    use super::*;
+
+    fn nested_relation_shapes(depth: usize) -> (RowSetNodeId, BTreeMap<RowSetNodeId, RowSetExpr>) {
+        let mut nodes = BTreeMap::new();
+        let leaf = RowSetNodeId("leaf".to_owned());
+        nodes.insert(
+            leaf.clone(),
+            RowSetExpr::ValueSource {
+                shape: "test".to_owned(),
+                columns: Vec::new(),
+                mode: ValueSourceMode::Inline,
+            },
+        );
+        let mut input = leaf.clone();
+        for index in 1..depth {
+            let node = RowSetNodeId(format!("nested-{index}"));
+            let side = RowSetNodeId(format!("side-{index}"));
+            nodes.insert(
+                side.clone(),
+                RowSetExpr::ValueSource {
+                    shape: format!("side-{index}"),
+                    columns: Vec::new(),
+                    mode: ValueSourceMode::Inline,
+                },
+            );
+            let expression = match index % 3 {
+                0 => RowSetExpr::Join {
+                    left: input,
+                    right: side,
+                    mode: JoinMode::Semi,
+                    on: PredicateExpr::True,
+                },
+                1 => RowSetExpr::Union {
+                    inputs: vec![UnionInput {
+                        node: input,
+                        label: format!("arm-{index}"),
+                    }],
+                },
+                _ => {
+                    let frontier = FrontierId(format!("frontier-{index}"));
+                    RowSetExpr::RecursiveRelation {
+                        seed: input,
+                        step: side,
+                        frontier: frontier.clone(),
+                        frontier_key: NormalizedValueRef::FrontierColumn {
+                            frontier,
+                            field: "key".to_owned(),
+                        },
+                        dedupe_keys: Vec::new(),
+                        bound: RecursionBound::MaxDepth(1),
+                    }
+                }
+            };
+            nodes.insert(node.clone(), expression);
+            input = node;
+        }
+        (input, nodes)
+    }
+
+    #[test]
+    fn row_set_nesting_accepts_the_limit_and_rejects_the_next_level() {
+        let (accepted_root, accepted_nodes) = nested_relation_shapes(MAX_ROW_SET_NESTING_DEPTH);
+        validate_row_set_nesting(&accepted_root, &accepted_nodes).expect("depth limit is accepted");
+
+        let (rejected_root, rejected_nodes) = nested_relation_shapes(MAX_ROW_SET_NESTING_DEPTH + 1);
+        let error = validate_row_set_nesting(&rejected_root, &rejected_nodes)
+            .expect_err("depth beyond limit is rejected");
+        assert!(
+            matches!(error, UnsupportedReason::Operator(message) if message.contains("MAX_ROW_SET_NESTING_DEPTH (256)"))
+        );
+    }
+
+    #[test]
+    fn row_set_nesting_and_analysis_accept_a_shared_child_diamond() {
+        let leaf = RowSetNodeId("shared".to_owned());
+        let root = RowSetNodeId("root".to_owned());
+        let nodes = BTreeMap::from([
+            (
+                leaf.clone(),
+                RowSetExpr::ValueSource {
+                    shape: "test".to_owned(),
+                    columns: Vec::new(),
+                    mode: ValueSourceMode::Inline,
+                },
+            ),
+            (
+                root.clone(),
+                RowSetExpr::Join {
+                    left: leaf.clone(),
+                    right: leaf,
+                    mode: JoinMode::Semi,
+                    on: PredicateExpr::True,
+                },
+            ),
+        ]);
+        validate_row_set_nesting(&root, &nodes).expect("shared DAG is valid");
+        analyze_relation_input_node(&root, &nodes, &mut BTreeSet::new())
+            .expect("shared DAG is duplicated into the owned analysis plan");
+    }
+
+    #[test]
+    fn row_set_nesting_rejects_an_active_path_cycle() {
+        let root = RowSetNodeId("cycle".to_owned());
+        let nodes = BTreeMap::from([(
+            root.clone(),
+            RowSetExpr::Project {
+                input: root.clone(),
+                columns: Vec::new(),
+            },
+        )]);
+        let error = validate_row_set_nesting(&root, &nodes).expect_err("cycle is invalid");
+        assert!(
+            matches!(error, UnsupportedReason::Operator(message) if message.contains("row-set nesting contains a cycle"))
+        );
+    }
+
+    #[test]
+    fn direct_relation_analysis_enforces_the_nesting_limit() {
+        let (root, nodes) = nested_relation_shapes(MAX_ROW_SET_NESTING_DEPTH + 1);
+        let error = analyze_relation_input_node(&root, &nodes, &mut BTreeSet::new())
+            .expect_err("closure callers must receive the nesting diagnostic");
+        assert!(
+            matches!(error, UnsupportedReason::Operator(message) if message.contains("MAX_ROW_SET_NESTING_DEPTH (256)"))
+        );
     }
 }

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -3,6 +3,47 @@
 use super::*;
 
 #[test]
+fn shared_row_set_dag_reaches_owned_plan_and_groove_lowering() {
+    let mut input = row_set_input(0xd9);
+    let shared_source = input.shape.root.clone();
+    let union = RowSetNodeId("shared-diamond".to_owned());
+    input.shape.nodes.insert(
+        union.clone(),
+        RowSetExpr::Union {
+            inputs: vec![
+                UnionInput {
+                    node: shared_source.clone(),
+                    label: "left".to_owned(),
+                },
+                UnionInput {
+                    node: shared_source,
+                    label: "right".to_owned(),
+                },
+            ],
+        },
+    );
+    input.shape.root = union;
+    let request = QueryProgramRequest {
+        authorization_mode: QueryAuthorizationMode::TrustedServing,
+        reads: QueryReadSet::primary(current_read_view()),
+        policy: system_policy_context(),
+        input,
+        output: RowSetOutputRequest {
+            app_rows: None,
+            facts: BTreeSet::from([ProgramFactKey::ResultMembership]),
+        },
+    };
+
+    let program = lower_query_program(request, &mut FakeSourceResolver::default())
+        .expect("shared child should become owned occurrences and lower");
+    assert!(program.lowered.terminals.iter().any(|terminal| {
+        graph_any(&terminal.graph, &|graph| {
+            matches!(graph, GraphBuilder::Union { .. })
+        })
+    }));
+}
+
+#[test]
 fn simple_current_table_root_query_lowers_for_local_edge_and_global_sync_outputs() {
     for tier in [
         DurabilityTier::Local,


### PR DESCRIPTION
🤖 Prevent deeply nested or cyclic policy row-set graphs from overflowing recursive lowering while preserving legitimate shared DAG subgraphs.

This replaces recursive input lowering with an iterative postorder traversal and establishes a hard maximum path depth of 256 before owned-plan construction. Validation distinguishes active-path revisits (cycles, rejected) from completed-node revisits (shared DAG nodes, accepted and reused for depth calculation). Each shared occurrence is then safely duplicated into the owned relation-input plan.

Receipts cover the 256/257 boundary across composite nodes, direct closure-analysis entry, a valid shared-child diamond, and deterministic cycle rejection. The original implementation received an adversarial review; the amended shared-DAG behavior is undergoing a fresh independent pass.