### PR TITLE
Run continuous seeded simulation soaks

### DIFF
--- a/.github/workflows/continuous-simulation-soak.yml
+++ b/.github/workflows/continuous-simulation-soak.yml
@@ -1,0 +1,149 @@
+name: Continuous simulation soak
+
+on:
+  schedule:
+    - cron: "30 7 * * *"
+  workflow_dispatch:
+    inputs:
+      sync_seeds: { description: "Sync seed count", required: false, default: "100" }
+      sync_commits: { description: "Commits per sync seed", required: false, default: "200" }
+      differential_seeds: { description: "Differential seed count", required: false, default: "50" }
+      differential_steps:
+        { description: "Steps per differential seed", required: false, default: "20" }
+      churn_depths:
+        { description: "Comma-separated churn depths", required: false, default: "10,1000" }
+
+permissions:
+  contents: read
+
+concurrency:
+  group: continuous-simulation-soak
+  cancel-in-progress: false
+
+jobs:
+  soak:
+    # A dispatch may be requested from another same-repository ref.  Do not run
+    # that ref on the persistent runner: both entry points are default-branch
+    # only, and checkout below independently pins the executed source.
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: [self-hosted, Linux, X64, jazz-ci]
+    timeout-minutes: 360
+    permissions:
+      contents: read
+      # A manually dispatched repro is read-only.  Only scheduled default-branch
+      # code receives the issue token used for durable overnight reporting.
+      issues: ${{ github.event_name == 'schedule' && 'write' || 'none' }}
+    env:
+      SOAK_DIR: ${{ runner.temp }}/simulation-soak
+      CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-target
+      SYNC_SEEDS: ${{ inputs.sync_seeds || '100' }}
+      SYNC_COMMITS: ${{ inputs.sync_commits || '200' }}
+      DIFFERENTIAL_SEEDS: ${{ inputs.differential_seeds || '50' }}
+      DIFFERENTIAL_STEPS: ${{ inputs.differential_steps || '20' }}
+      CHURN_DEPTHS: ${{ inputs.churn_depths || '10,1000' }}
+      # Two sequential 150-minute shards leave an hour for checkout,
+      # compilation, artifacts, and durable failure reporting under the 6h cap.
+      SHARD_BUDGET_SECONDS: "9000"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Record trusted source revision
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Runner baseline
+        run: |
+          set -euo pipefail
+          mkdir -p "$SOAK_DIR"
+          df -h > "$SOAK_DIR/df-before.txt"
+          free -h > "$SOAK_DIR/memory-before.txt"
+          sccache --show-stats > "$SOAK_DIR/sccache-before.txt" || true
+      - name: Run deterministic shard 1 of 2
+        id: shard_one
+        continue-on-error: true
+        run: dev/gates/run-continuous-simulation-soak.sh --output "$SOAK_DIR/shard-1" --shard-index 1 --shard-count 2 --sync-seeds "$SYNC_SEEDS" --sync-commits "$SYNC_COMMITS" --differential-seeds "$DIFFERENTIAL_SEEDS" --differential-steps "$DIFFERENTIAL_STEPS" --churn-depths "$CHURN_DEPTHS" --watchdog-seconds 80 --budget-seconds "$SHARD_BUDGET_SECONDS"
+      - name: Run deterministic shard 2 of 2
+        id: shard_two
+        continue-on-error: true
+        run: dev/gates/run-continuous-simulation-soak.sh --output "$SOAK_DIR/shard-2" --shard-index 2 --shard-count 2 --sync-seeds "$SYNC_SEEDS" --sync-commits "$SYNC_COMMITS" --differential-seeds "$DIFFERENTIAL_SEEDS" --differential-steps "$DIFFERENTIAL_STEPS" --churn-depths "$CHURN_DEPTHS" --watchdog-seconds 80 --budget-seconds "$SHARD_BUDGET_SECONDS"
+      - name: Report nightly failures as deduplicated issues
+        if: ${{ always() && github.event_name == 'schedule' && (steps.shard_one.outcome == 'failure' || steps.shard_two.outcome == 'failure') }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          SOAK_DIR: ${{ env.SOAK_DIR }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const failures = [1, 2].flatMap(shard => {
+              const file = path.join(process.env.SOAK_DIR, `shard-${shard}`, "summary.json");
+              return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")).failures : [];
+            });
+            const listed = await github.paginate(github.rest.issues.listForRepo, { ...context.repo, state: "all", per_page: 100 });
+            const byMarker = new Map(listed.flatMap(issue => {
+              const marker = typeof issue.body === "string" ? issue.body.match(/<!-- continuous-simulation-soak:[^>]+ -->/)?.[0] : null;
+              return marker ? [[marker, issue]] : [];
+            }));
+            const reportErrors = [];
+            for (const failure of failures) {
+              // This is a public-repository equivalent of the private sensitive-data
+              // publication guard. The manifest is generated by trusted default-branch
+              // code, but do not publish its free-form fields or test logs regardless:
+              // rebuild the issue from a closed template and allow-listed scalar values.
+              const fail = (message) => { throw new Error(`invalid soak failure: ${message}`); };
+              if (!["sync", "differential", "soak"].includes(failure.suite)) fail("suite");
+              if (!Number.isSafeInteger(failure.seed) || failure.seed < 0 || (failure.suite === "soak" && failure.seed !== 0)) fail("seed");
+              if (!["failed", "timeout", "budget_exhausted"].includes(failure.status)) fail("status");
+              const config = failure.config;
+              if (!config || !Number.isSafeInteger(config.sync_commits) || config.sync_commits < 1) fail("sync commits");
+              if (!Number.isSafeInteger(config.differential_steps) || config.differential_steps < 1) fail("differential steps");
+              if (!Number.isSafeInteger(config.watchdog_seconds) || config.watchdog_seconds < 1) fail("watchdog");
+              if (!Number.isSafeInteger(config.effective_timeout_seconds) || config.effective_timeout_seconds < 1 || config.effective_timeout_seconds > config.watchdog_seconds) fail("effective timeout");
+              if (typeof config.churn_depths !== "string" || !/^[1-9][0-9]*(,[1-9][0-9]*)*$/.test(config.churn_depths)) fail("churn depths");
+              const sha = process.env.SOURCE_SHA;
+              if (!/^[0-9a-f]{40}$/.test(sha ?? "")) fail("source SHA");
+              const { owner, repo } = context.repo;
+              if (!/^[A-Za-z0-9_.-]+$/.test(owner) || !/^[A-Za-z0-9_.-]+$/.test(repo)) fail("repository name");
+              const env = failure.suite === "sync"
+                ? `JAZZ_SEED=${failure.seed} JAZZ_COMMIT_COUNT=${config.sync_commits}`
+                : failure.suite === "differential" ? `JAZZ_SEED=${failure.seed} JAZZ_DIFFERENTIAL_STEP_COUNT=${config.differential_steps} JAZZ_DIFFERENTIAL_CHURN_DEPTHS=${config.churn_depths}` : "";
+              const test = failure.suite === "sync"
+                ? "node::tests::sync::convergence_and_fates::m3_seeded_sync_interleavings_converge_against_oracle -- --exact"
+                : failure.suite === "differential" ? "node::tests::harness::m3_maintained_one_shot_differential_oracle -- --exact --ignored" : "";
+              const replay = failure.suite === "soak" ? "Re-run the trusted workflow with a larger bounded budget." : `CARGO_TARGET_DIR=\${CARGO_TARGET_DIR:-target} timeout --kill-after=30s ${config.effective_timeout_seconds}s env ${env} cargo test -p jazz --lib --no-default-features --features testing,transport-compression-zstd ${test}`;
+              const key = `continuous-simulation-soak:${failure.suite}:${failure.seed}:${config.sync_commits}:${config.differential_steps}:${config.churn_depths}:${config.effective_timeout_seconds}`;
+              const marker = `<!-- ${key} -->`;
+              const title = `Simulation soak failure: ${failure.suite} seed ${failure.seed}`;
+              const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+              const body = `🤖 Nightly simulation soak failed.\n${marker}\n\nSHA: \`${sha}\`\nResult: \`${failure.status}\`\n\nReplay:\n\`\`\`sh\n${replay}\n\`\`\`\n\n[Run](${runUrl}) · [Artifacts](${runUrl}#artifacts)`;
+              try {
+                const existing = byMarker.get(marker);
+                if (existing) {
+                  await github.rest.issues.update({ ...context.repo, issue_number: existing.number, title, body, state: "open" });
+                } else {
+                  await github.rest.issues.create({ ...context.repo, title, body });
+                }
+              } catch (error) {
+                reportErrors.push(`${failure.suite}:${failure.seed}: ${error instanceof Error ? error.message : String(error)}`);
+              }
+            }
+            if (reportErrors.length) core.warning(`Could not publish ${reportErrors.length} soak issue(s): ${reportErrors.join(" | ")}`);
+      - name: Runner final snapshot
+        if: always()
+        run: |
+          df -h > "$SOAK_DIR/df-after.txt"
+          free -h > "$SOAK_DIR/memory-after.txt"
+          sccache --show-stats > "$SOAK_DIR/sccache-after.txt" || true
+      - name: Upload soak receipts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: continuous-simulation-soak-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.SOAK_DIR }}
+          retention-days: 14
+          if-no-files-found: warn
+      - name: Fail job when a shard failed
+        if: ${{ steps.shard_one.outcome == 'failure' || steps.shard_two.outcome == 'failure' }}
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,16 @@ Wide maintained-vs-one-shot soaks use
 `JAZZ_SEED_COUNT=2000 cargo test -p jazz m3_maintained_one_shot_differential_oracle`
 alongside the existing m3 soak conventions.
 
