### PR TITLE
Bound recursive sync message decoding

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -755,13 +755,13 @@ struct CountedDuplex {
 impl Transport for DuplexTransport {
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
         self.metrics.messages.set(self.metrics.messages.get() + 1);
-        if let SyncMessage::ViewUpdate {
+        if let SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             subscription,
             reset_result_set,
             version_bundles,
             result_member_adds,
             ..
-        } = &message
+        }) = &message
         {
             self.metrics
                 .view_updates

--- a/crates/jazz-sim/benches/policy_graph_concurrent.rs
+++ b/crates/jazz-sim/benches/policy_graph_concurrent.rs
@@ -532,7 +532,10 @@ struct ClientTransportCounters {
 impl Transport for QueueTransport {
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
         self.metrics.messages.set(self.metrics.messages.get() + 1);
-        if matches!(message, SyncMessage::ViewUpdate { .. }) {
+        if matches!(
+            message,
+            SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload { .. })
+        ) {
             self.metrics
                 .view_updates
                 .set(self.metrics.view_updates.get() + 1);

--- a/crates/jazz-sim/benches/s1_saas.rs
+++ b/crates/jazz-sim/benches/s1_saas.rs
@@ -1623,9 +1623,9 @@ fn apply_subscription_event(rows: &mut BTreeSet<(String, RowUuid)>, event: Subsc
 }
 
 fn collect_result_rows(update: &SyncMessage, rows: &mut BTreeSet<(String, RowUuid)>) {
-    if let SyncMessage::ViewUpdate {
+    if let SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = update
+    }) = update
     {
         for entry in result_member_adds {
             if let Some((table, row_uuid, _)) = entry.as_row() {
@@ -1637,9 +1637,9 @@ fn collect_result_rows(update: &SyncMessage, rows: &mut BTreeSet<(String, RowUui
 
 fn result_output_count(update: &SyncMessage, table: &str) -> usize {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             result_member_adds, ..
-        } => result_member_adds
+        }) => result_member_adds
             .iter()
             .filter_map(|entry| entry.as_row())
             .filter(|entry| entry.0.as_str() == table)
@@ -1650,13 +1650,13 @@ fn result_output_count(update: &SyncMessage, table: &str) -> usize {
 
 fn view_update_bytes(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles,
             peer_payload_inventory,
             result_member_adds,
             result_member_removes,
             ..
-        } => {
+        }) => {
             let bundle_bytes = version_bundles
                 .iter()
                 .flat_map(|bundle| bundle.versions.iter())
@@ -1673,9 +1673,9 @@ fn view_update_bytes(update: &SyncMessage) -> u64 {
 
 fn bytes_floor(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles, ..
-        } => version_bundles
+        }) => version_bundles
             .iter()
             .flat_map(|bundle| bundle.versions.iter())
             .map(|version| version.record().raw().len() as u64)

--- a/crates/jazz-sim/benches/s2_canvas.rs
+++ b/crates/jazz-sim/benches/s2_canvas.rs
@@ -1640,9 +1640,9 @@ fn observed_shape_tx_ids(update: &SyncMessage, read_tier: DurabilityTier) -> Vec
         return Vec::new();
     }
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             result_member_adds, ..
-        } => result_member_adds
+        }) => result_member_adds
             .iter()
             .filter_map(|entry| entry.as_row())
             .filter_map(|(table, _, tx_id)| (table.as_ref() == SHAPES).then_some(tx_id))
@@ -1656,9 +1656,9 @@ fn observed_at_read_tier(update: &SyncMessage, tier: DurabilityTier) -> bool {
         return true;
     }
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles, ..
-        } => version_bundles
+        }) => version_bundles
             .iter()
             .any(|bundle| bundle.durability >= tier && matches!(bundle.fate, Fate::Accepted)),
         SyncMessage::FateUpdate { durability, .. } => durability.is_some_and(|seen| seen >= tier),
@@ -2597,9 +2597,9 @@ fn is_ancestor(
 
 fn result_output_count(update: &SyncMessage, table: &str) -> usize {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             result_member_adds, ..
-        } => result_member_adds
+        }) => result_member_adds
             .iter()
             .filter_map(|entry| entry.as_row())
             .filter(|entry| entry.0.as_ref() == table)

--- a/crates/jazz-sim/benches/s3_permissions.rs
+++ b/crates/jazz-sim/benches/s3_permissions.rs
@@ -998,10 +998,10 @@ fn revoke_phase(
     let update = block_on(client.peer.query_update(&mut edge.node, shape, binding)).unwrap();
     let query_update_us = query_start.elapsed().as_micros() as u64;
     let removed = match &update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             result_member_removes,
             ..
-        } => result_member_removes.len(),
+        }) => result_member_removes.len(),
         _ => 0,
     };
     assert!(
@@ -1965,12 +1965,12 @@ fn deliver_update(
 }
 
 fn apply_client_update(client: &mut Client, message: SyncMessage) {
-    if let SyncMessage::ViewUpdate {
+    if let SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         ..
-    } = &message
+    }) = &message
     {
         if *reset_result_set {
             client.visible_rows.clear();
@@ -2835,11 +2835,11 @@ fn visible_rows_db_client(client: &DbClient) -> BTreeSet<RowUuid> {
 
 fn result_rows(update: &SyncMessage) -> Vec<ResultRowEntry> {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             result_member_adds,
             result_member_removes,
             ..
-        } => result_member_adds
+        }) => result_member_adds
             .iter()
             .chain(result_member_removes.iter())
             .filter_map(|entry| entry.as_row())
@@ -2850,12 +2850,12 @@ fn result_rows(update: &SyncMessage) -> Vec<ResultRowEntry> {
 
 fn view_update_bytes(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles,
             result_member_adds,
             result_member_removes,
             ..
-        } => {
+        }) => {
             let bundles = version_bundles
                 .iter()
                 .map(|bundle| {
@@ -2874,9 +2874,9 @@ fn view_update_bytes(update: &SyncMessage) -> u64 {
 
 fn bytes_floor(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles, ..
-        } => version_bundles
+        }) => version_bundles
             .iter()
             .flat_map(|bundle| bundle.versions.iter())
             .map(|version| version.record().raw().len() as u64)

--- a/crates/jazz-sim/benches/s4_order_processing.rs
+++ b/crates/jazz-sim/benches/s4_order_processing.rs
@@ -2138,13 +2138,13 @@ fn table_schema<'a>(schema: &'a JazzSchema, table: &str) -> &'a TableSchema {
 
 fn view_update_bytes(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles,
             peer_payload_inventory,
             result_member_adds,
             result_member_removes,
             ..
-        } => {
+        }) => {
             version_bundles
                 .iter()
                 .flat_map(|bundle| bundle.versions.iter())
@@ -2159,11 +2159,11 @@ fn view_update_bytes(update: &SyncMessage) -> u64 {
 
 fn result_row_count(update: &SyncMessage) -> usize {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             result_member_adds,
             result_member_removes,
             ..
-        } => result_member_adds.len() + result_member_removes.len(),
+        }) => result_member_adds.len() + result_member_removes.len(),
         _ => 0,
     }
 }

--- a/crates/jazz-sim/benches/s5_durable_stream.rs
+++ b/crates/jazz-sim/benches/s5_durable_stream.rs
@@ -1160,13 +1160,13 @@ fn commit_unit_bytes(update: &SyncMessage) -> u64 {
 
 fn view_update_bytes(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles,
             peer_payload_inventory,
             result_member_adds,
             result_member_removes,
             ..
-        } => {
+        }) => {
             version_bundles
                 .iter()
                 .flat_map(|bundle| bundle.versions.iter())
@@ -1181,11 +1181,11 @@ fn view_update_bytes(update: &SyncMessage) -> u64 {
 
 fn result_row_count(update: &SyncMessage) -> usize {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             result_member_adds,
             result_member_removes,
             ..
-        } => result_member_adds.len() + result_member_removes.len(),
+        }) => result_member_adds.len() + result_member_removes.len(),
         _ => 0,
     }
 }

--- a/crates/jazz-sim/benches/s9_durable_execution.rs
+++ b/crates/jazz-sim/benches/s9_durable_execution.rs
@@ -1171,13 +1171,13 @@ fn storage_bytes(path: &std::path::Path) -> u64 {
 
 fn view_update_bytes(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_bundles,
             peer_payload_inventory,
             result_member_adds,
             result_member_removes,
             ..
-        } => {
+        }) => {
             version_bundles
                 .iter()
                 .flat_map(|bundle| bundle.versions.iter())

--- a/crates/jazz-sim/src/fixture.rs
+++ b/crates/jazz-sim/src/fixture.rs
@@ -518,7 +518,10 @@ where
 {
     let update = jazz::db::block_on(peer.current_rows_update(from, options.table))
         .map_err(|err| format!("view update failed: {err}"))?;
-    if !matches!(update, SyncMessage::ViewUpdate { .. }) {
+    if !matches!(
+        update,
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload { .. })
+    ) {
         return Err("expected view update".to_owned());
     }
     ctx.send(options.from_name, options.to_name, update);

--- a/crates/jazz-sim/src/view_accounting.rs
+++ b/crates/jazz-sim/src/view_accounting.rs
@@ -1,6 +1,8 @@
 //! Shared simulation accounting for sync-message row delivery payloads.
 
-use jazz::protocol::{ResultMemberEntry, SyncMessage, VersionBundle, VersionRecord};
+use jazz::protocol::{
+    AuthorizationScopeViewPayload, ResultMemberEntry, SyncMessage, VersionBundle, VersionRecord,
+};
 use jazz::tx::Transaction;
 
 /// Estimate row-delivery bytes carried by a sync message.
@@ -27,7 +29,7 @@ pub fn view_update_bytes(update: &SyncMessage) -> u64 {
         SyncMessage::FateUpdate { .. } => tx_id_wire_bytes() + 16,
         // An authority scope view carries an ordinary settlement-bearing view
         // update. Its row payload is part of the simulated delivery cost.
-        SyncMessage::AuthorizationScopeView { view, .. } => view_update_bytes(view),
+        SyncMessage::AuthorizationScopeView { view, .. } => scope_view_update_bytes(view),
         SyncMessage::RegisterShape { .. }
         | SyncMessage::ChunkRequestBatch(_)
         | SyncMessage::ChunkResponseBatch(_)
@@ -67,9 +69,27 @@ pub fn bytes_floor(update: &SyncMessage) -> u64 {
             .flat_map(|bundle| &bundle.versions)
             .map(version_record_bytes)
             .sum(),
-        SyncMessage::AuthorizationScopeView { view, .. } => bytes_floor(view),
+        SyncMessage::AuthorizationScopeView { view, .. } => scope_view_bytes_floor(view),
         _ => 0,
     }
+}
+
+fn scope_view_update_bytes(view: &AuthorizationScopeViewPayload) -> u64 {
+    view.version_bundles
+        .iter()
+        .map(version_bundle_bytes)
+        .sum::<u64>()
+        + (view.peer_payload_inventory.complete_tx_payloads.len() as u64 * tx_id_wire_bytes())
+        + result_rows_bytes(&view.result_member_adds)
+        + result_rows_bytes(&view.result_member_removes)
+}
+
+fn scope_view_bytes_floor(view: &AuthorizationScopeViewPayload) -> u64 {
+    view.version_bundles
+        .iter()
+        .flat_map(|bundle| &bundle.versions)
+        .map(version_record_bytes)
+        .sum()
 }
 
 fn version_bundle_bytes(bundle: &VersionBundle) -> u64 {
@@ -197,7 +217,8 @@ mod tests {
             },
             clause_index: 0,
             clause_count: 1,
-            view: Box::new(nested),
+            view: jazz::protocol::AuthorizationScopeViewPayload::from_view_update(nested)
+                .expect("fixture is a view update"),
         };
 
         assert_eq!(view_update_bytes(&wrapped), nested_bytes);

--- a/crates/jazz-sim/src/view_accounting.rs
+++ b/crates/jazz-sim/src/view_accounting.rs
@@ -1,20 +1,20 @@
 //! Shared simulation accounting for sync-message row delivery payloads.
 
 use jazz::protocol::{
-    AuthorizationScopeViewPayload, ResultMemberEntry, SyncMessage, VersionBundle, VersionRecord,
+    ResultMemberEntry, SyncMessage, VersionBundle, VersionRecord, ViewUpdatePayload,
 };
 use jazz::tx::Transaction;
 
 /// Estimate row-delivery bytes carried by a sync message.
 pub fn view_update_bytes(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(ViewUpdatePayload {
             version_bundles,
             peer_payload_inventory,
             result_member_adds,
             result_member_removes,
             ..
-        } => {
+        }) => {
             version_bundles
                 .iter()
                 .map(version_bundle_bytes)
@@ -62,9 +62,9 @@ pub fn view_update_bytes(update: &SyncMessage) -> u64 {
 /// Estimate the irreducible row-version payload bytes carried by a sync message.
 pub fn bytes_floor(update: &SyncMessage) -> u64 {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(ViewUpdatePayload {
             version_bundles, ..
-        } => version_bundles
+        }) => version_bundles
             .iter()
             .flat_map(|bundle| &bundle.versions)
             .map(version_record_bytes)
@@ -74,7 +74,7 @@ pub fn bytes_floor(update: &SyncMessage) -> u64 {
     }
 }
 
-fn scope_view_update_bytes(view: &AuthorizationScopeViewPayload) -> u64 {
+fn scope_view_update_bytes(view: &ViewUpdatePayload) -> u64 {
     view.version_bundles
         .iter()
         .map(version_bundle_bytes)
@@ -84,7 +84,7 @@ fn scope_view_update_bytes(view: &AuthorizationScopeViewPayload) -> u64 {
         + result_rows_bytes(&view.result_member_removes)
 }
 
-fn scope_view_bytes_floor(view: &AuthorizationScopeViewPayload) -> u64 {
+fn scope_view_bytes_floor(view: &ViewUpdatePayload) -> u64 {
     view.version_bundles
         .iter()
         .flat_map(|bundle| &bundle.versions)
@@ -166,7 +166,7 @@ mod tests {
             None,
         )
         .expect("valid test wire record");
-        let nested = SyncMessage::ViewUpdate {
+        let nested = SyncMessage::ViewUpdate(ViewUpdatePayload {
             subscription: SubscriptionKey {
                 shape_id: ShapeId(uuid::Uuid::nil()),
                 binding_id: BindingId(uuid::Uuid::nil()),
@@ -201,7 +201,7 @@ mod tests {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        };
+        });
         let nested_bytes = view_update_bytes(&nested);
         let nested_floor = bytes_floor(&nested);
         assert!(nested_bytes > 0);
@@ -217,7 +217,7 @@ mod tests {
             },
             clause_index: 0,
             clause_count: 1,
-            view: jazz::protocol::AuthorizationScopeViewPayload::from_view_update(nested)
+            view: jazz::protocol::ViewUpdatePayload::from_view_update(nested)
                 .expect("fixture is a view update"),
         };
 

--- a/crates/jazz/benches/known_state_scaling.rs
+++ b/crates/jazz/benches/known_state_scaling.rs
@@ -66,7 +66,7 @@ fn main() {
             .len();
         let metrics = fixture.core.storage_read_metrics();
 
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             version_carriers,
             version_bundles,
             peer_payload_inventory,
@@ -75,7 +75,7 @@ fn main() {
             program_fact_adds,
             program_fact_removes,
             ..
-        } = &update
+        }) = &update
         else {
             panic!("expected one view update");
         };
@@ -188,7 +188,9 @@ impl Fixture {
             .current_rows_update(&mut self.core, TABLE)
             .expect("discover whole-table subscription key");
         match update {
-            SyncMessage::ViewUpdate { subscription, .. } => subscription,
+            SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload { subscription, .. }) => {
+                subscription
+            }
             _ => panic!("expected one view update"),
         }
     }

--- a/crates/jazz/benches/maintained_rehydrate_scaling.rs
+++ b/crates/jazz/benches/maintained_rehydrate_scaling.rs
@@ -164,13 +164,13 @@ fn run_rung(source_rows: usize) {
 }
 
 fn update_counts(update: &SyncMessage) -> (usize, usize, usize) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
         version_carriers,
         version_bundles,
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected one view update");
     };

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2068,7 +2068,7 @@ fn subscriber_inbound_message_is_authority_only(
         SyncMessage::FateUpdate { .. }
             | SyncMessage::SubscribeRejected { .. }
             | SyncMessage::CatalogueAck(_)
-            | SyncMessage::ViewUpdate { .. }
+            | SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. })
             | SyncMessage::RowVersionPayloads { .. }
             | SyncMessage::CatalogueSnapshot(_)
             | SyncMessage::PermissionAdviceResponse { .. }

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1519,19 +1519,10 @@ where
                                     drop_peer_request(&self.node);
                                     continue;
                                 };
-                                let SyncMessage::ViewUpdate {
-                                    subscription,
-                                    settled_through,
-                                    peer_payload_inventory,
-                                    ..
-                                } = view.as_ref()
-                                else {
-                                    drop_peer_request(&self.node);
-                                    continue;
-                                };
-                                let subscription = *subscription;
-                                let settled_through = *settled_through;
-                                let authorization_progress = peer_payload_inventory
+                                let subscription = view.subscription;
+                                let settled_through = view.settled_through;
+                                let authorization_progress = view
+                                    .peer_payload_inventory
                                     .authorization_progress
                                     .unwrap_or_default();
                                 if clause_count == 0
@@ -1601,7 +1592,7 @@ where
                                 // receipt can be accepted.
                                 push_view_update_message_for_receiver(
                                     &mut pending_view_updates,
-                                    *view,
+                                    view.into_view_update(),
                                     authority_receipt_eligible,
                                 )?;
                                 scope_view_cuts.insert(subscription, settled_through);
@@ -3475,7 +3466,10 @@ where
                     key: scope.key.clone(),
                     clause_index: index as u16,
                     clause_count,
-                    view: Box::new(clause.view.clone()),
+                    view: crate::protocol::AuthorizationScopeViewPayload::from_view_update(
+                        clause.view.clone(),
+                    )
+                    .expect("authority scope clauses are view updates"),
                 })
                 .map_err(transport_error)?;
         }
@@ -3592,7 +3586,10 @@ where
                 key: scope.key.clone(),
                 clause_index: index as u16,
                 clause_count,
-                view: Box::new(update.clone()),
+                view: crate::protocol::AuthorizationScopeViewPayload::from_view_update(
+                    update.clone(),
+                )
+                .expect("scope hydration produces view updates"),
             })
             .map_err(transport_error)?;
         support_subscriptions.push(subscription);

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1419,11 +1419,11 @@ where
                                     .await?;
                                 }
                                 let (subscription, settled_through) = match &repair.update {
-                                    SyncMessage::ViewUpdate {
+                                    SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                                         subscription,
                                         settled_through,
                                         ..
-                                    } => (*subscription, *settled_through),
+                                    }) => (*subscription, *settled_through),
                                     _ => {
                                         unreachable!("row-version repair must retain a view update")
                                     }
