### PR TITLE
Bind exclusive transactions to their begin identity

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -33,6 +33,8 @@ export declare class NapiDb {
   onMutationError(callback: (event: any) => void): void
   prepareQuery(query: Uint8Array): PreparedQuery
   all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  /** Read an open transaction using the identity bound at begin. */
+  allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
   allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
   allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -121,6 +121,16 @@ enum NapiDbInnerStorage {
     Persistent(Rc<CoreDb<CoreRocksDbStorage>>),
 }
 
+impl NapiDbInnerStorage {
+    fn shares_runtime_with(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Memory(left), Self::Memory(right)) => Rc::ptr_eq(left, right),
+            (Self::Persistent(left), Self::Persistent(right)) => Rc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
+}
+
 enum NapiWrite {
     Memory {
         db: Rc<CoreDb<CoreMemoryStorage>>,
@@ -1168,12 +1178,17 @@ impl NapiDb {
         )]
         opts: Option<JsonValue>,
     ) -> napi::Result<Uint8Array> {
-        let opts = core_read_opts_from_json(opts)?;
-        let open_tx = tx.open_tx()?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        if !db.shares_runtime_with(&tx.db) {
+            return Err(napi::Error::from_reason(
+                "transaction belongs to a different database runtime",
+            ));
+        }
+        let opts = core_read_opts_from_json(opts)?;
+        let open_tx = tx.open_tx()?;
         let rows = match (db, tx.kind) {
             (NapiDbInnerStorage::Memory(db), NapiTxKind::Mergeable) => core_block_on(
                 db.mergeable_tx_ref(open_tx)
@@ -4092,7 +4107,7 @@ mod tests {
             )))
             .unwrap(),
         );
-        let view = Rc::new(core_block_on(owner.register_schema_view(schema)).unwrap());
+        let view = Rc::new(core_block_on(owner.register_schema_view(schema.clone())).unwrap());
         let batch = CoreOpenBatchId::new();
         core_block_on(owner.begin_mergeable(batch)).unwrap();
         drop(Tx {
@@ -4153,8 +4168,57 @@ mod tests {
             binding.all_in_transaction(&query, &tx, None).is_ok(),
             "planted positive: the bound capability reads successfully"
         );
+
+        let other_owner = Rc::new(
+            core_block_on(CoreDb::open(CoreDbConfig::new(
+                schema.clone(),
+                CoreMemoryStorage::new(&refs),
+                CoreDbIdentity {
+                    node: CoreNodeUuid::from_bytes([0x46; 16]),
+                    author: CoreAuthorId::from_bytes([0xa6; 16]),
+                },
+            )))
+            .unwrap(),
+        );
+        let other_binding = NapiDb {
+            inner: Rc::new(RefCell::new(Some(NapiDbInnerStorage::Memory(Rc::clone(
+                &other_owner,
+            ))))),
+            owns_runtime: false,
+        };
+        other_binding
+            .begin_transaction(
+                bound.to_string(),
+                "exclusive".to_owned(),
+                Some(Uint8Array::new(alice.0.as_bytes().to_vec())),
+            )
+            .unwrap();
+        core_block_on(other_owner.exclusive_tx_ref(bound).insert_with_id(
+            "items",
+            CoreRowUuid::from_bytes([3; 16]),
+            BTreeMap::from([(
+                "label".to_owned(),
+                CoreValue::String("receiver-secret".to_owned()),
+            )]),
+        ))
+        .unwrap();
+        let other_query = PreparedQuery {
+            inner: other_owner
+                .prepare_query(&other_owner.table("items"))
+                .unwrap(),
+        };
+        assert!(
+            matches!(
+                other_binding.all_in_transaction(&other_query, &tx, None),
+                Err(error) if error.reason.contains("different database runtime")
+            ),
+            "a foreign Tx with the same open id must not access receiver rows"
+        );
         binding
             .commit_transaction(bound.to_string(), Some("exclusive".to_owned()))
+            .unwrap();
+        other_binding
+            .rollback_transaction(bound.to_string())
             .unwrap();
     }
 }

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -124,8 +124,8 @@ enum NapiDbInnerStorage {
 impl NapiDbInnerStorage {
     fn shares_runtime_with(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Memory(left), Self::Memory(right)) => Rc::ptr_eq(left, right),
-            (Self::Persistent(left), Self::Persistent(right)) => Rc::ptr_eq(left, right),
+            (Self::Memory(left), Self::Memory(right)) => left.shares_runtime_with(right),
+            (Self::Persistent(left), Self::Persistent(right)) => left.shares_runtime_with(right),
             _ => false,
         }
     }
@@ -4167,6 +4167,21 @@ mod tests {
         assert!(
             binding.all_in_transaction(&query, &tx, None).is_ok(),
             "planted positive: the bound capability reads successfully"
+        );
+        let view_binding = NapiDb {
+            inner: Rc::new(RefCell::new(Some(NapiDbInnerStorage::Memory(Rc::clone(
+                &view,
+            ))))),
+            owns_runtime: false,
+        };
+        let view_query = PreparedQuery {
+            inner: view.prepare_query(&view.table("items")).unwrap(),
+        };
+        assert!(
+            view_binding
+                .all_in_transaction(&view_query, &tx, None)
+                .is_ok(),
+            "a registered schema facade shares its owner's transaction runtime"
         );
 
         let other_owner = Rc::new(

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -994,11 +994,6 @@ impl NapiDb {
                 &kind,
             )));
         }
