### PR TITLE
test(examples): schedule deterministic transport faults

### DIFF
--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -5,6 +5,38 @@ bounded named phases, disconnect/reconnect/restart/failure callbacks, receipts,
 and replay commands. App scenarios continue to own schemas, fixtures,
 operations, and assertions.
 
+## Envelope faults
+
+The same module also provides `TopologyEnvelopeScheduler`, a test-only virtual
+time boundary around an app test transport's _delivery callback_. It does not
+instrument, patch, or otherwise change Jazz's runtime transport. Give messages
+stable endpoint names and non-sensitive test labels, then wrap delivery:
+
+```ts
+const envelopes = new TopologyEnvelopeScheduler(seed);
+await envelopes.intercept(
+  { from: "browser", to: "edge", label: "write" },
+  encodedMessage,
+  (message) => testTransport.deliver(message),
+);
+```
+
+Arm faults before the next intercepted envelope with
+`duplicateNext`, `delayNext(ticks)`, `reorderNext`, or
+`dropNextThenRetry(ticks)`. `partition(a, b)` holds traffic in both directions;
+`heal(a, b)` releases ready traffic. `advance(ticks)` moves only virtual time,
+so tests never need wall-clock sleeps to reproduce a schedule. Delivery order,
+attempt number, virtual tick, endpoint names, labels, and every fault action
+are retained in the payload-free scheduler receipt. Pass each scheduler through
+`envelopeSchedulers` on `runTopologyScenario`; the runner closes it after app
+cleanup and records discarded held envelopes, preventing a test fault from
+leaking into another scenario.
+
+The scheduler deliberately models message delivery only. Connection lifecycle,
+real transport retry policy, and application assertions remain app-owned. An
+app should use an explicit test transport seam (or its existing simulation
+link), rather than adding app-specific production hooks just for topology tests.
+
 Register a scenario in `dev/example-topology-scenarios.json` with a stable id,
 topology labels, working directory, and an argv array. Run the bounded smoke
 locally with:

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -30,7 +30,22 @@ attempt number, virtual tick, endpoint names, labels, and every fault action
 are retained in the payload-free scheduler receipt. Pass each scheduler through
 `envelopeSchedulers` on `runTopologyScenario`; the runner closes it after app
 cleanup and records discarded held envelopes, preventing a test fault from
-leaking into another scenario.
+leaking into another scenario. Delivery callbacks receive an `AbortSignal` and
+must stop work when it aborts: teardown awaits all in-flight callbacks up to
+the scenario's bounded fault timeout. A callback that ignores cancellation
+causes a visible cleanup-timeout receipt and scenario failure rather than a
+quiet cross-test leak.
+
+Envelope descriptors are deliberately narrow, immutable snapshots of
+`{ from, to, label? }`: endpoint names and labels are bounded, unknown metadata
+and NUL-containing endpoint names are rejected, and payloads are never recorded.
+Only one fault kind can be armed for an envelope (multiple duplicate copies are
+the sole composable case). The scheduler also bounds copies, virtual ticks, and
+outstanding work, partition links, and receipt activities to keep a bad randomized soak schedule finite. A logical
+envelope id remains stable across copies/retry while each actual delivery has a
+separate sequence and attempt; retry is recorded when the retry is delivered,
+not merely scheduled. A callback failure fail-stops the scheduler and records
+discarded remaining deliveries deterministically.
 
 The scheduler deliberately models message delivery only. Connection lifecycle,
 real transport retry policy, and application assertions remain app-owned. An

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -26,8 +26,10 @@ Arm faults before the next intercepted envelope with
 `dropNextThenRetry(ticks)`. `partition(a, b)` holds traffic in both directions;
 `heal(a, b)` releases ready traffic. `advance(ticks)` moves only virtual time,
 so tests never need wall-clock sleeps to reproduce a schedule. Delivery order,
-attempt number, virtual tick, endpoint names, labels, and every fault action
-are retained in the payload-free scheduler receipt. Pass each scheduler through
+attempt number, virtual tick, endpoint names, labels, and fault actions are
+retained in a bounded recent-history window in the payload-free scheduler
+receipt. `activitiesTruncated` reports how many older activities were evicted.
+Pass each scheduler through
 `envelopeSchedulers` on `runTopologyScenario`; the runner closes it after app
 cleanup and records discarded held envelopes, preventing a test fault from
 leaking into another scenario. Delivery callbacks receive an `AbortSignal` and
@@ -45,12 +47,13 @@ Envelope descriptors are deliberately narrow, immutable snapshots of
 `{ from, to, label? }`: endpoint names and labels are bounded, unknown metadata
 and NUL-containing endpoint names are rejected, and payloads are never recorded.
 Only one fault kind can be armed for an envelope (multiple duplicate copies are
-the sole composable case). The scheduler also bounds copies, virtual ticks, and
-outstanding work, partition links, and receipt activities to keep a bad randomized soak schedule finite. A logical
-envelope id remains stable across copies/retry while each actual delivery has a
-separate sequence and attempt; retry is recorded when the retry is delivered,
-not merely scheduled. A callback failure fail-stops the scheduler and records
-discarded remaining deliveries deterministically.
+the sole composable case). The scheduler also bounds copies, virtual ticks,
+outstanding work, partition links, and receipt activities to keep a bad
+randomized soak schedule finite. A logical envelope id remains stable across
+copies/retry while each actual delivery has a separate sequence and attempt;
+retry is recorded when the retry is delivered, not merely scheduled. A callback
+failure fail-stops the scheduler and records discarded remaining deliveries
+deterministically.
 
 The scheduler deliberately models message delivery only. Connection lifecycle,
 real transport retry policy, and application assertions remain app-owned. An

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -36,6 +36,11 @@ the scenario's bounded fault timeout. A callback that ignores cancellation
 causes a visible cleanup-timeout receipt and scenario failure rather than a
 quiet cross-test leak.
 
