### PR TITLE
fix(chat): bind message authorship to authenticated users

### DIFF
--- a/examples/chat-react/permissions.ts
+++ b/examples/chat-react/permissions.ts
@@ -39,7 +39,10 @@ export default definePermissions(app, ({ policy, session, allOf, anyOf, allowedT
     ]),
   );
   policy.messages.allowInsert.where((message) =>
-    policy.chatMembers.exists.where({ chatId: message.chatId, userId: session.user_id }),
+    allOf([
+      policy.chatMembers.exists.where({ chatId: message.chatId, userId: session.user_id }),
+      policy.profiles.exists.where({ id: message.senderId, userId: session.user_id }),
+    ]),
   );
   policy.messages.allowDelete.where((message) =>
     policy.profiles.exists.where({ id: message.senderId, userId: session.user_id }),

--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -169,6 +169,99 @@ describe("chat permissions", () => {
     );
   });
 
+  it("binds message attribution to the authenticated user's profile", async () => {
+    const aliceProfile = await testApp.seed((db) =>
+      db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      }),
+    );
+    const bobProfile = await testApp.seed((db) =>
+      db.insert(app.profiles, {
+        userId: "bob",
+        name: "Bob",
+      }),
+    );
+    const chat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Members only",
+        isPublic: false,
+        joinCode: "invite-authors",
+      }),
+    );
+    await testApp.seed((db) =>
+      db.insert(app.chatMembers, {
+        chatId: chat.id,
+        userId: "alice",
+        joinCode: "invite-authors",
+      }),
+    );
+
+    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+
+    aliceDb.expectAllowed((db) =>
+      db.insert(app.messages, {
+        chatId: chat.id,
+        text: "hello from alice",
+        senderId: aliceProfile.id,
+      }),
+    );
+    await aliceDb.expectDenied((db) =>
+      db.insert(app.messages, {
+        chatId: chat.id,
+        text: "forged message from bob",
+        senderId: bobProfile.id,
+      }),
+    );
+  });
+
+  it("binds reaction attribution to the authenticated user", async () => {
+    const aliceProfile = await testApp.seed((db) =>
+      db.insert(app.profiles, {
+        userId: "alice",
+        name: "Alice",
+      }),
+    );
+    const chat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Members only",
+        isPublic: false,
+        joinCode: "invite-reactions",
+      }),
+    );
+    await testApp.seed((db) =>
+      db.insert(app.chatMembers, {
+        chatId: chat.id,
+        userId: "alice",
+        joinCode: "invite-reactions",
+      }),
+    );
+    const message = await testApp.seed((db) =>
+      db.insert(app.messages, {
+        chatId: chat.id,
+        text: "react to this",
+        senderId: aliceProfile.id,
+      }),
+    );
+
+    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+
+    aliceDb.expectAllowed((db) =>
+      db.insert(app.reactions, {
+        messageId: message.id,
+        userId: "alice",
+        emoji: "thumbs-up",
+      }),
+    );
+    await aliceDb.expectDenied((db) =>
+      db.insert(app.reactions, {
+        messageId: message.id,
+        userId: "bob",
+        emoji: "fire",
+      }),
+    );
+  });
+
   it("inherits reaction reads from the parent message/chat chain", async () => {
     const aliceProfile = await testApp.seed((db) =>
       db.insert(app.profiles, {


### PR DESCRIPTION
## Summary

- require a message's sender profile to belong to the authenticated session
- prevent writers from attributing messages to another user's profile
- leave existing message reads, UI behavior, and already-secure reaction ownership unchanged

## Validation

- chat permission suite: 7 tests passed
- regression reproduces forged authorship before the policy change
- Oxfmt and Oxlint