-        if kind == "exclusive" && author.is_some() {
-            return Err(napi::Error::from_reason(
-                "exclusive transactions do not accept an identity override",
-            ));
-        }
         let db = self.inner.borrow();
         let db = db
             .as_ref()
@@ -1015,7 +1010,13 @@ impl NapiDb {
                             None => $db.begin_mergeable(open_batch_id).await,
                         }
                     } else {
-                        $db.begin_exclusive(open_batch_id).await
+                        match author {
+                            Some(author) => {
+                                $db.begin_exclusive_for_identity(open_batch_id, author)
+                                    .await
+                            }
+                            None => $db.begin_exclusive(open_batch_id).await,
+                        }
                     }
                 })
             };

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1157,6 +1157,47 @@ impl NapiDb {
             .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
+    /// Read through an open transaction using the identity bound at begin.
+    #[napi(js_name = "allInTransaction")]
+    pub fn all_in_transaction(
+        &self,
+        query: &PreparedQuery,
+        tx: &Tx,
+        #[napi(
+            ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
+        )]
+        opts: Option<JsonValue>,
+    ) -> napi::Result<Uint8Array> {
+        let opts = core_read_opts_from_json(opts)?;
+        let open_tx = tx.open_tx()?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let rows = match (db, tx.kind) {
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Mergeable) => core_block_on(
+                db.mergeable_tx_ref(open_tx)
+                    .all_prepared_with_opts(&query.inner, opts),
+            ),
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Mergeable) => core_block_on(
+                db.mergeable_tx_ref(open_tx)
+                    .all_prepared_with_opts(&query.inner, opts),
+            ),
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Exclusive) => core_block_on(
+                db.exclusive_tx_ref(open_tx)
+                    .all_prepared_with_opts(&query.inner, opts),
+            ),
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Exclusive) => core_block_on(
+                db.exclusive_tx_ref(open_tx)
+                    .all_prepared_with_opts(&query.inner, opts),
+            ),
+        }
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        encode_core_rows(&rows)
+            .map(Uint8Array::new)
+            .map_err(|error| napi::Error::from_reason(error.to_string()))
+    }
+
     #[napi(js_name = "setIdentityClaims")]
     pub fn set_identity_claims(
         &self,
@@ -3547,9 +3588,9 @@ mod tests {
     use std::rc::Rc;
 
     use crate::{
-        NapiDbInnerStorage, NapiTxKind, Tx, authority_epoch_from_bigint, core_block_on,
-        core_claim_value_from_json, core_read_opts_from_json, core_subscription_event_to_napi,
-        encode_core_subscription_delta, terminal_bytes_to_numbers,
+        NapiDb, NapiDbInnerStorage, NapiTxKind, PreparedQuery, Tx, authority_epoch_from_bigint,
+        core_block_on, core_claim_value_from_json, core_read_opts_from_json,
+        core_subscription_event_to_napi, encode_core_subscription_delta, terminal_bytes_to_numbers,
         unknown_transaction_kind_message,
     };
 
@@ -3576,8 +3617,10 @@ mod tests {
         ColumnType, PolicyExpr, Schema, SchemaBuilder, TableName, TablePolicies, TableSchema, Value,
     };
     use jazz::tx::DurabilityTier;
+    use napi::bindgen_prelude::Uint8Array;
     use napi::bindgen_prelude::{BigInt, Either, Either3, Either4};
     use serde_json::json;
+    use std::cell::RefCell;
 
     #[test]
     fn javascript_numeric_claims_preserve_safe_integers_and_fail_closed_when_lossy() {
@@ -4084,5 +4127,34 @@ mod tests {
         ))
         .unwrap();
         core_block_on(owner.commit_exclusive_handle(exclusive)).unwrap();
+
+        // The public NAPI batch surface binds Alice at begin. A later request
+        // cannot switch the transaction-local authorization subject to Bob.
+        let binding = NapiDb {
+            inner: Rc::new(RefCell::new(Some(NapiDbInnerStorage::Memory(Rc::clone(
+                &owner,
+            ))))),
+            owns_runtime: false,
+        };
+        let alice = CoreAuthorId::from_bytes([0xa6; 16]);
+        let bound = CoreOpenBatchId::new();
+        binding
+            .begin_transaction(
+                bound.to_string(),
+                "exclusive".to_owned(),
+                Some(Uint8Array::new(alice.0.as_bytes().to_vec())),
+            )
+            .unwrap();
+        let tx = binding.attach_exclusive_tx(bound.to_string()).unwrap();
+        let query = PreparedQuery {
+            inner: owner.prepare_query(&owner.table("items")).unwrap(),
+        };
+        assert!(
+            binding.all_in_transaction(&query, &tx, None).is_ok(),
+            "planted positive: the bound capability reads successfully"
+        );
+        binding
+            .commit_transaction(bound.to_string(), Some("exclusive".to_owned()))
+            .unwrap();
     }
 }

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -512,8 +512,15 @@ impl WasmDbInner {
         ))
     }
 
