### PR TITLE
fix(policy): retain complete scans for disjunctive proofs

### DIFF
--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -909,8 +909,7 @@ fn db_sync_surface_edge_session_read_policy_filters_private_table_query() {
 /// resource that grant authorizes.  The second subscription must publish a
 /// result membership even when the first subscription already delivered the
 /// resource as policy support.
-#[test]
-fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_proof() {
+fn membership_grant_then_parent_query_keeps_disjunctive_read_proof(indexed: bool) {
     let member_exists = public_exists(
         "members",
         [
@@ -918,41 +917,47 @@ fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_pro
             public_session_eq("subject", &["claims", "user_id"]),
         ],
     );
-    let schema = build_public_db_test_schema(
-        PublicSchemaBuilder::new()
-            .table(
-                PublicTableSchemaBuilder::new("workspaces")
-                    .column("owner_subject", PublicColumnType::Text)
-                    .policies(
-                        PublicTablePolicies::new()
-                            .with_select(PublicPolicyExpr::Or(vec![
-                                public_session_eq("owner_subject", &["claims", "user_id"]),
-                                member_exists,
-                            ]))
-                            .with_insert(PublicPolicyExpr::True),
-                    ),
-            )
-            .table(
-                PublicTableSchemaBuilder::new("members")
-                    .fk_column("workspace_id", "workspaces")
-                    .column("subject", PublicColumnType::Text)
-                    .policies(
-                        PublicTablePolicies::new()
-                            .with_select(PublicPolicyExpr::Or(vec![
-                                public_session_eq("subject", &["claims", "user_id"]),
-                                PublicPolicyExpr::Inherits {
-                                    operation: PublicOperation::Select,
-                                    via_column: "workspace_id".to_owned(),
-                                    max_depth: None,
-                                },
-                            ]))
-                            .with_insert(PublicPolicyExpr::True),
-                    ),
-            ),
-    );
-    let manager = AuthorId::from_bytes([0xa1; 16]);
-    let owner = AuthorId::from_bytes([0xb2; 16]);
-    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    let workspaces = PublicTableSchemaBuilder::new("workspaces")
+        .column("owner_subject", PublicColumnType::Text)
+        .policies(
+            PublicTablePolicies::new()
+                .with_select(PublicPolicyExpr::Or(vec![
+                    public_session_eq("owner_subject", &["claims", "user_id"]),
+                    member_exists,
+                ]))
+                .with_insert(PublicPolicyExpr::True),
+        );
+    let members = PublicTableSchemaBuilder::new("members")
+        .fk_column("workspace_id", "workspaces")
+        .column("subject", PublicColumnType::Text)
+        .column("role", PublicColumnType::Text)
+        .policies(
+            PublicTablePolicies::new()
+                .with_select(PublicPolicyExpr::Or(vec![
+                    public_session_eq("subject", &["claims", "user_id"]),
+                    PublicPolicyExpr::Inherits {
+                        operation: PublicOperation::Select,
+                        via_column: "workspace_id".to_owned(),
+                        max_depth: None,
+                    },
+                ]))
+                .with_insert(PublicPolicyExpr::True),
+        );
+    let workspaces = if indexed {
+        workspaces.index_only(["owner_subject"])
+    } else {
+        workspaces
+    };
+    let members = if indexed {
+        members.index_only(["workspace_id", "subject", "role"])
+    } else {
+        members
+    };
+    let schema =
+        build_public_db_test_schema(PublicSchemaBuilder::new().table(workspaces).table(members));
+    let manager = AuthorSubject::for_test_bytes([0xa1; 16]);
+    let owner = AuthorSubject::for_test_bytes([0xb2; 16]);
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
     let client = open_db(0xa1, manager, &schema);
     let owner_client = open_db(0xb2, owner, &schema);
     let (owner_transport, server_owner_transport) = duplex();
@@ -960,21 +965,27 @@ fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_pro
     let _owner_subscriber = server.accept_subscriber_with_claims(
         server_owner_transport,
         owner,
-        BTreeMap::from([("user_id".to_owned(), Value::String(owner.0.to_string()))]),
+        BTreeMap::from([(
+            "user_id".to_owned(),
+            Value::String(owner.test_uuid().to_string()),
+        )]),
     );
     let (client_transport, server_transport) = duplex();
     let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
     let _subscriber = server.accept_subscriber_with_claims(
         server_transport,
         manager,
-        BTreeMap::from([("user_id".to_owned(), Value::String(manager.0.to_string()))]),
+        BTreeMap::from([(
+            "user_id".to_owned(),
+            Value::String(manager.test_uuid().to_string()),
+        )]),
     );
     let workspace = owner_client
         .insert(
             "workspaces",
             BTreeMap::from([(
                 "owner_subject".to_owned(),
-                Value::String(owner.0.to_string()),
+                Value::String(owner.test_uuid().to_string()),
             )]),
         )
         .unwrap();
@@ -986,7 +997,11 @@ fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_pro
                     "workspace_id".to_owned(),
                     Value::Uuid(workspace.row_uuid().0),
                 ),
-                ("subject".to_owned(), Value::String(manager.0.to_string())),
+                (
+                    "subject".to_owned(),
+                    Value::String(manager.test_uuid().to_string()),
+                ),
+                ("role".to_owned(), Value::String("member".to_owned())),
             ]),
         )
         .unwrap();
