### PR TITLE
Compile effective DELETE policy fallback

### DIFF
--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -548,6 +548,24 @@ fn convert_table(
         "policies.select.using",
         table.policies.select.using.as_ref(),
     )?;
+    let update_using = convert_optional_policy(
+        schema,
+        table,
+        name,
+        "policies.update.using",
+        table.policies.update.using.as_ref(),
+    )?;
+    let delete_using = if table.policies.delete.using.is_some() {
+        convert_optional_policy(
+            schema,
+            table,
+            name,
+            "policies.delete.using",
+            table.policies.delete.using.as_ref(),
+        )?
+    } else {
+        update_using.clone()
+    };
     converted.write_policies = WritePolicies {
         insert_check: convert_optional_policy(
             schema,
@@ -556,13 +574,7 @@ fn convert_table(
             "policies.insert.with_check",
             table.policies.insert.with_check.as_ref(),
         )?,
-        update_using: convert_optional_policy(
-            schema,
-            table,
-            name,
-            "policies.update.using",
-            table.policies.update.using.as_ref(),
-        )?,
+        update_using,
         update_check: convert_optional_policy(
             schema,
             table,
@@ -570,13 +582,7 @@ fn convert_table(
             "policies.update.with_check",
             table.policies.update.with_check.as_ref(),
         )?,
-        delete_using: convert_optional_policy(
-            schema,
-            table,
-            name,
-            "policies.delete.using",
-            table.policies.delete.using.as_ref(),
-        )?,
+        delete_using,
     };
     Ok(converted)
 }
@@ -3889,6 +3895,15 @@ mod tests {
                         TablePolicies::new().with_update(Some(owner_policy), PolicyExpr::True),
                     ),
             )
+            .table(
+                TableSchemaBuilder::new("attachments")
+                    .fk_column("document_id", "documents")
+                    .policies(TablePolicies::new().with_insert(PolicyExpr::Inherits {
+                        operation: Operation::Delete,
+                        via_column: "document_id".to_owned(),
+                        max_depth: None,
+                    })),
+            )
             .build();
 
         let converted = convert_public_schema(&schema).unwrap();
@@ -3900,6 +3915,21 @@ mod tests {
         assert_eq!(
             documents.write_policies.delete_using, documents.write_policies.update_using,
             "DELETE must inherit UPDATE USING when no explicit DELETE USING is declared"
+        );
+        let attachments = converted
+            .tables
+            .iter()
+            .find(|table| table.name == "attachments")
+            .unwrap();
+        assert_eq!(
+            attachments
+                .write_policies
+                .insert_check
+                .as_ref()
+                .unwrap()
+                .inherits[0]
+                .operation,
+            InheritsOperation::Delete
         );
     }
 

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -3875,6 +3875,35 @@ mod tests {
     }
 
     #[test]
+    fn compiles_update_using_as_the_default_delete_policy() {
+        let owner_policy = PolicyExpr::Cmp {
+            column: "owner_id".to_owned(),
+            op: CmpOp::Eq,
+            value: PolicyValue::SessionRef(vec!["user_id".to_owned()]),
+        };
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchemaBuilder::new("documents")
+                    .column("owner_id", ColumnType::Text)
+                    .policies(
+                        TablePolicies::new().with_update(Some(owner_policy), PolicyExpr::True),
+                    ),
+            )
+            .build();
+
+        let converted = convert_public_schema(&schema).unwrap();
+        let documents = converted
+            .tables
+            .iter()
+            .find(|table| table.name == "documents")
+            .unwrap();
+        assert_eq!(
+            documents.write_policies.delete_using, documents.write_policies.update_using,
+            "DELETE must inherit UPDATE USING when no explicit DELETE USING is declared"
+        );
+    }
+
+    #[test]
     fn preserves_operation_specific_inherits_for_complex_child_write_policy() {
         let schema = SchemaBuilder::new()
             .table(


### PR DESCRIPTION
## Summary
- compile UPDATE USING as DELETE USING when no explicit delete predicate is declared
- preserve explicit DELETE USING precedence and accurate conversion error paths
- cover both direct delete policy output and inherited DELETE authorization metadata

## Why
The public schema contract documents DELETE USING as falling back to UPDATE USING. Conversion previously omitted that fallback even though inherited-policy admission already reasoned from the effective predicate, denying legitimate deletes and leaving inherited DELETE filters without a compiled parent predicate.

## Verification
- public schema conversion tests: 40 passed
- focused direct and inherited fallback regression passed
- `cargo clippy -p jazz --lib -- -D warnings`
- pre-commit hooks passed