+**Continuous simulation soak.** `.github/workflows/continuous-simulation-soak.yml`
+runs the deterministic M3 sync-convergence and maintained-vs-one-shot oracle
+nightly on the trusted `jazz-ci` runner, with individual seed receipts. Run the
+same driver locally with `dev/gates/run-continuous-simulation-soak.sh --sync-seeds
+2 --differential-seeds 2`; copy a failed case's replay command from
+`target/simulation-soak/summary.json`. The nightly default is sync 100×200
+commits and differential 50×20 steps at churn depths 10,1000. The 100000-depth
+churn is deliberately deferred from nightly: it is available through
+`--churn-depths 10,1000,100000` when a bounded weekly budget is established.
+
 **Don't rewrite existing tests without permission.** Existing tests encode decisions about what correct behaviour looks like. If the task explicitly involves changing behaviour, updating the tests to match is the right thing to do. But if a test is failing simply because the implementation diverges from what the test expects, rewriting the test to match the new behaviour is risky — the test may well be correct and the implementation wrong. Treat that as a human-in-the-loop decision: surface it to the user rather than resolving it unilaterally.
 
 **Gate cadence — batched (Anselm-approved 2026-07-11).** Levers may be _batched_

--- a/dev/gates/run-continuous-simulation-soak.sh
+++ b/dev/gates/run-continuous-simulation-soak.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run replayable, individual seeded simulation/oracle cases.  This intentionally
+# does not use JAZZ_SEED_COUNT: every seed has its own watchdog and receipt.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+usage() {
+  cat <<'EOF'
+Usage: dev/gates/run-continuous-simulation-soak.sh [options]
+
+  --output DIR          Receipt directory (default: target/simulation-soak)
+  --shard-index N       One-based deterministic shard (default: 1)
+  --shard-count N       Number of shards (default: 1)
+  --sync-seeds N        Number of sync seeds (default: 100)
+  --sync-commits N      Commits per sync seed (default: 200)
+  --differential-seeds N  Number of differential seeds (default: 50)
+  --differential-steps N  Steps per differential seed (default: 20)
+  --churn-depths CSV    Aggregate churn depths (default: 10,1000)
+  --watchdog-seconds N  Per-seed watchdog (default: 80)
+  --budget-seconds N    Cumulative shard budget; stops cleanly at boundary
+                        (default: 19800)
+  --reporting-reserve-seconds N  Time reserved for summary/artifacts (default: 300)
+
+Replay a recorded failure by copying its `replay` command from summary.json.
+EOF
+}
+
+output="target/simulation-soak"; shard_index=1; shard_count=1
+sync_seeds=100; sync_commits=200; differential_seeds=50; differential_steps=20
+churn_depths="10,1000"; watchdog_seconds=80; budget_seconds=19800; reporting_reserve_seconds=300
+while (($#)); do
+  case "$1" in
+    --output) output="$2"; shift 2;; --shard-index) shard_index="$2"; shift 2;;
+    --shard-count) shard_count="$2"; shift 2;; --sync-seeds) sync_seeds="$2"; shift 2;;
+    --sync-commits) sync_commits="$2"; shift 2;; --differential-seeds) differential_seeds="$2"; shift 2;;
+    --differential-steps) differential_steps="$2"; shift 2;; --churn-depths) churn_depths="$2"; shift 2;;
+    --watchdog-seconds) watchdog_seconds="$2"; shift 2;; --budget-seconds) budget_seconds="$2"; shift 2;; --reporting-reserve-seconds) reporting_reserve_seconds="$2"; shift 2;; -h|--help) usage; exit 0;;
+    *) usage >&2; exit 2;;
+  esac
+done
+for number in "$shard_index" "$shard_count" "$sync_seeds" "$sync_commits" "$differential_seeds" "$differential_steps" "$watchdog_seconds" "$budget_seconds" "$reporting_reserve_seconds"; do
+  [[ "$number" =~ ^[1-9][0-9]*$ ]] || { echo "positive integer required: $number" >&2; exit 2; }
+done
+(( shard_index <= shard_count )) || { echo "shard index exceeds shard count" >&2; exit 2; }
+(( sync_seeds <= 1000 && differential_seeds <= 1000 )) || { echo "seed counts are capped at 1000" >&2; exit 2; }
+(( sync_commits <= 10000 && differential_steps <= 1000 )) || { echo "workload depth exceeds driver cap" >&2; exit 2; }
+(( watchdog_seconds <= 900 && budget_seconds <= 19800 && reporting_reserve_seconds <= 1800 )) || { echo "watchdog/budget exceeds driver cap" >&2; exit 2; }
+[[ "$churn_depths" =~ ^[1-9][0-9]*(,[1-9][0-9]*)*$ ]] || { echo "invalid churn depths" >&2; exit 2; }
+
+# A whole shard must fit even if every selected case consumes its watchdog.
+# This makes the workflow's six-hour budget a provable bound, not a hope.
+assigned_cases=0
+for count in "$sync_seeds" "$differential_seeds"; do
+  for ((i=0; i<count; i++)); do (( i % shard_count == shard_index - 1 )) && ((assigned_cases+=1)); done
+done
+(( assigned_cases * (watchdog_seconds + 30) + reporting_reserve_seconds <= budget_seconds )) || { echo "worst-case shard time including kill grace/reporting reserve exceeds budget" >&2; exit 2; }
+
+mkdir -p "$output/logs"
+sha="$(git rev-parse HEAD)"
+config="$output/config.env"
+manifest="$output/manifest.jsonl"
+summary="$output/summary.json"
+printf '%s\n' "sha=$sha" "shard_index=$shard_index" "shard_count=$shard_count" "sync_seeds=$sync_seeds" "sync_commits=$sync_commits" "differential_seeds=$differential_seeds" "differential_steps=$differential_steps" "churn_depths=$churn_depths" "watchdog_seconds=$watchdog_seconds" "budget_seconds=$budget_seconds" > "$config"
+: > "$manifest"
+
+# Keep seed generation aligned with the tests' deterministic extension scheme.
+seed_for() { local suite="$1" index="$2"; if [[ "$suite" == sync ]]; then local fixed=(11 29 47 83 32676 40595 2234158 3715011 4372288); if (( index < ${#fixed[@]} )); then echo "${fixed[index]}"; else echo $((1000 + (index-${#fixed[@]}) * 7919)); fi; else local fixed=(11 29 47 4372288 7777013); if (( index < ${#fixed[@]} )); then echo "${fixed[index]}"; else echo $((9000 + (index-${#fixed[@]}) * 7919)); fi; fi; }
+failures=0; ran=0; budget_exhausted=false; deadline=$(( $(date +%s) + budget_seconds ))
+# Test-only deterministic clock seam: validates incomplete-run receipts without
+# sleeping or relying on host scheduling. It is not used by the workflow.
+[[ "${JAZZ_SOAK_TEST_EXHAUST_BUDGET:-}" == 1 ]] && deadline=$(date +%s)
+run_seed() {
+  local suite="$1" seed="$2" test_name env_args test_args log status replay
+  if [[ "$suite" == sync ]]; then
+    test_name="node::tests::sync::convergence_and_fates::m3_seeded_sync_interleavings_converge_against_oracle"
+    env_args=("JAZZ_SEED=$seed" "JAZZ_COMMIT_COUNT=$sync_commits")
+    test_args=(--exact)
+  else
+    test_name="node::tests::harness::m3_maintained_one_shot_differential_oracle"
+    env_args=("JAZZ_SEED=$seed" "JAZZ_DIFFERENTIAL_STEP_COUNT=$differential_steps" "JAZZ_DIFFERENTIAL_CHURN_DEPTHS=$churn_depths")
+    test_args=(--exact --ignored)
+  fi
+  log="$output/logs/${suite}-seed-${seed}.log"
+  replay="CARGO_TARGET_DIR=\${CARGO_TARGET_DIR:-target} timeout --kill-after=30s ${case_timeout}s env ${env_args[*]} cargo test -p jazz --lib --no-default-features --features testing,transport-compression-zstd ${test_name} -- ${test_args[*]}"
+  set +e
+  timeout --kill-after=30s "${case_timeout}s" env "${env_args[@]}" cargo test -p jazz --lib --no-default-features --features testing,transport-compression-zstd "$test_name" -- "${test_args[@]}" >"$log" 2>&1
+  status=$?
+  set -e
+  if (( status == 124 || status == 137 )); then result=timeout; else result=passed; (( status == 0 )) || result=failed; fi
+  printf '{"suite":"%s","seed":%s,"status":"%s","exit_code":%s,"config":{"sync_commits":%s,"differential_steps":%s,"churn_depths":"%s","watchdog_seconds":%s,"effective_timeout_seconds":%s},"log":"%s","replay":"%s"}\n' "$suite" "$seed" "$result" "$status" "$sync_commits" "$differential_steps" "$churn_depths" "$watchdog_seconds" "$case_timeout" "logs/${suite}-seed-${seed}.log" "$replay" >> "$manifest"
+  ((ran+=1)); if [[ "$result" != passed ]]; then ((failures+=1)); fi
+  echo "$suite seed=$seed status=$result replay: $replay"
+}
+for suite in sync differential; do
+  count="$sync_seeds"; [[ "$suite" == differential ]] && count="$differential_seeds"
+  for ((i=0; i<count; i++)); do
+    (( i % shard_count == shard_index - 1 )) || continue
+    remaining=$(( deadline - $(date +%s) - reporting_reserve_seconds ))
+    if (( remaining <= 30 )); then budget_exhausted=true; break 2; fi
+    case_timeout=$watchdog_seconds; (( case_timeout > remaining - 30 )) && case_timeout=$((remaining - 30))
+    # Deterministic test seam for the manifest/replay timeout contract.
+    [[ "${JAZZ_SOAK_TEST_EFFECTIVE_TIMEOUT:-}" =~ ^[1-9][0-9]*$ ]] && case_timeout="$JAZZ_SOAK_TEST_EFFECTIVE_TIMEOUT"
+    run_seed "$suite" "$(seed_for "$suite" "$i")"
+  done
+done
+if "$budget_exhausted"; then
+  printf '{"suite":"soak","seed":0,"status":"budget_exhausted","exit_code":3,"config":{"sync_commits":%s,"differential_steps":%s,"churn_depths":"%s","watchdog_seconds":%s,"effective_timeout_seconds":%s},"log":null,"replay":"Re-run the trusted workflow with a larger bounded budget."}\n' "$sync_commits" "$differential_steps" "$churn_depths" "$watchdog_seconds" "$watchdog_seconds" >> "$manifest"
+fi
+node -e 'const fs=require("fs"); const [manifest,summary,sha,budget]=process.argv.slice(1); const cases=fs.readFileSync(manifest,"utf8").trim().split("\n").filter(Boolean).map(JSON.parse); fs.writeFileSync(summary, JSON.stringify({schema_version:1,sha,budget_exhausted:budget==="true",cases,failures:cases.filter(x=>x.status!=="passed")},null,2)+"\n")' "$manifest" "$summary" "$sha" "$budget_exhausted"
+echo "Simulation soak summary: $summary ($ran cases, $failures failures, budget_exhausted=$budget_exhausted)"
+if "$budget_exhausted"; then exit 3; fi
+(( failures == 0 ))


### PR DESCRIPTION
🤖 Adds a trusted continuous seeded-simulation soak for the M3 convergence and maintained-vs-one-shot differential oracles.

The workflow runs nightly on the default branch or by trusted default-branch dispatch on the existing `jazz-ci` self-hosted pool. A deterministic driver records every seed and configuration before execution, applies per-seed and cumulative budgets, emits exact replay commands, and preserves manifests, summaries, logs, and host resource receipts.

Nightly failures create or update marker-deduplicated GitHub issues using a strictly allow-listed generated body. Closed matching issues are reopened; manual runs remain read-only and never publish issues.

Default coverage is 100 sync seeds at 200 commits and 50 differential seeds at 20 steps with churn depths 10 and 1,000, split across two sequential shards. Budget exhaustion is a visible synthetic failure rather than a silently incomplete green run.

Verified with tiny real sync/differential runs, deterministic timeout and budget-exhaustion seams, workflow/static gates, and an independent adversarial review.