-    fn begin_exclusive(&self, id: OpenTransactionId) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(db.begin_exclusive(id)))
+    fn begin_exclusive(
+        &self,
+        id: OpenTransactionId,
+        author: Option<AuthorId>,
+    ) -> Result<(), jazz::db::Error> {
+        with_wasm_db!(self, |db| match author {
+            Some(author) => block_on(db.begin_exclusive_for_identity(id, author)),
+            None => block_on(db.begin_exclusive(id)),
+        })
     }
 
     fn begin_mergeable(
@@ -1641,13 +1648,10 @@ impl WasmDb {
                 .inner
                 .begin_mergeable(open_batch_id, author)
                 .map_err(to_js_error),
-            "exclusive" if author.is_none() => self
+            "exclusive" => self
                 .inner
-                .begin_exclusive(open_batch_id)
+                .begin_exclusive(open_batch_id, author)
                 .map_err(to_js_error),
-            "exclusive" => Err(JsValue::from_str(
-                "exclusive transactions do not accept an identity override",
-            )),
             _ => Err(JsValue::from_str(&unknown_transaction_kind_message(&kind))),
         }
     }
@@ -2700,7 +2704,7 @@ impl WasmDb {
             .parse::<OpenTransactionId>()
             .map_err(|error| JsValue::from_str(&error))?;
         self.inner
-            .begin_exclusive(open_batch_id)
+            .begin_exclusive(open_batch_id, None)
             .map_err(to_js_error)?;
         Ok(WasmTx {
             db: self.inner.clone(),

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3784,7 +3784,8 @@ mod dynamic_schema_view_tests {
     }
     /// A short-lived WASM schema attachment must not abandon its owner's open
     /// batch when the JavaScript wrapper is collected.
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn attached_tx_drop_preserves_owner_batch() {
         let source = SchemaBuilder::new()
             .table(

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -293,6 +293,17 @@ impl Clone for WasmDbInner {
     }
 }
 
+impl WasmDbInner {
+    fn shares_runtime_with(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Memory(left), Self::Memory(right)) => Rc::ptr_eq(left, right),
+            #[cfg(target_arch = "wasm32")]
+            (Self::Browser(left), Self::Browser(right)) => Rc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
+}
+
 #[wasm_bindgen]
 pub struct WasmTransport {
     inner: WasmTransportInner,
@@ -1734,6 +1745,7 @@ impl WasmDb {
         tx: &WasmTx,
         opts: JsValue,
     ) -> Result<Vec<u8>, JsValue> {
+        ensure_transaction_runtime(&self.inner, tx)?;
         let opts = read_opts_from_js(opts)?;
         let tx_id = tx.open_tx_for_read()?;
         let rows = match tx.kind {
@@ -1752,6 +1764,7 @@ impl WasmDb {
         author: Vec<u8>,
         opts: JsValue,
     ) -> Result<Vec<u8>, JsValue> {
+        ensure_transaction_runtime(&self.inner, tx)?;
         let opts = read_opts_from_js(opts)?;
         let author = author_id_from_bytes(&author)?;
         let tx_id = tx.open_tx_for_read()?;
@@ -3096,6 +3109,7 @@ fn read_rows_for_transaction(
     author: Option<AuthorId>,
     opts: JsValue,
 ) -> Result<Vec<jazz::node::CurrentRow>, JsValue> {
+    ensure_transaction_runtime(db, tx)?;
     let opts = read_opts_from_js(opts)?;
     let tx_id = tx.open_tx_for_read()?;
     match (tx.kind, author) {
@@ -3111,6 +3125,16 @@ fn read_rows_for_transaction(
         (WasmTxKind::Exclusive, None) => db
             .exclusive_all(tx_id, &query.inner, opts)
             .map_err(to_js_error),
+    }
+}
+
+fn ensure_transaction_runtime(db: &WasmDbInner, tx: &WasmTx) -> Result<(), JsValue> {
+    if db.shares_runtime_with(&tx.db) {
+        Ok(())
+    } else {
+        Err(JsValue::from_str(
+            "transaction belongs to a different database runtime",
+        ))
     }
 }
 
@@ -3815,7 +3839,7 @@ mod dynamic_schema_view_tests {
             )))
             .unwrap(),
         );
-        let view = Rc::new(block_on(owner.register_schema_view(schema)).unwrap());
+        let view = Rc::new(block_on(owner.register_schema_view(schema.clone())).unwrap());
         let batch = OpenTransactionId::new();
         block_on(owner.begin_mergeable(batch)).unwrap();
         drop(WasmTx {
@@ -3890,6 +3914,63 @@ mod dynamic_schema_view_tests {
                     .is_ok(),
                 "planted positive: Alice retains the bound capability"
             );
+
+            let other_owner = Rc::new(
+                block_on(Db::open(DbConfig::new(
+                    schema.clone(),
+                    MemoryStorage::new(&refs),
+                    DbIdentity {
+                        node: jazz::ids::NodeUuid::from_bytes([0x47; 16]),
+                        author: alice,
+                    },
+                )))
+                .unwrap(),
+            );
+            let other_binding = WasmDb {
+                inner: WasmDbInner::Memory(Rc::clone(&other_owner)),
+                owns_runtime: false,
+            };
+            other_binding
+                .begin_transaction(
+                    bound.to_string(),
+                    "exclusive".to_owned(),
+                    Some(alice.0.as_bytes().to_vec()),
+                )
+                .unwrap();
+            block_on(other_owner.exclusive_tx_ref(bound).insert_with_id(
+                "items",
+                RowUuid::from_bytes([3; 16]),
+                BTreeMap::from([(
+                    "label".to_owned(),
+                    Value::String("receiver-secret".to_owned()),
+                )]),
+            ))
+            .unwrap();
+            let other_query = WasmPreparedQuery {
+                inner: other_owner
+                    .prepare_query(&other_owner.table("items"))
+                    .unwrap(),
+            };
+            let assert_foreign = |result: Result<Vec<u8>, JsValue>| {
+                assert!(result
+                    .unwrap_err()
+                    .as_string()
+                    .is_some_and(|message| { message.contains("different database runtime") }));
+            };
+            assert_foreign(other_binding.all_in_transaction(&other_query, &tx, JsValue::NULL));
+            assert_foreign(other_binding.all_in_transaction_for_identity(
+                &other_query,
+                &tx,
+                alice.0.as_bytes().to_vec(),
+                JsValue::NULL,
+            ));
+            assert_foreign(other_binding.one_in_transaction(&other_query, &tx, JsValue::NULL));
+            assert_foreign(other_binding.one_in_transaction_for_identity(
+                &other_query,
+                &tx,
+                alice.0.as_bytes().to_vec(),
+                JsValue::NULL,
+            ));
             let error = binding
                 .all_in_transaction_for_identity(
                     &query,
@@ -3903,6 +3984,9 @@ mod dynamic_schema_view_tests {
                 .is_some_and(|message| message.contains("bound identity")));
             binding
                 .commit_transaction(bound.to_string(), Some("exclusive".to_owned()))
+                .unwrap();
+            other_binding
+                .rollback_transaction(bound.to_string())
                 .unwrap();
         }
     }

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -296,9 +296,9 @@ impl Clone for WasmDbInner {
 impl WasmDbInner {
     fn shares_runtime_with(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Memory(left), Self::Memory(right)) => Rc::ptr_eq(left, right),
+            (Self::Memory(left), Self::Memory(right)) => left.shares_runtime_with(right),
             #[cfg(target_arch = "wasm32")]
-            (Self::Browser(left), Self::Browser(right)) => Rc::ptr_eq(left, right),
+            (Self::Browser(left), Self::Browser(right)) => left.shares_runtime_with(right),
             _ => false,
         }
     }
@@ -3913,6 +3913,38 @@ mod dynamic_schema_view_tests {
                     )
                     .is_ok(),
                 "planted positive: Alice retains the bound capability"
+            );
+            let view_binding = WasmDb {
+                inner: WasmDbInner::Memory(Rc::clone(&view)),
+                owns_runtime: false,
+            };
+            let view_query = WasmPreparedQuery {
+                inner: view.prepare_query(&view.table("items")).unwrap(),
+            };
+            assert!(view_binding
+                .all_in_transaction(&view_query, &tx, JsValue::NULL)
+                .is_ok());
+            assert!(view_binding
+                .all_in_transaction_for_identity(
+                    &view_query,
+                    &tx,
+                    alice.0.as_bytes().to_vec(),
+                    JsValue::NULL,
+                )
+                .is_ok());
+            assert!(view_binding
+                .one_in_transaction(&view_query, &tx, JsValue::NULL)
+                .is_ok());
+            assert!(
+                view_binding
+                    .one_in_transaction_for_identity(
+                        &view_query,
+                        &tx,
+                        alice.0.as_bytes().to_vec(),
+                        JsValue::NULL,
+                    )
+                    .is_ok(),
+                "registered schema facades share all owner transaction read overloads"
             );
 
             let other_owner = Rc::new(

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3854,5 +3854,55 @@ mod dynamic_schema_view_tests {
         ))
         .unwrap();
         block_on(owner.commit_exclusive_handle(exclusive)).unwrap();
+
+        // The public WASM batch surface binds Alice at begin. A later request
+        // cannot switch the transaction-local authorization subject to Bob.
+        // JsValue construction requires an actual wasm runtime.
+        #[cfg(target_arch = "wasm32")]
+        {
+            let binding = WasmDb {
+                inner: WasmDbInner::Memory(Rc::clone(&owner)),
+                owns_runtime: false,
+            };
+            let alice = AuthorId::from_bytes([0xa7; 16]);
+            let bob = AuthorId::from_bytes([0xb7; 16]);
+            let bound = OpenTransactionId::new();
+            binding
+                .begin_transaction(
+                    bound.to_string(),
+                    "exclusive".to_owned(),
+                    Some(alice.0.as_bytes().to_vec()),
+                )
+                .unwrap();
+            let tx = binding.attach_exclusive_tx(bound.to_string()).unwrap();
+            let query = WasmPreparedQuery {
+                inner: owner.prepare_query(&owner.table("items")).unwrap(),
+            };
+            assert!(
+                binding
+                    .all_in_transaction_for_identity(
+                        &query,
+                        &tx,
+                        alice.0.as_bytes().to_vec(),
+                        JsValue::NULL
+                    )
+                    .is_ok(),
+                "planted positive: Alice retains the bound capability"
+            );
+            let error = binding
+                .all_in_transaction_for_identity(
+                    &query,
+                    &tx,
+                    bob.0.as_bytes().to_vec(),
+                    JsValue::NULL,
+                )
+                .unwrap_err();
+            assert!(error
+                .as_string()
+                .is_some_and(|message| message.contains("bound identity")));
+            binding
+                .commit_transaction(bound.to_string(), Some("exclusive".to_owned()))
+                .unwrap();
+        }
     }
 }

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -845,11 +845,17 @@ fn exclusive_tx_ref_survives_handle_reconstruction_until_explicit_commit() {
 #[test]
 fn identity_bound_exclusive_transaction_rejects_cross_identity_reads_and_commits_as_bound_author() {
     let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
-    let alice = AuthorId::from_bytes([0xa1; 16]);
+    let alice = AuthorId::from_bytes([0xc1; 16]);
     let bob = AuthorId::from_bytes([0xb2; 16]);
     let open = OpenTransactionId::new();
     let row = row(0xa1);
-    let prepared = db.prepare_query(&db.table("todos")).unwrap();
+    assert_ne!(alice, db.identity.author);
+    let prepared = db
+        .prepare_query(
+            &db.table("todos")
+                .select(["title", "$createdBy", "$updatedBy"]),
+        )
+        .unwrap();
 
     db.begin_exclusive_for_identity(open, alice).unwrap();
     db.exclusive_tx_ref(open)
@@ -857,13 +863,14 @@ fn identity_bound_exclusive_transaction_rejects_cross_identity_reads_and_commits
         .unwrap();
 
     // Planted positive: the bound identity can read the transaction overlay.
-    assert_eq!(
-        db.exclusive_tx_ref(open)
-            .all_prepared_for_identity(&prepared, alice)
-            .unwrap()
-            .len(),
-        1
-    );
+    let staged = db
+        .exclusive_tx_ref(open)
+        .all_prepared_for_identity(&prepared, alice)
+        .unwrap();
+    assert_eq!(staged.len(), 1);
+    let staged_provenance = staged[0].provenance().unwrap().unwrap();
+    assert_eq!(staged_provenance.created_by, alice);
+    assert_eq!(staged_provenance.updated_by, alice);
     assert!(matches!(
         doctest_support::block_on(
             db.exclusive_tx_ref(open)
@@ -873,10 +880,36 @@ fn identity_bound_exclusive_transaction_rejects_cross_identity_reads_and_commits
     ));
 
     db.commit_exclusive_handle(open).unwrap();
-    assert_eq!(
-        prepared_one(&db, &db.table("todos")).unwrap().row_uuid(),
-        row
+    let committed = prepared_one(
+        &db,
+        &db.table("todos")
+            .select(["title", "$createdBy", "$updatedBy"]),
+    )
+    .unwrap();
+    assert_eq!(committed.row_uuid(), row);
+    let committed_provenance = committed.provenance().unwrap().unwrap();
+    assert_eq!(committed_provenance.created_by, alice);
+    assert_eq!(committed_provenance.updated_by, alice);
+}
+
+/// Mergeable serving reads retain their existing per-call identity semantics.
+#[test]
+fn mergeable_transaction_identity_reads_are_not_forced_to_begin_author() {
+    let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
+    let alice = AuthorId::from_bytes([0xa3; 16]);
+    let bob = AuthorId::from_bytes([0xb3; 16]);
+    let open = OpenTransactionId::new();
+    let prepared = db.prepare_query(&db.table("todos")).unwrap();
+
+    db.begin_mergeable_for_identity(open, alice).unwrap();
+    assert!(
+        doctest_support::block_on(
+            db.mergeable_tx_ref(open)
+                .all_prepared_for_identity(&prepared, bob),
+        )
+        .is_ok()
     );
+    db.abandon_transaction_handle(open).unwrap();
 }
 
 #[test]

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -895,19 +895,62 @@ fn identity_bound_exclusive_transaction_rejects_cross_identity_reads_and_commits
 /// Mergeable serving reads retain their existing per-call identity semantics.
 #[test]
 fn mergeable_transaction_identity_reads_are_not_forced_to_begin_author() {
-    let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
+    let schema = owner_read_schema();
+    let db = open_db(0xd3, AuthorId::SYSTEM, &schema);
     let alice = AuthorId::from_bytes([0xa3; 16]);
     let bob = AuthorId::from_bytes([0xb3; 16]);
     let open = OpenTransactionId::new();
-    let prepared = db.prepare_query(&db.table("todos")).unwrap();
+    let prepared = db
+        .prepare_query(&db.table("todos").filter(eq(col("owner"), claim("sub"))))
+        .unwrap();
+    db.set_identity_claims(
+        alice,
+        BTreeMap::from([("sub".to_owned(), Value::Uuid(alice.0))]),
+    );
+    db.set_identity_claims(
+        bob,
+        BTreeMap::from([("sub".to_owned(), Value::Uuid(bob.0))]),
+    );
+    let alice_row = row(0xa3);
+    let bob_row = row(0xb3);
+    db.insert_with_id("todos", alice_row, cells("alice", false, alice))
+        .unwrap();
+    db.insert_with_id("todos", bob_row, cells("bob", false, bob))
+        .unwrap();
+
+    assert_eq!(
+        block_on(db.all_for_identity(&prepared, ReadOpts::default(), alice))
+            .unwrap()
+            .iter()
+            .map(CurrentRow::row_uuid)
+            .collect::<Vec<_>>(),
+        vec![alice_row]
+    );
 
     db.begin_mergeable_for_identity(open, alice).unwrap();
-    assert!(
-        doctest_support::block_on(
-            db.mergeable_tx_ref(open)
-                .all_prepared_for_identity(&prepared, bob),
-        )
-        .is_ok()
+    let alice_rows = doctest_support::block_on(
+        db.mergeable_tx_ref(open)
+            .all_prepared_for_identity(&prepared, alice),
+    )
+    .unwrap();
+    let bob_rows = doctest_support::block_on(
+        db.mergeable_tx_ref(open)
+            .all_prepared_for_identity(&prepared, bob),
+    )
+    .unwrap();
+    assert_eq!(
+        alice_rows
+            .iter()
+            .map(CurrentRow::row_uuid)
+            .collect::<Vec<_>>(),
+        vec![alice_row]
+    );
+    assert_eq!(
+        bob_rows
+            .iter()
+            .map(CurrentRow::row_uuid)
+            .collect::<Vec<_>>(),
+        vec![bob_row]
     );
     db.abandon_transaction_handle(open).unwrap();
 }

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -840,6 +840,45 @@ fn exclusive_tx_ref_survives_handle_reconstruction_until_explicit_commit() {
     assert_eq!(current.cell(table, "done"), Some(Value::Bool(true)));
 }
 
+/// An exclusive transaction binds alice at begin: its staged read cannot be
+/// re-authorized as bob, while the handle commit consumes that bound identity.
+#[test]
+fn identity_bound_exclusive_transaction_rejects_cross_identity_reads_and_commits_as_bound_author() {
+    let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
+    let alice = AuthorId::from_bytes([0xa1; 16]);
+    let bob = AuthorId::from_bytes([0xb2; 16]);
+    let open = OpenTransactionId::new();
+    let row = row(0xa1);
+    let prepared = db.prepare_query(&db.table("todos")).unwrap();
+
+    db.begin_exclusive_for_identity(open, alice).unwrap();
+    db.exclusive_tx_ref(open)
+        .insert_with_id("todos", row, doctest_support::todo_cells("alice", false))
+        .unwrap();
+
+    // Planted positive: the bound identity can read the transaction overlay.
+    assert_eq!(
+        db.exclusive_tx_ref(open)
+            .all_prepared_for_identity(&prepared, alice)
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(matches!(
+        doctest_support::block_on(
+            db.exclusive_tx_ref(open)
+                .all_prepared_for_identity(&prepared, bob),
+        ),
+        Err(error) if error.code == ErrorCode::Protocol
+    ));
+
+    db.commit_exclusive_handle(open).unwrap();
+    assert_eq!(
+        prepared_one(&db, &db.table("todos")).unwrap().row_uuid(),
+        row
+    );
+}
+
 #[test]
 fn exclusive_tx_rejects_conflicting_concurrent_update() {
     let schema = schema();

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -466,6 +466,24 @@ where
         self.open_exclusive_handle(id).await
     }
 
+    /// Open an exclusive transaction whose identity is fixed for its lifetime.
+    ///
+    /// Transaction-local reads, authorization, provenance, and commit
+    /// attribution all use `author`; subsequent calls cannot replace it.
+    pub async fn begin_exclusive_for_identity(
+        &self,
+        id: OpenTransactionId,
+        author: AuthorId,
+    ) -> Result<(), Error> {
+        self.node
+            .node
+            .lock()
+            .await
+            .open_exclusive_for_identity(id, author)
+            .await
+            .map_err(Into::into)
+    }
+
     /// Return a non-owning operations handle for an already-open exclusive transaction.
     ///
     /// This handle never closes the transaction when dropped, so it is suitable
@@ -654,7 +672,7 @@ where
             .node
             .lock()
             .await
-            .commit_exclusive(open_tx_id, self.identity.author, self.next_now_ms())
+            .commit_exclusive_bound(open_tx_id, self.next_now_ms())
             .await?;
         let tx_id = published.tx_id;
         if self.node.defer_local_persistence.get() {

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -6,6 +6,14 @@ impl<S> Db<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
+    /// Return whether two schema facades share one open-transaction runtime.
+    ///
+    /// This compares the private runtime capability, not caller-controlled ids.
+    #[doc(hidden)]
+    pub fn shares_runtime_with(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.node, &other.node)
+    }
+
     /// Build a mergeable transaction that commits multiple writes under one id.
     pub async fn mergeable_tx(&self) -> Result<MergeableTx<'_, S>, Error> {
         let tx_id = OpenTransactionId::new();

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1868,6 +1868,9 @@ pub enum Error {
     /// A caller attempted to reuse an identity that still names live mutable work.
     #[error("duplicate open batch id: {0}")]
     DuplicateOpenBatch(OpenTransactionId),
+    /// A caller tried to use an open transaction as a different identity.
+    #[error("open transaction identity does not match its bound identity")]
+    OpenTransactionIdentityMismatch,
     /// Fate or global-current update was non-monotone.
     #[error("non-monotone state update: {0}")]
     NonMonotoneState(&'static str),

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -681,6 +681,9 @@ where
                 "open transaction is not exclusive",
             ));
         }
+        if self.open_tx(open_batch_id)?.provisional_author != made_by {
+            return Err(Error::OpenTransactionIdentityMismatch);
+        }
         if !self
             .open_exclusive_is_locally_serializable(open_batch_id)
             .await?
@@ -759,6 +762,16 @@ where
         self.open_tx.open_transactions.remove(&open_batch_id);
         self.open_tx.closed_batches.insert(open_batch_id);
         Ok((publication, SyncMessage::CommitUnit { tx, versions }))
+    }
+
+    /// Commit an exclusive transaction using the identity bound when it opened.
+    pub async fn commit_exclusive_bound(
+        &mut self,
+        open_batch_id: OpenTransactionId,
+        now_ms: u64,
+    ) -> Result<(PublishedTransaction, SyncMessage), Error> {
+        let author = self.open_tx(open_batch_id)?.provisional_author;
+        self.commit_exclusive(open_batch_id, author, now_ms).await
     }
 
     async fn open_exclusive_is_locally_serializable(

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -13,7 +13,12 @@ where
 {
     /// Open an exclusive transaction over the current snapshot.
     pub async fn open_exclusive(&mut self, id: OpenTransactionId) -> Result<(), Error> {
-        self.open_exclusive_for_identity(id, AuthorId::SYSTEM).await
+        self.open_transaction(
+            id,
+            OpenTransactionKind::Exclusive { bound_author: None },
+            AuthorId::SYSTEM,
+        )
+        .await
     }
 
     pub(crate) async fn open_exclusive_for_identity(
@@ -21,8 +26,14 @@ where
         id: OpenTransactionId,
         made_by: AuthorId,
     ) -> Result<(), Error> {
-        self.open_transaction(id, OpenTransactionKind::Exclusive, made_by)
-            .await
+        self.open_transaction(
+            id,
+            OpenTransactionKind::Exclusive {
+                bound_author: Some(made_by),
+            },
+            made_by,
+        )
+        .await
     }
 
     /// Open a mergeable transaction over the current snapshot.
@@ -366,7 +377,10 @@ where
         deletion: Option<DeletionEvent>,
         now_ms: Option<u64>,
     ) -> Result<(), Error> {
-        if !matches!(self.open_tx(tx_id)?.kind, OpenTransactionKind::Exclusive) {
+        if !matches!(
+            self.open_tx(tx_id)?.kind,
+            OpenTransactionKind::Exclusive { .. }
+        ) {
             return Err(Error::InvalidMergeableCommit(
                 "open transaction is not exclusive",
             ));
@@ -675,13 +689,18 @@ where
     ) -> Result<(PublishedTransaction, SyncMessage), Error> {
         if !matches!(
             self.open_tx(open_batch_id)?.kind,
-            OpenTransactionKind::Exclusive
+            OpenTransactionKind::Exclusive { .. }
         ) {
             return Err(Error::InvalidMergeableCommit(
                 "open transaction is not exclusive",
             ));
         }
-        if self.open_tx(open_batch_id)?.provisional_author != made_by {
+        if matches!(
+            self.open_tx(open_batch_id)?.kind,
+            OpenTransactionKind::Exclusive {
+                bound_author: Some(bound)
+            } if bound != made_by
+        ) {
             return Err(Error::OpenTransactionIdentityMismatch);
         }
         if !self
@@ -1227,7 +1246,11 @@ where
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum OpenTransactionKind {
-    Exclusive,
+    Exclusive {
+        /// Present only for identity-capability transactions opened by `Db`.
+        /// Low-level node transactions retain their historical commit-time author.
+        bound_author: Option<AuthorId>,
+    },
     Mergeable {
         made_by: AuthorId,
         permission_subject: Option<AuthorId>,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -2541,18 +2541,19 @@ where
         authorization_mode: QueryAuthorizationMode,
     ) -> Result<Vec<CurrentRow>, Error> {
         let identity = match self.open_tx(tx_id)?.kind {
-            OpenTransactionKind::Exclusive => {
-                let bound_identity = self.open_tx(tx_id)?.provisional_author;
+            OpenTransactionKind::Exclusive {
+                bound_author: Some(bound_identity),
+            } => {
                 if matches!(authorization_mode, QueryAuthorizationMode::TrustedServing)
                     && identity != bound_identity
                 {
                     return Err(Error::OpenTransactionIdentityMismatch);
                 }
-                // Exclusive transactions are identity capabilities: both ordinary
-                // binding reads and serving reads authorize against the identity
-                // fixed at begin, never an identity supplied by a later call.
+                // Explicitly bound exclusive transactions are identity capabilities:
+                // ordinary and serving reads use the identity fixed at begin.
                 bound_identity
             }
+            OpenTransactionKind::Exclusive { bound_author: None } => identity,
             OpenTransactionKind::Mergeable { .. } => identity,
         };
         let query = shape.query();

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -2540,6 +2540,16 @@ where
         include_deleted: bool,
         authorization_mode: QueryAuthorizationMode,
     ) -> Result<Vec<CurrentRow>, Error> {
+        let bound_identity = self.open_tx(tx_id)?.provisional_author;
+        if matches!(authorization_mode, QueryAuthorizationMode::TrustedServing)
+            && identity != bound_identity
+        {
+            return Err(Error::OpenTransactionIdentityMismatch);
+        }
+        // An open transaction is an identity capability: both ordinary binding
+        // reads and serving reads must authorize against the identity fixed at
+        // begin, never an identity supplied by a later call.
+        let identity = bound_identity;
         let query = shape.query();
         let predicate_len = self.open_tx(tx_id)?.predicate_reads.len();
         let table = self.table_in_schema(&query.table, shape.schema_version())?;

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -2540,16 +2540,21 @@ where
         include_deleted: bool,
         authorization_mode: QueryAuthorizationMode,
     ) -> Result<Vec<CurrentRow>, Error> {
-        let bound_identity = self.open_tx(tx_id)?.provisional_author;
-        if matches!(authorization_mode, QueryAuthorizationMode::TrustedServing)
-            && identity != bound_identity
-        {
-            return Err(Error::OpenTransactionIdentityMismatch);
-        }
-        // An open transaction is an identity capability: both ordinary binding
-        // reads and serving reads must authorize against the identity fixed at
-        // begin, never an identity supplied by a later call.
-        let identity = bound_identity;
+        let identity = match self.open_tx(tx_id)?.kind {
+            OpenTransactionKind::Exclusive => {
+                let bound_identity = self.open_tx(tx_id)?.provisional_author;
+                if matches!(authorization_mode, QueryAuthorizationMode::TrustedServing)
+                    && identity != bound_identity
+                {
+                    return Err(Error::OpenTransactionIdentityMismatch);
+                }
+                // Exclusive transactions are identity capabilities: both ordinary
+                // binding reads and serving reads authorize against the identity
+                // fixed at begin, never an identity supplied by a later call.
+                bound_identity
+            }
+            OpenTransactionKind::Mergeable { .. } => identity,
+        };
         let query = shape.query();
         let predicate_len = self.open_tx(tx_id)?.predicate_reads.len();
         let table = self.table_in_schema(&query.table, shape.schema_version())?;

--- a/crates/jazz/src/node/tests/exclusive_transactions.rs
+++ b/crates/jazz/src/node/tests/exclusive_transactions.rs
@@ -86,6 +86,32 @@ fn open_batch_identity_is_unique_and_terminal() {
     ));
 }
 
+/// Low-level exclusive transactions retain commit-time author selection, while
+/// explicitly identity-bound transactions reject a different commit author.
+#[test]
+fn exclusive_identity_binding_applies_only_to_explicitly_bound_node_transactions() {
+    let (_temp_dir, mut node) = open_node();
+    let alice = user(0xa1);
+    let bob = user(0xb2);
+
+    let unbound = OpenTransactionId::new();
+    node.open_exclusive(unbound).unwrap();
+    node.tx_write(unbound, "todos", row(1), title_cells("unbound"), None)
+        .unwrap();
+    node.commit_exclusive_settled(unbound, alice, 10).unwrap();
+
+    let bound = OpenTransactionId::new();
+    node.open_exclusive_for_identity(bound, alice).unwrap();
+    node.tx_write(bound, "todos", row(2), title_cells("bound"), None)
+        .unwrap();
+    assert!(matches!(
+        node.commit_exclusive_settled(bound, bob, 11),
+        Err(Error::OpenTransactionIdentityMismatch)
+    ));
+    // Planted positive: rejecting Bob does not consume Alice's capability.
+    node.commit_exclusive_settled(bound, alice, 11).unwrap();
+}
+
 #[test]
 fn exclusive_tx_snapshot_read_ignores_newer_commits_after_open() {
     let (_temp_dir, mut node) = open_node();


### PR DESCRIPTION
🤖 Closes #1804.

## Behavior

An exclusive transaction now captures the authorized identity when it begins. Every read and the eventual commit through that transaction capability use the captured identity; an explicit attempt to read it as another identity is rejected.

Mergeable transactions are unchanged: trusted serving APIs may still evaluate each read for the identity supplied to that call.

## Why

Previously a caller could open an exclusive transaction as one principal, inspect it as another, and commit through a third facade identity. That separated authorization from the transaction capability and from row provenance.

## Receipts

- A transaction begun as Alice stages and commits Alice-authored provenance even through identity-free N-API/WASM handles.
- An explicit Bob read against Alice’s exclusive transaction rejects.
- A mergeable transaction begun as Alice still returns Alice-scoped results for Alice and Bob-scoped results for Bob.
- The WASM mismatch path executes under a real wasm32 Node test.

The final stack passed independent adversarial review, including planted stale-commit and mergeable-identity regressions.