### PR TITLE
Add BandChat read benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -40,10 +40,10 @@ jobs:
         run: cargo install cargo-codspeed --version 5.0.1 --locked
 
       - name: Build example benchmark suites
-        run: cargo codspeed build --package jazz-example-benchmark-smoke --package jazz-example-big-label-benchmark
+        run: cargo codspeed build --package jazz-example-benchmark-smoke --package jazz-example-big-label-benchmark --package jazz-example-band-chat-benchmark
 
       - name: Run example benchmark suites
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: simulation
-          run: cargo codspeed run --package jazz-example-benchmark-smoke --package jazz-example-big-label-benchmark
+          run: cargo codspeed run --package jazz-example-benchmark-smoke --package jazz-example-big-label-benchmark --package jazz-example-band-chat-benchmark

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "jazz-example-band-chat-benchmark"
+version = "0.1.0"
+dependencies = [
+ "codspeed-divan-compat",
+ "jazz",
+]
+
+[[package]]
 name = "jazz-example-benchmark-smoke"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   # "examples/todo-server-rs",
   # "examples/docs/todo-server-rs",
   "examples/big-label/benchmarks",
+  "examples/band-chat/benchmarks",
   "examples/benchmarks/smoke",
   "dev/benchmarks/storage/bench-core",
 ]

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -862,6 +862,23 @@ test("CodSpeed builds and runs the BigLabel benchmark variant", () => {
   );
 });
 
