### PR TITLE
Gate legacy benchmark smoke on testing support

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -156,5 +156,9 @@ name = "async_open"
 required-features = ["testing"]
 
 [[test]]
+name = "legacy_benchmark_smoke"
+required-features = ["testing"]
+
+[[test]]
 name = "edge_fate_authority"
 required-features = ["runtime"]


### PR DESCRIPTION
🤖 Restores ordinary no-feature Jazz test compilation.

The legacy benchmark integration target calls diagnostics that intentionally exist only under the `testing` feature, but its Cargo target omitted the matching `required-features` declaration. This adds the same narrow gate already used by the benchmark and other testing-only integration targets; it does not expose production compatibility APIs.

Verified the testing-enabled target passes 5/5 and `cargo test -p jazz --no-run` succeeds without compiling the unsupported target.