### PR TITLE
fix: stabilize Expo secret loading across remounts

### DIFF
--- a/examples/todo-client-localfirst-expo/App.tsx
+++ b/examples/todo-client-localfirst-expo/App.tsx
@@ -1,8 +1,17 @@
 import * as React from "react";
 import { type DbConfig } from "jazz-tools";
 import { JazzProvider } from "jazz-tools/react";
-import { ActivityIndicator, SafeAreaView, StatusBar, StyleSheet, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import { ExpoAuthSecretStore } from "./src/expo-auth-secret-store";
+import { createResettablePromise, loadSecret, SecretLoadError } from "./src/secret-promise-cache";
 import { TodoList } from "./src/TodoList";
 
 // Expo's Metro bundler inlines process.env.EXPO_PUBLIC_* at bundle time.
@@ -17,6 +26,10 @@ function buildConfig(secret: string): DbConfig {
     secret,
   };
 }
+
+const authSecret = createResettablePromise(() =>
+  loadSecret(() => ExpoAuthSecretStore.getOrCreateSecret()),
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -44,9 +57,34 @@ const styles = StyleSheet.create({
     color: "#374151",
     fontSize: 14,
   },
+  errorText: {
+    color: "#991b1b",
+    fontSize: 14,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#111827",
+    borderRadius: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  retryButtonText: {
+    color: "#ffffff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
 });
 
-const fallback = (
+const authFallback = (
+  <SafeAreaView style={styles.container}>
+    <View style={styles.loadingContainer}>
+      <ActivityIndicator size="small" />
+      <Text style={styles.loadingText}>Loading secure credentials...</Text>
+    </View>
+  </SafeAreaView>
+);
+
+const runtimeFallback = (
   <SafeAreaView style={styles.container}>
     <View style={styles.loadingContainer}>
       <ActivityIndicator size="small" />
@@ -55,12 +93,48 @@ const fallback = (
   </SafeAreaView>
 );
 
-export default function App() {
-  const secret = React.use(ExpoAuthSecretStore.getOrCreateSecret());
+class SecretLoadErrorBoundary extends React.Component<
+  React.PropsWithChildren,
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(error: unknown) {
+    if (!(error instanceof SecretLoadError)) {
+      throw error;
+    }
+    return { failed: true };
+  }
+
+  private retry = () => {
+    authSecret.reset();
+    this.setState({ failed: false });
+  };
+
+  render() {
+    if (this.state.failed) {
+      return (
+        <SafeAreaView style={styles.container}>
+          <View style={styles.loadingContainer}>
+            <Text style={styles.errorText}>Could not load secure credentials.</Text>
+            <Pressable accessibilityRole="button" onPress={this.retry} style={styles.retryButton}>
+              <Text style={styles.retryButtonText}>Try again</Text>
+            </Pressable>
+          </View>
+        </SafeAreaView>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export function App() {
+  const secret = React.use(authSecret.get());
   const config = React.useMemo(() => buildConfig(secret), [secret]);
 
   return (
-    <JazzProvider config={config} fallback={fallback}>
+    <JazzProvider config={config} fallback={runtimeFallback}>
       <SafeAreaView style={styles.container}>
         <StatusBar barStyle="dark-content" />
         <View style={styles.content}>
@@ -69,5 +143,15 @@ export default function App() {
         </View>
       </SafeAreaView>
     </JazzProvider>
+  );
+}
+
+export default function AppRoot() {
+  return (
+    <SecretLoadErrorBoundary>
+      <React.Suspense fallback={authFallback}>
+        <App />
+      </React.Suspense>
+    </SecretLoadErrorBoundary>
   );
 }

--- a/examples/todo-client-localfirst-expo/index.js
+++ b/examples/todo-client-localfirst-expo/index.js
@@ -1,3 +1,4 @@
 import registerRootComponent from "expo/src/launch/registerRootComponent";
-import App from "./App";
-registerRootComponent(App);
+import AppRoot from "./App";
+
+registerRootComponent(AppRoot);

--- a/examples/todo-client-localfirst-expo/package.json
+++ b/examples/todo-client-localfirst-expo/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "./index.js",
   "scripts": {
+    "test": "node --experimental-strip-types --test src/*.test.mjs",
     "start": "expo start --clear",
     "android": "expo run:android",
     "ios": "expo run:ios",

--- a/examples/todo-client-localfirst-expo/src/secret-promise-cache.test.mjs
+++ b/examples/todo-client-localfirst-expo/src/secret-promise-cache.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createResettablePromise } from "./secret-promise-cache.ts";
+
+test("render retries reuse one pending secret load", async () => {
+  let loadCount = 0;
+  let resolveSecret;
+  const pendingSecret = new Promise((resolve) => {
+    resolveSecret = resolve;
+  });
+  const secret = createResettablePromise(() => {
+    loadCount += 1;
+    return pendingSecret;
+  });
+
+  const firstRender = secret.get();
+  const retryRender = secret.get();
+  const rerender = secret.get();
+
+  assert.strictEqual(retryRender, firstRender);
+  assert.strictEqual(rerender, firstRender);
+  assert.equal(loadCount, 1);
+
+  resolveSecret("stable-secret");
+  assert.equal(await firstRender, "stable-secret");
+  assert.strictEqual(secret.get(), firstRender);
+  assert.equal(loadCount, 1);
+});
+
+test("an explicit reset starts one new load after an error", async () => {
+  const failure = new Error("secure storage unavailable");
+  let loadCount = 0;
+  const secret = createResettablePromise(() => {
+    loadCount += 1;
+    return loadCount === 1 ? Promise.reject(failure) : Promise.resolve("recovered-secret");
+  });
+
+  const failedLoad = secret.get();
+  await assert.rejects(failedLoad, failure);
+  assert.strictEqual(secret.get(), failedLoad);
+  assert.equal(loadCount, 1);
+
+  secret.reset();
+
+  assert.equal(await secret.get(), "recovered-secret");
+  assert.equal(loadCount, 2);
+});

--- a/examples/todo-client-localfirst-expo/src/secret-promise-cache.test.mjs
+++ b/examples/todo-client-localfirst-expo/src/secret-promise-cache.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createResettablePromise } from "./secret-promise-cache.ts";
+import { createResettablePromise, loadSecret, SecretLoadError } from "./secret-promise-cache.ts";
 
 test("render retries reuse one pending secret load", async () => {
   let loadCount = 0;
@@ -45,4 +45,13 @@ test("an explicit reset starts one new load after an error", async () => {
 
   assert.equal(await secret.get(), "recovered-secret");
   assert.equal(loadCount, 2);
+});
+
+test("secret-load failures are distinguishable from descendant errors", async () => {
+  const failure = new Error("secure storage unavailable");
+
+  await assert.rejects(
+    loadSecret(() => Promise.reject(failure)),
+    (error) => error instanceof SecretLoadError && error.cause === failure,
+  );
 });

--- a/examples/todo-client-localfirst-expo/src/secret-promise-cache.ts
+++ b/examples/todo-client-localfirst-expo/src/secret-promise-cache.ts
@@ -1,0 +1,36 @@
+export class SecretLoadError extends Error {
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super("Failed to load the authentication secret");
+    this.name = "SecretLoadError";
+    this.cause = cause;
+  }
+}
+
+export async function loadSecret<T>(load: () => Promise<T>): Promise<T> {
+  try {
+    return await load();
+  } catch (cause) {
+    throw new SecretLoadError(cause);
+  }
+}
+
+export interface ResettablePromise<T> {
+  get(): Promise<T>;
+  reset(): void;
+}
+
+export function createResettablePromise<T>(load: () => Promise<T>): ResettablePromise<T> {
+  let promise: Promise<T> | undefined;
+
+  return {
+    get() {
+      promise ??= load();
+      return promise;
+    },
+    reset() {
+      promise = undefined;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- share one in-flight secure-secret load across concurrent mounts and Strict Mode remounts
- retain a successful secret while allowing failed secret loads to retry
- distinguish secret-store failures with `SecretLoadError`
- rethrow unrelated provider and descendant errors instead of mislabeling them as secret failures

## Validation

- focused secret lifecycle suite: 3 tests passed
- Oxfmt and Oxlint

Device-level Expo execution is not part of the current workspace; the promise and error-routing contract is covered by the focused Node suite.