### PR TITLE
Add CodSpeed example benchmark skeleton

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,49 @@
+name: CodSpeed Example Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: codspeed-example-benchmarks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  examples:
+    name: Example benchmark smoke
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.93.1
+
+      # Cache both Cargo's compiled benchmark graph and the cargo-codspeed
+      # binary. The smoke target is deliberately isolated so unrelated crates
+      # do not invalidate this hosted benchmark path.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: true
+          shared-key: codspeed-example-benches-v1
+          workspaces: examples/benchmarks/smoke -> target
+
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --version 5.0.1 --locked
+
+      - name: Build example benchmark suites
+        run: cargo codspeed build --package jazz-example-benchmark-smoke
+
+      - name: Run example benchmark suites
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+        with:
+          mode: simulation
+          run: cargo codspeed run --package jazz-example-benchmark-smoke

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -27,14 +27,14 @@ jobs:
         with:
           toolchain: 1.93.1
 
-      # Cache both Cargo's compiled benchmark graph and the cargo-codspeed
-      # binary. The smoke target is deliberately isolated so unrelated crates
-      # do not invalidate this hosted benchmark path.
+      # Cache Cargo's root-workspace target directory and the cargo-codspeed
+      # binary. Package selection below limits compilation to the smoke crate's
+      # dependency graph, while Cargo still writes artifacts to the root target.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: true
           shared-key: codspeed-example-benches-v1
