### PR TITLE
Ship WASM beside the browser worker

### DIFF
--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -159,6 +159,41 @@ function patchInstalledJazzNapi(appDir: string, repoRoot: string): void {
   }
 }
 
+/**
+ * The browser SharedWorker is a package-owned artifact: its wasm-bindgen glue
+ * resolves the binary beside itself. Check the installed tarball rather than
+ * the workspace source so the starter receipt catches an omitted package file
+ * before a release reaches adopters.
+ */
+function assertInstalledBrokerWorkerArtifacts(appDir: string): void {
+  const workerDir = path.join(appDir, "node_modules", "jazz-tools", "dist", "worker");
+  for (const filename of ["jazz-broker-worker.js", "jazz_wasm_bg.wasm"]) {
+    const artifact = path.join(workerDir, filename);
+    if (!fs.existsSync(artifact) || fs.statSync(artifact).size === 0) {
+      throw new Error(`Installed jazz-tools is missing browser worker artifact: ${artifact}`);
+    }
+  }
+}
+
+/**
+ * Keep the package boundary honest. A starter must never grow a copied
+ * `public/_jazz` binary as a side effect of a Next build; that used to mask a
+ * missing worker artifact in jazz-tools itself.
+ */
+function assertNoAppLocalJazzWasm(appDir: string): void {
+  const legacyAsset = path.join(appDir, "public", "_jazz", "jazz_wasm_bg.wasm");
+  if (fs.existsSync(legacyAsset)) {
+    throw new Error(`Starter generated an app-local Jazz WASM artifact: ${legacyAsset}`);
+  }
+}
+
+function removeStaleAppLocalJazzWasm(appDir: string): void {
+  // Starter sources can have an ignored build artifact left by a local Next
+  // invocation. Remove it before this fresh-package receipt so it cannot mask
+  // whether the current build regenerated the forbidden workaround.
+  fs.rmSync(path.join(appDir, "public", "_jazz"), { recursive: true, force: true });
+}
+
 function discoverPrebuiltTarballs(dir: string): Record<string, string> {
   if (!fs.existsSync(dir)) {
     throw new Error(`--tarball-dir ${dir} does not exist`);
@@ -315,6 +350,8 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
       );
     });
 
+    removeStaleAppLocalJazzWasm(appDir);
+    assertNoAppLocalJazzWasm(appDir);
     writeScaffoldedPnpmConfig(appDir, tarballs);
 
     await recordPhase("install", () =>
@@ -343,6 +380,7 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
     );
 
     patchInstalledJazzNapi(appDir, opts.repoRoot);
+    assertInstalledBrokerWorkerArtifacts(appDir);
 
     // Start the sync server before we write .env, so we can write the real
     // appId + serverUrl in one go and the build picks them up.
@@ -356,6 +394,9 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
         description: `pnpm build ${opts.starter}`,
       }),
     );
