### PR TITLE
fix: bound complete shape registrations before admission

### DIFF
--- a/crates/jazz/SPEC/13_transport_message_fragmentation.md
+++ b/crates/jazz/SPEC/13_transport_message_fragmentation.md
@@ -45,7 +45,8 @@ Transport-only limits to remove:
 Limits retained for semantic or adversarial-resource reasons:
 
 - `MAX_WIRE_FRAME_BYTES`: allocation bound before frame decode;
-- `MAX_SHAPE_AST_BYTES`: executable query/shape complexity admission;
+- `MAX_SHAPE_REGISTRATION_BYTES`: retained query/shape AST and read-view option
+  admission budget;
 - commit-version, repair-ref, branch-key-qualified repair, known-state-ref and structured
   result depth/width limits: CPU/fan-out/state bounds independent of framing;
 - receiver in-flight/aggregate/advertised-length budgets and WebSocket frame

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -57,7 +57,7 @@ use crate::protocol::{
     SubscriptionKey, SyncMessage, TableLens,
 };
 use crate::protocol_limits::{
-    validate_fetch_row_versions, validate_known_state_declaration, validate_shape_ast_size,
+    validate_fetch_row_versions, validate_known_state_declaration, validate_shape_registration_size,
 };
 use crate::query::{
     Binding, BindingId, Operand, Predicate, Query, QueryError, RelationQuery, ShapeId,

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -2659,6 +2659,14 @@ pub(super) fn unregister_upstream_subscription_owner(
     }
 }
 
+pub(super) fn register_shape_rejection_matches(
+    subscription: SubscriptionKey,
+    shape: &ValidatedQuery,
+    opts: &RegisterShapeOptions,
+) -> bool {
+    shape.shape_id() == subscription.shape_id && opts.read_view_key() == subscription.read_view
+}
+
 pub(super) fn route_upstream_subscription_rejection(
     subscriptions: &SubscriptionList,
     owners: &UpstreamSubscriptionOwners,
@@ -2687,13 +2695,12 @@ pub(super) fn route_upstream_subscription_rejection(
             continue;
         }
         let SubscriptionKind::Prepared { shape, binding, .. } = &state_ref.kind;
-        let read_view = RegisterShapeOptions {
+        let opts = RegisterShapeOptions {
             tier: state_ref.remote_read_tier.unwrap_or(state_ref.read_tier),
             read_view: state_ref.read_view.clone(),
             propagate_upstream: state_ref.remote_propagate_upstream,
-        }
-        .read_view_key();
-        if shape.shape_id() != subscription.shape_id || read_view != subscription.read_view {
+        };
+        if !register_shape_rejection_matches(subscription, shape, &opts) {
             continue;
         }
         if subscription.binding_id != BindingId(uuid::Uuid::nil())

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2142,25 +2142,17 @@ where
                             opts,
                             ast,
                         } => {
-                            let registration_key = (shape_id, opts.read_view_key());
-                            if let Err(message) = validate_shape_ast_size(&ast) {
-                                shape_registrations.insert(
-                                    registration_key,
-                                    SubscriberShapeRegistration::RejectedUnsupportedCapability(
-                                        message.clone(),
-                                    ),
-                                );
-                                send_unsupported_shape_capability_rejection(
-                                    &mut *self.transport,
-                                    register_shape_rejection_subscription(
-                                        shape_id,
-                                        opts.read_view_key(),
-                                    ),
-                                    message,
-                                )
-                                .map_err(transport_error)?;
-                                continue;
+                            if let Err(message) =
+                                validate_shape_registration_size(&ast, &opts)
+                            {
+                                // No stable subscription key exists before the
+                                // read-view key is derived. Fail the peer link
+                                // rather than inventing unnegotiated wire
+                                // semantics or hashing attacker-sized options.
+                                return Err(Error::new(ErrorCode::Protocol, message));
                             }
+                            let read_view_key = opts.read_view_key();
+                            let registration_key = (shape_id, read_view_key);
                             if let Err(error) = ensure_supported_register_shape_options(
                                 &opts,
                                 *local_receiver,
@@ -2176,7 +2168,7 @@ where
                                     &mut *self.transport,
                                     register_shape_rejection_subscription(
                                         shape_id,
-                                        opts.read_view_key(),
+                                        read_view_key,
                                     ),
                                     error.message,
                                 )
@@ -2196,7 +2188,7 @@ where
                                             &mut *self.transport,
                                             register_shape_rejection_subscription(
                                                 shape_id,
-                                                opts.read_view_key(),
+                                                read_view_key,
                                             ),
                                             &error,
                                         )
@@ -2247,7 +2239,7 @@ where
                                         let subscription = SubscriptionKey {
                                             shape_id,
                                             binding_id: binding.binding_id(),
-                                            read_view: opts.read_view_key(),
+                                            read_view: read_view_key,
                                         };
                                         send_unsupported_shape_capability_rejection(
                                             &mut *self.transport,
@@ -2262,7 +2254,7 @@ where
                                             SubscriptionKey {
                                                 shape_id,
                                                 binding_id: binding.binding_id(),
-                                                read_view: opts.read_view_key(),
+                                                read_view: read_view_key,
                                             },
                                             &error,
                                         )
@@ -2288,7 +2280,7 @@ where
                                             &mut *self.transport,
                                             register_shape_rejection_subscription(
                                                 shape_id,
-                                                opts.read_view_key(),
+                                                read_view_key,
                                             ),
                                             detail.clone(),
                                         )

--- a/crates/jazz/src/db/tests/mod.rs
+++ b/crates/jazz/src/db/tests/mod.rs
@@ -40,7 +40,7 @@ use crate::protocol::{
 };
 use crate::protocol_limits::{
     MAX_FETCH_ROW_VERSIONS, MAX_INFLIGHT_LOGICAL_MESSAGES, MAX_KNOWN_STATE_EXACT_REFS,
-    MAX_LOGICAL_MESSAGE_BYTES, MAX_SHAPE_AST_BYTES, MAX_WIRE_FRAME_BYTES,
+    MAX_LOGICAL_MESSAGE_BYTES, MAX_SHAPE_REGISTRATION_BYTES, MAX_WIRE_FRAME_BYTES,
 };
 use crate::query::{
     ArraySubquery, BindingId, Include, JoinMode, OrderDirection, Predicate, RelationOrderBy,

--- a/crates/jazz/src/db/tests/peer_connection/authorization_scope.rs
+++ b/crates/jazz/src/db/tests/peer_connection/authorization_scope.rs
@@ -861,35 +861,31 @@ fn oversized_register_shape_read_view_is_rejected_before_key_derivation_or_reten
                     local_base: TxTime(0),
                     dots: vec![
                         TxId::new(TxTime(1), NodeUuid::from_bytes([0x97; 16]));
-                        MAX_SHAPE_AST_BYTES
+                        MAX_SHAPE_REGISTRATION_BYTES
                     ],
                 },
             },
         },
         ..RegisterShapeOptions::default()
     };
