### PR TITLE
Fix correlated authorization join carriers

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering/collect_layout.rs
+++ b/crates/jazz/src/node/query_engine/lowering/collect_layout.rs
@@ -55,7 +55,7 @@ pub(super) fn collect_layout(
             })
         })
         .collect::<Vec<_>>();
-    let root_occurrence_inputs = root_join_occurrence_fields(plan, resolved_sources)?
+    let root_occurrence_inputs = root_join_occurrence_fields(plan, resolved_sources, request)?
         .into_iter()
         .filter(|(name, _)| available_fields.contains(name))
         .map(|(name, value_type)| {

--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -1190,6 +1190,12 @@ fn lower_linear_plan_steps_cached(
                     Some(LinearStep::Join { .. })
                 );
                 if *mode == JoinMode::Inner && next_is_join {
+                    // Consecutive joins must retain the right input for the
+                    // next predicate. Public queries also use those values as
+                    // occurrence carriers; authorization subplans keep the
+                    // same single lowering path, but mark them internal so a
+                    // decision terminal never asks for public row identity.
+                    let policy_subplan = omits_public_occurrence_carriers(request);
                     let (_, right_nullable, right_depths, right_fields) = last_join_right
                         .take()
                         .expect("inner join records its right input");
@@ -1207,7 +1213,11 @@ fn lower_linear_plan_steps_cached(
                     let mut next_nullable = nullable_fields.clone();
                     let mut next_depths = nullable_field_depths.clone();
                     for field in right_fields {
-                        let output = format!("__flat_join_source_{step_index}_{field}");
+                        let output = if policy_subplan {
+                            format!("__policy_join_source_{step_index}_{field}")
+                        } else {
+                            format!("__flat_join_source_{step_index}_{field}")
+                        };
                         projection.push(ProjectField::renamed(right_field(&field), output.clone()));
                         let nullable_depth = right_depths.get(&field).copied().unwrap_or(0);
                         accumulated_join_fields.insert(
@@ -1241,7 +1251,7 @@ fn lower_linear_plan_steps_cached(
                         &introduced_route_fields,
                     );
                     let mut occurrence_fields = BTreeSet::new();
-                    if *mode == JoinMode::Inner {
+                    if *mode == JoinMode::Inner && !omits_public_occurrence_carriers(request) {
                         for ((source_id, field), (output, _)) in &accumulated_join_fields {
                             let is_row_id = resolved_sources
                                 .get(source_id)
@@ -1464,6 +1474,18 @@ fn lower_linear_plan_steps_cached(
 
 fn uses_policy_value_comparison(request: &QueryProgramRequest) -> bool {
     matches!(request.policy, PolicyContext::AuthorizationSubplan { .. })
+}
+
+/// Policy-predicate programs reuse relation lowering but do not publish rows.
+/// Their intermediate join values remain available to later predicates, never
+/// becoming occurrence identity that a public terminal must retain.
+fn omits_public_occurrence_carriers(request: &QueryProgramRequest) -> bool {
+    uses_policy_value_comparison(request)
+        || request
+            .output
+            .app_rows
+            .as_ref()
+            .is_some_and(|output| !output.public_terminal)
 }
 
 fn policy_join_if_needed(

--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -1251,7 +1251,12 @@ fn lower_linear_plan_steps_cached(
                         &introduced_route_fields,
                     );
                     let mut occurrence_fields = BTreeSet::new();
-                    if *mode == JoinMode::Inner && !omits_public_occurrence_carriers(request) {
+                    if !omits_public_occurrence_carriers(request) {
+                        // A trailing semi-join filters the complete public
+                        // tuple but contributes no occurrence of its own.
+                        // Preserve the earlier inner-join row IDs from the
+                        // left input: terminals still use them to distinguish
+                        // public root occurrences.
                         for ((source_id, field), (output, _)) in &accumulated_join_fields {
                             let is_row_id = resolved_sources
                                 .get(source_id)
@@ -1264,6 +1269,8 @@ fn lower_linear_plan_steps_cached(
                                 occurrence_fields.insert(output.clone());
                             }
                         }
+                    }
+                    if *mode == JoinMode::Inner && !omits_public_occurrence_carriers(request) {
                         if let Some(right_source_id) = right.root_source() {
                             let right_source = resolved_sources.get(right_source_id).ok_or_else(|| {
                                 UnsupportedReason::Operator(format!(

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -957,7 +957,13 @@ pub(super) fn root_join_occurrence_fields(
 ) -> CapabilityResult<Vec<(String, ValueType)>> {
     // Authorization subplans are decision programs, not public row sets. Their
     // joins prove policy predicates and cannot contribute to a result address.
-    if matches!(request.policy, PolicyContext::AuthorizationSubplan { .. }) {
+    if matches!(request.policy, PolicyContext::AuthorizationSubplan { .. })
+        || request
+            .output
+            .app_rows
+            .as_ref()
+            .is_some_and(|output| !output.public_terminal)
+    {
         return Ok(Vec::new());
     }
     let Some(steps) = root_linear_steps(plan) else {

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -40,7 +40,7 @@ pub(super) fn lowered_terminals(
         .filter(|field| root_route_fields.contains(*field))
         .cloned()
         .collect::<BTreeSet<_>>();
-    let root_occurrence_fields = root_join_occurrence_fields(plan, resolved_sources)?
+    let root_occurrence_fields = root_join_occurrence_fields(plan, resolved_sources, request)?
         .into_iter()
         .map(|(name, _)| name)
         .filter(|name| available_fields.contains(name))
@@ -213,6 +213,7 @@ pub(super) fn lowered_terminals(
                 plan,
                 source,
                 resolved_sources,
+                request,
                 routing_param_fields.clone(),
             )?;
             // Closure membership is a root-row projection: it may discard
@@ -269,6 +270,7 @@ pub(super) fn lowered_terminals(
                         plan,
                         resolved_source,
                         resolved_sources,
+                        request,
                         claim_route_fields.clone(),
                     )?;
                     let graph = fact_terminal_graph(
@@ -305,6 +307,7 @@ pub(super) fn lowered_terminals(
                         plan,
                         resolved_source,
                         resolved_sources,
+                        request,
                         claim_route_fields.clone(),
                     )?;
                     let contribution_graph = join_contribution_membership_graph(
@@ -340,6 +343,7 @@ pub(super) fn lowered_terminals(
                     plan,
                     resolved_source,
                     resolved_sources,
+                    request,
                     BTreeSet::new(),
                 )?;
                 terminals.push(LoweredTerminal {
@@ -356,6 +360,7 @@ pub(super) fn lowered_terminals(
                     plan,
                     resolved_source,
                     resolved_sources,
+                    request,
                     BTreeSet::new(),
                 )?;
                 terminals.push(LoweredTerminal {
@@ -375,6 +380,7 @@ pub(super) fn lowered_terminals(
                     plan,
                     resolved_source,
                     resolved_sources,
+                    request,
                     BTreeSet::new(),
                 )?;
                 terminals.push(LoweredTerminal {
@@ -391,6 +397,7 @@ pub(super) fn lowered_terminals(
                     plan,
                     resolved_source,
                     resolved_sources,
+                    request,
                     BTreeSet::new(),
                 )?;
                 terminals.push(LoweredTerminal {
@@ -413,6 +420,7 @@ pub(super) fn lowered_terminals(
                 plan,
                 source,
                 resolved_sources,
+                request,
                 terminal_route_fields.clone(),
             )?;
             let terminal_graph =
@@ -945,7 +953,13 @@ fn collect_slot_input_for_value(
 pub(super) fn root_join_occurrence_fields(
     plan: &AnalyzedQueryPlan,
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
 ) -> CapabilityResult<Vec<(String, ValueType)>> {
+    // Authorization subplans are decision programs, not public row sets. Their
+    // joins prove policy predicates and cannot contribute to a result address.
+    if matches!(request.policy, PolicyContext::AuthorizationSubplan { .. }) {
+        return Ok(Vec::new());
+    }
     let Some(steps) = root_linear_steps(plan) else {
         return Ok(Vec::new());
     };
@@ -1081,6 +1095,7 @@ fn lowered_aggregate_terminals(
                 plan,
                 source,
                 &BTreeMap::new(),
+                request,
                 root_route_fields.clone(),
             )?;
             let graph = fact_terminal_graph(
@@ -1192,6 +1207,7 @@ fn fact_output(
     plan: &AnalyzedQueryPlan,
     source: &ResolvedSource,
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
     routing_param_fields: BTreeSet<String>,
 ) -> CapabilityResult<ProgramFactOutput> {
     fact_output_with_terminal(
@@ -1200,6 +1216,7 @@ fn fact_output(
         plan,
         source,
         resolved_sources,
+        request,
         routing_param_fields,
     )
 }
@@ -1210,6 +1227,7 @@ fn fact_output_with_terminal(
     plan: &AnalyzedQueryPlan,
     source: &ResolvedSource,
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
     routing_param_fields: BTreeSet<String>,
 ) -> CapabilityResult<ProgramFactOutput> {
     let schema = match key {
@@ -1230,9 +1248,10 @@ fn fact_output_with_terminal(
                 });
             }
             let version = version_witness_fields(&source.row_shape)?;
-            let occurrence_id_fields = result_occurrence_id_fields(plan, source, resolved_sources)?;
+            let occurrence_id_fields =
+                result_occurrence_id_fields(plan, source, resolved_sources, request)?;
             let occurrence_union_arm_fields =
-                result_occurrence_union_arm_fields(plan, source, resolved_sources)?;
+                result_occurrence_union_arm_fields(plan, source, resolved_sources, request)?;
             let flat_join_payload = flat_join_payload_fields(plan);
             let payload_fields = result_payload_fields(plan, source);
             let settle_position_field = flat_join_payload
@@ -1318,6 +1337,7 @@ fn result_occurrence_id_fields(
     plan: &AnalyzedQueryPlan,
     source: &ResolvedSource,
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
 ) -> CapabilityResult<Vec<String>> {
     let mut fields = vec![source.row_shape.row_uuid_field.clone()];
     if &source.row_shape.source != plan.root_source() {
@@ -1335,7 +1355,7 @@ fn result_occurrence_id_fields(
         }));
     } else {
         fields.extend(
-            root_join_occurrence_fields(plan, resolved_sources)?
+            root_join_occurrence_fields(plan, resolved_sources, request)?
                 .into_iter()
                 .filter_map(|(name, value_type)| (value_type == ValueType::Uuid).then_some(name)),
         );
@@ -1347,11 +1367,12 @@ fn result_occurrence_union_arm_fields(
     plan: &AnalyzedQueryPlan,
     source: &ResolvedSource,
     resolved_sources: &BTreeMap<SourceId, ResolvedSource>,
+    request: &QueryProgramRequest,
 ) -> CapabilityResult<BTreeMap<usize, String>> {
     if &source.row_shape.source != plan.root_source() {
         return Ok(BTreeMap::new());
     }
-    let fields = root_join_occurrence_fields(plan, resolved_sources)?;
+    let fields = root_join_occurrence_fields(plan, resolved_sources, request)?;
     let mut joined_position = 0usize;
     let mut pending_arm = None;
     let mut arms = BTreeMap::new();
@@ -1569,9 +1590,10 @@ fn fact_terminal_graph(
                 )?));
             }
             let mut occurrence_fields =
-                result_occurrence_id_fields(plan, source, resolved_sources)?;
+                result_occurrence_id_fields(plan, source, resolved_sources, request)?;
             occurrence_fields.extend(
-                result_occurrence_union_arm_fields(plan, source, resolved_sources)?.into_values(),
+                result_occurrence_union_arm_fields(plan, source, resolved_sources, request)?
+                    .into_values(),
             );
             let flat_join_payload = flat_join_payload_fields(plan);
             Ok(graph.project_fields(result_membership_fields(

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -1638,6 +1638,151 @@ fn prepared_policy_union_joins_claimless_arm_to_binding_route() {
     )));
 }
 
+// `allowedTo.insert(release)` followed by tenant-correlated `exists` checks
+// lowers to consecutive inner joins in the authorization program. Those joins
+// prove a decision; they are not a public flat result whose occurrence key
+// needs synthetic join-row carriers.
+#[test]
+fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurrence_carriers() {
+    let root = RowSetNodeId("assignment".to_owned());
+    let release_input = RowSetNodeId("release-source".to_owned());
+    let release_join = RowSetNodeId("release-allowed-to".to_owned());
+    let membership_input = RowSetNodeId("membership-source".to_owned());
+    let policy_root = RowSetNodeId("membership-tenant-check".to_owned());
+    let assignment = source("assignments", SourceRole::Root);
+    let release = source(
+        "releases",
+        SourceRole::Alias("allowed-to:release".to_owned()),
+    );
+    let membership = source(
+        "memberships",
+        SourceRole::Alias("exists:membership-tenant".to_owned()),
+    );
+    let request = QueryProgramRequest {
+        authorization_mode: QueryAuthorizationMode::TrustedServing,
+        reads: QueryReadSet::primary(ReadView {
+            read_schema: schema(0x91),
+            policy_schema: schema(0x92),
+            sources: BTreeMap::from([
+                (
+                    assignment.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    release.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    membership.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+            ]),
+        }),
+        policy: PolicyContext::AuthorizationSubplan {
+            protected_source: assignment.clone(),
+            role: PolicyDecisionRole::Write,
+            mode: PolicyEnforcementMode::Enforcing,
+            permission_subject: author(0x91),
+            claims: BTreeMap::new(),
+            attribution: None,
+        },
+        input: RowSetProgramInput {
+            shape: NormalizedRowSetShape {
+                identity: NormalizedShapeIdentity {
+                    shape_id: shape(0x91),
+                    canonical: vec![0x91],
+                },
+                root: policy_root.clone(),
+                result: ResultId::RealRow {
+                    table: "assignments".to_owned(),
+                    row: ResultRowRef::Source(assignment.clone()),
+                },
+                auxiliary_sources: BTreeSet::new(),
+                closure_paths: Vec::new(),
+                join_contributions: Vec::new(),
+                reachable_contributions: Vec::new(),
+                nodes: BTreeMap::from([
+                    (
+                        root.clone(),
+                        RowSetExpr::Source {
+                            source: assignment.clone(),
+                            visibility: RowVisibility::Visible,
+                        },
+                    ),
+                    (
+                        release_input,
+                        RowSetExpr::Source {
+                            source: release.clone(),
+                            visibility: RowVisibility::Visible,
+                        },
+                    ),
+                    (
+                        release_join.clone(),
+                        RowSetExpr::Join {
+                            left: root,
+                            right: RowSetNodeId("release-source".to_owned()),
+                            mode: JoinMode::Inner,
+                            on: PredicateExpr::Compare {
+                                left: NormalizedValueRef::RowId(RowIdRef::Source(
+                                    assignment.clone(),
+                                )),
+                                op: ComparisonOp::Eq,
+                                right: NormalizedValueRef::SourceField {
+                                    source: release.clone(),
+                                    field: "todo".to_owned(),
+                                },
+                            },
+                        },
+                    ),
+                    (
+                        membership_input,
+                        RowSetExpr::Source {
+                            source: membership.clone(),
+                            visibility: RowVisibility::Visible,
+                        },
+                    ),
+                    (
+                        policy_root,
+                        RowSetExpr::Join {
+                            left: release_join,
+                            right: RowSetNodeId("membership-source".to_owned()),
+                            mode: JoinMode::Inner,
+                            on: PredicateExpr::Compare {
+                                left: NormalizedValueRef::RowId(RowIdRef::Source(assignment)),
+                                op: ComparisonOp::Eq,
+                                right: NormalizedValueRef::SourceField {
+                                    source: membership,
+                                    field: "todo".to_owned(),
+                                },
+                            },
+                        },
+                    ),
+                ]),
+            },
+            binding: ProgramBinding {
+                id: BindingId(uuid::Uuid::from_bytes([0x91; 16])),
+                source_shape: None,
+                extra_user_params: BTreeMap::new(),
+                param_types: BTreeMap::new(),
+                claim_params: BTreeMap::new(),
+                values: BTreeMap::new(),
+            },
+        },
+        output: RowSetOutputRequest {
+            app_rows: None,
+            facts: BTreeSet::from([ProgramFactKey::AuthorizedRows]),
+        },
+    };
+
+    let program = lower_query_program(request, &mut FakeSourceResolver::default())
+        .expect("correlated write authorization should lower");
+    let graph = format!("{:?}", program.lowered.terminals);
+    assert!(
+        !graph.contains("__flat_join_source_"),
+        "authorization decision graph must not request public occurrence carriers: {graph}"
+    );
+}
+
 #[test]
 fn claim_filter_lowers_from_identity_policy_context() {
     let request = QueryProgramRequest {

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -1776,6 +1776,15 @@ fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurre
 
     let program = lower_query_program(request, &mut FakeSourceResolver::default())
         .expect("correlated write authorization should lower");
+    let graph = format!("{:?}", program.lowered.terminals);
+    assert!(
+        !graph.contains("__flat_join_source_"),
+        "authorization decision graph must not request public occurrence carriers: {graph}"
+    );
+    assert!(
+        graph.contains("__policy_join_source_0_"),
+        "the next correlated predicate still needs the first join's internal values: {graph}"
+    );
     let OutputTerminalSchema::Fact(ProgramFactOutput {
         schema: ProgramFactSchema::ResultMembership(schema),
         ..

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -1770,17 +1770,26 @@ fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurre
         },
         output: RowSetOutputRequest {
             app_rows: None,
-            facts: BTreeSet::from([ProgramFactKey::AuthorizedRows]),
+            facts: BTreeSet::from([ProgramFactKey::ResultMembership]),
         },
     };
 
     let program = lower_query_program(request, &mut FakeSourceResolver::default())
         .expect("correlated write authorization should lower");
-    let graph = format!("{:?}", program.lowered.terminals);
-    assert!(
-        !graph.contains("__flat_join_source_"),
-        "authorization decision graph must not request public occurrence carriers: {graph}"
-    );
+    let OutputTerminalSchema::Fact(ProgramFactOutput {
+        schema: ProgramFactSchema::ResultMembership(schema),
+        ..
+    }) = program
+        .lowered
+        .terminals
+        .iter()
+        .find(|terminal| terminal.sink == "maintained.result_current")
+        .map(|terminal| &terminal.output)
+        .expect("result-membership terminal")
+    else {
+        panic!("result-membership terminal must retain its schema");
+    };
+    assert_eq!(schema.occurrence_id_fields, vec!["row_uuid"]);
 }
 
 #[test]

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -1638,17 +1638,27 @@ fn prepared_policy_union_joins_claimless_arm_to_binding_route() {
     )));
 }
 
-// `allowedTo.insert(release)` followed by tenant-correlated `exists` checks
-// lowers to consecutive inner joins in the authorization program. Those joins
-// prove a decision; they are not a public flat result whose occurrence key
-// needs synthetic join-row carriers.
+/// Keeps a public assignment occurrence address through an inherited-policy
+/// semi-join while Alice's allowed release and tenant-correlated checks are
+/// lowered as consecutive joins.
+///
+/// ```text
+/// alice ──insert assignment──► release + membership + organization checks
+///                                  │
+///                                  └──► public assignment result occurrence
+/// ```
+///
+/// The matching authorization subplan keeps the same join inputs internal:
+/// its policy proof must never expose public occurrence carriers.
 #[test]
 fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurrence_carriers() {
     let root = RowSetNodeId("assignment".to_owned());
     let release_input = RowSetNodeId("release-source".to_owned());
     let release_join = RowSetNodeId("release-allowed-to".to_owned());
     let membership_input = RowSetNodeId("membership-source".to_owned());
-    let policy_root = RowSetNodeId("membership-tenant-check".to_owned());
+    let membership_join = RowSetNodeId("membership-tenant-check".to_owned());
+    let organization_input = RowSetNodeId("organization-source".to_owned());
+    let policy_root = RowSetNodeId("organization-tenant-check".to_owned());
     let assignment = source("assignments", SourceRole::Root);
     let release = source(
         "releases",
@@ -1657,6 +1667,10 @@ fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurre
     let membership = source(
         "memberships",
         SourceRole::Alias("exists:membership-tenant".to_owned()),
+    );
+    let organization = source(
+        "organizations",
+        SourceRole::Alias("exists:organization-tenant".to_owned()),
     );
     let request = QueryProgramRequest {
         authorization_mode: QueryAuthorizationMode::TrustedServing,
@@ -1674,6 +1688,10 @@ fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurre
                 ),
                 (
                     membership.clone(),
+                    requested_current_source(DurabilityTier::Global),
+                ),
+                (
+                    organization.clone(),
                     requested_current_source(DurabilityTier::Global),
                 ),
             ]),
@@ -1742,16 +1760,43 @@ fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurre
                         },
                     ),
                     (
-                        policy_root,
+                        membership_join,
                         RowSetExpr::Join {
                             left: release_join,
                             right: RowSetNodeId("membership-source".to_owned()),
                             mode: JoinMode::Inner,
                             on: PredicateExpr::Compare {
-                                left: NormalizedValueRef::RowId(RowIdRef::Source(assignment)),
+                                left: NormalizedValueRef::RowId(RowIdRef::Source(
+                                    assignment.clone(),
+                                )),
                                 op: ComparisonOp::Eq,
                                 right: NormalizedValueRef::SourceField {
                                     source: membership,
+                                    field: "todo".to_owned(),
+                                },
+                            },
+                        },
+                    ),
+                    (
+                        organization_input,
+                        RowSetExpr::Source {
+                            source: organization.clone(),
+                            visibility: RowVisibility::Visible,
+                        },
+                    ),
+                    (
+                        policy_root,
+                        RowSetExpr::Join {
+                            left: RowSetNodeId("membership-tenant-check".to_owned()),
+                            right: RowSetNodeId("organization-source".to_owned()),
+                            mode: JoinMode::Inner,
+                            on: PredicateExpr::Compare {
+                                left: NormalizedValueRef::RowId(RowIdRef::Source(
+                                    assignment.clone(),
+                                )),
+                                op: ComparisonOp::Eq,
+                                right: NormalizedValueRef::SourceField {
+                                    source: organization,
                                     field: "todo".to_owned(),
                                 },
                             },
@@ -1799,6 +1844,59 @@ fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurre
         panic!("result-membership terminal must retain its schema");
     };
     assert_eq!(schema.occurrence_id_fields, vec!["row_uuid"]);
+
+    // The source-read terminal uses an ordinary identity context, not the
+    // authorization-subplan context above. Its trailing inherited-policy
+    // semi-join must keep the first two public join carriers.
+    let mut public_input = program.request.input.clone();
+    let public_root = public_input.shape.root.clone();
+    let RowSetExpr::Join { mode, .. } = public_input
+        .shape
+        .nodes
+        .get_mut(&public_root)
+        .expect("public assignment root join")
+    else {
+        panic!("public assignment root must be a join");
+    };
+    *mode = JoinMode::Semi;
+    let public_request = QueryProgramRequest {
+        authorization_mode: QueryAuthorizationMode::TrustedServing,
+        reads: program.request.reads.clone(),
+        policy: PolicyContext::Identity {
+            mode: PolicyEnforcementMode::Enforcing,
+            permission_subject: author(0x91),
+            claims: BTreeMap::new(),
+            attribution: None,
+        },
+        input: public_input,
+        output: row_set_output(BTreeSet::new()),
+    };
+    let public_program = lower_query_program(public_request, &mut FakeSourceResolver::default())
+        .expect("public correlated assignment read should lower");
+    let public_terminal = public_program
+        .lowered
+        .terminals
+        .iter()
+        .find(|terminal| matches!(terminal.output, OutputTerminalSchema::AppRows(_)))
+        .expect("public app-rows terminal");
+    let collector_inputs = BTreeSet::from([
+        "__collect_root___flat_join_source_0_row_uuid".to_owned(),
+        "__collect_root___flat_join_source_1_row_uuid".to_owned(),
+    ]);
+    assert!(
+        graph_any(&public_terminal.graph, &|graph| matches!(
+            graph,
+            GraphBuilder::Project { fields, .. }
+                if collector_inputs.is_subset(
+                    &fields
+                        .iter()
+                        .map(|field| field.output_name.clone())
+                        .collect()
+                )
+        )),
+        "the collector must receive every projected public occurrence carrier: {:#?}",
+        public_terminal.graph
+    );
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -910,6 +910,180 @@ fn join_policy_authorizes_writes_reads_and_next_emission_revocation() {
     // output-row policies into the subscription graph.
 }
 
+/// `allowedTo.insert(release)` composes the release INSERT policy with the
+/// assignment's tenant-correlated existence checks. Its decision-only plan
+/// must reach an authorization fate without treating policy joins as a public
+/// result occurrence.
+#[test]
+fn correlated_inherited_insert_policy_accepts_owner_and_denies_cross_tenant_membership() {
+    let owner = user(0xa1);
+    let outsider = user(0xb2);
+    let organization = row(0xc1);
+    let foreign_organization = row(0xc2);
+    let owner_membership = row(0xd1);
+    let foreign_membership = row(0xd2);
+    let artist = row(0xd3);
+    let release = row(0xe1);
+    let owner_assignment = row(0xf1);
+    let outsider_assignment = row(0xf2);
+
+    let same_outer_organization = || {
+        PublicPolicyExpr::eq_session(
+            "organization",
+            vec!["__jazz_outer_row".to_owned(), "organization".to_owned()],
+        )
+    };
+    let release_insert_policy = PublicPolicyExpr::And(vec![
+        public_outer_exists(
+            "memberships",
+            "organization",
+            "organization",
+            [
+                public_claim_eq("user", "sub"),
+                public_literal_eq("role", PublicValue::Text("admin".to_owned())),
+            ],
+        ),
+        public_outer_exists(
+            "artists",
+            "id",
+            "artist",
+            [same_outer_organization()],
+        ),
+    ]);
+    let assignment_insert_policy = PublicPolicyExpr::And(vec![
+        PublicPolicyExpr::Inherits {
+            operation: PublicOperation::Insert,
+            via_column: "release".to_owned(),
+            max_depth: None,
+        },
+        public_outer_exists("releases", "id", "release", [same_outer_organization()]),
+        public_outer_exists(
+            "memberships",
+            "id",
+            "membership",
+            [same_outer_organization()],
+        ),
+    ]);
+    let schema = build_public_test_schema(
+        PublicSchemaBuilder::new()
+            .table(
+                PublicTableSchemaBuilder::new("organizations")
+                    .column("name", PublicColumnType::Text),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("memberships")
+                    .fk_column("organization", "organizations")
+                    .column("user", PublicColumnType::Uuid)
+                    .column("role", PublicColumnType::Text),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("releases")
+                    .fk_column("organization", "organizations")
+                    .fk_column("artist", "artists")
+                    .column("title", PublicColumnType::Text)
+                    .policies(PublicTablePolicies::new().with_insert(release_insert_policy)),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("artists")
+                    .fk_column("organization", "organizations")
+                    .column("name", PublicColumnType::Text),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("release_assignments")
+                    .fk_column("organization", "organizations")
+                    .fk_column("release", "releases")
+                    .fk_column("membership", "memberships")
+                    .policies(PublicTablePolicies::new().with_insert(assignment_insert_policy)),
+            ),
+    );
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+
+    accept_global(
+        &mut core,
+        MergeableCommit::new("organizations", organization, 1).cells(BTreeMap::from([(
+            "name".to_owned(),
+            Value::String("owner organization".to_owned()),
+        )])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("organizations", foreign_organization, 2).cells(BTreeMap::from([(
+            "name".to_owned(),
+            Value::String("foreign organization".to_owned()),
+        )])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("memberships", owner_membership, 3).cells(BTreeMap::from([
+            ("organization".to_owned(), Value::Uuid(organization.0)),
+            ("user".to_owned(), Value::Uuid(owner.0)),
+            ("role".to_owned(), Value::String("admin".to_owned())),
+        ])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("memberships", foreign_membership, 4).cells(BTreeMap::from([
+            ("organization".to_owned(), Value::Uuid(foreign_organization.0)),
+            ("user".to_owned(), Value::Uuid(outsider.0)),
+            ("role".to_owned(), Value::String("admin".to_owned())),
+        ])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("artists", artist, 5).cells(BTreeMap::from([
+            ("organization".to_owned(), Value::Uuid(organization.0)),
+            ("name".to_owned(), Value::String("artist".to_owned())),
+        ])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("releases", release, 6).cells(BTreeMap::from([
+            ("organization".to_owned(), Value::Uuid(organization.0)),
+            ("artist".to_owned(), Value::Uuid(artist.0)),
+            ("title".to_owned(), Value::String("release".to_owned())),
+        ])),
+    );
+    core.set_session_claims(owner, BTreeMap::from([("sub".to_owned(), Value::Uuid(owner.0))]));
+
+    let accepted = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("release_assignments", owner_assignment, 7)
+                .made_by(owner)
+                .cells(BTreeMap::from([
+                    ("organization".to_owned(), Value::Uuid(organization.0)),
+                    ("release".to_owned(), Value::Uuid(release.0)),
+                    ("membership".to_owned(), Value::Uuid(owner_membership.0)),
+                ])),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(accepted).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(accepted),
+        Some((Fate::Accepted, Some(_), DurabilityTier::Global))
+    ));
+
+    let denied = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("release_assignments", outsider_assignment, 8)
+                .made_by(owner)
+                .cells(BTreeMap::from([
+                    ("organization".to_owned(), Value::Uuid(organization.0)),
+                    ("release".to_owned(), Value::Uuid(release.0)),
+                    ("membership".to_owned(), Value::Uuid(foreign_membership.0)),
+                ])),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(denied).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(denied),
+        Some((
+            Fate::Rejected(RejectionReason::AuthorizationDenied),
+            None,
+            DurabilityTier::Local
+        ))
+    ));
+}
+
 #[test]
 fn write_policy_branch_or_join_allows_either_literal_branch_or_membership_join() {
     let invited = user(0xa1);

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -911,9 +911,9 @@ fn join_policy_authorizes_writes_reads_and_next_emission_revocation() {
 }
 
 /// `allowedTo.insert(release)` composes the release INSERT policy with the
-/// assignment's tenant-correlated existence checks. Its decision-only plan
-/// must reach an authorization fate without treating policy joins as a public
-/// result occurrence.
+/// assignment's tenant-correlated existence checks: an eligible owner is
+/// accepted while that same owner cannot attach a foreign membership. The
+/// compiler-plan regression separately asserts occurrence-carrier suppression.
 #[test]
 fn correlated_inherited_insert_policy_accepts_owner_and_denies_cross_tenant_membership() {
     let owner = user(0xa1);


### PR DESCRIPTION
🤖 Fixes #1855.

Correlated authorization joins produced by `allowedTo.insert(...)` plus an `exists` check were incorrectly treated as public-result occurrences. Lowering therefore requested the synthetic `__flat_join_source_0_row_uuid` field from an authorization-only plan and valid writes failed with a storage error.

This keeps the single existing occurrence/access-path lowering mechanism, but threads the request context through it:

- authorization subplans do not emit public occurrence-carrier fields
- ordinary public joins retain their existing occurrence identities and behavior
- a compiler regression preserves the exact formerly-invalid plan shape
- a NodeState receipt proves an eligible owner assignment commits
- the same owner with foreign-tenant membership still fails with `AuthorizationDenied`

Independent adversarial review confirmed that authorization predicates retain their internal join fields; only public-result occurrence carriers are suppressed. Planted compiler and authorization mutations proved both positive and negative sensitivity.

Focused tests and full CI are green.