### PR TITLE
Preserve policy classification across pending row versions

### DIFF
--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -222,6 +222,7 @@ where
                         &mut node,
                         ingest_context.identity,
                         &versions,
+                        tx.tx_id,
                     )
                     .await?;
                 }

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -143,6 +143,43 @@ where
             .await
     }
 
+    /// Return the newest locally known version for a row/layer except one
+    /// candidate transaction.  Authority finalization persists its candidate
+    /// before assigning fate, so policy classification must be able to find
+    /// the next older pending or accepted version rather than falling straight
+    /// through to global current state.
+    pub(super) async fn query_local_layer_winner_in_branch_excluding_tx(
+        &mut self,
+        table: &str,
+        branch_key: &BranchKey,
+        row_uuid: RowUuid,
+        layer: VersionLayer,
+        excluded_tx_id: TxId,
+    ) -> Result<Option<VersionRow>, Error> {
+        let mut winner = None;
+        for candidate in self
+            .query_row_versions_in_branch(table, branch_key, row_uuid)
+            .await?
+        {
+            if candidate.layer() != layer || self.version_tx_id(&candidate)? == excluded_tx_id {
+                continue;
+            }
+            let candidate_tx = self.version_tx_id(&candidate)?;
+            let replace = match winner.as_ref() {
+                None => true,
+                Some(current) => {
+                    let current_tx = self.version_tx_id(current)?;
+                    candidate.tx_time().sort_key(candidate_tx.node)
+                        > current.tx_time().sort_key(current_tx.node)
+                }
+            };
+            if replace {
+                winner = Some(candidate);
+            }
+        }
+        Ok(winner)
+    }
+
     #[allow(dead_code)] // Stage 1 read primitive; production reads switch in Stage 2.
     pub(super) async fn query_global_layer_winner(
         &mut self,

--- a/crates/jazz/src/node/ingest/fates.rs
+++ b/crates/jazz/src/node/ingest/fates.rs
@@ -382,7 +382,7 @@ where
         };
         for version in versions {
             if !self
-                .version_satisfies_write_policy(version, permission_subject)
+                .version_satisfies_write_policy(version, permission_subject, tx.tx_id)
                 .await?
             {
                 return Ok(false);
@@ -395,8 +395,10 @@ where
         &mut self,
         version: &VersionRecord,
         author: AuthorId,
+        candidate_tx_id: TxId,
     ) -> Result<bool, Error> {
-        self.write_policy_allows_version_record(version, author).await
+        self.write_policy_allows_version_record(version, author, Some(candidate_tx_id))
+            .await
     }
 
     pub(super) async fn cascade_root_for_versions(

--- a/crates/jazz/src/node/policy.rs
+++ b/crates/jazz/src/node/policy.rs
@@ -697,24 +697,32 @@ where
             }
         }
 
