### PR TITLE
fix: authenticate todo REST requests per session

### DIFF
--- a/examples/todo-server-ts/README.md
+++ b/examples/todo-server-ts/README.md
@@ -5,9 +5,9 @@ Node + Express REST API backed by Jazz as the database. No frontend — pure ser
 ## What it demonstrates
 
 - Using Jazz as a server-side backend via `jazz-tools/backend` and `createJazzContext` — no browser, no WASM.
-- CRUD over `/todos` (`GET`, `POST`, `PUT /:id`, `DELETE /:id`) with row-level permissions enforced server-side.
-- Per-session policy evaluation via `context.forSession(userId)` — the `/todos/as/:userId` endpoint impersonates a session so `definePermissions` filters rows by `owner_id`.
-- Server-Sent Events (`/todos/live`) pushing live snapshots to connected clients on every mutation.
+- Authenticated CRUD over `/todos` (`GET`, `POST`, `PUT /:id`, `DELETE /:id`) with row-level permissions enforced server-side.
+- Request authentication through `context.forRequest(req)`. Every `/todos` request sends `Authorization: Bearer <token>`; Jazz verifies the token and derives the session owner.
+- Server-Sent Events (`/todos/live`) pushing only the authenticated caller's live snapshot on every mutation.
 - Write durability control via `wait({ tier })` (`local`, `edge`, `global`).
 - Persistent Fjall storage rooted in a temp directory on cold start.
 
@@ -24,10 +24,24 @@ pnpm dev
 
 `pnpm dev` runs the server with `tsx watch` against `src/main.ts`. The HTTP API listens on a default port (see `main.ts`); a fresh Fjall database is created in a temp directory.
 
+## Authentication
+
+The API accepts Jazz local-first identity proofs as bearer tokens. A local-first client can mint
+one with `db.getLocalFirstIdentityProof()` and send it on every todo request:
+
+```bash
+curl -H "Authorization: Bearer $JAZZ_TOKEN" http://localhost:3000/todos
+```
+
+For an external auth provider, set either `JAZZ_JWKS_URL` or `JAZZ_JWT_PUBLIC_KEY` before
+starting the server. The JWT's verified `sub` claim becomes the Jazz session's `user_id`.
+Clients never send `owner_id`; `POST /todos` always assigns the authenticated session owner.
+The `/health` endpoint remains public.
+
 ## Tests
 
 ```bash
 pnpm test
 ```
 
-Vitest integration tests cover the CRUD lifecycle, session-scoped reads, and persistence/cold-start.
+Vitest integration tests cover request authentication, owner-scoped CRUD and live updates, and persistence/cold-start.

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -14,8 +14,6 @@ import { createJazzContext, type Db } from "jazz-tools/backend";
 import { app as schemaApp } from "../schema.js";
 import permissions from "../permissions.js";
 
-const DEFAULT_OWNER_ID = "93c209ee-dbae-5071-a90d-02f8c0bbcf6a";
-
 // ============================================================================
 // Types
 // ============================================================================
