### PR TITLE
🤖 Add the MusicAgent example and benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jazz-example-music-agent-benchmark"
+version = "0.1.0"
+dependencies = [
+ "codspeed-divan-compat",
+ "groove",
+ "jazz",
+]
+
+[[package]]
 name = "jazz-napi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   # "examples/docs/todo-server-rs",
   "examples/big-label/benchmarks",
   "examples/band-chat/benchmarks",
+  "examples/music-agent/benchmarks",
   "examples/benchmarks/smoke",
   "dev/benchmarks/storage/bench-core",
 ]

--- a/examples/music-agent/README.md
+++ b/examples/music-agent/README.md
@@ -1,0 +1,32 @@
+# MusicAgent
+
+MusicAgent is a deliberately provider-free LLM harness example. It records a
+conversation, streams a long assistant turn, records tool invocations, and
+keeps uploaded audio attachments as bytes. Its deterministic fake agent makes
+the complete flow useful in tests and demos without an API key.
+
+The family is split by concern:
+
+- `apps/ts-localfirst/` is the small application built on the `create-jazz`
+  TypeScript local-first shape.
+- `benchmarks/` is a self-contained native benchmark model. It measures the
+  append, range-read, and materialization shapes that make an agent transcript
+  different from an ordinary chat timeline.
+
+The application intentionally uses the public typed `Db` API for schema,
+queries, and streaming writes. The lower-level range/append methods are public
+on `JazzClient`, but are not yet promoted through typed `Db`; this example does
+not reach through `Db` internals to work around that gap.
+
+Run the app checks with:
+
+```sh
+pnpm --dir examples/music-agent/apps/ts-localfirst test
+pnpm --dir examples/music-agent/apps/ts-localfirst build
+```
+
+Run benchmark correctness checks with:
+
+```sh
+cargo test -p jazz-example-music-agent-benchmark
+```

--- a/examples/music-agent/apps/ts-localfirst/package.json
+++ b/examples/music-agent/apps/ts-localfirst/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "music-agent-ts-localfirst",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "jazz-tools": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:default",
+    "vitest": "catalog:default"
+  }
+}