+If a delivery itself produces another envelope, use the callback context's
+`enqueue(...)` function. That adds the follow-up to the same serialized drain
+without recursively waiting for the active callback. Ordinary concurrent calls
+to `intercept(...)` continue to resolve only after their deliveries settle.
+
 Envelope descriptors are deliberately narrow, immutable snapshots of
 `{ from, to, label? }`: endpoint names and labels are bounded, unknown metadata
 and NUL-containing endpoint names are rejected, and payloads are never recorded.

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -55,6 +55,10 @@ describe("shared example topology harness", () => {
     expect(receipt.activities.map(({ action }) => action)).toContain("dropped");
     expect(receipt.activities.map(({ action }) => action)).toContain("retried");
     expect(receipt.activities.map(({ action }) => action)).toContain("partitioned");
+    const retry = receipt.activities.find(({ action }) => action === "retried");
+    const dropped = receipt.activities.find(({ action }) => action === "dropped");
+    expect(retry?.envelopeId).toBe(dropped?.envelopeId);
+    expect(retry?.sequence).toBe(dropped?.sequence);
   });
 
   it("closes held envelopes after scenario cleanup, proving faults cannot leak between cases", async () => {
@@ -79,6 +83,182 @@ describe("shared example topology harness", () => {
     await expect(
       scheduler.intercept({ from: "a", to: "b" }, "late", () => undefined),
     ).rejects.toThrow("scheduler is closed");
+  });
+
+  it("waits for an in-flight delivery to finish before the scenario returns", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(19);
+    let deliveryFinished = false;
+    void scheduler.intercept(
+      { from: "a", to: "b", label: "in-flight" },
+      "in-flight",
+      (_, { signal }) =>
+        new Promise<void>((resolve) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              deliveryFinished = true;
+              resolve();
+            },
+            { once: true },
+          );
+        }),
+    );
+    await Promise.resolve();
+
+    const receipt = await runTopologyScenario({
+      id: "harness.fixture.in-flight-cleanup",
+      topology: ["fixture"],
+      seed: 19,
+      phaseTimeoutMs: 50,
+      faultTimeoutMs: 50,
+      targets: {},
+      replay: "in-flight-cleanup-fixture",
+      envelopeSchedulers: [scheduler],
+      phases: [],
+    });
+    expect(deliveryFinished).toBe(true);
+    expect(receipt.envelopes[0]).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
+    expect(receipt.envelopes[0]?.cleanup?.status).toBe("completed");
+  });
+
+  it("records a rejected delivery without retaining it for cleanup", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(23);
+    await expect(
+      scheduler.intercept({ from: "a", to: "b", label: "reject" }, "reject", () =>
+        Promise.reject(new Error("planted delivery rejection")),
+      ),
+    ).rejects.toThrow("planted delivery rejection");
+    await scheduler.close(20);
+    const receipt = scheduler.receipt();
+    expect(receipt).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
+    expect(receipt.activities.find(({ action }) => action === "deliveryFailed")?.error).toContain(
+      "planted delivery rejection",
+    );
+  });
+
+  it("bounds a delivery that ignores cancellation and retains an explicit timeout receipt", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(31);
+    let release!: () => void;
+    const delivery = scheduler.intercept(
+      { from: "a", to: "b", label: "ignores-abort" },
+      "ignores-abort",
+      () => new Promise<void>((resolve) => (release = resolve)),
+    );
+    await Promise.resolve();
+    let failure: unknown;
+    try {
+      await runTopologyScenario({
+        id: "harness.fixture.in-flight-timeout",
+        topology: ["fixture"],
+        seed: 31,
+        phaseTimeoutMs: 50,
+        faultTimeoutMs: 5,
+        targets: {},
+        replay: "in-flight-timeout-fixture",
+        envelopeSchedulers: [scheduler],
+        phases: [],
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(TopologyScenarioError);
+    const receipt = (failure as TopologyScenarioError).receipt.envelopes[0];
+    expect(receipt).toMatchObject({ closed: true, inFlight: 1, cleanup: { status: "failed" } });
+    expect(receipt?.activities.at(-1)?.action).toBe("closeTimedOut");
+    release();
+    await delivery;
+  });
+
+  it("serializes concurrent intercepts and permits a delivery to enqueue a follow-up", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(37);
+    let releaseFirst!: () => void;
+    const delivered: string[] = [];
+    const first = scheduler.intercept(
+      { from: "a", to: "b", label: "first" },
+      "first",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = () => {
+            delivered.push("first");
+            resolve();
+          };
+        }),
+    );
+    await Promise.resolve();
+    const second = scheduler.intercept(
+      { from: "a", to: "b", label: "second" },
+      "second",
+      () => void delivered.push("second"),
+    );
+    expect(delivered).toEqual([]);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(delivered).toEqual(["first", "second"]);
+
+    await scheduler.intercept({ from: "a", to: "b", label: "parent" }, "parent", async () => {
+      await scheduler.intercept(
+        { from: "a", to: "b", label: "child" },
+        "child",
+        () => void delivered.push("child"),
+      );
+      delivered.push("parent");
+    });
+    expect(delivered).toEqual(["first", "second", "parent", "child"]);
+    expect(
+      scheduler
+        .receipt()
+        .activities.filter(({ action }) => action === "delivered")
+        .map(({ label }) => label),
+    ).toEqual(["first", "second", "parent", "child"]);
+  });
+
+  it("snapshots bounded descriptors and rejects receipt-field or payload injection", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(41);
+    const envelope = { from: "a", to: "b", label: "before" };
+    scheduler.delayNext();
+    await scheduler.intercept(envelope, "value", () => undefined);
+    envelope.label = "after";
+    await scheduler.advance();
+    expect(
+      scheduler
+        .receipt()
+        .activities.filter(({ action }) => action === "delivered")
+        .map(({ label }) => label),
+    ).toEqual(["before"]);
+    await expect(
+      scheduler.intercept(
+        {
+          from: "a",
+          to: "b",
+          label: "safe",
+          action: "delivered",
+          payload: "not-a-receipt",
+        } as never,
+        "value",
+        () => undefined,
+      ),
+    ).rejects.toThrow("unsupported metadata");
+    await expect(
+      scheduler.intercept({ from: "a", to: "b", label: "x".repeat(257) }, "value", () => undefined),
+    ).rejects.toThrow("at most 256");
+    scheduler.delayNext();
+    expect(() => scheduler.reorderNext()).toThrow("only one envelope fault kind");
+  });
+
+  it("fail-stops after a callback failure and discards remaining duplicate deliveries", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(43);
+    scheduler.duplicateNext(2);
+    await expect(
+      scheduler.intercept({ from: "a", to: "b", label: "fail" }, "value", () => {
+        throw new Error("planted terminal delivery failure");
+      }),
+    ).rejects.toThrow("planted terminal delivery failure");
+    const receipt = scheduler.receipt();
+    expect(receipt.activities.filter(({ action }) => action === "deliveryFailed")).toHaveLength(1);
+    expect(receipt.activities.filter(({ action }) => action === "discarded")).toHaveLength(2);
+    await expect(
+      scheduler.intercept({ from: "a", to: "b" }, "later", () => undefined),
+    ).rejects.toThrow("scheduler is failed");
   });
 
   it("runs deterministic phases and every fault callback with a replayable receipt", async () => {

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  TopologyEnvelopeScheduler,
   TopologyScenarioError,
   deterministicRandom,
   runTopologyScenario,
@@ -7,6 +8,79 @@ import {
 } from "./harness.js";
 
 describe("shared example topology harness", () => {
+  it("deterministically plants envelope duplicates, delay, reordering, retry, and a healed partition", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(73);
+    const delivered: Array<{ value: string; attempt: number; tick: number }> = [];
+    const send = (value: string) =>
+      scheduler.intercept(
+        { from: "browser", to: "edge", label: value },
+        value,
+        (received, context) => void delivered.push({ value: received, ...context }),
+      );
+
+    scheduler.duplicateNext();
+    await send("duplicate");
+    scheduler.delayNext(2);
+    await send("delayed");
+    scheduler.reorderNext();
+    await send("first");
+    await send("second");
+    scheduler.dropNextThenRetry(3);
+    await send("retry");
+
+    expect(delivered.map(({ value, attempt }) => `${value}:${attempt}`)).toEqual([
+      "duplicate:1",
+      "duplicate:2",
+      "second:1",
+      "first:1",
+    ]);
+    await scheduler.advance(2);
+    expect(delivered.map(({ value }) => value)).toEqual([
+      "duplicate",
+      "duplicate",
+      "second",
+      "first",
+      "delayed",
+    ]);
+    await scheduler.advance();
+    expect(delivered.some(({ value }) => value === "retry")).toBe(true);
+    scheduler.partition("browser", "edge");
+    await send("partitioned");
+    expect(delivered.some(({ value }) => value === "partitioned")).toBe(false);
+    await scheduler.heal("browser", "edge");
+    expect(delivered.map(({ value }) => value)).toContain("partitioned");
+
+    const receipt = scheduler.receipt();
+    expect(receipt).toMatchObject({ seed: 73, tick: 3, pending: 0, closed: false });
+    expect(receipt.activities.map(({ action }) => action)).toContain("dropped");
+    expect(receipt.activities.map(({ action }) => action)).toContain("retried");
+    expect(receipt.activities.map(({ action }) => action)).toContain("partitioned");
+  });
+
+  it("closes held envelopes after scenario cleanup, proving faults cannot leak between cases", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(17);
+    scheduler.delayNext(10);
+    await scheduler.intercept({ from: "a", to: "b", label: "held" }, "held", () => undefined);
+
+    const receipt = await runTopologyScenario({
+      id: "harness.fixture.envelope-cleanup",
+      topology: ["fixture"],
+      seed: 17,
+      phaseTimeoutMs: 50,
+      faultTimeoutMs: 50,
+      targets: {},
+      replay: "envelope-cleanup-fixture",
+      envelopeSchedulers: [scheduler],
+      phases: [],
+    });
+    expect(receipt.envelopes).toHaveLength(1);
+    expect(receipt.envelopes[0]).toMatchObject({ closed: true, pending: 0 });
+    expect(receipt.envelopes[0]?.activities.at(-1)?.action).toBe("discarded");
+    await expect(
+      scheduler.intercept({ from: "a", to: "b" }, "late", () => undefined),
+    ).rejects.toThrow("scheduler is closed");
+  });
+
   it("runs deterministic phases and every fault callback with a replayable receipt", async () => {
     const seed = Number(process.env.JAZZ_EXAMPLE_TOPOLOGY_SEED ?? 29);
     const calls: string[] = [];

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -254,20 +254,17 @@ describe("shared example topology harness", () => {
 
   it("serializes concurrent intercepts and permits a delivery to enqueue a follow-up", async () => {
     const scheduler = new TopologyEnvelopeScheduler(37);
+    let signalFirstEntered!: () => void;
+    const firstEntered = new Promise<void>((resolve) => (signalFirstEntered = resolve));
     let releaseFirst!: () => void;
+    const firstReleased = new Promise<void>((resolve) => (releaseFirst = resolve));
     const delivered: string[] = [];
-    const first = scheduler.intercept(
-      { from: "a", to: "b", label: "first" },
-      "first",
-      () =>
-        new Promise<void>((resolve) => {
-          releaseFirst = () => {
-            delivered.push("first");
-            resolve();
-          };
-        }),
-    );
-    await Promise.resolve();
+    const first = scheduler.intercept({ from: "a", to: "b", label: "first" }, "first", async () => {
+      signalFirstEntered();
+      await firstReleased;
+      delivered.push("first");
+    });
+    await firstEntered;
     const second = scheduler.intercept(
       { from: "a", to: "b", label: "second" },
       "second",
@@ -275,7 +272,7 @@ describe("shared example topology harness", () => {
     );
     let secondSettled = false;
     void second.then(() => (secondSettled = true));
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(delivered).toEqual([]);
     expect(secondSettled).toBe(false);
     releaseFirst();

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -119,6 +119,11 @@ describe("shared example topology harness", () => {
     expect(deliveryFinished).toBe(true);
     expect(receipt.envelopes[0]).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
     expect(receipt.envelopes[0]?.cleanup?.status).toBe("completed");
+    expect(
+      receipt.envelopes[0]?.activities.filter(({ action }) =>
+        ["deliveryAborted", "delivered", "deliveryFailed"].includes(action),
+      ),
+    ).toMatchObject([{ action: "deliveryAborted" }]);
   });
 
   it("records a rejected delivery without retaining it for cleanup", async () => {
@@ -127,13 +132,16 @@ describe("shared example topology harness", () => {
       scheduler.intercept({ from: "a", to: "b", label: "reject" }, "reject", () =>
         Promise.reject(new Error("planted delivery rejection")),
       ),
-    ).rejects.toThrow("planted delivery rejection");
-    await scheduler.close(20);
+    ).rejects.toThrow("topology-envelope-delivery-callback-rejected");
+    await expect(scheduler.close(20)).rejects.toThrow(
+      "topology-envelope-delivery-callback-rejected",
+    );
     const receipt = scheduler.receipt();
     expect(receipt).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
-    expect(receipt.activities.find(({ action }) => action === "deliveryFailed")?.error).toContain(
-      "planted delivery rejection",
+    expect(receipt.activities.find(({ action }) => action === "deliveryFailed")?.error).toBe(
+      "delivery-callback-rejected",
     );
+    expect(JSON.stringify(receipt)).not.toContain("planted delivery rejection");
   });
 
   it("bounds a delivery that ignores cancellation and retains an explicit timeout receipt", async () => {
@@ -169,6 +177,81 @@ describe("shared example topology harness", () => {
     await delivery;
   });
 
+  it("fails scenario cleanup when an aborted callback genuinely rejects", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(33);
+    const delivery = scheduler
+      .intercept(
+        { from: "a", to: "b", label: "rejects-on-close" },
+        "value",
+        (_, { signal }) =>
+          new Promise<void>((_, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => reject(new Error("private callback detail must be redacted")),
+              { once: true },
+            );
+          }),
+      )
+      .catch(() => undefined);
+    await Promise.resolve();
+    await expect(
+      runTopologyScenario({
+        id: "harness.fixture.close-rejection",
+        topology: ["fixture"],
+        seed: 33,
+        phaseTimeoutMs: 50,
+        faultTimeoutMs: 50,
+        targets: {},
+        replay: "close-rejection-fixture",
+        envelopeSchedulers: [scheduler],
+        phases: [],
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof TopologyScenarioError &&
+        error.receipt.error?.includes("delivery-callback-rejected") === true &&
+        !JSON.stringify(error.receipt).includes("private callback detail"),
+    );
+    await delivery;
+    const terminal = scheduler
+      .receipt()
+      .activities.filter(({ action }) =>
+        ["deliveryAborted", "delivered", "deliveryFailed"].includes(action),
+      );
+    expect(terminal).toMatchObject([
+      { action: "deliveryFailed", error: "delivery-callback-rejected" },
+    ]);
+  });
+
+  it("treats rejecting with the abort reason as cooperative cancellation", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(34);
+    const delivery = scheduler.intercept(
+      { from: "a", to: "b", label: "cooperative-abort" },
+      "value",
+      (_, { signal }) =>
+        new Promise<void>((_, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+    await Promise.resolve();
+    await scheduler.close(50);
+    await delivery;
+    const receipt = scheduler.receipt();
+    expect(receipt.cleanup?.status).toBe("completed");
+    expect(
+      receipt.activities.filter(({ action }) =>
+        ["deliveryAborted", "delivered", "deliveryFailed"].includes(action),
+      ),
+    ).toMatchObject([{ action: "deliveryAborted" }]);
+  });
+
+  it("rejects impractical cleanup timers without starting close", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(35);
+    await expect(scheduler.close(Number.MAX_SAFE_INTEGER)).rejects.toThrow("at most 300000ms");
+    expect(scheduler.receipt().closed).toBe(false);
+    await scheduler.close(20);
+  });
+
   it("serializes concurrent intercepts and permits a delivery to enqueue a follow-up", async () => {
     const scheduler = new TopologyEnvelopeScheduler(37);
     let releaseFirst!: () => void;
@@ -190,19 +273,27 @@ describe("shared example topology harness", () => {
       "second",
       () => void delivered.push("second"),
     );
+    let secondSettled = false;
+    void second.then(() => (secondSettled = true));
+    await Promise.resolve();
     expect(delivered).toEqual([]);
+    expect(secondSettled).toBe(false);
     releaseFirst();
     await Promise.all([first, second]);
     expect(delivered).toEqual(["first", "second"]);
 
-    await scheduler.intercept({ from: "a", to: "b", label: "parent" }, "parent", async () => {
-      await scheduler.intercept(
-        { from: "a", to: "b", label: "child" },
-        "child",
-        () => void delivered.push("child"),
-      );
-      delivered.push("parent");
-    });
+    await scheduler.intercept(
+      { from: "a", to: "b", label: "parent" },
+      "parent",
+      (_, { enqueue }) => {
+        enqueue(
+          { from: "a", to: "b", label: "child" },
+          "child",
+          () => void delivered.push("child"),
+        );
+        delivered.push("parent");
+      },
+    );
     expect(delivered).toEqual(["first", "second", "parent", "child"]);
     expect(
       scheduler
@@ -252,13 +343,27 @@ describe("shared example topology harness", () => {
       scheduler.intercept({ from: "a", to: "b", label: "fail" }, "value", () => {
         throw new Error("planted terminal delivery failure");
       }),
-    ).rejects.toThrow("planted terminal delivery failure");
+    ).rejects.toThrow("topology-envelope-delivery-callback-rejected");
     const receipt = scheduler.receipt();
     expect(receipt.activities.filter(({ action }) => action === "deliveryFailed")).toHaveLength(1);
     expect(receipt.activities.filter(({ action }) => action === "discarded")).toHaveLength(2);
     await expect(
       scheduler.intercept({ from: "a", to: "b" }, "later", () => undefined),
     ).rejects.toThrow("scheduler is failed");
+  });
+
+  it("keeps terminal cleanup receipts after activity history truncates", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(47);
+    for (let index = 0; index < 2_100; index++) {
+      await scheduler.intercept({ from: "a", to: "b", label: "fill" }, index, () => undefined);
+    }
+    scheduler.delayNext(10);
+    await scheduler.intercept({ from: "a", to: "b", label: "held" }, "held", () => undefined);
+    await scheduler.close(20);
+    const receipt = scheduler.receipt();
+    expect(receipt.activitiesTruncated).toBeGreaterThan(0);
+    expect(receipt.activities.at(-1)).toMatchObject({ action: "discarded", label: "held" });
+    expect(receipt).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
   });
 
   it("runs deterministic phases and every fault callback with a replayable receipt", async () => {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -46,6 +46,7 @@ export interface TopologyScenario {
    * them after app cleanup so a held packet cannot leak into a later test.
    */
   envelopeSchedulers?: readonly TopologyEnvelopeScheduler[];
+  envelopeCleanupTimeoutMs?: number;
   cleanup?: (context: TopologyOperationContext) => Promise<void>;
   cleanupTimeoutMs?: number;
 }
@@ -187,7 +188,7 @@ export async function runTopologyScenario(
     }
     for (const scheduler of scenario.envelopeSchedulers ?? []) {
       try {
-        scheduler.close();
+        await scheduler.close(scenario.envelopeCleanupTimeoutMs ?? scenario.faultTimeoutMs);
       } catch (closeError) {
         const message = `envelope scheduler cleanup failed: ${errorMessage(closeError)}`;
         receipt.status = "failed";
@@ -204,16 +205,18 @@ export async function runTopologyScenario(
 
 /** A small, app-owned description of a message at a test transport boundary. */
 export interface TopologyTransportEnvelope {
-  from: string;
-  to: string;
+  readonly from: string;
+  readonly to: string;
   /** Stable test-only label; never inspect production payloads just to fault them. */
-  label?: string;
+  readonly label?: string;
 }
 
 export interface TopologyEnvelopeDeliveryContext {
+  envelopeId: number;
   attempt: number;
   tick: number;
   sequence: number;
+  signal: AbortSignal;
 }
 
 export type TopologyEnvelopeDelivery<T> = (
@@ -231,16 +234,21 @@ export type TopologyEnvelopeAction =
   | "retried"
   | "partitioned"
   | "healed"
-  | "discarded";
+  | "discarded"
+  | "deliveryFailed"
+  | "deliveryAborted"
+  | "closeTimedOut";
 
 export interface TopologyEnvelopeActivity {
   action: TopologyEnvelopeAction;
+  envelopeId?: number;
   sequence?: number;
   from?: string;
   to?: string;
   label?: string;
   tick: number;
   attempt?: number;
+  error?: string;
 }
 
 export interface TopologyEnvelopeSchedulerReceipt {
@@ -248,16 +256,20 @@ export interface TopologyEnvelopeSchedulerReceipt {
   tick: number;
   closed: boolean;
   pending: number;
+  inFlight: number;
+  cleanup?: TopologyActivityReceipt;
   activities: readonly TopologyEnvelopeActivity[];
 }
 
 interface PendingEnvelope<T> {
+  envelopeId: number;
   sequence: number;
   envelope: TopologyTransportEnvelope;
   value: T;
   deliver: TopologyEnvelopeDelivery<T>;
   dueTick: number;
   attempt: number;
+  retry: boolean;
 }
 
 interface NextEnvelopeFault {
@@ -265,6 +277,12 @@ interface NextEnvelopeFault {
   delayTicks: number;
   reorder: boolean;
   dropThenRetryTicks: number | undefined;
+}
+
+interface InFlightEnvelope {
+  pending: PendingEnvelope<unknown>;
+  controller: AbortController;
+  promise: Promise<void>;
 }
 
 /**
@@ -280,6 +298,7 @@ export class TopologyEnvelopeScheduler {
   readonly seed: number;
   #tick = 0;
   #sequence = 0;
+  #envelopeId = 0;
   #closed = false;
   #pending: PendingEnvelope<unknown>[] = [];
   #heldForReorder: PendingEnvelope<unknown> | undefined;
@@ -291,44 +310,67 @@ export class TopologyEnvelopeScheduler {
     dropThenRetryTicks: undefined,
   };
   #activities: TopologyEnvelopeActivity[] = [];
+  #inFlight = new Map<number, InFlightEnvelope>();
+  #closePromise: Promise<void> | undefined;
+  #cleanup: TopologyActivityReceipt | undefined;
+  #pumpPromise: Promise<void> | undefined;
+  #deliveryDepth = 0;
+  #failure: unknown;
 
   constructor(seed: number) {
+    if (!Number.isSafeInteger(seed) || seed < 0 || seed > 0xffff_ffff) {
+      throw new Error("topology envelope scheduler seed must be a uint32");
+    }
     this.seed = seed;
   }
 
   /** Deliver the next matching envelope more than once (one duplicate by default). */
   duplicateNext(copies = 1): void {
     this.assertOpen();
-    if (!Number.isInteger(copies) || copies < 1)
-      throw new Error("duplicate copies must be a positive integer");
+    this.assertArmedOnly("duplicate");
+    if (!Number.isSafeInteger(copies) || copies < 1 || copies > MAX_TOPOLOGY_COPIES)
+      throw new Error(`duplicate copies must be a positive integer at most ${MAX_TOPOLOGY_COPIES}`);
+    if (this.#next.duplicate + copies > MAX_TOPOLOGY_COPIES)
+      throw new Error(`duplicate copies must not exceed ${MAX_TOPOLOGY_COPIES}`);
     this.#next.duplicate += copies;
   }
 
   /** Hold the next matching envelope for virtual `ticks`; `advance` releases it. */
   delayNext(ticks = 1): void {
     this.assertOpen();
-    if (!Number.isInteger(ticks) || ticks < 1)
-      throw new Error("delay ticks must be a positive integer");
-    this.#next.delayTicks = Math.max(this.#next.delayTicks, ticks);
+    this.assertArmedOnly("delay");
+    assertTopologyTicks("delay", ticks);
+    this.#next.delayTicks = ticks;
   }
 
   /** Reverse the next pair of envelopes, retaining the first until the second arrives. */
   reorderNext(): void {
     this.assertOpen();
+    this.assertArmedOnly("reorder");
     this.#next.reorder = true;
   }
 
   /** Drop the next envelope, then make exactly one retry available after virtual `ticks`. */
   dropNextThenRetry(ticks = 1): void {
     this.assertOpen();
-    if (!Number.isInteger(ticks) || ticks < 1)
-      throw new Error("retry ticks must be a positive integer");
+    this.assertArmedOnly("drop-then-retry");
+    assertTopologyTicks("retry", ticks);
     this.#next.dropThenRetryTicks = ticks;
   }
 
   /** Block both directions between two named endpoints until `heal` is called. */
   partition(first: string, second: string): void {
     this.assertOpen();
+    assertEndpoint("first partition endpoint", first);
+    assertEndpoint("second partition endpoint", second);
+    if (
+      !this.#partitions.has(linkKey(first, second)) &&
+      this.#partitions.size >= MAX_TOPOLOGY_PARTITIONS
+    ) {
+      throw new Error(
+        `topology envelope scheduler partition capacity is ${MAX_TOPOLOGY_PARTITIONS}`,
+      );
+    }
     this.#partitions.add(linkKey(first, second));
     this.record({ action: "partitioned", from: first, to: second });
   }
@@ -339,6 +381,10 @@ export class TopologyEnvelopeScheduler {
     if ((first === undefined) !== (second === undefined)) {
       throw new Error("heal requires both endpoints or neither");
     }
+    if (first !== undefined) {
+      assertEndpoint("first heal endpoint", first);
+      assertEndpoint("second heal endpoint", second!);
+    }
     if (first === undefined) this.#partitions.clear();
     else this.#partitions.delete(linkKey(first, second!));
     this.record({ action: "healed", from: first, to: second });
@@ -348,8 +394,10 @@ export class TopologyEnvelopeScheduler {
   /** Advance deterministic virtual time and release due, non-partitioned envelopes. */
   async advance(ticks = 1): Promise<void> {
     this.assertOpen();
-    if (!Number.isInteger(ticks) || ticks < 1)
-      throw new Error("advance ticks must be a positive integer");
+    assertTopologyTicks("advance", ticks);
+    if (this.#tick + ticks > MAX_TOPOLOGY_TICKS) {
+      throw new Error(`topology virtual time must not exceed ${MAX_TOPOLOGY_TICKS} ticks`);
+    }
     this.#tick += ticks;
     await this.pump();
   }
@@ -364,37 +412,49 @@ export class TopologyEnvelopeScheduler {
     deliver: TopologyEnvelopeDelivery<T>,
   ): Promise<void> {
     this.assertOpen();
+    const descriptor = snapshotEnvelope(envelope);
     const pending: PendingEnvelope<T> = {
-      sequence: ++this.#sequence,
-      envelope,
+      envelopeId: this.allocateEnvelopeId(),
+      sequence: this.allocateSequence(),
+      envelope: descriptor,
       value,
       deliver,
       dueTick: this.#tick,
       attempt: 1,
+      retry: false,
     };
     this.recordPending("queued", pending);
     const fault = this.takeNextFault();
     if (fault.dropThenRetryTicks !== undefined) {
       this.recordPending("dropped", pending);
       pending.attempt = 2;
+      pending.retry = true;
       pending.dueTick += fault.dropThenRetryTicks;
-      this.recordPending("retried", pending);
+      this.ensureCapacity(1);
       this.#pending.push(pending as PendingEnvelope<unknown>);
     } else if (this.#heldForReorder || fault.reorder) {
       if (!this.#heldForReorder) {
+        this.ensureCapacity(1);
         this.#heldForReorder = pending as PendingEnvelope<unknown>;
         this.recordPending("reordered", pending);
       } else {
         this.recordPending("reordered", pending);
+        this.ensureCapacity(2);
         this.#pending.push(pending as PendingEnvelope<unknown>, this.#heldForReorder);
         this.#heldForReorder = undefined;
       }
     } else {
       pending.dueTick += fault.delayTicks;
       if (fault.delayTicks) this.recordPending("delayed", pending);
+      this.ensureCapacity(1 + fault.duplicate);
       this.#pending.push(pending as PendingEnvelope<unknown>);
       for (let copy = 0; copy < fault.duplicate; copy++) {
-        const duplicate = { ...pending, sequence: ++this.#sequence, attempt: copy + 2 };
+        const duplicate = {
+          ...pending,
+          sequence: this.allocateSequence(),
+          attempt: copy + 2,
+          retry: false,
+        };
         this.recordPending("duplicated", duplicate);
         this.#pending.push(duplicate as PendingEnvelope<unknown>);
       }
@@ -402,19 +462,18 @@ export class TopologyEnvelopeScheduler {
     await this.pump();
   }
 
-  /** Discard undelivered envelopes, including an incomplete reorder pair. Idempotent. */
-  close(): void {
-    if (this.#closed) return;
-    this.#closed = true;
-    for (const pending of [
-      ...this.#pending,
-      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
-    ]) {
-      this.recordPending("discarded", pending);
+  /**
+   * Abort and await in-flight delivery before returning. A callback which
+   * ignores its signal produces a bounded, visible cleanup failure rather
+   * than silently leaking into a later scenario. Idempotent.
+   */
+  close(timeoutMs: number): Promise<void> {
+    if (this.#closePromise) return this.#closePromise;
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 1) {
+      return Promise.reject(new Error("envelope cleanup timeout must be positive"));
     }
-    this.#pending = [];
-    this.#heldForReorder = undefined;
-    this.#partitions.clear();
+    this.#closePromise = this.closeInternal(timeoutMs);
+    return this.#closePromise;
   }
 
   receipt(): TopologyEnvelopeSchedulerReceipt {
@@ -423,6 +482,8 @@ export class TopologyEnvelopeScheduler {
       tick: this.#tick,
       closed: this.#closed,
       pending: this.#pending.length + Number(this.#heldForReorder !== undefined),
+      inFlight: this.#inFlight.size,
+      cleanup: this.#cleanup && { ...this.#cleanup },
       activities: this.#activities.map((activity) => ({ ...activity })),
     };
   }
@@ -433,19 +494,94 @@ export class TopologyEnvelopeScheduler {
     return next;
   }
 
+  private async closeInternal(timeoutMs: number): Promise<void> {
+    this.#closed = true;
+    for (const pending of [
+      ...this.#pending,
+      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
+    ]) {
+      this.recordPending("discarded", pending);
+    }
+    this.#pending = [];
+    this.#heldForReorder = undefined;
+    this.#partitions.clear();
+    const started = now();
+    this.#cleanup = { status: "attempted", elapsedMs: 0 };
+    const abort = new Error("topology envelope scheduler closed");
+    for (const inFlight of this.#inFlight.values()) {
+      inFlight.controller.abort(abort);
+      this.recordPending("deliveryAborted", inFlight.pending, abort);
+    }
+    try {
+      await waitForSettlement(
+        [...this.#inFlight.values()].map(({ promise }) => promise),
+        timeoutMs,
+      );
+      Object.assign(this.#cleanup, { status: "completed", elapsedMs: elapsed(started) });
+    } catch (error) {
+      const message = errorMessage(error);
+      Object.assign(this.#cleanup, {
+        status: "failed",
+        elapsedMs: elapsed(started),
+        error: message,
+      });
+      this.record({ action: "closeTimedOut", error: message });
+      throw error;
+    }
+  }
+
   private async pump(): Promise<void> {
+    // A delivery callback may await `intercept` to enqueue a follow-up. Do not
+    // make it await its own serialized drain; the outer drain will pick up the
+    // follow-up after the callback returns. Other callers still join the drain.
+    if (this.#pumpPromise) return this.#deliveryDepth > 0 ? undefined : this.#pumpPromise;
+    this.#pumpPromise = this.pumpInternal();
+    try {
+      await this.#pumpPromise;
+    } finally {
+      this.#pumpPromise = undefined;
+    }
+  }
+
+  private async pumpInternal(): Promise<void> {
     while (true) {
+      if (this.#closed) return;
       const index = this.#pending.findIndex(
         (pending) => pending.dueTick <= this.#tick && !this.isPartitioned(pending.envelope),
       );
       if (index === -1) return;
       const [pending] = this.#pending.splice(index, 1);
-      await pending.deliver(pending.value, {
-        attempt: pending.attempt,
-        tick: this.#tick,
-        sequence: pending.sequence,
-      });
+      await this.deliver(pending);
+    }
+  }
+
+  private async deliver(pending: PendingEnvelope<unknown>): Promise<void> {
+    const controller = new AbortController();
+    const promise = Promise.resolve().then(async () => {
+      this.#deliveryDepth++;
+      try {
+        await pending.deliver(pending.value, {
+          envelopeId: pending.envelopeId,
+          attempt: pending.attempt,
+          tick: this.#tick,
+          sequence: pending.sequence,
+          signal: controller.signal,
+        });
+      } finally {
+        this.#deliveryDepth--;
+      }
+    });
+    this.#inFlight.set(pending.sequence, { pending, controller, promise });
+    try {
+      if (pending.retry) this.recordPending("retried", pending);
+      await promise;
       this.recordPending("delivered", pending);
+    } catch (error) {
+      this.recordPending("deliveryFailed", pending, error);
+      this.failStop(error);
+      throw error;
+    } finally {
+      this.#inFlight.delete(pending.sequence);
     }
   }
 
@@ -453,26 +589,171 @@ export class TopologyEnvelopeScheduler {
     return this.#partitions.has(linkKey(envelope.from, envelope.to));
   }
 
-  private recordPending(action: TopologyEnvelopeAction, pending: PendingEnvelope<unknown>): void {
+  private recordPending(
+    action: TopologyEnvelopeAction,
+    pending: PendingEnvelope<unknown>,
+    error?: unknown,
+  ): void {
     this.record({
       action,
+      envelopeId: pending.envelopeId,
       sequence: pending.sequence,
       attempt: pending.attempt,
-      ...pending.envelope,
+      from: pending.envelope.from,
+      to: pending.envelope.to,
+      ...(pending.envelope.label === undefined ? {} : { label: pending.envelope.label }),
+      ...(error === undefined ? {} : { error: errorMessage(error) }),
     });
   }
 
   private record(activity: Omit<TopologyEnvelopeActivity, "tick">): void {
+    if (this.#activities.length >= MAX_TOPOLOGY_ACTIVITIES) {
+      throw new Error(
+        `topology envelope scheduler activity capacity is ${MAX_TOPOLOGY_ACTIVITIES}`,
+      );
+    }
     this.#activities.push({ ...activity, tick: this.#tick });
   }
 
   private assertOpen(): void {
     if (this.#closed) throw new Error("topology envelope scheduler is closed");
+    if (this.#failure !== undefined) {
+      throw new Error(`topology envelope scheduler is failed: ${errorMessage(this.#failure)}`);
+    }
+  }
+
+  private assertArmedOnly(kind: string): void {
+    const armed =
+      this.#next.duplicate > 0 ||
+      this.#next.delayTicks > 0 ||
+      this.#next.reorder ||
+      this.#next.dropThenRetryTicks !== undefined;
+    const duplicateOnly =
+      this.#next.duplicate > 0 &&
+      !this.#next.delayTicks &&
+      !this.#next.reorder &&
+      this.#next.dropThenRetryTicks === undefined;
+    if (armed && !(kind === "duplicate" && duplicateOnly)) {
+      throw new Error("only one envelope fault kind may be armed for the next envelope");
+    }
+  }
+
+  private allocateSequence(): number {
+    if (this.#sequence >= Number.MAX_SAFE_INTEGER)
+      throw new Error("topology delivery sequence exhausted");
+    return ++this.#sequence;
+  }
+
+  private allocateEnvelopeId(): number {
+    if (this.#envelopeId >= Number.MAX_SAFE_INTEGER)
+      throw new Error("topology envelope id exhausted");
+    return ++this.#envelopeId;
+  }
+
+  private ensureCapacity(additional: number): void {
+    if (
+      this.#pending.length +
+        Number(this.#heldForReorder !== undefined) +
+        this.#inFlight.size +
+        additional >
+      MAX_TOPOLOGY_ENVELOPES
+    ) {
+      throw new Error(`topology envelope scheduler capacity is ${MAX_TOPOLOGY_ENVELOPES}`);
+    }
+  }
+
+  private failStop(error: unknown): void {
+    if (this.#failure !== undefined) return;
+    this.#failure = error;
+    for (const queued of [
+      ...this.#pending,
+      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
+    ]) {
+      this.recordPending("discarded", queued, error);
+    }
+    this.#pending = [];
+    this.#heldForReorder = undefined;
   }
 }
 
 function linkKey(first: string, second: string): string {
   return first < second ? `${first}\u0000${second}` : `${second}\u0000${first}`;
+}
+
+const MAX_TOPOLOGY_ENDPOINT_LENGTH = 128;
+const MAX_TOPOLOGY_LABEL_LENGTH = 256;
+const MAX_TOPOLOGY_COPIES = 16;
+const MAX_TOPOLOGY_TICKS = 1_000_000;
+const MAX_TOPOLOGY_ENVELOPES = 4_096;
+const MAX_TOPOLOGY_PARTITIONS = 4_096;
+const MAX_TOPOLOGY_ACTIVITIES = 32_768;
+const ENVELOPE_KEYS = new Set(["from", "to", "label"]);
+
+function snapshotEnvelope(envelope: TopologyTransportEnvelope): TopologyTransportEnvelope {
+  if (
+    typeof envelope !== "object" ||
+    envelope === null ||
+    ![Object.prototype, null].includes(Object.getPrototypeOf(envelope))
+  ) {
+    throw new Error("topology envelope must be a plain descriptor");
+  }
+  for (const key of Reflect.ownKeys(envelope)) {
+    if (typeof key !== "string" || !ENVELOPE_KEYS.has(key)) {
+      throw new Error(`topology envelope contains unsupported metadata: ${String(key)}`);
+    }
+  }
+  const { from, to, label } = envelope;
+  assertEndpoint("from", from);
+  assertEndpoint("to", to);
+  if (
+    label !== undefined &&
+    (typeof label !== "string" || label.length > MAX_TOPOLOGY_LABEL_LENGTH)
+  ) {
+    throw new Error(
+      `topology envelope label must be a string at most ${MAX_TOPOLOGY_LABEL_LENGTH} characters`,
+    );
+  }
+  return label === undefined ? { from, to } : { from, to, label };
+}
+
+function assertEndpoint(name: string, value: unknown): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_TOPOLOGY_ENDPOINT_LENGTH ||
+    value.includes("\u0000")
+  ) {
+    throw new Error(
+      `topology envelope ${name} must be a non-empty string at most ${MAX_TOPOLOGY_ENDPOINT_LENGTH} characters without NUL`,
+    );
+  }
+}
+
+function assertTopologyTicks(name: string, ticks: unknown): asserts ticks is number {
+  if (!Number.isSafeInteger(ticks) || ticks < 1 || ticks > MAX_TOPOLOGY_TICKS) {
+    throw new Error(`${name} ticks must be a positive safe integer at most ${MAX_TOPOLOGY_TICKS}`);
+  }
+}
+
+async function waitForSettlement(
+  promises: readonly Promise<void>[],
+  timeoutMs: number,
+): Promise<void> {
+  if (promises.length === 0) return;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.allSettled(promises).then(() => undefined),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`topology envelope cleanup timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export class TopologyScenarioError extends Error {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -190,7 +190,7 @@ export async function runTopologyScenario(
       try {
         await scheduler.close(scenario.envelopeCleanupTimeoutMs ?? scenario.faultTimeoutMs);
       } catch (closeError) {
-        const message = `envelope scheduler cleanup failed: ${errorMessage(closeError)}`;
+        const message = `envelope scheduler cleanup failed: ${stableSchedulerError(closeError)}`;
         receipt.status = "failed";
         receipt.error = receipt.error ? `${receipt.error}; ${message}` : message;
         scenarioError ??= closeError;
@@ -217,6 +217,12 @@ export interface TopologyEnvelopeDeliveryContext {
   tick: number;
   sequence: number;
   signal: AbortSignal;
+  /** Enqueue follow-up delivery without recursively awaiting the active drain. */
+  enqueue<T>(
+    envelope: TopologyTransportEnvelope,
+    value: T,
+    deliver: TopologyEnvelopeDelivery<T>,
+  ): void;
 }
 
 export type TopologyEnvelopeDelivery<T> = (
@@ -258,6 +264,7 @@ export interface TopologyEnvelopeSchedulerReceipt {
   pending: number;
   inFlight: number;
   cleanup?: TopologyActivityReceipt;
+  activitiesTruncated: number;
   activities: readonly TopologyEnvelopeActivity[];
 }
 
@@ -314,8 +321,8 @@ export class TopologyEnvelopeScheduler {
   #closePromise: Promise<void> | undefined;
   #cleanup: TopologyActivityReceipt | undefined;
   #pumpPromise: Promise<void> | undefined;
-  #deliveryDepth = 0;
   #failure: unknown;
+  #activitiesTruncated = 0;
 
   constructor(seed: number) {
     if (!Number.isSafeInteger(seed) || seed < 0 || seed > 0xffff_ffff) {
@@ -411,6 +418,15 @@ export class TopologyEnvelopeScheduler {
     value: T,
     deliver: TopologyEnvelopeDelivery<T>,
   ): Promise<void> {
+    this.enqueueEnvelope(envelope, value, deliver);
+    await this.pump();
+  }
+
+  private enqueueEnvelope<T>(
+    envelope: TopologyTransportEnvelope,
+    value: T,
+    deliver: TopologyEnvelopeDelivery<T>,
+  ): void {
     this.assertOpen();
     const descriptor = snapshotEnvelope(envelope);
     const pending: PendingEnvelope<T> = {
@@ -459,7 +475,6 @@ export class TopologyEnvelopeScheduler {
         this.#pending.push(duplicate as PendingEnvelope<unknown>);
       }
     }
-    await this.pump();
   }
 
   /**
@@ -469,8 +484,12 @@ export class TopologyEnvelopeScheduler {
    */
   close(timeoutMs: number): Promise<void> {
     if (this.#closePromise) return this.#closePromise;
-    if (!Number.isFinite(timeoutMs) || timeoutMs < 1) {
-      return Promise.reject(new Error("envelope cleanup timeout must be positive"));
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_TOPOLOGY_TIMEOUT_MS) {
+      return Promise.reject(
+        new Error(
+          `envelope cleanup timeout must be a positive integer at most ${MAX_TOPOLOGY_TIMEOUT_MS}ms`,
+        ),
+      );
     }
     this.#closePromise = this.closeInternal(timeoutMs);
     return this.#closePromise;
@@ -484,6 +503,7 @@ export class TopologyEnvelopeScheduler {
       pending: this.#pending.length + Number(this.#heldForReorder !== undefined),
       inFlight: this.#inFlight.size,
       cleanup: this.#cleanup && { ...this.#cleanup },
+      activitiesTruncated: this.#activitiesTruncated,
       activities: this.#activities.map((activity) => ({ ...activity })),
     };
   }
@@ -510,31 +530,30 @@ export class TopologyEnvelopeScheduler {
     const abort = new Error("topology envelope scheduler closed");
     for (const inFlight of this.#inFlight.values()) {
       inFlight.controller.abort(abort);
-      this.recordPending("deliveryAborted", inFlight.pending, abort);
     }
     try {
       await waitForSettlement(
         [...this.#inFlight.values()].map(({ promise }) => promise),
         timeoutMs,
       );
+      if (this.#failure !== undefined) throw this.#failure;
       Object.assign(this.#cleanup, { status: "completed", elapsedMs: elapsed(started) });
     } catch (error) {
-      const message = errorMessage(error);
+      const message = stableSchedulerError(error);
       Object.assign(this.#cleanup, {
         status: "failed",
         elapsedMs: elapsed(started),
         error: message,
       });
-      this.record({ action: "closeTimedOut", error: message });
+      if (error instanceof TopologyEnvelopeCleanupTimeoutError) {
+        this.record({ action: "closeTimedOut", error: message });
+      }
       throw error;
     }
   }
 
   private async pump(): Promise<void> {
-    // A delivery callback may await `intercept` to enqueue a follow-up. Do not
-    // make it await its own serialized drain; the outer drain will pick up the
-    // follow-up after the callback returns. Other callers still join the drain.
-    if (this.#pumpPromise) return this.#deliveryDepth > 0 ? undefined : this.#pumpPromise;
+    if (this.#pumpPromise) return this.#pumpPromise;
     this.#pumpPromise = this.pumpInternal();
     try {
       await this.#pumpPromise;
@@ -557,27 +576,36 @@ export class TopologyEnvelopeScheduler {
 
   private async deliver(pending: PendingEnvelope<unknown>): Promise<void> {
     const controller = new AbortController();
-    const promise = Promise.resolve().then(async () => {
-      this.#deliveryDepth++;
-      try {
-        await pending.deliver(pending.value, {
+    const promise = Promise.resolve()
+      .then(() =>
+        pending.deliver(pending.value, {
           envelopeId: pending.envelopeId,
           attempt: pending.attempt,
           tick: this.#tick,
           sequence: pending.sequence,
           signal: controller.signal,
-        });
-      } finally {
-        this.#deliveryDepth--;
-      }
-    });
+          enqueue: (envelope, value, deliver) => this.enqueueEnvelope(envelope, value, deliver),
+        }),
+      )
+      .then(
+        () => {
+          this.recordPending(controller.signal.aborted ? "deliveryAborted" : "delivered", pending);
+        },
+        (error: unknown) => {
+          if (isCooperativeAbort(controller.signal, error)) {
+            this.recordPending("deliveryAborted", pending);
+            return;
+          }
+          const failure = new TopologyEnvelopeDeliveryError(error);
+          this.recordPending("deliveryFailed", pending, failure);
+          throw failure;
+        },
+      );
     this.#inFlight.set(pending.sequence, { pending, controller, promise });
     try {
       if (pending.retry) this.recordPending("retried", pending);
       await promise;
-      this.recordPending("delivered", pending);
     } catch (error) {
-      this.recordPending("deliveryFailed", pending, error);
       this.failStop(error);
       throw error;
     } finally {
@@ -602,15 +630,14 @@ export class TopologyEnvelopeScheduler {
       from: pending.envelope.from,
       to: pending.envelope.to,
       ...(pending.envelope.label === undefined ? {} : { label: pending.envelope.label }),
-      ...(error === undefined ? {} : { error: errorMessage(error) }),
+      ...(error === undefined ? {} : { error: stableSchedulerError(error) }),
     });
   }
 
   private record(activity: Omit<TopologyEnvelopeActivity, "tick">): void {
     if (this.#activities.length >= MAX_TOPOLOGY_ACTIVITIES) {
-      throw new Error(
-        `topology envelope scheduler activity capacity is ${MAX_TOPOLOGY_ACTIVITIES}`,
-      );
+      this.#activities.shift();
+      this.#activitiesTruncated++;
     }
     this.#activities.push({ ...activity, tick: this.#tick });
   }
@@ -618,7 +645,9 @@ export class TopologyEnvelopeScheduler {
   private assertOpen(): void {
     if (this.#closed) throw new Error("topology envelope scheduler is closed");
     if (this.#failure !== undefined) {
-      throw new Error(`topology envelope scheduler is failed: ${errorMessage(this.#failure)}`);
+      throw new Error(
+        `topology envelope scheduler is failed: ${stableSchedulerError(this.#failure)}`,
+      );
     }
   }
 
@@ -686,7 +715,8 @@ const MAX_TOPOLOGY_COPIES = 16;
 const MAX_TOPOLOGY_TICKS = 1_000_000;
 const MAX_TOPOLOGY_ENVELOPES = 4_096;
 const MAX_TOPOLOGY_PARTITIONS = 4_096;
-const MAX_TOPOLOGY_ACTIVITIES = 32_768;
+const MAX_TOPOLOGY_ACTIVITIES = 4_096;
+const MAX_TOPOLOGY_TIMEOUT_MS = 300_000;
 const ENVELOPE_KEYS = new Set(["from", "to", "label"]);
 
 function snapshotEnvelope(envelope: TopologyTransportEnvelope): TopologyTransportEnvelope {
@@ -742,18 +772,44 @@ async function waitForSettlement(
   if (promises.length === 0) return;
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.race([
-      Promise.allSettled(promises).then(() => undefined),
+    const results = await Promise.race([
+      Promise.allSettled(promises),
       new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`topology envelope cleanup timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
+        timer = setTimeout(() => reject(new TopologyEnvelopeCleanupTimeoutError()), timeoutMs);
       }),
     ]);
+    const rejected = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (rejected) throw rejected.reason;
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+class TopologyEnvelopeCleanupTimeoutError extends Error {
+  constructor() {
+    super("topology-envelope-cleanup-timeout");
+  }
+}
+
+class TopologyEnvelopeDeliveryError extends Error {
+  constructor(cause: unknown) {
+    super("topology-envelope-delivery-callback-rejected", { cause });
+  }
+}
+
+function isCooperativeAbort(signal: AbortSignal, error: unknown): boolean {
+  return (
+    signal.aborted &&
+    (error === signal.reason || (error instanceof DOMException && error.name === "AbortError"))
+  );
+}
+
+function stableSchedulerError(error: unknown): string {
+  if (error instanceof TopologyEnvelopeCleanupTimeoutError) return "cleanup-timeout";
+  if (error instanceof TopologyEnvelopeDeliveryError) return "delivery-callback-rejected";
+  return "scheduler-failed";
 }
 
 export class TopologyScenarioError extends Error {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -41,6 +41,11 @@ export interface TopologyScenario {
   targets: Readonly<Record<string, TopologyFaultTarget>>;
   phases: readonly TopologyPhase[];
   replay: string;
+  /**
+   * Test-only transport schedulers owned by this scenario. The runner closes
+   * them after app cleanup so a held packet cannot leak into a later test.
+   */
+  envelopeSchedulers?: readonly TopologyEnvelopeScheduler[];
   cleanup?: (context: TopologyOperationContext) => Promise<void>;
   cleanupTimeoutMs?: number;
 }
@@ -62,6 +67,7 @@ export interface TopologyReceipt {
   elapsedMs: number;
   phases: Array<TopologyActivityReceipt & { name: string }>;
   faults: Array<TopologyActivityReceipt & { kind: TopologyFaultKind; target: string }>;
+  envelopes: TopologyEnvelopeSchedulerReceipt[];
   cleanup?: TopologyActivityReceipt;
   replay: string;
   error?: string;
@@ -87,6 +93,7 @@ export async function runTopologyScenario(
     elapsedMs: 0,
     phases: [],
     faults: [],
+    envelopes: scenario.envelopeSchedulers?.map((scheduler) => scheduler.receipt()) ?? [],
     replay: scenario.replay,
   };
   const scenarioStarted = now();
@@ -178,10 +185,294 @@ export async function runTopologyScenario(
         scenarioError ??= cleanupError;
       }
     }
+    for (const scheduler of scenario.envelopeSchedulers ?? []) {
+      try {
+        scheduler.close();
+      } catch (closeError) {
+        const message = `envelope scheduler cleanup failed: ${errorMessage(closeError)}`;
+        receipt.status = "failed";
+        receipt.error = receipt.error ? `${receipt.error}; ${message}` : message;
+        scenarioError ??= closeError;
+      }
+    }
+    receipt.envelopes = scenario.envelopeSchedulers?.map((scheduler) => scheduler.receipt()) ?? [];
     receipt.elapsedMs = elapsed(scenarioStarted);
   }
   if (receipt.status === "failed") throw new TopologyScenarioError(receipt, scenarioError);
   return receipt;
+}
+
+/** A small, app-owned description of a message at a test transport boundary. */
+export interface TopologyTransportEnvelope {
+  from: string;
+  to: string;
+  /** Stable test-only label; never inspect production payloads just to fault them. */
+  label?: string;
+}
+
+export interface TopologyEnvelopeDeliveryContext {
+  attempt: number;
+  tick: number;
+  sequence: number;
+}
+
+export type TopologyEnvelopeDelivery<T> = (
+  value: T,
+  context: TopologyEnvelopeDeliveryContext,
+) => Promise<void> | void;
+
+export type TopologyEnvelopeAction =
+  | "queued"
+  | "delivered"
+  | "duplicated"
+  | "delayed"
+  | "reordered"
+  | "dropped"
+  | "retried"
+  | "partitioned"
+  | "healed"
+  | "discarded";
+
+export interface TopologyEnvelopeActivity {
+  action: TopologyEnvelopeAction;
+  sequence?: number;
+  from?: string;
+  to?: string;
+  label?: string;
+  tick: number;
+  attempt?: number;
+}
+
+export interface TopologyEnvelopeSchedulerReceipt {
+  seed: number;
+  tick: number;
+  closed: boolean;
+  pending: number;
+  activities: readonly TopologyEnvelopeActivity[];
+}
+
+interface PendingEnvelope<T> {
+  sequence: number;
+  envelope: TopologyTransportEnvelope;
+  value: T;
+  deliver: TopologyEnvelopeDelivery<T>;
+  dueTick: number;
+  attempt: number;
+}
+
+interface NextEnvelopeFault {
+  duplicate: number;
+  delayTicks: number;
+  reorder: boolean;
+  dropThenRetryTicks: number | undefined;
+}
+
+/**
+ * Deterministic, virtual-time transport envelope scheduler for example E2Es.
+ *
+ * Wrap only an app test transport's delivery callback with `intercept`; no
+ * Jazz runtime transport is altered. Normal envelopes deliver immediately.
+ * Faults are armed before the next matching envelope, then `advance`/`heal`
+ * releases held work in a deterministic order. Its receipt is intentionally
+ * payload-free, making it safe to include in scenario reports and replays.
+ */
+export class TopologyEnvelopeScheduler {
+  readonly seed: number;
+  #tick = 0;
+  #sequence = 0;
+  #closed = false;
+  #pending: PendingEnvelope<unknown>[] = [];
+  #heldForReorder: PendingEnvelope<unknown> | undefined;
+  #partitions = new Set<string>();
+  #next: NextEnvelopeFault = {
+    duplicate: 0,
+    delayTicks: 0,
+    reorder: false,
+    dropThenRetryTicks: undefined,
+  };
+  #activities: TopologyEnvelopeActivity[] = [];
+
+  constructor(seed: number) {
+    this.seed = seed;
+  }
+
+  /** Deliver the next matching envelope more than once (one duplicate by default). */
+  duplicateNext(copies = 1): void {
+    this.assertOpen();
+    if (!Number.isInteger(copies) || copies < 1)
+      throw new Error("duplicate copies must be a positive integer");
+    this.#next.duplicate += copies;
+  }
+
+  /** Hold the next matching envelope for virtual `ticks`; `advance` releases it. */
+  delayNext(ticks = 1): void {
+    this.assertOpen();
+    if (!Number.isInteger(ticks) || ticks < 1)
+      throw new Error("delay ticks must be a positive integer");
+    this.#next.delayTicks = Math.max(this.#next.delayTicks, ticks);
+  }
+
+  /** Reverse the next pair of envelopes, retaining the first until the second arrives. */
+  reorderNext(): void {
+    this.assertOpen();
+    this.#next.reorder = true;
+  }
+
+  /** Drop the next envelope, then make exactly one retry available after virtual `ticks`. */
+  dropNextThenRetry(ticks = 1): void {
+    this.assertOpen();
+    if (!Number.isInteger(ticks) || ticks < 1)
+      throw new Error("retry ticks must be a positive integer");
+    this.#next.dropThenRetryTicks = ticks;
+  }
+
+  /** Block both directions between two named endpoints until `heal` is called. */
+  partition(first: string, second: string): void {
+    this.assertOpen();
+    this.#partitions.add(linkKey(first, second));
+    this.record({ action: "partitioned", from: first, to: second });
+  }
+
+  /** Heal one link (or all links) and immediately deliver every now-ready envelope. */
+  async heal(first?: string, second?: string): Promise<void> {
+    this.assertOpen();
+    if ((first === undefined) !== (second === undefined)) {
+      throw new Error("heal requires both endpoints or neither");
+    }
+    if (first === undefined) this.#partitions.clear();
+    else this.#partitions.delete(linkKey(first, second!));
+    this.record({ action: "healed", from: first, to: second });
+    await this.pump();
+  }
+
+  /** Advance deterministic virtual time and release due, non-partitioned envelopes. */
+  async advance(ticks = 1): Promise<void> {
+    this.assertOpen();
+    if (!Number.isInteger(ticks) || ticks < 1)
+      throw new Error("advance ticks must be a positive integer");
+    this.#tick += ticks;
+    await this.pump();
+  }
+
+  /**
+   * Intercept one transport-envelope delivery. The caller retains ownership of
+   * transport connection/retry semantics; this models only message delivery.
+   */
+  async intercept<T>(
+    envelope: TopologyTransportEnvelope,
+    value: T,
+    deliver: TopologyEnvelopeDelivery<T>,
+  ): Promise<void> {
+    this.assertOpen();
+    const pending: PendingEnvelope<T> = {
+      sequence: ++this.#sequence,
+      envelope,
+      value,
+      deliver,
+      dueTick: this.#tick,
+      attempt: 1,
+    };
+    this.recordPending("queued", pending);
+    const fault = this.takeNextFault();
+    if (fault.dropThenRetryTicks !== undefined) {
+      this.recordPending("dropped", pending);
+      pending.attempt = 2;
+      pending.dueTick += fault.dropThenRetryTicks;
+      this.recordPending("retried", pending);
+      this.#pending.push(pending as PendingEnvelope<unknown>);
+    } else if (this.#heldForReorder || fault.reorder) {
+      if (!this.#heldForReorder) {
+        this.#heldForReorder = pending as PendingEnvelope<unknown>;
+        this.recordPending("reordered", pending);
+      } else {
+        this.recordPending("reordered", pending);
+        this.#pending.push(pending as PendingEnvelope<unknown>, this.#heldForReorder);
+        this.#heldForReorder = undefined;
+      }
+    } else {
+      pending.dueTick += fault.delayTicks;
+      if (fault.delayTicks) this.recordPending("delayed", pending);
+      this.#pending.push(pending as PendingEnvelope<unknown>);
+      for (let copy = 0; copy < fault.duplicate; copy++) {
+        const duplicate = { ...pending, sequence: ++this.#sequence, attempt: copy + 2 };
+        this.recordPending("duplicated", duplicate);
+        this.#pending.push(duplicate as PendingEnvelope<unknown>);
+      }
+    }
+    await this.pump();
+  }
+
+  /** Discard undelivered envelopes, including an incomplete reorder pair. Idempotent. */
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const pending of [
+      ...this.#pending,
+      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
+    ]) {
+      this.recordPending("discarded", pending);
+    }
+    this.#pending = [];
+    this.#heldForReorder = undefined;
+    this.#partitions.clear();
+  }
+
+  receipt(): TopologyEnvelopeSchedulerReceipt {
+    return {
+      seed: this.seed,
+      tick: this.#tick,
+      closed: this.#closed,
+      pending: this.#pending.length + Number(this.#heldForReorder !== undefined),
+      activities: this.#activities.map((activity) => ({ ...activity })),
+    };
+  }
+
+  private takeNextFault(): NextEnvelopeFault {
+    const next = this.#next;
+    this.#next = { duplicate: 0, delayTicks: 0, reorder: false, dropThenRetryTicks: undefined };
+    return next;
+  }
+
+  private async pump(): Promise<void> {
+    while (true) {
+      const index = this.#pending.findIndex(
+        (pending) => pending.dueTick <= this.#tick && !this.isPartitioned(pending.envelope),
+      );
+      if (index === -1) return;
+      const [pending] = this.#pending.splice(index, 1);
+      await pending.deliver(pending.value, {
+        attempt: pending.attempt,
+        tick: this.#tick,
+        sequence: pending.sequence,
+      });
+      this.recordPending("delivered", pending);
+    }
+  }
+
+  private isPartitioned(envelope: TopologyTransportEnvelope): boolean {
+    return this.#partitions.has(linkKey(envelope.from, envelope.to));
+  }
+
+  private recordPending(action: TopologyEnvelopeAction, pending: PendingEnvelope<unknown>): void {
+    this.record({
+      action,
+      sequence: pending.sequence,
+      attempt: pending.attempt,
+      ...pending.envelope,
+    });
+  }
+
+  private record(activity: Omit<TopologyEnvelopeActivity, "tick">): void {
+    this.#activities.push({ ...activity, tick: this.#tick });
+  }
+
+  private assertOpen(): void {
+    if (this.#closed) throw new Error("topology envelope scheduler is closed");
+  }
+}
+
+function linkKey(first: string, second: string): string {
+  return first < second ? `${first}\u0000${second}` : `${second}\u0000${first}`;
 }
 
 export class TopologyScenarioError extends Error {


### PR DESCRIPTION
🤖 Extends the shared example-topology harness with a deterministic virtual-time transport-envelope scheduler.

This lets adopter-facing example tests exercise duplicate, delayed, reordered, dropped/retried, and partitioned/healed delivery without embedding a second transport or app-specific fault system. Callers still use the normal topology links; the scheduler only controls when and how their envelopes are delivered.

Robustness details:

- callback-local reentrant delivery is supported without deadlocking, while ordinary concurrent intercepts wait for their delivery to settle;
- teardown is terminal, bounded, and propagates genuine callback failures;
- receipts retain a bounded recent activity window, report truncation, redact payloads/errors, and record exactly one terminal outcome per delivery;
- retry/copy IDs and attempts remain coherent and deterministic;
- abort-aware work is drained, while abort-ignoring work is bounded by a capped close timeout.

Verification:

- 15 focused topology-harness tests pass;
- TypeScript, formatting, and diff checks pass;
- independent adversarial review planted redaction, history-cap, and premature-settlement regressions and confirmed the committed tests catch each one.

Stacked on #1852, which establishes the shared topology harness.
