### PR TITLE
Retain provenance keys for ordered collectors

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering/collect_layout.rs
+++ b/crates/jazz/src/node/query_engine/lowering/collect_layout.rs
@@ -495,13 +495,16 @@ pub(super) fn collect_slot_builder(
 ) -> CollectBySlotBuilder {
     CollectBySlotBuilder::new(
         std::iter::once(parent_row_id.to_owned()).chain(route_fields.iter().cloned()),
-        slot.fields.iter().map(|field| {
-            if field.is_row_id || field.value_type == field.output_value_type {
-                CollectByField::renamed(&field.input, &field.output)
-            } else {
-                CollectByField::renamed_unwrap_nullable(&field.input, &field.output)
-            }
-        }),
+        slot.fields
+            .iter()
+            .filter(|field| field.is_output)
+            .map(|field| {
+                if field.is_row_id || field.value_type == field.output_value_type {
+                    CollectByField::renamed(&field.input, &field.output)
+                } else {
+                    CollectByField::renamed_unwrap_nullable(&field.input, &field.output)
+                }
+            }),
         &slot.collection_field,
         slot.children
             .iter()
@@ -551,6 +554,7 @@ fn collect_slot_output_descriptor(slot: &CollectSlotLayout) -> CapabilityResult<
     let mut fields = slot
         .fields
         .iter()
+        .filter(|field| field.is_output)
         .map(|field| (field.output.clone(), field.output_value_type.clone()))
         .collect::<Vec<_>>();
     fields.extend(

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -898,8 +898,8 @@ fn collect_root_input_for_value(
     layout: &CollectLayout,
     value: &NormalizedValueRef,
 ) -> CapabilityResult<String> {
-    match value {
-        NormalizedValueRef::SourceField { field, .. } => layout
+    match collect_source_field_for_value(value) {
+        Some(field) => layout
             .root_fields
             .iter()
             .find(|candidate| {
@@ -910,7 +910,7 @@ fn collect_root_input_for_value(
                         .is_some_and(|source| logical_user_column(source) == field)
             })
             .map(|candidate| candidate.input.clone()),
-        NormalizedValueRef::RowId(RowIdRef::Source(_)) => layout
+        None if matches!(value, NormalizedValueRef::RowId(RowIdRef::Source(_))) => layout
             .root_fields
             .iter()
             .find(|field| field.is_row_id)
@@ -928,8 +928,8 @@ fn collect_slot_input_for_value(
     slot: &CollectSlotLayout,
     value: &NormalizedValueRef,
 ) -> CapabilityResult<String> {
-    match value {
-        NormalizedValueRef::SourceField { field, .. } => slot
+    match collect_source_field_for_value(value) {
+        Some(field) => slot
             .fields
             .iter()
             .find(|candidate| {
@@ -940,7 +940,9 @@ fn collect_slot_input_for_value(
                         .is_some_and(|source| logical_user_column(source) == field)
             })
             .map(|candidate| candidate.input.clone()),
-        NormalizedValueRef::RowId(RowIdRef::Source(_)) => Some(slot.row_id_input.clone()),
+        None if matches!(value, NormalizedValueRef::RowId(RowIdRef::Source(_))) => {
+            Some(slot.row_id_input.clone())
+        }
         _ => None,
     }
     .ok_or_else(|| {
@@ -948,6 +950,22 @@ fn collect_slot_input_for_value(
             "collector window key {value:?} is not present in the child projection"
         )))
     })
+}
+
+/// Map a normalized field reference to the canonical name retained by a
+/// resolved source. Provenance is source metadata, not a public projection
+/// field, but ordered and sliced collectors still need it as an internal key.
+fn collect_source_field_for_value(value: &NormalizedValueRef) -> Option<&str> {
+    match value {
+        NormalizedValueRef::SourceField { field, .. } => Some(field),
+        NormalizedValueRef::Provenance { field, .. } => Some(match field {
+            ProvenanceField::CreatedAt => "$createdAt",
+            ProvenanceField::CreatedBy => "$createdBy",
+            ProvenanceField::UpdatedAt => "$updatedAt",
+            ProvenanceField::UpdatedBy => "$updatedBy",
+        }),
+        _ => None,
+    }
 }
 
 pub(super) fn root_join_occurrence_fields(

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -787,6 +787,9 @@ fn align_collect_join_key_types(
         for step in &path.child.steps {
             match step {
                 LinearStep::OrderBy(keys) => {
+                    for key in keys {
+                        retain_collect_slot_value(slot, &key.value, child)?;
+                    }
                     slot.order_cols = keys
                         .iter()
                         .map(|key| {
@@ -804,6 +807,9 @@ fn align_collect_join_key_types(
                     tie_breaker,
                     ..
                 } => {
+                    for value in tie_breaker {
+                        retain_collect_slot_value(slot, value, child)?;
+                    }
                     slot.offset = u64::from(*offset);
                     slot.limit = limit
                         .map(|limit| TopByLimit::Finite(u64::from(limit)))
@@ -891,6 +897,69 @@ fn align_collect_root_window(
             layout.root_tie_cols.push(occurrence.clone());
         }
     }
+    Ok(())
+}
+
+/// Keep values used to order or slice a nested collector slot in its internal
+/// input row. They are deliberately not public payload fields: a path can
+/// order by provenance even when its projection selects only ordinary columns.
+fn retain_collect_slot_value(
+    slot: &mut CollectSlotLayout,
+    value: &NormalizedValueRef,
+    source: &ResolvedSource,
+) -> CapabilityResult<()> {
+    let Some(requested_field) = collect_source_field_for_value(value) else {
+        return Ok(());
+    };
+    let source_field = if source
+        .row_shape
+        .descriptor
+        .field_index(requested_field)
+        .is_some()
+    {
+        requested_field.to_owned()
+    } else {
+        user_column_field(requested_field)
+    };
+    if slot
+        .fields
+        .iter()
+        .any(|field| field.source_field.as_deref() == Some(source_field.as_str()))
+    {
+        return Ok(());
+    }
+    let source_value_type = source_field_type(source, &source_field)
+        .cloned()
+        .ok_or_else(|| {
+            single_gap_report(UnsupportedReason::Operator(format!(
+                "collector child source {:?} does not provide window key {requested_field:?}",
+                source.row_shape.source
+            )))
+        })?;
+    let prefix = slot
+        .row_id_input
+        .strip_suffix(&format!("_{}", source.row_shape.row_uuid_field))
+        .ok_or_else(|| {
+            single_gap_report(UnsupportedReason::Runtime(format!(
+                "collector child row-id input {:?} does not match source row-id field {:?}",
+                slot.row_id_input, source.row_shape.row_uuid_field
+            )))
+        })?;
+    let value_type = if matches!(source_value_type, ValueType::Nullable(_)) {
+        source_value_type.clone()
+    } else {
+        ValueType::Nullable(Box::new(source_value_type.clone()))
+    };
+    slot.fields.push(CollectFlatField {
+        input: format!("{prefix}_{source_field}"),
+        output: source_field.clone(),
+        value_type,
+        output_value_type: source_value_type,
+        source_field: Some(source_field),
+        is_row_id: false,
+        is_presence: false,
+        is_output: false,
+    });
     Ok(())
 }
 

--- a/crates/jazz/src/node/query_engine/tests/support.rs
+++ b/crates/jazz/src/node/query_engine/tests/support.rs
@@ -679,7 +679,17 @@ impl SourceGraphPreparer for FakeSourceResolver {
 pub(super) struct InlineCollectorResolver {
     pub(super) requests: Vec<SourceRequest>,
     pub(super) denied_child_title: Option<&'static str>,
-    root_rows: Vec<(u8, &'static str, u64)>,
+    root_rows: Vec<InlineCollectorRootRow>,
+}
+
+#[derive(Clone, Copy)]
+struct InlineCollectorRootRow {
+    id: u8,
+    title: &'static str,
+    created_at: u64,
+    created_by: u8,
+    updated_at: u64,
+    updated_by: u8,
 }
 
 impl InlineCollectorResolver {
@@ -687,7 +697,14 @@ impl InlineCollectorResolver {
         Self {
             requests: Vec::new(),
             denied_child_title,
-            root_rows: vec![(0xd1, "parent", 10)],
+            root_rows: vec![InlineCollectorRootRow {
+                id: 0xd1,
+                title: "parent",
+                created_at: 10,
+                created_by: 0xa1,
+                updated_at: 11,
+                updated_by: 0xa1,
+            }],
         }
     }
 
@@ -697,7 +714,41 @@ impl InlineCollectorResolver {
         Self {
             requests: Vec::new(),
             denied_child_title: None,
-            root_rows: root_rows.into_iter().collect(),
+            root_rows: root_rows
+                .into_iter()
+                .map(|(id, title, created_at)| InlineCollectorRootRow {
+                    id,
+                    title,
+                    created_at,
+                    created_by: 0xa1,
+                    updated_at: created_at + 1,
+                    updated_by: 0xa1,
+                })
+                .collect(),
+        }
+    }
+
+    pub(super) fn with_provenance_root_rows(
+        root_rows: impl IntoIterator<Item = (u8, &'static str, u64, u8, u64, u8)>,
+    ) -> Self {
+        Self {
+            requests: Vec::new(),
+            denied_child_title: None,
+            root_rows: root_rows
+                .into_iter()
+                .map(
+                    |(id, title, created_at, created_by, updated_at, updated_by)| {
+                        InlineCollectorRootRow {
+                            id,
+                            title,
+                            created_at,
+                            created_by,
+                            updated_at,
+                            updated_by,
+                        }
+                    },
+                )
+                .collect(),
         }
     }
 }
@@ -716,21 +767,25 @@ impl SourceGraphPreparer for InlineCollectorResolver {
             ),
             ("user_todo", ValueType::Nullable(Box::new(ValueType::Uuid))),
             ("$createdAt", ValueType::U64),
+            ("$createdBy", ValueType::Uuid),
             ("$updatedAt", ValueType::U64),
+            ("$updatedBy", ValueType::Uuid),
         ]);
         let parent = row(0xd1).0;
         let rows = match request.source.table.as_str() {
             "todos" => self
                 .root_rows
                 .iter()
-                .map(|(id, title, created_at)| {
+                .map(|root| {
                     descriptor
                         .create(&[
-                            Value::Uuid(row(*id).0),
-                            Value::Nullable(Some(Box::new(Value::String((*title).to_owned())))),
+                            Value::Uuid(row(root.id).0),
+                            Value::Nullable(Some(Box::new(Value::String(root.title.to_owned())))),
                             Value::Nullable(None),
-                            Value::U64(*created_at),
-                            Value::U64(*created_at + 1),
+                            Value::U64(root.created_at),
+                            Value::Uuid(row(root.created_by).0),
+                            Value::U64(root.updated_at),
+                            Value::Uuid(row(root.updated_by).0),
                         ])
                         .expect("inline parent")
                 })
@@ -751,7 +806,9 @@ impl SourceGraphPreparer for InlineCollectorResolver {
                             Value::Nullable(Some(Box::new(Value::String(title.to_owned())))),
                             Value::Nullable(Some(Box::new(Value::Uuid(parent)))),
                             Value::U64(20),
+                            Value::Uuid(row(0xa2).0),
                             Value::U64(21),
+                            Value::Uuid(row(0xa2).0),
                         ])
                         .expect("inline child")
                 })
@@ -763,7 +820,9 @@ impl SourceGraphPreparer for InlineCollectorResolver {
                         Value::Nullable(Some(Box::new(Value::String("label".to_owned())))),
                         Value::Nullable(Some(Box::new(Value::Uuid(parent)))),
                         Value::U64(30),
+                        Value::Uuid(row(0xa3).0),
                         Value::U64(31),
+                        Value::Uuid(row(0xa3).0),
                     ])
                     .expect("inline sibling child"),
             ],
@@ -774,7 +833,9 @@ impl SourceGraphPreparer for InlineCollectorResolver {
                         Value::Nullable(Some(Box::new(Value::String("note".to_owned())))),
                         Value::Nullable(Some(Box::new(Value::Uuid(row(0xd2).0)))),
                         Value::U64(40),
+                        Value::Uuid(row(0xa4).0),
                         Value::U64(41),
+                        Value::Uuid(row(0xa4).0),
                     ])
                     .expect("inline grandchild"),
             ],

--- a/crates/jazz/src/node/query_engine/tests/support.rs
+++ b/crates/jazz/src/node/query_engine/tests/support.rs
@@ -679,6 +679,7 @@ impl SourceGraphPreparer for FakeSourceResolver {
 pub(super) struct InlineCollectorResolver {
     pub(super) requests: Vec<SourceRequest>,
     pub(super) denied_child_title: Option<&'static str>,
+    root_rows: Vec<(u8, &'static str, u64)>,
 }
 
 impl InlineCollectorResolver {
@@ -686,6 +687,17 @@ impl InlineCollectorResolver {
         Self {
             requests: Vec::new(),
             denied_child_title,
+            root_rows: vec![(0xd1, "parent", 10)],
+        }
+    }
+
+    pub(super) fn with_root_rows(
+        root_rows: impl IntoIterator<Item = (u8, &'static str, u64)>,
+    ) -> Self {
+        Self {
+            requests: Vec::new(),
+            denied_child_title: None,
+            root_rows: root_rows.into_iter().collect(),
         }
     }
 }
@@ -708,17 +720,21 @@ impl SourceGraphPreparer for InlineCollectorResolver {
         ]);
         let parent = row(0xd1).0;
         let rows = match request.source.table.as_str() {
-            "todos" => vec![
-                descriptor
-                    .create(&[
-                        Value::Uuid(parent),
-                        Value::Nullable(Some(Box::new(Value::String("parent".to_owned())))),
-                        Value::Nullable(None),
-                        Value::U64(10),
-                        Value::U64(11),
-                    ])
-                    .expect("inline parent"),
-            ],
+            "todos" => self
+                .root_rows
+                .iter()
+                .map(|(id, title, created_at)| {
+                    descriptor
+                        .create(&[
+                            Value::Uuid(row(*id).0),
+                            Value::Nullable(Some(Box::new(Value::String((*title).to_owned())))),
+                            Value::Nullable(None),
+                            Value::U64(*created_at),
+                            Value::U64(*created_at + 1),
+                        ])
+                        .expect("inline parent")
+                })
+                .collect(),
             "todo_tags" => [(0xd2, "allowed"), (0xd3, "denied")]
                 .into_iter()
                 .filter(|(_, title)| {

--- a/crates/jazz/src/node/query_engine/tests/terminals.rs
+++ b/crates/jazz/src/node/query_engine/tests/terminals.rs
@@ -234,6 +234,122 @@ fn collector_layout_retains_public_magic_timestamp_fields_on_child_rows() {
     assert!(row.field_index("$updatedBy").is_none());
 }
 
+// Internal compiler-boundary regression: the public useAll receipt is covered
+// by browser integration, while this test proves the collector retains a
+// provenance order key through source preparation without adding it to the
+// public row projection.
+#[test]
+fn collector_orders_and_slices_by_hidden_provenance_keys() {
+    for (direction, expected_title) in
+        [(SortDirection::Asc, "near"), (SortDirection::Desc, "later")]
+    {
+        let request = provenance_window_collector_request(direction, false);
+        let mut resolver = InlineCollectorResolver::with_root_rows([
+            (0xd1, "early", 10),
+            (0xd2, "near", 20),
+            (0xd3, "later", 30),
+            (0xd4, "late", 40),
+        ]);
+        let program = lower_query_program(request, &mut resolver)
+            .expect("hidden provenance window key should lower");
+        assert!(resolver.requests.iter().any(|request| {
+            request.source.table == "todos"
+                && request
+                    .requirements
+                    .metadata
+                    .contains(&SourceMetadataRequirement::Provenance(
+                        ProvenanceField::CreatedAt,
+                    ))
+        }));
+        let terminal = program
+            .lowered
+            .terminals
+            .iter()
+            .find(|terminal| terminal.sink == "app_rows")
+            .expect("app rows collector");
+        let OutputTerminalSchema::AppRows(schema) = &terminal.output else {
+            panic!("collector must expose app rows");
+        };
+        assert!(
+            schema.descriptor.field_index("$createdAt").is_none(),
+            "order keys must stay internal unless explicitly selected"
+        );
+
+        let rows = run_collector_graph(terminal.graph.clone());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0[1], Value::String(expected_title.to_owned()));
+    }
+}
+
+#[test]
+fn collector_exposes_provenance_only_when_selected() {
+    let request = provenance_window_collector_request(SortDirection::Asc, true);
+    let program = lower_query_program(request, &mut InlineCollectorResolver::new(None))
+        .expect("selected provenance window key should lower");
+    let terminal = program
+        .lowered
+        .terminals
+        .iter()
+        .find(|terminal| terminal.sink == "app_rows")
+        .expect("app rows collector");
+    let OutputTerminalSchema::AppRows(schema) = &terminal.output else {
+        panic!("collector must expose app rows");
+    };
+    assert!(schema.descriptor.field_index("$createdAt").is_some());
+}
+
+fn provenance_window_collector_request(
+    direction: SortDirection,
+    select_created_at: bool,
+) -> QueryProgramRequest {
+    let mut request = collector_request(system_policy_context());
+    let input = request.input.shape.root.clone();
+    let order = RowSetNodeId("root_provenance_order".to_owned());
+    let slice = RowSetNodeId("root_provenance_slice".to_owned());
+    let root_source = source("todos", SourceRole::Root);
+    request.input.shape.nodes.insert(
+        order.clone(),
+        RowSetExpr::OrderBy {
+            input,
+            keys: vec![OrderKey {
+                value: NormalizedValueRef::Provenance {
+                    source: root_source.clone(),
+                    field: ProvenanceField::CreatedAt,
+                },
+                direction,
+            }],
+        },
+    );
+    request.input.shape.nodes.insert(
+        slice.clone(),
+        RowSetExpr::Slice {
+            input: order,
+            partition_by: Vec::new(),
+            limit: Some(1),
+            offset: 1,
+            tie_breaker: vec![NormalizedValueRef::RowId(RowIdRef::Source(root_source))],
+            rank_output: None,
+        },
+    );
+    request.input.shape.root = slice;
+    let PayloadProjection::Tree(projection) = &mut request
+        .output
+        .app_rows
+        .as_mut()
+        .expect("app rows")
+        .projection
+    else {
+        panic!("collector request must use a tree projection");
+    };
+    projection.paths.clear();
+    let mut fields = BTreeSet::from(["title".to_owned()]);
+    if select_created_at {
+        fields.insert("$createdAt".to_owned());
+    }
+    projection.fields = FieldProjection::Fields(fields);
+    request
+}
+
 #[test]
 fn flat_collectors_bind_preserved_and_unwrapped_root_carriers() {
     let mut collect_all = collector_request(system_policy_context());

--- a/crates/jazz/src/node/query_engine/tests/terminals.rs
+++ b/crates/jazz/src/node/query_engine/tests/terminals.rs
@@ -243,7 +243,8 @@ fn collector_orders_and_slices_by_hidden_provenance_keys() {
     for (direction, expected_title) in
         [(SortDirection::Asc, "near"), (SortDirection::Desc, "later")]
     {
-        let request = provenance_window_collector_request(direction, false);
+        let request =
+            provenance_window_collector_request(ProvenanceField::CreatedAt, direction, false);
         let mut resolver = InlineCollectorResolver::with_root_rows([
             (0xd1, "early", 10),
             (0xd2, "near", 20),
@@ -282,8 +283,118 @@ fn collector_orders_and_slices_by_hidden_provenance_keys() {
 }
 
 #[test]
+fn collector_executes_every_hidden_provenance_order_key() {
+    let rows = [
+        (0xd1, "first", 30, 0xa3, 70, 0xa1),
+        (0xd2, "second", 10, 0xa1, 80, 0xa3),
+        (0xd3, "third", 20, 0xa2, 90, 0xa2),
+    ];
+    for (field, direction, expected_title) in [
+        (ProvenanceField::CreatedBy, SortDirection::Asc, "third"),
+        (ProvenanceField::UpdatedAt, SortDirection::Desc, "second"),
+        (ProvenanceField::UpdatedBy, SortDirection::Desc, "third"),
+    ] {
+        let request = provenance_window_collector_request(field, direction, false);
+        let mut resolver = InlineCollectorResolver::with_provenance_root_rows(rows);
+        let program = lower_query_program(request, &mut resolver)
+            .expect("hidden provenance window key should lower");
+        assert!(resolver.requests.iter().any(|request| {
+            request.source.table == "todos"
+                && request
+                    .requirements
+                    .metadata
+                    .contains(&SourceMetadataRequirement::Provenance(field))
+        }));
+        let terminal = program
+            .lowered
+            .terminals
+            .iter()
+            .find(|terminal| terminal.sink == "app_rows")
+            .expect("app rows collector");
+        let OutputTerminalSchema::AppRows(schema) = &terminal.output else {
+            panic!("collector must expose app rows");
+        };
+        assert!(
+            schema
+                .descriptor
+                .field_index(provenance_field_name(field))
+                .is_none(),
+            "order keys must stay internal unless explicitly selected"
+        );
+        let output = run_collector_graph(terminal.graph.clone());
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].0[1], Value::String(expected_title.to_owned()));
+    }
+}
+
+#[test]
+fn collector_uses_row_id_tie_breakers_for_hidden_provenance_windows() {
+    let request =
+        provenance_window_collector_request(ProvenanceField::CreatedAt, SortDirection::Asc, false);
+    let mut resolver = InlineCollectorResolver::with_root_rows([
+        (0xd1, "first", 10),
+        (0xd2, "second", 10),
+        (0xd3, "third", 10),
+    ]);
+    let program = lower_query_program(request, &mut resolver)
+        .expect("tied hidden provenance window key should lower");
+    let terminal = program
+        .lowered
+        .terminals
+        .iter()
+        .find(|terminal| terminal.sink == "app_rows")
+        .expect("app rows collector");
+    let output = run_collector_graph(terminal.graph.clone());
+    assert_eq!(output.len(), 1);
+    assert_eq!(
+        output[0].0[1],
+        Value::String("second".to_owned()),
+        "limit/offset must select the row after the stable row-id tie breaker"
+    );
+}
+
+#[test]
+fn shape_default_collector_hides_provenance_window_keys() {
+    let mut request = correlated_path_request(
+        CorrelationRequirement::Optional,
+        row_set_output(BTreeSet::new()),
+    );
+    add_root_provenance_window(
+        &mut request,
+        ProvenanceField::UpdatedAt,
+        SortDirection::Desc,
+    );
+    let mut resolver = InlineCollectorResolver::with_provenance_root_rows([
+        (0xd1, "first", 10, 0xa1, 20, 0xa1),
+        (0xd2, "second", 20, 0xa2, 30, 0xa2),
+        (0xd3, "third", 30, 0xa3, 40, 0xa3),
+    ]);
+    let program = lower_query_program(request, &mut resolver)
+        .expect("shape-default hidden provenance window should lower");
+    let terminal = program
+        .lowered
+        .terminals
+        .iter()
+        .find(|terminal| terminal.sink == "app_rows")
+        .expect("shape-default app rows collector");
+    let OutputTerminalSchema::AppRows(schema) = &terminal.output else {
+        panic!("collector must expose app rows");
+    };
+    for field in ["$createdAt", "$createdBy", "$updatedAt", "$updatedBy"] {
+        assert!(schema.descriptor.field_index(field).is_none());
+    }
+    let output = run_collector_graph(terminal.graph.clone());
+    assert_eq!(output.len(), 1);
+    assert_eq!(
+        output[0].0[1],
+        Value::Nullable(Some(Box::new(Value::String("second".to_owned()))))
+    );
+}
+
+#[test]
 fn collector_exposes_provenance_only_when_selected() {
-    let request = provenance_window_collector_request(SortDirection::Asc, true);
+    let request =
+        provenance_window_collector_request(ProvenanceField::CreatedAt, SortDirection::Asc, true);
     let program = lower_query_program(request, &mut InlineCollectorResolver::new(None))
         .expect("selected provenance window key should lower");
     let terminal = program
@@ -299,10 +410,35 @@ fn collector_exposes_provenance_only_when_selected() {
 }
 
 fn provenance_window_collector_request(
+    field: ProvenanceField,
     direction: SortDirection,
     select_created_at: bool,
 ) -> QueryProgramRequest {
     let mut request = collector_request(system_policy_context());
+    add_root_provenance_window(&mut request, field, direction);
+    let PayloadProjection::Tree(projection) = &mut request
+        .output
+        .app_rows
+        .as_mut()
+        .expect("app rows")
+        .projection
+    else {
+        panic!("collector request must use a tree projection");
+    };
+    projection.paths.clear();
+    let mut fields = BTreeSet::from(["title".to_owned()]);
+    if select_created_at {
+        fields.insert("$createdAt".to_owned());
+    }
+    projection.fields = FieldProjection::Fields(fields);
+    request
+}
+
+fn add_root_provenance_window(
+    request: &mut QueryProgramRequest,
+    field: ProvenanceField,
+    direction: SortDirection,
+) {
     let input = request.input.shape.root.clone();
     let order = RowSetNodeId("root_provenance_order".to_owned());
     let slice = RowSetNodeId("root_provenance_slice".to_owned());
@@ -314,7 +450,7 @@ fn provenance_window_collector_request(
             keys: vec![OrderKey {
                 value: NormalizedValueRef::Provenance {
                     source: root_source.clone(),
-                    field: ProvenanceField::CreatedAt,
+                    field,
                 },
                 direction,
             }],
@@ -332,22 +468,15 @@ fn provenance_window_collector_request(
         },
     );
     request.input.shape.root = slice;
-    let PayloadProjection::Tree(projection) = &mut request
-        .output
-        .app_rows
-        .as_mut()
-        .expect("app rows")
-        .projection
-    else {
-        panic!("collector request must use a tree projection");
-    };
-    projection.paths.clear();
-    let mut fields = BTreeSet::from(["title".to_owned()]);
-    if select_created_at {
-        fields.insert("$createdAt".to_owned());
+}
+
+fn provenance_field_name(field: ProvenanceField) -> &'static str {
+    match field {
+        ProvenanceField::CreatedAt => "$createdAt",
+        ProvenanceField::CreatedBy => "$createdBy",
+        ProvenanceField::UpdatedAt => "$updatedAt",
+        ProvenanceField::UpdatedBy => "$updatedBy",
     }
-    projection.fields = FieldProjection::Fields(fields);
-    request
 }
 
 #[test]
@@ -555,6 +684,97 @@ fn collector_tree_keeps_sibling_slots_distinct_and_nests_grandchildren_by_path()
         required_tags.len(),
         1,
         "a child whose required nested relation is missing must be filtered"
+    );
+}
+
+#[test]
+fn collector_orders_nested_slots_by_hidden_provenance_keys() {
+    let mut request = collector_request(system_policy_context());
+    let tags = source("todo_tags", SourceRole::CorrelatedChild("tags".to_owned()));
+    let order = RowSetNodeId("tags_provenance_order".to_owned());
+    let slice = RowSetNodeId("tags_provenance_slice".to_owned());
+    request.input.shape.nodes.insert(
+        order.clone(),
+        RowSetExpr::OrderBy {
+            input: RowSetNodeId("child".to_owned()),
+            keys: vec![OrderKey {
+                value: NormalizedValueRef::Provenance {
+                    source: tags.clone(),
+                    field: ProvenanceField::CreatedAt,
+                },
+                direction: SortDirection::Asc,
+            }],
+        },
+    );
+    request.input.shape.nodes.insert(
+        slice.clone(),
+        RowSetExpr::Slice {
+            input: order,
+            partition_by: Vec::new(),
+            limit: Some(1),
+            offset: 1,
+            tie_breaker: vec![NormalizedValueRef::RowId(RowIdRef::Source(tags.clone()))],
+            rank_output: None,
+        },
+    );
+    let RowSetExpr::CorrelatedPathProjection { child_input, .. } = request
+        .input
+        .shape
+        .nodes
+        .get_mut(&RowSetNodeId("path".to_owned()))
+        .expect("tags path")
+    else {
+        panic!("tags path must remain correlated");
+    };
+    *child_input = slice;
+
+    let mut resolver = InlineCollectorResolver::new(None);
+    let program = lower_query_program(request, &mut resolver)
+        .expect("nested hidden provenance window should lower");
+    assert!(resolver.requests.iter().any(|request| {
+        request.source == tags
+            && request
+                .requirements
+                .metadata
+                .contains(&SourceMetadataRequirement::Provenance(
+                    ProvenanceField::CreatedAt,
+                ))
+    }));
+    let terminal = program
+        .lowered
+        .terminals
+        .iter()
+        .find(|terminal| terminal.sink == "app_rows")
+        .expect("app rows collector");
+    let OutputTerminalSchema::AppRows(schema) = &terminal.output else {
+        panic!("collector must expose app rows");
+    };
+    let tags_descriptor = schema
+        .descriptor
+        .fields()
+        .iter()
+        .find(|field| field.name.as_deref() == Some("tags"))
+        .expect("tags output field");
+    let ValueType::Array(tag) = &tags_descriptor.value_type else {
+        panic!("tags must be an array");
+    };
+    let ValueType::Record(tag) = tag.as_ref() else {
+        panic!("tags must contain records");
+    };
+    assert!(tag.field_index("$createdAt").is_none());
+
+    let rows = run_collector_graph(terminal.graph.clone());
+    let Value::Array(tags) = &rows[0].0[3] else {
+        panic!("collector must render tags slot");
+    };
+    assert_eq!(tags.len(), 1);
+    let Value::Record(tag) = &tags[0] else {
+        panic!("tags slot must contain child records");
+    };
+    assert_eq!(
+        tag.to_values().expect("tag values")[1],
+        Value::String("denied".to_owned()),
+        "the nested slot must honor the hidden key's row-id tie breaker"
     );
 }
 

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -53,12 +53,20 @@ describe("translateQuery", () => {
   });
 
   it("keeps provenance order keys internal unless the caller selects them", () => {
-    const hidden = JSON.parse(
-      translateQuery(
-        app.projects.orderBy("$createdAt", "asc").limit(4).offset(2)._build(),
-        app.wasmSchema,
-      ),
-    );
+    for (const column of ["$createdAt", "$createdBy", "$updatedAt", "$updatedBy"] as const) {
+      const hidden = JSON.parse(
+        translateQuery(
+          app.projects.orderBy(column, "asc").limit(4).offset(2)._build(),
+          app.wasmSchema,
+        ),
+      );
+      expect(hidden).toMatchObject({
+        order_by: [{ column, direction: "Asc" }],
+        limit: 4,
+        offset: 2,
+      });
+      expect(hidden.select_columns).toBeUndefined();
+    }
     const selected = JSON.parse(
       translateQuery(
         app.projects
@@ -71,12 +79,6 @@ describe("translateQuery", () => {
       ),
     );
 
-    expect(hidden).toMatchObject({
-      order_by: [{ column: "$createdAt", direction: "Asc" }],
-      limit: 4,
-      offset: 2,
-    });
-    expect(hidden.select_columns).toBeUndefined();
     expect(selected).toMatchObject({
       select_columns: ["name", "$createdAt"],
       order_by: [{ column: "$createdAt", direction: "Desc" }],

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -52,6 +52,39 @@ describe("translateQuery", () => {
     expect(translated.array_subqueries).toHaveLength(1);
   });
 
+  it("keeps provenance order keys internal unless the caller selects them", () => {
+    const hidden = JSON.parse(
+      translateQuery(
+        app.projects.orderBy("$createdAt", "asc").limit(4).offset(2)._build(),
+        app.wasmSchema,
+      ),
+    );
+    const selected = JSON.parse(
+      translateQuery(
+        app.projects
+          .select("name", "$createdAt")
+          .orderBy("$createdAt", "desc")
+          .limit(4)
+          .offset(2)
+          ._build(),
+        app.wasmSchema,
+      ),
+    );
+
+    expect(hidden).toMatchObject({
+      order_by: [{ column: "$createdAt", direction: "Asc" }],
+      limit: 4,
+      offset: 2,
+    });
+    expect(hidden.select_columns).toBeUndefined();
+    expect(selected).toMatchObject({
+      select_columns: ["name", "$createdAt"],
+      order_by: [{ column: "$createdAt", direction: "Desc" }],
+      limit: 4,
+      offset: 2,
+    });
+  });
+
   it("keeps native relation IR for relation traversal queries", () => {
     const translated = JSON.parse(
       translateQuery(app.todos.where({ done: false }).hopTo("owner")._build(), app.wasmSchema),


### PR DESCRIPTION
🤖 Retains provenance keys used by root and nested collector windows without exposing them unless explicitly selected.

Flat and nested queries such as orderBy("$createdAt") previously translated correctly but lost the provenance key across collector projection/layout, yielding an unsupported window-key capability error and browser edge-coverage timeouts.

This branch uses the existing Rust lowering path to:
- retain $createdAt, $updatedAt, $createdBy, and $updatedBy sort/tie keys internally;
- preserve duplicate-time deterministic row-id ties with offset/limit;
- support nested collector slots;
- keep ShapeDefault/wildcard and nested descriptors free of hidden magic columns;
- expose only explicitly selected provenance fields.

Independent adversarial review approved it. Twenty-seven terminal tests, row-provenance receipts, 11 adapter tests, and planted retention/leak mutations pass.

This draft is stacked on the multi-key policy fix and will be linked into the existing official stack after the active upper auth branch is rebased.
