### PR TITLE
test(topology): validate browser helper commands

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -135,6 +135,7 @@
     "typecheck:react-native": "tsc --project tsconfig.react-native-tests.json",
     "test:browser": "node ../../dev/artifacts/verify-correctness-test-artifacts.mjs && vitest run --config vitest.config.browser.ts",
     "test:browser:focused": "node scripts/test-browser-focused.mjs",
+    "typecheck:browser-helpers": "tsc --project tests/browser/tsconfig.browser-helpers.json",
     "test:browser:contract": "node scripts/test-browser-focused.test.mjs",
     "test:terminal-layout-contract": "vitest run --config vitest.config.ts src/runtime/terminal-layout-contract-matrix.test.ts --reporter=verbose --passWithNoTests=false",
     "bench:abstract:node": "JAZZ_ABSTRACT_BENCH=1 vitest run --config vitest.config.ts src/runtime/schema-marshalling.abstract-bench.test.ts",

--- a/packages/jazz-tools/tests/browser/browser-commands.ts
+++ b/packages/jazz-tools/tests/browser/browser-commands.ts
@@ -1,0 +1,67 @@
+import { commands } from "vitest/browser";
+
+import type { JazzServerInfo } from "./testing-server.js";
+
+export interface JazzServerBrowserCommands {
+  jazzServerInfo(appId?: string, schema?: number[]): Promise<JazzServerInfo>;
+  jazzServerBlockNetwork(serverUrl: string): Promise<void>;
+  jazzServerUnblockNetwork(serverUrl: string): Promise<void>;
+  jazzServerJwtForUser(
+    userId: string,
+    claims?: Record<string, unknown>,
+    appId?: string,
+  ): Promise<string>;
+}
+
+export interface JazzTopologyBrowserCommands {
+  jazzBrowserTopologyLog(
+    status: "start" | "complete" | "failed",
+    label: string,
+    elapsedMs: number,
+  ): Promise<void>;
+}
+
+function hasFunction(value: object, key: string): boolean {
+  return key in value && typeof Reflect.get(value, key) === "function";
+}
+
+function isJazzServerBrowserCommands(value: unknown): value is JazzServerBrowserCommands {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    hasFunction(value, "jazzServerInfo") &&
+    hasFunction(value, "jazzServerBlockNetwork") &&
+    hasFunction(value, "jazzServerUnblockNetwork") &&
+    hasFunction(value, "jazzServerJwtForUser")
+  );
+}
+
+function isJazzTopologyBrowserCommands(value: unknown): value is JazzTopologyBrowserCommands {
+  return (
+    typeof value === "object" && value !== null && hasFunction(value, "jazzBrowserTopologyLog")
+  );
+}
+
+/**
+ * Read the commands configured by the current browser-test project.
+ *
+ * Vitest's browser entrypoint re-exports commands through peer dependencies,
+ * so test helpers deliberately validate the runtime command contract instead
+ * of relying on ambient augmentation from a particular package installation.
+ */
+export function jazzServerBrowserCommands(): JazzServerBrowserCommands {
+  if (!isJazzServerBrowserCommands(commands)) {
+    throw new Error(
+      "Browser test project is missing Jazz server commands. Configure jazzServerInfo, " +
+        "jazzServerBlockNetwork, jazzServerUnblockNetwork, and jazzServerJwtForUser.",
+    );
+  }
+  return commands;
+}
+
+export function jazzTopologyBrowserCommands(): JazzTopologyBrowserCommands {
+  if (!isJazzTopologyBrowserCommands(commands)) {
+    throw new Error("Browser test project is missing the jazzBrowserTopologyLog command.");
+  }
+  return commands;
+}

--- a/packages/jazz-tools/tests/browser/browser-helpers.typecheck.ts
+++ b/packages/jazz-tools/tests/browser/browser-helpers.typecheck.ts
@@ -1,0 +1,13 @@
+import {
+  blockJazzServerNetwork,
+  getJazzServerInfo,
+  getJazzServerJwtForUser,
+  unblockJazzServerNetwork,
+} from "./testing-server.js";
+import { browserTopologyReporter } from "./topology-harness.js";
+
+void getJazzServerInfo;
+void getJazzServerJwtForUser;
+void blockJazzServerNetwork;
+void unblockJazzServerNetwork;
+void browserTopologyReporter;

