### PR TITLE
Clear Inspector mutations on table navigation

### DIFF
--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -1,7 +1,8 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { Link, MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TableDataGrid } from "./TableDataGrid";
+import { DataExplorer } from "../../pages/data-explorer";
 
 const mockUseAll = vi.fn();
 const mockUpdate = vi.fn();
@@ -54,6 +55,22 @@ function renderGridUi() {
 
 function renderGrid() {
   return render(renderGridUi());
+}
+
+function renderRoutedGrid() {
+  return render(
+    <MemoryRouter initialEntries={["/data-explorer/todos/data"]}>
+      <Routes>
+        <Route path="data-explorer" element={<DataExplorer />}>
+          <Route path=":table/data" element={<TableDataGrid />} />
+          <Route
+            path=":table/schema"
+            element={<Link to="/data-explorer/todos/data">Return to data</Link>}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
 }
 
 const mockWasmSchema = {
@@ -865,11 +882,14 @@ describe("TableDataGrid", () => {
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
 
     fireEvent.doubleClick(screen.getByRole("gridcell", { name: "submitted" }));
-    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "later draft" } });
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "temporary" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "temporary" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "submitted" } });
     fireEvent.blur(screen.getByLabelText("Edit title"));
     await act(async () => resolveSave?.());
 
-    expect(screen.getByText("later draft")).not.toBeNull();
+    expect(screen.getByText("submitted")).not.toBeNull();
     expect(screen.getByRole("button", { name: "Save changes" })).not.toBeNull();
   });
 