--- a/examples/music-agent/apps/ts-localfirst/schema.ts
+++ b/examples/music-agent/apps/ts-localfirst/schema.ts
@@ -1,0 +1,34 @@
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  conversations: s.table({
+    title: s.string(),
+    created_at: s.timestamp(),
+  }),
+  turns: s.table({
+    conversation_id: s.ref("conversations"),
+    role: s.enum(["user", "assistant", "tool"]),
+    ordinal: s.int(),
+    // Streamed assistant prose is still an ordinary logical Text column.
+    body: s.string(),
+    created_at: s.timestamp(),
+  }),
+  tool_calls: s.table({
+    turn_id: s.ref("turns"),
+    name: s.string(),
+    arguments_json: s.string(),
+    result_json: s.string(),
+  }),
+  attachments: s.table({
+    turn_id: s.ref("turns"),
+    filename: s.string(),
+    media_type: s.string(),
+    payload: s.bytes(),
+    byte_length: s.int(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+export type Conversation = s.RowOf<typeof app.conversations>;
+export type Turn = s.RowOf<typeof app.turns>;

--- a/examples/music-agent/apps/ts-localfirst/schema.ts
+++ b/examples/music-agent/apps/ts-localfirst/schema.ts
@@ -7,7 +7,7 @@ const schema = {
   }),
   turns: s.table({
     conversation_id: s.ref("conversations"),
-    role: s.enum(["user", "assistant", "tool"]),
+    role: s.enum("user", "assistant", "tool"),
     ordinal: s.int(),
     // Streamed assistant prose is still an ordinary logical Text column.
     body: s.string(),

--- a/examples/music-agent/apps/ts-localfirst/src/music-agent.ts
+++ b/examples/music-agent/apps/ts-localfirst/src/music-agent.ts
@@ -1,0 +1,257 @@
+import type { Db, StreamingValueSource } from "jazz-tools";
+import { app } from "../schema.js";
+
+export type Role = "user" | "assistant" | "tool";
+
+export type TranscriptTurn = {
+  id: string;
+  conversationId: string;
+  role: Role;
+  ordinal: number;
+  body: string;
+};
+
+export type ToolCall = {
+  id: string;
+  turnId: string;
+  name: string;
+  argumentsJson: string;
+  resultJson: string;
+};
+
+export type Attachment = {
+  id: string;
+  turnId: string;
+  filename: string;
+  mediaType: string;
+  byteLength: number;
+  payload: Uint8Array;
+};
+
+/**
+ * Application-shaped persistence boundary. The in-memory implementation below
+ * is deterministic for E2E; JazzMusicStore maps the same operations to Jazz.
+ */
+export interface MusicStore {
+  createConversation(title: string): Promise<string>;
+  addTurn(turn: Omit<TranscriptTurn, "id">): Promise<string>;
+  streamTurn(
+    turn: Omit<TranscriptTurn, "id" | "body">,
+    body: StreamingValueSource,
+  ): Promise<string>;
+  addToolCall(call: Omit<ToolCall, "id">): Promise<string>;
+  addAttachment(
+    attachment: Omit<Attachment, "id" | "payload">,
+    payload: StreamingValueSource,
+  ): Promise<string>;
+  transcript(conversationId: string): Promise<TranscriptTurn[]>;
+  readAttachmentRange(id: string, start: number, end: number): Promise<Uint8Array>;
+}
+
+/** A Jazz adapter using the public typed Db surface, including streaming Text and Bytea writes. */
+export class JazzMusicStore implements MusicStore {
+  constructor(private readonly db: Db) {}
+
+  async createConversation(title: string): Promise<string> {
+    return this.db.insert(app.conversations, { title, created_at: new Date() }).value.id;
+  }
+
+  async addTurn(turn: Omit<TranscriptTurn, "id">): Promise<string> {
+    return this.db.insert(app.turns, {
+      conversation_id: turn.conversationId,
+      role: turn.role,
+      ordinal: turn.ordinal,
+      body: turn.body,
+      created_at: new Date(),
+    }).value.id;
+  }
+
+  async streamTurn(
+    turn: Omit<TranscriptTurn, "id" | "body">,
+    body: StreamingValueSource,
+  ): Promise<string> {
+    const write = await this.db.insertStreaming(app.turns, {
+      conversation_id: turn.conversationId,
+      role: turn.role,
+      ordinal: turn.ordinal,
+      body,
+      created_at: new Date(),
+    });
+    return write.value.id;
+  }
+
+  async addToolCall(call: Omit<ToolCall, "id">): Promise<string> {
+    return this.db.insert(app.tool_calls, {
+      turn_id: call.turnId,
+      name: call.name,
+      arguments_json: call.argumentsJson,
+      result_json: call.resultJson,
+    }).value.id;
+  }
+
+  async addAttachment(
+    attachment: Omit<Attachment, "id" | "payload">,
+    payload: StreamingValueSource,
+  ): Promise<string> {
+    const write = await this.db.insertStreaming(app.attachments, {
+      turn_id: attachment.turnId,
+      filename: attachment.filename,
+      media_type: attachment.mediaType,
+      payload,
+      byte_length: attachment.byteLength,
+    });
+    return write.value.id;
+  }
+
+  async transcript(conversationId: string): Promise<TranscriptTurn[]> {
+    const rows = await this.db.all(
+      app.turns.where({ conversation_id: conversationId }).orderBy("ordinal", "asc"),
+    );
+    return rows.map((row) => ({
+      id: row.id,
+      conversationId: row.conversation_id,
+      role: row.role as Role,
+      ordinal: row.ordinal,
+      body: row.body,
+    }));
+  }
+
+  async readAttachmentRange(_id: string, _start: number, _end: number): Promise<Uint8Array> {
+    // Typed Db currently has no range-read method. Deliberately do not access
+    // its private JazzClient; use the public JazzClient API when it is promoted
+    // to the typed facade.
+    throw new Error("Typed Db range reads are not available yet");
+  }
+}
+
+/** Provider-free agent with an intentionally stable transcript for E2E. */
+export class DeterministicMusicAgent {
+  constructor(private readonly store: MusicStore) {}
+
+  async answer(conversationId: string, prompt: string): Promise<TranscriptTurn[]> {
+    const existing = await this.store.transcript(conversationId);
+    const userId = await this.store.addTurn({
+      conversationId,
+      role: "user",
+      ordinal: existing.length,
+      body: prompt,
+    });
+    const assistantOrdinal = existing.length + 1;
+    const assistantId = await this.store.streamTurn(
+      { conversationId, role: "assistant", ordinal: assistantOrdinal },
+      chunks([
+        "I found a focused listening path for ",
+        prompt,
+        ". ",
+        "Starting with the live cut.",
+      ]),
+    );
+    await this.store.addToolCall({
+      turnId: assistantId,
+      name: "music.search",
+      argumentsJson: JSON.stringify({ query: prompt }),
+      resultJson: JSON.stringify({ track: "Midnight Practice", duration_seconds: 248 }),
+    });
+    await this.store.addTurn({
+      conversationId,
+      role: "tool",
+      ordinal: assistantOrdinal + 1,
+      body: `music.search selected Midnight Practice for ${userId}`,
+    });
+    return this.store.transcript(conversationId);
+  }
+}
+
+export async function* chunks(parts: readonly string[]): AsyncIterable<string> {
+  for (const part of parts) yield part;
+}
+
+/** Deterministic in-memory E2E store; it models materialization and ranges. */
+export class MemoryMusicStore implements MusicStore {
+  private readonly turns: TranscriptTurn[] = [];
+  private readonly toolCalls: ToolCall[] = [];
+  private readonly attachments = new Map<string, Attachment>();
+  private nextId = 1;
+
+  async createConversation(_title: string): Promise<string> {
+    return this.id("conversation");
+  }
+
+  async addTurn(turn: Omit<TranscriptTurn, "id">): Promise<string> {
+    const id = this.id("turn");
+    this.turns.push({ id, ...turn });
+    return id;
+  }
+
+  async streamTurn(
+    turn: Omit<TranscriptTurn, "id" | "body">,
+    body: StreamingValueSource,
+  ): Promise<string> {
+    const chunks = await collect(body);
+    return this.addTurn({ ...turn, body: new TextDecoder().decode(chunks) });
+  }
+
+  async addToolCall(call: Omit<ToolCall, "id">): Promise<string> {
+    const id = this.id("tool");
+    this.toolCalls.push({ id, ...call });
+    return id;
+  }
+
+  async addAttachment(
+    attachment: Omit<Attachment, "id" | "payload">,
+    payload: StreamingValueSource,
+  ): Promise<string> {
+    const id = this.id("attachment");
+    const materialized = await collect(payload);
+    this.attachments.set(id, {
+      id,
+      ...attachment,
+      byteLength: materialized.length,
+      payload: materialized,
+    });
+    return id;
+  }
+
+  async transcript(conversationId: string): Promise<TranscriptTurn[]> {
+    return this.turns
+      .filter((turn) => turn.conversationId === conversationId)
+      .sort((left, right) => left.ordinal - right.ordinal);
+  }
+
+  async readAttachmentRange(id: string, start: number, end: number): Promise<Uint8Array> {
+    return this.attachments.get(id)?.payload.slice(start, end) ?? new Uint8Array();
+  }
+
+  toolCallCount(): number {
+    return this.toolCalls.length;
+  }
+
+  private id(kind: string): string {
+    return `${kind}-${this.nextId++}`;
+  }
+}
+
+async function collect(source: StreamingValueSource): Promise<Uint8Array> {
+  const encoder = new TextEncoder();
+  const pieces: Uint8Array[] = [];
+  if (Symbol.asyncIterator in source) {
+    for await (const chunk of source as AsyncIterable<Uint8Array | string>) {
+      pieces.push(typeof chunk === "string" ? encoder.encode(chunk) : chunk);
+    }
+  } else {
+    const reader = (source as ReadableStream<Uint8Array | string>).getReader();
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      pieces.push(typeof next.value === "string" ? encoder.encode(next.value) : next.value);
+    }
+  }
+  const length = pieces.reduce((total, piece) => total + piece.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const piece of pieces) {
+    result.set(piece, offset);
+    offset += piece.length;
+  }
+  return result;
+}

--- a/examples/music-agent/apps/ts-localfirst/tests/music-agent.test.ts
+++ b/examples/music-agent/apps/ts-localfirst/tests/music-agent.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { DeterministicMusicAgent, MemoryMusicStore, chunks } from "../src/music-agent.js";
+
+describe("MusicAgent deterministic E2E", () => {
+  test("streams one assistant turn, records its tool call, and preserves ordering", async () => {
+    const store = new MemoryMusicStore();
+    const conversation = await store.createConversation("Late-night listening");
+    const transcript = await new DeterministicMusicAgent(store).answer(
+      conversation,
+      "warm saxophone",
+    );
+
+    expect(transcript.map((turn) => turn.role)).toEqual(["user", "assistant", "tool"]);
+    expect(transcript[1]?.body).toContain("warm saxophone");
+    expect(store.toolCallCount()).toBe(1);
+  });
+
+  test("materializes a streamed byte attachment and reads only its requested range", async () => {
+    const store = new MemoryMusicStore();
+    const conversation = await store.createConversation("Attachment");
+    const turnId = await store.addTurn({
+      conversationId: conversation,
+      role: "user",
+      ordinal: 0,
+      body: "identify this clip",
+    });
+    const attachment = await store.addAttachment(
+      { turnId, filename: "clip.raw", mediaType: "audio/raw", byteLength: 6 },
+      chunks(["ab", "cdef"]),
+    );
+
+    expect(Array.from(await store.readAttachmentRange(attachment, 2, 5))).toEqual([99, 100, 101]);
+  });
+});

--- a/examples/music-agent/apps/ts-localfirst/tsconfig.json
+++ b/examples/music-agent/apps/ts-localfirst/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["schema.ts", "src", "tests"]
+}

--- a/examples/music-agent/benchmarks/Cargo.toml
+++ b/examples/music-agent/benchmarks/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "jazz-example-music-agent-benchmark"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+jazz = { workspace = true, features = ["testing"] }
+groove = { workspace = true, features = ["test"] }
+
+[dev-dependencies]
+divan = { workspace = true }
+
+[[bench]]
+name = "loads"
+harness = false

--- a/examples/music-agent/benchmarks/README.md
+++ b/examples/music-agent/benchmarks/README.md
@@ -1,0 +1,15 @@
+# MusicAgent benchmark variant
+
+This native package duplicates the small MusicAgent schema and deterministic
+fixture. It does not import the TypeScript application or its fake provider.
+
+It measures the large-value shapes that matter for an LLM harness: append to a
+streamed assistant turn, a bounded byte-range read from an audio attachment,
+and ordinary transcript query materialization. Correctness tests also reopen
+the same durable fixture and verify that the transcript remains readable after
+restart.
+
+```sh
+cargo test -p jazz-example-music-agent-benchmark
+cargo bench -p jazz-example-music-agent-benchmark --bench loads
+```

--- a/examples/music-agent/benchmarks/benches/loads.rs
+++ b/examples/music-agent/benchmarks/benches/loads.rs
@@ -1,0 +1,22 @@
+use jazz_example_music_agent_benchmark::Fixture;
+
+fn main() {
+    divan::main();
+}
+
+#[divan::bench]
+fn append_assistant_tail(bencher: divan::Bencher<'_, '_>) {
+    bencher.bench_local(|| Fixture::new().append_assistant_tail());
+}
+
+#[divan::bench]
+fn attachment_range(bencher: divan::Bencher<'_, '_>) {
+    let fixture = Fixture::new();
+    bencher.bench_local(|| divan::black_box(fixture.attachment_range()));
+}
+
+#[divan::bench]
+fn materialized_transcript(bencher: divan::Bencher<'_, '_>) {
+    let fixture = Fixture::new();
+    bencher.bench_local(|| divan::black_box(fixture.materialized_transcript()));
+}

--- a/examples/music-agent/benchmarks/src/lib.rs
+++ b/examples/music-agent/benchmarks/src/lib.rs
@@ -1,0 +1,203 @@
+//! Self-contained MusicAgent large-value workloads.
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+
+use jazz::db::{Db, DbConfig, DbIdentity, PreparedQuery, block_on};
+use jazz::groove::large_values::{INLINE_VALUE_MAX_BYTES, LargeValueKind};
+use jazz::groove::records::Value;
+use jazz::groove::storage::TestStorage;
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::{OrderDirection, Query, col, eq, lit};
+use jazz::schema::{JazzSchema, TableSchema};
+use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+use jazz::tx::DurabilityTier;
+
+type BenchDb = Db<TestStorage>;
+
+pub struct Fixture {
+    db: BenchDb,
+    storage: TestStorage,
+    assistant: RowUuid,
+    attachment: RowUuid,
+    transcript: PreparedQuery,
+    turns: TableSchema,
+}
+
+impl Default for Fixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        let schema = schema();
+        let refs = schema.column_families();
+        let storage = TestStorage::new(&refs.iter().map(String::as_str).collect::<Vec<_>>());
+        let db = open(schema.clone(), storage.clone());
+        let conversation = row_id(1);
+        let assistant = row_id(2);
+        let attachment = row_id(3);
+        insert(
+            &db,
+            "conversations",
+            conversation,
+            BTreeMap::from([("title".into(), Value::String("Late listening".into()))]),
+        );
+        insert(
+            &db,
+            "turns",
+            row_id(4),
+            BTreeMap::from([
+                ("conversation".into(), Value::Uuid(conversation.0)),
+                ("ordinal".into(), Value::I32(0)),
+                ("role".into(), Value::String("user".into())),
+                ("body".into(), Value::String("warm saxophone".into())),
+            ]),
+        );
+        let text = format!("{}final chorus", "a".repeat(INLINE_VALUE_MAX_BYTES * 2));
+        let assistant_write = block_on(db.insert_streaming_value_with_id(
+            "turns",
+            assistant,
+            BTreeMap::from([
+                ("conversation".into(), Value::Uuid(conversation.0)),
+                ("ordinal".into(), Value::I32(1)),
+                ("role".into(), Value::String("assistant".into())),
+            ]),
+            "body",
+            LargeValueKind::String,
+            Cursor::new(text),
+        ))
+        .expect("stream assistant turn");
+        block_on(assistant_write.wait(DurabilityTier::Local)).expect("durable assistant turn");
+        let attachment_write = block_on(db.insert_streaming_value_with_id(
+            "attachments",
+            attachment,
+            BTreeMap::from([("turn".into(), Value::Uuid(assistant.0))]),
+            "payload",
+            LargeValueKind::Bytes,
+            Cursor::new(vec![7_u8; INLINE_VALUE_MAX_BYTES * 2]),
+        ))
+        .expect("stream audio attachment");
+        block_on(attachment_write.wait(DurabilityTier::Local)).expect("durable attachment");
+        let transcript = db
+            .prepare_query(
+                &Query::from("turns")
+                    .filter(eq(col("conversation"), lit(conversation.0)))
+                    .order_by("ordinal", OrderDirection::Asc),
+            )
+            .expect("prepare transcript");
+        Self {
+            db,
+            storage,
+            assistant,
+            attachment,
+            transcript,
+            turns: table(&schema, "turns"),
+        }
+    }
+
+    pub fn append_assistant_tail(&self) {
+        block_on(
+            self.db
+                .append_value("turns", self.assistant, "body", b"!".to_vec()),
+        )
+        .expect("append assistant tail");
+    }
+
+    pub fn attachment_range(&self) -> Vec<u8> {
+        block_on(
+            self.db
+                .read_value_range("attachments", self.attachment, "payload", 64..128),
+        )
+        .expect("read attachment range")
+    }
+
+    pub fn materialized_transcript(&self) -> Vec<String> {
+        self.db
+            .read(&self.transcript)
+            .expect("read transcript")
+            .into_iter()
+            .map(|row| match row.cell(&self.turns, "body") {
+                Some(Value::String(body)) => body,
+                other => panic!("unexpected transcript body: {other:?}"),
+            })
+            .collect()
+    }
+
+    pub fn restarted_transcript(&self) -> Vec<String> {
+        let reopened = open(schema(), self.storage.clone());
+        let conversation = row_id(1);
+        let query = reopened
+            .prepare_query(
+                &Query::from("turns")
+                    .filter(eq(col("conversation"), lit(conversation.0)))
+                    .order_by("ordinal", OrderDirection::Asc),
+            )
+            .expect("prepare restarted transcript");
+        let table = table(&schema(), "turns");
+        reopened
+            .read(&query)
+            .expect("read restarted transcript")
+            .into_iter()
+            .map(|row| match row.cell(&table, "body") {
+                Some(Value::String(body)) => body,
+                other => panic!("unexpected restarted body: {other:?}"),
+            })
+            .collect()
+    }
+}
+
+fn schema() -> JazzSchema {
+    JazzSchema::new(
+        &SchemaBuilder::new()
+            .table(TableSchemaBuilder::new("conversations").column("title", ColumnType::Text))
+            .table(
+                TableSchemaBuilder::new("turns")
+                    .fk_column("conversation", "conversations")
+                    .column("ordinal", ColumnType::Integer)
+                    .column("role", ColumnType::Text)
+                    .column("body", ColumnType::Text)
+                    .index_only(["conversation", "ordinal"]),
+            )
+            .table(
+                TableSchemaBuilder::new("attachments")
+                    .fk_column("turn", "turns")
+                    .column("payload", ColumnType::Bytea),
+            )
+            .build(),
+    )
+    .expect("MusicAgent schema compiles")
+}
+
+fn open(schema: JazzSchema, storage: TestStorage) -> BenchDb {
+    block_on(Db::open(DbConfig::new(
+        schema,
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x41; 16]),
+            author: AuthorId::from_bytes([0x51; 16]),
+        },
+    )))
+    .expect("open MusicAgent database")
+}
+
+fn table(schema: &JazzSchema, name: &str) -> TableSchema {
+    schema
+        .tables()
+        .iter()
+        .find(|table| table.name == name)
+        .unwrap_or_else(|| panic!("MusicAgent schema has {name}"))
+        .clone()
+}
+
+fn insert(db: &BenchDb, table: &str, row: RowUuid, cells: BTreeMap<String, Value>) {
+    let write =
+        block_on(db.insert_with_id(table, row, cells)).expect("insert MusicAgent fixture row");
+    block_on(write.wait(DurabilityTier::Local)).expect("durable fixture row");
+}
+
+fn row_id(last: u8) -> RowUuid {
+    RowUuid::from_bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, last])
+}

