### PR TITLE
Anchor sibling qualified policy joins to the protected row

### DIFF
--- a/.changeset/anchor-qualified-permission-joins.md
+++ b/.changeset/anchor-qualified-permission-joins.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Anchor qualified permission joins to their source relation scope
+
+Sibling qualified filters on directly related tables now join each related table from the protected row, while explicitly chained relation joins continue from the preceding joined table.

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -1136,6 +1136,76 @@ describe("permissions DSL", () => {
     });
   });
 
+  it("keeps chained relation joins anchored to the preceding joined table", () => {
+    let relation: PermissionRelation | undefined;
+    definePermissions(app, ({ policy }) => {
+      relation = policy.teams
+        .where({})
+        .join(policy.user_team_edges, { left: "id", right: "team" })
+        .join(policy.resource_access_edges, { left: "team", right: "team" });
+      return [];
+    });
+    if (!relation) {
+      throw new Error("Expected joined relation to be initialized.");
+    }
+
+    const ir = toAssertionRelExprForTest(relationToIr(relation));
+    expect(ir.type).toBe("Join");
+    if (ir.type !== "Join") {
+      throw new Error("Expected outer relation join.");
+    }
+    expect(ir.on[0]).toEqual({
+      left: { scope: "__join_0", column: "team" },
+      right: { scope: "__join_1", column: "team" },
+    });
+    expect(ir.left.type).toBe("Join");
+    if (ir.left.type !== "Join") {
+      throw new Error("Expected inner relation join.");
+    }
+    expect(ir.left.on[0]).toEqual({
+      left: { scope: "teams", column: "id" },
+      right: { scope: "__join_0", column: "team" },
+    });
+  });
+
+  it("anchors sibling qualified policy joins to the protected row", () => {
+    const compiled = definePermissions(app, ({ policy, session }) => [
+      policy.teams.allowRead.where({
+        "user_team_edges.user_id": session.userId,
+        "resource_access_edges.grant_role": "viewer",
+      } as Record<string, unknown>),
+    ]);
+
+    const using = compiled.teams!.select?.using;
+    expect(using?.type).toBe("ExistsRel");
+    if (!using || using.type !== "ExistsRel") {
+      throw new Error("Expected qualified rule predicate to compile to ExistsRel.");
+    }
+
+    const rel = toAssertionRelExprForTest(using.rel);
+    expect(rel.type).toBe("Filter");
+    if (rel.type !== "Filter" || rel.input.type !== "Filter") {
+      throw new Error("Expected correlated qualified policy filter.");
+    }
+    const siblingJoin = rel.input.input;
+    expect(siblingJoin.type).toBe("Join");
+    if (siblingJoin.type !== "Join") {
+      throw new Error("Expected outer sibling join.");
+    }
+    expect(siblingJoin.on[0]).toEqual({
+      left: { scope: "teams", column: "id" },
+      right: { scope: "__join_1", column: "team" },
+    });
+    expect(siblingJoin.left.type).toBe("Join");
+    if (siblingJoin.left.type !== "Join") {
+      throw new Error("Expected inner sibling join.");
+    }
+    expect(siblingJoin.left.on[0]).toEqual({
+      left: { scope: "teams", column: "id" },
+      right: { scope: "__join_0", column: "team" },
+    });
+  });
+
   it("compiles qualified allowRead.where(...) columns into implicit correlated exists relations", () => {
     const compiled = definePermissions(app, ({ policy, session }) => [
       policy.teams.allowRead.where({

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -111,6 +111,7 @@ type Condition =
 
 interface RelationJoinSpec {
   table: string;
+  leftScope: string;
   left: string;
   right: string;
   viaHop?: boolean;
@@ -222,11 +223,13 @@ class PermissionRelationBuilder implements PermissionRelation {
       throw new Error("join(...) does not support union(...) relations in MVP.");
     }
     const table = relationJoinTargetToTable(target);
+    const leftScope = currentRelationScope(this.state);
     const joins = [
       ...this.state.joins,
       {
         table,
         left: on.left,
+        leftScope,
         right: on.right,
       },
     ];
@@ -269,16 +272,19 @@ class PermissionRelationBuilder implements PermissionRelation {
         throw new Error("hopTo(...) cannot be composed after select(...).");
       }
       const rel = resolveNamedRelation(this.relations, this.state.outputTable, relationName);
+      const leftScope = currentRelationScope(this.state);
       const join: RelationJoinSpec =
         rel.type === "forward"
           ? {
               table: rel.toTable,
+              leftScope,
               left: rel.fromColumn,
               right: "id",
               viaHop: true,
             }
           : {
               table: rel.toTable,
+              leftScope,
               left: "id",
               right: rel.toColumn,
               viaHop: true,
@@ -312,6 +318,7 @@ class PermissionRelationBuilder implements PermissionRelation {
         joins: [
           ...this.state.joins,
           {
+            leftScope: currentRelationScope(this.state),
             table: rel.toTable,
             left: "id",
             right: rel.toColumn,
@@ -410,10 +417,7 @@ class PermissionRelationBuilder implements PermissionRelation {
             },
             on: [
               {
-                left: {
-                  scope: stepState.initialScope,
-                  column: stripQualifier(stepJoin.left),
-                },
+                left: relationColumnRef(stepJoin.left, stepJoin.leftScope),
                 right: { scope: recursiveHopScope, column: "id" },
               },
             ],
@@ -1149,7 +1153,7 @@ function buildGatherSeedState(
 
     let scope = qualifiedScopeByPrefix.get(prefix);
     if (!scope) {
-      const join = relationToJoinSpec(relation);
+      const join = relationToJoinSpec(relation, baseScope);
       joins.push(join);
       scope = relationJoinAlias(state.kind, join, joins.length - 1);
       qualifiedScopeByPrefix.set(prefix, scope);
@@ -1225,16 +1229,18 @@ function resolveQualifiedRuleRelation(
   );
 }
 
-function relationToJoinSpec(relation: Relation): RelationJoinSpec {
+function relationToJoinSpec(relation: Relation, leftScope: string): RelationJoinSpec {
   if (relation.type === "forward") {
     return {
       table: relation.toTable,
+      leftScope,
       left: relation.fromColumn,
       right: "id",
     };
   }
   return {
     table: relation.toTable,
+    leftScope,
     left: "id",
     right: relation.toColumn,
   };
@@ -1607,13 +1613,9 @@ function applyRelFilter(input: RelExpr, predicates: RelPredicateExpr[]): RelExpr
   };
 }
 
-function joinConditionFromSpec(
-  join: RelationJoinSpec,
-  leftScope: string,
-  rightScope: string,
-): RelJoinCondition {
+function joinConditionFromSpec(join: RelationJoinSpec, rightScope: string): RelJoinCondition {
   return {
-    left: relationColumnRef(join.left, leftScope),
+    left: relationColumnRef(join.left, join.leftScope),
     right: relationColumnRef(join.right, rightScope),
   };
 }
@@ -1653,7 +1655,7 @@ function applyRelationTail(options: {
             alias: rightScope,
           },
         },
-        on: [joinConditionFromSpec(join, defaultScope, rightScope)],
+        on: [joinConditionFromSpec(join, rightScope)],
         join_kind: "Inner",
       },
     };
@@ -1948,7 +1950,7 @@ function analyzeQualifiedWhereObject(
 
     let scope = qualifiedScopeByPrefix.get(prefix);
     if (!scope) {
-      const join = relationToJoinSpec(relation);
+      const join = relationToJoinSpec(relation, table);
       joins.push(join);
       scope = relationJoinAlias("table", join, joins.length - 1);
       qualifiedScopeByPrefix.set(prefix, scope);


### PR DESCRIPTION
## Summary

- retain an explicit left scope on each internal relation join specification
- keep independently inferred qualified joins anchored to the protected row
- preserve chaining for explicit nested relation tails and recursive gather lowering
- include a jazz-tools patch changeset

Previously, lowering advanced one mutable default scope after each join, so a second sibling relation could be joined from the first related table.

## Red/green commits

1. `a45b6c1c3` adds sibling and chained-join regressions
2. `dcd08a93b` preserves each join's selected source scope

## Verification

- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/permissions/index.test.ts` — 47 passed
- `oxfmt` and `oxlint` — passed
