### PR TITLE
Precompile simulation soaks before seed watchdogs

### DIFF
--- a/.github/workflows/continuous-simulation-soak.yml
+++ b/.github/workflows/continuous-simulation-soak.yml
@@ -36,9 +36,10 @@ jobs:
       DIFFERENTIAL_SEEDS: ${{ inputs.differential_seeds || '50' }}
       DIFFERENTIAL_STEPS: ${{ inputs.differential_steps || '20' }}
       CHURN_DEPTHS: ${{ inputs.churn_depths || '10,1000' }}
-      # Two sequential 150-minute shards leave an hour for checkout,
-      # compilation, artifacts, and durable failure reporting under the 6h cap.
+      # Two sequential 150-minute shards plus a separately bounded 15-minute
+      # cold compile leave 45 minutes for checkout, artifacts, and reporting.
       SHARD_BUDGET_SECONDS: "9000"
+      PRECOMPILE_TIMEOUT_SECONDS: "900"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -58,12 +59,32 @@ jobs:
           df -h > "$SOAK_DIR/df-before.txt"
           free -h > "$SOAK_DIR/memory-before.txt"
           sccache --show-stats > "$SOAK_DIR/sccache-before.txt" || true
+      - name: Precompile exact Jazz soak test binary
+        id: precompile
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          started="$(date -u +%FT%TZ)"
+          timeout --kill-after=30s "${PRECOMPILE_TIMEOUT_SECONDS}s" \
+            cargo test -p jazz --lib --no-default-features \
+              --features testing,transport-compression-zstd --no-run \
+            >"$SOAK_DIR/precompile.log" 2>&1
+          status=$?
+          set -e
+          result=passed
+          if ((status == 124 || status == 137)); then result=timeout; elif ((status != 0)); then result=failed; fi
+          node -e 'const fs=require("fs"); const [file,started,status,result,sha]=process.argv.slice(1); fs.writeFileSync(file, JSON.stringify({schema_version:1,phase:"precompile",started_at:started,status:result,exit_code:Number(status),sha},null,2)+"\n")' \
+            "$SOAK_DIR/precompile.json" "$started" "$status" "$result" "$(git rev-parse HEAD)"
+          exit "$status"
       - name: Run deterministic shard 1 of 2
         id: shard_one
+        if: steps.precompile.outcome == 'success'
         continue-on-error: true
         run: dev/gates/run-continuous-simulation-soak.sh --output "$SOAK_DIR/shard-1" --shard-index 1 --shard-count 2 --sync-seeds "$SYNC_SEEDS" --sync-commits "$SYNC_COMMITS" --differential-seeds "$DIFFERENTIAL_SEEDS" --differential-steps "$DIFFERENTIAL_STEPS" --churn-depths "$CHURN_DEPTHS" --watchdog-seconds 80 --budget-seconds "$SHARD_BUDGET_SECONDS"
       - name: Run deterministic shard 2 of 2
         id: shard_two
+        if: steps.precompile.outcome == 'success'
         continue-on-error: true
         run: dev/gates/run-continuous-simulation-soak.sh --output "$SOAK_DIR/shard-2" --shard-index 2 --shard-count 2 --sync-seeds "$SYNC_SEEDS" --sync-commits "$SYNC_COMMITS" --differential-seeds "$DIFFERENTIAL_SEEDS" --differential-steps "$DIFFERENTIAL_STEPS" --churn-depths "$CHURN_DEPTHS" --watchdog-seconds 80 --budget-seconds "$SHARD_BUDGET_SECONDS"
       - name: Runner final snapshot
@@ -81,7 +102,7 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
       - name: Fail job when a shard failed
-        if: ${{ steps.shard_one.outcome == 'failure' || steps.shard_two.outcome == 'failure' }}
+        if: ${{ steps.precompile.outcome == 'failure' || steps.shard_one.outcome == 'failure' || steps.shard_two.outcome == 'failure' }}
         run: exit 1
 
   report-nightly:
@@ -108,16 +129,21 @@ jobs:
             const fs = require("fs"), path = require("path");
             const summaries = [1, 2].flatMap(n => { const f = path.join("soak-receipts", `shard-${n}`, "summary.json"); return fs.existsSync(f) ? [JSON.parse(fs.readFileSync(f, "utf8"))] : []; });
             const failures = summaries.flatMap(s => s.failures || []);
