### PR TITLE
🤖 Expose typed large-value operations on the public Db API

### DIFF
--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -134,6 +134,8 @@ export type {
   TableInit,
   TableStreamingInit,
   TableStreamingUpdate,
+  TableBytesColumn,
+  TableTextColumn,
   TableWhereInput,
   TableSelectableColumn,
   TableOrderableColumn,

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -900,7 +900,7 @@ export class JazzClient {
     objectId: string,
     column: string,
     bytes: Uint8Array,
-  ): Promise<WriteHandle<{ id: string }>> {
+  ): Promise<WriteHandle> {
     if (!this.runtime.appendValue) throw new Error("Runtime does not support value append");
     const result = await this.runtime.appendValue(table, objectId, column, bytes);
     return new WriteHandle(committedBatchId(result), this);
@@ -913,7 +913,7 @@ export class JazzClient {
     offset: number,
     deleteLength: number,
     insert: Uint8Array,
-  ): Promise<WriteHandle<{ id: string }>> {
+  ): Promise<WriteHandle> {
     if (!this.runtime.spliceValue) throw new Error("Runtime does not support value splice");
     const result = await this.runtime.spliceValue(
       table,

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -4,6 +4,7 @@ import type { InsertValues, WasmRow, WasmSchema } from "../drivers/types.js";
 import { WriteHandle, WriteResult, JazzClient, type BatchId, type InsertResult } from "./client.js";
 import type { Session } from "./context.js";
 import { RuntimeSource, type RuntimeClientContext } from "./runtime-source.js";
+import { schema as s } from "../index.js";
 
 class TestRuntimeSource extends RuntimeSource<DbConfig> {
   constructor(private readonly client: JazzClient) {
@@ -48,6 +49,59 @@ function makeWriteHandle(transactionId: string): WriteHandle {
 }
 
 describe("Db runtime schema order", () => {
+  it("exposes typed byte and UTF-16 large-value operations through Db", async () => {
+    const app = s.defineApp({
+      notes: s.table({
+        body: s.string(),
+        attachment: s.bytes(),
+      }),
+    });
+    const append = makeWriteHandle("append-value");
+    const splice = makeWriteHandle("splice-value");
+    const client = {
+      readValueRange: vi.fn(async () => Uint8Array.from([2, 3])),
+      readTextUtf16Range: vi.fn(async () => "🙂"),
+      appendValue: vi.fn(async () => append),
+      spliceValue: vi.fn(async () => splice),
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const id = "00000000-0000-0000-0000-0000000000a1";
+
+    await expect(db.readValueRange(app.notes, id, "attachment", 2, 4)).resolves.toEqual(
+      Uint8Array.from([2, 3]),
+    );
+    await expect(db.readTextUtf16Range(app.notes, id, "body", 5, 7)).resolves.toBe("🙂");
+    await expect(db.appendValue(app.notes, id, "attachment", Uint8Array.of(4))).resolves.toBe(
+      append,
+    );
+    await expect(
+      db.spliceValue(app.notes, id, "attachment", 9, 3, Uint8Array.of(5, 6)),
+    ).resolves.toBe(splice);
+
+    expect(client.readValueRange).toHaveBeenCalledWith("notes", id, "attachment", 2, 4);
+    expect(client.readTextUtf16Range).toHaveBeenCalledWith("notes", id, "body", 5, 7);
+    expect(client.appendValue).toHaveBeenCalledWith("notes", id, "attachment", Uint8Array.of(4));
+    expect(client.spliceValue).toHaveBeenCalledWith(
+      "notes",
+      id,
+      "attachment",
+      9,
+      3,
+      Uint8Array.of(5, 6),
+    );
+
+    void (() => {
+      // @ts-expect-error byte ranges accept only `bytes` columns.
+      void db.readValueRange(app.notes, id, "body", 0, 1);
+      // @ts-expect-error UTF-16 ranges accept only `string` columns.
+      void db.readTextUtf16Range(app.notes, id, "attachment", 0, 1);
+      // @ts-expect-error byte append accepts only `bytes` columns.
+      void db.appendValue(app.notes, id, "body", Uint8Array.of(1));
+      // @ts-expect-error byte splice accepts only `bytes` columns.
+      void db.spliceValue(app.notes, id, "body", 0, 0, Uint8Array.of(1));
+    });
+  });
+
   it("derives a streaming insert branch selector from branchBy cells", async () => {
     const runtimeSchema: WasmSchema = {
       documents: {

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -31,6 +31,8 @@ class TestDb extends Db {
   protected override getRuntimeOperationContext(): { session?: Session } | null {
     return this.testContext;
   }
+
+  protected override async ensureReady(): Promise<void> {}
 }
 
 function makeHandleClient(): JazzClient {
@@ -71,9 +73,9 @@ describe("Db runtime schema order", () => {
       Uint8Array.from([2, 3]),
     );
     await expect(db.readTextUtf16Range(app.notes, id, "body", 5, 7)).resolves.toBe("🙂");
-    await expect(db.appendValue(app.notes, id, "attachment", Uint8Array.of(4))).resolves.toBe(
-      append,
-    );
+    const appendResult = await db.appendValue(app.notes, id, "attachment", Uint8Array.of(4));
+    expect(appendResult).toBe(append);
+    await expect(appendResult.wait({ tier: "local" })).resolves.toBeUndefined();
     await expect(
       db.spliceValue(app.notes, id, "attachment", 9, 3, Uint8Array.of(5, 6)),
     ).resolves.toBe(splice);

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1672,7 +1672,7 @@ export class Db {
     id: string,
     column: TableBytesColumn<TSchema, Extract<TTable, string>>,
     bytes: Uint8Array,
-  ): Promise<WriteHandle<{ id: string }>> {
+  ): Promise<WriteHandle> {
     const client = this.getClient(table._schema);
     return this.wrapWriteWait(await client.appendValue(table._table, id, column, bytes));
   }
@@ -1691,7 +1691,7 @@ export class Db {
     offset: number,
     deleteLength: number,
     insert: Uint8Array,
-  ): Promise<WriteHandle<{ id: string }>> {
+  ): Promise<WriteHandle> {
     const client = this.getClient(table._schema);
     return this.wrapWriteWait(
       await client.spliceValue(table._table, id, column, offset, deleteLength, insert),

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -51,6 +51,13 @@ import { SubscriptionManager, type SubscriptionDelta } from "./subscription-mana
 import { createAuthStateStore, type AuthState, type AuthStateStoreOptions } from "./auth-state.js";
 import { resolveClientSessionSync } from "./client-session.js";
 import { analyzeRelations } from "../codegen/relation-analyzer.js";
+import type {
+  Schema as TypedSchema,
+  SchemaDefinition as TypedSchemaDefinition,
+  Table as TypedTable,
+  TableBytesColumn,
+  TableTextColumn,
+} from "../typed-app.js";
 import { isPermissionIntrospectionColumn, magicColumnType } from "../magic-columns.js";
 import {
   normalizeBuiltQuery,
@@ -1616,6 +1623,78 @@ export class Db {
       normalizeUpdateOptions(table._schema, table._table, options),
       context?.session,
       context?.attribution,
+    );
+  }
+
+  /**
+   * Read a byte range from a `bytes` column without materializing its complete value.
+   * `start` and `end` are byte offsets, with `end` exclusive.
+   */
+  async readValueRange<
+    TSchema extends TypedSchema<any> | TypedSchemaDefinition,
+    TTable extends string,
+  >(
+    table: TypedTable<TTable, TSchema>,
+    id: string,
+    column: TableBytesColumn<TSchema, Extract<TTable, string>>,
+    start: number,
+    end: number,
+  ): Promise<Uint8Array> {
+    const client = this.getClient(table._schema);
+    return await client.readValueRange(table._table, id, column, start, end);
+  }
+
+  /**
+   * Read a UTF-16 range from a `string` column without materializing its complete value.
+   * `start` and `end` are UTF-16 code-unit offsets, with `end` exclusive; positions
+   * that split a surrogate pair are rejected.
+   */
+  async readTextUtf16Range<
+    TSchema extends TypedSchema<any> | TypedSchemaDefinition,
+    TTable extends string,
+  >(
+    table: TypedTable<TTable, TSchema>,
+    id: string,
+    column: TableTextColumn<TSchema, Extract<TTable, string>>,
+    start: number,
+    end: number,
+  ): Promise<string> {
+    const client = this.getClient(table._schema);
+    return await client.readTextUtf16Range(table._table, id, column, start, end);
+  }
+
+  /** Append bytes to a `bytes` column without materializing its existing value. */
+  async appendValue<
+    TSchema extends TypedSchema<any> | TypedSchemaDefinition,
+    TTable extends string,
+  >(
+    table: TypedTable<TTable, TSchema>,
+    id: string,
+    column: TableBytesColumn<TSchema, Extract<TTable, string>>,
+    bytes: Uint8Array,
+  ): Promise<WriteHandle<{ id: string }>> {
+    const client = this.getClient(table._schema);
+    return this.wrapWriteWait(await client.appendValue(table._table, id, column, bytes));
+  }
+
+  /**
+   * Replace a byte range in a `bytes` column without materializing its complete value.
+   * `offset` and `deleteLength` are byte offsets.
+   */
+  async spliceValue<
+    TSchema extends TypedSchema<any> | TypedSchemaDefinition,
+    TTable extends string,
+  >(
+    table: TypedTable<TTable, TSchema>,
+    id: string,
+    column: TableBytesColumn<TSchema, Extract<TTable, string>>,
+    offset: number,
+    deleteLength: number,
+    insert: Uint8Array,
+  ): Promise<WriteHandle<{ id: string }>> {
+    const client = this.getClient(table._schema);
+    return this.wrapWriteWait(
+      await client.spliceValue(table._table, id, column, offset, deleteLength, insert),
     );
   }
 

--- a/packages/jazz-tools/src/runtime/write-handle-public-api.typecheck.ts
+++ b/packages/jazz-tools/src/runtime/write-handle-public-api.typecheck.ts
@@ -6,6 +6,7 @@ import type {
   WriteHandle,
   WriteResult,
 } from "../index.js";
+import { schema as s } from "../index.js";
 
 type Todo = { id: string; title: string; done: boolean };
 type TodoInit = { title: string; done: boolean };
@@ -19,6 +20,13 @@ type TodoStreamingUpdate =
 declare const db: Db;
 declare const todos: TableProxy<Todo, TodoInit, TodoStreamingInit, TodoStreamingUpdate>;
 
+const largeValueApp = s.defineApp({
+  notes: s.table({
+    body: s.string(),
+    attachment: s.bytes(),
+  }),
+});
+
 async function assertWriteHandleContract() {
   const inserted: WriteResult<Todo> = db.insert(todos, { title: "todo", done: false });
   const restored: WriteResult<Todo> = db.restore(todos, "todo-1", {
@@ -28,6 +36,24 @@ async function assertWriteHandleContract() {
   const updated: WriteHandle = db.update(todos, "todo-1", { done: true });
   const upserted: WriteHandle = db.upsert(todos, "todo-1", { title: "todo", done: false });
   const deleted: WriteHandle = db.delete(todos, "todo-1");
+  const appended: Promise<WriteHandle> = db.appendValue(
+    largeValueApp.notes,
+    "note-1",
+    "attachment",
+    Uint8Array.of(1),
+  );
+  const spliced: Promise<WriteHandle> = db.spliceValue(
+    largeValueApp.notes,
+    "note-1",
+    "attachment",
+    0,
+    0,
+    Uint8Array.of(1),
+  );
+  const appendWait: void = await (await appended).wait({ tier: "local" });
+  const spliceWait: void = await (await spliced).wait({ tier: "edge" });
+  // @ts-expect-error Appending an existing row does not produce an inserted id.
+  const appendWithId: Promise<WriteHandle<{ id: string }>> = appended;
   const streamed: Promise<WriteHandle<{ id: string }>> = db.insertStreaming(todos, {
     done: false,
     title: (async function* () {
@@ -75,6 +101,9 @@ async function assertWriteHandleContract() {
   void updated;
   void upserted;
   void deleted;
+  void appendWait;
+  void spliceWait;
+  void appendWithId;
   void streamed;
   void streamedUpdate;
   void streamedUpsert;

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -251,6 +251,24 @@ type StreamingColumnName<TSchema extends SchemaLike, TTable extends TableName<TS
     : never;
 }[ColumnName<TSchema, TTable>];
 
+/** Column names whose declared storage type is `BYTEA`. */
+export type TableBytesColumn<TSchema extends SchemaLike, TTable extends TableName<TSchema>> = {
+  [TColumn in ColumnName<TSchema, TTable>]: ColumnBuilderSqlType<
+    BuilderForColumn<TSchema, TTable, TColumn>
+  > extends "BYTEA"
+    ? TColumn
+    : never;
+}[ColumnName<TSchema, TTable>];
+
+/** Column names whose declared storage type is `TEXT`. */
+export type TableTextColumn<TSchema extends SchemaLike, TTable extends TableName<TSchema>> = {
+  [TColumn in ColumnName<TSchema, TTable>]: ColumnBuilderSqlType<
+    BuilderForColumn<TSchema, TTable, TColumn>
+  > extends "TEXT"
+    ? TColumn
+    : never;
+}[ColumnName<TSchema, TTable>];
+
 /**
  * Input for a streaming insert. Exactly one Text, JSON, or Bytea column is
  * replaced by an asynchronous source; every other column retains its ordinary


### PR DESCRIPTION
🤖 Exposes typed byte-range and UTF-16 text-range reads plus append/splice operations on the public Db facade introduced by the Groove-native large-values work. Keeps internal clients private, preserves truthful WriteHandle<void> semantics, and adds runtime and compile-time coverage.