-        if let Some(current_version) = self
-            .query_local_layer_winner_in_branch(
-                subject_table,
-                version.branch_key(),
-                version.row_uuid(),
-                VersionLayer::Content,
-            )
-            .await?
-        {
-            // Pending candidates are stored before policy evaluation. They
-            // are not previous-row evidence for their own insert/update
-            // classification, but another transaction's local winner is.
-            if candidate_tx_id != Some(self.version_tx_id(&current_version)?) {
-                let (_policy_schema_version, projected_table, cells) =
-                    self.policy_projection_for_version_row(&current_version)?;
-                if projected_table.name == table.name {
-                    return current_row_from_cells(table, version.row_uuid(), &cells).map(Some);
-                }
+        let local_previous = match candidate_tx_id {
+            Some(candidate_tx_id) => {
+                self.query_local_layer_winner_in_branch_excluding_tx(
+                    subject_table,
+                    version.branch_key(),
+                    version.row_uuid(),
+                    VersionLayer::Content,
+                    candidate_tx_id,
+                )
+                .await?
+            }
+            None => {
+                self.query_local_layer_winner_in_branch(
+                    subject_table,
+                    version.branch_key(),
+                    version.row_uuid(),
+                    VersionLayer::Content,
+                )
+                .await?
+            }
+        };
+        if let Some(current_version) = local_previous {
+            let (_policy_schema_version, projected_table, cells) =
+                self.policy_projection_for_version_row(&current_version)?;
+            if projected_table.name == table.name {
+                return current_row_from_cells(table, version.row_uuid(), &cells).map(Some);
             }
         }
 

--- a/crates/jazz/src/node/policy.rs
+++ b/crates/jazz/src/node/policy.rs
@@ -21,9 +21,23 @@ where
     /// version record.  This is the sole bridge from committed wire data to
     /// authorization support hydration: callers must not substitute a
     /// table-wide or placeholder update action.
+    #[cfg(test)]
     pub(crate) async fn authorization_actions_for_versions(
         &mut self,
         versions: &[VersionRecord],
+    ) -> Result<Vec<PermissionAdviceAction>, Error> {
+        self.authorization_actions_for_versions_in_transaction(versions, None)
+            .await
+    }
+
+    /// Reconstruct operation-specific authorization actions while excluding
+    /// the candidate transaction from prior-row lookup.  An authority stores
+    /// a pending candidate before it assigns its fate, so treating that row as
+    /// prior evidence would turn a new insert into an update.
+    pub(crate) async fn authorization_actions_for_versions_in_transaction(
+        &mut self,
+        versions: &[VersionRecord],
+        candidate_tx_id: Option<TxId>,
     ) -> Result<Vec<PermissionAdviceAction>, Error> {
         let mut actions = Vec::with_capacity(versions.len());
         for version in versions {
@@ -37,7 +51,12 @@ where
                 continue;
             }
             let is_update = self
-                .policy_previous_content_subject_row(policy_schema_version, &table, version)
+                .policy_previous_content_subject_row(
+                    policy_schema_version,
+                    &table,
+                    version,
+                    candidate_tx_id,
+                )
                 .await?
                 .is_some();
             if is_update {
@@ -67,8 +86,9 @@ where
         &mut self,
         version: &VersionRecord,
         author: AuthorId,
+        candidate_tx_id: Option<TxId>,
     ) -> Result<bool, Error> {
-        self.write_policy_allows_version_record_for_view(version, author, None)
+        self.write_policy_allows_version_record_for_view(version, author, None, candidate_tx_id)
             .await
     }
 
@@ -77,6 +97,7 @@ where
         version: &VersionRecord,
         author: AuthorId,
         exact_view: Option<&JazzSchema>,
+        candidate_tx_id: Option<TxId>,
     ) -> Result<bool, Error> {
         if author == AuthorId::SYSTEM {
             return Ok(true);
@@ -113,7 +134,7 @@ where
                 return Ok(false);
             };
             let current = match self
-                .policy_delete_subject_row(policy_schema_version, &table, version)
+                .policy_delete_subject_row(policy_schema_version, &table, version, candidate_tx_id)
                 .await?
             {
                 Some(current) => current,
@@ -141,12 +162,22 @@ where
                 .await;
         }
         let is_update = self
-            .policy_previous_content_subject_row(policy_schema_version, &table, version)
+            .policy_previous_content_subject_row(
+                policy_schema_version,
+                &table,
+                version,
+                candidate_tx_id,
+            )
             .await?
             .is_some();
         if is_update {
             let Some(previous) = self
-                .policy_previous_content_subject_row(policy_schema_version, &table, version)
+                .policy_previous_content_subject_row(
+                    policy_schema_version,
+                    &table,
+                    version,
+                    candidate_tx_id,
+                )
                 .await?
             else {
                 return Ok(false);
@@ -221,8 +252,12 @@ where
         let write_schema_version = self.catalogue.current_write_schema.schema;
         let table = self.table_in_schema(&commit.table, write_schema_version)?;
         let version = VersionRecord::from_commit(&commit, &table, write_schema_version)?;
-        self.write_policy_allows_version_record(&version, commit.effective_permission_subject())
-            .await
+        self.write_policy_allows_version_record(
+            &version,
+            commit.effective_permission_subject(),
+            None,
+        )
+        .await
     }
 
     #[cfg(test)]
@@ -245,8 +280,12 @@ where
     ) -> Result<bool, Error> {
         let table = self.table_in_schema(&commit.table, write_schema_version)?;
         let version = VersionRecord::from_commit(&commit, &table, write_schema_version)?;
-        self.write_policy_allows_version_record(&version, commit.effective_permission_subject())
-            .await
+        self.write_policy_allows_version_record(
+            &version,
+            commit.effective_permission_subject(),
+            None,
+        )
+        .await
     }
 
     #[cfg(test)]
@@ -266,6 +305,7 @@ where
             &version,
             commit.effective_permission_subject(),
             Some(exact_view),
+            None,
         )
         .await
     }
@@ -595,9 +635,15 @@ where
         policy_schema_version: SchemaVersionId,
         table: &TableSchema,
         version: &VersionRecord,
+        candidate_tx_id: Option<TxId>,
     ) -> Result<Option<CurrentRow>, Error> {
-        self.policy_previous_content_subject_row(policy_schema_version, table, version)
-            .await
+        self.policy_previous_content_subject_row(
+            policy_schema_version,
+            table,
+            version,
+            candidate_tx_id,
+        )
+        .await
     }
 
     async fn policy_previous_content_subject_row(
@@ -605,6 +651,7 @@ where
         _policy_schema_version: SchemaVersionId,
         table: &TableSchema,
         version: &VersionRecord,
+        candidate_tx_id: Option<TxId>,
     ) -> Result<Option<CurrentRow>, Error> {
         let subject_table = if self
             .table_in_schema(version.table(), self.catalogue.current_write_schema.schema)
@@ -659,10 +706,15 @@ where
             )
             .await?
         {
-            let (_policy_schema_version, projected_table, cells) =
-                self.policy_projection_for_version_row(&current_version)?;
-            if projected_table.name == table.name {
-                return current_row_from_cells(table, version.row_uuid(), &cells).map(Some);
+            // Pending candidates are stored before policy evaluation. They
+            // are not previous-row evidence for their own insert/update
+            // classification, but another transaction's local winner is.
+            if candidate_tx_id != Some(self.version_tx_id(&current_version)?) {
+                let (_policy_schema_version, projected_table, cells) =
+                    self.policy_projection_for_version_row(&current_version)?;
+                if projected_table.name == table.name {
+                    return current_row_from_cells(table, version.row_uuid(), &cells).map(Some);
+                }
             }
         }
 
@@ -675,10 +727,12 @@ where
             )
             .await?
         {
-            let (_policy_schema_version, projected_table, cells) =
-                self.policy_projection_for_version_row(&current_version)?;
-            if projected_table.name == table.name {
-                return current_row_from_cells(table, version.row_uuid(), &cells).map(Some);
+            if candidate_tx_id != Some(self.version_tx_id(&current_version)?) {
+                let (_policy_schema_version, projected_table, cells) =
+                    self.policy_projection_for_version_row(&current_version)?;
+                if projected_table.name == table.name {
+                    return current_row_from_cells(table, version.row_uuid(), &cells).map(Some);
+                }
             }
         }
 

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -77,6 +77,73 @@ impl ReopenableStorage for FailTransactionReadMemoryStorage {
     }
 }
 
