### PR TITLE
test(examples): add shared topology fault harness

### DIFF
--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -1,0 +1,35 @@
+# Example topology harness
+
+`packages/jazz-tools/tests/topology/harness.ts` owns deterministic seeds,
+bounded named phases, disconnect/reconnect/restart/failure callbacks, receipts,
+and replay commands. App scenarios continue to own schemas, fixtures,
+operations, and assertions.
+
+Register a scenario in `dev/example-topology-scenarios.json` with a stable id,
+topology labels, working directory, and an argv array. Run the bounded smoke
+locally with:
+
+```sh
+node dev/gates/run-example-topology-soak.mjs --seed-count 1
+```
+
+Copy a failing case's `replay` field from
+`target/example-topology-soak/summary.json`. The runner never evaluates shell
+strings; registry commands remain explicit argv arrays.
+
+## Open app-branch integration
+
+The product apps are not on `main` yet. Their integration remains deliberately
+small and contains no app logic in this harness:
+
+- BandChat (`29d384798`): import `runTopologyScenario` and
+  `browserTopologyReporter` in `topology.e2e.test.ts`, express its existing
+  disconnect/reconnect/restart calls as fault targets, then register its focused
+  Vitest argv.
+- BigLabel (`3d6787b3b`): replace its local `browserTopologyPhase` helper with a
+  phase in the shared runner and register the focused browser test.
+- MusicAgent (`997894311`): use the shared browser reporter for its bounded
+  import/server/client phases and register its focused browser topology test.
+
+Those patches should land with their app branches so the public repository does
+not copy or prematurely own adopter schemas and workload semantics.

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -19,12 +19,14 @@ strings; registry commands remain explicit argv arrays.
 
 The registry is trusted repository code, not user input. Its path, every
 scenario working directory, and the output directory are confined to the
-repository before execution. The outer watchdog terminates the scenario's full
-process tree. In-process phases and faults receive an `AbortSignal`; they must
+repository after resolving symlinks and before execution. The outer watchdog
+enumerates and terminates the scenario's full descendant process tree, including
+children that create a new session. In-process phases, faults, and cleanup
+receive an `AbortSignal`; they must
 stop scheduled work when it aborts. Scenarios that acquire servers, clients, or
 other resources provide `cleanup`, which runs in `finally` and is independently
-bounded. Receipts retain attempted, completed, and failed activities and their
-errors.
+bounded and recorded. Receipts retain attempted, completed, and failed
+activities, durations, and errors.
 
 This is currently a tested scaffold and local soak entrypoint. It does not
 claim continuous app coverage until app-owned scenarios are registered and the

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -17,6 +17,19 @@ Copy a failing case's `replay` field from
 `target/example-topology-soak/summary.json`. The runner never evaluates shell
 strings; registry commands remain explicit argv arrays.
 
+The registry is trusted repository code, not user input. Its path, every
+scenario working directory, and the output directory are confined to the
+repository before execution. The outer watchdog terminates the scenario's full
+process tree. In-process phases and faults receive an `AbortSignal`; they must
+stop scheduled work when it aborts. Scenarios that acquire servers, clients, or
+other resources provide `cleanup`, which runs in `finally` and is independently
+bounded. Receipts retain attempted, completed, and failed activities and their
+errors.
+
+This is currently a tested scaffold and local soak entrypoint. It does not
+claim continuous app coverage until app-owned scenarios are registered and the
+browser-capable CI job invokes it.
+
 ## Open app-branch integration
 
 The product apps are not on `main` yet. Their integration remains deliberately

--- a/dev/example-topology-scenarios.json
+++ b/dev/example-topology-scenarios.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "harness.fixture.cross-topology-faults",
+      "topology": ["fixture"],
+      "cwd": ".",
+      "argv": ["pnpm", "--filter", "jazz-tools", "test:topology-fixture"]
+    }
+  ]
+}

--- a/dev/gates/run-example-topology-soak.mjs
+++ b/dev/gates/run-example-topology-soak.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { spawnSync } from "node:child_process";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { spawn, spawnSync } from "node:child_process";
 
 const root = resolve(import.meta.dirname, "../..");
 const registryPath = process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY
-  ? resolve(process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY)
+  ? confinedPath(process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY, "scenario registry")
   : resolve(root, "dev/example-topology-scenarios.json");
 const registry = JSON.parse(readFileSync(registryPath, "utf8"));
 validateRegistry(registry);