@@ -906,6 +926,49 @@ describe("TableDataGrid", () => {
     rerender(renderGridUi());
     expect(screen.getByText("A draft")).not.toBeNull();
     expect(screen.getByRole("alert").textContent).toContain("A save failed");
+  });
+
+  it("retains a deferred save failure across the schema route", async () => {
+    let rejectSave: ((error: Error) => void) | undefined;
+    mockUpdateWait.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSave = reject;
+        }),
+    );
+    renderRoutedGrid();
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "zeta" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "route draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("link", { name: "Schema" }));
+    expect(screen.getByText("Return to data")).not.toBeNull();
+    await act(async () => rejectSave?.(new Error("route save failed")));
+    fireEvent.click(screen.getByRole("link", { name: "Return to data" }));
+    expect(screen.getByText("route draft")).not.toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain("route save failed");
+  });
+
+  it("retains a deferred save success across the schema route", async () => {
+    let resolveSave: (() => void) | undefined;
+    mockUpdateWait.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    renderRoutedGrid();
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "zeta" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "route draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("link", { name: "Schema" }));
+    await act(async () => resolveSave?.());
+    fireEvent.click(screen.getByRole("link", { name: "Return to data" }));
+    expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("appends a staged insert row and inserts it from the banner", async () => {

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -893,6 +893,25 @@ describe("TableDataGrid", () => {
     expect(screen.getByRole("button", { name: "Save changes" })).not.toBeNull();
   });
 
+  it("admits only one same-table save before React disables the button", async () => {
+    let resolveSave: (() => void) | undefined;
+    mockUpdateWait.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    renderGrid();
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "zeta" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    const save = screen.getByRole("button", { name: "Save changes" });
+    fireEvent.click(save);
+    fireEvent.click(save);
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    await act(async () => resolveSave?.());
+  });
+
   it("keeps a failed save error scoped to its originating table after navigation", async () => {
     let rejectSave: ((error: Error) => void) | undefined;
     mockUpdateWait.mockImplementationOnce(

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -849,6 +849,30 @@ describe("TableDataGrid", () => {
     await waitFor(() => expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull());
   });
 
+  it("preserves a later same-table edit when an earlier save completes", async () => {
+    let resolveSave: (() => void) | undefined;
+    mockUpdateWait.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    renderGrid();
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "zeta" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "submitted" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "submitted" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "later draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    await act(async () => resolveSave?.());
+
+    expect(screen.getByText("later draft")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Save changes" })).not.toBeNull();
+  });
+
   it("keeps a failed save error scoped to its originating table after navigation", async () => {
     let rejectSave: ((error: Error) => void) | undefined;
     mockUpdateWait.mockImplementationOnce(

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -12,6 +12,7 @@ const mockInsertWait = vi.fn();
 const mockDeleteWait = vi.fn();
 let currentRows: Array<Record<string, unknown>>;
 let currentReferenceRowsByTable: Record<string, Array<Record<string, unknown>>>;
+let currentTable: string;
 
 function getContainingCell(element: HTMLElement | null): HTMLElement | null {
   return element?.closest('[role="gridcell"], td') ?? null;
@@ -105,7 +106,7 @@ vi.mock("react-router", async () => {
   const actual = await vi.importActual<typeof import("react-router")>("react-router");
   return {
     ...actual,
-    useParams: () => ({ table: "todos" }),
+    useParams: () => ({ table: currentTable }),
   };
 });
 
@@ -117,6 +118,7 @@ describe("TableDataGrid", () => {
 
   beforeEach(() => {
     localStorage.clear();
+    currentTable = "todos";
     currentRows = [
       {
         id: "row-2",
@@ -772,6 +774,24 @@ describe("TableDataGrid", () => {
     });
 
     expect(screen.queryByText("row-2")).toBeNull();
+  });
+
+  it("clears staged mutations when the routed table changes", async () => {
+    const { rerender } = renderGrid();
+    fireEvent.click(screen.getByRole("button", { name: "Insert row" }));
+    expect(screen.getByText("1 staged insert")).not.toBeNull();
+
+    currentTable = "users";
+    currentRows = [];
+    rerender(renderGridUi());
+
+    await waitFor(() => {
+      expect(screen.queryByText("1 staged insert")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+    });
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it("appends a staged insert row and inserts it from the banner", async () => {

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -776,7 +776,7 @@ describe("TableDataGrid", () => {
     expect(screen.queryByText("row-2")).toBeNull();
   });
 
-  it("clears staged mutations when the routed table changes", async () => {
+  it("keeps staged mutations scoped to their routed table", async () => {
     const { rerender } = renderGrid();
     fireEvent.click(screen.getByRole("button", { name: "Insert row" }));
     expect(screen.getByText("1 staged insert")).not.toBeNull();
@@ -792,6 +792,96 @@ describe("TableDataGrid", () => {
     expect(mockInsert).not.toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockDelete).not.toHaveBeenCalled();
+
+    currentTable = "todos";
+    currentRows = [
+      {
+        id: "row-2",
+        title: "zeta",
+        done: false,
+        maybe_done: null,
+        meta: { done: true },
+        owner_id: "owner-a",
+        blob: new Uint8Array([1, 2]),
+        status: "open",
+      },
+    ];
+    rerender(renderGridUi());
+
+    expect(screen.getByText("1 staged insert")).not.toBeNull();
+  });
+
+  it("keeps a completed save scoped to its originating table after navigation", async () => {
+    let resolveSave: (() => void) | undefined;
+    mockUpdateWait.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    mockUpdateWait.mockImplementationOnce(() => Promise.reject(new Error("B save failed")));
+    const { rerender } = renderGrid();
+
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "zeta" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "A draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+
+    currentTable = "users";
+    currentRows = [];
+    rerender(renderGridUi());
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "Alice" }));
+    fireEvent.change(screen.getByLabelText("Edit displayName"), { target: { value: "B draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit displayName"));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("B save failed"));
+
+    await act(async () => resolveSave?.());
+
+    expect(screen.getByText("B draft")).not.toBeNull();
+    expect(screen.getByText("1 edit across 1 row")).not.toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain("B save failed");
+
+    currentTable = "todos";
+    currentRows = [{ id: "row-2", title: "zeta", done: false, maybe_done: null, status: "open" }];
+    rerender(renderGridUi());
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull());
+  });
+
+  it("keeps a failed save error scoped to its originating table after navigation", async () => {
+    let rejectSave: ((error: Error) => void) | undefined;
+    mockUpdateWait.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSave = reject;
+        }),
+    );
+    const { rerender } = renderGrid();
+
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "zeta" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), { target: { value: "A draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit title"));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+
+    currentTable = "users";
+    currentRows = [];
+    rerender(renderGridUi());
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "Alice" }));
+    fireEvent.change(screen.getByLabelText("Edit displayName"), { target: { value: "B draft" } });
+    fireEvent.blur(screen.getByLabelText("Edit displayName"));
+
+    await act(async () => rejectSave?.(new Error("A save failed")));
+
+    expect(screen.getByText("B draft")).not.toBeNull();
+    expect(screen.queryByText("A save failed")).toBeNull();
+
+    currentTable = "todos";
+    currentRows = [{ id: "row-2", title: "zeta", done: false, maybe_done: null, status: "open" }];
+    rerender(renderGridUi());
+    expect(screen.getByText("A draft")).not.toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain("A save failed");
   });
 
   it("appends a staged insert row and inserts it from the banner", async () => {

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -24,7 +24,7 @@ import {
   type RefObject,
   type SetStateAction,
 } from "react";
-import { Link, Navigate, useParams, useSearchParams } from "react-router";
+import { Link, Navigate, useOutletContext, useParams, useSearchParams } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import { GenericQueryBuilder } from "../../utility/generic-query-builder.js";
 import { useLocalStorageState } from "../../utility/use-local-storage-state.js";
@@ -135,7 +135,7 @@ interface StagedInsert {
   edits: QueuedRowEdits;
 }
 
-interface TableMutationState {
+export interface TableMutationState {
   queuedEdits: Record<string, QueuedRowEdits>;
   stagedInserts: StagedInsert[];
   isQueuedSavePending: boolean;
@@ -153,6 +153,18 @@ function createTableMutationState(): TableMutationState {
     queuedDeletes: new Set(),
     pendingScrollToRowId: null,
   };
+}
+
+function queuedCellEditsEqual(a: QueuedCellEdit | undefined, b: QueuedCellEdit | undefined) {
+  return a?.text === b?.text && a?.isNull === b?.isNull;
+}
+
+function queuedRowEditsEqual(a: QueuedRowEdits, b: QueuedRowEdits) {
+  const aColumns = Object.keys(a);
+  return (
+    aColumns.length === Object.keys(b).length &&
+    aColumns.every((key) => queuedCellEditsEqual(a[key], b[key]))
+  );
 }
 
 interface EditableGridRow extends AnimatedGridRow {
@@ -735,9 +747,17 @@ export function TableDataGrid() {
       { replace: true },
     );
   };
-  const [mutationStateByTable, setMutationStateByTable] = useState<
+  const explorerContext = useOutletContext<{
+    mutationStateByTable: Record<string, TableMutationState>;
+    setMutationStateByTable: Dispatch<SetStateAction<Record<string, TableMutationState>>>;
+  } | null>();
+  const [fallbackMutationStateByTable, setFallbackMutationStateByTable] = useState<
     Record<string, TableMutationState>
   >({});
+  const mutationStateByTable =
+    explorerContext?.mutationStateByTable ?? fallbackMutationStateByTable;
+  const setMutationStateByTable =
+    explorerContext?.setMutationStateByTable ?? setFallbackMutationStateByTable;
   const [selectedRowIds, setSelectedRowIds] = useState<Set<string>>(new Set());
   const mutationState = mutationStateByTable[table] ?? createTableMutationState();
   const updateCurrentTableMutationState = (update: SetStateAction<TableMutationState>) => {
@@ -985,6 +1005,9 @@ export function TableDataGrid() {
     }
 
     const mutationTable = table;
+    const submittedQueuedEdits = queuedEdits;
+    const submittedStagedInserts = stagedInserts;
+    const submittedQueuedDeletes = queuedDeletes;
     try {
       setMutationStateByTable((current) => ({
         ...current,
@@ -1031,10 +1054,36 @@ export function TableDataGrid() {
       setMutationStateByTable((current) => ({
         ...current,
         [mutationTable]: {
-          ...(current[mutationTable] ?? createTableMutationState()),
-          queuedEdits: {},
-          stagedInserts: [],
-          queuedDeletes: new Set(),
+          ...(() => {
+            const previous = current[mutationTable] ?? createTableMutationState();
+            const nextQueuedEdits: Record<string, QueuedRowEdits> = {};
+            for (const [rowId, rowEdits] of Object.entries(previous.queuedEdits)) {
+              const submittedRowEdits = submittedQueuedEdits[rowId];
+              const remainingRowEdits = { ...rowEdits };
+              for (const [columnId, queuedEdit] of Object.entries(rowEdits)) {
+                if (queuedCellEditsEqual(queuedEdit, submittedRowEdits?.[columnId])) {
+                  delete remainingRowEdits[columnId];
+                }
+              }
+              if (Object.keys(remainingRowEdits).length > 0)
+                nextQueuedEdits[rowId] = remainingRowEdits;
+            }
+            const submittedInsertById = new Map(
+              submittedStagedInserts.map((insert) => [insert.id, insert]),
+            );
+            const nextStagedInserts = previous.stagedInserts.filter((insert) => {
+              const submitted = submittedInsertById.get(insert.id);
+              return !submitted || !queuedRowEditsEqual(insert.edits, submitted.edits);
+            });
+            const nextQueuedDeletes = new Set(previous.queuedDeletes);
+            for (const rowId of submittedQueuedDeletes) nextQueuedDeletes.delete(rowId);
+            return {
+              ...previous,
+              queuedEdits: nextQueuedEdits,
+              stagedInserts: nextStagedInserts,
+              queuedDeletes: nextQueuedDeletes,
+            };
+          })(),
         },
       }));
     } catch (error) {

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -758,14 +758,32 @@ export function TableDataGrid() {
   const explorerContext = useOutletContext<{
     mutationStateByTable: Record<string, TableMutationState>;
     setMutationStateByTable: Dispatch<SetStateAction<Record<string, TableMutationState>>>;
+    beginSave: (table: string) => symbol | null;
+    finishSave: (table: string, token: symbol) => boolean;
   } | null>();
   const [fallbackMutationStateByTable, setFallbackMutationStateByTable] = useState<
     Record<string, TableMutationState>
   >({});
+  const fallbackSaveTokens = useRef(new Map<string, symbol>());
   const mutationStateByTable =
     explorerContext?.mutationStateByTable ?? fallbackMutationStateByTable;
   const setMutationStateByTable =
     explorerContext?.setMutationStateByTable ?? setFallbackMutationStateByTable;
+  const beginSave =
+    explorerContext?.beginSave ??
+    ((targetTable: string) => {
+      if (fallbackSaveTokens.current.has(targetTable)) return null;
+      const token = Symbol(targetTable);
+      fallbackSaveTokens.current.set(targetTable, token);
+      return token;
+    });
+  const finishSave =
+    explorerContext?.finishSave ??
+    ((targetTable: string, token: symbol) => {
+      if (fallbackSaveTokens.current.get(targetTable) !== token) return false;
+      fallbackSaveTokens.current.delete(targetTable);
+      return true;
+    });
   const [selectedRowIds, setSelectedRowIds] = useState<Set<string>>(new Set());
   const mutationState = mutationStateByTable[table] ?? createTableMutationState();
   const updateCurrentTableMutationState = (update: SetStateAction<TableMutationState>) => {
@@ -1058,6 +1076,8 @@ export function TableDataGrid() {
     }
 
     const mutationTable = table;
+    const saveToken = beginSave(mutationTable);
+    if (!saveToken) return;
     const submittedQueuedEdits = queuedEdits;
     const submittedStagedInserts = stagedInserts;
     const submittedQueuedDeletes = queuedDeletes;
@@ -1174,6 +1194,7 @@ export function TableDataGrid() {
           isQueuedSavePending: false,
         },
       }));
+      finishSave(mutationTable, saveToken);
     }
   };
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -142,6 +142,10 @@ export interface TableMutationState {
   queuedSaveError: string | null;
   queuedDeletes: Set<string>;
   pendingScrollToRowId: string | null;
+  nextEntryRevision: number;
+  queuedEditRevisions: Record<string, Record<string, number>>;
+  stagedInsertRevisions: Record<string, number>;
+  queuedDeleteRevisions: Record<string, number>;
 }
 
 function createTableMutationState(): TableMutationState {
@@ -152,6 +156,10 @@ function createTableMutationState(): TableMutationState {
     queuedSaveError: null,
     queuedDeletes: new Set(),
     pendingScrollToRowId: null,
+    nextEntryRevision: 0,
+    queuedEditRevisions: {},
+    stagedInsertRevisions: {},
+    queuedDeleteRevisions: {},
   };
 }
 
@@ -774,25 +782,70 @@ export function TableDataGrid() {
   const queuedDeletes = mutationState.queuedDeletes;
   const pendingScrollToRowId = mutationState.pendingScrollToRowId;
   const setQueuedEdits: Dispatch<SetStateAction<Record<string, QueuedRowEdits>>> = (update) =>
-    updateCurrentTableMutationState((current) => ({
-      ...current,
-      queuedEdits: typeof update === "function" ? update(current.queuedEdits) : update,
-    }));
+    updateCurrentTableMutationState((current) => {
+      const nextEdits = typeof update === "function" ? update(current.queuedEdits) : update;
+      let nextRevision = current.nextEntryRevision;
+      const nextRevisions: Record<string, Record<string, number>> = {};
+      for (const [rowId, rowEdits] of Object.entries(nextEdits)) {
+        const rowRevisions: Record<string, number> = {};
+        for (const [columnId, value] of Object.entries(rowEdits)) {
+          const unchanged = queuedCellEditsEqual(value, current.queuedEdits[rowId]?.[columnId]);
+          rowRevisions[columnId] = unchanged
+            ? (current.queuedEditRevisions[rowId]?.[columnId] ?? ++nextRevision)
+            : ++nextRevision;
+        }
+        if (Object.keys(rowRevisions).length > 0) nextRevisions[rowId] = rowRevisions;
+      }
+      return {
+        ...current,
+        queuedEdits: nextEdits,
+        queuedEditRevisions: nextRevisions,
+        nextEntryRevision: nextRevision,
+      };
+    });
   const setStagedInserts: Dispatch<SetStateAction<StagedInsert[]>> = (update) =>
-    updateCurrentTableMutationState((current) => ({
-      ...current,
-      stagedInserts: typeof update === "function" ? update(current.stagedInserts) : update,
-    }));
+    updateCurrentTableMutationState((current) => {
+      const nextInserts = typeof update === "function" ? update(current.stagedInserts) : update;
+      const currentById = new Map(current.stagedInserts.map((insert) => [insert.id, insert]));
+      let nextRevision = current.nextEntryRevision;
+      const nextRevisions: Record<string, number> = {};
+      for (const insert of nextInserts) {
+        nextRevisions[insert.id] = queuedRowEditsEqual(
+          insert.edits,
+          currentById.get(insert.id)?.edits ?? {},
+        )
+          ? (current.stagedInsertRevisions[insert.id] ?? ++nextRevision)
+          : ++nextRevision;
+      }
+      return {
+        ...current,
+        stagedInserts: nextInserts,
+        stagedInsertRevisions: nextRevisions,
+        nextEntryRevision: nextRevision,
+      };
+    });
   const setQueuedSaveError: Dispatch<SetStateAction<string | null>> = (update) =>
     updateCurrentTableMutationState((current) => ({
       ...current,
       queuedSaveError: typeof update === "function" ? update(current.queuedSaveError) : update,
     }));
   const setQueuedDeletes: Dispatch<SetStateAction<Set<string>>> = (update) =>
-    updateCurrentTableMutationState((current) => ({
-      ...current,
-      queuedDeletes: typeof update === "function" ? update(current.queuedDeletes) : update,
-    }));
+    updateCurrentTableMutationState((current) => {
+      const nextDeletes = typeof update === "function" ? update(current.queuedDeletes) : update;
+      let nextRevision = current.nextEntryRevision;
+      const nextRevisions: Record<string, number> = {};
+      for (const rowId of nextDeletes) {
+        nextRevisions[rowId] = current.queuedDeletes.has(rowId)
+          ? (current.queuedDeleteRevisions[rowId] ?? ++nextRevision)
+          : ++nextRevision;
+      }
+      return {
+        ...current,
+        queuedDeletes: nextDeletes,
+        queuedDeleteRevisions: nextRevisions,
+        nextEntryRevision: nextRevision,
+      };
+    });
   const setPendingScrollToRowId: Dispatch<SetStateAction<string | null>> = (update) =>
     updateCurrentTableMutationState((current) => ({
       ...current,
@@ -1008,6 +1061,9 @@ export function TableDataGrid() {
     const submittedQueuedEdits = queuedEdits;
     const submittedStagedInserts = stagedInserts;
     const submittedQueuedDeletes = queuedDeletes;
+    const submittedQueuedEditRevisions = mutationState.queuedEditRevisions;
+    const submittedStagedInsertRevisions = mutationState.stagedInsertRevisions;
+    const submittedQueuedDeleteRevisions = mutationState.queuedDeleteRevisions;
     try {
       setMutationStateByTable((current) => ({
         ...current,
@@ -1061,7 +1117,11 @@ export function TableDataGrid() {
               const submittedRowEdits = submittedQueuedEdits[rowId];
               const remainingRowEdits = { ...rowEdits };
               for (const [columnId, queuedEdit] of Object.entries(rowEdits)) {
-                if (queuedCellEditsEqual(queuedEdit, submittedRowEdits?.[columnId])) {
+                if (
+                  queuedCellEditsEqual(queuedEdit, submittedRowEdits?.[columnId]) &&
+                  previous.queuedEditRevisions[rowId]?.[columnId] ===
+                    submittedQueuedEditRevisions[rowId]?.[columnId]
+                ) {
                   delete remainingRowEdits[columnId];
                 }
               }
@@ -1073,10 +1133,19 @@ export function TableDataGrid() {
             );
             const nextStagedInserts = previous.stagedInserts.filter((insert) => {
               const submitted = submittedInsertById.get(insert.id);
-              return !submitted || !queuedRowEditsEqual(insert.edits, submitted.edits);
+              return (
+                !submitted ||
+                !queuedRowEditsEqual(insert.edits, submitted.edits) ||
+                previous.stagedInsertRevisions[insert.id] !==
+                  submittedStagedInsertRevisions[insert.id]
+              );
             });
             const nextQueuedDeletes = new Set(previous.queuedDeletes);
-            for (const rowId of submittedQueuedDeletes) nextQueuedDeletes.delete(rowId);
+            for (const rowId of submittedQueuedDeletes) {
+              if (previous.queuedDeleteRevisions[rowId] === submittedQueuedDeleteRevisions[rowId]) {
+                nextQueuedDeletes.delete(rowId);
+              }
+            }
             return {
               ...previous,
               queuedEdits: nextQueuedEdits,

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -858,6 +858,14 @@ export function TableDataGrid() {
     setSelectedRowIds(new Set());
   }, [gridAnimationScopeKey]);
 
+  useEffect(() => {
+    setQueuedEdits({});
+    setStagedInserts([]);
+    setQueuedDeletes(new Set());
+    setQueuedSaveError(null);
+    setPendingScrollToRowId(null);
+  }, [table]);
+
   const handleSortColumnsChange = (nextSortColumns: SortColumn[]): void => {
     const nextSort =
       nextSortColumns.length === 0

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -135,6 +135,26 @@ interface StagedInsert {
   edits: QueuedRowEdits;
 }
 
+interface TableMutationState {
+  queuedEdits: Record<string, QueuedRowEdits>;
+  stagedInserts: StagedInsert[];
+  isQueuedSavePending: boolean;
+  queuedSaveError: string | null;
+  queuedDeletes: Set<string>;
+  pendingScrollToRowId: string | null;
+}
+
+function createTableMutationState(): TableMutationState {
+  return {
+    queuedEdits: {},
+    stagedInserts: [],
+    isQueuedSavePending: false,
+    queuedSaveError: null,
+    queuedDeletes: new Set(),
+    pendingScrollToRowId: null,
+  };
+}
+
 interface EditableGridRow extends AnimatedGridRow {
   row: DynamicTableRow;
   sourceRow: DynamicTableRow;
@@ -715,13 +735,50 @@ export function TableDataGrid() {
       { replace: true },
     );
   };
-  const [queuedEdits, setQueuedEdits] = useState<Record<string, QueuedRowEdits>>({});
-  const [stagedInserts, setStagedInserts] = useState<StagedInsert[]>([]);
+  const [mutationStateByTable, setMutationStateByTable] = useState<
+    Record<string, TableMutationState>
+  >({});
   const [selectedRowIds, setSelectedRowIds] = useState<Set<string>>(new Set());
-  const [isQueuedSavePending, setIsQueuedSavePending] = useState(false);
-  const [queuedSaveError, setQueuedSaveError] = useState<string | null>(null);
-  const [queuedDeletes, setQueuedDeletes] = useState<Set<string>>(new Set());
-  const [pendingScrollToRowId, setPendingScrollToRowId] = useState<string | null>(null);
+  const mutationState = mutationStateByTable[table] ?? createTableMutationState();
+  const updateCurrentTableMutationState = (update: SetStateAction<TableMutationState>) => {
+    setMutationStateByTable((current) => {
+      const previous = current[table] ?? createTableMutationState();
+      const next = typeof update === "function" ? update(previous) : update;
+      return { ...current, [table]: next };
+    });
+  };
+  const queuedEdits = mutationState.queuedEdits;
+  const stagedInserts = mutationState.stagedInserts;
+  const isQueuedSavePending = mutationState.isQueuedSavePending;
+  const queuedSaveError = mutationState.queuedSaveError;
+  const queuedDeletes = mutationState.queuedDeletes;
+  const pendingScrollToRowId = mutationState.pendingScrollToRowId;
+  const setQueuedEdits: Dispatch<SetStateAction<Record<string, QueuedRowEdits>>> = (update) =>
+    updateCurrentTableMutationState((current) => ({
+      ...current,
+      queuedEdits: typeof update === "function" ? update(current.queuedEdits) : update,
+    }));
+  const setStagedInserts: Dispatch<SetStateAction<StagedInsert[]>> = (update) =>
+    updateCurrentTableMutationState((current) => ({
+      ...current,
+      stagedInserts: typeof update === "function" ? update(current.stagedInserts) : update,
+    }));
+  const setQueuedSaveError: Dispatch<SetStateAction<string | null>> = (update) =>
+    updateCurrentTableMutationState((current) => ({
+      ...current,
+      queuedSaveError: typeof update === "function" ? update(current.queuedSaveError) : update,
+    }));
+  const setQueuedDeletes: Dispatch<SetStateAction<Set<string>>> = (update) =>
+    updateCurrentTableMutationState((current) => ({
+      ...current,
+      queuedDeletes: typeof update === "function" ? update(current.queuedDeletes) : update,
+    }));
+  const setPendingScrollToRowId: Dispatch<SetStateAction<string | null>> = (update) =>
+    updateCurrentTableMutationState((current) => ({
+      ...current,
+      pendingScrollToRowId:
+        typeof update === "function" ? update(current.pendingScrollToRowId) : update,
+    }));
   const [isColumnCustomizationOpen, setIsColumnCustomizationOpen] = useState(false);
   const columnPreferencesStorageKey = `${COLUMN_PREFERENCES_STORAGE_KEY_PREFIX}.${table}`;
   const [storedColumnPreferences, setStoredColumnPreferences] = useLocalStorageState<
@@ -858,14 +915,6 @@ export function TableDataGrid() {
     setSelectedRowIds(new Set());
   }, [gridAnimationScopeKey]);
 
-  useEffect(() => {
-    setQueuedEdits({});
-    setStagedInserts([]);
-    setQueuedDeletes(new Set());
-    setQueuedSaveError(null);
-    setPendingScrollToRowId(null);
-  }, [table]);
-
   const handleSortColumnsChange = (nextSortColumns: SortColumn[]): void => {
     const nextSort =
       nextSortColumns.length === 0
@@ -935,9 +984,16 @@ export function TableDataGrid() {
       return;
     }
 
+    const mutationTable = table;
     try {
-      setIsQueuedSavePending(true);
-      setQueuedSaveError(null);
+      setMutationStateByTable((current) => ({
+        ...current,
+        [mutationTable]: {
+          ...(current[mutationTable] ?? createTableMutationState()),
+          isQueuedSavePending: true,
+          queuedSaveError: null,
+        },
+      }));
 
       const rowUpdates = Object.entries(queuedEdits)
         .filter(([rowId]) => !queuedDeletes.has(rowId))
@@ -972,17 +1028,34 @@ export function TableDataGrid() {
         }),
       ]);
 
-      setQueuedEdits({});
-      setStagedInserts([]);
-      setQueuedDeletes(new Set());
+      setMutationStateByTable((current) => ({
+        ...current,
+        [mutationTable]: {
+          ...(current[mutationTable] ?? createTableMutationState()),
+          queuedEdits: {},
+          stagedInserts: [],
+          queuedDeletes: new Set(),
+        },
+      }));
     } catch (error) {
-      setQueuedSaveError(
-        error instanceof Error || (typeof Error.isError === "function" && Error.isError(error))
-          ? error.message
-          : "Could not persist queued cell edits.",
-      );
+      setMutationStateByTable((current) => ({
+        ...current,
+        [mutationTable]: {
+          ...(current[mutationTable] ?? createTableMutationState()),
+          queuedSaveError:
+            error instanceof Error || (typeof Error.isError === "function" && Error.isError(error))
+              ? error.message
+              : "Could not persist queued cell edits.",
+        },
+      }));
     } finally {
-      setIsQueuedSavePending(false);
+      setMutationStateByTable((current) => ({
+        ...current,
+        [mutationTable]: {
+          ...(current[mutationTable] ?? createTableMutationState()),
+          isQueuedSavePending: false,
+        },
+      }));
     }
   };
 

--- a/packages/inspector/src/pages/data-explorer/index.tsx
+++ b/packages/inspector/src/pages/data-explorer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { NavLink, Outlet, useNavigate, useOutletContext, useParams } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
@@ -79,10 +79,27 @@ export function DataExplorer() {
   const [mutationStateByTable, setMutationStateByTable] = useState<
     Record<string, TableMutationState>
   >({});
+  const activeSaveTokens = useRef(new Map<string, symbol>());
   const outletContext: {
     mutationStateByTable: Record<string, TableMutationState>;
     setMutationStateByTable: Dispatch<SetStateAction<Record<string, TableMutationState>>>;
-  } = { mutationStateByTable, setMutationStateByTable };
+    beginSave: (table: string) => symbol | null;
+    finishSave: (table: string, token: symbol) => boolean;
+  } = {
+    mutationStateByTable,
+    setMutationStateByTable,
+    beginSave: (table) => {
+      if (activeSaveTokens.current.has(table)) return null;
+      const token = Symbol(table);
+      activeSaveTokens.current.set(table, token);
+      return token;
+    },
+    finishSave: (table, token) => {
+      if (activeSaveTokens.current.get(table) !== token) return false;
+      activeSaveTokens.current.delete(table);
+      return true;
+    },
+  };
 
   return (
     <Group

--- a/packages/inspector/src/pages/data-explorer/index.tsx
+++ b/packages/inspector/src/pages/data-explorer/index.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { NavLink, Outlet, useNavigate, useOutletContext, useParams } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import { useLocalStorageState } from "../../utility/use-local-storage-state.js";
+import type { TableMutationState } from "../../components/data-explorer/TableDataGrid.js";
 import styles from "./index.module.css";
 
 const TABLES_SIDEBAR_SIZE_STORAGE_KEY = "jazz.inspector.dataExplorer.tablesSidebarSize";
@@ -75,6 +76,13 @@ export function DataExplorer() {
     TABLES_SIDEBAR_DEFAULT_SIZE,
     { isValid: isTablesSidebarSize },
   );
+  const [mutationStateByTable, setMutationStateByTable] = useState<
+    Record<string, TableMutationState>
+  >({});
+  const outletContext: {
+    mutationStateByTable: Record<string, TableMutationState>;
+    setMutationStateByTable: Dispatch<SetStateAction<Record<string, TableMutationState>>>;
+  } = { mutationStateByTable, setMutationStateByTable };
 
   return (
     <Group
@@ -115,7 +123,7 @@ export function DataExplorer() {
               <p className={styles.emptyText}>This schema doesn’t define any tables yet.</p>
             </section>
           ) : null}
-          <Outlet />
+          <Outlet context={outletContext} />
         </main>
       </Panel>
     </Group>


### PR DESCRIPTION
## Summary
- clear queued edits, inserts, deletes, save errors, and pending row scroll state when the routed table changes
- retain staged state across sort, filter, pagination, and column-layout changes within the same table
- cover navigation with a staged insert and prove no database mutation is issued

## Why
React Router reuses the data-grid component across table routes. Staged changes from table A could survive into table B and then be applied through table B's proxy and schema.

## Verification
- `TableDataGrid.test.tsx` (39 passed)
- Inspector TypeScript build passed
- changed files pass oxfmt and oxlint
- pre-commit hooks passed