+/// Pending local versions are materialized before self-finalization.  Their
+/// presence must not turn a new row into an update and thereby let an update
+/// policy stand in for a missing or rejecting INSERT policy.
+#[test]
+fn local_authority_keeps_insert_and_update_policies_distinct() {
+    let update_policy = || {
+        PublicTablePolicies::new()
+            .with_update(Some(PublicPolicyExpr::True), PublicPolicyExpr::True)
+    };
+    let schema_for = |insert_policy: Option<PublicPolicyExpr>| {
+        let policies = insert_policy.map_or_else(update_policy, |insert| {
+            update_policy().with_insert(insert)
+        });
+        build_public_test_schema(PublicSchemaBuilder::new().table(
+            PublicTableSchemaBuilder::new("todos")
+                .column("title", PublicColumnType::Text)
+                .column("owner", PublicColumnType::Uuid)
+                .policies(policies),
+        ))
+    };
+    let author = user(0xa1);
+
+    for (label, insert_policy) in [
+        ("omitted", None),
+        ("false", Some(PublicPolicyExpr::False)),
+    ] {
+        let schema = schema_for(insert_policy);
+        let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+        let tx_id = core
+            .commit_mergeable_settled(
+                MergeableCommit::new("todos", row(0x91), 10)
+                    .made_by(author)
+                    .cells(owner_cells(author, "must not insert")),
+            )
+            .unwrap();
+        core.finalize_local_mergeable_commit_settled(tx_id).unwrap();
+        assert!(matches!(
+            core.transaction_state_settled(tx_id),
+            Some((
+                Fate::Rejected(RejectionReason::AuthorizationDenied),
+                None,
+                DurabilityTier::Local
+            ))
+        ), "{label} INSERT policy must deny a new local row");
+    }
+
+    let schema = schema_for(None);
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let existing = row(0x92);
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", existing, 20).cells(owner_cells(author, "before")),
+    );
+    let tx_id = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", existing, 21)
+                .made_by(author)
+                .cells(owner_cells(author, "after")),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(tx_id).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(tx_id),
+        Some((Fate::Accepted, Some(_), DurabilityTier::Global))
+    ), "declared UPDATE policy must still permit an existing row");
+}
+
 #[test]
 fn attributed_write_retry_preserves_permission_subject_after_rejection_error() {
     let schema = owner_policy_schema();

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -142,6 +142,131 @@ fn local_authority_keeps_insert_and_update_policies_distinct() {
         core.transaction_state_settled(tx_id),
         Some((Fate::Accepted, Some(_), DurabilityTier::Global))
     ), "declared UPDATE policy must still permit an existing row");