@@ -1038,6 +1053,16 @@ fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_pro
         vec![workspace.row_uuid()],
     );
     assert!(workspace_subscription.try_next_event().is_some());
+}
+
+#[test]
+fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_proof() {
+    membership_grant_then_parent_query_keeps_disjunctive_read_proof(false);
+}
+
+#[test]
+fn db_sync_surface_indexed_membership_grant_then_parent_query_keeps_disjunctive_read_proof() {
+    membership_grant_then_parent_query_keeps_disjunctive_read_proof(true);
 }
 
 /// A prepared trusted-serving read binds each request session's text `user_id`

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -1027,6 +1027,17 @@ fn membership_grant_then_parent_query_keeps_disjunctive_read_proof(indexed: bool
             break;
         }
     }
+    if indexed {
+        assert_eq!(
+            server
+                .node()
+                .borrow()
+                .query_engine_read_metrics()
+                .source_index_probes,
+            0,
+            "the disjunctive policy must retain a complete source path",
+        );
+    }
     assert_eq!(
         prepared_all(&client, &grant_query, edge_subscribe_opts()).len(),
         1

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -905,6 +905,141 @@ fn db_sync_surface_edge_session_read_policy_filters_private_table_query() {
     assert!(prepared_all(&reader, &query, edge_subscribe_opts()).is_empty());
 }
 
+/// A real client commonly reads its self-membership grant before querying the
+/// resource that grant authorizes.  The second subscription must publish a
+/// result membership even when the first subscription already delivered the
+/// resource as policy support.
+#[test]
+fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_proof() {
+    let member_exists = public_exists(
+        "members",
+        [
+            public_outer_eq("workspace_id", "id"),
+            public_session_eq("subject", &["claims", "user_id"]),
+        ],
+    );
+    let schema = build_public_db_test_schema(
+        PublicSchemaBuilder::new()
+            .table(
+                PublicTableSchemaBuilder::new("workspaces")
+                    .column("owner_subject", PublicColumnType::Text)
+                    .policies(
+                        PublicTablePolicies::new()
+                            .with_select(PublicPolicyExpr::Or(vec![
+                                public_session_eq("owner_subject", &["claims", "user_id"]),
+                                member_exists,
+                            ]))
+                            .with_insert(PublicPolicyExpr::True),
+                    ),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("members")
+                    .fk_column("workspace_id", "workspaces")
+                    .column("subject", PublicColumnType::Text)
+                    .policies(
+                        PublicTablePolicies::new()
+                            .with_select(PublicPolicyExpr::Or(vec![
+                                public_session_eq("subject", &["claims", "user_id"]),
+                                PublicPolicyExpr::Inherits {
+                                    operation: PublicOperation::Select,
+                                    via_column: "workspace_id".to_owned(),
+                                    max_depth: None,
+                                },
+                            ]))
+                            .with_insert(PublicPolicyExpr::True),
+                    ),
+            ),
+    );
+    let manager = AuthorId::from_bytes([0xa1; 16]);
+    let owner = AuthorId::from_bytes([0xb2; 16]);
+    let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
+    let client = open_db(0xa1, manager, &schema);
+    let owner_client = open_db(0xb2, owner, &schema);
+    let (owner_transport, server_owner_transport) = duplex();
+    let _owner_upstream = crate::db::block_on(owner_client.connect_upstream(owner_transport));
+    let _owner_subscriber = server.accept_subscriber_with_claims(
+        server_owner_transport,
+        owner,
+        BTreeMap::from([("user_id".to_owned(), Value::String(owner.0.to_string()))]),
+    );
+    let (client_transport, server_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber_with_claims(
+        server_transport,
+        manager,
+        BTreeMap::from([("user_id".to_owned(), Value::String(manager.0.to_string()))]),
+    );
+    let workspace = owner_client
+        .insert(
+            "workspaces",
+            BTreeMap::from([(
+                "owner_subject".to_owned(),
+                Value::String(owner.0.to_string()),
+            )]),
+        )
+        .unwrap();
+    let grant = owner_client
+        .insert(
+            "members",
+            BTreeMap::from([
+                (
+                    "workspace_id".to_owned(),
+                    Value::Uuid(workspace.row_uuid().0),
+                ),
+                ("subject".to_owned(), Value::String(manager.0.to_string())),
+            ]),
+        )
+        .unwrap();
+    for _ in 0..16 {
+        owner_client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        if server.read(&server.table("members")).unwrap().len() == 1 {
+            break;
+        }
+    }
+    assert_eq!(server.read(&server.table("workspaces")).unwrap().len(), 1);
+    assert_eq!(server.read(&server.table("members")).unwrap().len(), 1);
+    let grant_query =
+        Query::from("members").filter(eq(col("id"), lit(Value::Uuid(grant.row_uuid().0))));
+    let mut grant_subscription =
+        prepared_subscribe(&client, &grant_query, edge_subscribe_opts()).unwrap();
+    for _ in 0..16 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        if !prepared_all(&client, &grant_query, edge_subscribe_opts()).is_empty() {
+            break;
+        }
+    }
+    assert_eq!(
+        prepared_all(&client, &grant_query, edge_subscribe_opts()).len(),
+        1
+    );
+    while grant_subscription.try_next_event().is_some() {}
+
+    let workspace_query =
+        Query::from("workspaces").filter(eq(col("id"), lit(Value::Uuid(workspace.row_uuid().0))));
+    let mut workspace_subscription =
+        prepared_subscribe(&client, &workspace_query, edge_subscribe_opts()).unwrap();
+    for _ in 0..16 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        if !prepared_all(&client, &workspace_query, edge_subscribe_opts()).is_empty() {
+            break;
+        }
+    }
+    assert_eq!(
+        prepared_all(&client, &workspace_query, edge_subscribe_opts())
+            .iter()
+            .map(CurrentRow::row_uuid)
+            .collect::<Vec<_>>(),
+        vec![workspace.row_uuid()],
+    );
+    assert!(workspace_subscription.try_next_event().is_some());
+}
+
 /// A prepared trusted-serving read binds each request session's text `user_id`
 /// independently: Alice receives her seeded message while Bob receives none.
 ///

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -2798,6 +2798,23 @@ where
         &self,
         request: &QueryProgramRequest,
     ) -> Result<BTreeMap<SourceId, CurrentAccessPath>, Error> {
+        // A policy proof may contain both an owner arm and a correlated
+        // membership arm for the same protected source.  Walking its nested
+        // nodes independently would see the owner's claim equality and apply
+        // that index path to the entire union, incorrectly excluding rows
+        // that only the membership arm authorizes.  The small planner does
+        // not prove per-arm coverage, so any alternative or relational proof
+        // retains full source scans.
+        if request.input.shape.nodes.values().any(|node| {
+            matches!(
+                node,
+                RowSetExpr::Union { .. }
+                    | RowSetExpr::Join { .. }
+                    | RowSetExpr::RecursiveRelation { .. }
+            )
+        }) {
+            return Ok(BTreeMap::new());
+        }
         self.normalized_program_access_paths(
             &request.input,
             &request.reads.primary,

--- a/crates/jazz/src/node/tests/policies_rls/read_delivery.rs
+++ b/crates/jazz/src/node/tests/policies_rls/read_delivery.rs
@@ -1392,18 +1392,28 @@ fn edge_rehydrate_member_grant_unlocks_parent_through_disjunctive_policy() {
             ),
     );
     let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    core.set_session_claims(
+        manager,
+        BTreeMap::from([(
+            "user_id".to_owned(),
+            Value::String(manager.test_uuid().to_string()),
+        )]),
+    );
     let workspace_tx = accept_global(
         &mut core,
         MergeableCommit::new("workspaces", workspace, 10).cells(BTreeMap::from([(
             "owner_subject".to_owned(),
-            Value::String(owner.0.to_string()),
+            Value::String(owner.test_uuid().to_string()),
         )])),
     );
     let _grant_tx = accept_global(
         &mut core,
         MergeableCommit::new("members", grant, 11).cells(BTreeMap::from([
             ("workspace_id".to_owned(), Value::Uuid(workspace.0)),
-            ("subject".to_owned(), Value::String(manager.0.to_string())),
+            (
+                "subject".to_owned(),
+                Value::String(manager.test_uuid().to_string()),
+            ),
         ])),
     );
     let shape = Query::from("workspaces")

--- a/crates/jazz/src/node/tests/policies_rls/read_delivery.rs
+++ b/crates/jazz/src/node/tests/policies_rls/read_delivery.rs
@@ -1350,6 +1350,114 @@ fn edge_query_rehydrate_ships_public_chat_from_chat_policy_schema() {
     assert_view_update_only_ships_rows(&update, BTreeSet::from([public_chat]));
 }
 
+/// A member can discover its own grant before the parent resource is visible.
+/// The parent then becomes readable through the grant's correlated EXISTS arm.
+/// Keep the grant's `allowedTo.read(parent)` alternative too: this is the
+/// policy-cycle shape real apps use, and a maintained edge rehydrate must not
+/// lose the direct-grant proof while lowering the disjunction.
+#[test]
+fn edge_rehydrate_member_grant_unlocks_parent_through_disjunctive_policy() {
+    let manager = user(0xa1);
+    let owner = user(0xb2);
+    let workspace = row(0x18);
+    let grant = row(0x19);
+    let member_exists = public_outer_exists(
+        "members",
+        "workspace_id",
+        "id",
+        [public_claim_eq("subject", "user_id")],
+    );
+    let schema = build_public_test_schema(
+        PublicSchemaBuilder::new()
+            .table(
+                PublicTableSchemaBuilder::new("workspaces")
+                    .column("owner_subject", PublicColumnType::Text)
+                    .policies(public_all_policies().with_select(PublicPolicyExpr::Or(vec![
+                        public_claim_eq("owner_subject", "user_id"),
+                        member_exists,
+                    ]))),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("members")
+                    .fk_column("workspace_id", "workspaces")
+                    .column("subject", PublicColumnType::Text)
+                    .policies(public_all_policies().with_select(PublicPolicyExpr::Or(vec![
+                        public_claim_eq("subject", "user_id"),
+                        PublicPolicyExpr::Inherits {
+                            operation: PublicOperation::Select,
+                            via_column: "workspace_id".to_owned(),
+                            max_depth: None,
+                        },
+                    ]))),
+            ),
+    );
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    let workspace_tx = accept_global(
+        &mut core,
+        MergeableCommit::new("workspaces", workspace, 10).cells(BTreeMap::from([(
+            "owner_subject".to_owned(),
+            Value::String(owner.0.to_string()),
+        )])),
+    );
+    let _grant_tx = accept_global(
+        &mut core,
+        MergeableCommit::new("members", grant, 11).cells(BTreeMap::from([
+            ("workspace_id".to_owned(), Value::Uuid(workspace.0)),
+            ("subject".to_owned(), Value::String(manager.0.to_string())),
+        ])),
+    );
+    let shape = Query::from("workspaces")
+        .validate(&core.catalogue.schema)
+        .unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    assert_eq!(
+        core.query_rows_for_link(&shape, &binding, DurabilityTier::Edge, manager)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([workspace]),
+    );
+
+    let mut manager_peer = PeerState::edge_client(manager);
+    let grant_shape = Query::from("members")
+        .filter(eq(col("id"), lit(Value::Uuid(grant.0))))
+        .validate(&core.catalogue.schema)
+        .unwrap();
+    let grant_binding = grant_shape.bind(BTreeMap::new()).unwrap();
+    let grant_update = manager_peer
+        .rehydrate_query_with_opts(
+            &mut core,
+            &grant_shape,
+            &grant_binding,
+            RegisterShapeOptions {
+                tier: DurabilityTier::Edge,
+                ..RegisterShapeOptions::default()
+            },
+        )
+        .unwrap();
+    assert_view_update_only_references_rows(&grant_update, BTreeSet::from([workspace, grant]));
+    assert_view_update_only_ships_rows(&grant_update, BTreeSet::from([workspace, grant]));
+    let update = manager_peer
+        .rehydrate_query_with_opts(
+            &mut core,
+            &shape,
+            &binding,
+            RegisterShapeOptions {
+                tier: DurabilityTier::Edge,
+                ..RegisterShapeOptions::default()
+            },
+        )
+        .unwrap();
+    assert_view_update_only_references_rows(&update, BTreeSet::from([workspace]));
+    assert_view_update_only_ships_rows(&update, BTreeSet::from([workspace]));
+    assert!(matches!(
+        update,
+        SyncMessage::ViewUpdate { result_member_adds, .. }
+            if result_member_adds.iter().any(|entry| entry == &("workspaces".to_owned().into(), workspace, workspace_tx))
+    ));
+}
+
 /// A source-harness regression for row-scoped read policy plus query output
 /// projection. Two fresh edge-client links ask for the same readable chat via
 /// different public projections; both wire payloads must be the identical

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -1675,4 +1675,13 @@ fn read_policy_branch_or_join_allows_public_or_membership_reads() {
             .collect::<BTreeSet<_>>(),
         BTreeSet::from([public_chat])
     );
+    // One-shot policy evaluation is not enough for an app client: this exact
+    // public-or-membership shape must seed the maintained link view with the
+    // same membership result.
+    assert_maintained_view_cold_snapshot_seed_matches_one_shot(
+        &mut core,
+        &shape,
+        &binding,
+        member,
+    );
 }

