### PR TITLE
Support runtime-comparable permission literals

### DIFF
--- a/.changeset/compile-policy-value-literals.md
+++ b/.changeset/compile-policy-value-literals.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Compile timestamp/`Date`, floating-point, byte-array, and array permission policy literals that the TypeScript authoring API already accepts. Invalid and pre-epoch dates, tagged timestamps outside the non-negative safe-integer millisecond range, and non-finite floating-point literals now fail at the TypeScript authoring boundary; core compilation independently enforces finite floating-point values.

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -2449,7 +2449,22 @@ fn convert_policy_literal(
         Value::Text(value) => Ok(GrooveValue::String(value.clone())),
         Value::Integer(value) => Ok(GrooveValue::I32(*value)),
         Value::BigInt(value) => Ok(GrooveValue::I64(*value)),
+        Value::Double(value) if value.is_finite() => Ok(GrooveValue::F64(*value)),
+        Value::Double(_) => Err(err(
+            format!("$.{}.{}", table.as_str(), path),
+            "core schema policy floating-point literals must be finite numbers",
+        )),
+        Value::Timestamp(value) => Ok(GrooveValue::U64(*value)),
         Value::Uuid(value) => Ok(GrooveValue::Uuid(*value.uuid())),
+        Value::Bytea(value) => Ok(GrooveValue::Bytes(value.clone())),
+        Value::Array(values) => values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                convert_policy_literal(table, &format!("{path}.Array[{index}]"), value)
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(GrooveValue::Array),
         other => Err(err(
             format!("$.{}.{}", table.as_str(), path),
             format!("core schema policies do not support {other:?} literals yet"),

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -3212,6 +3212,102 @@ mod tests {
     }
 
     #[test]
+    fn converts_runtime_comparable_policy_literal_categories() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchemaBuilder::new("events")
+                    .column("occurred_at", ColumnType::Timestamp)
+                    .column("ratio", ColumnType::Double)
+                    .column("digest", ColumnType::Bytea)
+                    .column(
+                        "roles",
+                        ColumnType::Array {
+                            element: Box::new(ColumnType::Text),
+                        },
+                    )
+                    .policies(TablePolicies::new().with_select(PolicyExpr::And(vec![
+                        PolicyExpr::eq_literal("occurred_at", Value::Timestamp(1_767_323_045_000)),
+                        PolicyExpr::eq_literal("ratio", Value::Double(1.5)),
+                        PolicyExpr::eq_literal("digest", Value::Bytea(vec![1, 2, 3])),
+                        PolicyExpr::eq_literal(
+                            "roles",
+                            Value::Array(vec![
+                                Value::Text("owner".to_owned()),
+                                Value::Text("editor".to_owned()),
+                            ]),
+                        ),
+                    ]))),
+            )
+            .build();
+
+        let converted =
+            convert_public_schema(&schema).expect("runtime-comparable policy literals compile");
+        let events = converted
+            .tables
+            .iter()
+            .find(|table| table.name == "events")
+            .unwrap();
+
+        assert_eq!(
+            events.read_policy.as_ref().unwrap().filters,
+            vec![
+                Predicate::Eq(
+                    Operand::Column("occurred_at".to_owned()),
+                    Operand::Literal(GrooveValue::U64(1_767_323_045_000)),
+                ),
+                Predicate::Eq(
+                    Operand::Column("ratio".to_owned()),
+                    Operand::Literal(GrooveValue::F64(1.5)),
+                ),
+                Predicate::Eq(
+                    Operand::Column("digest".to_owned()),
+                    Operand::Literal(GrooveValue::Bytes(vec![1, 2, 3])),
+                ),
+                Predicate::Eq(
+                    Operand::Column("roles".to_owned()),
+                    Operand::Literal(GrooveValue::Array(vec![
+                        GrooveValue::String("owner".to_owned()),
+                        GrooveValue::String("editor".to_owned()),
+                    ])),
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_policy_doubles_at_the_literal_path() {
+        for (literal, path_suffix) in [
+            (Value::Double(f64::NAN), ""),
+            (
+                Value::Array(vec![Value::Double(f64::INFINITY)]),
+                ".Array[0]",
+            ),
+        ] {
+            let schema = SchemaBuilder::new()
+                .table(
+                    TableSchemaBuilder::new("events")
+                        .column("ratio", ColumnType::Double)
+                        .policies(
+                            TablePolicies::new()
+                                .with_select(PolicyExpr::eq_literal("ratio", literal)),
+                        ),
+                )
+                .build();
+
+            let error =
+                convert_public_schema(&schema).expect_err("non-finite double must not compile");
+            assert_eq!(
+                error.path,
+                format!("$.events.policies.select.using{path_suffix}")
+            );
+            assert_eq!(
+                error.message,
+                "core schema policy floating-point literals must be finite numbers"
+            );
+        }
+    }
+
+    #[test]
     fn converts_auth_mode_session_comparison_to_reserved_claim() {
         let schema = SchemaBuilder::new()
             .table(

--- a/packages/jazz-tools/src/schema-permissions.test.ts
+++ b/packages/jazz-tools/src/schema-permissions.test.ts
@@ -147,4 +147,111 @@ describe("normalizePermissionsForWasm", () => {
       },
     });
   });
+
+  it.each([
+    ["Date", new Date("2026-01-02T03:04:05.000Z"), { type: "Timestamp", value: 1_767_323_045_000 }],
+    ["fractional number", 1.5, { type: "Double", value: 1.5 }],
+    ["byte array", Uint8Array.of(1, 2, 3), { type: "Bytea", value: Uint8Array.of(1, 2, 3) }],
+    [
+      "array",
+      ["owner", "editor"],
+      {
+        type: "Array",
+        value: [
+          { type: "Text", value: "owner" },
+          { type: "Text", value: "editor" },
+        ],
+      },
+    ],
+  ])("encodes %s policy literals for core compilation", (_name, value, encoded) => {
+    const normalized = normalizePermissionsForWasm({
+      resources: {
+        select: {
+          using: {
+            type: "Cmp",
+            column: "access",
+            op: "Eq",
+            value: { type: "Literal", value },
+          },
+        },
+      },
+    });
+
+    expect(normalized.resources?.select?.using).toMatchObject({
+      value: { type: "Literal", value: encoded },
+    });
+  });
+
+  it.each([
+    ["invalid Date", new Date(Number.NaN), "Permissions policy Date literals must be valid."],
+    [
+      "pre-epoch Date",
+      new Date("1969-12-31T23:59:59.999Z"),
+      "Permissions policy Date literals must be on or after 1970-01-01T00:00:00.000Z.",
+    ],
+  ])("rejects %s values at the authoring boundary", (_name, value, error) => {
+    expect(() =>
+      normalizePermissionsForWasm({
+        resources: {
+          select: {
+            using: {
+              type: "Cmp",
+              column: "occurredAt",
+              op: "Eq",
+              value: { type: "Literal", value },
+            },
+          },
+        },
+      }),
+    ).toThrowError(error);
+  });
+
+  it.each([
+    ["tagged", { type: "Timestamp", value: Number.NaN }],
+    ["legacy tagged", { Timestamp: -1 }],
+    ["nested tagged array", { type: "Array", value: [{ type: "Timestamp", value: -1 }] }],
+    ["nested legacy array", { Array: [{ Timestamp: Number.NaN }] }],
+  ])("does not let %s timestamp literals bypass range validation", (_name, value) => {
+    expect(() =>
+      normalizePermissionsForWasm({
+        resources: {
+          select: {
+            using: {
+              type: "Cmp",
+              column: "occurredAt",
+              op: "Eq",
+              value: { type: "Literal", value },
+            },
+          },
+        },
+      }),
+    ).toThrowError(
+      "Permissions policy timestamp literals must be non-negative safe integer milliseconds.",
+    );
+  });
+
+  it.each([
+    ["tagged", { type: "Double", value: Number.NaN }],
+    ["legacy tagged", { Double: Number.POSITIVE_INFINITY }],
+    [
+      "nested tagged array",
+      { type: "Array", value: [{ type: "Double", value: Number.NEGATIVE_INFINITY }] },
+    ],
+    ["nested legacy array", { Array: [{ Double: Number.NaN }] }],
+  ])("does not let %s floating-point literals bypass finite validation", (_name, value) => {
+    expect(() =>
+      normalizePermissionsForWasm({
+        resources: {
+          select: {
+            using: {
+              type: "Cmp",
+              column: "ratio",
+              op: "Eq",
+              value: { type: "Literal", value },
+            },
+          },
+        },
+      }),
+    ).toThrowError("Permissions policy floating-point literals must be finite numbers.");
+  });
 });

--- a/packages/jazz-tools/src/schema-permissions.test.ts
+++ b/packages/jazz-tools/src/schema-permissions.test.ts
@@ -148,6 +148,52 @@ describe("normalizePermissionsForWasm", () => {
     });
   });
 
