### PR TITLE
fix: make React client acquisition lifecycle-safe

### DIFF
--- a/.changeset/react-provider-ssr-lifecycle.md
+++ b/.changeset/react-provider-ssr-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Defer React `JazzProvider` client acquisition until the browser commit lifecycle so server rendering stays side-effect free and hydration starts from the configured fallback.

--- a/packages/jazz-tools/src/react-core/provider.ssr.test.tsx
+++ b/packages/jazz-tools/src/react-core/provider.ssr.test.tsx
@@ -1,0 +1,208 @@
+import React from "react";
+import { act, render, type RenderResult } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbConfig } from "../runtime/db.js";
+import { JazzProvider } from "./provider.js";
+import { makeFakeClient } from "./test-utils.js";
+
+const registry = vi.hoisted(() => {
+  const entries = new Map<string, { promise: Promise<unknown>; holders: Set<object> }>();
+  const events: string[] = [];
+  const releaseGates = new Map<string, Promise<void>>();
+
+  return {
+    entries,
+    events,
+    releaseGates,
+    acquireClient: vi.fn(
+      (key: string, create: () => Promise<unknown>, holder: object): Promise<unknown> => {
+        events.push(`acquire:${key}`);
+        let entry = entries.get(key);
+        if (!entry) {
+          entry = { promise: create(), holders: new Set() };
+          entries.set(key, entry);
+        }
+        entry.holders.add(holder);
+        return entry.promise;
+      },
+    ),
+    releaseClient: vi.fn(async (key: string, holder: object): Promise<void> => {
+      events.push(`release:${key}`);
+      await releaseGates.get(key);
+      const entry = entries.get(key);
+      if (!entry) return;
+      entry.holders.delete(holder);
+      if (entry.holders.size === 0) entries.delete(key);
+    }),
+  };
+});
+
+vi.mock("../runtime/client-registry.js", () => ({
+  acquireClient: registry.acquireClient,
+  releaseClient: registry.releaseClient,
+}));
+
+beforeEach(() => {
+  registry.entries.clear();
+  registry.releaseGates.clear();
+  registry.events.length = 0;
+  registry.acquireClient.mockClear();
+  registry.releaseClient.mockClear();
+});
+
+describe("JazzProvider client acquisition lifecycle", () => {
+  it("renders its fallback on the server without acquiring or retaining a client", () => {
+    const createJazzClient = vi.fn(async () =>
+      makeFakeClient({ authMode: "local-first", userId: "server", claims: {} }),
+    );
+
+    const html = renderToStaticMarkup(
+      <JazzProvider
+        config={{ appId: "app-1", serverUrl: "https://jazz.example.com" }}
+        createJazzClient={createJazzClient}
+        fallback={<p id="loading">loading</p>}
+      >
+        <p>ready</p>
+      </JazzProvider>,
+    );
+
+    expect(html).toBe('<p id="loading">loading</p>');
+    expect(registry.acquireClient).not.toHaveBeenCalled();
+    expect(createJazzClient).not.toHaveBeenCalled();
+    expect(registry.entries.size).toBe(0);
+  });
+
+  it("acquires one lease after mount and releases each config on replacement and unmount", async () => {
+    const initialConfig: DbConfig = {
+      appId: "app-1",
+      serverUrl: "https://jazz.example.com",
+      secret: "anonymous",
+    };
+    const replacementConfig: DbConfig = {
+      appId: "app-1",
+      serverUrl: "https://jazz.example.com",
+      jwtToken: "token",
+    };
+    const initialKey = `react:${JSON.stringify(initialConfig)}`;
+    const replacementKey = `react:${JSON.stringify(replacementConfig)}`;
+    const createJazzClient = vi.fn(async () =>
+      makeFakeClient({ authMode: "local-first", userId: "browser", claims: {} }),
+    );
+
+    let result!: RenderResult;
+    await act(async () => {
+      result = render(
+        <JazzProvider
+          config={initialConfig}
+          createJazzClient={createJazzClient}
+          fallback={<p>loading</p>}
+        >
+          <p>ready</p>
+        </JazzProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(registry.events).toEqual([`acquire:${initialKey}`]);
+    expect(registry.acquireClient).toHaveBeenCalledTimes(1);
+    expect(registry.entries.get(initialKey)?.holders.size).toBe(1);
+    const holder = registry.acquireClient.mock.calls[0]?.[2];
+
+    await act(async () => {
+      result.rerender(
+        <JazzProvider
+          config={replacementConfig}
+          createJazzClient={createJazzClient}
+          fallback={<p>loading</p>}
+        >
+          <p>ready</p>
+        </JazzProvider>,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(registry.events).toEqual([
+      `acquire:${initialKey}`,
+      `release:${initialKey}`,
+      `acquire:${replacementKey}`,
+    ]);
+    expect(registry.entries.has(initialKey)).toBe(false);
+    expect(registry.entries.get(replacementKey)?.holders).toEqual(new Set([holder]));
+
+    await act(async () => {
+      result.unmount();
+      await Promise.resolve();
+    });
+
+    expect(registry.events).toEqual([
+      `acquire:${initialKey}`,
+      `release:${initialKey}`,
+      `acquire:${replacementKey}`,
+      `release:${replacementKey}`,
+    ]);
+    expect(registry.entries.size).toBe(0);
+  });
+
+  it("does not acquire a replacement cancelled behind an in-flight release", async () => {
+    const initialConfig: DbConfig = {
+      appId: "app-1",
+      serverUrl: "https://jazz.example.com",
+      secret: "anonymous",
+    };
+    const replacementConfig: DbConfig = {
+      appId: "app-1",
+      serverUrl: "https://jazz.example.com",
+      jwtToken: "token",
+    };
+    const initialKey = `react:${JSON.stringify(initialConfig)}`;
+    let resolveRelease!: () => void;
+    const releaseGate = new Promise<void>((resolve) => {
+      resolveRelease = resolve;
+    });
+    const createJazzClient = vi.fn(async () =>
+      makeFakeClient({ authMode: "local-first", userId: "browser", claims: {} }),
+    );
+
+    let result!: RenderResult;
+    await act(async () => {
+      result = render(
+        <JazzProvider
+          config={initialConfig}
+          createJazzClient={createJazzClient}
+          fallback={<p>loading</p>}
+        >
+          <p>ready</p>
+        </JazzProvider>,
+      );
+      await Promise.resolve();
+    });
+    registry.releaseGates.set(initialKey, releaseGate);
+
+    await act(async () => {
+      result.rerender(
+        <JazzProvider
+          config={replacementConfig}
+          createJazzClient={createJazzClient}
+          fallback={<p>loading</p>}
+        >
+          <p>ready</p>
+        </JazzProvider>,
+      );
+      await Promise.resolve();
+    });
+    expect(registry.acquireClient).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.unmount();
+      resolveRelease();
+      await releaseGate;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(registry.acquireClient).toHaveBeenCalledTimes(1);
+    expect(registry.entries.size).toBe(0);
+  });
+});

--- a/packages/jazz-tools/src/react-core/provider.tsx
+++ b/packages/jazz-tools/src/react-core/provider.tsx
@@ -41,6 +41,7 @@ export type JazzClientProviderProps = {
 
 export type JazzProviderProps = {
   config: DbConfig;
+  /** Rendered during SSR and until client acquisition completes after browser commit. */
   fallback?: ReactNode;
   children: ReactNode;
   createJazzClient: CreateJazzClient;
@@ -200,8 +201,8 @@ export function JazzProvider({
   createJazzClient,
   onJWTExpired,
 }: JazzProviderProps) {
-  // Stable per-provider identity; used as the Set key so the useState
-  // initializer and useEffect don't double-count the same provider.
+  // Stable per-provider identity, used as the registry holder across effect
+  // cleanup and re-acquisition (including React Strict Mode's effect replay).
   const holder = useRef({}).current;
 
   // Keep the framework-level lease distinct from createJazzClient's own shared
@@ -209,36 +210,54 @@ export function JazzProvider({
   // makes provider teardown recursively release itself instead of the runtime.
   const configKey = `react:${JSON.stringify(config)}`;
 
-  const [clientPromise, setClientPromise] = useState(() => {
-    return acquireClient<CoreJazzClient>(configKey, config, createJazzClient, holder);
-  });
-  const activeConfigKey = useRef(configKey);
+  const [clientLease, setClientLease] = useState<{
+    configKey: string;
+    promise: Promise<CoreJazzClient>;
+  } | null>(null);
+  const lifecycle = useRef<{
+    configKey: string | null;
+    release: Promise<void>;
+  }>({ configKey: null, release: Promise.resolve() });
 
   useEffect(() => {
     let cancelled = false;
-    const previousConfigKey = activeConfigKey.current;
-    activeConfigKey.current = configKey;
-    const clientPromise =
-      previousConfigKey === configKey
-        ? acquireClient<CoreJazzClient>(configKey, config, createJazzClient, holder)
-        : releaseClient(previousConfigKey, holder)
-            .then(() => acquireClient<CoreJazzClient>(configKey, config, createJazzClient, holder))
-            .then((client) => {
-              if (cancelled) void releaseClient(configKey, holder);
-              return client;
-            });
-
-    setClientPromise(clientPromise);
+    let acquired = false;
+    const previous = lifecycle.current;
+    // A same-key re-acquire must run immediately so the registry can cancel its
+    // deferred release during Strict Mode replay. A different key waits for the
+    // complete prior lifecycle, including any replacement that was cancelled
+    // before it acquired a lease.
+    const ready = previous.configKey === configKey ? Promise.resolve() : previous.release;
+    const acquisition = ready.then(() => {
+      if (cancelled) return;
+      const promise = acquireClient<CoreJazzClient>(configKey, config, createJazzClient, holder);
+      acquired = true;
+      setClientLease({ configKey, promise });
+    });
 
     return () => {
       cancelled = true;
-      void releaseClient(configKey, holder);
+      lifecycle.current = {
+        configKey,
+        release: acquisition.then(() => {
+          if (acquired) {
+            return releaseClient(configKey, holder);
+          }
+        }),
+      };
     };
   }, [configKey, createJazzClient, holder]);
 
+  // Effects do not run during SSR. Rendering the same fallback before the first
+  // browser commit keeps hydration stable while deferring all registry work to
+  // the committed lifecycle.
+  if (clientLease?.configKey !== configKey) {
+    return <>{fallback}</>;
+  }
+
   return (
     <React.Suspense fallback={fallback}>
-      <JazzClientProvider client={clientPromise} onJWTExpired={onJWTExpired}>
+      <JazzClientProvider client={clientLease.promise} onJWTExpired={onJWTExpired}>
         {children}
       </JazzClientProvider>
     </React.Suspense>

--- a/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
+++ b/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import {
   JazzClientProvider as JazzProvider,
+  JazzProvider as ConfiguredJazzProvider,
   useDb,
   useSession,
 } from "../../src/react-core/provider.js";
@@ -119,6 +120,52 @@ afterEach(() => {
 });
 
 describe("react-core provider/hooks browser coverage", () => {
+  it("acquires configured clients after browser mount and releases replacements", async () => {
+    const initialClient = makeClient({ db: { name: "initial-db" } });
+    initialClient.shutdown = vi.fn(async () => {});
+    const replacementClient = makeClient({ db: { name: "replacement-db" } });
+    replacementClient.shutdown = vi.fn(async () => {});
+    const createJazzClient = vi
+      .fn()
+      .mockResolvedValueOnce(initialClient)
+      .mockResolvedValueOnce(replacementClient);
+
+    render(
+      <ConfiguredJazzProvider
+        config={{ appId: "provider-browser-lifecycle", secret: "anonymous" }}
+        createJazzClient={createJazzClient}
+        fallback={<div data-testid="configured-provider">loading</div>}
+      >
+        <DbNameView />
+      </ConfiguredJazzProvider>,
+    );
+
+    await expectText("db-name", "initial-db");
+    expect(createJazzClient).toHaveBeenCalledTimes(1);
+
+    render(
+      <ConfiguredJazzProvider
+        config={{ appId: "provider-browser-lifecycle", jwtToken: "token" }}
+        createJazzClient={createJazzClient}
+        fallback={<div data-testid="configured-provider">loading</div>}
+      >
+        <DbNameView />
+      </ConfiguredJazzProvider>,
+    );
+
+    await expectText("db-name", "replacement-db");
+    expect(initialClient.shutdown).toHaveBeenCalledOnce();
+    expect(createJazzClient).toHaveBeenCalledTimes(2);
+
+    render(null);
+
+    await waitForCondition(
+      () => vi.mocked(replacementClient.shutdown).mock.calls.length === 1,
+      3000,
+      "Expected the replacement configured client to shut down after unmount",
+    );
+  });
+
   it("RCB-B01: provider accepts already-resolved client object", async () => {
     const client = makeClient({ db: { name: "resolved-db" } });
 


### PR DESCRIPTION
## Summary

- keep `JazzProvider` from acquiring a shared client during server rendering
- serialize different-config client lifecycles so replacement waits for the previous release
- prevent a canceled replacement from acquiring after unmount
- preserve same-config Strict Mode reacquisition and release pending clients correctly

## Validation

- focused React provider suites: 2 files, 5 tests passed
- focused browser lifecycle scenario: 1 passed, 17 skipped
- `pnpm --filter jazz-tools check`
- Oxfmt and Oxlint