### PR TITLE
Deny client access to generated Better Auth tables

### DIFF
--- a/.changeset/secure-better-auth-tables.md
+++ b/.changeset/secure-better-auth-tables.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Generate deny-all client permissions for Better Auth tables while retaining backend adapter access.

--- a/docs/content/docs/recipes/auth/better-auth-adapter.mdx
+++ b/docs/content/docs/recipes/auth/better-auth-adapter.mdx
@@ -43,6 +43,22 @@ export const app: s.App<AppSchema> = s.defineApp(schema);
 
 The generated `schema-better-auth/schema.ts` also ships a `permissions` export that denies all operations on the Better Auth tables. Merge it with your own permissions so regular client sessions can't read or write Better Auth rows — the adapter itself uses `context.asBackend()`, which authenticates with `backendSecret` and bypasses permission checks entirely.
 
+```ts title="permissions.ts"
+import { definePermissions } from "jazz-tools/permissions";
+import { permissions as betterAuthPermissions } from "./schema-better-auth/schema";
+import { app } from "./schema";
+
+const appPermissions = definePermissions(app, ({ policy }) => {
+  // Define policies for your own tables.
+  policy.messages.allowRead.always();
+});
+
+export default {
+  ...betterAuthPermissions,
+  ...appPermissions,
+};
+```
+
 ## Database Adapter
 
 Create a server-side [Jazz context](/docs/getting-started/server-setup#backend-context-setup), then pass it to `jazzAdapter(...)` as the `database` in your Better Auth config. Point both `db` and `schema` at the merged `app` — not at the generated module directly — so Better Auth and your own tables share a single Jazz app.

--- a/examples/auth-betterauth-chat/README.md
+++ b/examples/auth-betterauth-chat/README.md
@@ -60,16 +60,16 @@ Open `NEXT_PUBLIC_APP_ORIGIN`.
 ### Server — `src/lib/auth.ts`, `src/lib/auth-jazz-context.ts`, and `schema-better-auth/schema.ts`
 
 `auth.ts` wires up the Better Auth instance with four plugins and points the adapter at the
-root Better Auth schema module:
+root app schema, which includes both the generated Better Auth tables and the chat table:
 
 ```ts
 import { jazzAdapter } from "jazz-tools/better-auth-adapter";
-import { app as authSchema } from "../../schema-better-auth/schema";
+import { app } from "../../schema";
 
 betterAuth({
   database: jazzAdapter({
-    db: () => authJazzContext().asBackend(authSchema),
-    schema: authSchema,
+    db: () => authJazzContext().asBackend(app),
+    schema: app.wasmSchema,
   }),
   emailAndPassword: { enabled: true, autoSignIn: true, minPasswordLength: 1 },
   plugins: [
@@ -92,13 +92,14 @@ betterAuth({
 });
 ```
 
-`schema-better-auth/schema.ts` is the Better Auth schema source file that the Jazz adapter now
-generates for the new root-schema workflow. `authJazzContext()` is a lazy accessor that returns
-a server-side Jazz context configured with `driver: { type: "memory" }`, the same `serverUrl`,
-and the same backend secret as the local sync server. It caches the context on `globalThis` so
-route modules don't instantiate it at import time (which would fail during Next's build-time
-page data collection before env vars are available). That keeps Better Auth state out of Better Auth's in-process memory
-adapter while still avoiding local on-disk storage in the Next app.
+`schema-better-auth/schema.ts` is the generated Better Auth schema source file. Its deny-all
+`permissions` export is spread into the root `permissions.ts` alongside the message policies, so
+ordinary clients cannot read or mutate authentication rows. `authJazzContext()` uses
+`asBackend(app)` with the sync server's backend secret, so the adapter can still access those rows.
+It caches the context on `globalThis` so route modules don't instantiate it at import time (which
+would fail during Next's build-time page data collection before env vars are available). That
+keeps Better Auth state out of Better Auth's in-process memory adapter while still avoiding local
+on-disk storage in the Next app.
 
 - **`nextCookies` integration** — lets Better Auth session cookies participate in Next.js route
   handlers and server actions.
@@ -112,6 +113,21 @@ adapter while still avoiding local on-disk storage in the Next app.
 The JWKS endpoint (`/api/auth/jwks`) is automatically provided by the `jwt` plugin and is what
 the Jazz sync server polls to verify every incoming token. The same sync server also accepts the
 backend secret used by the Better Auth Jazz context so auth rows can sync through Jazz too.