+test("CodSpeed builds and runs the BandChat benchmark variant", () => {
+  for (const command of ["build", "run"]) {
+    assert.match(
+      codspeedWorkflow,
+      new RegExp(`cargo codspeed ${command} [^\\n]*--package jazz-example-band-chat-benchmark`),
+    );
+  }
+  assert.throws(
+    () =>
+      assert.match(
+        codspeedWorkflow.replaceAll(" --package jazz-example-band-chat-benchmark", ""),
+        /jazz-example-band-chat-benchmark/,
+      ),
+    /jazz-example-band-chat-benchmark/,
+  );
+});
+
 test("Windows NAPI release builds provision libclang for RocksDB bindgen", () => {
   const windowsNapiSetup =
     /name: Install libclang for Windows bindgen[\s\S]*if: matrix\.platform == 'win32-x64-msvc'[\s\S]*choco install llvm --version=21\.1\.8 --yes --no-progress --limit-output[\s\S]*Test-Path \(Join-Path \$libclangPath "libclang\.dll"\)[\s\S]*LIBCLANG_PATH=\$libclangPath[\s\S]*\$env:GITHUB_PATH/;

--- a/examples/band-chat/benchmarks/Cargo.toml
+++ b/examples/band-chat/benchmarks/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "jazz-example-band-chat-benchmark"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+jazz = { workspace = true }
+
+[dev-dependencies]
+divan = { workspace = true }
+
+[[bench]]
+name = "loads"
+harness = false

--- a/examples/band-chat/benchmarks/README.md
+++ b/examples/band-chat/benchmarks/README.md
@@ -1,0 +1,23 @@
+# BandChat benchmark variant
+
+This self-contained Rust package duplicates only the BandChat schema and query
+shapes needed for measurement. It does not import the application runtime or its
+fixture helpers.
+
+At two scales (1,024 and 4,096 messages), the deterministic fixture creates 32
+users, one room per 16 messages, one membership per room, and a 100-message hot
+room. The measured prepared Jazz reads cover:
+
+- the second 25-message page of a room timeline, newest first;
+- unread rooms for one member, ordered by recent activity;
+- one author's message history, newest first.
+
+Database opening, schema compilation, seeding, local-durability waits, and query
+preparation occur before each Divan measured closure. Only the read and returned
+row count are measured and black-boxed. Tests separately assert exact result
+cardinality, pagination, filtering, and order.
+
+```sh
+cargo test -p jazz-example-band-chat-benchmark
+cargo bench -p jazz-example-band-chat-benchmark --bench loads
+```

--- a/examples/band-chat/benchmarks/README.md
+++ b/examples/band-chat/benchmarks/README.md
@@ -6,7 +6,8 @@ fixture helpers.
 
 At two scales (1,024 and 4,096 messages), the deterministic fixture creates 32
 users, one room per 16 messages, one membership per room, and a 100-message hot
-room. The measured prepared Jazz reads cover:
+room. Each member's successive room memberships alternate unread/read so the
+unread predicate selects a strict subset. The measured prepared Jazz reads cover:
 
 - the second 25-message page of a room timeline, newest first;
 - unread rooms for one member, ordered by recent activity;

--- a/examples/band-chat/benchmarks/benches/loads.rs
+++ b/examples/band-chat/benchmarks/benches/loads.rs
@@ -1,0 +1,23 @@
+use jazz_example_band_chat_benchmark::Fixture;
+
+fn main() {
+    divan::main();
+}
+
+#[divan::bench(args = [1024, 4096])]
+fn timeline_second_page(bencher: divan::Bencher<'_, '_>, message_count: usize) {
+    let fixture = Fixture::new(message_count);
+    bencher.bench_local(|| divan::black_box(fixture.timeline_page_count()));
+}
+
+#[divan::bench(args = [1024, 4096])]
+fn unread_recent_rooms(bencher: divan::Bencher<'_, '_>, message_count: usize) {
+    let fixture = Fixture::new(message_count);
+    bencher.bench_local(|| divan::black_box(fixture.unread_room_count()));
+}
+
+#[divan::bench(args = [1024, 4096])]
+fn author_history(bencher: divan::Bencher<'_, '_>, message_count: usize) {
+    let fixture = Fixture::new(message_count);
+    bencher.bench_local(|| divan::black_box(fixture.author_history_count()));
+}

--- a/examples/band-chat/benchmarks/src/lib.rs
+++ b/examples/band-chat/benchmarks/src/lib.rs
@@ -1,0 +1,248 @@
+//! Self-contained BandChat schema, fixture, and representative read workloads.
+//!
+//! The benchmark intentionally duplicates this small schema surface rather
+//! than importing application runtime or fixture helpers.
+
+use std::collections::BTreeMap;
+
+use jazz::db::{Db, DbConfig, DbIdentity, PreparedQuery, block_on};
+use jazz::groove::records::Value;
+use jazz::groove::storage::MemoryStorage;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, col, eq, lit};
+use jazz::schema::{JazzSchema, TableSchema};
+use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+use jazz::tx::DurabilityTier;
+
+const AUTHORS: usize = 32;
+const MESSAGES_PER_ROOM: usize = 16;
+const HOT_ROOM_MESSAGES: usize = 100;
+const TIMELINE_OFFSET: usize = 25;
+const TIMELINE_PAGE: usize = 25;
+
+type BenchDb = Db<MemoryStorage>;
+
+pub struct Fixture {
+    db: BenchDb,
+    messages_table: TableSchema,
+    memberships_table: TableSchema,
+    timeline: PreparedQuery,
+    unread_rooms: PreparedQuery,
+    author_history: PreparedQuery,
+}
+
+impl Fixture {
+    /// Open, seed, and prepare all query shapes before benchmark timing starts.
+    pub fn new(message_count: usize) -> Self {
+        assert!(message_count >= HOT_ROOM_MESSAGES + MESSAGES_PER_ROOM);
+        assert!(message_count.is_multiple_of(MESSAGES_PER_ROOM));
+        let room_count = message_count / MESSAGES_PER_ROOM;
+        let (db, messages_table, memberships_table) = open_db();
+
+        for author in 0..AUTHORS {
+            insert(
+                &db,
+                "users",
+                row_id(1, author),
+                BTreeMap::from([(
+                    "display_name".to_owned(),
+                    Value::String(format!("Member {author:02}")),
+                )]),
+            );
+        }
+        for room in 0..room_count {
+            insert(
+                &db,
+                "rooms",
+                row_id(2, room),
+                BTreeMap::from([("name".to_owned(), Value::String(format!("Room {room:04}")))]),
+            );
+            insert(
+                &db,
+                "memberships",
+                row_id(3, room),
+                BTreeMap::from([
+                    ("room".to_owned(), Value::Uuid(row_id(2, room).0)),
+                    (
+                        "member".to_owned(),
+                        Value::Uuid(row_id(1, room % AUTHORS).0),
+                    ),
+                    ("unread".to_owned(), Value::Bool(room.is_multiple_of(2))),
+                    ("last_activity".to_owned(), Value::U64(room as u64)),
+                ]),
+            );
+        }
+        for message in 0..message_count {
+            let room = if message < HOT_ROOM_MESSAGES {
+                0
+            } else {
+                1 + (message - HOT_ROOM_MESSAGES) % (room_count - 1)
+            };
+            insert(
+                &db,
+                "messages",
+                row_id(4, message),
+                BTreeMap::from([
+                    ("room".to_owned(), Value::Uuid(row_id(2, room).0)),
+                    (
+                        "author".to_owned(),
+                        Value::Uuid(row_id(1, message % AUTHORS).0),
+                    ),
+                    (
+                        "body".to_owned(),
+                        Value::String(format!("Message {message:06}")),
+                    ),
+                    ("sent_at".to_owned(), Value::U64(message as u64)),
+                ]),
+            );
+        }
+
+        let timeline = db
+            .prepare_query(
+                &Query::from("messages")
+                    .filter(eq(col("room"), lit(row_id(2, 0).0)))
+                    .order_by("sent_at", OrderDirection::Desc)
+                    .offset(TIMELINE_OFFSET)
+                    .limit(TIMELINE_PAGE),
+            )
+            .expect("prepare room timeline page");
+        let unread_rooms = db
+            .prepare_query(
+                &Query::from("memberships")
+                    .filter(eq(col("member"), lit(row_id(1, 0).0)))
+                    .filter(eq(col("unread"), lit(true)))
+                    .order_by("last_activity", OrderDirection::Desc),
+            )
+            .expect("prepare unread recent-room lookup");
+        let author_history = db
+            .prepare_query(
+                &Query::from("messages")
+                    .filter(eq(col("author"), lit(row_id(1, 0).0)))
+                    .order_by("sent_at", OrderDirection::Desc),
+            )
+            .expect("prepare author message history");
+
+        Self {
+            db,
+            messages_table,
+            memberships_table,
+            timeline,
+            unread_rooms,
+            author_history,
+        }
+    }
+
+    pub fn timeline_page_count(&self) -> usize {
+        self.read_count(&self.timeline)
+    }
+
+    pub fn unread_room_count(&self) -> usize {
+        self.read_count(&self.unread_rooms)
+    }
+
+    pub fn author_history_count(&self) -> usize {
+        self.read_count(&self.author_history)
+    }
+
+    pub fn timeline_sent_at(&self) -> Vec<u64> {
+        self.ordered_values(&self.timeline, &self.messages_table, "sent_at")
+    }
+
+    pub fn unread_room_activity(&self) -> Vec<u64> {
+        self.ordered_values(&self.unread_rooms, &self.memberships_table, "last_activity")
+    }
+
+    pub fn author_history_sent_at(&self) -> Vec<u64> {
+        self.ordered_values(&self.author_history, &self.messages_table, "sent_at")
+    }
+
+    fn read_count(&self, query: &PreparedQuery) -> usize {
+        self.db
+            .read(query)
+            .expect("BandChat benchmark read succeeds")
+            .len()
+    }
+
+    fn ordered_values(&self, query: &PreparedQuery, table: &TableSchema, column: &str) -> Vec<u64> {
+        self.db
+            .read(query)
+            .expect("BandChat benchmark read succeeds")
+            .into_iter()
+            .map(|row| match row.cell(table, column) {
+                Some(Value::U64(value)) => value,
+                other => panic!("unexpected {column} value: {other:?}"),
+            })
+            .collect()
+    }
+}
+
+pub fn expected_counts(message_count: usize) -> (usize, usize, usize) {
+    let room_count = message_count / MESSAGES_PER_ROOM;
+    (
+        TIMELINE_PAGE,
+        room_count.div_ceil(AUTHORS),
+        message_count.div_ceil(AUTHORS),
+    )
+}
+
+fn schema() -> JazzSchema {
+    let source = SchemaBuilder::new()
+        .table(TableSchemaBuilder::new("users").column("display_name", ColumnType::Text))
+        .table(TableSchemaBuilder::new("rooms").column("name", ColumnType::Text))
+        .table(
+            TableSchemaBuilder::new("memberships")
+                .fk_column("room", "rooms")
+                .fk_column("member", "users")
+                .column("unread", ColumnType::Boolean)
+                .column("last_activity", ColumnType::Timestamp)
+                .index_only(["room", "member", "unread", "last_activity"]),
+        )
+        .table(
+            TableSchemaBuilder::new("messages")
+                .fk_column("room", "rooms")
+                .fk_column("author", "users")
+                .column("body", ColumnType::Text)
+                .column("sent_at", ColumnType::Timestamp)
+                .index_only(["room", "author", "sent_at"]),
+        )
+        .build();
+    JazzSchema::new(&source).expect("BandChat benchmark schema compiles")
+}
+
+fn open_db() -> (BenchDb, TableSchema, TableSchema) {
+    let schema = schema();
+    let table = |name: &str| {
+        schema
+            .tables()
+            .iter()
+            .find(|table| table.name == name)
+            .unwrap_or_else(|| panic!("BandChat schema has {name}"))
+            .clone()
+    };
+    let messages_table = table("messages");
+    let memberships_table = table("memberships");
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        MemoryStorage::new(&family_refs),
+        DbIdentity {
+            node: NodeUuid::from_bytes([0xbc; 16]),
+            author: AuthorId::SYSTEM,
+        },
+    )))
+    .expect("open BandChat benchmark database");
+    (db, messages_table, memberships_table)
+}
+
+fn insert(db: &BenchDb, table: &str, id: RowUuid, cells: BTreeMap<String, Value>) {
+    let write = block_on(db.insert_with_id(table, id, cells)).expect("insert BandChat fixture row");
+    block_on(write.wait(DurabilityTier::Local)).expect("fixture row reaches local durability");
+}
+
+fn row_id(kind: u8, index: usize) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[0] = kind;
+    bytes[8..].copy_from_slice(&(index as u64).to_be_bytes());
+    RowUuid::from_bytes(bytes)
+}