@@ -1440,11 +1440,11 @@ where
                                 )?;
                                 scope_view_cuts.insert(subscription, settled_through);
                             }
-                            message @ SyncMessage::ViewUpdate {
+                            message @ SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                                 subscription,
                                 settled_through,
                                 ..
-                            } => {
+                            }) => {
                                 scope_receipts.remove(&subscription);
                                 #[cfg(not(feature = "sync-autopsy"))]
                                 let _ = subscription;
@@ -2519,7 +2519,7 @@ where
                                     read_view: upstream_opts.read_view_key(),
                                 });
                             let opening_pending = if !permissions_ready {
-                                Some(SyncMessage::ViewUpdate {
+                                Some(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                                     subscription,
                                     settled_through: self.node.borrow().committed_global_time(),
                                     reset_result_set: true,
@@ -2534,7 +2534,7 @@ where
                                     terminal_operations: Vec::new(),
                                     program_fact_adds: Vec::new(),
                                     program_fact_removes: Vec::new(),
-                                })
+                                }))
                             } else {
                                 None
                             };
@@ -3156,7 +3156,7 @@ fn serialized_sync_message_len(message: &SyncMessage) -> usize {
 
 fn view_update_parts_from_message(message: SyncMessage) -> ViewUpdateParts {
     match message {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through,
             reset_result_set,
@@ -3168,7 +3168,7 @@ fn view_update_parts_from_message(message: SyncMessage) -> ViewUpdateParts {
             terminal_operations,
             program_fact_adds,
             program_fact_removes,
-        } => ViewUpdateParts {
+        }) => ViewUpdateParts {
             subscription,
             settled_through,
             defer_settlement: false,
@@ -3205,11 +3205,11 @@ fn stage_initial_coverage_clear_for_update(
     latest: &LatestCoverageSubscriptions,
     clears: &mut BTreeSet<CoverageKey>,
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         peer_payload_inventory,
         ..
-    } = update
+    }) = update
     else {
         return;
     };
@@ -3466,10 +3466,8 @@ where
                     key: scope.key.clone(),
                     clause_index: index as u16,
                     clause_count,
-                    view: crate::protocol::AuthorizationScopeViewPayload::from_view_update(
-                        clause.view.clone(),
-                    )
-                    .expect("authority scope clauses are view updates"),
+                    view: crate::protocol::ViewUpdatePayload::from_view_update(clause.view.clone())
+                        .expect("authority scope clauses are view updates"),
                 })
                 .map_err(transport_error)?;
         }
@@ -3561,10 +3559,10 @@ where
                 .map_err(transport_error)?;
             return Ok(());
         };
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             settled_through: cut,
             ..
-        } = &update
+        }) = &update
         else {
             return Err(Error::new(
                 ErrorCode::Protocol,
@@ -3586,10 +3584,8 @@ where
                 key: scope.key.clone(),
                 clause_index: index as u16,
                 clause_count,
-                view: crate::protocol::AuthorizationScopeViewPayload::from_view_update(
-                    update.clone(),
-                )
-                .expect("scope hydration produces view updates"),
+                view: crate::protocol::ViewUpdatePayload::from_view_update(update.clone())
+                    .expect("scope hydration produces view updates"),
             })
             .map_err(transport_error)?;
         support_subscriptions.push(subscription);
@@ -3654,11 +3650,11 @@ fn authorization_scope_receipt_for_view<S>(
 where
     S: OrderedKvStorage,
 {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         ..
-    } = update
+    }) = update
     else {
         return None;
     };
@@ -3975,7 +3971,7 @@ fn summarize_sync_message(message: &SyncMessage) -> String {
             "SubscribeRejected {} reason={reason:?}",
             summarize_subscription_key(*subscription)
         ),
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through,
             reset_result_set,
@@ -3987,7 +3983,7 @@ fn summarize_sync_message(message: &SyncMessage) -> String {
             program_fact_adds,
             program_fact_removes,
             terminal_operations,
-        } => format!(
+        }) => format!(
             "ViewUpdate {} settled={} reset={} bundles={} inventory={} adds={} removes={} fact_adds={} fact_removes={} terminal_ops={}",
             summarize_subscription_key(*subscription),
             settled_through.0,
@@ -4040,11 +4036,11 @@ where
 {
     send_catalogue_snapshot_if_needed(node, peer, transport)?;
     let mut message = message;
-    if let SyncMessage::ViewUpdate {
+    if let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         peer_payload_inventory,
         ..
-    } = &mut message
+    }) = &mut message
     {
         peer_payload_inventory
             .authorization_progress
@@ -4109,7 +4105,9 @@ where
 
 fn view_update_subscription(message: &SyncMessage) -> Option<SubscriptionKey> {
     match message {
-        SyncMessage::ViewUpdate { subscription, .. } => Some(*subscription),
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { subscription, .. }) => {
+            Some(*subscription)
+        }
         _ => None,
     }
 }
@@ -4119,11 +4117,11 @@ fn stamp_view_update_authorization_progress_from(
     source_subscription: SubscriptionKey,
     message: &mut SyncMessage,
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         peer_payload_inventory,
         ..
-    } = message
+    }) = message
     else {
         return;
     };
@@ -4137,7 +4135,9 @@ fn stamp_view_update_authorization_progress_from(
 }
 
 fn retarget_view_update(mut message: SyncMessage, target: SubscriptionKey) -> SyncMessage {
-    if let SyncMessage::ViewUpdate { subscription, .. } = &mut message {
+    if let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { subscription, .. }) =
+        &mut message
+    {
         *subscription = target;
     }
     message
@@ -4286,7 +4286,7 @@ fn binding_values_in_param_order(shape: &ValidatedQuery, binding: &Binding) -> V
 /// nothing to ship to the subscriber this tick.
 pub(super) fn view_update_is_empty(message: &SyncMessage) -> bool {
     match message {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             reset_result_set,
             version_carriers,
             version_bundles,
@@ -4296,7 +4296,7 @@ pub(super) fn view_update_is_empty(message: &SyncMessage) -> bool {
             program_fact_adds,
             program_fact_removes,
             ..
-        } => {
+        }) => {
             !reset_result_set
                 && version_carriers.is_empty()
                 && version_bundles.is_empty()

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -620,11 +620,11 @@ fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
         .filter(|message| {
             matches!(
                 message,
-                SyncMessage::ViewUpdate {
+                SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                     result_member_adds,
                     settled_through,
                     ..
-                } if *settled_through > GlobalTime(0)
+                }) if *settled_through > GlobalTime(0)
                     && result_member_adds.iter().any(|member| {
                         member.as_row().is_some_and(|(table, row_uuid, tx_id)| {
                             table.as_str() == "todos"

--- a/crates/jazz/src/db/tests/peer_connection/authorization_scope.rs
+++ b/crates/jazz/src/db/tests/peer_connection/authorization_scope.rs
@@ -117,7 +117,7 @@ fn assert_delayed_duplicate_usage_reset(replacement_row: bool) {
         if server_sent.borrow().iter().any(|message| {
             matches!(
                 message,
-                SyncMessage::ViewUpdate { subscription, .. }
+                SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { subscription, .. })
                     if *subscription == second_subscription
             )
         }) {
@@ -131,21 +131,19 @@ fn assert_delayed_duplicate_usage_reset(replacement_row: bool) {
         .iter()
         .rev()
         .find_map(|message| match message {
-            SyncMessage::ViewUpdate { subscription, .. }
-                if *subscription == second_subscription =>
-            {
-                Some(message.clone())
-            }
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+                subscription, ..
+            }) if *subscription == second_subscription => Some(message.clone()),
             _ => None,
         })
         .expect("duplicate usage site must receive its own ViewUpdate");
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         peer_payload_inventory,
         result_member_adds,
         result_member_removes,
         ..
-    } = &second_update
+    }) = &second_update
     else {
         unreachable!();
     };
@@ -219,10 +217,10 @@ fn legacy_authorization_scope_subscribe_is_rejected_before_shape_admission() {
     while let Some(message) = client_transport.try_recv() {
         match message {
             SyncMessage::CatalogueSnapshot(_) => {}
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 subscription: received,
                 ..
-            } => {
+            }) => {
                 assert_eq!(received, subscription);
                 received_view = true;
             }
@@ -255,7 +253,7 @@ fn legacy_authorization_scope_subscribe_refreshes_claims() {
     let mut refreshed_receipt = None;
     while let Some(message) = client_transport.try_recv() {
         match message {
-            SyncMessage::ViewUpdate { .. } => refreshed_view = true,
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. }) => refreshed_view = true,
             SyncMessage::AuthorizationScopeReceipt { receipt, .. } => {
                 assert!(
                     refreshed_view,
@@ -409,7 +407,9 @@ fn legacy_authorization_scope_subscribe_never_assembles_multiple_clauses() {
     let mut saw_receipt = false;
     while let Some(message) = client_transport.try_recv() {
         match message {
-            SyncMessage::ViewUpdate { .. } => saw_second_view = true,
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. }) => {
+                saw_second_view = true
+            }
             SyncMessage::AuthorizationScopeReceipt { receipt, .. } => {
                 assert!(
                     saw_second_view,
@@ -692,7 +692,7 @@ fn legacy_authorization_scope_subscribe_rejects_every_read_view() {
     while let Some(message) = canonical_client.try_recv() {
         match message {
             SyncMessage::CatalogueSnapshot(_) => {}
-            SyncMessage::ViewUpdate { .. } => saw_view = true,
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. }) => saw_view = true,
             SyncMessage::AuthorizationScopeReceipt { .. } => {
                 assert!(saw_view, "canonical receipt follows its support view");
                 saw_receipt = true;
@@ -765,21 +765,23 @@ fn subscriber_cannot_spoof_authority_view_updates() {
             _ => continue,
         }
     };
-    let view_update = |opening_pending, settled_through| SyncMessage::ViewUpdate {
-        subscription,
-        settled_through: GlobalTime(settled_through),
-        reset_result_set: true,
-        version_carriers: Vec::new(),
-        version_bundles: Vec::new(),
-        peer_payload_inventory: crate::protocol::PeerPayloadInventory {
-            opening_pending,
-            ..Default::default()
-        },
-        result_member_adds: Vec::new(),
-        result_member_removes: Vec::new(),
-        terminal_operations: Vec::new(),
-        program_fact_adds: Vec::new(),
-        program_fact_removes: Vec::new(),
+    let view_update = |opening_pending, settled_through| {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+            subscription,
+            settled_through: GlobalTime(settled_through),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory {
+                opening_pending,
+                ..Default::default()
+            },
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
     };
     authority_transport.send(view_update(true, 1)).unwrap();
     edge.tick().unwrap();

--- a/crates/jazz/src/db/tests/reads.rs
+++ b/crates/jazz/src/db/tests/reads.rs
@@ -1159,11 +1159,11 @@ fn maintained_subscription_with_two_reference_includes_opens_with_source_coverag
         .unwrap();
 
     let message = drive_subscriber_until_payload(&subscriber, client_transport.as_mut());
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription: served,
         result_member_adds,
         ..
-    } = message
+    }) = message
     else {
         panic!("expected include subscription view update, got {message:?}");
     };
@@ -1188,11 +1188,11 @@ fn maintained_subscription_with_two_reference_includes_opens_with_source_coverag
         .unwrap();
 
     let message = drive_subscriber_until_payload(&subscriber, client_transport.as_mut());
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription: served,
         result_member_adds,
         ..
-    } = message
+    }) = message
     else {
         panic!("expected reopened include subscription view update, got {message:?}");
     };

--- a/crates/jazz/src/db/tests/subscriptions/coverage/server_protocol.rs
+++ b/crates/jazz/src/db/tests/subscriptions/coverage/server_protocol.rs
@@ -212,7 +212,9 @@ fn subscriber_connection_serves_default_ordered_window_alongside_unbounded_shape
     let subscriptions = drive_subscriber_until_payloads(&subscriber, client_transport.as_mut(), 2)
         .into_iter()
         .map(|message| match message {
-            SyncMessage::ViewUpdate { subscription, .. } => subscription,
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+                subscription, ..
+            }) => subscription,
             other => panic!("expected ViewUpdate, got {other:?}"),
         })
         .collect::<BTreeSet<_>>();
@@ -761,11 +763,11 @@ fn subscriber_connection_accepts_relation_register_shape_for_serving_subscriptio
         }))
         .unwrap();
 
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription: served,
         result_member_adds,
         ..
-    } = drive_subscriber_until_payload(&subscriber, client_transport.as_mut())
+    }) = drive_subscriber_until_payload(&subscriber, client_transport.as_mut())
     else {
         panic!("expected relation facade subscription view update");
     };

