### PR TITLE
fix(policy): retain shared-union occurrence carriers

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -1271,7 +1271,29 @@ fn lower_linear_plan_steps_cached(
                         }
                     }
                     if *mode == JoinMode::Inner && !omits_public_occurrence_carriers(request) {
-                        if let Some(right_source_id) = right.root_source() {
+                        // A union's root source is one of its arms, but its
+                        // public occurrence is the `(arm, row)` pair. Check
+                        // the relation shape before inspecting that source so
+                        // an aliased common arm cannot make us drop the union
+                        // carrier that result-membership terminals require.
+                        if matches!(right.as_ref(), RelationInputPlan::Union(_)) {
+                            if let Some((arm_field, row_field)) =
+                                &lowered_right.union_occurrence_carrier
+                            {
+                                let arm_output = format!("__root_join_arm_{step_index}");
+                                let row_output = format!("__root_join_row_{step_index}");
+                                projection.push(ProjectField::renamed(
+                                    right_field(arm_field),
+                                    arm_output.clone(),
+                                ));
+                                projection.push(ProjectField::renamed(
+                                    right_field(row_field),
+                                    row_output.clone(),
+                                ));
+                                occurrence_fields.insert(arm_output);
+                                occurrence_fields.insert(row_output);
+                            }
+                        } else if let Some(right_source_id) = right.root_source() {
                             let right_source = resolved_sources.get(right_source_id).ok_or_else(|| {
                                 UnsupportedReason::Operator(format!(
                                     "inner join occurrence source {right_source_id:?} was not resolved"
@@ -1294,21 +1316,6 @@ fn lower_linear_plan_steps_cached(
                                 ));
                                 occurrence_fields.insert(output);
                             }
-                        } else if let Some((arm_field, row_field)) =
-                            &lowered_right.union_occurrence_carrier
-                        {
-                            let arm_output = format!("__root_join_arm_{step_index}");
-                            let row_output = format!("__root_join_row_{step_index}");
-                            projection.push(ProjectField::renamed(
-                                right_field(arm_field),
-                                arm_output.clone(),
-                            ));
-                            projection.push(ProjectField::renamed(
-                                right_field(row_field),
-                                row_output.clone(),
-                            ));
-                            occurrence_fields.insert(arm_output);
-                            occurrence_fields.insert(row_output);
                         }
                     }
                     graph = graph.project_fields(projection);

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -534,6 +534,25 @@ fn current_join_via_lowers_as_left_deep_semijoin() {
 
 #[test]
 fn current_join_via_can_use_union_relation_input() {
+    assert_current_join_via_union_relation_input(
+        source("todo_tags", SourceRole::Policy("direct".to_owned())),
+        source("todo_tags", SourceRole::Policy("inherited".to_owned())),
+    );
+}
+
+/// A UNION may have a common aliased source even when each arm has different
+/// predicates. The root source is then available, but must not be mistaken
+/// for a non-union join occurrence.
+#[test]
+fn current_join_via_shared_alias_union_keeps_arm_and_row_carriers() {
+    let shared = source("todo_tags", SourceRole::Alias("policy_branch".to_owned()));
+    assert_current_join_via_union_relation_input(shared.clone(), shared);
+}
+
+fn assert_current_join_via_union_relation_input(
+    direct_source: SourceId,
+    inherited_source: SourceId,
+) {
     let root = RowSetNodeId("root".to_owned());
     let direct_source_node = RowSetNodeId("direct-source".to_owned());
     let direct_project = RowSetNodeId("direct-project".to_owned());
@@ -542,8 +561,6 @@ fn current_join_via_can_use_union_relation_input() {
     let union_node = RowSetNodeId("authorized-union".to_owned());
     let join_node = RowSetNodeId("join".to_owned());
     let root_source = source("todos", SourceRole::Root);
-    let direct_source = source("todo_tags", SourceRole::Policy("direct".to_owned()));
-    let inherited_source = source("todo_tags", SourceRole::Policy("inherited".to_owned()));
     let request = QueryProgramRequest {
         authorization_mode: QueryAuthorizationMode::TrustedServing,
         reads: QueryReadSet::primary(ReadView {


### PR DESCRIPTION
🤖 Preserves UNION occurrence carriers when public-policy lowering uses a shared aliased source.

The lowerer previously checked `root_source()` before dispatching on the relation-input shape. A UNION whose arms share an aliased source therefore looked like an ordinary source join: lowering omitted its `(arm, row)` occurrence carriers even though terminal result-membership metadata correctly requested `__root_join_arm_0` / `__root_join_row_0`. That produced the adopter-visible `graph field not found` failure.

The fix dispatches `RelationInputPlan::Union` first. UNION inputs retain their occurrence carriers; ordinary non-UNION sources keep the existing `root_source()` path. No policy semantics or authorization rule changes.

Receipts cover a shared-alias UNION, an ordinary heterogeneous UNION, and an ordinary non-UNION source-column join. Restoring the old dispatch makes the shared-alias receipt fail for exactly the missing carriers. Fresh native artifacts pass BandBinder’s direct stage-manager permission suite (2/2). Independent adversarial review approved the one-commit/two-file patch.

This fixes the missing-carrier crash tracked in #1871. A distinct browser/edge delivery symptom remains under investigation on the same issue: the membership grant arrives and local policy evaluation returns the workspace, but the maintained cross-topology workspace query remains empty.

Stacked directly on #1884.
