### PR TITLE
Move benchmark API checks off the PR critical path

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Prepare libclang for bindgen
         run: bash dev/benchmarks/realistic/prepare_libclang_env.sh
 
+      # Ordinary PR CI retains the deterministic benchmark-derived assertions.
+      # Compile all maintained benchmark APIs on this opt-in/native benchmark
+      # surface instead of extending every PR's Rust critical path.
+      - name: Compile maintained benchmark APIs
+        run: dev/gates/benchmark-smoke.sh --compile-ci
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -104,7 +104,7 @@ jobs:
           sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
       - name: Workspace Rust tests (bounded, sharded, receipted)
         run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features jazz/testing,jazz/transport-compression-zstd,jazz-server/test,jazz-cli/test
-      - name: Benchmark API and deterministic scenario smoke
+      - name: Benchmark deterministic scenario smoke
         run: dev/gates/benchmark-smoke.sh --ci
       - name: Verify Nextest partition coverage
         run: node --test dev/gates/test/nextest-partitions.test.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,9 @@ For ordinary Rust/core work, the full gate set is:
 - `cargo test -p jazz-otel` covers exporter/provider construction. Its ignored
   `sync_telemetry_otel` target is a manual receipt because it does not
   programmatically assert collector delivery.
-- `cargo check -p jazz-sim --benches` (always; it is cheap enough and catches bench API rot)
+- `cargo check -p jazz-sim --benches` on the realistic benchmark workflow
+  (benchmark-labeled PRs, default-branch pushes, and nightly); it catches
+  bench API rot without extending every ordinary PR's critical path.
 - `dev/gates/ts-wire-codec.sh` for TypeScript/native-runtime wire-codec coverage
   (Anselm-approved 2026-07-07)
 - `dev/gates/invariant-registry.sh` parses both invariant registries and fails on
@@ -91,9 +93,11 @@ Benchmark work has three deliberately separate gates:
   `dev/gates/benchmark-smoke.sh <jazz|jazz-sim> <bench>`. This is a debug
   `cargo check`, not `cargo bench`; it avoids release-wide RocksDB rebuilds and
   timing noise.
-- CI runs `dev/gates/benchmark-smoke.sh --ci`: benchmark API compilation plus
-  deterministic core and jazz-sim scenario assertions. Keep correctness
-  assertions in tests, not in a timing receipt.
+- Ordinary PR CI runs `dev/gates/benchmark-smoke.sh --ci`: deterministic core
+  and jazz-sim scenario assertions. The realistic benchmark workflow runs
+  `dev/gates/benchmark-smoke.sh --compile-ci` to compile every maintained
+  benchmark API on labeled PRs, default-branch pushes, and nightly. Keep
+  correctness assertions in tests, not in a timing receipt.
 - CodSpeed currently compares the example benchmark crates only. Apply the
   `benchmark` label when that coverage is relevant; it refreshes nightly on the
   default branch. Native `jazz` and `jazz-sim` timing remains in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,9 +103,10 @@ Benchmark work has three deliberately separate gates:
 - CodSpeed currently compares the example benchmark crates only. Apply the
   `benchmark` label when that coverage is relevant; it refreshes nightly on the
   default branch. Native `jazz` and `jazz-sim` timing remains in the
-  realistic benchmark workflow (labeled PRs plus scheduled/default-branch
-  runs) until those suites are ported to CodSpeed. Do not run a repository-wide
-  benchmark suite before push.
+  realistic benchmark workflow (same-repository benchmark-labeled PRs,
+  non-bot default-branch pushes, manual runs, and nightly) until those suites
+  are ported to CodSpeed. Do not run a repository-wide benchmark suite before
+  push.
 
 Any change to a public `jazz` type additionally gates the full workspace,
 including examples.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,9 @@ For ordinary Rust/core work, the full gate set is:
   `sync_telemetry_otel` target is a manual receipt because it does not
   programmatically assert collector delivery.
 - `cargo check -p jazz-sim --benches` on the realistic benchmark workflow
-  (benchmark-labeled PRs, default-branch pushes, and nightly); it catches
-  bench API rot without extending every ordinary PR's critical path.
+  (same-repository PRs bearing `benchmark`, non-bot default-branch pushes,
+  manual runs, and nightly); it catches bench API rot without extending every
+  ordinary PR's critical path.
 - `dev/gates/ts-wire-codec.sh` for TypeScript/native-runtime wire-codec coverage
   (Anselm-approved 2026-07-07)
 - `dev/gates/invariant-registry.sh` parses both invariant registries and fails on
