### PR TITLE
Carry large-value projection demand into Groove

### DIFF
--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -216,8 +216,9 @@ impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
 
 pub use crate::ivm::{
     CollectByField, GraphBuilder, IvmRuntimeError, MultisinkDeltas, MultisinkSubscription,
-    PredicateExpr, PreparedShapeId, ProjectField, PublicationUpdate, RoutedMultisinkTerminal,
-    Subscription, SubscriptionError, SubscriptionEvent, SubscriptionId,
+    MultisinkTerminal, OutputDemand, PredicateExpr, PreparedShapeId, ProjectField,
+    PublicationUpdate, RoutedMultisinkTerminal, Subscription, SubscriptionError, SubscriptionEvent,
+    SubscriptionId,
 };
 
 /// Schema-aware database facade over storage and IVM subscriptions.

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -231,10 +231,10 @@ impl Database {
     ///
     /// The initial message includes every sink, even if that sink is empty.
     /// Later messages are sent only when at least one sink has deltas.
-    pub fn subscribe<I, K>(&mut self, sinks: I) -> Result<MultisinkSubscription, Error>
+    pub fn subscribe<I>(&mut self, sinks: I) -> Result<MultisinkSubscription, Error>
     where
-        I: IntoIterator<Item = (K, GraphBuilder)>,
-        K: Into<String>,
+        I: IntoIterator,
+        I::Item: Into<crate::ivm::MultisinkTerminal>,
     {
         self.ensure_not_poisoned()?;
         let overlay = Rc::new(StagedWriteOverlay::new_owned(
@@ -715,10 +715,10 @@ impl Database {
 
     /// Run several named graph outputs against the same current storage
     /// snapshot without registering a live subscription.
-    pub async fn query_graphs<I, K>(&mut self, sinks: I) -> Result<MultisinkDeltas, Error>
+    pub async fn query_graphs<I>(&mut self, sinks: I) -> Result<MultisinkDeltas, Error>
     where
-        I: IntoIterator<Item = (K, GraphBuilder)>,
-        K: Into<String>,
+        I: IntoIterator,
+        I::Item: Into<crate::ivm::MultisinkTerminal>,
     {
         self.ensure_not_poisoned()?;
         let overlay = StagedWriteOverlay::new(&self.storage, &self.resident_writes);

--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -104,6 +104,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: None,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::InlineRecords { output, records } => {
@@ -125,6 +126,7 @@ impl IvmRuntime {
                     output: *output,
                     node,
                     root_ordering_node: None,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::Index {
@@ -156,6 +158,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: None,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::FrontierSource { binding, output } => {
@@ -174,6 +177,7 @@ impl IvmRuntime {
                     output: inferred_output,
                     node,
                     root_ordering_node: None,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::BindingSource { shape, output } => {
@@ -192,6 +196,7 @@ impl IvmRuntime {
                     output: inferred_output,
                     node,
                     root_ordering_node: None,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::Recursive {
@@ -236,6 +241,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: None,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::CollectBy { input, collect } => {
@@ -335,6 +341,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::ArgMinBy {
@@ -419,6 +426,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::TopBy {
@@ -502,6 +510,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: Some(node),
+                    demand: OutputDemand::default(),
                 })
             }
             _ => unreachable!("dispatcher routes only ordering graph builders here"),
@@ -560,6 +569,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::Filter {
@@ -586,6 +596,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::Project { input, fields } => {
@@ -627,6 +638,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::StreamingChecksum {
@@ -660,6 +672,7 @@ impl IvmRuntime {
                     output: inferred_output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::UnwrapNullable { input, field } => {
@@ -684,6 +697,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::Unnest {
@@ -713,6 +727,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::VariantProject { input, field, case } => {
@@ -744,6 +759,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: compiled_input.root_ordering_node,
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::Union { inputs } => {
@@ -774,6 +790,7 @@ impl IvmRuntime {
                     output,
                     node,
                     root_ordering_node: public_root_ordering,
+                    demand: OutputDemand::default(),
                 })
             }
             _ => unreachable!("dispatcher routes only unary graph builders here"),
@@ -846,6 +863,7 @@ impl IvmRuntime {
                     root_ordering_node: compiled_left
                         .root_ordering_node
                         .or(compiled_right.root_ordering_node),
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::SemiJoin {
@@ -903,6 +921,7 @@ impl IvmRuntime {
                     root_ordering_node: compiled_left
                         .root_ordering_node
                         .or(compiled_right.root_ordering_node),
+                    demand: OutputDemand::default(),
                 })
             }
             GraphBuilder::AntiJoin {
@@ -960,6 +979,7 @@ impl IvmRuntime {
                     root_ordering_node: compiled_left
                         .root_ordering_node
                         .or(compiled_right.root_ordering_node),
+                    demand: OutputDemand::default(),
                 })
             }
             _ => unreachable!("dispatcher routes only join graph builders here"),
@@ -1085,6 +1105,7 @@ impl IvmRuntime {
                 output,
                 node,
                 root_ordering_node: compiled_input.root_ordering_node,
+                demand: OutputDemand::default(),
             });
         }
         let child_fields = collect_by_projections(&input_output, &collect.child_fields)?;
@@ -1212,6 +1233,7 @@ impl IvmRuntime {
             // CollectBy changes representation, not the identity/order of
             // public roots selected upstream.
             root_ordering_node: compiled_input.root_ordering_node,
+            demand: OutputDemand::default(),
         })
     }
 
@@ -1399,6 +1421,7 @@ impl IvmRuntime {
             output: index_descriptor,
             node,
             root_ordering_node: None,
+            demand: OutputDemand::default(),
         })
     }
 }

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -2588,6 +2588,39 @@ impl TickEvaluator<'_> {
         }
     }
 
+    pub(super) fn materialize_indirect_output(
+        &mut self,
+        input: &Arc<RecordDeltas>,
+        demand: &OutputDemand,
+    ) -> Result<Arc<RecordDeltas>, IvmRuntimeError> {
+        let Some(evaluation_inputs) = self.evaluation_inputs.as_deref_mut() else {
+            return Ok(Arc::clone(input));
+        };
+        let mut deltas = Vec::with_capacity(input.deltas.len());
+        let mut changed = false;
+        for delta in &input.deltas {
+            let raw = crate::large_values::materialize_record_demand_attempt(
+                &input.descriptor,
+                delta.raw(),
+                demand.fields(),
+                evaluation_inputs,
+            )?;
+            changed |= raw.as_slice() != delta.raw();
+            deltas.push(RecordDelta {
+                record: raw.into(),
+                weight: delta.weight,
+            });
+        }
+        if changed {
+            Ok(Arc::new(RecordDeltas {
+                descriptor: input.descriptor,
+                deltas,
+            }))
+        } else {
+            Ok(Arc::clone(input))
+        }
+    }
+
     fn materialize_indirect_fields(
         &mut self,
         input: &Arc<RecordDeltas>,

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -20,6 +20,9 @@ struct EvaluationSession<'a> {
     relevant_nodes: HashSet<NodeId>,
     roots: HashSet<NodeId>,
     outputs: HashMap<NodeId, RecordDeltas>,
+    /// Per-root terminal demand for hydration. Ordinary internal hydration
+    /// leaves this empty and therefore retains full materialization.
+    output_demands: HashMap<NodeId, OutputDemand>,
     pending_outputs: HashMap<NodeId, RecordDeltas>,
     operator_states: HashMap<OperatorStateKey, OperatorState>,
     arrangement_states: HashMap<ArrangementKey, AsOf<ArrangementState, SubTick>>,
@@ -625,12 +628,10 @@ impl IncrementalEvaluation<'_> {
                         .insert(output.node, Arc::clone(&records));
                     records
                 };
-                let records = match evaluator.materialize_indirect_input(&physical_records) {
-                    Ok(records) => {
-                        self.pending_subscription_outputs
-                            .insert(output.node, Arc::clone(&records));
-                        records
-                    }
+                let records = match evaluator
+                    .materialize_indirect_output(&physical_records, &output.demand)
+                {
+                    Ok(records) => records,
                     Err(IvmRuntimeError::EvaluationBlocked) => {
                         self.terminal_deltas = std::mem::take(&mut evaluator.terminal_deltas);
                         self.root_ordering_windows =
@@ -898,6 +899,7 @@ impl<'a> EvaluationSession<'a> {
             relevant_nodes,
             roots: roots.into_iter().collect(),
             outputs: HashMap::default(),
+            output_demands: HashMap::default(),
             pending_outputs: HashMap::default(),
             operator_states,
             arrangement_states,
@@ -924,6 +926,18 @@ impl<'a> EvaluationSession<'a> {
         for node in &affected {
             let meta = self.node_meta.entry(*node).or_default();
             meta.input_generation = meta.input_generation.wrapping_add(1);
+        }
+    }
+
+    fn set_output_demands(&mut self, outputs: &BTreeMap<String, CompiledNode>) {
+        for output in outputs.values() {
+            self.output_demands
+                .entry(output.node)
+                // One shared graph can feed several terminal contracts. A
+                // conflicting read of the same field conservatively becomes
+                // full; independent field demands remain exact.
+                .and_modify(|existing| existing.merge_for_shared_output(&output.demand))
+                .or_insert_with(|| output.demand.clone());
         }
     }
 
@@ -992,9 +1006,13 @@ impl<'a> EvaluationSession<'a> {
                         let mut materialized = Vec::with_capacity(records.deltas.len());
                         let mut blocked = false;
                         for delta in &records.deltas {
-                            match crate::large_values::materialize_record_attempt(
+                            match crate::large_values::materialize_record_demand_attempt(
                                 &records.descriptor,
                                 delta.raw(),
+                                self.output_demands
+                                    .get(&node)
+                                    .map(OutputDemand::fields)
+                                    .unwrap_or(&BTreeMap::new()),
                                 &mut self.evaluation_inputs,
                             ) {
                                 Ok(record) => materialized.push(RecordDelta {
@@ -1137,6 +1155,7 @@ impl IvmRuntime {
             Ok::<_, IvmRuntimeError>(found || self.output_depends_on_aggregate(root)?)
         })?;
         let mut session = EvaluationSession::hydration(self, roots, storage)?;
+        session.set_output_demands(&outputs);
         if let Some(shape) = binding_frontier_advance {
             session.advance_binding_input(&self.graph, shape);
         }
@@ -1835,8 +1854,15 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage,
     {
-        self.hydration_roots_owned(roots, OwnedStorage::new(Rc::new(storage)), mode, None, None)
-            .await
+        self.hydration_roots_owned(
+            roots,
+            OwnedStorage::new(Rc::new(storage)),
+            mode,
+            None,
+            None,
+            None,
+        )
+        .await
     }
 
     async fn hydration_roots_owned<'a>(
@@ -1846,6 +1872,7 @@ impl IvmRuntime {
         mode: HydrationMode,
         binding_snapshots: Option<HashMap<String, RecordDeltas>>,
         binding_frontier_advance: Option<&str>,
+        output_demands: Option<&BTreeMap<String, CompiledNode>>,
     ) -> Result<HashMap<NodeId, RecordDeltas>, IvmRuntimeError> {
         let roots = roots.into_iter().collect::<VecDeque<_>>();
         let binding_snapshots = binding_snapshots.unwrap_or_else(|| self.binding_snapshot_deltas());
@@ -1858,6 +1885,9 @@ impl IvmRuntime {
                 Ok::<_, IvmRuntimeError>(found || self.output_depends_on_aggregate(root)?)
             })?;
         let mut session = EvaluationSession::hydration(self, roots, owned_storage)?;
+        if let Some(outputs) = output_demands {
+            session.set_output_demands(outputs);
+        }
         if let Some(shape) = binding_frontier_advance {
             session.advance_binding_input(&self.graph, shape);
         }
@@ -1916,6 +1946,7 @@ impl IvmRuntime {
                 mode,
                 binding_snapshots,
                 binding_frontier_advance,
+                Some(outputs),
             )
             .await?;
         subscription_snapshot_from_hydrated(outputs, &hydrated)

--- a/crates/groove/src/ivm/runtime/schema.rs
+++ b/crates/groove/src/ivm/runtime/schema.rs
@@ -756,42 +756,45 @@ impl IvmRuntime {
         Ok(records)
     }
 
-    pub async fn query_snapshots<I, K, S>(
+    pub async fn query_snapshots<I, S>(
         &mut self,
         sinks: I,
         storage: &S,
     ) -> Result<MultisinkDeltas, IvmRuntimeError>
     where
-        I: IntoIterator<Item = (K, GraphBuilder)>,
-        K: Into<String>,
+        I: IntoIterator,
+        I::Item: Into<MultisinkTerminal>,
         S: OrderedKvStorage,
     {
-        let sinks = sinks
-            .into_iter()
-            .map(|(sink, graph)| (sink.into(), graph))
-            .collect::<Vec<_>>();
+        let sinks = sinks.into_iter().map(Into::into).collect::<Vec<_>>();
         self.flush_pending_binding_retractions(storage).await?;
         if sinks.is_empty() {
             return Err(IvmRuntimeError::EmptyMultisinkSubscription);
         }
         let mut sink_names = HashSet::new();
-        for (sink, graph) in &sinks {
-            if !sink_names.insert(sink.clone()) {
-                return Err(IvmRuntimeError::DuplicateMultisinkSink(sink.clone()));
+        for terminal in &sinks {
+            if !sink_names.insert(terminal.sink.clone()) {
+                return Err(IvmRuntimeError::DuplicateMultisinkSink(
+                    terminal.sink.clone(),
+                ));
             }
-            if builder_contains_binding_source(graph) {
-                return Err(IvmRuntimeError::MultisinkSinkRequiresPrepare(sink.clone()));
+            if builder_contains_binding_source(&terminal.graph) {
+                return Err(IvmRuntimeError::MultisinkSinkRequiresPrepare(
+                    terminal.sink.clone(),
+                ));
             }
         }
         let mut query = super::graph_lifecycle::EphemeralGraphInstall::new(self);
         let runtime = query.runtime();
         runtime.logical_nodes_requested += sinks
             .iter()
-            .map(|(_, graph)| count_builder_nodes(graph))
+            .map(|terminal| count_builder_nodes(&terminal.graph))
             .sum::<usize>() as u64;
         let mut outputs = BTreeMap::new();
-        for (sink, graph) in sinks {
-            outputs.insert(sink, runtime.add_dedup_graph(&graph)?);
+        for terminal in sinks {
+            let mut output = runtime.add_dedup_graph(&terminal.graph)?;
+            output.demand = terminal.demand;
+            outputs.insert(terminal.sink, output);
         }
         runtime
             .hydration_snapshots(&outputs, storage, HydrationMode::Ordinary)

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -80,6 +80,87 @@ pub struct PreparedShape {
     pub(super) id: PreparedShapeId,
 }
 
+/// Per-field logical value requirements at a subscription output boundary.
+///
+/// Fields absent from this map retain the historical full-materialization
+/// behavior. This keeps ordinary subscriptions source compatible while letting
+/// callers ask the chunk reader for only a logical range of a large scalar.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct OutputDemand {
+    fields: BTreeMap<String, crate::large_values::LargeValueDemand>,
+}
+
+impl OutputDemand {
+    pub fn new(
+        fields: impl IntoIterator<Item = (impl Into<String>, crate::large_values::LargeValueDemand)>,
+    ) -> Self {
+        Self {
+            fields: fields
+                .into_iter()
+                .map(|(field, demand)| (field.into(), demand))
+                .collect(),
+        }
+    }
+
+    pub fn field(&self, name: &str) -> crate::large_values::LargeValueDemand {
+        self.fields
+            .get(name)
+            .cloned()
+            .unwrap_or(crate::large_values::LargeValueDemand::Full)
+    }
+
+    pub fn fields(&self) -> &BTreeMap<String, crate::large_values::LargeValueDemand> {
+        &self.fields
+    }
+
+    pub(crate) fn merge_for_shared_output(&mut self, other: &Self) {
+        for (field, demand) in &other.fields {
+            match self.fields.get(field) {
+                Some(current) if current != demand => {
+                    self.fields
+                        .insert(field.clone(), crate::large_values::LargeValueDemand::Full);
+                }
+                Some(_) => {}
+                None => {
+                    self.fields.insert(field.clone(), demand.clone());
+                }
+            }
+        }
+    }
+}
+
+/// One direct multisink output and its terminal materialization requirements.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisinkTerminal {
+    pub sink: String,
+    pub graph: GraphBuilder,
+    pub demand: OutputDemand,
+}
+
+impl MultisinkTerminal {
+    pub fn new(sink: impl Into<String>, graph: GraphBuilder) -> Self {
+        Self {
+            sink: sink.into(),
+            graph,
+            demand: OutputDemand::default(),
+        }
+    }
+
+    pub fn with_output_demand(mut self, demand: OutputDemand) -> Self {
+        self.demand = demand;
+        self
+    }
+}
+
+impl<K> From<(K, GraphBuilder)> for MultisinkTerminal
+where
+    K: Into<String>,
+{
+    fn from((sink, graph): (K, GraphBuilder)) -> Self {
+        Self::new(sink, graph)
+    }
+}
+
 impl PreparedShape {
     pub fn id(&self) -> PreparedShapeId {
         self.id
@@ -99,6 +180,7 @@ pub struct RoutedMultisinkTerminal {
     /// Binding descriptor positions paired with `route_fields`.
     pub route_value_indices: Vec<usize>,
     pub public_fields: Vec<String>,
+    pub demand: OutputDemand,
 }
 
 impl RoutedMultisinkTerminal {
@@ -116,6 +198,7 @@ impl RoutedMultisinkTerminal {
             route_fields,
             route_value_indices,
             public_fields: public_fields.into_iter().map(Into::into).collect(),
+            demand: OutputDemand::default(),
         }
     }
 
@@ -125,6 +208,11 @@ impl RoutedMultisinkTerminal {
         route_value_indices: impl IntoIterator<Item = usize>,
     ) -> Self {
         self.route_value_indices = route_value_indices.into_iter().collect();
+        self
+    }
+
+    pub fn with_output_demand(mut self, demand: OutputDemand) -> Self {
+        self.demand = demand;
         self
     }
 }
@@ -730,6 +818,8 @@ pub(super) struct CompiledNode {
     /// ambiguous once a structured plan contains independently ordered nested
     /// collections.
     pub(super) root_ordering_node: Option<NodeId>,
+    /// Materialization contract owned by this particular terminal output.
+    pub(super) demand: OutputDemand,
 }
 
 /// Descriptor plus a batch of weighted encoded record changes.
@@ -1993,26 +2083,24 @@ impl IvmRuntime {
             };
             return self.bind_shape_one_sink(shape_id, &[plan.binding_value], storage);
         }
-        let multisink = self.subscribe_staged(vec![(DEFAULT_SINK.to_owned(), graph)], storage)?;
+        let multisink =
+            self.subscribe_staged(vec![MultisinkTerminal::new(DEFAULT_SINK, graph)], storage)?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
         self.poll_ready_subscription_work_now()?;
         Ok(subscription)
     }
 
-    pub fn subscribe<I, K, S>(
+    pub fn subscribe<I, S>(
         &mut self,
         sinks: I,
         storage: &Rc<S>,
     ) -> Result<MultisinkSubscription, IvmRuntimeError>
     where
-        I: IntoIterator<Item = (K, GraphBuilder)>,
-        K: Into<String>,
+        I: IntoIterator,
+        I::Item: Into<MultisinkTerminal>,
         S: OrderedKvStorage + 'static,
     {
-        let sinks = sinks
-            .into_iter()
-            .map(|(sink, graph)| (sink.into(), graph))
-            .collect::<Vec<_>>();
+        let sinks = sinks.into_iter().map(Into::into).collect::<Vec<_>>();
         let subscription = self.subscribe_staged(sinks, storage)?;
         self.poll_ready_subscription_work_now()?;
         Ok(subscription)
@@ -2031,7 +2119,7 @@ impl IvmRuntime {
 
     fn subscribe_staged<S>(
         &mut self,
-        sinks: Vec<(String, GraphBuilder)>,
+        sinks: Vec<MultisinkTerminal>,
         storage: &Rc<S>,
     ) -> Result<MultisinkSubscription, IvmRuntimeError>
     where
@@ -2041,16 +2129,20 @@ impl IvmRuntime {
             return Err(IvmRuntimeError::EmptyMultisinkSubscription);
         }
         let mut sink_names = HashSet::new();
-        for (sink, _) in &sinks {
-            if !sink_names.insert(sink.clone()) {
-                return Err(IvmRuntimeError::DuplicateMultisinkSink(sink.clone()));
+        for terminal in &sinks {
+            if !sink_names.insert(terminal.sink.clone()) {
+                return Err(IvmRuntimeError::DuplicateMultisinkSink(
+                    terminal.sink.clone(),
+                ));
             }
         }
-        if let Some((sink, _)) = sinks
+        if let Some(terminal) = sinks
             .iter()
-            .find(|(_, graph)| builder_contains_binding_source(graph))
+            .find(|terminal| builder_contains_binding_source(&terminal.graph))
         {
-            return Err(IvmRuntimeError::MultisinkSinkRequiresPrepare(sink.clone()));
+            return Err(IvmRuntimeError::MultisinkSinkRequiresPrepare(
+                terminal.sink.clone(),
+            ));
         }
         let subscription_id = self.next_subscription_id();
         let (sender, receiver) = mpsc::channel();
@@ -2071,12 +2163,13 @@ impl IvmRuntime {
             let runtime = install.runtime();
             runtime.logical_nodes_requested += sinks
                 .iter()
-                .map(|(_, graph)| count_builder_nodes(graph))
+                .map(|terminal| count_builder_nodes(&terminal.graph))
                 .sum::<usize>() as u64;
             let mut outputs = BTreeMap::new();
-            for (sink, graph) in sinks {
-                let compiled = runtime.add_dedup_graph(&graph)?;
-                outputs.insert(sink, compiled);
+            for terminal in sinks {
+                let mut compiled = runtime.add_dedup_graph(&terminal.graph)?;
+                compiled.demand = terminal.demand;
+                outputs.insert(terminal.sink, compiled);
             }
             for output in outputs.values() {
                 runtime.retain_as_subscription(subscription_id, output.node);
@@ -2186,7 +2279,8 @@ impl IvmRuntime {
         }
         let mut terminal_states = BTreeMap::new();
         for terminal in terminals {
-            let output = self.add_dedup_graph(&terminal.graph)?;
+            let mut output = self.add_dedup_graph(&terminal.graph)?;
+            output.demand = terminal.demand.clone();
             self.add_retainer(
                 output.node,
                 Retainer::PreparedShape(shape_id.retainer_key()),
@@ -2273,7 +2367,8 @@ impl IvmRuntime {
                     terminal.public_fields = fields.clone();
                 }
                 let graph = bound_routed_multisink_graph(&terminal, binding_values);
-                let output = runtime.add_dedup_graph(&graph)?;
+                let mut output = runtime.add_dedup_graph(&graph)?;
+                output.demand = terminal.demand.clone();
                 outputs.insert(sink.clone(), output);
             }
             let binding_shape = runtime.binding_source_shape_name(shape_id)?;

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -46,6 +46,20 @@ pub enum LargeValueKind {
     Json,
 }
 
+/// The exact logical subset an evaluator needs from an indirect scalar.
+///
+/// This deliberately lives beside the chunk reader so a terminal can suspend
+/// only on intersecting authenticated nodes instead of hydrating a whole
+/// value before projecting it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LargeValueDemand {
+    Full,
+    Bytes(std::ops::Range<u64>),
+    TextUtf16(std::ops::Range<u64>),
+    TextUtf8(std::ops::Range<u64>),
+    JsonPointer(String),
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NodeRef {
     pub object_hash: ContentHash,
@@ -2603,6 +2617,40 @@ pub(crate) fn byte_range_attempt(
         return Err(IvmRuntimeError::EvaluationBlocked);
     }
     Ok(outputs.into_iter().flatten().collect())
+}
+
+/// Materialize precisely the logical subset requested by a terminal.
+///
+/// UTF-8 range requests use byte coordinates but validate that both endpoints
+/// are code-point boundaries. JSON pointers currently require a complete JSON
+/// document when the pointer cannot be proven from a prefix; keeping that
+/// fallback here preserves the evaluator's suspension protocol.
+#[allow(dead_code)] // Wired by demand-carrying terminals during the next runtime layer.
+pub(crate) fn materialize_demand_attempt(
+    value: &LargeValueRef,
+    demand: &LargeValueDemand,
+    inputs: &mut EvaluationInputs,
+) -> Result<Vec<u8>, IvmRuntimeError> {
+    match demand {
+        LargeValueDemand::Full => materialize_attempt(value, inputs),
+        LargeValueDemand::Bytes(range) => byte_range_attempt(value, range.clone(), inputs),
+        LargeValueDemand::TextUtf16(range) => utf16_range_attempt(value, range.clone(), inputs),
+        LargeValueDemand::TextUtf8(range) => {
+            let bytes = byte_range_attempt(value, range.clone(), inputs)?;
+            std::str::from_utf8(&bytes).map_err(|_| Error::InvalidUtf8)?;
+            Ok(bytes)
+        }
+        LargeValueDemand::JsonPointer(pointer) => {
+            let bytes = materialize_attempt(value, inputs)?;
+            let json: serde_json::Value =
+                serde_json::from_slice(&bytes).map_err(|_| Error::InvalidJson)?;
+            let selected = json
+                .pointer(pointer)
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+            serde_json::to_vec(&selected).map_err(|_| Error::InvalidJson.into())
+        }
+    }
 }
 
 /// Count UTF-16 units in a byte-coordinate range without hydrating complete

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -51,7 +51,7 @@ pub enum LargeValueKind {
 /// This deliberately lives beside the chunk reader so a terminal can suspend
 /// only on intersecting authenticated nodes instead of hydrating a whole
 /// value before projecting it.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum LargeValueDemand {
     Full,
     Bytes(std::ops::Range<u64>),
@@ -2295,6 +2295,37 @@ pub(crate) fn materialize_record_attempt(
     Ok(descriptor.create(&values)?)
 }
 
+/// Materialize a terminal record according to its per-field output contract.
+///
+/// The record descriptor remains unchanged: a range or pointer read simply
+/// replaces the indirect scalar in that field with the requested primitive.
+/// This is intentionally an output-boundary helper; operators continue to use
+/// their own full/field-specific reads to preserve relational semantics.
+pub(crate) fn materialize_record_demand_attempt(
+    descriptor: &RecordDescriptor,
+    raw: &[u8],
+    demands: &std::collections::BTreeMap<String, LargeValueDemand>,
+    inputs: &mut EvaluationInputs,
+) -> Result<Vec<u8>, IvmRuntimeError> {
+    let mut values = descriptor.bind(raw).to_values()?;
+    let mut blocked = false;
+    for (index, value) in values.iter_mut().enumerate() {
+        let field = descriptor
+            .fields()
+            .get(index)
+            .and_then(|field| field.name.as_deref());
+        let demand = field
+            .and_then(|field| demands.get(field))
+            .cloned()
+            .unwrap_or(LargeValueDemand::Full);
+        materialize_value_demand_attempt(value, &demand, inputs, &mut blocked)?;
+    }
+    if blocked {
+        return Err(IvmRuntimeError::EvaluationBlocked);
+    }
+    Ok(descriptor.create(&values)?)
+}
+
 /// Materialize only the logical fields an operator will inspect. Unselected
 /// indirect arms remain encoded as descriptors in the rebuilt record.
 pub(crate) fn materialize_record_fields_attempt(
@@ -2383,6 +2414,35 @@ fn materialize_value_attempt(
             Ok(())
         }
         _ => Ok(()),
+    }
+}
+
+fn materialize_value_demand_attempt(
+    value: &mut Value,
+    demand: &LargeValueDemand,
+    inputs: &mut EvaluationInputs,
+    blocked: &mut bool,
+) -> Result<(), IvmRuntimeError> {
+    match value {
+        Value::Large(large) => match materialize_demand_attempt(large, demand, inputs) {
+            Ok(bytes) => {
+                *value = match large.kind {
+                    LargeValueKind::Bytes => Value::Bytes(bytes),
+                    LargeValueKind::String | LargeValueKind::Json => {
+                        Value::String(String::from_utf8(bytes).map_err(|_| Error::InvalidUtf8)?)
+                    }
+                };
+                Ok(())
+            }
+            Err(IvmRuntimeError::EvaluationBlocked) => {
+                *blocked = true;
+                Ok(())
+            }
+            Err(error) => Err(error),
+        },
+        // A terminal's named demand applies only to that scalar field. Nested
+        // values preserve historical full materialization semantics.
+        _ => materialize_value_attempt(value, inputs, blocked),
     }
 }
 
@@ -4341,5 +4401,89 @@ mod tests {
                 assert_eq!(mapped, logical[range]);
             }
         }
+    }
+
+    #[test]
+    fn terminal_demands_return_logical_subset_primitives() {
+        fn materialize(
+            kind: LargeValueKind,
+            logical: &[u8],
+            descriptor: RecordDescriptor,
+            demand: LargeValueDemand,
+        ) -> Value {
+            let prepared = prepare(kind, logical, deterministic_locator).unwrap();
+            let available = prepared
+                .staged_chunks
+                .iter()
+                .map(|chunk| {
+                    (
+                        ChunkRequest {
+                            object_hash: chunk.node_ref.object_hash.0,
+                            locator: chunk.node_ref.locator.0.clone(),
+                        },
+                        bytes::Bytes::copy_from_slice(&chunk.encoded),
+                    )
+                })
+                .collect::<std::collections::BTreeMap<_, _>>();
+            let raw = descriptor
+                .create(&[Value::Large(prepared.value_ref)])
+                .unwrap();
+            let mut inputs = EvaluationInputs::default();
+            loop {
+                match materialize_record_demand_attempt(
+                    &descriptor,
+                    &raw,
+                    &std::collections::BTreeMap::from([("body".to_owned(), demand.clone())]),
+                    &mut inputs,
+                ) {
+                    Ok(materialized) => {
+                        return descriptor.bind(&materialized).to_values().unwrap()[0].clone();
+                    }
+                    Err(IvmRuntimeError::EvaluationBlocked) => {
+                        for request in inputs.take_missing_chunks() {
+                            inputs.install_chunk(request.clone(), available[&request].clone());
+                        }
+                    }
+                    Err(error) => panic!("unexpected terminal materialization error: {error}"),
+                }
+            }
+        }
+
+        assert_eq!(
+            materialize(
+                LargeValueKind::Bytes,
+                b"abcdef",
+                RecordDescriptor::new([("body", crate::records::ValueType::Bytes)]),
+                LargeValueDemand::Bytes(1..4),
+            ),
+            Value::Bytes(b"bcd".to_vec())
+        );
+        assert_eq!(
+            materialize(
+                LargeValueKind::String,
+                "a😀bc".as_bytes(),
+                RecordDescriptor::new([("body", crate::records::ValueType::String)]),
+                LargeValueDemand::TextUtf16(1..3),
+            ),
+            Value::String("😀".to_owned())
+        );
+        assert_eq!(
+            materialize(
+                LargeValueKind::String,
+                "a😀bc".as_bytes(),
+                RecordDescriptor::new([("body", crate::records::ValueType::String)]),
+                LargeValueDemand::TextUtf8(1..5),
+            ),
+            Value::String("😀".to_owned())
+        );
+        assert_eq!(
+            materialize(
+                LargeValueKind::String,
+                br#"{"nested":{"value":7},"other":true}"#,
+                RecordDescriptor::new([("body", crate::records::ValueType::String)]),
+                LargeValueDemand::JsonPointer("/nested/value".to_owned()),
+            ),
+            Value::String("7".to_owned())
+        );
     }
 }

--- a/crates/groove/tests/large_value_query.rs
+++ b/crates/groove/tests/large_value_query.rs
@@ -8,9 +8,11 @@ use std::{
 use bytes::Bytes;
 use futures::task::noop_waker;
 use groove::chunks::{ChunkError, ChunkRequest, OwnedChunkProvider, TestChunkProvider};
-use groove::db::{Database, GraphBuilder, PredicateExpr};
+use groove::db::{Database, GraphBuilder, MultisinkTerminal, OutputDemand, PredicateExpr};
 use groove::ivm::{AggregateExpr, AggregateFunction, ProjectField};
-use groove::large_values::{LargeValueKind, Locator, TailAppendOutcome, append_tail, prepare};
+use groove::large_values::{
+    LargeValueDemand, LargeValueKind, Locator, TailAppendOutcome, append_tail, prepare,
+};
 use groove::records::{RecordDescriptor, Value, ValueType};
 use groove::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema,
@@ -289,6 +291,261 @@ async fn subscription_materializes_large_insert_and_update_deltas_atomically() {
     assert_eq!(updated.len(), 2);
     assert!(updated.contains(&(vec![Value::U64(1), Value::String(first_text)], -1)));
     assert!(updated.contains(&(vec![Value::U64(1), Value::String(second_text)], 1)));
+}
+
+#[futures_test::test]
+async fn direct_subscription_range_demand_reads_only_the_intersecting_chunks() {
+    let logical = (0_u8..=255).cycle().take(800_000).collect::<Vec<_>>();
+    let prepared = prepare(LargeValueKind::Bytes, &logical, |hash| {
+        Locator(hash.0[..24].to_vec())
+    })
+    .unwrap();
+    // `prepare` stages leaves before their parent branches. Serving only the
+    // first leaf and root is a planted sensitivity check: full hydration would
+    // request a missing later leaf and fail this subscription.
+    let required = prepared
+        .staged_chunks
+        .iter()
+        .enumerate()
+        .filter(|(index, chunk)| *index == 0 || chunk.node_ref == prepared.value_ref.root)
+        .map(|(_, chunk)| {
+            (
+                ChunkRequest {
+                    object_hash: chunk.node_ref.object_hash.0,
+                    locator: chunk.node_ref.locator.0.clone(),
+                },
+                Bytes::copy_from_slice(&chunk.encoded),
+            )
+        })
+        .collect::<Vec<_>>();
+    let expected_requests = required
+        .iter()
+        .map(|(request, _)| request.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    let (provider, control) = TestChunkProvider::controlled(required);
+    let schema = DatabaseSchema::new([TableSchema::new(
+        "docs",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("body", ColumnType::Bytes),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let column_families = schema
+        .column_families()
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let column_family_refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let mut database = Database::new(schema, MemoryStorage::new(&column_family_refs))
+        .await
+        .unwrap();
+    database.set_chunk_provider(Rc::new(provider));
+    let subscription = database
+        .subscribe([MultisinkTerminal::new("docs", GraphBuilder::table("docs"))
+            .with_output_demand(OutputDemand::new([(
+                "body",
+                LargeValueDemand::Bytes(13..29),
+            )]))])
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "docs",
+        vec![Value::U64(1), Value::Large(prepared.value_ref)],
+    );
+    let publication = database.apply_batch(batch).await.unwrap();
+    database
+        .finish_persistence(publication.persist().await)
+        .unwrap();
+
+    let delivered = subscription.recv().unwrap();
+    let rows = delivered.sinks["docs"].to_values().unwrap();
+    assert_eq!(
+        rows,
+        vec![(
+            vec![Value::U64(1), Value::Bytes(logical[13..29].to_vec())],
+            1
+        )]
+    );
+    assert_eq!(
+        control
+            .observed()
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>(),
+        expected_requests
+    );
+}
+
+#[futures_test::test]
+async fn one_shot_multisink_range_demand_uses_the_same_terminal_boundary() {
+    let logical = vec![0x5a; 800_000];
+    let prepared = prepare(LargeValueKind::Bytes, &logical, |hash| {
+        Locator(hash.0[..24].to_vec())
+    })
+    .unwrap();
+    let chunks = prepared
+        .staged_chunks
+        .iter()
+        .enumerate()
+        .filter(|(index, chunk)| *index == 0 || chunk.node_ref == prepared.value_ref.root)
+        .map(|(_, chunk)| {
+            (
+                ChunkRequest {
+                    object_hash: chunk.node_ref.object_hash.0,
+                    locator: chunk.node_ref.locator.0.clone(),
+                },
+                Bytes::copy_from_slice(&chunk.encoded),
+            )
+        })
+        .collect::<Vec<_>>();
+    let (provider, _) = TestChunkProvider::controlled(chunks);
+    let mut database = Database::new(DatabaseSchema::new([]), MemoryStorage::new(&[]))
+        .await
+        .unwrap();
+    database.set_chunk_provider(Rc::new(provider));
+    let descriptor = RecordDescriptor::new([("body", ValueType::Bytes)]);
+    let rows = database
+        .query_graphs([MultisinkTerminal::new(
+            "body",
+            GraphBuilder::values(descriptor, [vec![Value::Large(prepared.value_ref)]]).unwrap(),
+        )
+        .with_output_demand(OutputDemand::new([(
+            "body",
+            LargeValueDemand::Bytes(100..117),
+        )]))])
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.sinks["body"].to_values().unwrap(),
+        vec![(vec![Value::Bytes(logical[100..117].to_vec())], 1)]
+    );
+}
+
+#[futures_test::test]
+async fn prepared_multisink_terminal_demands_survive_initial_hydration() {
+    let first_bytes = vec![0x31; 800_000];
+    let second_bytes = vec![0x62; 800_000];
+    let first = prepare(LargeValueKind::Bytes, &first_bytes, |hash| {
+        let mut locator = b"first/".to_vec();
+        locator.extend_from_slice(&hash.0[..20]);
+        Locator(locator)
+    })
+    .unwrap();
+    let second = prepare(LargeValueKind::Bytes, &second_bytes, |hash| {
+        let mut locator = b"second/".to_vec();
+        locator.extend_from_slice(&hash.0[..20]);
+        Locator(locator)
+    })
+    .unwrap();
+    let chunks = [(&first, 0usize), (&second, 0usize)]
+        .into_iter()
+        .flat_map(|(prepared, first_leaf)| {
+            prepared
+                .staged_chunks
+                .iter()
+                .enumerate()
+                .filter(move |(index, chunk)| {
+                    *index == first_leaf || chunk.node_ref == prepared.value_ref.root
+                })
+                .map(|(_, chunk)| {
+                    (
+                        ChunkRequest {
+                            object_hash: chunk.node_ref.object_hash.0,
+                            locator: chunk.node_ref.locator.0.clone(),
+                        },
+                        Bytes::copy_from_slice(&chunk.encoded),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let (provider, _) = TestChunkProvider::controlled(chunks);
+    let schema = DatabaseSchema::new([TableSchema::new(
+        "docs",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("first", ColumnType::Bytes),
+            ColumnSchema::new("second", ColumnType::Bytes),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let column_families = schema
+        .column_families()
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let column_family_refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let mut database = Database::new(schema, MemoryStorage::new(&column_family_refs))
+        .await
+        .unwrap();
+    database.set_chunk_provider(Rc::new(provider));
+    let mut batch = database.open_batch();
+    batch.insert(
+        "docs",
+        vec![
+            Value::U64(1),
+            Value::Large(first.value_ref),
+            Value::Large(second.value_ref),
+        ],
+    );
+    let publication = database.apply_batch(batch).await.unwrap();
+    database
+        .finish_persistence(publication.persist().await)
+        .unwrap();
+
+    let shape = database
+        .prepare(
+            [
+                groove::db::RoutedMultisinkTerminal::new(
+                    "first",
+                    GraphBuilder::table("docs").project(["id", "first"]),
+                    std::iter::empty::<&str>(),
+                    ["id", "first"],
+                )
+                .with_output_demand(OutputDemand::new([(
+                    "first",
+                    LargeValueDemand::Bytes(4..11),
+                )])),
+                groove::db::RoutedMultisinkTerminal::new(
+                    "second",
+                    GraphBuilder::table("docs").project(["id", "second"]),
+                    std::iter::empty::<&str>(),
+                    ["id", "second"],
+                )
+                .with_output_demand(OutputDemand::new([(
+                    "second",
+                    LargeValueDemand::Bytes(9..16),
+                )])),
+            ],
+            "test/no-params",
+            RecordDescriptor::new(std::iter::empty::<(String, ValueType)>()),
+        )
+        .await
+        .unwrap();
+    let subscription = database.bind_shape(shape.id(), &[]).await.unwrap();
+    let initial = subscription.recv().unwrap();
+    assert_eq!(
+        initial.sinks["first"].to_values().unwrap(),
+        vec![(
+            vec![Value::U64(1), Value::Bytes(first_bytes[4..11].to_vec())],
+            1
+        )]
+    );
+    assert_eq!(
+        initial.sinks["second"].to_values().unwrap(),
+        vec![(
+            vec![Value::U64(1), Value::Bytes(second_bytes[9..16].to_vec())],
+            1
+        )]
+    );
 }
 
 #[futures_test::test]

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -2208,6 +2208,7 @@ mod tests {
                 ),
                 ("__jazz_include_project".to_owned(), "project".to_owned()),
             ]),
+            demand: crate::node::query_engine::AppProjectionTree::default(),
         };
         let layout = terminal_root_layout(&rows);
         assert_eq!(

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -750,4 +750,7 @@ pub(crate) struct LoweredTerminal {
     pub(crate) graph: GraphBuilder,
     /// Typed terminal output contract.
     pub(crate) output: OutputTerminalSchema,
+    /// Public large-value demand associated with this terminal. Fact terminals
+    /// use the default full demand.
+    pub(crate) demand: AppProjectionTree,
 }

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -174,6 +174,7 @@ pub(super) fn lowered_terminals(
                         closure.visible_root.clone(),
                         &AppProjectionTree {
                             fields: FieldProjection::All,
+                            demands: BTreeMap::new(),
                             paths: Vec::new(),
                         },
                         plan,

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -87,6 +87,10 @@ pub(super) fn lowered_terminals(
     // array queries on their existing fact-terminal path; the tree collector
     // cannot retain any routed binding fields yet.
     if let Some(app_rows) = &request.output.app_rows {
+        let terminal_demand = match &app_rows.projection {
+            PayloadProjection::Tree(tree) => tree.clone(),
+            PayloadProjection::ShapeDefault => AppProjectionTree::default(),
+        };
         let projected_output = projected_multisource_terminal(plan, source);
         let (graph, descriptor, hidden_fields, carrier, field_carriers, public_field_names) =
             match app_rows.projection.clone() {
@@ -203,7 +207,9 @@ pub(super) fn lowered_terminals(
                 carrier,
                 field_carriers,
                 public_field_names,
+                demand: terminal_demand.clone(),
             }),
+            demand: terminal_demand,
         });
     }
 
@@ -247,6 +253,7 @@ pub(super) fn lowered_terminals(
                 sink: fact_sink_name(fact),
                 graph: result_graph,
                 output: OutputTerminalSchema::Fact(output.clone()),
+                demand: AppProjectionTree::default(),
             });
             // A flat join's one wide primary terminal is its public output.
             // The ordinary closure terminals are source-only membership facts;
@@ -285,6 +292,7 @@ pub(super) fn lowered_terminals(
                         sink: scoped_fact_sink_name(fact, &source_id),
                         graph,
                         output: OutputTerminalSchema::Fact(output),
+                        demand: AppProjectionTree::default(),
                     });
                 }
             }
@@ -330,6 +338,7 @@ pub(super) fn lowered_terminals(
                         sink: scoped_fact_sink_name(fact, &contribution.source),
                         graph,
                         output: OutputTerminalSchema::Fact(output),
+                        demand: AppProjectionTree::default(),
                     });
                 }
             }
@@ -347,6 +356,7 @@ pub(super) fn lowered_terminals(
                     sink: scoped_fact_sink_name(fact, source_id),
                     graph: content_version_witness_graph(resolved_source, "version_content")?,
                     output: OutputTerminalSchema::Fact(content_output),
+                    demand: AppProjectionTree::default(),
                 });
                 if resolved_source.deletion_register.is_none() {
                     continue;
@@ -366,6 +376,7 @@ pub(super) fn lowered_terminals(
                         "version_deletion",
                     )?,
                     output: OutputTerminalSchema::Fact(deletion_output),
+                    demand: AppProjectionTree::default(),
                 });
             }
         } else if matches!(fact, ProgramFactKey::ReplacementWitnesses) {
@@ -382,6 +393,7 @@ pub(super) fn lowered_terminals(
                     sink: scoped_fact_sink_name(fact, source_id),
                     graph: content_version_witness_graph(resolved_source, "replacement_content")?,
                     output: OutputTerminalSchema::Fact(content_output),
+                    demand: AppProjectionTree::default(),
                 });
                 if resolved_source.deletion_register.is_none() {
                     continue;
@@ -401,6 +413,7 @@ pub(super) fn lowered_terminals(
                         "replacement_deletion",
                     )?,
                     output: OutputTerminalSchema::Fact(deletion_output),
+                    demand: AppProjectionTree::default(),
                 });
             }
         } else {
@@ -431,6 +444,7 @@ pub(super) fn lowered_terminals(
                 sink: fact_sink_name(fact),
                 graph,
                 output: OutputTerminalSchema::Fact(output),
+                demand: AppProjectionTree::default(),
             });
         }
     }
@@ -1063,6 +1077,15 @@ fn lowered_aggregate_terminals(
         )
     };
     if request.output.app_rows.is_some() {
+        let terminal_demand = request
+            .output
+            .app_rows
+            .as_ref()
+            .and_then(|rows| match &rows.projection {
+                PayloadProjection::Tree(tree) => Some(tree.clone()),
+                PayloadProjection::ShapeDefault => None,
+            })
+            .unwrap_or_default();
         terminals.push(LoweredTerminal {
             sink: "app_rows".to_owned(),
             graph: aggregate_graph.clone(),
@@ -1072,7 +1095,9 @@ fn lowered_aggregate_terminals(
                 carrier: AppRowCarrier::Logical,
                 field_carriers: BTreeMap::new(),
                 public_field_names: BTreeMap::new(),
+                demand: terminal_demand.clone(),
             }),
+            demand: terminal_demand,
         });
     }
     for fact in &request.output.facts {
@@ -1097,6 +1122,7 @@ fn lowered_aggregate_terminals(
                 sink: fact_sink_name(fact),
                 graph,
                 output: OutputTerminalSchema::Fact(output),
+                demand: AppProjectionTree::default(),
             });
         }
     }

--- a/crates/jazz/src/node/query_engine/output.rs
+++ b/crates/jazz/src/node/query_engine/output.rs
@@ -34,6 +34,10 @@ pub(crate) enum PayloadProjection {
 pub(crate) struct AppProjectionTree {
     /// Root public field projection.
     pub(crate) fields: FieldProjection,
+    /// Per-field large-value demand.  Absent entries retain ordinary full
+    /// materialization semantics; this lets old terminals coexist while the
+    /// evaluator lowers demand-aware chunk reads.
+    pub(crate) demands: BTreeMap<String, crate::query::SelectProjection>,
     /// Nested path/relation projections.
     pub(crate) paths: Vec<AppPathProjection>,
 }

--- a/crates/jazz/src/node/query_engine/output.rs
+++ b/crates/jazz/src/node/query_engine/output.rs
@@ -42,6 +42,16 @@ pub(crate) struct AppProjectionTree {
     pub(crate) paths: Vec<AppPathProjection>,
 }
 
+impl Default for AppProjectionTree {
+    fn default() -> Self {
+        Self {
+            fields: FieldProjection::All,
+            demands: BTreeMap::new(),
+            paths: Vec::new(),
+        }
+    }
+}
+
 /// Field projection for app rows.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum FieldProjection {

--- a/crates/jazz/src/node/query_engine/schemas.rs
+++ b/crates/jazz/src/node/query_engine/schemas.rs
@@ -33,6 +33,9 @@ pub(crate) struct AppRowSchema {
     /// with `user_`, which is otherwise the physical CurrentRow source-cell
     /// namespace.
     pub(crate) public_field_names: BTreeMap<String, String>,
+    /// Root large-value requirements retained through lowering to the Groove
+    /// subscription boundary.
+    pub(crate) demand: AppProjectionTree,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -330,6 +330,7 @@ fn current_source_select_projection_and_default_ordered_slice_lower() {
                 public_terminal: true,
                 projection: PayloadProjection::Tree(AppProjectionTree {
                     fields: FieldProjection::Fields(BTreeSet::from(["title".to_owned()])),
+                    demands: BTreeMap::new(),
                     paths: Vec::new(),
                 }),
             }),

--- a/crates/jazz/src/node/query_engine/tests/requirements.rs
+++ b/crates/jazz/src/node/query_engine/tests/requirements.rs
@@ -86,6 +86,7 @@ fn closure_requirements_merge_sparse_root_and_every_alias_hop_key() {
     output.app_rows.as_mut().expect("app rows").projection =
         PayloadProjection::Tree(AppProjectionTree {
             fields: FieldProjection::Fields(BTreeSet::from(["title".to_owned()])),
+            demands: BTreeMap::new(),
             paths: Vec::new(),
         });
     let request = QueryProgramRequest {

--- a/crates/jazz/src/node/query_engine/tests/support.rs
+++ b/crates/jazz/src/node/query_engine/tests/support.rs
@@ -808,6 +808,7 @@ pub(super) fn collector_path_projection(children: Vec<AppPathProjection>) -> App
     let child_source = source("todo_tags", SourceRole::CorrelatedChild("tags".to_owned()));
     AppProjectionTree {
         fields: FieldProjection::All,
+        demands: BTreeMap::new(),
         paths: vec![app_path_projection(
             parent_source,
             child_source,

--- a/crates/jazz/src/node/query_engine/tests/terminals.rs
+++ b/crates/jazz/src/node/query_engine/tests/terminals.rs
@@ -370,6 +370,7 @@ fn collector_tree_keeps_sibling_slots_distinct_and_nests_grandchildren_by_path()
         .expect("app rows")
         .projection = PayloadProjection::Tree(AppProjectionTree {
         fields: FieldProjection::All,
+        demands: BTreeMap::new(),
         paths: vec![
             app_path_projection(
                 parent.clone(),

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -3010,11 +3010,14 @@ fn local_maintained_view_content_witness<'a>(
 fn current_row_has_required_subscription_cells(
     row: &CurrentRow,
     table: &TableSchema,
-    projection: Option<&[String]>,
+    projection: Option<&[crate::query::SelectProjection]>,
 ) -> bool {
     table.columns.iter().all(|column| {
-        projection.is_some_and(|columns| !columns.contains(&column.name))
-            || matches!(column.column_type, ValueType::Nullable(_))
+        projection.is_some_and(|columns| {
+            !columns
+                .iter()
+                .any(|selected| selected.column() == column.name)
+        }) || matches!(column.column_type, ValueType::Nullable(_))
             || row.cell(table, &column.name).is_some()
     })
 }

--- a/crates/jazz/src/node/query_eval/lowering.rs
+++ b/crates/jazz/src/node/query_eval/lowering.rs
@@ -43,6 +43,52 @@ fn app_row_terminal_schema(output: &ProgramOutputSchemas) -> Result<&AppRowSchem
         ))
 }
 
+fn groove_output_demand(
+    schema: &AppRowSchema,
+    demand_tree: &AppProjectionTree,
+) -> groove::ivm::OutputDemand {
+    groove::ivm::OutputDemand::new(schema.descriptor.fields().iter().filter_map(|field| {
+        let physical = field.name.as_deref()?;
+        let public = schema
+            .public_field_names
+            .get(physical)
+            .map(String::as_str)
+            .unwrap_or(physical);
+        let projection = demand_tree
+            .demands
+            .get(public)
+            .or_else(|| demand_tree.demands.get(physical))?;
+        let demand = match projection {
+            crate::query::SelectProjection::Full { .. } => {
+                groove::large_values::LargeValueDemand::Full
+            }
+            crate::query::SelectProjection::Bytes { from, to, .. } => {
+                groove::large_values::LargeValueDemand::Bytes(*from..*to)
+            }
+            crate::query::SelectProjection::TextUtf16 { from, to, .. } => {
+                groove::large_values::LargeValueDemand::TextUtf16(*from..*to)
+            }
+            crate::query::SelectProjection::TextUtf8 { from, to, .. } => {
+                groove::large_values::LargeValueDemand::TextUtf8(*from..*to)
+            }
+            crate::query::SelectProjection::JsonPointer { at, .. } => {
+                groove::large_values::LargeValueDemand::JsonPointer(at.clone())
+            }
+        };
+        Some((physical.to_owned(), demand))
+    }))
+}
+
+fn terminal_groove_output_demand(
+    output: &OutputTerminalSchema,
+    demand_tree: &AppProjectionTree,
+) -> groove::ivm::OutputDemand {
+    match output {
+        OutputTerminalSchema::AppRows(schema) => groove_output_demand(schema, demand_tree),
+        OutputTerminalSchema::Fact(_) => groove::ivm::OutputDemand::default(),
+    }
+}
+
 pub(super) fn lowered_terminal_graph(
     program: &QueryProgram,
     sink: &str,
@@ -94,12 +140,18 @@ pub(super) fn lowered_materialization_app_rows_graph(
         .unwrap_or_else(|| lowered_app_rows_graph(program))
 }
 
-pub(super) fn lowered_program_sinks(program: &QueryProgram) -> Vec<(String, GraphBuilder)> {
+pub(super) fn lowered_program_sinks(program: &QueryProgram) -> Vec<groove::ivm::MultisinkTerminal> {
     program
         .lowered
         .terminals
         .iter()
-        .map(|terminal| (terminal.sink.clone(), terminal.graph.clone()))
+        .map(|terminal| {
+            groove::ivm::MultisinkTerminal::new(terminal.sink.clone(), terminal.graph.clone())
+                .with_output_demand(terminal_groove_output_demand(
+                    &terminal.output,
+                    &terminal.demand,
+                ))
+        })
         .collect()
 }
 
@@ -521,6 +573,18 @@ where
         _binding: &Binding,
     ) -> Result<PreparedQueryPlan, Error> {
         let app_row_fields = app_row_terminal_fields(&program.lowered.output)?;
+        let app_row_demand = groove_output_demand(
+            app_row_terminal_schema(&program.lowered.output)?,
+            &program
+                .lowered
+                .terminals
+                .iter()
+                .find(|terminal| terminal.sink == JAZZ_APP_ROWS_SINK)
+                .ok_or(Error::InvalidStoredValue(
+                    "query program did not emit app row terminal",
+                ))?
+                .demand,
+        );
         let graph = lowered_materialization_app_rows_graph(&program)?;
         let params = prepared_params_from_domain(&program.lowered.parameters);
         let route_eligible_fields =
@@ -566,7 +630,8 @@ where
                         route_fields,
                         app_row_fields,
                     )
-                    .with_route_value_indices(route_value_indices)],
+                    .with_route_value_indices(route_value_indices)
+                    .with_output_demand(app_row_demand)],
                     binding_source_shape,
                     binding_descriptor,
                 )
@@ -588,11 +653,17 @@ where
         let params = prepared_params_from_domain(&program.lowered.parameters);
         let route_params = prepared_route_param_names(&program.lowered.parameters);
         if params.is_empty() {
-            let sinks: Vec<(String, GraphBuilder)> = program
+            let sinks: Vec<groove::ivm::MultisinkTerminal> = program
                 .lowered
                 .terminals
                 .into_iter()
-                .map(|terminal| (terminal.sink, terminal.graph))
+                .map(|terminal| {
+                    groove::ivm::MultisinkTerminal::new(terminal.sink, terminal.graph)
+                        .with_output_demand(terminal_groove_output_demand(
+                            &terminal.output,
+                            &terminal.demand,
+                        ))
+                })
                 .collect();
             return self.database.subscribe(sinks).map_err(Error::Groove);
         }
@@ -629,7 +700,11 @@ where
                     route_fields,
                     public_fields,
                 )
-                .with_route_value_indices(route_value_indices))
+                .with_route_value_indices(route_value_indices)
+                .with_output_demand(terminal_groove_output_demand(
+                    &terminal.output,
+                    &terminal.demand,
+                )))
             })
             .collect::<Result<Vec<_>, Error>>()?;
         let prepared = self

--- a/crates/jazz/src/node/query_eval/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/maintained_views.rs
@@ -17,7 +17,7 @@ pub(crate) struct LocalMaintainedViewSubscription {
     pub(super) result_table: String,
     pub(super) result_schema_version: SchemaVersionId,
     pub(super) binding_view_key: BindingViewKey,
-    pub(super) result_select: Option<Vec<String>>,
+    pub(super) result_select: Option<Vec<crate::query::SelectProjection>>,
     pub(super) result_set: BTreeSet<ResultMemberEntry>,
     pub(super) authoritative_result_generation: u64,
     pub(super) authoritative_reconciliation_deferred: bool,
@@ -126,7 +126,12 @@ impl LocalMaintainedViewSubscription {
             + self
                 .result_select
                 .as_ref()
-                .map(|columns| columns.iter().map(String::len).sum::<usize>())
+                .map(|columns| {
+                    columns
+                        .iter()
+                        .map(|column| column.column().len())
+                        .sum::<usize>()
+                })
                 .unwrap_or_default()
             + result_set_bytes
             + result_payloads_bytes

--- a/crates/jazz/src/node/query_eval/materialization.rs
+++ b/crates/jazz/src/node/query_eval/materialization.rs
@@ -526,7 +526,13 @@ where
         {
             let mut row = self.current_row_from_result_payload(&table, payload)?;
             if let Some(columns) = &local.result_select {
-                row = row.project(&table, columns)?;
+                row = row.project(
+                    &table,
+                    &columns
+                        .iter()
+                        .map(|projection| projection.column().to_owned())
+                        .collect::<Vec<_>>(),
+                )?;
             }
             return Ok(Some(row));
         }
@@ -578,7 +584,13 @@ where
                 "maintained result witness does not project into the read schema",
             ))?;
         if let Some(columns) = &local.result_select {
-            row = row.project(&table, columns)?;
+            row = row.project(
+                &table,
+                &columns
+                    .iter()
+                    .map(|projection| projection.column().to_owned())
+                    .collect::<Vec<_>>(),
+            )?;
         }
         Ok(Some(row))
     }
@@ -1340,7 +1352,13 @@ where
         };
         let table = self.table_in_schema(&query.table, schema_version)?;
         for row in rows {
-            *row = row.project(&table, columns)?;
+            *row = row.project(
+                &table,
+                &columns
+                    .iter()
+                    .map(|projection| projection.column().to_owned())
+                    .collect::<Vec<_>>(),
+            )?;
         }
         Ok(())
     }

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -124,7 +124,21 @@ fn app_row_payload_projection(
             FieldProjection::Fields(fields)
         })
         .unwrap_or(FieldProjection::All);
-    PayloadProjection::Tree(AppProjectionTree { fields, paths })
+    let demands = query
+        .select
+        .as_ref()
+        .map(|select| {
+            select
+                .iter()
+                .map(|projection| (projection.column().to_owned(), projection.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+    PayloadProjection::Tree(AppProjectionTree {
+        fields,
+        demands,
+        paths,
+    })
 }
 
 fn app_row_path_projections(

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -113,8 +113,8 @@ fn app_row_payload_projection(
         .map(|select| {
             let mut fields = select
                 .iter()
-                .filter(|field| !is_implicit_row_id_alias(schema, &query.table, field))
-                .cloned()
+                .filter(|field| !is_implicit_row_id_alias(schema, &query.table, field.column()))
+                .map(|field| field.column().to_owned())
                 .collect::<BTreeSet<_>>();
             for include in &query.includes {
                 if let Some(root_field) = include.path.split('.').next() {

--- a/crates/jazz/src/node/query_eval/tests/materialization.rs
+++ b/crates/jazz/src/node/query_eval/tests/materialization.rs
@@ -70,7 +70,7 @@ fn required_cell_guard_resolves_a_later_projected_column_by_name() {
     assert!(current_row_has_required_subscription_cells(
         &complete,
         &table,
-        Some(&["third".to_owned()]),
+        Some(&[crate::query::SelectProjection::from("third")]),
     ));
 
     let missing = current_row_from_cells(
@@ -87,7 +87,7 @@ fn required_cell_guard_resolves_a_later_projected_column_by_name() {
     assert!(!current_row_has_required_subscription_cells(
         &missing,
         &table,
-        Some(&["third".to_owned()]),
+        Some(&[crate::query::SelectProjection::from("third")]),
     ));
 }
 

--- a/crates/jazz/src/query/ast.rs
+++ b/crates/jazz/src/query/ast.rs
@@ -53,7 +53,7 @@ pub struct Query {
 /// The descriptor is part of the query shape (and therefore subscription
 /// identity), rather than a client-side post-processing hint.
 #[allow(missing_docs)]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SelectProjection {
     Full { column: String },

--- a/crates/jazz/src/query/ast.rs
+++ b/crates/jazz/src/query/ast.rs
@@ -31,7 +31,7 @@ pub struct Query {
     pub array_subqueries: Vec<ArraySubquery>,
     /// Selected application columns. Row id is always included.
     #[serde(default)]
-    pub select: Option<Vec<String>>,
+    pub select: Option<Vec<SelectProjection>>,
     /// Result-level ordering keys, applied in order before pagination.
     #[serde(default)]
     pub order_by: Vec<OrderBy>,
@@ -47,6 +47,36 @@ pub struct Query {
     #[serde(default)]
     pub offset: usize,
 }
+
+/// A selected application column, optionally narrowed to a large-value subset.
+///
+/// The descriptor is part of the query shape (and therefore subscription
+/// identity), rather than a client-side post-processing hint.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SelectProjection {
+    Full { column: String },
+    Bytes { column: String, from: u64, to: u64 },
+    TextUtf16 { column: String, from: u64, to: u64 },
+    TextUtf8 { column: String, from: u64, to: u64 },
+    JsonPointer { column: String, at: String },
+}
+
+impl SelectProjection {
+    /// Select a byte range using half-open byte offsets.
+    pub fn bytes(column: impl Into<String>, from: u64, to: u64) -> Self { Self::Bytes { column: column.into(), from, to } }
+    /// Select a string range using half-open UTF-16 code-unit offsets.
+    pub fn text_utf16(column: impl Into<String>, from: u64, to: u64) -> Self { Self::TextUtf16 { column: column.into(), from, to } }
+    /// Select a string range using half-open UTF-8 byte offsets.
+    pub fn text_utf8(column: impl Into<String>, from: u64, to: u64) -> Self { Self::TextUtf8 { column: column.into(), from, to } }
+    /// Select the JSON value addressed by an RFC 6901 pointer.
+    pub fn json_pointer(column: impl Into<String>, at: impl Into<String>) -> Self { Self::JsonPointer { column: column.into(), at: at.into() } }
+    pub(crate) fn column(&self) -> &str { match self { Self::Full { column } | Self::Bytes { column, .. } | Self::TextUtf16 { column, .. } | Self::TextUtf8 { column, .. } | Self::JsonPointer { column, .. } => column } }
+}
+
+impl From<String> for SelectProjection { fn from(column: String) -> Self { Self::Full { column } } }
+impl From<&str> for SelectProjection { fn from(column: &str) -> Self { Self::Full { column: column.to_owned() } } }
 
 /// Output-changing relational join syntax.
 ///

--- a/crates/jazz/src/query/builders.rs
+++ b/crates/jazz/src/query/builders.rs
@@ -575,8 +575,14 @@ impl Query {
     /// query.validate(&doctest_support::schema())?;
     /// # Ok::<(), jazz::query::QueryError>(())
     /// ```
-    pub fn select(mut self, columns: impl IntoIterator<Item = impl Into<String>>) -> Self {
+    pub fn select(mut self, columns: impl IntoIterator<Item = impl Into<SelectProjection>>) -> Self {
         self.select = Some(columns.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Select one typed large-value projection.
+    pub fn select_projection(mut self, projection: SelectProjection) -> Self {
+        self.select.get_or_insert_default().push(projection);
         self
     }
 

--- a/crates/jazz/src/query/canonical_request.rs
+++ b/crates/jazz/src/query/canonical_request.rs
@@ -225,6 +225,16 @@ fn canonical_array_subquery_key(subquery: &ArraySubquery) -> Vec<u8> {
     bytes
 }
 
+fn put_select_projection(bytes: &mut Vec<u8>, projection: &SelectProjection) {
+    match projection {
+        SelectProjection::Full { column } => { bytes.push(b'f'); put_str(bytes, column); }
+        SelectProjection::Bytes { column, from, to } => { bytes.push(b'b'); put_str(bytes, column); bytes.extend_from_slice(&from.to_be_bytes()); bytes.extend_from_slice(&to.to_be_bytes()); }
+        SelectProjection::TextUtf16 { column, from, to } => { bytes.push(b'6'); put_str(bytes, column); bytes.extend_from_slice(&from.to_be_bytes()); bytes.extend_from_slice(&to.to_be_bytes()); }
+        SelectProjection::TextUtf8 { column, from, to } => { bytes.push(b'8'); put_str(bytes, column); bytes.extend_from_slice(&from.to_be_bytes()); bytes.extend_from_slice(&to.to_be_bytes()); }
+        SelectProjection::JsonPointer { column, at } => { bytes.push(b'j'); put_str(bytes, column); put_str(bytes, at); }
+    }
+}
+
 fn canonical_reachable_key(reachable: &ReachableVia) -> Vec<u8> {
     canonical_reachable_key_with_seed_type(reachable, None)
 }
@@ -549,8 +559,8 @@ fn canonical_query_bytes_for_schema(
     if let Some(select) = &query.select {
         bytes.push(b's');
         put_len(&mut bytes, select.len());
-        for column in select {
-            put_str(&mut bytes, column);
+        for projection in select {
+            put_select_projection(&mut bytes, projection);
         }
     }
     if !query.order_by.is_empty() {

--- a/crates/jazz/src/query/tests.rs
+++ b/crates/jazz/src/query/tests.rs
@@ -375,9 +375,9 @@ mod tests {
             validated.query().select.as_deref(),
             Some(
                 [
-                    "$createdAt".to_owned(),
-                    "state".to_owned(),
-                    "title".to_owned()
+                    SelectProjection::from("$createdAt"),
+                    SelectProjection::from("state"),
+                    SelectProjection::from("title")
                 ]
                 .as_slice()
             )
@@ -459,7 +459,7 @@ mod tests {
         query.flat_join.as_mut().unwrap().sources.clear();
         cases.push(query);
         let mut query = flat();
-        query.select = Some(vec!["title".to_owned()]);
+        query.select = Some(vec![SelectProjection::from("title")]);
         cases.push(query);
         let mut query = flat();
         query.order_by.push(OrderBy {

--- a/crates/jazz/src/query/validation.rs
+++ b/crates/jazz/src/query/validation.rs
@@ -299,7 +299,7 @@ fn validate_query_canonical_parts(
     )?;
     if let Some(select) = &query.select {
         for column in select {
-            validate_select_column(&root, column)?;
+            validate_select_projection(&root, column)?;
         }
     }
     if let Some(aggregate) = &query.aggregate {
@@ -769,6 +769,18 @@ fn validate_select_column(table: &TableSchema, column: &str) -> Result<(), Query
             column: name.to_owned(),
         }),
         name => column_type(table, name).map(|_| ()),
+    }
+}
+
+fn validate_select_projection(table: &TableSchema, projection: &SelectProjection) -> Result<(), QueryError> {
+    validate_select_column(table, projection.column())?;
+    match projection {
+        SelectProjection::Full { .. } => Ok(()),
+        SelectProjection::Bytes { from, to, .. }
+        | SelectProjection::TextUtf16 { from, to, .. }
+        | SelectProjection::TextUtf8 { from, to, .. } if from <= to => Ok(()),
+        SelectProjection::JsonPointer { at, .. } if at.is_empty() || at.starts_with('/') => Ok(()),
+        _ => Err(QueryError::OperandTypeMismatch),
     }
 }
 

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -2184,14 +2184,23 @@ impl PublicQueryDecoder {
                 })
                 .collect();
         }
-        let columns = query.select.clone().unwrap_or_else(|| {
-            table_schema
-                .columns
-                .columns
-                .iter()
-                .map(|column| column.name.as_str().to_string())
-                .collect()
-        });
+        let columns: Vec<String> = query
+            .select
+            .as_ref()
+            .map(|columns| {
+                columns
+                    .iter()
+                    .map(|column| column.column().to_owned())
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                table_schema
+                    .columns
+                    .columns
+                    .iter()
+                    .map(|column| column.name.as_str().to_string())
+                    .collect()
+            });
         let rows = rows
             .into_iter()
             .map(|row| {
@@ -2321,14 +2330,23 @@ impl PublicQueryDecoder {
             }
             return Ok(names);
         }
-        let mut names = query.select.clone().unwrap_or_else(|| {
-            table_schema
-                .columns
-                .columns
-                .iter()
-                .map(|column| column.name.as_str().to_owned())
-                .collect()
-        });
+        let mut names: Vec<String> = query
+            .select
+            .as_ref()
+            .map(|columns| {
+                columns
+                    .iter()
+                    .map(|column| column.column().to_owned())
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                table_schema
+                    .columns
+                    .columns
+                    .iter()
+                    .map(|column| column.name.as_str().to_owned())
+                    .collect()
+            });
         names.extend(
             query
                 .array_subqueries


### PR DESCRIPTION
🤖 Stacked on #1833. Carries typed large-value projection demand through Jazz query identity and maintained terminal metadata into Groove demand-aware materialization, so byte, UTF-16, UTF-8, and JSON-pointer selections can request only the required chunks. Runtime terminal routing and full subscription coverage are still in progress.