### PR TITLE
Run CodSpeed nightly and on labeled PRs

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,10 +1,12 @@
 name: CodSpeed Example Benchmarks
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    types: [labeled, synchronize, reopened]
+  schedule:
+    # Nightly default-branch baseline. The non-round minute avoids the busiest
+    # part of GitHub's scheduler window.
+    - cron: "17 3 * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,6 +19,9 @@ concurrency:
 
 jobs:
   examples:
+    # Scheduled/manual runs benchmark the default branch. PR runs are opt-in,
+    # but keep refreshing on new commits while the label remains present.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')
     name: Example benchmark smoke
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -843,6 +843,39 @@ test("CodSpeed caches the root-workspace Cargo target", () => {
   );
 });
 
+test("CodSpeed runs nightly on main and only for benchmark-labeled PRs", () => {
+  const document = parse(codspeedWorkflow);
+  assert.equal(document.on.push, undefined, "ordinary main pushes must not run CodSpeed");
+  assert.deepEqual(document.on.pull_request, {
+    types: ["labeled", "synchronize", "reopened"],
+  });
+  assert.deepEqual(document.on.schedule, [{ cron: "17 3 * * *" }]);
+  assert.equal(document.on.workflow_dispatch, null);
+  assert.equal(
+    document.jobs.examples.if,
+    "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')",
+  );
+
+  assert.throws(() => {
+    const unsafe = parse(
+      codspeedWorkflow.replace("  schedule:\n", "  push:\n    branches: [main]\n  schedule:\n"),
+    );
+    assert.equal(unsafe.on.push, undefined, "ordinary main pushes must not run CodSpeed");
+  }, /ordinary main pushes/);
+  assert.throws(() => {
+    const unsafe = parse(
+      codspeedWorkflow.replace(
+        "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')",
+        "true",
+      ),
+    );
+    assert.equal(
+      unsafe.jobs.examples.if,
+      "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')",
+    );
+  }, /strictly equal/);
+});
+
 test("CodSpeed builds and runs the BigLabel benchmark variant", () => {
   for (const command of ["build", "run"]) {
     assert.match(


### PR DESCRIPTION
🤖 Reduce CodSpeed frequency while preserving useful PR and baseline reporting.

- remove ordinary main-push runs
- run nightly against the default branch at 03:17 UTC
- run PR benchmarks only while the PR has the benchmark label, including refreshes on synchronize/reopen
- retain workflow_dispatch for manual runs and CodSpeed backtests

Executable workflow-contract tests reject reintroducing push runs or removing the PR label gate. Focused contract suite: 25/25 passed.