### PR TITLE
Add BigLabel browser topology E2E

### DIFF
--- a/examples/big-label/README.md
+++ b/examples/big-label/README.md
@@ -29,6 +29,11 @@ Run `pnpm --dir examples/big-label test` for the deterministic fixture and isola
 
 - `jazz-sim s1_saas`: tenant cold load, indexed owned-slice filtering, relations/includes, write churn.
 - Policy-graph fixture: organization → membership → team/assignment authorization shape.
+- CB-012: the valid release-owner assignment path is covered by both the
+  deployed authority receipt and browser topology phase. It currently exposes
+  a core correlated-`allowedTo.insert()` lowering fault
+  (`__flat_join_source_0_row_uuid`), rather than an app policy denial; see
+  `tests/correlated-assignment.repro.test.ts`.
 - Future blocker: schema migrations/versioned reconnect are recorded for a shared migration/topology lane. This example does not invent a migration mechanism.
 
 All identities, names, and IDs are generated public fixtures; no adopter data is used.

--- a/examples/big-label/next.config.ts
+++ b/examples/big-label/next.config.ts
@@ -1,11 +1,12 @@
 import { withJazz } from "jazz-tools/dev/next";
+import { serverSecret } from "./src/lib/server-secret";
 
 const origin = process.env.NEXT_PUBLIC_APP_ORIGIN ?? "http://127.0.0.1:3000";
 export default withJazz(
   { reactStrictMode: true, serverExternalPackages: ["jazz-napi", "jazz-tools/backend"] },
   {
     server: {
-      backendSecret: process.env.BACKEND_SECRET ?? "big-label-dev-backend",
+      backendSecret: serverSecret("BACKEND_SECRET", "big-label-dev-backend"),
       jwksUrl: `${origin}/api/auth/jwks`,
     },
   },

--- a/examples/big-label/src/lib/auth.ts
+++ b/examples/big-label/src/lib/auth.ts
@@ -4,14 +4,16 @@ import { bearer, jwt } from "better-auth/plugins";
 import { jazzAdapter } from "jazz-tools/better-auth-adapter";
 import { app } from "../../schema";
 import { authJazzContext } from "./auth-jazz-context";
+import { serverSecret } from "./server-secret";
 
 const origin = process.env.NEXT_PUBLIC_APP_ORIGIN ?? "http://127.0.0.1:3000";
 
 export const auth = betterAuth({
   baseURL: origin,
-  secret:
-    process.env.BETTER_AUTH_SECRET ??
+  secret: serverSecret(
+    "BETTER_AUTH_SECRET",
     "9d1b6e04f3a2c8517d0ea13b8c5f9264d1e6a3b74f0c28d915be46a7f38cd205",
+  ),
   trustedOrigins: [origin],
   database: jazzAdapter({ db: () => authJazzContext().asBackend(app), schema: app.wasmSchema }),
   emailAndPassword: { enabled: true, autoSignIn: true, minPasswordLength: 8 },

--- a/examples/big-label/src/lib/bootstrap.ts
+++ b/examples/big-label/src/lib/bootstrap.ts
@@ -9,27 +9,36 @@ import { authJazzContext } from "./auth-jazz-context";
 export async function ensurePersonalOrganization(userId: string, name: string) {
   const db = authJazzContext().asBackend(app);
   const slug = `personal-${userId}`;
-  const existing = await db.one(app.organizations.where({ slug }));
-  if (existing) return existing;
-
-  const organizationId = randomUUID();
-  const personId = randomUUID();
-  const membershipId = randomUUID();
+  let organizationId: string;
   try {
-    const write = await db.exclusiveTransaction((tx) => {
+    const write = await db.exclusiveTransaction(async (tx) => {
+      // This lookup is part of the exclusive transaction's read set. Two
+      // concurrent first requests therefore cannot both commit a tenant for
+      // the same external-user key.
+      const existing = await tx.one(app.organizations.where({ slug }));
+      if (existing) return existing.id;
+
+      const createdOrganizationId = randomUUID();
+      const personId = randomUUID();
+      const membershipId = randomUUID();
       tx.insert(app.people, { userId, name }, { id: personId });
-      tx.insert(app.organizations, { name: `${name}'s label`, slug }, { id: organizationId });
+      tx.insert(
+        app.organizations,
+        { name: `${name}'s label`, slug },
+        { id: createdOrganizationId },
+      );
       tx.insert(
         app.memberships,
-        { organizationId, personId, userId, role: "admin" },
+        { organizationId: createdOrganizationId, personId, userId, role: "admin" },
         { id: membershipId },
       );
-      return organizationId;
+      return createdOrganizationId;
     });
-    await write.wait();
+    organizationId = await write.wait();
   } catch (error) {
-    // Concurrent authenticated requests may race the initial ensure. Re-read
-    // the stable external-user key; only return a committed organization.
+    // An exclusive transaction that raced another committed bootstrap may be
+    // rejected. Re-read the stable external-user key; only return a committed
+    // organization, and preserve unrelated errors.
     const raced = await db.one(app.organizations.where({ slug }));
     if (raced) return raced;
     throw error;

--- a/examples/big-label/src/lib/server-secret.ts
+++ b/examples/big-label/src/lib/server-secret.ts
@@ -1,0 +1,15 @@
+/**
+ * Return a server-only secret, allowing an intentionally convenient fallback
+ * only while running this copyable example in development.
+ *
+ * A committed fallback is never an acceptable production credential: anyone
+ * who can read the example source can impersonate that server capability.
+ */
+export function serverSecret(name: string, developmentFallback: string): string {
+  const configured = process.env[name];
+  if (configured) return configured;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(`${name} must be configured in production.`);
+  }
+  return developmentFallback;
+}

--- a/examples/big-label/tests/authority.server.test.ts
+++ b/examples/big-label/tests/authority.server.test.ts
@@ -46,6 +46,18 @@ describe("BigLabel deployed tenant authority", () => {
         role: "editor",
       })
       .wait({ tier: "edge" });
+    // Planted positive: the release owner assignment takes its write authority
+    // from the parent release, then proves that both referenced rows belong to
+    // this tenant. A timeout/rejection here is a propagation or policy-engine
+    // defect, not an intentionally denied cross-tenant case below.
+    await admin
+      .insert(app.releaseAssignments, {
+        organizationId: seeded.org.id,
+        releaseId: seeded.release.id,
+        membershipId: seeded.adminMembership.id,
+        role: "owner",
+      })
+      .wait({ tier: "edge" });
     await member.expectDenied((db) =>
       db.update(app.memberships, seeded.memberMembership.id, { role: "admin" }),
     );

--- a/examples/big-label/tests/authority.server.test.ts
+++ b/examples/big-label/tests/authority.server.test.ts
@@ -3,6 +3,8 @@ import { createPolicyTestApp, type PolicyTestApp } from "jazz-tools/testing";
 import { app } from "../schema.js";
 import permissions from "../permissions.js";
 
+const BIG_LABEL_ISSUER = "https://auth.biglabel.example";
+
 let testApp: PolicyTestApp | undefined;
 afterEach(async () => await testApp?.shutdown());
 
@@ -10,10 +12,26 @@ describe("BigLabel deployed tenant authority", () => {
   it("admits only the server-bootstrap identity or an existing organization admin", async () => {
     testApp = await createPolicyTestApp(app, permissions, expect);
     const seeded = await seed(testApp);
-    const admin = testApp.as({ user_id: "admin", claims: {}, authMode: "local-first" });
-    const member = testApp.as({ user_id: "member", claims: {}, authMode: "local-first" });
-    const outsider = testApp.as({ user_id: "outsider", claims: {}, authMode: "local-first" });
+    const admin = testApp.as({
+      issuer: BIG_LABEL_ISSUER,
+      user_id: "admin",
+      claims: {},
+      authMode: "external",
+    });
+    const member = testApp.as({
+      issuer: BIG_LABEL_ISSUER,
+      user_id: "member",
+      claims: {},
+      authMode: "external",
+    });
+    const outsider = testApp.as({
+      issuer: BIG_LABEL_ISSUER,
+      user_id: "outsider",
+      claims: {},
+      authMode: "external",
+    });
     const bootstrap = testApp.as({
+      issuer: BIG_LABEL_ISSUER,
       user_id: "bootstrap",
       claims: { biglabel_admin: true },
       authMode: "external",

--- a/examples/big-label/tests/correlated-assignment.repro.test.ts
+++ b/examples/big-label/tests/correlated-assignment.repro.test.ts
@@ -47,7 +47,12 @@ describe("CB-012 correlated assignment policy", () => {
     const membership = await testApp.seed((db) =>
       db.insert(app.memberships, { organizationId: foreign.id, userId: "foreign" }),
     );
-    const user = testApp.as({ user_id: "user", claims: {}, authMode: "external" });
+    const user = testApp.as({
+      issuer: "https://auth.biglabel.example",
+      user_id: "user",
+      claims: {},
+      authMode: "external",
+    });
     await user.expectDenied((db) =>
       db.insert(app.assignments, {
         organizationId: owned.id,

--- a/examples/big-label/tests/server-secret.test.ts
+++ b/examples/big-label/tests/server-secret.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { serverSecret } from "../src/lib/server-secret.js";
+
+const originalEnvironment = process.env.NODE_ENV;
+const secretName = "BIG_LABEL_TEST_SERVER_SECRET";
+const originalSecret = process.env[secretName];
+
+afterEach(() => {
+  if (originalEnvironment === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalEnvironment;
+  if (originalSecret === undefined) delete process.env[secretName];
+  else process.env[secretName] = originalSecret;
+});
+
+describe("BigLabel server secrets", () => {
+  it("requires configured production credentials instead of using source-visible fallbacks", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env[secretName];
+
+    expect(() => serverSecret(secretName, "development-only")).toThrow(
+      `${secretName} must be configured in production.`,
+    );
+  });
+
+  it("uses an explicit secret in every environment and a fallback only in development", () => {
+    process.env.NODE_ENV = "production";
+    process.env[secretName] = "configured-production-secret";
+    expect(serverSecret(secretName, "development-only")).toBe("configured-production-secret");
+
+    delete process.env[secretName];
+    process.env.NODE_ENV = "development";
+    expect(serverSecret(secretName, "development-only")).toBe("development-only");
+  });
+});

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createDb, generateAuthSecret, type Db } from "../../src/index.js";
+import { createDb, type Db } from "../../src/index.js";
 import {
   fetchPermissionsHead,
   publishStoredPermissions,
   publishStoredSchema,
 } from "../../src/runtime/schema-fetch.js";
 import { TestCleanup, uniqueDbName, waitForCondition } from "./support.js";
-import { getJazzServerInfo, getJazzServerJwtForUser } from "./testing-server.js";
+import {
+  bootstrapBigLabelOrganization,
+  getJazzServerInfo,
+  getJazzServerJwtForUser,
+} from "./testing-server.js";
 import { browserTopologyPhase } from "./topology-harness.js";
 
 const ctx = new TestCleanup();
@@ -20,7 +24,7 @@ describe("BigLabel browser edge/core topology", () => {
         import("../../../../examples/big-label/permissions.js").then((module) => module.default),
       ]),
     );
-    const { appId, serverUrl, adminSecret } = await browserTopologyPhase(
+    const { appId, serverUrl, adminSecret, backendSecret } = await browserTopologyPhase(
       "start BigLabel core",
       () => getJazzServerInfo(uniqueDbName("big-label-topology")),
     );
@@ -39,45 +43,62 @@ describe("BigLabel browser edge/core topology", () => {
         expectedParentBundleObjectId: head?.bundleObjectId ?? null,
       });
     });
-    // Backend provisioning still needs a concrete local identity so the
-    // browser worker can complete its authenticated transport bootstrap.
-    const core = await browserTopologyPhase("open authenticated provisioning edge", () =>
-      openDb({
-        appId,
-        serverUrl,
-        adminSecret,
-        secret: generateAuthSecret(),
-        label: "big-label-core",
-      }),
+    const org = await browserTopologyPhase(
+      "bootstrap BigLabel admin through backend authority",
+      () =>
+        bootstrapBigLabelOrganization(
+          { appId, serverUrl, adminSecret, backendSecret },
+          "admin",
+          "Admin",
+        ),
     );
-    const org = await core
-      .insert(app.organizations, { name: "Night Shift", slug: "night-shift" })
-      .wait({ tier: "edge" });
-    const adminPerson = core.insert(app.people, { userId: "admin", name: "Admin" }).value;
-    const editorPerson = core.insert(app.people, { userId: "editor", name: "Editor" }).value;
-    const adminMembership = core.insert(app.memberships, {
-      organizationId: org.id,
-      personId: adminPerson.id,
-      userId: "admin",
-      role: "admin",
-    }).value;
-    await core
-      .insert(app.memberships, {
-        organizationId: org.id,
-        personId: editorPerson.id,
-        userId: "editor",
-        role: "editor",
-      })
-      .wait({ tier: "edge" });
+    // A user legitimately provisions their own person record before an
+    // organization admin admits them to this label. This keeps the role grant
+    // on the same public policy path used by the app instead of making a test
+    // authority bypass.
+    await browserTopologyPhase("bootstrap BigLabel editor through backend authority", () =>
+      bootstrapBigLabelOrganization(
+        { appId, serverUrl, adminSecret, backendSecret },
+        "editor",
+        "Editor",
+      ),
+    );
     const [adminToken, editorToken] = await Promise.all([
       getJazzServerJwtForUser("admin", {}, appId),
       getJazzServerJwtForUser("editor", {}, appId),
     ]);
-    const writer = await openDb({
-      appId,
-      serverUrl,
-      jwtToken: adminToken,
-      label: "big-label-writer",
+    const writer = await browserTopologyPhase("open authenticated admin edge", () =>
+      openDb({
+        appId,
+        serverUrl,
+        jwtToken: adminToken,
+        label: "big-label-writer",
+      }),
+    );
+    const adminMembership = await browserTopologyPhase(
+      "read bootstrapped admin membership",
+      async () => {
+        const memberships = await writer.all(app.memberships.where({ organizationId: org.id }), {
+          tier: "edge",
+        });
+        expect(memberships).toHaveLength(1);
+        return memberships[0]!;
+      },
+    );
+    const editorPerson = await browserTopologyPhase("read bootstrapped editor person", async () => {
+      const people = await writer.all(app.people.where({ userId: "editor" }), { tier: "edge" });
+      expect(people).toHaveLength(1);
+      return people[0]!;
+    });
+    await browserTopologyPhase("admit editor through admin membership grant", async () => {
+      await writer
+        .insert(app.memberships, {
+          organizationId: org.id,
+          personId: editorPerson.id,
+          userId: "editor",
+          role: "editor",
+        })
+        .wait({ tier: "edge" });
     });
     const reader = await openDb({
       appId,

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -100,23 +100,27 @@ describe("BigLabel browser edge/core topology", () => {
         })
         .wait({ tier: "edge" });
     });
-    const reader = await openDb({
-      appId,
-      serverUrl,
-      jwtToken: editorToken,
-      label: "big-label-reader",
-    });
-    await Promise.all([
-      writer
+    const reader = await browserTopologyPhase("open authenticated editor edge", () =>
+      openDb({
+        appId,
+        serverUrl,
+        jwtToken: editorToken,
+        label: "big-label-reader",
+      }),
+    );
+    await browserTopologyPhase("writer seeds initial artist", async () => {
+      await writer
         .insert(app.artists, {
           organizationId: org.id,
           name: "Aster",
           genre: "ambient",
           status: "active",
         })
-        .wait({ tier: "edge" }),
+        .wait({ tier: "edge" });
+    });
+    await browserTopologyPhase("editor reads admitted organization roster", () =>
       reader.all(app.artists.where({ organizationId: org.id }), { tier: "edge" }),
-    ]);
+    );
     const snapshots: string[][] = [];
     ctx.trackSubscription(
       reader.subscribeAll(

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createDb, type Db } from "../../src/index.js";
+import { createDb, generateAuthSecret, type Db } from "../../src/index.js";
 import {
   fetchPermissionsHead,
   publishStoredPermissions,
@@ -39,7 +39,17 @@ describe("BigLabel browser edge/core topology", () => {
         expectedParentBundleObjectId: head?.bundleObjectId ?? null,
       });
     });
-    const core = await openDb({ appId, serverUrl, adminSecret, label: "big-label-core" });
+    // Backend provisioning still needs a concrete local identity so the
+    // browser worker can complete its authenticated transport bootstrap.
+    const core = await browserTopologyPhase("open authenticated provisioning edge", () =>
+      openDb({
+        appId,
+        serverUrl,
+        adminSecret,
+        secret: generateAuthSecret(),
+        label: "big-label-core",
+      }),
+    );
     const org = await core
       .insert(app.organizations, { name: "Night Shift", slug: "night-shift" })
       .wait({ tier: "edge" });
@@ -138,6 +148,7 @@ async function openDb(input: {
   appId: string;
   serverUrl: string;
   adminSecret?: string;
+  secret?: string;
   jwtToken?: string;
   label: string;
 }): Promise<Db> {
@@ -145,7 +156,9 @@ async function openDb(input: {
     await createDb({
       appId: input.appId,
       serverUrl: input.serverUrl,
-      ...(input.adminSecret ? { adminSecret: input.adminSecret } : { jwtToken: input.jwtToken! }),
+      ...(input.adminSecret
+        ? { adminSecret: input.adminSecret, secret: input.secret! }
+        : { jwtToken: input.jwtToken! }),
       driver: { type: "persistent", dbName: uniqueDbName(input.label) },
     }),
   );

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -146,6 +146,16 @@ describe("BigLabel browser edge/core topology", () => {
         .wait({ tier: "edge" });
     });
     const roster = app.artists.where({ organizationId: org.id }).orderBy("name", "asc").limit(2);
+    // This is the application's other primary read shape: a bounded release
+    // pipeline whose included artist must remain tenant-scoped throughout
+    // offline recovery. Keep it separate from the roster so the receipt
+    // catches a regression in include delivery even if the base artist query
+    // still converges.
+    const releasePipeline = app.releases
+      .where({ organizationId: org.id })
+      .orderBy("releaseDate", "asc")
+      .limit(1)
+      .include({ artist: true });
     const snapshots: string[][] = [];
     await runTopologyScenario(
       {
@@ -226,6 +236,19 @@ describe("BigLabel browser edge/core topology", () => {
                   role: "owner",
                 })
                 .wait({ tier: "edge" });
+              // A second authorized release is a planted positive for the
+              // query's bound below. If lowering drops `limit(1)`, the edge
+              // and reopened-local assertions must expose it instead of
+              // merely proving eventual include delivery.
+              await writer
+                .insert(app.releases, {
+                  organizationId: org.id,
+                  artistId: artist.id,
+                  title: "Second Light",
+                  releaseDate: new Date("2027-01-01"),
+                  status: "scheduled",
+                })
+                .wait({ tier: "edge" });
             },
           },
           {
@@ -238,7 +261,7 @@ describe("BigLabel browser edge/core topology", () => {
             faultsAfter: [{ kind: "reconnect", target: "browser-edge" }],
           },
           {
-            name: "editor subscription converges after reconnect",
+            name: "editor subscription and bounded release include converge after reconnect",
             async run() {
               await waitForCondition(
                 async () =>
@@ -248,10 +271,14 @@ describe("BigLabel browser edge/core topology", () => {
                 15_000,
                 "reader did not retain the ordered bounded BigLabel roster after reconnect",
               );
+              await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toMatchObject([
+                { title: "First Light", artist: { name: "Blue Hour" } },
+              ]);
+              await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toHaveLength(1);
             },
           },
           {
-            name: "editor reopens persistent cache without refetching the roster",
+            name: "editor reopens persistent cache without refetching bounded app queries",
             async run() {
               ctx.untrack(reader);
               await reader.close();
@@ -266,10 +293,28 @@ describe("BigLabel browser edge/core topology", () => {
                 { name: "Blue Hour" },
               ]);
               await expect(reader.all(roster, { tier: "local" })).resolves.toHaveLength(2);
+              await expect(reader.all(releasePipeline, { tier: "local" })).resolves.toMatchObject([
+                { title: "First Light", artist: { name: "Blue Hour" } },
+              ]);
+              await expect(reader.all(releasePipeline, { tier: "local" })).resolves.toHaveLength(1);
             },
           },
           {
-            name: "revoking editor membership removes the roster",
+            name: "unaffiliated external edge cannot read either tenant query shape",
+            async run() {
+              const outsiderToken = await getJazzServerJwtForUser("outsider", {}, appId);
+              const outsider = await openDb({
+                appId,
+                serverUrl,
+                jwtToken: outsiderToken,
+                label: "big-label-outsider",
+              });
+              await expect(outsider.all(roster, { tier: "edge" })).resolves.toEqual([]);
+              await expect(outsider.all(releasePipeline, { tier: "edge" })).resolves.toEqual([]);
+            },
+          },
+          {
+            name: "revoking editor membership removes bounded tenant queries and includes",
             async run() {
               const editorMembership = await writer.all(
                 app.memberships.where({ organizationId: org.id, userId: "editor" }).limit(1),
@@ -278,9 +323,15 @@ describe("BigLabel browser edge/core topology", () => {
               expect(editorMembership).toHaveLength(1);
               await writer.delete(app.memberships, editorMembership[0]!.id).wait({ tier: "edge" });
               await waitForCondition(
-                async () => (await reader.all(roster, { tier: "edge" })).length === 0,
+                async () => {
+                  const [artists, releases] = await Promise.all([
+                    reader.all(roster, { tier: "edge" }),
+                    reader.all(releasePipeline, { tier: "edge" }),
+                  ]);
+                  return artists.length === 0 && releases.length === 0;
+                },
                 15_000,
-                "revoked editor retained BigLabel roster",
+                "revoked editor retained a BigLabel tenant query or included artist",
               );
             },
           },

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -50,13 +50,23 @@ describe("BigLabel browser edge/core topology", () => {
       });
     });
     const org = await browserTopologyPhase(
-      "bootstrap BigLabel admin through backend authority",
-      () =>
-        bootstrapBigLabelOrganization(
-          { appId, serverUrl, adminSecret, backendSecret },
-          "admin",
-          "Admin",
-        ),
+      "concurrently ensure one BigLabel admin tenant through backend authority",
+      async () => {
+        const [first, second] = await Promise.all([
+          bootstrapBigLabelOrganization(
+            { appId, serverUrl, adminSecret, backendSecret },
+            "admin",
+            "Admin",
+          ),
+          bootstrapBigLabelOrganization(
+            { appId, serverUrl, adminSecret, backendSecret },
+            "admin",
+            "Admin",
+          ),
+        ]);
+        expect(second.id).toBe(first.id);
+        return first;
+      },
     );
     // A user legitimately provisions their own person record before an
     // organization admin admits them to this label. This keeps the role grant
@@ -82,12 +92,23 @@ describe("BigLabel browser edge/core topology", () => {
       }),
     );
     const adminMembership = await browserTopologyPhase(
-      "read bootstrapped admin membership",
+      "prove concurrent bootstrap produced one complete tenant graph",
       async () => {
+        const organizations = await writer.all(
+          app.organizations.where({ slug: "personal-admin" }),
+          {
+            tier: "edge",
+          },
+        );
+        const people = await writer.all(app.people.where({ userId: "admin" }), { tier: "edge" });
         const memberships = await writer.all(app.memberships.where({ organizationId: org.id }), {
           tier: "edge",
         });
+        expect(organizations).toHaveLength(1);
+        expect(organizations[0]!.id).toBe(org.id);
+        expect(people).toHaveLength(1);
         expect(memberships).toHaveLength(1);
+        expect(memberships[0]!.personId).toBe(people[0]!.id);
         return memberships[0]!;
       },
     );

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -5,13 +5,19 @@ import {
   publishStoredPermissions,
   publishStoredSchema,
 } from "../../src/runtime/schema-fetch.js";
-import { TestCleanup, uniqueDbName, waitForCondition } from "./support.js";
+import { sleep, TestCleanup, uniqueDbName, waitForCondition } from "./support.js";
 import {
+  blockJazzServerNetwork,
   bootstrapBigLabelOrganization,
   getJazzServerInfo,
   getJazzServerJwtForUser,
+  unblockJazzServerNetwork,
 } from "./testing-server.js";
-import { browserTopologyPhase } from "./topology-harness.js";
+import {
+  browserTopologyPhase,
+  browserTopologyReporter,
+  runTopologyScenario,
+} from "./topology-harness.js";
 
 const ctx = new TestCleanup();
 afterEach(async () => ctx.cleanup());
@@ -100,7 +106,7 @@ describe("BigLabel browser edge/core topology", () => {
         })
         .wait({ tier: "edge" });
     });
-    const reader = await browserTopologyPhase("open authenticated editor edge", () =>
+    let reader = await browserTopologyPhase("open authenticated editor edge", () =>
       openDb({
         appId,
         serverUrl,
@@ -118,60 +124,133 @@ describe("BigLabel browser edge/core topology", () => {
         })
         .wait({ tier: "edge" });
     });
-    await browserTopologyPhase("editor reads admitted organization roster", () =>
-      reader.all(app.artists.where({ organizationId: org.id }), { tier: "edge" }),
-    );
+    const roster = app.artists.where({ organizationId: org.id }).orderBy("name", "asc").limit(2);
     const snapshots: string[][] = [];
-    await browserTopologyPhase("start editor ordered-roster subscription", () => {
-      ctx.trackSubscription(
-        reader.subscribeAll(
-          app.artists.where({ organizationId: org.id }).orderBy("name", "asc"),
-          (delta) => {
-            snapshots.push(delta.all.map((artist) => artist.name));
+    await runTopologyScenario(
+      {
+        id: "big-label.admin-roster.reconnect-reopen-revocation",
+        topology: ["browser", "edge", "core"],
+        seed: 1719,
+        phaseTimeoutMs: 20_000,
+        faultTimeoutMs: 10_000,
+        replay: "pnpm --filter jazz-tools test:browser -- big-label.e2e.test.ts",
+        targets: {
+          "browser-edge": {
+            async disconnect() {
+              await blockJazzServerNetwork(serverUrl);
+              // Route blocking applies only to future WebSocket connections.
+              // Close the live reader connection so this phase exercises the
+              // actual offline cache path rather than a still-open socket.
+              await reader.disconnect();
+              await sleep(100);
+            },
+            async reconnect() {
+              await unblockJazzServerNetwork(serverUrl);
+              await reader.reconnect();
+              await sleep(100);
+            },
           },
-        ),
-      );
-    });
-    const artist = await browserTopologyPhase("writer adds convergent artist", () =>
-      writer
-        .insert(app.artists, {
-          organizationId: org.id,
-          name: "Blue Hour",
-          genre: "jazz",
-          status: "active",
-        })
-        .wait({ tier: "edge" }),
-    );
-    const release = await browserTopologyPhase("writer adds artist release", () =>
-      writer
-        .insert(app.releases, {
-          organizationId: org.id,
-          artistId: artist.id,
-          title: "First Light",
-          releaseDate: new Date("2026-01-01"),
-          status: "scheduled",
-        })
-        .wait({ tier: "edge" }),
-    );
-    await browserTopologyPhase("writer assigns release owner", () =>
-      writer
-        .insert(app.releaseAssignments, {
-          organizationId: org.id,
-          releaseId: release.id,
-          membershipId: adminMembership.id,
-          role: "owner",
-        })
-        .wait({ tier: "edge" }),
-    );
-    await browserTopologyPhase(
-      "reader subscription converges ordered roster",
-      () =>
-        waitForCondition(
-          async () => snapshots.some((rows) => rows.includes("Blue Hour")),
-          15_000,
-          "reader did not receive BigLabel artist",
-        ),
-      20_000,
+        },
+        phases: [
+          {
+            name: "editor reads exact bounded roster and subscribes",
+            async run() {
+              await expect(reader.all(roster, { tier: "edge" })).resolves.toMatchObject([
+                { name: "Aster" },
+              ]);
+              ctx.trackSubscription(
+                reader.subscribeAll(roster, (delta) =>
+                  snapshots.push(delta.all.map((artist) => artist.name)),
+                ),
+              );
+            },
+            faultsAfter: [{ kind: "disconnect", target: "browser-edge" }],
+          },
+          {
+            name: "admin writes artist and release while editor is offline",
+            async run() {
+              const artist = await writer
+                .insert(app.artists, {
+                  organizationId: org.id,
+                  name: "Blue Hour",
+                  genre: "jazz",
+                  status: "active",
+                })
+                .wait({ tier: "edge" });
+              const release = await writer
+                .insert(app.releases, {
+                  organizationId: org.id,
+                  artistId: artist.id,
+                  title: "First Light",
+                  releaseDate: new Date("2026-01-01"),
+                  status: "scheduled",
+                })
+                .wait({ tier: "edge" });
+              await writer
+                .insert(app.releaseAssignments, {
+                  organizationId: org.id,
+                  releaseId: release.id,
+                  membershipId: adminMembership.id,
+                  role: "owner",
+                })
+                .wait({ tier: "edge" });
+            },
+          },
+          {
+            name: "offline editor retains its bounded local roster",
+            async run() {
+              const localRows = await reader.all(roster, { tier: "local" });
+              expect(localRows.map((artist) => artist.name)).toContain("Aster");
+              expect(localRows).toHaveLength(1);
+            },
+            faultsAfter: [{ kind: "reconnect", target: "browser-edge" }],
+          },
+          {
+            name: "editor subscription converges after reconnect",
+            async run() {
+              await waitForCondition(
+                async () => snapshots.some((rows) => rows.includes("Blue Hour")),
+                15_000,
+                "reader did not receive BigLabel artist after reconnect",
+              );
+            },
+          },
+          {
+            name: "editor reopens persistent cache without refetching the roster",
+            async run() {
+              ctx.untrack(reader);
+              await reader.close();
+              reader = await openDb({
+                appId,
+                serverUrl,
+                jwtToken: editorToken,
+                label: "big-label-reader",
+              });
+              await expect(reader.all(roster, { tier: "local" })).resolves.toMatchObject([
+                { name: "Aster" },
+                { name: "Blue Hour" },
+              ]);
+            },
+          },
+          {
+            name: "revoking editor membership removes the roster",
+            async run() {
+              const editorMembership = await writer.all(
+                app.memberships.where({ organizationId: org.id, userId: "editor" }).limit(1),
+                { tier: "edge" },
+              );
+              expect(editorMembership).toHaveLength(1);
+              await writer.delete(app.memberships, editorMembership[0]!.id).wait({ tier: "edge" });
+              await waitForCondition(
+                async () => (await reader.all(roster, { tier: "edge" })).length === 0,
+                15_000,
+                "revoked editor retained BigLabel roster",
+              );
+            },
+          },
+        ],
+      },
+      browserTopologyReporter,
     );
     expect(snapshots.at(-1)).toContain("Blue Hour");
   }, 60_000);

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createDb, type Db } from "../../src/index.js";
+import {
+  fetchPermissionsHead,
+  publishStoredPermissions,
+  publishStoredSchema,
+} from "../../src/runtime/schema-fetch.js";
+import { TestCleanup, uniqueDbName, waitForCondition } from "./support.js";
+import { getJazzServerInfo, getJazzServerJwtForUser } from "./testing-server.js";
+import { browserTopologyPhase } from "./topology-harness.js";
+
+const ctx = new TestCleanup();
+afterEach(async () => ctx.cleanup());
+
+describe("BigLabel browser edge/core topology", () => {
+  it("converges an ordered artist-release roster through two authenticated peer edges", async () => {
+    const [{ app }, permissions] = await browserTopologyPhase("load BigLabel adopter modules", () =>
+      Promise.all([
+        import("../../../../examples/big-label/schema.js"),
+        import("../../../../examples/big-label/permissions.js").then((module) => module.default),
+      ]),
+    );
+    const { appId, serverUrl, adminSecret } = await browserTopologyPhase(
+      "start BigLabel core",
+      () => getJazzServerInfo(uniqueDbName("big-label-topology")),
+    );
+    await browserTopologyPhase("publish BigLabel authority", async () => {
+      const { hash } = await publishStoredSchema(serverUrl, {
+        appId,
+        adminSecret,
+        schema: app.wasmSchema,
+      });
+      const { head } = await fetchPermissionsHead(serverUrl, { appId, adminSecret });
+      await publishStoredPermissions(serverUrl, {
+        appId,
+        adminSecret,
+        schemaHash: hash,
+        permissions,
+        expectedParentBundleObjectId: head?.bundleObjectId ?? null,
+      });
+    });
+    const core = await openDb({ appId, serverUrl, adminSecret, label: "big-label-core" });
+    const org = await core
+      .insert(app.organizations, { name: "Night Shift", slug: "night-shift" })
+      .wait({ tier: "edge" });
+    const adminPerson = core.insert(app.people, { userId: "admin", name: "Admin" }).value;
+    const editorPerson = core.insert(app.people, { userId: "editor", name: "Editor" }).value;
+    const adminMembership = core.insert(app.memberships, {
+      organizationId: org.id,
+      personId: adminPerson.id,
+      userId: "admin",
+      role: "admin",
+    }).value;
+    await core
+      .insert(app.memberships, {
+        organizationId: org.id,
+        personId: editorPerson.id,
+        userId: "editor",
+        role: "editor",
+      })
+      .wait({ tier: "edge" });
+    const [adminToken, editorToken] = await Promise.all([
+      getJazzServerJwtForUser("admin", {}, appId),
+      getJazzServerJwtForUser("editor", {}, appId),
+    ]);
+    const writer = await openDb({
+      appId,
+      serverUrl,
+      jwtToken: adminToken,
+      label: "big-label-writer",
+    });
+    const reader = await openDb({
+      appId,
+      serverUrl,
+      jwtToken: editorToken,
+      label: "big-label-reader",
+    });
+    await Promise.all([
+      writer
+        .insert(app.artists, {
+          organizationId: org.id,
+          name: "Aster",
+          genre: "ambient",
+          status: "active",
+        })
+        .wait({ tier: "edge" }),
+      reader.all(app.artists.where({ organizationId: org.id }), { tier: "edge" }),
+    ]);
+    const snapshots: string[][] = [];
+    ctx.trackSubscription(
+      reader.subscribeAll(
+        app.artists.where({ organizationId: org.id }).orderBy("name", "asc"),
+        (delta) => {
+          snapshots.push(delta.all.map((artist) => artist.name));
+        },
+      ),
+    );
+    const artist = await writer
+      .insert(app.artists, {
+        organizationId: org.id,
+        name: "Blue Hour",
+        genre: "jazz",
+        status: "active",
+      })
+      .wait({ tier: "edge" });
+    const release = await writer
+      .insert(app.releases, {
+        organizationId: org.id,
+        artistId: artist.id,
+        title: "First Light",
+        releaseDate: new Date("2026-01-01"),
+        status: "scheduled",
+      })
+      .wait({ tier: "edge" });
+    await writer
+      .insert(app.releaseAssignments, {
+        organizationId: org.id,
+        releaseId: release.id,
+        membershipId: adminMembership.id,
+        role: "owner",
+      })
+      .wait({ tier: "edge" });
+    await browserTopologyPhase(
+      "reader subscription converges ordered roster",
+      () =>
+        waitForCondition(
+          async () => snapshots.some((rows) => rows.includes("Blue Hour")),
+          15_000,
+          "reader did not receive BigLabel artist",
+        ),
+      20_000,
+    );
+    expect(snapshots.at(-1)).toContain("Blue Hour");
+  }, 60_000);
+});
+
+async function openDb(input: {
+  appId: string;
+  serverUrl: string;
+  adminSecret?: string;
+  jwtToken?: string;
+  label: string;
+}): Promise<Db> {
+  return ctx.track(
+    await createDb({
+      appId: input.appId,
+      serverUrl: input.serverUrl,
+      ...(input.adminSecret ? { adminSecret: input.adminSecret } : { jwtToken: input.jwtToken! }),
+      driver: { type: "persistent", dbName: uniqueDbName(input.label) },
+    }),
+  );
+}

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -234,7 +234,6 @@ describe("BigLabel browser edge/core topology", () => {
       .limit(1)
       .include({ artist: true });
     const snapshots: string[][] = [];
-    let serverNetworkBlocked = false;
     await runTopologyScenario(
       {
         id: "big-label.admin-roster.reconnect-reopen-revocation",
@@ -245,11 +244,13 @@ describe("BigLabel browser edge/core topology", () => {
         replay: "pnpm --filter jazz-tools test:browser -- big-label.e2e.test.ts",
         targets: {
           "browser-edge": {
-            async disconnect() {
+            async disconnect({ defer }) {
               // Record the healing obligation before awaiting the command: a
               // command which installs the route and then rejects must still
-              // be paired with a best-effort unblock during cleanup.
-              serverNetworkBlocked = true;
+              // be paired with a bounded unblock by the topology harness.
+              defer("unblock BigLabel browser route", async () => {
+                await unblockJazzServerNetwork(serverUrl);
+              });
               await blockJazzServerNetwork(serverUrl);
               // Route blocking applies only to future WebSocket connections.
               // Close the live reader connection so this phase exercises the
@@ -259,7 +260,6 @@ describe("BigLabel browser edge/core topology", () => {
             },
             async reconnect() {
               await unblockJazzServerNetwork(serverUrl);
-              serverNetworkBlocked = false;
               await reader.reconnect();
               await sleep(100);
             },
@@ -460,22 +460,7 @@ describe("BigLabel browser edge/core topology", () => {
             },
           },
         ],
-        cleanup: async () => {
-          let unblockError: unknown;
-          if (serverNetworkBlocked) {
-            try {
-              await unblockJazzServerNetwork(serverUrl);
-              serverNetworkBlocked = false;
-            } catch (error) {
-              // Preserve this as a cleanup error after all Db resources have
-              // still been released. The harness retains an earlier scenario
-              // error and appends cleanup failure context rather than hiding it.
-              unblockError = error;
-            }
-          }
-          await ctx.cleanup();
-          if (unblockError) throw unblockError;
-        },
+        cleanup: async () => ctx.cleanup(),
         cleanupTimeoutMs: 10_000,
       },
       browserTopologyReporter,

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -22,8 +22,20 @@ import {
 const ctx = new TestCleanup();
 afterEach(async () => ctx.cleanup());
 
+const BIG_LABEL_PHASE_TIMEOUT_MS = 20_000;
+const BIG_LABEL_FAULT_TIMEOUT_MS = 10_000;
+const BIG_LABEL_SETUP_AND_CLEANUP_BUDGET_MS = 80_000;
+const BIG_LABEL_OUTER_TIMEOUT_MS =
+  8 * BIG_LABEL_PHASE_TIMEOUT_MS +
+  6 * BIG_LABEL_FAULT_TIMEOUT_MS +
+  BIG_LABEL_SETUP_AND_CLEANUP_BUDGET_MS;
+
+function bigLabelTopologyTest(name: string, run: () => Promise<void>): void {
+  it(name, run, BIG_LABEL_OUTER_TIMEOUT_MS);
+}
+
 describe("BigLabel browser edge/core topology", () => {
-  it("converges an ordered artist-release roster through two authenticated peer edges", async () => {
+  bigLabelTopologyTest("converges the BigLabel roster across authenticated edges", async () => {
     const [{ app }, permissions] = await browserTopologyPhase("load BigLabel adopter modules", () =>
       Promise.all([
         import("../../../../examples/big-label/schema.js"),
@@ -228,14 +240,17 @@ describe("BigLabel browser edge/core topology", () => {
         id: "big-label.admin-roster.reconnect-reopen-revocation",
         topology: ["browser", "edge", "core"],
         seed: 1719,
-        phaseTimeoutMs: 20_000,
-        faultTimeoutMs: 10_000,
+        phaseTimeoutMs: BIG_LABEL_PHASE_TIMEOUT_MS,
+        faultTimeoutMs: BIG_LABEL_FAULT_TIMEOUT_MS,
         replay: "pnpm --filter jazz-tools test:browser -- big-label.e2e.test.ts",
         targets: {
           "browser-edge": {
             async disconnect() {
-              await blockJazzServerNetwork(serverUrl);
+              // Record the healing obligation before awaiting the command: a
+              // command which installs the route and then rejects must still
+              // be paired with a best-effort unblock during cleanup.
               serverNetworkBlocked = true;
+              await blockJazzServerNetwork(serverUrl);
               // Route blocking applies only to future WebSocket connections.
               // Close the live reader connection so this phase exercises the
               // actual offline cache path rather than a still-open socket.
@@ -258,8 +273,10 @@ describe("BigLabel browser edge/core topology", () => {
                 expect.objectContaining({ name: "Aster", organizationId: org.id }),
               ]);
               ctx.trackSubscription(
-                reader.subscribeAll(roster, (delta) =>
-                  snapshots.push(delta.all.map((artist) => artist.name)),
+                reader.subscribeAll(
+                  roster,
+                  (delta) => snapshots.push(delta.all.map((artist) => artist.name)),
+                  { tier: "edge" },
                 ),
               );
             },
@@ -332,12 +349,12 @@ describe("BigLabel browser edge/core topology", () => {
             name: "editor subscription and bounded release include converge after reconnect",
             async run() {
               await waitForCondition(
-                async () =>
-                  snapshots.some(
-                    (rows) => rows.length === 2 && rows[0] === "Aster" && rows[1] === "Blue Hour",
-                  ),
+                async () => {
+                  const latest = snapshots.at(-1);
+                  return latest?.length === 2 && latest[0] === "Aster" && latest[1] === "Blue Hour";
+                },
                 15_000,
-                "reader did not retain the ordered bounded BigLabel roster after reconnect",
+                "reader's latest edge-settled snapshot was not the exact bounded roster",
               );
               await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toMatchObject([
                 {
@@ -347,6 +364,16 @@ describe("BigLabel browser edge/core topology", () => {
                 },
               ]);
               await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toHaveLength(1);
+
+              const outsiderToken = await getJazzServerJwtForUser("outsider", {}, appId);
+              const outsider = await openDb({
+                appId,
+                serverUrl,
+                jwtToken: outsiderToken,
+                label: "big-label-outsider",
+              });
+              await expect(outsider.all(roster, { tier: "edge" })).resolves.toEqual([]);
+              await expect(outsider.all(releasePipeline, { tier: "edge" })).resolves.toEqual([]);
             },
             faultsAfter: [{ kind: "disconnect", target: "browser-edge" }],
           },
@@ -381,20 +408,6 @@ describe("BigLabel browser edge/core topology", () => {
               await expect(reader.all(releasePipeline, { tier: "local" })).resolves.toHaveLength(1);
             },
             faultsAfter: [{ kind: "reconnect", target: "browser-edge" }],
-          },
-          {
-            name: "unaffiliated external edge cannot read either tenant query shape",
-            async run() {
-              const outsiderToken = await getJazzServerJwtForUser("outsider", {}, appId);
-              const outsider = await openDb({
-                appId,
-                serverUrl,
-                jwtToken: outsiderToken,
-                label: "big-label-outsider",
-              });
-              await expect(outsider.all(roster, { tier: "edge" })).resolves.toEqual([]);
-              await expect(outsider.all(releasePipeline, { tier: "edge" })).resolves.toEqual([]);
-            },
           },
           {
             name: "revoking editor membership removes bounded tenant queries and includes",
@@ -467,16 +480,14 @@ describe("BigLabel browser edge/core topology", () => {
       },
       browserTopologyReporter,
     );
-    expect(snapshots.at(-1)).toContain("Blue Hour");
-  }, 60_000);
+    expect(snapshots.at(-1)).toEqual(["Aster", "Blue Hour"]);
+  });
 });
 
 async function openDb(input: {
   appId: string;
   serverUrl: string;
-  adminSecret?: string;
-  secret?: string;
-  jwtToken?: string;
+  jwtToken: string;
   label: string;
   dbName?: string;
 }): Promise<Db> {
@@ -484,9 +495,7 @@ async function openDb(input: {
     await createDb({
       appId: input.appId,
       serverUrl: input.serverUrl,
-      ...(input.adminSecret
-        ? { adminSecret: input.adminSecret, secret: input.secret! }
-        : { jwtToken: input.jwtToken! }),
+      jwtToken: input.jwtToken,
       driver: { type: "persistent", dbName: input.dbName ?? uniqueDbName(input.label) },
     }),
   );

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -79,9 +79,23 @@ describe("BigLabel browser edge/core topology", () => {
         "Editor",
       ),
     );
-    const [adminToken, editorToken] = await Promise.all([
+    // Give the editor a second, real tenant before opening their edge. The
+    // application queries below deliberately stay scoped to `org`: a dropped
+    // `organizationId` constraint would otherwise be invisible because all
+    // rows the editor can read happen to belong to the same organization.
+    const foreignOrg = await browserTopologyPhase(
+      "bootstrap a second BigLabel tenant through backend authority",
+      () =>
+        bootstrapBigLabelOrganization(
+          { appId, serverUrl, adminSecret, backendSecret },
+          "foreign-admin",
+          "Foreign Admin",
+        ),
+    );
+    const [adminToken, editorToken, foreignAdminToken] = await Promise.all([
       getJazzServerJwtForUser("admin", {}, appId),
       getJazzServerJwtForUser("editor", {}, appId),
+      getJazzServerJwtForUser("foreign-admin", {}, appId),
     ]);
     const writer = await browserTopologyPhase("open authenticated admin edge", () =>
       openDb({
@@ -124,6 +138,52 @@ describe("BigLabel browser edge/core topology", () => {
           personId: editorPerson.id,
           userId: "editor",
           role: "editor",
+        })
+        .wait({ tier: "edge" });
+    });
+    const foreignWriter = await browserTopologyPhase("open second tenant admin edge", () =>
+      openDb({
+        appId,
+        serverUrl,
+        jwtToken: foreignAdminToken,
+        label: "big-label-foreign-writer",
+      }),
+    );
+    await browserTopologyPhase("admit editor to the second tenant", async () => {
+      const foreignEditor = await foreignWriter.all(
+        app.people.where({ userId: "editor" }).limit(1),
+        { tier: "edge" },
+      );
+      expect(foreignEditor).toHaveLength(1);
+      await foreignWriter
+        .insert(app.memberships, {
+          organizationId: foreignOrg.id,
+          personId: foreignEditor[0]!.id,
+          userId: "editor",
+          role: "editor",
+        })
+        .wait({ tier: "edge" });
+    });
+    await browserTopologyPhase("seed readable foreign tenant rows", async () => {
+      // These values sort before the org-one rows below. They are intentionally
+      // authorized for the same editor, so removing either query's
+      // `organizationId` predicate makes its bounded result deterministically
+      // contain a foreign row rather than merely widening an invisible set.
+      const foreignArtist = await foreignWriter
+        .insert(app.artists, {
+          organizationId: foreignOrg.id,
+          name: "Aardvark",
+          genre: "ambient",
+          status: "active",
+        })
+        .wait({ tier: "edge" });
+      await foreignWriter
+        .insert(app.releases, {
+          organizationId: foreignOrg.id,
+          artistId: foreignArtist.id,
+          title: "Foreign Prelude",
+          releaseDate: new Date("2025-01-01"),
+          status: "scheduled",
         })
         .wait({ tier: "edge" });
     });
@@ -186,8 +246,8 @@ describe("BigLabel browser edge/core topology", () => {
           {
             name: "editor reads exact bounded roster and subscribes",
             async run() {
-              await expect(reader.all(roster, { tier: "edge" })).resolves.toMatchObject([
-                { name: "Aster" },
+              await expect(reader.all(roster, { tier: "edge" })).resolves.toEqual([
+                expect.objectContaining({ name: "Aster", organizationId: org.id }),
               ]);
               ctx.trackSubscription(
                 reader.subscribeAll(roster, (delta) =>
@@ -272,7 +332,11 @@ describe("BigLabel browser edge/core topology", () => {
                 "reader did not retain the ordered bounded BigLabel roster after reconnect",
               );
               await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toMatchObject([
-                { title: "First Light", artist: { name: "Blue Hour" } },
+                {
+                  title: "First Light",
+                  organizationId: org.id,
+                  artist: { name: "Blue Hour", organizationId: org.id },
+                },
               ]);
               await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toHaveLength(1);
             },
@@ -289,12 +353,16 @@ describe("BigLabel browser edge/core topology", () => {
                 label: "big-label-reader",
               });
               await expect(reader.all(roster, { tier: "local" })).resolves.toMatchObject([
-                { name: "Aster" },
-                { name: "Blue Hour" },
+                { name: "Aster", organizationId: org.id },
+                { name: "Blue Hour", organizationId: org.id },
               ]);
               await expect(reader.all(roster, { tier: "local" })).resolves.toHaveLength(2);
               await expect(reader.all(releasePipeline, { tier: "local" })).resolves.toMatchObject([
-                { title: "First Light", artist: { name: "Blue Hour" } },
+                {
+                  title: "First Light",
+                  organizationId: org.id,
+                  artist: { name: "Blue Hour", organizationId: org.id },
+                },
               ]);
               await expect(reader.all(releasePipeline, { tier: "local" })).resolves.toHaveLength(1);
             },

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -222,6 +222,7 @@ describe("BigLabel browser edge/core topology", () => {
       .limit(1)
       .include({ artist: true });
     const snapshots: string[][] = [];
+    let serverNetworkBlocked = false;
     await runTopologyScenario(
       {
         id: "big-label.admin-roster.reconnect-reopen-revocation",
@@ -234,6 +235,7 @@ describe("BigLabel browser edge/core topology", () => {
           "browser-edge": {
             async disconnect() {
               await blockJazzServerNetwork(serverUrl);
+              serverNetworkBlocked = true;
               // Route blocking applies only to future WebSocket connections.
               // Close the live reader connection so this phase exercises the
               // actual offline cache path rather than a still-open socket.
@@ -242,6 +244,7 @@ describe("BigLabel browser edge/core topology", () => {
             },
             async reconnect() {
               await unblockJazzServerNetwork(serverUrl);
+              serverNetworkBlocked = false;
               await reader.reconnect();
               await sleep(100);
             },
@@ -345,10 +348,15 @@ describe("BigLabel browser edge/core topology", () => {
               ]);
               await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toHaveLength(1);
             },
+            faultsAfter: [{ kind: "disconnect", target: "browser-edge" }],
           },
           {
-            name: "editor reopens persistent cache without refetching bounded app queries",
+            name: "editor reopens the same persistent cache while physically offline",
             async run() {
+              // Route blocking remains active across close/open, so the new Db
+              // cannot refill from edge. These local reads therefore prove the
+              // bounded roster and include were durably stored in this exact
+              // IndexedDB database by the preceding online subscription/read.
               ctx.untrack(reader);
               await reader.close();
               reader = await openDb({
@@ -372,6 +380,7 @@ describe("BigLabel browser edge/core topology", () => {
               ]);
               await expect(reader.all(releasePipeline, { tier: "local" })).resolves.toHaveLength(1);
             },
+            faultsAfter: [{ kind: "reconnect", target: "browser-edge" }],
           },
           {
             name: "unaffiliated external edge cannot read either tenant query shape",
@@ -438,6 +447,23 @@ describe("BigLabel browser edge/core topology", () => {
             },
           },
         ],
+        cleanup: async () => {
+          let unblockError: unknown;
+          if (serverNetworkBlocked) {
+            try {
+              await unblockJazzServerNetwork(serverUrl);
+              serverNetworkBlocked = false;
+            } catch (error) {
+              // Preserve this as a cleanup error after all Db resources have
+              // still been released. The harness retains an earlier scenario
+              // error and appends cleanup failure context rather than hiding it.
+              unblockError = error;
+            }
+          }
+          await ctx.cleanup();
+          if (unblockError) throw unblockError;
+        },
+        cleanupTimeoutMs: 10_000,
       },
       browserTopologyReporter,
     );

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -177,6 +177,17 @@ describe("BigLabel browser edge/core topology", () => {
                   status: "active",
                 })
                 .wait({ tier: "edge" });
+              // A third row proves the subscriber keeps the query's actual
+              // ordered window rather than merely eventually receiving all
+              // authorized artists after reconnect.
+              await writer
+                .insert(app.artists, {
+                  organizationId: org.id,
+                  name: "Zither",
+                  genre: "folk",
+                  status: "active",
+                })
+                .wait({ tier: "edge" });
               const release = await writer
                 .insert(app.releases, {
                   organizationId: org.id,
@@ -209,9 +220,12 @@ describe("BigLabel browser edge/core topology", () => {
             name: "editor subscription converges after reconnect",
             async run() {
               await waitForCondition(
-                async () => snapshots.some((rows) => rows.includes("Blue Hour")),
+                async () =>
+                  snapshots.some(
+                    (rows) => rows.length === 2 && rows[0] === "Aster" && rows[1] === "Blue Hour",
+                  ),
                 15_000,
-                "reader did not receive BigLabel artist after reconnect",
+                "reader did not retain the ordered bounded BigLabel roster after reconnect",
               );
             },
           },
@@ -230,6 +244,7 @@ describe("BigLabel browser edge/core topology", () => {
                 { name: "Aster" },
                 { name: "Blue Hour" },
               ]);
+              await expect(reader.all(roster, { tier: "local" })).resolves.toHaveLength(2);
             },
           },
           {

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -122,39 +122,47 @@ describe("BigLabel browser edge/core topology", () => {
       reader.all(app.artists.where({ organizationId: org.id }), { tier: "edge" }),
     );
     const snapshots: string[][] = [];
-    ctx.trackSubscription(
-      reader.subscribeAll(
-        app.artists.where({ organizationId: org.id }).orderBy("name", "asc"),
-        (delta) => {
-          snapshots.push(delta.all.map((artist) => artist.name));
-        },
-      ),
+    await browserTopologyPhase("start editor ordered-roster subscription", () => {
+      ctx.trackSubscription(
+        reader.subscribeAll(
+          app.artists.where({ organizationId: org.id }).orderBy("name", "asc"),
+          (delta) => {
+            snapshots.push(delta.all.map((artist) => artist.name));
+          },
+        ),
+      );
+    });
+    const artist = await browserTopologyPhase("writer adds convergent artist", () =>
+      writer
+        .insert(app.artists, {
+          organizationId: org.id,
+          name: "Blue Hour",
+          genre: "jazz",
+          status: "active",
+        })
+        .wait({ tier: "edge" }),
     );
-    const artist = await writer
-      .insert(app.artists, {
-        organizationId: org.id,
-        name: "Blue Hour",
-        genre: "jazz",
-        status: "active",
-      })
-      .wait({ tier: "edge" });
-    const release = await writer
-      .insert(app.releases, {
-        organizationId: org.id,
-        artistId: artist.id,
-        title: "First Light",
-        releaseDate: new Date("2026-01-01"),
-        status: "scheduled",
-      })
-      .wait({ tier: "edge" });
-    await writer
-      .insert(app.releaseAssignments, {
-        organizationId: org.id,
-        releaseId: release.id,
-        membershipId: adminMembership.id,
-        role: "owner",
-      })
-      .wait({ tier: "edge" });
+    const release = await browserTopologyPhase("writer adds artist release", () =>
+      writer
+        .insert(app.releases, {
+          organizationId: org.id,
+          artistId: artist.id,
+          title: "First Light",
+          releaseDate: new Date("2026-01-01"),
+          status: "scheduled",
+        })
+        .wait({ tier: "edge" }),
+    );
+    await browserTopologyPhase("writer assigns release owner", () =>
+      writer
+        .insert(app.releaseAssignments, {
+          organizationId: org.id,
+          releaseId: release.id,
+          membershipId: adminMembership.id,
+          role: "owner",
+        })
+        .wait({ tier: "edge" }),
+    );
     await browserTopologyPhase(
       "reader subscription converges ordered roster",
       () =>

--- a/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
+++ b/packages/jazz-tools/tests/browser/big-label.e2e.test.ts
@@ -187,12 +187,17 @@ describe("BigLabel browser edge/core topology", () => {
         })
         .wait({ tier: "edge" });
     });
+    // Keep this stable across the explicit close/reopen phases below. A fresh
+    // `uniqueDbName()` on every `createDb()` would only prove a cold edge
+    // fetch, not that the browser's persisted application cache rehydrates.
+    const readerDbName = uniqueDbName("big-label-reader");
     let reader = await browserTopologyPhase("open authenticated editor edge", () =>
       openDb({
         appId,
         serverUrl,
         jwtToken: editorToken,
         label: "big-label-reader",
+        dbName: readerDbName,
       }),
     );
     await browserTopologyPhase("writer seeds initial artist", async () => {
@@ -351,6 +356,7 @@ describe("BigLabel browser edge/core topology", () => {
                 serverUrl,
                 jwtToken: editorToken,
                 label: "big-label-reader",
+                dbName: readerDbName,
               });
               await expect(reader.all(roster, { tier: "local" })).resolves.toMatchObject([
                 { name: "Aster", organizationId: org.id },
@@ -402,6 +408,34 @@ describe("BigLabel browser edge/core topology", () => {
                 "revoked editor retained a BigLabel tenant query or included artist",
               );
             },
+            faultsAfter: [{ kind: "disconnect", target: "browser-edge" }],
+          },
+          {
+            name: "revocation survives an offline persistent-cache reopen",
+            async run() {
+              // Reopen the same IndexedDB cache while its route remains
+              // blocked. This catches stale authorized rows which disappear
+              // from a live query but are not durably removed from the cache.
+              ctx.untrack(reader);
+              await reader.close();
+              reader = await openDb({
+                appId,
+                serverUrl,
+                jwtToken: editorToken,
+                label: "big-label-reader",
+                dbName: readerDbName,
+              });
+              await expect(reader.all(roster, { tier: "local" })).resolves.toEqual([]);
+              await expect(reader.all(releasePipeline, { tier: "local" })).resolves.toEqual([]);
+            },
+            faultsAfter: [{ kind: "reconnect", target: "browser-edge" }],
+          },
+          {
+            name: "reconnected reopened editor remains unable to read revoked tenant data",
+            async run() {
+              await expect(reader.all(roster, { tier: "edge" })).resolves.toEqual([]);
+              await expect(reader.all(releasePipeline, { tier: "edge" })).resolves.toEqual([]);
+            },
           },
         ],
       },
@@ -418,6 +452,7 @@ async function openDb(input: {
   secret?: string;
   jwtToken?: string;
   label: string;
+  dbName?: string;
 }): Promise<Db> {
   return ctx.track(
     await createDb({
@@ -426,7 +461,7 @@ async function openDb(input: {
       ...(input.adminSecret
         ? { adminSecret: input.adminSecret, secret: input.secret! }
         : { jwtToken: input.jwtToken! }),
-      driver: { type: "persistent", dbName: uniqueDbName(input.label) },
+      driver: { type: "persistent", dbName: input.dbName ?? uniqueDbName(input.label) },
     }),
   );
 }

--- a/packages/jazz-tools/tests/browser/browser-commands.ts
+++ b/packages/jazz-tools/tests/browser/browser-commands.ts
@@ -21,6 +21,11 @@ export interface JazzTopologyBrowserCommands {
   ): Promise<void>;
 }
 
+/** Browser command contract used only by the BigLabel topology receipt. */
+export interface BigLabelBrowserCommands {
+  bigLabelBootstrap(info: JazzServerInfo, userId: string, name: string): Promise<{ id: string }>;
+}
+
 function hasFunction(value: object, key: string): boolean {
   return key in value && typeof Reflect.get(value, key) === "function";
 }
@@ -40,6 +45,10 @@ function isJazzTopologyBrowserCommands(value: unknown): value is JazzTopologyBro
   return (
     typeof value === "object" && value !== null && hasFunction(value, "jazzBrowserTopologyLog")
   );
+}
+
+function isBigLabelBrowserCommands(value: unknown): value is BigLabelBrowserCommands {
+  return typeof value === "object" && value !== null && hasFunction(value, "bigLabelBootstrap");
 }
 
 /**
@@ -62,6 +71,15 @@ export function jazzServerBrowserCommands(): JazzServerBrowserCommands {
 export function jazzTopologyBrowserCommands(): JazzTopologyBrowserCommands {
   if (!isJazzTopologyBrowserCommands(commands)) {
     throw new Error("Browser test project is missing the jazzBrowserTopologyLog command.");
+  }
+  return commands;
+}
+
+export function bigLabelBrowserCommands(): BigLabelBrowserCommands {
+  if (!isBigLabelBrowserCommands(commands)) {
+    throw new Error(
+      "Browser test project is missing the BigLabel bootstrap command. Configure bigLabelBootstrap.",
+    );
   }
   return commands;
 }

--- a/packages/jazz-tools/tests/browser/browser-helpers.typecheck.ts
+++ b/packages/jazz-tools/tests/browser/browser-helpers.typecheck.ts
@@ -1,5 +1,6 @@
 import {
   blockJazzServerNetwork,
+  bootstrapBigLabelOrganization,
   getJazzServerInfo,
   getJazzServerJwtForUser,
   unblockJazzServerNetwork,
@@ -10,4 +11,5 @@ void getJazzServerInfo;
 void getJazzServerJwtForUser;
 void blockJazzServerNetwork;
 void unblockJazzServerNetwork;
+void bootstrapBigLabelOrganization;
 void browserTopologyReporter;

--- a/packages/jazz-tools/tests/browser/testing-server-node.ts
+++ b/packages/jazz-tools/tests/browser/testing-server-node.ts
@@ -12,6 +12,7 @@ interface StartedJazzServer {
   appId: string;
   serverUrl: string;
   adminSecret: string;
+  backendSecret: string;
 }
 
 const DEFAULT_JAZZ_SERVER_KEY = "__default__";
@@ -49,6 +50,7 @@ async function startJazzServer(
     appId: server.appId,
     serverUrl: server.url,
     adminSecret: server.adminSecret,
+    backendSecret: server.backendSecret,
   };
 }
 
@@ -89,12 +91,14 @@ export async function jazzServerInfo(
   appId: string;
   serverUrl: string;
   adminSecret: string;
+  backendSecret: string;
 }> {
   const started = await getOrStartJazzServer(appId, schema);
   return {
     appId: started.appId,
     serverUrl: started.serverUrl,
     adminSecret: started.adminSecret,
+    backendSecret: started.backendSecret,
   };
 }
 

--- a/packages/jazz-tools/tests/browser/testing-server.ts
+++ b/packages/jazz-tools/tests/browser/testing-server.ts
@@ -1,9 +1,10 @@
-import { jazzServerBrowserCommands } from "./browser-commands.js";
+import { bigLabelBrowserCommands, jazzServerBrowserCommands } from "./browser-commands.js";
 
 export interface JazzServerInfo {
   appId: string;
   serverUrl: string;
   adminSecret: string;
+  backendSecret: string;
 }
 
 export interface JazzServerNetworkDebugState {
@@ -13,6 +14,13 @@ export interface JazzServerNetworkDebugState {
   activePatterns: string[];
 }
 
+export function bootstrapBigLabelOrganization(
+  info: JazzServerInfo,
+  userId: string,
+  name: string,
+): Promise<{ id: string }> {
+  return bigLabelBrowserCommands().bigLabelBootstrap(info, userId, name);
+}
 export function getJazzServerInfo(appId?: string, schema?: Uint8Array): Promise<JazzServerInfo> {
   return jazzServerBrowserCommands().jazzServerInfo(appId, schema ? [...schema] : undefined);
 }

--- a/packages/jazz-tools/tests/browser/topology-harness.ts
+++ b/packages/jazz-tools/tests/browser/topology-harness.ts
@@ -1,5 +1,6 @@
 import { jazzTopologyBrowserCommands } from "./browser-commands.js";
 import type { TopologyReporter } from "../topology/harness.js";
+import { withTimeout } from "./support.js";
 export * from "../topology/harness.js";
 
 /** Reporter which mirrors browser lifecycle phases to the Node test process. */
@@ -11,3 +12,30 @@ export const browserTopologyReporter: TopologyReporter = {
       .catch(() => undefined);
   },
 };
+
+/**
+ * Compatibility boundary for the first browser topology receipt. New cases
+ * should use `runTopologyScenario` directly so faults and cleanup are recorded
+ * in the shared receipt; this keeps the pre-existing named phases observable
+ * while those cases are migrated.
+ */
+export async function browserTopologyPhase<T>(
+  label: string,
+  operation: () => Promise<T>,
+  timeoutMs = 10_000,
+): Promise<T> {
+  const started = performance.now();
+  browserTopologyReporter.phase("start", label, 0);
+  try {
+    const result = await withTimeout(
+      operation(),
+      timeoutMs,
+      `Browser topology phase timed out: ${label}`,
+    );
+    browserTopologyReporter.phase("complete", label, Math.round(performance.now() - started));
+    return result;
+  } catch (error) {
+    browserTopologyReporter.phase("failed", label, Math.round(performance.now() - started));
+    throw error;
+  }
+}

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -67,6 +67,8 @@ export default defineConfig({
       // directory. The package manifest selects pkg/jazz_wasm.js; wasm-pack's
       // web target intentionally does not emit a second manifest in pkg/.
       "jazz-wasm": resolve(__dirname, "../../crates/jazz-wasm"),
+      "jazz-tools": resolve(__dirname, "src/index.ts"),
+      "jazz-tools/permissions": resolve(__dirname, "src/permissions/index.ts"),
     },
   },
   worker: {

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -96,6 +96,14 @@ export default defineConfig({
           console.info(`[jazz-browser-topology] ${status} ${label} (${elapsedMs}ms)`);
         },
         jazzServerInfo: async (_context, appId, schema) => jazzServerInfo(appId, schema),
+        bigLabelBootstrap: async (_context, info, userId, name) => {
+          process.env.NEXT_PUBLIC_JAZZ_APP_ID = info.appId;
+          process.env.NEXT_PUBLIC_JAZZ_SERVER_URL = info.serverUrl;
+          process.env.BACKEND_SECRET = info.backendSecret;
+          const { ensurePersonalOrganization } =
+            await import("../../examples/big-label/src/lib/bootstrap.js");
+          return ensurePersonalOrganization(userId, name);
+        },
         jazzServerBlockNetwork: async ({ context }, serverUrl) =>
           blockJazzServerNetwork(context, serverUrl),
         jazzServerUnblockNetwork: async ({ context }, serverUrl) =>

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -67,8 +67,8 @@ export default defineConfig({
       // directory. The package manifest selects pkg/jazz_wasm.js; wasm-pack's
       // web target intentionally does not emit a second manifest in pkg/.
       "jazz-wasm": resolve(__dirname, "../../crates/jazz-wasm"),
-      "jazz-tools": resolve(__dirname, "src/index.ts"),
       "jazz-tools/permissions": resolve(__dirname, "src/permissions/index.ts"),
+      "jazz-tools": resolve(__dirname, "src/index.ts"),
     },
   },
   worker: {


### PR DESCRIPTION
🤖 Stacked on #1719. Starts bounded, adopter-facing BigLabel browser topology coverage with real schema and permissions, authenticated writer/reader clients, artist/release/assignment writes, and ordered subscription convergence across the core path. Revocation, offline replay, restart, and deterministic fault expansion are in progress.