--- a/packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts
+++ b/packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts
@@ -141,6 +141,45 @@ const chatStyleMessagePermissions = schema.definePermissions(app, ({ policy, any
   policy.announcements.allowDelete.always(),
 ]);
 
+// Keep this separate from `chatStyleMessagePermissions`: the public branch in
+// that policy is a constant predicate.  This receipt needs both branches to
+// read session claims, matching the owner-or-membership bootstrap used by
+// application schemas.
+const ownerOrMembershipPermissions = schema.definePermissions(
+  app,
+  ({ policy, anyOf, allowedTo, session }) => [
+    policy.chats.allowRead.where((chat) =>
+      anyOf([
+        { owner_id: session.user_id },
+        policy.chat_members.exists.where({
+          chat_id: chat.id,
+          user_id: session.user_id,
+        }),
+      ]),
+    ),
+    policy.chats.allowInsert.always(),
+    policy.chats.allowUpdate.always(),
+    policy.chats.allowDelete.always(),
+
+    policy.chat_members.allowRead.where(
+      anyOf([{ user_id: session.user_id }, allowedTo.read("chat_id")]),
+    ),
+    policy.chat_members.allowInsert.always(),
+    policy.chat_members.allowUpdate.always(),
+    policy.chat_members.allowDelete.always(),
+
+    policy.messages.allowRead.never(),
+    policy.messages.allowInsert.never(),
+    policy.messages.allowUpdate.never(),
+    policy.messages.allowDelete.never(),
+
+    policy.announcements.allowRead.never(),
+    policy.announcements.allowInsert.never(),
+    policy.announcements.allowUpdate.never(),
+    policy.announcements.allowDelete.never(),
+  ],
+);
+
 const camelChatStyleMessagePermissions = schema.definePermissions(
   camelChatApp,
   ({ policy, anyOf, allowedTo, session }) => [
@@ -726,6 +765,54 @@ describe("raw websocket private read gate", () => {
           .orderBy("createdAt", "desc"),
         (rows) => rows.some((row) => row.id === bobMessage.id),
         "Alice should receive Bob's private invite message",
+        15_000,
+        "edge",
+      ),
+    ).resolves.toBeDefined();
+  }, 60_000);
+
+  it("delivers a parent row after an external-JWT membership grant satisfies a claim disjunction", async () => {
+    const { appId, serverUrl, adminSecret } = await getJazzServerInfo(
+      uniqueDbName("external-owner-or-member-read"),
+    );
+    await publishSchemaAndPermissions(appId, serverUrl, adminSecret, ownerOrMembershipPermissions);
+
+    const [ownerToken, managerToken] = await Promise.all([
+      getJazzServerJwtForUser("external-owner", undefined, appId),
+      getJazzServerJwtForUser("external-manager", undefined, appId),
+    ]);
+    const owner = await openJwtUserDb(appId, serverUrl, "external-owner", ownerToken);
+    const manager = await openJwtUserDb(appId, serverUrl, "external-manager", managerToken);
+    const chat = await owner
+      .insert(app.chats, {
+        title: `owner-or-member-${Date.now()}`,
+        visibility: "private",
+        owner_id: "external-owner",
+      })
+      .wait({ tier: "edge" });
+    await owner
+      .insert(app.chat_members, { chat_id: chat.id, user_id: "external-owner" })
+      .wait({ tier: "edge" });
+    const managerMembership = await owner
+      .insert(app.chat_members, { chat_id: chat.id, user_id: "external-manager" })
+      .wait({ tier: "edge" });
+
+    await expect(
+      waitForQuery(
+        manager,
+        app.chat_members.where({ id: managerMembership.id, user_id: "external-manager" }),
+        (rows) => rows.length === 1,
+        "external manager receives its direct membership grant",
+        15_000,
+        "edge",
+      ),
+    ).resolves.toBeDefined();
+    await expect(
+      waitForQuery(
+        manager,
+        app.chats.where({ id: chat.id }),
+        (rows) => rows.some((row) => row.id === chat.id),
+        "external manager receives the parent through the membership disjunct",
         15_000,
         "edge",
       ),

--- a/packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts
+++ b/packages/jazz-tools/tests/browser/db.private-read-gate.server.test.ts
@@ -180,6 +180,49 @@ const ownerOrMembershipPermissions = schema.definePermissions(
   ],
 );
 
+// This isolates the index-only physical shape used by application schemas.
+// The smaller receipt above proves the logical policy and external-JWT path;
+// this one keeps the same proof while exercising selective access paths.
+const indexedOwnerMembershipApp = schema.defineApp({
+  chats: schema
+    .table({
+      title: schema.string(),
+      owner_id: schema.string(),
+    })
+    .indexOnly(["owner_id"]),
+  chat_members: schema
+    .table({
+      chat_id: schema.ref("chats"),
+      user_id: schema.string(),
+      role: schema.enum("owner", "member"),
+    })
+    .indexOnly(["chat_id", "user_id", "role"]),
+});
+
+const indexedOwnerOrMembershipPermissions = schema.definePermissions(
+  indexedOwnerMembershipApp,
+  ({ policy, anyOf, allowedTo, session }) => [
+    policy.chats.allowRead.where((chat) =>
+      anyOf([
+        { owner_id: session.user_id },
+        policy.chat_members.exists.where({
+          chat_id: chat.id,
+          user_id: session.user_id,
+        }),
+      ]),
+    ),
+    policy.chats.allowInsert.always(),
+    policy.chats.allowUpdate.always(),
+    policy.chats.allowDelete.always(),
+    policy.chat_members.allowRead.where(
+      anyOf([{ user_id: session.user_id }, allowedTo.read("chat_id")]),
+    ),
+    policy.chat_members.allowInsert.always(),
+    policy.chat_members.allowUpdate.always(),
+    policy.chat_members.allowDelete.always(),
+  ],
+);
+
 const camelChatStyleMessagePermissions = schema.definePermissions(
   camelChatApp,
   ({ policy, anyOf, allowedTo, session }) => [
@@ -813,6 +856,70 @@ describe("raw websocket private read gate", () => {
         app.chats.where({ id: chat.id }),
         (rows) => rows.some((row) => row.id === chat.id),
         "external manager receives the parent through the membership disjunct",
+        15_000,
+        "edge",
+      ),
+    ).resolves.toBeDefined();
+  }, 60_000);
+
+  it("delivers the indexed parent after an external-JWT membership grant", async () => {
+    const { appId, serverUrl, adminSecret } = await getJazzServerInfo(
+      uniqueDbName("external-indexed-owner-or-member-read"),
+    );
+    await publishSchemaAndPermissions(
+      appId,
+      serverUrl,
+      adminSecret,
+      indexedOwnerOrMembershipPermissions,
+      indexedOwnerMembershipApp,
+    );
+
+    const [ownerToken, managerToken] = await Promise.all([
+      getJazzServerJwtForUser("indexed-external-owner", undefined, appId),
+      getJazzServerJwtForUser("indexed-external-manager", undefined, appId),
+    ]);
+    const owner = await openJwtUserDb(appId, serverUrl, "indexed-external-owner", ownerToken);
+    const manager = await openJwtUserDb(appId, serverUrl, "indexed-external-manager", managerToken);
+    const chat = await owner
+      .insert(indexedOwnerMembershipApp.chats, {
+        title: `indexed-owner-or-member-${Date.now()}`,
+        owner_id: "indexed-external-owner",
+      })
+      .wait({ tier: "edge" });
+    await owner
+      .insert(indexedOwnerMembershipApp.chat_members, {
+        chat_id: chat.id,
+        user_id: "indexed-external-owner",
+        role: "owner",
+      })
+      .wait({ tier: "edge" });
+    const managerMembership = await owner
+      .insert(indexedOwnerMembershipApp.chat_members, {
+        chat_id: chat.id,
+        user_id: "indexed-external-manager",
+        role: "member",
+      })
+      .wait({ tier: "edge" });
+
+    await expect(
+      waitForQuery(
+        manager,
+        indexedOwnerMembershipApp.chat_members.where({
+          id: managerMembership.id,
+          user_id: "indexed-external-manager",
+        }),
+        (rows) => rows.length === 1,
+        "external manager receives its indexed direct membership grant",
+        15_000,
+        "edge",
+      ),
+    ).resolves.toBeDefined();
+    await expect(
+      waitForQuery(
+        manager,
+        indexedOwnerMembershipApp.chats.where({ id: chat.id }),
+        (rows) => rows.some((row) => row.id === chat.id),
+        "external manager receives the indexed parent through membership",
         15_000,
         "edge",
       ),


### PR DESCRIPTION
🤖 Prevents indexed policy proof evaluation from dropping rows authorized by an alternative relational branch.

## Before

Access-path derivation collected equality constraints from an entire normalized authorization program and applied them as if every proof route required them. For a policy such as:

```text
owner_id = session.user_id
OR EXISTS members(chat_id = row.id AND user_id = session.user_id)
```

adding indexes on `owner_id` and membership columns could restrict the protected-table scan to the owner branch. A non-owner member then received its membership row but never the authorized parent row. The identical schema and data passed when indexes were absent.

## After

- Proof programs containing `Union`, `Join`, or `RecursiveRelation` do not advertise a derived source access path unless the planner can prove arm/source coverage.
- Those authorization proofs take the existing complete-scan path and continue through the same lowered evaluator.
- Pure conjunctive/scalar proofs retain their selective indexed access paths.
- Ordinary application query planning, ordering, and bounds are unchanged.

This is deliberately conservative: some relational policies may scan more than necessary, but indexes can no longer change authorization results. A future planner may recover those optimizations by deriving covered access paths per source/union arm.

## Receipts

- Paired indexed and unindexed real-DB membership-grant receipts produce the same authorized parent.
- Edge rehydration delivers the parent after the membership grant arrives.
- External-JWT browser coverage reproduces the same indexed shape.
- A probe metric proves the unsafe disjunctive proof takes zero index probes, while a simple conjunctive policy still indexes.
- Removing the bailout makes the indexed semantic receipt fail with an empty result.

## Verification

- `cargo test -p jazz --lib node::tests::harness:: -- --nocapture`: **450 passed, 0 failed, 2 ignored**
- Focused indexed/unindexed receipts: **2 passed**
- Independent adversarial review approved the conservative boundary and planted the no-bail regression.
- Rust formatting, clippy, sensitive-data guard, and diff checks pass.

The browser receipt will receive its final fresh-artifact run on the combined stack; the equivalent core failure and repair are deterministic.