@@ -25,12 +23,12 @@ export interface Todo {
   title: string;
   done: boolean;
   description?: string;
+  owner_id: string;
 }
 
 interface CreateTodoRequest {
   title: string;
   description?: string;
-  owner_id?: string;
 }
 
 interface UpdateTodoRequest {
@@ -60,7 +58,7 @@ export interface RunningServer extends TodoServer {
  * Create a todo server.
  *
  * @param dataPath Optional path to local Fjall database file. If omitted, uses a temp directory.
- * @returns TodoServer with app, db, and shutdown function
+ * @returns TodoServer with the Express app, administrative database handle, and lifecycle functions
  */
 export async function createServer(dataPath?: string): Promise<TodoServer> {
   const dbPath = dataPath ?? join(mkdtempSync(join(tmpdir(), "jazz-todo-")), "jazz.db");
@@ -72,28 +70,32 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     permissions,
     driver: { type: "persistent", dataPath: dbPath },
     env: "dev",
+    jwksUrl: process.env.JAZZ_JWKS_URL,
+    jwtPublicKey: process.env.JAZZ_JWT_PUBLIC_KEY,
   });
+  // Preserve the programmatic administrative handle for embedding and tests.
+  // Network routes below exclusively use request-scoped databases.
   const db = context.asBackend();
 
-  // Create Express app
   const app = express();
-  app.use(express.json());
 
-  // Track active SSE connections for live updates
-  const sseConnections = new Set<Response>();
+  const sseConnections = new Map<Response, Db>();
 
-  // Helper to broadcast current todos to all SSE connections
   async function broadcastTodos() {
-    if (sseConnections.size === 0) {
-      return;
-    }
+    await Promise.all(
+      Array.from(sseConnections, async ([res, requestDb]) => {
+        const todos = await requestDb.all(schemaApp.todos);
+        res.write(`data: ${JSON.stringify(todos)}\n\n`);
+      }),
+    );
+  }
 
-    const todos = await db.all(schemaApp.todos);
-    const data = `data: ${JSON.stringify(todos)}\n\n`;
-
-    for (const res of sseConnections) {
-      res.write(data);
+  function requestDb(res: Response): Db {
+    const db = res.locals.requestDb as Db | undefined;
+    if (!db) {
+      throw new Error("Authenticated request database is unavailable");
     }
+    return db;
   }
 
   // ========================================================================
@@ -105,17 +107,35 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     res.json({ status: "healthy" });
   });
 
-  // List all todos
+  // Authenticate every todo request before selecting a session-scoped database.
+  app.use("/todos", async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const db = await context.forRequest(req);
+      const session = db.getAuthState().session;
+      if (!session) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+      res.locals.requestDb = db;
+      res.locals.userId = session.user_id;
+      next();
+    } catch {
+      res.status(401).json({ error: "Unauthorized" });
+    }
+  });
+  app.use(express.json());
+
+  // List the authenticated caller's todos
   app.get("/todos", async (_req: Request, res: Response, next: NextFunction) => {
     try {
-      const todos = await db.all(schemaApp.todos);
+      const todos = await requestDb(res).all(schemaApp.todos);
       res.json(todos);
     } catch (e) {
       next(e);
     }
   });
 