+
+The root permission bundle composes the generated auth-table policies with the chat policies:
+
+```ts
+import { permissions as betterAuthPermissions } from "./schema-better-auth/schema";
+
+const messagePermissions = definePermissions(app, ({ policy }) => {
+  // Message policies...
+});
+
+export default {
+  ...betterAuthPermissions,
+  ...messagePermissions,
+};
+```
 
 ### Client — `src/lib/auth-client.ts`
 

--- a/examples/auth-betterauth-chat/permissions.ts
+++ b/examples/auth-betterauth-chat/permissions.ts
@@ -1,10 +1,11 @@
 import { definePermissions } from "jazz-tools/permissions";
+import { permissions as betterAuthPermissions } from "./schema-better-auth/schema";
 import { app } from "./schema";
 
 const ANNOUNCEMENTS_CHAT_ID = process.env.NEXT_PUBLIC_ANNOUNCEMENTS_CHAT_ID!;
 const CHAT_ID = process.env.NEXT_PUBLIC_CHAT_ID!;
 
-export default definePermissions(app, ({ policy, allOf, anyOf, session }) => {
+const messagePermissions = definePermissions(app, ({ policy, allOf, session }) => {
   const isAuthenticated = session.where({ authMode: "external" });
   const canMutateGenericChat = { $createdBy: session.user_id };
 
@@ -24,3 +25,8 @@ export default definePermissions(app, ({ policy, allOf, anyOf, session }) => {
   policy.messages.allowDelete.where(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAuthenticated]));
   policy.messages.allowDelete.where(allOf([{ chat_id: CHAT_ID }, canMutateGenericChat]));
 });
+
+export default {
+  ...betterAuthPermissions,
+  ...messagePermissions,
+};

--- a/examples/auth-betterauth-chat/schema-better-auth/schema.ts
+++ b/examples/auth-betterauth-chat/schema-better-auth/schema.ts
@@ -55,3 +55,34 @@ export const schema = {
     expiresAt: s.timestamp().optional(),
   }),
 };
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+export const wasmSchema = app.wasmSchema;
+
+export const permissions = s.definePermissions(app, ({ policy }) => {
+  policy.better_auth_user.allowRead.never();
+  policy.better_auth_user.allowInsert.never();
+  policy.better_auth_user.allowUpdate.never();
+  policy.better_auth_user.allowDelete.never();
+
+  policy.better_auth_session.allowRead.never();
+  policy.better_auth_session.allowInsert.never();
+  policy.better_auth_session.allowUpdate.never();
+  policy.better_auth_session.allowDelete.never();
+
+  policy.better_auth_account.allowRead.never();
+  policy.better_auth_account.allowInsert.never();
+  policy.better_auth_account.allowUpdate.never();
+  policy.better_auth_account.allowDelete.never();
+
+  policy.better_auth_verification.allowRead.never();
+  policy.better_auth_verification.allowInsert.never();
+  policy.better_auth_verification.allowUpdate.never();
+  policy.better_auth_verification.allowDelete.never();
+
+  policy.better_auth_jwks.allowRead.never();
+  policy.better_auth_jwks.allowInsert.never();
+  policy.better_auth_jwks.allowUpdate.never();
+  policy.better_auth_jwks.allowDelete.never();
+});

--- a/examples/auth-betterauth-chat/tests/browser/auth-betterauth-chat.test.ts
+++ b/examples/auth-betterauth-chat/tests/browser/auth-betterauth-chat.test.ts
@@ -13,6 +13,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { type JazzClient, createJazzClient } from "jazz-tools/react";
 import { app } from "../../schema.js";
+import permissions from "../../permissions.js";
+import { schema as betterAuthSchema } from "../../schema-better-auth/schema.js";
 
 const clients: JazzClient[] = [];
 