+    let shape_id = shape.shape_id();
     let (mut client_transport, server_transport) = duplex();
     let subscriber = server.accept_subscriber(server_transport, AuthorId::from_bytes([0x96; 16]));
 
     client_transport
         .send(SyncMessage::RegisterShape {
-            shape_id: shape.shape_id(),
+            shape_id,
             ast: ShapeAst::from_validated(&shape),
             opts: oversized_opts,
         })
         .unwrap();
-    subscriber.borrow_mut().tick().unwrap();
+    let error = subscriber.borrow_mut().tick().unwrap_err();
 
-    assert_subscribe_rejected_unsupported_shape_capability_detail(
-        client_transport
-            .try_recv()
-            .expect("oversized registration must receive a rejection"),
-        SubscriptionKey {
-            shape_id: shape.shape_id(),
-            binding_id: BindingId(uuid::Uuid::nil()),
-            read_view: crate::protocol::ReadViewKey::default(),
-        },
-        "shape registration size",
+    assert_eq!(error.code, crate::db::ErrorCode::Protocol);
+    assert!(error.message.contains("shape registration size"));
+    assert!(
+        client_transport.try_recv().is_none(),
+        "an invalid oversized registration must terminate the link instead of using a new wire-level rejection convention"
     );
     let subscriber = subscriber.borrow();
     let crate::db::peer_connection::ConnectionLink::Subscriber(state) = &subscriber.link else {
@@ -905,7 +901,7 @@ fn oversized_register_shape_read_view_is_rejected_before_key_derivation_or_reten
 fn oversized_register_shape_is_rejected_at_admission() {
     let schema = schema();
     let server = open_core(0x5e, AuthorId::SYSTEM, &schema);
-    let huge_table = "t".repeat(MAX_SHAPE_AST_BYTES + 1);
+    let huge_table = "t".repeat(MAX_SHAPE_REGISTRATION_BYTES + 1);
     let ast = ShapeAst::new(Query::from(huge_table), schema.version_id());
     let error = server
         .node()
@@ -918,7 +914,7 @@ fn oversized_register_shape_is_rejected_at_admission() {
         .unwrap_err();
     assert!(matches!(
         error,
-        crate::node::Error::UnsupportedSyncMessage("shape AST exceeds byte limit")
+        crate::node::Error::UnsupportedSyncMessage("shape registration exceeds byte limit")
     ));
 }
 

--- a/crates/jazz/src/db/tests/peer_connection/authorization_scope.rs
+++ b/crates/jazz/src/db/tests/peer_connection/authorization_scope.rs
@@ -845,6 +845,62 @@ fn subscriber_cannot_spoof_authority_view_updates() {
     assert!(!node.opening_pending_for_binding_view(binding_view));
 }
 
+// This stays internal because the admission ordering and retained peer registration
+// state are not exposed through the public client API.
+#[test]
+fn oversized_register_shape_read_view_is_rejected_before_key_derivation_or_retention() {
+    let schema = schema();
+    let server = open_core(0x5d, AuthorId::SYSTEM, &schema);
+    let shape = Query::from("todos").validate(&schema).unwrap();
+    let oversized_opts = RegisterShapeOptions {
+        read_view: ReadViewSpec {
+            source: ReadViewSourceSpec::Snapshot {
+                snapshot: SnapshotRef {
+                    owner: NodeUuid::from_bytes([0x98; 16]),
+                    global_base: GlobalTime(0),
+                    local_base: TxTime(0),
+                    dots: vec![
+                        TxId::new(TxTime(1), NodeUuid::from_bytes([0x97; 16]));
+                        MAX_SHAPE_AST_BYTES
+                    ],
+                },
+            },
+        },
+        ..RegisterShapeOptions::default()
+    };
+    let (mut client_transport, server_transport) = duplex();
+    let subscriber = server.accept_subscriber(server_transport, AuthorId::from_bytes([0x96; 16]));
+
+    client_transport
+        .send(SyncMessage::RegisterShape {
+            shape_id: shape.shape_id(),
+            ast: ShapeAst::from_validated(&shape),
+            opts: oversized_opts,
+        })
+        .unwrap();
+    subscriber.borrow_mut().tick().unwrap();
+
+    assert_subscribe_rejected_unsupported_shape_capability_detail(
+        client_transport
+            .try_recv()
+            .expect("oversized registration must receive a rejection"),
+        SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: BindingId(uuid::Uuid::nil()),
+            read_view: crate::protocol::ReadViewKey::default(),
+        },
+        "shape registration size",
+    );
+    let subscriber = subscriber.borrow();
+    let crate::db::peer_connection::ConnectionLink::Subscriber(state) = &subscriber.link else {
+        panic!("accepted subscriber must retain subscriber connection state");
+    };
+    assert!(
+        state.shape_registrations.is_empty(),
+        "oversized read-view options must not be retained"
+    );
+}
+
 #[test]
 fn oversized_register_shape_is_rejected_at_admission() {
     let schema = schema();

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -10,7 +10,7 @@
 use super::*;
 use crate::protocol::{CatalogueAck, LensOp, SchemaLineagePublication, VersionBundleRef};
 use crate::protocol_limits::{
-    commit_unit_limit_violation, validate_known_state_declaration, validate_shape_ast_size,
+    commit_unit_limit_violation, validate_known_state_declaration, validate_shape_registration_size,
 };
 use crate::schema::{ColumnSchema, MERGE_HEADS_TABLE};
 use groove::records::ValueType;

--- a/crates/jazz/src/node/ingest/catalogue.rs
+++ b/crates/jazz/src/node/ingest/catalogue.rs
@@ -254,10 +254,10 @@ where
                 SyncMessage::RegisterShape {
                     shape_id,
                     ast,
-                    opts: _,
+                    opts,
                 } => {
-                    validate_shape_ast_size(&ast).map_err(|_| {
-                        Error::UnsupportedSyncMessage("shape AST exceeds byte limit")
+                    validate_shape_registration_size(&ast, &opts).map_err(|_| {
+                        Error::UnsupportedSyncMessage("shape registration exceeds byte limit")
                     })?;
                     self.register_shape(shape_id, ast)?;
                     Ok(PublicationOutcome::settled(Vec::new()))

--- a/crates/jazz/src/protocol_limits.rs
+++ b/crates/jazz/src/protocol_limits.rs
@@ -1,10 +1,13 @@
 //! Admission and semantic size limits for Jazz protocol payloads.
 //!
-//! These limits protect allocation at the wire boundary and keep oversized
-//! semantic requests recoverable. Server shells may eventually surface these as
-//! configuration, but the core owns the default contract.
+//! These limits protect allocation at the wire boundary. Oversized operations
+//! with an already-derived correlation key can be rejected in-band; an
+//! oversized shape registration is rejected before key derivation and is
+//! therefore fatal to the offending peer link. The core owns this contract.
 
-use crate::protocol::{KnownStateDeclaration, RowVersionRef, ShapeAst, VersionRecord};
+use crate::protocol::{
+    KnownStateDeclaration, RegisterShapeOptions, RowVersionRef, ShapeAst, VersionRecord,
+};
 
 /// Maximum encoded `WireFrame` bytes accepted before postcard decode.
 ///
@@ -32,13 +35,20 @@ pub const MAX_INFLIGHT_LOGICAL_MESSAGE_BYTES: usize = MAX_LOGICAL_MESSAGE_BYTES;
 /// Per-peer fairness bound for concurrently incomplete logical messages.
 pub const MAX_INFLIGHT_LOGICAL_MESSAGES: usize = 4;
 
-/// Maximum postcard-encoded query shape registration payload.
+/// Maximum postcard-encoded query shape AST payload.
 ///
-/// Source: existing wire fixtures use tiny shapes; 64 KiB leaves headroom for
-/// generated policy/query shapes without letting `ShapeAst` become an allocation
+/// This remains the public AST-only contract for callers that validate shapes
+/// before constructing registration options.
+pub const MAX_SHAPE_AST_BYTES: usize = 64 * 1024;
+
+/// Maximum postcard-encoded retained shape registration payload.
+///
+/// Source: existing wire fixtures use tiny registrations; 64 KiB leaves
+/// headroom for generated policy/query shapes and ordinary read views without
+/// letting either `ShapeAst` or `RegisterShapeOptions` become an allocation
 /// vector. Server shells may make this configurable later for unusually large
 /// generated schemas.
-pub const MAX_SHAPE_AST_BYTES: usize = 64 * 1024;
+pub const MAX_SHAPE_REGISTRATION_BYTES: usize = MAX_SHAPE_AST_BYTES;
 
 /// Maximum number of row-version records in one commit unit.
 ///
@@ -69,11 +79,22 @@ pub fn validate_logical_message_len(len: usize) -> Result<(), String> {
     validate_len("logical message payload", len, MAX_LOGICAL_MESSAGE_BYTES)
 }
 
-/// Validate a shape registration after sync-message decode but before storing it.
+/// Validate the shape AST independently of its registration options.
 pub fn validate_shape_ast_size(ast: &ShapeAst) -> Result<(), String> {
-    let bytes = postcard::to_allocvec(ast)
+    let size = postcard::experimental::serialized_size(ast)
         .map_err(|err| format!("failed to measure shape AST payload: {err}"))?;
-    validate_len("shape AST", bytes.len(), MAX_SHAPE_AST_BYTES)
+    validate_len("shape AST", size, MAX_SHAPE_AST_BYTES)
+}
+
+/// Validate a complete shape registration after sync-message decode but before
+/// deriving its read-view key or storing either component.
+pub fn validate_shape_registration_size(
+    ast: &ShapeAst,
+    opts: &RegisterShapeOptions,
+) -> Result<(), String> {
+    let size = postcard::experimental::serialized_size(&(ast, opts))
+        .map_err(|err| format!("failed to measure shape registration payload: {err}"))?;
+    validate_len("shape registration", size, MAX_SHAPE_REGISTRATION_BYTES)
 }
 
 /// Validate row-version repair request size after sync-message decode.


### PR DESCRIPTION
## Summary

- apply the shape-registration byte limit to the complete serialized `(ShapeAst, RegisterShapeOptions)` payload
- reject oversized peer registrations before read-view-key derivation or retained registration state
- preserve the existing AST-only public limit APIs and wire protocol version
- treat an oversized registration as fatal to the offending peer link because no stable subscription key exists before key derivation

## Validation

- `dev/t db::tests::peer_connection::authorization_scope::oversized_register_shape_read_view_is_rejected_before_key_derivation_or_retention`
- `dev/t db::tests::peer_connection::authorization_scope::oversized_register_shape_is_rejected_at_admission`
- `dev/t db::tests::peer_connection::authorization_scope::legacy_authorization_scope_subscribe_rejects_every_read_view`
- `cargo test -p jazz --test wire_fixtures wire_message_frame_fixtures_are_current -- --exact`
- pre-commit Rustfmt and Clippy checks