@@ -96,8 +97,9 @@ Benchmark work has three deliberately separate gates:
 - Ordinary PR CI runs `dev/gates/benchmark-smoke.sh --ci`: deterministic core
   and jazz-sim scenario assertions. The realistic benchmark workflow runs
   `dev/gates/benchmark-smoke.sh --compile-ci` to compile every maintained
-  benchmark API on labeled PRs, default-branch pushes, and nightly. Keep
-  correctness assertions in tests, not in a timing receipt.
+  benchmark API on same-repository benchmark-labeled PRs, non-bot
+  default-branch pushes, manual runs, and nightly. Keep correctness assertions
+  in tests, not in a timing receipt.
 - CodSpeed currently compares the example benchmark crates only. Apply the
   `benchmark` label when that coverage is relevant; it refreshes nightly on the
   default branch. Native `jazz` and `jazz-sim` timing remains in the

--- a/crates/jazz/SPEC/D_testing_gates.md
+++ b/crates/jazz/SPEC/D_testing_gates.md
@@ -43,12 +43,12 @@ For a benchmark edit, locally run
 compile check. Ordinary PR CI runs `dev/gates/benchmark-smoke.sh --ci`, which
 executes deterministic core and jazz-sim scenario assertions. The realistic
 benchmark workflow runs `dev/gates/benchmark-smoke.sh --compile-ci` to check
-all maintained benchmark APIs on labeled PRs, default-branch pushes, and
-nightly. CodSpeed evaluates the example benchmark crates on benchmark-labeled
-PRs and nightly; native `jazz` and `jazz-sim` timing remains in the realistic
-benchmark workflow until it is ported. No local omnibus benchmark script is a
-push gate. A change to a public `jazz` type additionally gates the full
-workspace, including examples.
+all maintained benchmark APIs on same-repository benchmark-labeled PRs,
+non-bot default-branch pushes, manual runs, and nightly. CodSpeed evaluates the
+example benchmark crates on benchmark-labeled PRs and nightly; native `jazz`
+and `jazz-sim` timing remains in the realistic benchmark workflow until it is
+ported. No local omnibus benchmark script is a push gate. A change to a public
+`jazz` type additionally gates the full workspace, including examples.
 
 Use a `-j` appropriate for the box; see PR #1157 for the rationale behind
 replacing the former fixed `-j 2` guidance.
@@ -57,9 +57,9 @@ replacing the former fixed `-j 2` guidance.
 
 - **Crate tests** — integration and crate tests for `jazz` and `groove`.
 - **Bench API compilation** — `cargo check -p jazz-sim --benches` runs on the
-  realistic benchmark workflow (benchmark-labeled PRs, default-branch pushes,
-  and nightly), where it catches benchmark API rot without extending every
-  ordinary PR's critical path.
+  realistic benchmark workflow (same-repository benchmark-labeled PRs,
+  non-bot default-branch pushes, manual runs, and nightly), where it catches
+  benchmark API rot without extending every ordinary PR's critical path.
 - **TS/native wire codec** — `dev/gates/ts-wire-codec.sh` is the current
   TypeScript/native-runtime wire-codec gate. `dev/gates/` currently contains
   this gate and no legacy JS ABI decoder or WASM binding script.

--- a/crates/jazz/SPEC/D_testing_gates.md
+++ b/crates/jazz/SPEC/D_testing_gates.md
@@ -31,7 +31,7 @@ For ordinary Rust/core work, the full gate set is:
 1. `cargo test -p jazz`
 2. `cargo test -p groove`
 3. `cargo test -p jazz --no-default-features --features testing,transport-compression-zstd`
-4. `cargo check -p jazz-sim --benches`
+4. `cargo check -p jazz-sim --benches` on the realistic benchmark workflow
 5. `dev/gates/ts-wire-codec.sh`
 6. `JAZZ_SEED_COUNT=300 cargo test -p jazz m3_maintained_one_shot_differential_oracle`
 7. `cargo test -p jazz --test incremental_delivery_canary maintained_relation_include_single_row_changes_are_scale_independent -- --exact`
@@ -40,13 +40,15 @@ For ordinary Rust/core work, the full gate set is:
 
 For a benchmark edit, locally run
 `dev/gates/benchmark-smoke.sh <jazz|jazz-sim> <bench>`; it is a targeted debug
