### PR TITLE
Block index registration while publications are resident

### DIFF
--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -499,6 +499,8 @@ pub enum Error {
     TableFieldDefinitionMismatch { table: String, field: String },
     #[error("index definition does not match the live catalogue: {table}.{index}")]
     TableIndexDefinitionMismatch { table: String, index: String },
+    #[error("cannot register index {table}.{index} while database publications remain resident")]
+    TableIndexRegistrationWhilePublicationsResident { table: String, index: String },
     #[error("index {table}.{index} references unknown field {field}")]
     TableIndexFieldNotFound {
         table: String,

--- a/crates/groove/src/db/schema_admission.rs
+++ b/crates/groove/src/db/schema_admission.rs
@@ -262,6 +262,12 @@ impl Database {
                 });
             }
         }
+        if !self.resident_publications.is_empty() {
+            return Err(Error::TableIndexRegistrationWhilePublicationsResident {
+                table: table.to_owned(),
+                index: index.name,
+            });
+        }
         if let Err(error) = self
             .ivm_runtime
             .register_table_index(table, index, &self.storage)

--- a/crates/groove/src/db/tests/indices.rs
+++ b/crates/groove/src/db/tests/indices.rs
@@ -1279,13 +1279,15 @@ async fn live_index_registration_rejects_while_a_publication_is_resident() {
     let applied = database.apply_batch(batch).await.unwrap();
     let index = IndexSchema::new("albums_by_title", ["title"]);
 
-    assert!(
-        database
-            .register_table_index("albums", index.clone())
-            .await
-            .is_err(),
-        "schema mutation must not race a resident publication"
-    );
+    let error = database
+        .register_table_index("albums", index.clone())
+        .await
+        .expect_err("schema mutation must not race a resident publication");
+    assert!(matches!(
+        error,
+        Error::TableIndexRegistrationWhilePublicationsResident { table, index }
+            if table == "albums" && index == "albums_by_title"
+    ));
 
     let persisted = applied.persist().await;
     database.finish_persistence(persisted).unwrap();

--- a/crates/groove/src/db/tests/indices.rs
+++ b/crates/groove/src/db/tests/indices.rs
@@ -1266,3 +1266,44 @@ async fn persisted_indices_can_be_deleted_after_restart() {
         );
     }
 }
+
+#[futures_test::test]
+async fn live_index_registration_rejects_while_a_publication_is_resident() {
+    let storage = MemoryStorage::new(&["albums", "indices"]);
+    let mut database = Database::new(albums_schema(), storage).await.unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    let applied = database.apply_batch(batch).await.unwrap();
+    let index = IndexSchema::new("albums_by_title", ["title"]);
+
+    assert!(
+        database
+            .register_table_index("albums", index.clone())
+            .await
+            .is_err(),
+        "schema mutation must not race a resident publication"
+    );
+
+    let persisted = applied.persist().await;
+    database.finish_persistence(persisted).unwrap();
+    database
+        .register_table_index("albums", index)
+        .await
+        .unwrap();
+    assert_eq!(
+        record_values(
+            database
+                .index_scan(
+                    "albums",
+                    "albums_by_title",
+                    &[Value::String("Blue Train".to_owned())],
+                )
+                .await
+                .unwrap()
+        ),
+        [vec![Value::U64(7), Value::String("Blue Train".to_owned())]]
+    );
+}


### PR DESCRIPTION
## Summary
- reject new live index registration while any publication remains resident
- preserve idempotent registration and invalid-field error precedence
- verify registration succeeds after the resident publication becomes durable and backfills the row

## Why
Live index backfill reads durable storage. Registering an index while applied writes are resident could publish an index definition whose initial contents omit those writes.

## Verification
- `cargo test -p groove db::tests::indices` (25 passed)
- `cargo clippy -p groove --lib -- -D warnings`
- pre-commit hooks passed