### PR TITLE
fix(groove): compile recursive policy graphs iteratively

### DIFF
--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -520,6 +520,53 @@ impl GraphBuilder {
         }
     }
 
+    /// Return all builder fragments in child-before-parent order without
+    /// recursion. Runtime setup uses this for deeply nested valid query and
+    /// policy graphs, which must not consume the owner thread's call stack.
+    pub(crate) fn postorder(&self) -> Vec<&Self> {
+        let mut pending = vec![(self, false)];
+        let mut ordered = Vec::new();
+        while let Some((graph, visited)) = pending.pop() {
+            if visited {
+                ordered.push(graph);
+                continue;
+            }
+            pending.push((graph, true));
+            match graph {
+                Self::Filter { input, .. }
+                | Self::Project { input, .. }
+                | Self::StreamingChecksum { input, .. }
+                | Self::UnwrapNullable { input, .. }
+                | Self::Unnest { input, .. }
+                | Self::VariantProject { input, .. }
+                | Self::ArgMaxBy { input, .. }
+                | Self::ArgMinBy { input, .. }
+                | Self::TopBy { input, .. }
+                | Self::CollectBy { input, .. }
+                | Self::Aggregate { input, .. } => pending.push((input, false)),
+                Self::Union { inputs } => {
+                    pending.extend(inputs.iter().rev().map(|input| (input, false)));
+                }
+                Self::Join { left, right, .. }
+                | Self::SemiJoin { left, right, .. }
+                | Self::AntiJoin { left, right, .. } => {
+                    pending.push((right, false));
+                    pending.push((left, false));
+                }
+                Self::Recursive { seed, step, .. } => {
+                    pending.push((step, false));
+                    pending.push((seed, false));
+                }
+                Self::Table { .. }
+                | Self::InlineRecords { .. }
+                | Self::Index { .. }
+                | Self::FrontierSource { .. }
+                | Self::BindingSource { .. } => {}
+            }
+        }
+        ordered
+    }
+
     pub fn join(
         left: GraphBuilder,
         right: GraphBuilder,

--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -29,16 +29,31 @@ impl IvmRuntime {
     ) -> Result<CompiledNode, IvmRuntimeError> {
         validate_collect_by_terminality(graph)?;
         let mut output_memo = HashMap::default();
-        self.add_dedup_graph_cached(graph, &mut output_memo)
+        // Precompute descriptors once for the complete graph. The postorder
+        // compiler below can then reuse those descriptors without repeatedly
+        // traversing a long policy graph from each parent.
+        self.infer_builder_output_cached(graph, &mut output_memo)?;
+        let mut compiled_memo = HashMap::default();
+        for builder in graph.postorder() {
+            self.add_dedup_graph_cached(builder, &mut output_memo, &mut compiled_memo)?;
+        }
+        compiled_memo
+            .remove(&graph_builder_key(graph))
+            .ok_or(IvmRuntimeError::UnsupportedOperator)
     }
 
     fn add_dedup_graph_cached(
         &mut self,
         graph: &GraphBuilder,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
+        compiled_memo: &mut HashMap<usize, CompiledNode>,
     ) -> Result<CompiledNode, IvmRuntimeError> {
+        let key = graph_builder_key(graph);
+        if let Some(compiled) = compiled_memo.get(&key) {
+            return Ok(compiled.clone());
+        }
         let inferred_output = self.infer_builder_output_cached(graph, output_memo)?;
-        match graph {
+        let compiled = match graph {
             GraphBuilder::Table { .. }
             | GraphBuilder::InlineRecords { .. }
             | GraphBuilder::Index { .. }
@@ -46,12 +61,12 @@ impl IvmRuntime {
             | GraphBuilder::BindingSource { .. }
             | GraphBuilder::Recursive { .. }
             | GraphBuilder::CollectBy { .. } => {
-                self.add_dedup_source_graph(graph, inferred_output, output_memo)
+                self.add_dedup_source_graph(graph, inferred_output, output_memo, compiled_memo)
             }
             GraphBuilder::ArgMaxBy { .. }
             | GraphBuilder::ArgMinBy { .. }
             | GraphBuilder::TopBy { .. } => {
-                self.add_dedup_ordering_graph(graph, inferred_output, output_memo)
+                self.add_dedup_ordering_graph(graph, inferred_output, output_memo, compiled_memo)
             }
             GraphBuilder::Aggregate { .. }
             | GraphBuilder::Filter { .. }
@@ -61,14 +76,16 @@ impl IvmRuntime {
             | GraphBuilder::Unnest { .. }
             | GraphBuilder::VariantProject { .. }
             | GraphBuilder::Union { .. } => {
-                self.add_dedup_unary_graph(graph, inferred_output, output_memo)
+                self.add_dedup_unary_graph(graph, inferred_output, output_memo, compiled_memo)
             }
             GraphBuilder::Join { .. }
             | GraphBuilder::SemiJoin { .. }
             | GraphBuilder::AntiJoin { .. } => {
-                self.add_dedup_join_graph(graph, inferred_output, output_memo)
+                self.add_dedup_join_graph(graph, inferred_output, output_memo, compiled_memo)
             }
-        }
+        }?;
+        compiled_memo.insert(key, compiled.clone());
+        Ok(compiled)
     }
 
     #[inline(never)]
@@ -77,6 +94,7 @@ impl IvmRuntime {
         graph: &GraphBuilder,
         inferred_output: RecordDescriptor,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
+        compiled_memo: &mut HashMap<usize, CompiledNode>,
     ) -> Result<CompiledNode, IvmRuntimeError> {
         match graph {
             GraphBuilder::Table {
@@ -203,8 +221,10 @@ impl IvmRuntime {
                 if builder_contains_recursive(seed) || builder_contains_recursive(step) {
                     return Err(IvmRuntimeError::UnsupportedNestedRecursion);
                 }
-                let compiled_seed = self.add_dedup_graph_cached(seed, output_memo)?;
-                let compiled_step = self.add_dedup_graph_cached(step, output_memo)?;
+                let compiled_seed =
+                    self.add_dedup_graph_cached(seed, output_memo, compiled_memo)?;
+                let compiled_step =
+                    self.add_dedup_graph_cached(step, output_memo, compiled_memo)?;
                 if !compiled_seed
                     .output
                     .registry_compatible_with(&compiled_step.output)
@@ -238,9 +258,13 @@ impl IvmRuntime {
                     root_ordering_node: None,
                 })
             }
-            GraphBuilder::CollectBy { input, collect } => {
-                self.add_collect_by_graph(input, collect, inferred_output, output_memo)
-            }
+            GraphBuilder::CollectBy { input, collect } => self.add_collect_by_graph(
+                input,
+                collect,
+                inferred_output,
+                output_memo,
+                compiled_memo,
+            ),
             _ => unreachable!("dispatcher routes only source graph builders here"),
         }
     }
@@ -251,6 +275,7 @@ impl IvmRuntime {
         graph: &GraphBuilder,
         inferred_output: RecordDescriptor,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
+        compiled_memo: &mut HashMap<usize, CompiledNode>,
     ) -> Result<CompiledNode, IvmRuntimeError> {
         match graph {
             GraphBuilder::ArgMaxBy {
@@ -258,7 +283,8 @@ impl IvmRuntime {
                 group_cols,
                 order_cols,
             } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let output = inferred_output;
                 let group_field_indices = group_cols
                     .iter()
@@ -342,7 +368,8 @@ impl IvmRuntime {
                 group_cols,
                 order_cols,
             } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let output = inferred_output;
                 let group_field_indices = group_cols
                     .iter()
@@ -429,7 +456,8 @@ impl IvmRuntime {
                 offset,
                 limit,
             } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let output = inferred_output;
                 let group_field_indices = group_cols
                     .iter()
@@ -514,6 +542,7 @@ impl IvmRuntime {
         graph: &GraphBuilder,
         inferred_output: RecordDescriptor,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
+        compiled_memo: &mut HashMap<usize, CompiledNode>,
     ) -> Result<CompiledNode, IvmRuntimeError> {
         match graph {
             GraphBuilder::Aggregate {
@@ -521,7 +550,8 @@ impl IvmRuntime {
                 group_cols,
                 aggregates,
             } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let input_node = compiled_input.node;
                 let input_output = compiled_input.output;
                 let output = inferred_output;
@@ -567,7 +597,8 @@ impl IvmRuntime {
                 predicate,
                 comparison,
             } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let input_node = compiled_input.node;
                 let output = inferred_output;
                 let node = self.graph.dedup_node(
@@ -589,7 +620,8 @@ impl IvmRuntime {
                 })
             }
             GraphBuilder::Project { input, fields } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let input_node = compiled_input.node;
                 let input_output = compiled_input.output;
                 let output = inferred_output;
@@ -639,7 +671,8 @@ impl IvmRuntime {
                 if *window_bytes == 0 || *max_bytes_per_turn == 0 {
                     return Err(IvmRuntimeError::InvalidStreamingChecksumBudget);
                 }
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let field_idx = resolve_field_ref(&compiled_input.output, field)?;
                 let node = self.graph.dedup_node(
                     NodeDescriptor::new(
@@ -663,7 +696,8 @@ impl IvmRuntime {
                 })
             }
             GraphBuilder::UnwrapNullable { input, field } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let input_node = compiled_input.node;
                 let input_output = compiled_input.output;
                 let field_idx = resolve_field_ref(&input_output, field)?;
@@ -691,7 +725,8 @@ impl IvmRuntime {
                 array_field,
                 element_field,
             } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let input_node = compiled_input.node;
                 let input_output = compiled_input.output;
                 let array_field_idx = resolve_field_ref(&input_output, array_field)?;
@@ -716,7 +751,8 @@ impl IvmRuntime {
                 })
             }
             GraphBuilder::VariantProject { input, field, case } => {
-                let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                let compiled_input =
+                    self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                 let input_node = compiled_input.node;
                 let input_output = compiled_input.output;
                 let field_idx = resolve_field_ref(&input_output, field)?;
@@ -750,7 +786,8 @@ impl IvmRuntime {
                 let mut input_nodes = Vec::with_capacity(inputs.len());
                 let mut public_root_ordering = None;
                 for input in inputs {
-                    let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+                    let compiled_input =
+                        self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
                     if input_nodes.is_empty() {
                         // Structured lowering places the public/root anchor
                         // first; later arms carry association rows and may
@@ -786,6 +823,7 @@ impl IvmRuntime {
         graph: &GraphBuilder,
         inferred_output: RecordDescriptor,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
+        compiled_memo: &mut HashMap<usize, CompiledNode>,
     ) -> Result<CompiledNode, IvmRuntimeError> {
         match graph {
             GraphBuilder::Join {
@@ -795,8 +833,10 @@ impl IvmRuntime {
                 right_on,
                 comparison,
             } => {
-                let compiled_left = self.add_dedup_graph_cached(left, output_memo)?;
-                let compiled_right = self.add_dedup_graph_cached(right, output_memo)?;
+                let compiled_left =
+                    self.add_dedup_graph_cached(left, output_memo, compiled_memo)?;
+                let compiled_right =
+                    self.add_dedup_graph_cached(right, output_memo, compiled_memo)?;
                 let output = inferred_output;
                 let left_descriptor = compiled_left.output;
                 let right_descriptor = compiled_right.output;
@@ -855,8 +895,10 @@ impl IvmRuntime {
                 right_on,
                 comparison,
             } => {
-                let compiled_left = self.add_dedup_graph_cached(left, output_memo)?;
-                let compiled_right = self.add_dedup_graph_cached(right, output_memo)?;
+                let compiled_left =
+                    self.add_dedup_graph_cached(left, output_memo, compiled_memo)?;
+                let compiled_right =
+                    self.add_dedup_graph_cached(right, output_memo, compiled_memo)?;
                 let output = inferred_output;
                 let left_descriptor = compiled_left.output;
                 let right_descriptor = compiled_right.output;
@@ -912,8 +954,10 @@ impl IvmRuntime {
                 right_on,
                 comparison,
             } => {
-                let compiled_left = self.add_dedup_graph_cached(left, output_memo)?;
-                let compiled_right = self.add_dedup_graph_cached(right, output_memo)?;
+                let compiled_left =
+                    self.add_dedup_graph_cached(left, output_memo, compiled_memo)?;
+                let compiled_right =
+                    self.add_dedup_graph_cached(right, output_memo, compiled_memo)?;
                 let output = inferred_output;
                 let left_descriptor = compiled_left.output;
                 let right_descriptor = compiled_right.output;
@@ -972,8 +1016,9 @@ impl IvmRuntime {
         collect: &CollectByBuilder,
         output: RecordDescriptor,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
+        compiled_memo: &mut HashMap<usize, CompiledNode>,
     ) -> Result<CompiledNode, IvmRuntimeError> {
-        let compiled_input = self.add_dedup_graph_cached(input, output_memo)?;
+        let compiled_input = self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
         let input_output = compiled_input.output;
         let group_field_indices = collect
             .group_cols
@@ -1401,4 +1446,8 @@ impl IvmRuntime {
             root_ordering_node: None,
         })
     }
+}
+
+fn graph_builder_key(graph: &GraphBuilder) -> usize {
+    std::ptr::from_ref(graph).addr()
 }

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -125,31 +125,10 @@ pub(super) fn record_deltas_digest(deltas: &RecordDeltas) -> u64 {
 }
 
 pub(super) fn builder_contains_recursive(graph: &GraphBuilder) -> bool {
-    match graph {
-        GraphBuilder::Recursive { .. } => true,
-        GraphBuilder::Filter { input, .. }
-        | GraphBuilder::Project { input, .. }
-        | GraphBuilder::StreamingChecksum { input, .. }
-        | GraphBuilder::UnwrapNullable { input, .. }
-        | GraphBuilder::Unnest { input, .. }
-        | GraphBuilder::VariantProject { input, .. }
-        | GraphBuilder::ArgMaxBy { input, .. }
-        | GraphBuilder::ArgMinBy { input, .. }
-        | GraphBuilder::TopBy { input, .. }
-        | GraphBuilder::CollectBy { input, .. }
-        | GraphBuilder::Aggregate { input, .. } => builder_contains_recursive(input),
-        GraphBuilder::Union { inputs } => inputs.iter().any(builder_contains_recursive),
-        GraphBuilder::Join { left, right, .. }
-        | GraphBuilder::SemiJoin { left, right, .. }
-        | GraphBuilder::AntiJoin { left, right, .. } => {
-            builder_contains_recursive(left) || builder_contains_recursive(right)
-        }
-        GraphBuilder::Table { .. }
-        | GraphBuilder::InlineRecords { .. }
-        | GraphBuilder::Index { .. }
-        | GraphBuilder::FrontierSource { .. }
-        | GraphBuilder::BindingSource { .. } => false,
-    }
+    graph
+        .postorder()
+        .iter()
+        .any(|node| matches!(node, GraphBuilder::Recursive { .. }))
 }
 
 pub(super) fn validate_arg_by_primary_key_indices(

--- a/crates/groove/src/ivm/runtime/record_projection.rs
+++ b/crates/groove/src/ivm/runtime/record_projection.rs
@@ -528,12 +528,18 @@ pub(super) fn validate_collect_by_key_types(
 }
 
 pub(super) fn validate_collect_by_terminality(graph: &GraphBuilder) -> Result<(), IvmRuntimeError> {
-    fn contains_collect_by(graph: &GraphBuilder) -> bool {
-        match graph {
-            GraphBuilder::CollectBy { .. } => true,
-            GraphBuilder::Recursive { seed, step, .. } => {
-                contains_collect_by(seed) || contains_collect_by(step)
-            }
+    fn contains(
+        children: impl IntoIterator<Item = *const GraphBuilder>,
+        seen: &HashMap<usize, bool>,
+    ) -> bool {
+        children
+            .into_iter()
+            .any(|child| seen.get(&(child as usize)).copied().unwrap_or(false))
+    }
+
+    let mut contains_collect = HashMap::default();
+    for node in graph.postorder() {
+        let children_contain_collect = match node {
             GraphBuilder::Filter { input, .. }
             | GraphBuilder::Project { input, .. }
             | GraphBuilder::StreamingChecksum { input, .. }
@@ -543,80 +549,50 @@ pub(super) fn validate_collect_by_terminality(graph: &GraphBuilder) -> Result<()
             | GraphBuilder::ArgMaxBy { input, .. }
             | GraphBuilder::ArgMinBy { input, .. }
             | GraphBuilder::TopBy { input, .. }
-            | GraphBuilder::Aggregate { input, .. } => contains_collect_by(input),
-            GraphBuilder::Union { inputs } => inputs.iter().any(contains_collect_by),
+            | GraphBuilder::CollectBy { input, .. }
+            | GraphBuilder::Aggregate { input, .. } => {
+                contains([input.as_ref() as *const GraphBuilder], &contains_collect)
+            }
+            GraphBuilder::Union { inputs } => contains(
+                inputs.iter().map(|input| input as *const GraphBuilder),
+                &contains_collect,
+            ),
             GraphBuilder::Join { left, right, .. }
             | GraphBuilder::SemiJoin { left, right, .. }
-            | GraphBuilder::AntiJoin { left, right, .. } => {
-                contains_collect_by(left) || contains_collect_by(right)
-            }
+            | GraphBuilder::AntiJoin { left, right, .. } => contains(
+                [
+                    left.as_ref() as *const GraphBuilder,
+                    right.as_ref() as *const GraphBuilder,
+                ],
+                &contains_collect,
+            ),
+            GraphBuilder::Recursive { seed, step, .. } => contains(
+                [
+                    seed.as_ref() as *const GraphBuilder,
+                    step.as_ref() as *const GraphBuilder,
+                ],
+                &contains_collect,
+            ),
             GraphBuilder::Table { .. }
             | GraphBuilder::InlineRecords { .. }
             | GraphBuilder::Index { .. }
             | GraphBuilder::FrontierSource { .. }
             | GraphBuilder::BindingSource { .. } => false,
-        }
-    }
+        };
 
-    match graph {
-        GraphBuilder::CollectBy { input, .. } => {
-            if contains_collect_by(input) {
-                return Err(IvmRuntimeError::CollectByMustBeTerminal);
-            }
-            validate_collect_by_terminality(input)
+        let collect_is_terminal = matches!(
+            node,
+            GraphBuilder::Filter { .. } | GraphBuilder::Project { .. }
+        );
+        if children_contain_collect && !collect_is_terminal {
+            return Err(IvmRuntimeError::CollectByMustBeTerminal);
         }
-        GraphBuilder::Recursive { seed, step, .. } => {
-            if contains_collect_by(seed) || contains_collect_by(step) {
-                return Err(IvmRuntimeError::CollectByMustBeTerminal);
-            }
-            validate_collect_by_terminality(seed)?;
-            validate_collect_by_terminality(step)
-        }
-        GraphBuilder::Filter { input, .. } | GraphBuilder::Project { input, .. } => {
-            validate_collect_by_terminality(input)
-        }
-        GraphBuilder::StreamingChecksum { input, .. } => {
-            if contains_collect_by(input) {
-                return Err(IvmRuntimeError::CollectByMustBeTerminal);
-            }
-            validate_collect_by_terminality(input)
-        }
-        GraphBuilder::UnwrapNullable { input, .. }
-        | GraphBuilder::Unnest { input, .. }
-        | GraphBuilder::VariantProject { input, .. }
-        | GraphBuilder::ArgMaxBy { input, .. }
-        | GraphBuilder::ArgMinBy { input, .. }
-        | GraphBuilder::TopBy { input, .. }
-        | GraphBuilder::Aggregate { input, .. } => {
-            if contains_collect_by(input) {
-                return Err(IvmRuntimeError::CollectByMustBeTerminal);
-            }
-            validate_collect_by_terminality(input)
-        }
-        GraphBuilder::Union { inputs } => {
-            if inputs.iter().any(contains_collect_by) {
-                return Err(IvmRuntimeError::CollectByMustBeTerminal);
-            }
-            for input in inputs {
-                validate_collect_by_terminality(input)?;
-            }
-            Ok(())
-        }
-        GraphBuilder::Join { left, right, .. }
-        | GraphBuilder::SemiJoin { left, right, .. }
-        | GraphBuilder::AntiJoin { left, right, .. } => {
-            if contains_collect_by(left) || contains_collect_by(right) {
-                return Err(IvmRuntimeError::CollectByMustBeTerminal);
-            }
-            validate_collect_by_terminality(left)?;
-            validate_collect_by_terminality(right)
-        }
-        GraphBuilder::Table { .. }
-        | GraphBuilder::InlineRecords { .. }
-        | GraphBuilder::Index { .. }
-        | GraphBuilder::FrontierSource { .. }
-        | GraphBuilder::BindingSource { .. } => Ok(()),
+        contains_collect.insert(
+            node as *const GraphBuilder as usize,
+            children_contain_collect || matches!(node, GraphBuilder::CollectBy { .. }),
+        );
     }
+    Ok(())
 }
 
 pub(super) fn project_field_expr(

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -2729,9 +2729,22 @@ impl IvmRuntime {
         if let Some(output) = output_memo.get(&memo_key) {
             return Ok(*output);
         }
-        let output = self.infer_builder_output_uncached(graph, output_memo)?;
-        output_memo.insert(memo_key, output);
-        Ok(output)
+        // A legal policy graph can be deeply nested (for example a recursive
+        // inheritance policy after its public result and routing projections
+        // have been attached). Infer every child before its parent explicitly
+        // so descriptor inference does not consume the server owner's stack.
+        for builder in graph.postorder() {
+            let key = builder as *const GraphBuilder as usize;
+            if output_memo.contains_key(&key) {
+                continue;
+            }
+            let output = self.infer_builder_output_uncached(builder, output_memo)?;
+            output_memo.insert(key, output);
+        }
+        output_memo
+            .get(&memo_key)
+            .copied()
+            .ok_or(IvmRuntimeError::UnsupportedOperator)
     }
 
     fn infer_builder_output_uncached(

--- a/crates/jazz-testkit/tests/policies_integration/inheritance_validation.rs
+++ b/crates/jazz-testkit/tests/policies_integration/inheritance_validation.rs
@@ -6,7 +6,6 @@ use jazz_testkit::{connect_ready_client, connect_ready_user, wait_for_edge_txs};
 /// Verifies that recursive inherited access fails closed when row data forms a
 /// cycle and no reachable ancestor grants the session access.
 #[tokio::test]
-#[ignore = "#1763: recursive INHERITS policy cycles currently overflow the Rust evaluator stack"]
 async fn rebac_recursive_inherits_cycle_does_not_overgrant() {
     tokio::task::LocalSet::new()
         .run_until(rebac_recursive_inherits_cycle_does_not_overgrant_inner())


### PR DESCRIPTION
🤖 Compiles deep recursive policy graphs iteratively instead of consuming the server thread’s call stack.

The failing recursive-`INHERITS` graph is semantically valid, but public/routing projections make it roughly 91 graph nodes deep. Groove recursively walked that owned graph during descriptor inference, terminal validation, nested-recursion detection, and compilation; the server shell’s ordinary thread stack overflowed before evaluation. Increasing the stack proved the policy result itself was correct, but would only hide the unbounded implementation.

`GraphBuilder::postorder()` now produces one child-first traversal used by all four phases. Compilation caches child fragments before their parents, retaining declared UNION/JOIN/Recursive ordering, node deduplication, descriptor errors, and nested-recursion rejection without recursive fallback. No inheritance, cycle, or authorization semantics change.

The previously ignored single-table cyclic-`INHERITS` fail-closed integration receipt is active and passes. Independent adversarial review restored recursive inference, parent-first traversal, and missing compiled-memo reuse; each mutation reproduced the exact stack overflow. Full Groove passes (481, 2 documented ignored), full policy integration passes (57, 48 documented ignored), and focused deep recursion, nested rejection, duplicate derivation/node reuse, format, and diff gates are green.

A separate mutual-table recursion overflow occurs earlier in Jazz public-schema conversion and remains tracked under #1763; this PR does not conflate that path.

Closes #1885. Stacked on #1896.