+  it("encodes relation literals nested in EnumMatch payloads", () => {
+    const normalized = normalizePermissionsForWasm({
+      resources: {
+        select: {
+          using: {
+            type: "ExistsRel",
+            rel: {
+              Filter: {
+                input: { TableScan: { table: "resource_access_edges" } },
+                predicate: {
+                  EnumMatch: {
+                    column: { column: "subject" },
+                    case: "individual",
+                    payload: {
+                      Cmp: {
+                        left: { column: "expiresAt" },
+                        op: "Gt",
+                        right: { Literal: new Date("2026-01-02T03:04:05.000Z") },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(normalized.resources?.select?.using).toMatchObject({
+      rel: {
+        Filter: {
+          predicate: {
+            EnumMatch: {
+              payload: {
+                Cmp: {
+                  right: { Literal: { type: "Timestamp", value: 1_767_323_045_000 } },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
   it.each([
     ["Date", new Date("2026-01-02T03:04:05.000Z"), { type: "Timestamp", value: 1_767_323_045_000 }],
     ["fractional number", 1.5, { type: "Double", value: 1.5 }],
@@ -248,6 +294,38 @@ describe("normalizePermissionsForWasm", () => {
               column: "ratio",
               op: "Eq",
               value: { type: "Literal", value },
+            },
+          },
+        },
+      }),
+    ).toThrowError("Permissions policy floating-point literals must be finite numbers.");
+  });
+
+  it("rejects non-finite literals nested in EnumMatch payloads", () => {
+    expect(() =>
+      normalizePermissionsForWasm({
+        resources: {
+          select: {
+            using: {
+              type: "ExistsRel",
+              rel: {
+                Filter: {
+                  input: { TableScan: { table: "resource_access_edges" } },
+                  predicate: {
+                    EnumMatch: {
+                      column: { column: "subject" },
+                      case: "individual",
+                      payload: {
+                        Cmp: {
+                          left: { column: "ratio" },
+                          op: "Eq",
+                          right: { Literal: Number.NaN },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
         },

--- a/packages/jazz-tools/src/schema-permissions.ts
+++ b/packages/jazz-tools/src/schema-permissions.ts
@@ -52,6 +52,22 @@ function isWasmValueLike(value: unknown): value is WasmValue {
   ].includes(value.type);
 }
 
+function normalizeTimestampLiteral(value: unknown): WasmValue {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(
+      "Permissions policy timestamp literals must be non-negative safe integer milliseconds.",
+    );
+  }
+  return { type: "Timestamp", value };
+}
+
+function normalizeDoubleLiteral(value: unknown): WasmValue {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error("Permissions policy floating-point literals must be finite numbers.");
+  }
+  return { type: "Double", value };
+}
+
 function normalizeLegacyTaggedValue(type: string, value: unknown): WasmValue {
   switch (type) {
     case "Null":
@@ -92,10 +108,12 @@ function normalizeLegacyTaggedValue(type: string, value: unknown): WasmValue {
         return { type: "BigInt", value };
       }
       return { type, value } as WasmValue;
+    case "Timestamp":
+      return normalizeTimestampLiteral(value);
     case "Double":
+      return normalizeDoubleLiteral(value);
     case "Boolean":
     case "Text":
-    case "Timestamp":
     case "Uuid":
       return { type, value } as WasmValue;
     default:
@@ -108,7 +126,16 @@ function normalizeWasmLiteral(value: unknown): WasmValue {
     return { type: "Null" };
   }
   if (value instanceof Date) {
-    return { type: "Timestamp", value: value.getTime() };
+    const timestamp = value.getTime();
+    if (!Number.isFinite(timestamp)) {
+      throw new Error("Permissions policy Date literals must be valid.");
+    }
+    if (timestamp < 0) {
+      throw new Error(
+        "Permissions policy Date literals must be on or after 1970-01-01T00:00:00.000Z.",
+      );
+    }
+    return normalizeTimestampLiteral(timestamp);
   }
   if (value instanceof Uint8Array) {
     return { type: "Bytea", value };
@@ -118,10 +145,10 @@ function normalizeWasmLiteral(value: unknown): WasmValue {
   }
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
-      throw new Error("Permissions literals only support finite numbers.");
+      return normalizeDoubleLiteral(value);
     }
     if (!Number.isInteger(value)) {
-      return { type: "Double", value };
+      return normalizeDoubleLiteral(value);
     }
     if (value >= -2147483648 && value <= 2147483647) {
       return { type: "Integer", value };
@@ -129,7 +156,7 @@ function normalizeWasmLiteral(value: unknown): WasmValue {
     if (Number.isSafeInteger(value)) {
       return { type: "BigInt", value: BigInt(value) };
     }
-    return { type: "Double", value };
+    return normalizeDoubleLiteral(value);
   }
   if (typeof value === "bigint") {
     return { type: "BigInt", value };
@@ -141,6 +168,18 @@ function normalizeWasmLiteral(value: unknown): WasmValue {
     return { type: "Array", value: value.map((entry) => normalizeWasmLiteral(entry)) };
   }
   if (isWasmValueLike(value)) {
+    if (value.type === "Timestamp") {
+      return normalizeTimestampLiteral(value.value);
+    }
+    if (value.type === "Double") {
+      return normalizeDoubleLiteral(value.value);
+    }
+    if (value.type === "Array") {
+      return {
+        type: "Array",
+        value: value.value.map((entry) => normalizeWasmLiteral(entry)),
+      };
+    }
     return value;
   }
   if (isRecord(value) && Object.keys(value).length === 1) {

--- a/packages/jazz-tools/src/schema-permissions.ts
+++ b/packages/jazz-tools/src/schema-permissions.ts
@@ -238,6 +238,15 @@ function normalizeRelationPredicateForWasm(predicate: RelPredicateExpr): RelPred
     };
   }
 
+  if ("EnumMatch" in predicate) {
+    return {
+      EnumMatch: {
+        ...predicate.EnumMatch,
+        payload: normalizeRelationPredicateForWasm(predicate.EnumMatch.payload),
+      },
+    };
+  }
+
   if ("In" in predicate) {
     return {
       In: {


### PR DESCRIPTION
## Summary

- compile timestamp, finite double, byte-array, and recursively supported array policy literals into existing runtime values
- reject invalid or pre-epoch timestamps at the TypeScript authoring boundary
- reject non-finite doubles in raw, tagged, legacy-tagged, nested, and core-schema forms with precise paths
- include a jazz-tools patch changeset

Previously, TypeScript accepted these policy values but core schema compilation rejected them later.

## Red/green commits

1. `13d809dab` adds the failing cross-layer regressions
2. `a5f6b6756` implements the consistent TypeScript/core contract

## Verification

- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/schema-permissions.test.ts` — 16 passed
- runtime-comparable Rust compiler regression — passed
- non-finite Rust literal rejection regression — passed
- `oxfmt`, `cargo fmt`, and `oxlint` — passed