@@ -33,28 +33,25 @@ if (scenarios.length === 0 || selected.some((id) => !scenarios.some((item) => it
   usage("unknown or empty scenario selection");
 }
 
-const outputDir = resolve(root, output);
+const outputDir = confinedPath(output, "output");
 mkdirSync(resolve(outputDir, "logs"), { recursive: true });
 const fixedSeeds = [11, 29, 47, 83, 32676, 40595, 2234158, 3715011, 4372288];
 const cases = [];
 for (const scenario of scenarios) {
   for (let index = 0; index < seedCount; index++) {
     const seed = fixedSeeds[index] ?? 1000 + (index - fixedSeeds.length) * 7919;
-    const logName = `${scenario.id.replaceAll(/[^a-zA-Z0-9.-]/g, "-")}-seed-${seed}.log`;
+    const logName = `${cases.length}-${scenario.id.replaceAll(/[^a-zA-Z0-9.-]/g, "-")}-seed-${seed}.log`;
     const command = [`JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed}`, ...scenario.argv.map(shellQuote)].join(
       " ",
     );
     const replay = scenario.cwd === "." ? command : `cd ${shellQuote(scenario.cwd)} && ${command}`;
     const started = Date.now();
-    const result = spawnSync(scenario.argv[0], scenario.argv.slice(1), {
-      cwd: resolve(root, scenario.cwd),
+    const result = await runProcess(scenario.argv[0], scenario.argv.slice(1), {
+      cwd: confinedPath(scenario.cwd, `scenario ${scenario.id} cwd`),
       env: { ...process.env, JAZZ_EXAMPLE_TOPOLOGY_SEED: String(seed) },
-      encoding: "utf8",
-      timeout: watchdogSeconds * 1000,
-      killSignal: "SIGKILL",
+      timeoutMs: watchdogSeconds * 1000,
     });
-    const status =
-      result.error?.code === "ETIMEDOUT" ? "timeout" : result.status === 0 ? "passed" : "failed";
+    const status = result.timedOut ? "timeout" : result.status === 0 ? "passed" : "failed";
     writeFileSync(
       resolve(outputDir, "logs", logName),
       `${result.stdout ?? ""}${result.stderr ?? ""}`,
@@ -90,6 +87,57 @@ function shellQuote(value) {
   return /^[a-zA-Z0-9_./:@=-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
+function confinedPath(value, label) {
+  const path = resolve(root, value);
+  const fromRoot = relative(root, path);
+  if (fromRoot === ".." || fromRoot.startsWith(`..${sep}`) || isAbsolute(fromRoot)) {
+    usage(`${label} must remain inside the repository`);
+  }
+  return path;
+}
+
+function runProcess(command, args, { cwd, env, timeoutMs }) {
+  return new Promise((resolveResult) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    child.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
+    child.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminateProcessTree(child.pid);
+    }, timeoutMs);
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      resolveResult({ status: null, stdout, stderr: `${stderr}${error.message}\n`, timedOut });
+    });
+    child.on("close", (status) => {
+      clearTimeout(timer);
+      resolveResult({ status, stdout, stderr, timedOut });
+    });
+  });
+}
+
+function terminateProcessTree(pid) {
+  if (!pid) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], { windowsHide: true });
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
 function validateRegistry(value) {
   if (value?.schemaVersion !== 1 || !Array.isArray(value.scenarios)) {
     usage("scenario registry must have schemaVersion 1 and a scenarios array");
@@ -103,6 +151,10 @@ function validateRegistry(value) {
     ids.add(scenario.id);
     if (!Array.isArray(scenario.topology) || scenario.topology.length === 0) {
       usage(`scenario ${scenario.id} requires at least one topology`);
+    }
+    const topologyKinds = new Set(["core", "edge", "browser", "native", "fixture"]);
+    if (scenario.topology.some((kind) => !topologyKinds.has(kind))) {
+      usage(`scenario ${scenario.id} has an unknown topology`);
     }
     if (typeof scenario.cwd !== "string" || scenario.cwd.length === 0) {
       usage(`scenario ${scenario.id} requires cwd`);

--- a/dev/gates/run-example-topology-soak.mjs
+++ b/dev/gates/run-example-topology-soak.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = resolve(import.meta.dirname, "../..");
+const registry = JSON.parse(
+  readFileSync(resolve(root, "dev/example-topology-scenarios.json"), "utf8"),
+);
+let output = "target/example-topology-soak";
+let seedCount = 3;
+let watchdogSeconds = 90;
+let selected = [];
+for (let index = 2; index < process.argv.length; index++) {
+  const option = process.argv[index];
+  if (option === "--output") output = process.argv[++index];
+  else if (option === "--seed-count") seedCount = positiveInteger(process.argv[++index], option);
+  else if (option === "--watchdog-seconds")
+    watchdogSeconds = positiveInteger(process.argv[++index], option);
+  else if (option === "--scenario") selected.push(process.argv[++index]);
+  else if (option === "--list") {
+    for (const scenario of registry.scenarios) console.log(scenario.id);
+    process.exit(0);
+  } else usage(`unknown option: ${option}`);
+}
+if (seedCount > 100 || watchdogSeconds > 900) usage("seed/watchdog cap exceeded");
+const scenarios = registry.scenarios.filter(
+  ({ id }) => selected.length === 0 || selected.includes(id),
+);
+if (scenarios.length === 0 || selected.some((id) => !scenarios.some((item) => item.id === id))) {
+  usage("unknown or empty scenario selection");
+}
+
+const outputDir = resolve(root, output);
+mkdirSync(resolve(outputDir, "logs"), { recursive: true });
+const fixedSeeds = [11, 29, 47, 83, 32676, 40595, 2234158, 3715011, 4372288];
+const cases = [];
+for (const scenario of scenarios) {
+  for (let index = 0; index < seedCount; index++) {
+    const seed = fixedSeeds[index] ?? 1000 + (index - fixedSeeds.length) * 7919;
+    const logName = `${scenario.id.replaceAll(/[^a-zA-Z0-9.-]/g, "-")}-seed-${seed}.log`;
+    const replay = [`JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed}`, ...scenario.argv.map(shellQuote)].join(
+      " ",
+    );
+    const started = Date.now();
+    const result = spawnSync(scenario.argv[0], scenario.argv.slice(1), {
+      cwd: resolve(root, scenario.cwd),
+      env: { ...process.env, JAZZ_EXAMPLE_TOPOLOGY_SEED: String(seed) },
+      encoding: "utf8",
+      timeout: watchdogSeconds * 1000,
+      killSignal: "SIGKILL",
+    });
+    const status =
+      result.error?.code === "ETIMEDOUT" ? "timeout" : result.status === 0 ? "passed" : "failed";
+    writeFileSync(
+      resolve(outputDir, "logs", logName),
+      `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    );
+    cases.push({
+      scenario: scenario.id,
+      topology: scenario.topology,
+      seed,
+      status,
+      exitCode: result.status,
+      elapsedMs: Date.now() - started,
+      log: `logs/${logName}`,
+      replay,
+    });
+    console.log(`${scenario.id} seed=${seed} status=${status}; replay: ${replay}`);
+  }
+}
+const summary = {
+  schemaVersion: 1,
+  sha: spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).stdout.trim(),
+  cases,
+  failures: cases.filter(({ status }) => status !== "passed"),
+};
+writeFileSync(resolve(outputDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+process.exitCode = summary.failures.length === 0 ? 0 : 1;
+
+function positiveInteger(value, option) {
+  if (!/^[1-9][0-9]*$/.test(value ?? "")) usage(`${option} requires a positive integer`);
+  return Number(value);
+}
+
+function shellQuote(value) {
+  return /^[a-zA-Z0-9_./:@=-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function usage(error) {
+  if (error) console.error(error);
+  console.error(
+    "Usage: run-example-topology-soak.mjs [--list] [--scenario ID] [--seed-count N] [--watchdog-seconds N] [--output DIR]",
+  );
+  process.exit(2);
+}

--- a/dev/gates/run-example-topology-soak.mjs
+++ b/dev/gates/run-example-topology-soak.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 
-const root = resolve(import.meta.dirname, "../..");
+const root = realpathSync(resolve(import.meta.dirname, "../.."));
 const registryPath = process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY
-  ? confinedPath(process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY, "scenario registry")
-  : resolve(root, "dev/example-topology-scenarios.json");
+  ? confinedExistingPath(process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY, "scenario registry")
+  : confinedExistingPath("dev/example-topology-scenarios.json", "scenario registry");
 const registry = JSON.parse(readFileSync(registryPath, "utf8"));
 validateRegistry(registry);
 let output = "target/example-topology-soak";
@@ -33,7 +33,7 @@ if (scenarios.length === 0 || selected.some((id) => !scenarios.some((item) => it
   usage("unknown or empty scenario selection");
 }
 
-const outputDir = confinedPath(output, "output");
+const outputDir = confinedCreatablePath(output, "output");
 mkdirSync(resolve(outputDir, "logs"), { recursive: true });
 const fixedSeeds = [11, 29, 47, 83, 32676, 40595, 2234158, 3715011, 4372288];
 const cases = [];
@@ -47,7 +47,7 @@ for (const scenario of scenarios) {
     const replay = scenario.cwd === "." ? command : `cd ${shellQuote(scenario.cwd)} && ${command}`;
     const started = Date.now();
     const result = await runProcess(scenario.argv[0], scenario.argv.slice(1), {
-      cwd: confinedPath(scenario.cwd, `scenario ${scenario.id} cwd`),
+      cwd: confinedExistingPath(scenario.cwd, `scenario ${scenario.id} cwd`),
       env: { ...process.env, JAZZ_EXAMPLE_TOPOLOGY_SEED: String(seed) },
       timeoutMs: watchdogSeconds * 1000,
     });
@@ -87,13 +87,34 @@ function shellQuote(value) {
   return /^[a-zA-Z0-9_./:@=-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
-function confinedPath(value, label) {
+function lexicalConfinedPath(value, label) {
   const path = resolve(root, value);
+  assertConfined(path, label);
+  return path;
+}
+
+function confinedExistingPath(value, label) {
+  const path = realpathSync(lexicalConfinedPath(value, label));
+  assertConfined(path, label);
+  return path;
+}
+
+function confinedCreatablePath(value, label) {
+  const path = lexicalConfinedPath(value, label);
+  let existing = path;
+  while (!existsSync(existing)) existing = dirname(existing);
+  assertConfined(realpathSync(existing), label);
+  mkdirSync(path, { recursive: true });
+  const canonical = realpathSync(path);
+  assertConfined(canonical, label);
+  return canonical;
+}
+
+function assertConfined(path, label) {
   const fromRoot = relative(root, path);
   if (fromRoot === ".." || fromRoot.startsWith(`..${sep}`) || isAbsolute(fromRoot)) {
     usage(`${label} must remain inside the repository`);
   }
-  return path;
 }
 
 function runProcess(command, args, { cwd, env, timeoutMs }) {
@@ -131,8 +152,38 @@ function terminateProcessTree(pid) {
     spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], { windowsHide: true });
     return;
   }
+  const descendants = descendantPids(pid);
+  for (const descendant of descendants.reverse()) killPid(descendant);
   try {
     process.kill(-pid, "SIGKILL");
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+  killPid(pid);
+}
+
+function descendantPids(rootPid) {
+  const processList = spawnSync("ps", ["-eo", "pid=,ppid="], { encoding: "utf8" });
+  if (processList.status !== 0) return [];
+  const children = new Map();
+  for (const line of processList.stdout.trim().split("\n")) {
+    const [pid, parentPid] = line.trim().split(/\s+/).map(Number);
+    if (!children.has(parentPid)) children.set(parentPid, []);
+    children.get(parentPid).push(pid);
+  }
+  const found = [];
+  const pending = [...(children.get(rootPid) ?? [])];
+  while (pending.length > 0) {
+    const pid = pending.pop();
+    found.push(pid);
+    pending.push(...(children.get(pid) ?? []));
+  }
+  return found;
+}
+
+function killPid(pid) {
+  try {
+    process.kill(pid, "SIGKILL");
   } catch (error) {
     if (error?.code !== "ESRCH") throw error;
   }

--- a/dev/gates/run-example-topology-soak.mjs
+++ b/dev/gates/run-example-topology-soak.mjs
@@ -4,9 +4,11 @@ import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const root = resolve(import.meta.dirname, "../..");
-const registry = JSON.parse(
-  readFileSync(resolve(root, "dev/example-topology-scenarios.json"), "utf8"),
-);
+const registryPath = process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY
+  ? resolve(process.env.JAZZ_EXAMPLE_TOPOLOGY_REGISTRY)
+  : resolve(root, "dev/example-topology-scenarios.json");
+const registry = JSON.parse(readFileSync(registryPath, "utf8"));
+validateRegistry(registry);
 let output = "target/example-topology-soak";
 let seedCount = 3;
 let watchdogSeconds = 90;
@@ -39,9 +41,10 @@ for (const scenario of scenarios) {
   for (let index = 0; index < seedCount; index++) {
     const seed = fixedSeeds[index] ?? 1000 + (index - fixedSeeds.length) * 7919;
     const logName = `${scenario.id.replaceAll(/[^a-zA-Z0-9.-]/g, "-")}-seed-${seed}.log`;
-    const replay = [`JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed}`, ...scenario.argv.map(shellQuote)].join(
+    const command = [`JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed}`, ...scenario.argv.map(shellQuote)].join(
       " ",
     );
+    const replay = scenario.cwd === "." ? command : `cd ${shellQuote(scenario.cwd)} && ${command}`;
     const started = Date.now();
     const result = spawnSync(scenario.argv[0], scenario.argv.slice(1), {
       cwd: resolve(root, scenario.cwd),
@@ -85,6 +88,33 @@ function positiveInteger(value, option) {
 
 function shellQuote(value) {
   return /^[a-zA-Z0-9_./:@=-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function validateRegistry(value) {
+  if (value?.schemaVersion !== 1 || !Array.isArray(value.scenarios)) {
+    usage("scenario registry must have schemaVersion 1 and a scenarios array");
+  }
+  const ids = new Set();
+  for (const scenario of value.scenarios) {
+    if (typeof scenario?.id !== "string" || scenario.id.length === 0) {
+      usage("each scenario requires a non-empty id");
+    }
+    if (ids.has(scenario.id)) usage(`duplicate scenario id: ${scenario.id}`);
+    ids.add(scenario.id);
+    if (!Array.isArray(scenario.topology) || scenario.topology.length === 0) {
+      usage(`scenario ${scenario.id} requires at least one topology`);
+    }
+    if (typeof scenario.cwd !== "string" || scenario.cwd.length === 0) {
+      usage(`scenario ${scenario.id} requires cwd`);
+    }
+    if (
+      !Array.isArray(scenario.argv) ||
+      scenario.argv.length === 0 ||
+      scenario.argv.some((argument) => typeof argument !== "string")
+    ) {
+      usage(`scenario ${scenario.id} requires a non-empty string argv`);
+    }
+  }
 }
 
 function usage(error) {

--- a/dev/gates/test/example-topology-soak.test.mjs
+++ b/dev/gates/test/example-topology-soak.test.mjs
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
@@ -9,7 +8,7 @@ const root = resolve(import.meta.dirname, "../../..");
 const runner = resolve(root, "dev/gates/run-example-topology-soak.mjs");
 
 test("records pass, failure, timeout, and reproducible commands", () => {
-  const temporary = mkdtempSync(resolve(tmpdir(), "jazz-topology-soak-"));
+  const temporary = mkdtempSync(resolve(root, "target/jazz-topology-soak-"));
   const registry = resolve(temporary, "registry.json");
   const output = resolve(temporary, "output");
   writeFileSync(
@@ -55,10 +54,11 @@ test("records pass, failure, timeout, and reproducible commands", () => {
     /^cd packages\/jazz-tools && JAZZ_EXAMPLE_TOPOLOGY_SEED=11 node -e /,
   );
   assert.equal(summary.failures.length, 2);
+  rmSync(temporary, { recursive: true });
 });
 
 test("rejects duplicate scenario ids", () => {
-  const temporary = mkdtempSync(resolve(tmpdir(), "jazz-topology-soak-"));
+  const temporary = mkdtempSync(resolve(root, "target/jazz-topology-soak-"));
   const registry = resolve(temporary, "registry.json");
   writeFileSync(
     registry,
@@ -77,4 +77,58 @@ test("rejects duplicate scenario ids", () => {
   });
   assert.equal(result.status, 2);
   assert.match(result.stderr, /duplicate scenario id: duplicate/);
+  rmSync(temporary, { recursive: true });
 });
+
+test("timeout terminates descendants", async () => {
+  const temporary = mkdtempSync(resolve(root, "target/jazz-topology-soak-"));
+  const registry = resolve(temporary, "registry.json");
+  const childPid = resolve(temporary, "child.pid");
+  const program = `
+    const { spawn } = require("node:child_process");
+    const { writeFileSync } = require("node:fs");
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    writeFileSync(${JSON.stringify(childPid)}, String(child.pid));
+    setInterval(() => {}, 1000);
+  `;
+  writeFileSync(
+    registry,
+    JSON.stringify({
+      schemaVersion: 1,
+      scenarios: [
+        {
+          id: "planted.descendant-timeout",
+          topology: ["fixture"],
+          cwd: ".",
+          argv: ["node", "-e", program],
+        },
+      ],
+    }),
+  );
+  const result = spawnSync(
+    "node",
+    [runner, "--seed-count", "1", "--watchdog-seconds", "1", "--output", temporary],
+    {
+      cwd: root,
+      env: { ...process.env, JAZZ_EXAMPLE_TOPOLOGY_REGISTRY: registry },
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1, result.stderr);
+  const pid = Number(readFileSync(childPid, "utf8"));
+  await assertProcessGone(pid);
+  rmSync(temporary, { recursive: true });
+});
+
+async function assertProcessGone(pid) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      process.kill(pid, 0);
+      await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+    } catch (error) {
+      if (error.code === "ESRCH") return;
+      throw error;
+    }
+  }
+  assert.fail(`descendant process ${pid} survived timeout`);
+}

--- a/dev/gates/test/example-topology-soak.test.mjs
+++ b/dev/gates/test/example-topology-soak.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
@@ -87,7 +88,7 @@ test("timeout terminates descendants", async () => {
   const program = `
     const { spawn } = require("node:child_process");
     const { writeFileSync } = require("node:fs");
-    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore" });
     writeFileSync(${JSON.stringify(childPid)}, String(child.pid));
     setInterval(() => {}, 1000);
   `;
@@ -118,6 +119,34 @@ test("timeout terminates descendants", async () => {
   const pid = Number(readFileSync(childPid, "utf8"));
   await assertProcessGone(pid);
   rmSync(temporary, { recursive: true });
+});
+
+test("rejects an output path that escapes through a symlink", () => {
+  const temporary = mkdtempSync(resolve(root, "target/jazz-topology-soak-"));
+  const outside = mkdtempSync(resolve(tmpdir(), "jazz-topology-outside-"));
+  const registry = resolve(temporary, "registry.json");
+  const link = resolve(temporary, "outside-link");
+  symlinkSync(outside, link, "dir");
+  writeFileSync(
+    registry,
+    JSON.stringify({
+      schemaVersion: 1,
+      scenarios: [
+        { id: "planted.pass", topology: ["fixture"], cwd: ".", argv: ["node", "-e", ""] },
+      ],
+    }),
+  );
+  const escapedOutput = resolve(link, "should-not-exist");
+  const result = spawnSync("node", [runner, "--seed-count", "1", "--output", escapedOutput], {
+    cwd: root,
+    env: { ...process.env, JAZZ_EXAMPLE_TOPOLOGY_REGISTRY: registry },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /output must remain inside the repository/);
+  assert.equal(existsSync(resolve(outside, "should-not-exist")), false);
+  rmSync(temporary, { recursive: true });
+  rmSync(outside, { recursive: true });
 });
 
 async function assertProcessGone(pid) {

--- a/dev/gates/test/example-topology-soak.test.mjs
+++ b/dev/gates/test/example-topology-soak.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const root = resolve(import.meta.dirname, "../../..");
+const runner = resolve(root, "dev/gates/run-example-topology-soak.mjs");
+
+test("records pass, failure, timeout, and reproducible commands", () => {
+  const temporary = mkdtempSync(resolve(tmpdir(), "jazz-topology-soak-"));
+  const registry = resolve(temporary, "registry.json");
+  const output = resolve(temporary, "output");
+  writeFileSync(
+    registry,
+    JSON.stringify({
+      schemaVersion: 1,
+      scenarios: [
+        { id: "planted.pass", topology: ["fixture"], cwd: ".", argv: ["node", "-e", ""] },
+        {
+          id: "planted.failure",
+          topology: ["fixture"],
+          cwd: "packages/jazz-tools",
+          argv: ["node", "-e", "process.exit(7)"],
+        },
+        {
+          id: "planted.timeout",
+          topology: ["fixture"],
+          cwd: ".",
+          argv: ["node", "-e", "setTimeout(() => {}, 5000)"],
+        },
+      ],
+    }),
+  );
+
+  const result = spawnSync(
+    "node",
+    [runner, "--seed-count", "1", "--watchdog-seconds", "1", "--output", output],
+    {
+      cwd: root,
+      env: { ...process.env, JAZZ_EXAMPLE_TOPOLOGY_REGISTRY: registry },
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1, result.stderr);
+  const summary = JSON.parse(readFileSync(resolve(output, "summary.json"), "utf8"));
+  assert.deepEqual(
+    summary.cases.map(({ status }) => status),
+    ["passed", "failed", "timeout"],
+  );
+  assert.equal(summary.cases[1].exitCode, 7);
+  assert.match(
+    summary.cases[1].replay,
+    /^cd packages\/jazz-tools && JAZZ_EXAMPLE_TOPOLOGY_SEED=11 node -e /,
+  );
+  assert.equal(summary.failures.length, 2);
+});
+
+test("rejects duplicate scenario ids", () => {
+  const temporary = mkdtempSync(resolve(tmpdir(), "jazz-topology-soak-"));
+  const registry = resolve(temporary, "registry.json");
+  writeFileSync(
+    registry,
+    JSON.stringify({
+      schemaVersion: 1,
+      scenarios: [
+        { id: "duplicate", topology: ["fixture"], cwd: ".", argv: ["node", "-e", ""] },
+        { id: "duplicate", topology: ["fixture"], cwd: ".", argv: ["node", "-e", ""] },
+      ],
+    }),
+  );
+  const result = spawnSync("node", [runner, "--list"], {
+    cwd: root,
+    env: { ...process.env, JAZZ_EXAMPLE_TOPOLOGY_REGISTRY: registry },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /duplicate scenario id: duplicate/);
+});

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -127,6 +127,7 @@
     "check": "tsc --noEmit",
     "test": "pnpm test:browser:contract || status=1; pnpm test:node || status=1; pnpm test:react || status=1; pnpm test:svelte || status=1; pnpm test:solid || status=1; pnpm typecheck:react-native || status=1; exit ${status:-0}",
     "test:node": "vitest run --config vitest.config.ts",
+    "test:topology-fixture": "vitest run --config vitest.config.ts tests/topology/harness.test.ts",
     "test:react": "vitest run --config vitest.config.react.ts",
     "test:solid": "vitest run --config vitest.config.solid.ts",
     "test:svelte": "vitest run --config vitest.config.svelte.ts",

--- a/packages/jazz-tools/tests/browser/topology-harness.ts
+++ b/packages/jazz-tools/tests/browser/topology-harness.ts
@@ -1,0 +1,21 @@
+import { commands } from "vitest/browser";
+import type { TopologyReporter } from "../topology/harness.js";
+export * from "../topology/harness.js";
+
+declare module "vitest/internal/browser" {
+  interface BrowserCommands {
+    jazzBrowserTopologyLog: (
+      status: "start" | "complete" | "failed",
+      label: string,
+      elapsedMs: number,
+    ) => Promise<void>;
+  }
+}
+
+/** Reporter which mirrors browser lifecycle phases to the Node test process. */
+export const browserTopologyReporter: TopologyReporter = {
+  phase(status, label, elapsedMs) {
+    console.info(`[jazz-browser-topology] ${status} ${label} (${elapsedMs}ms)`);
+    void commands.jazzBrowserTopologyLog(status, label, elapsedMs).catch(() => undefined);
+  },
+};

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -95,4 +95,44 @@ describe("shared example topology harness", () => {
     expect(cleanedUp).toBe(true);
     expect(postTimeoutEffect).toBe(false);
   });
+
+  it("aborts timed-out cleanup before it can mutate", async () => {
+    let postTimeoutEffect = false;
+    await expect(
+      runTopologyScenario({
+        id: "harness.fixture.cleanup-timeout",
+        topology: ["fixture"],
+        seed: 11,
+        phaseTimeoutMs: 50,
+        faultTimeoutMs: 50,
+        cleanupTimeoutMs: 5,
+        targets: {},
+        phases: [],
+        replay: "cleanup-timeout-fixture",
+        cleanup: ({ signal }) =>
+          new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+              postTimeoutEffect = true;
+              resolve();
+            }, 30);
+            signal.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(timer);
+                resolve();
+              },
+              { once: true },
+            );
+          }),
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof TopologyScenarioError &&
+        error.receipt.cleanup?.status === "failed" &&
+        error.receipt.cleanup.elapsedMs >= 5 &&
+        error.receipt.cleanup.error?.includes("cleanup timed out"),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(postTimeoutEffect).toBe(false);
+  });
 });

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -3,21 +3,19 @@ import {
   TopologyScenarioError,
   deterministicRandom,
   runTopologyScenario,
-  type TopologyFaultKind,
+  type TopologyFaultTarget,
 } from "./harness.js";
 
 describe("shared example topology harness", () => {
   it("runs deterministic phases and every fault callback with a replayable receipt", async () => {
     const seed = Number(process.env.JAZZ_EXAMPLE_TOPOLOGY_SEED ?? 29);
     const calls: string[] = [];
-    const target = Object.fromEntries(
-      (["disconnect", "reconnect", "restart", "failure"] as const).map((kind) => [
-        kind,
-        async () => {
-          calls.push(kind);
-        },
-      ]),
-    ) as Record<TopologyFaultKind, () => Promise<void>>;
+    const target: TopologyFaultTarget = {
+      disconnect: async () => void calls.push("disconnect"),
+      reconnect: async () => void calls.push("reconnect"),
+      restart: async () => void calls.push("restart"),
+      failure: async () => void calls.push("failure"),
+    };
     const receipt = await runTopologyScenario({
       id: "harness.fixture.cross-topology-faults",
       topology: ["core", "edge", "browser", "native", "fixture"],
@@ -46,10 +44,13 @@ describe("shared example topology harness", () => {
       "restart",
       "failure",
     ]);
+    expect(receipt.phases[0]?.status).toBe("completed");
+    expect(receipt.faults.every(({ status }) => status === "completed")).toBe(true);
   });
 
   it("bounds a stalled phase and retains its exact replay command", async () => {
-    const pending = new Promise<void>(() => undefined);
+    let postTimeoutEffect = false;
+    let cleanedUp = false;
     await expect(
       runTopologyScenario({
         id: "harness.fixture.timeout",
@@ -59,13 +60,39 @@ describe("shared example topology harness", () => {
         faultTimeoutMs: 5,
         targets: {},
         replay: "JAZZ_EXAMPLE_TOPOLOGY_SEED=11 replay-fixture",
-        phases: [{ name: "planted stall", run: () => pending }],
+        cleanup: async () => {
+          cleanedUp = true;
+        },
+        phases: [
+          {
+            name: "planted stall",
+            run: ({ signal }) =>
+              new Promise<void>((resolve) => {
+                const timer = setTimeout(() => {
+                  postTimeoutEffect = true;
+                  resolve();
+                }, 30);
+                signal.addEventListener(
+                  "abort",
+                  () => {
+                    clearTimeout(timer);
+                    resolve();
+                  },
+                  { once: true },
+                );
+              }),
+          },
+        ],
       }),
     ).rejects.toSatisfy(
       (error: unknown) =>
         error instanceof TopologyScenarioError &&
         error.receipt.replay.includes("JAZZ_EXAMPLE_TOPOLOGY_SEED=11") &&
-        error.receipt.error?.includes("planted stall"),
+        error.receipt.error?.includes("planted stall") &&
+        error.receipt.phases[0]?.status === "failed",
     );
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(cleanedUp).toBe(true);
+    expect(postTimeoutEffect).toBe(false);
   });
 });

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  TopologyScenarioError,
+  deterministicRandom,
+  runTopologyScenario,
+  type TopologyFaultKind,
+} from "./harness.js";
+
+describe("shared example topology harness", () => {
+  it("runs deterministic phases and every fault callback with a replayable receipt", async () => {
+    const seed = Number(process.env.JAZZ_EXAMPLE_TOPOLOGY_SEED ?? 29);
+    const calls: string[] = [];
+    const target = Object.fromEntries(
+      (["disconnect", "reconnect", "restart", "failure"] as const).map((kind) => [
+        kind,
+        async () => {
+          calls.push(kind);
+        },
+      ]),
+    ) as Record<TopologyFaultKind, () => Promise<void>>;
+    const receipt = await runTopologyScenario({
+      id: "harness.fixture.cross-topology-faults",
+      topology: ["core", "edge", "browser", "native", "fixture"],
+      seed,
+      phaseTimeoutMs: 500,
+      faultTimeoutMs: 500,
+      targets: { subject: target },
+      replay: `JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed} pnpm --filter jazz-tools test:topology-fixture`,
+      phases: [
+        {
+          name: "deterministic setup",
+          run: async ({ random }) => calls.push(random().toFixed(8)),
+          faultsAfter: (["disconnect", "reconnect", "restart", "failure"] as const).map((kind) => ({
+            kind,
+            target: "subject",
+          })),
+        },
+      ],
+    });
+    const expectedRandom = deterministicRandom(seed)().toFixed(8);
+    expect(calls).toEqual([expectedRandom, "disconnect", "reconnect", "restart", "failure"]);
+    expect(receipt).toMatchObject({ status: "passed", seed, schemaVersion: 1 });
+    expect(receipt.faults.map(({ kind }) => kind)).toEqual([
+      "disconnect",
+      "reconnect",
+      "restart",
+      "failure",
+    ]);
+  });
+
+  it("bounds a stalled phase and retains its exact replay command", async () => {
+    const pending = new Promise<void>(() => undefined);
+    await expect(
+      runTopologyScenario({
+        id: "harness.fixture.timeout",
+        topology: ["fixture"],
+        seed: 11,
+        phaseTimeoutMs: 5,
+        faultTimeoutMs: 5,
+        targets: {},
+        replay: "JAZZ_EXAMPLE_TOPOLOGY_SEED=11 replay-fixture",
+        phases: [{ name: "planted stall", run: () => pending }],
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof TopologyScenarioError &&
+        error.receipt.replay.includes("JAZZ_EXAMPLE_TOPOLOGY_SEED=11") &&
+        error.receipt.error?.includes("planted stall"),
+    );
+  });
+});

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -41,7 +41,7 @@ export interface TopologyScenario {
   targets: Readonly<Record<string, TopologyFaultTarget>>;
   phases: readonly TopologyPhase[];
   replay: string;
-  cleanup?: () => Promise<void>;
+  cleanup?: (context: TopologyOperationContext) => Promise<void>;
   cleanupTimeoutMs?: number;
 }
 
@@ -62,6 +62,7 @@ export interface TopologyReceipt {
   elapsedMs: number;
   phases: Array<TopologyActivityReceipt & { name: string }>;
   faults: Array<TopologyActivityReceipt & { kind: TopologyFaultKind; target: string }>;
+  cleanup?: TopologyActivityReceipt;
   replay: string;
   error?: string;
 }
@@ -134,7 +135,7 @@ export async function runTopologyScenario(
             throw new Error(`topology target ${fault.target} does not support ${fault.kind}`);
           }
           await withTopologyTimeout(
-            operation,
+            (signal) => operation({ signal }),
             fault.timeoutMs ?? scenario.faultTimeoutMs,
             `topology fault timed out: ${fault.kind} ${fault.target}`,
           );
@@ -155,14 +156,23 @@ export async function runTopologyScenario(
     scenarioError = error;
   } finally {
     if (scenario.cleanup) {
+      const started = now();
+      const activity: TopologyActivityReceipt = { status: "attempted", elapsedMs: 0 };
+      receipt.cleanup = activity;
       try {
         await withTopologyTimeout(
-          () => scenario.cleanup!(),
+          (signal) => scenario.cleanup!({ signal }),
           scenario.cleanupTimeoutMs ?? scenario.faultTimeoutMs,
           "topology scenario cleanup timed out",
         );
+        Object.assign(activity, { status: "completed", elapsedMs: elapsed(started) });
       } catch (cleanupError) {
         const message = `cleanup failed: ${errorMessage(cleanupError)}`;
+        Object.assign(activity, {
+          status: "failed",
+          elapsedMs: elapsed(started),
+          error: errorMessage(cleanupError),
+        });
         receipt.status = "failed";
         receipt.error = receipt.error ? `${receipt.error}; ${message}` : message;
         scenarioError ??= cleanupError;

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -2,11 +2,15 @@ export type TopologyKind = "core" | "edge" | "browser" | "native" | "fixture";
 
 export type TopologyFaultKind = "disconnect" | "reconnect" | "restart" | "failure";
 
+export interface TopologyOperationContext {
+  signal: AbortSignal;
+}
+
 export interface TopologyFaultTarget {
-  disconnect?: () => Promise<void>;
-  reconnect?: () => Promise<void>;
-  restart?: () => Promise<void>;
-  fail?: () => Promise<void>;
+  disconnect?: (context: TopologyOperationContext) => Promise<void>;
+  reconnect?: (context: TopologyOperationContext) => Promise<void>;
+  restart?: (context: TopologyOperationContext) => Promise<void>;
+  failure?: (context: TopologyOperationContext) => Promise<void>;
 }
 
 export interface TopologyFault {
@@ -18,6 +22,7 @@ export interface TopologyFault {
 export interface TopologyPhaseContext {
   seed: number;
   random: () => number;
+  signal: AbortSignal;
 }
 
 export interface TopologyPhase {
@@ -36,6 +41,16 @@ export interface TopologyScenario {
   targets: Readonly<Record<string, TopologyFaultTarget>>;
   phases: readonly TopologyPhase[];
   replay: string;
+  cleanup?: () => Promise<void>;
+  cleanupTimeoutMs?: number;
+}
+
+export type TopologyActivityStatus = "attempted" | "completed" | "failed";
+
+export interface TopologyActivityReceipt {
+  status: TopologyActivityStatus;
+  elapsedMs: number;
+  error?: string;
 }
 
 export interface TopologyReceipt {
@@ -45,8 +60,8 @@ export interface TopologyReceipt {
   seed: number;
   status: "passed" | "failed";
   elapsedMs: number;
-  phases: Array<{ name: string; elapsedMs: number }>;
-  faults: Array<{ kind: TopologyFaultKind; target: string; elapsedMs: number }>;
+  phases: Array<TopologyActivityReceipt & { name: string }>;
+  faults: Array<TopologyActivityReceipt & { kind: TopologyFaultKind; target: string }>;
   replay: string;
   error?: string;
 }
@@ -75,49 +90,87 @@ export async function runTopologyScenario(
   };
   const scenarioStarted = now();
   const random = deterministicRandom(scenario.seed);
+  let scenarioError: unknown;
   try {
     for (const phase of scenario.phases) {
       const started = now();
+      const activity: TopologyReceipt["phases"][number] = {
+        name: phase.name,
+        status: "attempted",
+        elapsedMs: 0,
+      };
+      receipt.phases.push(activity);
       reporter.phase("start", phase.name, 0);
       try {
         await withTopologyTimeout(
-          phase.run({ seed: scenario.seed, random }),
+          (signal) => phase.run({ seed: scenario.seed, random, signal }),
           phase.timeoutMs ?? scenario.phaseTimeoutMs,
           `topology phase timed out: ${phase.name}`,
         );
         const elapsedMs = elapsed(started);
-        receipt.phases.push({ name: phase.name, elapsedMs });
+        Object.assign(activity, { status: "completed", elapsedMs });
         reporter.phase("complete", phase.name, elapsedMs);
       } catch (error) {
-        reporter.phase("failed", phase.name, elapsed(started));
+        Object.assign(activity, {
+          status: "failed",
+          elapsedMs: elapsed(started),
+          error: errorMessage(error),
+        });
+        reporter.phase("failed", phase.name, activity.elapsedMs);
         throw error;
       }
       for (const fault of phase.faultsAfter ?? []) {
-        const target = scenario.targets[fault.target];
-        const operation = target?.[fault.kind];
-        if (!operation) {
-          throw new Error(`topology target ${fault.target} does not support ${fault.kind}`);
-        }
         const started = now();
-        await withTopologyTimeout(
-          operation(),
-          fault.timeoutMs ?? scenario.faultTimeoutMs,
-          `topology fault timed out: ${fault.kind} ${fault.target}`,
-        );
-        receipt.faults.push({
+        const activity: TopologyReceipt["faults"][number] = {
           kind: fault.kind,
           target: fault.target,
-          elapsedMs: elapsed(started),
-        });
+          status: "attempted",
+          elapsedMs: 0,
+        };
+        receipt.faults.push(activity);
+        try {
+          const operation = scenario.targets[fault.target]?.[fault.kind];
+          if (!operation) {
+            throw new Error(`topology target ${fault.target} does not support ${fault.kind}`);
+          }
+          await withTopologyTimeout(
+            operation,
+            fault.timeoutMs ?? scenario.faultTimeoutMs,
+            `topology fault timed out: ${fault.kind} ${fault.target}`,
+          );
+          Object.assign(activity, { status: "completed", elapsedMs: elapsed(started) });
+        } catch (error) {
+          Object.assign(activity, {
+            status: "failed",
+            elapsedMs: elapsed(started),
+            error: errorMessage(error),
+          });
+          throw error;
+        }
       }
     }
   } catch (error) {
     receipt.status = "failed";
-    receipt.error = error instanceof Error ? error.message : String(error);
-    throw new TopologyScenarioError(receipt, error);
+    receipt.error = errorMessage(error);
+    scenarioError = error;
   } finally {
+    if (scenario.cleanup) {
+      try {
+        await withTopologyTimeout(
+          () => scenario.cleanup!(),
+          scenario.cleanupTimeoutMs ?? scenario.faultTimeoutMs,
+          "topology scenario cleanup timed out",
+        );
+      } catch (cleanupError) {
+        const message = `cleanup failed: ${errorMessage(cleanupError)}`;
+        receipt.status = "failed";
+        receipt.error = receipt.error ? `${receipt.error}; ${message}` : message;
+        scenarioError ??= cleanupError;
+      }
+    }
     receipt.elapsedMs = elapsed(scenarioStarted);
   }
+  if (receipt.status === "failed") throw new TopologyScenarioError(receipt, scenarioError);
   return receipt;
 }
 
@@ -142,21 +195,31 @@ export function deterministicRandom(seed: number): () => number {
 }
 
 export async function withTopologyTimeout<T>(
-  operation: Promise<T>,
+  operation: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
   label: string,
 ): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const controller = new AbortController();
+  const pending = operation(controller.signal);
   try {
     return await Promise.race([
-      operation,
+      pending,
       new Promise<T>((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`${label} after ${timeoutMs}ms`)), timeoutMs);
+        timer = setTimeout(() => {
+          const error = new Error(`${label} after ${timeoutMs}ms`);
+          reject(error);
+          controller.abort(error);
+        }, timeoutMs);
       }),
     ]);
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function now(): number {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -1,0 +1,168 @@
+export type TopologyKind = "core" | "edge" | "browser" | "native" | "fixture";
+
+export type TopologyFaultKind = "disconnect" | "reconnect" | "restart" | "failure";
+
+export interface TopologyFaultTarget {
+  disconnect?: () => Promise<void>;
+  reconnect?: () => Promise<void>;
+  restart?: () => Promise<void>;
+  fail?: () => Promise<void>;
+}
+
+export interface TopologyFault {
+  kind: TopologyFaultKind;
+  target: string;
+  timeoutMs?: number;
+}
+
+export interface TopologyPhaseContext {
+  seed: number;
+  random: () => number;
+}
+
+export interface TopologyPhase {
+  name: string;
+  run: (context: TopologyPhaseContext) => Promise<void>;
+  faultsAfter?: readonly TopologyFault[];
+  timeoutMs?: number;
+}
+
+export interface TopologyScenario {
+  id: string;
+  topology: readonly TopologyKind[];
+  seed: number;
+  phaseTimeoutMs: number;
+  faultTimeoutMs: number;
+  targets: Readonly<Record<string, TopologyFaultTarget>>;
+  phases: readonly TopologyPhase[];
+  replay: string;
+}
+
+export interface TopologyReceipt {
+  schemaVersion: 1;
+  scenario: string;
+  topology: readonly TopologyKind[];
+  seed: number;
+  status: "passed" | "failed";
+  elapsedMs: number;
+  phases: Array<{ name: string; elapsedMs: number }>;
+  faults: Array<{ kind: TopologyFaultKind; target: string; elapsedMs: number }>;
+  replay: string;
+  error?: string;
+}
+
+export interface TopologyReporter {
+  phase(status: "start" | "complete" | "failed", label: string, elapsedMs: number): void;
+}
+
+const noReporter: TopologyReporter = { phase() {} };
+
+/** Run app-owned phases with shared deterministic fault and timeout plumbing. */
+export async function runTopologyScenario(
+  scenario: TopologyScenario,
+  reporter: TopologyReporter = noReporter,
+): Promise<TopologyReceipt> {
+  const receipt: TopologyReceipt = {
+    schemaVersion: 1,
+    scenario: scenario.id,
+    topology: scenario.topology,
+    seed: scenario.seed,
+    status: "passed",
+    elapsedMs: 0,
+    phases: [],
+    faults: [],
+    replay: scenario.replay,
+  };
+  const scenarioStarted = now();
+  const random = deterministicRandom(scenario.seed);
+  try {
+    for (const phase of scenario.phases) {
+      const started = now();
+      reporter.phase("start", phase.name, 0);
+      try {
+        await withTopologyTimeout(
+          phase.run({ seed: scenario.seed, random }),
+          phase.timeoutMs ?? scenario.phaseTimeoutMs,
+          `topology phase timed out: ${phase.name}`,
+        );
+        const elapsedMs = elapsed(started);
+        receipt.phases.push({ name: phase.name, elapsedMs });
+        reporter.phase("complete", phase.name, elapsedMs);
+      } catch (error) {
+        reporter.phase("failed", phase.name, elapsed(started));
+        throw error;
+      }
+      for (const fault of phase.faultsAfter ?? []) {
+        const target = scenario.targets[fault.target];
+        const operation = target?.[fault.kind];
+        if (!operation) {
+          throw new Error(`topology target ${fault.target} does not support ${fault.kind}`);
+        }
+        const started = now();
+        await withTopologyTimeout(
+          operation(),
+          fault.timeoutMs ?? scenario.faultTimeoutMs,
+          `topology fault timed out: ${fault.kind} ${fault.target}`,
+        );
+        receipt.faults.push({
+          kind: fault.kind,
+          target: fault.target,
+          elapsedMs: elapsed(started),
+        });
+      }
+    }
+  } catch (error) {
+    receipt.status = "failed";
+    receipt.error = error instanceof Error ? error.message : String(error);
+    throw new TopologyScenarioError(receipt, error);
+  } finally {
+    receipt.elapsedMs = elapsed(scenarioStarted);
+  }
+  return receipt;
+}
+
+export class TopologyScenarioError extends Error {
+  constructor(
+    readonly receipt: TopologyReceipt,
+    options?: unknown,
+  ) {
+    super(`${receipt.scenario} seed=${receipt.seed}: ${receipt.error}`, { cause: options });
+  }
+}
+
+export function deterministicRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+export async function withTopologyTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function now(): number {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+function elapsed(started: number): number {
+  return Math.max(0, Math.round(now() - started));
+}

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -90,6 +90,9 @@ export default defineConfig({
         },
       ],
       commands: {
+        jazzBrowserTopologyLog: async (_context, status, label, elapsedMs) => {
+          console.info(`[jazz-browser-topology] ${status} ${label} (${elapsedMs}ms)`);
+        },
         jazzServerInfo: async (_context, appId, schema) => jazzServerInfo(appId, schema),
         jazzServerBlockNetwork: async ({ context }, serverUrl) =>
           blockJazzServerNetwork(context, serverUrl),

--- a/packages/jazz-tools/vitest.config.ts
+++ b/packages/jazz-tools/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     // Native/WASM integration tests use process isolation; this is unrelated
     // to the removed SQLite docs-index resolver.
     pool: "forks",
-    include: ["src/**/*.test.ts", "tests/ts-dsl/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "tests/ts-dsl/**/*.test.ts", "tests/topology/**/*.test.ts"],
     exclude: ["tests/browser/**", "node_modules/**", "src/**/*.svelte.test.ts", "src/solid/**"],
   },
 });


### PR DESCRIPTION
🤖 Establishes shared, app-agnostic topology and fault-test plumbing for the example catalogue.

- deterministic, bounded scenario phases across core, edge, browser, and native roles
- disconnect, reconnect, restart, and injected-failure adapters
- cooperative timeout cancellation with bounded cleanup
- receipts containing attempted/completed/failed activities, durations, errors, exact seeds, and replay commands
- descendant process-tree termination for pnpm, Vitest, browser, and server runs
- symlink-safe repository confinement for manifests, working directories, and outputs
- manifest-driven registration into a shared soak runner
- integration seams documented for the existing BandChat, BigLabel, and MusicAgent topology branches

This deliberately shares only topology/fault plumbing; app logic and scenarios remain self-contained.

Verification:
- topology fixture: 3/3
- process/soak runner tests: 4/4, including planted timeout, detached-descendant, and symlink-escape failures
- deterministic fixture soak seed 11
- jazz-tools TypeScript and lint checks
- independent adversarial review approved after two fix/review iterations

The current PR is the tested harness/local soak entrypoint. Registering each real app and attaching browser-capable nightly CI follows on the app branches.