### PR TITLE
fix(napi): export generated JsonValue type

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -178,6 +178,17 @@ export declare class Write {
   close(): boolean
 }
 
+/**
+ * Any JSON-compatible value crossing the native JavaScript boundary.
+ *
+ * Keep this alias exported through napi-rs rather than relying on its Rust
+ * import name: exported methods use `JsonValue` throughout their generated
+ * declarations, so the package must define that name for TypeScript
+ * consumers.
+ */
+export type JsonValue =
+  any
+
 export declare function mintLocalFirstToken(seedB64: string, audience: string, ttlSeconds: number): string
 
 /** Exact build/ABI fingerprint for the generated native artifact. */

--- a/crates/jazz-napi/package.json
+++ b/crates/jazz-napi/package.json
@@ -41,7 +41,8 @@
     "typecheck:consumer": "tsc --project tests/types/tsconfig.json"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3"
+    "@napi-rs/cli": "^3",
+    "@types/node": "catalog:default"
   },
   "napi": {
     "binaryName": "jazz-napi",

--- a/crates/jazz-napi/package.json
+++ b/crates/jazz-napi/package.json
@@ -36,7 +36,9 @@
     "build": "node scripts/build.js",
     "build:debug": "node scripts/build.js --debug",
     "build:perf": "node scripts/build.js --profile perf",
-    "build:perf:sccache": "RUSTC_WRAPPER=sccache node scripts/build.js --profile perf"
+    "build:perf:sccache": "RUSTC_WRAPPER=sccache node scripts/build.js --profile perf",
+    "test": "pnpm typecheck:consumer",
+    "typecheck:consumer": "tsc --project tests/types/tsconfig.json"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3"

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -32,7 +32,14 @@ use napi::sys;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
+/// Any JSON-compatible value crossing the native JavaScript boundary.
+///
+/// Keep this alias exported through napi-rs rather than relying on its Rust
+/// import name: exported methods use `JsonValue` throughout their generated
+/// declarations, so the package must define that name for TypeScript
+/// consumers.
+#[napi]
+pub type JsonValue = serde_json::Value;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::future::Future;

--- a/crates/jazz-napi/tests/types/package-consumer.ts
+++ b/crates/jazz-napi/tests/types/package-consumer.ts
@@ -1,0 +1,12 @@
+import { NapiDb, type JsonValue } from "jazz-napi";
+
+const branch: JsonValue = {
+  name: "draft",
+  parents: ["main"],
+  archived: false,
+};
+
+declare const db: NapiDb;
+declare const encodedRow: Uint8Array;
+
+db.insertWithIdEncodedInBranch("documents", encodedRow, encodedRow, branch);

--- a/crates/jazz-napi/tests/types/tsconfig.json
+++ b/crates/jazz-napi/tests/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["package-consumer.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,10 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3
-        version: 3.5.1(@emnapi/runtime@1.8.1)(@types/node@25.6.0)
+        version: 3.5.1(@emnapi/runtime@1.8.1)(@types/node@22.19.13)
+      '@types/node':
+        specifier: catalog:default
+        version: 22.19.13
 
   crates/jazz-rn:
     dependencies:
@@ -14784,14 +14787,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/checkbox@5.1.0(@types/node@25.6.0)':
+  '@inquirer/checkbox@5.1.0(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/confirm@5.1.21(@types/node@25.6.0)':
     dependencies:
@@ -14800,12 +14803,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/confirm@6.0.8(@types/node@25.6.0)':
+  '@inquirer/confirm@6.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/core@10.3.2(@types/node@25.6.0)':
     dependencies:
@@ -14820,17 +14823,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/core@11.1.5(@types/node@25.6.0)':
+  '@inquirer/core@11.1.5(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/editor@4.2.23(@types/node@25.6.0)':
     dependencies:
@@ -14840,13 +14843,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/editor@5.0.8(@types/node@25.6.0)':
+  '@inquirer/editor@5.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/external-editor': 2.0.3(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/expand@4.0.23(@types/node@25.6.0)':
     dependencies:
@@ -14856,12 +14859,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/expand@5.0.8(@types/node@25.6.0)':
+  '@inquirer/expand@5.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
     dependencies:
@@ -14870,12 +14873,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/external-editor@2.0.3(@types/node@25.6.0)':
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.13)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/figures@1.0.15': {}
 
@@ -14888,12 +14891,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/input@5.0.8(@types/node@25.6.0)':
+  '@inquirer/input@5.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/number@3.0.23(@types/node@25.6.0)':
     dependencies:
@@ -14902,12 +14905,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/number@4.0.8(@types/node@25.6.0)':
+  '@inquirer/number@4.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/password@4.0.23(@types/node@25.6.0)':
     dependencies:
@@ -14917,13 +14920,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/password@5.0.8(@types/node@25.6.0)':
+  '@inquirer/password@5.0.8(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/prompts@7.10.1(@types/node@25.6.0)':
     dependencies:
@@ -14940,20 +14943,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/prompts@8.3.0(@types/node@25.6.0)':
+  '@inquirer/prompts@8.3.0(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/checkbox': 5.1.0(@types/node@25.6.0)
-      '@inquirer/confirm': 6.0.8(@types/node@25.6.0)
-      '@inquirer/editor': 5.0.8(@types/node@25.6.0)
-      '@inquirer/expand': 5.0.8(@types/node@25.6.0)
-      '@inquirer/input': 5.0.8(@types/node@25.6.0)
-      '@inquirer/number': 4.0.8(@types/node@25.6.0)
-      '@inquirer/password': 5.0.8(@types/node@25.6.0)
-      '@inquirer/rawlist': 5.2.4(@types/node@25.6.0)
-      '@inquirer/search': 4.1.4(@types/node@25.6.0)
-      '@inquirer/select': 5.1.0(@types/node@25.6.0)
+      '@inquirer/checkbox': 5.1.0(@types/node@22.19.13)
+      '@inquirer/confirm': 6.0.8(@types/node@22.19.13)
+      '@inquirer/editor': 5.0.8(@types/node@22.19.13)
+      '@inquirer/expand': 5.0.8(@types/node@22.19.13)
+      '@inquirer/input': 5.0.8(@types/node@22.19.13)
+      '@inquirer/number': 4.0.8(@types/node@22.19.13)
+      '@inquirer/password': 5.0.8(@types/node@22.19.13)
+      '@inquirer/rawlist': 5.2.4(@types/node@22.19.13)
+      '@inquirer/search': 4.1.4(@types/node@22.19.13)
+      '@inquirer/select': 5.1.0(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/rawlist@4.1.11(@types/node@25.6.0)':
     dependencies:
@@ -14963,12 +14966,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/rawlist@5.2.4(@types/node@25.6.0)':
+  '@inquirer/rawlist@5.2.4(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/search@3.2.2(@types/node@25.6.0)':
     dependencies:
@@ -14979,13 +14982,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/search@4.1.4(@types/node@25.6.0)':
+  '@inquirer/search@4.1.4(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/select@4.4.2(@types/node@25.6.0)':
     dependencies:
@@ -14997,22 +15000,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/select@5.1.0(@types/node@25.6.0)':
+  '@inquirer/select@5.1.0(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/type@3.0.10(@types/node@25.6.0)':
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/type@4.0.3(@types/node@25.6.0)':
+  '@inquirer/type@4.0.3(@types/node@22.19.13)':
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -15278,9 +15281,9 @@ snapshots:
 
   '@multiavatar/multiavatar@1.0.7': {}
 
-  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.8.1)(@types/node@25.6.0)':
+  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.8.1)(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/prompts': 8.3.0(@types/node@25.6.0)
+      '@inquirer/prompts': 8.3.0(@types/node@22.19.13)
       '@napi-rs/cross-toolchain': 1.0.3
       '@napi-rs/wasm-tools': 1.0.1
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
🤖 Fixes #1932.

## Before

The generated `jazz-napi` declaration used `JsonValue` throughout its public methods without declaring or importing that name. Direct package consumers therefore failed typechecking, even though the checked-in declaration still byte-matched fresh generation.

## After

- napi-rs owns and emits the public `JsonValue` alias from `#[napi] pub type JsonValue = serde_json::Value`.
- The generated package declaration is self-contained. At this raw FFI boundary napi-rs represents `serde_json::Value` as `any`; higher Jazz APIs retain their typed JSON surfaces.
- A package-name consumer receipt imports both `NapiDb` and `JsonValue`, and normal Turbo `test` selection runs it.
- `jazz-napi` explicitly owns the Node declarations needed by its generated `Buffer` references, rather than relying on root hoisting.

## Verification

- fresh NAPI generation byte-matches the checked-in declaration;
- isolated package consumer TypeScript passes after a frozen install;
- Turbo executes `jazz-napi:test` successfully;
- `cargo test -p jazz-napi --lib`: 15/15;
- NAPI artifact contract: 7/7;
- planted removal of either the Rust export or checked alias makes the relevant generation/consumer receipt fail.

This is stacked on #1903 and changes no runtime behavior.
