### PR TITLE
Bind trusted exclusive transactions to their opening identity

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -258,12 +258,6 @@ type NativeDb = {
   mergeableTxForIdentity?(openBatchId: OpenBatchId, author: Uint8Array): Tx;
   exclusiveTx?(openBatchId: OpenBatchId): Tx;
   allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): Uint8Array;
-  allInTransactionForIdentity?(
-    query: PreparedQuery,
-    tx: Tx,
-    author: Uint8Array,
-    opts: unknown,
-  ): Uint8Array;
   setTickScheduler(
     callback:
       | ((urgency: "immediate" | "deferred") => void)
@@ -1130,7 +1124,10 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     const session = sessionFromWriteContext(sessionJson);
     this.applySessionClaims(session);
-    const identity = kind === "mergeable" ? this.trustedWriteIdentity(session) : undefined;
+    // The native core binds an exclusive transaction's identity at begin. Keep
+    // the trusted-serving subject here so every staged operation and its
+    // commit are authorized as that one subject.
+    const identity = this.trustedWriteIdentity(session);
     this.db.beginTransaction(id, kind, identity);
     this.pendingTxs.set(id, { id, kind, identity, writes: [], txByView: new Map() });
     return id;
@@ -1660,17 +1657,6 @@ export class NativeRuntimeAdapter implements Runtime {
     pendingTx: PendingTx | undefined,
   ): Uint8Array {
     if (!pendingTx) return this.readRowsForHost(query, opts, session?.identity);
-    if (this.readAuthorizationHost === "trusted-serving") {
-      if (!this.db.allInTransactionForIdentity) {
-        throw new Error("Native runtime does not support trusted-serving transaction reads");
-      }
-      return this.db.allInTransactionForIdentity(
-        query,
-        this.txForRead(pendingTx),
-        session?.identity ?? this.peerIdentity,
-        opts,
-      );
-    }
     if (!this.db.allInTransaction) {
       throw new Error("Native runtime does not support transaction reads");
     }
@@ -1900,11 +1886,8 @@ export class NativeRuntimeAdapter implements Runtime {
 
   private txForWrite(pending: PendingTx, identity: Uint8Array | undefined): Tx {
     if (pending.kind === "exclusive") {
-      if (identity && schemaHasPolicies(this.schema)) {
-        throw new Error(
-          "Native runtime cannot perform session-scoped exclusive transaction writes: " +
-            "the native runtime exclusive transaction API has no identity-aware staging methods.",
-        );
+      if (pending.identity && (!identity || !sameBytes(pending.identity, identity))) {
+        throw new Error("Native runtime exclusive transaction cannot mix write identities");
       }
       return this.txForRead(pending);
     }
@@ -3191,10 +3174,6 @@ function errorMessage(error: unknown): string {
 function contextualError(context: string, error: unknown): Error {
   const cause = error instanceof Error ? error : new Error(errorMessage(error));
   return new Error(`${context}: ${cause.message}`, { cause });
-}
-
-function schemaHasPolicies(schema: WasmSchema): boolean {
-  return Object.values(schema).some((table) => table.policies !== undefined);
 }
 
 function rejectionCode(message: string): string {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -296,6 +296,127 @@ it("uses identity-aware core txs only on an explicit trusted-serving host", () =
   expect(staged).toEqual(["todos"]);
 });
 
+it("binds a trusted-serving exclusive transaction to its opening identity", () => {
+  const alice = "00000000-0000-0000-0000-0000000000a1";
+  const beganAs: string[] = [];
+  const policySchema = {
+    todos: {
+      ...testSchema.todos,
+      policies: {},
+    },
+  } satisfies WasmSchema;
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () => {
+        const db = fakeDb({
+          all: () => encodeRows([]),
+          allForIdentity: () => encodeRows([]),
+          exclusiveTx: () => fakeTx(),
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+        }) as unknown as {
+          beginTransaction(
+            openBatchId: string,
+            kind: "mergeable" | "exclusive",
+            author?: Uint8Array,
+          ): void;
+        };
+        const begin = db.beginTransaction.bind(db);
+        db.beginTransaction = (openBatchId, kind, author) => {
+          beganAs.push(author === undefined ? "none" : formatUuidForTest(author));
+          begin(openBatchId, kind, author);
+        };
+        return db;
+      },
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    policySchema,
+    new Uint8Array(16),
+    new Uint8Array(16),
+    1,
+    true,
+    { readAuthorizationHost: "trusted-serving" },
+  );
+
+  const tx = createOpenBatchId();
+  runtime.beginTransaction("exclusive", tx, JSON.stringify({ user_id: alice }));
+  runtime.insert(
+    "todos",
+    { title: { type: "Text", value: "session-scoped exclusive write" } },
+    JSON.stringify({ batch_id: tx, session: { user_id: alice } }),
+    "00000000-0000-0000-0000-000000000001",
+  );
+
+  expect(beganAs).toEqual([alice]);
+  expect(() =>
+    runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "wrong subject" } },
+      JSON.stringify({
+        batch_id: tx,
+        session: { user_id: "00000000-0000-0000-0000-0000000000b2" },
+      }),
+      "00000000-0000-0000-0000-000000000002",
+    ),
+  ).toThrow("Native runtime exclusive transaction cannot mix write identities");
+});
+
+it("uses the opening identity for trusted-serving transaction reads", async () => {
+  const alice = "00000000-0000-0000-0000-0000000000a1";
+  const tx = fakeTx();
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          all: () => encodeRows([]),
+          allForIdentity: () => encodeRows([]),
+          allInTransaction: (_query: object, receivedTx: TxForTest) => {
+            expect(receivedTx).toBe(tx);
+            return encodeRows([
+              {
+                table: "todos",
+                rowId: uuidBytes("00000000-0000-0000-0000-000000000001"),
+                title: "Alice's pending row",
+              },
+            ]);
+          },
+          exclusiveTx: () => tx,
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    new Uint8Array(16),
+    1,
+    true,
+    { readAuthorizationHost: "trusted-serving" },
+  );
+
+  const transactionId = createOpenBatchId();
+  runtime.beginTransaction("exclusive", transactionId, JSON.stringify({ user_id: alice }));
+
+  await expect(
+    runtime.query(
+      JSON.stringify({ table: "todos" }),
+      JSON.stringify({ user_id: "00000000-0000-0000-0000-0000000000b2" }),
+      "local",
+      JSON.stringify({ transaction_batch_id: transactionId }),
+    ),
+  ).resolves.toEqual([
+    {
+      table: "todos",
+      id: "00000000-0000-0000-0000-000000000001",
+      values: [{ type: "Text", value: "Alice's pending row" }],
+    },
+  ]);
+});
+
 it("rejects a duplicate live OpenBatchId without replacing its staged transaction", () => {
   const stagedTransactions: string[][] = [];
   const runtime = new NativeRuntimeAdapter(


### PR DESCRIPTION
🤖 Supplies the Jazz-owned transaction correctness prerequisite for #1746.

Trusted-serving exclusive transactions now bind the authenticated session identity at begin, just like the core primitive introduced in #1805. Reads and writes use that bound identity throughout the transaction; a later request cannot switch subjects by supplying a different session. This leaves the adopter PR responsible only for adapting Better Auth operations to the supported Jazz transaction surface.

Includes lifecycle regressions for begin-time binding, cross-subject rejection, and bound-identity reads. Independent adversarial review found no authorization regression at `fce1b591d`; focused lifecycle tests pass 12/12.