### PR TITLE
Bind persistence receipts to their database instance

### DIFF
--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -417,6 +417,9 @@ impl Database {
         &mut self,
         persistence: PersistedBatch,
     ) -> Result<PublicationId, Error> {
+        if !Rc::ptr_eq(&self.publication_persistence, &persistence.receipt.order) {
+            return Err(Error::PublicationNotFound(persistence.publication));
+        }
         persistence.receipt.finish();
         self.last_tick_metrics = Some(persistence.metrics.tick.clone());
         self.last_commit_metrics = Some(persistence.metrics.clone());

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -346,6 +346,7 @@ impl AppliedBatch {
             },
             receipt: PersistenceReceipt {
                 lifecycle: Rc::clone(&self.lifecycle),
+                order: Rc::clone(&self.order),
                 abandoned_application: Rc::clone(&self.abandoned_application),
             },
         }
@@ -392,6 +393,7 @@ pub struct PersistedBatch {
 
 struct PersistenceReceipt {
     lifecycle: Rc<Cell<AppliedBatchLifecycle>>,
+    order: Rc<RefCell<PersistenceOrder>>,
     abandoned_application: Rc<Cell<bool>>,
 }
 

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -2393,7 +2393,7 @@ async fn persistence_receipts_cannot_settle_another_database() {
         "albums",
         vec![Value::U64(2), Value::String("second".to_owned())],
     );
-    let _second_applied = second.apply_batch(second_batch).await.unwrap();
+    let second_applied = second.apply_batch(second_batch).await.unwrap();
 
     let foreign_persistence = first_applied.persist().await;
     assert!(matches!(
@@ -2402,6 +2402,16 @@ async fn persistence_receipts_cannot_settle_another_database() {
     ));
     assert_eq!(first.durable_publication_frontier(), None);
     assert_eq!(second.durable_publication_frontier(), None);
+
+    let second_persistence = second_applied.persist().await;
+    assert_eq!(
+        second.finish_persistence(second_persistence).unwrap(),
+        PublicationId(1)
+    );
+    assert_eq!(
+        second.durable_publication_frontier(),
+        Some(PublicationId(1))
+    );
     assert_eq!(
         second
             .query_graph(GraphBuilder::table("albums"))

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -2371,3 +2371,44 @@ async fn same_batch_same_key_operations_emit_only_the_consolidated_final_delta()
         )]
     );
 }
+
+#[futures_test::test]
+async fn persistence_receipts_cannot_settle_another_database() {
+    let mut first = Database::new(albums_schema(), MemoryStorage::new(&["albums"]))
+        .await
+        .unwrap();
+    let mut second = Database::new(albums_schema(), MemoryStorage::new(&["albums"]))
+        .await
+        .unwrap();
+
+    let mut first_batch = first.open_batch();
+    first_batch.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("first".to_owned())],
+    );
+    let first_applied = first.apply_batch(first_batch).await.unwrap();
+
+    let mut second_batch = second.open_batch();
+    second_batch.insert(
+        "albums",
+        vec![Value::U64(2), Value::String("second".to_owned())],
+    );
+    let _second_applied = second.apply_batch(second_batch).await.unwrap();
+
+    let foreign_persistence = first_applied.persist().await;
+    assert!(matches!(
+        second.finish_persistence(foreign_persistence),
+        Err(Error::PublicationNotFound(PublicationId(1)))
+    ));
+    assert_eq!(first.durable_publication_frontier(), None);
+    assert_eq!(second.durable_publication_frontier(), None);
+    assert_eq!(
+        second
+            .query_graph(GraphBuilder::table("albums"))
+            .await
+            .unwrap()
+            .to_values()
+            .unwrap(),
+        [(vec![Value::U64(2), Value::String("second".to_owned())], 1)]
+    );
+}


### PR DESCRIPTION
## Summary
- carry the originating database's persistence-order identity in each receipt
- reject foreign receipts before changing metrics, publication state, or the durable frontier
- cover same-numbered resident publications in two independent databases

## Why
Publication IDs are database-local. A receipt for publication 1 in one database could previously settle publication 1 in another database, removing the wrong resident write and advancing the wrong durable frontier.

## Verification
- `cargo test -p groove db::tests::batches` (31 passed)
- `cargo clippy -p groove --lib -- -D warnings`
- pre-commit hooks passed