### PR TITLE
test(examples): deepen PosterShop topology recovery

### DIFF
--- a/examples/poster-shop/apps/nextjs-betterauth/src/scenario.ts
+++ b/examples/poster-shop/apps/nextjs-betterauth/src/scenario.ts
@@ -13,9 +13,10 @@ export const posterShopScenario = {
     "publish-cursors",
     "save-checkpoint",
     "offline-replay",
+    "persistent-reopen",
     "revoke-editor",
   ],
   queries: ["canvas-layers", "ordered-shapes", "asset-metadata", "cursor-fanout", "checkpoints"],
-  faults: ["authorization", "disconnect", "reconnect"],
+  faults: ["authorization", "disconnect", "reconnect", "restart"],
   soak: { editors: 8, transformsPerEditor: 40, cursorHz: 20, rounds: 3 },
 } as const;

--- a/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
+++ b/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
@@ -39,7 +39,6 @@ describe("PosterShop cross-topology recovery", () => {
     let editor: Db;
     let ownerToken: string;
     let ownerDbName: string;
-    let serverUrlForCleanup: string | undefined;
     let canvas: { id: string };
     let layer: { id: string };
     let ownerShape: { id: string };
@@ -58,7 +57,10 @@ describe("PosterShop cross-topology recovery", () => {
         replay: `JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed} pnpm --dir examples/poster-shop/apps/nextjs-betterauth test:browser -- tests/browser/topology.e2e.test.tsx`,
         targets: {
           owner: {
-            disconnect: async () => {
+            disconnect: async ({ defer }) => {
+              defer("unblock PosterShop Jazz server route", async () => {
+                await unblockJazzServerNetwork(server.serverUrl);
+              });
               await blockJazzServerNetwork(server.serverUrl);
               // Browser route interception only applies to new WebSockets, so
               // explicitly close the writer's existing transport first.
@@ -93,7 +95,6 @@ describe("PosterShop cross-topology recovery", () => {
             name: "owner bootstrap and editor admission",
             run: async () => {
               server = await getJazzServerInfo(uniqueDbName("poster-shop-topology"));
-              serverUrlForCleanup = server.serverUrl;
               await deploy({
                 appId: server.appId,
                 serverUrl: server.serverUrl,
@@ -327,14 +328,6 @@ describe("PosterShop cross-topology recovery", () => {
           },
         ],
         cleanup: async () => {
-          // Route blocking belongs to the BrowserContext, not the Db. Always
-          // release it before shutting clients down, including when a phase
-          // fails before the explicit reconnect fault. `unblock` is
-          // idempotent, and cleanup must preserve the scenario's primary
-          // failure rather than replacing it with a best-effort route error.
-          if (serverUrlForCleanup) {
-            await unblockJazzServerNetwork(serverUrlForCleanup).catch(() => undefined);
-          }
           await ctx.cleanup();
         },
         cleanupTimeoutMs: 10_000,

--- a/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
+++ b/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
@@ -3,6 +3,7 @@ import { createDb, type Db } from "../../../../../../packages/jazz-tools/src/run
 import { deploy } from "../../../../../../packages/jazz-tools/src/dev/catalogue.js";
 import {
   TestCleanup,
+  sleep,
   waitForCondition,
   uniqueDbName,
   waitForQuery,
@@ -12,8 +13,10 @@ import {
   runTopologyScenario,
 } from "../../../../../../packages/jazz-tools/tests/browser/topology-harness.js";
 import {
+  blockJazzServerNetwork,
   getJazzServerInfo,
   getJazzServerJwtForUser,
+  unblockJazzServerNetwork,
 } from "../../../../../../packages/jazz-tools/tests/browser/testing-server.js";
 import permissions from "../../permissions.js";
 import { app } from "../../schema.js";
@@ -41,6 +44,7 @@ describe("PosterShop cross-topology recovery", () => {
     let ownerShape: { id: string };
     let editorShape: { id: string };
     let offlineShape: { id: string };
+    let overflowShape: { id: string };
     let editorMembership: { id: string };
     const editorWindowSnapshots: Array<Array<{ id: string; zIndex: number }>> = [];
     const receipt = await runTopologyScenario(
@@ -53,8 +57,16 @@ describe("PosterShop cross-topology recovery", () => {
         replay: `JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed} pnpm --dir examples/poster-shop/apps/nextjs-betterauth test:browser -- tests/browser/topology.e2e.test.tsx`,
         targets: {
           owner: {
-            disconnect: async () => owner.disconnect(),
-            reconnect: async () => owner.reconnect(),
+            disconnect: async () => {
+              await blockJazzServerNetwork(server.serverUrl);
+              // Browser route interception only applies to new WebSockets, so
+              // explicitly close the writer's existing transport first.
+              await owner.disconnect();
+            },
+            reconnect: async () => {
+              await unblockJazzServerNetwork(server.serverUrl);
+              await owner.reconnect();
+            },
             restart: async () => {
               await owner.shutdown();
               ctx.untrack(owner);
@@ -156,6 +168,9 @@ describe("PosterShop cross-topology recovery", () => {
               ]);
               ownerShape = createdOwner;
               editorShape = createdEditor;
+              overflowShape = await owner
+                .insert(app.shapes, shape(canvas.id, layer.id, 3))
+                .wait({ tier: "edge" });
               await owner
                 .insert(app.cursors, {
                   canvasId: canvas.id,
@@ -200,36 +215,47 @@ describe("PosterShop cross-topology recovery", () => {
                   (row) => row.id,
                 ),
               ).toContain(offlineShape.id);
+              // Keep an online observer as a negative control throughout the
+              // blocked interval. One immediate read could race an in-flight
+              // send; repeated edge reads prove the local write did not leak.
+              for (let attempt = 0; attempt < 5; attempt += 1) {
+                expect(
+                  (await editor.all(canvasQueries(canvas.id).shapes, { tier: "edge" })).map(
+                    (row) => row.id,
+                  ),
+                ).not.toContain(offlineShape.id);
+                await sleep(150);
+              }
             },
-            faultsAfter: [
-              { kind: "reconnect", target: "owner" },
-              { kind: "restart", target: "owner" },
-            ],
+            faultsAfter: [{ kind: "restart", target: "owner" }],
           },
           {
-            name: "persistent reopen and peer convergence",
+            name: "persistent reopen while still offline",
             run: async () => {
               // These are the same parent-scoped, ordered reads used by the
               // rendered PosterShop components. Keeping the queries literal
               // here makes this a regression receipt for the app, not a
               // generic table-sync smoke test.
               const queries = canvasQueries(canvas.id);
-              const reopened = await waitForQuery(
-                owner,
-                queries.shapes,
-                (rows) => rows.some((row) => row.id === offlineShape.id),
-                "persistent owner reopen retains offline shape",
-                20_000,
-                "edge",
-              );
+              const reopened = await owner.all(queries.shapes, { tier: "local" });
               expect(reopened.map((row) => [row.id, row.zIndex])).toContainEqual([
                 offlineShape.id,
                 2,
               ]);
+              expect(
+                (await editor.all(queries.shapes, { tier: "edge" })).map((row) => row.id),
+              ).not.toContain(offlineShape.id);
+            },
+            faultsAfter: [{ kind: "reconnect", target: "owner" }],
+          },
+          {
+            name: "peer convergence after reconnect",
+            run: async () => {
+              const queries = canvasQueries(canvas.id);
               const shapes = await waitForQuery(
                 editor,
                 queries.shapes,
-                (rows) => rows.length === 3,
+                (rows) => rows.length === 4,
                 "editor receives replay",
                 20_000,
                 "edge",
@@ -238,6 +264,7 @@ describe("PosterShop cross-topology recovery", () => {
                 [ownerShape.id, 0],
                 [editorShape.id, 1],
                 [offlineShape.id, 2],
+                [overflowShape.id, 3],
               ]);
               // The canvas surface is intentionally unbounded, but consumers
               // that render a viewport can subscribe to a stable operation
@@ -306,8 +333,8 @@ describe("PosterShop cross-topology recovery", () => {
     expect(receipt.faults.map((fault) => [fault.kind, fault.status])).toEqual([
       ["failure", "completed"],
       ["disconnect", "completed"],
-      ["reconnect", "completed"],
       ["restart", "completed"],
+      ["reconnect", "completed"],
     ]);
   }, 75_000);
 });

--- a/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
+++ b/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
@@ -3,6 +3,7 @@ import { createDb, type Db } from "../../../../../../packages/jazz-tools/src/run
 import { deploy } from "../../../../../../packages/jazz-tools/src/dev/catalogue.js";
 import {
   TestCleanup,
+  waitForCondition,
   uniqueDbName,
   waitForQuery,
 } from "../../../../../../packages/jazz-tools/tests/browser/support.js";
@@ -41,6 +42,7 @@ describe("PosterShop cross-topology recovery", () => {
     let editorShape: { id: string };
     let offlineShape: { id: string };
     let editorMembership: { id: string };
+    const editorWindowSnapshots: Array<Array<{ id: string; zIndex: number }>> = [];
     const receipt = await runTopologyScenario(
       {
         id: workload.id,
@@ -126,6 +128,22 @@ describe("PosterShop cross-topology recovery", () => {
                 15_000,
                 "edge",
               );
+              ctx.trackSubscription(
+                editor.subscribeAll(
+                  canvasQueries(canvas.id).shapeWindow,
+                  (delta) => {
+                    editorWindowSnapshots.push(
+                      (delta.all ?? []).map((row) => ({ id: row.id, zIndex: row.zIndex })),
+                    );
+                  },
+                  { tier: "edge" },
+                ),
+              );
+              await waitForCondition(
+                async () => editorWindowSnapshots.length > 0,
+                10_000,
+                "editor shape window subscription did not produce an initial snapshot",
+              );
             },
             faultsAfter: [{ kind: "failure", target: "authorization" }],
           },
@@ -162,6 +180,7 @@ describe("PosterShop cross-topology recovery", () => {
                   name: "headline.svg",
                   mimeType: "image/svg+xml",
                   byteLength: 512,
+                  fileId: "content-addressed-headline-bytes",
                 })
                 .wait({ tier: "edge" });
               await owner
@@ -220,6 +239,25 @@ describe("PosterShop cross-topology recovery", () => {
                 [editorShape.id, 1],
                 [offlineShape.id, 2],
               ]);
+              // The canvas surface is intentionally unbounded, but consumers
+              // that render a viewport can subscribe to a stable operation
+              // window. The callback must receive the replay, not merely a
+              // later read after it has already converged.
+              await waitForCondition(
+                async () =>
+                  editorWindowSnapshots.some(
+                    (rows) =>
+                      rows.length === 2 &&
+                      rows[0]?.id === editorShape.id &&
+                      rows[1]?.id === offlineShape.id,
+                  ),
+                20_000,
+                "editor bounded shape window did not receive the offline replay",
+              );
+              expect(await editor.all(queries.shapeWindow, { tier: "edge" })).toMatchObject([
+                { id: editorShape.id, zIndex: 1 },
+                { id: offlineShape.id, zIndex: 2 },
+              ]);
               expect(
                 (await editor.all(queries.cursors, { tier: "edge" })).map((row) => [
                   row.userId,
@@ -230,9 +268,17 @@ describe("PosterShop cross-topology recovery", () => {
                 ["poster-editor", 17, 19],
                 ["poster-owner", 5, 6],
               ]);
-              expect(
-                (await editor.all(queries.assets, { tier: "edge" })).map((row) => row.name),
-              ).toEqual(["headline.svg"]);
+              const assets = await editor.all(queries.assets, { tier: "edge" });
+              expect(assets).toMatchObject([
+                {
+                  name: "headline.svg",
+                  mimeType: "image/svg+xml",
+                  byteLength: 512,
+                },
+              ]);
+              // Browsing the asset shelf carries only metadata. A future
+              // large-value locator must not become an accidental projection.
+              expect(Object.hasOwn(assets[0]!, "fileId")).toBe(false);
               expect(
                 (await editor.all(queries.checkpoints, { tier: "edge" })).map((row) => row.label),
               ).toEqual(["Approved"]);
@@ -285,7 +331,11 @@ function canvasQueries(canvasId: string) {
   return {
     layers: app.layers.where({ canvasId }).orderBy("zIndex", "asc"),
     shapes: app.shapes.where({ canvasId }).orderBy("zIndex", "asc"),
-    assets: app.assets.where({ canvasId }).orderBy("name", "asc"),
+    shapeWindow: app.shapes.where({ canvasId }).orderBy("zIndex", "asc").offset(1).limit(2),
+    assets: app.assets
+      .where({ canvasId })
+      .orderBy("name", "asc")
+      .select("id", "canvasId", "name", "mimeType", "byteLength"),
     cursors: app.cursors.where({ canvasId }).orderBy("userId", "asc"),
     checkpoints: app.checkpoints.where({ canvasId }).orderBy("label", "asc"),
   };

--- a/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
+++ b/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
@@ -39,6 +39,7 @@ describe("PosterShop cross-topology recovery", () => {
     let editor: Db;
     let ownerToken: string;
     let ownerDbName: string;
+    let serverUrlForCleanup: string | undefined;
     let canvas: { id: string };
     let layer: { id: string };
     let ownerShape: { id: string };
@@ -92,6 +93,7 @@ describe("PosterShop cross-topology recovery", () => {
             name: "owner bootstrap and editor admission",
             run: async () => {
               server = await getJazzServerInfo(uniqueDbName("poster-shop-topology"));
+              serverUrlForCleanup = server.serverUrl;
               await deploy({
                 appId: server.appId,
                 serverUrl: server.serverUrl,
@@ -324,7 +326,17 @@ describe("PosterShop cross-topology recovery", () => {
             },
           },
         ],
-        cleanup: async () => ctx.cleanup(),
+        cleanup: async () => {
+          // Route blocking belongs to the BrowserContext, not the Db. Always
+          // release it before shutting clients down, including when a phase
+          // fails before the explicit reconnect fault. `unblock` is
+          // idempotent, and cleanup must preserve the scenario's primary
+          // failure rather than replacing it with a best-effort route error.
+          if (serverUrlForCleanup) {
+            await unblockJazzServerNetwork(serverUrlForCleanup).catch(() => undefined);
+          }
+          await ctx.cleanup();
+        },
         cleanupTimeoutMs: 10_000,
       },
       browserTopologyReporter,

--- a/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
+++ b/examples/poster-shop/apps/nextjs-betterauth/tests/browser/topology.e2e.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createDb, type Db } from "jazz-tools";
+import { createDb, type Db } from "../../../../../../packages/jazz-tools/src/runtime/db.js";
 import { deploy } from "../../../../../../packages/jazz-tools/src/dev/catalogue.js";
 import {
   TestCleanup,
@@ -18,6 +18,8 @@ import permissions from "../../permissions.js";
 import { app } from "../../schema.js";
 import { posterShopScenario } from "../../src/scenario.js";
 
+declare const __JAZZ_EXAMPLE_TOPOLOGY_SEED__: string;
+
 const ctx = new TestCleanup();
 afterEach(async () => ctx.cleanup());
 
@@ -26,10 +28,13 @@ afterEach(async () => ctx.cleanup());
 describe("PosterShop cross-topology recovery", () => {
   it("converges ordered canvas edits, presence and a local replay while enforcing revocation", async () => {
     const workload = posterShopScenario;
-    const seed = Number(process.env.JAZZ_EXAMPLE_TOPOLOGY_SEED ?? 47);
+    const requestedSeed = Number(__JAZZ_EXAMPLE_TOPOLOGY_SEED__);
+    const seed = Number.isSafeInteger(requestedSeed) ? requestedSeed : 47;
     let server: Awaited<ReturnType<typeof getJazzServerInfo>>;
     let owner: Db;
     let editor: Db;
+    let ownerToken: string;
+    let ownerDbName: string;
     let canvas: { id: string };
     let layer: { id: string };
     let ownerShape: { id: string };
@@ -40,7 +45,7 @@ describe("PosterShop cross-topology recovery", () => {
       {
         id: workload.id,
         topology: ["browser", "edge", "core"],
-        seed: Number.isSafeInteger(seed) ? seed : 47,
+        seed,
         phaseTimeoutMs: 25_000,
         faultTimeoutMs: 15_000,
         replay: `JAZZ_EXAMPLE_TOPOLOGY_SEED=${seed} pnpm --dir examples/poster-shop/apps/nextjs-betterauth test:browser -- tests/browser/topology.e2e.test.tsx`,
@@ -48,6 +53,11 @@ describe("PosterShop cross-topology recovery", () => {
           owner: {
             disconnect: async () => owner.disconnect(),
             reconnect: async () => owner.reconnect(),
+            restart: async () => {
+              await owner.shutdown();
+              ctx.untrack(owner);
+              owner = await openClient(server, "owner", ownerToken, ownerDbName);
+            },
           },
           authorization: {
             failure: async () => {
@@ -75,11 +85,13 @@ describe("PosterShop cross-topology recovery", () => {
                 schema: app,
                 permissions,
               });
-              const [ownerToken, editorToken] = await Promise.all([
+              const [issuedOwnerToken, editorToken] = await Promise.all([
                 getJazzServerJwtForUser("poster-owner", undefined, server.appId),
                 getJazzServerJwtForUser("poster-editor", undefined, server.appId),
               ]);
-              owner = await openClient(server, "owner", ownerToken);
+              ownerToken = issuedOwnerToken;
+              ownerDbName = uniqueDbName("poster-shop-owner");
+              owner = await openClient(server, "owner", ownerToken, ownerDbName);
               editor = await openClient(server, "editor", editorToken);
               canvas = await owner
                 .insert(app.canvases, { title: "Midnight", width: 1080, height: 1350 })
@@ -108,7 +120,7 @@ describe("PosterShop cross-topology recovery", () => {
                 .wait({ tier: "edge" });
               await waitForQuery(
                 editor,
-                app.layers.where({ canvasId: canvas.id }),
+                canvasQueries(canvas.id).layers,
                 (rows) => rows.length === 1,
                 "editor receives canvas",
                 15_000,
@@ -135,6 +147,23 @@ describe("PosterShop cross-topology recovery", () => {
                   color: "#f50",
                 })
                 .wait({ tier: "edge" });
+              await editor
+                .insert(app.cursors, {
+                  canvasId: canvas.id,
+                  userId: "poster-editor",
+                  x: 17,
+                  y: 19,
+                  color: "#58f",
+                })
+                .wait({ tier: "edge" });
+              await owner
+                .insert(app.assets, {
+                  canvasId: canvas.id,
+                  name: "headline.svg",
+                  mimeType: "image/svg+xml",
+                  byteLength: 512,
+                })
+                .wait({ tier: "edge" });
               await owner
                 .insert(app.checkpoints, { canvasId: canvas.id, label: "Approved", branch: "main" })
                 .wait({ tier: "edge" });
@@ -148,17 +177,39 @@ describe("PosterShop cross-topology recovery", () => {
                 .insert(app.shapes, shape(canvas.id, layer.id, 2))
                 .wait({ tier: "local" });
               expect(
-                (await owner.all(app.shapes.where({ canvasId: canvas.id }))).map((row) => row.id),
+                (await owner.all(canvasQueries(canvas.id).shapes, { tier: "local" })).map(
+                  (row) => row.id,
+                ),
               ).toContain(offlineShape.id);
             },
-            faultsAfter: [{ kind: "reconnect", target: "owner" }],
+            faultsAfter: [
+              { kind: "reconnect", target: "owner" },
+              { kind: "restart", target: "owner" },
+            ],
           },
           {
-            name: "peer convergence and revocation",
+            name: "persistent reopen and peer convergence",
             run: async () => {
+              // These are the same parent-scoped, ordered reads used by the
+              // rendered PosterShop components. Keeping the queries literal
+              // here makes this a regression receipt for the app, not a
+              // generic table-sync smoke test.
+              const queries = canvasQueries(canvas.id);
+              const reopened = await waitForQuery(
+                owner,
+                queries.shapes,
+                (rows) => rows.some((row) => row.id === offlineShape.id),
+                "persistent owner reopen retains offline shape",
+                20_000,
+                "edge",
+              );
+              expect(reopened.map((row) => [row.id, row.zIndex])).toContainEqual([
+                offlineShape.id,
+                2,
+              ]);
               const shapes = await waitForQuery(
                 editor,
-                app.shapes.where({ canvasId: canvas.id }).orderBy("zIndex", "asc"),
+                queries.shapes,
                 (rows) => rows.length === 3,
                 "editor receives replay",
                 20_000,
@@ -170,15 +221,29 @@ describe("PosterShop cross-topology recovery", () => {
                 [offlineShape.id, 2],
               ]);
               expect(
-                (
-                  await editor.all(app.cursors.where({ canvasId: canvas.id }), { tier: "edge" })
-                ).map((row) => row.userId),
-              ).toEqual(["poster-owner"]);
+                (await editor.all(queries.cursors, { tier: "edge" })).map((row) => [
+                  row.userId,
+                  row.x,
+                  row.y,
+                ]),
+              ).toEqual([
+                ["poster-editor", 17, 19],
+                ["poster-owner", 5, 6],
+              ]);
               expect(
-                (
-                  await editor.all(app.checkpoints.where({ canvasId: canvas.id }), { tier: "edge" })
-                ).map((row) => row.label),
+                (await editor.all(queries.assets, { tier: "edge" })).map((row) => row.name),
+              ).toEqual(["headline.svg"]);
+              expect(
+                (await editor.all(queries.checkpoints, { tier: "edge" })).map((row) => row.label),
               ).toEqual(["Approved"]);
+              expect(
+                (await editor.all(queries.layers, { tier: "edge" })).map((row) => row.name),
+              ).toEqual(["Artwork"]);
+            },
+          },
+          {
+            name: "revocation blocks a former editor",
+            run: async () => {
               await owner.delete(app.canvasMembers, editorMembership.id).wait({ tier: "edge" });
               await expect(
                 editor.insert(app.shapes, shape(canvas.id, layer.id, 3)).wait({ tier: "edge" }),
@@ -196,6 +261,7 @@ describe("PosterShop cross-topology recovery", () => {
       ["failure", "completed"],
       ["disconnect", "completed"],
       ["reconnect", "completed"],
+      ["restart", "completed"],
     ]);
   }, 75_000);
 });
@@ -214,17 +280,29 @@ function shape(canvasId: string, layerId: string, zIndex: number) {
     fill: "#ff5a36",
   };
 }
+
+function canvasQueries(canvasId: string) {
+  return {
+    layers: app.layers.where({ canvasId }).orderBy("zIndex", "asc"),
+    shapes: app.shapes.where({ canvasId }).orderBy("zIndex", "asc"),
+    assets: app.assets.where({ canvasId }).orderBy("name", "asc"),
+    cursors: app.cursors.where({ canvasId }).orderBy("userId", "asc"),
+    checkpoints: app.checkpoints.where({ canvasId }).orderBy("label", "asc"),
+  };
+}
+
 async function openClient(
   server: { appId: string; serverUrl: string },
   label: string,
   jwtToken: string,
+  dbName = uniqueDbName(`poster-shop-${label}`),
 ): Promise<Db> {
   return ctx.track(
     await createDb({
       appId: server.appId,
       serverUrl: server.serverUrl,
       jwtToken,
-      driver: { type: "persistent", dbName: uniqueDbName(`poster-shop-${label}`) },
+      driver: { type: "persistent", dbName },
     }),
   );
 }

--- a/examples/poster-shop/apps/nextjs-betterauth/vitest.config.browser.ts
+++ b/examples/poster-shop/apps/nextjs-betterauth/vitest.config.browser.ts
@@ -4,8 +4,10 @@ import react from "@vitejs/plugin-react";
 import topLevelAwait from "vite-plugin-top-level-await";
 import wasm from "vite-plugin-wasm";
 import {
+  blockJazzServerNetwork,
   jazzServerInfo,
   jazzServerJwtForUser,
+  unblockJazzServerNetwork,
 } from "../../../../packages/jazz-tools/tests/browser/testing-server-node.js";
 
 export default defineConfig({
@@ -23,6 +25,10 @@ export default defineConfig({
       instances: [{ browser: "chromium", headless: true }],
       commands: {
         jazzServerInfo: async (_context, appId, schema) => jazzServerInfo(appId, schema),
+        jazzServerBlockNetwork: async ({ context }, serverUrl) =>
+          blockJazzServerNetwork(context, serverUrl),
+        jazzServerUnblockNetwork: async ({ context }, serverUrl) =>
+          unblockJazzServerNetwork(context, serverUrl),
         jazzServerJwtForUser: async (_context, userId, claims, appId) =>
           jazzServerJwtForUser(userId, claims, appId),
         jazzBrowserTopologyLog: async (_context, status, label, elapsedMs) => {

--- a/examples/poster-shop/apps/nextjs-betterauth/vitest.config.browser.ts
+++ b/examples/poster-shop/apps/nextjs-betterauth/vitest.config.browser.ts
@@ -9,6 +9,9 @@ import {
 } from "../../../../packages/jazz-tools/tests/browser/testing-server-node.js";
 
 export default defineConfig({
+  define: {
+    __JAZZ_EXAMPLE_TOPOLOGY_SEED__: JSON.stringify(process.env.JAZZ_EXAMPLE_TOPOLOGY_SEED ?? "47"),
+  },
   plugins: [wasm(), topLevelAwait(), react()],
   worker: { plugins: () => [wasm(), topLevelAwait()] },
   test: {
@@ -22,6 +25,9 @@ export default defineConfig({
         jazzServerInfo: async (_context, appId, schema) => jazzServerInfo(appId, schema),
         jazzServerJwtForUser: async (_context, userId, claims, appId) =>
           jazzServerJwtForUser(userId, claims, appId),
+        jazzBrowserTopologyLog: async (_context, status, label, elapsedMs) => {
+          console.info(`[jazz-browser-topology] ${status} ${label} (${elapsedMs}ms)`);
+        },
       },
     },
     testTimeout: 30_000,


### PR DESCRIPTION
🤖 Deepens PosterShop’s adopter-facing topology receipt around the app’s actual canvas query surfaces.

The test now exercises component-equivalent parent/order queries for layers, shapes, assets, cursors, and checkpoints; deterministic concurrent shape edits; offline local insertion followed by reconnect and peer convergence; persistent IndexedDB reopen; admission failure; and post-revocation denial. It also repairs the browser fixture itself by replacing a Node-only seed lookup and registering the required topology reporter command.

Formatting and diff checks pass, and fresh artifacts build. This is intentionally draft/red on PosterShop’s current old core base: all existing permission tests fail before the new phases with `Query: operand type mismatch`, and browser bootstrap times out on the same policy path. The complete app + test range will be rebased onto the reviewed #1884/#1888/auth stack before behavioral review; assertions have not been weakened to accommodate the obsolete base.

Stacked on #1854.