-  // Create a todo
+  // Create a todo owned by the authenticated caller
   app.post("/todos", async (req: Request, res: Response, next: NextFunction) => {
     try {
       const body = req.body as CreateTodoRequest;
@@ -125,65 +145,48 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         return;
       }
 
-      const inserted = db.insert(schemaApp.todos, {
+      const inserted = requestDb(res).insert(schemaApp.todos, {
         title: body.title,
         done: false,
         description: body.description?.trim(),
-        owner_id: body.owner_id ?? DEFAULT_OWNER_ID,
+        owner_id: res.locals.userId as string,
       });
       await inserted.wait({ tier: "local" });
+      await broadcastTodos();
 
       res.status(201).json(inserted.value);
-
-      // Notify SSE connections
-      await broadcastTodos();
     } catch (e) {
       next(e);
     }
   });
 
-  // List todos as a specific session user (for policy verification/testing)
-  app.get("/todos/as/:userId", async (req: Request, res: Response, next: NextFunction) => {
+  // Live SSE stream of the authenticated caller's todos (must be before /todos/:id)
+  app.get("/todos/live", async (_req: Request, res: Response, next: NextFunction) => {
     try {
-      const userDb = context.forSession({
-        user_id: req.params.userId,
-        authMode: "external",
-        claims: {},
+      const db = requestDb(res);
+      res.setHeader("Content-Type", "text/event-stream");
+      res.setHeader("Cache-Control", "no-cache");
+      res.setHeader("Connection", "keep-alive");
+      res.flushHeaders();
+
+      sseConnections.set(res, db);
+
+      const todos = await db.all(schemaApp.todos);
+      res.write(`data: ${JSON.stringify(todos)}\n\n`);
+
+      res.on("close", () => {
+        sseConnections.delete(res);
       });
-      const todos = await userDb.all(schemaApp.todos);
-      res.json(todos);
     } catch (e) {
       next(e);
     }
   });
 
-  // Live SSE stream of all todos (must be before /todos/:id)
-  app.get("/todos/live", async (_req: Request, res: Response) => {
-    // Set SSE headers
-    res.setHeader("Content-Type", "text/event-stream");
-    res.setHeader("Cache-Control", "no-cache");
-    res.setHeader("Connection", "keep-alive");
-    res.flushHeaders();
-
-    // Register this connection
-    sseConnections.add(res);
-
-    // Send initial state
-    const todos = await db.all(schemaApp.todos);
-    res.write(`data: ${JSON.stringify(todos)}\n\n`);
-
-    // Clean up on disconnect
-    res.on("close", () => {
-      sseConnections.delete(res);
-    });
-  });
-
-  // Get a single todo
+  // Get a single todo visible to the authenticated caller
   app.get("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params;
-
-      const todo = await db.one(schemaApp.todos.where({ id }));
+      const todo = await requestDb(res).one(schemaApp.todos.where({ id }));
       if (!todo) {
         res.status(404).json({ error: "Todo not found" });
         return;
@@ -195,11 +198,17 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     }
   });
 
-  // Update a todo
+  // Update a todo visible to the authenticated caller
   app.put("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params;
       const body = req.body as UpdateTodoRequest;
+      const db = requestDb(res);
+      const existing = await db.one(schemaApp.todos.where({ id }));
+      if (!existing) {
+        res.status(404).json({ error: "Todo not found" });
+        return;
+      }
 
       const updates = {
         title: body.title,
@@ -207,51 +216,38 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         description: body.description === undefined ? undefined : body.description.trim(),
       };
 
-      if (Object.values(updates).every((value) => value === undefined)) {
-        // No updates, just return the current todo
-        const todo = await db.one(schemaApp.todos.where({ id }));
-        if (!todo) {
-          res.status(404).json({ error: "Todo not found" });
-          return;
-        }
-        res.json(todo);
-        return;
+      if (Object.values(updates).some((value) => value !== undefined)) {
+        await db.update(schemaApp.todos, id, updates).wait({ tier: "local" });
+        await broadcastTodos();
       }
 
-      await db.update(schemaApp.todos, id, updates).wait({ tier: "local" });
-
-      // Fetch updated todo
       const todo = await db.one(schemaApp.todos.where({ id }));
       if (!todo) {
         res.status(404).json({ error: "Todo not found after update" });
         return;
       }
       res.json(todo);
-
-      // Notify SSE connections
-      await broadcastTodos();
     } catch (e) {
       next(e);
     }
   });
 
-  // Delete a todo
+  // Delete a todo visible to the authenticated caller
   app.delete("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params;
+      const db = requestDb(res);
+      const existing = await db.one(schemaApp.todos.where({ id }));
+      if (!existing) {
+        res.status(404).json({ error: "Todo not found" });
+        return;
+      }
 
       await db.delete(schemaApp.todos, id).wait({ tier: "local" });
-      res.status(204).send();
-
-      // Notify SSE connections
       await broadcastTodos();
+      res.status(204).send();
     } catch (e) {
-      const error = e as Error;
-      if (error.message?.includes("NotFound")) {
-        res.status(404).json({ error: "Todo not found" });
-      } else {
-        next(e);
-      }
+      next(e);
     }
   });
 

--- a/examples/todo-server-ts/tests/authentication.test.ts
+++ b/examples/todo-server-ts/tests/authentication.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mintLocalFirstToken, verifyLocalFirstIdentityProof } from "jazz-napi";
+import { randomUUID } from "node:crypto";
+import {
+  createServer,
+  startServer,
+  stopServer,
+  type RunningServer,
+  type Todo,
+} from "../src/main.ts";
+
+const APP_ID = "019d4349-244c-74d4-8573-8e1b24cf21e2";
+
+type Identity = {
+  token: string;
+  userId: string;
+};
+
+type OwnedTodo = Todo & {
+  owner_id: string;
+};
+
+function createIdentity(name: string): Identity {
+  const seed = Buffer.from(name.padEnd(32, "-").slice(0, 32)).toString("base64url");
+  const token = mintLocalFirstToken(seed, APP_ID, 60);
+  const result = verifyLocalFirstIdentityProof(token, APP_ID);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+  return { token, userId: result.id };
+}
+
+function authorization(identity: Identity): Record<string, string> {
+  return { Authorization: `Bearer ${identity.token}` };
+}
+
+describe("Todo Server request authentication", () => {
+  let server: RunningServer;
+  let baseUrl: string;
+  const alice = createIdentity("todo-rest-auth-alice");
+  const bob = createIdentity("todo-rest-auth-bob");
+
+  beforeAll(async () => {
+    server = await startServer(await createServer(), 0);
+    baseUrl = server.baseUrl;
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await stopServer(server);
+    }
+  });
+
+  const protectedRequests: Array<[string, string, RequestInit]> = [
+    ["list", "/todos", {}],
+    [
+      "create",
+      "/todos",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "must authenticate" }),
+      },
+    ],
+    ["read", `/todos/${randomUUID()}`, {}],
+    [
+      "update",
+      `/todos/${randomUUID()}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ done: true }),
+      },
+    ],
+    ["delete", `/todos/${randomUUID()}`, { method: "DELETE" }],
+    ["live stream", "/todos/live", {}],
+  ];
+
+  it.each(protectedRequests)("rejects missing credentials for %s", async (_name, path, init) => {
+    const response = await fetch(`${baseUrl}${path}`, init);
+    expect(response.status).toBe(401);
+    await response.body?.cancel();
+  });
+
+  it.each(protectedRequests)("rejects invalid credentials for %s", async (_name, path, init) => {
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: {
+        ...init.headers,
+        Authorization: "Bearer not-a-valid-token",
+      },
+    });
+    expect(response.status).toBe(401);
+    await response.body?.cancel();
+  });
+
+  it("derives ownership from the credential and enforces it across CRUD", async () => {
+    const createResponse = await fetch(`${baseUrl}/todos`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authorization(alice),
+      },
+      body: JSON.stringify({
+        title: "Alice private todo",
+        owner_id: bob.userId,
+      }),
+    });
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as OwnedTodo;
+    expect(created.owner_id).toBe(alice.userId);
+
+    const aliceListResponse = await fetch(`${baseUrl}/todos`, {
+      headers: authorization(alice),
+    });
+    expect(aliceListResponse.status).toBe(200);
+    const aliceTodos = (await aliceListResponse.json()) as OwnedTodo[];
+    expect(aliceTodos.map((todo) => todo.id)).toContain(created.id);
+
+    const bobListResponse = await fetch(`${baseUrl}/todos`, {
+      headers: authorization(bob),
+    });
+    expect(bobListResponse.status).toBe(200);
+    const bobTodos = (await bobListResponse.json()) as OwnedTodo[];
+    expect(bobTodos.map((todo) => todo.id)).not.toContain(created.id);
+
+    const bobReadResponse = await fetch(`${baseUrl}/todos/${created.id}`, {
+      headers: authorization(bob),
+    });
+    expect(bobReadResponse.status).toBe(404);
+
+    const bobUpdateResponse = await fetch(`${baseUrl}/todos/${created.id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        ...authorization(bob),
+      },
+      body: JSON.stringify({ done: true }),
+    });
+    expect(bobUpdateResponse.status).toBe(404);
+
+    const bobDeleteResponse = await fetch(`${baseUrl}/todos/${created.id}`, {
+      method: "DELETE",
+      headers: authorization(bob),
+    });
+    expect(bobDeleteResponse.status).toBe(404);
+
+    const aliceUpdateResponse = await fetch(`${baseUrl}/todos/${created.id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        ...authorization(alice),
+      },
+      body: JSON.stringify({ done: true }),
+    });
+    expect(aliceUpdateResponse.status).toBe(200);
+    expect(((await aliceUpdateResponse.json()) as Todo).done).toBe(true);
+
+    const aliceDeleteResponse = await fetch(`${baseUrl}/todos/${created.id}`, {
+      method: "DELETE",
+      headers: authorization(alice),
+    });
+    expect(aliceDeleteResponse.status).toBe(204);
+  });
+
+  it("does not expose a route that impersonates a caller-selected user", async () => {
+    const response = await fetch(`${baseUrl}/todos/as/${bob.userId}`, {
+      headers: authorization(alice),
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/examples/todo-server-ts/tests/integration.test.ts
+++ b/examples/todo-server-ts/tests/integration.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { randomUUID } from "node:crypto";
+import { mintLocalFirstToken, verifyLocalFirstIdentityProof } from "jazz-napi";
 import { tmpdir } from "node:os";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
@@ -17,6 +17,35 @@ import {
   type RunningServer,
   type Todo,
 } from "../src/main.ts";
+
+const APP_ID = "019d4349-244c-74d4-8573-8e1b24cf21e2";
+
+type Identity = {
+  token: string;
+  userId: string;
+};
+
+function createIdentity(name: string): Identity {
+  const seed = Buffer.from(name.padEnd(32, "-").slice(0, 32)).toString("base64url");
+  const token = mintLocalFirstToken(seed, APP_ID, 60);
+  const result = verifyLocalFirstIdentityProof(token, APP_ID);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+  return { token, userId: result.id };
+}
+
+const primaryIdentity = createIdentity("todo-rest-integration");
+
+function authenticatedFetch(
+  input: string | URL,
+  init: RequestInit = {},
+  identity = primaryIdentity,
+): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${identity.token}`);
+  return fetch(input, { ...init, headers });
+}
 
 describe("Todo Server Integration", () => {
   let server: RunningServer;
@@ -50,7 +79,7 @@ describe("Todo Server Integration", () => {
     let createdTodoId: string;
 
     it("creates a todo", async () => {
-      const res = await fetch(`${baseUrl}/todos`, {
+      const res = await authenticatedFetch(`${baseUrl}/todos`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -70,7 +99,7 @@ describe("Todo Server Integration", () => {
     });
 
     it("lists todos", async () => {
-      const res = await fetch(`${baseUrl}/todos`);
+      const res = await authenticatedFetch(`${baseUrl}/todos`);
       expect(res.status).toBe(200);
       const todos: Todo[] = await res.json();
       expect(Array.isArray(todos)).toBe(true);
@@ -82,7 +111,7 @@ describe("Todo Server Integration", () => {
     });
 
     it("gets a single todo", async () => {
-      const res = await fetch(`${baseUrl}/todos/${createdTodoId}`);
+      const res = await authenticatedFetch(`${baseUrl}/todos/${createdTodoId}`);
       expect(res.status).toBe(200);
       const todo: Todo = await res.json();
       expect(todo.id).toBe(createdTodoId);
@@ -90,7 +119,7 @@ describe("Todo Server Integration", () => {
     });
 
     it("updates a todo", async () => {
-      const res = await fetch(`${baseUrl}/todos/${createdTodoId}`, {
+      const res = await authenticatedFetch(`${baseUrl}/todos/${createdTodoId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -106,25 +135,25 @@ describe("Todo Server Integration", () => {
     });
 
     it("deletes a todo", async () => {
-      const res = await fetch(`${baseUrl}/todos/${createdTodoId}`, {
+      const res = await authenticatedFetch(`${baseUrl}/todos/${createdTodoId}`, {
         method: "DELETE",
       });
       expect(res.status).toBe(204);
 
       // Verify it's gone
-      const getRes = await fetch(`${baseUrl}/todos/${createdTodoId}`);
+      const getRes = await authenticatedFetch(`${baseUrl}/todos/${createdTodoId}`);
       expect(getRes.status).toBe(404);
     });
   });
 
   describe("Error Handling", () => {
     it("returns 404 for non-existent todo", async () => {
-      const res = await fetch(`${baseUrl}/todos/00000000-0000-0000-0000-000000000000`);
+      const res = await authenticatedFetch(`${baseUrl}/todos/00000000-0000-0000-0000-000000000000`);
       expect(res.status).toBe(404);
     });
 
     it("returns 400 for missing title", async () => {
-      const res = await fetch(`${baseUrl}/todos`, {
+      const res = await authenticatedFetch(`${baseUrl}/todos`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -133,46 +162,64 @@ describe("Todo Server Integration", () => {
     });
   });
 
-  describe("Policy-Aware Session Reads", () => {
-    it("filters rows by owner_id when querying with session context", async () => {
+  describe("Policy-Aware Requests", () => {
+    it("filters rows by the authenticated session owner", async () => {
+      const alice = createIdentity("todo-rest-policy-alice");
+      const bob = createIdentity("todo-rest-policy-bob");
       const aliceTitle = `Alice private ${Date.now()}`;
       const bobTitle = `Bob private ${Date.now()}`;
-      const aliceId = randomUUID();
-      const bobId = randomUUID();
 
-      const createAlice = await fetch(`${baseUrl}/todos`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: aliceTitle, owner_id: aliceId }),
-      });
+      const createAlice = await authenticatedFetch(
+        `${baseUrl}/todos`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: aliceTitle }),
+        },
+        alice,
+      );
       expect(createAlice.status).toBe(201);
       const aliceTodo: Todo = await createAlice.json();
+      expect(aliceTodo.owner_id).toBe(alice.userId);
 
-      const createBob = await fetch(`${baseUrl}/todos`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: bobTitle, owner_id: bobId }),
-      });
+      const createBob = await authenticatedFetch(
+        `${baseUrl}/todos`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: bobTitle }),
+        },
+        bob,
+      );
       expect(createBob.status).toBe(201);
       const bobTodo: Todo = await createBob.json();
+      expect(bobTodo.owner_id).toBe(bob.userId);
 
-      const aliceViewRes = await fetch(`${baseUrl}/todos/as/${aliceId}`);
+      const aliceViewRes = await authenticatedFetch(`${baseUrl}/todos`, {}, alice);
       expect(aliceViewRes.status).toBe(200);
       const aliceView: Todo[] = await aliceViewRes.json();
       const aliceTitles = new Set(aliceView.map((todo) => todo.title));
       expect(aliceTitles.has(aliceTitle)).toBe(true);
       expect(aliceTitles.has(bobTitle)).toBe(false);
 
-      const bobViewRes = await fetch(`${baseUrl}/todos/as/${bobId}`);
+      const bobViewRes = await authenticatedFetch(`${baseUrl}/todos`, {}, bob);
       expect(bobViewRes.status).toBe(200);
       const bobView: Todo[] = await bobViewRes.json();
       const bobTitles = new Set(bobView.map((todo) => todo.title));
       expect(bobTitles.has(bobTitle)).toBe(true);
       expect(bobTitles.has(aliceTitle)).toBe(false);
 
-      const deleteAlice = await fetch(`${baseUrl}/todos/${aliceTodo.id}`, { method: "DELETE" });
+      const deleteAlice = await authenticatedFetch(
+        `${baseUrl}/todos/${aliceTodo.id}`,
+        { method: "DELETE" },
+        alice,
+      );
       expect(deleteAlice.status).toBe(204);
-      const deleteBob = await fetch(`${baseUrl}/todos/${bobTodo.id}`, { method: "DELETE" });
+      const deleteBob = await authenticatedFetch(
+        `${baseUrl}/todos/${bobTodo.id}`,
+        { method: "DELETE" },
+        bob,
+      );
       expect(deleteBob.status).toBe(204);
     });
   });
@@ -186,7 +233,7 @@ describe("Todo Server Integration", () => {
       // --- First boot: create some todos ---
       const server1 = await startServer(await createServer(dbPath), 0);
 
-      const createRes1 = await fetch(`${server1.baseUrl}/todos`, {
+      const createRes1 = await authenticatedFetch(`${server1.baseUrl}/todos`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: "Survive restart", description: "persistent" }),
@@ -194,7 +241,7 @@ describe("Todo Server Integration", () => {
       expect(createRes1.status).toBe(201);
       const todo1: Todo = await createRes1.json();
 
-      const createRes2 = await fetch(`${server1.baseUrl}/todos`, {
+      const createRes2 = await authenticatedFetch(`${server1.baseUrl}/todos`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: "Also persist" }),
@@ -209,7 +256,7 @@ describe("Todo Server Integration", () => {
       // --- Second boot: same data path, fresh server ---
       const server2 = await startServer(await createServer(dbPath), 0);
 
-      const listRes = await fetch(`${server2.baseUrl}/todos`);
+      const listRes = await authenticatedFetch(`${server2.baseUrl}/todos`);
       expect(listRes.status).toBe(200);
       const todos: Todo[] = await listRes.json();
 
@@ -231,14 +278,27 @@ describe("Todo Server Integration", () => {
   });
 
   describe("SSE Live Endpoint", () => {
-    it("streams all todos and updates on changes", async () => {
+    it("streams only the authenticated caller's todos and updates on changes", async () => {
       // Use an isolated server instance so this test has an independent persistence context.
       const sseServer = await startServer(await createServer(), 0);
       const sseBaseUrl = sseServer.baseUrl;
       let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
       try {
+        const otherIdentity = createIdentity("todo-rest-sse-other");
+        const foreignCreate = await authenticatedFetch(
+          `${sseBaseUrl}/todos`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ title: "Another user's todo" }),
+          },
+          otherIdentity,
+        );
+        expect(foreignCreate.status).toBe(201);
+        const foreignTodo: Todo = await foreignCreate.json();
+
         // Connect to SSE endpoint
-        const res = await fetch(`${sseBaseUrl}/todos/live`);
+        const res = await authenticatedFetch(`${sseBaseUrl}/todos/live`);
         expect(res.status).toBe(200);
         expect(res.headers.get("content-type")).toBe("text/event-stream");
 
@@ -272,7 +332,7 @@ describe("Todo Server Integration", () => {
         expect(initial).toEqual([]);
 
         // 2. Create a todo - should see it in next event
-        const createRes = await fetch(`${sseBaseUrl}/todos`, {
+        const createRes = await authenticatedFetch(`${sseBaseUrl}/todos`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ title: "SSE Test Todo" }),
@@ -286,7 +346,7 @@ describe("Todo Server Integration", () => {
         expect(afterCreate[0].title).toBe("SSE Test Todo");
 
         // 3. Update the todo - should see updated state
-        await fetch(`${sseBaseUrl}/todos/${createdTodo.id}`, {
+        await authenticatedFetch(`${sseBaseUrl}/todos/${createdTodo.id}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ done: true }),
@@ -297,12 +357,19 @@ describe("Todo Server Integration", () => {
         expect(afterUpdate[0].done).toBe(true);
 
         // 4. Delete the todo - should see empty list again
-        await fetch(`${sseBaseUrl}/todos/${createdTodo.id}`, {
+        await authenticatedFetch(`${sseBaseUrl}/todos/${createdTodo.id}`, {
           method: "DELETE",
         });
 
         const afterDelete = await readEvent();
         expect(afterDelete).toEqual([]);
+
+        const deleteForeign = await authenticatedFetch(
+          `${sseBaseUrl}/todos/${foreignTodo.id}`,
+          { method: "DELETE" },
+          otherIdentity,
+        );
+        expect(deleteForeign.status).toBe(204);
       } finally {
         if (reader) {
           await reader.cancel().catch(() => undefined);


### PR DESCRIPTION
## Summary

- create a request-scoped Jazz database for every REST and event-stream request
- derive todo ownership from the authenticated session rather than request input
- route all network reads and writes through normal permission evaluation
- retain the exported administrative database handle for trusted setup callers without using it in routes

## Validation

- REST authentication suite: 14 tests passed
- todo integration suite: 11 tests passed
- Oxfmt and Oxlint