--- a/crates/jazz/src/db/tests/subscriptions/coverage/settlement/authority_receipts.rs
+++ b/crates/jazz/src/db/tests/subscriptions/coverage/settlement/authority_receipts.rs
@@ -134,18 +134,20 @@ fn nonselected_view_update_demotes_receipts_for_other_recomputed_views() {
     let client = open_db(0xc1, client_author, &schema);
     let all_query = Query::from("todos");
     let filtered_query = Query::from("todos").filter(eq(col("title"), lit("matching")));
-    let view_update = |subscription, settled_through| SyncMessage::ViewUpdate {
-        subscription,
-        settled_through,
-        reset_result_set: true,
-        version_carriers: Vec::new(),
-        version_bundles: Vec::new(),
-        peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
-        result_member_adds: Vec::new(),
-        result_member_removes: Vec::new(),
-        terminal_operations: Vec::new(),
-        program_fact_adds: Vec::new(),
-        program_fact_removes: Vec::new(),
+    let view_update = |subscription, settled_through| {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+            subscription,
+            settled_through,
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
     };
 
     let (old_client_transport, mut old_authority) = duplex();
@@ -313,18 +315,20 @@ fn fallback_staged_cut_blocks_older_selected_confirmation() {
     let client_author = AuthorId::from_bytes([0xc1; 16]);
     let client = open_db(0xc1, client_author, &schema);
     let query = Query::from("todos");
-    let update = |subscription, settled_through| SyncMessage::ViewUpdate {
-        subscription,
-        settled_through,
-        reset_result_set: true,
-        version_carriers: Vec::new(),
-        version_bundles: Vec::new(),
-        peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
-        result_member_adds: Vec::new(),
-        result_member_removes: Vec::new(),
-        terminal_operations: Vec::new(),
-        program_fact_adds: Vec::new(),
-        program_fact_removes: Vec::new(),
+    let update = |subscription, settled_through| {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+            subscription,
+            settled_through,
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
     };
 
     let (old_client_transport, mut old_authority) = duplex();
@@ -387,18 +391,20 @@ fn fallback_replay_of_preselection_row_repair_cannot_settle() {
             _ => continue,
         }
     };
-    let view_update = |subscription, settled_through| SyncMessage::ViewUpdate {
-        subscription,
-        settled_through,
-        reset_result_set: true,
-        version_carriers: Vec::new(),
-        version_bundles: Vec::new(),
-        peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
-        result_member_adds: Vec::new(),
-        result_member_removes: Vec::new(),
-        terminal_operations: Vec::new(),
-        program_fact_adds: Vec::new(),
-        program_fact_removes: Vec::new(),
+    let view_update = |subscription, settled_through| {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+            subscription,
+            settled_through,
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
     };
     old_authority_transport
         .send(view_update(old_subscription, GlobalTime(1)))

--- a/crates/jazz/src/db/tests/subscriptions/coverage/settlement/usage_coverage.rs
+++ b/crates/jazz/src/db/tests/subscriptions/coverage/settlement/usage_coverage.rs
@@ -119,19 +119,21 @@ fn one_shot_local_coverage_does_not_require_authority_continuity() {
         }
     };
     authority_transport
-        .send(SyncMessage::ViewUpdate {
-            subscription,
-            settled_through: GlobalTime(1),
-            reset_result_set: true,
-            version_carriers: Vec::new(),
-            version_bundles: Vec::new(),
-            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
-            result_member_adds: Vec::new(),
-            result_member_removes: Vec::new(),
-            terminal_operations: Vec::new(),
-            program_fact_adds: Vec::new(),
-            program_fact_removes: Vec::new(),
-        })
+        .send(SyncMessage::ViewUpdate(
+            crate::protocol::ViewUpdatePayload {
+                subscription,
+                settled_through: GlobalTime(1),
+                reset_result_set: true,
+                version_carriers: Vec::new(),
+                version_bundles: Vec::new(),
+                peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+                result_member_adds: Vec::new(),
+                result_member_removes: Vec::new(),
+                terminal_operations: Vec::new(),
+                program_fact_adds: Vec::new(),
+                program_fact_removes: Vec::new(),
+            },
+        ))
         .unwrap();
     client.tick().unwrap();
     assert!(client.query_attachment_is_covered(&attachment));
@@ -639,18 +641,20 @@ fn malformed_authority_opening_keeps_shared_coverage_provisional() {
             _ => continue,
         }
     };
-    let update = |version_bundles| SyncMessage::ViewUpdate {
-        subscription,
-        settled_through: GlobalTime(1),
-        reset_result_set: true,
-        version_carriers: Vec::new(),
-        version_bundles,
-        peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
-        result_member_adds: Vec::new(),
-        result_member_removes: Vec::new(),
-        terminal_operations: Vec::new(),
-        program_fact_adds: Vec::new(),
-        program_fact_removes: Vec::new(),
+    let update = |version_bundles| {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+            subscription,
+            settled_through: GlobalTime(1),
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles,
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
     };
     authority_transport
         .send(update(vec![crate::protocol::VersionBundle {

--- a/crates/jazz/src/db/tests/subscriptions/materialization.rs
+++ b/crates/jazz/src/db/tests/subscriptions/materialization.rs
@@ -700,7 +700,7 @@ fn view_update_is_not_empty_when_it_only_carries_program_facts() {
         binding_id: crate::query::BindingId(uuid::Uuid::from_bytes([0x22; 16])),
         read_view: Default::default(),
     };
-    let empty = SyncMessage::ViewUpdate {
+    let empty = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: crate::time::GlobalTime(0),
         reset_result_set: false,
@@ -712,10 +712,10 @@ fn view_update_is_not_empty_when_it_only_carries_program_facts() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
     assert!(view_update_is_empty(&empty));
 
-    let fact_only = SyncMessage::ViewUpdate {
+    let fact_only = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: crate::time::GlobalTime(0),
         reset_result_set: false,
@@ -735,6 +735,6 @@ fn view_update_is_not_empty_when_it_only_carries_program_facts() {
             },
         )],
         program_fact_removes: Vec::new(),
-    };
+    });
     assert!(!view_update_is_empty(&fact_only));
 }

--- a/crates/jazz/src/db/tests/support.rs
+++ b/crates/jazz/src/db/tests/support.rs
@@ -683,7 +683,7 @@ pub(super) fn assert_view_update_for_subscription(
     expected_subscription: SubscriptionKey,
 ) {
     match message {
-        SyncMessage::ViewUpdate { subscription, .. } => {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { subscription, .. }) => {
             assert_eq!(subscription, expected_subscription);
         }
         other => panic!("expected ViewUpdate, got {other:?}"),

--- a/crates/jazz/src/node/ingest/catalogue.rs
+++ b/crates/jazz/src/node/ingest/catalogue.rs
@@ -219,7 +219,7 @@ where
                         .await?;
                     self.drain_parked_commit_units().await
                 }
-                SyncMessage::ViewUpdate {
+                SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                     subscription,
                     settled_through,
                     reset_result_set,
@@ -231,7 +231,7 @@ where
                     terminal_operations,
                     program_fact_adds,
                     program_fact_removes,
-                } => {
+                }) => {
                     self.apply_view_update(ViewUpdateParts {
                         subscription,
                         settled_through,

--- a/crates/jazz/src/node/query_eval/tests/authorization.rs
+++ b/crates/jazz/src/node/query_eval/tests/authorization.rs
@@ -627,9 +627,9 @@ fn prepared_nested_policy_claim_routes_keep_outer_descriptor_slots() {
     let normal_versions = normal_update
         .expand_version_carriers_for_receive()
         .expect("expand normal-member message include/order payloads");
-    if let SyncMessage::ViewUpdate {
+    if let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         version_bundles, ..
-    } = &normal_versions
+    }) = &normal_versions
     {
         let (profile_bundle, profile_version) = version_bundles
             .iter()
@@ -1015,11 +1015,11 @@ fn missing_policy_seed_claim_denies_authorization_support_rehydration() {
     let update = peer
         .rehydrate_authorization_support_query(&mut node, &shape, &binding, options)
         .expect("missing policy seed claim must hydrate as an empty authorization proof");
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("authorization support must return a settled view update");
     };

--- a/crates/jazz/src/node/query_eval/tests/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/tests/maintained_views.rs
@@ -217,10 +217,10 @@ fn recursive_reachability_subscription_grants_and_revokes_incrementally() {
     let initial = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
     assert!(matches!(
         initial,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             result_member_adds,
             ..
-        } if result_member_adds.iter().filter_map(crate::protocol::ResultMemberEntry::as_row).any(|(_, row_uuid, _)| row_uuid == resource1)
+        }) if result_member_adds.iter().filter_map(crate::protocol::ResultMemberEntry::as_row).any(|(_, row_uuid, _)| row_uuid == resource1)
             && result_member_adds.iter().filter_map(crate::protocol::ResultMemberEntry::as_row).all(|(_, row_uuid, _)| row_uuid != resource2)
     ));
 
@@ -239,11 +239,11 @@ fn recursive_reachability_subscription_grants_and_revokes_incrementally() {
     let grant = peer.query_update(&mut core, &shape, &binding).unwrap();
     assert!(matches!(
         grant,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             result_member_adds,
             result_member_removes,
             ..
-        } if result_member_adds.iter().filter_map(crate::protocol::ResultMemberEntry::as_row).any(|(_, row_uuid, _)| row_uuid == resource2)
+        }) if result_member_adds.iter().filter_map(crate::protocol::ResultMemberEntry::as_row).any(|(_, row_uuid, _)| row_uuid == resource2)
             && result_member_removes.is_empty()
     ));
 
@@ -251,11 +251,11 @@ fn recursive_reachability_subscription_grants_and_revokes_incrementally() {
     let revoke = peer.query_update(&mut core, &shape, &binding).unwrap();
     assert!(matches!(
         revoke,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             result_member_adds,
             result_member_removes,
             ..
-        } if result_member_adds.is_empty()
+        }) if result_member_adds.is_empty()
             && result_member_removes.iter().filter_map(crate::protocol::ResultMemberEntry::as_row).any(|(_, row_uuid, _)| row_uuid == resource1)
             && result_member_removes.iter().filter_map(crate::protocol::ResultMemberEntry::as_row).any(|(_, row_uuid, _)| row_uuid == resource2)
     ));

--- a/crates/jazz/src/node/query_eval/tests/materialization.rs
+++ b/crates/jazz/src/node/query_eval/tests/materialization.rs
@@ -754,11 +754,11 @@ fn flat_join_correlates_projected_v1_sources_across_table_rename() {
     client
         .apply_sync_message_settled(update.clone())
         .expect("apply maintained v2 flat join on client");
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         ..
-    } = update
+    }) = update
     else {
         panic!("flat join rehydrate must emit a view update");
     };
@@ -809,7 +809,7 @@ fn flat_join_correlates_projected_v1_sources_across_table_rename() {
         )
         .expect("publish flat tuple replacement")
         .expect("expected view update");
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         version_carriers,
         version_bundles,
@@ -818,7 +818,7 @@ fn flat_join_correlates_projected_v1_sources_across_table_rename() {
         program_fact_adds,
         program_fact_removes,
         ..
-    } = &replacement
+    }) = &replacement
     else {
         panic!("flat tuple replacement must emit a view update");
     };

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -92,19 +92,19 @@ fn query_subscription_result_sets_track_bindings_and_rehydrate() {
         .unwrap();
     assert!(matches!(
         removed_delta,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             result_member_adds,
             result_member_removes,
             ..
-        } if result_member_adds.is_empty() && result_member_removes.is_empty()
+        }) if result_member_adds.is_empty() && result_member_removes.is_empty()
     ));
 
     let reset = peer
         .rehydrate_query(&mut server, &shape, &alice_binding)
         .unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set, ..
-    } = &reset
+    }) = &reset
     else {
         panic!("expected view update");
     };
@@ -276,9 +276,9 @@ fn query_subscription_ships_provenance_closure_for_local_evaluation() {
     register_shape_binding_for_receiver(&mut reader, &shape, &binding);
     let mut peer = PeerState::new();
     let update = peer.rehydrate_query(&mut server, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/state/read_payload.rs
+++ b/crates/jazz/src/node/state/read_payload.rs
@@ -452,14 +452,14 @@ where
             version_bundles,
             program_fact_adds,
         ) = match message {
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 subscription,
                 result_member_adds,
                 version_carriers,
                 version_bundles,
                 program_fact_adds,
                 ..
-            } => (
+            }) => (
                 *subscription,
                 result_member_adds,
                 version_carriers,

--- a/crates/jazz/src/node/tests/catalogue_lenses/enum_projection.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses/enum_projection.rs
@@ -543,7 +543,7 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     let initial = title_peer
         .rehydrate_query(&mut core, &title_only, &title_binding)
         .expect("old-schema title subscription opens over known case");
-    let SyncMessage::ViewUpdate { reset_result_set, result_member_adds, .. } = initial else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { reset_result_set, result_member_adds, .. }) = initial else {
         panic!("expected initial maintained view update");
     };
     assert!(reset_result_set);
@@ -554,13 +554,13 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     let unchanged = title_peer
         .query_update(&mut core, &title_only, &title_binding)
         .expect("identical projection target remains registered");
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         terminal_operations,
         ..
-    } = unchanged else {
+    }) = unchanged else {
         panic!("expected maintained view update");
     };
     assert!(!reset_result_set, "idempotent target registration must not reset");
@@ -579,7 +579,7 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
     let update = title_peer
         .query_update(&mut core, &title_only, &title_binding)
         .expect("unused unknown enum must not break maintained title output");
-    let SyncMessage::ViewUpdate { reset_result_set, result_member_adds, .. } = update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { reset_result_set, result_member_adds, .. }) = update else {
         panic!("expected maintained view update");
     };
     assert!(!reset_result_set);
@@ -620,7 +620,7 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
             status_options.clone(),
         )
         .expect("required unknown enum case is a row exclusion");
-    let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { result_member_adds, .. }) = update else {
         panic!("expected initial maintained view update");
     };
     assert_eq!(result_member_adds.len(), 1);
@@ -648,7 +648,7 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
         )
         .expect("newly incompatible delta removes the row")
         .expect("expected view update");
-    let SyncMessage::ViewUpdate { result_member_removes, .. } = update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { result_member_removes, .. }) = update else {
         panic!("expected maintained view update");
     };
     assert!(result_member_removes.iter().any(|member| {
@@ -671,7 +671,7 @@ fn maintained_old_enum_subscriptions_omit_rows_that_require_new_cases() {
         )
         .expect("newly compatible delta re-adds the row")
         .expect("expected view update");
-    let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { result_member_adds, .. }) = update else {
         panic!("expected maintained view update");
     };
     assert!(result_member_adds.iter().any(|member| {
@@ -736,7 +736,7 @@ fn maintained_old_payload_enum_subscription_omits_new_case_without_aliasing() {
     let update = required_peer
         .rehydrate_query(&mut core, &required, &binding)
         .expect("unknown payload case is a row exclusion");
-    let SyncMessage::ViewUpdate { result_member_adds, .. } = update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { result_member_adds, .. }) = update else {
         panic!("expected initial maintained view update");
     };
     assert!(result_member_adds.is_empty());

--- a/crates/jazz/src/node/tests/catalogue_lenses/replication.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses/replication.rs
@@ -412,7 +412,7 @@ fn batched_view_update_rejects_incomplete_authored_row_before_storage() {
     assert_eq!(bundles.len(), 1);
     let version = bundles[0].versions[0].clone();
     bundles[0].versions = vec![zero_column_version_claiming_schema(&base, &version)];
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         reset_result_set,
@@ -423,7 +423,7 @@ fn batched_view_update_rejects_incomplete_authored_row_before_storage() {
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -473,7 +473,7 @@ fn view_update_rejects_incomplete_authored_row_before_storage() {
     let mut bundles = version_bundles_for_update(&update);
     let version = bundles[0].versions[0].clone();
     bundles[0].versions = vec![zero_column_version_claiming_schema(&base, &version)];
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         reset_result_set,
@@ -484,14 +484,14 @@ fn view_update_rejects_incomplete_authored_row_before_storage() {
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
 
     let (_reader_dir, mut reader) = open_node_with_schema(node(0x6f), base);
     assert!(matches!(
-        reader.apply_sync_message_settled(SyncMessage::ViewUpdate {
+        reader.apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through,
             reset_result_set,
@@ -503,7 +503,7 @@ fn view_update_rejects_incomplete_authored_row_before_storage() {
             terminal_operations,
             program_fact_adds,
             program_fact_removes,
-        }),
+        })),
         Err(Error::MalformedViewUpdate(
             "row version does not carry the complete descriptor of its authored schema"
         ))
@@ -562,7 +562,7 @@ fn reset_view_update_rejection_does_not_leave_initial_sync_flush_active() {
     let mut bundles = version_bundles_for_update(&update);
     let version = bundles[0].versions[0].clone();
     bundles[0].versions = vec![zero_column_version_claiming_schema(&base, &version)];
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         peer_payload_inventory,
@@ -572,7 +572,7 @@ fn reset_view_update_rejection_does_not_leave_initial_sync_flush_active() {
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -631,7 +631,7 @@ fn batched_view_update_rejection_is_atomic_across_valid_and_malformed_bundles() 
     let malformed = bundles[1].versions[0].clone();
     bundles[1].versions = vec![zero_column_version_claiming_schema(&base, &malformed)];
     let valid_tx_id = bundles[0].tx.tx_id;
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         peer_payload_inventory,
@@ -641,7 +641,7 @@ fn batched_view_update_rejection_is_atomic_across_valid_and_malformed_bundles() 
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs
@@ -354,9 +354,9 @@ fn publishing_schema_registers_new_tables_without_storage_reopen() {
     .unwrap();
     let update = peer.current_rows_update(&mut core, "notes").unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = update
+    }) = update
     else {
         panic!("current-row subscription should produce a view update");
     };

--- a/crates/jazz/src/node/tests/counter_merge.rs
+++ b/crates/jazz/src/node/tests/counter_merge.rs
@@ -28,11 +28,11 @@ fn core_creates_merge_versions_for_concurrent_heads() {
 
     let update = core.view_update_for_current_rows("todos").unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/exclusive_transactions.rs
+++ b/crates/jazz/src/node/tests/exclusive_transactions.rs
@@ -1214,12 +1214,12 @@ fn receiver_tracks_partial_exclusive_payload_coverage_per_view() {
     let mut peer = PeerState::new();
     let update = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
     let mut version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         result_member_adds,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1238,7 +1238,7 @@ fn receiver_tracks_partial_exclusive_payload_coverage_per_view() {
 
     register_shape_binding_for_receiver(&mut reader, &shape, &binding);
     reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through,
             reset_result_set: false,
@@ -1250,7 +1250,7 @@ fn receiver_tracks_partial_exclusive_payload_coverage_per_view() {
                 terminal_operations: Vec::new(),
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
     assert!(reader
         .current_rows("todos", DurabilityTier::Global)
@@ -1300,11 +1300,11 @@ fn malformed_exclusive_partial_result_row_add_is_rejected() {
     let mut peer = PeerState::new();
     let update = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1315,7 +1315,7 @@ fn malformed_exclusive_partial_result_row_add_is_rejected() {
 
     register_shape_binding_for_receiver(&mut reader, &shape, &binding);
     let err = reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through,
             reset_result_set: false,
@@ -1327,7 +1327,7 @@ fn malformed_exclusive_partial_result_row_add_is_rejected() {
                 terminal_operations: Vec::new(),
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap_err();
 
     assert!(matches!(
@@ -1380,10 +1380,10 @@ fn partial_exclusive_payload_does_not_establish_tx_level_complete_tx_ref() {
         .rehydrate_query(&mut core, &first_shape, &first_binding)
         .unwrap();
     let version_bundles = version_bundles_for_update(&first);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         ..
-    } = first
+    }) = first
     else {
         panic!("expected view update");
     };
@@ -1397,10 +1397,10 @@ fn partial_exclusive_payload_does_not_establish_tx_level_complete_tx_ref() {
         .rehydrate_query(&mut core, &second_shape, &second_binding)
         .unwrap();
     let version_bundles = version_bundles_for_update(&second);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         ..
-    } = second
+    }) = second
     else {
         panic!("expected view update");
     };
@@ -1441,10 +1441,10 @@ fn exclusive_view_shipping_is_view_atomic_per_recipient() {
     let mut link_a = PeerState::client_link(author_a);
     let update_a = link_a.current_rows_update(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&update_a);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         ..
-    } = &update_a
+    }) = &update_a
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/lens_projected_maintained.rs
+++ b/crates/jazz/src/node/tests/lens_projected_maintained.rs
@@ -76,12 +76,12 @@ fn maintained_projected_current_picks_winner_before_lens_projection() {
     let mut peer = PeerState::new();
     let update = peer.current_rows_update(&mut core, "todos").unwrap();
     let bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         reset_result_set,
         ..
-    } = update
+    }) = update
     else {
         panic!("current-row subscription should produce a view update");
     };

--- a/crates/jazz/src/node/tests/m3_differential.rs
+++ b/crates/jazz/src/node/tests/m3_differential.rs
@@ -1618,12 +1618,12 @@ fn apply_result_members(
     update: &SyncMessage,
     root_table: &str,
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1647,12 +1647,12 @@ fn apply_result_members(
 }
 
 fn apply_aggregate_payload(values: &mut BTreeMap<u64, Value>, update: &SyncMessage, output: &str) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/policies_rls/includes.rs
+++ b/crates/jazz/src/node/tests/policies_rls/includes.rs
@@ -265,11 +265,11 @@ fn seed_multi_segment_include_fixture(
 }
 
 fn canonical_view_update_rows(update: &SyncMessage) -> (Vec<ResultRowEntry>, Vec<ResultRowEntry>) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -456,9 +456,9 @@ fn prepared_subscription_multi_segment_forward_include_keeps_root_delta() {
     core.accept_global_for_test(update_tx).unwrap();
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/policies_rls/read_delivery.rs
+++ b/crates/jazz/src/node/tests/policies_rls/read_delivery.rs
@@ -398,10 +398,10 @@ fn camel_case_message_read_policy_incrementally_adds_member_message() {
     assert_view_update_only_ships_rows(&update, BTreeSet::from([bob_message, bob_profile]));
     assert!(matches!(
         update,
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 result_member_adds: ref adds,
                 ..
-        } if adds.iter().any(|entry| entry == &("messages".to_owned().into(), bob_message, bob_message_tx))
+        }) if adds.iter().any(|entry| entry == &("messages".to_owned().into(), bob_message, bob_message_tx))
     ));
     let _ = bob_membership_tx;
 }
@@ -676,10 +676,10 @@ fn edge_membership_insert_updates_previously_empty_private_message_query() {
         .unwrap();
     assert!(matches!(
         update,
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 result_member_adds: ref adds,
                 ..
-        } if adds.iter().any(|entry| entry == &("messages".to_owned().into(), seed_message, seed_tx))
+        }) if adds.iter().any(|entry| entry == &("messages".to_owned().into(), seed_message, seed_tx))
     ));
 }
 
@@ -738,11 +738,11 @@ fn edge_rehydrate_refreshes_previously_covered_private_message_query() {
         .unwrap();
     assert!(matches!(
         initial,
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 result_member_adds: ref adds,
                 reset_result_set: true,
                 ..
-        } if adds.iter().any(|entry| entry == &("messages".to_owned().into(), seed_message, seed_tx))
+        }) if adds.iter().any(|entry| entry == &("messages".to_owned().into(), seed_message, seed_tx))
     ));
 
     let bob_membership_tx = core
@@ -775,11 +775,11 @@ fn edge_rehydrate_refreshes_previously_covered_private_message_query() {
     let rehydrated = alice_peer
         .rehydrate_query_with_opts(&mut core, &shape, &binding, opts)
         .unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         reset_result_set,
         ..
-    } = rehydrated
+    }) = rehydrated
     else {
         panic!("expected rehydrate view update");
     };
@@ -934,17 +934,17 @@ fn composed_read_policy_grants_and_revokes_incrementally() {
         .unwrap();
     assert!(matches!(
         invited_initial,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             result_member_adds: ref adds,
             ..
-        } if adds.is_empty()
+        }) if adds.is_empty()
     ));
     assert!(matches!(
         spy_initial,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             result_member_adds: ref adds,
             ..
-        } if adds.is_empty()
+        }) if adds.is_empty()
     ));
     assert_eq!(
         core.query
@@ -975,11 +975,11 @@ fn composed_read_policy_grants_and_revokes_incrementally() {
     let grant_update = invited_link
         .query_update(&mut core, &shape, &binding)
         .unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = grant_update
+    }) = grant_update
     else {
         panic!("expected grant update");
     };