-compile check. CI runs `dev/gates/benchmark-smoke.sh --ci`, which checks all
-maintained benchmark APIs and executes deterministic core and jazz-sim scenario
-assertions. CodSpeed evaluates the example benchmark crates on benchmark-labeled
-PRs and nightly; native `jazz` and `jazz-sim` timing remains in the
-realistic benchmark workflow until it is ported. No local omnibus benchmark
-script is a push gate. A change to a public `jazz` type additionally gates the
-full workspace, including examples.
+compile check. Ordinary PR CI runs `dev/gates/benchmark-smoke.sh --ci`, which
+executes deterministic core and jazz-sim scenario assertions. The realistic
+benchmark workflow runs `dev/gates/benchmark-smoke.sh --compile-ci` to check
+all maintained benchmark APIs on labeled PRs, default-branch pushes, and
+nightly. CodSpeed evaluates the example benchmark crates on benchmark-labeled
+PRs and nightly; native `jazz` and `jazz-sim` timing remains in the realistic
+benchmark workflow until it is ported. No local omnibus benchmark script is a
+push gate. A change to a public `jazz` type additionally gates the full
+workspace, including examples.
 
 Use a `-j` appropriate for the box; see PR #1157 for the rationale behind
 replacing the former fixed `-j 2` guidance.
@@ -54,9 +56,10 @@ replacing the former fixed `-j 2` guidance.
 ### D.2 The tiers
 
 - **Crate tests** — integration and crate tests for `jazz` and `groove`.
-- **Bench API compilation** — `cargo check -p jazz-sim --benches` is always in
-  the ordinary gate set because benchmark API rot has previously hidden until
-  late in a lane.
+- **Bench API compilation** — `cargo check -p jazz-sim --benches` runs on the
+  realistic benchmark workflow (benchmark-labeled PRs, default-branch pushes,
+  and nightly), where it catches benchmark API rot without extending every
+  ordinary PR's critical path.
 - **TS/native wire codec** — `dev/gates/ts-wire-codec.sh` is the current
   TypeScript/native-runtime wire-codec gate. `dev/gates/` currently contains
   this gate and no legacy JS ABI decoder or WASM binding script.
@@ -80,10 +83,11 @@ cargo test -p jazz --lib node::tests::harness::m3_maintained_one_shot_differenti
 - **Sensitive-data guard** — the guard in `jazz-private/dev/gates/` keeps
   customer-specific fixture names, domains, and ids out of the public
   repository.
-- **Benchmark API and scenario smoke** — CI compiles all maintained benchmark
-  targets and runs deterministic scenario assertions. CodSpeed compares example
-  benchmark crates; native `jazz` and `jazz-sim` timing stays in the
-  realistic workflow until migrated.
+- **Benchmark API and scenario smoke** — Ordinary CI runs deterministic
+  scenario assertions. The realistic benchmark workflow compiles all
+  maintained benchmark targets; CodSpeed compares example benchmark crates;
+  native `jazz` and `jazz-sim` timing stays in the realistic workflow until
+  migrated.
 - **Public type changes** — changes to public `jazz` types additionally gate the
   full workspace, including examples.
 - **Server shell** — the server-shell tests are included in the `jazz` package

--- a/dev/gates/benchmark-smoke.sh
+++ b/dev/gates/benchmark-smoke.sh
@@ -9,19 +9,41 @@ usage() {
 Usage:
   dev/gates/benchmark-smoke.sh <jazz|jazz-sim> <bench>
   dev/gates/benchmark-smoke.sh --ci
+  dev/gates/benchmark-smoke.sh --compile-ci
 
 The local form performs one debug-profile `cargo check` only. It never runs
 `cargo bench`, never writes a timing ledger, and does not request release
-RocksDB artifacts. `--ci` checks all maintained benchmark APIs and executes
-the deterministic jazz-sim scenario assertions.
+RocksDB artifacts. `--ci` executes deterministic correctness assertions on
+ordinary PR CI. `--compile-ci` checks all maintained benchmark APIs on the
+realistic benchmark workflow, where compile/performance coverage already lives.
 EOF
 }
 
