### PR TITLE
Complete client cleanup after shutdown failures

### DIFF
--- a/.changeset/ordered-shutdown-cleanup.md
+++ b/.changeset/ordered-shutdown-cleanup.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Complete browser and React Native client teardown even when an earlier shutdown step fails, while preserving the first failure.

--- a/packages/jazz-tools/src/react-native/create-jazz-client.shutdown.test.ts
+++ b/packages/jazz-tools/src/react-native/create-jazz-client.shutdown.test.ts
@@ -1,0 +1,54 @@
+import { expect, it, type Mock, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const createDb = vi.fn();
+  const orchestratorInstances: Array<{
+    init: Mock;
+    shutdown: Mock;
+    setSession: Mock;
+  }> = [];
+
+  class MockSubscriptionsOrchestrator {
+    readonly init = vi.fn(async () => undefined);
+    readonly shutdown = vi.fn(async () => undefined);
+    readonly setSession = vi.fn();
+
+    constructor() {
+      orchestratorInstances.push(this);
+    }
+  }
+
+  return { createDb, orchestratorInstances, MockSubscriptionsOrchestrator };
+});
+
+vi.mock("./create-db.js", () => ({
+  createDb: mocks.createDb,
+}));
+
+vi.mock("../subscriptions-orchestrator.js", () => ({
+  SubscriptionsOrchestrator: mocks.MockSubscriptionsOrchestrator,
+  trackPromise: <T>(promise: Promise<T>) => promise,
+}));
+
+import { createJazzClient } from "./create-jazz-client.js";
+
+it("continues React Native database teardown after orchestrator shutdown fails", async () => {
+  const managerError = new Error("orchestrator shutdown failed");
+  const dbError = new Error("database shutdown failed");
+  const db = {
+    getAuthState: vi.fn(() => ({ status: "unauthenticated", session: null })),
+    onAuthChanged: vi.fn(() => () => undefined),
+    shutdown: vi.fn(async () => {
+      throw dbError;
+    }),
+  };
+  mocks.createDb.mockResolvedValueOnce(db);
+
+  const client = await createJazzClient({ appId: "react-native-shutdown-failure" });
+  const manager = mocks.orchestratorInstances[0]!;
+  manager.shutdown.mockRejectedValueOnce(managerError);
+
+  await expect(client.shutdown()).rejects.toBe(managerError);
+  expect(manager.shutdown).toHaveBeenCalledOnce();
+  expect(db.shutdown).toHaveBeenCalledOnce();
+});

--- a/packages/jazz-tools/src/react-native/create-jazz-client.ts
+++ b/packages/jazz-tools/src/react-native/create-jazz-client.ts
@@ -1,5 +1,6 @@
 import type { Session } from "../runtime/context.js";
 import type { Db } from "../runtime/db.js";
+import { runCleanupSteps } from "../runtime/run-cleanup-steps.js";
 import { SubscriptionsOrchestrator, trackPromise } from "../subscriptions-orchestrator.js";
 import { attachSubscriptionStore } from "../subscription-store-internal.js";
 import { createDb, type DbConfig } from "./create-db.js";