@@ -996,11 +996,11 @@ fn composed_read_policy_grants_and_revokes_incrementally() {
     let spy_update = spy_link.query_update(&mut core, &shape, &binding).unwrap();
     assert!(matches!(
         spy_update,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             result_member_adds: ref adds,
             result_member_removes: ref removes,
             ..
-        } if adds.is_empty() && removes.is_empty()
+        }) if adds.is_empty() && removes.is_empty()
     ));
     assert_eq!(spy_link.metrics.result_adds_out, 0);
     assert_eq!(spy_link.metrics.version_bundles_out, 0);
@@ -1020,11 +1020,11 @@ fn composed_read_policy_grants_and_revokes_incrementally() {
     let revoke_update = invited_link
         .query_update(&mut core, &shape, &binding)
         .unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = revoke_update
+    }) = revoke_update
     else {
         panic!("expected revoke update");
     };
@@ -1513,12 +1513,12 @@ fn edge_query_rehydrate_resets_empty_result_for_denied_private_chat() {
         )
         .unwrap();
 
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         version_bundles,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/policies_rls/support.rs
+++ b/crates/jazz/src/node/tests/policies_rls/support.rs
@@ -26,11 +26,11 @@ fn assert_view_update_rows<const A: usize, const R: usize>(
     expected_adds: [(&str, RowUuid, TxId); A],
     expected_removes: [(&str, RowUuid, TxId); R],
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -607,14 +607,14 @@ fn maintained_public_query_bundle_filters_private_rows_from_same_tx() {
         .rehydrate_query(&mut core, &shape, &binding)
         .unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads, ..
             },
         result_member_adds,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -676,7 +676,7 @@ fn owner_transfer_removes_settled_result_set_without_redacting_local_copy() {
 
     let tx_b = commit_core_owner_fixture(&mut core, row_uuid, author_b, "owned by B", 11);
     let update = link_a.current_rows_update(&mut core, "todos").unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         version_bundles,
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
@@ -685,7 +685,7 @@ fn owner_transfer_removes_settled_result_set_without_redacting_local_copy() {
         result_member_adds,
         result_member_removes,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -889,9 +889,9 @@ fn join_policy_authorizes_writes_reads_and_next_emission_revocation() {
     let revoked_update = invited_link
         .current_rows_update(&mut core, "canvases")
         .unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_removes, ..
-    } = &revoked_update
+    }) = &revoked_update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -2840,10 +2840,10 @@ fn query_payload_dedup_is_per_peer_across_subscriptions() {
         .rehydrate_query(&mut core, &all_shape, &all_binding)
         .unwrap();
     let version_bundles = version_bundles_for_update(&first);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         ..
-    } = first
+    }) = first
     else {
         panic!("expected first view update");
     };
@@ -2855,10 +2855,10 @@ fn query_payload_dedup_is_per_peer_across_subscriptions() {
         .rehydrate_query(&mut core, &filtered_shape, &filtered_binding)
         .unwrap();
     let version_bundles = version_bundles_for_update(&second);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         ..
-    } = second
+    }) = second
     else {
         panic!("expected second view update");
     };
@@ -2901,10 +2901,10 @@ fn partial_mergeable_payload_does_not_establish_tx_level_complete_tx_ref() {
         .rehydrate_query(&mut core, &first_shape, &first_binding)
         .unwrap();
     let version_bundles = version_bundles_for_update(&first);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         ..
-    } = first
+    }) = first
     else {
         panic!("expected first view update");
     };
@@ -2917,10 +2917,10 @@ fn partial_mergeable_payload_does_not_establish_tx_level_complete_tx_ref() {
         .rehydrate_query(&mut core, &second_shape, &second_binding)
         .unwrap();
     let version_bundles = version_bundles_for_update(&second);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         ..
-    } = second
+    }) = second
     else {
         panic!("expected second view update");
     };

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -1002,7 +1002,7 @@ fn reopen_in_place_recovers_history_watermarks_pending_edges_and_rehydrates_peer
         )
         .unwrap();
     let update = peer.current_rows_update(&mut core, "todos").unwrap();
-    assert!(matches!(update, SyncMessage::ViewUpdate { .. }));
+    assert!(matches!(update, SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. })));
 
     let mut reopened = core.reopen_in_place().unwrap();
     assert_eq!(
@@ -1024,7 +1024,7 @@ fn reopen_in_place_recovers_history_watermarks_pending_edges_and_rehydrates_peer
     );
 
     let rehydrated = peer.rehydrate_current_rows(&mut reopened, "todos").unwrap();
