### PR TITLE
Hydrate large values across public bindings

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -77,11 +77,11 @@ export declare class NapiDb {
   setLargeValueStagingPolicy(incomingBytesPerWindow: number, windowMs: number, maxAgeMs?: number | undefined | null): void
   /** Run one idempotent expiry pass; native hosts normally call this on a timer. */
   evictExpiredStagedLargeValues(): number
-  readValueRange(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array
-  readTextUtf16Range(table: string, rowId: Uint8Array, column: string, start: number, end: number): string
-  readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): string | null
-  appendValue(table: string, rowId: Uint8Array, column: string, bytes: Uint8Array): Write
-  spliceValue(table: string, rowId: Uint8Array, column: string, offset: number, deleteLength: number, insert: Uint8Array): Write
+  readValueRange(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array | PendingNativeRead
+  readTextUtf16Range(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array | PendingNativeRead
+  readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): Uint8Array | PendingNativeRead
+  appendValue(table: string, rowId: Uint8Array, column: string, bytes: Uint8Array): Write | PendingNativeWrite
+  spliceValue(table: string, rowId: Uint8Array, column: string, offset: number, deleteLength: number, insert: Uint8Array): Write | PendingNativeWrite
   setNonDurableClient(): void
   connectUpstream(): Transport
   connectUpstreamWithSession(protocolVersion: number, features: number, remoteNode: Buffer, remoteEpoch: bigint, localNode: Buffer, localEpoch: bigint): Transport
@@ -117,6 +117,10 @@ export declare class Subscription {
 
 export declare class PendingNativeRead {
   poll(): Uint8Array | null
+}
+
+export declare class PendingNativeWrite {
+  poll(): Write | null
 }
 
 export declare class PendingNativeSubscriptionBatch {}

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -126,6 +126,7 @@ export declare class Transport {
   routeAuxiliaryWireFrame(frame: Uint8Array): Uint8Array | null
   recvAuxiliaryWireFrames(): Array<Uint8Array>
   auxiliaryOutboundReady(): boolean
+  nextAuxiliaryRetryDelayMs(): number | null
   sendWireFrame(frame: Uint8Array): void
   sendWireFrames(frames: Array<Uint8Array>): void
   recvWireFrames(): Array<Uint8Array>

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -33,15 +33,15 @@ export declare class NapiDb {
   setTickScheduler(callback: ((err: Error | null, arg: string) => void)): void
   onMutationError(callback: (event: any) => void): void
   prepareQuery(query: Uint8Array): PreparedQuery
-  all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   /** Read an open transaction using the identity bound at begin. */
-  allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
-  allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  allRelationSnapshotForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  allRelationQuery(queryJson: string, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  allRelationQueryForIdentity(queryJson: string, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  allRelationSnapshotForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  allRelationQuery(queryJson: string, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  allRelationQueryForIdentity(queryJson: string, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   localCurrentRow(table: string, rowId: Uint8Array): Uint8Array
   attachQuery(query: PreparedQuery, opts?: any | undefined | null): QueryAttachment
   attachQueryForIdentity(query: PreparedQuery, author: Uint8Array, opts?: any | undefined | null): QueryAttachment
@@ -110,10 +110,16 @@ export declare class StreamingMutation {
 }
 
 export declare class Subscription {
-  readAll(): Array<SubscriptionEvent>
-  drain(): Array<SubscriptionEvent>
+  readAll(): Array<SubscriptionEvent> | PendingNativeSubscriptionBatch
+  drain(): Array<SubscriptionEvent> | PendingNativeSubscriptionBatch
   close(): boolean
 }
+
+export declare class PendingNativeRead {
+  poll(): Uint8Array | null
+}
+
+export declare class PendingNativeSubscriptionBatch {}
 
 export declare class TestJwtIssuer {
   static start(): Promise<TestJwtIssuer>

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -437,8 +437,16 @@ impl NapiTransportInner {
 }
 
 enum NapiSubscription {
-    Memory(SubscriptionStream),
-    Persistent(SubscriptionStream),
+    Memory {
+        db: Rc<CoreDb<CoreMemoryStorage>>,
+        stream: SubscriptionStream,
+        pending_event: Option<CoreSubscriptionEvent>,
+    },
+    Persistent {
+        db: Rc<CoreDb<CoreRocksDbStorage>>,
+        stream: SubscriptionStream,
+        pending_event: Option<CoreSubscriptionEvent>,
+    },
 }
 
 #[napi(js_name = "Tx")]
@@ -664,11 +672,40 @@ impl Subscription {
         let mut events = Vec::new();
         loop {
             let event = match subscription {
-                NapiSubscription::Memory(stream) => stream.try_next_event(),
-                NapiSubscription::Persistent(stream) => stream.try_next_event(),
-            };
-            let Some(event) = event else {
-                break;
+                NapiSubscription::Memory {
+                    db,
+                    stream,
+                    pending_event,
+                } => {
+                    let Some(mut event) = pending_event.take().or_else(|| stream.try_next_event())
+                    else {
+                        break;
+                    };
+                    if let Err(error) =
+                        core_block_on(db.hydrate_subscription_event_for_binding(&mut event))
+                    {
+                        *pending_event = Some(event);
+                        return Err(napi::Error::from_reason(error.to_string()));
+                    }
+                    event
+                }
+                NapiSubscription::Persistent {
+                    db,
+                    stream,
+                    pending_event,
+                } => {
+                    let Some(mut event) = pending_event.take().or_else(|| stream.try_next_event())
+                    else {
+                        break;
+                    };
+                    if let Err(error) =
+                        core_block_on(db.hydrate_subscription_event_for_binding(&mut event))
+                    {
+                        *pending_event = Some(event);
+                        return Err(napi::Error::from_reason(error.to_string()));
+                    }
+                    event
+                }
             };
             events.push(core_subscription_event_to_napi(
                 &event,
@@ -1751,14 +1788,18 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe(&query.inner, opts))
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe(&query.inner, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe(&query.inner, opts))
+                pending_event: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe(&query.inner, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+                pending_event: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),
@@ -1783,14 +1824,18 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
+                pending_event: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+                pending_event: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),
@@ -1814,14 +1859,18 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe_relation_query(&query, opts))
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_relation_query(&query, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe_relation_query(&query, opts))
+                pending_event: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_relation_query(&query, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+                pending_event: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),
@@ -1847,14 +1896,22 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe_relation_query_for_identity(&query, opts, author))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe_relation_query_for_identity(&query, opts, author))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(
+                    db.subscribe_relation_query_for_identity(&query, opts, author),
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+                pending_event: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(
+                    db.subscribe_relation_query_for_identity(&query, opts, author),
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+                pending_event: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1582,12 +1582,21 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
+        let mut snapshot = match db {
             NapiDbInnerStorage::Memory(db) => {
                 core_block_on(db.all_relation_snapshot(&query.inner, opts))
             }
             NapiDbInnerStorage::Persistent(db) => {
                 core_block_on(db.all_relation_snapshot(&query.inner, opts))
+            }
+        }
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => {
+                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
             }
         }
         .map_err(|error| napi::Error::from_reason(error.to_string()))?;
@@ -1612,12 +1621,21 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
+        let mut snapshot = match db {
             NapiDbInnerStorage::Memory(db) => {
                 core_block_on(db.all_relation_snapshot_for_identity(&query.inner, opts, author))
             }
             NapiDbInnerStorage::Persistent(db) => {
                 core_block_on(db.all_relation_snapshot_for_identity(&query.inner, opts, author))
+            }
+        }
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => {
+                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
             }
         }
         .map_err(|error| napi::Error::from_reason(error.to_string()))?;

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -608,6 +608,13 @@ impl Transport {
         self.auxiliary_pump.outbound_is_ready()
     }
 
+    #[napi(js_name = "nextAuxiliaryRetryDelayMs")]
+    pub fn next_auxiliary_retry_delay_ms(&self) -> Option<f64> {
+        self.auxiliary_pump
+            .next_retry_delay()
+            .map(|delay| delay.as_millis() as f64)
+    }
+
     #[napi(js_name = "sendWireFrame")]
     pub fn send_wire_frame(&self, frame: Uint8Array) {
         self.queues.inbound.borrow_mut().push_back(frame.to_vec());

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -229,6 +229,56 @@ pub struct PendingNativeRead {
     future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Uint8Array>>>>>,
 }
 
+struct PendingSubscriptionBatchCompletion {
+    events: Vec<SubscriptionEvent>,
+    layouts: HashSet<String>,
+}
+
+/// Opaque marker returned by `Subscription.readAll()` while its retained raw
+/// batch is waiting for a peer chunk. JavaScript must await a transport wake
+/// and call `readAll()` again; it never polls this object directly.
+#[napi]
+pub struct PendingNativeSubscriptionBatch {
+    future: Rc<
+        RefCell<Option<LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchCompletion>>>>,
+    >,
+}
+
+impl Clone for PendingNativeSubscriptionBatch {
+    fn clone(&self) -> Self {
+        Self {
+            future: Rc::clone(&self.future),
+        }
+    }
+}
+
+impl PendingNativeSubscriptionBatch {
+    fn new(
+        future: LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchCompletion>>,
+    ) -> Self {
+        Self {
+            future: Rc::new(RefCell::new(Some(future))),
+        }
+    }
+
+    fn poll_once(&self) -> napi::Result<Option<PendingSubscriptionBatchCompletion>> {
+        let Some(mut future) = self.future.borrow_mut().take() else {
+            return Err(napi::Error::from_reason(
+                "native pending subscription batch is already complete",
+            ));
+        };
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        match Pin::new(&mut future).poll(&mut context) {
+            Poll::Ready(result) => result.map(Some),
+            Poll::Pending => {
+                *self.future.borrow_mut() = Some(future);
+                Ok(None)
+            }
+        }
+    }
+}
+
 impl PendingNativeRead {
     fn new(future: LocalBoxFuture<'static, napi::Result<Uint8Array>>) -> Self {
         Self {
@@ -498,11 +548,13 @@ enum NapiSubscription {
         db: Rc<CoreDb<CoreMemoryStorage>>,
         stream: SubscriptionStream,
         pending_events: VecDeque<CoreSubscriptionEvent>,
+        pending_batch: Option<PendingNativeSubscriptionBatch>,
     },
     Persistent {
         db: Rc<CoreDb<CoreRocksDbStorage>>,
         stream: SubscriptionStream,
         pending_events: VecDeque<CoreSubscriptionEvent>,
+        pending_batch: Option<PendingNativeSubscriptionBatch>,
     },
 }
 
@@ -728,7 +780,9 @@ impl Transport {
 #[napi]
 impl Subscription {
     #[napi(js_name = "readAll")]
-    pub fn read_all(&mut self) -> napi::Result<Vec<SubscriptionEvent>> {
+    pub fn read_all(
+        &mut self,
+    ) -> napi::Result<Either<Vec<SubscriptionEvent>, PendingNativeSubscriptionBatch>> {
         let subscription = self
             .inner
             .as_mut()
@@ -739,26 +793,38 @@ impl Subscription {
                 db,
                 stream,
                 pending_events,
-            } => read_subscription_batch(
+                pending_batch,
+            } => read_or_start_subscription_batch(
+                db,
+                stream,
                 pending_events,
-                || stream.try_next_event(),
-                |event| hydrate_subscription_event_for_napi(db, event),
+                pending_batch,
                 published_terminal_layouts,
             ),
             NapiSubscription::Persistent {
                 db,
                 stream,
                 pending_events,
-            } => read_subscription_batch(
+                pending_batch,
+            } => read_or_start_subscription_batch(
+                db,
+                stream,
                 pending_events,
-                || stream.try_next_event(),
-                |event| hydrate_subscription_event_for_napi(db, event),
+                pending_batch,
                 published_terminal_layouts,
             ),
         };
         match result {
-            Ok(events) => Ok(events),
-            Err(NapiSubscriptionBatchError::Retryable(error)) => Err(error),
+            Ok(Some(events)) => Ok(Either::A(events)),
+            Ok(None) => match subscription {
+                NapiSubscription::Memory { pending_batch, .. }
+                | NapiSubscription::Persistent { pending_batch, .. } => Ok(Either::B(
+                    pending_batch
+                        .as_ref()
+                        .expect("pending subscription batch is retained")
+                        .clone(),
+                )),
+            },
             Err(NapiSubscriptionBatchError::Fatal(error)) => {
                 // A malformed/integrity/backend hydration failure cannot be
                 // repaired by replaying the same retained source batch. Drop
@@ -772,7 +838,9 @@ impl Subscription {
     }
 
     #[napi]
-    pub fn drain(&mut self) -> napi::Result<Vec<SubscriptionEvent>> {
+    pub fn drain(
+        &mut self,
+    ) -> napi::Result<Either<Vec<SubscriptionEvent>, PendingNativeSubscriptionBatch>> {
         self.read_all()
     }
 
@@ -789,71 +857,81 @@ impl Subscription {
 /// hydration and encoding of the entire batch succeed, so retry is lossless
 /// and preserves source order.
 enum NapiSubscriptionBatchError {
-    /// Peer-backed chunk demand is in flight. Retain the batch for a later
-    /// pull after the binding has driven its auxiliary transport.
-    Retryable(napi::Error),
     /// Replaying cannot change this error and must not retain memory forever.
     Fatal(napi::Error),
 }
 
-fn hydrate_subscription_event_for_napi<S>(
+fn read_or_start_subscription_batch<S>(
     db: &Rc<CoreDb<S>>,
-    event: &mut CoreSubscriptionEvent,
-) -> std::result::Result<(), NapiSubscriptionBatchError>
+    stream: &mut SubscriptionStream,
+    pending_events: &mut VecDeque<CoreSubscriptionEvent>,
+    pending_batch: &mut Option<PendingNativeSubscriptionBatch>,
+    published_terminal_layouts: &mut HashSet<String>,
+) -> std::result::Result<Option<Vec<SubscriptionEvent>>, NapiSubscriptionBatchError>
 where
     S: CoreOrderedKvStorage + CoreReopenableStorage + 'static,
 {
-    match core_block_on(db.hydrate_subscription_event_for_binding_outcome(event)) {
-        Ok(()) => Ok(()),
-        Err(jazz::db::BindingHydrationError::ChunkUnavailable) => {
-            Err(NapiSubscriptionBatchError::Retryable(
-                napi::Error::from_reason("large-value chunk is not locally available"),
-            ))
+    if let Some(batch) = pending_batch.as_ref() {
+        match batch.poll_once() {
+            Ok(Some(completion)) => {
+                *pending_batch = None;
+                *published_terminal_layouts = completion.layouts;
+                return Ok(Some(completion.events));
+            }
+            Ok(None) => return Ok(None),
+            Err(error) => return Err(NapiSubscriptionBatchError::Fatal(error)),
         }
-        Err(jazz::db::BindingHydrationError::Error(error)) => Err(
-            NapiSubscriptionBatchError::Fatal(napi::Error::from_reason(error.to_string())),
-        ),
     }
-}
-
-fn read_subscription_batch<F>(
-    pending_events: &mut VecDeque<CoreSubscriptionEvent>,
-    mut next: F,
-    mut hydrate: impl FnMut(
-        &mut CoreSubscriptionEvent,
-    ) -> std::result::Result<(), NapiSubscriptionBatchError>,
-    published_terminal_layouts: &mut HashSet<String>,
-) -> std::result::Result<Vec<SubscriptionEvent>, NapiSubscriptionBatchError>
-where
-    F: FnMut() -> Option<CoreSubscriptionEvent>,
-{
-    let mut batch = std::mem::take(pending_events)
+    let mut raw_events = std::mem::take(pending_events)
         .into_iter()
         .collect::<Vec<_>>();
-    while let Some(event) = next() {
-        batch.push(event);
+    while let Some(event) = stream.try_next_event() {
+        raw_events.push(event);
     }
-    for event in &mut batch {
-        if let Err(error) = hydrate(event) {
-            if matches!(error, NapiSubscriptionBatchError::Retryable(_)) {
-                pending_events.extend(batch);
+    if raw_events.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let db = Rc::clone(db);
+    let layouts = published_terminal_layouts.clone();
+    let batch = PendingNativeSubscriptionBatch::new(Box::pin(async move {
+        let mut raw_events = raw_events;
+        for event in &mut raw_events {
+            match db
+                .hydrate_subscription_event_for_binding_outcome(event)
+                .await
+            {
+                Ok(()) => {}
+                Err(jazz::db::BindingHydrationError::ChunkUnavailable) => {
+                    return Err(napi::Error::from_reason(
+                        "large-value chunk is unavailable and cannot be retried",
+                    ));
+                }
+                Err(jazz::db::BindingHydrationError::Error(error)) => {
+                    return Err(napi::Error::from_reason(error.to_string()));
+                }
             }
-            return Err(error);
         }
-    }
-    let mut prospective_layouts = published_terminal_layouts.clone();
-    let mut output = Vec::with_capacity(batch.len());
-    for event in &batch {
-        match core_subscription_event_to_napi(event, &mut prospective_layouts) {
-            Ok(event) => output.push(event),
-            Err(error) => {
-                pending_events.extend(batch);
-                return Err(NapiSubscriptionBatchError::Fatal(error));
-            }
+        let mut layouts = layouts;
+        let mut output = Vec::with_capacity(raw_events.len());
+        for event in &raw_events {
+            output.push(core_subscription_event_to_napi(event, &mut layouts)?);
         }
+        Ok(PendingSubscriptionBatchCompletion {
+            events: output,
+            layouts,
+        })
+    }));
+    match batch.poll_once() {
+        Ok(Some(completion)) => {
+            *published_terminal_layouts = completion.layouts;
+            Ok(Some(completion.events))
+        }
+        Ok(None) => {
+            *pending_batch = Some(batch);
+            Ok(None)
+        }
+        Err(error) => Err(NapiSubscriptionBatchError::Fatal(error)),
     }
-    *published_terminal_layouts = prospective_layouts;
-    Ok(output)
 }
 
 #[napi]
@@ -1873,23 +1951,39 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let query = core_relation_query_from_json(&query_json)?;
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
-            NapiDbInnerStorage::Memory(db) => core_block_on(db.all_relation_query(&query, opts)),
+        match db {
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let snapshot = db
+                        .all_relation_query(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
+            }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_query(&query, opts))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let snapshot = db
+                        .all_relation_query(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&snapshot.rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationQueryForIdentity")]
@@ -1901,7 +1995,7 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let query = core_relation_query_from_json(&query_json)?;
         let author = core_author_id_from_bytes(&author)?;
         let opts = core_read_opts_from_json(opts)?;
@@ -1909,18 +2003,32 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_relation_query_for_identity(&query, opts, author))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let snapshot = db
+                        .all_relation_query_for_identity(&query, opts, author)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_query_for_identity(&query, opts, author))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let snapshot = db
+                        .all_relation_query_for_identity(&query, opts, author)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&snapshot.rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "localCurrentRow")]
@@ -2032,12 +2140,14 @@ impl NapiDb {
                 stream: core_block_on(db.subscribe(&query.inner, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe(&query.inner, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
         };
         Ok(Subscription {
@@ -2068,12 +2178,14 @@ impl NapiDb {
                 stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
         };
         Ok(Subscription {
@@ -2103,12 +2215,14 @@ impl NapiDb {
                 stream: core_block_on(db.subscribe_relation_query(&query, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe_relation_query(&query, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
         };
         Ok(Subscription {
@@ -2142,6 +2256,7 @@ impl NapiDb {
                 )
                 .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
@@ -2150,6 +2265,7 @@ impl NapiDb {
                 )
                 .map_err(|error| napi::Error::from_reason(error.to_string()))?,
                 pending_events: VecDeque::new(),
+                pending_batch: None,
             },
         };
         Ok(Subscription {
@@ -4419,14 +4535,14 @@ pub fn verify_local_first_identity_proof_napi(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashSet, VecDeque};
+    use std::collections::{BTreeMap, HashSet};
     use std::rc::Rc;
 
     use crate::{
         NapiDb, NapiDbInnerStorage, NapiTxKind, PreparedQuery, Tx, authority_epoch_from_bigint,
         core_block_on, core_claim_value_from_json, core_read_opts_from_json,
-        core_subscription_event_to_napi, encode_core_subscription_delta, read_subscription_batch,
-        terminal_bytes_to_numbers, unknown_transaction_kind_message,
+        core_subscription_event_to_napi, encode_core_subscription_delta, terminal_bytes_to_numbers,
+        unknown_transaction_kind_message,
     };
 
     #[test]
@@ -4703,56 +4819,6 @@ mod tests {
         assert!(!payload.delta.is_empty());
         assert!(payload.terminal_operations.is_empty());
         assert_eq!(payload.tier, "Local");
-    }
-
-    #[test]
-    fn subscription_batch_retry_preserves_success_prefix_before_hydration_failure() {
-        let mut pending = VecDeque::new();
-        let mut source = VecDeque::from([
-            CoreSubscriptionEvent::Closed,
-            CoreSubscriptionEvent::Rejected {
-                reason: jazz::protocol::SubscribeRejectReason::UnsupportedShapeCapability {
-                    detail: "deliberately unavailable descriptor".to_owned(),
-                },
-            },
-        ]);
-        let mut published = HashSet::new();
-        let fail_second = true;
-        let error = match read_subscription_batch(
-            &mut pending,
-            || source.pop_front(),
-            |event| {
-                if fail_second && matches!(event, CoreSubscriptionEvent::Rejected { .. }) {
-                    return Err(napi::Error::from_reason("planned hydration failure"));
-                }
-                Ok(())
-            },
-            &mut published,
-        ) {
-            Ok(_) => panic!("planned hydration failure must abort the batch"),
-            Err(error) => error,
-        };
-        assert_eq!(error.reason, "planned hydration failure");
-        assert_eq!(pending.len(), 2, "successful prefix is retained for retry");
-        assert!(
-            source.is_empty(),
-            "all source events were captured in the retry queue"
-        );
-
-        let replayed = read_subscription_batch(
-            &mut pending,
-            || source.pop_front(),
-            |_| Ok(()),
-            &mut published,
-        )
-        .expect("retry succeeds");
-        assert!(pending.is_empty());
-        assert_eq!(replayed.len(), 2);
-        assert!(matches!(replayed[0], Either3::C(_)), "A keeps its position");
-        assert!(
-            matches!(replayed[1], Either3::B(_)),
-            "B follows A exactly once"
-        );
     }
 
     #[test]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -229,6 +229,14 @@ pub struct PendingNativeRead {
     future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Uint8Array>>>>>,
 }
 
+/// JS-thread-owned mutation setup suspended on async storage or a peer chunk.
+/// The completed write retains its ordinary settlement handle; only setup is
+/// pending here.
+#[napi]
+pub struct PendingNativeWrite {
+    future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Write>>>>>,
+}
+
 struct PendingSubscriptionBatchCompletion {
     events: Vec<SubscriptionEvent>,
     layouts: HashSet<String>,
@@ -304,6 +312,31 @@ impl PendingNativeRead {
     }
 }
 
+impl PendingNativeWrite {
+    fn new(future: LocalBoxFuture<'static, napi::Result<Write>>) -> Self {
+        Self {
+            future: Rc::new(RefCell::new(Some(future))),
+        }
+    }
+
+    fn poll_once(&self) -> napi::Result<Option<Write>> {
+        let Some(mut future) = self.future.borrow_mut().take() else {
+            return Err(napi::Error::from_reason(
+                "native pending write is already complete",
+            ));
+        };
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        match Pin::new(&mut future).poll(&mut context) {
+            Poll::Ready(result) => result.map(Some),
+            Poll::Pending => {
+                *self.future.borrow_mut() = Some(future);
+                Ok(None)
+            }
+        }
+    }
+}
+
 #[napi]
 impl PendingNativeRead {
     /// Advance this read once. `null` means its concrete storage/peer wake has
@@ -314,12 +347,31 @@ impl PendingNativeRead {
     }
 }
 
+#[napi]
+impl PendingNativeWrite {
+    /// Advance mutation setup once after a concrete storage/peer wake.
+    #[napi]
+    pub fn poll(&self) -> napi::Result<Option<Write>> {
+        self.poll_once()
+    }
+}
+
 fn native_read_or_pending(
     future: LocalBoxFuture<'static, napi::Result<Uint8Array>>,
 ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
     let pending = PendingNativeRead::new(future);
     match pending.poll_once()? {
         Some(bytes) => Ok(Either::A(bytes)),
+        None => Ok(Either::B(pending)),
+    }
+}
+
+fn native_write_or_pending(
+    future: LocalBoxFuture<'static, napi::Result<Write>>,
+) -> napi::Result<Either<Write, PendingNativeWrite>> {
+    let pending = PendingNativeWrite::new(future);
+    match pending.poll_once()? {
+        Some(write) => Ok(Either::A(write)),
         None => Ok(Either::B(pending)),
     }
 }
@@ -3073,23 +3125,33 @@ impl NapiDb {
         column: String,
         start: f64,
         end: f64,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let range = checked_u64_range(start, end)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let bytes = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.read_value_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_value_range(&table, row_id, &column, range)
+                        .await
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.read_value_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_value_range(&table, row_id, &column, range)
+                        .await
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        Ok(Uint8Array::new(bytes))
     }
 
     #[napi(js_name = "readTextUtf16Range")]
@@ -3100,7 +3162,7 @@ impl NapiDb {
         column: String,
         start: f64,
         end: f64,
-    ) -> napi::Result<String> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let range = checked_u64_range(start, end)?;
         let db = self.inner.borrow();
@@ -3109,13 +3171,24 @@ impl NapiDb {
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.read_text_utf16_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_text_utf16_range(&table, row_id, &column, range)
+                        .await
+                        .map(|text| Uint8Array::new(text.into_bytes()))
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.read_text_utf16_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_text_utf16_range(&table, row_id, &column, range)
+                        .await
+                        .map(|text| Uint8Array::new(text.into_bytes()))
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "readJsonPointer")]
@@ -3125,25 +3198,38 @@ impl NapiDb {
         row_id: Uint8Array,
         column: String,
         pointer: String,
-    ) -> napi::Result<Option<String>> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let value = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.read_json_pointer(&table, row_id, &column, &pointer))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let value = db
+                        .read_json_pointer(&table, row_id, &column, &pointer)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    serde_json::to_vec(&value)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.read_json_pointer(&table, row_id, &column, &pointer))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let value = db
+                        .read_json_pointer(&table, row_id, &column, &pointer)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    serde_json::to_vec(&value)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        value
-            .map(|value| serde_json::to_string(&value))
-            .transpose()
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "appendValue")]
@@ -3153,23 +3239,33 @@ impl NapiDb {
         row_id: Uint8Array,
         column: String,
         bytes: Uint8Array,
-    ) -> napi::Result<Write> {
+    ) -> napi::Result<Either<Write, PendingNativeWrite>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.append_value(&table, row_id, &column, bytes.to_vec()))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.append_value(&table, row_id, &column, bytes.to_vec()))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .append_value(&table, row_id, &column, bytes.to_vec())
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    core_write_memory(db, write)
+                }))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .append_value(&table, row_id, &column, bytes.to_vec())
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    core_write_persistent(db, write)
+                }))
+            }
         }
     }
 
@@ -3182,7 +3278,7 @@ impl NapiDb {
         offset: f64,
         delete_length: f64,
         insert: Uint8Array,
-    ) -> napi::Result<Write> {
+    ) -> napi::Result<Either<Write, PendingNativeWrite>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let offset = checked_u64(offset, "offset")?;
         let delete_length = checked_u64(delete_length, "deleteLength")?;
@@ -3191,30 +3287,40 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.splice_value(
-                    &table,
-                    row_id,
-                    &column,
-                    offset,
-                    delete_length,
-                    insert.to_vec(),
-                ))
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.splice_value(
-                    &table,
-                    row_id,
-                    &column,
-                    offset,
-                    delete_length,
-                    insert.to_vec(),
-                ))
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .splice_value(
+                            &table,
+                            row_id,
+                            &column,
+                            offset,
+                            delete_length,
+                            insert.to_vec(),
+                        )
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    core_write_memory(db, write)
+                }))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .splice_value(
+                            &table,
+                            row_id,
+                            &column,
+                            offset,
+                            delete_length,
+                            insert.to_vec(),
+                        )
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    core_write_persistent(db, write)
+                }))
+            }
         }
     }
 
@@ -4539,13 +4645,14 @@ mod tests {
     use std::rc::Rc;
 
     use super::{
-        PendingNativeRead, PendingNativeSubscriptionBatch, PendingSubscriptionBatchCompletion,
+        PendingNativeRead, PendingNativeSubscriptionBatch, PendingNativeWrite,
+        PendingSubscriptionBatchCompletion, Write,
     };
     use crate::{
-        NapiDb, NapiDbInnerStorage, NapiTxKind, PreparedQuery, Tx, authority_epoch_from_bigint,
-        core_block_on, core_claim_value_from_json, core_read_opts_from_json,
-        core_subscription_event_to_napi, encode_core_subscription_delta, terminal_bytes_to_numbers,
-        unknown_transaction_kind_message,
+        NapiDb, NapiDbInnerStorage, NapiTxKind, PreparedQuery, TransactionId, Tx, TxId,
+        authority_epoch_from_bigint, core_block_on, core_claim_value_from_json,
+        core_read_opts_from_json, core_subscription_event_to_napi, encode_core_subscription_delta,
+        terminal_bytes_to_numbers, unknown_transaction_kind_message,
     };
     use futures::channel::oneshot;
 
@@ -4578,6 +4685,33 @@ mod tests {
     }
 
     #[test]
+    fn pending_native_read_reports_a_later_fatal_error_exactly_once() {
+        let (sender, receiver) = oneshot::channel::<()>();
+        let pending = PendingNativeRead::new(Box::pin(async move {
+            receiver
+                .await
+                .map_err(|_| napi::Error::from_reason("planned sender drop"))?;
+            Err(napi::Error::from_reason("fatal chunk integrity failure"))
+        }));
+        assert!(pending.poll_once().unwrap().is_none());
+        assert!(sender.send(()).is_ok());
+        let first_error = match pending.poll_once() {
+            Err(error) => error,
+            Ok(_) => panic!("fatal pending read must fail"),
+        };
+        assert!(
+            first_error
+                .to_string()
+                .contains("fatal chunk integrity failure")
+        );
+        let repeated_error = match pending.poll_once() {
+            Err(error) => error,
+            Ok(_) => panic!("completed pending read must not replay"),
+        };
+        assert!(repeated_error.to_string().contains("already complete"));
+    }
+
+    #[test]
     fn pending_native_subscription_batch_preserves_one_future_until_completion() {
         let (sender, receiver) = oneshot::channel::<PendingSubscriptionBatchCompletion>();
         let pending = PendingNativeSubscriptionBatch::new(Box::pin(async move {
@@ -4600,6 +4734,28 @@ mod tests {
             pending.poll_once().is_err(),
             "completed batch cannot replay"
         );
+    }
+
+    #[test]
+    fn pending_native_write_preserves_one_suspended_future_until_completion() {
+        let (sender, receiver) = oneshot::channel::<Write>();
+        let pending = PendingNativeWrite::new(Box::pin(async move {
+            receiver
+                .await
+                .map_err(|_| napi::Error::from_reason("planned sender drop"))
+        }));
+        assert!(pending.poll_once().unwrap().is_none());
+        let expected = Write {
+            payload: vec![9],
+            batch_id: TransactionId::from_committed_tx(TxId::new(
+                jazz::time::TxTime::from(1),
+                jazz::ids::NodeUuid::from_bytes([3; 16]),
+            )),
+            inner: None,
+        };
+        assert!(sender.send(expected).is_ok());
+        assert_eq!(pending.poll_once().unwrap().unwrap().payload, vec![9]);
+        assert!(pending.poll_once().is_err());
     }
     use jazz::db::{
         Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -913,6 +913,25 @@ enum NapiSubscriptionBatchError {
     Fatal(napi::Error),
 }
 
+/// Bound the raw source events retained while one event waits for remote
+/// large-value hydration.  Further events remain in the subscription receiver
+/// and are pulled by the adapter after this batch completes.
+const MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS: usize = 256;
+
+fn take_bounded_subscription_batch<T>(
+    pending: &mut VecDeque<T>,
+    mut try_next: impl FnMut() -> Option<T>,
+) -> Vec<T> {
+    let mut batch = Vec::with_capacity(MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS);
+    while batch.len() < MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS {
+        let Some(event) = pending.pop_front().or_else(&mut try_next) else {
+            break;
+        };
+        batch.push(event);
+    }
+    batch
+}
+
 fn read_or_start_subscription_batch<S>(
     db: &Rc<CoreDb<S>>,
     stream: &mut SubscriptionStream,
@@ -934,12 +953,7 @@ where
             Err(error) => return Err(NapiSubscriptionBatchError::Fatal(error)),
         }
     }
-    let mut raw_events = std::mem::take(pending_events)
-        .into_iter()
-        .collect::<Vec<_>>();
-    while let Some(event) = stream.try_next_event() {
-        raw_events.push(event);
-    }
+    let raw_events = take_bounded_subscription_batch(pending_events, || stream.try_next_event());
     if raw_events.is_empty() {
         return Ok(Some(Vec::new()));
     }
@@ -4641,12 +4655,13 @@ pub fn verify_local_first_identity_proof_napi(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::{BTreeMap, HashSet, VecDeque};
     use std::rc::Rc;
 
     use super::{
-        PendingNativeRead, PendingNativeSubscriptionBatch, PendingNativeWrite,
-        PendingSubscriptionBatchCompletion, Write,
+        MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS, PendingNativeRead, PendingNativeSubscriptionBatch,
+        PendingNativeWrite, PendingSubscriptionBatchCompletion, Write,
+        take_bounded_subscription_batch,
     };
     use crate::{
         NapiDb, NapiDbInnerStorage, NapiTxKind, PreparedQuery, TransactionId, Tx, TxId,
@@ -4756,6 +4771,20 @@ mod tests {
         assert!(sender.send(expected).is_ok());
         assert_eq!(pending.poll_once().unwrap().unwrap().payload, vec![9]);
         assert!(pending.poll_once().is_err());
+    }
+
+    #[test]
+    fn suspended_subscription_batches_leave_excess_events_at_the_source() {
+        let mut pending = (0..MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS + 3).collect::<VecDeque<_>>();
+        let mut source_calls = 0;
+        let batch = take_bounded_subscription_batch(&mut pending, || {
+            source_calls += 1;
+            Some(usize::MAX)
+        });
+
+        assert_eq!(batch.len(), MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS);
+        assert_eq!(pending.len(), 3, "excess retained events stay queued");
+        assert_eq!(source_calls, 0, "the source is not drained past the bound");
     }
     use jazz::db::{
         Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -36,13 +36,15 @@ use serde_json::Value as JsonValue;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::future::Future;
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Mutex;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use futures::future::LocalBoxFuture;
 use futures::lock::Mutex as LocalMutex;
 use jazz::db::StreamingMutationKind as CoreStreamingMutationKind;
 use jazz::db::{
@@ -215,6 +217,61 @@ pub struct Transport {
     auxiliary_pump: jazz::db::PeerIoPump,
     protocol_version: u16,
     features: u64,
+}
+
+/// A JS-thread-owned read that suspended on async storage or a peer chunk.
+///
+/// napi-rs promises run on a Send Tokio executor, while Jazz's database is
+/// deliberately `Rc`/thread-affine.  This small pull object keeps the local
+/// future alive across JS turns without ever blocking the Node event loop.
+#[napi]
+pub struct PendingNativeRead {
+    future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Uint8Array>>>>>,
+}
+
+impl PendingNativeRead {
+    fn new(future: LocalBoxFuture<'static, napi::Result<Uint8Array>>) -> Self {
+        Self {
+            future: Rc::new(RefCell::new(Some(future))),
+        }
+    }
+
+    fn poll_once(&self) -> napi::Result<Option<Uint8Array>> {
+        let Some(mut future) = self.future.borrow_mut().take() else {
+            return Err(napi::Error::from_reason(
+                "native pending read is already complete",
+            ));
+        };
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        match Pin::new(&mut future).poll(&mut context) {
+            Poll::Ready(result) => result.map(Some),
+            Poll::Pending => {
+                *self.future.borrow_mut() = Some(future);
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[napi]
+impl PendingNativeRead {
+    /// Advance this read once. `null` means its concrete storage/peer wake has
+    /// not fired yet; callers must await transport work before asking again.
+    #[napi]
+    pub fn poll(&self) -> napi::Result<Option<Uint8Array>> {
+        self.poll_once()
+    }
+}
+
+fn native_read_or_pending(
+    future: LocalBoxFuture<'static, napi::Result<Uint8Array>>,
+) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
+    let pending = PendingNativeRead::new(future);
+    match pending.poll_once()? {
+        Some(bytes) => Ok(Either::A(bytes)),
+        None => Ok(Either::B(pending)),
+    }
 }
 
 #[napi(js_name = "Subscription")]
@@ -1528,20 +1585,39 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let rows = match db {
-            NapiDbInnerStorage::Memory(db) => core_block_on(db.all(&query.inner, opts)),
-            NapiDbInnerStorage::Persistent(db) => core_block_on(db.all(&query.inner, opts)),
+        let query = query.inner.clone();
+        match db {
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .all(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .all(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
+            }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     /// Read through an open transaction using the identity bound at begin.
@@ -1554,7 +1630,7 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let db = self.inner.borrow();
         let db = db
             .as_ref()
@@ -1566,28 +1642,61 @@ impl NapiDb {
         }
         let opts = core_read_opts_from_json(opts)?;
         let open_tx = tx.open_tx()?;
-        let rows = match (db, tx.kind) {
-            (NapiDbInnerStorage::Memory(db), NapiTxKind::Mergeable) => core_block_on(
-                db.mergeable_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
-            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Mergeable) => core_block_on(
-                db.mergeable_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
-            (NapiDbInnerStorage::Memory(db), NapiTxKind::Exclusive) => core_block_on(
-                db.exclusive_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
-            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Exclusive) => core_block_on(
-                db.exclusive_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
+        let query = query.inner.clone();
+        match (db, tx.kind) {
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Mergeable) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .mergeable_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
+            }
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Mergeable) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .mergeable_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
+            }
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Exclusive) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .exclusive_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
+            }
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Exclusive) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .exclusive_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
+            }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "setIdentityClaims")]
@@ -1620,25 +1729,40 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let author = core_author_id_from_bytes(&author)?;
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let rows = match db {
+        let query = query.inner.clone();
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_for_identity(&query.inner, opts, author))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .all_for_identity(&query, opts, author)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_for_identity(&query.inner, opts, author))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let rows = db
+                        .all_for_identity(&query, opts, author)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationSnapshot")]
@@ -1649,33 +1773,45 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let mut snapshot = match db {
-            NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_relation_snapshot(&query.inner, opts))
-            }
-            NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_snapshot(&query.inner, opts))
-            }
-        }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        let query = query.inner.clone();
         match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot(&query, opts)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_relation_snapshot(&snapshot)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationSnapshotForIdentity")]
@@ -1687,34 +1823,46 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let author = core_author_id_from_bytes(&author)?;
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let mut snapshot = match db {
-            NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_relation_snapshot_for_identity(&query.inner, opts, author))
-            }
-            NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_snapshot_for_identity(&query.inner, opts, author))
-            }
-        }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+        let query = query.inner.clone();
         match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot_for_identity(&query, opts, author)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot_for_identity(&query, opts, author)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_relation_snapshot(&snapshot)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationQuery")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -677,7 +677,7 @@ impl Subscription {
             .as_mut()
             .ok_or_else(|| napi::Error::from_reason("subscription is closed"))?;
         let published_terminal_layouts = &mut self.published_terminal_layouts;
-        match subscription {
+        let result = match subscription {
             NapiSubscription::Memory {
                 db,
                 stream,
@@ -685,10 +685,7 @@ impl Subscription {
             } => read_subscription_batch(
                 pending_events,
                 || stream.try_next_event(),
-                |event| {
-                    core_block_on(db.hydrate_subscription_event_for_binding(event))
-                        .map_err(|error| napi::Error::from_reason(error.to_string()))
-                },
+                |event| hydrate_subscription_event_for_napi(db, event),
                 published_terminal_layouts,
             ),
             NapiSubscription::Persistent {
@@ -698,12 +695,22 @@ impl Subscription {
             } => read_subscription_batch(
                 pending_events,
                 || stream.try_next_event(),
-                |event| {
-                    core_block_on(db.hydrate_subscription_event_for_binding(event))
-                        .map_err(|error| napi::Error::from_reason(error.to_string()))
-                },
+                |event| hydrate_subscription_event_for_napi(db, event),
                 published_terminal_layouts,
             ),
+        };
+        match result {
+            Ok(events) => Ok(events),
+            Err(NapiSubscriptionBatchError::Retryable(error)) => Err(error),
+            Err(NapiSubscriptionBatchError::Fatal(error)) => {
+                // A malformed/integrity/backend hydration failure cannot be
+                // repaired by replaying the same retained source batch. Drop
+                // the stream exactly once so its cleanup releases the batch
+                // and callers observe one terminal error rather than an
+                // unbounded `readAll` loop.
+                self.inner.take();
+                Err(error)
+            }
         }
     }
 
@@ -724,12 +731,42 @@ impl Subscription {
 /// have no way to recover that prefix. Keep every source event until both
 /// hydration and encoding of the entire batch succeed, so retry is lossless
 /// and preserves source order.
+enum NapiSubscriptionBatchError {
+    /// Peer-backed chunk demand is in flight. Retain the batch for a later
+    /// pull after the binding has driven its auxiliary transport.
+    Retryable(napi::Error),
+    /// Replaying cannot change this error and must not retain memory forever.
+    Fatal(napi::Error),
+}
+
+fn hydrate_subscription_event_for_napi<S>(
+    db: &Rc<CoreDb<S>>,
+    event: &mut CoreSubscriptionEvent,
+) -> std::result::Result<(), NapiSubscriptionBatchError>
+where
+    S: CoreOrderedKvStorage + CoreReopenableStorage + 'static,
+{
+    match core_block_on(db.hydrate_subscription_event_for_binding_outcome(event)) {
+        Ok(()) => Ok(()),
+        Err(jazz::db::BindingHydrationError::ChunkUnavailable) => {
+            Err(NapiSubscriptionBatchError::Retryable(
+                napi::Error::from_reason("large-value chunk is not locally available"),
+            ))
+        }
+        Err(jazz::db::BindingHydrationError::Error(error)) => Err(
+            NapiSubscriptionBatchError::Fatal(napi::Error::from_reason(error.to_string())),
+        ),
+    }
+}
+
 fn read_subscription_batch<F>(
     pending_events: &mut VecDeque<CoreSubscriptionEvent>,
     mut next: F,
-    mut hydrate: impl FnMut(&mut CoreSubscriptionEvent) -> napi::Result<()>,
+    mut hydrate: impl FnMut(
+        &mut CoreSubscriptionEvent,
+    ) -> std::result::Result<(), NapiSubscriptionBatchError>,
     published_terminal_layouts: &mut HashSet<String>,
-) -> napi::Result<Vec<SubscriptionEvent>>
+) -> std::result::Result<Vec<SubscriptionEvent>, NapiSubscriptionBatchError>
 where
     F: FnMut() -> Option<CoreSubscriptionEvent>,
 {
@@ -741,7 +778,9 @@ where
     }
     for event in &mut batch {
         if let Err(error) = hydrate(event) {
-            pending_events.extend(batch);
+            if matches!(error, NapiSubscriptionBatchError::Retryable(_)) {
+                pending_events.extend(batch);
+            }
             return Err(error);
         }
     }
@@ -752,7 +791,7 @@ where
             Ok(event) => output.push(event),
             Err(error) => {
                 pending_events.extend(batch);
-                return Err(error);
+                return Err(NapiSubscriptionBatchError::Fatal(error));
             }
         }
     }

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -4538,18 +4538,67 @@ mod tests {
     use std::collections::{BTreeMap, HashSet};
     use std::rc::Rc;
 
+    use super::{
+        PendingNativeRead, PendingNativeSubscriptionBatch, PendingSubscriptionBatchCompletion,
+    };
     use crate::{
         NapiDb, NapiDbInnerStorage, NapiTxKind, PreparedQuery, Tx, authority_epoch_from_bigint,
         core_block_on, core_claim_value_from_json, core_read_opts_from_json,
         core_subscription_event_to_napi, encode_core_subscription_delta, terminal_bytes_to_numbers,
         unknown_transaction_kind_message,
     };
+    use futures::channel::oneshot;
 
     #[test]
     fn transaction_binding_diagnostics_use_transaction_vocabulary() {
         assert_eq!(
             unknown_transaction_kind_message("invalid"),
             "unknown transaction kind invalid"
+        );
+    }
+
+    #[test]
+    fn pending_native_read_preserves_one_suspended_future_until_the_next_js_poll() {
+        let (sender, receiver) = oneshot::channel::<Uint8Array>();
+        let pending = PendingNativeRead::new(Box::pin(async move {
+            receiver
+                .await
+                .map_err(|_| napi::Error::from_reason("planned sender drop"))
+        }));
+        assert!(
+            pending.poll_once().unwrap().is_none(),
+            "first JS turn only registers demand"
+        );
+        assert!(sender.send(Uint8Array::new(vec![7])).is_ok());
+        assert_eq!(pending.poll_once().unwrap().unwrap().to_vec(), vec![7]);
+        assert!(
+            pending.poll_once().is_err(),
+            "completed reads cannot replay their result"
+        );
+    }
+
+    #[test]
+    fn pending_native_subscription_batch_preserves_one_future_until_completion() {
+        let (sender, receiver) = oneshot::channel::<PendingSubscriptionBatchCompletion>();
+        let pending = PendingNativeSubscriptionBatch::new(Box::pin(async move {
+            receiver
+                .await
+                .map_err(|_| napi::Error::from_reason("planned sender drop"))
+        }));
+        assert!(pending.poll_once().unwrap().is_none());
+        assert!(
+            sender
+                .send(PendingSubscriptionBatchCompletion {
+                    events: Vec::new(),
+                    layouts: HashSet::new(),
+                })
+                .is_ok()
+        );
+        let completed = pending.poll_once().unwrap().unwrap();
+        assert!(completed.events.is_empty());
+        assert!(
+            pending.poll_once().is_err(),
+            "completed batch cannot replay"
         );
     }
     use jazz::db::{

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -440,12 +440,12 @@ enum NapiSubscription {
     Memory {
         db: Rc<CoreDb<CoreMemoryStorage>>,
         stream: SubscriptionStream,
-        pending_event: Option<CoreSubscriptionEvent>,
+        pending_events: VecDeque<CoreSubscriptionEvent>,
     },
     Persistent {
         db: Rc<CoreDb<CoreRocksDbStorage>>,
         stream: SubscriptionStream,
-        pending_event: Option<CoreSubscriptionEvent>,
+        pending_events: VecDeque<CoreSubscriptionEvent>,
     },
 }
 
@@ -669,50 +669,35 @@ impl Subscription {
             .inner
             .as_mut()
             .ok_or_else(|| napi::Error::from_reason("subscription is closed"))?;
-        let mut events = Vec::new();
-        loop {
-            let event = match subscription {
-                NapiSubscription::Memory {
-                    db,
-                    stream,
-                    pending_event,
-                } => {
-                    let Some(mut event) = pending_event.take().or_else(|| stream.try_next_event())
-                    else {
-                        break;
-                    };
-                    if let Err(error) =
-                        core_block_on(db.hydrate_subscription_event_for_binding(&mut event))
-                    {
-                        *pending_event = Some(event);
-                        return Err(napi::Error::from_reason(error.to_string()));
-                    }
-                    event
-                }
-                NapiSubscription::Persistent {
-                    db,
-                    stream,
-                    pending_event,
-                } => {
-                    let Some(mut event) = pending_event.take().or_else(|| stream.try_next_event())
-                    else {
-                        break;
-                    };
-                    if let Err(error) =
-                        core_block_on(db.hydrate_subscription_event_for_binding(&mut event))
-                    {
-                        *pending_event = Some(event);
-                        return Err(napi::Error::from_reason(error.to_string()));
-                    }
-                    event
-                }
-            };
-            events.push(core_subscription_event_to_napi(
-                &event,
-                &mut self.published_terminal_layouts,
-            )?);
+        let published_terminal_layouts = &mut self.published_terminal_layouts;
+        match subscription {
+            NapiSubscription::Memory {
+                db,
+                stream,
+                pending_events,
+            } => read_subscription_batch(
+                pending_events,
+                || stream.try_next_event(),
+                |event| {
+                    core_block_on(db.hydrate_subscription_event_for_binding(event))
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                },
+                published_terminal_layouts,
+            ),
+            NapiSubscription::Persistent {
+                db,
+                stream,
+                pending_events,
+            } => read_subscription_batch(
+                pending_events,
+                || stream.try_next_event(),
+                |event| {
+                    core_block_on(db.hydrate_subscription_event_for_binding(event))
+                        .map_err(|error| napi::Error::from_reason(error.to_string()))
+                },
+                published_terminal_layouts,
+            ),
         }
-        Ok(events)
     }
 
     #[napi]
@@ -724,6 +709,48 @@ impl Subscription {
     pub fn close(&mut self) -> bool {
         self.inner.take().is_some()
     }
+}
+
+/// Drain a subscription batch atomically at the JavaScript boundary.
+///
+/// A binding cannot return a prefix and then report an error: JavaScript would
+/// have no way to recover that prefix. Keep every source event until both
+/// hydration and encoding of the entire batch succeed, so retry is lossless
+/// and preserves source order.
+fn read_subscription_batch<F>(
+    pending_events: &mut VecDeque<CoreSubscriptionEvent>,
+    mut next: F,
+    mut hydrate: impl FnMut(&mut CoreSubscriptionEvent) -> napi::Result<()>,
+    published_terminal_layouts: &mut HashSet<String>,
+) -> napi::Result<Vec<SubscriptionEvent>>
+where
+    F: FnMut() -> Option<CoreSubscriptionEvent>,
+{
+    let mut batch = std::mem::take(pending_events)
+        .into_iter()
+        .collect::<Vec<_>>();
+    while let Some(event) = next() {
+        batch.push(event);
+    }
+    for event in &mut batch {
+        if let Err(error) = hydrate(event) {
+            pending_events.extend(batch);
+            return Err(error);
+        }
+    }
+    let mut prospective_layouts = published_terminal_layouts.clone();
+    let mut output = Vec::with_capacity(batch.len());
+    for event in &batch {
+        match core_subscription_event_to_napi(event, &mut prospective_layouts) {
+            Ok(event) => output.push(event),
+            Err(error) => {
+                pending_events.extend(batch);
+                return Err(error);
+            }
+        }
+    }
+    *published_terminal_layouts = prospective_layouts;
+    Ok(output)
 }
 
 #[napi]
@@ -1810,13 +1837,13 @@ impl NapiDb {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe(&query.inner, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe(&query.inner, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
         };
         Ok(Subscription {
@@ -1846,13 +1873,13 @@ impl NapiDb {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
         };
         Ok(Subscription {
@@ -1881,13 +1908,13 @@ impl NapiDb {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe_relation_query(&query, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
                 stream: core_block_on(db.subscribe_relation_query(&query, opts))
                     .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
         };
         Ok(Subscription {
@@ -1920,7 +1947,7 @@ impl NapiDb {
                     db.subscribe_relation_query_for_identity(&query, opts, author),
                 )
                 .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
             NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
                 db: Rc::clone(db),
@@ -1928,7 +1955,7 @@ impl NapiDb {
                     db.subscribe_relation_query_for_identity(&query, opts, author),
                 )
                 .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                pending_event: None,
+                pending_events: VecDeque::new(),
             },
         };
         Ok(Subscription {
@@ -4198,14 +4225,14 @@ pub fn verify_local_first_identity_proof_napi(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::{BTreeMap, HashSet, VecDeque};
     use std::rc::Rc;
 
     use crate::{
         NapiDb, NapiDbInnerStorage, NapiTxKind, PreparedQuery, Tx, authority_epoch_from_bigint,
         core_block_on, core_claim_value_from_json, core_read_opts_from_json,
-        core_subscription_event_to_napi, encode_core_subscription_delta, terminal_bytes_to_numbers,
-        unknown_transaction_kind_message,
+        core_subscription_event_to_napi, encode_core_subscription_delta, read_subscription_batch,
+        terminal_bytes_to_numbers, unknown_transaction_kind_message,
     };
 
     #[test]
@@ -4482,6 +4509,56 @@ mod tests {
         assert!(!payload.delta.is_empty());
         assert!(payload.terminal_operations.is_empty());
         assert_eq!(payload.tier, "Local");
+    }
+
+    #[test]
+    fn subscription_batch_retry_preserves_success_prefix_before_hydration_failure() {
+        let mut pending = VecDeque::new();
+        let mut source = VecDeque::from([
+            CoreSubscriptionEvent::Closed,
+            CoreSubscriptionEvent::Rejected {
+                reason: jazz::protocol::SubscribeRejectReason::UnsupportedShapeCapability {
+                    detail: "deliberately unavailable descriptor".to_owned(),
+                },
+            },
+        ]);
+        let mut published = HashSet::new();
+        let fail_second = true;
+        let error = match read_subscription_batch(
+            &mut pending,
+            || source.pop_front(),
+            |event| {
+                if fail_second && matches!(event, CoreSubscriptionEvent::Rejected { .. }) {
+                    return Err(napi::Error::from_reason("planned hydration failure"));
+                }
+                Ok(())
+            },
+            &mut published,
+        ) {
+            Ok(_) => panic!("planned hydration failure must abort the batch"),
+            Err(error) => error,
+        };
+        assert_eq!(error.reason, "planned hydration failure");
+        assert_eq!(pending.len(), 2, "successful prefix is retained for retry");
+        assert!(
+            source.is_empty(),
+            "all source events were captured in the retry queue"
+        );
+
+        let replayed = read_subscription_batch(
+            &mut pending,
+            || source.pop_front(),
+            |_| Ok(()),
+            &mut published,
+        )
+        .expect("retry succeeds");
+        assert!(pending.is_empty());
+        assert_eq!(replayed.len(), 2);
+        assert!(matches!(replayed[0], Either3::C(_)), "A keeps its position");
+        assert!(
+            matches!(replayed[1], Either3::B(_)),
+            "B follows A exactly once"
+        );
     }
 
     #[test]

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -415,6 +415,18 @@ impl WasmDbInner {
             _ => false,
         }
     }
+
+    async fn hydrate_relation_snapshot_for_binding(
+        &self,
+        snapshot: &mut jazz::node::RelationSnapshot,
+    ) -> Result<(), jazz::db::Error> {
+        match self {
+            Self::Memory(db) => db.hydrate_relation_snapshot_for_binding(snapshot).await,
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => db.hydrate_relation_snapshot_for_binding(snapshot).await,
+            Self::Closed => panic!("WasmDb is closed"),
+        }
+    }
 }
 
 #[wasm_bindgen]
@@ -2025,8 +2037,12 @@ impl WasmDb {
         let opts = read_opts_from_js(opts)?;
         let query = query.inner.clone();
         Ok(future_to_promise(async move {
-            let snapshot = inner
+            let mut snapshot = inner
                 .all_relation_snapshot(&query, opts)
+                .await
+                .map_err(to_js_error)?;
+            inner
+                .hydrate_relation_snapshot_for_binding(&mut snapshot)
                 .await
                 .map_err(to_js_error)?;
             bytes_to_js(encode_relation_snapshot(&snapshot).map_err(to_js_error)?)
@@ -2045,8 +2061,12 @@ impl WasmDb {
         let author = author_id_from_bytes(&author)?;
         let query = query.inner.clone();
         Ok(future_to_promise(async move {
-            let snapshot = inner
+            let mut snapshot = inner
                 .all_relation_snapshot_for_identity(&query, opts, author)
+                .await
+                .map_err(to_js_error)?;
+            inner
+                .hydrate_relation_snapshot_for_binding(&mut snapshot)
                 .await
                 .map_err(to_js_error)?;
             bytes_to_js(encode_relation_snapshot(&snapshot).map_err(to_js_error)?)

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -165,18 +165,24 @@ pub fn mint_anonymous_token(
     .map_err(|e| JsValue::from_str(&e))
 }
 
+/// Stable postcard envelope accepted by [`WasmDb::open_memory`] and
+/// `WasmDb.openMemory`.
+///
+/// The schema travels as public-schema JSON; this separately encodes only the
+/// runtime identity and deterministic test/open options.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct WasmOpenDbConfig {
-    identity: WasmDbIdentity,
-    row_id_seed: Option<u64>,
-    history_complete: bool,
-    initial_sync_flush_every: Option<u32>,
+pub struct WasmOpenDbConfig {
+    pub identity: WasmDbIdentity,
+    pub row_id_seed: Option<u64>,
+    pub history_complete: bool,
+    pub initial_sync_flush_every: Option<u32>,
 }
 
+/// Runtime identity carried in [`WasmOpenDbConfig`].
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-struct WasmDbIdentity {
-    node: NodeUuid,
-    author: AuthorId,
+pub struct WasmDbIdentity {
+    pub node: NodeUuid,
+    pub author: AuthorId,
 }
 
 impl From<WasmDbIdentity> for DbIdentity {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use futures_util::lock::Mutex as LocalMutex;
+use futures_util::stream;
 use futures_util::{Stream, StreamExt};
 #[cfg(target_arch = "wasm32")]
 use idb_tree::IndexedDbPageStore;
@@ -424,6 +425,18 @@ impl WasmDbInner {
             Self::Memory(db) => db.hydrate_relation_snapshot_for_binding(snapshot).await,
             #[cfg(target_arch = "wasm32")]
             Self::Browser(db) => db.hydrate_relation_snapshot_for_binding(snapshot).await,
+            Self::Closed => panic!("WasmDb is closed"),
+        }
+    }
+
+    async fn hydrate_subscription_event_for_binding(
+        &self,
+        event: &mut SubscriptionEvent,
+    ) -> Result<(), jazz::db::Error> {
+        match self {
+            Self::Memory(db) => db.hydrate_subscription_event_for_binding(event).await,
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => db.hydrate_subscription_event_for_binding(event).await,
             Self::Closed => panic!("WasmDb is closed"),
         }
     }
@@ -2080,7 +2093,7 @@ impl WasmDb {
             .inner
             .subscribe(&query.inner, opts)
             .map_err(to_js_error)?;
-        subscription_stream_to_js(stream)
+        subscription_stream_to_js(self.inner.clone(), stream)
     }
 
     #[wasm_bindgen(js_name = subscribeForIdentity)]
@@ -2096,7 +2109,7 @@ impl WasmDb {
             .inner
             .subscribe_for_identity(&query.inner, opts, author)
             .map_err(to_js_error)?;
-        subscription_stream_to_js(stream)
+        subscription_stream_to_js(self.inner.clone(), stream)
     }
 
     #[wasm_bindgen(js_name = subscribeRelationQuery)]
@@ -2111,7 +2124,7 @@ impl WasmDb {
             .inner
             .subscribe_relation_query(&query, opts)
             .map_err(to_js_error)?;
-        subscription_stream_to_js(stream)
+        subscription_stream_to_js(self.inner.clone(), stream)
     }
 
     #[wasm_bindgen(js_name = subscribeRelationQueryForIdentity)]
@@ -2128,7 +2141,7 @@ impl WasmDb {
             .inner
             .subscribe_relation_query_for_identity(&query, opts, author)
             .map_err(to_js_error)?;
-        subscription_stream_to_js(stream)
+        subscription_stream_to_js(self.inner.clone(), stream)
     }
 
     #[wasm_bindgen(js_name = attachQuery)]
@@ -3987,11 +4000,39 @@ fn encode_subscription_delta<'a>(
 }
 
 fn subscription_stream_to_js(
+    db: WasmDbInner,
     stream: impl Stream<Item = SubscriptionEvent> + 'static,
 ) -> Result<JsValue, JsValue> {
-    readable_stream_from_stream(stream.scan(HashSet::new(), |layouts, event| {
-        std::future::ready(Some(subscription_chunk_to_js(event, layouts)))
-    }))
+    let state = (
+        db,
+        Box::pin(stream) as Pin<Box<dyn Stream<Item = SubscriptionEvent>>>,
+        None::<SubscriptionEvent>,
+        HashSet::<String>::new(),
+    );
+    readable_stream_from_stream(stream::unfold(
+        state,
+        |(db, mut source, pending, layouts)| async move {
+            let mut event = match pending {
+                Some(event) => event,
+                None => match source.next().await {
+                    Some(event) => event,
+                    None => return None,
+                },
+            };
+            if db
+                .hydrate_subscription_event_for_binding(&mut event)
+                .await
+                .is_err()
+            {
+                return Some((Ok(None), (db, source, Some(event), layouts)));
+            }
+            let mut prospective_layouts = layouts.clone();
+            match subscription_chunk_to_js(event, &mut prospective_layouts) {
+                Ok(chunk) => Some((Ok(Some(chunk)), (db, source, None, prospective_layouts))),
+                Err(error) => Some((Err(error), (db, source, None, layouts))),
+            }
+        },
+    ))
 }
 
 fn subscription_chunk_to_js(
@@ -4141,11 +4182,11 @@ fn set_prop(object: &js_sys::Object, name: &str, value: JsValue) -> Result<(), J
     js_sys::Reflect::set(object, &JsValue::from_str(name), &value).map(|_| ())
 }
 
-type JsResultStream = dyn Stream<Item = Result<JsValue, JsValue>>;
+type JsResultStream = dyn Stream<Item = Result<Option<JsValue>, JsValue>>;
 
 fn readable_stream_from_stream<St>(stream: St) -> Result<JsValue, JsValue>
 where
-    St: Stream<Item = Result<JsValue, JsValue>> + 'static,
+    St: Stream<Item = Result<Option<JsValue>, JsValue>> + 'static,
 {
     let stream: Pin<Box<JsResultStream>> = Box::pin(stream);
     let state = std::rc::Rc::new(std::cell::RefCell::new(Some(stream)));
@@ -4162,9 +4203,12 @@ where
             };
             let next = stream.next().await;
             match next {
-                Some(Ok(chunk)) => {
+                Some(Ok(Some(chunk))) => {
                     *pull_state.borrow_mut() = Some(stream);
                     call_controller_method(&controller, "enqueue", Some(&chunk))?;
+                }
+                Some(Ok(None)) => {
+                    *pull_state.borrow_mut() = Some(stream);
                 }
                 Some(Err(error)) => {
                     call_controller_method(&controller, "error", Some(&error))?;

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3324,8 +3324,12 @@ impl WasmTransport {
     #[wasm_bindgen(js_name = tick)]
     pub fn tick(&self) -> js_sys::Promise {
         let inner = self.inner.clone();
+        let auxiliary_pump = self.auxiliary_pump.clone();
         future_to_promise(async move {
-            let work = inner.tick().await?;
+            let work = inner
+                .tick()
+                .await?
+                .saturating_add(auxiliary_pump.tick() as u32);
             Ok(JsValue::from_f64(work as f64))
         })
     }

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 type BrowserStorage = IdbStorage<IndexedDbPageStore>;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::future_to_promise;
+use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 mod identity;
 
@@ -3283,18 +3283,14 @@ impl WasmTransport {
     pub fn auxiliary_outbound_ready(&self) -> js_sys::Promise {
         let pump = self.auxiliary_pump.clone();
         future_to_promise(async move {
-            pump.outbound_ready().await;
+            if let Some(delay) = pump.next_retry_delay() {
+                JsFuture::from(js_timeout(delay.as_millis() as i32)?).await?;
+                pump.tick();
+            } else {
+                pump.outbound_ready().await;
+            }
             Ok(JsValue::UNDEFINED)
         })
-    }
-
-    /// One-shot retry deadline for a host-owned transport timer. The host must
-    /// call `tick()` when it fires; this avoids subscription-pull polling.
-    #[wasm_bindgen(js_name = nextAuxiliaryRetryDelayMs)]
-    pub fn next_auxiliary_retry_delay_ms(&self) -> Option<f64> {
-        self.auxiliary_pump
-            .next_retry_delay()
-            .map(|delay| delay.as_millis() as f64)
     }
 
     #[wasm_bindgen(js_name = sendWireFrame)]
@@ -3348,6 +3344,21 @@ impl WasmTransport {
         self.auxiliary_pump.disconnect();
         self.inner.close()
     }
+}
+
+fn js_timeout(delay_ms: i32) -> Result<js_sys::Promise, JsValue> {
+    let set_timeout = js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("setTimeout"))?
+        .dyn_into::<js_sys::Function>()?;
+    Ok(js_sys::Promise::new(&mut |resolve, _reject| {
+        let callback = Closure::once_into_js(move || {
+            let _ = resolve.call0(&JsValue::UNDEFINED);
+        });
+        let _ = set_timeout.call2(
+            &JsValue::UNDEFINED,
+            &callback,
+            &JsValue::from_f64(delay_ms as f64),
+        );
+    }))
 }
 
 #[wasm_bindgen]

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3284,7 +3284,7 @@ impl WasmTransport {
         let pump = self.auxiliary_pump.clone();
         future_to_promise(async move {
             if let Some(delay) = pump.next_retry_delay() {
-                JsFuture::from(js_timeout(delay.as_millis() as i32)?).await?;
+                JsFuture::from(js_timeout(delay.as_millis() as f64)?).await?;
                 pump.tick();
             } else {
                 pump.outbound_ready().await;
@@ -3346,18 +3346,18 @@ impl WasmTransport {
     }
 }
 
-fn js_timeout(delay_ms: i32) -> Result<js_sys::Promise, JsValue> {
+fn js_timeout(delay_ms: f64) -> Result<js_sys::Promise, JsValue> {
     let set_timeout = js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("setTimeout"))?
         .dyn_into::<js_sys::Function>()?;
-    Ok(js_sys::Promise::new(&mut |resolve, _reject| {
+    Ok(js_sys::Promise::new(&mut |resolve, reject| {
         let callback = Closure::once_into_js(move || {
             let _ = resolve.call0(&JsValue::UNDEFINED);
         });
-        let _ = set_timeout.call2(
-            &JsValue::UNDEFINED,
-            &callback,
-            &JsValue::from_f64(delay_ms as f64),
-        );
+        if let Err(error) =
+            set_timeout.call2(&JsValue::UNDEFINED, &callback, &JsValue::from_f64(delay_ms))
+        {
+            let _ = reject.call1(&JsValue::UNDEFINED, &error);
+        }
     }))
 }
 

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3283,13 +3283,37 @@ impl WasmTransport {
     pub fn auxiliary_outbound_ready(&self) -> js_sys::Promise {
         let pump = self.auxiliary_pump.clone();
         future_to_promise(async move {
-            if let Some(delay) = pump.next_retry_delay() {
-                JsFuture::from(js_timeout(delay.as_millis() as f64)?).await?;
-                pump.tick();
-            } else {
-                pump.outbound_ready().await;
+            // The retry deadline is only a snapshot.  A new request, a
+            // shorter Retryable response, cancellation, completion, or link
+            // replacement wakes `outbound_ready` through the resolver's
+            // schedule generation, so an old JS timeout is never allowed to
+            // starve the current carrier.
+            loop {
+                if pump.outbound_is_ready() || pump.is_disconnected() {
+                    return Ok(JsValue::UNDEFINED);
+                }
+                let schedule_change = pump.outbound_ready();
+                if let Some(delay) = pump.next_retry_delay() {
+                    // Browsers clamp overflowing setTimeout delays to an
+                    // immediate callback.  Clamp deliberately and recompute
+                    // after each bounded wait so a u64 retry remains a real
+                    // delay instead of a hot loop.
+                    const MAX_JS_TIMEOUT_MS: u64 = i32::MAX as u64;
+                    let timeout = JsFuture::from(js_timeout(
+                        delay.as_millis().min(u128::from(MAX_JS_TIMEOUT_MS)) as f64,
+                    )?);
+                    futures_util::pin_mut!(schedule_change, timeout);
+                    match futures_util::future::select(schedule_change, timeout).await {
+                        futures_util::future::Either::Left(((), _)) => continue,
+                        futures_util::future::Either::Right((result, _)) => {
+                            result?;
+                            pump.tick();
+                        }
+                    }
+                } else {
+                    schedule_change.await;
+                }
             }
-            Ok(JsValue::UNDEFINED)
         })
     }
 
@@ -4052,7 +4076,17 @@ fn subscription_stream_to_js(
             match db.hydrate_subscription_event_for_binding(&mut event).await {
                 Ok(()) => {}
                 Err(jazz::db::BindingHydrationError::ChunkUnavailable) => {
-                    return Some((Ok(None), (db, source, Some(event), layouts)));
+                    // Peer-resolved chunk absence remains pending inside the
+                    // resolver until a Retryable deadline or terminal answer;
+                    // reaching this boundary therefore has no awaitable wake.
+                    // Returning an empty successful pull would make JS spin
+                    // forever on the same retained event.
+                    return Some((
+                        Err(JsValue::from_str(
+                            "large-value chunk is unavailable and cannot be retried",
+                        )),
+                        (db, source, None, layouts),
+                    ));
                 }
                 Err(jazz::db::BindingHydrationError::Error(error)) => {
                     return Some((Err(to_js_error(error)), (db, source, None, layouts)));

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3288,6 +3288,15 @@ impl WasmTransport {
         })
     }
 
+    /// One-shot retry deadline for a host-owned transport timer. The host must
+    /// call `tick()` when it fires; this avoids subscription-pull polling.
+    #[wasm_bindgen(js_name = nextAuxiliaryRetryDelayMs)]
+    pub fn next_auxiliary_retry_delay_ms(&self) -> Option<f64> {
+        self.auxiliary_pump
+            .next_retry_delay()
+            .map(|delay| delay.as_millis() as f64)
+    }
+
     #[wasm_bindgen(js_name = sendWireFrame)]
     pub fn send_wire_frame(&self, frame: Vec<u8>) {
         self.queues.inbound.borrow_mut().push_back(frame);

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -165,24 +165,18 @@ pub fn mint_anonymous_token(
     .map_err(|e| JsValue::from_str(&e))
 }
 
-/// Stable postcard envelope accepted by [`WasmDb::open_memory`] and
-/// `WasmDb.openMemory`.
-///
-/// The schema travels as public-schema JSON; this separately encodes only the
-/// runtime identity and deterministic test/open options.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct WasmOpenDbConfig {
-    pub identity: WasmDbIdentity,
-    pub row_id_seed: Option<u64>,
-    pub history_complete: bool,
-    pub initial_sync_flush_every: Option<u32>,
+struct WasmOpenDbConfig {
+    identity: WasmDbIdentity,
+    row_id_seed: Option<u64>,
+    history_complete: bool,
+    initial_sync_flush_every: Option<u32>,
 }
 
-/// Runtime identity carried in [`WasmOpenDbConfig`].
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct WasmDbIdentity {
-    pub node: NodeUuid,
-    pub author: AuthorId,
+struct WasmDbIdentity {
+    node: NodeUuid,
+    author: AuthorId,
 }
 
 impl From<WasmDbIdentity> for DbIdentity {
@@ -438,11 +432,17 @@ impl WasmDbInner {
     async fn hydrate_subscription_event_for_binding(
         &self,
         event: &mut SubscriptionEvent,
-    ) -> Result<(), jazz::db::Error> {
+    ) -> Result<(), jazz::db::BindingHydrationError> {
         match self {
-            Self::Memory(db) => db.hydrate_subscription_event_for_binding(event).await,
+            Self::Memory(db) => {
+                db.hydrate_subscription_event_for_binding_outcome(event)
+                    .await
+            }
             #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => db.hydrate_subscription_event_for_binding(event).await,
+            Self::Browser(db) => {
+                db.hydrate_subscription_event_for_binding_outcome(event)
+                    .await
+            }
             Self::Closed => panic!("WasmDb is closed"),
         }
     }
@@ -4025,12 +4025,14 @@ fn subscription_stream_to_js(
                     None => return None,
                 },
             };
-            if db
-                .hydrate_subscription_event_for_binding(&mut event)
-                .await
-                .is_err()
-            {
-                return Some((Ok(None), (db, source, Some(event), layouts)));
+            match db.hydrate_subscription_event_for_binding(&mut event).await {
+                Ok(()) => {}
+                Err(jazz::db::BindingHydrationError::ChunkUnavailable) => {
+                    return Some((Ok(None), (db, source, Some(event), layouts)));
+                }
+                Err(jazz::db::BindingHydrationError::Error(error)) => {
+                    return Some((Err(to_js_error(error)), (db, source, None, layouts)));
+                }
             }
             let mut prospective_layouts = layouts.clone();
             match subscription_chunk_to_js(event, &mut prospective_layouts) {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -680,23 +680,31 @@ impl WasmDbInner {
         with_wasm_db!(self, |db| db.prepare_query(query))
     }
 
-    fn all(
+    async fn all(
         &self,
         query: &PreparedQuery,
         opts: ReadOpts,
     ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(db.all(query, opts)))
+        match self {
+            Self::Memory(db) => db.all(query, opts).await,
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => db.all(query, opts).await,
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
-    fn all_for_identity(
+    async fn all_for_identity(
         &self,
         query: &PreparedQuery,
         opts: ReadOpts,
         author: AuthorId,
     ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.all_for_identity(query, opts, author)
-        ))
+        match self {
+            Self::Memory(db) => db.all_for_identity(query, opts, author).await,
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => db.all_for_identity(query, opts, author).await,
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
     fn begin_exclusive(
@@ -721,54 +729,94 @@ impl WasmDbInner {
         })
     }
 
-    fn exclusive_all_for_identity(
+    async fn exclusive_all_for_identity(
         &self,
         tx_id: OpenTransactionId,
         query: &PreparedQuery,
         author: AuthorId,
         opts: ReadOpts,
     ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id)
-                .all_prepared_for_identity_with_opts(query, author, opts)
-        ))
+        match self {
+            Self::Memory(db) => {
+                db.exclusive_tx_ref(tx_id)
+                    .all_prepared_for_identity_with_opts(query, author, opts)
+                    .await
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                db.exclusive_tx_ref(tx_id)
+                    .all_prepared_for_identity_with_opts(query, author, opts)
+                    .await
+            }
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
-    fn exclusive_all(
+    async fn exclusive_all(
         &self,
         tx_id: OpenTransactionId,
         query: &PreparedQuery,
         opts: ReadOpts,
     ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id)
-                .all_prepared_with_opts(query, opts)
-        ))
+        match self {
+            Self::Memory(db) => {
+                db.exclusive_tx_ref(tx_id)
+                    .all_prepared_with_opts(query, opts)
+                    .await
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                db.exclusive_tx_ref(tx_id)
+                    .all_prepared_with_opts(query, opts)
+                    .await
+            }
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
-    fn mergeable_all_for_identity(
+    async fn mergeable_all_for_identity(
         &self,
         tx_id: OpenTransactionId,
         query: &PreparedQuery,
         author: AuthorId,
         opts: ReadOpts,
     ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .all_prepared_for_identity_with_opts(query, author, opts)
-        ))
+        match self {
+            Self::Memory(db) => {
+                db.mergeable_tx_ref(tx_id)
+                    .all_prepared_for_identity_with_opts(query, author, opts)
+                    .await
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                db.mergeable_tx_ref(tx_id)
+                    .all_prepared_for_identity_with_opts(query, author, opts)
+                    .await
+            }
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
-    fn mergeable_all(
+    async fn mergeable_all(
         &self,
         tx_id: OpenTransactionId,
         query: &PreparedQuery,
         opts: ReadOpts,
     ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .all_prepared_with_opts(query, opts)
-        ))
+        match self {
+            Self::Memory(db) => {
+                db.mergeable_tx_ref(tx_id)
+                    .all_prepared_with_opts(query, opts)
+                    .await
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                db.mergeable_tx_ref(tx_id)
+                    .all_prepared_with_opts(query, opts)
+                    .await
+            }
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
     fn abandon_transaction(&self, tx_id: OpenTransactionId) -> Result<(), jazz::db::Error> {
@@ -1899,19 +1947,55 @@ impl WasmDb {
         })
     }
 
+    /// Internal write-merge bridge. Client WASM runtimes use in-memory storage,
+    /// so this exact primary-key lookup cannot suspend on a peer chunk. Public
+    /// query reads use the Promise-returning methods below.
+    #[wasm_bindgen(js_name = localCurrentRow)]
+    pub fn local_current_row(&self, table: String, row_id: Vec<u8>) -> Result<Vec<u8>, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let row = match &self.inner {
+            WasmDbInner::Memory(db) => block_on(db.local_current_row(&table, row_id)),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(_) => {
+                return Err(JsValue::from_str(
+                    "browser storage does not support synchronous write-merge inspection",
+                ));
+            }
+            WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+        }
+        .map_err(to_js_error)?;
+        encode_rows(&row.into_iter().collect::<Vec<_>>()).map_err(to_js_error)
+    }
+
     #[wasm_bindgen(js_name = all)]
-    pub fn all(&self, query: &WasmPreparedQuery, opts: JsValue) -> Result<Vec<u8>, JsValue> {
+    pub fn all(
+        &self,
+        query: &WasmPreparedQuery,
+        opts: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let inner = self.inner.clone();
+        let query = query.inner.clone();
         let opts = read_opts_from_js(opts)?;
-        let rows = self.inner.all(&query.inner, opts).map_err(to_js_error)?;
-        encode_rows(&rows).map_err(to_js_error)
+        Ok(future_to_promise(async move {
+            let rows = inner.all(&query, opts).await.map_err(to_js_error)?;
+            bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+        }))
     }
 
     #[wasm_bindgen(js_name = one)]
-    pub fn one(&self, query: &WasmPreparedQuery, opts: JsValue) -> Result<Vec<u8>, JsValue> {
+    pub fn one(
+        &self,
+        query: &WasmPreparedQuery,
+        opts: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let inner = self.inner.clone();
+        let query = query.inner.clone();
         let opts = read_opts_from_js(opts)?;
-        let mut rows = self.inner.all(&query.inner, opts).map_err(to_js_error)?;
-        rows.truncate(1);
-        encode_rows(&rows).map_err(to_js_error)
+        Ok(future_to_promise(async move {
+            let mut rows = inner.all(&query, opts).await.map_err(to_js_error)?;
+            rows.truncate(1);
+            bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+        }))
     }
 
     #[wasm_bindgen(js_name = allInTransaction)]
@@ -1920,16 +2004,21 @@ impl WasmDb {
         query: &WasmPreparedQuery,
         tx: &WasmTx,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
+    ) -> Result<js_sys::Promise, JsValue> {
         ensure_transaction_runtime(&self.inner, tx)?;
+        let inner = self.inner.clone();
+        let query = query.inner.clone();
         let opts = read_opts_from_js(opts)?;
         let tx_id = tx.open_tx_for_read()?;
-        let rows = match tx.kind {
-            WasmTxKind::Mergeable => self.inner.mergeable_all(tx_id, &query.inner, opts),
-            WasmTxKind::Exclusive => self.inner.exclusive_all(tx_id, &query.inner, opts),
-        }
-        .map_err(to_js_error)?;
-        encode_rows(&rows).map_err(to_js_error)
+        let kind = tx.kind;
+        Ok(future_to_promise(async move {
+            let rows = match kind {
+                WasmTxKind::Mergeable => inner.mergeable_all(tx_id, &query, opts).await,
+                WasmTxKind::Exclusive => inner.exclusive_all(tx_id, &query, opts).await,
+            }
+            .map_err(to_js_error)?;
+            bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+        }))
     }
 
     #[wasm_bindgen(js_name = allInTransactionForIdentity)]
@@ -1939,23 +2028,30 @@ impl WasmDb {
         tx: &WasmTx,
         author: Vec<u8>,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
+    ) -> Result<js_sys::Promise, JsValue> {
         ensure_transaction_runtime(&self.inner, tx)?;
+        let inner = self.inner.clone();
+        let query = query.inner.clone();
         let opts = read_opts_from_js(opts)?;
         let author = author_id_from_bytes(&author)?;
         let tx_id = tx.open_tx_for_read()?;
-        let rows = match tx.kind {
-            WasmTxKind::Mergeable => {
-                self.inner
-                    .mergeable_all_for_identity(tx_id, &query.inner, author, opts)
+        let kind = tx.kind;
+        Ok(future_to_promise(async move {
+            let rows = match kind {
+                WasmTxKind::Mergeable => {
+                    inner
+                        .mergeable_all_for_identity(tx_id, &query, author, opts)
+                        .await
+                }
+                WasmTxKind::Exclusive => {
+                    inner
+                        .exclusive_all_for_identity(tx_id, &query, author, opts)
+                        .await
+                }
             }
-            WasmTxKind::Exclusive => {
-                self.inner
-                    .exclusive_all_for_identity(tx_id, &query.inner, author, opts)
-            }
-        }
-        .map_err(to_js_error)?;
-        encode_rows(&rows).map_err(to_js_error)
+            .map_err(to_js_error)?;
+            bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+        }))
     }
 
     #[wasm_bindgen(js_name = oneInTransaction)]
@@ -1964,10 +2060,19 @@ impl WasmDb {
         query: &WasmPreparedQuery,
         tx: &WasmTx,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
-        let mut rows = read_rows_for_transaction(&self.inner, query, tx, None, opts)?;
-        rows.truncate(1);
-        encode_rows(&rows).map_err(to_js_error)
+    ) -> Result<js_sys::Promise, JsValue> {
+        ensure_transaction_runtime(&self.inner, tx)?;
+        let inner = self.inner.clone();
+        let query = query.inner.clone();
+        let opts = read_opts_from_js(opts)?;
+        let tx_id = tx.open_tx_for_read()?;
+        let kind = tx.kind;
+        Ok(future_to_promise(async move {
+            let mut rows =
+                read_rows_for_transaction(&inner, &query, tx_id, kind, None, opts).await?;
+            rows.truncate(1);
+            bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+        }))
     }
 
     #[wasm_bindgen(js_name = oneInTransactionForIdentity)]
@@ -1977,11 +2082,20 @@ impl WasmDb {
         tx: &WasmTx,
         author: Vec<u8>,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
+    ) -> Result<js_sys::Promise, JsValue> {
+        ensure_transaction_runtime(&self.inner, tx)?;
+        let inner = self.inner.clone();
+        let query = query.inner.clone();
+        let opts = read_opts_from_js(opts)?;
         let author = author_id_from_bytes(&author)?;
-        let mut rows = read_rows_for_transaction(&self.inner, query, tx, Some(author), opts)?;
-        rows.truncate(1);
-        encode_rows(&rows).map_err(to_js_error)
+        let tx_id = tx.open_tx_for_read()?;
+        let kind = tx.kind;
+        Ok(future_to_promise(async move {
+            let mut rows =
+                read_rows_for_transaction(&inner, &query, tx_id, kind, Some(author), opts).await?;
+            rows.truncate(1);
+            bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+        }))
     }
 
     #[wasm_bindgen(js_name = setIdentityClaims)]
@@ -1998,14 +2112,18 @@ impl WasmDb {
         query: &WasmPreparedQuery,
         author: Vec<u8>,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
+    ) -> Result<js_sys::Promise, JsValue> {
+        let inner = self.inner.clone();
+        let query = query.inner.clone();
         let opts = read_opts_from_js(opts)?;
         let author = author_id_from_bytes(&author)?;
-        let rows = self
-            .inner
-            .all_for_identity(&query.inner, opts, author)
-            .map_err(to_js_error)?;
-        encode_rows(&rows).map_err(to_js_error)
+        Ok(future_to_promise(async move {
+            let rows = inner
+                .all_for_identity(&query, opts, author)
+                .await
+                .map_err(to_js_error)?;
+            bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+        }))
     }
 
     #[wasm_bindgen(js_name = allRelationQuery)]
@@ -3672,28 +3790,30 @@ impl WasmTx {
     }
 }
 
-fn read_rows_for_transaction(
+async fn read_rows_for_transaction(
     db: &WasmDbInner,
-    query: &WasmPreparedQuery,
-    tx: &WasmTx,
+    query: &PreparedQuery,
+    tx_id: OpenTransactionId,
+    kind: WasmTxKind,
     author: Option<AuthorId>,
-    opts: JsValue,
+    opts: ReadOpts,
 ) -> Result<Vec<jazz::node::CurrentRow>, JsValue> {
-    ensure_transaction_runtime(db, tx)?;
-    let opts = read_opts_from_js(opts)?;
-    let tx_id = tx.open_tx_for_read()?;
-    match (tx.kind, author) {
+    match (kind, author) {
         (WasmTxKind::Mergeable, Some(author)) => db
-            .mergeable_all_for_identity(tx_id, &query.inner, author, opts)
+            .mergeable_all_for_identity(tx_id, query, author, opts)
+            .await
             .map_err(to_js_error),
         (WasmTxKind::Mergeable, None) => db
-            .mergeable_all(tx_id, &query.inner, opts)
+            .mergeable_all(tx_id, query, opts)
+            .await
             .map_err(to_js_error),
         (WasmTxKind::Exclusive, Some(author)) => db
-            .exclusive_all_for_identity(tx_id, &query.inner, author, opts)
+            .exclusive_all_for_identity(tx_id, query, author, opts)
+            .await
             .map_err(to_js_error),
         (WasmTxKind::Exclusive, None) => db
-            .exclusive_all(tx_id, &query.inner, opts)
+            .exclusive_all(tx_id, query, opts)
+            .await
             .map_err(to_js_error),
     }
 }
@@ -4490,9 +4610,12 @@ mod dynamic_schema_view_tests {
         ))
         .unwrap();
         let prepared = view.prepare_query(&view.table("items")).unwrap();
-        let rows = WasmDbInner::Memory(Rc::clone(&view))
-            .mergeable_all(batch, &prepared, ReadOpts::default())
-            .unwrap();
+        let rows = block_on(WasmDbInner::Memory(Rc::clone(&view)).mergeable_all(
+            batch,
+            &prepared,
+            ReadOpts::default(),
+        ))
+        .unwrap();
         assert_eq!(rows.len(), 1, "the attached view reads staged rows");
         block_on(owner.commit_mergeable_handle(batch)).unwrap();
 

--- a/crates/jazz-wasm/tests/wasm.rs
+++ b/crates/jazz-wasm/tests/wasm.rs
@@ -315,9 +315,13 @@ async fn public_wasm_large_values_hydrate_before_direct_relation_and_subscriptio
         Some(&Value::String(json.clone()))
     );
 
+    let direct_bytes = await_promise(db.all(&query, JsValue::NULL).expect("direct public read"))
+        .await
+        .dyn_into::<js_sys::Uint8Array>()
+        .expect("direct public read resolves Uint8Array")
+        .to_vec();
     let direct: Vec<DecodedRowBatch> =
-        postcard::from_bytes(&db.all(&query, JsValue::NULL).expect("direct public read"))
-            .expect("decode direct public rows");
+        postcard::from_bytes(&direct_bytes).expect("decode direct public rows");
     let direct_values = values_from_batches(&direct);
     assert_eq!(
         direct_values.get("text"),

--- a/crates/jazz-wasm/tests/wasm.rs
+++ b/crates/jazz-wasm/tests/wasm.rs
@@ -4,11 +4,22 @@
 
 #![cfg(target_arch = "wasm32")]
 
+use std::collections::BTreeMap;
+
+use jazz::groove::records::{BorrowedRecord, RecordDescriptor, Value};
+use jazz::ids::{AuthorId, NodeUuid, RowUuid};
+use jazz::query::Query;
+use jazz::tools::{ColumnType, PolicyExpr, SchemaBuilder, TablePolicies, TableSchema};
+use jazz_wasm::{
+    current_timestamp, derive_user_id, generate_id, mint_anonymous_token, WasmDb, WasmDbIdentity,
+    WasmOpenDbConfig,
+};
+use serde::Deserialize;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
-
-use jazz_wasm::{current_timestamp, derive_user_id, generate_id, mint_anonymous_token};
 
 #[wasm_bindgen_test]
 fn test_generate_id() {
@@ -57,4 +68,270 @@ fn test_identity_helpers_reject_invalid_seed() {
     let err = derive_user_id("not-base64url".to_string()).expect_err("invalid seed should fail");
     let message = err.as_string().unwrap_or_default();
     assert!(message.contains("seed"));
+}
+
+#[derive(Deserialize)]
+struct DecodedRow {
+    raw: Vec<u8>,
+}
+
+#[derive(Deserialize)]
+struct DecodedRowBatch {
+    table: String,
+    descriptor: RecordDescriptor,
+    rows: Vec<DecodedRow>,
+}
+
+#[derive(Deserialize)]
+struct DecodedRelationSnapshot {
+    root_count: u64,
+    rows: Vec<DecodedRowBatch>,
+}
+
+#[derive(Deserialize)]
+struct DecodedSubscriptionDelta {
+    added: Vec<DecodedRowBatch>,
+    updated: Vec<DecodedRowBatch>,
+}
+
+fn fixture_db() -> WasmDb {
+    let schema = SchemaBuilder::new()
+        .table(
+            TableSchema::builder("values")
+                .column("text", ColumnType::Text)
+                .column("bytes", ColumnType::Bytea)
+                .column("json", ColumnType::Json { schema: None })
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::True)
+                        .with_insert(PolicyExpr::True)
+                        .with_update(Some(PolicyExpr::True), PolicyExpr::True)
+                        .with_delete(PolicyExpr::True),
+                ),
+        )
+        .build();
+    let config = WasmOpenDbConfig {
+        identity: WasmDbIdentity {
+            node: NodeUuid::from_bytes([0x51; 16]),
+            author: AuthorId::from_bytes([0xa1; 16]),
+        },
+        row_id_seed: Some(51),
+        history_complete: false,
+        initial_sync_flush_every: None,
+    };
+    WasmDb::open_memory(
+        serde_json::to_vec(&schema).expect("encode public schema JSON"),
+        postcard::to_allocvec(&config).expect("encode open config postcard"),
+    )
+    .expect("open public WASM memory binding")
+}
+
+fn empty_cells() -> Vec<u8> {
+    postcard::to_allocvec(&(
+        RecordDescriptor::new(Vec::<(String, _)>::new()),
+        Vec::<u8>::new(),
+    ))
+    .expect("encode empty cell envelope")
+}
+
+async fn await_promise(promise: js_sys::Promise) -> JsValue {
+    JsFuture::from(promise)
+        .await
+        .expect("WASM promise resolves")
+}
+
+async fn next_stream_chunk(reader: &JsValue) -> JsValue {
+    let read = js_sys::Reflect::get(reader, &JsValue::from_str("read"))
+        .expect("ReadableStream reader has read")
+        .dyn_into::<js_sys::Function>()
+        .expect("reader.read is callable");
+    let promise = read
+        .call0(reader)
+        .expect("call reader.read")
+        .dyn_into::<js_sys::Promise>()
+        .expect("reader.read returns promise");
+    await_promise(promise).await
+}
+
+fn stream_reader(stream: JsValue) -> JsValue {
+    let get_reader = js_sys::Reflect::get(&stream, &JsValue::from_str("getReader"))
+        .expect("ReadableStream has getReader")
+        .dyn_into::<js_sys::Function>()
+        .expect("ReadableStream.getReader is callable");
+    get_reader.call0(&stream).expect("obtain stream reader")
+}
+
+fn stream_delta(chunk: &JsValue) -> DecodedSubscriptionDelta {
+    assert_eq!(
+        js_sys::Reflect::get(chunk, &JsValue::from_str("type"))
+            .expect("subscription chunk type")
+            .as_string()
+            .as_deref(),
+        Some("delta"),
+        "large-value hydration must not close or reject the JS stream"
+    );
+    let bytes = js_sys::Reflect::get(chunk, &JsValue::from_str("delta"))
+        .expect("subscription delta")
+        .dyn_into::<js_sys::Uint8Array>()
+        .expect("subscription delta is Uint8Array")
+        .to_vec();
+    postcard::from_bytes(&bytes).expect("decode public subscription delta")
+}
+
+fn values_from_batches(batches: &[DecodedRowBatch]) -> BTreeMap<String, Value> {
+    let batch = batches
+        .iter()
+        .find(|batch| batch.table == "values" && !batch.rows.is_empty())
+        .expect("values output batch");
+    let values = BorrowedRecord::new(&batch.rows[0].raw, &batch.descriptor)
+        .to_values()
+        .expect("decode logical public row");
+    batch
+        .descriptor
+        .fields()
+        .iter()
+        .zip(values)
+        .filter_map(|(field, value)| field.name.as_ref().map(|name| (name.clone(), value)))
+        .collect()
+}
+
+#[wasm_bindgen_test(async)]
+async fn public_wasm_large_values_hydrate_before_direct_relation_and_subscription_encoding() {
+    // This is deliberately through the wasm-bindgen exported surface: public
+    // schema JSON + postcard open config, streaming mutation promises, prepared
+    // query, direct read, relation snapshot promise, and ReadableStream pulls.
+    let db = fixture_db();
+    let query = db
+        .prepare_query(postcard::to_allocvec(&Query::from("values")).expect("encode query"))
+        .expect("prepare public query");
+    let reader = stream_reader(
+        db.subscribe(&query, JsValue::NULL)
+            .expect("create public subscription"),
+    );
+
+    // The initial empty delta proves that the stream is live before the write.
+    let initial = next_stream_chunk(&reader).await;
+    let initial_delta = stream_delta(&initial);
+    assert!(initial_delta.added.is_empty() && initial_delta.updated.is_empty());
+
+    let row = RowUuid::from_bytes([0x71; 16]).0.as_bytes().to_vec();
+    let text = format!("{}🙂", "text-".repeat(20_000));
+    let bytes = (0..120_000)
+        .map(|index| (index % 251) as u8)
+        .collect::<Vec<_>>();
+    let json = format!(r#"{{"kind":"large","body":"{}"}}"#, "json-".repeat(20_000));
+    let cells = empty_cells();
+
+    let text_upload = db
+        .begin_streaming_mutation_encoded(
+            "values".to_owned(),
+            row.clone(),
+            cells.clone(),
+            "text".to_owned(),
+            "Text".to_owned(),
+            Some("insert".to_owned()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("begin text upload");
+    await_promise(text_upload.push(text.as_bytes().to_vec())).await;
+    await_promise(text_upload.finish()).await;
+
+    let bytes_upload = db
+        .begin_streaming_mutation_encoded(
+            "values".to_owned(),
+            row.clone(),
+            cells.clone(),
+            "bytes".to_owned(),
+            "Bytea".to_owned(),
+            Some("update".to_owned()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("begin bytea upload");
+    await_promise(bytes_upload.push(bytes.clone())).await;
+    await_promise(bytes_upload.finish()).await;
+
+    let json_upload = db
+        .begin_streaming_mutation_encoded(
+            "values".to_owned(),
+            row,
+            cells,
+            "json".to_owned(),
+            "Json".to_owned(),
+            Some("update".to_owned()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("begin JSON upload");
+    await_promise(json_upload.push(json.as_bytes().to_vec())).await;
+    await_promise(json_upload.finish()).await;
+
+    // One delta per local commit is retained in source order. In particular,
+    // a hydration delay is not allowed to drop the raw event, close the stream,
+    // or let a later update overtake it.
+    let mut subscription_values = None;
+    for _ in 0..3 {
+        let delta = stream_delta(&next_stream_chunk(&reader).await);
+        let batches = if delta.added.is_empty() {
+            &delta.updated
+        } else {
+            &delta.added
+        };
+        subscription_values = Some(values_from_batches(batches));
+    }
+    let subscription_values =
+        subscription_values.expect("three post-write subscription deltas without stream closure");
+    assert_eq!(
+        subscription_values.get("text"),
+        Some(&Value::String(text.clone()))
+    );
+    assert_eq!(
+        subscription_values.get("bytes"),
+        Some(&Value::Bytes(bytes.clone()))
+    );
+    assert_eq!(
+        subscription_values.get("json"),
+        Some(&Value::String(json.clone()))
+    );
+
+    let direct: Vec<DecodedRowBatch> =
+        postcard::from_bytes(&db.all(&query, JsValue::NULL).expect("direct public read"))
+            .expect("decode direct public rows");
+    let direct_values = values_from_batches(&direct);
+    assert_eq!(
+        direct_values.get("text"),
+        Some(&Value::String(text.clone()))
+    );
+    assert_eq!(
+        direct_values.get("bytes"),
+        Some(&Value::Bytes(bytes.clone()))
+    );
+    assert_eq!(
+        direct_values.get("json"),
+        Some(&Value::String(json.clone()))
+    );
+
+    let relation = await_promise(
+        db.all_relation_snapshot(&query, JsValue::NULL)
+            .expect("start public relation snapshot"),
+    )
+    .await;
+    let relation_bytes = relation
+        .dyn_into::<js_sys::Uint8Array>()
+        .expect("relation snapshot resolves Uint8Array")
+        .to_vec();
+    let relation: DecodedRelationSnapshot =
+        postcard::from_bytes(&relation_bytes).expect("decode public relation snapshot");
+    assert_eq!(relation.root_count, 1);
+    let relation_values = values_from_batches(&relation.rows);
+    assert_eq!(relation_values.get("text"), Some(&Value::String(text)));
+    assert_eq!(relation_values.get("bytes"), Some(&Value::Bytes(bytes)));
+    assert_eq!(relation_values.get("json"), Some(&Value::String(json)));
 }

--- a/crates/jazz-wasm/tests/wasm.rs
+++ b/crates/jazz-wasm/tests/wasm.rs
@@ -10,11 +10,8 @@ use jazz::groove::records::{BorrowedRecord, RecordDescriptor, Value};
 use jazz::ids::{AuthorId, NodeUuid, RowUuid};
 use jazz::query::Query;
 use jazz::tools::{ColumnType, PolicyExpr, SchemaBuilder, TablePolicies, TableSchema};
-use jazz_wasm::{
-    current_timestamp, derive_user_id, generate_id, mint_anonymous_token, WasmDb, WasmDbIdentity,
-    WasmOpenDbConfig,
-};
-use serde::Deserialize;
+use jazz_wasm::{current_timestamp, derive_user_id, generate_id, mint_anonymous_token, WasmDb};
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
@@ -94,6 +91,23 @@ struct DecodedSubscriptionDelta {
     updated: Vec<DecodedRowBatch>,
 }
 
+// This mirrors the private postcard input envelope exactly. It is intentionally
+// local to the binding receipt: making the config a Rust API would freeze an
+// implementation detail that JavaScript only ever sees as bytes.
+#[derive(Serialize)]
+struct OpenDbConfigFixture {
+    identity: OpenDbIdentityFixture,
+    row_id_seed: Option<u64>,
+    history_complete: bool,
+    initial_sync_flush_every: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct OpenDbIdentityFixture {
+    node: NodeUuid,
+    author: AuthorId,
+}
+
 fn fixture_db() -> WasmDb {
     let schema = SchemaBuilder::new()
         .table(
@@ -110,8 +124,8 @@ fn fixture_db() -> WasmDb {
                 ),
         )
         .build();
-    let config = WasmOpenDbConfig {
-        identity: WasmDbIdentity {
+    let config = OpenDbConfigFixture {
+        identity: OpenDbIdentityFixture {
             node: NodeUuid::from_bytes([0x51; 16]),
             author: AuthorId::from_bytes([0xa1; 16]),
         },

--- a/crates/jazz/SPEC/2_data_model_identity.md
+++ b/crates/jazz/SPEC/2_data_model_identity.md
@@ -102,13 +102,13 @@ schema.
 
 ### 2.3.1 Ordinary-value baseline
 
-`string` and `bytes` are ordinary column values with ordinary Jazz row history.
-The current core has no specialized Text/Blob large-value type, edit API,
-materialized value handle, content store, extent/chunk protocol traffic, or
-large-value query source. Sync transports only ordinary commit, schema, query,
-and subscription data. A future large-value design is tracked in
-[#1757](https://github.com/garden-co/jazz/issues/1757); it must be introduced as
-new semantics rather than inferred from this baseline.
+`string`, `bytes`, and JSON are ordinary logical column values with ordinary
+Jazz row history. Their storage may switch transparently between inline and
+indirect large-value encoding; this does not introduce a specialized Jazz
+column type, query source, or second synchronization model. Groove owns the
+physical tree and logical value operations, while Jazz owns the authorized
+row/version and auxiliary chunk transport, as specified in chapter 19 and
+Groove chapter 9.
 
 ### 2.4 Schema identity is content-addressed
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1614,6 +1614,8 @@ mod lifecycle;
 mod mutations;
 pub use mutations::{StreamingMutationKind, StreamingValueUpload};
 mod reads;
+#[doc(hidden)]
+pub use reads::BindingHydrationError;
 mod subscriptions;
 mod transactions;
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -27,6 +27,7 @@ use groove::storage::{OrderedKvStorage, ReopenableStorage};
 use thiserror::Error;
 #[cfg(feature = "cold-settle-attribution")]
 use web_time::Instant;
+use web_time::{Duration, Instant};
 
 use crate::authorization_scope::{
     AuthorityContext, AuthorityScopeAggregate, AuthorizationScopeAcquisition,
@@ -108,6 +109,7 @@ struct PendingChunkDemand {
     upstream_id: u64,
     remaining_hops: u8,
     waiters: Vec<ChunkDemandWaiter>,
+    retry_at: Option<Instant>,
 }
 
 #[derive(Default)]
@@ -194,6 +196,7 @@ impl PeerChunkResolver {
                 upstream_id,
                 remaining_hops,
                 waiters: vec![waiter],
+                retry_at: None,
             },
         );
         if let Some(connection) = state.upstream_connection {
@@ -243,7 +246,33 @@ impl PeerChunkResolver {
         }
     }
 
+    fn promote_due_retries(&self) -> usize {
+        let now = Instant::now();
+        let mut state = self.state.borrow_mut();
+        let mut promoted = Vec::new();
+        for (request, pending) in &mut state.pending_by_chunk {
+            if pending.retry_at.is_some_and(|deadline| deadline <= now) {
+                pending.retry_at = None;
+                promoted.push(ChunkRequestEntry {
+                    request_id: pending.upstream_id,
+                    locator: request.locator.clone(),
+                    expected_hash: request.object_hash,
+                    remaining_hops: pending.remaining_hops,
+                });
+            }
+        }
+        let count = promoted.len();
+        state.outbound.extend(promoted);
+        if count > 0
+            && let Some(connection) = state.upstream_connection
+        {
+            Self::wake_connection(&mut state, connection);
+        }
+        count
+    }
+
     fn take_outbound(&self, limit: usize) -> Vec<ChunkRequestEntry> {
+        self.promote_due_retries();
         let mut state = self.state.borrow_mut();
         let count = limit.min(state.outbound.len());
         state.outbound.drain(..count).collect()
@@ -263,9 +292,21 @@ impl PeerChunkResolver {
 
     fn complete(&self, response: ChunkResponseEntry) {
         let mut state = self.state.borrow_mut();
-        let Some(request) = state.chunk_by_upstream_id.remove(&response.request_id) else {
+        let Some(request) = state
+            .chunk_by_upstream_id
+            .get(&response.request_id)
+            .cloned()
+        else {
             return;
         };
+        if let ChunkResponse::Retryable { retry_after_ms } = response.result {
+            if let Some(pending) = state.pending_by_chunk.get_mut(&request) {
+                pending.retry_at =
+                    Some(Instant::now() + Duration::from_millis(u64::from(retry_after_ms)));
+            }
+            return;
+        }
+        state.chunk_by_upstream_id.remove(&response.request_id);
         let Some(pending) = state.pending_by_chunk.remove(&request) else {
             return;
         };
@@ -276,10 +317,13 @@ impl PeerChunkResolver {
                 ChunkDemandWaiter::Local { sender, .. } => {
                     let result = match &response.result {
                         ChunkResponse::Found(bytes) => Ok(bytes::Bytes::copy_from_slice(bytes)),
-                        ChunkResponse::Unavailable => Err(groove::chunks::ChunkError::Unavailable),
-                        ChunkResponse::Retryable { .. } => {
-                            Err(groove::chunks::ChunkError::Unavailable)
-                        }
+                        // A peer explicitly answered this exact request. That
+                        // is terminal for this attempt; only Retryable keeps
+                        // the waiter alive for a scheduled requeue.
+                        ChunkResponse::Unavailable => Err(groove::chunks::ChunkError::Backend(
+                            "upstream reported requested chunk unavailable".to_owned(),
+                        )),
+                        ChunkResponse::Retryable { .. } => unreachable!("retry remains pending"),
                     };
                     let _ = sender.send(result);
                 }
@@ -581,6 +625,12 @@ impl PeerIoPump {
                 ))
             }
         }
+    }
+
+    /// Advance delayed auxiliary retry work. Hosts call this from their normal
+    /// link timer; unlike a binding pull it never re-evaluates a subscription.
+    pub fn tick(&self) -> usize {
+        self.resolver.promote_due_retries()
     }
 
     fn restore_outbound(&self, message: SyncMessage) {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -271,6 +271,17 @@ impl PeerChunkResolver {
         count
     }
 
+    fn next_retry_delay(&self) -> Option<Duration> {
+        let now = Instant::now();
+        self.state
+            .borrow()
+            .pending_by_chunk
+            .values()
+            .filter_map(|pending| pending.retry_at)
+            .min()
+            .map(|deadline| deadline.saturating_duration_since(now))
+    }
+
     fn take_outbound(&self, limit: usize) -> Vec<ChunkRequestEntry> {
         self.promote_due_retries();
         let mut state = self.state.borrow_mut();
@@ -631,6 +642,12 @@ impl PeerIoPump {
     /// link timer; unlike a binding pull it never re-evaluates a subscription.
     pub fn tick(&self) -> usize {
         self.resolver.promote_due_retries()
+    }
+
+    /// Delay until the next retry becomes eligible. Hosts should install one
+    /// one-shot timer for this value, then call [`Self::tick`].
+    pub fn next_retry_delay(&self) -> Option<Duration> {
+        self.resolver.next_retry_delay()
     }
 
     fn restore_outbound(&self, message: SyncMessage) {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -25,8 +25,6 @@ use groove::records::{OwnedRecord, RecordDescriptor, Value};
 use groove::schema::ColumnType as GrooveColumnType;
 use groove::storage::{OrderedKvStorage, ReopenableStorage};
 use thiserror::Error;
-#[cfg(feature = "cold-settle-attribution")]
-use web_time::Instant;
 use web_time::{Duration, Instant};
 
 use crate::authorization_scope::{
@@ -124,6 +122,13 @@ struct ChunkDemandState {
     disconnected_connections: BTreeSet<u64>,
     upstream_connection: Option<u64>,
     upstream_connections: BTreeSet<u64>,
+    /// Bumped for every change that can alter either the next retry deadline
+    /// or the carrier that is responsible for draining auxiliary traffic.
+    ///
+    /// A binding may be sleeping until an old deadline when a new request,
+    /// an earlier retry, or a successor link appears.  It must wake and
+    /// recompute rather than wait for that stale timer.
+    schedule_generation: u64,
     completion_generation: u64,
 }
 
@@ -157,10 +162,23 @@ impl PeerChunkResolver {
             state.upstream_connections.insert(connection);
             state.upstream_connection.get_or_insert(connection);
         }
+        Self::schedule_changed(&mut state);
     }
 
     fn wake_connection(state: &mut ChunkDemandState, connection: u64) {
         if let Some(waker) = state.outbound_wakers.remove(&connection) {
+            waker.wake();
+        }
+    }
+
+    /// Wake every carrier-local waiter after changing retry scheduling.  The
+    /// map is deliberately per connection, while the generation is shared:
+    /// replacement upstreams need to observe a demand that was created before
+    /// they became active, and an old carrier must stop waiting before it can
+    /// accidentally flush onto its replacement.
+    fn schedule_changed(state: &mut ChunkDemandState) {
+        state.schedule_generation = state.schedule_generation.wrapping_add(1);
+        for (_, waker) in std::mem::take(&mut state.outbound_wakers) {
             waker.wake();
         }
     }
@@ -174,6 +192,7 @@ impl PeerChunkResolver {
         let mut state = self.state.borrow_mut();
         if let Some(pending) = state.pending_by_chunk.get_mut(&request) {
             pending.waiters.push(waiter);
+            Self::schedule_changed(&mut state);
             return Ok(());
         }
         if state.pending_by_chunk.len() >= MAX_PENDING_CHUNK_DEMANDS {
@@ -199,6 +218,7 @@ impl PeerChunkResolver {
                 retry_at: None,
             },
         );
+        Self::schedule_changed(&mut state);
         if let Some(connection) = state.upstream_connection {
             Self::wake_connection(&mut state, connection);
         }
@@ -263,10 +283,11 @@ impl PeerChunkResolver {
         }
         let count = promoted.len();
         state.outbound.extend(promoted);
-        if count > 0
-            && let Some(connection) = state.upstream_connection
-        {
-            Self::wake_connection(&mut state, connection);
+        if count > 0 {
+            Self::schedule_changed(&mut state);
+            if let Some(connection) = state.upstream_connection {
+                Self::wake_connection(&mut state, connection);
+            }
         }
         count
     }
@@ -314,6 +335,7 @@ impl PeerChunkResolver {
             if let Some(pending) = state.pending_by_chunk.get_mut(&request) {
                 pending.retry_at =
                     Some(Instant::now() + Duration::from_millis(u64::from(retry_after_ms)));
+                Self::schedule_changed(&mut state);
             }
             return;
         }
@@ -322,6 +344,7 @@ impl PeerChunkResolver {
             return;
         };
         state.completion_generation = state.completion_generation.wrapping_add(1);
+        Self::schedule_changed(&mut state);
         debug_assert_eq!(pending.upstream_id, response.request_id);
         for waiter in pending.waiters {
             match waiter {
@@ -371,6 +394,7 @@ impl PeerChunkResolver {
             state
                 .outbound
                 .retain(|outbound| outbound.request_id != upstream_id);
+            Self::schedule_changed(&mut state);
         }
     }
 
@@ -404,6 +428,7 @@ impl PeerChunkResolver {
                     Self::wake_connection(&mut state, successor);
                 }
             }
+            Self::schedule_changed(&mut state);
             drop(state);
             if let Some(waker) = disconnected_waker {
                 waker.wake();
@@ -427,6 +452,7 @@ impl PeerChunkResolver {
                     .retain(|entry| entry.request_id != upstream_id);
             }
         }
+        Self::schedule_changed(&mut state);
         drop(state);
         if let Some(waker) = disconnected_waker {
             waker.wake();
@@ -664,6 +690,7 @@ impl PeerIoPump {
             }
             _ => {}
         }
+        PeerChunkResolver::schedule_changed(&mut state);
     }
 
     /// Encode one bounded auxiliary payload for a binding-owned socket channel.
@@ -680,7 +707,11 @@ impl PeerIoPump {
     /// semantic tick. Browser microtasks, NAPI async notifications, and native
     /// socket tasks can all await this same executor-independent future.
     pub fn outbound_ready(&self) -> PeerIoOutboundReady {
-        PeerIoOutboundReady { pump: self.clone() }
+        let generation = self.resolver.state.borrow().schedule_generation;
+        PeerIoOutboundReady {
+            pump: self.clone(),
+            observed_generation: generation,
+        }
     }
 
     /// Non-blocking readiness probe for hosts that drive local futures by
@@ -709,7 +740,9 @@ impl PeerIoPump {
         }
     }
 
-    fn is_disconnected(&self) -> bool {
+    /// Whether this binding-owned carrier has been detached.  Hosts use this
+    /// after an auxiliary wake to avoid flushing a timer from an old link.
+    pub fn is_disconnected(&self) -> bool {
         self.resolver
             .state
             .borrow()
@@ -721,21 +754,34 @@ impl PeerIoPump {
 /// Future completed when a [`PeerIoPump`] has outbound auxiliary traffic.
 pub struct PeerIoOutboundReady {
     pump: PeerIoPump,
+    observed_generation: u64,
 }
 
 impl Future for PeerIoOutboundReady {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.pump.has_outbound() || self.pump.is_disconnected() {
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let pump = self.pump.clone();
+        let mut state = pump.resolver.state.borrow_mut();
+        let has_outbound = match pump.role {
+            PeerIoPumpRole::Upstream => !state.outbound.is_empty(),
+            PeerIoPumpRole::Subscriber => state
+                .relay_responses
+                .get(&pump.connection)
+                .is_some_and(|responses| !responses.is_empty()),
+        };
+        if has_outbound || state.disconnected_connections.contains(&pump.connection) {
+            Poll::Ready(())
+        } else if state.schedule_generation != self.observed_generation {
+            // A deadline/carrier changed while this waiter was registered.  A
+            // host that is racing a native timer must now discard that timer
+            // and obtain the current deadline before sleeping again.
+            self.observed_generation = state.schedule_generation;
             Poll::Ready(())
         } else {
-            self.pump
-                .resolver
-                .state
-                .borrow_mut()
+            state
                 .outbound_wakers
-                .insert(self.pump.connection, context.waker().clone());
+                .insert(pump.connection, context.waker().clone());
             Poll::Pending
         }
     }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -415,13 +415,20 @@ impl PeerChunkResolver {
                         .collect::<BTreeSet<_>>();
                     let retries = state
                         .pending_by_chunk
-                        .iter()
+                        .iter_mut()
                         .filter(|(_, pending)| !queued.contains(&pending.upstream_id))
-                        .map(|(request, pending)| ChunkRequestEntry {
-                            request_id: pending.upstream_id,
-                            locator: request.locator.clone(),
-                            expected_hash: request.object_hash,
-                            remaining_hops: pending.remaining_hops,
+                        .map(|(request, pending)| {
+                            // Failover is the retry for this pending demand.
+                            // Disarm the old carrier's deadline so it cannot
+                            // enqueue the same request again after the
+                            // successor has already sent it.
+                            pending.retry_at = None;
+                            ChunkRequestEntry {
+                                request_id: pending.upstream_id,
+                                locator: request.locator.clone(),
+                                expected_hash: request.object_hash,
+                                remaining_hops: pending.remaining_hops,
+                            }
                         })
                         .collect::<Vec<_>>();
                     state.outbound.extend(retries);

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -459,7 +459,7 @@ where
         .await
     }
 
-    /// Stream one large scalar into a newly inserted row without retaining the
+    /// Stream one large value into a newly inserted row without retaining the
     /// complete logical value in Jazz memory.
     ///
     /// `cells` contains the other row fields; `column` is inserted from
@@ -487,7 +487,7 @@ where
             .await
     }
 
-    /// Stream one large scalar into a newly inserted row with an explicit row
+    /// Stream one large value into a newly inserted row with an explicit row
     /// id. Binding adapters use this to choose the public id before consuming
     /// an asynchronous host stream.
     #[cfg(not(target_family = "wasm"))]

--- a/crates/jazz/src/db/reads.rs
+++ b/crates/jazz/src/db/reads.rs
@@ -302,13 +302,15 @@ where
                     .await
                 }
             }?;
-            return Ok(snapshot
+            let mut rows = snapshot
                 .rows
                 .into_iter()
                 .take(snapshot.root_count)
-                .collect());
+                .collect::<Vec<_>>();
+            node.hydrate_current_rows(&mut rows).await?;
+            return Ok(rows);
         }
-        match (opts.include_deleted, authorization_mode) {
+        let mut rows = match (opts.include_deleted, authorization_mode) {
             (true, mode) => {
                 node.query_rows_including_deleted_in_authorization_mode(
                     &prepared.shape,
@@ -337,7 +339,27 @@ where
                     .await
             }
         }
-        .map_err(Into::into)
+        .map_err(Error::from)?;
+        node.hydrate_current_rows(&mut rows).await?;
+        Ok(rows)
+    }
+
+    /// Resolve physical indirect scalars before a subscription event crosses
+    /// a language binding boundary.
+    #[doc(hidden)]
+    pub async fn hydrate_subscription_event_for_binding(
+        &self,
+        event: &mut SubscriptionEvent,
+    ) -> Result<(), Error> {
+        let SubscriptionEvent::Delta { added, updated, .. } = event else {
+            return Ok(());
+        };
+        let node = self.node.node.lock().await;
+        for output in added.iter_mut().chain(updated.iter_mut()) {
+            node.hydrate_current_rows(std::slice::from_mut(&mut output.row))
+                .await?;
+        }
+        Ok(())
     }
 
     /// Tier-gated one-shot relation read evaluated as the database identity.

--- a/crates/jazz/src/db/reads.rs
+++ b/crates/jazz/src/db/reads.rs
@@ -362,6 +362,29 @@ where
         Ok(())
     }
 
+    /// Resolve physical indirect scalars in ordinary row output immediately
+    /// before a language binding encodes it.
+    #[doc(hidden)]
+    pub async fn hydrate_rows_for_binding(&self, rows: &mut [CurrentRow]) -> Result<(), Error> {
+        self.node
+            .node
+            .lock()
+            .await
+            .hydrate_current_rows(rows)
+            .await?;
+        Ok(())
+    }
+
+    /// Resolve physical indirect scalars in a relation snapshot immediately
+    /// before a language binding encodes it.
+    #[doc(hidden)]
+    pub async fn hydrate_relation_snapshot_for_binding(
+        &self,
+        snapshot: &mut RelationSnapshot,
+    ) -> Result<(), Error> {
+        self.hydrate_rows_for_binding(&mut snapshot.rows).await
+    }
+
     /// Tier-gated one-shot relation read evaluated as the database identity.
     pub async fn all_relation_snapshot(
         &self,

--- a/crates/jazz/src/db/reads.rs
+++ b/crates/jazz/src/db/reads.rs
@@ -2,6 +2,37 @@
 
 use super::*;
 
+/// Binding-only classification for a value whose referenced immutable content
+/// has not arrived locally yet. This deliberately preserves the distinction
+/// between an ordinary, retryable chunk absence and corrupted/permanent
+/// storage errors before they are flattened into a public [`Error`].
+#[doc(hidden)]
+pub enum BindingHydrationError {
+    ChunkUnavailable,
+    Error(Error),
+}
+
+fn binding_hydration_error(error: crate::node::Error) -> BindingHydrationError {
+    use groove::chunks::ChunkError;
+    use groove::ivm::runtime::IvmRuntimeError;
+
+    let unavailable = matches!(
+        &error,
+        crate::node::Error::ChunkStorage(groove::chunks::ChunkStorageError::Unavailable)
+            | crate::node::Error::LargeValueReachability(
+                groove::large_values::ReachabilityError::Chunk(ChunkError::Unavailable)
+            )
+            | crate::node::Error::Groove(groove::db::Error::IvmRuntime(IvmRuntimeError::Chunk(
+                ChunkError::Unavailable
+            )))
+    );
+    if unavailable {
+        BindingHydrationError::ChunkUnavailable
+    } else {
+        BindingHydrationError::Error(error.into())
+    }
+}
+
 impl<S> Db<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
@@ -351,13 +382,32 @@ where
         &self,
         event: &mut SubscriptionEvent,
     ) -> Result<(), Error> {
+        self.hydrate_subscription_event_for_binding_outcome(event)
+            .await
+            .map_err(|error| match error {
+                BindingHydrationError::ChunkUnavailable => Error::new(
+                    ErrorCode::NotObserved,
+                    "large-value chunk is not locally available",
+                ),
+                BindingHydrationError::Error(error) => error,
+            })
+    }
+
+    /// Like [`Self::hydrate_subscription_event_for_binding`], but retains the
+    /// sole retryable cause for host bindings that can await chunk delivery.
+    #[doc(hidden)]
+    pub async fn hydrate_subscription_event_for_binding_outcome(
+        &self,
+        event: &mut SubscriptionEvent,
+    ) -> Result<(), BindingHydrationError> {
         let SubscriptionEvent::Delta { added, updated, .. } = event else {
             return Ok(());
         };
         let node = self.node.node.lock().await;
         for output in added.iter_mut().chain(updated.iter_mut()) {
             node.hydrate_current_rows(std::slice::from_mut(&mut output.row))
-                .await?;
+                .await
+                .map_err(binding_hydration_error)?;
         }
         Ok(())
     }

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -6,6 +6,7 @@ use std::task::{Context, Poll};
 use groove::chunks::{ChunkProvider, ChunkStorage, MissingChunkResolver};
 
 use super::super::*;
+use super::test_empty_local_chunk_reader;
 
 #[test]
 fn auxiliary_pump_completes_a_suspended_groove_chunk_read_without_a_semantic_tick() {
@@ -212,5 +213,61 @@ fn a_late_response_from_a_disconnected_upstream_cannot_complete_reassigned_deman
             .await
             .unwrap();
         assert_eq!(pending.await.unwrap().as_ref(), &[2]);
+    });
+}
+
+#[test]
+fn successor_reissue_disarms_the_disconnected_upstreams_retry_deadline() {
+    crate::db::block_on(async {
+        let resolver = PeerChunkResolver::default();
+        let first = PeerIoPump::new(
+            resolver.clone(),
+            test_empty_local_chunk_reader(),
+            20,
+            PeerIoPumpRole::Upstream,
+        );
+        let successor = PeerIoPump::new(
+            resolver.clone(),
+            test_empty_local_chunk_reader(),
+            21,
+            PeerIoPumpRole::Upstream,
+        );
+        let request = groove::chunks::ChunkRequest {
+            object_hash: [8; 32],
+            locator: vec![9; 16],
+        };
+        let _pending = resolver.resolve(request);
+        let request_id = match first.take_outbound(64).unwrap() {
+            SyncMessage::ChunkRequestBatch(batch) => batch.requests[0].request_id,
+            _ => unreachable!(),
+        };
+        first
+            .route_incoming(SyncMessage::ChunkResponseBatch(ChunkResponseBatch {
+                responses: vec![ChunkResponseEntry {
+                    request_id,
+                    result: ChunkResponse::Retryable { retry_after_ms: 1 },
+                }],
+            }))
+            .await
+            .unwrap();
+
+        first.disconnect();
+        let replacement = match successor.take_outbound(64).unwrap() {
+            SyncMessage::ChunkRequestBatch(batch) => batch.requests,
+            _ => unreachable!(),
+        };
+        assert_eq!(replacement.len(), 1, "failover reissues exactly once");
+        assert_eq!(replacement[0].request_id, request_id);
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert_eq!(
+            resolver.promote_due_retries(),
+            0,
+            "the old carrier deadline must be disarmed by successor reissue"
+        );
+        assert!(
+            successor.take_outbound(64).is_none(),
+            "no duplicate may queue after the old deadline"
+        );
     });
 }

--- a/crates/jazz/src/db/tests/mod.rs
+++ b/crates/jazz/src/db/tests/mod.rs
@@ -79,6 +79,35 @@ use super::peer_connection::{
     aggregate_authorization_scope_bounds, authorization_scope_receipt_matches_transport_context,
     authorization_scope_support_options_match, remove_scope_aggregate_member, view_update_is_empty,
 };
+
+#[test]
+fn retryable_chunk_response_keeps_the_original_waiter_until_the_scheduled_reissue() {
+    use groove::chunks::MissingChunkResolver;
+
+    let resolver = PeerChunkResolver::default();
+    resolver.register_connection(7, true);
+    let request = groove::chunks::ChunkRequest {
+        object_hash: [0x31; 32],
+        locator: b"retryable-binding-receipt".to_vec(),
+    };
+    let waiter = resolver.resolve(request.clone());
+    let response_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id: response_id,
+        result: ChunkResponse::Retryable { retry_after_ms: 1 },
+    });
+    assert!(resolver.take_outbound(1).is_empty(), "no eager reissue");
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    assert_eq!(resolver.promote_due_retries(), 1, "one scheduled reissue");
+    let retry = resolver.take_outbound(1);
+    assert_eq!(retry.len(), 1);
+    assert_eq!(retry[0].request_id, response_id, "same pending request id");
+    resolver.complete(ChunkResponseEntry {
+        request_id: response_id,
+        result: ChunkResponse::Found(vec![0x42]),
+    });
+    assert_eq!(crate::db::block_on(waiter).unwrap().as_ref(), &[0x42]);
+}
 use catalogue::assert_authority_rejects_staged_write;
 use support::block_on;
 use support::*;

--- a/crates/jazz/src/db/tests/mod.rs
+++ b/crates/jazz/src/db/tests/mod.rs
@@ -108,6 +108,56 @@ fn retryable_chunk_response_keeps_the_original_waiter_until_the_scheduled_reissu
     });
     assert_eq!(crate::db::block_on(waiter).unwrap().as_ref(), &[0x42]);
 }
+
+#[test]
+fn cancelled_chunk_waiter_removes_its_pending_retry_state() {
+    use groove::chunks::MissingChunkResolver;
+
+    let resolver = PeerChunkResolver::default();
+    resolver.register_connection(8, true);
+    let request = groove::chunks::ChunkRequest {
+        object_hash: [0x32; 32],
+        locator: b"cancelled-binding-receipt".to_vec(),
+    };
+    let waiter = resolver.resolve(request);
+    let request_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id,
+        result: ChunkResponse::Retryable {
+            retry_after_ms: 60_000,
+        },
+    });
+    drop(waiter);
+    assert!(resolver.state.borrow().pending_by_chunk.is_empty());
+    assert!(resolver.next_retry_delay().is_none());
+    assert!(resolver.take_outbound(1).is_empty());
+}
+
+#[test]
+fn terminal_chunk_unavailable_completes_waiter_once_as_an_error() {
+    use groove::chunks::MissingChunkResolver;
+
+    let resolver = PeerChunkResolver::default();
+    resolver.register_connection(9, true);
+    let waiter = resolver.resolve(groove::chunks::ChunkRequest {
+        object_hash: [0x33; 32],
+        locator: b"terminal-binding-receipt".to_vec(),
+    });
+    let request_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id,
+        result: ChunkResponse::Unavailable,
+    });
+    assert!(matches!(
+        crate::db::block_on(waiter),
+        Err(groove::chunks::ChunkError::Backend(_))
+    ));
+    resolver.complete(ChunkResponseEntry {
+        request_id,
+        result: ChunkResponse::Found(vec![1]),
+    });
+    assert!(resolver.state.borrow().pending_by_chunk.is_empty());
+}
 use catalogue::assert_authority_rejects_staged_write;
 use support::block_on;
 use support::*;

--- a/crates/jazz/src/db/tests/mod.rs
+++ b/crates/jazz/src/db/tests/mod.rs
@@ -102,11 +102,153 @@ fn retryable_chunk_response_keeps_the_original_waiter_until_the_scheduled_reissu
     let retry = resolver.take_outbound(1);
     assert_eq!(retry.len(), 1);
     assert_eq!(retry[0].request_id, response_id, "same pending request id");
+    assert!(
+        resolver.take_outbound(1).is_empty(),
+        "promoting a retry clears its deadline; a later tick must not enqueue a duplicate"
+    );
     resolver.complete(ChunkResponseEntry {
         request_id: response_id,
         result: ChunkResponse::Found(vec![0x42]),
     });
     assert_eq!(crate::db::block_on(waiter).unwrap().as_ref(), &[0x42]);
+}
+
+#[test]
+fn auxiliary_waiter_recomputes_a_long_retry_when_immediate_demand_arrives() {
+    use groove::chunks::MissingChunkResolver;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    let resolver = PeerChunkResolver::default();
+    resolver.register_connection(41, true);
+    let pump = PeerIoPump::new(
+        resolver.clone(),
+        test_empty_local_chunk_reader(),
+        41,
+        PeerIoPumpRole::Upstream,
+    );
+    let long = resolver.resolve(test_chunk_request(0x41));
+    let long_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id: long_id,
+        result: ChunkResponse::Retryable {
+            retry_after_ms: 60_000,
+        },
+    });
+    let mut wake = pump.outbound_ready();
+    let waker = futures::task::noop_waker();
+    let mut context = Context::from_waker(&waker);
+    assert!(matches!(
+        Pin::new(&mut wake).poll(&mut context),
+        Poll::Pending
+    ));
+
+    let immediate = resolver.resolve(test_chunk_request(0x42));
+    assert!(matches!(
+        Pin::new(&mut wake).poll(&mut context),
+        Poll::Ready(())
+    ));
+    drop(long);
+    drop(immediate);
+}
+
+#[test]
+fn auxiliary_waiter_recomputes_when_an_earlier_retry_replaces_its_deadline() {
+    use groove::chunks::MissingChunkResolver;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    let resolver = PeerChunkResolver::default();
+    resolver.register_connection(42, true);
+    let pump = PeerIoPump::new(
+        resolver.clone(),
+        test_empty_local_chunk_reader(),
+        42,
+        PeerIoPumpRole::Upstream,
+    );
+    let long = resolver.resolve(test_chunk_request(0x43));
+    let long_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id: long_id,
+        result: ChunkResponse::Retryable {
+            retry_after_ms: 60_000,
+        },
+    });
+    let mut wake = pump.outbound_ready();
+    let waker = futures::task::noop_waker();
+    let mut context = Context::from_waker(&waker);
+    assert!(matches!(
+        Pin::new(&mut wake).poll(&mut context),
+        Poll::Pending
+    ));
+
+    let earlier = resolver.resolve(test_chunk_request(0x44));
+    let earlier_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id: earlier_id,
+        result: ChunkResponse::Retryable { retry_after_ms: 1 },
+    });
+    assert!(matches!(
+        Pin::new(&mut wake).poll(&mut context),
+        Poll::Ready(())
+    ));
+    drop(long);
+    drop(earlier);
+}
+
+#[test]
+fn auxiliary_waiter_recomputes_when_last_retry_waiter_is_cancelled() {
+    use groove::chunks::MissingChunkResolver;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    let resolver = PeerChunkResolver::default();
+    resolver.register_connection(43, true);
+    let pump = PeerIoPump::new(
+        resolver.clone(),
+        test_empty_local_chunk_reader(),
+        43,
+        PeerIoPumpRole::Upstream,
+    );
+    let demand = resolver.resolve(test_chunk_request(0x45));
+    let request_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id,
+        result: ChunkResponse::Retryable {
+            retry_after_ms: 60_000,
+        },
+    });
+    let mut wake = pump.outbound_ready();
+    let waker = futures::task::noop_waker();
+    let mut context = Context::from_waker(&waker);
+    assert!(matches!(
+        Pin::new(&mut wake).poll(&mut context),
+        Poll::Pending
+    ));
+
+    drop(demand);
+    assert!(matches!(
+        Pin::new(&mut wake).poll(&mut context),
+        Poll::Ready(())
+    ));
+    assert!(resolver.next_retry_delay().is_none());
+}
+
+fn test_chunk_request(byte: u8) -> groove::chunks::ChunkRequest {
+    groove::chunks::ChunkRequest {
+        object_hash: [byte; 32],
+        locator: vec![byte; 16],
+    }
+}
+
+fn test_empty_local_chunk_reader() -> groove::chunks::LocalChunkReader {
+    let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());
+    let database = crate::db::block_on(groove::db::Database::new(
+        schema,
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    database.local_chunk_reader()
 }
 
 #[test]

--- a/crates/jazz/src/db/tests/mutations.rs
+++ b/crates/jazz/src/db/tests/mutations.rs
@@ -242,7 +242,59 @@ fn high_level_large_value_apis_keep_descriptors_private_and_publish_edits() {
         .unwrap();
     assert_eq!(
         rows[0].cell(&doctest_support::schema().tables[0], "title"),
-        Some(Value::String(title))
+        Some(Value::String(title.clone()))
+    );
+
+    let prepared = db.prepare_query(&db.table("todos")).unwrap();
+    let rows = block_on(db.all(&prepared, ReadOpts::default())).unwrap();
+    assert_eq!(
+        rows[0].cell(&doctest_support::schema().tables[0], "title"),
+        Some(Value::String(title.clone())),
+        "the async public read boundary must materialize the indirect text scalar"
+    );
+
+    let mut subscription = block_on(db.subscribe(&prepared, ReadOpts::default())).unwrap();
+    let mut event = block_on(subscription.next_raw()).unwrap();
+    let SubscriptionEvent::Delta { added, .. } = &mut event else {
+        panic!("expected opening subscription delta");
+    };
+    let (descriptor, record) = added[0].row.encoded_record();
+    let descriptor = descriptor.clone();
+    let mut values = descriptor.bind(record).to_values().unwrap();
+    let title_index = values
+        .iter()
+        .position(|value| {
+            matches!(value, Value::String(value) if value == &title)
+                || matches!(value, Value::Nullable(Some(value)) if matches!(value.as_ref(), Value::String(value) if value == &title))
+        })
+        .expect("opening row contains the logical title");
+    values[title_index] = match &values[title_index] {
+        Value::Nullable(_) => Value::Nullable(Some(Box::new(Value::Large(edited_ref.clone())))),
+        _ => Value::Large(edited_ref.clone()),
+    };
+    added[0].row = CurrentRow::new(
+        "todos",
+        OwnedRecord::new(descriptor.create(&values).unwrap(), descriptor),
+    );
+    assert!(
+        matches!(
+            added[0]
+                .row
+                .cell(&doctest_support::schema().tables[0], "title"),
+            Some(Value::Large(_))
+        ),
+        "planted positive: the maintained event reaches the binding with a physical descriptor"
+    );
+    block_on(db.hydrate_subscription_event_for_binding(&mut event)).unwrap();
+    let SubscriptionEvent::Delta { added, .. } = event else {
+        panic!("expected opening subscription delta");
+    };
+    assert_eq!(
+        added[0]
+            .row
+            .cell(&doctest_support::schema().tables[0], "title"),
+        Some(Value::String(title.clone())),
+        "the subscription binding boundary must materialize the indirect text scalar"
     );
 
     let json = format!(

--- a/crates/jazz/src/db/tests/mutations.rs
+++ b/crates/jazz/src/db/tests/mutations.rs
@@ -297,6 +297,33 @@ fn high_level_large_value_apis_keep_descriptors_private_and_publish_edits() {
         "the subscription binding boundary must materialize the indirect text scalar"
     );
 
+    let mut snapshot = RelationSnapshot {
+        root_count: 1,
+        rows: vec![added[0].row.clone()],
+        edges: Vec::new(),
+    };
+    let (descriptor, record) = snapshot.rows[0].encoded_record();
+    let descriptor = descriptor.clone();
+    let mut values = descriptor.bind(record).to_values().unwrap();
+    values[title_index] = match &values[title_index] {
+        Value::Nullable(_) => Value::Nullable(Some(Box::new(Value::Large(edited_ref.clone())))),
+        _ => Value::Large(edited_ref.clone()),
+    };
+    snapshot.rows[0] = CurrentRow::new(
+        "todos",
+        OwnedRecord::new(descriptor.create(&values).unwrap(), descriptor),
+    );
+    assert!(matches!(
+        snapshot.rows[0].cell(&doctest_support::schema().tables[0], "title"),
+        Some(Value::Large(_))
+    ));
+    block_on(db.hydrate_relation_snapshot_for_binding(&mut snapshot)).unwrap();
+    assert_eq!(
+        snapshot.rows[0].cell(&doctest_support::schema().tables[0], "title"),
+        Some(Value::String(title.clone())),
+        "relation snapshots must not encode physical indirect scalars for bindings"
+    );
+
     let json = format!(
         "{{\"padding\":\"{}\",\"selected\":{{\"answer\":42}}}}",
         "p".repeat(groove::large_values::INLINE_VALUE_MAX_BYTES)

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1533,7 +1533,7 @@ impl MergeableCommit {
         self
     }
 
-    /// Attach Jazz-private provenance for a Groove-staged large scalar. This
+    /// Attach Jazz-private provenance for a Groove-staged large value. This
     /// remains crate-private so public callers cannot bless handcrafted
     /// descriptors.
     pub(crate) fn staged_large_cell(

--- a/crates/jazz/src/protocol_limits.rs
+++ b/crates/jazz/src/protocol_limits.rs
@@ -9,7 +9,7 @@ use crate::protocol::{KnownStateDeclaration, RowVersionRef, ShapeAst, VersionRec
 /// Maximum encoded `WireFrame` bytes accepted before postcard decode.
 ///
 /// Source: twice the 1 MiB scalar-byte payload budget called out by the
-/// unbounded-payload issue, leaving room for one legitimate large scalar row and
+/// unbounded-payload issue, leaving room for one legitimate large-value row and
 /// envelope overhead while forcing large batches to split by bytes.
 pub const MAX_WIRE_FRAME_BYTES: usize = 2 * 1024 * 1024;
 

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -355,15 +355,23 @@ async fn drive_upstream_wire(
             }
         }
 
-        let external_wake = wake_rx.next();
-        let auxiliary_wake = io.pump.outbound_ready();
-        futures::pin_mut!(external_wake, auxiliary_wake);
-        match futures::future::select(external_wake, auxiliary_wake).await {
-            futures::future::Either::Left((Some(()), _))
-            | futures::future::Either::Right(((), _)) => {}
-            futures::future::Either::Left((None, _)) => {
-                io.pump.disconnect();
-                return;
+        if let Some(delay) = io.pump.next_retry_delay() {
+            tokio::select! {
+                wake = wake_rx.next() => if wake.is_none() { io.pump.disconnect(); return; },
+                _ = io.pump.outbound_ready() => {},
+                _ = tokio::time::sleep(delay) => { io.pump.tick(); },
+            }
+        } else {
+            let external_wake = wake_rx.next();
+            let auxiliary_wake = io.pump.outbound_ready();
+            futures::pin_mut!(external_wake, auxiliary_wake);
+            match futures::future::select(external_wake, auxiliary_wake).await {
+                futures::future::Either::Left((Some(()), _))
+                | futures::future::Either::Right(((), _)) => {}
+                futures::future::Either::Left((None, _)) => {
+                    io.pump.disconnect();
+                    return;
+                }
             }
         }
     }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -90,6 +90,8 @@ type PendingNativeRead = {
 
 type NativeReadResult = Uint8Array | PendingNativeRead;
 
+type PendingNativeSubscriptionBatch = object;
+
 function isPendingNativeRead(value: NativeReadResult): value is PendingNativeRead {
   return typeof (value as PendingNativeRead).poll === "function";
 }
@@ -107,12 +109,12 @@ type NativeDb = {
   attachExclusiveTx?(openBatchId: string): Tx;
   all(query: PreparedQuery, opts: unknown): NativeReadResult;
   allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): NativeReadResult;
-  allRelationQuery?(queryJson: string, opts: unknown): Uint8Array | Promise<Uint8Array>;
+  allRelationQuery?(queryJson: string, opts: unknown): NativeReadResult | Promise<NativeReadResult>;
   allRelationQueryForIdentity?(
     queryJson: string,
     author: Uint8Array,
     opts: unknown,
-  ): Uint8Array | Promise<Uint8Array>;
+  ): NativeReadResult | Promise<NativeReadResult>;
   allRelationSnapshot?(
     query: PreparedQuery,
     opts: unknown,
@@ -363,8 +365,8 @@ type NativePermissionAdviceRequest = {
 type PreparedQuery = object;
 
 type Subscription = {
-  readAll(): unknown[];
-  drain?(): unknown[];
+  readAll(): unknown[] | PendingNativeSubscriptionBatch;
+  drain?(): unknown[] | PendingNativeSubscriptionBatch;
   close?(): boolean;
 };
 
@@ -1515,17 +1517,21 @@ export class NativeRuntimeAdapter implements Runtime {
         if (!this.db.allRelationQueryForIdentity) {
           throw new Error("Native runtime does not support trusted-serving relation queries");
         }
-        const payload = await this.db.allRelationQueryForIdentity(
-          coreQueryJson,
-          session?.identity ?? this.peerIdentity,
-          opts,
+        const payload = await this.awaitNativeRead(
+          await this.db.allRelationQueryForIdentity(
+            coreQueryJson,
+            session?.identity ?? this.peerIdentity,
+            opts,
+          ),
         );
         return rowsFromBatches(readRowBatches(payload), this.schema);
       }
       if (!this.db.allRelationQuery) {
         throw new Error("Native runtime does not support relation queries");
       }
-      const payload = await this.db.allRelationQuery(coreQueryJson, opts);
+      const payload = await this.awaitNativeRead(
+        await this.db.allRelationQuery(coreQueryJson, opts),
+      );
       return rowsFromBatches(readRowBatches(payload), this.schema);
     }
     const query = this.prepareQuery(coreQueryJson);
@@ -1995,32 +2001,36 @@ export class NativeRuntimeAdapter implements Runtime {
     for (;;) {
       const value = pending.poll();
       if (value) return value;
-      const transport = this.serverTransport;
-      const carrier = this.serverCarrier;
-      if (!transport || !carrier || this.closed) {
-        throw new Error("large-value hydration is waiting for an unavailable upstream transport");
+      await this.waitForNativeHydrationWake();
+    }
+  }
+
+  private async waitForNativeHydrationWake(): Promise<void> {
+    const transport = this.serverTransport;
+    const carrier = this.serverCarrier;
+    if (!transport || !carrier || this.closed) {
+      throw new Error("large-value hydration is waiting for an unavailable upstream transport");
+    }
+    const generation = this.serverConnectionGeneration;
+    const observedWork = this.serverTransportWorkEpoch;
+    const work = this.waitForServerTransportWork("edge", observedWork);
+    try {
+      this.flushAuxiliaryOutbound(transport, carrier, generation);
+      void this.pumpServerTransport();
+      if (!work) {
+        throw new Error("large-value hydration has no concrete transport wake");
       }
-      const generation = this.serverConnectionGeneration;
-      const observedWork = this.serverTransportWorkEpoch;
-      const work = this.waitForServerTransportWork("edge", observedWork);
-      try {
-        this.flushAuxiliaryOutbound(transport, carrier, generation);
-        void this.pumpServerTransport();
-        if (!work) {
-          throw new Error("large-value hydration has no concrete transport wake");
-        }
-        await work.promise;
-      } finally {
-        work?.cancel();
-      }
-      if (
-        this.closed ||
-        generation !== this.serverConnectionGeneration ||
-        transport !== this.serverTransport ||
-        carrier !== this.serverCarrier
-      ) {
-        throw new Error("large-value hydration transport was replaced before completion");
-      }
+      await work.promise;
+    } finally {
+      work?.cancel();
+    }
+    if (
+      this.closed ||
+      generation !== this.serverConnectionGeneration ||
+      transport !== this.serverTransport ||
+      carrier !== this.serverCarrier
+    ) {
+      throw new Error("large-value hydration transport was replaced before completion");
     }
   }
 
@@ -2407,7 +2417,9 @@ export class NativeRuntimeAdapter implements Runtime {
     if (subscription.cancelled) return;
     for (const source of subscription.sources) {
       if (!isReadableSubscriptionReader(source.source)) {
-        this.drainNativeSubscription(handle, subscription, source);
+        if (source.reading) continue;
+        source.reading = true;
+        void this.drainNativeSubscription(handle, subscription, source);
         continue;
       }
       if (source.reading) continue;
@@ -2440,22 +2452,34 @@ export class NativeRuntimeAdapter implements Runtime {
     }
   }
 
-  private drainNativeSubscription(
+  private async drainNativeSubscription(
     handle: number,
     subscription: SubscriptionState,
     source: SubscriptionSourceState,
-  ): void {
+  ): Promise<void> {
     if (isReadableSubscriptionReader(source.source)) return;
-    for (const event of source.source.readAll()) {
-      if (subscription.cancelled || this.subscriptions.get(handle) !== subscription) return;
-      try {
-        this.applySubscriptionChunk(subscription, event);
-      } catch (error) {
-        this.failSubscription(
-          subscription,
-          error instanceof Error ? error : new Error(String(error)),
-        );
+    try {
+      while (!subscription.cancelled && this.subscriptions.get(handle) === subscription) {
+        const batch = source.source.readAll();
+        if (!Array.isArray(batch)) {
+          await this.waitForNativeHydrationWake();
+          continue;
+        }
+        for (const event of batch) {
+          if (subscription.cancelled || this.subscriptions.get(handle) !== subscription) return;
+          try {
+            this.applySubscriptionChunk(subscription, event);
+          } catch (error) {
+            this.failSubscription(
+              subscription,
+              error instanceof Error ? error : new Error(String(error)),
+            );
+          }
+        }
+        return;
       }
+    } finally {
+      source.reading = false;
     }
   }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1253,7 +1253,7 @@ export class NativeRuntimeAdapter implements Runtime {
     const tx = this.currentTx(writeContext, "Upsert");
     const existing = tx
       ? (this.stagedRowForWriteMerge(tx, table, rowId) ?? this.readRowForWriteMerge(table, rowId))
-      : this.readRow(table, rowId, writeIdentity);
+      : this.readRowForWriteMerge(table, rowId);
     let cells: Uint8Array;
     try {
       cells = existing
@@ -1893,35 +1893,6 @@ export class NativeRuntimeAdapter implements Runtime {
     this.scheduleServerPump();
     this.notifyPeerTransportWork();
     return { kind: "committed", batchId };
-  }
-
-  private resultForRow(
-    table: string,
-    rowId: Uint8Array,
-    receipt: { kind: "committed"; batchId: BatchId } | { kind: "staged"; openBatchId: OpenBatchId },
-    identity?: Uint8Array,
-  ): InsertResult {
-    const row = this.readRow(table, rowId, identity);
-    return { id: formatUuid(rowId), values: row?.values ?? [], ...receipt };
-  }
-
-  private readRow(table: string, rowId: Uint8Array, identity?: Uint8Array): RowState | undefined {
-    if (!identity) return this.readRowForWriteMerge(table, rowId);
-    const query = this.prepareQuery(JSON.stringify({ table }));
-    const rows = this.db.allForIdentity(query, identity, readOptions());
-    if (rows instanceof Promise) {
-      throw new Error(
-        "write result inspection cannot synchronously await an asynchronous binding read",
-      );
-    }
-    if (isPendingNativeRead(rows)) {
-      throw new Error(
-        "write result inspection cannot synchronously hydrate a remote large value; read it after transport progress",
-      );
-    }
-    return rowsFromBatches(readRowBatches(rows), this.schema).find(
-      (row) => row.table === table && row.id === formatUuid(rowId),
-    );
   }
 
   private readRowForWriteMerge(table: string, rowId: Uint8Array): RowState | undefined {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -423,6 +423,7 @@ export type Transport = {
   routeAuxiliaryWireFrame?(frame: Uint8Array): unknown | Promise<unknown>;
   recvAuxiliaryWireFrames?(): unknown[];
   auxiliaryOutboundReady?(): boolean | Promise<void>;
+  nextAuxiliaryRetryDelayMs?(): number | null;
   tick(): number | Promise<number>;
   updateAuthenticatedClaims?(claims: Record<string, unknown>): void | Promise<void>;
   free?(): void;
@@ -2782,7 +2783,14 @@ export class NativeRuntimeAdapter implements Runtime {
       generation === this.serverConnectionGeneration
     ) {
       const readiness = transport.auxiliaryOutboundReady?.();
-      if (!readiness || typeof readiness === "boolean") return;
+      if (!readiness || typeof readiness === "boolean") {
+        const delay = transport.nextAuxiliaryRetryDelayMs?.();
+        if (delay == null) return;
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+        await transport.tick();
+        this.flushAuxiliaryOutbound(transport, carrier, generation);
+        continue;
+      }
       await readiness;
       if (transport !== this.serverTransport || carrier !== this.serverCarrier) return;
       this.flushAuxiliaryOutbound(transport, carrier, generation);

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -84,6 +84,16 @@ type NativeDbConstructor = {
   openPersistent?(dataPath: string, schema: Uint8Array, config: Uint8Array): NativeDb;
 };
 
+type PendingNativeRead = {
+  poll(): Uint8Array | null;
+};
+
+type NativeReadResult = Uint8Array | PendingNativeRead;
+
+function isPendingNativeRead(value: NativeReadResult): value is PendingNativeRead {
+  return typeof (value as PendingNativeRead).poll === "function";
+}
+
 type NativeDb = {
   // Native runtime adapters may close synchronously or asynchronously and may
   // report whether they transitioned state. The adapter awaits either form and
@@ -95,20 +105,23 @@ type NativeDb = {
   rollbackTransaction(openBatchId: string): void;
   attachMergeableTx(openBatchId: string): Tx;
   attachExclusiveTx?(openBatchId: string): Tx;
-  all(query: PreparedQuery, opts: unknown): Uint8Array;
-  allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): Uint8Array;
+  all(query: PreparedQuery, opts: unknown): NativeReadResult;
+  allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): NativeReadResult;
   allRelationQuery?(queryJson: string, opts: unknown): Uint8Array | Promise<Uint8Array>;
   allRelationQueryForIdentity?(
     queryJson: string,
     author: Uint8Array,
     opts: unknown,
   ): Uint8Array | Promise<Uint8Array>;
-  allRelationSnapshot?(query: PreparedQuery, opts: unknown): Uint8Array | Promise<Uint8Array>;
+  allRelationSnapshot?(
+    query: PreparedQuery,
+    opts: unknown,
+  ): NativeReadResult | Promise<NativeReadResult>;
   allRelationSnapshotForIdentity?(
     query: PreparedQuery,
     author: Uint8Array,
     opts: unknown,
-  ): Uint8Array | Promise<Uint8Array>;
+  ): NativeReadResult | Promise<NativeReadResult>;
   setIdentityClaims?(author: Uint8Array, claims: Record<string, unknown> | undefined | null): void;
   attachQuery?(query: PreparedQuery, opts: unknown): unknown;
   attachQueryForIdentity?(query: PreparedQuery, author: Uint8Array, opts: unknown): unknown;
@@ -273,7 +286,7 @@ type NativeDb = {
   mergeableTx(openBatchId: OpenBatchId): Tx;
   mergeableTxForIdentity?(openBatchId: OpenBatchId, author: Uint8Array): Tx;
   exclusiveTx?(openBatchId: OpenBatchId): Tx;
-  allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): Uint8Array;
+  allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): NativeReadResult;
   setTickScheduler(
     callback:
       | ((urgency: "immediate" | "deferred") => void)
@@ -1525,10 +1538,12 @@ export class NativeRuntimeAdapter implements Runtime {
           if (!this.db.allRelationSnapshotForIdentity) {
             throw new Error("Native runtime does not support trusted-serving relation snapshots");
           }
-          const payload = await this.db.allRelationSnapshotForIdentity(
-            query,
-            session?.identity ?? this.peerIdentity,
-            opts,
+          const payload = await this.awaitNativeRead(
+            await this.db.allRelationSnapshotForIdentity(
+              query,
+              session?.identity ?? this.peerIdentity,
+              opts,
+            ),
           );
           return rowsFromRelationSnapshot(
             readRelationSnapshot(payload),
@@ -1539,7 +1554,7 @@ export class NativeRuntimeAdapter implements Runtime {
         if (!this.db.allRelationSnapshot) {
           throw new Error("Native runtime does not support relation snapshots");
         }
-        const payload = await this.db.allRelationSnapshot(query, opts);
+        const payload = await this.awaitNativeRead(await this.db.allRelationSnapshot(query, opts));
         return rowsFromRelationSnapshot(
           readRelationSnapshot(payload),
           this.schema,
@@ -1547,12 +1562,12 @@ export class NativeRuntimeAdapter implements Runtime {
         );
       }
       const pendingTx = pendingTxFromOptions(optionsJson, this.pendingTxs);
-      let rows = this.readPlainRows(query, opts, session ?? undefined, pendingTx);
+      let rows = await this.readPlainRows(query, opts, session ?? undefined, pendingTx);
       let rowStates = rowsFromBatches(readRowBatches(rows), this.schema);
       if (!pendingTx && (tier === "edge" || tier === "global") && rowStates.length > 0) {
         await this.refreshRowsFromEdge(session, rowStates);
         if (this.closed) return [];
-        rows = this.readPlainRows(query, opts, session ?? undefined, pendingTx);
+        rows = await this.readPlainRows(query, opts, session ?? undefined, pendingTx);
         rowStates = rowsFromBatches(readRowBatches(rows), this.schema);
       }
       return rowStates;
@@ -1868,7 +1883,12 @@ export class NativeRuntimeAdapter implements Runtime {
   private readRow(table: string, rowId: Uint8Array, identity?: Uint8Array): RowState | undefined {
     if (!identity) return this.readRowForWriteMerge(table, rowId);
     const query = this.prepareQuery(JSON.stringify({ table }));
-    const rows = this.readRowsForHost(query, readOptions(), identity);
+    const rows = this.db.allForIdentity(query, identity, readOptions());
+    if (isPendingNativeRead(rows)) {
+      throw new Error(
+        "write result inspection cannot synchronously hydrate a remote large value; read it after transport progress",
+      );
+    }
     return rowsFromBatches(readRowBatches(rows), this.schema).find(
       (row) => row.table === table && row.id === formatUuid(rowId),
     );
@@ -1887,6 +1907,11 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     const query = this.prepareQuery(JSON.stringify({ table }));
     const rows = this.db.all(query, readOptions());
+    if (isPendingNativeRead(rows)) {
+      throw new Error(
+        "write merge cannot synchronously hydrate a remote large value; use the exact local row reader",
+      );
+    }
     return rowsFromBatches(readRowBatches(rows), this.schema).find(
       (row) => row.table === table && row.id === formatUuid(rowId),
     );
@@ -1934,17 +1959,17 @@ export class NativeRuntimeAdapter implements Runtime {
     return this.rowStateFromValues(table, rowId, merged);
   }
 
-  private readPlainRows(
+  private async readPlainRows(
     query: PreparedQuery,
     opts: unknown,
     session: RuntimeSession | undefined,
     pendingTx: PendingTx | undefined,
-  ): Uint8Array {
+  ): Promise<Uint8Array> {
     if (!pendingTx) return this.readRowsForHost(query, opts, session?.identity);
     if (!this.db.allInTransaction) {
       throw new Error("Native runtime does not support transaction reads");
     }
-    return this.db.allInTransaction(query, this.txForRead(pendingTx), opts);
+    return this.awaitNativeRead(this.db.allInTransaction(query, this.txForRead(pendingTx), opts));
   }
 
   /**
@@ -1952,10 +1977,51 @@ export class NativeRuntimeAdapter implements Runtime {
    * explicitly configured serving host may select the policy-enforcing entry
    * point, with a request session supplying its subject when present.
    */
-  private readRowsForHost(query: PreparedQuery, opts: unknown, identity?: Uint8Array): Uint8Array {
-    return this.readAuthorizationHost === "trusted-serving"
-      ? this.db.allForIdentity(query, identity ?? this.peerIdentity, opts)
-      : this.db.all(query, opts);
+  private async readRowsForHost(
+    query: PreparedQuery,
+    opts: unknown,
+    identity?: Uint8Array,
+  ): Promise<Uint8Array> {
+    return this.awaitNativeRead(
+      this.readAuthorizationHost === "trusted-serving"
+        ? this.db.allForIdentity(query, identity ?? this.peerIdentity, opts)
+        : this.db.all(query, opts),
+    );
+  }
+
+  private async awaitNativeRead(result: NativeReadResult): Promise<Uint8Array> {
+    if (!isPendingNativeRead(result)) return result;
+    const pending = result;
+    for (;;) {
+      const value = pending.poll();
+      if (value) return value;
+      const transport = this.serverTransport;
+      const carrier = this.serverCarrier;
+      if (!transport || !carrier || this.closed) {
+        throw new Error("large-value hydration is waiting for an unavailable upstream transport");
+      }
+      const generation = this.serverConnectionGeneration;
+      const observedWork = this.serverTransportWorkEpoch;
+      const work = this.waitForServerTransportWork("edge", observedWork);
+      try {
+        this.flushAuxiliaryOutbound(transport, carrier, generation);
+        void this.pumpServerTransport();
+        if (!work) {
+          throw new Error("large-value hydration has no concrete transport wake");
+        }
+        await work.promise;
+      } finally {
+        work?.cancel();
+      }
+      if (
+        this.closed ||
+        generation !== this.serverConnectionGeneration ||
+        transport !== this.serverTransport ||
+        carrier !== this.serverCarrier
+      ) {
+        throw new Error("large-value hydration transport was replaced before completion");
+      }
+    }
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2485,7 +2485,17 @@ export class NativeRuntimeAdapter implements Runtime {
             );
           }
         }
-        return;
+        // Native batches are deliberately bounded so one remotely hydrated
+        // event cannot retain an unbounded receiver backlog. Keep draining
+        // completed batches until the binding reports that its queue is empty.
+        if (batch.length === 0) return;
+      }
+    } catch (error) {
+      if (!subscription.cancelled && this.subscriptions.get(handle) === subscription) {
+        this.failSubscription(
+          subscription,
+          error instanceof Error ? error : new Error(String(error)),
+        );
       }
     } finally {
       source.reading = false;

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -84,16 +84,21 @@ type NativeDbConstructor = {
   openPersistent?(dataPath: string, schema: Uint8Array, config: Uint8Array): NativeDb;
 };
 
-type PendingNativeRead = {
-  poll(): Uint8Array | null;
-};
+type PendingNativeValue<T> = { poll(): T | null };
+type PendingNativeRead = PendingNativeValue<Uint8Array>;
+type PendingNativeWrite = PendingNativeValue<Write>;
 
 type NativeReadResult = Uint8Array | PendingNativeRead;
+type NativeReadStart = NativeReadResult | Promise<NativeReadResult>;
 
 type PendingNativeSubscriptionBatch = object;
 
-function isPendingNativeRead(value: NativeReadResult): value is PendingNativeRead {
-  return typeof (value as PendingNativeRead).poll === "function";
+function isPendingNativeRead(value: unknown): value is PendingNativeRead {
+  return typeof (value as PendingNativeRead | null)?.poll === "function";
+}
+
+function isPendingNativeWrite(value: unknown): value is PendingNativeWrite {
+  return typeof (value as PendingNativeWrite | null)?.poll === "function";
 }
 
 type NativeDb = {
@@ -107,23 +112,20 @@ type NativeDb = {
   rollbackTransaction(openBatchId: string): void;
   attachMergeableTx(openBatchId: string): Tx;
   attachExclusiveTx?(openBatchId: string): Tx;
-  all(query: PreparedQuery, opts: unknown): NativeReadResult;
-  allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): NativeReadResult;
-  allRelationQuery?(queryJson: string, opts: unknown): NativeReadResult | Promise<NativeReadResult>;
+  all(query: PreparedQuery, opts: unknown): NativeReadStart;
+  allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): NativeReadStart;
+  allRelationQuery?(queryJson: string, opts: unknown): NativeReadStart;
   allRelationQueryForIdentity?(
     queryJson: string,
     author: Uint8Array,
     opts: unknown,
-  ): NativeReadResult | Promise<NativeReadResult>;
-  allRelationSnapshot?(
-    query: PreparedQuery,
-    opts: unknown,
-  ): NativeReadResult | Promise<NativeReadResult>;
+  ): NativeReadStart;
+  allRelationSnapshot?(query: PreparedQuery, opts: unknown): NativeReadStart;
   allRelationSnapshotForIdentity?(
     query: PreparedQuery,
     author: Uint8Array,
     opts: unknown,
-  ): NativeReadResult | Promise<NativeReadResult>;
+  ): NativeReadStart;
   setIdentityClaims?(author: Uint8Array, claims: Record<string, unknown> | undefined | null): void;
   attachQuery?(query: PreparedQuery, opts: unknown): unknown;
   attachQueryForIdentity?(query: PreparedQuery, author: Uint8Array, opts: unknown): unknown;
@@ -288,7 +290,7 @@ type NativeDb = {
   mergeableTx(openBatchId: OpenBatchId): Tx;
   mergeableTxForIdentity?(openBatchId: OpenBatchId, author: Uint8Array): Tx;
   exclusiveTx?(openBatchId: OpenBatchId): Tx;
-  allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): NativeReadResult;
+  allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): NativeReadStart;
   setTickScheduler(
     callback:
       | ((urgency: "immediate" | "deferred") => void)
@@ -308,14 +310,14 @@ type NativeDb = {
     column: string,
     start: number,
     end: number,
-  ): Uint8Array | Promise<Uint8Array>;
+  ): NativeReadStart;
   readTextUtf16Range?(
     table: string,
     rowId: Uint8Array,
     column: string,
     start: number,
     end: number,
-  ): string | Promise<string>;
+  ): string | NativeReadStart | Promise<string | NativeReadResult>;
   readJsonPointer?(
     table: string,
     rowId: Uint8Array,
@@ -327,7 +329,7 @@ type NativeDb = {
     rowId: Uint8Array,
     column: string,
     bytes: Uint8Array,
-  ): Write | Promise<Write>;
+  ): Write | PendingNativeWrite | Promise<Write | PendingNativeWrite>;
   spliceValue?(
     table: string,
     rowId: Uint8Array,
@@ -335,7 +337,7 @@ type NativeDb = {
     offset: number,
     deleteLength: number,
     insert: Uint8Array,
-  ): Write | Promise<Write>;
+  ): Write | PendingNativeWrite | Promise<Write | PendingNativeWrite>;
   connectUpstream(): Transport;
   connectUpstreamWithSession?(
     protocolVersion: number,
@@ -779,7 +781,9 @@ export class NativeRuntimeAdapter implements Runtime {
       return await this.ownerRuntime.readValueRange(table, objectId, column, start, end);
     }
     if (!this.db.readValueRange) throw new Error("Native runtime does not expose value ranges");
-    return await this.db.readValueRange(table, parseUuid(objectId), column, start, end);
+    return await this.awaitNativeRead(
+      this.db.readValueRange(table, parseUuid(objectId), column, start, end),
+    );
   }
 
   async readTextUtf16Range(
@@ -795,7 +799,11 @@ export class NativeRuntimeAdapter implements Runtime {
     if (!this.db.readTextUtf16Range) {
       throw new Error("Native runtime does not expose UTF-16 value ranges");
     }
-    return await this.db.readTextUtf16Range(table, parseUuid(objectId), column, start, end);
+    const value = await this.db.readTextUtf16Range(table, parseUuid(objectId), column, start, end);
+    if (isPendingNativeRead(value)) {
+      return new TextDecoder().decode(await this.awaitNativeRead(value));
+    }
+    return value instanceof Uint8Array ? new TextDecoder().decode(value) : value;
   }
 
   async readJsonPointer(
@@ -808,7 +816,9 @@ export class NativeRuntimeAdapter implements Runtime {
       return await this.ownerRuntime.readJsonPointer(table, objectId, column, pointer);
     }
     if (!this.db.readJsonPointer) throw new Error("Native runtime does not expose JSON pointers");
-    const value = await this.db.readJsonPointer(table, parseUuid(objectId), column, pointer);
+    let value = await this.db.readJsonPointer(table, parseUuid(objectId), column, pointer);
+    if (isPendingNativeRead(value)) value = await this.awaitNativeRead(value);
+    if (value instanceof Uint8Array) value = new TextDecoder().decode(value);
     return typeof value === "string" ? JSON.parse(value) : value;
   }
 
@@ -822,8 +832,9 @@ export class NativeRuntimeAdapter implements Runtime {
       return await this.ownerRuntime.appendValue(table, objectId, column, bytes);
     }
     if (!this.db.appendValue) throw new Error("Native runtime does not expose value append");
+    const write = await this.db.appendValue(table, parseUuid(objectId), column, bytes);
     return this.finishMutation(
-      await this.db.appendValue(table, parseUuid(objectId), column, bytes),
+      isPendingNativeWrite(write) ? await this.awaitNativeValue(write) : write,
     );
   }
 
@@ -846,8 +857,16 @@ export class NativeRuntimeAdapter implements Runtime {
       );
     }
     if (!this.db.spliceValue) throw new Error("Native runtime does not expose value splice");
+    const write = await this.db.spliceValue(
+      table,
+      parseUuid(objectId),
+      column,
+      offset,
+      deleteLength,
+      insert,
+    );
     return this.finishMutation(
-      await this.db.spliceValue(table, parseUuid(objectId), column, offset, deleteLength, insert),
+      isPendingNativeWrite(write) ? await this.awaitNativeValue(write) : write,
     );
   }
 
@@ -1890,6 +1909,11 @@ export class NativeRuntimeAdapter implements Runtime {
     if (!identity) return this.readRowForWriteMerge(table, rowId);
     const query = this.prepareQuery(JSON.stringify({ table }));
     const rows = this.db.allForIdentity(query, identity, readOptions());
+    if (rows instanceof Promise) {
+      throw new Error(
+        "write result inspection cannot synchronously await an asynchronous binding read",
+      );
+    }
     if (isPendingNativeRead(rows)) {
       throw new Error(
         "write result inspection cannot synchronously hydrate a remote large value; read it after transport progress",
@@ -1913,6 +1937,11 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     const query = this.prepareQuery(JSON.stringify({ table }));
     const rows = this.db.all(query, readOptions());
+    if (rows instanceof Promise) {
+      throw new Error(
+        "write merge cannot synchronously await an asynchronous binding read; use the exact local row reader",
+      );
+    }
     if (isPendingNativeRead(rows)) {
       throw new Error(
         "write merge cannot synchronously hydrate a remote large value; use the exact local row reader",
@@ -1995,12 +2024,21 @@ export class NativeRuntimeAdapter implements Runtime {
     );
   }
 
-  private async awaitNativeRead(result: NativeReadResult): Promise<Uint8Array> {
-    if (!isPendingNativeRead(result)) return result;
-    const pending = result;
+  private async awaitNativeRead(result: NativeReadStart): Promise<Uint8Array> {
+    return this.awaitNativeValue(result);
+  }
+
+  private async awaitNativeValue<T>(
+    result: T | PendingNativeValue<T> | Promise<T | PendingNativeValue<T>>,
+  ): Promise<T> {
+    const started = await result;
+    if (typeof (started as PendingNativeValue<T> | null)?.poll !== "function") {
+      return started as T;
+    }
+    const pending = started as PendingNativeValue<T>;
     for (;;) {
       const value = pending.poll();
-      if (value) return value;
+      if (value !== null) return value;
       await this.waitForNativeHydrationWake();
     }
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2786,13 +2786,62 @@ export class NativeRuntimeAdapter implements Runtime {
       if (!readiness || typeof readiness === "boolean") {
         const delay = transport.nextAuxiliaryRetryDelayMs?.();
         if (delay == null) return;
-        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+        // NAPI exposes a synchronous readiness probe, so race its current
+        // retry deadline with normal transport activity.  A Retryable response
+        // can install an earlier deadline (or an immediate request can appear)
+        // while this timer is pending; in either case discard the old timer and
+        // ask the transport for the current schedule again.
+        const observedWork = this.serverTransportWorkEpoch;
+        const work = this.waitForServerTransportWork("edge", observedWork);
+        let wake: "timer" | "work";
+        try {
+          const timer = new Promise<"timer">((resolve, reject) => {
+            try {
+              setTimeout(() => resolve("timer"), delay);
+            } catch (error) {
+              reject(error);
+            }
+          });
+          wake = await Promise.race([
+            timer,
+            work?.promise.then(() => "work" as const) ?? new Promise<never>(() => {}),
+          ]);
+        } catch (error) {
+          this.handleServerTransportError(error, generation);
+          return;
+        } finally {
+          work?.cancel();
+        }
+        if (
+          this.closed ||
+          generation !== this.serverConnectionGeneration ||
+          transport !== this.serverTransport ||
+          carrier !== this.serverCarrier
+        ) {
+          return;
+        }
+        if (wake === "work") continue;
         await transport.tick();
+        if (
+          this.closed ||
+          generation !== this.serverConnectionGeneration ||
+          transport !== this.serverTransport ||
+          carrier !== this.serverCarrier
+        ) {
+          return;
+        }
         this.flushAuxiliaryOutbound(transport, carrier, generation);
         continue;
       }
       await readiness;
-      if (transport !== this.serverTransport || carrier !== this.serverCarrier) return;
+      if (
+        this.closed ||
+        generation !== this.serverConnectionGeneration ||
+        transport !== this.serverTransport ||
+        carrier !== this.serverCarrier
+      ) {
+        return;
+      }
       this.flushAuxiliaryOutbound(transport, carrier, generation);
     }
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -228,6 +228,76 @@ describe("NativeRuntimeAdapter server transport", () => {
     await runtime.close();
   });
 
+  it("retries one retained native subscription batch only after its routed chunk response", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+
+    let chunkArrived = false;
+    const pendingBatch = {};
+    let batchReads = 0;
+    const subscription = {
+      readAll: () => {
+        batchReads += 1;
+        return chunkArrived ? [{ type: "closed" }] : pendingBatch;
+      },
+      close: () => true,
+    };
+    const transport = Object.assign(new FakeTransport([]), {
+      routeAuxiliaryWireFrame: () => {
+        chunkArrived = true;
+        return null;
+      },
+    });
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: () => new Uint8Array([0]),
+            subscribe: () => subscription,
+            connectUpstream: () => transport,
+            prepareQuery: () => ({}),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    const handle = runtime.createSubscription(
+      JSON.stringify({ table: "todos" }),
+      undefined,
+      "local",
+    );
+    runtime.executeSubscription(handle, () => {
+      throw new Error("closed subscription must not publish a value");
+    });
+    await Promise.resolve();
+    expect(batchReads).toBe(1);
+
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([Uint8Array.from([0x42])]));
+    await waitForFakeWebSocketNegotiation();
+
+    // The NAPI Subscription owns its retained raw batch internally.  The TS
+    // Routing intentionally publishes arrival and post-evaluation wake edges.
+    // Those yield two bounded re-pulls, never a tight loop or a reconstructed
+    // subscription source.
+    expect(batchReads).toBe(3);
+    await runtime.close();
+  });
+
   it("pumps the newly owned transport before auth-refresh reconnect readiness", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -364,6 +364,48 @@ describe("NativeRuntimeAdapter server transport", () => {
     await runtime.close();
   });
 
+  it("terminates a native subscription once when retained hydration fails fatally", async () => {
+    const close = vi.fn(() => true);
+    const subscription = {
+      readAll: () => {
+        throw new Error("planned fatal chunk integrity failure");
+      },
+      close,
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: () => new Uint8Array([0]),
+            subscribe: () => subscription,
+            prepareQuery: () => ({}),
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+    const updates = vi.fn();
+    const handle = runtime.createSubscription(
+      JSON.stringify({ table: "todos" }),
+      undefined,
+      "local",
+    );
+    runtime.executeSubscription(handle, updates);
+    await waitForFakeWebSocketNegotiation();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(updates).toHaveBeenCalledTimes(1);
+    expect(updates.mock.calls[0]![0]).toEqual(new Error("planned fatal chunk integrity failure"));
+    expect(updates.mock.calls[0]![1]).toBeNull();
+    await runtime.close();
+  });
+
   it("pumps the newly owned transport before auth-refresh reconnect readiness", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -211,7 +211,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     await runtime.waitForUpstreamServerConnection();
 
     const read = runtime.query(JSON.stringify({ table: "todos" }), undefined, "local");
-    await Promise.resolve();
+    await waitForFakeWebSocketNegotiation();
     expect(polls).toBe(1);
 
     // This is the native host's concrete wake: the websocket response enters
@@ -225,6 +225,72 @@ describe("NativeRuntimeAdapter server transport", () => {
     // call may restart a large-value hydration attempt.
     expect(polls).toBe(3);
     expect(allCalls).toBe(1);
+    await runtime.close();
+  });
+
+  it("re-polls one pending native large-value write after its routed chunk response", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+
+    let chunkArrived = false;
+    let polls = 0;
+    let appendCalls = 0;
+    const transport = Object.assign(new FakeTransport([]), {
+      routeAuxiliaryWireFrame: () => {
+        chunkArrived = true;
+        return null;
+      },
+    });
+    const pendingWrite = {
+      poll: () => {
+        polls += 1;
+        return chunkArrived ? fakeWrite() : null;
+      },
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            appendValue: () => {
+              appendCalls += 1;
+              return pendingWrite;
+            },
+            connectUpstream: () => transport,
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+
+    const write = runtime.appendValue(
+      "todos",
+      "00000000-0000-7000-8000-000000000001",
+      "title",
+      Uint8Array.from([1]),
+    );
+    await waitForFakeWebSocketNegotiation();
+    expect(polls).toBe(1);
+
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([Uint8Array.from([0x42])]));
+
+    await expect(write).resolves.toMatchObject({ kind: "committed" });
+    expect(polls).toBe(3);
+    expect(appendCalls).toBe(1);
     await runtime.close();
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -160,6 +160,74 @@ describe("NativeRuntimeAdapter server transport", () => {
     ]);
   });
 
+  it("re-polls one pending native read after its routed chunk response", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+
+    let chunkArrived = false;
+    let polls = 0;
+    let allCalls = 0;
+    const transport = Object.assign(new FakeTransport([]), {
+      routeAuxiliaryWireFrame: () => {
+        chunkArrived = true;
+        return null;
+      },
+    });
+    const pendingRead = {
+      poll: () => {
+        polls += 1;
+        return chunkArrived ? new Uint8Array([0]) : null;
+      },
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: () => {
+              allCalls += 1;
+              return pendingRead;
+            },
+            connectUpstream: () => transport,
+            prepareQuery: () => ({}),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      new Uint8Array(16),
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+
+    const read = runtime.query(JSON.stringify({ table: "todos" }), undefined, "local");
+    await Promise.resolve();
+    expect(polls).toBe(1);
+
+    // This is the native host's concrete wake: the websocket response enters
+    // the adapter, is routed through the owned transport, and only then
+    // resumes the exact retained pending read.
+    sockets[0]!.emitMessage(encodeWebSocketFrameBatch([Uint8Array.from([0x42])]));
+
+    await expect(read).resolves.toEqual([]);
+    // Inbound routing intentionally publishes arrival and post-evaluation
+    // work edges. Both re-poll the *same* retained future; no fresh all()
+    // call may restart a large-value hydration attempt.
+    expect(polls).toBe(3);
+    expect(allCalls).toBe(1);
+    await runtime.close();
+  });
+
   it("pumps the newly owned transport before auth-refresh reconnect readiness", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/src/runtime/native-runtime/server-convergence.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/server-convergence.test.ts
@@ -51,6 +51,30 @@ const arraySchema = {
   },
 } satisfies WasmSchema;
 
+// Keep the three physical encodings in separate rows.  That makes the receipt
+// exercise the public streaming create API for each encoding, without turning
+// this topology test into a test of multi-column mutation encoding.
+const largeValueSchema = {
+  large_values: {
+    columns: [
+      { name: "kind", column_type: { type: "Text" }, nullable: false },
+      { name: "value", column_type: { type: "Text" }, nullable: false },
+    ],
+  },
+  large_bytes: {
+    columns: [
+      { name: "kind", column_type: { type: "Text" }, nullable: false },
+      { name: "value", column_type: { type: "Bytea" }, nullable: false },
+    ],
+  },
+  large_json: {
+    columns: [
+      { name: "kind", column_type: { type: "Text" }, nullable: false },
+      { name: "value", column_type: { type: "Json" }, nullable: false },
+    ],
+  },
+} satisfies WasmSchema;
+
 describe("NativeRuntimeAdapter server convergence", () => {
   let server: LocalJazzServerHandle | null = null;
   const clients: JazzClient[] = [];
@@ -259,6 +283,129 @@ describe("NativeRuntimeAdapter server convergence", () => {
     },
     20_000,
   );
+
+  // TODO(#1857): Enable after the runtime streaming-create spin is repaired.
+  // This is intentionally a real two-client/server receipt rather than a
+  // mocked resolver test: it catches a JS-thread deadlock that unit-level
+  // pending-read receipts cannot observe.
+  it.skip("hydrates streamed Text, Bytea, and Json from the server without blocking the reader event loop", async () => {
+    globalThis.WebSocket ??= WebSocket as unknown as typeof globalThis.WebSocket;
+
+    const appId = "00000000-0000-0000-0000-00000000c005";
+    server = await startLocalJazzServer({
+      appId,
+      inMemory: true,
+      adminSecret: "native-runtime-large-value-hydration-admin",
+      schema: encodeSchema(largeValueSchema),
+    });
+
+    const writer = await createClient({
+      appId,
+      serverUrl: server.url,
+      peer: "large-value-writer",
+      schema: largeValueSchema,
+    });
+    clients.push(writer);
+    writer.connectTransport(server.url, { admin_secret: server.adminSecret });
+
+    // Streaming always creates an indirect tree, even below the ordinary
+    // inline-write threshold.  Keep this topology receipt compact: #1857
+    // separately tracks the current oversized upload CPU spin, while this
+    // test proves the remote descriptor/chunk hydration path itself.
+    const text = `opening:${"é🎷".repeat(1024)}`;
+    const bytes = Uint8Array.from({ length: 20 * 1024 }, (_, index) => index % 251);
+    const document = JSON.stringify({
+      title: "hydration receipt",
+      notes: Array.from({ length: 1_024 }, (_, index) => ({ index, text: "🎵" })),
+    });
+
+    const textWrite = await writer.insertStreaming(
+      "large_values",
+      { kind: { type: "Text", value: "text" } },
+      "value",
+      chunked(text),
+    );
+    const bytesWrite = await writer.insertStreaming(
+      "large_bytes",
+      { kind: { type: "Text", value: "bytes" } },
+      "value",
+      chunked(bytes),
+    );
+    const jsonWrite = await writer.insertStreaming(
+      "large_json",
+      { kind: { type: "Text", value: "json" } },
+      "value",
+      chunked(document),
+    );
+    await Promise.all([
+      waitForPromise(textWrite.wait({ tier: "edge" }), "Text streaming insert did not settle"),
+      waitForPromise(bytesWrite.wait({ tier: "edge" }), "Bytea streaming insert did not settle"),
+      waitForPromise(jsonWrite.wait({ tier: "edge" }), "Json streaming insert did not settle"),
+    ]);
+
+    // B starts after the writes have settled.  It therefore only has the row
+    // descriptors initially; hydration must request the referenced chunks
+    // through the real websocket server, without synchronously parking the
+    // JS thread that receives the response.
+    const reader = await createClient({
+      appId,
+      serverUrl: server.url,
+      peer: "large-value-reader",
+      schema: largeValueSchema,
+    });
+    clients.push(reader);
+    reader.connectTransport(server.url, { admin_secret: server.adminSecret });
+
+    const subscriptionValues: string[] = [];
+    const subscription = new Promise<void>((resolve) => {
+      reader.subscribe(
+        JSON.stringify({ table: "large_values" }),
+        (delta) => {
+          for (const change of normalizeTestDelta(delta, largeValueSchema)) {
+            const value = "row" in change ? change.row?.values[1] : undefined;
+            if (value?.type === "Text" && value.value === text) {
+              subscriptionValues.push(value.value);
+              resolve();
+            }
+          }
+        },
+        { tier: "local" },
+      );
+    });
+
+    const [hydratedText, hydratedBytes, hydratedJson] = await Promise.all([
+      waitFor(async () => {
+        const rows = await reader.query(JSON.stringify({ table: "large_values" }), {
+          tier: "local",
+        });
+        const row = rows.find((candidate) => candidate.id === textWrite.value.id);
+        const value = row?.values[1];
+        return value?.type === "Text" && value.value === text ? value.value : undefined;
+      }, 15_000),
+      waitFor(async () => {
+        const rows = await reader.query(JSON.stringify({ table: "large_bytes" }), {
+          tier: "local",
+        });
+        const row = rows.find((candidate) => candidate.id === bytesWrite.value.id);
+        const value = row?.values[1];
+        return value?.type === "Bytea" ? value.value : undefined;
+      }, 15_000),
+      waitFor(async () => {
+        const rows = await reader.query(JSON.stringify({ table: "large_json" }), {
+          tier: "local",
+        });
+        const row = rows.find((candidate) => candidate.id === jsonWrite.value.id);
+        const value = row?.values[1];
+        return value?.type === "Json" ? value.value : undefined;
+      }, 15_000),
+      waitForPromise(subscription, "subscription did not resume after Text hydration", 15_000),
+    ]);
+
+    expect(hydratedText).toBe(text);
+    expect(Array.from(hydratedBytes)).toEqual(Array.from(bytes));
+    expect(hydratedJson).toEqual(JSON.parse(document));
+    expect(subscriptionValues).toEqual([text]);
+  }, 45_000);
 
   maybeIt("replays accepted BYTEA rows to a fresh websocket subscriber", async () => {
     globalThis.WebSocket ??= WebSocket as unknown as typeof globalThis.WebSocket;
@@ -480,5 +627,18 @@ async function waitForPromise<T>(
     ]);
   } finally {
     if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function* chunked(value: string | Uint8Array): AsyncGenerator<string | Uint8Array> {
+  const chunkBytes = 16 * 1024;
+  if (typeof value === "string") {
+    for (let offset = 0; offset < value.length; offset += chunkBytes) {
+      yield value.slice(offset, offset + chunkBytes);
+    }
+    return;
+  }
+  for (let offset = 0; offset < value.byteLength; offset += chunkBytes) {
+    yield value.subarray(offset, offset + chunkBytes);
   }
 }

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -141,9 +141,21 @@ declare module "jazz-wasm" {
     attachExclusiveTx(openBatchId: string): WasmTx;
 
     prepareQuery(query: Uint8Array): WasmPreparedQuery;
-    all(query: WasmPreparedQuery, opts: unknown): Uint8Array;
-    one(query: WasmPreparedQuery, opts: unknown): Uint8Array;
-    allForIdentity(query: WasmPreparedQuery, author: Uint8Array, opts: unknown): Uint8Array;
+    all(query: WasmPreparedQuery, opts: unknown): Promise<Uint8Array>;
+    one(query: WasmPreparedQuery, opts: unknown): Promise<Uint8Array>;
+    allForIdentity(
+      query: WasmPreparedQuery,
+      author: Uint8Array,
+      opts: unknown,
+    ): Promise<Uint8Array>;
+    allInTransaction(query: WasmPreparedQuery, tx: WasmTx, opts: unknown): Promise<Uint8Array>;
+    allInTransactionForIdentity(
+      query: WasmPreparedQuery,
+      tx: WasmTx,
+      author: Uint8Array,
+      opts: unknown,
+    ): Promise<Uint8Array>;
+    localCurrentRow(table: string, rowId: Uint8Array): Uint8Array;
     allRelationQuery(queryJson: string, opts: unknown): Promise<Uint8Array>;
     allRelationQueryForIdentity(
       queryJson: string,


### PR DESCRIPTION
🤖 Draft overnight stack layer for #1844.

Public NAPI and WASM reads now treat a missing large-value chunk as an asynchronous storage dependency instead of leaking physical descriptors, blocking the JavaScript thread, restarting hydration, or spinning empty pulls.

Behavior covered in this branch:

- flat, relation, transaction, and subscription results hydrate Text, Bytea, and JSON before public encoding;
- one-shot reads, identity reads, transaction reads, partial ranges/JSON pointers, and append/splice use retained futures;
- WASM ordinary reads return Promises rather than synchronously blocking async storage;
- transient missing chunks retain demand and resume after routed transport wake; fatal errors terminate exactly once;
- retry schedules use generations/deadlines, ignore stale carriers, and disarm predecessor deadlines on failover;
- suspended NAPI subscription batches retain at most 256 events and drain later batches without loss;
- docs remove obsolete scalar/no-large-values language.

Focused Rust, NAPI, WASM, and Jazz-tools receipts pass. The full native-runtime file has the exact same six pre-existing NotCovered unhandled rejections as the measured base.

One real two-runtime/server Text/Bytea/JSON topology receipt is intentionally preserved and skipped against #1857. It is parameterized and can be enabled directly once the creation-path repair lands.

This PR is intentionally draft. It still needs:

- the #1857 fix integrated and the real server topology enabled;
- a final adversarial pass over the repaired head;
- actual restacking after #1750 so upper app layers inherit both identity and hydration fixes;
- canonical full gates after that restack.