### PR TITLE
Isolate CI cache credentials by trust level

### DIFF
--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -1,0 +1,297 @@
+name: CI suite
+
+on:
+  workflow_call:
+    inputs:
+      trusted-cache:
+        description: Allow OIDC-backed cache access from trusted runs.
+        required: true
+        type: boolean
+      sccache-write:
+        description: Use the main-only sccache writer role instead of the trusted PR reader role.
+        required: true
+        type: boolean
+
+env:
+  CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
+  # The entry workflow grants this suite OIDC only for trusted invocations.
+  # In the unmodified base workflow, PR and manual callers set id-token: none,
+  # do not inherit secrets, and disable every credentialed cross-ref cache below.
+  # GitHub's native repository/ref-scoped cache actions remain available to all
+  # callers without receiving an explicit cloud credential here.
+
+jobs:
+  lint:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Authenticate trusted sccache writer
+        if: inputs.trusted-cache && inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache reader
+        if: inputs.trusted-cache && !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Export trusted sccache configuration
+        if: inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '')
+        env:
+          CACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+          CACHE_REGION: ${{ vars.SCCACHE_REGION }}
+        run: |
+          echo "SCCACHE_BUCKET=${CACHE_BUCKET}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=${CACHE_REGION}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_USE_SSL=true" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_KEY_PREFIX=jazz-ci/v1/production/blacksmith-v1" >> "${GITHUB_ENV}"
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
+
+      - run: pnpm format:check
+      - run: pnpm lint
+      # Keep workflow assertions required without adding another Rust build.
+      - run: pnpm test:ci-workflow
+      - name: Verify Turbo artifact cache inputs
+        run: pnpm test:turbo-cache-inputs
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats
+
+  test-rust-workspace:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Authenticate trusted sccache writer
+        if: inputs.trusted-cache && inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache reader
+        if: inputs.trusted-cache && !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Export trusted sccache configuration
+        if: inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '')
+        env:
+          CACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+          CACHE_REGION: ${{ vars.SCCACHE_REGION }}
+        run: |
+          echo "SCCACHE_BUCKET=${CACHE_BUCKET}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=${CACHE_REGION}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_USE_SSL=true" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_KEY_PREFIX=jazz-ci/v1/production/blacksmith-v1" >> "${GITHUB_ENV}"
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
+      - name: Workspace Rust tests (bounded, sharded, receipted)
+        run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features jazz/testing,jazz/transport-compression-zstd,jazz-server/test,jazz-cli/test
+      - name: Verify Nextest partition coverage
+        run: node --test dev/gates/test/nextest-partitions.test.mjs
+      - name: Upload Rust test receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rust-test-receipt
+          path: target/test-receipts/*.json
+          if-no-files-found: error
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats
+
+  # This runs a bounded real M3 oracle smoke separately from the workspace
+  # suite. The Rust test remains #[ignore] because its full randomized matrix
+  # is a long-running manual soak; CI deliberately invokes the bounded,
+  # deterministic canonical seed 11. Do not persist this randomized test
+  # job's target directory in the Rust artifact cache.
+  test-rust-differential:
+    # The full randomized matrix remains a long-running manual soak; this job
+    # intentionally exercises one bounded deterministic seed.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Authenticate trusted sccache writer
+        if: inputs.trusted-cache && inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache reader
+        if: inputs.trusted-cache && !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Export trusted sccache configuration
+        if: inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '')
+        env:
+          CACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+          CACHE_REGION: ${{ vars.SCCACHE_REGION }}
+        run: |
+          echo "SCCACHE_BUCKET=${CACHE_BUCKET}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=${CACHE_REGION}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_USE_SSL=true" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_KEY_PREFIX=jazz-ci/v1/production/blacksmith-v1" >> "${GITHUB_ENV}"
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
+          rust-cache: "false"
+      # Compile only the library test binary first. The semantic oracle timeout
+      # below must not charge a cold compile or unrelated integration binaries.
+      - name: Compile M3 differential oracle libtest
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_binary="$(cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json | node -e '
+            const readline = require("node:readline");
+            let executable;
+            const lines = readline.createInterface({ input: process.stdin });
+            lines.on("line", (line) => {
+              try {
+                const message = JSON.parse(line);
+                if (message.reason === "compiler-artifact" && message.target.name === "jazz" && message.executable)
+                  executable = message.executable;
+              } catch {}
+            });
+            lines.on("close", () => {
+              if (!executable) process.exitCode = 1;
+              else console.log(executable);
+            });
+          ')"
+          test -x "${test_binary}"
+          echo "M3_ORACLE_TEST_BINARY=${test_binary}" >> "${GITHUB_ENV}"
+      # The smallest stable real oracle smoke: fixed seed 11, the two smallest
+      # aggregate churn depths, and the normal three differential steps.
+      - name: Run maintained-vs-one-shot differential oracle smoke
+        shell: bash
+        run: |
+          timeout 60s env \
+            JAZZ_SEED=11 \
+            JAZZ_DIFFERENTIAL_CHURN_DEPTHS=10,1000 \
+            JAZZ_DIFFERENTIAL_STEP_COUNT=3 \
+            "${M3_ORACLE_TEST_BINARY}" node::tests::harness::m3_maintained_one_shot_differential_oracle --exact --ignored
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats
+
+  # Branch protection requires this stable check name. It aggregates both Rust
+  # correctness jobs and stays red whenever either dependency fails or is cancelled.
+  test-rust:
+    if: always()
+    needs: [test-rust-workspace, test-rust-differential]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: Require all Rust partitions
+        env:
+          WORKSPACE_RESULT: ${{ needs.test-rust-workspace.result }}
+          DIFFERENTIAL_RESULT: ${{ needs.test-rust-differential.result }}
+        run: |
+          test "${WORKSPACE_RESULT}" = success
+          test "${DIFFERENTIAL_RESULT}" = success
+
+  test-ts:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 20
+    # JAZZ_NAPI_RELEASE=0 (debug builds) removed 2026-07-19: debug-profile
+    # jazz-napi .node files fail dlopen on the Linux runners deterministically
+    # (root cause TBD; see dev/CI_NOTES.md). Release builds load fine.
+
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Authenticate trusted sccache writer
+        if: inputs.trusted-cache && inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache reader
+        if: inputs.trusted-cache && !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Export trusted sccache configuration
+        if: inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '')
+        env:
+          CACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+          CACHE_REGION: ${{ vars.SCCACHE_REGION }}
+        run: |
+          echo "SCCACHE_BUCKET=${CACHE_BUCKET}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=${CACHE_REGION}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_USE_SSL=true" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_KEY_PREFIX=jazz-ci/v1/production/blacksmith-v1" >> "${GITHUB_ENV}"
+      - name: Export trusted Turbo cache signing key
+        if: inputs.trusted-cache
+        env:
+          CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+        run: echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=${CACHE_SIGNATURE_KEY}" >> "${GITHUB_ENV}"
+      - name: Set up signed Turbo Remote Cache
+        if: inputs.trusted-cache
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: garden-co
+          policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c
+          audience: https://github.com/garden-co
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
+
+      # Keep the integration-branch compile gate, but run it as the first
+      # phase of this trusted-runner job. Keeping it here avoids a separate
+      # checkout/setup phase on the PR critical path.
+      #
+      # PR-level checks cannot catch two independently green PRs whose merged
+      # tree no longer compiles. This runs on every push to the integration
+      # branch before building the TypeScript correctness artifacts.
+      - name: Check integration workspace
+        run: cargo check --workspace --all-targets
+
+      # Correctness tests use an unoptimised, provenance-checked WASM build.
+      # Package/publish workflows continue to use jazz-wasm's release build.
+      # The script reuses the restored default Cargo target, runs NAPI alone,
+      # then overlaps CLI with fast WASM. Each deterministic build is a signed
+      # Turbo task; the nondeterministic test suites below remain uncached.
+      - name: Build correctness-test artifacts
+        run: pnpm build:test-artifacts
+      - name: Verify preinstalled Chromium
+        run: pnpm exec playwright install --dry-run chromium
+      # Both suites consume the already-built artifacts and do not write shared
+      # outputs. Running them together avoids extending the PR critical path
+      # while retaining the complete Node and browser coverage in this gate.
+      - name: Run Node and browser test suites in parallel
+        run: dev/gates/run-ts-tests.sh
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,11 @@ name: CI
 
 on:
   workflow_dispatch:
+  # Deliberately unfiltered so every layer of a stacked PR receives CI even
+  # when its base is another feature branch.
   pull_request:
-    branches: [main, codex/jazz-core-engine-swap]
   push:
-    branches: [main, codex/jazz-core-engine-swap]
+    branches: [main]
 
 concurrency:
   # For pushes, this lets concurrent runs happen, so each push gets a result.
@@ -13,265 +14,52 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
-env:
-  CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
-  SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-  SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
-  SCCACHE_S3_USE_SSL: "true"
-  SCCACHE_S3_KEY_PREFIX: jazz-ci/v1/production/blacksmith-v1
-  # The AWS roles enforce the cache boundary: PR credentials cannot PutObject,
-  # while trusted branch-push credentials can. workflow_dispatch never receives
-  # either role, even when dispatched from a trusted branch. sccache has no S3
-  # read-only switch.
-
+# Security boundary: the repository's workflow maintainers and write-capable
+# collaborators are trusted. A same-repository author who can modify this file
+# could directly request OIDC or reference Actions secrets, which YAML in this
+# same repository cannot prevent. For the unmodified base workflow enforced
+# below, untrusted PRs (including forks and Dependabot) and workflow_dispatch
+# receive no OIDC permission, inherited secrets, or credentialed cross-ref
+# cache access. GitHub's native repository/ref-scoped cache remains available
+# without any explicit cloud credential from this workflow.
 jobs:
-  lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 10
+  untrusted:
+    if: github.event_name != 'push' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+    permissions:
+      contents: read
+      id-token: none
+      packages: read
+    uses: ./.github/workflows/ci-suite.yml
+    with:
+      trusted-cache: false
+      sccache-write: false
+
+  trusted:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     permissions:
       contents: read
       id-token: write
       packages: read
-    container:
-      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Authenticate read-only PR sccache
-        if: github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - name: Authenticate trusted sccache writer
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - uses: ./.github/actions/setup-blacksmith
-        with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
+    uses: ./.github/workflows/ci-suite.yml
+    with:
+      trusted-cache: true
+      sccache-write: ${{ github.event_name == 'push' }}
+    secrets: inherit
 
-      - run: pnpm format:check
-      - run: pnpm lint
-      # Keep workflow assertions required without adding another Rust build.
-      - run: pnpm test:ci-workflow
-      - name: Verify Turbo artifact cache inputs
-        run: pnpm test:turbo-cache-inputs
-      - name: Report sccache statistics
-        if: always()
-        run: sccache --show-stats
-
-  test-rust-workspace:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-      packages: read
-    container:
-      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Authenticate read-only PR sccache
-        if: github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - name: Authenticate trusted sccache writer
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - uses: ./.github/actions/setup-blacksmith
-        with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
-      - name: Workspace Rust tests (bounded, sharded, receipted)
-        run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features jazz/testing,jazz/transport-compression-zstd,jazz-server/test,jazz-cli/test
-      - name: Verify Nextest partition coverage
-        run: node --test dev/gates/test/nextest-partitions.test.mjs
-      - name: Upload Rust test receipt
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: rust-test-receipt
-          path: target/test-receipts/*.json
-          if-no-files-found: error
-      - name: Report sccache statistics
-        if: always()
-        run: sccache --show-stats
-
-  # This runs a bounded real M3 oracle smoke separately from the workspace
-  # suite. The Rust test remains #[ignore] because its full randomized matrix
-  # is a long-running manual soak; CI deliberately invokes the bounded,
-  # deterministic canonical seed 11. Do not persist this randomized test
-  # job's target directory in the Rust artifact cache.
-  test-rust-differential:
-    # The full randomized matrix remains a long-running manual soak; this job
-    # intentionally exercises one bounded deterministic seed.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-      packages: read
-    container:
-      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Authenticate read-only PR sccache
-        if: github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - name: Authenticate trusted sccache writer
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - uses: ./.github/actions/setup-blacksmith
-        with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
-          rust-cache: "false"
-      # Compile only the library test binary first. The semantic oracle timeout
-      # below must not charge a cold compile or unrelated integration binaries.
-      - name: Compile M3 differential oracle libtest
-        shell: bash
-        run: |
-          set -euo pipefail
-          test_binary="$(cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json | node -e '
-            const readline = require("node:readline");
-            let executable;
-            const lines = readline.createInterface({ input: process.stdin });
-            lines.on("line", (line) => {
-              try {
-                const message = JSON.parse(line);
-                if (message.reason === "compiler-artifact" && message.target.name === "jazz" && message.executable)
-                  executable = message.executable;
-              } catch {}
-            });
-            lines.on("close", () => {
-              if (!executable) process.exitCode = 1;
-              else console.log(executable);
-            });
-          ')"
-          test -x "${test_binary}"
-          echo "M3_ORACLE_TEST_BINARY=${test_binary}" >> "${GITHUB_ENV}"
-      # The smallest stable real oracle smoke: fixed seed 11, the two smallest
-      # aggregate churn depths, and the normal three differential steps.
-      - name: Run maintained-vs-one-shot differential oracle smoke
-        shell: bash
-        run: |
-          timeout 60s env \
-            JAZZ_SEED=11 \
-            JAZZ_DIFFERENTIAL_CHURN_DEPTHS=10,1000 \
-            JAZZ_DIFFERENTIAL_STEP_COUNT=3 \
-            "${M3_ORACLE_TEST_BINARY}" node::tests::harness::m3_maintained_one_shot_differential_oracle --exact --ignored
-      - name: Report sccache statistics
-        if: always()
-        run: sccache --show-stats
-
-  # Branch protection requires this stable check name. It aggregates both Rust
-  # correctness jobs and stays red whenever either dependency fails or is cancelled.
+  # Preserve the branch-protection check name while the implementation jobs
+  # live in the reusable suite. Exactly one invocation must have completed.
   test-rust:
     if: always()
-    needs: [test-rust-workspace, test-rust-differential]
+    needs: [untrusted, trusted]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 2
     permissions:
       contents: read
     steps:
-      - name: Require all Rust partitions
+      - name: Require the selected CI suite
         env:
-          WORKSPACE_RESULT: ${{ needs.test-rust-workspace.result }}
-          DIFFERENTIAL_RESULT: ${{ needs.test-rust-differential.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
         run: |
-          test "${WORKSPACE_RESULT}" = success
-          test "${DIFFERENTIAL_RESULT}" = success
-
-  test-ts:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    timeout-minutes: 20
-    # JAZZ_NAPI_RELEASE=0 (debug builds) removed 2026-07-19: debug-profile
-    # jazz-napi .node files fail dlopen on the Linux runners deterministically
-    # (root cause TBD; see dev/CI_NOTES.md). Release builds load fine.
-
-    permissions:
-      contents: read
-      id-token: write
-      packages: read
-    container:
-      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Authenticate read-only PR sccache
-        if: github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - name: Authenticate trusted sccache writer
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
-        with:
-          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
-          aws-region: ${{ vars.SCCACHE_REGION }}
-      - name: Export trusted Turbo cache signing key
-        if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        env:
-          CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-        run: echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=${CACHE_SIGNATURE_KEY}" >> "${GITHUB_ENV}"
-      - name: Set up signed Turbo Remote Cache
-        if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
-        with:
-          team: garden-co
-          policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c
-          audience: https://github.com/garden-co
-      - uses: ./.github/actions/setup-blacksmith
-        with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
-
-      # Keep the integration-branch compile gate, but run it as the first
-      # phase of this trusted-runner job. Keeping it here avoids a separate
-      # checkout/setup phase on the PR critical path.
-      #
-      # PR-level checks cannot catch two independently green PRs whose merged
-      # tree no longer compiles. This runs on every push to the integration
-      # branch before building the TypeScript correctness artifacts.
-      - name: Check integration workspace
-        run: cargo check --workspace --all-targets
-
-      # Correctness tests use an unoptimised, provenance-checked WASM build.
-      # Package/publish workflows continue to use jazz-wasm's release build.
-      # The script reuses the restored default Cargo target, runs NAPI alone,
-      # then overlaps CLI with fast WASM. Each deterministic build is a signed
-      # Turbo task; the nondeterministic test suites below remain uncached.
-      - name: Build correctness-test artifacts
-        run: pnpm build:test-artifacts
-      - name: Verify preinstalled Chromium
-        run: pnpm exec playwright install --dry-run chromium
-      # Both suites consume the already-built artifacts and do not write shared
-      # outputs. Running them together avoids extending the PR critical path
-      # while retaining the complete Node and browser coverage in this gate.
-      - name: Run Node and browser test suites in parallel
-        run: dev/gates/run-ts-tests.sh
-      - name: Report sccache statistics
-        if: always()
-        run: sccache --show-stats
+          test "${UNTRUSTED_RESULT}:${TRUSTED_RESULT}" = "success:skipped" || \
+            test "${UNTRUSTED_RESULT}:${TRUSTED_RESULT}" = "skipped:success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ env:
   SCCACHE_S3_USE_SSL: "true"
   SCCACHE_S3_KEY_PREFIX: jazz-ci/v1/production/blacksmith-v1
   # The AWS roles enforce the cache boundary: PR credentials cannot PutObject,
-  # while trusted branch credentials can. sccache has no S3 read-only switch.
+  # while trusted branch-push credentials can. workflow_dispatch never receives
+  # either role, even when dispatched from a trusted branch. sccache has no S3
+  # read-only switch.
 
 jobs:
   lint:
@@ -44,14 +46,14 @@ jobs:
           role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - name: Authenticate trusted sccache writer
-        if: github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
           role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - uses: ./.github/actions/setup-blacksmith
         with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
+          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
 
       - run: pnpm format:check
       - run: pnpm lint
@@ -84,14 +86,14 @@ jobs:
           role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - name: Authenticate trusted sccache writer
-        if: github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
           role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - uses: ./.github/actions/setup-blacksmith
         with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
+          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
       - name: Workspace Rust tests (bounded, sharded, receipted)
         run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features jazz/testing,jazz/transport-compression-zstd,jazz-server/test,jazz-cli/test
       - name: Verify Nextest partition coverage
@@ -135,14 +137,14 @@ jobs:
           role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - name: Authenticate trusted sccache writer
-        if: github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
           role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - uses: ./.github/actions/setup-blacksmith
         with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
+          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
           rust-cache: "false"
       # Compile only the library test binary first. The semantic oracle timeout
       # below must not charge a cold compile or unrelated integration binaries.
@@ -227,13 +229,13 @@ jobs:
           role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - name: Authenticate trusted sccache writer
-        if: github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
         with:
           role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
       - name: Set up signed Turbo Remote Cache
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
         with:
           team: garden-co
@@ -241,7 +243,7 @@ jobs:
           audience: https://github.com/garden-co
       - uses: ./.github/actions/setup-blacksmith
         with:
-          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
+          sccache-s3: ${{ (github.event_name == 'pull_request' && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap') && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '') }}
 
       # Keep the integration-branch compile gate, but run it as the first
       # phase of this trusted-runner job. Keeping it here avoids a separate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,6 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Authenticate read-only PR sccache
@@ -234,6 +232,11 @@ jobs:
         with:
           role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
           aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Export trusted Turbo cache signing key
+        if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+        run: echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=${CACHE_SIGNATURE_KEY}" >> "${GITHUB_ENV}"
       - name: Set up signed Turbo Remote Cache
         if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -4,9 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { parse } from "yaml";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const workflow = fs.readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
+const workflowSuite = fs.readFileSync(path.join(root, ".github/workflows/ci-suite.yml"), "utf8");
 const setupBuildAction = fs.readFileSync(
   path.join(root, ".github/actions/setup-build/action.yml"),
   "utf8",
@@ -25,7 +27,7 @@ const packageBuild = fs.readFileSync(
 );
 const otherWorkflows = fs
   .readdirSync(path.join(root, ".github/workflows"))
-  .filter((name) => name.endsWith(".yml") && name !== "ci.yml")
+  .filter((name) => name.endsWith(".yml") && !["ci.yml", "ci-suite.yml"].includes(name))
   .map((name) => fs.readFileSync(path.join(root, ".github/workflows", name), "utf8"));
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 const toolBundleValidator = fs.readFileSync(
@@ -37,16 +39,16 @@ const m3Differential = fs.readFileSync(
   "utf8",
 );
 const jobs = (() => {
-  const jobsStart = workflow.indexOf("\njobs:\n");
+  const jobsStart = workflowSuite.indexOf("\njobs:\n");
   assert.notEqual(jobsStart, -1, "missing jobs section");
-  const matches = [...workflow.slice(jobsStart).matchAll(/^  ([A-Za-z0-9_-]+):\s*$/gm)];
+  const matches = [...workflowSuite.slice(jobsStart).matchAll(/^  ([A-Za-z0-9_-]+):\s*$/gm)];
   assert.ok(matches.length > 0, "CI workflow must define at least one job");
   return new Map(
     matches.map((match, index) => [
       match[1],
-      workflow.slice(
+      workflowSuite.slice(
         jobsStart + match.index,
-        index + 1 < matches.length ? jobsStart + matches[index + 1].index : workflow.length,
+        index + 1 < matches.length ? jobsStart + matches[index + 1].index : workflowSuite.length,
       ),
     ]),
   );
@@ -82,36 +84,136 @@ const assertIntegrationCheckIsGating = (typescriptJob) => {
     "integration workspace check must not suppress its failure",
   );
 };
-const trustedCachePush =
-  "github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap')";
-const sccacheReader = "github.event_name == 'pull_request'";
-const sccacheWriter = `${trustedCachePush} && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''`;
-const sccacheS3 = `(${sccacheReader} && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (${sccacheWriter})`;
-const turboCache = `(${trustedCachePush}) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)`;
+const trustedCachePullRequest =
+  'github.event_name == \'pull_request\' && github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON(\'["OWNER","MEMBER","COLLABORATOR"]\'), github.event.pull_request.author_association)';
+const trustedCacheCondition =
+  "github.event_name == 'push' && github.ref == 'refs/heads/main' || " + trustedCachePullRequest;
+const untrustedCacheCondition = "github.event_name != 'push' && !(" + trustedCachePullRequest + ")";
+const sccacheWriter =
+  "inputs.trusted-cache && inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''";
+const sccacheReader =
+  "inputs.trusted-cache && !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''";
+const sccacheS3 =
+  "inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '')";
+const turboCache = "inputs.trusted-cache";
 const regex = (source) => new RegExp(source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
 const assertSccacheTrustBoundary = (source) => {
-  assert.match(source, regex(`if: ${sccacheReader} && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''`));
   assert.match(source, regex(`if: ${sccacheWriter}`));
+  assert.match(source, regex(`if: ${sccacheReader}`));
   assert.match(source, regex("sccache-s3: ${{ " + sccacheS3 + " }}"));
-  assert.doesNotMatch(
-    source,
-    /github\.event_name != 'pull_request'/,
-    "a non-PR condition would give workflow_dispatch the writer role",
-  );
 };
-const cacheAccessFor = ({ eventName, ref, sameRepositoryPr = false }) => ({
-  sccache:
-    eventName === "pull_request"
-      ? "reader"
-      : eventName === "push" &&
-          ["refs/heads/main", "refs/heads/codex/jazz-core-engine-swap"].includes(ref)
-        ? "writer"
-        : "none",
-  turbo:
-    (eventName === "push" &&
-      ["refs/heads/main", "refs/heads/codex/jazz-core-engine-swap"].includes(ref)) ||
-    (eventName === "pull_request" && sameRepositoryPr),
-});
+const s3Environment = [
+  "SCCACHE_BUCKET",
+  "SCCACHE_REGION",
+  "SCCACHE_S3_KEY_PREFIX",
+  "SCCACHE_S3_USE_SSL",
+];
+const assertSuiteS3ConfigurationBoundary = (source) => {
+  const document = parse(source);
+  for (const name of s3Environment)
+    assert.equal(
+      document.env?.[name],
+      undefined,
+      `untrusted suite callers must not inherit ${name}`,
+    );
+
+  for (const name of ["lint", "test-rust-workspace", "test-rust-differential", "test-ts"]) {
+    const parsedJob = document.jobs[name];
+    assert.equal(parsedJob.env, undefined, `${name} must not configure S3 at job scope`);
+    const exportIndex = parsedJob.steps.findIndex(
+      (step) => step.name === "Export trusted sccache configuration",
+    );
+    const setupIndex = parsedJob.steps.findIndex(
+      (step) => step.uses === "./.github/actions/setup-blacksmith",
+    );
+    assert.notEqual(exportIndex, -1, `${name} is missing trusted S3 configuration export`);
+    assert.ok(exportIndex < setupIndex, `${name} must export S3 configuration before setup`);
+    const exportStep = parsedJob.steps[exportIndex];
+    assert.equal(exportStep.if, sccacheS3);
+    assert.deepEqual(exportStep.env, {
+      CACHE_BUCKET: "${{ vars.SCCACHE_BUCKET }}",
+      CACHE_REGION: "${{ vars.SCCACHE_REGION }}",
+    });
+    for (const variable of s3Environment)
+      assert.match(exportStep.run, new RegExp(`echo "${variable}=`));
+    assert.equal(parsedJob.steps[setupIndex].with["sccache-s3"], "${{ " + sccacheS3 + " }}");
+  }
+};
+const cacheAccessFor = ({ eventName, ref, sameRepository = false, authorAssociation = "NONE" }) => {
+  const trustedPullRequest =
+    eventName === "pull_request" &&
+    sameRepository &&
+    ["OWNER", "MEMBER", "COLLABORATOR"].includes(authorAssociation);
+  const trusted = (eventName === "push" && ref === "refs/heads/main") || trustedPullRequest;
+  return {
+    invocation: trusted ? "trusted" : "untrusted",
+    idToken: trusted ? "write" : "none",
+    sccache: trusted ? (eventName === "push" ? "writer" : "reader") : "none",
+    turbo: trusted,
+  };
+};
+const workflowDocumentFor = (source) => {
+  const document = parse(source);
+  assert.equal(typeof document, "object", "CI entry workflow must be a YAML mapping");
+  assert.equal(typeof document.jobs, "object", "CI entry workflow must define a jobs mapping");
+  return document;
+};
+const assertEntryCacheTrustBoundary = (source) => {
+  const document = workflowDocumentFor(source);
+  const entryJobs = document.jobs;
+  assert.deepEqual(
+    Object.keys(entryJobs).sort(),
+    ["test-rust", "trusted", "untrusted"],
+    "the credential boundary must account for every entry-workflow job",
+  );
+  const { untrusted, trusted, "test-rust": aggregate } = entryJobs;
+  assert.deepEqual(
+    Object.keys(untrusted).sort(),
+    ["if", "permissions", "uses", "with"],
+    "untrusted caller must expose no additional execution or credential surface",
+  );
+  assert.equal(untrusted.if, untrustedCacheCondition);
+  assert.deepEqual(untrusted.permissions, {
+    contents: "read",
+    "id-token": "none",
+    packages: "read",
+  });
+  assert.equal(untrusted.uses, "./.github/workflows/ci-suite.yml");
+  assert.deepEqual(untrusted.with, { "sccache-write": false, "trusted-cache": false });
+
+  assert.deepEqual(
+    Object.keys(trusted).sort(),
+    ["if", "permissions", "secrets", "uses", "with"],
+    "trusted caller credential surface must stay explicit",
+  );
+  assert.equal(trusted.if, trustedCacheCondition);
+  assert.deepEqual(trusted.permissions, {
+    contents: "read",
+    "id-token": "write",
+    packages: "read",
+  });
+  assert.equal(trusted.uses, "./.github/workflows/ci-suite.yml");
+  assert.deepEqual(trusted.with, {
+    "sccache-write": "${{ github.event_name == 'push' }}",
+    "trusted-cache": true,
+  });
+  assert.equal(trusted.secrets, "inherit");
+
+  assert.deepEqual(Object.keys(aggregate).sort(), [
+    "if",
+    "needs",
+    "permissions",
+    "runs-on",
+    "steps",
+    "timeout-minutes",
+  ]);
+  assert.equal(aggregate.if, "always()");
+  assert.deepEqual(aggregate.needs, ["untrusted", "trusted"]);
+  assert.deepEqual(aggregate.permissions, { contents: "read" });
+  assert.equal(document.on.pull_request_target, undefined);
+  assert.equal(document.on.pull_request, null, "stacked PR bases must not be branch-filtered");
+  assert.deepEqual(document.on.push, { branches: ["main"] });
+};
 const assertTurboSigningKeyTrustBoundary = (typescriptJob) => {
   assert.doesNotMatch(
     typescriptJob,
@@ -134,7 +236,7 @@ const assertTurboSigningKeyTrustBoundary = (typescriptJob) => {
 };
 const assertTurboCredentialConditions = (typescriptJob) => {
   assertTurboSigningKeyTrustBoundary(typescriptJob);
-  const trustedConditions = typescriptJob.match(new RegExp(regex(`if: ${turboCache}`).source, "g"));
+  const trustedConditions = typescriptJob.match(/^        if: inputs\.trusted-cache$/gm);
   assert.equal(
     trustedConditions?.length,
     2,
@@ -148,7 +250,7 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
   const differentialRust = job("test-rust-differential");
   const typescript = job("test-ts");
 
-  assert.doesNotMatch(workflow, /cargo install cargo-nextest/);
+  assert.doesNotMatch(workflowSuite, /cargo install cargo-nextest/);
   assert.match(setupBlacksmithAction, /cargo-nextest --version \| grep -F "0\.9\.143"/);
   assert.match(setupBlacksmithAction, /wasm-pack --version \| grep -F "0\.13\.1"/);
   for (const rust of [workspaceRust, differentialRust]) {
@@ -470,7 +572,7 @@ test("the TypeScript CI job checks the integration workspace before TypeScript a
   );
 
   // Keeping these phases together avoids a separate checkout/setup phase.
-  assert.doesNotMatch(workflow, /^  build-integration:/m);
+  assert.doesNotMatch(workflowSuite, /^  build-integration:/m);
   assert.match(
     typescript,
     /name: Check integration workspace\s+run: cargo check --workspace --all-targets/,
@@ -490,7 +592,7 @@ test("every CI job uses an independently sized Blacksmith runner", () => {
   }
 });
 
-test("Turbo cache uses pinned OIDC policy only for trusted pushes and same-repository PRs", () => {
+test("Turbo cache uses its pinned OIDC policy only inside the trusted suite invocation", () => {
   const typescript = job("test-ts");
   assertTurboCredentialConditions(typescript);
   assert.match(typescript, /policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c/);
@@ -510,64 +612,106 @@ test("Turbo cache uses pinned OIDC policy only for trusted pushes and same-repos
     );
 });
 
-test("shared Rust cache separates read-only PRs from trusted writers", () => {
+test("shared Rust cache writes are main-only while trusted PRs receive read access", () => {
   for (const name of ["lint", "test-rust-workspace", "test-rust-differential", "test-ts"]) {
     const source = job(name);
-    assert.match(source, /role-to-assume: \$\{\{ vars\.SCCACHE_PR_READER_AWS_ROLE_ARN \}\}/);
     assert.match(source, /role-to-assume: \$\{\{ vars\.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN \}\}/);
+    assert.match(source, /role-to-assume: \$\{\{ vars\.SCCACHE_PR_READER_AWS_ROLE_ARN \}\}/);
     assertSccacheTrustBoundary(source);
   }
-  assert.match(workflow, /SCCACHE_S3_KEY_PREFIX: jazz-ci\/v1\/production\/blacksmith-v1/);
+  assertSuiteS3ConfigurationBoundary(workflowSuite);
   assert.doesNotMatch(
-    workflow,
+    workflowSuite,
     /SCCACHE_S3_RW_MODE/,
-    "sccache has no S3 read-only switch; the distinct IAM roles enforce this boundary",
+    "sccache has no S3 read-only switch; untrusted jobs must not enable the S3 tier",
   );
   assert.match(setupBlacksmithAction, /SCCACHE_MULTILEVEL_CHAIN=disk,s3/);
   assert.match(setupBlacksmithAction, /SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY=l0/);
 });
 
-test("cache credential policy has no manual-dispatch writer path", () => {
+test("entry workflow grants credentialed cross-ref caches to main and trusted stacked PRs", () => {
   const cases = [
     [
       "main push",
       { eventName: "push", ref: "refs/heads/main" },
-      { sccache: "writer", turbo: true },
-    ],
-    [
-      "integration push",
-      { eventName: "push", ref: "refs/heads/codex/jazz-core-engine-swap" },
-      { sccache: "writer", turbo: true },
+      { invocation: "trusted", idToken: "write", sccache: "writer", turbo: true },
     ],
     [
       "feature push",
       { eventName: "push", ref: "refs/heads/feature/cache-auth" },
-      { sccache: "none", turbo: false },
+      { invocation: "untrusted", idToken: "none", sccache: "none", turbo: false },
     ],
     [
-      "same-repository PR",
-      { eventName: "pull_request", ref: "refs/pull/1/merge", sameRepositoryPr: true },
-      { sccache: "reader", turbo: true },
+      "trusted same-repository PR",
+      {
+        eventName: "pull_request",
+        ref: "refs/pull/1/merge",
+        sameRepository: true,
+        authorAssociation: "MEMBER",
+      },
+      { invocation: "trusted", idToken: "write", sccache: "reader", turbo: true },
+    ],
+    [
+      "trusted upper stack layer",
+      {
+        eventName: "pull_request",
+        ref: "refs/pull/2/merge",
+        sameRepository: true,
+        authorAssociation: "COLLABORATOR",
+      },
+      { invocation: "trusted", idToken: "write", sccache: "reader", turbo: true },
+    ],
+    [
+      "outside contributor on same repository",
+      {
+        eventName: "pull_request",
+        ref: "refs/pull/3/merge",
+        sameRepository: true,
+        authorAssociation: "CONTRIBUTOR",
+      },
+      { invocation: "untrusted", idToken: "none", sccache: "none", turbo: false },
     ],
     [
       "fork PR",
-      { eventName: "pull_request", ref: "refs/pull/1/merge" },
-      { sccache: "reader", turbo: false },
+      {
+        eventName: "pull_request",
+        ref: "refs/pull/4/merge",
+        sameRepository: false,
+        authorAssociation: "MEMBER",
+      },
+      { invocation: "untrusted", idToken: "none", sccache: "none", turbo: false },
+    ],
+    [
+      "Dependabot PR",
+      {
+        eventName: "pull_request",
+        ref: "refs/pull/5/merge",
+        sameRepository: true,
+        authorAssociation: "CONTRIBUTOR",
+      },
+      { invocation: "untrusted", idToken: "none", sccache: "none", turbo: false },
     ],
     [
       "manual main",
       { eventName: "workflow_dispatch", ref: "refs/heads/main" },
-      { sccache: "none", turbo: false },
+      { invocation: "untrusted", idToken: "none", sccache: "none", turbo: false },
     ],
     [
       "manual feature",
       { eventName: "workflow_dispatch", ref: "refs/heads/feature/cache-auth" },
-      { sccache: "none", turbo: false },
+      { invocation: "untrusted", idToken: "none", sccache: "none", turbo: false },
     ],
   ];
 
   for (const [name, input, expected] of cases)
     assert.deepEqual(cacheAccessFor(input), expected, name);
+
+  assertEntryCacheTrustBoundary(workflow);
+  assert.doesNotMatch(
+    workflowSuite,
+    /^\s+id-token:/m,
+    "the reusable suite must inherit the caller's job-level OIDC ceiling",
+  );
 });
 
 test("Blacksmith and cache trust contracts reject planted unsafe changes", () => {
@@ -576,30 +720,58 @@ test("Blacksmith and cache trust contracts reject planted unsafe changes", () =>
     () => assertUsesBlacksmithRunner("test-ts", typescript.replace("blacksmith-16vcpu", "jazz-ci")),
     /blacksmith-16vcpu/,
   );
-  assert.doesNotMatch(
-    typescript.replace(
-      "github.event.pull_request.head.repo.full_name == github.repository",
-      "true",
-    ),
-    /if: github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+  assert.throws(
+    () => assertEntryCacheTrustBoundary(workflow.replace("id-token: none", "id-token: write")),
+    /strictly deep-equal/,
+  );
+  assert.throws(
+    () =>
+      assertEntryCacheTrustBoundary(
+        workflow.replace(
+          "\n  trusted:\n",
+          '\n  "credential:escape":\n    permissions:\n      id-token: write\n    runs-on: ubuntu-latest\n    env:\n      AWS_SECRET_ACCESS_KEY: ${{ secrets.CACHE_ESCAPE_KEY }}\n    steps:\n      - run: echo unsafe\n\n  trusted:\n',
+        ),
+      ),
+    /credential boundary must account for every entry-workflow job/,
+  );
+  assert.throws(
+    () =>
+      assertEntryCacheTrustBoundary(
+        workflow.replace(trustedCacheCondition, "github.event_name != 'pull_request'"),
+      ),
+    /strictly equal/,
+  );
+  assert.throws(
+    () =>
+      assertSuiteS3ConfigurationBoundary(
+        workflowSuite.replace(
+          "env:\n  CACHE_SCOPE_REPOSITORY_ID:",
+          "env:\n  SCCACHE_BUCKET: unsafe\n  CACHE_SCOPE_REPOSITORY_ID:",
+        ),
+      ),
+    /untrusted suite callers must not inherit SCCACHE_BUCKET/,
+  );
+  assert.throws(
+    () =>
+      assertSuiteS3ConfigurationBoundary(
+        workflowSuite.replace(
+          `name: Export trusted sccache configuration\n        if: ${sccacheS3}`,
+          "name: Export trusted sccache configuration\n        if: true",
+        ),
+      ),
+    /strictly equal/,
   );
   assert.throws(
     () =>
       assertSccacheTrustBoundary(
-        typescript.replace(
-          sccacheWriter,
-          "github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''",
-        ),
+        typescript.replace("sccache-s3: ${{ " + sccacheS3 + " }}", "sccache-s3: true"),
       ),
-    /a non-PR condition|github\.event_name == 'push'/,
+    /sccache-s3/,
   );
   assert.throws(
     () =>
       assertTurboCredentialConditions(
-        typescript.replace(
-          turboCache,
-          "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository",
-        ),
+        typescript.replace("if: inputs.trusted-cache\n        env:", "if: true\n        env:"),
       ),
     /if:/,
   );

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -112,6 +112,35 @@ const cacheAccessFor = ({ eventName, ref, sameRepositoryPr = false }) => ({
       ["refs/heads/main", "refs/heads/codex/jazz-core-engine-swap"].includes(ref)) ||
     (eventName === "pull_request" && sameRepositoryPr),
 });
+const assertTurboSigningKeyTrustBoundary = (typescriptJob) => {
+  assert.doesNotMatch(
+    typescriptJob,
+    /^      TURBO_REMOTE_CACHE_SIGNATURE_KEY:/m,
+    "the job environment must not expose the signing key to manual feature runs",
+  );
+  const start = typescriptJob.indexOf("name: Export trusted Turbo cache signing key");
+  assert.notEqual(start, -1, "missing conditional Turbo signing-key export");
+  const end = typescriptJob.indexOf("\n      - ", start);
+  const exportStep = typescriptJob.slice(start, end === -1 ? typescriptJob.length : end);
+  assert.match(exportStep, regex(`if: ${turboCache}`));
+  assert.match(
+    exportStep,
+    /CACHE_SIGNATURE_KEY: \$\{\{ secrets\.TURBO_REMOTE_CACHE_SIGNATURE_KEY \}\}/,
+  );
+  assert.match(
+    exportStep,
+    /echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=\$\{CACHE_SIGNATURE_KEY\}" >> "\$\{GITHUB_ENV\}"/,
+  );
+};
+const assertTurboCredentialConditions = (typescriptJob) => {
+  assertTurboSigningKeyTrustBoundary(typescriptJob);
+  const trustedConditions = typescriptJob.match(new RegExp(regex(`if: ${turboCache}`).source, "g"));
+  assert.equal(
+    trustedConditions?.length,
+    2,
+    "the signing-key export and Turbo OIDC setup must share the exact trusted condition",
+  );
+};
 
 test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for wasm-pack", () => {
   const lint = job("lint");
@@ -463,13 +492,14 @@ test("every CI job uses an independently sized Blacksmith runner", () => {
 
 test("Turbo cache uses pinned OIDC policy only for trusted pushes and same-repository PRs", () => {
   const typescript = job("test-ts");
-  assert.match(typescript, regex(`if: ${turboCache}`));
+  assertTurboCredentialConditions(typescript);
   assert.match(typescript, /policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c/);
   assert.match(typescript, /audience: https:\/\/github\.com\/garden-co/);
   assert.match(typescript, /team: garden-co/);
-  assert.match(
-    typescript,
-    /TURBO_REMOTE_CACHE_SIGNATURE_KEY: \$\{\{ secrets\.TURBO_REMOTE_CACHE_SIGNATURE_KEY \}\}/,
+  assert.ok(
+    typescript.indexOf("name: Export trusted Turbo cache signing key") <
+      typescript.indexOf("name: Set up signed Turbo Remote Cache"),
+    "export the signing key before the trusted Turbo setup step",
   );
   assert.match(fs.readFileSync(path.join(root, "turbo.json"), "utf8"), /"signature": true/);
   for (const releaseWorkflow of otherWorkflows)
@@ -565,14 +595,23 @@ test("Blacksmith and cache trust contracts reject planted unsafe changes", () =>
   );
   assert.throws(
     () =>
-      assert.match(
+      assertTurboCredentialConditions(
         typescript.replace(
           turboCache,
           "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository",
         ),
-        regex(`if: ${turboCache}`),
       ),
     /if:/,
+  );
+  assert.throws(
+    () =>
+      assertTurboSigningKeyTrustBoundary(
+        typescript.replace(
+          "    steps:\n",
+          "    env:\n      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}\n    steps:\n",
+        ),
+      ),
+    /job environment must not expose the signing key/,
   );
 });
 

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -82,6 +82,36 @@ const assertIntegrationCheckIsGating = (typescriptJob) => {
     "integration workspace check must not suppress its failure",
   );
 };
+const trustedCachePush =
+  "github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/codex/jazz-core-engine-swap')";
+const sccacheReader = "github.event_name == 'pull_request'";
+const sccacheWriter = `${trustedCachePush} && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''`;
+const sccacheS3 = `(${sccacheReader} && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') || (${sccacheWriter})`;
+const turboCache = `(${trustedCachePush}) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)`;
+const regex = (source) => new RegExp(source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+const assertSccacheTrustBoundary = (source) => {
+  assert.match(source, regex(`if: ${sccacheReader} && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''`));
+  assert.match(source, regex(`if: ${sccacheWriter}`));
+  assert.match(source, regex("sccache-s3: ${{ " + sccacheS3 + " }}"));
+  assert.doesNotMatch(
+    source,
+    /github\.event_name != 'pull_request'/,
+    "a non-PR condition would give workflow_dispatch the writer role",
+  );
+};
+const cacheAccessFor = ({ eventName, ref, sameRepositoryPr = false }) => ({
+  sccache:
+    eventName === "pull_request"
+      ? "reader"
+      : eventName === "push" &&
+          ["refs/heads/main", "refs/heads/codex/jazz-core-engine-swap"].includes(ref)
+        ? "writer"
+        : "none",
+  turbo:
+    (eventName === "push" &&
+      ["refs/heads/main", "refs/heads/codex/jazz-core-engine-swap"].includes(ref)) ||
+    (eventName === "pull_request" && sameRepositoryPr),
+});
 
 test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for wasm-pack", () => {
   const lint = job("lint");
@@ -431,12 +461,9 @@ test("every CI job uses an independently sized Blacksmith runner", () => {
   }
 });
 
-test("Turbo cache uses pinned OIDC policy, signing, and excludes fork PRs", () => {
+test("Turbo cache uses pinned OIDC policy only for trusted pushes and same-repository PRs", () => {
   const typescript = job("test-ts");
-  assert.match(
-    typescript,
-    /if: github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
-  );
+  assert.match(typescript, regex(`if: ${turboCache}`));
   assert.match(typescript, /policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c/);
   assert.match(typescript, /audience: https:\/\/github\.com\/garden-co/);
   assert.match(typescript, /team: garden-co/);
@@ -458,6 +485,7 @@ test("shared Rust cache separates read-only PRs from trusted writers", () => {
     const source = job(name);
     assert.match(source, /role-to-assume: \$\{\{ vars\.SCCACHE_PR_READER_AWS_ROLE_ARN \}\}/);
     assert.match(source, /role-to-assume: \$\{\{ vars\.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN \}\}/);
+    assertSccacheTrustBoundary(source);
   }
   assert.match(workflow, /SCCACHE_S3_KEY_PREFIX: jazz-ci\/v1\/production\/blacksmith-v1/);
   assert.doesNotMatch(
@@ -467,6 +495,49 @@ test("shared Rust cache separates read-only PRs from trusted writers", () => {
   );
   assert.match(setupBlacksmithAction, /SCCACHE_MULTILEVEL_CHAIN=disk,s3/);
   assert.match(setupBlacksmithAction, /SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY=l0/);
+});
+
+test("cache credential policy has no manual-dispatch writer path", () => {
+  const cases = [
+    [
+      "main push",
+      { eventName: "push", ref: "refs/heads/main" },
+      { sccache: "writer", turbo: true },
+    ],
+    [
+      "integration push",
+      { eventName: "push", ref: "refs/heads/codex/jazz-core-engine-swap" },
+      { sccache: "writer", turbo: true },
+    ],
+    [
+      "feature push",
+      { eventName: "push", ref: "refs/heads/feature/cache-auth" },
+      { sccache: "none", turbo: false },
+    ],
+    [
+      "same-repository PR",
+      { eventName: "pull_request", ref: "refs/pull/1/merge", sameRepositoryPr: true },
+      { sccache: "reader", turbo: true },
+    ],
+    [
+      "fork PR",
+      { eventName: "pull_request", ref: "refs/pull/1/merge" },
+      { sccache: "reader", turbo: false },
+    ],
+    [
+      "manual main",
+      { eventName: "workflow_dispatch", ref: "refs/heads/main" },
+      { sccache: "none", turbo: false },
+    ],
+    [
+      "manual feature",
+      { eventName: "workflow_dispatch", ref: "refs/heads/feature/cache-auth" },
+      { sccache: "none", turbo: false },
+    ],
+  ];
+
+  for (const [name, input, expected] of cases)
+    assert.deepEqual(cacheAccessFor(input), expected, name);
 });
 
 test("Blacksmith and cache trust contracts reject planted unsafe changes", () => {
@@ -481,6 +552,27 @@ test("Blacksmith and cache trust contracts reject planted unsafe changes", () =>
       "true",
     ),
     /if: github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+  );
+  assert.throws(
+    () =>
+      assertSccacheTrustBoundary(
+        typescript.replace(
+          sccacheWriter,
+          "github.event_name != 'pull_request' && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''",
+        ),
+      ),
+    /a non-PR condition|github\.event_name == 'push'/,
+  );
+  assert.throws(
+    () =>
+      assert.match(
+        typescript.replace(
+          turboCache,
+          "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository",
+        ),
+        regex(`if: ${turboCache}`),
+      ),
+    /if:/,
   );
 });
 

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -427,7 +427,7 @@ test("aborting a real subprocess terminates its spawned child", async () => {
 
 test("CI uses the correctness artifact path while package builds keep release WASM", () => {
   const workflow = readFileSync(
-    new URL("../../../.github/workflows/ci.yml", import.meta.url),
+    new URL("../../../.github/workflows/ci-suite.yml", import.meta.url),
     "utf8",
   );
   const packageJson = readFileSync(new URL("../../../package.json", import.meta.url), "utf8");

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "pkg-pr-new": "^0.0.75",
     "playwright": "^1.58.2",
     "turbo": "^2.0.0",
-    "typescript": "catalog:default"
+    "typescript": "catalog:default",
+    "yaml": "2.8.2"
   },
   "engines": {
     "node": ">=22.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       typescript:
         specifier: catalog:default
         version: 6.0.2
+      yaml:
+        specifier: 2.8.2
+        version: 2.8.2
 
   crates: {}
 


### PR DESCRIPTION
🤖 Make the CI cache credential boundary explicit at the job-permission level while preserving fast CI for heavily stacked trusted work.

The entry workflow has two mutually exclusive reusable-suite callers:

- pushes to `main`, plus same-repository PRs authored by `OWNER`, `MEMBER`, or `COLLABORATOR`, receive OIDC, inherited cache secrets, sccache writer access, and signed Turbo caches;
- outside contributors, forks, Dependabot, and manual dispatches run with `id-token: none`, no inherited secrets, no S3 configuration, and disk-only sccache.

Pull requests are deliberately unfiltered by base branch, so every upper layer of a feature-branch stack receives CI. The former integration branch has no trigger or privileged role.

The reusable suite contains the shared full CI coverage and cannot elevate the caller permission ceiling. A stable aggregate `test-rust` check preserves branch-protection behavior.

The executable contract structurally parses YAML, requires exactly the intended entry jobs, and asserts each permission/input/secret surface. Planted broad-writer, Turbo, job-level-secret, suite-elevation, unexpected-job, quoted-colon credential-escape, contributor, fork-identity, and PR-base-filter mutations are detected.

Threat model: repository workflow maintainers and write-capable collaborators are trusted control-plane actors. The trust predicate reflects that model; it does not grant credentials to forked PR code.

Independent adversarial review passed across the security redesign and trusted-stack amendment. The previous real GitHub untrusted run completed fully green with disk-only sccache; this amended run will exercise the trusted PR path.