-    assert!(matches!(rehydrated, SyncMessage::ViewUpdate { .. }));
+    assert!(matches!(rehydrated, SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. })));
 }
 #[test]
 fn empty_string_cells_and_absent_cells_survive_restart() {

--- a/crates/jazz/src/node/tests/support.rs
+++ b/crates/jazz/src/node/tests/support.rs
@@ -25,11 +25,11 @@ where
 }
 fn version_bundles_for_update(update: &SyncMessage) -> Vec<VersionBundle> {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             version_carriers,
             version_bundles,
             ..
-        } => {
+        }) => {
             let mut bundles = version_bundles.clone();
             bundles.extend(
                 crate::protocol::expand_version_carriers(version_carriers)
@@ -933,7 +933,7 @@ impl PerNodeKnowledge {
     }
 
     fn record_view_delivery(&mut self, message: &SyncMessage) {
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             reset_result_set,
             version_carriers,
             version_bundles,
@@ -943,7 +943,7 @@ impl PerNodeKnowledge {
             program_fact_adds,
             program_fact_removes,
             ..
-        } = message
+        }) = message
         else {
             return;
         };
@@ -1056,13 +1056,13 @@ fn assert_global_rows_match_known_oracle(
 }
 fn assert_view_update_result_set_matches_current_rows(node: &mut NodeState<RocksDbStorage>) {
     let update = node.view_update_for_current_rows("todos").unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         version_bundles: _,
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1411,10 +1411,10 @@ fn commit_core_owner_fixture(
     tx_id
 }
 fn assert_view_update_only_references_rows(update: &SyncMessage, expected_rows: BTreeSet<RowUuid>) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1432,7 +1432,7 @@ fn assert_view_update_only_references_rows(update: &SyncMessage, expected_rows: 
     assert_eq!(referenced_rows, expected_rows);
 }
 fn assert_view_update_only_ships_rows(update: &SyncMessage, expected_rows: BTreeSet<RowUuid>) {
-    if !matches!(update, SyncMessage::ViewUpdate { .. }) {
+    if !matches!(update, SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. })) {
         panic!("expected view update");
     }
     let version_bundles = version_bundles_for_update(update);
@@ -1467,7 +1467,7 @@ fn enqueue_rehydrate_with_dedup_assertion(
     let subscription = core.whole_table_subscription_key("todos").unwrap();
     peer.forget_subscription(subscription);
     let update = peer.reset_current_rows(core, "todos").unwrap();
-    let SyncMessage::ViewUpdate { .. } = &update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. }) = &update else {
         panic!("expected view update");
     };
     let version_bundles = version_bundles_for_update(&update);

--- a/crates/jazz/src/node/tests/sync/convergence_and_fates.rs
+++ b/crates/jazz/src/node/tests/sync/convergence_and_fates.rs
@@ -14,7 +14,7 @@ fn view_updates_drop_unknown_usage_site_bindings() {
     // in-flight traffic by design, so unknown per-subscription packets are
     // benign drops, not protocol corruption.
     reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription: unknown_usage_site,
             settled_through: GlobalTime(0),
             reset_result_set: false,
@@ -26,7 +26,7 @@ fn view_updates_drop_unknown_usage_site_bindings() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
 
     assert_eq!(
@@ -519,7 +519,7 @@ fn peer_rejects_sequenced_non_global_view_bundle_before_persisting_it() {
     let bad_tx = TxId::new(TxTime::from(10), node(8));
     let subscription = receiver.whole_table_subscription_key("todos").unwrap();
     receiver
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: GlobalTime(0),
             reset_result_set: true,
@@ -534,7 +534,7 @@ fn peer_rejects_sequenced_non_global_view_bundle_before_persisting_it() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
     let binding_view = receiver
         .binding_view_key_for_subscription(subscription)
@@ -542,7 +542,7 @@ fn peer_rejects_sequenced_non_global_view_bundle_before_persisting_it() {
     let before_generation = receiver.applied_view_update_generation(binding_view);
     assert!(receiver.opening_pending_for_binding_view(binding_view));
     let received = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        receiver.apply_sync_message_settled(SyncMessage::ViewUpdate {
+        receiver.apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: GlobalTime(0),
             reset_result_set: true,
@@ -576,7 +576,7 @@ fn peer_rejects_sequenced_non_global_view_bundle_before_persisting_it() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
     }));
     assert!(received.is_ok(), "a peer view must not panic the receiver");
     assert!(matches!(
@@ -592,7 +592,7 @@ fn peer_rejects_sequenced_non_global_view_bundle_before_persisting_it() {
         before_generation
     );
     receiver
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: GlobalTime(1),
             reset_result_set: true,
@@ -604,7 +604,7 @@ fn peer_rejects_sequenced_non_global_view_bundle_before_persisting_it() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
     assert!(!receiver.opening_pending_for_binding_view(binding_view));
     assert_eq!(

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -55,7 +55,7 @@ fn late_view_update_for_detached_subscription_is_dropped_and_counted() {
         binding_view_key
     );
     reader.apply_unsubscribe(usage_subscription);
-    let late = SyncMessage::ViewUpdate {
+    let late = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription: usage_subscription,
         settled_through: GlobalTime(2),
         reset_result_set: false,
@@ -71,7 +71,7 @@ fn late_view_update_for_detached_subscription_is_dropped_and_counted() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
     reader.apply_sync_message_settled(late).unwrap();
 
     assert_eq!(
@@ -100,7 +100,7 @@ fn late_view_update_for_never_registered_subscription_is_dropped_and_counted() {
         binding_id: BindingId(uuid::Uuid::from_bytes([0x66; 16])),
         read_view: Default::default(),
     };
-    let late = SyncMessage::ViewUpdate {
+    let late = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: GlobalTime(1),
         reset_result_set: true,
@@ -112,7 +112,7 @@ fn late_view_update_for_never_registered_subscription_is_dropped_and_counted() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
 
     reader.apply_sync_message_settled(late).unwrap();
 
@@ -160,7 +160,7 @@ fn known_state_removal_without_local_body_clears_membership_without_repair() {
     );
 
     let invisible_tx = TxId::new(TxTime(999), node(44));
-    let removal = SyncMessage::ViewUpdate {
+    let removal = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: GlobalTime(2),
         reset_result_set: false,
@@ -176,7 +176,7 @@ fn known_state_removal_without_local_body_clears_membership_without_repair() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
     assert!(
         reader
             .missing_known_state_row_version_refs(&removal)
@@ -209,7 +209,7 @@ fn known_state_removal_for_never_known_row_is_noop_but_settles() {
     let subscription = reader.whole_table_subscription_key("todos").unwrap();
     let binding_view_key = BindingViewKey::from_canonical_subscription_key(subscription);
 
-    let removal = SyncMessage::ViewUpdate {
+    let removal = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: GlobalTime(3),
         reset_result_set: false,
@@ -225,7 +225,7 @@ fn known_state_removal_for_never_known_row_is_noop_but_settles() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
 
     assert!(
         reader
@@ -305,7 +305,7 @@ fn empty_reset_for_duplicate_usage_subscription_does_not_degrade_canonical_view(
     );
 
     reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription: duplicate_subscription,
             settled_through: GlobalTime(2),
             reset_result_set: true,
@@ -317,7 +317,7 @@ fn empty_reset_for_duplicate_usage_subscription_does_not_degrade_canonical_view(
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
 
     assert_eq!(
@@ -376,10 +376,10 @@ fn known_state_rehydrate_skips_known_bodies_and_repairs_missing_payload() {
         .unwrap()
         .expect("expected view update");
     let control_version_bundles = version_bundles_for_update(&control_update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds: control_result_member_adds,
         ..
-    } = &control_update
+    }) = &control_update
     else {
         panic!("expected control view update");
     };
@@ -406,12 +406,12 @@ fn known_state_rehydrate_skips_known_bodies_and_repairs_missing_payload() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         settled_through,
         reset_result_set,
         result_member_adds,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -487,13 +487,13 @@ fn fast_known_state_rehydrate_ships_only_members_after_declared_position() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         settled_through,
         reset_result_set,
         result_member_adds,
         result_member_removes,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -572,10 +572,10 @@ fn exact_known_state_rehydrate_skips_known_bodies_but_preserves_membership() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -626,12 +626,12 @@ fn fast_known_state_noop_rehydrate_is_apply_safe_for_warm_reader() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -716,12 +716,12 @@ fn fast_known_state_noop_rehydrate_is_apply_safe_after_reader_reopen() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -913,10 +913,10 @@ fn slow_known_state_declaration_skips_exact_local_versions_only() {
         .unwrap()
         .expect("expected view update");
     let control_bundles = version_bundles_for_update(&control_update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds: control_members,
         ..
-    } = &control_update
+    }) = &control_update
     else {
         panic!("expected control update");
     };
@@ -936,10 +936,10 @@ fn slow_known_state_declaration_skips_exact_local_versions_only() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected declared update");
     };
@@ -1010,10 +1010,10 @@ fn over_cap_slow_known_state_declaration_degrades_to_full_ship() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected full update");
     };
@@ -1170,10 +1170,10 @@ fn known_state_declaration_never_skips_unfated_edge_members() {
         .unwrap()
         .expect("expected view update");
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/sync/performance_receipt.rs
+++ b/crates/jazz/src/node/tests/sync/performance_receipt.rs
@@ -336,11 +336,11 @@ fn policy_graph_perf_dropdown_entry_reset_ingest_timing_receipt() {
     let serve_start = std::time::Instant::now();
     let update = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
     let serve_elapsed = serve_start.elapsed();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         version_bundles,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/sync/receiver_batches.rs
+++ b/crates/jazz/src/node/tests/sync/receiver_batches.rs
@@ -26,9 +26,9 @@ fn cold_reset_bulk_ingest_matches_incremental_ingest() {
     let mut peer = PeerState::new();
     let update = peer.rehydrate_current_rows(&mut core, "todos").unwrap();
     let mut incremental_update = update.clone();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set, ..
-    } = &mut incremental_update
+    }) = &mut incremental_update
     else {
         panic!("expected view update");
     };
@@ -82,7 +82,7 @@ fn receiver_batch_ingests_non_reset_complete_bundles_once() {
 
     let update = core.view_update_for_current_rows("todos").unwrap();
     let mut version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         peer_payload_inventory,
@@ -91,7 +91,7 @@ fn receiver_batch_ingests_non_reset_complete_bundles_once() {
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -769,7 +769,7 @@ fn receiver_tracks_partial_mergeable_payload_coverage() {
     redacted_tx.n_total_writes = 1;
 
     reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: GlobalTime(0),
             reset_result_set: false,
@@ -788,7 +788,7 @@ fn receiver_tracks_partial_mergeable_payload_coverage() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
     assert_eq!(
         reader.current_rows("todos", DurabilityTier::Local).unwrap(),
@@ -805,7 +805,7 @@ fn receiver_tracks_partial_mergeable_payload_coverage() {
     );
 
     reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: GlobalTime(0),
             reset_result_set: false,
@@ -824,7 +824,7 @@ fn receiver_tracks_partial_mergeable_payload_coverage() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
     assert_eq!(
         reader.current_rows("todos", DurabilityTier::Local).unwrap(),
@@ -857,7 +857,7 @@ fn view_scoped_cardinality_survives_reopen_and_upgrades_to_complete_payload() {
     let mut redacted_tx = tx.clone();
     redacted_tx.n_total_writes = 1;
     reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: GlobalTime(1),
             reset_result_set: false,
@@ -876,7 +876,7 @@ fn view_scoped_cardinality_survives_reopen_and_upgrades_to_complete_payload() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
     assert!(reader.query_transaction(tx_id).unwrap().unwrap().view_scoped_cardinality);
 
@@ -884,7 +884,7 @@ fn view_scoped_cardinality_survives_reopen_and_upgrades_to_complete_payload() {
     let mut reader = reopen_node_at(&reader_dir, node(3), schema());
     assert!(reader.query_transaction(tx_id).unwrap().unwrap().view_scoped_cardinality);
     reader
-        .apply_sync_message_settled(SyncMessage::ViewUpdate {
+        .apply_sync_message_settled(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: GlobalTime(1),
             reset_result_set: false,
@@ -903,7 +903,7 @@ fn view_scoped_cardinality_survives_reopen_and_upgrades_to_complete_payload() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        })
+        }))
         .unwrap();
     let stored = reader.query_transaction(tx_id).unwrap().unwrap();
     assert_eq!(stored.tx.n_total_writes, 2);

--- a/crates/jazz/src/node/tests/sync/repair.rs
+++ b/crates/jazz/src/node/tests/sync/repair.rs
@@ -92,12 +92,12 @@ fn declared_known_state_view_update_repairs_withheld_row_version_body() {
         .unwrap();
 
     let mut update = core.view_update_for_current_rows("todos").unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         version_carriers,
         version_bundles,
         result_member_adds,
         ..
-    } = &mut update
+    }) = &mut update
     else {
         panic!("expected view update");
     };
@@ -250,7 +250,7 @@ fn renamed_known_state_repair_round_trips_canonical_authored_payload() {
     let (shape, binding) = core.whole_table_shape_binding("tasks").unwrap();
     register_shape_binding(&mut reader, &shape, &binding);
 
-    let update = SyncMessage::ViewUpdate {
+    let update = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription: crate::protocol::SubscriptionKey {
             shape_id: shape.shape_id(),
             binding_id: binding.binding_id(),
@@ -266,11 +266,11 @@ fn renamed_known_state_repair_round_trips_canonical_authored_payload() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
-    let SyncMessage::ViewUpdate {
+    });
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -305,10 +305,10 @@ fn renamed_known_state_repair_round_trips_canonical_authored_payload() {
     assert_eq!(version_bundles[0].versions[0].table(), "todos");
     assert_eq!(version_bundles[0].versions[0].schema_version(), base_version);
     let mut inline_update = update.clone();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         version_bundles: inline_bundles,
         ..
-    } = &mut inline_update
+    }) = &mut inline_update
     else {
         unreachable!();
     };
@@ -524,7 +524,7 @@ fn inline_known_state_witness_rejects_reused_logical_table_name() {
         None,
     )
     .unwrap();
-    let update = SyncMessage::ViewUpdate {
+    let update = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription: crate::protocol::SubscriptionKey {
             shape_id: shape.shape_id(),
             binding_id: binding.binding_id(),
@@ -547,7 +547,7 @@ fn inline_known_state_witness_rejects_reused_logical_table_name() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
     assert_eq!(
         receiver.missing_known_state_row_version_refs(&update).unwrap(),
         vec![RowVersionRef::new("tasks", task_row, tx_id)],

--- a/crates/jazz/src/node/tests/sync/view_delivery.rs
+++ b/crates/jazz/src/node/tests/sync/view_delivery.rs
@@ -23,7 +23,7 @@ fn view_updates_ship_current_versions_to_downstream_nodes() {
 
     let update = core.view_update_for_current_rows("todos").unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         reset_result_set,
@@ -34,7 +34,7 @@ fn view_updates_ship_current_versions_to_downstream_nodes() {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -142,9 +142,9 @@ fn global_read_ignores_a_newer_unacknowledged_local_write() {
 
     let mut link = PeerState::client_link(AuthorId::SYSTEM);
     let update = link.current_rows_update(&mut core, "todos").unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         settled_through, ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -179,7 +179,7 @@ fn view_updates_use_peer_payload_inventory_refs_for_previously_shipped_complete_
 
     let initial = core.view_update_for_current_rows("todos").unwrap();
     let version_bundles = version_bundles_for_update(&initial);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through,
         reset_result_set,
@@ -190,7 +190,7 @@ fn view_updates_use_peer_payload_inventory_refs_for_previously_shipped_complete_
         result_member_adds,
         result_member_removes,
         ..
-    } = initial
+    }) = initial
     else {
         panic!("expected view update");
     };
@@ -225,7 +225,7 @@ fn view_updates_use_peer_payload_inventory_refs_for_previously_shipped_complete_
         )
         .unwrap();
     let version_bundles = version_bundles_for_update(&deduped);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         settled_through,
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
@@ -234,7 +234,7 @@ fn view_updates_use_peer_payload_inventory_refs_for_previously_shipped_complete_
         result_member_adds,
         result_member_removes,
         ..
-    } = deduped
+    }) = deduped
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/tests/view_update_capture.rs
+++ b/crates/jazz/src/node/tests/view_update_capture.rs
@@ -70,7 +70,7 @@ fn canonical_version_record(record: VersionRecord) -> CanonicalVersionRecord {
 
 fn capture_view_update(update: SyncMessage) -> CanonicalViewUpdate {
     let normalized_version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         reset_result_set,
         peer_payload_inventory: crate::protocol::PeerPayloadInventory {
@@ -79,7 +79,7 @@ fn capture_view_update(update: SyncMessage) -> CanonicalViewUpdate {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -223,12 +223,12 @@ fn apply_capture_result_delta(
     result_set: &mut BTreeSet<ResultRowEntry>,
     update: &SyncMessage,
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -254,10 +254,10 @@ fn apply_capture_delivery_state(
     update: &SyncMessage,
 ) {
     apply_capture_result_delta(result_set, update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -272,7 +272,7 @@ fn apply_capture_delivery_state(
 }
 
 fn view_update_full_bundle_count(update: &SyncMessage) -> usize {
-    let SyncMessage::ViewUpdate { .. } = update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. }) = update else {
         panic!("expected view update");
     };
     version_bundles_for_update(update).len()
@@ -465,10 +465,10 @@ impl MaintainedSubscriptionViewSubscription {
             },
         )
         .resolve()?;
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             reset_result_set: update_reset,
             ..
-        } = &mut update
+        }) = &mut update
         else {
             panic!("expected view update");
         };
@@ -483,7 +483,7 @@ fn assert_shipped_content_rows(
     expected_rows: &[RowUuid],
     absent_rows: &[RowUuid],
 ) {
-    let SyncMessage::ViewUpdate { .. } = update else {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. }) = update else {
         panic!("expected view update");
     };
     let version_bundles = version_bundles_for_update(update);
@@ -517,13 +517,13 @@ fn assert_retraction_without_replacement_leak(
     old_tx_id: TxId,
     unreadable_tx_id: TxId,
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         version_bundles,
         peer_payload_inventory: crate::protocol::PeerPayloadInventory { complete_tx_payloads: complete_tx_payload_refs, .. },
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -769,23 +769,25 @@ where
         }
         let version_carriers = build_version_carriers_from_singletons(version_bundles)
             .map_err(|_| Error::InvalidStoredValue("failed to build version-bundle run"))?;
-        Ok(SyncMessage::ViewUpdate {
-            subscription,
-            settled_through: self.clock.committed_global_time,
-            reset_result_set: false,
-            version_carriers,
-            version_bundles: Vec::new(),
-            peer_payload_inventory: PeerPayloadInventory {
-                complete_tx_payloads: peer_payload_inventory_refs,
-                authorization_progress: None,
-                opening_pending: false,
+        Ok(SyncMessage::ViewUpdate(
+            crate::protocol::ViewUpdatePayload {
+                subscription,
+                settled_through: self.clock.committed_global_time,
+                reset_result_set: false,
+                version_carriers,
+                version_bundles: Vec::new(),
+                peer_payload_inventory: PeerPayloadInventory {
+                    complete_tx_payloads: peer_payload_inventory_refs,
+                    authorization_progress: None,
+                    opening_pending: false,
+                },
+                result_member_adds: result_member_adds.into_iter().collect(),
+                result_member_removes: result_member_removes.into_iter().collect(),
+                terminal_operations: Vec::new(),
+                program_fact_adds,
+                program_fact_removes,
             },
-            result_member_adds: result_member_adds.into_iter().collect(),
-            result_member_removes: result_member_removes.into_iter().collect(),
-            terminal_operations: Vec::new(),
-            program_fact_adds,
-            program_fact_removes,
-        })
+        ))
     }
 
     /// Apply a downstream current-row view update.

--- a/crates/jazz/src/peer/delivery.rs
+++ b/crates/jazz/src/peer/delivery.rs
@@ -225,9 +225,9 @@ fn storage_read_bucket_field(name: &str, bucket: StorageReadBucket) -> String {
 }
 
 pub(super) fn view_update_reset_result_set(update: &mut SyncMessage) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set, ..
-    } = update
+    }) = update
     else {
         return;
     };

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -411,7 +411,7 @@ impl PeerState {
         self.clear_stale_groove_runtime_handles(node, subscription);
         self.ensure_query_subscription_registered(node, subscription, shape, binding)?;
         let Some(state) = self.publication_states.get(&subscription) else {
-            return Ok(Some(SyncMessage::ViewUpdate {
+            return Ok(Some(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 subscription,
                 settled_through: binding_settlement_time(node, subscription, shape, binding),
                 reset_result_set: false,
@@ -423,7 +423,7 @@ impl PeerState {
                 terminal_operations: Vec::new(),
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-            }));
+            })));
         };
         if state.maintained_subscription_view.is_some() {
             return self.query_update_maintained_subscription_view(
@@ -572,7 +572,7 @@ impl PeerState {
             &program_fact_adds,
             &program_fact_removes,
         ) {
-            return Ok(Some(SyncMessage::ViewUpdate {
+            return Ok(Some(SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 subscription,
                 settled_through: binding_settlement_time(node, subscription, shape, binding),
                 reset_result_set: false,
@@ -584,7 +584,7 @@ impl PeerState {
                 terminal_operations: Vec::new(),
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-            }));
+            })));
         }
         let previous_result_tx_ids = previous_member_result_set
             .iter()
@@ -641,10 +641,10 @@ impl PeerState {
             )
         };
         let mut update = update.await?;
-        if let SyncMessage::ViewUpdate {
+        if let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             terminal_operations: outgoing,
             ..
-        } = &mut update
+        }) = &mut update
         {
             *outgoing = terminal_operations;
         }
@@ -652,11 +652,11 @@ impl PeerState {
         let bundle_reads = trace_rehydrate.then(|| node.take_storage_read_metrics());
         if trace_rehydrate {
             let bundle_count = match &update {
-                SyncMessage::ViewUpdate {
+                SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                     version_carriers,
                     version_bundles,
                     ..
-                } => view_update_singleton_bundles(version_carriers, version_bundles).len(),
+                }) => view_update_singleton_bundles(version_carriers, version_bundles).len(),
                 _ => 0,
             };
             let drain_reads = drain_reads.expect("trace reads captured");
@@ -896,7 +896,7 @@ impl PeerState {
             Err(Error::AuthorizationSupportMissingClaim(_))
                 if purpose == RehydratePurpose::AuthorizationSupport =>
             {
-                let update = SyncMessage::ViewUpdate {
+                let update = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                     subscription,
                     settled_through: binding_settlement_time(node, subscription, shape, binding),
                     reset_result_set,
@@ -908,7 +908,7 @@ impl PeerState {
                     terminal_operations: Vec::new(),
                     program_fact_adds: Vec::new(),
                     program_fact_removes: Vec::new(),
-                };
+                });
                 self.record_outgoing_view_update(&update);
                 self.publication_states
                     .entry(subscription)
@@ -1091,11 +1091,11 @@ impl PeerState {
         }
         if trace_rehydrate {
             let bundle_count = match &update {
-                SyncMessage::ViewUpdate {
+                SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                     version_carriers,
                     version_bundles,
                     ..
-                } => view_update_singleton_bundles(version_carriers, version_bundles).len(),
+                }) => view_update_singleton_bundles(version_carriers, version_bundles).len(),
                 _ => 0,
             };
             let open_reads = open_reads.expect("trace reads captured");
@@ -1403,7 +1403,7 @@ impl PeerState {
             || !source_program_fact_adds.is_empty()
             || !source_program_fact_removes.is_empty()
         {
-            self.apply_outgoing_view_update_result_set(&SyncMessage::ViewUpdate {
+            self.apply_outgoing_view_update_result_set(&SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 subscription: maintained_subscription,
                 settled_through: canonical_subscription_settlement_time(
                     node,
@@ -1418,7 +1418,7 @@ impl PeerState {
                 terminal_operations: source_terminal_operations,
                 program_fact_adds: source_program_fact_adds,
                 program_fact_removes: source_program_fact_removes,
-            });
+            }));
         }
         let canonical_state = self
             .publication_states

--- a/crates/jazz/src/peer/repair.rs
+++ b/crates/jazz/src/peer/repair.rs
@@ -119,14 +119,14 @@ impl PeerState {
     }
 
     fn record_outgoing_view_update_metadata(&mut self, update: &SyncMessage) {
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             version_carriers,
             version_bundles,
             peer_payload_inventory,
             result_member_adds,
             result_member_removes,
             ..
-        } = update
+        }) = update
         else {
             return;
         };
@@ -214,9 +214,9 @@ impl PeerState {
                     .await;
                     self.role = previous_role;
                     self.permission_identity = previous_permission_identity;
-                    let SyncMessage::ViewUpdate {
+                    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                         settled_through, ..
-                    } = update?
+                    }) = update?
                     else {
                         return Err(Error::UnsupportedSyncMessage(
                             "terminal authority support hydration did not return a view",
@@ -325,9 +325,9 @@ impl PeerState {
                 self.role = previous_role;
                 self.permission_identity = previous_permission_identity;
                 let update = rehydrate?;
-                let SyncMessage::ViewUpdate {
+                let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                     settled_through, ..
-                } = update
+                }) = update
                 else {
                     return Err(Error::UnsupportedSyncMessage(
                         "authority support hydration did not return a view",
@@ -442,7 +442,7 @@ impl PeerState {
     }
 
     fn apply_outgoing_view_update_result_set(&mut self, update: &SyncMessage) {
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             reset_result_set,
             result_member_adds,
@@ -450,7 +450,7 @@ impl PeerState {
             program_fact_adds,
             program_fact_removes,
             ..
-        } = update
+        }) = update
         else {
             return;
         };

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -199,11 +199,11 @@ fn client_fast_cursor_authorization_proof_controls_rehydrate_reset() {
     let mut fresh = PeerState::client_link(identity);
     fresh.declare_known_state(subscription, known(1, 0));
     let fresh_update = fresh.rehydrate_query(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         ..
-    } = fresh_update
+    }) = fresh_update
     else {
         panic!("expected view update");
     };
@@ -237,11 +237,11 @@ fn client_fast_cursor_authorization_proof_controls_rehydrate_reset() {
 
     fresh.declare_known_state(subscription, known(1, 0));
     let retained_update = fresh.rehydrate_query(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         ..
-    } = retained_update
+    }) = retained_update
     else {
         panic!("expected view update");
     };
@@ -266,9 +266,9 @@ fn client_fast_cursor_authorization_proof_controls_rehydrate_reset() {
     accept_global(&mut core, deleted_tx, 2);
     fresh.declare_known_state(subscription, known(2, 1));
     let revoke_update = fresh.rehydrate_query(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set, ..
-    } = revoke_update
+    }) = revoke_update
     else {
         panic!("expected view update");
     };
@@ -325,9 +325,9 @@ fn duplicate_structured_query_authorization_mismatch_forces_reset() {
         )
         .unwrap()
         .expect("expected view update");
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set, ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -424,7 +424,7 @@ fn incremental_delivery_keeps_terminal_children_with_their_root() {
         binding_id: crate::query::BindingId(uuid::Uuid::from_u128(42)),
         read_view: Default::default(),
     };
-    let update = |adds, removes| SyncMessage::ViewUpdate {
+    let update = |adds, removes| SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: GlobalTime(0),
         reset_result_set: false,
@@ -436,7 +436,7 @@ fn incremental_delivery_keeps_terminal_children_with_their_root() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
     let mut peer = PeerState::default();
     peer.apply_outgoing_view_update_result_set(&update(
         vec![root_member.clone(), child_member.clone()],
@@ -484,7 +484,7 @@ fn maintained_delivery_does_not_leak_intermediate_replacement_refcounts() {
         binding_id: crate::query::BindingId(uuid::Uuid::from_u128(12)),
         read_view: Default::default(),
     };
-    let update = |adds, removes| SyncMessage::ViewUpdate {
+    let update = |adds, removes| SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: GlobalTime(0),
         reset_result_set: false,
@@ -496,7 +496,7 @@ fn maintained_delivery_does_not_leak_intermediate_replacement_refcounts() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
     let mut peer = PeerState::default();
     peer.apply_outgoing_view_update_result_set(&update(vec![tx10.clone()], Vec::new()));
     peer.apply_outgoing_view_update_result_set(&update(
@@ -524,7 +524,7 @@ fn maintained_delivery_rekeys_delta_and_reset_by_output_occurrence() {
         binding_id: crate::query::BindingId(uuid::Uuid::from_u128(2)),
         read_view: Default::default(),
     };
-    let update = |reset_result_set, adds, removes| SyncMessage::ViewUpdate {
+    let update = |reset_result_set, adds, removes| SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         subscription,
         settled_through: GlobalTime(0),
         reset_result_set,
@@ -536,7 +536,7 @@ fn maintained_delivery_rekeys_delta_and_reset_by_output_occurrence() {
         terminal_operations: Vec::new(),
         program_fact_adds: Vec::new(),
         program_fact_removes: Vec::new(),
-    };
+    });
     let mut peer = PeerState::default();
 
     peer.apply_outgoing_view_update_result_set(&update(
@@ -1109,11 +1109,11 @@ fn register_shape_binding_for_receiver_with_opts(
 
 fn version_bundles_for_update(update: &SyncMessage) -> Vec<VersionBundle> {
     match update {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             version_carriers,
             version_bundles,
             ..
-        } => {
+        }) => {
             let mut bundles = version_bundles.clone();
             bundles.extend(
                 crate::protocol::expand_version_carriers(version_carriers)
@@ -1200,12 +1200,12 @@ fn aggregate_cells(row: &crate::node::CurrentRow) -> BTreeMap<String, Value> {
 }
 
 fn view_update_added_rows(update: SyncMessage) -> BTreeSet<RowUuid> {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1223,11 +1223,11 @@ fn assert_view_update_rows(
     expected_adds: Vec<(&str, RowUuid, TxId)>,
     expected_removes: Vec<(&str, RowUuid, TxId)>,
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1254,11 +1254,11 @@ fn assert_view_update_row_order(
     expected_adds: Vec<(&str, RowUuid, TxId)>,
     expected_removes: Vec<(&str, RowUuid, TxId)>,
 ) {
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1351,14 +1351,14 @@ fn maintained_structured_terminal_only_change_is_not_dropped_by_empty_guard() {
         .unwrap();
     accept_global(&mut core, child_update_tx, 3);
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         program_fact_adds,
         program_fact_removes,
         terminal_operations,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update")
     };
@@ -1414,9 +1414,9 @@ fn maintained_rehydrate_run_emission_matches_forced_singleton_receiver_results()
         .rehydrate_query(&mut core, &shape, &binding)
         .unwrap();
 
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         version_carriers, ..
-    } = &run_update
+    }) = &run_update
     else {
         panic!("expected view update");
     };
@@ -1502,11 +1502,11 @@ fn maintained_subscription_view_limit_one_installs_subscription() {
             .unsupported_skips_out,
         0
     );
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1556,9 +1556,9 @@ fn maintained_subscription_view_cold_rehydrate_after_restore_ships_restored_cont
 
     let update = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
 
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -1647,9 +1647,9 @@ fn local_rehydrate_after_edge_restore_ships_restored_row() {
         .rehydrate_query_with_opts(&mut core, &shape, &binding, opts.clone())
         .unwrap();
 
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -1722,9 +1722,9 @@ fn local_rehydrate_after_edge_restore_transaction_ships_restored_row() {
         .rehydrate_query_with_opts(&mut core, &shape, &binding, opts.clone())
         .unwrap();
 
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -1796,11 +1796,11 @@ fn maintained_subscription_view_limit_one_switches_after_winner_delete_and_lower
         .unwrap();
     accept_global(&mut core, delete_first_tx, 3);
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -1821,11 +1821,11 @@ fn maintained_subscription_view_limit_one_switches_after_winner_delete_and_lower
         .unwrap();
     accept_global(&mut core, new_first_tx, 4);
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -2476,14 +2476,14 @@ fn maintained_subscription_view_aggregate_rehydrate_ships_payload_fact() {
     let update = peer
         .rehydrate_query(&mut core, &aggregate_shape, &aggregate_binding)
         .unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -2520,9 +2520,9 @@ fn maintained_subscription_view_aggregate_updates_incrementally() {
     let mut peer = PeerState::new();
 
     let initial = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         program_fact_adds, ..
-    } = initial
+    }) = initial
     else {
         panic!("expected view update");
     };
@@ -2540,14 +2540,14 @@ fn maintained_subscription_view_aggregate_updates_incrementally() {
     let update = peer
         .query_update_for_subscription(&mut core, subscription, &shape, &binding)
         .unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         result_member_adds,
         result_member_removes,
         program_fact_adds,
         program_fact_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -2661,7 +2661,7 @@ fn maintained_subscription_view_forget_with_node_unsubscribes_and_drops_state() 
     let stale_tick = peer.query_update(&mut core, &shape, &binding).unwrap();
     assert_eq!(
         stale_tick,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription,
             settled_through: crate::time::GlobalTime(0),
             reset_result_set: false,
@@ -2673,7 +2673,7 @@ fn maintained_subscription_view_forget_with_node_unsubscribes_and_drops_state() 
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        }
+        })
     );
 }
 
@@ -2749,11 +2749,11 @@ fn maintained_subscription_view_contains_literal_stays_maintained() {
     accept_global(&mut core, added, 3);
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -2795,11 +2795,11 @@ fn maintained_subscription_view_contains_param_stays_maintained() {
     accept_global(&mut core, added, 3);
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -2879,11 +2879,11 @@ fn maintained_subscription_view_ne_param_stays_maintained() {
     accept_global(&mut core, still_excluded, 4);
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -3162,11 +3162,11 @@ fn maintained_subscription_view_exclusive_delta_stays_maintained() {
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -3199,7 +3199,7 @@ fn maintained_subscription_view_exclusive_delta_ships_view_scoped_partial_bundle
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3208,7 +3208,7 @@ fn maintained_subscription_view_exclusive_delta_ships_view_scoped_partial_bundle
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -3251,7 +3251,7 @@ fn maintained_subscription_view_can_ship_complete_exclusive_payload_for_writer_p
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3260,7 +3260,7 @@ fn maintained_subscription_view_can_ship_complete_exclusive_payload_for_writer_p
         result_member_adds,
         result_member_removes,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected view update");
     };
@@ -3351,9 +3351,9 @@ fn maintained_subscription_view_tags_terminal_columns_by_table() {
     let mut peer = PeerState::new();
     let update = peer.current_rows_update(&mut core, "orderLines").unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -3401,7 +3401,7 @@ fn maintained_subscription_view_policy_view_exclusive_delta_ships_identity_scope
     core.reset_query_engine_read_metrics();
     let update = peer.current_rows_update(&mut core, "docs").unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3410,7 +3410,7 @@ fn maintained_subscription_view_policy_view_exclusive_delta_ships_identity_scope
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -3466,9 +3466,9 @@ fn maintained_subscription_view_rehydrate_replaces_subscription_and_fresh_indexe
         .expect("replacement maintained subscription missing");
     assert_ne!(old_id, new_id);
     assert!(!core.unsubscribe_groove_subscription(old_id));
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set, ..
-    } = &rehydrate
+    }) = &rehydrate
     else {
         panic!("expected view update");
     };
@@ -3520,12 +3520,12 @@ fn maintained_subscription_view_new_binding_after_forget_has_no_stale_state() {
             other_tx,
         )]))
     );
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         reset_result_set,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -3549,7 +3549,7 @@ fn peer_state_dedups_version_payloads_across_subscription_views() {
 
     let first = peer.current_rows_update(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&first);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3558,7 +3558,7 @@ fn peer_state_dedups_version_payloads_across_subscription_views() {
         result_member_adds,
         result_member_removes,
         ..
-    } = first
+    }) = first
     else {
         panic!("expected view update");
     };
@@ -3572,7 +3572,7 @@ fn peer_state_dedups_version_payloads_across_subscription_views() {
 
     let second = peer.current_rows_update(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&second);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3581,7 +3581,7 @@ fn peer_state_dedups_version_payloads_across_subscription_views() {
         result_member_adds,
         result_member_removes,
         ..
-    } = second
+    }) = second
     else {
         panic!("expected view update");
     };
@@ -3683,7 +3683,7 @@ fn grant_later_exclusive_tx_extends_view_scoped_partial_bundle_after_policy_gran
     let mut peer = PeerState::client_link(user);
     let first_update = peer.current_rows_update(&mut core, "docs").unwrap();
     let version_bundles = version_bundles_for_update(&first_update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3691,7 +3691,7 @@ fn grant_later_exclusive_tx_extends_view_scoped_partial_bundle_after_policy_gran
             },
         result_member_adds,
         ..
-    } = &first_update
+    }) = &first_update
     else {
         panic!("expected view update");
     };
@@ -3726,7 +3726,7 @@ fn grant_later_exclusive_tx_extends_view_scoped_partial_bundle_after_policy_gran
 
     let grant_update = peer.current_rows_update(&mut core, "docs").unwrap();
     let version_bundles = version_bundles_for_update(&grant_update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3735,7 +3735,7 @@ fn grant_later_exclusive_tx_extends_view_scoped_partial_bundle_after_policy_gran
         result_member_adds,
         result_member_removes,
         ..
-    } = &grant_update
+    }) = &grant_update
     else {
         panic!("expected view update");
     };
@@ -3775,9 +3775,9 @@ fn all_exclusive_never_gated_stays_incremental() {
 
     let empty = peer.current_rows_update(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&empty);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds, ..
-    } = empty
+    }) = empty
     else {
         panic!("expected view update");
     };
@@ -3795,7 +3795,7 @@ fn all_exclusive_never_gated_stays_incremental() {
 
     let update = peer.current_rows_update(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&update);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
@@ -3804,7 +3804,7 @@ fn all_exclusive_never_gated_stays_incremental() {
             },
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected view update");
     };
@@ -3841,7 +3841,7 @@ fn peer_state_records_current_result_set_and_can_rehydrate() {
     assert!(peer.subscription_result_sets(subscription).is_none());
     let rehydrated = peer.current_rows_update(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&rehydrated);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -3850,7 +3850,7 @@ fn peer_state_records_current_result_set_and_can_rehydrate() {
         result_member_adds,
         result_member_removes,
         ..
-    } = rehydrated
+    }) = rehydrated
     else {
         panic!("expected view update");
     };
@@ -3901,10 +3901,10 @@ fn rehydrate_keeps_peer_payload_dedup_but_resends_result_set() {
         .unwrap();
     accept_global(&mut core, deletion_tx, 3);
     let missed_remove = peer.current_rows_update(&mut core, "todos").unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_removes,
         ..
-    } = &missed_remove
+    }) = &missed_remove
     else {
         panic!("expected view update");
     };
@@ -3915,7 +3915,7 @@ fn rehydrate_keeps_peer_payload_dedup_but_resends_result_set() {
 
     let rehydrated = peer.reset_current_rows(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&rehydrated);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
@@ -3925,7 +3925,7 @@ fn rehydrate_keeps_peer_payload_dedup_but_resends_result_set() {
         result_member_adds,
         result_member_removes,
         ..
-    } = &rehydrated
+    }) = &rehydrated
     else {
         panic!("expected view update");
     };
@@ -3983,11 +3983,11 @@ fn peer_state_sends_result_removes_after_deletes() {
         .unwrap();
     accept_global(&mut core, deletion_tx, 2);
     let removed = peer.current_rows_update(&mut core, "todos").unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = &removed
+    }) = &removed
     else {
         panic!("expected view update");
     };
@@ -4040,7 +4040,7 @@ fn whole_table_incremental_delta_ships_restore_register_witness() {
     accept_global(&mut core, restore_tx, 3);
     let restored = peer.current_rows_update(&mut core, "todos").unwrap();
     let version_bundles = version_bundles_for_update(&restored);
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         peer_payload_inventory:
             crate::protocol::PeerPayloadInventory {
                 complete_tx_payloads: complete_tx_payload_refs,
@@ -4049,7 +4049,7 @@ fn whole_table_incremental_delta_ships_restore_register_witness() {
         result_member_adds,
         result_member_removes,
         ..
-    } = &restored
+    }) = &restored
     else {
         panic!("expected view update");
     };
@@ -4116,11 +4116,11 @@ fn incremental_query_result_set_tracks_identical_cell_rewrite_tx_id() {
         .unwrap();
     accept_global(&mut core, second_tx, 2);
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected query view update");
     };
@@ -4170,11 +4170,11 @@ fn incremental_query_result_set_drops_enter_then_leave_same_drain_cycle() {
     accept_global(&mut core, unmatch_tx, 2);
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected query view update");
     };
@@ -4237,11 +4237,11 @@ fn incremental_query_result_set_keeps_leave_then_reenter_same_drain_cycle() {
     accept_global(&mut core, second_match_tx, 3);
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = &update
+    }) = &update
     else {
         panic!("expected query view update");
     };
@@ -4340,11 +4340,11 @@ fn incremental_query_result_set_rebuilds_stale_closure_rows() {
     accept_global(&mut core, second_line_tx, 4);
 
     let update = peer.query_update(&mut core, &shape, &binding).unwrap();
-    let SyncMessage::ViewUpdate {
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         result_member_adds,
         result_member_removes,
         ..
-    } = update
+    }) = update
     else {
         panic!("expected query view update");
     };

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -229,8 +229,11 @@ pub enum SyncMessage {
         /// Total number of authority clauses in this hydration.
         clause_count: u16,
         /// Ordinary settlement-bearing `ViewUpdate` payload.
-        #[serde(deserialize_with = "deserialize_authorization_scope_view")]
-        view: Box<SyncMessage>,
+        ///
+        /// This deliberately is not a `SyncMessage`: an authority scope view
+        /// has exactly one wrapper around a view update, never another scope
+        /// wrapper.
+        view: AuthorizationScopeViewPayload,
     },
     /// Aggregate proof for every clause sent in an authority scope view set.
     AuthorizationScopeAggregateReceipt {
@@ -262,43 +265,100 @@ pub enum SyncMessage {
     ChunkUploadResult(ChunkUploadResult),
 }
 
-thread_local! {
-    static AUTHORIZATION_SCOPE_VIEW_DEPTH: std::cell::Cell<usize> = const {
-        std::cell::Cell::new(0)
-    };
+/// The payload permitted inside [`SyncMessage::AuthorizationScopeView`].
+///
+/// Keeping this separate from `SyncMessage` makes recursive authorization
+/// scope wrappers impossible to construct and decode.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct AuthorizationScopeViewPayload {
+    /// Target subscription whose result set this update changes.
+    pub subscription: SubscriptionKey,
+    /// Authority cut through which this view has settled.
+    pub settled_through: GlobalTime,
+    /// Whether the receiver must replace its current result membership.
+    pub reset_result_set: bool,
+    /// Compact carriers for versions referenced by this update.
+    pub version_carriers: Vec<VersionCarrier>,
+    /// Explicit version bundles required by this update.
+    pub version_bundles: Vec<VersionBundle>,
+    /// Per-peer payload coverage and authorization progress.
+    pub peer_payload_inventory: PeerPayloadInventory,
+    /// Result members added by the update.
+    pub result_member_adds: Vec<ResultMemberEntry>,
+    /// Result members removed by the update.
+    pub result_member_removes: Vec<ResultMemberEntry>,
+    /// Terminal-owned structural result edits.
+    pub terminal_operations: Vec<groove::ivm::TerminalOperation>,
+    /// Program facts added by this update.
+    pub program_fact_adds: Vec<ProgramFactEntry>,
+    /// Program facts removed by this update.
+    pub program_fact_removes: Vec<ProgramFactEntry>,
 }
 
-struct AuthorizationScopeViewDepthGuard;
-
-impl Drop for AuthorizationScopeViewDepthGuard {
-    fn drop(&mut self) {
-        AUTHORIZATION_SCOPE_VIEW_DEPTH.with(|depth| {
-            depth.set(depth.get().saturating_sub(1));
-        });
+impl AuthorizationScopeViewPayload {
+    /// Splits an ordinary view update into the only payload valid inside an
+    /// authorization scope wrapper.
+    pub fn from_view_update(message: SyncMessage) -> Option<Self> {
+        let SyncMessage::ViewUpdate {
+            subscription,
+            settled_through,
+            reset_result_set,
+            version_carriers,
+            version_bundles,
+            peer_payload_inventory,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
+        } = message
+        else {
+            return None;
+        };
+        Some(Self {
+            subscription,
+            settled_through,
+            reset_result_set,
+            version_carriers,
+            version_bundles,
+            peer_payload_inventory,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
+        })
     }
-}
 
-fn deserialize_authorization_scope_view<'de, D>(
-    deserializer: D,
-) -> Result<Box<SyncMessage>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let admitted = AUTHORIZATION_SCOPE_VIEW_DEPTH.with(|depth| {
-        let current = depth.get();
-        if current >= crate::protocol_limits::MAX_SYNC_MESSAGE_NESTING_DEPTH {
-            return false;
+    /// Restores this payload to the ordinary view-update pipeline.
+    pub fn into_view_update(self) -> SyncMessage {
+        let Self {
+            subscription,
+            settled_through,
+            reset_result_set,
+            version_carriers,
+            version_bundles,
+            peer_payload_inventory,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
+        } = self;
+        SyncMessage::ViewUpdate {
+            subscription,
+            settled_through,
+            reset_result_set,
+            version_carriers,
+            version_bundles,
+            peer_payload_inventory,
+            result_member_adds,
+            result_member_removes,
+            terminal_operations,
+            program_fact_adds,
+            program_fact_removes,
         }
-        depth.set(current + 1);
-        true
-    });
-    if !admitted {
-        return Err(<D::Error as serde::de::Error>::custom(
-            "sync message nesting depth exceeds limit",
-        ));
     }
-    let _guard = AuthorizationScopeViewDepthGuard;
-    <Box<SyncMessage> as serde::Deserialize>::deserialize(deserializer)
 }
 
 /// Bounded batch of exact immutable-chunk requests on one peer link.

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -620,13 +620,9 @@ impl SyncMessage {
         match self {
             Self::ViewUpdate {
                 version_carriers, ..
-            } => {
-                for carrier in version_carriers {
-                    if let VersionCarrier::Run(run) = carrier {
-                        run.validate()?;
-                    }
-                }
-                Ok(())
+            } => validate_version_carrier_runs(version_carriers),
+            Self::AuthorizationScopeView { view, .. } => {
+                validate_version_carrier_runs(&view.version_carriers)
             }
             _ => Ok(()),
         }
@@ -645,6 +641,17 @@ impl SyncMessage {
         }
         Ok(self)
     }
+}
+
+fn validate_version_carrier_runs(
+    version_carriers: &[VersionCarrier],
+) -> Result<(), VersionBundleRunError> {
+    for carrier in version_carriers {
+        if let VersionCarrier::Run(run) = carrier {
+            run.validate()?;
+        }
+    }
+    Ok(())
 }
 
 /// Exact row-version identity used by known-state repair requests.

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -112,52 +112,7 @@ pub enum SyncMessage {
     /// Catalogue-lane acknowledgement.
     CatalogueAck(CatalogueAck),
     /// Downstream current-row view update.
-    ViewUpdate {
-        /// Query binding result set addressed by this update.
-        subscription: SubscriptionKey,
-        /// Core-assigned `GlobalTime` through which the canonical binding view
-        /// was evaluated. It is durable known-state evidence, reusable after
-        /// reconnecting to an edge serving the same authoritative database
-        /// lineage for payload dedup/repair; it is not evidence that an
-        /// upstream connection is currently live and cannot alone settle a
-        /// subscription.
-        settled_through: GlobalTime,
-        /// Whether receiver result_set should be reset first.
-        reset_result_set: bool,
-        /// General carrier stream for singleton bundles and packed runs.
-        ///
-        /// Receivers validate this stream and apply packed runs directly.
-        /// Legacy/test paths may still expand carriers into `version_bundles`.
-        version_carriers: Vec<VersionCarrier>,
-        /// Version bundles not previously shipped on the peer.
-        ///
-        /// Partial bundles may contain only the versions that contribute to this
-        /// update. Exclusive bundles are view-atomic: they contain all versions
-        /// required by this subscription view, not necessarily all transaction writes.
-        version_bundles: Vec<VersionBundle>,
-        /// Peer-scoped payload coverage that may be referenced instead of
-        /// resending bytes.
-        ///
-        /// The currently implemented tier is complete transaction payload
-        /// coverage only. It does not mean the peer knows every concrete row
-        /// version relevant to a partial transaction, nor that an exclusive
-        /// transaction is complete for this subscription view. Partial/view-
-        /// scoped payloads remain explicit bundles until the protocol grows
-        /// finer coverage refs.
-        peer_payload_inventory: PeerPayloadInventory,
-        /// Typed result membership additions for the subscription.
-        result_member_adds: Vec<ResultMemberEntry>,
-        /// Typed result membership removals for the subscription.
-        result_member_removes: Vec<ResultMemberEntry>,
-        /// Terminal-owned structural edits, addressed by stable result keys and
-        /// typed paths. These are applied after an authoritative reset or the
-        /// preceding update on this FIFO link.
-        terminal_operations: Vec<groove::ivm::TerminalOperation>,
-        /// Non-row program fact additions, such as relation edges.
-        program_fact_adds: Vec<ProgramFactEntry>,
-        /// Non-row program fact removals, such as relation edges.
-        program_fact_removes: Vec<ProgramFactEntry>,
-    },
+    ViewUpdate(ViewUpdatePayload),
     /// Repair-lane request for exact row-version payloads referenced by known-state dedup.
     FetchRowVersions {
         /// Exact version identities requested by the receiver.
@@ -233,7 +188,7 @@ pub enum SyncMessage {
         /// This deliberately is not a `SyncMessage`: an authority scope view
         /// has exactly one wrapper around a view update, never another scope
         /// wrapper.
-        view: AuthorizationScopeViewPayload,
+        view: ViewUpdatePayload,
     },
     /// Aggregate proof for every clause sent in an authority scope view set.
     AuthorizationScopeAggregateReceipt {
@@ -265,12 +220,14 @@ pub enum SyncMessage {
     ChunkUploadResult(ChunkUploadResult),
 }
 
-/// The payload permitted inside [`SyncMessage::AuthorizationScopeView`].
+/// Shared payload for ordinary and authorization-scope view updates.
 ///
-/// Keeping this separate from `SyncMessage` makes recursive authorization
-/// scope wrappers impossible to construct and decode.
+/// [`SyncMessage::ViewUpdate`] carries it directly, while
+/// [`SyncMessage::AuthorizationScopeView`] adds scope metadata around the same
+/// payload. Keeping the payload separate from `SyncMessage` makes recursive
+/// authorization-scope wrappers impossible to construct and decode.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthorizationScopeViewPayload {
+pub struct ViewUpdatePayload {
     /// Target subscription whose result set this update changes.
     pub subscription: SubscriptionKey,
     /// Authority cut through which this view has settled.
@@ -295,69 +252,18 @@ pub struct AuthorizationScopeViewPayload {
     pub program_fact_removes: Vec<ProgramFactEntry>,
 }
 
-impl AuthorizationScopeViewPayload {
-    /// Splits an ordinary view update into the only payload valid inside an
-    /// authorization scope wrapper.
+impl ViewUpdatePayload {
+    /// Extracts the shared payload from an ordinary view-update message.
     pub fn from_view_update(message: SyncMessage) -> Option<Self> {
-        let SyncMessage::ViewUpdate {
-            subscription,
-            settled_through,
-            reset_result_set,
-            version_carriers,
-            version_bundles,
-            peer_payload_inventory,
-            result_member_adds,
-            result_member_removes,
-            terminal_operations,
-            program_fact_adds,
-            program_fact_removes,
-        } = message
-        else {
-            return None;
-        };
-        Some(Self {
-            subscription,
-            settled_through,
-            reset_result_set,
-            version_carriers,
-            version_bundles,
-            peer_payload_inventory,
-            result_member_adds,
-            result_member_removes,
-            terminal_operations,
-            program_fact_adds,
-            program_fact_removes,
-        })
+        match message {
+            SyncMessage::ViewUpdate(payload) => Some(payload),
+            _ => None,
+        }
     }
 
-    /// Restores this payload to the ordinary view-update pipeline.
+    /// Wraps this payload in an ordinary view-update message.
     pub fn into_view_update(self) -> SyncMessage {
-        let Self {
-            subscription,
-            settled_through,
-            reset_result_set,
-            version_carriers,
-            version_bundles,
-            peer_payload_inventory,
-            result_member_adds,
-            result_member_removes,
-            terminal_operations,
-            program_fact_adds,
-            program_fact_removes,
-        } = self;
-        SyncMessage::ViewUpdate {
-            subscription,
-            settled_through,
-            reset_result_set,
-            version_carriers,
-            version_bundles,
-            peer_payload_inventory,
-            result_member_adds,
-            result_member_removes,
-            terminal_operations,
-            program_fact_adds,
-            program_fact_removes,
-        }
+        SyncMessage::ViewUpdate(self)
     }
 }
 
@@ -617,24 +523,25 @@ impl SyncMessage {
 
     /// Validate any packed view-update carrier runs in this message.
     pub fn validate_version_carriers(&self) -> Result<(), VersionBundleRunError> {
+        self.carried_view_update().map_or(Ok(()), |view| {
+            validate_version_carrier_runs(&view.version_carriers)
+        })
+    }
+
+    fn carried_view_update(&self) -> Option<&ViewUpdatePayload> {
         match self {
-            Self::ViewUpdate {
-                version_carriers, ..
-            } => validate_version_carrier_runs(version_carriers),
-            Self::AuthorizationScopeView { view, .. } => {
-                validate_version_carrier_runs(&view.version_carriers)
-            }
-            _ => Ok(()),
+            Self::ViewUpdate(view) | Self::AuthorizationScopeView { view, .. } => Some(view),
+            _ => None,
         }
     }
 
     /// Expand packed view-update carriers into `version_bundles` for legacy paths/tests.
     pub fn expand_version_carriers_for_receive(mut self) -> Result<Self, VersionBundleRunError> {
-        if let Self::ViewUpdate {
+        if let Self::ViewUpdate(ViewUpdatePayload {
             version_carriers,
             version_bundles,
             ..
-        } = &mut self
+        }) = &mut self
         {
             version_bundles.extend(expand_version_carriers(version_carriers)?);
             version_carriers.clear();

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -229,6 +229,7 @@ pub enum SyncMessage {
         /// Total number of authority clauses in this hydration.
         clause_count: u16,
         /// Ordinary settlement-bearing `ViewUpdate` payload.
+        #[serde(deserialize_with = "deserialize_authorization_scope_view")]
         view: Box<SyncMessage>,
     },
     /// Aggregate proof for every clause sent in an authority scope view set.
@@ -259,6 +260,45 @@ pub enum SyncMessage {
     ChunkUploadNodes(ChunkUploadNodes),
     /// Receiver acknowledgement for a pushed upload.
     ChunkUploadResult(ChunkUploadResult),
+}
+
+thread_local! {
+    static AUTHORIZATION_SCOPE_VIEW_DEPTH: std::cell::Cell<usize> = const {
+        std::cell::Cell::new(0)
+    };
+}
+
+struct AuthorizationScopeViewDepthGuard;
+
+impl Drop for AuthorizationScopeViewDepthGuard {
+    fn drop(&mut self) {
+        AUTHORIZATION_SCOPE_VIEW_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+        });
+    }
+}
+
+fn deserialize_authorization_scope_view<'de, D>(
+    deserializer: D,
+) -> Result<Box<SyncMessage>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let admitted = AUTHORIZATION_SCOPE_VIEW_DEPTH.with(|depth| {
+        let current = depth.get();
+        if current >= crate::protocol_limits::MAX_SYNC_MESSAGE_NESTING_DEPTH {
+            return false;
+        }
+        depth.set(current + 1);
+        true
+    });
+    if !admitted {
+        return Err(<D::Error as serde::de::Error>::custom(
+            "sync message nesting depth exceeds limit",
+        ));
+    }
+    let _guard = AuthorizationScopeViewDepthGuard;
+    <Box<SyncMessage> as serde::Deserialize>::deserialize(deserializer)
 }
 
 /// Bounded batch of exact immutable-chunk requests on one peer link.

--- a/crates/jazz/src/protocol_limits.rs
+++ b/crates/jazz/src/protocol_limits.rs
@@ -32,6 +32,13 @@ pub const MAX_INFLIGHT_LOGICAL_MESSAGE_BYTES: usize = MAX_LOGICAL_MESSAGE_BYTES;
 /// Per-peer fairness bound for concurrently incomplete logical messages.
 pub const MAX_INFLIGHT_LOGICAL_MESSAGES: usize = 4;
 
+/// Maximum recursively wrapped semantic messages decoded from one peer payload.
+///
+/// Production authorization-scope messages contain exactly one wrapper around
+/// a `ViewUpdate`; this extra headroom keeps forward-compatible nesting bounded
+/// before serde can exhaust the process stack.
+pub const MAX_SYNC_MESSAGE_NESTING_DEPTH: usize = 8;
+
 /// Maximum postcard-encoded query shape registration payload.
 ///
 /// Source: existing wire fixtures use tiny shapes; 64 KiB leaves headroom for

--- a/crates/jazz/src/protocol_limits.rs
+++ b/crates/jazz/src/protocol_limits.rs
@@ -32,13 +32,6 @@ pub const MAX_INFLIGHT_LOGICAL_MESSAGE_BYTES: usize = MAX_LOGICAL_MESSAGE_BYTES;
 /// Per-peer fairness bound for concurrently incomplete logical messages.
 pub const MAX_INFLIGHT_LOGICAL_MESSAGES: usize = 4;
 
-/// Maximum recursively wrapped semantic messages decoded from one peer payload.
-///
-/// Production authorization-scope messages contain exactly one wrapper around
-/// a `ViewUpdate`; this extra headroom keeps forward-compatible nesting bounded
-/// before serde can exhaust the process stack.
-pub const MAX_SYNC_MESSAGE_NESTING_DEPTH: usize = 8;
-
 /// Maximum postcard-encoded query shape registration payload.
 ///
 /// Source: existing wire fixtures use tiny shapes; 64 KiB leaves headroom for

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -1002,7 +1002,7 @@ fn sync_message_name(message: &SyncMessage) -> &'static str {
         SyncMessage::PublishLens { .. } => "PublishLens",
         SyncMessage::SetCurrentWriteSchema { .. } => "SetCurrentWriteSchema",
         SyncMessage::CatalogueAck(_) => "CatalogueAck",
-        SyncMessage::ViewUpdate { .. } => "ViewUpdate",
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload { .. }) => "ViewUpdate",
         SyncMessage::FetchRowVersions { .. } => "FetchRowVersions",
         SyncMessage::RowVersionPayloads { .. } => "RowVersionPayloads",
         SyncMessage::CatalogueSnapshot(_) => "CatalogueSnapshot",

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -698,9 +698,10 @@ mod tests {
     use crate::ids::SchemaVersionId;
     use crate::ids::{NodeUuid, RowUuid};
     use crate::protocol::{
-        AuthorizationScopePurpose, PermissionAdviceAction, RegisterShapeOptions, ResultRowEntry,
-        ShapeAst, Subscribe, SubscribeRejectReason, SubscriptionKey, VersionBundle,
-        VersionBundleRun, VersionBundleRunError, VersionCarrier, VersionRecord,
+        AuthorizationScopePurpose, AuthorizationSupportScopeKey, PermissionAdviceAction,
+        PermissionAdviceRequestId, RegisterShapeOptions, ResultRowEntry, ShapeAst, Subscribe,
+        SubscribeRejectReason, SubscriptionKey, VersionBundle, VersionBundleRun,
+        VersionBundleRunError, VersionCarrier, VersionRecord,
         build_version_bundle_runs_from_singletons,
     };
     use crate::protocol_limits::MAX_WIRE_FRAME_BYTES;
@@ -854,6 +855,31 @@ mod tests {
         let decoded = decode_sync_message(&encoded).unwrap();
 
         assert_eq!(decoded, message);
+    }
+
+    #[test]
+    fn deeply_nested_authorization_scope_views_are_rejected() {
+        let mut message = view_update_with_carriers(Vec::new());
+        for _ in 0..32 {
+            message = SyncMessage::AuthorizationScopeView {
+                request_id: PermissionAdviceRequestId([0x11; 16]),
+                key: AuthorizationSupportScopeKey {
+                    support_shape_digest: [0x22; 32],
+                    subject: AuthorId::from_bytes([0x33; 16]),
+                    claims_digest: [0x44; 32],
+                    policy_digest: [0x55; 32],
+                },
+                clause_index: 0,
+                clause_count: 1,
+                view: Box::new(message),
+            };
+        }
+        let encoded = encode_sync_message(&message).expect("encode nested fixture");
+
+        assert!(
+            decode_sync_message(&encoded).is_err(),
+            "remote recursive messages must be rejected under a bounded decode depth"
+        );
     }
 
     #[test]

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -704,7 +704,7 @@ mod tests {
         VersionBundleRunError, VersionCarrier, VersionRecord,
         build_version_bundle_runs_from_singletons,
     };
-    use crate::protocol_limits::{MAX_SYNC_MESSAGE_NESTING_DEPTH, MAX_WIRE_FRAME_BYTES};
+    use crate::protocol_limits::MAX_WIRE_FRAME_BYTES;
     use crate::query::{BindingId, Query, ShapeId};
     use crate::schema::{ColumnSchema, TableSchema};
     use crate::time::{GlobalTime, TxTime};
@@ -858,29 +858,12 @@ mod tests {
     }
 
     #[test]
-    fn deeply_nested_authorization_scope_views_are_rejected() {
-        let mut message = view_update_with_carriers(Vec::new());
-        for _ in 0..MAX_SYNC_MESSAGE_NESTING_DEPTH {
-            message = SyncMessage::AuthorizationScopeView {
-                request_id: PermissionAdviceRequestId([0x11; 16]),
-                key: AuthorizationSupportScopeKey {
-                    support_shape_digest: [0x22; 32],
-                    subject: AuthorId::from_bytes([0x33; 16]),
-                    claims_digest: [0x44; 32],
-                    policy_digest: [0x55; 32],
-                },
-                clause_index: 0,
-                clause_count: 1,
-                view: Box::new(message),
-            };
-        }
-        let encoded = encode_sync_message(&message).expect("encode limit-depth fixture");
-        assert_eq!(
-            decode_sync_message(&encoded).expect("limit-depth fixture remains valid"),
-            message
-        );
-
-        let over_limit = SyncMessage::AuthorizationScopeView {
+    fn authorization_scope_view_has_a_nonrecursive_view_update_payload() {
+        let view = crate::protocol::AuthorizationScopeViewPayload::from_view_update(
+            view_update_with_carriers(Vec::new()),
+        )
+        .expect("fixture is a view update");
+        let message = SyncMessage::AuthorizationScopeView {
             request_id: PermissionAdviceRequestId([0x11; 16]),
             key: AuthorizationSupportScopeKey {
                 support_shape_digest: [0x22; 32],
@@ -890,12 +873,13 @@ mod tests {
             },
             clause_index: 0,
             clause_count: 1,
-            view: Box::new(message),
+            view,
         };
-        let encoded = encode_sync_message(&over_limit).expect("encode over-limit fixture");
-        assert!(
-            decode_sync_message(&encoded).is_err(),
-            "remote recursive messages must be rejected above the bounded decode depth"
+        let encoded = encode_sync_message(&message).expect("encode scope view fixture");
+        assert_eq!(
+            decode_sync_message(&encoded).expect("decode scope view fixture"),
+            message,
+            "the scope wrapper admits only its dedicated, non-recursive payload"
         );
     }
 

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -704,7 +704,7 @@ mod tests {
         VersionBundleRunError, VersionCarrier, VersionRecord,
         build_version_bundle_runs_from_singletons,
     };
-    use crate::protocol_limits::MAX_WIRE_FRAME_BYTES;
+    use crate::protocol_limits::{MAX_SYNC_MESSAGE_NESTING_DEPTH, MAX_WIRE_FRAME_BYTES};
     use crate::query::{BindingId, Query, ShapeId};
     use crate::schema::{ColumnSchema, TableSchema};
     use crate::time::{GlobalTime, TxTime};
@@ -860,7 +860,7 @@ mod tests {
     #[test]
     fn deeply_nested_authorization_scope_views_are_rejected() {
         let mut message = view_update_with_carriers(Vec::new());
-        for _ in 0..32 {
+        for _ in 0..MAX_SYNC_MESSAGE_NESTING_DEPTH {
             message = SyncMessage::AuthorizationScopeView {
                 request_id: PermissionAdviceRequestId([0x11; 16]),
                 key: AuthorizationSupportScopeKey {
@@ -874,11 +874,28 @@ mod tests {
                 view: Box::new(message),
             };
         }
-        let encoded = encode_sync_message(&message).expect("encode nested fixture");
+        let encoded = encode_sync_message(&message).expect("encode limit-depth fixture");
+        assert_eq!(
+            decode_sync_message(&encoded).expect("limit-depth fixture remains valid"),
+            message
+        );
 
+        let over_limit = SyncMessage::AuthorizationScopeView {
+            request_id: PermissionAdviceRequestId([0x11; 16]),
+            key: AuthorizationSupportScopeKey {
+                support_shape_digest: [0x22; 32],
+                subject: AuthorId::from_bytes([0x33; 16]),
+                claims_digest: [0x44; 32],
+                policy_digest: [0x55; 32],
+            },
+            clause_index: 0,
+            clause_count: 1,
+            view: Box::new(message),
+        };
+        let encoded = encode_sync_message(&over_limit).expect("encode over-limit fixture");
         assert!(
             decode_sync_message(&encoded).is_err(),
-            "remote recursive messages must be rejected under a bounded decode depth"
+            "remote recursive messages must be rejected above the bounded decode depth"
         );
     }
 

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -859,9 +859,9 @@ mod tests {
 
     #[test]
     fn authorization_scope_view_has_a_nonrecursive_view_update_payload() {
-        let view = crate::protocol::AuthorizationScopeViewPayload::from_view_update(
-            view_update_with_carriers(Vec::new()),
-        )
+        let view = crate::protocol::ViewUpdatePayload::from_view_update(view_update_with_carriers(
+            Vec::new(),
+        ))
         .expect("fixture is a view update");
         let message = SyncMessage::AuthorizationScopeView {
             request_id: PermissionAdviceRequestId([0x11; 16]),
@@ -880,6 +880,65 @@ mod tests {
             decode_sync_message(&encoded).expect("decode scope view fixture"),
             message,
             "the scope wrapper admits only its dedicated, non-recursive payload"
+        );
+    }
+
+    #[test]
+    fn shared_view_update_payload_preserves_postcard_shape() {
+        #[allow(dead_code)]
+        #[derive(serde::Serialize)]
+        enum LegacySyncMessage {
+            V0,
+            V1,
+            V2,
+            V3,
+            V4,
+            V5,
+            V6,
+            V7,
+            V8,
+            V9,
+            V10,
+            V11,
+            V12,
+            V13,
+            ViewUpdate {
+                subscription: SubscriptionKey,
+                settled_through: GlobalTime,
+                reset_result_set: bool,
+                version_carriers: Vec<VersionCarrier>,
+                version_bundles: Vec<VersionBundle>,
+                peer_payload_inventory: crate::protocol::PeerPayloadInventory,
+                result_member_adds: Vec<crate::protocol::ResultMemberEntry>,
+                result_member_removes: Vec<crate::protocol::ResultMemberEntry>,
+                terminal_operations: Vec<groove::ivm::TerminalOperation>,
+                program_fact_adds: Vec<crate::protocol::ProgramFactEntry>,
+                program_fact_removes: Vec<crate::protocol::ProgramFactEntry>,
+            },
+        }
+
+        let SyncMessage::ViewUpdate(payload) = view_update_with_carriers(Vec::new()) else {
+            unreachable!()
+        };
+        let legacy = LegacySyncMessage::ViewUpdate {
+            subscription: payload.subscription,
+            settled_through: payload.settled_through,
+            reset_result_set: payload.reset_result_set,
+            version_carriers: payload.version_carriers.clone(),
+            version_bundles: payload.version_bundles.clone(),
+            peer_payload_inventory: payload.peer_payload_inventory.clone(),
+            result_member_adds: payload.result_member_adds.clone(),
+            result_member_removes: payload.result_member_removes.clone(),
+            terminal_operations: payload.terminal_operations.clone(),
+            program_fact_adds: payload.program_fact_adds.clone(),
+            program_fact_removes: payload.program_fact_removes.clone(),
+        };
+        let current = SyncMessage::ViewUpdate(payload);
+
+        assert_eq!(
+            encode_sync_message(&current).unwrap(),
+            postcard::to_allocvec(&legacy).unwrap(),
+            "a newtype struct is postcard-transparent relative to the former struct variant"
         );
     }
 
@@ -903,11 +962,11 @@ mod tests {
 
         assert_eq!(decode_sync_message_for_receive(&encoded).unwrap(), message);
         let expanded = message.expand_version_carriers_for_receive().unwrap();
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             version_carriers,
             version_bundles,
             ..
-        } = expanded
+        }) = expanded
         else {
             panic!("expected view update");
         };
@@ -926,9 +985,9 @@ mod tests {
 
         assert_eq!(decode_sync_message_for_receive(&encoded).unwrap(), message);
         let expanded = message.expand_version_carriers_for_receive().unwrap();
-        let SyncMessage::ViewUpdate {
+        let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             version_bundles, ..
-        } = expanded
+        }) = expanded
         else {
             panic!("expected view update");
         };
@@ -970,9 +1029,9 @@ mod tests {
             },
             clause_index: 0,
             clause_count: 1,
-            view: crate::protocol::AuthorizationScopeViewPayload::from_view_update(
-                view_update_with_carriers(vec![VersionCarrier::Run(run)]),
-            )
+            view: crate::protocol::ViewUpdatePayload::from_view_update(view_update_with_carriers(
+                vec![VersionCarrier::Run(run)],
+            ))
             .expect("fixture is a view update"),
         };
 
@@ -1031,7 +1090,7 @@ mod tests {
     }
 
     fn view_update_with_carriers(version_carriers: Vec<VersionCarrier>) -> SyncMessage {
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription: SubscriptionKey {
                 shape_id: ShapeId(uuid::Uuid::from_bytes([0x22; 16])),
                 binding_id: BindingId(uuid::Uuid::from_bytes([0x33; 16])),
@@ -1047,7 +1106,7 @@ mod tests {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        }
+        })
     }
 
     fn version_bundles(count: usize) -> Vec<VersionBundle> {
@@ -1219,7 +1278,7 @@ mod tests {
                         batch: Some(tx),
                         settle_position: Some(GlobalTime(10_000 + i)),
                     });
-                SyncMessage::ViewUpdate {
+                SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                     subscription,
                     settled_through: GlobalTime(10_000 + i),
                     reset_result_set: false,
@@ -1231,7 +1290,7 @@ mod tests {
                     program_fact_adds: Vec::new(),
                     program_fact_removes: Vec::new(),
                     terminal_operations: Vec::new(),
-                }
+                })
             })
             .collect::<Vec<_>>();
         let mut raw = 0_u64;
@@ -1307,7 +1366,7 @@ mod tests {
                     code: crate::protocol::SubscribeServerFailureCode::TableNotFound,
                 },
             },
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
                 subscription,
                 settled_through: GlobalTime(7),
                 reset_result_set: true,
@@ -1323,7 +1382,7 @@ mod tests {
                 terminal_operations: Vec::new(),
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-            },
+            }),
             SyncMessage::CommitUnit {
                 tx: Transaction {
                     tx_id,
@@ -1380,7 +1439,7 @@ mod tests {
         let row = RowUuid::from_bytes([0x22; 16]);
         let tx_id = TxId::new(TxTime(21), NodeUuid::from_bytes([0x33; 16]));
         let entry: ResultRowEntry = (Intern::new("todos".to_owned()), row, tx_id);
-        let message = SyncMessage::ViewUpdate {
+        let message = SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
             subscription: SubscriptionKey {
                 shape_id: ShapeId(uuid::Uuid::from_bytes([0x44; 16])),
                 binding_id: BindingId(uuid::Uuid::from_bytes([0x55; 16])),
@@ -1400,7 +1459,7 @@ mod tests {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        };
+        });
 
         let encoded = encode_sync_message(&message).unwrap();
         let decoded = decode_sync_message(&encoded).unwrap();

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -953,6 +953,39 @@ mod tests {
     }
 
     #[test]
+    fn malformed_version_carrier_run_is_rejected_in_ordinary_and_scope_views() {
+        let mut run = build_version_bundle_runs_from_singletons(&version_bundles(2))
+            .unwrap()
+            .remove(0);
+        run.header.body_count = 3;
+
+        let ordinary = view_update_with_carriers(vec![VersionCarrier::Run(run.clone())]);
+        let scope_view = SyncMessage::AuthorizationScopeView {
+            request_id: PermissionAdviceRequestId([0x11; 16]),
+            key: AuthorizationSupportScopeKey {
+                support_shape_digest: [0x22; 32],
+                subject: AuthorId::from_bytes([0x33; 16]),
+                claims_digest: [0x44; 32],
+                policy_digest: [0x55; 32],
+            },
+            clause_index: 0,
+            clause_count: 1,
+            view: crate::protocol::AuthorizationScopeViewPayload::from_view_update(
+                view_update_with_carriers(vec![VersionCarrier::Run(run)]),
+            )
+            .expect("fixture is a view update"),
+        };
+
+        for message in [ordinary, scope_view] {
+            let encoded = encode_sync_message(&message).expect("encode malformed fixture");
+            assert!(
+                decode_sync_message(&encoded).is_err(),
+                "malformed runs must be rejected at either view-update seam"
+            );
+        }
+    }
+
+    #[test]
     fn malformed_version_carrier_run_override_index_is_rejected() {
         let mut run = build_version_bundle_runs_from_singletons(&version_bundles(2))
             .unwrap()

--- a/crates/jazz/tests/four_tier.rs
+++ b/crates/jazz/tests/four_tier.rs
@@ -1301,7 +1301,7 @@ fn edge_accepted_mergeable_is_final_at_core_after_policy_revocation() {
     let binding = shape.bind(BTreeMap::new()).unwrap();
     apply_message(
         &mut core,
-        SyncMessage::ViewUpdate {
+        SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             subscription: SubscriptionKey {
                 shape_id: shape.shape_id(),
                 binding_id: binding.binding_id(),
@@ -1324,7 +1324,7 @@ fn edge_accepted_mergeable_is_final_at_core_after_policy_revocation() {
             terminal_operations: Vec::new(),
             program_fact_adds: Vec::new(),
             program_fact_removes: Vec::new(),
-        },
+        }),
     );
 
     let (fate, global_time, durability) = transaction_state(&mut core, tx_id);

--- a/crates/jazz/tests/wire_fixtures.rs
+++ b/crates/jazz/tests/wire_fixtures.rs
@@ -280,7 +280,7 @@ fn wire_fixture_messages() -> Vec<(&'static str, &'static str, SyncMessage)> {
         (
             "view_update_reset_with_row_add",
             "ViewUpdate",
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
                 subscription,
                 settled_through: GlobalTime(7),
                 reset_result_set: true,
@@ -296,12 +296,12 @@ fn wire_fixture_messages() -> Vec<(&'static str, &'static str, SyncMessage)> {
                 terminal_operations: Vec::new(),
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-            },
+            }),
         ),
         (
             "view_update_mixed_version_carrier_runs",
             "ViewUpdate",
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
                 subscription,
                 settled_through: GlobalTime(8),
                 reset_result_set: false,
@@ -313,12 +313,12 @@ fn wire_fixture_messages() -> Vec<(&'static str, &'static str, SyncMessage)> {
                 terminal_operations: Vec::new(),
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-            },
+            }),
         ),
         (
             "view_update_terminal_patch",
             "ViewUpdate",
-            SyncMessage::ViewUpdate {
+            SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
                 subscription,
                 settled_through: GlobalTime(9),
                 reset_result_set: false,
@@ -338,7 +338,7 @@ fn wire_fixture_messages() -> Vec<(&'static str, &'static str, SyncMessage)> {
                 }],
                 program_fact_adds: Vec::new(),
                 program_fact_removes: Vec::new(),
-            },
+            }),
         ),
         (
             "commit_unit_mergeable_empty",


### PR DESCRIPTION
## Summary
- cap nested authorization-scope view decoding at eight wrappers
- reject excess depth during serde descent rather than after constructing the recursive value
- preserve the existing wire format and accept the exact configured boundary

## Why
A peer-controlled sync message can recursively wrap `AuthorizationScopeView` values. Frame-size limits cap bytes but do not provide a safe stack-depth invariant during postcard deserialization.

## Verification
- `cargo test -p jazz wire::tests` (22 passed)
- exact boundary regression test passed
- `cargo clippy -p jazz --lib -- -D warnings`
- pre-commit hooks passed