+
+    let schema = schema_for(None);
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let coalesced_row = row(0x94);
+    let open_tx = OpenTransactionId::new();
+    crate::db::block_on(core.open_mergeable(open_tx, author, Some(author))).unwrap();
+    crate::db::block_on(core.tx_write_mergeable(
+        open_tx,
+        "todos",
+        coalesced_row,
+        owner_cells(author, "coalesced insert"),
+        None,
+        Vec::new(),
+        Some(25),
+        false,
+    ))
+    .unwrap();
+    crate::db::block_on(core.tx_patch_mergeable(
+        open_tx,
+        "todos",
+        coalesced_row,
+        BTreeMap::from([("title".to_owned(), Value::String("patched insert".to_owned()))]),
+        Some(26),
+    ))
+    .unwrap();
+    let tx_id = core
+        .commit_mergeable_open_settled(open_tx, || 27)
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(tx_id).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(tx_id),
+        Some((
+            Fate::Rejected(RejectionReason::AuthorizationDenied),
+            None,
+            DurabilityTier::Local
+        ))
+    ), "coalesced insert-then-update must remain an INSERT for policy purposes");
+
+    let pending_update_denied = PublicTablePolicies::new()
+        .with_insert(PublicPolicyExpr::True)
+        .with_update(Some(PublicPolicyExpr::False), PublicPolicyExpr::False);
+    let schema = build_public_test_schema(PublicSchemaBuilder::new().table(
+        PublicTableSchemaBuilder::new("todos")
+            .column("title", PublicColumnType::Text)
+            .column("owner", PublicColumnType::Uuid)
+            .policies(pending_update_denied),
+    ));
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let pending_row = row(0x93);
+    let first = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", pending_row, 30)
+                .made_by(author)
+                .cells(owner_cells(author, "first pending insert")),
+        )
+        .unwrap();
+    let second = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", pending_row, 31)
+                .made_by(author)
+                .cells(owner_cells(author, "second pending update")),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(second).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(second),
+        Some((
+            Fate::Rejected(RejectionReason::AuthorizationDenied),
+            None,
+            DurabilityTier::Local
+        ))
+    ), "a newer pending row must classify against the older pending insert");
+    assert!(matches!(
+        core.transaction_state_settled(first),
+        Some((Fate::Pending, None, DurabilityTier::Local))
+    ), "the predecessor remains independently pending");
+}
+
+#[test]
+fn local_insert_policy_classification_survives_finalization_retry() {
+    let schema = build_public_test_schema(PublicSchemaBuilder::new().table(
+        PublicTableSchemaBuilder::new("todos")
+            .column("title", PublicColumnType::Text)
+            .column("owner", PublicColumnType::Uuid)
+            .policies(
+                PublicTablePolicies::new()
+                    .with_update(Some(PublicPolicyExpr::True), PublicPolicyExpr::True),
+            ),
+    ));
+    let column_families = schema.column_families();
+    let column_family_refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailTransactionReadMemoryStorage::new(&column_family_refs);
+    let mut core = NodeState::new(node(0x95), schema, storage.clone()).unwrap();
+    let author = user(0xa1);
+    let tx_id = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row(0x95), 10)
+                .made_by(author)
+                .cells(owner_cells(author, "retrying insert")),
+        )
+        .unwrap();
+
+    storage.fail_after_transaction_reads(2);
+    assert!(core
+        .finalize_local_mergeable_commit_settled(tx_id)
+        .expect_err("injected finalization failure")
+        .to_string()
+        .contains("injected transaction read failure"));
+    assert!(matches!(
+        core.transaction_state_settled(tx_id),
+        Some((Fate::Pending, None, DurabilityTier::Local))
+    ));
+
+    core.finalize_local_mergeable_commit_settled(tx_id).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(tx_id),
+        Some((
+            Fate::Rejected(RejectionReason::AuthorizationDenied),
+            None,
+            DurabilityTier::Local
+        ))
+    ), "retry must reapply INSERT policy, not reinterpret the candidate as an update");
 }
 
 #[test]