--- a/examples/music-agent/benchmarks/tests/workloads.rs
+++ b/examples/music-agent/benchmarks/tests/workloads.rs
@@ -1,0 +1,13 @@
+use jazz_example_music_agent_benchmark::Fixture;
+
+#[test]
+fn append_range_materialization_and_restart_keep_one_logical_transcript() {
+    let fixture = Fixture::new();
+    assert_eq!(fixture.attachment_range(), vec![7; 64]);
+    let before = fixture.materialized_transcript();
+    assert_eq!(before.len(), 2);
+    fixture.append_assistant_tail();
+    let after = fixture.materialized_transcript();
+    assert!(after[1].ends_with('!'));
+    assert_eq!(fixture.restarted_transcript(), after);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -871,6 +871,19 @@ importers:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  examples/music-agent/apps/ts-localfirst:
+    dependencies:
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../../../../packages/jazz-tools
+    devDependencies:
+      typescript:
+        specifier: catalog:default
+        version: 6.0.2
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
   examples/nextjs-csr-ssr:
     dependencies:
       jazz-napi:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - crates/jazz-rn
   - starters/*
   - examples/*
+  - examples/*/apps/*
   # React Native/Expo surfaces are paused; keep their source archived but out of active workspace installs.
   - "!examples/todo-client-localfirst-expo"
   - examples/docs/*


### PR DESCRIPTION
🤖 Starts the MusicAgent example family: a self-contained local-first TypeScript agent transcript with streaming text and attachments, plus a native Rust benchmark covering append, range reads, materialization, and restart correctness. This is an early WIP example surface intended to grow with the examples correctness campaign.