@@ -27,9 +28,11 @@ async function createJazzClientInternal(config: DbConfig): Promise<JazzClient> {
         return session;
       },
       async shutdown() {
-        stopSessionSync?.();
-        await manager.shutdown();
-        await db.shutdown();
+        await runCleanupSteps([
+          () => stopSessionSync?.(),
+          () => manager.shutdown(),
+          () => db.shutdown(),
+        ]);
       },
     },
     manager,

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import type { JazzClient } from "../client.js";
+import type { BrowserWorkerConnection } from "../runtime-source.js";
+import { BrowserConnectionManager } from "./browser-connection-manager.js";
+import type { DbForConnection } from "./types.js";
+
+describe("BrowserConnectionManager.shutdown", () => {
+  it("continues teardown after flush fails and preserves the flush error", async () => {
+    const flushError = new Error("flush failed");
+    const workerShutdownError = new Error("worker shutdown failed");
+    const connection: BrowserWorkerConnection = {
+      ready: vi.fn(async () => undefined),
+      waitForServerConnection: vi.fn(async () => undefined),
+      updateAuth: vi.fn(async () => undefined),
+      disconnect: vi.fn(async () => undefined),
+      reconnect: vi.fn(async () => undefined),
+      deleteStorage: vi.fn(async () => undefined),
+      flushLocal: vi.fn(async () => {
+        throw flushError;
+      }),
+      openInspectorControlPort: vi.fn(async () => ({}) as MessagePort),
+      shutdown: vi.fn(async () => {
+        throw workerShutdownError;
+      }),
+    };
+    const client = {
+      discard: vi.fn(),
+    } as unknown as JazzClient;
+    const disposeRuntimeTelemetry = vi.fn();
+    const manager = new BrowserConnectionManager({} as DbForConnection);
+    Object.assign(
+      manager as unknown as {
+        connection: BrowserWorkerConnection;
+        client: JazzClient;
+        disposeRuntimeTelemetry: () => void;
+      },
+      { connection, client, disposeRuntimeTelemetry },
+    );
+
+    await expect(manager.shutdown()).rejects.toBe(flushError);
+
+    expect(client.discard).toHaveBeenCalledOnce();
+    expect(disposeRuntimeTelemetry).toHaveBeenCalledOnce();
+    expect(connection.shutdown).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -3,6 +3,7 @@ import { resolveClientSessionSync } from "../client-session.js";
 import type { Session } from "../context.js";
 import type { BrowserWorkerConnection } from "../runtime-source.js";
 import { reloadAfterStorageInvalidation } from "../browser-storage-invalidation.js";
+import { runCleanupSteps } from "../run-cleanup-steps.js";
 import {
   ConnectionManager,
   type ConnectionManagerClientInput,
@@ -144,16 +145,22 @@ export class BrowserConnectionManager extends ConnectionManager {
     this.connection = null;
     this.connectionReady = null;
     this.resolveReconnectWaiters();
-    this.unregisterInspectorControl?.();
+    const unregisterInspectorControl = this.unregisterInspectorControl;
     this.unregisterInspectorControl = null;
-    await connection?.flushLocal();
-    // The tab runtime is explicitly non-durable; once its worker peer has
-    // flushed, graceful evaluator teardown cannot add durability and may wait
-    // on suspended recursive/include work. Abandon that view and let the
-    // durable worker own orderly persistence shutdown.
-    this.detachClient()?.discard();
-    await super.shutdown();
-    await connection?.shutdown();
+
+    await runCleanupSteps([
+      () => unregisterInspectorControl?.(),
+      () => connection?.flushLocal(),
+      () => {
+        // The tab runtime is explicitly non-durable; once its worker peer has
+        // flushed, graceful evaluator teardown cannot add durability and may wait
+        // on suspended recursive/include work. Abandon that view and let the
+        // durable worker own orderly persistence shutdown.
+        this.detachClient()?.discard();
+      },
+      () => super.shutdown(),
+      () => connection?.shutdown(),
+    ]);
   }
 
   private resolveReconnectWaiters(): void {

--- a/packages/jazz-tools/src/runtime/run-cleanup-steps.ts
+++ b/packages/jazz-tools/src/runtime/run-cleanup-steps.ts
@@ -1,0 +1,20 @@
+type CleanupStep = () => void | PromiseLike<void>;
+
+/** Runs teardown steps in order, then rethrows the first value that failed. */
+export async function runCleanupSteps(steps: readonly CleanupStep[]): Promise<void> {
+  let failed = false;
+  let firstError: unknown;
+
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (error) {
+      if (!failed) {
+        failed = true;
+        firstError = error;
+      }
+    }
+  }
+
+  if (failed) throw firstError;
+}

--- a/packages/jazz-tools/src/web/create-jazz-client.test.ts
+++ b/packages/jazz-tools/src/web/create-jazz-client.test.ts
@@ -137,6 +137,22 @@ describe("framework-agnostic/createAgnosticJazzClient", () => {
     );
   });
 
+  it("continues database teardown after orchestrator shutdown fails", async () => {
+    const managerError = new Error("orchestrator shutdown failed");
+    const dbError = new Error("database shutdown failed");
+    const db = createMockDb("shutdown-failure");
+    db.shutdown.mockRejectedValueOnce(dbError);
+    mocks.createDb.mockResolvedValue(db);
+
+    const client = await createJazzClient({ appId: "shutdown-failure" });
+    const manager = mocks.orchestratorInstances[0]!;
+    manager.shutdown.mockRejectedValueOnce(managerError);
+
+    await expect(client.shutdown()).resolves.toBeUndefined();
+    expect(manager.shutdown).toHaveBeenCalledOnce();
+    expect(db.shutdown).toHaveBeenCalledOnce();
+  });
+
   it("AGC-02: rejects when db creation fails", async () => {
     const config: JazzClientConfig = {
       appId: "solid-unit-2",

--- a/packages/jazz-tools/src/web/create-jazz-client.ts
+++ b/packages/jazz-tools/src/web/create-jazz-client.ts
@@ -2,6 +2,7 @@ import type { Session } from "../runtime/context.js";
 import { acquireClient, releaseClient } from "../runtime/client-registry.js";
 import type { Db, DbConfig } from "../runtime/db.js";
 import { createDb } from "../runtime/db.js";
+import { runCleanupSteps } from "../runtime/run-cleanup-steps.js";
 import { SubscriptionsOrchestrator, trackPromise } from "../subscriptions-orchestrator.js";
 import { attachSubscriptionStore, getSubscriptionStore } from "../subscription-store-internal.js";
 import { registerWindowJazzStorageClient } from "../window-client-storage.js";
@@ -32,10 +33,12 @@ async function createJazzClientInternal(config: DbConfig): Promise<JazzClient> {
         return session;
       },
       async shutdown() {
-        stopSessionSync?.();
-        unregisterWindowJazzStorageClient();
-        await manager.shutdown();
-        await db.shutdown();
+        await runCleanupSteps([
+          () => stopSessionSync?.(),
+          () => unregisterWindowJazzStorageClient(),
+          () => manager.shutdown(),
+          () => db.shutdown(),
+        ]);
       },
     },
     manager,


### PR DESCRIPTION
## Summary

- run browser, web, and React Native cleanup steps sequentially even after an earlier synchronous throw or rejected promise
- preserve and rethrow the first failure after every remaining cleanup step has been attempted
- retain the existing browser lifecycle ordering: worker flush, client discard, telemetry/base teardown, then worker shutdown
- include a jazz-tools patch changeset

Previously, a failed worker flush or subscription-manager shutdown skipped database, telemetry, client, and worker cleanup.

## Red/green commits

1. `c6788a301` adds failing browser/web/React Native regressions
2. `c75f818c0` implements ordered best-effort teardown

## Verification

- focused browser manager, web client, and React Native client suites — 11 passed