+    // Check again after production build: a framework adapter must not hide a
+    // package artifact failure by copying the binary into the app.
+    assertNoAppLocalJazzWasm(appDir);
 
     if (!opts.skipE2E) {
       // Each scaffolded starter pins its own @playwright/test version, which

--- a/packages/jazz-tools/scripts/bundle-broker-worker.mjs
+++ b/packages/jazz-tools/scripts/bundle-broker-worker.mjs
@@ -3,11 +3,15 @@
 // not reliably discover and bundle its imports themselves.
 import { build } from "esbuild";
 import { existsSync } from "node:fs";
-import { rm } from "node:fs/promises";
+import { copyFile, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const entry = fileURLToPath(new URL("../src/worker/jazz-broker-worker.ts", import.meta.url));
 const outfile = fileURLToPath(new URL("../dist/worker/jazz-broker-worker.js", import.meta.url));
+const wasmSource = fileURLToPath(
+  new URL("../../../crates/jazz-wasm/pkg/jazz_wasm_bg.wasm", import.meta.url),
+);
+const wasmOutfile = fileURLToPath(new URL("../dist/worker/jazz_wasm_bg.wasm", import.meta.url));
 
 await build({
   entryPoints: [entry],
@@ -18,6 +22,13 @@ await build({
   target: "es2022",
   legalComments: "none",
 });
+
+// The worker bundles wasm-bindgen's JS glue. Its default initializer resolves
+// `jazz_wasm_bg.wasm` relative to that glue, which esbuild places in this
+// worker bundle. Keep the binary beside the shipped worker so every consumer
+// bundler sees one complete, package-owned worker artifact; applications do
+// not need to copy Jazz assets into their own public directory.
+await copyFile(wasmSource, wasmOutfile);
 
 for (const stale of [`${outfile}.map`, outfile.replace(/\.js$/, ".ts")]) {
   if (existsSync(stale)) await rm(stale);

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { access, readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
@@ -40,10 +40,7 @@ beforeEach(async () => {
   delete process.env.JAZZ_ADMIN_SECRET;
   delete process.env.BACKEND_SECRET;
 
-  // withJazz copies jazz_wasm_bg.wasm into the host app's public/ dir
-  // (derived from process.cwd() when no appRoot is provided). Redirect cwd to a
-  // per-test temp dir so tests that don't pass appRoot don't pollute the
-  // package directory.
+  // Redirect cwd to a per-test directory for managed-runtime state.
   const fakeCwd = await tempRoots.create("jazz-next-test-cwd-");
   vi.spyOn(process, "cwd").mockReturnValue(fakeCwd);
 });
@@ -78,10 +75,7 @@ describe("withJazz", () => {
     );
 
     expect(resolved.reactStrictMode).toBe(true);
-    expect(resolved.env).toEqual({
-      EXISTING_ENV: "1",
-      NEXT_PUBLIC_JAZZ_WASM_URL: "/_jazz/jazz_wasm_bg.wasm",
-    });
+    expect(resolved.env).toEqual({ EXISTING_ENV: "1" });
     expect(resolved.serverExternalPackages).toEqual(
       expect.arrayContaining(["sharp", "jazz-tools", "jazz-napi"]),
     );
@@ -113,43 +107,6 @@ describe("withJazz", () => {
     expect(resolved.env?.NEXT_PUBLIC_JAZZ_SERVER_URL).toBeUndefined();
     expect(process.env.NEXT_PUBLIC_JAZZ_APP_ID).toBeUndefined();
     expect(process.env.NEXT_PUBLIC_JAZZ_SERVER_URL).toBeUndefined();
-  });
-
-  it("prefixes NEXT_PUBLIC_JAZZ_WASM_URL with basePath", async () => {
-    const resolved = await resolveWrappedConfig(
-      withJazz({ basePath: "/myapp" }),
-      PRODUCTION_BUILD_PHASE,
-    );
-
-    expect(resolved.env?.NEXT_PUBLIC_JAZZ_WASM_URL).toBe("/myapp/_jazz/jazz_wasm_bg.wasm");
-  });
-
-  it("omits basePath when not configured", async () => {
-    const resolved = await resolveWrappedConfig(withJazz({}), PRODUCTION_BUILD_PHASE);
-
-    expect(resolved.env?.NEXT_PUBLIC_JAZZ_WASM_URL).toBe("/_jazz/jazz_wasm_bg.wasm");
-  });
-
-  it("copies wasm into appRoot instead of schemaDir when both differ", async () => {
-    const appRoot = await tempRoots.create("jazz-next-app-root-");
-    const schemaDir = await tempRoots.create("jazz-next-schema-dir-");
-    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
-
-    await resolveWrappedConfig(
-      withJazz(
-        {},
-        {
-          appRoot,
-          schemaDir,
-        },
-      ),
-      PRODUCTION_BUILD_PHASE,
-    );
-
-    await expect(
-      access(join(appRoot, "public", "_jazz", "jazz_wasm_bg.wasm")),
-    ).resolves.toBeUndefined();
-    await expect(access(join(schemaDir, "public", "_jazz", "jazz_wasm_bg.wasm"))).rejects.toThrow();
   });
 
   it("starts a local server in development and injects NEXT_PUBLIC_JAZZ_* env vars", async () => {

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -1,5 +1,4 @@
-import { createRequire } from "node:module";
-import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
@@ -36,8 +35,6 @@ const PRODUCTION_BUILD_PHASE = "phase-production-build";
 const PUBLIC_APP_ID_ENV = "NEXT_PUBLIC_JAZZ_APP_ID";
 const PUBLIC_SERVER_URL_ENV = "NEXT_PUBLIC_JAZZ_SERVER_URL";
 const PUBLIC_TELEMETRY_COLLECTOR_URL_ENV = "NEXT_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL";
-const PUBLIC_WASM_URL_ENV = "NEXT_PUBLIC_JAZZ_WASM_URL";
-const PUBLIC_WASM_SUBPATH = "_jazz/jazz_wasm_bg.wasm";
 const SCHEMA_HASH_STUB_SUBPATH = join("node_modules", ".cache", "jazz", "schema-hash.js");
 const SCHEMA_HASH_ALIAS = "jazz-tools/_dev/schema-hash";
 
@@ -47,29 +44,11 @@ async function writeSchemaHashStub(appRoot: string, hash: string): Promise<void>
   await writeFile(stubPath, `export const HASH = ${JSON.stringify(hash)};\n`);
 }
 
-function buildPublicWasmUrl(basePath: unknown): string {
-  if (typeof basePath !== "string" || basePath.length === 0) {
-    return `/${PUBLIC_WASM_SUBPATH}`;
-  }
-  const trimmed = basePath.replace(/\/+$/, "");
-  const prefix = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return `${prefix}/${PUBLIC_WASM_SUBPATH}`;
-}
-
 const runtime = new ManagedDevRuntime({
   appId: PUBLIC_APP_ID_ENV,
   serverUrl: PUBLIC_SERVER_URL_ENV,
   telemetryCollectorUrl: PUBLIC_TELEMETRY_COLLECTOR_URL_ENV,
 });
-
-async function copyWasmToPublic(appRoot: string): Promise<void> {
-  const require = createRequire(import.meta.url);
-  const pkgJsonPath = require.resolve("jazz-wasm/package.json");
-  const wasmSource = join(dirname(pkgJsonPath), "pkg", "jazz_wasm_bg.wasm");
-  const wasmDest = join(appRoot, "public", PUBLIC_WASM_SUBPATH);
-  await mkdir(dirname(wasmDest), { recursive: true });
-  await copyFile(wasmSource, wasmDest);
-}
 
 function mergeServerExternalPackages(existing: string[] | undefined): string[] {
   return Array.from(new Set([...(existing ?? []), "jazz-napi"]));
@@ -100,29 +79,10 @@ export function withJazz(
       serverExternalPackages: mergeServerExternalPackages(resolved.serverExternalPackages),
     };
 
-    // Copy jazz-wasm bytes into the host app's public/ dir so they're served
-    // at a stable origin-root URL. Works around bundlers (Turbopack) that
-    // don't transform wasm-bindgen's `new URL('*.wasm', import.meta.url)`
-    // pattern inside worker chunks. Runs in dev and production-build so the
-    // asset is present in the built output.
-    const copyAndAdvertiseWasm = phase === DEVELOPMENT_PHASE || phase === PRODUCTION_BUILD_PHASE;
-    if (copyAndAdvertiseWasm) {
-      await copyWasmToPublic(options.appRoot ?? process.cwd());
-    }
-    const mergedWithWasmEnv: NextConfigLike = copyAndAdvertiseWasm
-      ? {
-          ...merged,
-          env: {
-            ...merged.env,
-            [PUBLIC_WASM_URL_ENV]: buildPublicWasmUrl(merged.basePath),
-          },
-        }
-      : merged;
-
     // Everything below is dev-only: managed server, APP_ID/SERVER_URL
     // injection. In production the host app supplies those via its own env.
     if (phase !== DEVELOPMENT_PHASE || options.server === false) {
-      return mergedWithWasmEnv;
+      return merged;
     }
 
     const serverOpt = options.server;
@@ -154,15 +114,15 @@ export function withJazz(
     // refuses to resolve them. Use the project-root-relative form there. Webpack
     // is happy with either, so feed it the absolute path for clarity.
     const turbopackStubPath = `./${SCHEMA_HASH_STUB_SUBPATH}`;
-    const previousWebpack = mergedWithWasmEnv.webpack as
+    const previousWebpack = merged.webpack as
       | ((config: WebpackConfig, ctx: unknown) => WebpackConfig)
       | undefined;
-    const previousTurbopack = (mergedWithWasmEnv.turbopack as TurbopackConfig | undefined) ?? {};
+    const previousTurbopack = (merged.turbopack as TurbopackConfig | undefined) ?? {};
 
     return {
-      ...mergedWithWasmEnv,
+      ...merged,
       env: {
-        ...mergedWithWasmEnv.env,
+        ...merged.env,
         [PUBLIC_APP_ID_ENV]: managed.appId,
         [PUBLIC_SERVER_URL_ENV]: managed.serverUrl,
         ...(managed.telemetryCollectorUrl

--- a/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
+++ b/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { execFile } from "node:child_process";
-import { readFile, rm } from "node:fs/promises";
+import { access, readFile, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -15,13 +15,16 @@ describe("broker worker packaging", () => {
     const outfile = fileURLToPath(
       new URL("../../dist/worker/jazz-broker-worker.js", import.meta.url),
     );
+    const wasmOutfile = fileURLToPath(
+      new URL("../../dist/worker/jazz_wasm_bg.wasm", import.meta.url),
+    );
     const pkgPath = fileURLToPath(new URL("../../package.json", import.meta.url));
     const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
     expect(pkg.scripts["build:runtime"]).toContain("bundle-broker-worker");
 
     // Delete the pre-existing build output so a no-op or broken script cannot
     // false-green by inspecting an artifact produced by an earlier command.
-    await rm(outfile, { force: true });
+    await Promise.all([rm(outfile, { force: true }), rm(wasmOutfile, { force: true })]);
     await execFileAsync(process.execPath, [bundleScript], { cwd: packageRoot });
 
     const source = await readFile(outfile, "utf8");
@@ -30,5 +33,6 @@ describe("broker worker packaging", () => {
     expect(source).not.toMatch(/\bfrom\s*["']\.\.?\//);
     expect(source).not.toMatch(/\bimport\s*\(\s*["']\.\.?\//);
     expect(source).toMatch(/onconnect/);
+    await expect(access(wasmOutfile)).resolves.toBeUndefined();
   });
 });

--- a/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
+++ b/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { execFile } from "node:child_process";
-import { access, readFile, rm } from "node:fs/promises";
+import { access, readFile, rm, stat } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -34,5 +34,6 @@ describe("broker worker packaging", () => {
     expect(source).not.toMatch(/\bimport\s*\(\s*["']\.\.?\//);
     expect(source).toMatch(/onconnect/);
     await expect(access(wasmOutfile)).resolves.toBeUndefined();
+    expect((await stat(wasmOutfile)).size).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
🤖 Fixes #1816 by making the browser worker package self-contained: `jazz_wasm_bg.wasm` is staged beside `jazz-broker-worker.js` and the obsolete Next-specific `public/_jazz` copy/env path is removed.

Behavior:

- workspace and packed-package consumers resolve the worker and WASM through one canonical sibling-artifact path;
- a generated Next.js starter installed from the packed tarball completes a production build without creating app-local `_jazz` assets;
- the release starter E2E fails before build when either installed worker artifact is missing or empty.

Verification:

- `jazz-tools` runtime build and focused worker/Next tests pass;
- clean generated `next-localfirst` tarball install, production build, and Playwright receipt pass;
- package dry run contains both worker and nonempty sibling WASM;
- independent review planted a missing installed WASM and an obsolete app-local copy; both were caught and restored.

No sync/runtime semantics change; this repairs artifact placement and its packaged-production receipt.