+            const precompileFile = path.join("soak-receipts", "precompile.json");
+            if (fs.existsSync(precompileFile)) {
+              const precompile = JSON.parse(fs.readFileSync(precompileFile, "utf8"));
+              if (precompile.status !== "passed") failures.push({suite:"precompile",seed:0,status:precompile.status,sha:precompile.sha,config:{sync_commits:1,differential_steps:1,churn_depths:"1",watchdog_seconds:900,effective_timeout_seconds:900}});
+            }
             if (!failures.length) return;
             const issues = await github.paginate(github.rest.issues.listForRepo, { ...context.repo, state: "all", per_page: 100 });
             const reportErrors = [];
             for (const f of failures) {
               try {
               const fail = message => { throw new Error(`invalid soak receipt: ${message}`); };
-              if (!["sync", "differential", "soak"].includes(f.suite)) fail("suite");
+                if (!["sync", "differential", "soak", "precompile"].includes(f.suite)) fail("suite");
               if (!["failed", "timeout", "budget_exhausted"].includes(f.status)) fail("status");
               if (!Number.isSafeInteger(f.seed) || f.seed < 0 || f.seed > 9_999_999 || (f.suite === "soak" && f.seed !== 0)) fail("seed");
-              const c = f.config, sha = summaries.find(s => s.failures?.includes(f))?.sha;
+                const c = f.config, sha = f.sha || summaries.find(s => s.failures?.includes(f))?.sha;
               if (!c || !/^[0-9a-f]{40}$/.test(sha || "")) fail("config or SHA");
               for (const key of ["sync_commits", "differential_steps", "watchdog_seconds", "effective_timeout_seconds"]) {
                 if (!Number.isSafeInteger(c[key]) || c[key] < 1 || c[key] > 10_000) fail(key);
@@ -127,7 +153,7 @@ jobs:
               const key = `continuous-simulation-soak:${f.suite}:${f.seed}:${c.sync_commits}:${c.differential_steps}:${c.churn_depths}:${c.effective_timeout_seconds}`, marker = `<!-- ${key} -->`;
               const env = f.suite === "sync" ? `JAZZ_SEED=${f.seed} JAZZ_COMMIT_COUNT=${c.sync_commits}` : `JAZZ_SEED=${f.seed} JAZZ_DIFFERENTIAL_STEP_COUNT=${c.differential_steps} JAZZ_DIFFERENTIAL_CHURN_DEPTHS=${c.churn_depths}`;
               const test = f.suite === "sync" ? "node::tests::sync::convergence_and_fates::m3_seeded_sync_interleavings_converge_against_oracle -- --exact" : "node::tests::harness::m3_maintained_one_shot_differential_oracle -- --exact --ignored";
-              const replay = f.suite === "soak" ? "Re-run the trusted workflow with a larger bounded budget." : `CARGO_TARGET_DIR=\${CARGO_TARGET_DIR:-target} timeout --kill-after=30s ${c.effective_timeout_seconds}s env ${env} cargo test -p jazz --lib --no-default-features --features testing,transport-compression-zstd ${test}`;
+                const replay = f.suite === "soak" ? "Re-run the trusted workflow with a larger bounded budget." : f.suite === "precompile" ? "CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} timeout --kill-after=30s 900s cargo test -p jazz --lib --no-default-features --features testing,transport-compression-zstd --no-run" : `CARGO_TARGET_DIR=\${CARGO_TARGET_DIR:-target} timeout --kill-after=30s ${c.effective_timeout_seconds}s env ${env} cargo test -p jazz --lib --no-default-features --features testing,transport-compression-zstd ${test}`;
               const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`, body = `🤖 Nightly simulation soak failed.\n${marker}\n\nSHA: \`${sha}\`\nResult: \`${f.status}\`\n\nReplay:\n\`\`\`sh\n${replay}\n\`\`\`\n\n[Run](${url}) · [Artifacts](${url}#artifacts)`;
               const existing = issues.find(i => i.body?.includes(marker));
               if (existing) await github.rest.issues.update({ ...context.repo, issue_number: existing.number, title: `Simulation soak failure: ${f.suite} seed ${f.seed}`, body, state: "open" }); else await github.rest.issues.create({ ...context.repo, title: `Simulation soak failure: ${f.suite} seed ${f.seed}`, body });

--- a/.github/workflows/continuous-simulation-soak.yml
+++ b/.github/workflows/continuous-simulation-soak.yml
@@ -40,6 +40,7 @@ jobs:
       # cold compile leave 45 minutes for checkout, artifacts, and reporting.
       SHARD_BUDGET_SECONDS: "9000"
       PRECOMPILE_TIMEOUT_SECONDS: "900"
+      # GNU timeout's 30s kill grace makes this phase's hard ceiling 930s.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -270,21 +270,40 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
 });
 
 test("continuous soak precompiles outside seed watchdogs and preserves failure artifacts", () => {
-  const workflow = fs.readFileSync(
+  const source = fs.readFileSync(
     path.join(root, ".github/workflows/continuous-simulation-soak.yml"),
     "utf8",
   );
-  const compile = workflow.indexOf("name: Precompile exact Jazz soak test binary");
-  const shard = workflow.indexOf("name: Run deterministic shard 1 of 2");
-  assert.ok(compile >= 0 && compile < shard, "cold compile must precede seeded cases");
-  assert.match(
-    workflow,
-    /timeout --kill-after=30s "\$\{PRECOMPILE_TIMEOUT_SECONDS\}s"[\s\S]*cargo test -p jazz --lib --no-default-features[\s\S]*--features testing,transport-compression-zstd --no-run/,
+  const parsed = parse(source);
+  const steps = parsed.jobs.soak.steps;
+  const precompile = steps.find((step) => step.name === "Precompile exact Jazz soak test binary");
+  const assertPrecompileCommand = (run) => {
+    assert.match(run, /timeout --kill-after=30s "\$\{PRECOMPILE_TIMEOUT_SECONDS\}s"/);
+    assert.match(
+      run,
+      /cargo test -p jazz --lib --no-default-features \\\n\s+--features testing,transport-compression-zstd --no-run \\\n/,
+    );
+    assert.doesNotMatch(run, /--no-exec/);
+  };
+  assert.ok(precompile, "missing named cold precompile step");
+  assertPrecompileCommand(precompile.run);
+  assert.throws(
+    () => assertPrecompileCommand(precompile.run.replace("--no-run", "--no-exec")),
+    /does not match|match the regular expression/,
+    "contract must reject a planted precompile flag regression",
   );
-  assert.match(workflow, /if: steps\.precompile\.outcome == 'success'/);
-  assert.match(workflow, /name: Upload soak receipts\n\s+if: always\(\)/);
-  assert.match(workflow, /steps\.precompile\.outcome == 'failure'/);
-  assert.match(workflow, /phase:\s*"precompile"/);
+  for (const id of ["shard_one", "shard_two"])
+    assert.equal(
+      steps.find((step) => step.id === id)?.if,
+      "steps.precompile.outcome == 'success'",
+      `${id} must require successful precompile`,
+    );
+  assert.equal(steps.find((step) => step.name === "Upload soak receipts")?.if, "always()");
+  assert.match(
+    steps.find((step) => step.name === "Fail job when a shard failed")?.if,
+    /steps\.precompile\.outcome == 'failure'/,
+  );
+  assert.match(precompile.run, /phase:\s*"precompile"/);
 });
 
 test("build setup scopes mutable pnpm and sccache state to the agent temp directory", () => {

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -269,6 +269,24 @@ test("Rust CI uses pinned prebuilt tools without charging Rust-only jobs for was
     assert.match(source, /uses: \.\/\.github\/actions\/setup-blacksmith/);
 });
 
+test("continuous soak precompiles outside seed watchdogs and preserves failure artifacts", () => {
+  const workflow = fs.readFileSync(
+    path.join(root, ".github/workflows/continuous-simulation-soak.yml"),
+    "utf8",
+  );
+  const compile = workflow.indexOf("name: Precompile exact Jazz soak test binary");
+  const shard = workflow.indexOf("name: Run deterministic shard 1 of 2");
+  assert.ok(compile >= 0 && compile < shard, "cold compile must precede seeded cases");
+  assert.match(
+    workflow,
+    /timeout --kill-after=30s "\$\{PRECOMPILE_TIMEOUT_SECONDS\}s"[\s\S]*cargo test -p jazz --lib --no-default-features[\s\S]*--features testing,transport-compression-zstd --no-run/,
+  );
+  assert.match(workflow, /if: steps\.precompile\.outcome == 'success'/);
+  assert.match(workflow, /name: Upload soak receipts\n\s+if: always\(\)/);
+  assert.match(workflow, /steps\.precompile\.outcome == 'failure'/);
+  assert.match(workflow, /phase:\s*"precompile"/);
+});
+
 test("build setup scopes mutable pnpm and sccache state to the agent temp directory", () => {
   assert.match(setupBuildAction, /dest: \$\{\{ runner\.temp \}\}\/setup-pnpm/);
   assert.match(setupBuildAction, /sccache_dir="\$\{RUNNER_TEMP\}\/sccache"/);


### PR DESCRIPTION
🤖 Fixes the false timeout exposed by manual soak run 32674229935.

Seed 11 spent its entire 80-second per-case watchdog compiling a cold Cargo target; after compilation, every executed simulation passed. The workflow now performs one separately bounded `--no-run` compile using the exact test profile/features before either shard, records distinct compile receipts, and keeps compilation outside per-seed watchdogs. Compile failure skips both shards, still uploads artifacts, and is reported distinctly on nightly runs.

Independent review approved `c2601f819`; mutation-sensitive workflow contracts pass 51/51.