-          workspaces: examples/benchmarks/smoke -> target
+          workspaces: . -> target
 
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed --version 5.0.1 --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +544,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -574,10 +584,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.2",
+ "glob",
+ "libc",
+ "nix 0.31.3",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-divan-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1065d507e1cbab731a7976db4cef7e47e49b87b4dbc0a925df07d343558420"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-divan-compat-macros",
+ "codspeed-divan-compat-walltime",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-divan-compat-macros"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd05482a95823ffe421e8a9ba24fa22a6a30d594e2c60455cbb43a41bf2d8fa"
+dependencies = [
+ "divan-macros",
+ "itertools 0.14.0",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "codspeed-divan-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f8eae75b8fa85357020a404899c4280d590c9fd1c47640b3ce53106c62d2ee"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "codspeed",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
@@ -955,6 +1040,17 @@ name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1988,6 +2084,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "jazz-example-benchmark-smoke"
+version = "0.1.0"
+dependencies = [
+ "codspeed-divan-compat",
+]
+
+[[package]]
 name = "jazz-napi"
 version = "0.1.0"
 dependencies = [
@@ -2295,9 +2398,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -2591,6 +2694,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,7 +2857,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3089,7 +3204,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "smallvec",
  "spin 0.10.0",
@@ -3133,7 +3248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3451,6 +3575,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -4037,6 +4167,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "str_indices"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4150,6 +4290,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
@@ -4321,14 +4471,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5046,6 +5226,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   # gates until they are rebuilt around the new server boundary.
   # "examples/todo-server-rs",
   # "examples/docs/todo-server-rs",
+  "examples/benchmarks/smoke",
   "dev/benchmarks/storage/bench-core",
 ]
 exclude = ["crates/jazz-rn/rust", "examples/todo-server-rs", "examples/docs/todo-server-rs"]
@@ -37,6 +38,7 @@ jazz-otel = { path = "crates/jazz-otel" }
 jazz-storage-rocksdb = { path = "crates/jazz-storage-rocksdb" }
 jazz-native-transport = { path = "crates/jazz-native-transport" }
 rustc-hash = "2.1.1"
+divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 
 [patch.crates-io]
 rust-rocksdb = { git = "https://github.com/zaidoon1/rust-rocksdb.git", tag = "v0.48.0" }

--- a/dev/EXAMPLES_AND_BENCHMARKS_PROGRAM.md
+++ b/dev/EXAMPLES_AND_BENCHMARKS_PROGRAM.md
@@ -121,6 +121,14 @@ The gallery's interactive deployment is not itself the topology test harness.
 E2E tests control failure injection, clocks where needed, fixture seeds, and
 assertions; benchmark runs additionally record their environment and phases.
 
+## Rust benchmark convention
+
+New Rust benchmark variants use the self-contained package convention in
+[Example benchmarks](../examples/benchmarks/README.md). The workspace-level
+Divan compatibility dependency and CodSpeed workflow provide only discovery,
+instrumentation, and hosted reporting; each app keeps its own schema, fixture,
+scenario construction, scale profiles, and topology metadata.
+
 ## Correctness-forcing loop
 
 When an app exposes a defect, preserve three levels of evidence:

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -23,6 +23,7 @@ const packageBuild = fs.readFileSync(
   path.join(root, ".github/workflows/build-jazz-packages.yml"),
   "utf8",
 );
+const codspeedWorkflow = fs.readFileSync(path.join(root, ".github/workflows/codspeed.yml"), "utf8");
 const otherWorkflows = fs
   .readdirSync(path.join(root, ".github/workflows"))
   .filter((name) => name.endsWith(".yml") && name !== "ci.yml")
@@ -521,6 +522,22 @@ test("CI runs the workflow contract test through its package script", () => {
     "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs && node dev/gates/test-burndown-ts.mjs",
   );
   assert.match(lint, /run: pnpm test:ci-workflow/);
+});
+
+test("CodSpeed caches the root-workspace Cargo target", () => {
+  const rootTarget = /workspaces: \. -> target/;
+  assert.match(codspeedWorkflow, rootTarget);
+  assert.throws(
+    () =>
+      assert.match(
+        codspeedWorkflow.replace(
+          "workspaces: . -> target",
+          "workspaces: examples/benchmarks/smoke -> target",
+        ),
+        rootTarget,
+      ),
+    /workspaces/,
+  );
 });
 
 test("Windows NAPI release builds provision libclang for RocksDB bindgen", () => {

--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -1,0 +1,35 @@
+# Example benchmarks
+
+Every catalogue app owns a **self-contained benchmark variant** beside its
+public schema, deterministic fixture generator, and scenario driver. The
+benchmark variant intentionally duplicates the app's schema and workload shape
+instead of importing a shared app-runtime helper: it must stay understandable
+when opened in isolation and keep its measurement inputs explicit.
+
+The `smoke` crate proves the common Rust/CodSpeed plumbing only. It is not an
+app workload and must not become a place for shared application fixtures.
+
+## Add an app benchmark variant
+
+1. Add a small Rust package under `examples/<app>/benchmarks/` (or another
+   app-local benchmark directory) and list it in the root Cargo workspace.
+2. Put the app's deterministic, synthetic fixture and workload construction in
+   that package. Seed/profile/topology metadata belongs to the app variant,
+   not to this directory.
+3. Depend on `divan = { workspace = true }`, add one `[[bench]]` target with
+   `harness = false`, and use `divan::black_box` or a returned result so the
+   measured work is not optimized out.
+4. Run the focused local receipt:
+
+   ```sh
+   cargo bench -p <app-benchmark-package> --bench <suite>
+   ```
+
+5. Once the app benchmark is ready for hosted measurement, add it to the
+   `cargo codspeed build` and `cargo codspeed run` selection in
+   `.github/workflows/codspeed.yml`. Keep setup outside the measured closure;
+   use Divan's `Bencher` when a workload needs fresh per-iteration input.
+
+CodSpeed's compatibility crate is intentionally named `divan` at the workspace
+level. This keeps the Rust benchmark source identical for local `cargo bench`
+and hosted CodSpeed instrumentation.

--- a/examples/benchmarks/smoke/Cargo.toml
+++ b/examples/benchmarks/smoke/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "jazz-example-benchmark-smoke"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dev-dependencies]
+divan = { workspace = true }
+
+[[bench]]
+name = "fixture"
+harness = false

--- a/examples/benchmarks/smoke/benches/fixture.rs
+++ b/examples/benchmarks/smoke/benches/fixture.rs
@@ -1,0 +1,11 @@
+fn main() {
+    divan::main();
+}
+
+#[divan::bench(args = [(4, 128), (16, 512)])]
+fn indexed_fixture_count((tenant_count, records_per_tenant): (usize, usize)) -> usize {
+    jazz_example_benchmark_smoke::indexed_fixture_count(
+        divan::black_box(tenant_count),
+        divan::black_box(records_per_tenant),
+    )
+}

--- a/examples/benchmarks/smoke/src/lib.rs
+++ b/examples/benchmarks/smoke/src/lib.rs
@@ -1,0 +1,13 @@
+//! Small, intentionally self-contained fixture used to prove the example
+//! benchmark runner. Product examples own their own schema, fixture, and
+//! workload code; this crate is only a discovery smoke test.
+
+pub fn indexed_fixture_count(tenant_count: usize, records_per_tenant: usize) -> usize {
+    (0..tenant_count)
+        .map(|tenant| {
+            (0..records_per_tenant)
+                .filter(|record| record % tenant_count == tenant)
+                .count()
+        })
+        .sum()
+}


### PR DESCRIPTION
🤖 Establish the self-contained benchmark variant structure for example applications using Divan-compatible CodSpeed instrumentation.

This adds a small deterministic smoke fixture under `examples/benchmarks`, workspace wiring through `codspeed-divan-compat` exposed as `divan`, local and hosted command documentation, and a focused GitHub workflow for CodSpeed simulation. The benchmark returns and black-boxes its result so the work cannot be optimized away.

The workflow caches the actual root Cargo target used by the workspace. A planted-sensitive contract rejects the obsolete nested target path.

Independent review verified Cargo metadata, local Divan execution, exact CodSpeed build/run discovery of both cases, non-elided scaling, cache syntax, workflow security/events, and the self-contained variant documentation. External setup remaining after merge: connect the CodSpeed GitHub App for hosted uploads.