### PR TITLE
Configure continuous-soak paths at runner time

### DIFF
--- a/.github/workflows/continuous-simulation-soak.yml
+++ b/.github/workflows/continuous-simulation-soak.yml
@@ -31,8 +31,6 @@ jobs:
     permissions:
       contents: read
     env:
-      SOAK_DIR: ${{ runner.temp }}/simulation-soak
-      CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-target
       SYNC_SEEDS: ${{ inputs.sync_seeds || '100' }}
       SYNC_COMMITS: ${{ inputs.sync_commits || '200' }}
       DIFFERENTIAL_SEEDS: ${{ inputs.differential_seeds || '50' }}
@@ -46,6 +44,10 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+      - name: Configure runner-local paths
+        run: |
+          echo "SOAK_DIR=$RUNNER_TEMP/simulation-soak" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_DIR=$RUNNER_TEMP/cargo-target" >> "$GITHUB_ENV"
       - name: Record trusted source revision
         id: source
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -75,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: continuous-simulation-soak-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ env.SOAK_DIR }}
+          path: ${{ runner.temp }}/simulation-soak
           retention-days: 14
           if-no-files-found: warn
       - name: Fail job when a shard failed


### PR DESCRIPTION
🤖 Fixes the remaining workflow-schema error exposed by the first post-#1821 dispatch.

GitHub does not expose the `runner` context in job-level `env`. The workflow now derives runner-local paths from `$RUNNER_TEMP` at runtime via `$GITHUB_ENV`; the artifact step uses the legal step-level `runner.temp` context and resolves to the identical directory.

Independent review validated every expression context, path handoff, artifact/report path, and persistent-runner isolation at `7037a0cfc`. Repository workflow tests pass 50/50.