+run_phase() {
+  local phase="$1"
+  shift
+  local started_seconds=$SECONDS
+  local status=0
+  if "$@"; then
+    status=0
+  else
+    status=$?
+  fi
+  printf 'benchmark-smoke phase=%s duration_seconds=%s status=%s\n' \
+    "$phase" "$((SECONDS - started_seconds))" "$status"
+  return "$status"
+}
+
 if [[ "${1:-}" == "--ci" && $# == 1 ]]; then
-  cargo check -p jazz --benches --features testing
-  cargo check -p jazz-sim --benches
-  cargo test -p jazz --features testing --test legacy_benchmark_smoke
-  cargo test -p jazz-sim --test scenario_smoke
+  run_phase legacy-benchmark-correctness \
+    cargo test -p jazz --features testing --test legacy_benchmark_smoke
+  run_phase jazz-sim-scenario-correctness cargo test -p jazz-sim --test scenario_smoke
+  exit 0
+fi
+
+if [[ "${1:-}" == "--compile-ci" && $# == 1 ]]; then
+  run_phase jazz-benchmark-api cargo check -p jazz --benches --features testing
+  run_phase jazz-sim-benchmark-api cargo check -p jazz-sim --benches
   exit 0
 fi
 

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -955,12 +955,10 @@ test("realistic benchmark compilation has an explicit guarded trigger matrix", (
   const native = document.jobs.native;
   assert.deepEqual(native["runs-on"], ["self-hosted", "linux", "x64", "jazz-bench"]);
   assert.equal(native["timeout-minutes"], 180);
-  assert.match(native.if, /github\.actor != 'github-actions\[bot\]'/);
-  assert.match(native.if, /contains\(github\.event\.pull_request\.labels\.\*\.name, 'benchmark'\)/);
-  assert.match(
-    native.if,
-    /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
-  );
+  const expectedNativeCondition =
+    "${{ (github.event_name != 'push' || github.actor != 'github-actions[bot]') && ( github.event_name != 'pull_request' || ( contains(github.event.pull_request.labels.*.name, 'benchmark') && github.event.pull_request.head.repo.full_name == github.repository ) ) }}";
+  const normalizeCondition = (condition) => condition.replace(/\s+/g, " ").trim();
+  assert.equal(normalizeCondition(native.if), expectedNativeCondition);
 
   assert.throws(() => {
     const unsafe = parse(realisticWorkflow.replace('  schedule:\n    - cron: "0 5 * * *"\n', ""));
@@ -973,11 +971,17 @@ test("realistic benchmark compilation has an explicit guarded trigger matrix", (
         "true",
       ),
     );
-    assert.match(
-      unsafe.jobs.native.if,
-      /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+    assert.equal(normalizeCondition(unsafe.jobs.native.if), expectedNativeCondition);
+  }, /true/);
+  assert.throws(() => {
+    const unsafe = parse(
+      realisticWorkflow.replace(
+        "        )\n      }}\n    runs-on:",
+        "        ) || true\n      }}\n    runs-on:",
+      ),
     );
-  }, /repo/);
+    assert.equal(normalizeCondition(unsafe.jobs.native.if), expectedNativeCondition);
+  }, /true/);
 });
 
 test("realistic timing retains every retired legacy smoke suite", () => {

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -64,6 +64,14 @@ const job = (name) => {
   assert.notEqual(source, undefined, `missing ${name} job`);
   return source;
 };
+const benchmarkSmokeMode = (mode) => {
+  const start = `if [[ "\${1:-}" == "--${mode}" && $# == 1 ]]; then`;
+  const startIndex = benchmarkSmokeGate.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing --${mode} benchmark smoke mode`);
+  const endIndex = benchmarkSmokeGate.indexOf("\nfi", startIndex);
+  assert.notEqual(endIndex, -1, `unterminated --${mode} benchmark smoke mode`);
+  return benchmarkSmokeGate.slice(startIndex + start.length, endIndex);
+};
 const assertUsesBlacksmithRunner = (jobName, jobSource) => {
   const cpu = jobName === "test-ts" ? 16 : 4;
   assert.match(jobSource, new RegExp(`runs-on: blacksmith-${cpu}vcpu-ubuntu-2404`));
@@ -881,21 +889,38 @@ test("CodSpeed runs nightly on main and only for benchmark-labeled PRs", () => {
   }, /strictly equal/);
 });
 
-test("benchmark correctness is CI-gated while CodSpeed scope stays explicit", () => {
+test("benchmark correctness stays on ordinary CI while API compilation uses realistic benchmarks", () => {
   const workspace = job("test-rust-workspace");
+  const scenarioMode = benchmarkSmokeMode("ci");
+  const compileMode = benchmarkSmokeMode("compile-ci");
   assert.match(
     workspace,
-    /name: Benchmark API and deterministic scenario smoke\s+run: dev\/gates\/benchmark-smoke\.sh --ci/,
+    /name: Benchmark deterministic scenario smoke\s+run: dev\/gates\/benchmark-smoke\.sh --ci/,
   );
-  assert.match(benchmarkSmokeGate, /cargo check -p jazz --benches --features testing/);
-  assert.match(benchmarkSmokeGate, /cargo check -p jazz-sim --benches/);
+  assert.match(
+    realisticWorkflow,
+    /name: Compile maintained benchmark APIs\s+run: dev\/gates\/benchmark-smoke\.sh --compile-ci/,
+  );
+  assert.match(
+    compileMode,
+    /run_phase jazz-benchmark-api cargo check -p jazz --benches --features testing/,
+  );
+  assert.match(compileMode, /run_phase jazz-sim-benchmark-api cargo check -p jazz-sim --benches/);
+  assert.doesNotMatch(scenarioMode, /cargo check -p (?:jazz|jazz-sim) --benches/);
+  assert.doesNotMatch(compileMode, /cargo test -p (?:jazz|jazz-sim)/);
   assert.match(benchmarkSmokeGate, /cargo metadata --no-deps --format-version 1/);
   assert.match(benchmarkSmokeGate, /required-features/);
-  assert.match(
-    benchmarkSmokeGate,
-    /cargo test -p jazz --features testing --test legacy_benchmark_smoke/,
+  assert.match(scenarioMode, /cargo test -p jazz --features testing --test legacy_benchmark_smoke/);
+  assert.match(scenarioMode, /cargo test -p jazz-sim --test scenario_smoke/);
+  assert.match(benchmarkSmokeGate, /benchmark-smoke phase=%s duration_seconds=%s status=%s/);
+  assert.throws(
+    () =>
+      assert.match(
+        scenarioMode.replace("cargo test -p jazz-sim --test scenario_smoke", "true"),
+        /cargo test -p jazz-sim --test scenario_smoke/,
+      ),
+    /scenario_smoke/,
   );
-  assert.match(benchmarkSmokeGate, /cargo test -p jazz-sim --test scenario_smoke/);
   assert.doesNotMatch(benchmarkSmokeGate, /^\s*cargo bench|^\s*.*--release/m);
   assert.throws(
     () =>

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -940,6 +940,46 @@ test("benchmark correctness stays on ordinary CI while API compilation uses real
   );
 });
 
+test("realistic benchmark compilation has an explicit guarded trigger matrix", () => {
+  const document = parse(realisticWorkflow);
+  assert.deepEqual(document.on.pull_request, {
+    branches: ["main"],
+    types: ["opened", "reopened", "synchronize", "labeled"],
+  });
+  assert.deepEqual(document.on.push, { branches: ["main"] });
+  assert.deepEqual(document.on.schedule, [{ cron: "0 5 * * *" }]);
+  assert.equal(document.on.workflow_dispatch.inputs.profile.default, "s");
+  assert.equal(document.on.workflow_dispatch.inputs.include_browser.type, "boolean");
+  assert.deepEqual(document.permissions, { contents: "read", issues: "write" });
+
+  const native = document.jobs.native;
+  assert.deepEqual(native["runs-on"], ["self-hosted", "linux", "x64", "jazz-bench"]);
+  assert.equal(native["timeout-minutes"], 180);
+  assert.match(native.if, /github\.actor != 'github-actions\[bot\]'/);
+  assert.match(native.if, /contains\(github\.event\.pull_request\.labels\.\*\.name, 'benchmark'\)/);
+  assert.match(
+    native.if,
+    /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+  );
+
+  assert.throws(() => {
+    const unsafe = parse(realisticWorkflow.replace('  schedule:\n    - cron: "0 5 * * *"\n', ""));
+    assert.ok(unsafe.on.schedule, "nightly schedule must remain");
+  }, /nightly schedule/);
+  assert.throws(() => {
+    const unsafe = parse(
+      realisticWorkflow.replace(
+        "github.event.pull_request.head.repo.full_name == github.repository",
+        "true",
+      ),
+    );
+    assert.match(
+      unsafe.jobs.native.if,
+      /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+    );
+  }, /repo/);
+});
+
 test("realistic timing retains every retired legacy smoke suite", () => {
   for (const bench of [
     "cold_subscription",


### PR DESCRIPTION
🤖 Removes the dominant avoidable work from ordinary PR CI while retaining every deterministic correctness assertion.

Recent successful `test-rust-workspace` jobs took 8–15 minutes; the benchmark smoke phase alone consumed roughly 4.5–8.5 minutes. Ordinary CI now keeps all 15 legacy/scenario assertions, while two compile-only benchmark API checks move to the existing trusted realistic-benchmark surface for same-repository benchmark-labeled PRs, non-bot main pushes, manual runs, and nightly runs. Both modes emit per-phase timing/status diagnostics.

The workflow security contract exactly pins the trusted native-job expression and rejects planted fork bypasses such as `|| true`. Independent adversarial review approved `7a167b755`; workflow contracts pass 51/51.