--- a/examples/band-chat/benchmarks/src/lib.rs
+++ b/examples/band-chat/benchmarks/src/lib.rs
@@ -67,7 +67,10 @@ impl Fixture {
                         "member".to_owned(),
                         Value::Uuid(row_id(1, room % AUTHORS).0),
                     ),
-                    ("unread".to_owned(), Value::Bool(room.is_multiple_of(2))),
+                    (
+                        "unread".to_owned(),
+                        Value::Bool((room / AUTHORS).is_multiple_of(2)),
+                    ),
                     ("last_activity".to_owned(), Value::U64(room as u64)),
                 ]),
             );
@@ -180,7 +183,7 @@ pub fn expected_counts(message_count: usize) -> (usize, usize, usize) {
     let room_count = message_count / MESSAGES_PER_ROOM;
     (
         TIMELINE_PAGE,
-        room_count.div_ceil(AUTHORS),
+        room_count.div_ceil(AUTHORS * 2),
         message_count.div_ceil(AUTHORS),
     )
 }

--- a/examples/band-chat/benchmarks/tests/workloads.rs
+++ b/examples/band-chat/benchmarks/tests/workloads.rs
@@ -20,7 +20,7 @@ fn representative_loads_have_exact_cardinality_and_order() {
 
         let room_count = message_count / 16;
         let unread_rooms = (0..room_count as u64)
-            .filter(|room| room % 32 == 0)
+            .filter(|room| room % 64 == 0)
             .rev()
             .collect::<Vec<_>>();
         assert_eq!(fixture.unread_room_activity(), unread_rooms);

--- a/examples/band-chat/benchmarks/tests/workloads.rs
+++ b/examples/band-chat/benchmarks/tests/workloads.rs
@@ -1,0 +1,34 @@
+use jazz_example_band_chat_benchmark::{Fixture, expected_counts};
+
+#[test]
+fn representative_loads_have_exact_cardinality_and_order() {
+    for message_count in [1024, 4096] {
+        let fixture = Fixture::new(message_count);
+        assert_eq!(
+            (
+                fixture.timeline_page_count(),
+                fixture.unread_room_count(),
+                fixture.author_history_count(),
+            ),
+            expected_counts(message_count),
+        );
+
+        assert_eq!(
+            fixture.timeline_sent_at(),
+            (50..=74).rev().collect::<Vec<_>>()
+        );
+
+        let room_count = message_count / 16;
+        let unread_rooms = (0..room_count as u64)
+            .filter(|room| room % 32 == 0)
+            .rev()
+            .collect::<Vec<_>>();
+        assert_eq!(fixture.unread_room_activity(), unread_rooms);
+
+        let author_messages = (0..message_count as u64)
+            .filter(|message| message % 32 == 0)
+            .rev()
+            .collect::<Vec<_>>();
+        assert_eq!(fixture.author_history_sent_at(), author_messages);
+    }
+}


### PR DESCRIPTION
🤖 Add the BandChat benchmark variant as the third layer of the example benchmark stack.

The package is self-contained and duplicates only users, rooms, memberships, and messages needed for representative chat reads. Deterministic fixtures cover 1024 and 4096 messages.

Divan/CodSpeed measures three prepared indexed loads at both scales:
- the second 25-row page of a hot-room timeline, newest first
- unread rooms for one member ordered by recent activity
- one author’s message history, newest first

Schema compilation, database open, seeding, durability waits, and query preparation occur outside the measured closures. Exact receipts verify pagination, filtering, ordering, and cardinality. Membership state alternates read/unread within each member’s rooms, so removing only the unread predicate fails deterministically.

Independent adversarial review passed. After restacking, combined CodSpeed build/simulation discovered all 14 smoke, BigLabel, and BandChat cases.

Stack: #1738 → #1740 → this PR.