--- a/packages/jazz-tools/tests/browser/testing-server.ts
+++ b/packages/jazz-tools/tests/browser/testing-server.ts
@@ -1,4 +1,4 @@
-import { commands } from "vitest/browser";
+import { jazzServerBrowserCommands } from "./browser-commands.js";
 
 export interface JazzServerInfo {
   appId: string;
@@ -13,29 +13,16 @@ export interface JazzServerNetworkDebugState {
   activePatterns: string[];
 }
 
-declare module "vitest/internal/browser" {
-  interface BrowserCommands {
-    jazzServerInfo: (appId?: string, schema?: number[]) => Promise<JazzServerInfo>;
-    jazzServerBlockNetwork: (serverUrl: string) => Promise<void>;
-    jazzServerUnblockNetwork: (serverUrl: string) => Promise<void>;
-    jazzServerJwtForUser: (
-      userId: string,
-      claims?: Record<string, unknown>,
-      appId?: string,
-    ) => Promise<string>;
-  }
-}
-
 export function getJazzServerInfo(appId?: string, schema?: Uint8Array): Promise<JazzServerInfo> {
-  return commands.jazzServerInfo(appId, schema ? [...schema] : undefined);
+  return jazzServerBrowserCommands().jazzServerInfo(appId, schema ? [...schema] : undefined);
 }
 
 export function blockJazzServerNetwork(serverUrl: string): Promise<void> {
-  return commands.jazzServerBlockNetwork(serverUrl);
+  return jazzServerBrowserCommands().jazzServerBlockNetwork(serverUrl);
 }
 
 export function unblockJazzServerNetwork(serverUrl: string): Promise<void> {
-  return commands.jazzServerUnblockNetwork(serverUrl);
+  return jazzServerBrowserCommands().jazzServerUnblockNetwork(serverUrl);
 }
 
 export async function getJazzServerJwtForUser(
@@ -43,5 +30,5 @@ export async function getJazzServerJwtForUser(
   claims?: Record<string, unknown>,
   appId?: string,
 ): Promise<string> {
-  return commands.jazzServerJwtForUser(userId, claims, appId);
+  return jazzServerBrowserCommands().jazzServerJwtForUser(userId, claims, appId);
 }

--- a/packages/jazz-tools/tests/browser/topology-harness.ts
+++ b/packages/jazz-tools/tests/browser/topology-harness.ts
@@ -1,21 +1,13 @@
-import { commands } from "vitest/browser";
+import { jazzTopologyBrowserCommands } from "./browser-commands.js";
 import type { TopologyReporter } from "../topology/harness.js";
 export * from "../topology/harness.js";
-
-declare module "vitest/internal/browser" {
-  interface BrowserCommands {
-    jazzBrowserTopologyLog: (
-      status: "start" | "complete" | "failed",
-      label: string,
-      elapsedMs: number,
-    ) => Promise<void>;
-  }
-}
 
 /** Reporter which mirrors browser lifecycle phases to the Node test process. */
 export const browserTopologyReporter: TopologyReporter = {
   phase(status, label, elapsedMs) {
     console.info(`[jazz-browser-topology] ${status} ${label} (${elapsedMs}ms)`);
-    void commands.jazzBrowserTopologyLog(status, label, elapsedMs).catch(() => undefined);
+    void jazzTopologyBrowserCommands()
+      .jazzBrowserTopologyLog(status, label, elapsedMs)
+      .catch(() => undefined);
   },
 };

--- a/packages/jazz-tools/tests/browser/tsconfig.browser-helpers.json
+++ b/packages/jazz-tools/tests/browser/tsconfig.browser-helpers.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "files": [
+    "browser-commands.ts",
+    "testing-server.ts",
+    "topology-harness.ts",
+    "browser-helpers.typecheck.ts"
+  ]
+}

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -279,6 +279,11 @@ interface PendingEnvelope<T> {
   retry: boolean;
 }
 
+type PendingEnvelopeReceipt = Pick<
+  PendingEnvelope<unknown>,
+  "envelopeId" | "sequence" | "envelope" | "attempt"
+>;
+
 interface NextEnvelopeFault {
   duplicate: number;
   delayTicks: number;
@@ -619,7 +624,7 @@ export class TopologyEnvelopeScheduler {
 
   private recordPending(
     action: TopologyEnvelopeAction,
-    pending: PendingEnvelope<unknown>,
+    pending: PendingEnvelopeReceipt,
     error?: unknown,
   ): void {
     this.record({
@@ -760,7 +765,12 @@ function assertEndpoint(name: string, value: unknown): asserts value is string {
 }
 
 function assertTopologyTicks(name: string, ticks: unknown): asserts ticks is number {
-  if (!Number.isSafeInteger(ticks) || ticks < 1 || ticks > MAX_TOPOLOGY_TICKS) {
+  if (
+    typeof ticks !== "number" ||
+    !Number.isSafeInteger(ticks) ||
+    ticks < 1 ||
+    ticks > MAX_TOPOLOGY_TICKS
+  ) {
     throw new Error(`${name} ticks must be a positive safe integer at most ${MAX_TOPOLOGY_TICKS}`);
   }
 }


### PR DESCRIPTION
🤖 Makes shared browser topology commands explicit, typechecked, and runtime-validated.

## Why

Vitest 4 browser command types can resolve through different pnpm peer instances. Ambient augmentation of `vitest/browser` or `vitest/internal/browser` therefore let app code compile while describing commands that its browser project never registered; the failure surfaced only as `commands.<name> is not a function` at runtime.

## Change

- Replace ambient command augmentation in the shared helpers with explicit `JazzServerBrowserCommands` and `JazzTopologyBrowserCommands` adapters.
- Validate the complete configured command surface at runtime and report a direct browser-project configuration error when a handler is absent.
- Add a focused browser-helper TypeScript project so both helper entrypoints are actually compiled by CI/local gates.
- Keep app-specific Vitest projects responsible for registering the handlers they use.

## Verification

- `pnpm --dir packages/jazz-tools run typecheck:browser-helpers`
- topology harness: 15 passed
- Independent adversarial review planted a missing handler and observed the intended configuration diagnostic.
- A real Jamazon browser project exposed and then repaired its missing network handlers through this contract, proving the check is not declaration-only.

This is a test/tooling contract change only; Jazz runtime semantics are unchanged.