@@ -44,6 +46,18 @@ async function send(client: JazzClient, chat_id: string, text: string): Promise<
 }
 
 describe("auth-betterauth-chat permissions", () => {
+  it("composes deny-all CRUD policies for every generated Better Auth table", () => {
+    for (const tableName of Object.keys(betterAuthSchema)) {
+      const tablePermissions = permissions[tableName]!;
+
+      expect(tablePermissions.select?.using).toEqual({ type: "False" });
+      expect(tablePermissions.insert?.with_check).toEqual({ type: "False" });
+      expect(tablePermissions.update?.using).toEqual({ type: "False" });
+      expect(tablePermissions.update?.with_check).toEqual({ type: "False" });
+      expect(tablePermissions.delete?.using).toEqual({ type: "False" });
+    }
+  });
+
   it("authenticated JWT can post to Announcements and General", async () => {
     const client = await makeClient(__USER_JWT__);
     await expect(send(client, __ANNOUNCEMENTS_CHAT_ID__, "user-ann")).resolves.toBeUndefined();

--- a/packages/jazz-tools/src/better-auth-adapter/fixtures/schema.ts
+++ b/packages/jazz-tools/src/better-auth-adapter/fixtures/schema.ts
@@ -1,6 +1,6 @@
 import { schema as s } from "jazz-tools";
 
-const schema = {
+export const schema = {
   better_auth_user: s.table({
     name: s.string(),
     email: s.string(),

--- a/packages/jazz-tools/src/better-auth-adapter/index.test.ts
+++ b/packages/jazz-tools/src/better-auth-adapter/index.test.ts
@@ -1,13 +1,95 @@
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { betterAuth, type BetterAuthOptions, type DBAdapter } from "better-auth";
+import { mintLocalFirstToken } from "jazz-napi";
 import { createJazzContext, type JazzContext } from "../backend/index.js";
 import { startLocalJazzServer, type LocalJazzServerHandle } from "../testing/index.js";
 import { deploy as deployProject } from "../dev/catalogue-project.js";
-import { wasmSchema as wasmSchemaExample } from "./fixtures/schema.js";
+import {
+  app as fixtureApp,
+  permissions as fixturePermissions,
+  schema as fixtureSchema,
+  wasmSchema as wasmSchemaExample,
+} from "./fixtures/schema.js";
 import { jazzAdapter } from "./index.js";
 
 describe("jazzAdapter", () => {
+  describe("generated auth-table permissions", () => {
+    it("denies client CRUD for every generated Better Auth table", () => {
+      expect(Object.keys(fixturePermissions).sort()).toEqual(Object.keys(fixtureSchema).sort());
+
+      for (const tableName of Object.keys(fixtureSchema)) {
+        const tablePermissions = fixturePermissions[tableName]!;
+
+        expect(tablePermissions.select?.using).toEqual({ type: "False" });
+        expect(tablePermissions.insert?.with_check).toEqual({ type: "False" });
+        expect(tablePermissions.update?.using).toEqual({ type: "False" });
+        expect(tablePermissions.update?.with_check).toEqual({ type: "False" });
+        expect(tablePermissions.delete?.using).toEqual({ type: "False" });
+      }
+    });
+  });
+
+  it("rejects ordinary-session reads and writes to Better Auth tables", async () => {
+    const server = await startLocalJazzServer({
+      allowLocalFirstAuth: true,
+    });
+    await deployProject({
+      serverUrl: server.url,
+      appId: server.appId,
+      adminSecret: server.adminSecret,
+      schemaDir: join(import.meta.dirname, "fixtures"),
+    });
+    const context = createJazzContext({
+      appId: server.appId,
+      app: fixtureApp,
+      permissions: fixturePermissions,
+      driver: { type: "memory" },
+      serverUrl: server.url,
+      backendSecret: server.backendSecret,
+    });
+
+    try {
+      const adapter = jazzAdapter({
+        db: () => context.asBackend(fixtureApp),
+        schema: fixtureApp.wasmSchema,
+      })({});
+      await adapter.create({
+        model: "user",
+        data: {
+          name: "Backend user",
+          email: "backend@example.com",
+          emailVerified: false,
+          image: null,
+        },
+      });
+
+      const localFirstSecret = Buffer.alloc(32, 7).toString("base64url");
+      const token = mintLocalFirstToken(localFirstSecret, server.appId, 60);
+      const sessionDb = await context.forRequest({
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      await expect(sessionDb.all(fixtureApp.better_auth_user, { tier: "edge" })).resolves.toEqual(
+        [],
+      );
+      await expect(
+        sessionDb
+          .insert(fixtureApp.better_auth_user, {
+            name: "Client user",
+            email: "client@example.com",
+            emailVerified: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .wait({ tier: "edge" }),
+      ).rejects.toThrow(/AuthorizationDenied|Write rejected by server authorization/);
+    } finally {
+      await context.shutdown();
+      await server.stop();
+    }
+  }, 30_000);
+
   describe("adapter methods", () => {
     let adapter: DBAdapter<BetterAuthOptions>;
     let context: JazzContext;
@@ -43,7 +125,7 @@ describe("jazzAdapter", () => {
       await server.stop();
     });
 
-    it("creates records with Jazz ids", async () => {
+    it("backend access can insert and read despite deny-all client policies", async () => {
       const created = await adapter.create({
         model: "user",
         data: {
@@ -134,7 +216,7 @@ describe("jazzAdapter", () => {
       ).resolves.toBe(3);
     });
 
-    it("updates and deletes records using non-id filters", async () => {
+    it("backend access can update and delete despite deny-all client policies", async () => {
       const alpha = await adapter.create<any>({
         model: "user",
         data: {
@@ -455,8 +537,13 @@ describe("jazzAdapter", () => {
       });
       expect(generated.code).toContain('import { schema as s } from "jazz-tools";');
       expect(generated.code).toContain("export const app: s.App<AppSchema> = s.defineApp(schema);");
-      expect(generated.code).not.toContain("definePermissions");
-      expect(generated.code).not.toContain("allowRead");
+      expect(generated.code).toContain(
+        "export const permissions = s.definePermissions(app, ({ policy }) => {",
+      );
+      expect(generated.code).toContain("policy.better_auth_user.allowRead.never();");
+      expect(generated.code).toContain("policy.better_auth_user.allowInsert.never();");
+      expect(generated.code).toContain("policy.better_auth_user.allowUpdate.never();");
+      expect(generated.code).toContain("policy.better_auth_user.allowDelete.never();");
     });
   });
 

--- a/packages/jazz-tools/src/better-auth-adapter/schema.test.ts
+++ b/packages/jazz-tools/src/better-auth-adapter/schema.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { BetterAuthDBSchema } from "better-auth/db";
-import { buildJazzSchemaSourceTextFromTables, buildJazzSchemaFromTables } from "./schema.js";
+import {
+  buildJazzSchemaSourceText,
+  buildJazzSchemaSourceTextFromTables,
+  buildJazzSchemaFromTables,
+} from "./schema.js";
 
 describe("better-auth schema helpers", () => {
   it("builds a Jazz schema from Better Auth tables using transformed names", () => {
@@ -188,7 +192,72 @@ describe("better-auth schema helpers", () => {
         "export const app: s.App<AppSchema> = s.defineApp(schema);",
         "export const wasmSchema = app.wasmSchema;",
         "",
+        "export const permissions = s.definePermissions(app, ({ policy }) => {",
+        "  policy.accountHolders.allowRead.never();",
+        "  policy.accountHolders.allowInsert.never();",
+        "  policy.accountHolders.allowUpdate.never();",
+        "  policy.accountHolders.allowDelete.never();",
+        "",
+        "  policy.devices.allowRead.never();",
+        "  policy.devices.allowInsert.never();",
+        "  policy.devices.allowUpdate.never();",
+        "  policy.devices.allowDelete.never();",
+        "",
+        "  policy.sessions.allowRead.never();",
+        "  policy.sessions.allowInsert.never();",
+        "  policy.sessions.allowUpdate.never();",
+        "  policy.sessions.allowDelete.never();",
+        "});",
+        "",
       ].join("\n"),
+    );
+  });
+
+  it("generates deny-all policies for every Better Auth table", () => {
+    const tables = {
+      user: {
+        modelName: "user",
+        fields: {
+          id: {
+            type: "string",
+            required: true,
+          },
+        },
+      },
+      session: {
+        modelName: "session",
+        fields: {
+          id: {
+            type: "string",
+            required: true,
+          },
+        },
+      },
+    } as BetterAuthDBSchema;
+    const tableNamesByModel = {
+      user: "better_auth_user",
+      session: "better-auth-session",
+    } as const;
+    const source = buildJazzSchemaSourceText({
+      tables,
+      getModelName: (model) => tableNamesByModel[model as keyof typeof tableNamesByModel],
+      getFieldName: ({ field }) => field,
+    });
+
+    for (const tableName of Object.values(tableNamesByModel)) {
+      const policyTarget =
+        tableName === "better_auth_user"
+          ? "policy.better_auth_user"
+          : 'policy["better-auth-session"]';
+
+      expect(source).toContain(`${policyTarget}.allowRead.never();`);
+      expect(source).toContain(`${policyTarget}.allowInsert.never();`);
+      expect(source).toContain(`${policyTarget}.allowUpdate.never();`);
+      expect(source).toContain(`${policyTarget}.allowDelete.never();`);
+    }
+
+    expect(source.match(/\.allow(Read|Insert|Update|Delete)\.never\(\);/g)).toHaveLength(
+      Object.keys(tables).length * 4,
     );
   });
 

--- a/packages/jazz-tools/src/better-auth-adapter/schema.ts
+++ b/packages/jazz-tools/src/better-auth-adapter/schema.ts
@@ -130,6 +130,12 @@ function formatObjectKey(key: string): string {
   return JS_IDENTIFIER_PATTERN.test(key) ? key : JSON.stringify(key);
 }
 
+function formatPropertyAccess(objectName: string, key: string): string {
+  return JS_IDENTIFIER_PATTERN.test(key)
+    ? `${objectName}.${key}`
+    : `${objectName}[${formatStringLiteral(key)}]`;
+}
+
 function withOptionalSuffix(expression: string, field: DBFieldAttribute): string {
   return field.required === false ? `${expression}.optional()` : expression;
 }
@@ -333,6 +339,7 @@ export function buildJazzSchemaSourceText(args: {
 }): string {
   const { tables, getModelName, getFieldName } = args;
   const blocks: string[] = [];
+  const permissionsBlocks: string[] = [];
 
   for (const [modelName, model] of Object.entries(tables)) {
     const tableName = getModelName(modelName);
@@ -359,6 +366,16 @@ export function buildJazzSchemaSourceText(args: {
 
     lines.push("  }),");
     blocks.push(lines.join("\n"));
+
+    const policy = formatPropertyAccess("policy", tableName);
+    permissionsBlocks.push(
+      [
+        `  ${policy}.allowRead.never();`,
+        `  ${policy}.allowInsert.never();`,
+        `  ${policy}.allowUpdate.never();`,
+        `  ${policy}.allowDelete.never();`,
+      ].join("\n"),
+    );
   }
 
   return [
@@ -371,6 +388,10 @@ export function buildJazzSchemaSourceText(args: {
     "type AppSchema = s.Schema<typeof schema>;",
     "export const app: s.App<AppSchema> = s.defineApp(schema);",
     "export const wasmSchema = app.wasmSchema;",
+    "",
+    "export const permissions = s.definePermissions(app, ({ policy }) => {",
+    ...permissionsBlocks.flatMap((block, index) => (index === 0 ? [block] : ["", block])),
+    "});",
     "",
   ].join("\n");
 }


### PR DESCRIPTION
## What changed

- Generate explicit deny rules for reading, inserting, updating, and deleting every Better Auth table.
- Support generated table names that are not valid JavaScript identifiers.
- Merge those rules into the official Better Auth example alongside the app's message rules.
- Document the required permission setup and add a patch changeset for `jazz-tools`.

## Why

Jazz closes access one table at a time. Adding rules for an application table does not protect other tables that were left out of the permission set. The generated Better Auth tables were left out, so ordinary clients could access authentication records.

The generated rules now deny all ordinary client access to those tables. The Better Auth adapter still uses its backend connection, so its database operations continue to work.

## Testing

The first commit adds the regression tests and leaves them failing:

- Three Better Auth adapter checks fail because the generated schema has no table rules.
- The example check fails because its final permission set has no rules for the generated auth tables.

The second commit adds the fix:

- Better Auth adapter tests: 30 passed. The suite's existing duplicate-email restart case remains marked as an expected failure.
- Better Auth example browser tests: 3 passed.
- `jazz-tools` TypeScript check passed.
- Pre-commit formatting, lint, documentation type checks, and sensitive-data checks passed.

## Build note

A separate full test-artifact build rebuilt the release NAPI and WebAssembly artifacts, then stopped in an unrelated existing `jazz-tools` test-build step because `Required<Where>` no longer has `mode` and `@vue/server-renderer` is missing. The artifact verifier and the focused tests above passed.