### PR TITLE
Add BigLabel read benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -40,10 +40,10 @@ jobs:
         run: cargo install cargo-codspeed --version 5.0.1 --locked
 
       - name: Build example benchmark suites
-        run: cargo codspeed build --package jazz-example-benchmark-smoke
+        run: cargo codspeed build --package jazz-example-benchmark-smoke --package jazz-example-big-label-benchmark
 
       - name: Run example benchmark suites
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: simulation
-          run: cargo codspeed run --package jazz-example-benchmark-smoke
+          run: cargo codspeed run --package jazz-example-benchmark-smoke --package jazz-example-big-label-benchmark

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "jazz-example-big-label-benchmark"
+version = "0.1.0"
+dependencies = [
+ "codspeed-divan-compat",
+ "jazz",
+]
+
+[[package]]
 name = "jazz-napi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   # gates until they are rebuilt around the new server boundary.
   # "examples/todo-server-rs",
   # "examples/docs/todo-server-rs",
+  "examples/big-label/benchmarks",
   "examples/benchmarks/smoke",
   "dev/benchmarks/storage/bench-core",
 ]

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -843,6 +843,25 @@ test("CodSpeed caches the root-workspace Cargo target", () => {
   );
 });
 
+test("CodSpeed builds and runs the BigLabel benchmark variant", () => {
+  for (const command of ["build", "run"]) {
+    assert.match(
+      codspeedWorkflow,
+      new RegExp(
+        `cargo codspeed ${command} --package jazz-example-benchmark-smoke --package jazz-example-big-label-benchmark`,
+      ),
+    );
+  }
+  assert.throws(
+    () =>
+      assert.match(
+        codspeedWorkflow.replaceAll(" --package jazz-example-big-label-benchmark", ""),
+        /jazz-example-big-label-benchmark/,
+      ),
+    /jazz-example-big-label-benchmark/,
+  );
+});
+
 test("Windows NAPI release builds provision libclang for RocksDB bindgen", () => {
   const windowsNapiSetup =
     /name: Install libclang for Windows bindgen[\s\S]*if: matrix\.platform == 'win32-x64-msvc'[\s\S]*choco install llvm --version=21\.1\.8 --yes --no-progress --limit-output[\s\S]*Test-Path \(Join-Path \$libclangPath "libclang\.dll"\)[\s\S]*LIBCLANG_PATH=\$libclangPath[\s\S]*\$env:GITHUB_PATH/;

--- a/examples/big-label/benchmarks/Cargo.toml
+++ b/examples/big-label/benchmarks/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "jazz-example-big-label-benchmark"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+jazz = { workspace = true }
+
+[dev-dependencies]
+divan = { workspace = true }
+
+[[bench]]
+name = "loads"
+harness = false

--- a/examples/big-label/benchmarks/README.md
+++ b/examples/big-label/benchmarks/README.md
@@ -1,0 +1,24 @@
+# BigLabel benchmark variant
+
+This package is a self-contained Rust model of BigLabel's read-heavy record-label
+workload. It intentionally duplicates the schema and deterministic fixture needed
+for measurement; it does not import application runtime helpers.
+
+The fixture creates four catalogues, eight labels, 32 artists, and either 512 or
+4,096 releases. Release rows carry indexed label, primary-artist, catalogue, and
+release-time fields. The measured workloads are prepared, ordered Jazz reads for:
+
+- a label's releases;
+- an artist's releases;
+- a catalogue's releases.
+
+Database opening, schema compilation, fixture insertion, local-durability waits,
+and query preparation happen before each measured closure. The returned row count
+is black-boxed so the read cannot be optimized away.
+
+Run locally with:
+
+```sh
+cargo test -p jazz-example-big-label-benchmark
+cargo bench -p jazz-example-big-label-benchmark --bench loads
+```

--- a/examples/big-label/benchmarks/benches/loads.rs
+++ b/examples/big-label/benchmarks/benches/loads.rs
@@ -1,0 +1,23 @@
+use jazz_example_big_label_benchmark::Fixture;
+
+fn main() {
+    divan::main();
+}
+
+#[divan::bench(args = [512, 4096])]
+fn label_load(bencher: divan::Bencher<'_, '_>, release_count: usize) {
+    let fixture = Fixture::new(release_count);
+    bencher.bench_local(|| divan::black_box(fixture.label_load()));
+}
+
+#[divan::bench(args = [512, 4096])]
+fn artist_load(bencher: divan::Bencher<'_, '_>, release_count: usize) {
+    let fixture = Fixture::new(release_count);
+    bencher.bench_local(|| divan::black_box(fixture.artist_load()));
+}
+
+#[divan::bench(args = [512, 4096])]
+fn catalog_load(bencher: divan::Bencher<'_, '_>, release_count: usize) {
+    let fixture = Fixture::new(release_count);
+    bencher.bench_local(|| divan::black_box(fixture.catalog_load()));
+}

--- a/examples/big-label/benchmarks/src/lib.rs
+++ b/examples/big-label/benchmarks/src/lib.rs
@@ -10,7 +10,7 @@ use jazz::groove::records::Value;
 use jazz::groove::storage::MemoryStorage;
 use jazz::ids::{AuthorId, NodeUuid, RowUuid};
 use jazz::query::{OrderDirection, Query, col, eq, lit};
-use jazz::schema::JazzSchema;
+use jazz::schema::{JazzSchema, TableSchema};
 use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
 use jazz::tx::DurabilityTier;
 
@@ -24,6 +24,7 @@ type BenchDb = Db<MemoryStorage>;
 /// outside the measured closure.
 pub struct Fixture {
     db: BenchDb,
+    release_table: TableSchema,
     label_load: PreparedQuery,
     artist_load: PreparedQuery,
     catalog_load: PreparedQuery,
@@ -32,7 +33,7 @@ pub struct Fixture {
 impl Fixture {
     pub fn new(release_count: usize) -> Self {
         assert!(release_count > 0, "fixture requires at least one release");
-        let db = open_db();
+        let (db, release_table) = open_db();
 
         for label in 0..LABELS {
             insert(
@@ -100,6 +101,7 @@ impl Fixture {
         let catalog_load = prepare_release_load(&db, "catalog", row_id(3, 0));
         Self {
             db,
+            release_table,
             label_load,
             artist_load,
             catalog_load,
@@ -118,11 +120,27 @@ impl Fixture {
         self.read_count(&self.catalog_load)
     }
 
+    pub fn label_release_order(&self) -> Vec<u64> {
+        self.release_order(&self.label_load)
+    }
+
     fn read_count(&self, query: &PreparedQuery) -> usize {
         self.db
             .read(query)
             .expect("BigLabel benchmark read succeeds")
             .len()
+    }
+
+    fn release_order(&self, query: &PreparedQuery) -> Vec<u64> {
+        self.db
+            .read(query)
+            .expect("BigLabel benchmark read succeeds")
+            .into_iter()
+            .map(|row| match row.cell(&self.release_table, "released_at") {
+                Some(Value::U64(released_at)) => released_at,
+                other => panic!("release has unexpected released_at value: {other:?}"),
+            })
+            .collect()
     }
 }
 
@@ -162,8 +180,14 @@ fn schema() -> JazzSchema {
     JazzSchema::new(&source).expect("BigLabel benchmark schema compiles")
 }
 
-fn open_db() -> BenchDb {
+fn open_db() -> (BenchDb, TableSchema) {
     let schema = schema();
+    let release_table = schema
+        .tables()
+        .iter()
+        .find(|table| table.name == "releases")
+        .expect("BigLabel schema has releases")
+        .clone();
     let families = schema.column_families();
     let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
     let db = block_on(Db::open(DbConfig::new(
@@ -187,7 +211,7 @@ fn open_db() -> BenchDb {
             )]),
         );
     }
-    db
+    (db, release_table)
 }
 
 fn insert(db: &BenchDb, table: &str, id: RowUuid, cells: BTreeMap<String, Value>) {

--- a/examples/big-label/benchmarks/src/lib.rs
+++ b/examples/big-label/benchmarks/src/lib.rs
@@ -1,0 +1,212 @@
+//! Self-contained BigLabel fixture and representative read workloads.
+//!
+//! This deliberately duplicates the small schema surface needed by the
+//! benchmark. It does not import an application runtime or fixture helper.
+
+use std::collections::BTreeMap;
+
+use jazz::db::{Db, DbConfig, DbIdentity, PreparedQuery, block_on};
+use jazz::groove::records::Value;
+use jazz::groove::storage::MemoryStorage;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, col, eq, lit};
+use jazz::schema::JazzSchema;
+use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+use jazz::tx::DurabilityTier;
+
+const LABELS: usize = 8;
+const ARTISTS: usize = 32;
+const CATALOGS: usize = 4;
+
+type BenchDb = Db<MemoryStorage>;
+
+/// Prepared BigLabel fixture. Construction and seeding are intentionally kept
+/// outside the measured closure.
+pub struct Fixture {
+    db: BenchDb,
+    label_load: PreparedQuery,
+    artist_load: PreparedQuery,
+    catalog_load: PreparedQuery,
+}
+
+impl Fixture {
+    pub fn new(release_count: usize) -> Self {
+        assert!(release_count > 0, "fixture requires at least one release");
+        let db = open_db();
+
+        for label in 0..LABELS {
+            insert(
+                &db,
+                "labels",
+                row_id(1, label),
+                BTreeMap::from([
+                    (
+                        "name".to_owned(),
+                        Value::String(format!("Label {label:02}")),
+                    ),
+                    (
+                        "catalog".to_owned(),
+                        Value::Uuid(row_id(3, label % CATALOGS).0),
+                    ),
+                ]),
+            );
+        }
+        for artist in 0..ARTISTS {
+            insert(
+                &db,
+                "artists",
+                row_id(2, artist),
+                BTreeMap::from([
+                    (
+                        "name".to_owned(),
+                        Value::String(format!("Artist {artist:03}")),
+                    ),
+                    (
+                        "label".to_owned(),
+                        Value::Uuid(row_id(1, artist % LABELS).0),
+                    ),
+                ]),
+            );
+        }
+        for release in 0..release_count {
+            insert(
+                &db,
+                "releases",
+                row_id(4, release),
+                BTreeMap::from([
+                    (
+                        "title".to_owned(),
+                        Value::String(format!("Release {release:06}")),
+                    ),
+                    (
+                        "label".to_owned(),
+                        Value::Uuid(row_id(1, release % LABELS).0),
+                    ),
+                    (
+                        "artist".to_owned(),
+                        Value::Uuid(row_id(2, release % ARTISTS).0),
+                    ),
+                    (
+                        "catalog".to_owned(),
+                        Value::Uuid(row_id(3, release % CATALOGS).0),
+                    ),
+                    ("released_at".to_owned(), Value::U64(release as u64)),
+                ]),
+            );
+        }
+
+        let label_load = prepare_release_load(&db, "label", row_id(1, 0));
+        let artist_load = prepare_release_load(&db, "artist", row_id(2, 0));
+        let catalog_load = prepare_release_load(&db, "catalog", row_id(3, 0));
+        Self {
+            db,
+            label_load,
+            artist_load,
+            catalog_load,
+        }
+    }
+
+    pub fn label_load(&self) -> usize {
+        self.read_count(&self.label_load)
+    }
+
+    pub fn artist_load(&self) -> usize {
+        self.read_count(&self.artist_load)
+    }
+
+    pub fn catalog_load(&self) -> usize {
+        self.read_count(&self.catalog_load)
+    }
+
+    fn read_count(&self, query: &PreparedQuery) -> usize {
+        self.db
+            .read(query)
+            .expect("BigLabel benchmark read succeeds")
+            .len()
+    }
+}
+
+pub fn expected_counts(release_count: usize) -> (usize, usize, usize) {
+    (
+        release_count.div_ceil(LABELS),
+        release_count.div_ceil(ARTISTS),
+        release_count.div_ceil(CATALOGS),
+    )
+}
+
+fn schema() -> JazzSchema {
+    let source = SchemaBuilder::new()
+        .table(
+            TableSchemaBuilder::new("labels")
+                .column("name", ColumnType::Text)
+                .fk_column("catalog", "catalogs")
+                .index_only(["catalog"]),
+        )
+        .table(
+            TableSchemaBuilder::new("artists")
+                .column("name", ColumnType::Text)
+                .fk_column("label", "labels")
+                .index_only(["label"]),
+        )
+        .table(TableSchemaBuilder::new("catalogs").column("name", ColumnType::Text))
+        .table(
+            TableSchemaBuilder::new("releases")
+                .column("title", ColumnType::Text)
+                .fk_column("label", "labels")
+                .fk_column("artist", "artists")
+                .fk_column("catalog", "catalogs")
+                .column("released_at", ColumnType::Timestamp)
+                .index_only(["label", "artist", "catalog", "released_at"]),
+        )
+        .build();
+    JazzSchema::new(&source).expect("BigLabel benchmark schema compiles")
+}
+
+fn open_db() -> BenchDb {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        MemoryStorage::new(&family_refs),
+        DbIdentity {
+            node: NodeUuid::from_bytes([0xb1; 16]),
+            author: AuthorId::SYSTEM,
+        },
+    )))
+    .expect("open BigLabel benchmark database");
+
+    for catalog in 0..CATALOGS {
+        insert(
+            &db,
+            "catalogs",
+            row_id(3, catalog),
+            BTreeMap::from([(
+                "name".to_owned(),
+                Value::String(format!("Catalog {catalog:02}")),
+            )]),
+        );
+    }
+    db
+}
+
+fn insert(db: &BenchDb, table: &str, id: RowUuid, cells: BTreeMap<String, Value>) {
+    let write = block_on(db.insert_with_id(table, id, cells)).expect("insert BigLabel fixture row");
+    block_on(write.wait(DurabilityTier::Local)).expect("fixture row reaches local durability");
+}
+
+fn prepare_release_load(db: &BenchDb, column: &str, id: RowUuid) -> PreparedQuery {
+    db.prepare_query(
+        &Query::from("releases")
+            .filter(eq(col(column), lit(id.0)))
+            .order_by("released_at", OrderDirection::Desc),
+    )
+    .expect("prepare BigLabel release load")
+}
+
+fn row_id(kind: u8, index: usize) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[0] = kind;
+    bytes[8..].copy_from_slice(&(index as u64).to_be_bytes());
+    RowUuid::from_bytes(bytes)
+}

--- a/examples/big-label/benchmarks/tests/workloads.rs
+++ b/examples/big-label/benchmarks/tests/workloads.rs
@@ -12,3 +12,15 @@ fn representative_loads_return_exact_rows_at_each_benchmark_scale() {
         assert_eq!(actual, expected_counts(release_count));
     }
 }
+
+#[test]
+fn representative_loads_are_newest_release_first() {
+    let release_count = 512;
+    let fixture = Fixture::new(release_count);
+
+    let expected = (0..release_count as u64)
+        .filter(|release| release % 8 == 0)
+        .rev()
+        .collect::<Vec<_>>();
+    assert_eq!(fixture.label_release_order(), expected);
+}

--- a/examples/big-label/benchmarks/tests/workloads.rs
+++ b/examples/big-label/benchmarks/tests/workloads.rs
@@ -1,0 +1,14 @@
+use jazz_example_big_label_benchmark::{Fixture, expected_counts};
+
+#[test]
+fn representative_loads_return_exact_rows_at_each_benchmark_scale() {
+    for release_count in [512, 4096] {
+        let fixture = Fixture::new(release_count);
+        let actual = (
+            fixture.label_load(),
+            fixture.artist_load(),
+            fixture.catalog_load(),
+        );
+        assert_eq!(actual, expected_counts(release_count));
+    }
+}


### PR DESCRIPTION
🤖 Add the first app-specific benchmark variant on top of #1738 using BigLabel-shaped catalogue reads.

The package is self-contained: it duplicates only the label, artist, catalogue, and release schema/query shapes needed for the workload rather than importing app runtime helpers. Deterministic fixtures cover 512 and 4096 releases with indexed foreign keys and release timestamps.

Divan/CodSpeed measures three prepared ordered reads at both scales:
- releases for a label
- releases for an artist
- releases for a catalogue

Schema compilation, database open, seeding, durability waits, and query preparation all occur outside the measured closure. Results are black-boxed. Receipts assert exact cardinalities and descending release order through the same prepared query; planted filter and ordering regressions fail deterministically.

Independent adversarial review passed. Local Divan and CodSpeed simulation discovered all six cases.

Stack: #1738 → this PR.