--- a/crates/jazz/src/peer/repair.rs
+++ b/crates/jazz/src/peer/repair.rs
@@ -27,6 +27,7 @@ impl PeerState {
             node,
             permission_identity,
             &versions,
+            Some(tx.tx_id),
             true,
         )
         .await?
@@ -81,6 +82,7 @@ impl PeerState {
                     node,
                     fate.permission_identity,
                     &fate.versions,
+                    Some(tx_id),
                     false,
                 )
                 .await?
@@ -154,11 +156,15 @@ impl PeerState {
         node: &mut NodeState<S>,
         writer: AuthorId,
         versions: &[VersionRecord],
+        candidate_tx_id: TxId,
     ) -> Result<(), Error>
     where
         S: OrderedKvStorage,
     {
-        for action in node.authorization_actions_for_versions(versions).await? {
+        for action in node
+            .authorization_actions_for_versions_in_transaction(versions, Some(candidate_tx_id))
+            .await?
+        {
             let scope = node.authorization_support_scope(writer, &action)?;
             if scope.subscriptions.is_empty() {
                 continue;
@@ -247,13 +253,17 @@ impl PeerState {
         node: &mut NodeState<S>,
         writer: AuthorId,
         versions: &[VersionRecord],
+        candidate_tx_id: Option<TxId>,
         retained_scope_is_unsettled: bool,
     ) -> Result<Option<Vec<SubscriptionKey>>, Error>
     where
         S: OrderedKvStorage,
     {
         let mut unsettled = Vec::new();
-        for action in node.authorization_actions_for_versions(versions).await? {
+        for action in node
+            .authorization_actions_for_versions_in_transaction(versions, candidate_tx_id)
+            .await?
+        {
             let scope = node.authorization_support_scope(writer, &action)?;
             if scope.subscriptions.is_empty() {
                 // A policy with no support clauses is structurally complete;

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -801,7 +801,7 @@ fn edge_support_hydration_uses_writer_claims_and_fails_closed_when_missing() {
     let mut wrong_subject_peer =
         PeerState::edge_client_with_permission_identity(transport_identity, transport_identity);
     let bound_subscriptions = wrong_subject_peer
-        .unsettled_authority_scope_subscriptions(&mut bound_edge, writer, &versions, true)
+        .unsettled_authority_scope_subscriptions(&mut bound_edge, writer, &versions, None, true)
         .expect("edge support must bind the writer rather than the transport identity");
     let bound_subscription = bound_subscriptions
         .and_then(|subscriptions| subscriptions.into_iter().next())
@@ -831,7 +831,13 @@ fn edge_support_hydration_uses_writer_claims_and_fails_closed_when_missing() {
     let mut wrong_type_peer =
         PeerState::edge_client_with_permission_identity(transport_identity, transport_identity);
     wrong_type_peer
-        .unsettled_authority_scope_subscriptions(&mut wrong_type_edge, writer, &versions, true)
+        .unsettled_authority_scope_subscriptions(
+            &mut wrong_type_edge,
+            writer,
+            &versions,
+            None,
+            true,
+        )
         .expect_err("present ill-typed claim must remain an error");
     assert_eq!(wrong_type_peer.link_identity(), transport_identity);
     assert_eq!(wrong_type_peer.identity(), transport_identity);


### PR DESCRIPTION
🤖 Closes #1806. Related to #1731.

## Behavior

Policy classification now searches local row history for the newest version from a transaction other than the candidate before falling back to globally settled history.

That means:
- the first pending version of a new row is an insert;
- a newer pending transaction touching that row is an update;
- insert then patch within one transaction remains one insert;
- retry after a failed finalization keeps the same classification.

## Why

The candidate was installed as the local winner before policy evaluation. Looking up “previous” content could therefore find the candidate itself, or skip local history entirely and incorrectly treat later pending writes as inserts.

## Evidence

Focused receipts cover distinct pending transactions, same-transaction coalescing, finalization retry, global fallback, and edge-authority updates. A planted candidate-self regression makes the insert-policy receipt fail. The full Jazz library suite passed: 1,243 tests.

Independently adversarially reviewed.