### PR TITLE
fix: generate row UUIDv7 IDs in Rust

### DIFF
--- a/crates/jazz-cli/tests/cli_dry_run.rs
+++ b/crates/jazz-cli/tests/cli_dry_run.rs
@@ -806,10 +806,13 @@ fn server_command_loads_published_schema_and_persists_ws_data_across_restart() {
         subject,
         identity_for_subject(0xc1, subject),
     );
-    let write = block_on(writer.db.insert_with_id(
+    let write = block_on(writer.db.insert(
         "todos",
-        RowUuid::from_bytes([0x41; 16]),
         todo_cells("durable cli row", true),
+        jazz::db::InsertOptions {
+            row_id: Some(RowUuid::from_bytes([0x41; 16])),
+            ..Default::default()
+        },
     ))
     .expect("write todo through client db");
     assert!(pump_websocket(&mut writer.socket, &writer.db, &writer.wire,));
@@ -868,15 +871,17 @@ fn websocket_reconnect_resets_structured_terminal_before_live_patches() {
         subject,
         identity_for_subject(0xd1, subject),
     );
-    block_on(writer.db.insert_with_id(
+    block_on(writer.db.insert(
         "users",
-        RowUuid::from_bytes([0xa1; 16]),
         BTreeMap::from([("name".to_owned(), Value::String("owner".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(RowUuid::from_bytes([0xa1; 16])),
+            ..Default::default()
+        },
     ))
     .unwrap();
-    block_on(writer.db.insert_with_id(
+    block_on(writer.db.insert(
         "todos",
-        RowUuid::from_bytes([0xb1; 16]),
         BTreeMap::from([
             ("title".to_owned(), Value::String("first".to_owned())),
             (
@@ -884,6 +889,10 @@ fn websocket_reconnect_resets_structured_terminal_before_live_patches() {
                 Value::Uuid(RowUuid::from_bytes([0xa1; 16]).0),
             ),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(RowUuid::from_bytes([0xb1; 16])),
+            ..Default::default()
+        },
     ))
     .unwrap();
     assert!(pump_websocket(&mut writer.socket, &writer.db, &writer.wire));
@@ -925,9 +934,8 @@ fn websocket_reconnect_resets_structured_terminal_before_live_patches() {
     // and the same SubscriptionStream.
     drop(reader.socket);
 
-    block_on(writer.db.insert_with_id(
+    block_on(writer.db.insert(
         "todos",
-        RowUuid::from_bytes([0xb2; 16]),
         BTreeMap::from([
             ("title".to_owned(), Value::String("second".to_owned())),
             (
@@ -935,6 +943,10 @@ fn websocket_reconnect_resets_structured_terminal_before_live_patches() {
                 Value::Uuid(RowUuid::from_bytes([0xa1; 16]).0),
             ),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(RowUuid::from_bytes([0xb2; 16])),
+            ..Default::default()
+        },
     ))
     .unwrap();
     assert!(pump_websocket(&mut writer.socket, &writer.db, &writer.wire));
@@ -989,9 +1001,8 @@ fn websocket_reconnect_resets_structured_terminal_before_live_patches() {
     assert!(terminal_operations.is_empty());
     while subscription.next().now_or_never().flatten().is_some() {}
 
-    block_on(writer.db.insert_with_id(
+    block_on(writer.db.insert(
         "todos",
-        RowUuid::from_bytes([0xb3; 16]),
         BTreeMap::from([
             ("title".to_owned(), Value::String("third".to_owned())),
             (
@@ -999,6 +1010,10 @@ fn websocket_reconnect_resets_structured_terminal_before_live_patches() {
                 Value::Uuid(RowUuid::from_bytes([0xa1; 16]).0),
             ),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(RowUuid::from_bytes([0xb3; 16])),
+            ..Default::default()
+        },
     ))
     .unwrap();
     assert!(pump_websocket(&mut writer.socket, &writer.db, &writer.wire));

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -12,6 +12,11 @@ export declare class JazzServer {
 }
 
 export declare class NapiDb {
+  insertEncoded(table: string, cells: Uint8Array, options?: InsertOptions | undefined | null): Write
+  updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array, options?: UpdateOptions | undefined | null): Write
+  upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, options?: UpsertOptions | undefined | null): Write
+  deleteEncoded(table: string, rowId: Uint8Array, options?: DeleteOptions | undefined | null): Write
+  restoreEncoded(table: string, rowId: Uint8Array, cells?: Uint8Array | undefined | null, options?: RestoreOptions | undefined | null): Write
   beginStreamingMutationEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, column: string, kind: string, mutation?: string | undefined | null, author?: Uint8Array | undefined | null, updatedAtMs?: number | undefined | null, head?: JsonValue | undefined | null, base?: JsonValue | undefined | null): StreamingMutation
   static openMemory(schema: Uint8Array, config: Uint8Array): NapiDb
   static openPersistent(dataPath: string, schema: Uint8Array, config: Uint8Array): NapiDb
@@ -51,31 +56,6 @@ export declare class NapiDb {
   subscribeForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Subscription
   subscribeRelationQuery(queryJson: string, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Subscription
   subscribeRelationQueryForIdentity(queryJson: string, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Subscription
-  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  insertEncodedForIdentity(table: string, cells: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  insertEncodedInBranch(table: string, cells: Uint8Array, branch: JsonValue): Write
-  insertEncodedInBranchForIdentity(table: string, cells: Uint8Array, branch: JsonValue, author: Uint8Array): Write
-  insertWithIdEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  insertWithIdEncodedInBranch(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue): Write
-  insertWithIdEncodedInBranchForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue, author: Uint8Array): Write
-  insertWithIdEncodedForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  updateEncodedInBranch(table: string, rowId: Uint8Array, patch: Uint8Array, branch: JsonValue): Write
-  updateEncodedInBranchView(table: string, rowId: Uint8Array, patch: Uint8Array, head: JsonValue, base?: JsonValue | undefined | null): Write
-  updateEncodedInBranchViewForIdentity(table: string, rowId: Uint8Array, patch: Uint8Array, head: JsonValue, base: JsonValue | undefined | null, author: Uint8Array): Write
-  updateEncodedForIdentity(table: string, rowId: Uint8Array, patch: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  upsertEncodedForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  delete(table: string, rowId: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  deleteInBranch(table: string, rowId: Uint8Array, branch: JsonValue): Write
-  deleteInBranchView(table: string, rowId: Uint8Array, head: JsonValue, base?: JsonValue | undefined | null): Write
-  deleteInBranchViewForIdentity(table: string, rowId: Uint8Array, head: JsonValue, base: JsonValue | undefined | null, author: Uint8Array): Write
-  deleteForIdentity(table: string, rowId: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  restoreEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): Write
-  restoreInBranch(table: string, rowId: Uint8Array, branch: JsonValue): Write
-  restoreEncodedInBranch(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue): Write
-  restoreEncodedInBranchForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue, author: Uint8Array): Write
-  restoreEncodedForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
   tick(): void
   /** Configure Jazz-owned upload ingress and unpublished-tree expiry limits. */
   setLargeValueStagingPolicy(incomingBytesPerWindow: number, windowMs: number, maxAgeMs?: number | undefined | null): void
@@ -138,17 +118,11 @@ export declare class Transport {
 }
 
 export declare class Tx {
-  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | undefined | null): Uint8Array
-  insertEncodedInBranch(table: string, cells: Uint8Array, branch: JsonValue): Uint8Array
-  insertWithIdEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): void
-  insertWithIdEncodedInBranch(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue): void
-  updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array, updatedAtMs?: number | undefined | null): void
-  updateEncodedInBranchView(table: string, rowId: Uint8Array, patch: Uint8Array, head: JsonValue, base?: JsonValue | undefined | null): void
-  upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): void
-  delete(table: string, rowId: Uint8Array, updatedAtMs?: number | undefined | null): void
-  deleteInBranchView(table: string, rowId: Uint8Array, head: JsonValue, base?: JsonValue | undefined | null): void
-  restoreEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): void
-  restoreEncodedInBranch(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue): void
+  insertEncoded(table: string, cells: Uint8Array, options?: InsertOptions | undefined | null): Uint8Array
+  updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array, options?: UpdateOptions | undefined | null): void
+  upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, options?: UpsertOptions | undefined | null): void
+  deleteEncoded(table: string, rowId: Uint8Array, options?: DeleteOptions | undefined | null): void
+  restoreEncoded(table: string, rowId: Uint8Array, cells?: Uint8Array | undefined | null, options?: RestoreOptions | undefined | null): void
   commit(): Write
   rollback(): void
 }
@@ -162,7 +136,27 @@ export declare class Write {
   close(): boolean
 }
 
+export interface DeleteOptions {
+  author?: Uint8Array
+  head?: JsonValue
+  base?: JsonValue
+  updatedAtMs?: number
+}
+
+export interface InsertOptions {
+  rowId?: Uint8Array
+  author?: Uint8Array
+  branch?: JsonValue
+  updatedAtMs?: number
+}
+
 export declare function mintLocalFirstToken(seedB64: string, audience: string, ttlSeconds: number): string
+
+export interface RestoreOptions {
+  author?: Uint8Array
+  branch?: JsonValue
+  updatedAtMs?: number
+}
 
 export interface SubscriptionClosedEvent {
   type: 'closed'
@@ -280,6 +274,19 @@ export interface SubscriptionTerminalUpdateEdit {
 export interface SubscriptionUnsupportedShapeCapabilityReason {
   type: 'UnsupportedShapeCapability'
   detail: string
+}
+
+export interface UpdateOptions {
+  author?: Uint8Array
+  head?: JsonValue
+  base?: JsonValue
+  updatedAtMs?: number
+}
+
+export interface UpsertOptions {
+  author?: Uint8Array
+  branch?: JsonValue
+  updatedAtMs?: number
 }
 
 export declare function verifyLocalFirstIdentityProof(token: string | undefined | null, expectedAudience: string): VerifyTokenResult

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -51,6 +51,10 @@ export declare class NapiDb {
   subscribeForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Subscription
   subscribeRelationQuery(queryJson: string, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Subscription
   subscribeRelationQueryForIdentity(queryJson: string, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Subscription
+  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | undefined | null): Write
+  insertEncodedForIdentity(table: string, cells: Uint8Array, author: Uint8Array, updatedAtMs?: number | undefined | null): Write
+  insertEncodedInBranch(table: string, cells: Uint8Array, branch: JsonValue): Write
+  insertEncodedInBranchForIdentity(table: string, cells: Uint8Array, branch: JsonValue, author: Uint8Array): Write
   insertWithIdEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): Write
   insertWithIdEncodedInBranch(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue): Write
   insertWithIdEncodedInBranchForIdentity(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue, author: Uint8Array): Write
@@ -134,6 +138,8 @@ export declare class Transport {
 }
 
 export declare class Tx {
+  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | undefined | null): Uint8Array
+  insertEncodedInBranch(table: string, cells: Uint8Array, branch: JsonValue): Uint8Array
   insertWithIdEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, updatedAtMs?: number | undefined | null): void
   insertWithIdEncodedInBranch(table: string, rowId: Uint8Array, cells: Uint8Array, branch: JsonValue): void
   updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array, updatedAtMs?: number | undefined | null): void
@@ -150,6 +156,7 @@ export declare class Tx {
 export declare class Write {
   get batchId(): string
   get payload(): Uint8Array
+  get rowId(): Uint8Array
   writeState(): any
   wait(tier: string): Promise<undefined>
   close(): boolean

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -204,6 +204,7 @@ pub struct QueryAttachment {
 #[napi(js_name = "Write")]
 pub struct Write {
     payload: Vec<u8>,
+    row_id: CoreRowUuid,
     batch_id: TransactionId,
     inner: Option<NapiWrite>,
 }
@@ -543,6 +544,11 @@ impl Write {
         Uint8Array::new(self.payload.clone())
     }
 
+    #[napi(getter, js_name = "rowId")]
+    pub fn row_id(&self) -> Uint8Array {
+        Uint8Array::new(self.row_id.to_bytes())
+    }
+
     #[napi(js_name = "writeState")]
     pub fn write_state(&self) -> napi::Result<serde_json::Value> {
         let Some(write) = &self.inner else {
@@ -691,6 +697,48 @@ impl Subscription {
 
 #[napi]
 impl Tx {
+    #[napi(js_name = "insertEncoded")]
+    pub fn insert_encoded(
+        &mut self,
+        table: String,
+        cells: Uint8Array,
+        updated_at_ms: Option<f64>,
+    ) -> napi::Result<Uint8Array> {
+        let cells = decode_core_cells(&cells)?;
+        let now_ms = updated_at_ms.map(|value| value as u64);
+        let row_id = match self.kind {
+            NapiTxKind::Mergeable => match now_ms {
+                Some(now_ms) => {
+                    with_napi_mergeable_tx!(self, |tx| tx.insert_at_ms(&table, cells, now_ms))
+                }
+                None => with_napi_mergeable_tx!(self, |tx| tx.insert(&table, cells)),
+            },
+            NapiTxKind::Exclusive => {
+                with_napi_exclusive_tx!(self, |tx| tx.insert(&table, cells))
+            }
+        }?;
+        Ok(Uint8Array::new(row_id.to_bytes()))
+    }
+
+    #[napi(js_name = "insertEncodedInBranch")]
+    pub fn insert_encoded_in_branch(
+        &mut self,
+        table: String,
+        cells: Uint8Array,
+        branch: JsonValue,
+    ) -> napi::Result<Uint8Array> {
+        if !matches!(self.kind, NapiTxKind::Mergeable) {
+            return Err(napi::Error::from_reason(
+                "branch writes require a mergeable transaction",
+            ));
+        }
+        let cells = decode_core_cells(&cells)?;
+        let branch = core_branch_selector_from_json(branch)?;
+        let row_id =
+            with_napi_mergeable_tx!(self, |tx| tx.insert_in_branch(&table, branch, cells))?;
+        Ok(Uint8Array::new(row_id.to_bytes()))
+    }
+
     #[napi(js_name = "insertWithIdEncoded")]
     pub fn insert_with_id_encoded(
         &mut self,
@@ -1860,6 +1908,134 @@ impl NapiDb {
             inner: Some(inner),
             published_terminal_layouts: HashSet::new(),
         })
+    }
+
+    #[napi(js_name = "insertEncoded")]
+    pub fn insert_encoded(
+        &self,
+        table: String,
+        cells: Uint8Array,
+        updated_at_ms: Option<f64>,
+    ) -> napi::Result<Write> {
+        let cells = decode_core_cells(&cells)?;
+        let updated_at_ms = updated_at_ms.map(|value| value as u64);
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on_optional!(
+                    updated_at_ms,
+                    |now_ms| db.insert_at_ms(&table, cells, now_ms),
+                    db.insert(&table, cells)
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on_optional!(
+                    updated_at_ms,
+                    |now_ms| db.insert_at_ms(&table, cells, now_ms),
+                    db.insert(&table, cells)
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
+    #[napi(js_name = "insertEncodedForIdentity")]
+    pub fn insert_encoded_for_identity(
+        &self,
+        table: String,
+        cells: Uint8Array,
+        author: Uint8Array,
+        updated_at_ms: Option<f64>,
+    ) -> napi::Result<Write> {
+        let cells = decode_core_cells(&cells)?;
+        let author = core_author_id_from_bytes(&author)?;
+        let updated_at_ms = updated_at_ms.map(|value| value as u64);
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on_optional!(
+                    updated_at_ms,
+                    |now_ms| db.insert_for_identity_at_ms(author, &table, cells, now_ms),
+                    db.insert_for_identity(author, &table, cells)
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on_optional!(
+                    updated_at_ms,
+                    |now_ms| db.insert_for_identity_at_ms(author, &table, cells, now_ms),
+                    db.insert_for_identity(author, &table, cells)
+                )
+                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
+    #[napi(js_name = "insertEncodedInBranch")]
+    pub fn insert_encoded_in_branch(
+        &self,
+        table: String,
+        cells: Uint8Array,
+        branch: JsonValue,
+    ) -> napi::Result<Write> {
+        let cells = decode_core_cells(&cells)?;
+        let branch = core_branch_selector_from_json(branch)?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on(db.insert_in_branch(&table, branch, cells))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on(db.insert_in_branch(&table, branch, cells))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
+    #[napi(js_name = "insertEncodedInBranchForIdentity")]
+    pub fn insert_encoded_in_branch_for_identity(
+        &self,
+        table: String,
+        cells: Uint8Array,
+        branch: JsonValue,
+        author: Uint8Array,
+    ) -> napi::Result<Write> {
+        let cells = decode_core_cells(&cells)?;
+        let branch = core_branch_selector_from_json(branch)?;
+        let author = core_author_id_from_bytes(&author)?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on(db.insert_in_branch_for_identity(author, &table, branch, cells))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on(db.insert_in_branch_for_identity(author, &table, branch, cells))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
     }
 
     #[napi(js_name = "insertWithIdEncoded")]
@@ -3162,6 +3338,7 @@ fn core_write_memory(
     Ok(Write {
         payload: postcard::to_allocvec(&result)
             .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+        row_id: result.row_id,
         batch_id: TransactionId::from_committed_tx(tx_id),
         inner: Some(NapiWrite::Memory { db, tx_id }),
     })
@@ -3179,6 +3356,7 @@ fn core_write_persistent(
     Ok(Write {
         payload: postcard::to_allocvec(&result)
             .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+        row_id: result.row_id,
         batch_id: TransactionId::from_committed_tx(tx_id),
         inner: Some(NapiWrite::Persistent { db, tx_id }),
     })
@@ -3245,6 +3423,7 @@ fn core_tx_write(tx_id: TxId, inner: Option<NapiWrite>) -> napi::Result<Write> {
     Ok(Write {
         payload: postcard::to_allocvec(&result)
             .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+        row_id: result.row_id,
         batch_id: TransactionId::from_committed_tx(tx_id),
         inner,
     })

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -103,6 +103,44 @@ struct CoreOpenDbIdentity {
     author: CoreAuthorId,
 }
 
+#[napi(object)]
+pub struct InsertOptions {
+    pub row_id: Option<Uint8Array>,
+    pub author: Option<Uint8Array>,
+    pub branch: Option<JsonValue>,
+    pub updated_at_ms: Option<f64>,
+}
+
+#[napi(object)]
+pub struct UpdateOptions {
+    pub author: Option<Uint8Array>,
+    pub head: Option<JsonValue>,
+    pub base: Option<JsonValue>,
+    pub updated_at_ms: Option<f64>,
+}
+
+#[napi(object)]
+pub struct UpsertOptions {
+    pub author: Option<Uint8Array>,
+    pub branch: Option<JsonValue>,
+    pub updated_at_ms: Option<f64>,
+}
+
+#[napi(object)]
+pub struct DeleteOptions {
+    pub author: Option<Uint8Array>,
+    pub head: Option<JsonValue>,
+    pub base: Option<JsonValue>,
+    pub updated_at_ms: Option<f64>,
+}
+
+#[napi(object)]
+pub struct RestoreOptions {
+    pub author: Option<Uint8Array>,
+    pub branch: Option<JsonValue>,
+    pub updated_at_ms: Option<f64>,
+}
+
 impl From<CoreOpenDbIdentity> for CoreDbIdentity {
     fn from(identity: CoreOpenDbIdentity) -> Self {
         Self {
@@ -490,15 +528,6 @@ macro_rules! with_napi_exclusive_tx {
     }};
 }
 
-macro_rules! core_block_on_optional {
-    ($option:expr, |$value:ident| $some:expr, $none:expr) => {
-        match $option {
-            Some($value) => core_block_on($some),
-            None => core_block_on($none),
-        }
-    };
-}
-
 impl Write {
     fn wait_promise(
         &self,
@@ -698,242 +727,106 @@ impl Subscription {
 #[napi]
 impl Tx {
     #[napi(js_name = "insertEncoded")]
-    pub fn insert_encoded(
+    pub fn insert_encoded_with_options(
         &mut self,
         table: String,
         cells: Uint8Array,
-        updated_at_ms: Option<f64>,
+        options: Option<InsertOptions>,
     ) -> napi::Result<Uint8Array> {
         let cells = decode_core_cells(&cells)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
+        let options = core_insert_options(options)?;
         let row_id = match self.kind {
-            NapiTxKind::Mergeable => match now_ms {
-                Some(now_ms) => {
-                    with_napi_mergeable_tx!(self, |tx| tx.insert_at_ms(&table, cells, now_ms))
-                }
-                None => with_napi_mergeable_tx!(self, |tx| tx.insert(&table, cells)),
-            },
+            NapiTxKind::Mergeable => {
+                with_napi_mergeable_tx!(self, |tx| tx.insert(&table, cells, options))
+            }
             NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.insert(&table, cells))
+                with_napi_exclusive_tx!(self, |tx| tx.insert(&table, cells, options))
             }
         }?;
         Ok(Uint8Array::new(row_id.to_bytes()))
     }
 
-    #[napi(js_name = "insertEncodedInBranch")]
-    pub fn insert_encoded_in_branch(
-        &mut self,
-        table: String,
-        cells: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<Uint8Array> {
-        if !matches!(self.kind, NapiTxKind::Mergeable) {
-            return Err(napi::Error::from_reason(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let row_id =
-            with_napi_mergeable_tx!(self, |tx| tx.insert_in_branch(&table, branch, cells))?;
-        Ok(Uint8Array::new(row_id.to_bytes()))
-    }
-
-    #[napi(js_name = "insertWithIdEncoded")]
-    pub fn insert_with_id_encoded(
-        &mut self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<()> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
-        match self.kind {
-            NapiTxKind::Mergeable => match now_ms {
-                Some(now_ms) => with_napi_mergeable_tx!(self, |tx| tx
-                    .insert_with_id_at_ms(&table, row_id, cells, now_ms)),
-                None => {
-                    with_napi_mergeable_tx!(self, |tx| tx.insert_with_id(&table, row_id, cells))
-                }
-            },
-            NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.insert_with_id(&table, row_id, cells))
-            }
-        }
-    }
-
-    #[napi(js_name = "insertWithIdEncodedInBranch")]
-    pub fn insert_with_id_encoded_in_branch(
-        &mut self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<()> {
-        if !matches!(self.kind, NapiTxKind::Mergeable) {
-            return Err(napi::Error::from_reason(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        with_napi_mergeable_tx!(self, |tx| tx
-            .insert_with_id_in_branch(&table, branch, row_id, cells))
-    }
-
     #[napi(js_name = "updateEncoded")]
-    pub fn update_encoded(
+    pub fn update_encoded_with_options(
         &mut self,
         table: String,
         row_id: Uint8Array,
         patch: Uint8Array,
-        updated_at_ms: Option<f64>,
+        options: Option<UpdateOptions>,
     ) -> napi::Result<()> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let patch = decode_core_cells(&patch)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
+        let options = core_update_options(options)?;
         match self.kind {
-            NapiTxKind::Mergeable => match now_ms {
-                Some(now_ms) => with_napi_mergeable_tx!(self, |tx| tx
-                    .update_at_ms(&table, row_id, patch, now_ms)),
-                None => with_napi_mergeable_tx!(self, |tx| tx.update(&table, row_id, patch)),
-            },
+            NapiTxKind::Mergeable => {
+                with_napi_mergeable_tx!(self, |tx| tx.update(&table, row_id, patch, options))
+            }
             NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.update(&table, row_id, patch))
+                with_napi_exclusive_tx!(self, |tx| tx.update(&table, row_id, patch, options))
             }
         }
-    }
-
-    #[napi(js_name = "updateEncodedInBranchView")]
-    pub fn update_encoded_in_branch_view(
-        &mut self,
-        table: String,
-        row_id: Uint8Array,
-        patch: Uint8Array,
-        head: JsonValue,
-        base: Option<JsonValue>,
-    ) -> napi::Result<()> {
-        if !matches!(self.kind, NapiTxKind::Mergeable) {
-            return Err(napi::Error::from_reason(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let patch = decode_core_cells(&patch)?;
-        let head = core_branch_selector_from_json(head)?;
-        let base = core_branch_base_from_json(base)?;
-        with_napi_mergeable_tx!(self, |tx| tx
-            .update_in_branch_view(&table, head, base, row_id, patch))
+        .map(|_| ())
     }
 
     #[napi(js_name = "upsertEncoded")]
-    pub fn upsert_encoded(
+    pub fn upsert_encoded_with_options(
         &mut self,
         table: String,
         row_id: Uint8Array,
         cells: Uint8Array,
-        updated_at_ms: Option<f64>,
+        options: Option<UpsertOptions>,
     ) -> napi::Result<()> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let cells = decode_core_cells(&cells)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
+        let options = core_upsert_options(options)?;
         match self.kind {
-            NapiTxKind::Mergeable => match now_ms {
-                Some(now_ms) => with_napi_mergeable_tx!(self, |tx| tx
-                    .update_at_ms(&table, row_id, cells, now_ms)),
-                None => with_napi_mergeable_tx!(self, |tx| tx.update(&table, row_id, cells)),
-            },
+            NapiTxKind::Mergeable => {
+                with_napi_mergeable_tx!(self, |tx| tx.upsert(&table, row_id, cells, options))
+            }
             NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.update(&table, row_id, cells))
+                with_napi_exclusive_tx!(self, |tx| tx.upsert(&table, row_id, cells, options))
             }
         }
     }
 
-    #[napi(js_name = "delete")]
-    pub fn delete_encoded(
+    #[napi(js_name = "deleteEncoded")]
+    pub fn delete_encoded_with_options(
         &mut self,
         table: String,
         row_id: Uint8Array,
-        updated_at_ms: Option<f64>,
+        options: Option<DeleteOptions>,
     ) -> napi::Result<()> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
+        let options = core_delete_options(options)?;
         match self.kind {
-            NapiTxKind::Mergeable => match updated_at_ms.map(|value| value as u64) {
-                Some(now_ms) => {
-                    with_napi_mergeable_tx!(self, |tx| tx.delete_at_ms(&table, row_id, now_ms))
-                }
-                None => with_napi_mergeable_tx!(self, |tx| tx.delete(&table, row_id)),
-            },
+            NapiTxKind::Mergeable => {
+                with_napi_mergeable_tx!(self, |tx| tx.delete(&table, row_id, options))
+            }
             NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.delete(&table, row_id))
+                with_napi_exclusive_tx!(self, |tx| tx.delete(&table, row_id, options))
             }
         }
-    }
-
-    #[napi(js_name = "deleteInBranchView")]
-    pub fn delete_in_branch_view(
-        &mut self,
-        table: String,
-        row_id: Uint8Array,
-        head: JsonValue,
-        base: Option<JsonValue>,
-    ) -> napi::Result<()> {
-        if !matches!(self.kind, NapiTxKind::Mergeable) {
-            return Err(napi::Error::from_reason(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let head = core_branch_selector_from_json(head)?;
-        let base = core_branch_base_from_json(base)?;
-        with_napi_mergeable_tx!(self, |tx| tx
-            .delete_in_branch_view(&table, head, base, row_id))
     }
 
     #[napi(js_name = "restoreEncoded")]
-    pub fn restore_encoded(
+    pub fn restore_encoded_with_options(
         &mut self,
         table: String,
         row_id: Uint8Array,
-        cells: Uint8Array,
-        updated_at_ms: Option<f64>,
+        cells: Option<Uint8Array>,
+        options: Option<RestoreOptions>,
     ) -> napi::Result<()> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
+        let cells = cells.map(|cells| decode_core_cells(&cells)).transpose()?;
+        let options = core_restore_options(options)?;
         match self.kind {
-            NapiTxKind::Mergeable => match now_ms {
-                Some(now_ms) => with_napi_mergeable_tx!(self, |tx| tx
-                    .restore_at_ms(&table, row_id, cells, now_ms)),
-                None => with_napi_mergeable_tx!(self, |tx| tx.restore(&table, row_id, cells)),
-            },
+            NapiTxKind::Mergeable => {
+                with_napi_mergeable_tx!(self, |tx| tx.restore(&table, row_id, cells, options))
+            }
             NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.restore(&table, row_id, cells))
+                with_napi_exclusive_tx!(self, |tx| tx.restore(&table, row_id, cells, options))
             }
         }
-    }
-
-    #[napi(js_name = "restoreEncodedInBranch")]
-    pub fn restore_encoded_in_branch(
-        &mut self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<()> {
-        if !matches!(self.kind, NapiTxKind::Mergeable) {
-            return Err(napi::Error::from_reason(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        with_napi_mergeable_tx!(self, |tx| tx
-            .restore_in_branch(&table, branch, row_id, cells))
     }
 
     #[napi]
@@ -1115,6 +1008,147 @@ impl StreamingMutation {
 
 #[napi]
 impl NapiDb {
+    #[napi(js_name = "insertEncoded")]
+    pub fn insert_encoded_with_options(
+        &self,
+        table: String,
+        cells: Uint8Array,
+        options: Option<InsertOptions>,
+    ) -> napi::Result<Write> {
+        let cells = decode_core_cells(&cells)?;
+        let options = core_insert_options(options)?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on(db.insert(&table, cells, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on(db.insert(&table, cells, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
+    #[napi(js_name = "updateEncoded")]
+    pub fn update_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Uint8Array,
+        patch: Uint8Array,
+        options: Option<UpdateOptions>,
+    ) -> napi::Result<Write> {
+        let row_id = core_row_uuid_from_bytes(&row_id)?;
+        let patch = decode_core_cells(&patch)?;
+        let options = core_update_options(options)?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on(db.update(&table, row_id, patch, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on(db.update(&table, row_id, patch, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
+    #[napi(js_name = "upsertEncoded")]
+    pub fn upsert_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Uint8Array,
+        cells: Uint8Array,
+        options: Option<UpsertOptions>,
+    ) -> napi::Result<Write> {
+        let row_id = core_row_uuid_from_bytes(&row_id)?;
+        let cells = decode_core_cells(&cells)?;
+        let options = core_upsert_options(options)?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on(db.upsert(&table, row_id, cells, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on(db.upsert(&table, row_id, cells, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
+    #[napi(js_name = "deleteEncoded")]
+    pub fn delete_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Uint8Array,
+        options: Option<DeleteOptions>,
+    ) -> napi::Result<Write> {
+        let row_id = core_row_uuid_from_bytes(&row_id)?;
+        let options = core_delete_options(options)?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on(db.delete(&table, row_id, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on(db.delete(&table, row_id, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
+    #[napi(js_name = "restoreEncoded")]
+    pub fn restore_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Uint8Array,
+        cells: Option<Uint8Array>,
+        options: Option<RestoreOptions>,
+    ) -> napi::Result<Write> {
+        let row_id = core_row_uuid_from_bytes(&row_id)?;
+        let cells = cells.map(|cells| decode_core_cells(&cells)).transpose()?;
+        let options = core_restore_options(options)?;
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        match db {
+            NapiDbInnerStorage::Memory(db) => core_write_memory(
+                Rc::clone(db),
+                core_block_on(db.restore(&table, row_id, cells, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
+                Rc::clone(db),
+                core_block_on(db.restore(&table, row_id, cells, options))
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
+            ),
+        }
+    }
+
     #[napi(js_name = "beginStreamingMutationEncoded")]
     #[allow(clippy::too_many_arguments)] // Flat arguments are the generated NAPI ABI.
     pub fn begin_streaming_mutation_encoded(
@@ -1908,859 +1942,6 @@ impl NapiDb {
             inner: Some(inner),
             published_terminal_layouts: HashSet::new(),
         })
-    }
-
-    #[napi(js_name = "insertEncoded")]
-    pub fn insert_encoded(
-        &self,
-        table: String,
-        cells: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let cells = decode_core_cells(&cells)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.insert_at_ms(&table, cells, now_ms),
-                    db.insert(&table, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.insert_at_ms(&table, cells, now_ms),
-                    db.insert(&table, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "insertEncodedForIdentity")]
-    pub fn insert_encoded_for_identity(
-        &self,
-        table: String,
-        cells: Uint8Array,
-        author: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let cells = decode_core_cells(&cells)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.insert_for_identity_at_ms(author, &table, cells, now_ms),
-                    db.insert_for_identity(author, &table, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.insert_for_identity_at_ms(author, &table, cells, now_ms),
-                    db.insert_for_identity(author, &table, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "insertEncodedInBranch")]
-    pub fn insert_encoded_in_branch(
-        &self,
-        table: String,
-        cells: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<Write> {
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.insert_in_branch(&table, branch, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.insert_in_branch(&table, branch, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "insertEncodedInBranchForIdentity")]
-    pub fn insert_encoded_in_branch_for_identity(
-        &self,
-        table: String,
-        cells: Uint8Array,
-        branch: JsonValue,
-        author: Uint8Array,
-    ) -> napi::Result<Write> {
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.insert_in_branch_for_identity(author, &table, branch, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.insert_in_branch_for_identity(author, &table, branch, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "insertWithIdEncoded")]
-    pub fn insert_with_id_encoded(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.insert_with_id_at_ms(&table, row_id, cells, now_ms),
-                    db.insert_with_id(&table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.insert_with_id_at_ms(&table, row_id, cells, now_ms),
-                    db.insert_with_id(&table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "insertWithIdEncodedInBranch")]
-    pub fn insert_with_id_encoded_in_branch(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.insert_with_id_in_branch(&table, branch, row_id, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.insert_with_id_in_branch(&table, branch, row_id, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "insertWithIdEncodedInBranchForIdentity")]
-    pub fn insert_with_id_encoded_in_branch_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        branch: JsonValue,
-        author: Uint8Array,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(
-                    db.insert_with_id_in_branch_for_identity(author, &table, branch, row_id, cells),
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(
-                    db.insert_with_id_in_branch_for_identity(author, &table, branch, row_id, cells),
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "insertWithIdEncodedForIdentity")]
-    pub fn insert_with_id_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        author: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db
-                        .insert_with_id_for_identity_at_ms(author, &table, row_id, cells, now_ms),
-                    db.insert_with_id_for_identity(author, &table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db
-                        .insert_with_id_for_identity_at_ms(author, &table, row_id, cells, now_ms),
-                    db.insert_with_id_for_identity(author, &table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "updateEncoded")]
-    pub fn update_encoded(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        patch: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let patch = decode_core_cells(&patch)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.update_at_ms(&table, row_id, patch, now_ms),
-                    db.update(&table, row_id, patch)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.update_at_ms(&table, row_id, patch, now_ms),
-                    db.update(&table, row_id, patch)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "updateEncodedInBranch")]
-    pub fn update_encoded_in_branch(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        patch: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let patch = decode_core_cells(&patch)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.update_in_branch(&table, branch, row_id, patch))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.update_in_branch(&table, branch, row_id, patch))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "updateEncodedInBranchView")]
-    pub fn update_encoded_in_branch_view(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        patch: Uint8Array,
-        head: JsonValue,
-        base: Option<JsonValue>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let patch = decode_core_cells(&patch)?;
-        let head = core_branch_selector_from_json(head)?;
-        let base = core_branch_base_from_json(base)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.update_in_branch_view(&table, head, base, row_id, patch))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.update_in_branch_view(&table, head, base, row_id, patch))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "updateEncodedInBranchViewForIdentity")]
-    pub fn update_encoded_in_branch_view_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        patch: Uint8Array,
-        head: JsonValue,
-        base: Option<JsonValue>,
-        author: Uint8Array,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let patch = decode_core_cells(&patch)?;
-        let head = core_branch_selector_from_json(head)?;
-        let base = core_branch_base_from_json(base)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => {
-                core_write_memory(
-                    Rc::clone(db),
-                    core_block_on(db.update_in_branch_view_for_identity(
-                        author, &table, head, base, row_id, patch,
-                    ))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                )
-            }
-            NapiDbInnerStorage::Persistent(db) => {
-                core_write_persistent(
-                    Rc::clone(db),
-                    core_block_on(db.update_in_branch_view_for_identity(
-                        author, &table, head, base, row_id, patch,
-                    ))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-                )
-            }
-        }
-    }
-
-    #[napi(js_name = "updateEncodedForIdentity")]
-    pub fn update_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        patch: Uint8Array,
-        author: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let patch = decode_core_cells(&patch)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.update_for_identity_at_ms(author, &table, row_id, patch, now_ms),
-                    db.update_for_identity(author, &table, row_id, patch)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.update_for_identity_at_ms(author, &table, row_id, patch, now_ms),
-                    db.update_for_identity(author, &table, row_id, patch)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "upsertEncoded")]
-    pub fn upsert_encoded(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.upsert_at_ms(&table, row_id, cells, now_ms),
-                    db.upsert(&table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.upsert_at_ms(&table, row_id, cells, now_ms),
-                    db.upsert(&table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "upsertEncodedForIdentity")]
-    pub fn upsert_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        author: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.upsert_for_identity_at_ms(author, &table, row_id, cells, now_ms),
-                    db.upsert_for_identity(author, &table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.upsert_for_identity_at_ms(author, &table, row_id, cells, now_ms),
-                    db.upsert_for_identity(author, &table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "delete")]
-    pub fn delete_encoded(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.delete_at_ms(&table, row_id, now_ms),
-                    db.delete(&table, row_id)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.delete_at_ms(&table, row_id, now_ms),
-                    db.delete(&table, row_id)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "deleteInBranch")]
-    pub fn delete_in_branch(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.delete_in_branch(&table, branch, row_id))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.delete_in_branch(&table, branch, row_id))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "deleteInBranchView")]
-    pub fn delete_in_branch_view(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        head: JsonValue,
-        base: Option<JsonValue>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let head = core_branch_selector_from_json(head)?;
-        let base = core_branch_base_from_json(base)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.delete_in_branch_view(&table, head, base, row_id))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.delete_in_branch_view(&table, head, base, row_id))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "deleteInBranchViewForIdentity")]
-    pub fn delete_in_branch_view_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        head: JsonValue,
-        base: Option<JsonValue>,
-        author: Uint8Array,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let head = core_branch_selector_from_json(head)?;
-        let base = core_branch_base_from_json(base)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(
-                    db.delete_in_branch_view_for_identity(author, &table, head, base, row_id),
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(
-                    db.delete_in_branch_view_for_identity(author, &table, head, base, row_id),
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "deleteForIdentity")]
-    pub fn delete_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        author: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.delete_for_identity_at_ms(author, &table, row_id, now_ms),
-                    db.delete_for_identity(author, &table, row_id)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.delete_for_identity_at_ms(author, &table, row_id, now_ms),
-                    db.delete_for_identity(author, &table, row_id)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "restoreEncoded")]
-    pub fn restore_encoded(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.restore_at_ms(&table, row_id, cells, now_ms),
-                    db.restore(&table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.restore_at_ms(&table, row_id, cells, now_ms),
-                    db.restore(&table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "restoreInBranch")]
-    pub fn restore_in_branch(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.restore_in_branch(&table, branch, row_id))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.restore_in_branch(&table, branch, row_id))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "restoreEncodedInBranch")]
-    pub fn restore_encoded_in_branch(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        branch: JsonValue,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.restore_with_cells_in_branch(&table, branch, row_id, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.restore_with_cells_in_branch(&table, branch, row_id, cells))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "restoreEncodedInBranchForIdentity")]
-    pub fn restore_encoded_in_branch_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        branch: JsonValue,
-        author: Uint8Array,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let branch = core_branch_selector_from_json(branch)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.restore_with_cells_in_branch_as_identity(
-                    author, &table, branch, row_id, cells,
-                ))
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.restore_with_cells_in_branch_as_identity(
-                    author, &table, branch, row_id, cells,
-                ))
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
-    }
-
-    #[napi(js_name = "restoreEncodedForIdentity")]
-    pub fn restore_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Uint8Array,
-        cells: Uint8Array,
-        author: Uint8Array,
-        updated_at_ms: Option<f64>,
-    ) -> napi::Result<Write> {
-        let row_id = core_row_uuid_from_bytes(&row_id)?;
-        let cells = decode_core_cells(&cells)?;
-        let author = core_author_id_from_bytes(&author)?;
-        let updated_at_ms = updated_at_ms.map(|value| value as u64);
-        let db = self.inner.borrow();
-        let db = db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.restore_for_identity_at_ms(author, &table, row_id, cells, now_ms),
-                    db.restore_for_identity(author, &table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on_optional!(
-                    updated_at_ms,
-                    |now_ms| db.restore_for_identity_at_ms(author, &table, row_id, cells, now_ms),
-                    db.restore_for_identity(author, &table, row_id, cells)
-                )
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-        }
     }
 
     #[napi]
@@ -3653,6 +2834,103 @@ fn core_branch_base_from_json(
             })
         })
         .transpose()
+}
+
+fn core_write_identity(author: Option<Uint8Array>) -> napi::Result<jazz::db::WriteIdentity> {
+    author
+        .map(|author| core_author_id_from_bytes(&author).map(jazz::db::WriteIdentity::Session))
+        .transpose()
+        .map(|identity| identity.unwrap_or_default())
+}
+
+fn core_insert_options(options: Option<InsertOptions>) -> napi::Result<jazz::db::InsertOptions> {
+    let Some(options) = options else {
+        return Ok(Default::default());
+    };
+    Ok(jazz::db::InsertOptions {
+        row_id: options
+            .row_id
+            .map(|row_id| core_row_uuid_from_bytes(&row_id))
+            .transpose()?,
+        identity: core_write_identity(options.author)?,
+        target: options
+            .branch
+            .map(core_branch_selector_from_json)
+            .transpose()?
+            .map(jazz::db::ExactWriteTarget::Branch)
+            .unwrap_or_default(),
+        updated_at_ms: options.updated_at_ms.map(|value| value as u64),
+    })
+}
+
+fn core_update_options(options: Option<UpdateOptions>) -> napi::Result<jazz::db::UpdateOptions> {
+    let Some(options) = options else {
+        return Ok(Default::default());
+    };
+    let target = match options.head {
+        Some(head) => jazz::db::WriteTarget::BranchView {
+            head: core_branch_selector_from_json(head)?,
+            base: core_branch_base_from_json(options.base)?,
+        },
+        None if options.base.is_none() => Default::default(),
+        None => {
+            return Err(napi::Error::from_reason(
+                "branch view base requires a head selector",
+            ));
+        }
+    };
+    Ok(jazz::db::UpdateOptions {
+        identity: core_write_identity(options.author)?,
+        target,
+        updated_at_ms: options.updated_at_ms.map(|value| value as u64),
+    })
+}
+
+fn core_upsert_options(options: Option<UpsertOptions>) -> napi::Result<jazz::db::UpsertOptions> {
+    let Some(options) = options else {
+        return Ok(Default::default());
+    };
+    Ok(jazz::db::UpsertOptions {
+        identity: core_write_identity(options.author)?,
+        target: options
+            .branch
+            .map(core_branch_selector_from_json)
+            .transpose()?
+            .map(jazz::db::ExactWriteTarget::Branch)
+            .unwrap_or_default(),
+        updated_at_ms: options.updated_at_ms.map(|value| value as u64),
+    })
+}
+
+fn core_delete_options(options: Option<DeleteOptions>) -> napi::Result<jazz::db::DeleteOptions> {
+    let options = options.map(|options| UpdateOptions {
+        author: options.author,
+        head: options.head,
+        base: options.base,
+        updated_at_ms: options.updated_at_ms,
+    });
+    let options = core_update_options(options)?;
+    Ok(jazz::db::DeleteOptions {
+        identity: options.identity,
+        target: options.target,
+        updated_at_ms: options.updated_at_ms,
+    })
+}
+
+fn core_restore_options(options: Option<RestoreOptions>) -> napi::Result<jazz::db::RestoreOptions> {
+    let Some(options) = options else {
+        return Ok(Default::default());
+    };
+    Ok(jazz::db::RestoreOptions {
+        identity: core_write_identity(options.author)?,
+        target: options
+            .branch
+            .map(core_branch_selector_from_json)
+            .transpose()?
+            .map(jazz::db::ExactWriteTarget::Branch)
+            .unwrap_or_default(),
+        updated_at_ms: options.updated_at_ms.map(|value| value as u64),
+    })
 }
 
 fn core_durability_tier_from_str(tier: &str) -> napi::Result<CoreDurabilityTier> {
@@ -4833,10 +4111,13 @@ mod tests {
             open_tx: Some(batch),
             owns_lifetime: false,
         });
-        core_block_on(view.mergeable_tx_ref(batch).insert_with_id(
+        core_block_on(view.mergeable_tx_ref(batch).insert(
             "items",
-            CoreRowUuid::from_bytes([1; 16]),
             BTreeMap::from([("label".to_owned(), CoreValue::String("kept".to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(CoreRowUuid::from_bytes([1; 16])),
+                ..Default::default()
+            },
         ))
         .unwrap();
         core_block_on(owner.commit_mergeable_handle(batch)).unwrap();
@@ -4849,13 +4130,16 @@ mod tests {
             open_tx: Some(exclusive),
             owns_lifetime: false,
         });
-        core_block_on(view.exclusive_tx_ref(exclusive).insert_with_id(
+        core_block_on(view.exclusive_tx_ref(exclusive).insert(
             "items",
-            CoreRowUuid::from_bytes([2; 16]),
             BTreeMap::from([(
                 "label".to_owned(),
                 CoreValue::String("exclusive-kept".to_owned()),
             )]),
+            jazz::db::InsertOptions {
+                row_id: Some(CoreRowUuid::from_bytes([2; 16])),
+                ..Default::default()
+            },
         ))
         .unwrap();
         core_block_on(owner.commit_exclusive_handle(exclusive)).unwrap();
@@ -4925,13 +4209,16 @@ mod tests {
                 Some(Uint8Array::new(alice.0.as_bytes().to_vec())),
             )
             .unwrap();
-        core_block_on(other_owner.exclusive_tx_ref(bound).insert_with_id(
+        core_block_on(other_owner.exclusive_tx_ref(bound).insert(
             "items",
-            CoreRowUuid::from_bytes([3; 16]),
             BTreeMap::from([(
                 "label".to_owned(),
                 CoreValue::String("receiver-secret".to_owned()),
             )]),
+            jazz::db::InsertOptions {
+                row_id: Some(CoreRowUuid::from_bytes([3; 16])),
+                ..Default::default()
+            },
         ))
         .unwrap();
         let other_query = PreparedQuery {

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -1798,6 +1798,7 @@ mod tests {
                     ("title".to_owned(), CoreValue::String(title.to_owned())),
                     ("done".to_owned(), CoreValue::Bool(false)),
                 ]),
+                Default::default(),
             ))
             .expect("insert client row")
             .row_uuid()
@@ -1810,6 +1811,7 @@ mod tests {
                     ("title".to_owned(), CoreValue::String(title.to_owned())),
                     ("done".to_owned(), CoreValue::Bool(false)),
                 ]),
+                Default::default(),
             ))
             .expect("insert client row")
             .mergeable_tx_id()
@@ -1823,6 +1825,7 @@ mod tests {
                     ("title".to_owned(), CoreValue::String(title.to_owned())),
                     ("owner".to_owned(), CoreValue::String(owner)),
                 ]),
+                Default::default(),
             ))
             .expect("insert client doc")
             .row_uuid()

--- a/crates/jazz-sim/benches/s1_saas.rs
+++ b/crates/jazz-sim/benches/s1_saas.rs
@@ -238,9 +238,15 @@ pub fn db_surface_smoke() {
     assert!(subscription2_rows.is_empty());
 
     for commit in &fixture.commits {
-        let handle =
-            block_on(db.insert_with_id(&commit.table, commit.row_uuid, commit.cells.clone()))
-                .expect("db fixture insert");
+        let handle = block_on(db.insert(
+            &commit.table,
+            commit.cells.clone(),
+            jazz::db::InsertOptions {
+                row_id: Some(commit.row_uuid),
+                ..Default::default()
+            },
+        ))
+        .expect("db fixture insert");
         block_on(handle.wait(DurabilityTier::Local)).expect("fixture insert local wait");
         oracle.apply_insert(commit);
     }
@@ -283,7 +289,8 @@ pub fn db_surface_smoke() {
             Value::String("db-surface-state-transition".to_owned()),
         ),
     ]);
-    let handle = block_on(db.update(ISSUES, edited_issue, patch.clone())).expect("db issue update");
+    let handle = block_on(db.update(ISSUES, edited_issue, patch.clone(), Default::default()))
+        .expect("db issue update");
     block_on(handle.wait(DurabilityTier::Local)).expect("issue update local wait");
     oracle.apply_patch(ISSUES, edited_issue, patch);
 

--- a/crates/jazz-sim/benches/s2_canvas.rs
+++ b/crates/jazz-sim/benches/s2_canvas.rs
@@ -1822,17 +1822,27 @@ fn run_db_surface(config: &Config, coalesced: bool) -> DbSurfaceSummary {
     let canvas = canvas_id();
     let (_dir, db) = open_db(node(70), participant_author(0), schema.clone());
 
-    let canvas_write =
-        block_on(db.insert_with_id(CANVASES, canvas, canvas_cells())).expect("db canvas insert");
+    let canvas_write = block_on(db.insert(
+        CANVASES,
+        canvas_cells(),
+        jazz::db::InsertOptions {
+            row_id: Some(canvas),
+            ..Default::default()
+        },
+    ))
+    .expect("db canvas insert");
     block_on(canvas_write.wait(DurabilityTier::Local)).expect("db canvas local wait");
     for idx in 0..(config.active + config.passive) {
-        let invite = block_on(db.insert_with_id(
+        let invite = block_on(db.insert(
             INVITES,
-            row(10_000 + idx),
             BTreeMap::from([
                 ("canvas".to_owned(), Value::Uuid(canvas.0)),
                 ("userID".to_owned(), Value::Uuid(participant_author(idx).0)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(row(10_000 + idx)),
+                ..Default::default()
+            },
         ))
         .expect("db invite insert");
         block_on(invite.wait(DurabilityTier::Local)).expect("db invite local wait");
@@ -1841,8 +1851,12 @@ fn run_db_surface(config: &Config, coalesced: bool) -> DbSurfaceSummary {
     let mut shape_rows = Vec::with_capacity(config.shapes);
     let mut expected = BTreeMap::new();
     for idx in 0..config.shapes {
-        let write = block_on(db.insert(SHAPES, shape_cells(canvas, idx, idx as f64, idx as f64)))
-            .expect("db shape insert");
+        let write = block_on(db.insert(
+            SHAPES,
+            shape_cells(canvas, idx, idx as f64, idx as f64),
+            Default::default(),
+        ))
+        .expect("db shape insert");
         let row_uuid = write.row_uuid();
         block_on(write.wait(DurabilityTier::Local)).expect("db shape local wait");
         shape_rows.push(row_uuid);
@@ -1896,7 +1910,8 @@ fn run_db_surface(config: &Config, coalesced: bool) -> DbSurfaceSummary {
                 ("y".to_owned(), Value::F64(y)),
             ]);
             let start = Instant::now();
-            let write = block_on(db.update(SHAPES, row_uuid, patch)).expect("db shape update");
+            let write = block_on(db.update(SHAPES, row_uuid, patch, Default::default()))
+                .expect("db shape update");
             block_on(write.wait(DurabilityTier::Local)).expect("db update local wait");
             write_latencies.push(start.elapsed().as_micros() as u64);
             expected.insert(row_uuid, (x.to_bits(), y.to_bits()));

--- a/crates/jazz-sim/benches/s4_order_processing.rs
+++ b/crates/jazz-sim/benches/s4_order_processing.rs
@@ -817,7 +817,7 @@ async fn apply_jazz_op(
             let district_cells = tx.read(DISTRICTS, d).await?.expect("district");
             tx.read(CUSTOMERS, c).await?;
             let order_number = u64_cell(&district_cells, "nextOrderNumber");
-            tx.insert_with_id(
+            tx.upsert(
                 DISTRICTS,
                 d,
                 cells([
@@ -826,10 +826,11 @@ async fn apply_jazz_op(
                     ("nextOrderNumber", Value::U64(order_number + 1)),
                     ("ytd", Value::F64(f64_cell(&district_cells, "ytd"))),
                 ]),
+                Default::default(),
             )
             .await?;
             let order = order_row(*warehouse, *district, order_number);
-            tx.insert_with_id(
+            tx.upsert(
                 ORDERS,
                 order,
                 cells([
@@ -840,6 +841,7 @@ async fn apply_jazz_op(
                     ("lineCount", Value::U64(items.len() as u64)),
                     ("delivered", Value::Bool(false)),
                 ]),
+                Default::default(),
             )
             .await?;
             for (line_idx, (item, quantity)) in items.iter().enumerate() {
@@ -850,7 +852,7 @@ async fn apply_jazz_op(
                 let price = f64_cell(&item_cells, "price");
                 let old_qty = u64_cell(&stock_cells, "quantity");
                 let new_qty = old_qty.saturating_sub(*quantity);
-                tx.insert_with_id(
+                tx.upsert(
                     STOCK,
                     stock,
                     cells([
@@ -859,9 +861,10 @@ async fn apply_jazz_op(
                         ("quantity", Value::U64(new_qty)),
                         ("ytd", Value::U64(u64_cell(&stock_cells, "ytd") + quantity)),
                     ]),
+                    Default::default(),
                 )
                 .await?;
-                tx.insert_with_id(
+                tx.upsert(
                     ORDER_LINES,
                     order_line_row(*warehouse, *district, order_number, line_idx),
                     cells([
@@ -872,6 +875,7 @@ async fn apply_jazz_op(
                         ("amount", Value::F64(price * *quantity as f64)),
                         ("delivered", Value::Bool(false)),
                     ]),
+                    Default::default(),
                 )
                 .await?;
             }
@@ -888,7 +892,7 @@ async fn apply_jazz_op(
             let warehouse_cells = tx.read(WAREHOUSES, w).await?.expect("warehouse");
             let district_cells = tx.read(DISTRICTS, d).await?.expect("district");
             let customer_cells = tx.read(CUSTOMERS, c).await?.expect("customer");
-            tx.insert_with_id(
+            tx.upsert(
                 WAREHOUSES,
                 w,
                 cells([
@@ -898,9 +902,10 @@ async fn apply_jazz_op(
                         Value::F64(f64_cell(&warehouse_cells, "ytd") + amount),
                     ),
                 ]),
+                Default::default(),
             )
             .await?;
-            tx.insert_with_id(
+            tx.upsert(
                 DISTRICTS,
                 d,
                 cells([
@@ -912,9 +917,10 @@ async fn apply_jazz_op(
                     ),
                     ("ytd", Value::F64(f64_cell(&district_cells, "ytd") + amount)),
                 ]),
+                Default::default(),
             )
             .await?;
-            tx.insert_with_id(
+            tx.upsert(
                 CUSTOMERS,
                 c,
                 cells([
@@ -930,9 +936,10 @@ async fn apply_jazz_op(
                         Value::U64(u64_cell(&customer_cells, "paymentCount") + 1),
                     ),
                 ]),
+                Default::default(),
             )
             .await?;
-            tx.insert_with_id(
+            tx.upsert(
                 PAYMENTS,
                 payment_row(*warehouse, *district, *customer, now_ms),
                 cells([
@@ -941,6 +948,7 @@ async fn apply_jazz_op(
                     ("customer", Value::Uuid(c.0)),
                     ("amount", Value::F64(*amount)),
                 ]),
+                Default::default(),
             )
             .await?;
         }
@@ -971,7 +979,7 @@ async fn apply_jazz_op(
                     Value::Uuid(value) => RowUuid(*value),
                     other => panic!("expected customer uuid, got {other:?}"),
                 };
-                tx.insert_with_id(
+                tx.upsert(
                     ORDERS,
                     order,
                     cells([
@@ -985,6 +993,7 @@ async fn apply_jazz_op(
                         ("lineCount", Value::U64(u64_cell(&order_cells, "lineCount"))),
                         ("delivered", Value::Bool(true)),
                     ]),
+                    Default::default(),
                 )
                 .await?;
                 let mut total = 0.0;
@@ -992,7 +1001,7 @@ async fn apply_jazz_op(
                     let line = order_line_row(*warehouse, *district, order_number, line_idx);
                     let line_cells = tx.read(ORDER_LINES, line).await?.expect("line");
                     total += f64_cell(&line_cells, "amount");
-                    tx.insert_with_id(
+                    tx.upsert(
                         ORDER_LINES,
                         line,
                         cells([
@@ -1003,11 +1012,12 @@ async fn apply_jazz_op(
                             ("amount", line_cells.get("amount").unwrap().clone()),
                             ("delivered", Value::Bool(true)),
                         ]),
+                        Default::default(),
                     )
                     .await?;
                 }
                 let customer_cells = tx.read(CUSTOMERS, customer).await?.expect("customer");
-                tx.insert_with_id(
+                tx.upsert(
                     CUSTOMERS,
                     customer,
                     cells([
@@ -1029,6 +1039,7 @@ async fn apply_jazz_op(
                             customer_cells.get("paymentCount").unwrap().clone(),
                         ),
                     ]),
+                    Default::default(),
                 )
                 .await?;
             }

--- a/crates/jazz-sim/benches/s5_durable_stream.rs
+++ b/crates/jazz-sim/benches/s5_durable_stream.rs
@@ -421,10 +421,13 @@ fn run_db_surface(config: &Config) -> DbSurfaceSummary {
     let mut edge_acceptance = Histogram::new(3).unwrap();
     let mut contents = vec![Vec::<u8>::new(); config.streams];
     for stream in 0..config.streams {
-        let stream_write = block_on(db.insert_with_id(
+        let stream_write = block_on(db.insert(
             STREAMS,
-            stream_row(stream),
             cells([("name", Value::String(format!("stream-{stream}")))]),
+            jazz::db::InsertOptions {
+                row_id: Some(stream_row(stream)),
+                ..Default::default()
+            },
         ))
         .expect("db stream insert");
         block_on(stream_write.wait(DurabilityTier::Local)).expect("db stream local wait");
@@ -437,13 +440,16 @@ fn run_db_surface(config: &Config) -> DbSurfaceSummary {
             &mut core,
             &mut edge_acceptance,
         );
-        let doc_write = block_on(db.insert_with_id(
+        let doc_write = block_on(db.insert(
             STREAM_DOCS,
-            stream_doc_row(stream),
             cells([
                 ("stream", Value::Uuid(stream_row(stream).0)),
                 ("content", Value::Bytes(Vec::new())),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(stream_doc_row(stream)),
+                ..Default::default()
+            },
         ))
         .expect("db stream doc insert");
         block_on(doc_write.wait(DurabilityTier::Local)).expect("db stream doc local wait");
@@ -498,6 +504,7 @@ fn run_db_surface(config: &Config) -> DbSurfaceSummary {
                 STREAM_DOCS,
                 stream_doc_row(stream),
                 cells([("content", Value::Bytes(content))]),
+                Default::default(),
             ))
             .expect("db stream doc update");
             update_latencies.push(update_start.elapsed().as_micros() as u64);

--- a/crates/jazz-sim/benches/s7_migrations.rs
+++ b/crates/jazz-sim/benches/s7_migrations.rs
@@ -199,7 +199,15 @@ fn commit_client_mergeable(
     cells: BTreeMap<String, Value>,
 ) -> SyncMessage {
     let tx = jazz::db::block_on(client.db.mergeable_tx()).unwrap();
-    jazz::db::block_on(tx.insert_with_id(table, row, cells)).unwrap();
+    jazz::db::block_on(tx.insert(
+        table,
+        cells,
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    ))
+    .unwrap();
     jazz::db::block_on(tx.commit()).unwrap();
     jazz::db::block_on(client.db.tick()).unwrap();
     client

--- a/crates/jazz-sim/benches/s8_branch_views.rs
+++ b/crates/jazz-sim/benches/s8_branch_views.rs
@@ -46,10 +46,8 @@ pub(crate) fn run(row_count: usize) {
     let seed_started = Instant::now();
     let seed = block_on(db.mergeable_tx()).unwrap();
     for index in 0..row_count {
-        block_on(seed.insert_with_id_in_branch(
+        block_on(seed.insert(
             "items",
-            base.clone(),
-            row(index),
             BTreeMap::from([
                 (
                     "title".to_owned(),
@@ -57,6 +55,11 @@ pub(crate) fn run(row_count: usize) {
                 ),
                 ("rank".to_owned(), Value::I64(index as i64)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(row(index)),
+                target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+                ..Default::default()
+            },
         ))
         .unwrap();
     }
@@ -67,15 +70,20 @@ pub(crate) fn run(row_count: usize) {
     let overlay = block_on(db.mergeable_tx()).unwrap();
     let overlaid = (row_count / 4).max(1);
     for index in 0..overlaid {
-        block_on(overlay.update_in_branch_view(
+        block_on(overlay.update(
             "items",
-            head.clone(),
-            Some(BranchViewBase::Current(base.clone())),
             row(index),
             BTreeMap::from([(
                 "title".to_owned(),
                 Value::String(format!("draft-{index:08}")),
             )]),
+            jazz::db::UpdateOptions {
+                target: jazz::db::WriteTarget::BranchView {
+                    head: head.clone(),
+                    base: Some(BranchViewBase::Current(base.clone())),
+                },
+                ..Default::default()
+            },
         ))
         .unwrap();
     }
@@ -126,14 +134,17 @@ pub(crate) fn run(row_count: usize) {
     let cross = block_on(db.mergeable_tx()).unwrap();
     let cross_row = row(row_count + 1);
     for (branch, title) in [(base.clone(), "base"), (head.clone(), "head")] {
-        block_on(cross.insert_with_id_in_branch(
+        block_on(cross.insert(
             "items",
-            branch,
-            cross_row,
             BTreeMap::from([
                 ("title".to_owned(), Value::String(title.to_owned())),
                 ("rank".to_owned(), Value::I64(row_count as i64 + 1)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(cross_row),
+                target: jazz::db::ExactWriteTarget::Branch(branch),
+                ..Default::default()
+            },
         ))
         .unwrap();
     }

--- a/crates/jazz-sim/benches/s9_durable_execution.rs
+++ b/crates/jazz-sim/benches/s9_durable_execution.rs
@@ -566,15 +566,18 @@ fn apply_transition(
     } else {
         "running"
     };
-    jazz::db::block_on(tx.insert_with_id(
+    jazz::db::block_on(tx.insert(
         INSTANCES,
-        row,
         cells_map([
             ("workflow", Value::Uuid(workflow.0)),
             ("state", Value::String(state.to_owned())),
             ("currentStep", Value::U64(next_step)),
             ("wakeAt", Value::U64(0)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
     ))?;
     let _tx_id = jazz::db::block_on(tx.commit())?;
     jazz::db::block_on(client.db.tick())?;

--- a/crates/jazz-testkit/tests/reconnect_write_durability.rs
+++ b/crates/jazz-testkit/tests/reconnect_write_durability.rs
@@ -166,6 +166,7 @@ fn detaching_the_upstream_resolves_pending_global_wait() {
             "title".to_owned(),
             Value::String("pending for a silent upstream".to_owned()),
         )]),
+        Default::default(),
     ))
     .expect("insert local document");
     let tx_id = write.mergeable_tx_id();

--- a/crates/jazz-testkit/tests/replica_settlement.rs
+++ b/crates/jazz-testkit/tests/replica_settlement.rs
@@ -109,9 +109,12 @@ mod relay_topology {
         let (seeder_transport, authority_seed_transport) = duplex();
         let _seeder_connection = block_on(seeder.connect_upstream(seeder_transport));
         let _authority_seed_subscriber = authority.accept_subscriber(authority_seed_transport, bob);
-        let seeded =
-            block_on(seeder.insert("documents", document_cells("settled at the authority")))
-                .expect("seed authority document");
+        let seeded = block_on(seeder.insert(
+            "documents",
+            document_cells("settled at the authority"),
+            Default::default(),
+        ))
+        .expect("seed authority document");
         tick(&seeder, "upload seeded document");
         tick(&authority, "accept seeded document");
         tick(&seeder, "apply seeded document fate");
@@ -270,8 +273,12 @@ mod relay_topology {
     fn relay_without_any_upstream_settles_downstream_local_reads() {
         let alice = AuthorId::from_bytes([0xa3; 16]);
         let relay = open_db(0x23, AuthorId::SYSTEM);
-        block_on(relay.insert("documents", document_cells("stored before alice opens")))
-            .expect("seed relay document");
+        block_on(relay.insert(
+            "documents",
+            document_cells("stored before alice opens"),
+            Default::default(),
+        ))
+        .expect("seed relay document");
 
         let client = open_db(0x13, alice);
         client.set_non_durable_client();
@@ -327,8 +334,12 @@ mod relay_topology {
         let (upstream_transport, _held_far_end) = duplex();
         let _upstream = block_on(node.connect_upstream(upstream_transport));
 
-        let written = block_on(node.insert("documents", document_cells("locally visible")))
-            .expect("insert local document");
+        let written = block_on(node.insert(
+            "documents",
+            document_cells("locally visible"),
+            Default::default(),
+        ))
+        .expect("insert local document");
 
         let documents = node
             .prepare_query(&node.table("documents"))
@@ -419,8 +430,12 @@ mod relay_topology {
     fn node_subscription_without_any_upstream_settles_locally() {
         let alice = AuthorId::from_bytes([0xa6; 16]);
         let node = open_db(0x16, alice);
-        let written = block_on(node.insert("documents", document_cells("settles locally")))
-            .expect("insert local document");
+        let written = block_on(node.insert(
+            "documents",
+            document_cells("settles locally"),
+            Default::default(),
+        ))
+        .expect("insert local document");
 
         let documents = node
             .prepare_query(&node.table("documents"))
@@ -527,9 +542,12 @@ mod relay_topology {
         let (upstream_transport, _held_far_end) = duplex();
         let upstream = block_on(node.connect_upstream(upstream_transport));
 
-        let written =
-            block_on(node.insert("documents", document_cells("local answer after detach")))
-                .expect("insert local document");
+        let written = block_on(node.insert(
+            "documents",
+            document_cells("local answer after detach"),
+            Default::default(),
+        ))
+        .expect("insert local document");
 
         let documents = node
             .prepare_query(&node.table("documents"))

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -750,221 +750,6 @@ impl WasmDbInner {
         with_wasm_db!(self, |db| db.abandon_transaction_handle(tx_id))
     }
 
-    fn mergeable_insert(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        now_ms: Option<u64>,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| match now_ms {
-            Some(now_ms) => block_on(
-                db.mergeable_tx_ref(tx_id)
-                    .insert_with_id_at_ms(table, row_id, cells, now_ms)
-            ),
-            None => block_on(
-                db.mergeable_tx_ref(tx_id)
-                    .insert_with_id(table, row_id, cells)
-            ),
-        })
-    }
-
-    fn mergeable_insert_in_branch(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .insert_with_id_in_branch(table, branch, row_id, cells)
-        ))
-    }
-
-    fn mergeable_insert_generated(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        cells: RowCells,
-        now_ms: Option<u64>,
-    ) -> Result<RowUuid, jazz::db::Error> {
-        with_wasm_db!(self, |db| match now_ms {
-            Some(now_ms) => block_on(
-                db.mergeable_tx_ref(tx_id)
-                    .insert_at_ms(table, cells, now_ms)
-            ),
-            None => block_on(db.mergeable_tx_ref(tx_id).insert(table, cells)),
-        })
-    }
-
-    fn mergeable_insert_generated_in_branch(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<RowUuid, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .insert_in_branch(table, branch, cells)
-        ))
-    }
-
-    fn mergeable_update(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        patch: RowCells,
-        now_ms: Option<u64>,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| match now_ms {
-            Some(now_ms) => block_on(
-                db.mergeable_tx_ref(tx_id)
-                    .update_at_ms(table, row_id, patch, now_ms)
-            ),
-            None => block_on(db.mergeable_tx_ref(tx_id).update(table, row_id, patch)),
-        })
-    }
-
-    fn mergeable_update_in_branch_view(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        patch: RowCells,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .update_in_branch_view(table, head, base, row_id, patch)
-        ))
-    }
-
-    fn mergeable_delete(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        now_ms: Option<u64>,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| match now_ms {
-            Some(now_ms) => block_on(
-                db.mergeable_tx_ref(tx_id)
-                    .delete_at_ms(table, row_id, now_ms)
-            ),
-            None => block_on(db.mergeable_tx_ref(tx_id).delete(table, row_id)),
-        })
-    }
-
-    fn mergeable_delete_in_branch_view(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .delete_in_branch_view(table, head, base, row_id)
-        ))
-    }
-
-    fn mergeable_restore(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        now_ms: Option<u64>,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| match now_ms {
-            Some(now_ms) => block_on(
-                db.mergeable_tx_ref(tx_id)
-                    .restore_at_ms(table, row_id, cells, now_ms)
-            ),
-            None => block_on(db.mergeable_tx_ref(tx_id).restore(table, row_id, cells)),
-        })
-    }
-
-    fn mergeable_restore_in_branch(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .restore_in_branch(table, branch, row_id, cells)
-        ))
-    }
-
-    fn exclusive_write(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id)
-                .insert_with_id(table, row_id, cells)
-        ))
-    }
-
-    fn exclusive_insert_generated(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        cells: RowCells,
-    ) -> Result<RowUuid, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id).insert(table, cells)
-        ))
-    }
-
-    fn exclusive_update(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        patch: RowCells,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id).update(table, row_id, patch)
-        ))
-    }
-
-    fn exclusive_delete(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id).delete(table, row_id)
-        ))
-    }
-
-    fn exclusive_restore(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-    ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id).restore(table, row_id, cells)
-        ))
-    }
-
     fn commit_exclusive(&self, tx_id: OpenTransactionId) -> Result<TxId, jazz::db::Error> {
         with_wasm_db!(self, |db| block_on(db.commit_exclusive_handle(tx_id)))
     }
@@ -1097,730 +882,6 @@ impl WasmDbInner {
         with_wasm_db!(self, |db| db.set_tick_scheduler(Some(scheduler)))
     }
 
-    fn insert(
-        &self,
-        table: &str,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.insert_at_ms(table, cells, now_ms)),
-                    None => block_on(db.insert(table, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.insert_at_ms(table, cells, now_ms)),
-                    None => block_on(db.insert(table, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn insert_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => {
-                            block_on(db.insert_for_identity_at_ms(identity, table, cells, now_ms))
-                        }
-                        None => block_on(db.insert_for_identity(identity, table, cells)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => {
-                            block_on(db.insert_for_identity_at_ms(identity, table, cells, now_ms))
-                        }
-                        None => block_on(db.insert_for_identity(identity, table, cells)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn insert_in_branch(
-        &self,
-        table: &str,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.insert_in_branch(table, branch, cells)).map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                block_on(db.insert_in_branch(table, branch, cells)).map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn insert_in_branch_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    block_on(db.insert_in_branch_for_identity(identity, table, branch, cells))
-                        .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    block_on(db.insert_in_branch_for_identity(identity, table, branch, cells))
-                        .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn insert_with_id(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.insert_with_id_at_ms(table, row_id, cells, now_ms)),
-                    None => block_on(db.insert_with_id(table, row_id, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.insert_with_id_at_ms(table, row_id, cells, now_ms)),
-                    None => block_on(db.insert_with_id(table, row_id, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn insert_with_id_in_branch(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.insert_with_id_in_branch(table, branch, row_id, cells))
-                    .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                block_on(db.insert_with_id_in_branch(table, branch, row_id, cells))
-                    .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn insert_with_id_in_branch_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    block_on(db.insert_with_id_in_branch_for_identity(
-                        identity, table, branch, row_id, cells,
-                    ))
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    block_on(db.insert_with_id_in_branch_for_identity(
-                        identity, table, branch, row_id, cells,
-                    ))
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn insert_with_id_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(db.insert_with_id_for_identity_at_ms(
-                            identity, table, row_id, cells, now_ms,
-                        )),
-                        None => {
-                            block_on(db.insert_with_id_for_identity(identity, table, row_id, cells))
-                        }
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(db.insert_with_id_for_identity_at_ms(
-                            identity, table, row_id, cells, now_ms,
-                        )),
-                        None => {
-                            block_on(db.insert_with_id_for_identity(identity, table, row_id, cells))
-                        }
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn update(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        patch: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.update_at_ms(table, row_id, patch, now_ms)),
-                    None => block_on(db.update(table, row_id, patch)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.update_at_ms(table, row_id, patch, now_ms)),
-                    None => block_on(db.update(table, row_id, patch)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn update_in_branch(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        patch: RowCells,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match base {
-                    Some(base) => {
-                        block_on(db.update_in_branch_view(table, head, Some(base), row_id, patch))
-                    }
-                    None => block_on(db.update_in_branch(table, head, row_id, patch)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match base {
-                    Some(base) => {
-                        block_on(db.update_in_branch_view(table, head, Some(base), row_id, patch))
-                    }
-                    None => block_on(db.update_in_branch(table, head, row_id, patch)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn update_in_branch_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        patch: RowCells,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    block_on(db.update_in_branch_view_for_identity(
-                        identity, table, head, base, row_id, patch,
-                    ))
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    block_on(db.update_in_branch_view_for_identity(
-                        identity, table, head, base, row_id, patch,
-                    ))
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn update_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        patch: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(
-                            db.update_for_identity_at_ms(identity, table, row_id, patch, now_ms),
-                        ),
-                        None => block_on(db.update_for_identity(identity, table, row_id, patch)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(
-                            db.update_for_identity_at_ms(identity, table, row_id, patch, now_ms),
-                        ),
-                        None => block_on(db.update_for_identity(identity, table, row_id, patch)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn upsert(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.upsert_at_ms(table, row_id, cells, now_ms)),
-                    None => block_on(db.upsert(table, row_id, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.upsert_at_ms(table, row_id, cells, now_ms)),
-                    None => block_on(db.upsert(table, row_id, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn upsert_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(
-                            db.upsert_for_identity_at_ms(identity, table, row_id, cells, now_ms),
-                        ),
-                        None => block_on(db.upsert_for_identity(identity, table, row_id, cells)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(
-                            db.upsert_for_identity_at_ms(identity, table, row_id, cells, now_ms),
-                        ),
-                        None => block_on(db.upsert_for_identity(identity, table, row_id, cells)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn delete(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        now_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match now_ms {
-                    Some(now_ms) => block_on(db.delete_at_ms(table, row_id, now_ms)),
-                    None => block_on(db.delete(table, row_id)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match now_ms {
-                    Some(now_ms) => block_on(db.delete_at_ms(table, row_id, now_ms)),
-                    None => block_on(db.delete(table, row_id)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn delete_in_branch(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match base {
-                    Some(base) => {
-                        block_on(db.delete_in_branch_view(table, head, Some(base), row_id))
-                    }
-                    None => block_on(db.delete_in_branch(table, head, row_id)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match base {
-                    Some(base) => {
-                        block_on(db.delete_in_branch_view(table, head, Some(base), row_id))
-                    }
-                    None => block_on(db.delete_in_branch(table, head, row_id)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn delete_in_branch_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    block_on(
-                        db.delete_in_branch_view_for_identity(identity, table, head, base, row_id),
-                    )
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    block_on(
-                        db.delete_in_branch_view_for_identity(identity, table, head, base, row_id),
-                    )
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn delete_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        now_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    match now_ms {
-                        Some(now_ms) => {
-                            block_on(db.delete_for_identity_at_ms(identity, table, row_id, now_ms))
-                        }
-                        None => block_on(db.delete_for_identity(identity, table, row_id)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    match now_ms {
-                        Some(now_ms) => {
-                            block_on(db.delete_for_identity_at_ms(identity, table, row_id, now_ms))
-                        }
-                        None => block_on(db.delete_for_identity(identity, table, row_id)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn restore(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.restore_at_ms(table, row_id, cells, now_ms)),
-                    None => block_on(db.restore(table, row_id, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => block_on(db.restore_at_ms(table, row_id, cells, now_ms)),
-                    None => block_on(db.restore(table, row_id, cells)),
-                }
-                .map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn restore_in_branch(
-        &self,
-        table: &str,
-        row_id: RowUuid,
-        branch: BranchSelector,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.restore_in_branch(table, branch, row_id)).map_err(to_js_error)?,
-            ),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                block_on(db.restore_in_branch(table, branch, row_id)).map_err(to_js_error)?,
-            ),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn restore_with_cells_in_branch(
-        &self,
-        identity: Option<AuthorId>,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        branch: BranchSelector,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                if let Some(identity) = identity {
-                    set_identity_claims(db, identity);
-                }
-                wasm_write_memory(
-                    Rc::clone(db),
-                    match identity {
-                        Some(identity) => block_on(db.restore_with_cells_in_branch_as_identity(
-                            identity, table, branch, row_id, cells,
-                        )),
-                        None => {
-                            block_on(db.restore_with_cells_in_branch(table, branch, row_id, cells))
-                        }
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                if let Some(identity) = identity {
-                    set_identity_claims(db, identity);
-                }
-                wasm_write_browser(
-                    Rc::clone(db),
-                    match identity {
-                        Some(identity) => block_on(db.restore_with_cells_in_branch_as_identity(
-                            identity, table, branch, row_id, cells,
-                        )),
-                        None => {
-                            block_on(db.restore_with_cells_in_branch(table, branch, row_id, cells))
-                        }
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    fn restore_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row_id: RowUuid,
-        cells: RowCells,
-        updated_at_ms: Option<u64>,
-    ) -> Result<WasmWrite, JsValue> {
-        match self {
-            Self::Memory(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_memory(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(
-                            db.restore_for_identity_at_ms(identity, table, row_id, cells, now_ms),
-                        ),
-                        None => block_on(db.restore_for_identity(identity, table, row_id, cells)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(db) => {
-                set_identity_claims(db, identity);
-                wasm_write_browser(
-                    Rc::clone(db),
-                    match updated_at_ms {
-                        Some(now_ms) => block_on(
-                            db.restore_for_identity_at_ms(identity, table, row_id, cells, now_ms),
-                        ),
-                        None => block_on(db.restore_for_identity(identity, table, row_id, cells)),
-                    }
-                    .map_err(to_js_error)?,
-                )
-            }
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
     async fn tick(&self) -> Result<(), jazz::db::Error> {
         with_wasm_db!(self, |db| db.tick().await)
     }
@@ -1854,6 +915,127 @@ enum WasmTxKind {
 
 #[wasm_bindgen]
 impl WasmDb {
+    #[wasm_bindgen(js_name = insertEncoded)]
+    pub fn insert_encoded_with_options(
+        &self,
+        table: String,
+        cells: Vec<u8>,
+        options: JsValue,
+    ) -> Result<WasmWrite, JsValue> {
+        let cells = decode_cells(&cells)?;
+        let options = insert_options_from_js(options)?;
+        match &self.inner {
+            WasmDbInner::Memory(db) => wasm_write_memory(
+                Rc::clone(db),
+                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
+            ),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
+            ),
+            WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = updateEncoded)]
+    pub fn update_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        patch: Vec<u8>,
+        options: JsValue,
+    ) -> Result<WasmWrite, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let patch = decode_cells(&patch)?;
+        let options = update_options_from_js(options)?;
+        match &self.inner {
+            WasmDbInner::Memory(db) => wasm_write_memory(
+                Rc::clone(db),
+                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
+            ),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
+            ),
+            WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = upsertEncoded)]
+    pub fn upsert_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        cells: Vec<u8>,
+        options: JsValue,
+    ) -> Result<WasmWrite, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let cells = decode_cells(&cells)?;
+        let options = upsert_options_from_js(options)?;
+        match &self.inner {
+            WasmDbInner::Memory(db) => wasm_write_memory(
+                Rc::clone(db),
+                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
+            ),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
+            ),
+            WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = deleteEncoded)]
+    pub fn delete_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        options: JsValue,
+    ) -> Result<WasmWrite, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let options = delete_options_from_js(options)?;
+        match &self.inner {
+            WasmDbInner::Memory(db) => wasm_write_memory(
+                Rc::clone(db),
+                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
+            ),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
+            ),
+            WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
+    }
+
+    #[wasm_bindgen(js_name = restoreEncoded)]
+    pub fn restore_encoded_with_options(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        cells: Vec<u8>,
+        options: JsValue,
+    ) -> Result<WasmWrite, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let cells = decode_cells(&cells)?;
+        let options = restore_options_from_js(options)?;
+        match &self.inner {
+            WasmDbInner::Memory(db) => wasm_write_memory(
+                Rc::clone(db),
+                block_on(db.restore(&table, row_id, Some(cells), options)).map_err(to_js_error)?,
+            ),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.restore(&table, row_id, Some(cells), options)).map_err(to_js_error)?,
+            ),
+            WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
+    }
+
     #[wasm_bindgen(js_name = openMemory)]
     pub fn open_memory(schema: Vec<u8>, config: Vec<u8>) -> Result<WasmDb, JsValue> {
         console_error_panic_hook::set_once();
@@ -2322,68 +1504,6 @@ impl WasmDb {
         }
     }
 
-    #[wasm_bindgen(js_name = insertEncoded)]
-    pub fn insert_encoded(
-        &self,
-        table: String,
-        cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let cells = decode_cells(&cells)?;
-        self.inner
-            .insert(&table, cells, updated_at_ms.map(|value| value as u64))
-    }
-
-    #[wasm_bindgen(js_name = insertEncodedForIdentity)]
-    pub fn insert_encoded_for_identity(
-        &self,
-        table: String,
-        cells: Vec<u8>,
-        author: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let cells = decode_cells(&cells)?;
-        let author = author_id_from_bytes(&author)?;
-        self.inner.insert_for_identity(
-            author,
-            &table,
-            cells,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = insertEncodedInBranch)]
-    pub fn insert_encoded_in_branch(
-        &self,
-        table: String,
-        cells: Vec<u8>,
-        branch: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.insert_in_branch(
-            &table,
-            decode_cells(&cells)?,
-            serde_wasm_bindgen::from_value(branch)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-        )
-    }
-
-    #[wasm_bindgen(js_name = insertEncodedInBranchForIdentity)]
-    pub fn insert_encoded_in_branch_for_identity(
-        &self,
-        table: String,
-        cells: Vec<u8>,
-        branch: JsValue,
-        author: Vec<u8>,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.insert_in_branch_for_identity(
-            author_id_from_bytes(&author)?,
-            &table,
-            decode_cells(&cells)?,
-            serde_wasm_bindgen::from_value(branch)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-        )
-    }
-
     #[wasm_bindgen(js_name = canInsertEncoded)]
     pub fn can_insert_encoded(&self, table: String, cells: Vec<u8>) -> Result<String, JsValue> {
         let cells = decode_cells(&cells)?;
@@ -2427,166 +1547,6 @@ impl WasmDb {
             })
     }
 
-    #[wasm_bindgen(js_name = insertWithIdEncoded)]
-    pub fn insert_with_id_encoded(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        self.inner.insert_with_id(
-            &table,
-            row_id,
-            cells,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = insertWithIdEncodedInBranch)]
-    pub fn insert_with_id_encoded_in_branch(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        branch: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.insert_with_id_in_branch(
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            decode_cells(&cells)?,
-            serde_wasm_bindgen::from_value(branch)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-        )
-    }
-
-    #[wasm_bindgen(js_name = insertWithIdEncodedInBranchForIdentity)]
-    pub fn insert_with_id_encoded_in_branch_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        branch: JsValue,
-        author: Vec<u8>,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.insert_with_id_in_branch_for_identity(
-            author_id_from_bytes(&author)?,
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            decode_cells(&cells)?,
-            serde_wasm_bindgen::from_value(branch)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-        )
-    }
-
-    #[wasm_bindgen(js_name = insertWithIdEncodedForIdentity)]
-    pub fn insert_with_id_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        author: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        let author = author_id_from_bytes(&author)?;
-        self.inner.insert_with_id_for_identity(
-            author,
-            &table,
-            row_id,
-            cells,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = updateEncoded)]
-    pub fn update_encoded(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let patch = decode_cells(&patch)?;
-        self.inner.update(
-            &table,
-            row_id,
-            patch,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = updateEncodedInBranch)]
-    pub fn update_encoded_in_branch(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        head: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.update_in_branch(
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            decode_cells(&patch)?,
-            serde_wasm_bindgen::from_value(head)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-            None,
-        )
-    }
-
-    #[wasm_bindgen(js_name = updateEncodedInBranchView)]
-    pub fn update_encoded_in_branch_view(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        head: JsValue,
-        base: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.update_in_branch(
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            decode_cells(&patch)?,
-            serde_wasm_bindgen::from_value(head)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-            Some(serde_wasm_bindgen::from_value(base).map_err(|error| {
-                JsValue::from_str(&format!("invalid branch view base: {error}"))
-            })?),
-        )
-    }
-
-    #[wasm_bindgen(js_name = updateEncodedInBranchViewForIdentity)]
-    pub fn update_encoded_in_branch_view_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        head: JsValue,
-        base: JsValue,
-        author: Vec<u8>,
-    ) -> Result<WasmWrite, JsValue> {
-        let base = if base.is_null() || base.is_undefined() {
-            None
-        } else {
-            Some(serde_wasm_bindgen::from_value(base).map_err(|error| {
-                JsValue::from_str(&format!("invalid branch view base: {error}"))
-            })?)
-        };
-        self.inner.update_in_branch_for_identity(
-            author_id_from_bytes(&author)?,
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            decode_cells(&patch)?,
-            serde_wasm_bindgen::from_value(head)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-            base,
-        )
-    }
-
     #[wasm_bindgen(js_name = requestUpdatePermissionAdviceEncoded)]
     pub fn request_update_permission_advice_encoded(
         &self,
@@ -2602,139 +1562,6 @@ impl WasmDb {
             })
     }
 
-    #[wasm_bindgen(js_name = updateEncodedForIdentity)]
-    pub fn update_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        author: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let patch = decode_cells(&patch)?;
-        let author = author_id_from_bytes(&author)?;
-        self.inner.update_for_identity(
-            author,
-            &table,
-            row_id,
-            patch,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = upsertEncoded)]
-    pub fn upsert_encoded(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        self.inner.upsert(
-            &table,
-            row_id,
-            cells,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = upsertEncodedForIdentity)]
-    pub fn upsert_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        author: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        let author = author_id_from_bytes(&author)?;
-        self.inner.upsert_for_identity(
-            author,
-            &table,
-            row_id,
-            cells,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = delete)]
-    pub fn delete(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        self.inner
-            .delete(&table, row_id, updated_at_ms.map(|value| value as u64))
-    }
-
-    #[wasm_bindgen(js_name = deleteInBranch)]
-    pub fn delete_in_branch(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        head: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.delete_in_branch(
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            serde_wasm_bindgen::from_value(head)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-            None,
-        )
-    }
-
-    #[wasm_bindgen(js_name = deleteInBranchView)]
-    pub fn delete_in_branch_view(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        head: JsValue,
-        base: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.delete_in_branch(
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            serde_wasm_bindgen::from_value(head)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-            Some(serde_wasm_bindgen::from_value(base).map_err(|error| {
-                JsValue::from_str(&format!("invalid branch view base: {error}"))
-            })?),
-        )
-    }
-
-    #[wasm_bindgen(js_name = deleteInBranchViewForIdentity)]
-    pub fn delete_in_branch_view_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        head: JsValue,
-        base: JsValue,
-        author: Vec<u8>,
-    ) -> Result<WasmWrite, JsValue> {
-        let base = if base.is_null() || base.is_undefined() {
-            None
-        } else {
-            Some(serde_wasm_bindgen::from_value(base).map_err(|error| {
-                JsValue::from_str(&format!("invalid branch view base: {error}"))
-            })?)
-        };
-        self.inner.delete_in_branch_for_identity(
-            author_id_from_bytes(&author)?,
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            serde_wasm_bindgen::from_value(head)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-            base,
-        )
-    }
-
     #[wasm_bindgen(js_name = requestDeletePermissionAdvice)]
     pub fn request_delete_permission_advice(
         &self,
@@ -2748,114 +1575,6 @@ impl WasmDb {
             })
     }
 
-    #[wasm_bindgen(js_name = deleteForIdentity)]
-    pub fn delete_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        author: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let author = author_id_from_bytes(&author)?;
-        self.inner.delete_for_identity(
-            author,
-            &table,
-            row_id,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = restoreEncoded)]
-    pub fn restore_encoded(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        self.inner.restore(
-            &table,
-            row_id,
-            cells,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
-
-    #[wasm_bindgen(js_name = restoreInBranch)]
-    pub fn restore_in_branch(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        branch: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.restore_in_branch(
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            serde_wasm_bindgen::from_value(branch)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-        )
-    }
-
-    #[wasm_bindgen(js_name = restoreEncodedInBranch)]
-    pub fn restore_encoded_in_branch(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        branch: JsValue,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.restore_with_cells_in_branch(
-            None,
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            decode_cells(&cells)?,
-            serde_wasm_bindgen::from_value(branch)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-        )
-    }
-
-    #[wasm_bindgen(js_name = restoreEncodedInBranchForIdentity)]
-    pub fn restore_encoded_in_branch_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        branch: JsValue,
-        author: Vec<u8>,
-    ) -> Result<WasmWrite, JsValue> {
-        self.inner.restore_with_cells_in_branch(
-            Some(author_id_from_bytes(&author)?),
-            &table,
-            row_uuid_from_bytes(&row_id)?,
-            decode_cells(&cells)?,
-            serde_wasm_bindgen::from_value(branch)
-                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
-        )
-    }
-
-    #[wasm_bindgen(js_name = restoreEncodedForIdentity)]
-    pub fn restore_encoded_for_identity(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        author: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<WasmWrite, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        let author = author_id_from_bytes(&author)?;
-        self.inner.restore_for_identity(
-            author,
-            &table,
-            row_id,
-            cells,
-            updated_at_ms.map(|value| value as u64),
-        )
-    }
     #[wasm_bindgen(js_name = tick)]
     pub fn tick(&self) -> js_sys::Promise {
         let inner = self.inner.clone();
@@ -3504,268 +2223,121 @@ impl WasmTransport {
 #[wasm_bindgen]
 impl WasmTx {
     #[wasm_bindgen(js_name = insertEncoded)]
-    pub fn insert_encoded(
+    pub fn insert_encoded_with_options(
         &mut self,
         table: String,
         cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
+        options: JsValue,
     ) -> Result<Vec<u8>, JsValue> {
         let cells = decode_cells(&cells)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
+        let options = insert_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        let row_id = match self.kind {
-            WasmTxKind::Mergeable => self
-                .db
-                .mergeable_insert_generated(open_tx, &table, cells, now_ms),
-            WasmTxKind::Exclusive => self.db.exclusive_insert_generated(open_tx, &table, cells),
-        }
+        let row = with_wasm_db!(&self.db, |db| match self.kind {
+            WasmTxKind::Mergeable =>
+                block_on(db.mergeable_tx_ref(open_tx).insert(&table, cells, options,)),
+            WasmTxKind::Exclusive =>
+                block_on(db.exclusive_tx_ref(open_tx).insert(&table, cells, options,)),
+        })
         .map_err(to_js_error)?;
-        Ok(row_id.to_bytes())
-    }
-
-    #[wasm_bindgen(js_name = insertEncodedInBranch)]
-    pub fn insert_encoded_in_branch(
-        &mut self,
-        table: String,
-        cells: Vec<u8>,
-        branch: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
-        if !matches!(self.kind, WasmTxKind::Mergeable) {
-            return Err(JsValue::from_str(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let branch = serde_wasm_bindgen::from_value(branch)
-            .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?;
-        let row_id = self
-            .db
-            .mergeable_insert_generated_in_branch(
-                self.open_tx_for_read()?,
-                &table,
-                decode_cells(&cells)?,
-                branch,
-            )
-            .map_err(to_js_error)?;
-        Ok(row_id.to_bytes())
-    }
-
-    #[wasm_bindgen(js_name = insertWithIdEncoded)]
-    pub fn insert_with_id_encoded(
-        &mut self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<(), JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
-        let open_tx = self.open_tx_for_read()?;
-        match self.kind {
-            WasmTxKind::Mergeable => self
-                .db
-                .mergeable_insert(open_tx, &table, row_id, cells, now_ms),
-            WasmTxKind::Exclusive => self.db.exclusive_write(open_tx, &table, row_id, cells),
-        }
-        .map_err(to_js_error)?;
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = insertWithIdEncodedInBranch)]
-    pub fn insert_with_id_encoded_in_branch(
-        &mut self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        branch: JsValue,
-    ) -> Result<(), JsValue> {
-        if !matches!(self.kind, WasmTxKind::Mergeable) {
-            return Err(JsValue::from_str(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let branch = serde_wasm_bindgen::from_value(branch)
-            .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?;
-        self.db
-            .mergeable_insert_in_branch(
-                self.open_tx_for_read()?,
-                &table,
-                row_uuid_from_bytes(&row_id)?,
-                decode_cells(&cells)?,
-                branch,
-            )
-            .map_err(to_js_error)
+        Ok(row.to_bytes())
     }
 
     #[wasm_bindgen(js_name = updateEncoded)]
-    pub fn update_encoded(
+    pub fn update_encoded_with_options(
         &mut self,
         table: String,
         row_id: Vec<u8>,
         patch: Vec<u8>,
-        updated_at_ms: Option<f64>,
+        options: JsValue,
     ) -> Result<(), JsValue> {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let patch = decode_cells(&patch)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
+        let options = update_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        match self.kind {
-            WasmTxKind::Mergeable => self
-                .db
-                .mergeable_update(open_tx, &table, row_id, patch, now_ms),
-            WasmTxKind::Exclusive => self.db.exclusive_update(open_tx, &table, row_id, patch),
-        }
-        .map_err(to_js_error)?;
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = updateEncodedInBranchView)]
-    pub fn update_encoded_in_branch_view(
-        &mut self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        head: JsValue,
-        base: JsValue,
-    ) -> Result<(), JsValue> {
-        if !matches!(self.kind, WasmTxKind::Mergeable) {
-            return Err(JsValue::from_str(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let head = serde_wasm_bindgen::from_value(head)
-            .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?;
-        let base = if base.is_null() || base.is_undefined() {
-            None
-        } else {
-            Some(serde_wasm_bindgen::from_value(base).map_err(|error| {
-                JsValue::from_str(&format!("invalid branch view base: {error}"))
-            })?)
-        };
-        self.db
-            .mergeable_update_in_branch_view(
-                self.open_tx_for_read()?,
-                &table,
-                row_uuid_from_bytes(&row_id)?,
-                decode_cells(&patch)?,
-                head,
-                base,
-            )
-            .map_err(to_js_error)
+        with_wasm_db!(&self.db, |db| match self.kind {
+            WasmTxKind::Mergeable => block_on(
+                db.mergeable_tx_ref(open_tx)
+                    .update(&table, row_id, patch, options,)
+            ),
+            WasmTxKind::Exclusive => block_on(
+                db.exclusive_tx_ref(open_tx)
+                    .update(&table, row_id, patch, options,)
+            ),
+        })
+        .map_err(to_js_error)
     }
 
     #[wasm_bindgen(js_name = upsertEncoded)]
-    pub fn upsert_encoded(
+    pub fn upsert_encoded_with_options(
         &mut self,
         table: String,
         row_id: Vec<u8>,
         cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<(), JsValue> {
-        self.insert_with_id_encoded(table, row_id, cells, updated_at_ms)
-    }
-
-    #[wasm_bindgen(js_name = delete)]
-    pub fn delete(
-        &mut self,
-        table: String,
-        row_id: Vec<u8>,
-        updated_at_ms: Option<f64>,
-    ) -> Result<(), JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let open_tx = self.open_tx_for_read()?;
-        match self.kind {
-            WasmTxKind::Mergeable => self.db.mergeable_delete(
-                open_tx,
-                &table,
-                row_id,
-                updated_at_ms.map(|value| value as u64),
-            ),
-            WasmTxKind::Exclusive => self.db.exclusive_delete(open_tx, &table, row_id),
-        }
-        .map_err(to_js_error)?;
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = deleteInBranchView)]
-    pub fn delete_in_branch_view(
-        &mut self,
-        table: String,
-        row_id: Vec<u8>,
-        head: JsValue,
-        base: JsValue,
-    ) -> Result<(), JsValue> {
-        if !matches!(self.kind, WasmTxKind::Mergeable) {
-            return Err(JsValue::from_str(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let head = serde_wasm_bindgen::from_value(head)
-            .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?;
-        let base = if base.is_null() || base.is_undefined() {
-            None
-        } else {
-            Some(serde_wasm_bindgen::from_value(base).map_err(|error| {
-                JsValue::from_str(&format!("invalid branch view base: {error}"))
-            })?)
-        };
-        self.db
-            .mergeable_delete_in_branch_view(
-                self.open_tx_for_read()?,
-                &table,
-                row_uuid_from_bytes(&row_id)?,
-                head,
-                base,
-            )
-            .map_err(to_js_error)
-    }
-
-    #[wasm_bindgen(js_name = restoreEncoded)]
-    pub fn restore_encoded(
-        &mut self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        updated_at_ms: Option<f64>,
+        options: JsValue,
     ) -> Result<(), JsValue> {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let cells = decode_cells(&cells)?;
-        let now_ms = updated_at_ms.map(|value| value as u64);
+        let options = upsert_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        match self.kind {
-            WasmTxKind::Mergeable => self
-                .db
-                .mergeable_restore(open_tx, &table, row_id, cells, now_ms),
-            WasmTxKind::Exclusive => self.db.exclusive_restore(open_tx, &table, row_id, cells),
-        }
-        .map_err(to_js_error)?;
-        Ok(())
+        with_wasm_db!(&self.db, |db| match self.kind {
+            WasmTxKind::Mergeable => block_on(
+                db.mergeable_tx_ref(open_tx)
+                    .upsert(&table, row_id, cells, options,)
+            ),
+            WasmTxKind::Exclusive => block_on(
+                db.exclusive_tx_ref(open_tx)
+                    .upsert(&table, row_id, cells, options,)
+            ),
+        })
+        .map_err(to_js_error)
     }
 
-    #[wasm_bindgen(js_name = restoreEncodedInBranch)]
-    pub fn restore_encoded_in_branch(
+    #[wasm_bindgen(js_name = deleteEncoded)]
+    pub fn delete_encoded_with_options(
+        &mut self,
+        table: String,
+        row_id: Vec<u8>,
+        options: JsValue,
+    ) -> Result<(), JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let options = delete_options_from_js(options)?;
+        let open_tx = self.open_tx_for_read()?;
+        with_wasm_db!(&self.db, |db| match self.kind {
+            WasmTxKind::Mergeable => {
+                block_on(db.mergeable_tx_ref(open_tx).delete(&table, row_id, options))
+            }
+            WasmTxKind::Exclusive => {
+                block_on(db.exclusive_tx_ref(open_tx).delete(&table, row_id, options))
+            }
+        })
+        .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = restoreEncoded)]
+    pub fn restore_encoded_with_options(
         &mut self,
         table: String,
         row_id: Vec<u8>,
         cells: Vec<u8>,
-        branch: JsValue,
+        options: JsValue,
     ) -> Result<(), JsValue> {
-        if !matches!(self.kind, WasmTxKind::Mergeable) {
-            return Err(JsValue::from_str(
-                "branch writes require a mergeable transaction",
-            ));
-        }
-        let branch = serde_wasm_bindgen::from_value(branch)
-            .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?;
-        self.db
-            .mergeable_restore_in_branch(
-                self.open_tx_for_read()?,
-                &table,
-                row_uuid_from_bytes(&row_id)?,
-                decode_cells(&cells)?,
-                branch,
-            )
-            .map_err(to_js_error)
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let cells = decode_cells(&cells)?;
+        let options = restore_options_from_js(options)?;
+        let open_tx = self.open_tx_for_read()?;
+        with_wasm_db!(&self.db, |db| match self.kind {
+            WasmTxKind::Mergeable =>
+                block_on(
+                    db.mergeable_tx_ref(open_tx)
+                        .restore(&table, row_id, Some(cells), options,)
+                ),
+            WasmTxKind::Exclusive =>
+                block_on(
+                    db.exclusive_tx_ref(open_tx)
+                        .restore(&table, row_id, Some(cells), options,)
+                ),
+        })
+        .map_err(to_js_error)
     }
 
     #[wasm_bindgen(js_name = commit)]
@@ -3885,6 +2457,110 @@ fn decode_cells(bytes: &[u8]) -> Result<RowCells, JsValue> {
         cells.insert(name.clone(), value);
     }
     Ok(cells)
+}
+
+fn write_option(options: &JsValue, name: &str) -> Result<Option<JsValue>, JsValue> {
+    if options.is_null() || options.is_undefined() {
+        return Ok(None);
+    }
+    let value = js_sys::Reflect::get(options, &JsValue::from_str(name))?;
+    Ok((!value.is_null() && !value.is_undefined()).then_some(value))
+}
+
+fn write_identity_option(options: &JsValue) -> Result<jazz::db::WriteIdentity, JsValue> {
+    write_option(options, "author")?
+        .map(|author| {
+            author_id_from_bytes(&js_sys::Uint8Array::new(&author).to_vec())
+                .map(jazz::db::WriteIdentity::Session)
+        })
+        .transpose()
+        .map(|identity| identity.unwrap_or_default())
+}
+
+fn write_timestamp_option(options: &JsValue) -> Result<Option<u64>, JsValue> {
+    write_option(options, "updatedAtMs")?
+        .map(|value| {
+            value
+                .as_f64()
+                .map(|value| value as u64)
+                .ok_or_else(|| JsValue::from_str("updatedAtMs must be a number"))
+        })
+        .transpose()
+}
+
+fn insert_options_from_js(options: JsValue) -> Result<jazz::db::InsertOptions, JsValue> {
+    Ok(jazz::db::InsertOptions {
+        row_id: write_option(&options, "rowId")?
+            .map(|row_id| row_uuid_from_bytes(&js_sys::Uint8Array::new(&row_id).to_vec()))
+            .transpose()?,
+        identity: write_identity_option(&options)?,
+        target: write_option(&options, "branch")?
+            .map(|branch| {
+                serde_wasm_bindgen::from_value(branch)
+                    .map(jazz::db::ExactWriteTarget::Branch)
+                    .map_err(to_js_error)
+            })
+            .transpose()?
+            .unwrap_or_default(),
+        updated_at_ms: write_timestamp_option(&options)?,
+    })
+}
+
+fn update_options_from_js(options: JsValue) -> Result<jazz::db::UpdateOptions, JsValue> {
+    let head = write_option(&options, "head")?;
+    let base = write_option(&options, "base")?;
+    let target = match head {
+        Some(head) => jazz::db::WriteTarget::BranchView {
+            head: serde_wasm_bindgen::from_value(head).map_err(to_js_error)?,
+            base: base
+                .map(|base| serde_wasm_bindgen::from_value(base).map_err(to_js_error))
+                .transpose()?,
+        },
+        None if base.is_none() => Default::default(),
+        None => {
+            return Err(JsValue::from_str(
+                "branch view base requires a head selector",
+            ))
+        }
+    };
+    Ok(jazz::db::UpdateOptions {
+        identity: write_identity_option(&options)?,
+        target,
+        updated_at_ms: write_timestamp_option(&options)?,
+    })
+}
+
+fn upsert_options_from_js(options: JsValue) -> Result<jazz::db::UpsertOptions, JsValue> {
+    Ok(jazz::db::UpsertOptions {
+        identity: write_identity_option(&options)?,
+        target: write_option(&options, "branch")?
+            .map(|branch| {
+                serde_wasm_bindgen::from_value(branch)
+                    .map(jazz::db::ExactWriteTarget::Branch)
+                    .map_err(to_js_error)
+            })
+            .transpose()?
+            .unwrap_or_default(),
+        updated_at_ms: write_timestamp_option(&options)?,
+    })
+}
+
+fn delete_options_from_js(options: JsValue) -> Result<jazz::db::DeleteOptions, JsValue> {
+    let options = update_options_from_js(options)?;
+    Ok(jazz::db::DeleteOptions {
+        identity: options.identity,
+        target: options.target,
+        updated_at_ms: options.updated_at_ms,
+    })
+}
+
+fn restore_options_from_js(options: JsValue) -> Result<jazz::db::RestoreOptions, JsValue> {
+    let options = upsert_options_from_js(options)?;
+    Ok(jazz::db::RestoreOptions {
+        identity: options.identity,
+        target: options.target,
+        updated_at_ms: options.updated_at_ms,
+    })
 }
 
 fn decode_open_args(
@@ -4016,21 +2692,6 @@ fn author_id_from_bytes(bytes: &[u8]) -> Result<AuthorId, JsValue> {
         .try_into()
         .map_err(|_| JsValue::from_str("author id must be 16 bytes"))?;
     Ok(AuthorId::from_bytes(bytes))
-}
-
-fn set_identity_claims<S>(db: &Db<S>, author: AuthorId)
-where
-    S: OrderedKvStorage + ReopenableStorage + 'static,
-{
-    let subject = author.0.to_string();
-    db.set_identity_claims(
-        author,
-        BTreeMap::from([
-            ("subject".to_owned(), Value::String(subject.clone())),
-            ("sub".to_owned(), Value::String(subject.clone())),
-            ("user_id".to_owned(), Value::String(subject)),
-        ]),
-    );
 }
 
 fn claims_from_js(author: AuthorId, claims: JsValue) -> Result<BTreeMap<String, Value>, JsValue> {
@@ -4605,10 +3266,13 @@ mod dynamic_schema_view_tests {
             open_tx: Some(batch),
             owns_lifetime: false,
         });
-        block_on(view.mergeable_tx_ref(batch).insert_with_id(
+        block_on(view.mergeable_tx_ref(batch).insert(
             "items",
-            RowUuid::from_bytes([1; 16]),
             BTreeMap::from([("label".to_owned(), Value::String("kept".to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(RowUuid::from_bytes([1; 16])),
+                ..Default::default()
+            },
         ))
         .unwrap();
         let prepared = view.prepare_query(&view.table("items")).unwrap();
@@ -4626,13 +3290,16 @@ mod dynamic_schema_view_tests {
             open_tx: Some(exclusive),
             owns_lifetime: false,
         });
-        block_on(view.exclusive_tx_ref(exclusive).insert_with_id(
+        block_on(view.exclusive_tx_ref(exclusive).insert(
             "items",
-            RowUuid::from_bytes([2; 16]),
             BTreeMap::from([(
                 "label".to_owned(),
                 Value::String("exclusive-kept".to_owned()),
             )]),
+            jazz::db::InsertOptions {
+                row_id: Some(RowUuid::from_bytes([2; 16])),
+                ..Default::default()
+            },
         ))
         .unwrap();
         block_on(owner.commit_exclusive_handle(exclusive)).unwrap();
@@ -4726,13 +3393,16 @@ mod dynamic_schema_view_tests {
                     Some(alice.0.as_bytes().to_vec()),
                 )
                 .unwrap();
-            block_on(other_owner.exclusive_tx_ref(bound).insert_with_id(
+            block_on(other_owner.exclusive_tx_ref(bound).insert(
                 "items",
-                RowUuid::from_bytes([3; 16]),
                 BTreeMap::from([(
                     "label".to_owned(),
                     Value::String("receiver-secret".to_owned()),
                 )]),
+                jazz::db::InsertOptions {
+                    row_id: Some(RowUuid::from_bytes([3; 16])),
+                    ..Default::default()
+                },
             ))
             .unwrap();
             let other_query = WasmPreparedQuery {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -206,6 +206,7 @@ pub struct WasmQueryAttachment {
 #[wasm_bindgen]
 pub struct WasmWrite {
     payload: Vec<u8>,
+    row_id: RowUuid,
     batch_id: TransactionId,
     inner: Option<WasmWriteInner>,
 }
@@ -345,6 +346,11 @@ impl WasmWrite {
     #[wasm_bindgen(getter, js_name = payload)]
     pub fn payload(&self) -> Vec<u8> {
         self.payload.clone()
+    }
+
+    #[wasm_bindgen(getter, js_name = rowId)]
+    pub fn row_id(&self) -> Vec<u8> {
+        self.row_id.to_bytes()
     }
 
     #[wasm_bindgen(js_name = writeState)]
@@ -778,6 +784,35 @@ impl WasmDbInner {
         ))
     }
 
+    fn mergeable_insert_generated(
+        &self,
+        tx_id: OpenTransactionId,
+        table: &str,
+        cells: RowCells,
+        now_ms: Option<u64>,
+    ) -> Result<RowUuid, jazz::db::Error> {
+        with_wasm_db!(self, |db| match now_ms {
+            Some(now_ms) => block_on(
+                db.mergeable_tx_ref(tx_id)
+                    .insert_at_ms(table, cells, now_ms)
+            ),
+            None => block_on(db.mergeable_tx_ref(tx_id).insert(table, cells)),
+        })
+    }
+
+    fn mergeable_insert_generated_in_branch(
+        &self,
+        tx_id: OpenTransactionId,
+        table: &str,
+        cells: RowCells,
+        branch: BranchSelector,
+    ) -> Result<RowUuid, jazz::db::Error> {
+        with_wasm_db!(self, |db| block_on(
+            db.mergeable_tx_ref(tx_id)
+                .insert_in_branch(table, branch, cells)
+        ))
+    }
+
     fn mergeable_update(
         &self,
         tx_id: OpenTransactionId,
@@ -881,6 +916,17 @@ impl WasmDbInner {
         with_wasm_db!(self, |db| block_on(
             db.exclusive_tx_ref(tx_id)
                 .insert_with_id(table, row_id, cells)
+        ))
+    }
+
+    fn exclusive_insert_generated(
+        &self,
+        tx_id: OpenTransactionId,
+        table: &str,
+        cells: RowCells,
+    ) -> Result<RowUuid, jazz::db::Error> {
+        with_wasm_db!(self, |db| block_on(
+            db.exclusive_tx_ref(tx_id).insert(table, cells)
         ))
     }
 
@@ -1051,17 +1097,118 @@ impl WasmDbInner {
         with_wasm_db!(self, |db| db.set_tick_scheduler(Some(scheduler)))
     }
 
-    fn insert(&self, table: &str, cells: RowCells) -> Result<WasmWrite, JsValue> {
+    fn insert(
+        &self,
+        table: &str,
+        cells: RowCells,
+        updated_at_ms: Option<u64>,
+    ) -> Result<WasmWrite, JsValue> {
         match self {
             Self::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                block_on(db.insert(table, cells)).map_err(to_js_error)?,
+                match updated_at_ms {
+                    Some(now_ms) => block_on(db.insert_at_ms(table, cells, now_ms)),
+                    None => block_on(db.insert(table, cells)),
+                }
+                .map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
             Self::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.insert(table, cells)).map_err(to_js_error)?,
+                match updated_at_ms {
+                    Some(now_ms) => block_on(db.insert_at_ms(table, cells, now_ms)),
+                    None => block_on(db.insert(table, cells)),
+                }
+                .map_err(to_js_error)?,
             ),
+            Self::Closed => panic!("WasmDb is closed"),
+        }
+    }
+
+    fn insert_for_identity(
+        &self,
+        identity: AuthorId,
+        table: &str,
+        cells: RowCells,
+        updated_at_ms: Option<u64>,
+    ) -> Result<WasmWrite, JsValue> {
+        match self {
+            Self::Memory(db) => {
+                set_identity_claims(db, identity);
+                wasm_write_memory(
+                    Rc::clone(db),
+                    match updated_at_ms {
+                        Some(now_ms) => {
+                            block_on(db.insert_for_identity_at_ms(identity, table, cells, now_ms))
+                        }
+                        None => block_on(db.insert_for_identity(identity, table, cells)),
+                    }
+                    .map_err(to_js_error)?,
+                )
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                set_identity_claims(db, identity);
+                wasm_write_browser(
+                    Rc::clone(db),
+                    match updated_at_ms {
+                        Some(now_ms) => {
+                            block_on(db.insert_for_identity_at_ms(identity, table, cells, now_ms))
+                        }
+                        None => block_on(db.insert_for_identity(identity, table, cells)),
+                    }
+                    .map_err(to_js_error)?,
+                )
+            }
+            Self::Closed => panic!("WasmDb is closed"),
+        }
+    }
+
+    fn insert_in_branch(
+        &self,
+        table: &str,
+        cells: RowCells,
+        branch: BranchSelector,
+    ) -> Result<WasmWrite, JsValue> {
+        match self {
+            Self::Memory(db) => wasm_write_memory(
+                Rc::clone(db),
+                block_on(db.insert_in_branch(table, branch, cells)).map_err(to_js_error)?,
+            ),
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.insert_in_branch(table, branch, cells)).map_err(to_js_error)?,
+            ),
+            Self::Closed => panic!("WasmDb is closed"),
+        }
+    }
+
+    fn insert_in_branch_for_identity(
+        &self,
+        identity: AuthorId,
+        table: &str,
+        cells: RowCells,
+        branch: BranchSelector,
+    ) -> Result<WasmWrite, JsValue> {
+        match self {
+            Self::Memory(db) => {
+                set_identity_claims(db, identity);
+                wasm_write_memory(
+                    Rc::clone(db),
+                    block_on(db.insert_in_branch_for_identity(identity, table, branch, cells))
+                        .map_err(to_js_error)?,
+                )
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                set_identity_claims(db, identity);
+                wasm_write_browser(
+                    Rc::clone(db),
+                    block_on(db.insert_in_branch_for_identity(identity, table, branch, cells))
+                        .map_err(to_js_error)?,
+                )
+            }
             Self::Closed => panic!("WasmDb is closed"),
         }
     }
@@ -2176,9 +2323,65 @@ impl WasmDb {
     }
 
     #[wasm_bindgen(js_name = insertEncoded)]
-    pub fn insert_encoded(&self, table: String, cells: Vec<u8>) -> Result<WasmWrite, JsValue> {
+    pub fn insert_encoded(
+        &self,
+        table: String,
+        cells: Vec<u8>,
+        updated_at_ms: Option<f64>,
+    ) -> Result<WasmWrite, JsValue> {
         let cells = decode_cells(&cells)?;
-        self.inner.insert(&table, cells)
+        self.inner
+            .insert(&table, cells, updated_at_ms.map(|value| value as u64))
+    }
+
+    #[wasm_bindgen(js_name = insertEncodedForIdentity)]
+    pub fn insert_encoded_for_identity(
+        &self,
+        table: String,
+        cells: Vec<u8>,
+        author: Vec<u8>,
+        updated_at_ms: Option<f64>,
+    ) -> Result<WasmWrite, JsValue> {
+        let cells = decode_cells(&cells)?;
+        let author = author_id_from_bytes(&author)?;
+        self.inner.insert_for_identity(
+            author,
+            &table,
+            cells,
+            updated_at_ms.map(|value| value as u64),
+        )
+    }
+
+    #[wasm_bindgen(js_name = insertEncodedInBranch)]
+    pub fn insert_encoded_in_branch(
+        &self,
+        table: String,
+        cells: Vec<u8>,
+        branch: JsValue,
+    ) -> Result<WasmWrite, JsValue> {
+        self.inner.insert_in_branch(
+            &table,
+            decode_cells(&cells)?,
+            serde_wasm_bindgen::from_value(branch)
+                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
+        )
+    }
+
+    #[wasm_bindgen(js_name = insertEncodedInBranchForIdentity)]
+    pub fn insert_encoded_in_branch_for_identity(
+        &self,
+        table: String,
+        cells: Vec<u8>,
+        branch: JsValue,
+        author: Vec<u8>,
+    ) -> Result<WasmWrite, JsValue> {
+        self.inner.insert_in_branch_for_identity(
+            author_id_from_bytes(&author)?,
+            &table,
+            decode_cells(&cells)?,
+            serde_wasm_bindgen::from_value(branch)
+                .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?,
+        )
     }
 
     #[wasm_bindgen(js_name = canInsertEncoded)]
@@ -3300,6 +3503,52 @@ impl WasmTransport {
 
 #[wasm_bindgen]
 impl WasmTx {
+    #[wasm_bindgen(js_name = insertEncoded)]
+    pub fn insert_encoded(
+        &mut self,
+        table: String,
+        cells: Vec<u8>,
+        updated_at_ms: Option<f64>,
+    ) -> Result<Vec<u8>, JsValue> {
+        let cells = decode_cells(&cells)?;
+        let now_ms = updated_at_ms.map(|value| value as u64);
+        let open_tx = self.open_tx_for_read()?;
+        let row_id = match self.kind {
+            WasmTxKind::Mergeable => self
+                .db
+                .mergeable_insert_generated(open_tx, &table, cells, now_ms),
+            WasmTxKind::Exclusive => self.db.exclusive_insert_generated(open_tx, &table, cells),
+        }
+        .map_err(to_js_error)?;
+        Ok(row_id.to_bytes())
+    }
+
+    #[wasm_bindgen(js_name = insertEncodedInBranch)]
+    pub fn insert_encoded_in_branch(
+        &mut self,
+        table: String,
+        cells: Vec<u8>,
+        branch: JsValue,
+    ) -> Result<Vec<u8>, JsValue> {
+        if !matches!(self.kind, WasmTxKind::Mergeable) {
+            return Err(JsValue::from_str(
+                "branch writes require a mergeable transaction",
+            ));
+        }
+        let branch = serde_wasm_bindgen::from_value(branch)
+            .map_err(|error| JsValue::from_str(&format!("invalid branch selector: {error}")))?;
+        let row_id = self
+            .db
+            .mergeable_insert_generated_in_branch(
+                self.open_tx_for_read()?,
+                &table,
+                decode_cells(&cells)?,
+                branch,
+            )
+            .map_err(to_js_error)?;
+        Ok(row_id.to_bytes())
+    }
+
     #[wasm_bindgen(js_name = insertWithIdEncoded)]
     pub fn insert_with_id_encoded(
         &mut self,
@@ -3842,6 +4091,7 @@ fn wasm_write_memory(
     };
     Ok(WasmWrite {
         payload: postcard::to_allocvec(&result).map_err(to_js_error)?,
+        row_id: result.row_id,
         batch_id: TransactionId::from_committed_tx(tx_id),
         inner: Some(WasmWriteInner::MemoryTx { db, tx_id }),
     })
@@ -3859,6 +4109,7 @@ fn wasm_write_browser(
     };
     Ok(WasmWrite {
         payload: postcard::to_allocvec(&result).map_err(to_js_error)?,
+        row_id: result.row_id,
         batch_id: TransactionId::from_committed_tx(tx_id),
         inner: Some(WasmWriteInner::BrowserTx { db, tx_id }),
     })
@@ -3871,6 +4122,7 @@ fn wasm_tx_write(tx_id: TxId, inner: Option<WasmWriteInner>) -> Result<WasmWrite
     };
     Ok(WasmWrite {
         payload: postcard::to_allocvec(&result).map_err(to_js_error)?,
+        row_id: result.row_id,
         batch_id: TransactionId::from_committed_tx(tx_id),
         inner,
     })

--- a/crates/jazz/benches/authorization_scope_benchmark.rs
+++ b/crates/jazz/benches/authorization_scope_benchmark.rs
@@ -94,7 +94,11 @@ fn setup(row_count: usize, extra_columns: usize, seed: u64) -> DirectDb {
 
     for index in 0..row_count {
         let write = db
-            .insert("items", item_cells(index, extra_columns))
+            .insert(
+                "items",
+                item_cells(index, extra_columns),
+                Default::default(),
+            )
             .expect("insert benchmark item");
         block_on(write.wait(DurabilityTier::Local)).expect("seed row should be local");
     }

--- a/crates/jazz/benches/db_benchmark.rs
+++ b/crates/jazz/benches/db_benchmark.rs
@@ -143,7 +143,7 @@ fn seed_documents(db: &DirectDb, count: usize) -> Vec<RowUuid> {
     (0..count)
         .map(|index| {
             let write = db
-                .insert("documents", cells(index))
+                .insert("documents", cells(index), Default::default())
                 .expect("seed core benchmark row");
             block_on(write.wait(DurabilityTier::Local)).expect("seed row should be local");
             write.row_uuid()
@@ -155,7 +155,7 @@ fn seed_filtered_documents(db: &DirectDb, count: usize) -> Vec<RowUuid> {
     (0..count)
         .map(|index| {
             let write = db
-                .insert("documents", filtered_cells(index))
+                .insert("documents", filtered_cells(index), Default::default())
                 .expect("seed core benchmark row");
             block_on(write.wait(DurabilityTier::Local)).expect("seed row should be local");
             write.row_uuid()
@@ -166,10 +166,13 @@ fn seed_filtered_documents(db: &DirectDb, count: usize) -> Vec<RowUuid> {
 fn seed_reachable_policy_fixture(db: &DirectDb, count: usize) -> Vec<RowUuid> {
     for (row, name) in [(USER_TEAM, "user team"), (PARENT_TEAM, "parent team")] {
         let write = db
-            .insert_with_id(
+            .insert(
                 "teams",
-                row,
                 BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+                jazz::db::InsertOptions {
+                    row_id: Some(row),
+                    ..Default::default()
+                },
             )
             .expect("seed team");
         block_on(write.wait(DurabilityTier::Local)).expect("seed team should be local");
@@ -182,6 +185,7 @@ fn seed_reachable_policy_fixture(db: &DirectDb, count: usize) -> Vec<RowUuid> {
                 ("member".to_owned(), Value::Uuid(USER_TEAM.0)),
                 ("parent".to_owned(), Value::Uuid(PARENT_TEAM.0)),
             ]),
+            Default::default(),
         )
         .expect("seed team edge");
     block_on(write.wait(DurabilityTier::Local)).expect("seed edge should be local");
@@ -195,6 +199,7 @@ fn seed_reachable_policy_fixture(db: &DirectDb, count: usize) -> Vec<RowUuid> {
                     ("document".to_owned(), Value::Uuid(row.0)),
                     ("team".to_owned(), Value::Uuid(PARENT_TEAM.0)),
                 ]),
+                Default::default(),
             )
             .expect("seed document access");
         block_on(write.wait(DurabilityTier::Local)).expect("seed access should be local");
@@ -232,7 +237,7 @@ fn core_insert(c: &mut Criterion) {
                 b.iter(|| {
                     next += 1;
                     let write = db
-                        .insert("documents", cells(next))
+                        .insert("documents", cells(next), Default::default())
                         .expect("core insert should succeed");
                     block_on(write.wait(DurabilityTier::Local)).expect("insert should be local");
                     write.row_uuid()
@@ -268,6 +273,7 @@ fn core_update_and_read(c: &mut Criterion) {
                             "content".to_owned(),
                             Value::String(format!("Updated content {index}")),
                         )]),
+                        Default::default(),
                     )
                     .expect("core update should succeed");
                     db.read(&query).expect("core read should succeed").len()
@@ -355,7 +361,7 @@ fn core_subscribed_write(c: &mut Criterion) {
 
                 b.iter(|| {
                     next += 1;
-                    db.insert("documents", cells(next))
+                    db.insert("documents", cells(next), Default::default())
                         .expect("core subscribed insert should succeed");
                     match block_on(subscription.next_event()) {
                         Some(SubscriptionEvent::Delta { added, .. }) => added.len(),
@@ -391,7 +397,7 @@ fn core_owner_policy_insert(c: &mut Criterion) {
                         PermissionAdvice::Unknown,
                     );
                     let write = db
-                        .insert("documents", candidate)
+                        .insert("documents", candidate, Default::default())
                         .expect("owner policy insert should succeed");
                     block_on(write.wait(DurabilityTier::Local))
                         .expect("owner policy insert should be local");

--- a/crates/jazz/benches/insert_benchmark.rs
+++ b/crates/jazz/benches/insert_benchmark.rs
@@ -164,14 +164,25 @@ fn seed_data(db: &BenchDb, scale: usize) -> BenchmarkData {
         let owner = if is_owned { AUTHOR } else { OTHER_AUTHOR };
 
         let write = db
-            .insert_with_id("folders", folder, folder_cells(index, owner))
+            .insert(
+                "folders",
+                folder_cells(index, owner),
+                jazz::db::InsertOptions {
+                    row_id: Some(folder),
+                    ..Default::default()
+                },
+            )
             .expect("seed folder");
         wait_local(write);
 
         if is_owned || is_team_accessible {
             let role = if is_owned { "owner" } else { "member" };
             let write = db
-                .insert("folder_access", access_cells(folder, AUTHOR, role))
+                .insert(
+                    "folder_access",
+                    access_cells(folder, AUTHOR, role),
+                    Default::default(),
+                )
                 .expect("seed folder access");
             wait_local(write);
         }
@@ -204,6 +215,7 @@ fn seed_data(db: &BenchDb, scale: usize) -> BenchmarkData {
                     author,
                     index as u64,
                 ),
+                Default::default(),
             )
             .expect("seed document");
         wait_local(write);
@@ -238,6 +250,7 @@ fn insert_own_folder(c: &mut Criterion) {
                             AUTHOR,
                             current_timestamp(),
                         ),
+                        Default::default(),
                     )
                     .expect("own-folder insert should succeed");
                 wait_local(write)
@@ -271,6 +284,7 @@ fn insert_team_folder(c: &mut Criterion) {
                             OTHER_AUTHOR,
                             current_timestamp(),
                         ),
+                        Default::default(),
                     )
                     .expect("team-folder insert should succeed via folder access");
                 wait_local(write)
@@ -317,6 +331,7 @@ fn insert_batch(c: &mut Criterion) {
                                     AUTHOR,
                                     timestamp + index as u64,
                                 ),
+                                Default::default(),
                             )
                             .expect("batch insert should succeed");
                         wait_local(write);

--- a/crates/jazz/benches/observer_write_path.rs
+++ b/crates/jazz/benches/observer_write_path.rs
@@ -75,7 +75,7 @@ fn document_cells(index: usize) -> BTreeMap<String, Value> {
 fn seed_documents(db: &BenchDb, count: usize) -> Vec<RowUuid> {
     (0..count)
         .map(|index| {
-            db.insert("documents", document_cells(index))
+            db.insert("documents", document_cells(index), Default::default())
                 .expect("seed core observer benchmark row")
                 .row_uuid()
         })
@@ -117,8 +117,13 @@ fn update_write_path_with_and_without_observer(c: &mut Criterion) {
                     let row = rows[row_index % rows.len()];
                     row_index += 1;
 
-                    db.update("documents", row, content_update(update_index))
-                        .expect("core update without observer should succeed")
+                    db.update(
+                        "documents",
+                        row,
+                        content_update(update_index),
+                        Default::default(),
+                    )
+                    .expect("core update without observer should succeed")
                 });
             },
         );
@@ -149,8 +154,13 @@ fn update_write_path_with_and_without_observer(c: &mut Criterion) {
                     let row = rows[row_index % rows.len()];
                     row_index += 1;
 
-                    db.update("documents", row, content_update(update_index))
-                        .expect("core update with observer should succeed");
+                    db.update(
+                        "documents",
+                        row,
+                        content_update(update_index),
+                        Default::default(),
+                    )
+                    .expect("core update with observer should succeed");
                     match block_on(subscription.next_event()) {
                         Some(SubscriptionEvent::Delta { updated, .. }) => updated.len(),
                         other => panic!("expected subscription delta event, got {other:?}"),

--- a/crates/jazz/benches/owner_filter_diagnostic.rs
+++ b/crates/jazz/benches/owner_filter_diagnostic.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use jazz::db::{
-    Db, DbConfig, DbIdentity, LocalUpdates, MergeableTxOps, Propagation, ReadOpts,
+    Db, DbConfig, DbIdentity, InsertOptions, LocalUpdates, MergeableTxOps, Propagation, ReadOpts,
     SeededRowIdSource, block_on,
 };
 use jazz::groove::db::StorageReadMetrics;
@@ -146,9 +146,8 @@ fn seed_rows(db: &Db<RocksDbStorage>, table_rows: usize, owned_rows: usize, batc
             } else {
                 OTHER_AUTHOR
             };
-            block_on(tx.insert_with_id(
+            block_on(tx.insert(
                 TABLE,
-                row(index),
                 BTreeMap::from([
                     ("owner".to_owned(), Value::Uuid(owner.0)),
                     ("active".to_owned(), Value::Bool(true)),
@@ -158,6 +157,10 @@ fn seed_rows(db: &Db<RocksDbStorage>, table_rows: usize, owned_rows: usize, batc
                         Value::String(format!("document-{index}")),
                     ),
                 ]),
+                InsertOptions {
+                    row_id: Some(row(index)),
+                    ..Default::default()
+                },
             ))
             .expect("stage owner-filter row");
         }

--- a/crates/jazz/benches/realistic_phase1.rs
+++ b/crates/jazz/benches/realistic_phase1.rs
@@ -518,8 +518,15 @@ where
         .map(|index| {
             let row = row_uuid(0x11, index);
             wait_local(
-                db.insert_with_id("users", row, user_cells(index))
-                    .expect("seed user"),
+                db.insert(
+                    "users",
+                    user_cells(index),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
+                )
+                .expect("seed user"),
             );
             row
         })
@@ -529,8 +536,15 @@ where
         .map(|index| {
             let row = row_uuid(0x1f, index);
             wait_local(
-                db.insert_with_id("organizations", row, organization_cells(index))
-                    .expect("seed organization"),
+                db.insert(
+                    "organizations",
+                    organization_cells(index),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
+                )
+                .expect("seed organization"),
             );
             row
         })
@@ -541,6 +555,7 @@ where
             db.insert(
                 "memberships",
                 membership_cells(index, &organizations, &users),
+                Default::default(),
             )
             .expect("seed membership"),
         );
@@ -550,10 +565,13 @@ where
         .map(|index| {
             let row = row_uuid(0x22, index);
             wait_local(
-                db.insert_with_id(
+                db.insert(
                     "projects",
-                    row,
                     project_cells(index, &organizations, &users),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
                 )
                 .expect("seed project"),
             );
@@ -565,8 +583,15 @@ where
         .map(|index| {
             let row = row_uuid(0x33, index);
             wait_local(
-                db.insert_with_id("tasks", row, task_cells(index, &projects, &users))
-                    .expect("seed task"),
+                db.insert(
+                    "tasks",
+                    task_cells(index, &projects, &users),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
+                )
+                .expect("seed task"),
             );
             row
         })
@@ -574,8 +599,12 @@ where
 
     for index in 0..profile.comments {
         wait_local(
-            db.insert("comments", comment_cells(index, &tasks, &users))
-                .expect("seed comment"),
+            db.insert(
+                "comments",
+                comment_cells(index, &tasks, &users),
+                Default::default(),
+            )
+            .expect("seed comment"),
         );
     }
 
@@ -583,7 +612,7 @@ where
         for watcher_offset in 0..profile.watchers_per_task {
             let user = users[(task_index + watcher_offset) % users.len()];
             wait_local(
-                db.insert("watchers", watcher_cells(*task, user))
+                db.insert("watchers", watcher_cells(*task, user), Default::default())
                     .expect("seed watcher"),
             );
         }
@@ -591,8 +620,12 @@ where
 
     for index in 0..profile.activity_events {
         wait_local(
-            db.insert("activity", activity_cells(index, &projects, &tasks, &users))
-                .expect("seed activity"),
+            db.insert(
+                "activity",
+                activity_cells(index, &projects, &tasks, &users),
+                Default::default(),
+            )
+            .expect("seed activity"),
         );
     }
 
@@ -611,8 +644,15 @@ where
         .map(|index| {
             let row = row_uuid(0x41, index);
             wait_local(
-                db.insert_with_id("users", row, user_cells(index))
-                    .expect("seed resume user"),
+                db.insert(
+                    "users",
+                    user_cells(index),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
+                )
+                .expect("seed resume user"),
             );
             row
         })
@@ -622,8 +662,15 @@ where
         .map(|index| {
             let row = row_uuid(0x42, index);
             wait_local(
-                db.insert_with_id("organizations", row, organization_cells(index))
-                    .expect("seed resume organization"),
+                db.insert(
+                    "organizations",
+                    organization_cells(index),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
+                )
+                .expect("seed resume organization"),
             );
             row
         })
@@ -633,10 +680,13 @@ where
         .map(|index| {
             let row = row_uuid(0x43, index);
             wait_local(
-                db.insert_with_id(
+                db.insert(
                     "projects",
-                    row,
                     project_cells(index, &organizations, &users),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
                 )
                 .expect("seed resume project"),
             );
@@ -648,8 +698,15 @@ where
         .map(|index| {
             let row = row_uuid(0x44, index);
             wait_local(
-                db.insert_with_id("tasks", row, task_cells(index, &projects, &users))
-                    .expect("seed resume task"),
+                db.insert(
+                    "tasks",
+                    task_cells(index, &projects, &users),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
+                )
+                .expect("seed resume task"),
             );
             row
         })
@@ -774,8 +831,15 @@ fn seed_recursive_permissions_fixture(db: &BenchDb) {
         (RECURSIVE_HIDDEN_TEAM, "hidden"),
     ] {
         wait_local(
-            db.insert_with_id("teams", team, recursive_team_cells(name))
-                .expect("seed recursive team"),
+            db.insert(
+                "teams",
+                recursive_team_cells(name),
+                jazz::db::InsertOptions {
+                    row_id: Some(team),
+                    ..Default::default()
+                },
+            )
+            .expect("seed recursive team"),
         );
     }
 
@@ -785,8 +849,15 @@ fn seed_recursive_permissions_fixture(db: &BenchDb) {
         (RECURSIVE_DOC_HIDDEN, "hidden", "hidden"),
     ] {
         wait_local(
-            db.insert_with_id("docs", doc, recursive_doc_cells(title, kind))
-                .expect("seed recursive doc"),
+            db.insert(
+                "docs",
+                recursive_doc_cells(title, kind),
+                jazz::db::InsertOptions {
+                    row_id: Some(doc),
+                    ..Default::default()
+                },
+            )
+            .expect("seed recursive doc"),
         );
     }
 
@@ -796,8 +867,12 @@ fn seed_recursive_permissions_fixture(db: &BenchDb) {
         (RECURSIVE_DOC_HIDDEN, RECURSIVE_HIDDEN_TEAM),
     ] {
         wait_local(
-            db.insert("doc_access", recursive_doc_access_cells(doc, team))
-                .expect("seed recursive doc access"),
+            db.insert(
+                "doc_access",
+                recursive_doc_access_cells(doc, team),
+                Default::default(),
+            )
+            .expect("seed recursive doc access"),
         );
     }
 
@@ -805,6 +880,7 @@ fn seed_recursive_permissions_fixture(db: &BenchDb) {
         db.insert(
             "team_edges",
             recursive_team_edge_cells(RECURSIVE_READER_TEAM, RECURSIVE_PARENT_TEAM),
+            Default::default(),
         )
         .expect("seed recursive team edge"),
     );
@@ -817,16 +893,26 @@ fn seed_permission_resume_fixture(db: &BenchDb) {
         (RECURSIVE_HIDDEN_TEAM, "hidden"),
     ] {
         wait_local(
-            db.insert_with_id("teams", team, recursive_team_cells(name))
-                .expect("seed resume permission team"),
+            db.insert(
+                "teams",
+                recursive_team_cells(name),
+                jazz::db::InsertOptions {
+                    row_id: Some(team),
+                    ..Default::default()
+                },
+            )
+            .expect("seed resume permission team"),
         );
     }
 
     wait_local(
-        db.insert_with_id(
+        db.insert(
             "team_edges",
-            RESUME_EDGE_READER_PARENT,
             recursive_team_edge_cells(RECURSIVE_READER_TEAM, RECURSIVE_PARENT_TEAM),
+            jazz::db::InsertOptions {
+                row_id: Some(RESUME_EDGE_READER_PARENT),
+                ..Default::default()
+            },
         )
         .expect("seed resume permission team edge"),
     );
@@ -838,8 +924,15 @@ fn seed_permission_resume_fixture(db: &BenchDb) {
         (RESUME_DOC_NEVER, "never", "never-visible"),
     ] {
         wait_local(
-            db.insert_with_id("docs", doc, recursive_doc_cells(title, kind))
-                .expect("seed resume permission doc"),
+            db.insert(
+                "docs",
+                recursive_doc_cells(title, kind),
+                jazz::db::InsertOptions {
+                    row_id: Some(doc),
+                    ..Default::default()
+                },
+            )
+            .expect("seed resume permission doc"),
         );
     }
 
@@ -857,8 +950,15 @@ fn seed_permission_resume_fixture(db: &BenchDb) {
         (RESUME_ACCESS_NEVER, RESUME_DOC_NEVER, RECURSIVE_HIDDEN_TEAM),
     ] {
         wait_local(
-            db.insert_with_id("doc_access", access, recursive_doc_access_cells(doc, team))
-                .expect("seed resume permission access"),
+            db.insert(
+                "doc_access",
+                recursive_doc_access_cells(doc, team),
+                jazz::db::InsertOptions {
+                    row_id: Some(access),
+                    ..Default::default()
+                },
+            )
+            .expect("seed resume permission access"),
         );
     }
 }
@@ -1041,6 +1141,7 @@ fn r1_crud(c: &mut Criterion) {
                         .insert(
                             "tasks",
                             task_cells(next_task, &fixture.projects, &fixture.users),
+                            Default::default(),
                         )
                         .expect("insert task");
                     let inserted_row = inserted.row_uuid();
@@ -1056,12 +1157,16 @@ fn r1_crud(c: &mut Criterion) {
                                 ("status".to_owned(), Value::String("review".to_owned())),
                                 ("updated_at".to_owned(), Value::U64(next_task as u64)),
                             ]),
+                            Default::default(),
                         )
                         .expect("update task"),
                     );
                     update_index += 1;
 
-                    wait_local(db.delete("tasks", inserted_row).expect("delete task"));
+                    wait_local(
+                        db.delete("tasks", inserted_row, Default::default())
+                            .expect("delete task"),
+                    );
                 });
             },
         );
@@ -1637,6 +1742,7 @@ fn r4_hot_task_history(c: &mut Criterion) {
                                 ),
                                 ("updated_at".to_owned(), Value::U64(event_index as u64)),
                             ]),
+                            Default::default(),
                         )
                         .expect("hot task update"),
                     );
@@ -1644,6 +1750,7 @@ fn r4_hot_task_history(c: &mut Criterion) {
                         db.insert(
                             "comments",
                             comment_cells(event_index, &[hot_task], &fixture.users),
+                            Default::default(),
                         )
                         .expect("hot task comment"),
                     );
@@ -1656,6 +1763,7 @@ fn r4_hot_task_history(c: &mut Criterion) {
                                 &[hot_task],
                                 &fixture.users,
                             ),
+                            Default::default(),
                         )
                         .expect("hot task activity"),
                     );
@@ -1712,6 +1820,7 @@ fn r9_subscribed_write(c: &mut Criterion) {
                                 ("status".to_owned(), Value::String("doing".to_owned())),
                                 ("updated_at".to_owned(), Value::U64(task_index as u64)),
                             ]),
+                            Default::default(),
                         )
                         .expect("subscribed task update"),
                     );
@@ -1791,6 +1900,7 @@ fn r10_sync_fanout(c: &mut Criterion) {
                                         Value::U64((profile.tasks + update_index) as u64),
                                     ),
                                 ]),
+                                Default::default(),
                             )
                             .expect("writer project-board update"),
                     );
@@ -1889,7 +1999,7 @@ fn r11_byte_wire_resume(c: &mut Criterion) {
                                         Value::String(changed_status.to_owned()),
                                     ),
                                     ("updated_at".to_owned(), Value::U64(9_001)),
-                                ]),
+                                ]), Default::default()
                             )
                             .expect("writer disconnected task update"),
                     );
@@ -2052,22 +2162,26 @@ fn run_permission_filtered_resume(
                     "doc_access",
                     RESUME_ACCESS_REVOKED,
                     recursive_doc_access_cells(RESUME_DOC_REVOKED, RECURSIVE_HIDDEN_TEAM),
+                    Default::default(),
                 )
                 .expect("hide disconnected doc access before revoke"),
         );
         wait_local(
             writer
-                .delete("doc_access", RESUME_ACCESS_REVOKED)
+                .delete("doc_access", RESUME_ACCESS_REVOKED, Default::default())
                 .expect("revoke disconnected doc access"),
         );
     }
     if churn.grants() {
         wait_local(
             writer
-                .insert_with_id(
+                .insert(
                     "doc_access",
-                    RESUME_ACCESS_GRANTED,
                     recursive_doc_access_cells(RESUME_DOC_GRANTED, RECURSIVE_PARENT_TEAM),
+                    jazz::db::InsertOptions {
+                        row_id: Some(RESUME_ACCESS_GRANTED),
+                        ..Default::default()
+                    },
                 )
                 .expect("grant disconnected doc access"),
         );
@@ -2175,10 +2289,13 @@ fn run_claim_filtered_resume(
     ] {
         wait_local(
             writer
-                .insert_with_id(
+                .insert(
                     "claim_docs",
-                    row,
                     BTreeMap::from([("title".to_owned(), Value::String(title.to_owned()))]),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row),
+                        ..Default::default()
+                    },
                 )
                 .expect("seed claim-resume doc"),
         );

--- a/crates/jazz/benches/relation_include_delivery.rs
+++ b/crates/jazz/benches/relation_include_delivery.rs
@@ -318,9 +318,8 @@ fn measure_single_child_insert(scale: usize, sample: usize) -> Measurement {
 
     reset_alloc_counter();
     let start = Instant::now();
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         "children",
-        row(10_000_000),
         BTreeMap::from([
             ("parent_id".to_owned(), Value::Uuid(parent.0)),
             (
@@ -329,6 +328,10 @@ fn measure_single_child_insert(scale: usize, sample: usize) -> Measurement {
             ),
             ("ordinal".to_owned(), Value::I32(1)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(10_000_000)),
+            ..Default::default()
+        },
     ))
     .expect("insert exactly one measured child");
     let event = block_on(stream.next_event()).expect("measured relation update");
@@ -346,9 +349,8 @@ fn measure_single_child_insert(scale: usize, sample: usize) -> Measurement {
 
 fn seed_relation_fixture(db: &Db<MemoryStorage>, child_rows: usize) -> RowUuid {
     let parent = row(1);
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         "parents",
-        parent,
         BTreeMap::from([
             (
                 "label".to_owned(),
@@ -356,17 +358,24 @@ fn seed_relation_fixture(db: &Db<MemoryStorage>, child_rows: usize) -> RowUuid {
             ),
             ("ordinal".to_owned(), Value::I32(0)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(parent),
+            ..Default::default()
+        },
     ))
     .expect("insert parent");
     for index in 0..child_rows {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             "children",
-            row(1_000 + index as u64),
             BTreeMap::from([
                 ("parent_id".to_owned(), Value::Uuid(parent.0)),
                 ("label".to_owned(), Value::String(format!("child-{index}"))),
                 ("ordinal".to_owned(), Value::I32(index as i32)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(row(1_000 + index as u64)),
+                ..Default::default()
+            },
         ))
         .unwrap_or_else(|error| panic!("seed child {index}: {error}"));
     }

--- a/crates/jazz/benches/route_subscription_curve.rs
+++ b/crates/jazz/benches/route_subscription_curve.rs
@@ -349,9 +349,8 @@ fn seed_fixture(db: &BenchDb) {
 }
 
 fn insert_document(db: &BenchDb, row: RowUuid, team: usize, updated_at: u64) {
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         DOCUMENTS,
-        row,
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(team_row(team).0)),
             ("updated_at".to_owned(), Value::U64(updated_at)),
@@ -360,6 +359,10 @@ fn insert_document(db: &BenchDb, row: RowUuid, team: usize, updated_at: u64) {
                 Value::String(format!("route {team} document {updated_at}")),
             ),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
     ))
     .expect("insert route curve document");
 }

--- a/crates/jazz/benches/selective_global_hydration.rs
+++ b/crates/jazz/benches/selective_global_hydration.rs
@@ -324,9 +324,8 @@ fn seed_rows(db: &Db<RocksDbStorage>, config: ConfigRef, table_rows: usize) {
             } else {
                 (filler_row(index), filler_team(), index)
             };
-            block_on(tx.insert_with_id(
+            block_on(tx.insert(
                 TABLE,
-                row,
                 BTreeMap::from([
                     ("team".to_owned(), Value::Uuid(team.0)),
                     ("active".to_owned(), Value::Bool(true)),
@@ -336,6 +335,10 @@ fn seed_rows(db: &Db<RocksDbStorage>, config: ConfigRef, table_rows: usize) {
                         Value::String(format!("document-{index}")),
                     ),
                 ]),
+                jazz::db::InsertOptions {
+                    row_id: Some(row),
+                    ..Default::default()
+                },
             ))
             .expect("stage selective-hydration seed row");
         }

--- a/crates/jazz/benches/subscription_benchmark.rs
+++ b/crates/jazz/benches/subscription_benchmark.rs
@@ -104,7 +104,7 @@ fn filtered_cells(index: usize) -> BTreeMap<String, Value> {
 fn seed_documents(db: &CoreDb, count: usize) {
     for index in 0..count {
         let write = db
-            .insert("documents", cells(index))
+            .insert("documents", cells(index), Default::default())
             .expect("seed core benchmark row");
         block_on(write.wait(DurabilityTier::Local)).expect("seed row should be local");
     }
@@ -113,7 +113,7 @@ fn seed_documents(db: &CoreDb, count: usize) {
 fn seed_filtered_documents(db: &CoreDb, count: usize) {
     for index in 0..count {
         let write = db
-            .insert("documents", filtered_cells(index))
+            .insert("documents", filtered_cells(index), Default::default())
             .expect("seed core benchmark row");
         block_on(write.wait(DurabilityTier::Local)).expect("seed row should be local");
     }
@@ -175,7 +175,7 @@ fn single_subscription_latency(c: &mut Criterion) {
 
             b.iter(|| {
                 next += 1;
-                db.insert("documents", cells(next))
+                db.insert("documents", cells(next), Default::default())
                     .expect("core subscribed insert should succeed");
                 assert_eq!(read_added_len(block_on(subscription.next_event())), 1);
             });
@@ -211,7 +211,7 @@ fn fanout_latency(c: &mut Criterion) {
 
                 b.iter(|| {
                     next += 1;
-                    db.insert("documents", cells(next))
+                    db.insert("documents", cells(next), Default::default())
                         .expect("core fanout insert should succeed");
 
                     let notified = subscriptions
@@ -277,7 +277,7 @@ fn filtered_subscription_latency(c: &mut Criterion) {
 
                 b.iter(|| {
                     next += 2;
-                    db.insert("documents", filtered_cells(next))
+                    db.insert("documents", filtered_cells(next), Default::default())
                         .expect("core filtered insert should succeed");
                     assert_eq!(read_added_len(block_on(subscription.next_event())), 1);
                 });
@@ -313,7 +313,7 @@ fn batch_insert_subscription_latency(c: &mut Criterion) {
                         .expect("core batch transaction should open");
                     for _ in 0..batch_size {
                         next += 2;
-                        tx.insert("documents", filtered_cells(next))
+                        tx.insert("documents", filtered_cells(next), Default::default())
                             .expect("core batch insert should stage");
                     }
                     tx.commit().expect("core batch insert should commit");

--- a/crates/jazz/benches/update_benchmark.rs
+++ b/crates/jazz/benches/update_benchmark.rs
@@ -108,6 +108,7 @@ fn seed_fixture(db: &CoreDb, count: usize) -> Fixture {
                 .insert(
                     "folders",
                     BTreeMap::from([("name".to_owned(), Value::String(format!("Folder {index}")))]),
+                    Default::default(),
                 )
                 .expect("seed folder");
             block_on(write.wait(DurabilityTier::Local)).expect("folder seed should be local");
@@ -119,7 +120,11 @@ fn seed_fixture(db: &CoreDb, count: usize) -> Fixture {
         .map(|index| {
             let folder = owned_folders[index % owned_folders.len()];
             let write = db
-                .insert("documents", document_cells(index, folder))
+                .insert(
+                    "documents",
+                    document_cells(index, folder),
+                    Default::default(),
+                )
                 .expect("seed owned document");
             block_on(write.wait(DurabilityTier::Local)).expect("document seed should be local");
             write.row_uuid()
@@ -159,6 +164,7 @@ fn update_own_documents(c: &mut Criterion) {
                             format!("Updated Title {update_counter}"),
                             "Updated content",
                         ),
+                        Default::default(),
                     )
                     .expect("update own document should succeed");
                 block_on(write.wait(DurabilityTier::Local)).expect("update should be local");
@@ -206,6 +212,7 @@ fn update_batch(c: &mut Criterion) {
                                     format!("Batch {batch_counter} Update {i}"),
                                     "Batch updated content",
                                 ),
+                                Default::default(),
                             )
                             .expect("batch update should succeed");
                         block_on(write.wait(DurabilityTier::Local))

--- a/crates/jazz/examples/commit_superlinearity_native.rs
+++ b/crates/jazz/examples/commit_superlinearity_native.rs
@@ -82,7 +82,11 @@ fn run_case(max_rows: usize, subscribed: bool) -> Result<(), Box<dyn std::error:
         let tx = block_on(db.mergeable_tx())?;
         let stage_start = Instant::now();
         for row in rows_before..rows_after {
-            block_on(tx.insert("todos", todo_cells(format!("todo {row:06}"), false)))?;
+            block_on(tx.insert(
+                "todos",
+                todo_cells(format!("todo {row:06}"), false),
+                Default::default(),
+            ))?;
         }
         let stage_ms = stage_start.elapsed().as_secs_f64() * 1000.0;
 

--- a/crates/jazz/examples/permissions.rs
+++ b/crates/jazz/examples/permissions.rs
@@ -222,7 +222,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(owner_db.read(&todos)?.len(), 0);
 
     let row = RowUuid::from_bytes([0x33; 16]);
-    block_on(owner_db.insert_with_id("todos", row, todo_cells("private", false, owner)))?;
+    block_on(owner_db.insert(
+        "todos",
+        todo_cells("private", false, owner),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    ))?;
 
     assert_eq!(owner_db.can_read("todos", row)?, PermissionAdvice::Unknown);
     assert_eq!(
@@ -254,10 +261,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         todo_cells("written by core for user", false, attributed_user),
     )?;
 
-    let client_err = match block_on(owner_db.insert_attributed(
-        other,
+    let client_err = match block_on(owner_db.insert(
         "todos",
         todo_cells("forged", false, other),
+        jazz::db::InsertOptions {
+            identity: jazz::db::WriteIdentity::Attribution(other),
+            ..Default::default()
+        },
     )) {
         Ok(_) => panic!("clients cannot attribute writes to another user"),
         Err(err) => err,
@@ -270,10 +280,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let forbidden_row = RowUuid::from_bytes([0x44; 16]);
-    let forbidden = block_on(other_db.insert_with_id(
+    let forbidden = block_on(other_db.insert(
         "todos",
-        forbidden_row,
         todo_cells("forbidden at authority", false, owner),
+        jazz::db::InsertOptions {
+            row_id: Some(forbidden_row),
+            ..Default::default()
+        },
     ))?;
     assert_eq!(
         block_on(forbidden.write_state())?,

--- a/crates/jazz/examples/todo.rs
+++ b/crates/jazz/examples/todo.rs
@@ -60,11 +60,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         id_source: Some(Box::new(SeededRowIdSource::new(0x1111))),
     }))?;
 
-    let insert_milk = block_on(db.insert("todos", todo_cells("buy milk", false)))?;
+    let insert_milk =
+        block_on(db.insert("todos", todo_cells("buy milk", false), Default::default()))?;
     let buy_milk = insert_milk.row_uuid();
     block_on(insert_milk.wait(DurabilityTier::Local))?;
 
-    let insert_docs = block_on(db.insert("todos", todo_cells("write docs", false)))?;
+    let insert_docs =
+        block_on(db.insert("todos", todo_cells("write docs", false), Default::default()))?;
     let write_docs = insert_docs.row_uuid();
     block_on(insert_docs.wait(DurabilityTier::Local))?;
 
@@ -76,10 +78,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "todos",
         buy_milk,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+        Default::default(),
     ))?;
     block_on(update_milk.wait(DurabilityTier::Local))?;
 
-    let delete_docs = block_on(db.delete("todos", write_docs))?;
+    let delete_docs = block_on(db.delete("todos", write_docs, Default::default()))?;
     block_on(delete_docs.wait(DurabilityTier::Local))?;
 
     let rows = block_on(db.all(&query, ReadOpts::default()))?;

--- a/crates/jazz/examples/transactions.rs
+++ b/crates/jazz/examples/transactions.rs
@@ -223,8 +223,16 @@ fn write_rejected(reason: RejectionReason) -> RejectionReason {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db = open_db()?;
     let mergeable = block_on(db.mergeable_tx())?;
-    let first = block_on(mergeable.insert("todos", todo_cells("write examples", false)))?;
-    let second = block_on(mergeable.insert("todos", todo_cells("run examples", true)))?;
+    let first = block_on(mergeable.insert(
+        "todos",
+        todo_cells("write examples", false),
+        Default::default(),
+    ))?;
+    let second = block_on(mergeable.insert(
+        "todos",
+        todo_cells("run examples", true),
+        Default::default(),
+    ))?;
     let mergeable_tx = block_on(mergeable.commit())?;
 
     let todos = db.prepare_query(&db.table("todos"))?;

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2090,6 +2090,140 @@ fn subscriber_permission_subject(ingest: CommitUnitIngestContext) -> AuthorId {
 /// Row cells supplied to write methods.
 pub type RowCells = BTreeMap<String, Value>;
 
+/// Identity used to author and authorize a standalone write.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum WriteIdentity {
+    /// Use the identity that opened the database.
+    #[default]
+    Database,
+    /// Author and authorize the write as this trusted session identity.
+    Session(AuthorId),
+    /// Attribute provenance while retaining the database identity as policy subject.
+    /// Client databases reject attribution to a different author.
+    Attribution(AuthorId),
+}
+
+/// Exact branch selected by an insert, upsert, or restore.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum ExactWriteTarget {
+    /// Write to the database's current root branch.
+    #[default]
+    Root,
+    /// Write to one exact branch key.
+    Branch(BranchSelector),
+}
+
+impl ExactWriteTarget {
+    fn branch(&self) -> BranchSelector {
+        match self {
+            Self::Root => BranchSelector::default(),
+            Self::Branch(branch) => branch.clone(),
+        }
+    }
+}
+
+/// Root or head-over-base view selected by an update or delete.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum WriteTarget {
+    /// Write to the database's current root branch.
+    #[default]
+    Root,
+    /// Write through a branch view, materializing inherited state in `head`.
+    BranchView {
+        /// Exact branch receiving the local write.
+        head: BranchSelector,
+        /// Optional inherited base view visible below `head`.
+        base: Option<BranchViewBase>,
+    },
+}
+
+/// Options for [`Db::insert`] and mergeable transaction inserts.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InsertOptions {
+    /// Caller-supplied row id, or a generated UUIDv7 row id when omitted.
+    pub row_id: Option<RowUuid>,
+    /// Standalone-write identity. Transactions use the identity chosen when opened.
+    pub identity: WriteIdentity,
+    /// Exact branch receiving the row.
+    pub target: ExactWriteTarget,
+    /// Explicit provenance timestamp, or the database clock when omitted.
+    pub updated_at_ms: Option<u64>,
+}
+
+/// Options for [`Db::update`] and mergeable transaction updates.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct UpdateOptions {
+    /// Standalone-write identity. Transactions use the identity chosen when opened.
+    pub identity: WriteIdentity,
+    /// Root or branch view through which the patch is applied.
+    pub target: WriteTarget,
+    /// Explicit provenance timestamp, or the database clock when omitted.
+    pub updated_at_ms: Option<u64>,
+}
+
+/// Options for [`Db::upsert`] and mergeable transaction upserts.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct UpsertOptions {
+    /// Standalone-write identity. Transactions use the identity chosen when opened.
+    pub identity: WriteIdentity,
+    /// Exact branch receiving the insert or update.
+    pub target: ExactWriteTarget,
+    /// Explicit provenance timestamp, or the database clock when omitted.
+    pub updated_at_ms: Option<u64>,
+}
+
+/// Options for [`Db::delete`] and mergeable transaction deletes.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DeleteOptions {
+    /// Standalone-write identity. Transactions use the identity chosen when opened.
+    pub identity: WriteIdentity,
+    /// Root or branch view through which the row is deleted.
+    pub target: WriteTarget,
+    /// Explicit provenance timestamp, or the database clock when omitted.
+    pub updated_at_ms: Option<u64>,
+}
+
+/// Options for [`Db::restore`] and mergeable transaction restores.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RestoreOptions {
+    /// Standalone-write identity. Transactions use the identity chosen when opened.
+    pub identity: WriteIdentity,
+    /// Exact branch whose deletion register is restored.
+    pub target: ExactWriteTarget,
+    /// Explicit provenance timestamp, or the database clock when omitted.
+    pub updated_at_ms: Option<u64>,
+}
+
+fn ensure_transaction_identity(identity: WriteIdentity) -> Result<(), Error> {
+    if identity == WriteIdentity::Database {
+        return Ok(());
+    }
+    Err(Error::new(
+        ErrorCode::Schema,
+        "transaction identity is selected when the transaction is opened",
+    ))
+}
+
+fn ensure_exclusive_target(target: &ExactWriteTarget) -> Result<(), Error> {
+    if *target != ExactWriteTarget::Root {
+        return Err(Error::new(
+            ErrorCode::Schema,
+            "exclusive transactions do not support branch writes",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_exclusive_view_target(target: &WriteTarget) -> Result<(), Error> {
+    if *target != WriteTarget::Root {
+        return Err(Error::new(
+            ErrorCode::Schema,
+            "exclusive transactions do not support branch writes",
+        ));
+    }
+    Ok(())
+}
+
 /// Build [`RowCells`] with bare identifier column names.
 ///
 /// Keys are converted to column names with `stringify!`, and values are
@@ -2106,6 +2240,7 @@ pub type RowCells = BTreeMap<String, Value>;
 ///         title: "Ship it",
 ///         done: false,
 ///     },
+///     Default::default(),
 /// ))?;
 /// block_on(write.wait(DurabilityTier::Local))?;
 ///
@@ -2142,152 +2277,168 @@ where
     /// The id of the already-open transaction.
     fn tx_id(&self) -> OpenTransactionId;
 
-    /// Stage an insert with a generated row id.
-    async fn insert(&self, table: &str, cells: RowCells) -> Result<RowUuid, Error> {
-        let row = self.db().row_id_source.borrow_mut().next_row_id();
-        self.insert_with_id(table, row, cells).await?;
-        Ok(row)
-    }
-
-    /// Stage an insert with a generated row id and explicit millisecond provenance time.
-    async fn insert_at_ms(
+    /// Stage one insert. Transaction identity is fixed when the transaction opens.
+    async fn insert(
         &self,
         table: &str,
         cells: RowCells,
-        now_ms: u64,
+        options: InsertOptions,
     ) -> Result<RowUuid, Error> {
-        let row = self.db().row_id_source.borrow_mut().next_row_id();
-        self.insert_with_id_at_ms(table, row, cells, now_ms).await?;
+        ensure_transaction_identity(options.identity)?;
+        let row = options
+            .row_id
+            .unwrap_or_else(|| self.db().row_id_source.borrow_mut().next_row_id());
+        match options.target {
+            ExactWriteTarget::Root => {
+                self.db()
+                    .stage_mergeable_insert(self.tx_id(), table, row, cells, options.updated_at_ms)
+                    .await?;
+            }
+            ExactWriteTarget::Branch(branch) => {
+                self.db()
+                    .stage_mergeable_insert_in_branch(
+                        self.tx_id(),
+                        table,
+                        branch,
+                        row,
+                        cells,
+                        options.updated_at_ms,
+                    )
+                    .await?;
+            }
+        }
         Ok(row)
     }
 
-    /// Stage an insert with a caller-supplied row id.
-    async fn insert_with_id(
+    /// Stage one update; omitted fields keep the transaction-local value.
+    async fn update(
         &self,
         table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<(), Error> {
-        self.insert_with_id_at_ms_option(table, row, cells, None)
-            .await
-    }
-
-    /// Stage an insert in one exact branch-local row.
-    async fn insert_with_id_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_insert_in_branch(self.tx_id(), table, branch, row, cells, None)
-            .await
-    }
-
-    /// Stage an insert in one exact branch-local row with a generated row id.
-    async fn insert_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        cells: RowCells,
-    ) -> Result<RowUuid, Error> {
-        let row = self.db().row_id_source.borrow_mut().next_row_id();
-        self.insert_with_id_in_branch(table, branch, row, cells)
-            .await?;
-        Ok(row)
-    }
-
-    /// Stage an insert with a caller-supplied row id and explicit millisecond provenance time.
-    async fn insert_with_id_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<(), Error> {
-        self.insert_with_id_at_ms_option(table, row, cells, Some(now_ms))
-            .await
-    }
-
-    /// Stage an update; omitted fields keep the transaction-local value.
-    async fn update(&self, table: &str, row: RowUuid, patch: RowCells) -> Result<(), Error> {
-        self.update_at_ms_option(table, row, patch, None).await
-    }
-
-    /// Stage an update through a head-over-base branch view.
-    async fn update_in_branch_view(
-        &self,
-        table: &str,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
         row: RowUuid,
         patch: RowCells,
+        options: UpdateOptions,
     ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_update_in_branch_view(
-                self.tx_id(),
-                table,
-                head,
-                base,
-                row,
-                patch,
-                None,
+        ensure_transaction_identity(options.identity)?;
+        match options.target {
+            WriteTarget::Root => {
+                self.db()
+                    .stage_mergeable_update(self.tx_id(), table, row, patch, options.updated_at_ms)
+                    .await
+            }
+            WriteTarget::BranchView { head, base } => {
+                self.db()
+                    .stage_mergeable_update_in_branch_view(
+                        self.tx_id(),
+                        table,
+                        head,
+                        base,
+                        row,
+                        patch,
+                        options.updated_at_ms,
+                    )
+                    .await
+            }
+        }
+    }
+
+    /// Stage one upsert.
+    async fn upsert(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: RowCells,
+        options: UpsertOptions,
+    ) -> Result<(), Error> {
+        ensure_transaction_identity(options.identity)?;
+        match options.target {
+            ExactWriteTarget::Root => {
+                if self.read(table, row).await?.is_some() {
+                    self.db()
+                        .stage_mergeable_update(
+                            self.tx_id(),
+                            table,
+                            row,
+                            cells,
+                            options.updated_at_ms,
+                        )
+                        .await
+                } else {
+                    self.db()
+                        .stage_mergeable_insert(
+                            self.tx_id(),
+                            table,
+                            row,
+                            cells,
+                            options.updated_at_ms,
+                        )
+                        .await
+                }
+            }
+            ExactWriteTarget::Branch(_) => Err(Error::new(
+                ErrorCode::Schema,
+                "branch upserts are not supported inside transactions",
+            )),
+        }
+    }
+
+    /// Stage one soft delete.
+    async fn delete(&self, table: &str, row: RowUuid, options: DeleteOptions) -> Result<(), Error> {
+        ensure_transaction_identity(options.identity)?;
+        match options.target {
+            WriteTarget::Root => {
+                self.db()
+                    .stage_mergeable_delete(self.tx_id(), table, row, options.updated_at_ms)
+                    .await
+            }
+            WriteTarget::BranchView { head, base } => {
+                self.db()
+                    .stage_mergeable_delete_in_branch_view(
+                        self.tx_id(),
+                        table,
+                        head,
+                        base,
+                        row,
+                        options.updated_at_ms,
+                    )
+                    .await
+            }
+        }
+    }
+
+    /// Stage one restore, optionally replacing row content.
+    async fn restore(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: Option<RowCells>,
+        options: RestoreOptions,
+    ) -> Result<(), Error> {
+        ensure_transaction_identity(options.identity)?;
+        let cells = cells.ok_or_else(|| {
+            Error::new(
+                ErrorCode::Schema,
+                "transaction restores currently require replacement cells",
             )
-            .await
-    }
-
-    /// Stage an update with an explicit millisecond provenance time.
-    async fn update_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        patch: RowCells,
-        now_ms: u64,
-    ) -> Result<(), Error> {
-        self.update_at_ms_option(table, row, patch, Some(now_ms))
-            .await
-    }
-
-    /// Stage a soft delete.
-    async fn delete(&self, table: &str, row: RowUuid) -> Result<(), Error> {
-        self.delete_at_ms_option(table, row, None).await
-    }
-
-    /// Stage a deletion through a head-over-base branch view.
-    async fn delete_in_branch_view(
-        &self,
-        table: &str,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-        row: RowUuid,
-    ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_delete_in_branch_view(self.tx_id(), table, head, base, row, None)
-            .await
-    }
-
-    /// Stage a soft delete with explicit millisecond provenance time.
-    async fn delete_at_ms(&self, table: &str, row: RowUuid, now_ms: u64) -> Result<(), Error> {
-        self.delete_at_ms_option(table, row, Some(now_ms)).await
-    }
-
-    /// Stage a restore, applying defaults for omitted columns.
-    async fn restore(&self, table: &str, row: RowUuid, cells: RowCells) -> Result<(), Error> {
-        self.restore_at_ms_option(table, row, cells, None).await
-    }
-
-    /// Stage a restore in one exact branch-local row.
-    async fn restore_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_restore_in_branch(self.tx_id(), table, branch, row, cells, None)
-            .await
+        })?;
+        match options.target {
+            ExactWriteTarget::Root => {
+                self.db()
+                    .stage_mergeable_restore(self.tx_id(), table, row, cells, options.updated_at_ms)
+                    .await
+            }
+            ExactWriteTarget::Branch(branch) => {
+                self.db()
+                    .stage_mergeable_restore_in_branch(
+                        self.tx_id(),
+                        table,
+                        branch,
+                        row,
+                        cells,
+                        options.updated_at_ms,
+                    )
+                    .await
+            }
+        }
     }
 
     /// Stage an atomic move of one object branch-local row between exact branch
@@ -2333,20 +2484,28 @@ where
             .project_branch_selector(table_schema, &target)
             .map_err(|message| Error::new(ErrorCode::Schema, message))?;
         cells.extend(target_cells);
-        self.restore_in_branch(table, target, row, cells).await?;
-        self.delete_in_branch_view(table, source, None, row).await
-    }
-
-    /// Stage a restore with explicit millisecond provenance time, applying defaults for omitted columns.
-    async fn restore_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<(), Error> {
-        self.restore_at_ms_option(table, row, cells, Some(now_ms))
-            .await
+        self.restore(
+            table,
+            row,
+            Some(cells),
+            RestoreOptions {
+                target: ExactWriteTarget::Branch(target),
+                ..Default::default()
+            },
+        )
+        .await?;
+        self.delete(
+            table,
+            row,
+            DeleteOptions {
+                target: WriteTarget::BranchView {
+                    head: source,
+                    base: None,
+                },
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     /// Read one row with this transaction's pending writes overlaid.
@@ -2390,57 +2549,6 @@ where
     ) -> Result<Vec<CurrentRow>, Error> {
         self.db()
             .transaction_all_for_identity(self.tx_id(), prepared, author, opts)
-            .await
-    }
-
-    /// Stage an insert with an optional explicit provenance time.
-    async fn insert_with_id_at_ms_option(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: Option<u64>,
-    ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_insert(self.tx_id(), table, row, cells, now_ms)
-            .await
-    }
-
-    /// Stage an update with an optional explicit provenance time.
-    async fn update_at_ms_option(
-        &self,
-        table: &str,
-        row: RowUuid,
-        patch: RowCells,
-        now_ms: Option<u64>,
-    ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_update(self.tx_id(), table, row, patch, now_ms)
-            .await
-    }
-
-    /// Stage a deletion with an optional explicit provenance time.
-    async fn delete_at_ms_option(
-        &self,
-        table: &str,
-        row: RowUuid,
-        now_ms: Option<u64>,
-    ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_delete(self.tx_id(), table, row, now_ms)
-            .await
-    }
-
-    /// Stage a restore with an optional explicit provenance time.
-    async fn restore_at_ms_option(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: Option<u64>,
-    ) -> Result<(), Error> {
-        self.db()
-            .stage_mergeable_restore(self.tx_id(), table, row, cells, now_ms)
             .await
     }
 }
@@ -2598,41 +2706,83 @@ where
             .await
     }
 
-    /// Stage an insert with a generated row id.
-    async fn insert(&self, table: &str, cells: RowCells) -> Result<RowUuid, Error> {
-        let row = self.db().row_id_source.borrow_mut().next_row_id();
-        self.insert_with_id(table, row, cells).await?;
+    /// Stage one insert.
+    async fn insert(
+        &self,
+        table: &str,
+        cells: RowCells,
+        options: InsertOptions,
+    ) -> Result<RowUuid, Error> {
+        ensure_transaction_identity(options.identity)?;
+        ensure_exclusive_target(&options.target)?;
+        let row = options
+            .row_id
+            .unwrap_or_else(|| self.db().row_id_source.borrow_mut().next_row_id());
+        self.db()
+            .stage_exclusive_insert(self.tx_id(), table, row, cells)
+            .await?;
         Ok(row)
     }
 
-    /// Stage an insert with a caller-supplied row id.
-    async fn insert_with_id(
+    /// Stage an update; omitted fields keep the transaction-local value.
+    async fn update(
         &self,
         table: &str,
         row: RowUuid,
-        cells: RowCells,
+        patch: RowCells,
+        options: UpdateOptions,
     ) -> Result<(), Error> {
+        ensure_transaction_identity(options.identity)?;
+        ensure_exclusive_view_target(&options.target)?;
+        let mut cells = self.read(table, row).await?.unwrap_or_default();
+        cells.extend(patch);
         self.db()
             .stage_exclusive_insert(self.tx_id(), table, row, cells)
             .await
     }
 
-    /// Stage an update; omitted fields keep the transaction-local value.
-    async fn update(&self, table: &str, row: RowUuid, patch: RowCells) -> Result<(), Error> {
+    /// Stage one upsert.
+    async fn upsert(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: RowCells,
+        options: UpsertOptions,
+    ) -> Result<(), Error> {
+        ensure_transaction_identity(options.identity)?;
+        ensure_exclusive_target(&options.target)?;
+        let mut merged = self.read(table, row).await?.unwrap_or_default();
+        merged.extend(cells);
         self.db()
-            .stage_exclusive_update(self.tx_id(), table, row, patch)
+            .stage_exclusive_insert(self.tx_id(), table, row, merged)
             .await
     }
 
     /// Stage a soft delete.
-    async fn delete(&self, table: &str, row: RowUuid) -> Result<(), Error> {
+    async fn delete(&self, table: &str, row: RowUuid, options: DeleteOptions) -> Result<(), Error> {
+        ensure_transaction_identity(options.identity)?;
+        ensure_exclusive_view_target(&options.target)?;
         self.db()
             .stage_exclusive_delete(self.tx_id(), table, row)
             .await
     }
 
     /// Stage a restore, applying defaults for omitted columns.
-    async fn restore(&self, table: &str, row: RowUuid, cells: RowCells) -> Result<(), Error> {
+    async fn restore(
+        &self,
+        table: &str,
+        row: RowUuid,
+        cells: Option<RowCells>,
+        options: RestoreOptions,
+    ) -> Result<(), Error> {
+        ensure_transaction_identity(options.identity)?;
+        ensure_exclusive_target(&options.target)?;
+        let cells = cells.ok_or_else(|| {
+            Error::new(
+                ErrorCode::Schema,
+                "exclusive transaction restores require replacement cells",
+            )
+        })?;
         self.db()
             .stage_exclusive_restore(self.tx_id(), table, row, cells)
             .await
@@ -2746,7 +2896,11 @@ where
     /// ```rust
     /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
     /// let db = block_on(open_todos_db())?;
-    /// let write = block_on(db.insert("todos", todo_cells("has id", false)))?;
+    /// let write = block_on(db.insert(
+    ///     "todos",
+    ///     todo_cells("has id", false),
+    ///     Default::default(),
+    /// ))?;
     ///
     /// let _row_id = write.row_uuid();
     /// let _tx_id = write.mergeable_tx_id();
@@ -2762,7 +2916,11 @@ where
     /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
     /// # use jazz::tx::DurabilityTier;
     /// let db = block_on(open_todos_db())?;
-    /// let write = block_on(db.insert("todos", todo_cells("wait locally", false)))?;
+    /// let write = block_on(db.insert(
+    ///     "todos",
+    ///     todo_cells("wait locally", false),
+    ///     Default::default(),
+    /// ))?;
     ///
     /// let tx_id = block_on(write.wait(DurabilityTier::Local))?;
     /// assert_eq!(tx_id, write.mergeable_tx_id());

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2749,10 +2749,8 @@ where
     ) -> Result<(), Error> {
         ensure_transaction_identity(options.identity)?;
         ensure_exclusive_target(&options.target)?;
-        let mut merged = self.read(table, row).await?.unwrap_or_default();
-        merged.extend(cells);
         self.db()
-            .stage_exclusive_insert(self.tx_id(), table, row, merged, options.updated_at_ms)
+            .stage_exclusive_upsert(self.tx_id(), table, row, cells, options.updated_at_ms)
             .await
     }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2719,7 +2719,7 @@ where
             .row_id
             .unwrap_or_else(|| self.db().row_id_source.borrow_mut().next_row_id());
         self.db()
-            .stage_exclusive_insert(self.tx_id(), table, row, cells)
+            .stage_exclusive_insert(self.tx_id(), table, row, cells, options.updated_at_ms)
             .await?;
         Ok(row)
     }
@@ -2752,7 +2752,7 @@ where
         let mut merged = self.read(table, row).await?.unwrap_or_default();
         merged.extend(cells);
         self.db()
-            .stage_exclusive_insert(self.tx_id(), table, row, merged)
+            .stage_exclusive_insert(self.tx_id(), table, row, merged, options.updated_at_ms)
             .await
     }
 
@@ -2761,7 +2761,7 @@ where
         ensure_transaction_identity(options.identity)?;
         ensure_exclusive_view_target(&options.target)?;
         self.db()
-            .stage_exclusive_delete(self.tx_id(), table, row)
+            .stage_exclusive_delete(self.tx_id(), table, row, options.updated_at_ms)
             .await
     }
 
@@ -2782,7 +2782,7 @@ where
             )
         })?;
         self.db()
-            .stage_exclusive_restore(self.tx_id(), table, row, cells)
+            .stage_exclusive_restore(self.tx_id(), table, row, cells, options.updated_at_ms)
             .await
     }
 }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2149,6 +2149,18 @@ where
         Ok(row)
     }
 
+    /// Stage an insert with a generated row id and explicit millisecond provenance time.
+    async fn insert_at_ms(
+        &self,
+        table: &str,
+        cells: RowCells,
+        now_ms: u64,
+    ) -> Result<RowUuid, Error> {
+        let row = self.db().row_id_source.borrow_mut().next_row_id();
+        self.insert_with_id_at_ms(table, row, cells, now_ms).await?;
+        Ok(row)
+    }
+
     /// Stage an insert with a caller-supplied row id.
     async fn insert_with_id(
         &self,
@@ -2171,6 +2183,19 @@ where
         self.db()
             .stage_mergeable_insert_in_branch(self.tx_id(), table, branch, row, cells, None)
             .await
+    }
+
+    /// Stage an insert in one exact branch-local row with a generated row id.
+    async fn insert_in_branch(
+        &self,
+        table: &str,
+        branch: BranchSelector,
+        cells: RowCells,
+    ) -> Result<RowUuid, Error> {
+        let row = self.db().row_id_source.borrow_mut().next_row_id();
+        self.insert_with_id_in_branch(table, branch, row, cells)
+            .await?;
+        Ok(row)
     }
 
     /// Stage an insert with a caller-supplied row id and explicit millisecond provenance time.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2734,10 +2734,8 @@ where
     ) -> Result<(), Error> {
         ensure_transaction_identity(options.identity)?;
         ensure_exclusive_view_target(&options.target)?;
-        let mut cells = self.read(table, row).await?.unwrap_or_default();
-        cells.extend(patch);
         self.db()
-            .stage_exclusive_insert(self.tx_id(), table, row, cells)
+            .stage_exclusive_update(self.tx_id(), table, row, patch, options.updated_at_ms)
             .await
     }
 

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -229,6 +229,7 @@ where
                         column.to_owned(),
                         preserve_nullable(Value::Bytes(current), nullable),
                     )]),
+                    Default::default(),
                 )
                 .await
             }
@@ -244,6 +245,7 @@ where
                         column.to_owned(),
                         preserve_nullable(Value::String(current), nullable),
                     )]),
+                    Default::default(),
                 )
                 .await
             }
@@ -285,6 +287,7 @@ where
                         column.to_owned(),
                         preserve_nullable(Value::Bytes(current), nullable),
                     )]),
+                    Default::default(),
                 )
                 .await
             }
@@ -301,6 +304,7 @@ where
                         column.to_owned(),
                         preserve_nullable(Value::String(text), nullable),
                     )]),
+                    Default::default(),
                 )
                 .await
             }
@@ -430,15 +434,21 @@ where
         Ok(Some(tx_id))
     }
 
-    /// Insert a row locally, generating a uuidv7-shaped row id.
+    /// Insert a row locally.
     ///
-    /// The generated id is available from [`WriteHandle::row_uuid`].
+    /// By default this uses the database identity, root branch, current
+    /// timestamp, and a generated UUIDv7 row id. Every supported variation is
+    /// selected through [`InsertOptions`]; there are no parallel insert paths.
     ///
     /// ```rust
     /// # use jazz::db::doctest_support::{block_on, open_todos_db};
     /// # use jazz::tx::DurabilityTier;
     /// let db = block_on(open_todos_db())?;
-    /// let write = block_on(db.insert("todos", jazz::row! { title: "new todo", done: false }))?;
+    /// let write = block_on(db.insert(
+    ///     "todos",
+    ///     jazz::row! { title: "new todo", done: false },
+    ///     Default::default(),
+    /// ))?;
     /// let row = write.row_uuid();
     /// block_on(write.wait(DurabilityTier::Local))?;
     ///
@@ -446,37 +456,44 @@ where
     /// assert_eq!(db.read(&todos)?.len(), 1);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub async fn insert(&self, table: &str, cells: RowCells) -> Result<WriteHandle<S>, Error> {
-        let row = self.row_id_source.borrow_mut().next_row_id();
-        self.write_mergeable(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            Vec::new(),
-            None,
-        )
-        .await
-    }
-
-    /// Insert a row with a generated id and an explicit millisecond provenance time.
-    pub async fn insert_at_ms(
+    pub async fn insert(
         &self,
         table: &str,
         cells: RowCells,
-        now_ms: u64,
+        options: InsertOptions,
     ) -> Result<WriteHandle<S>, Error> {
-        let row = self.row_id_source.borrow_mut().next_row_id();
-        self.write_mergeable_at_ms(
-            self.identity.author,
-            None,
+        let InsertOptions {
+            row_id,
+            identity,
+            target,
+            updated_at_ms,
+        } = options;
+        let supplied_row_id = row_id.is_some();
+        let row = row_id.unwrap_or_else(|| self.row_id_source.borrow_mut().next_row_id());
+        let (made_by, permission_subject) = self.resolve_write_identity(identity)?;
+        let branch = target.branch();
+
+        if supplied_row_id {
+            match target {
+                ExactWriteTarget::Root => self.ensure_row_absent(table, row, made_by).await?,
+                ExactWriteTarget::Branch(_) => {
+                    self.ensure_exact_branch_row_absent(table, &branch, row)
+                        .await?
+                }
+            }
+        }
+
+        self.write_mergeable_at_ms_with_authorship_in_branch(
+            made_by,
+            permission_subject,
             table,
             row,
             cells,
             Vec::new(),
             None,
-            now_ms,
+            None,
+            updated_at_ms.unwrap_or_else(|| self.next_now_ms()),
+            branch,
         )
         .await
     }
@@ -996,203 +1013,6 @@ where
         self.finish_published_write(row, published).await
     }
 
-    /// Insert a row while attributing provenance to `made_by`.
-    ///
-    /// The Db's authenticated identity remains the write-policy subject. Client
-    /// facades can only write as themselves; trusted-backend attribution is a
-    /// serving-node concern on inbound commit-unit ingestion.
-    pub async fn insert_attributed(
-        &self,
-        made_by: AuthorId,
-        table: &str,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        let row = self.row_id_source.borrow_mut().next_row_id();
-        self.write_mergeable_as_session_subject(made_by, table, row, cells, Vec::new(), None)
-            .await
-    }
-
-    /// Insert a row with a caller-supplied id.
-    ///
-    /// This is a niche path for imports from legacy systems or other cases
-    /// where row identity already exists. New local rows should generally use
-    /// [`Db::insert`] so the database generates the id.
-    pub async fn insert_with_id(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_absent(table, row, self.identity.author)
-            .await?;
-        self.write_mergeable(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            Vec::new(),
-            None,
-        )
-        .await
-    }
-
-    /// Insert one exact branch-local row with a caller-supplied row id.
-    pub async fn insert_with_id_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_exact_branch_row_absent(table, &branch, row)
-            .await?;
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            Vec::new(),
-            None,
-            None,
-            self.next_now_ms(),
-            branch,
-        )
-        .await
-    }
-
-    /// Insert one exact branch-local row while evaluating policy as `identity`.
-    pub async fn insert_with_id_in_branch_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_exact_branch_row_absent(table, &branch, row)
-            .await?;
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            Vec::new(),
-            None,
-            None,
-            self.next_now_ms(),
-            branch,
-        )
-        .await
-    }
-
-    /// Insert a caller-id row while attributing provenance to `made_by`.
-    ///
-    /// See [`Db::insert_attributed`] for the security boundary.
-    pub async fn insert_with_id_attributed(
-        &self,
-        made_by: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_absent(table, row, self.identity.author)
-            .await?;
-        self.write_mergeable_as_session_subject(made_by, table, row, cells, Vec::new(), None)
-            .await
-    }
-
-    /// Insert a row while evaluating write policy as `identity`.
-    pub async fn insert_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        let row = self.row_id_source.borrow_mut().next_row_id();
-        self.insert_with_id_for_identity(identity, table, row, cells)
-            .await
-    }
-
-    /// Insert a caller-id row with an explicit millisecond provenance time.
-    pub async fn insert_with_id_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_absent(table, row, self.identity.author)
-            .await?;
-        self.write_mergeable_at_ms(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            Vec::new(),
-            None,
-            now_ms,
-        )
-        .await
-    }
-
-    /// Insert a caller-id row while evaluating write policy as `identity`.
-    ///
-    /// This is a trusted serving-node API for terminated backend/request
-    /// sessions. It records provenance as `identity` and evaluates policy as
-    /// the same identity, without changing the Db's own authority.
-    pub async fn insert_with_id_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_absent(table, row, identity).await?;
-        let cells = self.apply_insert_defaults(table, cells)?;
-        // Client writes are admitted structurally and staged optimistically.
-        // A trusted serving authority evaluates policy and returns the fate.
-        self.write_mergeable(
-            identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            Vec::new(),
-            None,
-        )
-        .await
-    }
-
-    /// Insert a caller-id row for `identity` with an explicit millisecond provenance time.
-    pub async fn insert_with_id_for_identity_at_ms(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_absent(table, row, identity).await?;
-        let cells = self.apply_insert_defaults(table, cells)?;
-        // See `insert_with_id_for_identity`: policy fate belongs to the
-        // trusted serving authority, not this local client admission path.
-        self.write_mergeable_at_ms(
-            identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            Vec::new(),
-            None,
-            now_ms,
-        )
-        .await
-    }
-
     /// Advise whether an insert may be allowed.
     ///
     /// A `Db` is ordinarily a client-local replica, whose policy evidence may
@@ -1233,1004 +1053,278 @@ where
             .map_err(Into::into)
     }
 
-    /// Update a row locally; omitted fields keep their current local value.
-    ///
-    /// ```rust
-    /// # use std::collections::BTreeMap;
-    /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
-    /// # use jazz::ids::RowUuid;
-    /// # use jazz::groove::records::Value;
-    /// let db = block_on(open_todos_db())?;
-    /// let todo = RowUuid::from_bytes([1; 16]);
-    /// block_on(db.insert_with_id("todos", todo, todo_cells("draft", false)))?;
-    ///
-    /// block_on(db.update(
-    ///     "todos",
-    ///     todo,
-    ///     BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
-    /// ))?;
-    /// let todos = db.prepare_query(&db.table("todos"))?;
-    /// assert_eq!(db.read(&todos)?.len(), 1);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
+    /// Update one row, optionally through a branch view.
     pub async fn update(
         &self,
         table: &str,
         row: RowUuid,
         patch: RowCells,
+        options: UpdateOptions,
     ) -> Result<WriteHandle<S>, Error> {
-        if patch.is_empty() {
-            return self
-                .no_op_update_handle_for_client(table, row, self.identity.author)
-                .await;
-        }
-        let (cells, parent, authored_columns) =
-            self.merge_existing_cells(table, row, patch).await?;
-        self.write_mergeable_with_authored_columns(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            parent.into_iter().collect(),
-            None,
-            authored_columns,
-        )
-        .await
-    }
-
-    /// Patch one exact branch-local row.
-    pub async fn update_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        patch: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        if patch.is_empty() {
-            return Err(Error::new(
-                ErrorCode::Schema,
-                "exact branch update requires at least one authored column",
-            ));
-        }
-        let mut node = self.node.node.lock().await;
-        let Some(mut cells) = node
-            .visible_current_cells_in_branch(table, &branch, row)
-            .await?
-        else {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("branch-local row not observed: {}", row.0),
-            ));
-        };
-        let parent = node
-            .local_content_winner_tx_id_in_branch(table, &branch, row)
-            .await?;
-        drop(node);
-        let authored_columns = patch.keys().cloned().collect();
-        cells.extend(patch);
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            parent.into_iter().collect(),
-            None,
-            Some(authored_columns),
-            self.next_now_ms(),
-            branch,
-        )
-        .await
-    }
-
-    /// Patch one exact branch-local row while evaluating policy as `identity`.
-    pub async fn update_in_branch_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        patch: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        if patch.is_empty() {
-            return Err(Error::new(
-                ErrorCode::Schema,
-                "exact branch update requires at least one authored column",
-            ));
-        }
-        let mut node = self.node.node.lock().await;
-        let Some(mut cells) = node
-            .visible_current_cells_in_branch(table, &branch, row)
-            .await?
-        else {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("branch-local row not observed: {}", row.0),
-            ));
-        };
-        let parent = node
-            .local_content_winner_tx_id_in_branch(table, &branch, row)
-            .await?;
-        drop(node);
-        let authored_columns = patch.keys().cloned().collect();
-        cells.extend(patch);
-        self.write_mergeable_at_ms_with_authorship_in_branch(
+        let UpdateOptions {
             identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            parent.into_iter().collect(),
-            None,
-            Some(authored_columns),
-            self.next_now_ms(),
-            branch,
-        )
-        .await
-    }
+            target,
+            updated_at_ms,
+        } = options;
+        let (made_by, permission_subject) = self.resolve_write_identity(identity)?;
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
 
-    /// Patch a row through a head-over-base view, copying inherited content
-    /// into the head branch-local row without a cross-branch causal parent.
-    pub async fn update_in_branch_view(
-        &self,
-        table: &str,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-        row: RowUuid,
-        patch: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        if self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch(table, &head, row)
-            .await?
-            .is_some()
-        {
-            return self.update_in_branch(table, head, row, patch).await;
-        }
-        let Some(mut inherited) = self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch_view(table, &head, base.as_ref(), row)
-            .await?
-        else {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("row is not visible in branch view: {}", row.0),
-            ));
-        };
-        inherited.extend(patch);
-        self.insert_with_id_in_branch(table, head, row, inherited)
-            .await
-    }
-
-    /// Patch through a branch view while evaluating policy as `identity`.
-    pub async fn update_in_branch_view_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-        row: RowUuid,
-        patch: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        if self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch(table, &head, row)
-            .await?
-            .is_some()
-        {
-            return self
-                .update_in_branch_for_identity(identity, table, head, row, patch)
-                .await;
-        }
-        let Some(mut inherited) = self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch_view(table, &head, base.as_ref(), row)
-            .await?
-        else {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("row is not visible in branch view: {}", row.0),
-            ));
-        };
-        inherited.extend(patch);
-        self.insert_with_id_in_branch_for_identity(identity, table, head, row, inherited)
-            .await
-    }
-
-    /// Insert or patch one exact branch-local row.
-    pub async fn upsert_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        let exists = self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch(table, &branch, row)
-            .await?
-            .is_some();
-        if exists {
-            self.update_in_branch(table, branch, row, cells).await
-        } else {
-            self.insert_with_id_in_branch(table, branch, row, cells)
+        match target {
+            WriteTarget::Root => {
+                if patch.is_empty() {
+                    return match identity {
+                        WriteIdentity::Database | WriteIdentity::Attribution(_) => {
+                            self.no_op_update_handle_for_client(table, row, made_by)
+                                .await
+                        }
+                        WriteIdentity::Session(author) => {
+                            self.no_op_update_handle_for_identity(table, row, author)
+                                .await
+                        }
+                    };
+                }
+                let (cells, parent, authored_columns) = match identity {
+                    WriteIdentity::Database | WriteIdentity::Attribution(_) => {
+                        self.merge_existing_cells(table, row, patch).await?
+                    }
+                    WriteIdentity::Session(author) => {
+                        self.merge_existing_cells_for_identity(table, row, patch, author)
+                            .await?
+                    }
+                };
+                self.write_mergeable_at_ms_with_authorship(
+                    made_by,
+                    permission_subject,
+                    table,
+                    row,
+                    cells,
+                    parent.into_iter().collect(),
+                    None,
+                    Some(authored_columns),
+                    now_ms,
+                )
                 .await
+            }
+            WriteTarget::BranchView { head, base } => {
+                if patch.is_empty() {
+                    return Err(Error::new(
+                        ErrorCode::Schema,
+                        "branch update requires at least one authored column",
+                    ));
+                }
+                let local = self
+                    .node
+                    .node
+                    .lock()
+                    .await
+                    .visible_current_cells_in_branch(table, &head, row)
+                    .await?;
+                let (mut cells, parents, authored_columns) = if let Some(cells) = local {
+                    let parent = self
+                        .node
+                        .node
+                        .lock()
+                        .await
+                        .local_content_winner_tx_id_in_branch(table, &head, row)
+                        .await?;
+                    (
+                        cells,
+                        parent.into_iter().collect(),
+                        Some(patch.keys().cloned().collect()),
+                    )
+                } else {
+                    let inherited = self
+                        .node
+                        .node
+                        .lock()
+                        .await
+                        .visible_current_cells_in_branch_view(table, &head, base.as_ref(), row)
+                        .await?
+                        .ok_or_else(|| {
+                            Error::new(
+                                ErrorCode::NotObserved,
+                                format!("row is not visible in branch view: {}", row.0),
+                            )
+                        })?;
+                    (inherited, Vec::new(), None)
+                };
+                cells.extend(patch);
+                self.write_mergeable_at_ms_with_authorship_in_branch(
+                    made_by,
+                    permission_subject,
+                    table,
+                    row,
+                    cells,
+                    parents,
+                    None,
+                    authored_columns,
+                    now_ms,
+                    head,
+                )
+                .await
+            }
         }
     }
 
-    /// Update a row with an explicit millisecond provenance time.
-    pub async fn update_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        patch: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        if patch.is_empty() {
-            return self
-                .no_op_update_handle_for_client(table, row, self.identity.author)
-                .await;
-        }
-        let (cells, parent, authored_columns) =
-            self.merge_existing_cells(table, row, patch).await?;
-        self.write_mergeable_at_ms_with_authorship(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            parent.into_iter().collect(),
-            None,
-            Some(authored_columns),
-            now_ms,
-        )
-        .await
-    }
-
-    /// Update a row while attributing provenance to `made_by`.
-    ///
-    /// See [`Db::insert_attributed`] for the security boundary.
-    pub async fn update_attributed(
-        &self,
-        made_by: AuthorId,
-        table: &str,
-        row: RowUuid,
-        patch: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.check_attribution_allowed(made_by)?;
-        if patch.is_empty() {
-            return self
-                .no_op_update_handle_for_client(table, row, self.identity.author)
-                .await;
-        }
-        let (cells, parent, authored_columns) =
-            self.merge_existing_cells(table, row, patch).await?;
-        self.write_mergeable_as_session_subject_with_authored_columns(
-            made_by,
-            table,
-            row,
-            cells,
-            parent.into_iter().collect(),
-            None,
-            authored_columns,
-        )
-        .await
-    }
-
-    /// Update a row while evaluating write policy as `identity`.
-    pub async fn update_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        patch: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        if patch.is_empty() {
-            return self
-                .no_op_update_handle_for_identity(table, row, identity)
-                .await;
-        }
-        let (cells, parent, authored_columns) = self
-            .merge_existing_cells_for_identity(table, row, patch, identity)
-            .await?;
-        let parents = parent.into_iter().collect::<Vec<_>>();
-        self.write_mergeable_with_authored_columns(
-            identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            parents,
-            None,
-            authored_columns,
-        )
-        .await
-    }
-
-    /// Update a row for `identity` with an explicit millisecond provenance time.
-    pub async fn update_for_identity_at_ms(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        patch: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        if patch.is_empty() {
-            return self
-                .no_op_update_handle_for_identity(table, row, identity)
-                .await;
-        }
-        let (cells, parent, authored_columns) = self
-            .merge_existing_cells_for_identity(table, row, patch, identity)
-            .await?;
-        let parents = parent.into_iter().collect::<Vec<_>>();
-        self.write_mergeable_at_ms_with_authorship(
-            identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            parents,
-            None,
-            Some(authored_columns),
-            now_ms,
-        )
-        .await
-    }
-
-    /// Upsert a row locally.
-    ///
-    /// This explicit-id path is primarily for importing rows from legacy
-    /// systems. New local rows should generally use [`Db::insert`] and then
-    /// update the returned [`WriteHandle::row_uuid`] when needed.
-    ///
-    /// ```rust
-    /// # use std::collections::BTreeMap;
-    /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
-    /// # use jazz::ids::RowUuid;
-    /// # use jazz::groove::records::Value;
-    /// let db = block_on(open_todos_db())?;
-    /// let todo = RowUuid::from_bytes([1; 16]);
-    ///
-    /// block_on(db.upsert("todos", todo, todo_cells("created", false)))?;
-    /// block_on(db.upsert(
-    ///     "todos",
-    ///     todo,
-    ///     BTreeMap::from([("title".to_owned(), Value::String("renamed".to_owned()))]),
-    /// ))?;
-    /// let todos = db.prepare_query(&db.table("todos"))?;
-    /// assert_eq!(db.one(&todos)?.unwrap().row_uuid(), todo);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
+    /// Insert or update one row through a single implementation.
     pub async fn upsert(
         &self,
         table: &str,
         row: RowUuid,
         cells: RowCells,
+        options: UpsertOptions,
     ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_not_deleted(table, row).await?;
-        let (cells, parents, authored_columns) = if self
-            .upsert_target_for_client_identity(table, row, self.identity.author)
-            .await?
-            .is_some()
-        {
-            let (cells, parent, authored_columns) =
-                self.merge_existing_cells(table, row, cells).await?;
-            (cells, parent.into_iter().collect(), Some(authored_columns))
-        } else {
-            (cells, Vec::new(), None)
-        };
-        self.write_mergeable_at_ms_with_authorship(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            parents,
-            None,
-            authored_columns,
-            self.next_now_ms(),
-        )
-        .await
-    }
-
-    /// Upsert a row with an explicit millisecond provenance time.
-    pub async fn upsert_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_not_deleted(table, row).await?;
-        let (cells, parents, authored_columns) = if self
-            .upsert_target_for_client_identity(table, row, self.identity.author)
-            .await?
-            .is_some()
-        {
-            let (cells, parent, authored_columns) =
-                self.merge_existing_cells(table, row, cells).await?;
-            (cells, parent.into_iter().collect(), Some(authored_columns))
-        } else {
-            (cells, Vec::new(), None)
-        };
-        self.write_mergeable_at_ms_with_authorship(
-            self.identity.author,
-            None,
-            table,
-            row,
-            cells,
-            parents,
-            None,
-            authored_columns,
-            now_ms,
-        )
-        .await
-    }
-
-    /// Upsert a row while evaluating write policy as `identity`.
-    pub async fn upsert_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_not_deleted(table, row).await?;
-        let (cells, parents, authored_columns) = if self
-            .upsert_target_for_trusted_identity(table, row, identity)
-            .await?
-            .is_some()
-        {
-            let (cells, parent, authored_columns) = self
-                .merge_existing_cells_for_identity(table, row, cells, identity)
-                .await?;
-            (cells, parent.into_iter().collect(), Some(authored_columns))
-        } else {
-            (cells, Vec::new(), None)
-        };
-        self.write_mergeable_at_ms_with_authorship(
+        let UpsertOptions {
             identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            parents,
-            None,
-            authored_columns,
-            self.next_now_ms(),
-        )
-        .await
-    }
+            target,
+            updated_at_ms,
+        } = options;
+        let (made_by, permission_subject) = self.resolve_write_identity(identity)?;
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        let branch = target.branch();
 
-    /// Upsert a row for `identity` with an explicit millisecond provenance time.
-    pub async fn upsert_for_identity_at_ms(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_not_deleted(table, row).await?;
-        let (cells, parents, authored_columns) = if self
-            .upsert_target_for_trusted_identity(table, row, identity)
-            .await?
-            .is_some()
-        {
-            let (cells, parent, authored_columns) = self
-                .merge_existing_cells_for_identity(table, row, cells, identity)
-                .await?;
-            (cells, parent.into_iter().collect(), Some(authored_columns))
-        } else {
-            (cells, Vec::new(), None)
-        };
-        self.write_mergeable_at_ms_with_authorship(
-            identity,
-            Some(identity),
-            table,
-            row,
-            cells,
-            parents,
-            None,
-            authored_columns,
-            now_ms,
-        )
-        .await
-    }
-
-    /// Soft-delete a row locally.
-    ///
-    /// ```rust
-    /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
-    /// # use jazz::ids::RowUuid;
-    /// let db = block_on(open_todos_db())?;
-    /// let todo = RowUuid::from_bytes([1; 16]);
-    /// block_on(db.insert_with_id("todos", todo, todo_cells("remove me", false)))?;
-    ///
-    /// block_on(db.delete("todos", todo))?;
-    /// let todos = db.prepare_query(&db.table("todos"))?;
-    /// assert!(db.read(&todos)?.is_empty());
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    pub async fn delete(&self, table: &str, row: RowUuid) -> Result<WriteHandle<S>, Error> {
-        self.delete_at_ms_option(table, row, None).await
-    }
-
-    /// Soft-delete one exact branch-local row.
-    pub async fn delete_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-    ) -> Result<WriteHandle<S>, Error> {
-        let mut node = self.node.node.lock().await;
-        if node
-            .visible_current_cells_in_branch(table, &branch, row)
-            .await?
-            .is_none()
-        {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("branch-local row not observed: {}", row.0),
-            ));
-        }
-        let deletion_parent = node
-            .local_deletion_winner_tx_id_in_branch(table, &branch, row)
-            .await?;
-        let content_parent = node
-            .local_content_winner_tx_id_in_branch(table, &branch, row)
-            .await?;
-        let parents = deletion_parent.or(content_parent).into_iter().collect();
-        drop(node);
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            self.identity.author,
-            None,
-            table,
-            row,
-            BTreeMap::new(),
-            parents,
-            Some(DeletionEvent::Deleted),
-            None,
-            self.next_now_ms(),
-            branch,
-        )
-        .await
-    }
-
-    /// Delete one exact branch-local row while evaluating policy as `identity`.
-    pub async fn delete_in_branch_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-    ) -> Result<WriteHandle<S>, Error> {
-        let mut node = self.node.node.lock().await;
-        if node
-            .visible_current_cells_in_branch(table, &branch, row)
-            .await?
-            .is_none()
-        {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("branch-local row not observed: {}", row.0),
-            ));
-        }
-        let deletion_parent = node
-            .local_deletion_winner_tx_id_in_branch(table, &branch, row)
-            .await?;
-        let content_parent = node
-            .local_content_winner_tx_id_in_branch(table, &branch, row)
-            .await?;
-        let parents = deletion_parent.or(content_parent).into_iter().collect();
-        drop(node);
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            identity,
-            Some(identity),
-            table,
-            row,
-            BTreeMap::new(),
-            parents,
-            Some(DeletionEvent::Deleted),
-            None,
-            self.next_now_ms(),
-            branch,
-        )
-        .await
-    }
-
-    /// Delete a row through a head-over-base view. An inherited base row is
-    /// masked by a deletion register in the head branch-local row.
-    pub async fn delete_in_branch_view(
-        &self,
-        table: &str,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-        row: RowUuid,
-    ) -> Result<WriteHandle<S>, Error> {
-        if self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch(table, &head, row)
-            .await?
-            .is_some()
-        {
-            return self.delete_in_branch(table, head, row).await;
-        }
-        if self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch_view(table, &head, base.as_ref(), row)
-            .await?
-            .is_none()
-        {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("row is not visible in branch view: {}", row.0),
-            ));
-        }
-        let parent = self
-            .node
-            .node
-            .lock()
-            .await
-            .local_deletion_winner_tx_id_in_branch(table, &head, row)
-            .await?;
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            self.identity.author,
-            None,
-            table,
-            row,
-            BTreeMap::new(),
-            parent.into_iter().collect(),
-            Some(DeletionEvent::Deleted),
-            None,
-            self.next_now_ms(),
-            head,
-        )
-        .await
-    }
-
-    /// Delete through a branch view while evaluating policy as `identity`.
-    pub async fn delete_in_branch_view_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        head: BranchSelector,
-        base: Option<BranchViewBase>,
-        row: RowUuid,
-    ) -> Result<WriteHandle<S>, Error> {
-        if self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch(table, &head, row)
-            .await?
-            .is_some()
-        {
-            return self
-                .delete_in_branch_for_identity(identity, table, head, row)
-                .await;
-        }
-        if self
-            .node
-            .node
-            .lock()
-            .await
-            .visible_current_cells_in_branch_view(table, &head, base.as_ref(), row)
-            .await?
-            .is_none()
-        {
-            return Err(Error::new(
-                ErrorCode::NotObserved,
-                format!("row is not visible in branch view: {}", row.0),
-            ));
-        }
-        let parent = self
-            .node
-            .node
-            .lock()
-            .await
-            .local_deletion_winner_tx_id_in_branch(table, &head, row)
-            .await?;
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            identity,
-            Some(identity),
-            table,
-            row,
-            BTreeMap::new(),
-            parent.into_iter().collect(),
-            Some(DeletionEvent::Deleted),
-            None,
-            self.next_now_ms(),
-            head,
-        )
-        .await
-    }
-
-    /// Restore the deletion register of one exact branch-local row.
-    pub async fn restore_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-    ) -> Result<WriteHandle<S>, Error> {
-        let parent = self
-            .node
-            .node
-            .lock()
-            .await
-            .local_deletion_winner_tx_id_in_branch(table, &branch, row)
-            .await?
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorCode::NotObserved,
-                    format!("branch deletion not observed: {}", row.0),
-                )
-            })?;
-        self.write_mergeable_at_ms_with_authorship_in_branch(
-            self.identity.author,
-            None,
-            table,
-            row,
-            BTreeMap::new(),
-            vec![parent],
-            Some(DeletionEvent::Restored),
-            None,
-            self.next_now_ms(),
-            branch,
-        )
-        .await
-    }
-
-    /// Restore an exact branch-local row and replace its content atomically.
-    pub async fn restore_with_cells_in_branch(
-        &self,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.restore_with_cells_in_branch_for_identity(
-            self.identity.author,
-            None,
-            table,
-            branch,
-            row,
-            cells,
-        )
-        .await
-    }
-
-    /// Restore an exact branch-local row while evaluating policy as `identity`.
-    pub async fn restore_with_cells_in_branch_as_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.restore_with_cells_in_branch_for_identity(
-            identity,
-            Some(identity),
-            table,
-            branch,
-            row,
-            cells,
-        )
-        .await
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn restore_with_cells_in_branch_for_identity(
-        &self,
-        made_by: AuthorId,
-        permission_subject: Option<AuthorId>,
-        table: &str,
-        branch: BranchSelector,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        let cells = self.apply_insert_defaults(table, cells)?;
-        let (content_parents, deletion_parents) = {
-            let mut node = self.node.node.lock().await;
-            let deletion_parent = node
-                .local_deletion_winner_tx_id_in_branch(table, &branch, row)
-                .await?
-                .ok_or_else(|| {
-                    Error::new(
-                        ErrorCode::NotObserved,
-                        format!("branch deletion not observed: {}", row.0),
+        let (cells, parents, authored_columns) = match target {
+            ExactWriteTarget::Root => {
+                self.ensure_row_not_deleted(table, row).await?;
+                let exists = match identity {
+                    WriteIdentity::Database | WriteIdentity::Attribution(_) => self
+                        .upsert_target_for_client_identity(table, row, made_by)
+                        .await?
+                        .is_some(),
+                    WriteIdentity::Session(author) => self
+                        .upsert_target_for_trusted_identity(table, row, author)
+                        .await?
+                        .is_some(),
+                };
+                if exists {
+                    let (cells, parent, authored_columns) = match identity {
+                        WriteIdentity::Database | WriteIdentity::Attribution(_) => {
+                            self.merge_existing_cells(table, row, cells).await?
+                        }
+                        WriteIdentity::Session(author) => {
+                            self.merge_existing_cells_for_identity(table, row, cells, author)
+                                .await?
+                        }
+                    };
+                    (cells, parent.into_iter().collect(), Some(authored_columns))
+                } else {
+                    (cells, Vec::new(), None)
+                }
+            }
+            ExactWriteTarget::Branch(_) => {
+                let mut node = self.node.node.lock().await;
+                let existing = node
+                    .visible_current_cells_in_branch(table, &branch, row)
+                    .await?;
+                let parent = if existing.is_some() {
+                    node.local_content_winner_tx_id_in_branch(table, &branch, row)
+                        .await?
+                } else {
+                    None
+                };
+                drop(node);
+                if let Some(mut existing) = existing {
+                    if cells.is_empty() {
+                        return Err(Error::new(
+                            ErrorCode::Schema,
+                            "branch upsert update requires at least one authored column",
+                        ));
+                    }
+                    let authored_columns = cells.keys().cloned().collect();
+                    existing.extend(cells);
+                    (
+                        existing,
+                        parent.into_iter().collect(),
+                        Some(authored_columns),
                     )
-                })?;
-            (
-                node.local_content_winner_tx_id_in_branch(table, &branch, row)
-                    .await?
-                    .into_iter()
-                    .collect::<Vec<_>>(),
-                vec![deletion_parent],
-            )
-        };
-        let content = MergeableCommit::new(table, row, self.next_now_ms())
-            .branch(branch.clone())
-            .made_by(made_by)
-            .parents(content_parents)
-            .cells(cells);
-        let deletion = MergeableCommit::new(table, row, self.next_now_ms())
-            .branch(branch)
-            .made_by(made_by)
-            .parents(deletion_parents)
-            .cells(BTreeMap::<String, Value>::new())
-            .deletion(DeletionEvent::Restored);
-        let (content, deletion) = match permission_subject {
-            Some(subject) => (
-                content.permission_subject(subject),
-                deletion.permission_subject(subject),
-            ),
-            None => (content, deletion),
-        };
-        let published = self
-            .node
-            .node
-            .lock()
-            .await
-            .commit_mergeable_many_in_schema(self.schema_version_id, vec![content, deletion])
-            .await?;
-        self.finish_published_write(row, published).await
-    }
-
-    /// Soft-delete a row with explicit millisecond provenance time.
-    pub async fn delete_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.delete_at_ms_option(table, row, Some(now_ms)).await
-    }
-
-    pub(super) async fn delete_at_ms_option(
-        &self,
-        table: &str,
-        row: RowUuid,
-        now_ms: Option<u64>,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_not_deleted(table, row).await?;
-        let (parents, _) = self.row_layer_parents(table, row).await?;
-        match now_ms {
-            Some(now_ms) => {
-                self.write_mergeable_at_ms(
-                    self.identity.author,
-                    None,
-                    table,
-                    row,
-                    BTreeMap::new(),
-                    parents,
-                    Some(DeletionEvent::Deleted),
-                    now_ms,
-                )
-                .await
+                } else {
+                    (cells, Vec::new(), None)
+                }
             }
-            None => {
-                self.write_mergeable(
-                    self.identity.author,
-                    None,
-                    table,
-                    row,
-                    BTreeMap::new(),
-                    parents,
-                    Some(DeletionEvent::Deleted),
-                )
-                .await
-            }
-        }
-    }
+        };
 
-    /// Soft-delete a row while attributing provenance to `made_by`.
-    ///
-    /// See [`Db::insert_attributed`] for the security boundary.
-    pub async fn delete_attributed(
-        &self,
-        made_by: AuthorId,
-        table: &str,
-        row: RowUuid,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_not_deleted(table, row).await?;
-        let (parents, _) = self.row_layer_parents(table, row).await?;
-        self.write_mergeable_as_session_subject(
+        self.write_mergeable_at_ms_with_authorship_in_branch(
             made_by,
+            permission_subject,
+            table,
+            row,
+            cells,
+            parents,
+            None,
+            authored_columns,
+            now_ms,
+            branch,
+        )
+        .await
+    }
+
+    /// Soft-delete one row, optionally through a branch view.
+    pub async fn delete(
+        &self,
+        table: &str,
+        row: RowUuid,
+        options: DeleteOptions,
+    ) -> Result<WriteHandle<S>, Error> {
+        let DeleteOptions {
+            identity,
+            target,
+            updated_at_ms,
+        } = options;
+        let (made_by, permission_subject) = self.resolve_write_identity(identity)?;
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+
+        let (branch, parents) = match target {
+            WriteTarget::Root => {
+                self.ensure_row_not_deleted(table, row).await?;
+                let (parents, _) = self.row_layer_parents(table, row).await?;
+                (BranchSelector::default(), parents)
+            }
+            WriteTarget::BranchView { head, base } => {
+                let mut node = self.node.node.lock().await;
+                let local = node
+                    .visible_current_cells_in_branch(table, &head, row)
+                    .await?;
+                let parents = if local.is_some() {
+                    let deletion = node
+                        .local_deletion_winner_tx_id_in_branch(table, &head, row)
+                        .await?;
+                    let content = node
+                        .local_content_winner_tx_id_in_branch(table, &head, row)
+                        .await?;
+                    deletion.or(content).into_iter().collect()
+                } else {
+                    if node
+                        .visible_current_cells_in_branch_view(table, &head, base.as_ref(), row)
+                        .await?
+                        .is_none()
+                    {
+                        return Err(Error::new(
+                            ErrorCode::NotObserved,
+                            format!("row is not visible in branch view: {}", row.0),
+                        ));
+                    }
+                    node.local_deletion_winner_tx_id_in_branch(table, &head, row)
+                        .await?
+                        .into_iter()
+                        .collect()
+                };
+                (head, parents)
+            }
+        };
+
+        self.write_mergeable_at_ms_with_authorship_in_branch(
+            made_by,
+            permission_subject,
             table,
             row,
             BTreeMap::new(),
             parents,
             Some(DeletionEvent::Deleted),
+            None,
+            now_ms,
+            branch,
         )
         .await
-    }
-
-    /// Soft-delete a row while evaluating write policy as `identity`.
-    pub async fn delete_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.delete_for_identity_at_ms_option(identity, table, row, None)
-            .await
-    }
-
-    /// Soft-delete a row while evaluating write policy as `identity`, with explicit time.
-    pub async fn delete_for_identity_at_ms(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.delete_for_identity_at_ms_option(identity, table, row, Some(now_ms))
-            .await
-    }
-
-    async fn delete_for_identity_at_ms_option(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        now_ms: Option<u64>,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.ensure_row_not_deleted(table, row).await?;
-        let (parents, _) = self.row_layer_parents(table, row).await?;
-        match now_ms {
-            Some(now_ms) => {
-                self.write_mergeable_at_ms(
-                    identity,
-                    Some(identity),
-                    table,
-                    row,
-                    BTreeMap::new(),
-                    parents,
-                    Some(DeletionEvent::Deleted),
-                    now_ms,
-                )
-                .await
-            }
-            None => {
-                self.write_mergeable(
-                    identity,
-                    Some(identity),
-                    table,
-                    row,
-                    BTreeMap::new(),
-                    parents,
-                    Some(DeletionEvent::Deleted),
-                )
-                .await
-            }
-        }
     }
 
     /// Advise whether a read may be allowed. Client-local replicas return
@@ -2312,305 +1406,83 @@ where
             .map_err(Into::into)
     }
 
-    /// Restore a row locally, applying defaults for omitted columns.
+    /// Restore a deleted row through one root-or-branch implementation.
     ///
-    /// ```rust
-    /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
-    /// # use jazz::ids::RowUuid;
-    /// let db = block_on(open_todos_db())?;
-    /// let todo = RowUuid::from_bytes([1; 16]);
-    /// block_on(db.insert_with_id("todos", todo, todo_cells("archived", false)))?;
-    /// block_on(db.delete("todos", todo))?;
-    ///
-    /// block_on(db.restore("todos", todo, todo_cells("restored", false)))?;
-    /// let todos = db.prepare_query(&db.table("todos"))?;
-    /// assert_eq!(db.one(&todos)?.unwrap().row_uuid(), todo);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
+    /// `cells` replaces the content atomically when present. `None` only
+    /// restores the deletion register and therefore preserves existing content.
     pub async fn restore(
         &self,
         table: &str,
         row: RowUuid,
-        cells: RowCells,
+        cells: Option<RowCells>,
+        options: RestoreOptions,
     ) -> Result<WriteHandle<S>, Error> {
-        let cells = self.apply_insert_defaults(table, cells)?;
-        self.ensure_row_deleted(table, row, self.identity.author)
-            .await?;
-        let (content_parents, deletion_parents) = {
-            let mut node = self.node.node.lock().await;
-            let content_parents = node
-                .local_content_winner_tx_id(table, row)
-                .await?
-                .into_iter()
-                .collect::<Vec<_>>();
-            let deletion_parents = node
-                .local_deletion_winner_tx_id(table, row)
-                .await?
-                .into_iter()
-                .collect::<Vec<_>>();
-            (content_parents, deletion_parents)
+        let RestoreOptions {
+            identity,
+            target,
+            updated_at_ms,
+        } = options;
+        let (made_by, permission_subject) = self.resolve_write_identity(identity)?;
+        let branch = target.branch();
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        let cells = cells
+            .map(|cells| self.apply_insert_defaults(table, cells))
+            .transpose()?;
+        let (content_parents, deletion_parents) = match target {
+            ExactWriteTarget::Root => {
+                self.ensure_row_deleted(table, row, made_by).await?;
+                self.row_layer_parents(table, row).await?
+            }
+            ExactWriteTarget::Branch(_) => {
+                let mut node = self.node.node.lock().await;
+                let deletion = node
+                    .local_deletion_winner_tx_id_in_branch(table, &branch, row)
+                    .await?
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorCode::NotObserved,
+                            format!("branch deletion not observed: {}", row.0),
+                        )
+                    })?;
+                let content = node
+                    .local_content_winner_tx_id_in_branch(table, &branch, row)
+                    .await?
+                    .into_iter()
+                    .collect();
+                (content, vec![deletion])
+            }
         };
-        let published = self
-            .node
-            .node
-            .lock()
-            .await
-            .commit_mergeable_many_in_schema(
-                self.schema_version_id,
-                vec![
-                    MergeableCommit::new(table, row, self.next_now_ms())
-                        .made_by(self.identity.author)
-                        .parents(content_parents)
-                        .cells(cells),
-                    MergeableCommit::new(table, row, self.next_now_ms())
-                        .made_by(self.identity.author)
-                        .parents(deletion_parents)
-                        .cells(BTreeMap::<String, Value>::new())
-                        .deletion(DeletionEvent::Restored),
-                ],
-            )
-            .await?;
-        self.finish_published_write(row, published).await
-    }
 
-    /// Restore a row while evaluating write policy as `identity`.
-    pub async fn restore_for_identity(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-    ) -> Result<WriteHandle<S>, Error> {
-        let cells = self.apply_insert_defaults(table, cells)?;
-        self.ensure_row_deleted(table, row, identity).await?;
-        let (content_parents, deletion_parents) = {
-            let mut node = self.node.node.lock().await;
-            let content_parents = node
-                .local_content_winner_tx_id(table, row)
-                .await?
-                .into_iter()
-                .collect::<Vec<_>>();
-            let deletion_parents = node
-                .local_deletion_winner_tx_id(table, row)
-                .await?
-                .into_iter()
-                .collect::<Vec<_>>();
-            (content_parents, deletion_parents)
+        let with_subject = |commit: MergeableCommit| match permission_subject {
+            Some(subject) => commit.permission_subject(subject),
+            None => commit,
         };
+        let mut commits = Vec::with_capacity(if cells.is_some() { 2 } else { 1 });
+        if let Some(cells) = cells {
+            commits.push(with_subject(
+                MergeableCommit::new(table, row, now_ms)
+                    .branch(branch.clone())
+                    .made_by(made_by)
+                    .parents(content_parents)
+                    .cells(cells),
+            ));
+        }
+        commits.push(with_subject(
+            MergeableCommit::new(table, row, now_ms)
+                .branch(branch)
+                .made_by(made_by)
+                .parents(deletion_parents)
+                .cells(BTreeMap::<String, Value>::new())
+                .deletion(DeletionEvent::Restored),
+        ));
         let published = self
             .node
             .node
             .lock()
             .await
-            .commit_mergeable_many_in_schema(
-                self.schema_version_id,
-                vec![
-                    MergeableCommit::new(table, row, self.next_now_ms())
-                        .made_by(identity)
-                        .permission_subject(identity)
-                        .parents(content_parents)
-                        .cells(cells),
-                    MergeableCommit::new(table, row, self.next_now_ms())
-                        .made_by(identity)
-                        .permission_subject(identity)
-                        .parents(deletion_parents)
-                        .cells(BTreeMap::<String, Value>::new())
-                        .deletion(DeletionEvent::Restored),
-                ],
-            )
+            .commit_mergeable_many_in_schema(self.schema_version_id, commits)
             .await?;
         self.finish_published_write(row, published).await
-    }
-
-    async fn write_mergeable_as_session_subject(
-        &self,
-        made_by: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        parents: Vec<TxId>,
-        deletion: Option<DeletionEvent>,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.check_attribution_allowed(made_by)?;
-        self.write_mergeable(
-            made_by,
-            Some(self.identity.author),
-            table,
-            row,
-            cells,
-            parents,
-            deletion,
-        )
-        .await
-    }
-
-    async fn write_mergeable_as_session_subject_with_authored_columns(
-        &self,
-        made_by: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        parents: Vec<TxId>,
-        deletion: Option<DeletionEvent>,
-        authored_columns: BTreeSet<String>,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.check_attribution_allowed(made_by)?;
-        self.write_mergeable_with_authored_columns(
-            made_by,
-            Some(self.identity.author),
-            table,
-            row,
-            cells,
-            parents,
-            deletion,
-            authored_columns,
-        )
-        .await
-    }
-
-    /// Restore a row with an explicit millisecond provenance time.
-    pub async fn restore_at_ms(
-        &self,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        let cells = self.apply_insert_defaults(table, cells)?;
-        self.ensure_row_deleted(table, row, self.identity.author)
-            .await?;
-        let (content_parents, deletion_parents) = self.row_layer_parents(table, row).await?;
-        let published = self
-            .node
-            .node
-            .lock()
-            .await
-            .commit_mergeable_many_in_schema(
-                self.schema_version_id,
-                vec![
-                    MergeableCommit::new(table, row, now_ms)
-                        .made_by(self.identity.author)
-                        .parents(content_parents)
-                        .cells(cells),
-                    MergeableCommit::new(table, row, now_ms)
-                        .made_by(self.identity.author)
-                        .parents(deletion_parents)
-                        .cells(BTreeMap::<String, Value>::new())
-                        .deletion(DeletionEvent::Restored),
-                ],
-            )
-            .await?;
-        self.finish_published_write(row, published).await
-    }
-
-    /// Restore a row for `identity` with an explicit millisecond provenance time.
-    pub async fn restore_for_identity_at_ms(
-        &self,
-        identity: AuthorId,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        let cells = self.apply_insert_defaults(table, cells)?;
-        self.ensure_row_deleted(table, row, identity).await?;
-        let (content_parents, deletion_parents) = self.row_layer_parents(table, row).await?;
-        let published = self
-            .node
-            .node
-            .lock()
-            .await
-            .commit_mergeable_many_in_schema(
-                self.schema_version_id,
-                vec![
-                    MergeableCommit::new(table, row, now_ms)
-                        .made_by(identity)
-                        .permission_subject(identity)
-                        .parents(content_parents)
-                        .cells(cells),
-                    MergeableCommit::new(table, row, now_ms)
-                        .made_by(identity)
-                        .permission_subject(identity)
-                        .parents(deletion_parents)
-                        .cells(BTreeMap::<String, Value>::new())
-                        .deletion(DeletionEvent::Restored),
-                ],
-            )
-            .await?;
-        self.finish_published_write(row, published).await
-    }
-
-    async fn write_mergeable(
-        &self,
-        made_by: AuthorId,
-        permission_subject: Option<AuthorId>,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        parents: Vec<TxId>,
-        deletion: Option<DeletionEvent>,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.write_mergeable_at_ms(
-            made_by,
-            permission_subject,
-            table,
-            row,
-            cells,
-            parents,
-            deletion,
-            self.next_now_ms(),
-        )
-        .await
-    }
-
-    async fn write_mergeable_at_ms(
-        &self,
-        made_by: AuthorId,
-        permission_subject: Option<AuthorId>,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        parents: Vec<TxId>,
-        deletion: Option<DeletionEvent>,
-        now_ms: u64,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.write_mergeable_at_ms_with_authorship(
-            made_by,
-            permission_subject,
-            table,
-            row,
-            cells,
-            parents,
-            deletion,
-            None,
-            now_ms,
-        )
-        .await
-    }
-
-    async fn write_mergeable_with_authored_columns(
-        &self,
-        made_by: AuthorId,
-        permission_subject: Option<AuthorId>,
-        table: &str,
-        row: RowUuid,
-        cells: RowCells,
-        parents: Vec<TxId>,
-        deletion: Option<DeletionEvent>,
-        authored_columns: BTreeSet<String>,
-    ) -> Result<WriteHandle<S>, Error> {
-        self.write_mergeable_at_ms_with_authorship(
-            made_by,
-            permission_subject,
-            table,
-            row,
-            cells,
-            parents,
-            deletion,
-            Some(authored_columns),
-            self.next_now_ms(),
-        )
-        .await
     }
 
     async fn write_mergeable_at_ms_with_authorship(
@@ -2765,14 +1637,21 @@ where
         })
     }
 
-    fn check_attribution_allowed(&self, made_by: AuthorId) -> Result<(), Error> {
-        if made_by == self.identity.author {
-            return Ok(());
+    fn resolve_write_identity(
+        &self,
+        identity: WriteIdentity,
+    ) -> Result<(AuthorId, Option<AuthorId>), Error> {
+        match identity {
+            WriteIdentity::Database => Ok((self.identity.author, None)),
+            WriteIdentity::Session(author) => Ok((author, Some(author))),
+            WriteIdentity::Attribution(author) if author == self.identity.author => {
+                Ok((author, Some(self.identity.author)))
+            }
+            WriteIdentity::Attribution(_) => Err(Error::new(
+                ErrorCode::WriteRejected,
+                "attribution requires a trusted serving node",
+            )),
         }
-        Err(Error::new(
-            ErrorCode::WriteRejected,
-            "attribution requires a trusted serving node",
-        ))
     }
 
     pub(super) fn check_catalogue_admin(&self) -> Result<(), Error> {

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -460,6 +460,27 @@ where
         .await
     }
 
+    /// Insert a row with a generated id and an explicit millisecond provenance time.
+    pub async fn insert_at_ms(
+        &self,
+        table: &str,
+        cells: RowCells,
+        now_ms: u64,
+    ) -> Result<WriteHandle<S>, Error> {
+        let row = self.row_id_source.borrow_mut().next_row_id();
+        self.write_mergeable_at_ms(
+            self.identity.author,
+            None,
+            table,
+            row,
+            cells,
+            Vec::new(),
+            None,
+            now_ms,
+        )
+        .await
+    }
+
     /// Stream one large scalar into a newly inserted row without retaining the
     /// complete logical value in Jazz memory.
     ///

--- a/crates/jazz/src/db/reads.rs
+++ b/crates/jazz/src/db/reads.rs
@@ -30,7 +30,11 @@ where
     /// ```rust
     /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
     /// let db = block_on(open_todos_db())?;
-    /// let write = block_on(db.insert("todos", todo_cells("write docs", false)))?;
+    /// let write = block_on(db.insert(
+    ///     "todos",
+    ///     todo_cells("write docs", false),
+    ///     Default::default(),
+    /// ))?;
     /// let todo = write.row_uuid();
     ///
     /// let query = db.prepare_query(&db.table("todos"))?;
@@ -160,7 +164,12 @@ where
     /// ```rust
     /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
     /// let db = block_on(open_todos_db())?;
-    /// let todo = block_on(db.insert("todos", todo_cells("first item", false)))?.row_uuid();
+    /// let todo = block_on(db.insert(
+    ///     "todos",
+    ///     todo_cells("first item", false),
+    ///     Default::default(),
+    /// ))?
+    /// .row_uuid();
     ///
     /// let todos = db.prepare_query(&db.table("todos"))?;
     /// let found = db.one(&todos)?;
@@ -215,7 +224,11 @@ where
     /// # use jazz::db::doctest_support::{block_on, open_todos_db, todo_cells};
     /// # use jazz::tx::DurabilityTier;
     /// let db = block_on(open_todos_db())?;
-    /// block_on(db.insert("todos", todo_cells("visible locally", false)))?;
+    /// block_on(db.insert(
+    ///     "todos",
+    ///     todo_cells("visible locally", false),
+    ///     Default::default(),
+    /// ))?;
     ///
     /// let opts = ReadOpts {
     ///     tier: DurabilityTier::Local,

--- a/crates/jazz/src/db/subscriptions.rs
+++ b/crates/jazz/src/db/subscriptions.rs
@@ -31,7 +31,11 @@ where
     /// assert!(reset);
     /// assert!(added.is_empty());
     ///
-    /// block_on(db.insert("todos", todo_cells("notify subscribers", false)))?;
+    /// block_on(db.insert(
+    ///     "todos",
+    ///     todo_cells("notify subscribers", false),
+    ///     Default::default(),
+    /// ))?;
     /// let changed = block_on(subscription.next_event()).unwrap();
     /// let SubscriptionEvent::Delta { added, updated, removed, .. } = changed else {
     ///     panic!("expected subscription delta");

--- a/crates/jazz/src/db/tests/catalogue.rs
+++ b/crates/jazz/src/db/tests/catalogue.rs
@@ -42,8 +42,12 @@ fn live_subscription_rebuilds_after_shared_current_descriptor_widens() {
     let evolved = evolved_owner_write_schema();
     let author = AuthorId::from_bytes([0xa1; 16]);
     let db = open_db(0x5d, author, &base);
-    db.insert("todos", cells("before evolution", false, author))
-        .unwrap();
+    db.insert(
+        "todos",
+        cells("before evolution", false, author),
+        Default::default(),
+    )
+    .unwrap();
 
     let query = Query::from("todos");
     let mut subscription = prepared_subscribe(
@@ -111,8 +115,12 @@ fn live_subscription_rebuilds_after_shared_current_descriptor_widens() {
         SubscriptionEvent::Delta { reset: true, .. }
     ));
 
-    db.insert("todos", cells("after evolution", true, author))
-        .unwrap();
+    db.insert(
+        "todos",
+        cells("after evolution", true, author),
+        Default::default(),
+    )
+    .unwrap();
     let (added, updated, removed) = delta_rows(
         subscription
             .try_next_event()
@@ -163,6 +171,7 @@ fn old_enum_subscription_rebuilds_across_registry_and_layout_growth() {
                 ("title".to_owned(), Value::String("before".to_owned())),
                 ("status".to_owned(), empty_payload_case(0)),
             ]),
+            Default::default(),
         )
         .unwrap();
     let query = Query::from("items");

--- a/crates/jazz/src/db/tests/lifecycle.rs
+++ b/crates/jazz/src/db/tests/lifecycle.rs
@@ -9,6 +9,7 @@ fn db_facade_opens_writes_and_reads_todos_end_to_end() {
         .insert(
             "todos",
             doctest_support::todo_cells("learn the db facade", false),
+            Default::default(),
         )
         .unwrap();
     let todo = write.row_uuid();
@@ -40,8 +41,12 @@ fn db_facade_opens_writes_and_reads_todos_end_to_end() {
 #[test]
 fn db_close_is_idempotent() {
     let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
-    db.insert("todos", doctest_support::todo_cells("close me", false))
-        .unwrap();
+    db.insert(
+        "todos",
+        doctest_support::todo_cells("close me", false),
+        Default::default(),
+    )
+    .unwrap();
 
     doctest_support::block_on(db.close()).unwrap();
     doctest_support::block_on(db.close()).unwrap();

--- a/crates/jazz/src/db/tests/mutations.rs
+++ b/crates/jazz/src/db/tests/mutations.rs
@@ -71,11 +71,14 @@ fn admitted_server_authorizes_branch_write_through_referenced_application_row() 
     let _outsider_subscriber = server.accept_subscriber(outsider_server_transport, outsider);
 
     let accepted = owner_client
-        .insert_with_id_in_branch(
+        .insert(
             "todos",
-            selector.clone(),
-            row(0x79),
             BTreeMap::from([("title".to_owned(), Value::String("allowed".to_owned()))]),
+            crate::db::InsertOptions {
+                row_id: Some(row(0x79)),
+                target: crate::db::ExactWriteTarget::Branch(selector.clone()),
+                ..Default::default()
+            },
         )
         .unwrap();
     owner_client.tick().unwrap();
@@ -87,11 +90,14 @@ fn admitted_server_authorizes_branch_write_through_referenced_application_row() 
     );
 
     let denied = outsider_client
-        .insert_with_id_in_branch(
+        .insert(
             "todos",
-            selector,
-            row(0x7a),
             BTreeMap::from([("title".to_owned(), Value::String("denied".to_owned()))]),
+            crate::db::InsertOptions {
+                row_id: Some(row(0x7a)),
+                target: crate::db::ExactWriteTarget::Branch(selector),
+                ..Default::default()
+            },
         )
         .unwrap();
     assert_authority_rejects_staged_write(&outsider_client, &server, &denied);
@@ -104,7 +110,11 @@ fn db_facade_mutation_lifecycle_writes_reads_deletes_and_restores() {
     let table = &doctest_support::schema().tables[0];
 
     let write = db
-        .insert("todos", doctest_support::todo_cells("draft todo", false))
+        .insert(
+            "todos",
+            doctest_support::todo_cells("draft todo", false),
+            Default::default(),
+        )
         .unwrap();
     let todo = write.row_uuid();
     doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -122,6 +132,7 @@ fn db_facade_mutation_lifecycle_writes_reads_deletes_and_restores() {
             "todos",
             todo,
             BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
         )
         .unwrap();
     doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -134,7 +145,7 @@ fn db_facade_mutation_lifecycle_writes_reads_deletes_and_restores() {
     );
     assert_eq!(rows[0].cell(table, "done"), Some(Value::Bool(true)));
 
-    let write = db.delete("todos", todo).unwrap();
+    let write = db.delete("todos", todo, Default::default()).unwrap();
     doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
     assert!(prepared_read(&db, &query).is_empty());
 
@@ -142,7 +153,8 @@ fn db_facade_mutation_lifecycle_writes_reads_deletes_and_restores() {
         .restore(
             "todos",
             todo,
-            doctest_support::todo_cells("restored todo", true),
+            Some(doctest_support::todo_cells("restored todo", true)),
+            Default::default(),
         )
         .unwrap();
     doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -162,7 +174,11 @@ fn high_level_large_value_apis_keep_descriptors_private_and_publish_edits() {
     let mut title = "a".repeat(groove::large_values::INLINE_VALUE_MAX_BYTES + 257);
     title.push_str("🙂tail");
     let write = db
-        .insert("todos", doctest_support::todo_cells(&title, false))
+        .insert(
+            "todos",
+            doctest_support::todo_cells(&title, false),
+            Default::default(),
+        )
         .unwrap();
     let row = write.row_uuid();
     block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -184,6 +200,7 @@ fn high_level_large_value_apis_keep_descriptors_private_and_publish_edits() {
             "todos",
             row,
             BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
         )
         .unwrap();
     block_on(unrelated.wait(DurabilityTier::Local)).unwrap();
@@ -250,7 +267,11 @@ fn high_level_large_value_apis_keep_descriptors_private_and_publish_edits() {
         "p".repeat(groove::large_values::INLINE_VALUE_MAX_BYTES)
     );
     let json_row = db
-        .insert("todos", doctest_support::todo_cells(&json, false))
+        .insert(
+            "todos",
+            doctest_support::todo_cells(&json, false),
+            Default::default(),
+        )
         .unwrap()
         .row_uuid();
     assert_eq!(
@@ -282,19 +303,25 @@ fn high_level_large_value_reads_authorize_before_descriptor_lookup() {
     let db = open_db(0x4e, reader, &schema);
     let visible = row(0x4e);
     let hidden = row(0x4f);
-    db.insert_with_id(
+    db.insert(
         "documents",
-        visible,
         BTreeMap::from([("body".to_owned(), Value::String(allowed.clone()))]),
+        InsertOptions {
+            row_id: Some(visible),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "documents",
-        hidden,
         BTreeMap::from([(
             "body".to_owned(),
             Value::String(format!("{}x", &allowed[..allowed.len() - 1])),
         )]),
+        InsertOptions {
+            row_id: Some(hidden),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -314,13 +341,16 @@ fn nullable_large_text_uses_the_same_high_level_read_and_edit_surface() {
     let db = open_db(0x4d, AuthorId::SYSTEM, &schema);
     let row = row(0x4d);
     let body = "n".repeat(groove::large_values::INLINE_VALUE_MAX_BYTES + 73);
-    db.insert_with_id(
+    db.insert(
         "notes",
-        row,
         BTreeMap::from([(
             "body".to_owned(),
             Value::Nullable(Some(Box::new(Value::String(body.clone())))),
         )]),
+        InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -361,7 +391,11 @@ fn db_facade_runs_saas_shaped_local_lane_end_to_end() {
 
     let query = Query::from("todos");
     let write = db
-        .insert("todos", cells("ship facade", false, owner))
+        .insert(
+            "todos",
+            cells("ship facade", false, owner),
+            Default::default(),
+        )
         .unwrap();
     let todo = write.row_uuid();
     let table = &schema.tables[0];
@@ -377,6 +411,7 @@ fn db_facade_runs_saas_shaped_local_lane_end_to_end() {
         "todos",
         todo,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+        Default::default(),
     )
     .unwrap();
     let updated = prepared_all(&db, &query, ReadOpts::default());
@@ -415,7 +450,11 @@ fn db_sync_surface_uploads_client_writes_for_authority_fate() {
 
     // A local client write is Local and queued for upload.
     let write = client
-        .insert("todos", cells("from client", false, author))
+        .insert(
+            "todos",
+            cells("from client", false, author),
+            Default::default(),
+        )
         .unwrap();
     let row = write.row_uuid();
 
@@ -448,7 +487,11 @@ fn byte_wire_uploads_client_writes_for_authority_fate() {
     let _subscriber = server.accept_subscriber(server_transport, author);
 
     let write = client
-        .insert("todos", cells("from client", false, author))
+        .insert(
+            "todos",
+            cells("from client", false, author),
+            Default::default(),
+        )
         .unwrap();
     let row = write.row_uuid();
 
@@ -479,7 +522,14 @@ fn db_sync_surface_uploads_client_exclusive_commit_for_global_fate() {
     let row = row(0xe1);
     let exclusive = client.exclusive_tx().unwrap();
     exclusive
-        .insert_with_id("todos", row, cells("exclusive", false, author))
+        .insert(
+            "todos",
+            cells("exclusive", false, author),
+            crate::db::InsertOptions {
+                row_id: Some(row),
+                ..Default::default()
+            },
+        )
         .unwrap();
     let tx_id = exclusive.commit().unwrap();
 
@@ -522,10 +572,24 @@ fn db_sync_surface_returns_exclusive_conflict_fate_to_client() {
     let first = client.exclusive_tx().unwrap();
     let second = client.exclusive_tx().unwrap();
     first
-        .insert_with_id("todos", row, cells("first", false, author))
+        .insert(
+            "todos",
+            cells("first", false, author),
+            crate::db::InsertOptions {
+                row_id: Some(row),
+                ..Default::default()
+            },
+        )
         .unwrap();
     second
-        .insert_with_id("todos", row, cells("second", false, author))
+        .insert(
+            "todos",
+            cells("second", false, author),
+            crate::db::InsertOptions {
+                row_id: Some(row),
+                ..Default::default()
+            },
+        )
         .unwrap();
     let first_tx = first.commit().unwrap();
     let second_error = second.commit().unwrap_err();
@@ -570,7 +634,11 @@ fn unhandled_rejection_is_delivered_as_mutation_error() {
     }));
 
     let write = client
-        .insert("todos", cells("rejected", false, author))
+        .insert(
+            "todos",
+            cells("rejected", false, author),
+            Default::default(),
+        )
         .unwrap();
     authority_transport
         .send(SyncMessage::FateUpdate {
@@ -619,7 +687,11 @@ fn waited_rejection_is_not_delivered_as_mutation_error() {
     }));
 
     let write = client
-        .insert("todos", cells("waited rejection", false, author))
+        .insert(
+            "todos",
+            cells("waited rejection", false, author),
+            Default::default(),
+        )
         .unwrap();
     let wait_result = Rc::new(RefCell::new(None));
     let callback_result = Rc::clone(&wait_result);
@@ -671,7 +743,11 @@ fn wait_after_rejection_suppresses_queued_mutation_error() {
     }));
 
     let write = client
-        .insert("todos", cells("late wait rejection", false, author))
+        .insert(
+            "todos",
+            cells("late wait rejection", false, author),
+            Default::default(),
+        )
         .unwrap();
     authority_transport
         .send(SyncMessage::FateUpdate {
@@ -731,7 +807,11 @@ fn undelivered_mutation_error_is_recovered_after_reopen() {
     let (client_transport, mut authority_transport) = duplex();
     let upstream = crate::db::block_on(client.connect_upstream(client_transport));
     let write = client
-        .insert("todos", cells("rejected before reopen", false, author))
+        .insert(
+            "todos",
+            cells("rejected before reopen", false, author),
+            Default::default(),
+        )
         .unwrap();
     let tx_id = write.mergeable_tx_id();
     authority_transport
@@ -802,7 +882,11 @@ fn write_fate_and_durability_are_queryable_through_facade() {
     let _subscriber = server.accept_subscriber(server_transport, author);
 
     let write = client
-        .insert("todos", cells("facade state", false, author))
+        .insert(
+            "todos",
+            cells("facade state", false, author),
+            Default::default(),
+        )
         .unwrap();
     assert_eq!(
         write.write_state().unwrap(),
@@ -888,7 +972,11 @@ fn session_upload_uses_connection_identity_for_write_policy() {
     let _subscriber = server.accept_subscriber(server_transport, session_author);
 
     let write = client
-        .insert("todos", cells("honest", false, session_author))
+        .insert(
+            "todos",
+            cells("honest", false, session_author),
+            Default::default(),
+        )
         .unwrap();
     let row = write.row_uuid();
 
@@ -949,6 +1037,7 @@ fn admitted_server_prepared_write_policy_binds_text_user_id_claim() {
                     Value::String("alice-subject".to_owned()),
                 ),
             ]),
+            Default::default(),
         )
         .unwrap();
     alice_client.tick().unwrap();
@@ -961,10 +1050,8 @@ fn admitted_server_prepared_write_policy_binds_text_user_id_claim() {
     );
 
     let denied = bob_client
-        .insert_with_id_for_identity(
-            bob,
+        .insert(
             "messages",
-            row(0xb2),
             BTreeMap::from([
                 (
                     "body".to_owned(),
@@ -975,6 +1062,11 @@ fn admitted_server_prepared_write_policy_binds_text_user_id_claim() {
                     Value::String("alice-subject".to_owned()),
                 ),
             ]),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xb2)),
+                identity: crate::db::WriteIdentity::Session(bob),
+                ..Default::default()
+            },
         )
         .unwrap();
     assert_authority_rejects_staged_write(&bob_client, &server, &denied);
@@ -1015,6 +1107,7 @@ fn admitted_server_prepared_write_policy_coerces_string_user_id_to_uuid_column()
                 ),
                 ("owner_id".to_owned(), Value::Uuid(alice.0)),
             ]),
+            Default::default(),
         )
         .unwrap();
     alice_client.tick().unwrap();
@@ -1027,10 +1120,8 @@ fn admitted_server_prepared_write_policy_coerces_string_user_id_to_uuid_column()
     );
 
     let denied = bob_client
-        .insert_with_id_for_identity(
-            bob,
+        .insert(
             "messages",
-            row(0xb3),
             BTreeMap::from([
                 (
                     "body".to_owned(),
@@ -1038,6 +1129,11 @@ fn admitted_server_prepared_write_policy_coerces_string_user_id_to_uuid_column()
                 ),
                 ("owner_id".to_owned(), Value::Uuid(alice.0)),
             ]),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xb3)),
+                identity: crate::db::WriteIdentity::Session(bob),
+                ..Default::default()
+            },
         )
         .unwrap();
     assert_authority_rejects_staged_write(&bob_client, &server, &denied);
@@ -1068,6 +1164,7 @@ fn admitted_server_prepared_write_policy_fails_closed_for_wrong_user_id_type() {
                 ),
                 ("owner_id".to_owned(), Value::String("true".to_owned())),
             ]),
+            Default::default(),
         )
         .unwrap();
 
@@ -1097,7 +1194,11 @@ fn session_delete_uses_current_row_for_owner_write_policy() {
     let _subscriber = server.accept_subscriber(server_transport, session_author);
 
     let write = client
-        .insert("todos", cells("owned", false, session_author))
+        .insert(
+            "todos",
+            cells("owned", false, session_author),
+            Default::default(),
+        )
         .unwrap();
     let row = write.row_uuid();
     client.tick().unwrap();
@@ -1106,7 +1207,14 @@ fn session_delete_uses_current_row_for_owner_write_policy() {
     block_on(write.wait(DurabilityTier::Global)).unwrap();
 
     let bad_delete = client
-        .delete_for_identity(other_author, "todos", row)
+        .delete(
+            "todos",
+            row,
+            crate::db::DeleteOptions {
+                identity: crate::db::WriteIdentity::Session(other_author),
+                ..Default::default()
+            },
+        )
         .unwrap();
     assert_authority_rejects_staged_write(&client, &server, &bad_delete);
     let client_rows = prepared_read(&client, &Query::from("todos"));
@@ -1117,7 +1225,14 @@ fn session_delete_uses_current_row_for_owner_write_policy() {
     assert_eq!(rows[0].row_uuid(), row);
 
     let delete = client
-        .delete_for_identity(session_author, "todos", row)
+        .delete(
+            "todos",
+            row,
+            crate::db::DeleteOptions {
+                identity: crate::db::WriteIdentity::Session(session_author),
+                ..Default::default()
+            },
+        )
         .unwrap();
     client.tick().unwrap();
     server.tick().unwrap();
@@ -1199,11 +1314,14 @@ fn trusted_backend_upload_applies_session_claim_assertions_for_write_policy() {
         BTreeMap::from([("role".to_owned(), Value::String("editor".to_owned()))]),
     );
     let write = backend
-        .insert_with_id_for_identity(
-            editor_author,
+        .insert(
             "todos",
-            row(0xe1),
             cells("claim-backed", false, editor_author),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xe1)),
+                identity: crate::db::WriteIdentity::Session(editor_author),
+                ..Default::default()
+            },
         )
         .unwrap();
 
@@ -1236,11 +1354,14 @@ fn session_claim_assertions_require_trusted_backend_upload() {
         BTreeMap::from([("role".to_owned(), Value::String("editor".to_owned()))]),
     );
     let write = client
-        .insert_with_id_for_identity(
-            session_author,
+        .insert(
             "todos",
-            row(0xe2),
             cells("claim-backed", false, session_author),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xe2)),
+                identity: crate::db::WriteIdentity::Session(session_author),
+                ..Default::default()
+            },
         )
         .unwrap();
 
@@ -1270,11 +1391,14 @@ fn trusted_backend_delete_uses_permission_subject_parent_for_write_policy() {
     );
 
     let insert = backend
-        .insert_with_id_for_identity(
-            attributed_user,
+        .insert(
             "todos",
-            row(0xf3),
             cells("attributed", false, attributed_user),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xf3)),
+                identity: crate::db::WriteIdentity::Session(attributed_user),
+                ..Default::default()
+            },
         )
         .unwrap();
     backend.tick().unwrap();
@@ -1283,7 +1407,14 @@ fn trusted_backend_delete_uses_permission_subject_parent_for_write_policy() {
     block_on(insert.wait(DurabilityTier::Global)).unwrap();
 
     let delete = backend
-        .delete_for_identity(attributed_user, "todos", row(0xf3))
+        .delete(
+            "todos",
+            row(0xf3),
+            crate::db::DeleteOptions {
+                identity: crate::db::WriteIdentity::Session(attributed_user),
+                ..Default::default()
+            },
+        )
         .unwrap();
     backend.tick().unwrap();
     server.tick().unwrap();
@@ -1341,7 +1472,14 @@ fn client_delete_advice_is_unknown_without_mutating() {
     let other_db = open_db(0xb2, other, &schema);
     let row = row(1);
     let write = owner_db
-        .insert_with_id("todos", row, cells("owned", false, owner))
+        .insert(
+            "todos",
+            cells("owned", false, owner),
+            crate::db::InsertOptions {
+                row_id: Some(row),
+                ..Default::default()
+            },
+        )
         .unwrap();
     block_on(write.wait(DurabilityTier::Local)).unwrap();
     other_db
@@ -1417,10 +1555,13 @@ fn client_attributed_insert_to_different_user_is_rejected() {
     let client = open_db(0xc1, client_author, &schema);
 
     let err = match client
-        .insert_attributed(
-            attributed_user,
+        .insert(
             "todos",
             cells("forged", false, client_author),
+            crate::db::InsertOptions {
+                identity: crate::db::WriteIdentity::Attribution(attributed_user),
+                ..Default::default()
+            },
         )
         .resolve()
     {
@@ -1437,7 +1578,9 @@ fn default_insert_keeps_subject_and_made_by_equal() {
     let schema = owner_write_schema();
     let owner = AuthorId::from_bytes([0xa1; 16]);
     let db = open_db(0xa1, owner, &schema);
-    let write = db.insert("todos", cells("default", false, owner)).unwrap();
+    let write = db
+        .insert("todos", cells("default", false, owner), Default::default())
+        .unwrap();
     let unit = db
         .node
         .node

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -20,6 +20,7 @@ fn large_write_pushes_staging_before_syncing_its_referencing_row() {
                 ("done".to_owned(), Value::Bool(false)),
                 ("owner".to_owned(), Value::Uuid(author.0)),
             ]),
+            Default::default(),
         )
         .unwrap();
 
@@ -71,6 +72,7 @@ fn large_value_pushes_through_edge_then_pulls_from_core_after_edge_chunk_evictio
                 ("done".to_owned(), Value::Bool(false)),
                 ("owner".to_owned(), Value::Uuid(author.0)),
             ]),
+            Default::default(),
         )
         .unwrap();
 
@@ -226,6 +228,7 @@ fn rate_limited_push_waits_then_retries_the_exact_batch_without_rejecting_the_wr
                 ("done".to_owned(), Value::Bool(false)),
                 ("owner".to_owned(), Value::Uuid(author.0)),
             ]),
+            Default::default(),
         )
         .unwrap();
 
@@ -361,6 +364,7 @@ fn unauthenticated_reconnect_restarts_after_deadline_and_does_not_prevent_ttl_cl
                 ("done".to_owned(), Value::Bool(false)),
                 ("owner".to_owned(), Value::Uuid(author.0)),
             ]),
+            Default::default(),
         )
         .unwrap();
 
@@ -478,6 +482,7 @@ fn assert_different_authenticated_destination_restarts_upload(
                 ("done".to_owned(), Value::Bool(false)),
                 ("owner".to_owned(), Value::Uuid(author.0)),
             ]),
+            Default::default(),
         )
         .unwrap();
     writer.tick().unwrap();
@@ -607,7 +612,14 @@ fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
     let _alice_upstream = crate::db::block_on(alice_edge.connect_upstream(alice_transport));
     let _core_alice = core.accept_subscriber(core_alice_transport, alice);
     let write = alice_edge
-        .insert_with_id("todos", row(0xd5), cells("later row", false, alice))
+        .insert(
+            "todos",
+            cells("later row", false, alice),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xd5)),
+                ..Default::default()
+            },
+        )
         .unwrap();
 
     // One edge tick uploads Alice's local commit; one Core tick finalizes it
@@ -682,7 +694,14 @@ fn edge_later_client_upload_flushes_earlier_upstream_in_same_tick() {
     let _edge_client = edge.accept_subscriber(edge_client_transport, alice);
 
     let write = client
-        .insert_with_id("todos", row(0xd3), cells("later upload", false, alice))
+        .insert(
+            "todos",
+            cells("later upload", false, alice),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xd3)),
+                ..Default::default()
+            },
+        )
         .unwrap();
     client.tick().unwrap();
     edge.tick().unwrap();
@@ -733,7 +752,11 @@ fn write_state_waiter_resolves_on_remote_fate_update() {
     let _subscriber = server.accept_subscriber(server_transport, client_author);
 
     let write = client
-        .insert("todos", cells("wait for fate", false, owner))
+        .insert(
+            "todos",
+            cells("wait for fate", false, owner),
+            Default::default(),
+        )
         .unwrap();
     let tx_id = write.mergeable_tx_id();
     assert_eq!(
@@ -878,6 +901,7 @@ fn db_sync_surface_edge_session_read_policy_filters_private_table_query() {
                 ("body".to_owned(), Value::String("alice private".to_owned())),
                 ("owner_id".to_owned(), Value::String(alice.0.to_string())),
             ]),
+            Default::default(),
         )
         .unwrap();
     writer.tick().unwrap();
@@ -951,6 +975,7 @@ fn prepared_server_read_binds_text_session_user_id_per_session() {
                     Value::Nullable(Some(Box::new(Value::String(alice_subject.into())))),
                 ),
             ]),
+            Default::default(),
         )
         .expect("system seed must write the protected message");
     block_on(seeded.wait(DurabilityTier::Local)).expect("seed must settle locally");
@@ -1027,6 +1052,7 @@ fn db_sync_surface_edge_session_read_policy_filters_after_runtime_schema_publish
                 ("body".to_owned(), Value::String("alice private".to_owned())),
                 ("owner_id".to_owned(), Value::String(alice.0.to_string())),
             ]),
+            Default::default(),
         )
         .unwrap();
     writer.tick().unwrap();

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -434,7 +434,7 @@ fn terminal_core_write_fates_prove_exact_insert_update_and_delete_actions() {
     let subscriber = server.accept_subscriber(server_transport, alice);
 
     let inserted = client
-        .insert("todos", cells("owned", false, alice))
+        .insert("todos", cells("owned", false, alice), Default::default())
         .unwrap();
     client.tick().unwrap();
     server.tick().unwrap();
@@ -447,6 +447,7 @@ fn terminal_core_write_fates_prove_exact_insert_update_and_delete_actions() {
             "todos",
             inserted.row_uuid(),
             BTreeMap::from([("owner".to_owned(), Value::Uuid(bob.0))]),
+            Default::default(),
         )
         .unwrap();
     client.tick().unwrap();
@@ -457,7 +458,9 @@ fn terminal_core_write_fates_prove_exact_insert_update_and_delete_actions() {
         Fate::Rejected(_)
     ));
 
-    let deleted = client.delete("todos", inserted.row_uuid()).unwrap();
+    let deleted = client
+        .delete("todos", inserted.row_uuid(), Default::default())
+        .unwrap();
     client.tick().unwrap();
     server.tick().unwrap();
     client.tick().unwrap();
@@ -573,6 +576,7 @@ fn edge_route_capacity_rejects_instead_of_reporting_edge_acceptance() {
         .insert(
             "todos",
             BTreeMap::from([("title".to_owned(), Value::String("bounded".to_owned()))]),
+            Default::default(),
         )
         .unwrap();
     let queue = Rc::new(RefCell::new(Vec::new()));
@@ -642,6 +646,7 @@ fn admitted_edge_session_routes_selected_authority_fate_to_uploading_client() {
         .insert(
             "todos",
             BTreeMap::from([("title".to_owned(), Value::String("routed".to_owned()))]),
+            Default::default(),
         )
         .unwrap();
     let tx_id = write.mergeable_tx_id();
@@ -923,6 +928,7 @@ fn edge_fate_handoff_redrives_real_downstream_write_and_ignores_old_authority() 
         .insert(
             "todos",
             BTreeMap::from([("title".to_owned(), Value::String("handoff".to_owned()))]),
+            Default::default(),
         )
         .unwrap();
     client.tick().unwrap();
@@ -1068,6 +1074,7 @@ fn edge_parks_downstream_fate_until_a_later_authority_connects() {
         .insert(
             "todos",
             BTreeMap::from([("title".to_owned(), Value::String("parked".to_owned()))]),
+            Default::default(),
         )
         .unwrap();
     client.tick().unwrap();
@@ -1142,7 +1149,11 @@ fn edge_write_before_upstream_admission_binds_and_redrives_fate_route() {
     );
 
     let write = client
-        .insert("todos", cells("startup race", false, alice))
+        .insert(
+            "todos",
+            cells("startup race", false, alice),
+            Default::default(),
+        )
         .unwrap();
     let tx_id = write.mergeable_tx_id();
     client.tick().unwrap();
@@ -1253,6 +1264,7 @@ fn stale_same_authority_session_cannot_settle_or_forward_a_routed_fate() {
         .insert(
             "todos",
             BTreeMap::from([("title".to_owned(), Value::String("epoch".to_owned()))]),
+            Default::default(),
         )
         .unwrap();
     client.tick().unwrap();

--- a/crates/jazz/src/db/tests/reads.rs
+++ b/crates/jazz/src/db/tests/reads.rs
@@ -172,8 +172,15 @@ fn simple_prepared_current_write_query_uses_lowered_plan() {
     let schema = schema();
     let author = AuthorId::from_bytes([0xa1; 16]);
     let db = open_db(0xa3, author, &schema);
-    db.insert_with_id("todos", row(1), cells("simple", false, author))
-        .unwrap();
+    db.insert(
+        "todos",
+        cells("simple", false, author),
+        crate::db::InsertOptions {
+            row_id: Some(row(1)),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let prepared = db.prepare_query(&Query::from("todos")).unwrap();
     assert!(!prepared.has_plan_for_tier(DurabilityTier::Local));
@@ -196,8 +203,15 @@ fn filtered_root_prepared_query_still_reads_without_preinstalled_plan() {
     let schema = schema();
     let author = AuthorId::from_bytes([0xa1; 16]);
     let db = open_db(0xa4, author, &schema);
-    db.insert_with_id("todos", row(1), cells("wanted", false, author))
-        .unwrap();
+    db.insert(
+        "todos",
+        cells("wanted", false, author),
+        crate::db::InsertOptions {
+            row_id: Some(row(1)),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let prepared = db
         .prepare_query(&Query::from("todos").filter(eq(col("title"), lit("wanted"))))
@@ -278,34 +292,46 @@ fn authoritative_global_bound_read_uses_the_declared_index() {
 fn relation_query_one_shot_hop_uses_unified_query_path() {
     let schema = relation_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("alice".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xb1),
         BTreeMap::from([("name".to_owned(), Value::String("bob".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xb1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x11),
         BTreeMap::from([
             ("title".to_owned(), Value::String("alice todo".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x22),
         BTreeMap::from([
             ("title".to_owned(), Value::String("bob todo".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xb1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x22)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -375,34 +401,46 @@ fn relation_query_one_shot_hop_uses_unified_query_path() {
 fn relation_query_one_shot_hop_accepts_runtime_uuid_literal_filter() {
     let schema = relation_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("alice".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xb1),
         BTreeMap::from([("name".to_owned(), Value::String("bob".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xb1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x11),
         BTreeMap::from([
             ("title".to_owned(), Value::String("alice todo".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x22),
         BTreeMap::from([
             ("title".to_owned(), Value::String("bob todo".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xb1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x22)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -476,21 +514,26 @@ fn relation_query_one_shot_hop_accepts_runtime_uuid_literal_filter() {
 fn relation_query_one_shot_multi_hop_scalar_fk_uses_nested_join_path() {
     let schema = relation_hop_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "orgs",
-        row(0x01),
         BTreeMap::from([("name".to_owned(), Value::String("Org A".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x01)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "orgs",
-        row(0x02),
         BTreeMap::from([("name".to_owned(), Value::String("Org B".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x02)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "teams",
-        row(0x11),
         BTreeMap::from([
             ("name".to_owned(), Value::String("Team A".to_owned())),
             (
@@ -498,11 +541,14 @@ fn relation_query_one_shot_multi_hop_scalar_fk_uses_nested_join_path() {
                 Value::Nullable(Some(Box::new(Value::Uuid(row(0x01).0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0x21),
         BTreeMap::from([
             ("name".to_owned(), Value::String("User A".to_owned())),
             (
@@ -510,6 +556,10 @@ fn relation_query_one_shot_multi_hop_scalar_fk_uses_nested_join_path() {
                 Value::Nullable(Some(Box::new(Value::Uuid(row(0x11).0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x21)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -523,19 +573,25 @@ fn relation_query_one_shot_multi_hop_scalar_fk_uses_nested_join_path() {
 fn relation_query_subscription_hop_uses_unified_query_path() {
     let schema = relation_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("alice".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x11),
         BTreeMap::from([
             ("title".to_owned(), Value::String("alice todo".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -597,15 +653,17 @@ fn relation_query_subscription_hop_preserves_projected_self_reference_cells() {
     let parent = row(0x10);
     let team = row(0x11);
     let user = row(0x21);
-    db.insert_with_id(
+    db.insert(
         "teams",
-        parent,
         BTreeMap::from([("name".to_owned(), Value::String("Parent".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(parent),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "teams",
-        team,
         BTreeMap::from([
             ("name".to_owned(), Value::String("Team A".to_owned())),
             (
@@ -613,11 +671,14 @@ fn relation_query_subscription_hop_preserves_projected_self_reference_cells() {
                 Value::Nullable(Some(Box::new(Value::Uuid(parent.0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(team),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        user,
         BTreeMap::from([
             ("name".to_owned(), Value::String("User A".to_owned())),
             (
@@ -625,6 +686,10 @@ fn relation_query_subscription_hop_preserves_projected_self_reference_cells() {
                 Value::Nullable(Some(Box::new(Value::Uuid(team.0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(user),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -659,6 +724,7 @@ fn relation_query_subscription_hop_preserves_projected_self_reference_cells() {
         "teams",
         team,
         BTreeMap::from([("name".to_owned(), Value::String("Team B".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     let (_, changed, removed) = delta_rows(stream.try_next_event().expect("updated event"));
@@ -745,15 +811,17 @@ fn relation_query_subscription_multi_hop_scalar_fk_uses_nested_join_path() {
     let mut stream = block_on(db.subscribe_relation_query(&query, ReadOpts::default())).unwrap();
     assert!(opened_rows(stream.try_next_event().expect("opened event")).is_empty());
 
-    db.insert_with_id(
+    db.insert(
         "orgs",
-        row(0x01),
         BTreeMap::from([("name".to_owned(), Value::String("Org A".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x01)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "teams",
-        row(0x11),
         BTreeMap::from([
             ("name".to_owned(), Value::String("Team A".to_owned())),
             (
@@ -761,11 +829,14 @@ fn relation_query_subscription_multi_hop_scalar_fk_uses_nested_join_path() {
                 Value::Nullable(Some(Box::new(Value::Uuid(row(0x01).0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0x21),
         BTreeMap::from([
             ("name".to_owned(), Value::String("User A".to_owned())),
             (
@@ -773,6 +844,10 @@ fn relation_query_subscription_multi_hop_scalar_fk_uses_nested_join_path() {
                 Value::Nullable(Some(Box::new(Value::Uuid(row(0x11).0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x21)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -861,15 +936,17 @@ fn relation_query_gather_uses_unified_reachable_lowering_for_reads_and_subscript
     let root = row(0x01);
     let middle = row(0x02);
     let leaf = row(0x03);
-    db.insert_with_id(
+    db.insert(
         "teams",
-        root,
         BTreeMap::from([("name".to_owned(), Value::String("root".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(root),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "teams",
-        middle,
         BTreeMap::from([
             ("name".to_owned(), Value::String("middle".to_owned())),
             (
@@ -877,11 +954,14 @@ fn relation_query_gather_uses_unified_reachable_lowering_for_reads_and_subscript
                 Value::Nullable(Some(Box::new(Value::Uuid(root.0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(middle),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "teams",
-        leaf,
         BTreeMap::from([
             ("name".to_owned(), Value::String("leaf".to_owned())),
             (
@@ -889,6 +969,10 @@ fn relation_query_gather_uses_unified_reachable_lowering_for_reads_and_subscript
                 Value::Nullable(Some(Box::new(Value::Uuid(middle.0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(leaf),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -1054,31 +1138,40 @@ fn teams_gather_relation_query() -> RelationQuery {
 fn relation_snapshot_reverse_array_skips_deleted_children() {
     let schema = relation_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("alice".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x11),
         BTreeMap::from([
             ("title".to_owned(), Value::String("deleted todo".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x22),
         BTreeMap::from([
             ("title".to_owned(), Value::String("visible todo".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x22)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.delete("todos", row(0x11)).unwrap();
+    db.delete("todos", row(0x11), Default::default()).unwrap();
 
     let query = Query::from("users")
         .filter(eq(col("id"), lit(Value::Uuid(row(0xa1).0))))
@@ -1217,15 +1310,17 @@ fn relation_snapshot_reverse_array_skips_deleted_children_with_camel_case_ref() 
             ),
     );
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("alice".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x11),
         BTreeMap::from([
             ("title".to_owned(), Value::String("deleted todo".to_owned())),
             ("done".to_owned(), Value::Bool(false)),
@@ -1234,11 +1329,14 @@ fn relation_snapshot_reverse_array_skips_deleted_children_with_camel_case_ref() 
                 Value::Nullable(Some(Box::new(Value::Uuid(row(0xa1).0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x22),
         BTreeMap::from([
             ("title".to_owned(), Value::String("visible todo".to_owned())),
             ("done".to_owned(), Value::Bool(false)),
@@ -1247,6 +1345,10 @@ fn relation_snapshot_reverse_array_skips_deleted_children_with_camel_case_ref() 
                 Value::Nullable(Some(Box::new(Value::Uuid(row(0xa1).0)))),
             ),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x22)),
+            ..Default::default()
+        },
     )
     .unwrap();
     let joined_before_delete = prepared_read(
@@ -1307,7 +1409,7 @@ fn relation_snapshot_reverse_array_skips_deleted_children_with_camel_case_ref() 
             .iter()
             .all(|output| output.occurrence_id.canonical_bytes().len() == 32)
     );
-    db.delete("todos", row(0x11)).unwrap();
+    db.delete("todos", row(0x11), Default::default()).unwrap();
     db.tick().unwrap();
     let SubscriptionEvent::Delta { removed, .. } = block_on(subscription.next_raw()).unwrap()
     else {
@@ -1354,6 +1456,7 @@ fn relation_snapshot_reverse_array_reads_local_nullable_ref_child() {
         .insert(
             "users",
             BTreeMap::from([("name".to_owned(), Value::String("alice".to_owned()))]),
+            Default::default(),
         )
         .unwrap()
         .row_uuid();
@@ -1367,6 +1470,7 @@ fn relation_snapshot_reverse_array_reads_local_nullable_ref_child() {
                     Value::Nullable(Some(Box::new(Value::Uuid(user.0)))),
                 ),
             ]),
+            Default::default(),
         )
         .unwrap()
         .row_uuid();
@@ -1404,6 +1508,7 @@ fn relation_snapshot_reverse_array_limit_reads_local_child() {
         .insert(
             "projects",
             BTreeMap::from([("name".to_owned(), Value::String("Announcements".to_owned()))]),
+            Default::default(),
         )
         .unwrap()
         .row_uuid();
@@ -1414,6 +1519,7 @@ fn relation_snapshot_reverse_array_limit_reads_local_child() {
                 ("title".to_owned(), Value::String("visible todo".to_owned())),
                 ("projectId".to_owned(), Value::Uuid(project.0)),
             ]),
+            Default::default(),
         )
         .unwrap()
         .row_uuid();
@@ -1442,23 +1548,29 @@ fn relation_snapshot_unordered_array_offset_uses_child_row_id_order() {
     let schema = relation_schema();
     let db = open_db(0xd4, AuthorId::from_bytes([0xd4; 16]), &schema);
     let parent = row(0x41);
-    db.insert_with_id(
+    db.insert(
         "todos",
-        parent,
         BTreeMap::from([
             ("title".to_owned(), Value::String("parent".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(parent),
+            ..Default::default()
+        },
     )
     .unwrap();
     for id in [0xb1, 0xb2, 0xb3] {
-        db.insert_with_id(
+        db.insert(
             "comments",
-            row(id),
             BTreeMap::from([
                 ("body".to_owned(), Value::String("tie".to_owned())),
                 ("todo_id".to_owned(), Value::Uuid(parent.0)),
             ]),
+            crate::db::InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -1500,15 +1612,17 @@ fn relation_snapshot_reverse_array_projects_provenance_magic_columns() {
             .table(PublicTableSchemaBuilder::new("users").column("name", PublicColumnType::Text)),
     );
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "projects",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("Announcements".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x22),
         BTreeMap::from([
             ("title".to_owned(), Value::String("Write tests".to_owned())),
             ("done".to_owned(), Value::Bool(false)),
@@ -1520,6 +1634,10 @@ fn relation_snapshot_reverse_array_projects_provenance_magic_columns() {
             ("ownerId".to_owned(), Value::Nullable(None)),
             ("assigneesIds".to_owned(), Value::Array(Vec::new())),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x22)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -1562,11 +1680,14 @@ fn relation_snapshot_reverse_array_projects_provenance_magic_columns() {
 fn version_bearing_current_source_preserves_provenance_timestamps() {
     let db = block_on(doctest_support::open_todos_db()).unwrap();
     let id = row(0x7a);
-    db.insert_with_id_at_ms(
+    db.insert(
         "todos",
-        id,
         doctest_support::todo_cells("provenance", false),
-        1_234,
+        crate::db::InsertOptions {
+            row_id: Some(id),
+            updated_at_ms: Some(1_234),
+            ..Default::default()
+        },
     )
     .unwrap();
     {
@@ -1654,15 +1775,17 @@ fn db_query_builder_expresses_s1_shaped_filters_and_include_modes() {
     }))
     .unwrap();
 
-    db.insert_with_id(
+    db.insert(
         "projects",
-        row(10),
         BTreeMap::from([("name".to_owned(), Value::String("Platform".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(10)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "issues",
-        row(1),
         issue_cells(
             "ship api query builder",
             "open",
@@ -1672,24 +1795,37 @@ fn db_query_builder_expresses_s1_shaped_filters_and_include_modes() {
             &["api", "platform"],
             None,
         ),
+        crate::db::InsertOptions {
+            row_id: Some(row(1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "issues",
-        row(2),
         issue_cells("closed work", "done", alice, row(10), 3, &["api"], Some(99)),
+        crate::db::InsertOptions {
+            row_id: Some(row(2)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "issues",
-        row(3),
         issue_cells("someone else", "open", bob, row(10), 8, &["platform"], None),
+        crate::db::InsertOptions {
+            row_id: Some(row(3)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "issues",
-        row(4),
         issue_cells("missing project", "open", alice, row(99), 6, &["api"], None),
+        crate::db::InsertOptions {
+            row_id: Some(row(4)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -1766,16 +1902,22 @@ fn payload_enum_match_filters_one_shot_and_maintained_case_transitions() {
     let db = open_db(0xe7, AuthorId::from_bytes([0xe7; 16]), &schema);
     let matching = row(0xe1);
     let other_case = row(0xe2);
-    db.insert_with_id(
+    db.insert(
         "events",
-        matching,
         BTreeMap::from([("event".to_owned(), payload_message(2))]),
+        crate::db::InsertOptions {
+            row_id: Some(matching),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "events",
-        other_case,
         BTreeMap::from([("event".to_owned(), payload_closed(2))]),
+        crate::db::InsertOptions {
+            row_id: Some(other_case),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -1798,6 +1940,7 @@ fn payload_enum_match_filters_one_shot_and_maintained_case_transitions() {
         "events",
         matching,
         BTreeMap::from([("event".to_owned(), payload_closed(2))]),
+        Default::default(),
     )
     .unwrap();
     let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
@@ -1816,6 +1959,7 @@ fn payload_enum_match_filters_one_shot_and_maintained_case_transitions() {
         "events",
         other_case,
         BTreeMap::from([("event".to_owned(), payload_message(2))]),
+        Default::default(),
     )
     .unwrap();
     let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
@@ -2005,7 +2149,11 @@ fn read_opts_default_and_effective_tier_preserve_local_update_contract() {
 fn edge_read_opts_and_wait_honor_edge_durability() {
     let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
     let write = db
-        .insert("todos", doctest_support::todo_cells("edge observed", false))
+        .insert(
+            "todos",
+            doctest_support::todo_cells("edge observed", false),
+            Default::default(),
+        )
         .unwrap();
     let query = db.table("todos");
     let prepared_query = prepared(&db, &query);

--- a/crates/jazz/src/db/tests/subscriptions/authorization.rs
+++ b/crates/jazz/src/db/tests/subscriptions/authorization.rs
@@ -23,6 +23,7 @@ fn maintained_subscription_emits_created_by_scoped_insert_after_empty_seed() {
                 ),
                 ("done".to_owned(), Value::Bool(false)),
             ]),
+            Default::default(),
         )
         .unwrap();
     block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -129,7 +130,11 @@ fn dropping_one_local_stream_preserves_a_sibling_on_the_same_binding() {
     );
 
     let write = db
-        .insert("todos", doctest_support::todo_cells("match", false))
+        .insert(
+            "todos",
+            doctest_support::todo_cells("match", false),
+            Default::default(),
+        )
         .unwrap();
     let (added, updated, removed) = delta_rows(block_on(survivor.next_raw()).unwrap());
     assert_eq!(row_ids(&added), vec![write.row_uuid()]);
@@ -159,6 +164,7 @@ fn maintained_subscription_emits_created_by_scoped_insert_for_explicit_identity(
                 ),
                 ("done".to_owned(), Value::Bool(false)),
             ]),
+            Default::default(),
         )
         .unwrap();
     block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -207,6 +213,7 @@ fn local_propagating_subscription_emits_created_by_scoped_insert_after_empty_see
                 ),
                 ("done".to_owned(), Value::Bool(false)),
             ]),
+            Default::default(),
         )
         .unwrap();
     block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -246,6 +253,7 @@ fn local_propagating_subscription_coerces_user_id_claim_for_created_by() {
         .insert(
             "todos",
             doctest_support::todo_cells("created by alice", false),
+            Default::default(),
         )
         .unwrap();
     block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -578,10 +586,13 @@ fn direct_multi_identity_subscribe_reuses_shared_seeded_fragments_without_leakin
     let member = AuthorId::from_bytes([0x12; 16]);
     let other = AuthorId::from_bytes([0x13; 16]);
     let spy = AuthorId::from_bytes([0x99; 16]);
-    db.insert_with_id(
+    db.insert(
         "org",
-        row(0x01),
         BTreeMap::from([("label".to_owned(), Value::String("org".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x01)),
+            ..Default::default()
+        },
     )
     .unwrap();
     let direct_group = row(0x31);
@@ -595,24 +606,41 @@ fn direct_multi_identity_subscribe_reuses_shared_seeded_fragments_without_leakin
         (transitive_group, "transitive"),
         (hidden_group, "hidden"),
     ] {
-        db.insert_with_id("group", group, team_cells(name)).unwrap();
+        db.insert(
+            "group",
+            team_cells(name),
+            crate::db::InsertOptions {
+                row_id: Some(group),
+                ..Default::default()
+            },
+        )
+        .unwrap();
     }
-    db.insert_with_id(
+    db.insert(
         "group_access_edges",
-        row(0xa1),
         group_access_test_cells(direct_group, member),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "group_access_edges",
-        row(0xa2),
         group_access_test_cells(hidden_group, other),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa2)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "group_entry",
-        row(0xc1),
         group_entry_test_cells(direct_group, transitive_group, false),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xc1)),
+            ..Default::default()
+        },
     )
     .unwrap();
     for (resource, title) in [
@@ -620,18 +648,28 @@ fn direct_multi_identity_subscribe_reuses_shared_seeded_fragments_without_leakin
         (transitive, "transitive"),
         (hidden, "hidden"),
     ] {
-        db.insert_with_id("res_i", resource, resource_test_cells(title))
-            .unwrap();
+        db.insert(
+            "res_i",
+            resource_test_cells(title),
+            crate::db::InsertOptions {
+                row_id: Some(resource),
+                ..Default::default()
+            },
+        )
+        .unwrap();
     }
     for (edge, resource, group) in [
         (row(0xb1), direct, direct_group),
         (row(0xb2), transitive, transitive_group),
         (row(0xb3), hidden, hidden_group),
     ] {
-        db.insert_with_id(
+        db.insert(
             "res_i_access_edges",
-            edge,
             resource_access_test_cells(resource, group, false),
+            crate::db::InsertOptions {
+                row_id: Some(edge),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -688,27 +726,44 @@ fn direct_same_identity_subscribe_reuses_shared_seeded_fragments_across_shapes()
     let schema = customer_two_resource_policy_minimal_schema();
     let db = open_db(0x6a, AuthorId::SYSTEM, &schema);
     let member = AuthorId::from_bytes([0x12; 16]);
-    db.insert_with_id(
+    db.insert(
         "org",
-        row(0x01),
         BTreeMap::from([("label".to_owned(), Value::String("org".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x01)),
+            ..Default::default()
+        },
     )
     .unwrap();
     let direct_group = row(0x31);
     let transitive_group = row(0x32);
     for (group, name) in [(direct_group, "direct"), (transitive_group, "transitive")] {
-        db.insert_with_id("group", group, team_cells(name)).unwrap();
+        db.insert(
+            "group",
+            team_cells(name),
+            crate::db::InsertOptions {
+                row_id: Some(group),
+                ..Default::default()
+            },
+        )
+        .unwrap();
     }
-    db.insert_with_id(
+    db.insert(
         "group_access_edges",
-        row(0xa1),
         group_access_test_cells(direct_group, member),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "group_entry",
-        row(0xc1),
         group_entry_test_cells(direct_group, transitive_group, false),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xc1)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -722,8 +777,15 @@ fn direct_same_identity_subscribe_reuses_shared_seeded_fragments_across_shapes()
         ("res_j", res_j_direct, "j-direct"),
         ("res_j", res_j_transitive, "j-transitive"),
     ] {
-        db.insert_with_id(table, resource, resource_test_cells(title))
-            .unwrap();
+        db.insert(
+            table,
+            resource_test_cells(title),
+            crate::db::InsertOptions {
+                row_id: Some(resource),
+                ..Default::default()
+            },
+        )
+        .unwrap();
     }
     for (table, edge, resource, group) in [
         ("res_i_access_edges", row(0xb1), res_i_direct, direct_group),
@@ -741,10 +803,13 @@ fn direct_same_identity_subscribe_reuses_shared_seeded_fragments_across_shapes()
             transitive_group,
         ),
     ] {
-        db.insert_with_id(
+        db.insert(
             table,
-            edge,
             resource_access_test_cells(resource, group, false),
+            crate::db::InsertOptions {
+                row_id: Some(edge),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -1179,7 +1244,14 @@ fn inherited_child_insert_uses_parent_update_where_old_only() {
     let _member_upstream = crate::db::block_on(member_db.connect_upstream(member_transport));
     let _member_subscriber = server.accept_subscriber(server_member_transport, member);
     let allowed = member_db
-        .insert_with_id("children", row(0xf2), child_insert_cells(parent, "allowed"))
+        .insert(
+            "children",
+            child_insert_cells(parent, "allowed"),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xf2)),
+                ..Default::default()
+            },
+        )
         .unwrap();
     member_db.tick().unwrap();
     server.tick().unwrap();
@@ -1198,7 +1270,14 @@ fn inherited_child_insert_uses_parent_update_where_old_only() {
     let _other_upstream = crate::db::block_on(other_db.connect_upstream(other_transport));
     let _other_subscriber = server.accept_subscriber(server_other_transport, other);
     let denied = other_db
-        .insert_with_id("children", row(0xf3), child_insert_cells(parent, "denied"))
+        .insert(
+            "children",
+            child_insert_cells(parent, "denied"),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xf3)),
+                ..Default::default()
+            },
+        )
         .unwrap();
     assert_authority_rejects_staged_write(&other_db, &server, &denied);
     let other_rows = prepared_read(&other_db, &Query::from("children"));

--- a/crates/jazz/src/db/tests/subscriptions/coverage/local_lifecycle.rs
+++ b/crates/jazz/src/db/tests/subscriptions/coverage/local_lifecycle.rs
@@ -77,6 +77,7 @@ fn db_facade_subscription_refresh_preserves_read_tier() {
     db.insert(
         "todos",
         doctest_support::todo_cells("pending local-only write", true),
+        Default::default(),
     )
     .unwrap();
 
@@ -100,6 +101,7 @@ fn db_facade_subscription_accepts_local_tier_for_alpha_style_live_reads() {
     db.insert(
         "todos",
         doctest_support::todo_cells("local callback", false),
+        Default::default(),
     )
     .unwrap();
     let changed = doctest_support::block_on(subscription.next_raw()).unwrap();
@@ -122,6 +124,7 @@ fn local_write_is_readable_synchronously_without_running_tick() {
     db.insert(
         "todos",
         doctest_support::todo_cells("read before tick", false),
+        Default::default(),
     )
     .unwrap();
 
@@ -145,6 +148,7 @@ fn local_write_notifies_subscription_synchronously_without_running_tick() {
     db.insert(
         "todos",
         doctest_support::todo_cells("notify before tick", false),
+        Default::default(),
     )
     .unwrap();
 

--- a/crates/jazz/src/db/tests/subscriptions/coverage/settlement/local_and_branch.rs
+++ b/crates/jazz/src/db/tests/subscriptions/coverage/settlement/local_and_branch.rs
@@ -12,14 +12,21 @@ fn local_subscription_emits_removed_row_for_fire_and_forget_delete() {
     assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
 
     let row_id = row(0x31);
-    db.insert_with_id("todos", row_id, cells("delete me", false, owner))
-        .unwrap();
+    db.insert(
+        "todos",
+        cells("delete me", false, owner),
+        crate::db::InsertOptions {
+            row_id: Some(row_id),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
     assert_eq!(row_ids(&added), vec![row_id]);
     assert!(updated.is_empty());
     assert!(removed.is_empty());
 
-    db.delete("todos", row_id).unwrap();
+    db.delete("todos", row_id, Default::default()).unwrap();
     let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
     assert!(added.is_empty());
     assert!(updated.is_empty());
@@ -42,9 +49,8 @@ fn one_shot_and_subscription_rows_keep_identical_record_descriptors() {
     let _ = block_on(subscription.next_raw()).unwrap();
 
     let row_id = row(0x32);
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row_id,
         BTreeMap::from([
             (
                 "title".to_owned(),
@@ -52,6 +58,10 @@ fn one_shot_and_subscription_rows_keep_identical_record_descriptors() {
             ),
             ("done".to_owned(), Value::Bool(false)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row_id),
+            ..Default::default()
+        },
     )
     .unwrap();
     let (added, _, _) = delta_rows(block_on(subscription.next_raw()).unwrap());
@@ -84,14 +94,17 @@ fn session_scoped_subscription_emits_removed_row_for_owned_delete() {
     assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
 
     let row_id = row(0x32);
-    db.insert_with_id_for_identity(
-        author,
+    db.insert(
         "messages",
-        row_id,
         BTreeMap::from([
             ("body".to_owned(), Value::String("delete me".to_owned())),
             ("owner_id".to_owned(), Value::String(user_id.to_owned())),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row_id),
+            identity: crate::db::WriteIdentity::Session(author),
+            ..Default::default()
+        },
     )
     .unwrap();
     let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
@@ -99,7 +112,15 @@ fn session_scoped_subscription_emits_removed_row_for_owned_delete() {
     assert!(updated.is_empty());
     assert!(removed.is_empty());
 
-    db.delete_for_identity(author, "messages", row_id).unwrap();
+    db.delete(
+        "messages",
+        row_id,
+        crate::db::DeleteOptions {
+            identity: crate::db::WriteIdentity::Session(author),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
     assert!(added.is_empty());
     assert!(updated.is_empty());

--- a/crates/jazz/src/db/tests/subscriptions/materialization.rs
+++ b/crates/jazz/src/db/tests/subscriptions/materialization.rs
@@ -70,13 +70,34 @@ fn authoritative_reset_rebuilds_occurrence_sidecar_after_order_and_count_change(
     let middle = row(0x72);
     let last = row(0x73);
     let first_write = client
-        .insert_with_id("todos", first, cells("alpha", false, client_author))
+        .insert(
+            "todos",
+            cells("alpha", false, client_author),
+            crate::db::InsertOptions {
+                row_id: Some(first),
+                ..Default::default()
+            },
+        )
         .unwrap();
     let _middle_write = client
-        .insert_with_id("todos", middle, cells("middle", false, client_author))
+        .insert(
+            "todos",
+            cells("middle", false, client_author),
+            crate::db::InsertOptions {
+                row_id: Some(middle),
+                ..Default::default()
+            },
+        )
         .unwrap();
     let last_write = client
-        .insert_with_id("todos", last, cells("omega", false, client_author))
+        .insert(
+            "todos",
+            cells("omega", false, client_author),
+            crate::db::InsertOptions {
+                row_id: Some(last),
+                ..Default::default()
+            },
+        )
         .unwrap();
     client.tick().unwrap();
 
@@ -97,6 +118,7 @@ fn authoritative_reset_rebuilds_occurrence_sidecar_after_order_and_count_change(
             "todos",
             first,
             BTreeMap::from([("title".to_owned(), Value::String("zulu".to_owned()))]),
+            Default::default(),
         )
         .unwrap();
     let binding_view_key = BindingViewKey::new(

--- a/crates/jazz/src/db/tests/subscriptions/structured.rs
+++ b/crates/jazz/src/db/tests/subscriptions/structured.rs
@@ -6,16 +6,22 @@ use super::*;
 fn array_subquery_live_subscription_publishes_only_terminal_root_rows() {
     let schema = relation_schema();
     let db = open_db(0xc1, AuthorId::from_bytes([0xc1; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("alice".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xb1),
         BTreeMap::from([("name".to_owned(), Value::String("bob".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xb1)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -43,13 +49,16 @@ fn array_subquery_live_subscription_publishes_only_terminal_root_rows() {
     );
     assert!(snapshot.edges.is_empty());
 
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x11),
         BTreeMap::from([
             ("title".to_owned(), Value::String("first".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x11)),
+            ..Default::default()
+        },
     )
     .unwrap();
     db.tick().unwrap();
@@ -86,6 +95,7 @@ fn array_subquery_live_subscription_publishes_only_terminal_root_rows() {
         "todos",
         row(0x11),
         BTreeMap::from([("owner_id".to_owned(), Value::Uuid(row(0xb1).0))]),
+        Default::default(),
     )
     .unwrap();
     let removed_child = block_on(subscription.next_raw()).unwrap();
@@ -99,6 +109,7 @@ fn array_subquery_live_subscription_publishes_only_terminal_root_rows() {
         "todos",
         row(0x11),
         BTreeMap::from([("owner_id".to_owned(), Value::Uuid(row(0xa1).0))]),
+        Default::default(),
     )
     .unwrap();
     let restored_child = block_on(subscription.next_raw()).unwrap();
@@ -113,10 +124,13 @@ fn array_subquery_live_subscription_publishes_only_terminal_root_rows() {
 fn structured_subscription_splices_in_terminal_root_order_after_insert() {
     let schema = relation_schema();
     let db = open_db(0xc4, AuthorId::from_bytes([0xc4; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("zulu".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -134,10 +148,13 @@ fn structured_subscription_splices_in_terminal_root_order_after_insert() {
     let snapshot = snapshot_from_event(initial);
     assert_eq!(row_ids(&snapshot.rows), vec![row(0xa1)]);
 
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xb1),
         BTreeMap::from([("name".to_owned(), Value::String("alpha".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xb1)),
+            ..Default::default()
+        },
     )
     .unwrap();
     db.tick().unwrap();
@@ -200,6 +217,7 @@ fn structured_subscription_splices_in_terminal_root_order_after_insert() {
         "users",
         row(0xb1),
         BTreeMap::from([("name".to_owned(), Value::String("zzzz".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     db.tick().unwrap();
@@ -233,7 +251,7 @@ fn structured_subscription_splices_in_terminal_root_order_after_insert() {
         ] if remove_path.is_empty() && insert_path.is_empty()
     ));
 
-    db.delete("users", row(0xa1)).unwrap();
+    db.delete("users", row(0xa1), Default::default()).unwrap();
     db.tick().unwrap();
     let removed = block_on(subscription.next_raw()).unwrap();
     let SubscriptionEvent::Delta { reset, .. } = &removed else {
@@ -380,14 +398,17 @@ fn propagated_structured_subscription_rehydrates_after_membership_scoped_one_sho
     client.detach_query(normal_chat_attachment);
 
     let accepted_membership = invite_client
-        .insert_with_id(
+        .insert(
             "chat_members",
-            row(0xc2),
             BTreeMap::from([
                 ("chat_id".to_owned(), Value::Uuid(chat.0)),
                 ("user_id".to_owned(), Value::String(reader.0.to_string())),
                 ("join_code".to_owned(), Value::Nullable(None)),
             ]),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xc2)),
+                ..Default::default()
+            },
         )
         .unwrap();
     invite_client.tick().unwrap();
@@ -489,16 +510,22 @@ fn propagated_structured_subscription_rehydrates_after_membership_scoped_one_sho
 fn flat_subscription_hydrates_in_declared_root_order() {
     let schema = relation_schema();
     let db = open_db(0xd4, AuthorId::from_bytes([0xd4; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("zulu".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xb1),
         BTreeMap::from([("name".to_owned(), Value::String("alpha".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xb1)),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -515,10 +542,13 @@ fn flat_subscription_hydrates_in_default_row_id_order() {
     let schema = relation_schema();
     let db = open_db(0xd7, AuthorId::from_bytes([0xd7; 16]), &schema);
     for id in [0xb1, 0xa1] {
-        db.insert_with_id(
+        db.insert(
             "users",
-            row(id),
             BTreeMap::from([("name".to_owned(), Value::String(format!("user-{id}")))]),
+            crate::db::InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -540,10 +570,13 @@ fn flat_subscription_inserts_at_declared_root_position() {
     let _initial = block_on(subscription.next_raw()).unwrap();
 
     for (id, name) in [(0xa1, "zulu"), (0xb1, "zzzz")] {
-        db.insert_with_id(
+        db.insert(
             "users",
-            row(id),
             BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            crate::db::InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
         db.tick().unwrap();
@@ -571,6 +604,7 @@ fn flat_subscription_inserts_at_declared_root_position() {
         "users",
         row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("yyyy".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     db.tick().unwrap();
@@ -595,19 +629,21 @@ fn flat_subscription_updates_with_nullable_sort_payload() {
         ),
     );
     let db = open_db(0xd6, AuthorId::from_bytes([0xd6; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([
             ("name".to_owned(), Value::String("before".to_owned())),
             ("rank".to_owned(), Value::Nullable(None)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
     for (id, rank) in [(0xb1, 1), (0xc1, 2)] {
-        db.insert_with_id(
+        db.insert(
             "users",
-            row(id),
             BTreeMap::from([
                 ("name".to_owned(), Value::String(format!("rank-{rank}"))),
                 (
@@ -615,6 +651,10 @@ fn flat_subscription_updates_with_nullable_sort_payload() {
                     Value::Nullable(Some(Box::new(Value::I32(rank)))),
                 ),
             ]),
+            crate::db::InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -627,6 +667,7 @@ fn flat_subscription_updates_with_nullable_sort_payload() {
         "users",
         row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("after".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     db.tick().unwrap();
@@ -665,13 +706,16 @@ fn flat_subscription_update_respects_descending_row_id_tie_break() {
     );
     let db = open_db(0xd8, AuthorId::from_bytes([0xd8; 16]), &schema);
     for (id, rank) in [(0xf0, 1), (0xe0, 1), (0x10, 2)] {
-        db.insert_with_id(
+        db.insert(
             "users",
-            row(id),
             BTreeMap::from([
                 ("name".to_owned(), Value::String(format!("user-{id}"))),
                 ("rank".to_owned(), Value::I32(rank)),
             ]),
+            InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -690,6 +734,7 @@ fn flat_subscription_update_respects_descending_row_id_tie_break() {
         "users",
         row(0x10),
         BTreeMap::from([("rank".to_owned(), Value::I32(1))]),
+        Default::default(),
     )
     .unwrap();
     db.tick().unwrap();
@@ -720,13 +765,16 @@ fn flat_subscription_update_moves_largest_descending_row_id_to_front() {
     );
     let db = open_db(0xd9, AuthorId::from_bytes([0xd9; 16]), &schema);
     for (id, rank) in [(0xf0, 1), (0xe0, 1), (0xff, 2)] {
-        db.insert_with_id(
+        db.insert(
             "users",
-            row(id),
             BTreeMap::from([
                 ("name".to_owned(), Value::String(format!("user-{id}"))),
                 ("rank".to_owned(), Value::I32(rank)),
             ]),
+            InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -741,6 +789,7 @@ fn flat_subscription_update_moves_largest_descending_row_id_to_front() {
         "users",
         row(0xff),
         BTreeMap::from([("rank".to_owned(), Value::I32(1))]),
+        Default::default(),
     )
     .unwrap();
     db.tick().unwrap();
@@ -765,10 +814,13 @@ fn flat_subscription_shifts_offset_window_when_leading_row_is_deleted() {
     let schema = relation_schema();
     let db = open_db(0xd8, AuthorId::from_bytes([0xd8; 16]), &schema);
     for (id, name) in [(0xa1, "a"), (0xb1, "b"), (0xc1, "c"), (0xd1, "d")] {
-        db.insert_with_id(
+        db.insert(
             "users",
-            row(id),
             BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            crate::db::InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -781,7 +833,7 @@ fn flat_subscription_shifts_offset_window_when_leading_row_is_deleted() {
     let initial = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
     assert_eq!(row_ids(&initial.rows), vec![row(0xb1), row(0xc1)]);
 
-    db.delete("users", row(0xa1)).unwrap();
+    db.delete("users", row(0xa1), Default::default()).unwrap();
     db.tick().unwrap();
     let event = block_on(subscription.next_raw()).unwrap();
     assert!(matches!(
@@ -796,13 +848,16 @@ fn flat_subscription_shifts_offset_window_when_leading_row_is_deleted() {
 fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
     let schema = relation_schema();
     let db = open_db(0xc2, AuthorId::from_bytes([0xc2; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x21),
         BTreeMap::from([
             ("title".to_owned(), Value::String("parent".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x21)),
+            ..Default::default()
+        },
     )
     .unwrap();
     let query = Query::from("todos")
@@ -816,13 +871,16 @@ fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
         Vec::<String>::new()
     );
 
-    db.insert_with_id(
+    db.insert(
         "comments",
-        row(0xc1),
         BTreeMap::from([
             ("body".to_owned(), Value::String("first".to_owned())),
             ("todo_id".to_owned(), Value::Uuid(row(0x21).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xc1)),
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(matches!(
@@ -838,6 +896,7 @@ fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
         "comments",
         row(0xc1),
         BTreeMap::from([("body".to_owned(), Value::String("edited".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     let SubscriptionEvent::Delta {
@@ -868,7 +927,8 @@ fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
         "canonical replacement must address one stable child identity"
     );
 
-    db.delete("comments", row(0xc1)).unwrap();
+    db.delete("comments", row(0xc1), Default::default())
+        .unwrap();
     assert!(matches!(
         block_on(subscription.next_raw()).unwrap(),
         SubscriptionEvent::Delta { terminal_operations, .. }
@@ -878,13 +938,16 @@ fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
             ))
     ));
 
-    db.insert_with_id(
+    db.insert(
         "comments",
-        row(0xc2),
         BTreeMap::from([
             ("body".to_owned(), Value::String("second".to_owned())),
             ("todo_id".to_owned(), Value::Uuid(row(0x21).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xc2)),
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(matches!(
@@ -896,7 +959,7 @@ fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
             ))
     ));
 
-    db.delete("todos", row(0x21)).unwrap();
+    db.delete("todos", row(0x21), Default::default()).unwrap();
     assert!(matches!(
         block_on(subscription.next_raw()).unwrap(),
         SubscriptionEvent::Delta { terminal_operations, .. }
@@ -911,13 +974,16 @@ fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
 fn array_subquery_subscription_updates_child_order_limit_boundary() {
     let schema = relation_schema();
     let db = open_db(0xc3, AuthorId::from_bytes([0xc3; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x31),
         BTreeMap::from([
             ("title".to_owned(), Value::String("parent".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x31)),
+            ..Default::default()
+        },
     )
     .unwrap();
     let query = Query::from("todos").array_subquery(
@@ -935,13 +1001,16 @@ fn array_subquery_subscription_updates_child_order_limit_boundary() {
         Vec::<String>::new()
     );
 
-    db.insert_with_id(
+    db.insert(
         "comments",
-        row(0xd1),
         BTreeMap::from([
             ("body".to_owned(), Value::String("b".to_owned())),
             ("todo_id".to_owned(), Value::Uuid(row(0x31).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xd1)),
+            ..Default::default()
+        },
     )
     .unwrap();
     db.tick().unwrap();
@@ -954,13 +1023,16 @@ fn array_subquery_subscription_updates_child_order_limit_boundary() {
         Vec::<String>::new()
     );
 
-    db.insert_with_id(
+    db.insert(
         "comments",
-        row(0xd2),
         BTreeMap::from([
             ("body".to_owned(), Value::String("c".to_owned())),
             ("todo_id".to_owned(), Value::Uuid(row(0x31).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xd2)),
+            ..Default::default()
+        },
     )
     .unwrap();
     db.tick().unwrap();
@@ -983,13 +1055,16 @@ fn array_subquery_subscription_updates_child_order_limit_boundary() {
     };
     expect_inserted_child(block_on(subscription.next_raw()).unwrap(), row(0xd2));
 
-    db.insert_with_id(
+    db.insert(
         "comments",
-        row(0xd3),
         BTreeMap::from([
             ("body".to_owned(), Value::String("a".to_owned())),
             ("todo_id".to_owned(), Value::Uuid(row(0x31).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xd3)),
+            ..Default::default()
+        },
     )
     .unwrap();
     db.tick().unwrap();
@@ -999,6 +1074,7 @@ fn array_subquery_subscription_updates_child_order_limit_boundary() {
         "comments",
         row(0xd3),
         BTreeMap::from([("body".to_owned(), Value::String("z".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     db.tick().unwrap();
@@ -1012,24 +1088,30 @@ fn array_subquery_policy_oracle_filters_child_array_contents_per_identity() {
     let other = AuthorId::from_bytes([0xb1; 16]);
     let spy = AuthorId::from_bytes([0xc1; 16]);
     let db = open_db(0xc4, AuthorId::SYSTEM, &schema);
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x41),
         BTreeMap::from([("title".to_owned(), Value::String("parent".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x41)),
+            ..Default::default()
+        },
     )
     .unwrap();
     for (id, body, owner) in [
         (0xe1, "member-visible", member),
         (0xe2, "other-visible", other),
     ] {
-        db.insert_with_id(
+        db.insert(
             "comments",
-            row(id),
             BTreeMap::from([
                 ("body".to_owned(), Value::String(body.to_owned())),
                 ("todo_id".to_owned(), Value::Uuid(row(0x41).0)),
                 ("owner".to_owned(), Value::Uuid(owner.0)),
             ]),
+            crate::db::InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -1072,23 +1154,29 @@ fn array_subquery_policy_oracle_filters_child_array_contents_per_identity() {
 fn array_subquery_one_shot_and_maintained_subscription_are_equivalent() {
     let schema = relation_schema();
     let db = open_db(0xc5, AuthorId::from_bytes([0xc5; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x51),
         BTreeMap::from([
             ("title".to_owned(), Value::String("parent".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x51)),
+            ..Default::default()
+        },
     )
     .unwrap();
     for (id, body) in [(0xf1, "first"), (0xf2, "second")] {
-        db.insert_with_id(
+        db.insert(
             "comments",
-            row(id),
             BTreeMap::from([
                 ("body".to_owned(), Value::String(body.to_owned())),
                 ("todo_id".to_owned(), Value::Uuid(row(0x51).0)),
             ]),
+            crate::db::InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -1112,10 +1200,13 @@ fn array_subquery_one_shot_and_maintained_subscription_are_equivalent() {
 fn array_subquery_subscription_projects_late_root_and_existing_forward_target() {
     let schema = relation_schema();
     let db = open_db(0xc7, AuthorId::from_bytes([0xc7; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "users",
-        row(0xa1),
         BTreeMap::from([("name".to_owned(), Value::String("owner".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa1)),
+            ..Default::default()
+        },
     )
     .unwrap();
     let query = Query::from("todos")
@@ -1126,13 +1217,16 @@ fn array_subquery_subscription_projects_late_root_and_existing_forward_target() 
     let opened = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
     assert!(opened.rows.is_empty());
 
-    db.insert_with_id(
+    db.insert(
         "todos",
-        row(0x52),
         BTreeMap::from([
             ("title".to_owned(), Value::String("late root".to_owned())),
             ("owner_id".to_owned(), Value::Uuid(row(0xa1).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x52)),
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(matches!(
@@ -1149,10 +1243,13 @@ fn array_subquery_subscription_projects_late_root_and_existing_forward_target() 
 fn array_subquery_subscription_projects_late_camel_case_root_and_existing_forward_target() {
     let schema = issue_schema();
     let db = open_db(0xc8, AuthorId::from_bytes([0xc8; 16]), &schema);
-    db.insert_with_id(
+    db.insert(
         "projects",
-        row(0xa2),
         BTreeMap::from([("name".to_owned(), Value::String("project".to_owned()))]),
+        crate::db::InsertOptions {
+            row_id: Some(row(0xa2)),
+            ..Default::default()
+        },
     )
     .unwrap();
     let query = Query::from("issues").select(["title"]).array_subquery(
@@ -1163,9 +1260,8 @@ fn array_subquery_subscription_projects_late_camel_case_root_and_existing_forwar
     let opened = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
     assert!(opened.rows.is_empty());
 
-    db.insert_with_id(
+    db.insert(
         "issues",
-        row(0x53),
         issue_cells(
             "late issue",
             "open",
@@ -1175,6 +1271,10 @@ fn array_subquery_subscription_projects_late_camel_case_root_and_existing_forwar
             &[],
             None,
         ),
+        crate::db::InsertOptions {
+            row_id: Some(row(0x53)),
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(matches!(
@@ -1294,14 +1394,17 @@ fn ordered_suffix_delta_preserves_typed_union_occurrence_ids_for_duplicate_rows(
     let schema = schema();
     let db = open_db(0xd1, AuthorId::SYSTEM, &schema);
     let root = row(0xd2);
-    db.insert_with_id(
+    db.insert(
         "todos",
-        root,
         BTreeMap::from([
             ("title".to_owned(), Value::String("same source".to_owned())),
             ("done".to_owned(), Value::Bool(false)),
             ("owner".to_owned(), Value::Uuid(row(0xd3).0)),
         ]),
+        crate::db::InsertOptions {
+            row_id: Some(root),
+            ..Default::default()
+        },
     )
     .unwrap();
     let source_row = prepared_one(&db, &Query::from("todos")).expect("inserted source row");

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -8,8 +8,15 @@ fn exclusive_transactions_lower_oversized_scalars_before_publication() {
     let title = "x".repeat(groove::large_values::INLINE_VALUE_MAX_BYTES + 91);
     let row = row(0x4e);
     let tx = db.exclusive_tx().unwrap();
-    tx.insert_with_id("todos", row, doctest_support::todo_cells(&title, false))
-        .unwrap();
+    tx.insert(
+        "todos",
+        doctest_support::todo_cells(&title, false),
+        InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     tx.commit().unwrap();
 
     let physical = block_on(async {
@@ -46,6 +53,7 @@ fn exclusive_transactions_lower_oversized_scalars_before_publication() {
             "todos",
             row,
             BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
         )
         .unwrap();
     update.commit().unwrap();
@@ -75,13 +83,16 @@ fn exclusive_transactions_lower_oversized_scalars_before_publication() {
 
     let forged = db.exclusive_tx().unwrap();
     forged
-        .insert_with_id(
+        .insert(
             "todos",
-            RowUuid::from_bytes([0x4f; 16]),
             BTreeMap::from([
                 ("title".to_owned(), physical),
                 ("done".to_owned(), Value::Bool(false)),
             ]),
+            InsertOptions {
+                row_id: Some(RowUuid::from_bytes([0x4f; 16])),
+                ..Default::default()
+            },
         )
         .unwrap();
     let error = block_on(forged.commit()).unwrap_err();
@@ -115,11 +126,14 @@ fn attached_schema_mergeable_batch_is_queryable_after_owner_commit() {
     owner.begin_mergeable(open).unwrap();
     let inserted = row(0x91);
     view.mergeable_tx_ref(open)
-        .insert_with_id_at_ms(
+        .insert(
             "todos",
-            inserted,
             doctest_support::todo_cells("attached", false),
-            1_704_067_200_123,
+            crate::db::InsertOptions {
+                row_id: Some(inserted),
+                updated_at_ms: Some(1_704_067_200_123),
+                ..Default::default()
+            },
         )
         .unwrap();
     owner.commit_mergeable_handle(open).unwrap();
@@ -169,11 +183,14 @@ fn attached_schema_mergeable_batch_is_queryable_after_owner_commit() {
     let overlay_inserted = row(0x93);
     let overlay_tx = view.mergeable_tx_ref(overlay_open);
     overlay_tx
-        .insert_with_id_at_ms(
+        .insert(
             "todos",
-            overlay_inserted,
             doctest_support::todo_cells("overlay", true),
-            1_704_067_200_456,
+            crate::db::InsertOptions {
+                row_id: Some(overlay_inserted),
+                updated_at_ms: Some(1_704_067_200_456),
+                ..Default::default()
+            },
         )
         .unwrap();
     let prepared = view
@@ -232,27 +249,36 @@ fn attached_schema_mergeable_batch_is_queryable_after_owner_commit() {
 fn mergeable_overlay_uses_staged_provenance_and_preserves_it_at_commit() {
     let db = block_on(doctest_support::open_todos_db()).unwrap();
     let existing = row(0xa1);
-    db.insert_with_id_at_ms(
+    db.insert(
         "todos",
-        existing,
         doctest_support::todo_cells("existing", false),
-        100,
+        crate::db::InsertOptions {
+            row_id: Some(existing),
+            updated_at_ms: Some(100),
+            ..Default::default()
+        },
     )
     .unwrap();
     let inserted = row(0xa2);
     let tx = db.mergeable_tx().unwrap();
-    tx.insert_with_id_at_ms(
+    tx.insert(
         "todos",
-        inserted,
         doctest_support::todo_cells("inserted", false),
-        200,
+        crate::db::InsertOptions {
+            row_id: Some(inserted),
+            updated_at_ms: Some(200),
+            ..Default::default()
+        },
     )
     .unwrap();
-    tx.update_at_ms(
+    tx.update(
         "todos",
         existing,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
-        300,
+        crate::db::UpdateOptions {
+            updated_at_ms: Some(300),
+            ..Default::default()
+        },
     )
     .unwrap();
     let query = db
@@ -307,25 +333,32 @@ fn mergeable_overlay_uses_staged_provenance_and_preserves_it_at_commit() {
 fn exclusive_overlay_reserves_stable_provenance_for_insert_and_update() {
     let db = block_on(doctest_support::open_todos_db()).unwrap();
     let existing = row(0xb1);
-    db.insert_with_id_at_ms(
+    db.insert(
         "todos",
-        existing,
         doctest_support::todo_cells("existing", false),
-        100,
+        crate::db::InsertOptions {
+            row_id: Some(existing),
+            updated_at_ms: Some(100),
+            ..Default::default()
+        },
     )
     .unwrap();
     let inserted = row(0xb2);
     let tx = db.exclusive_tx().unwrap();
-    tx.insert_with_id(
+    tx.insert(
         "todos",
-        inserted,
         doctest_support::todo_cells("inserted", false),
+        crate::db::InsertOptions {
+            row_id: Some(inserted),
+            ..Default::default()
+        },
     )
     .unwrap();
     tx.update(
         "todos",
         existing,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+        Default::default(),
     )
     .unwrap();
     let query = db
@@ -456,7 +489,16 @@ fn exclusive_tx_overlay_scopes_same_row_uuid_by_table() {
         ("table_b", shared_row, current_b.clone()),
         ("table_b", other_b, nonmatching_b.clone()),
     ] {
-        let write = db.insert_with_id(table, row_uuid, row_cells).unwrap();
+        let write = db
+            .insert(
+                table,
+                row_cells,
+                crate::db::InsertOptions {
+                    row_id: Some(row_uuid),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
         block_on(write.wait(DurabilityTier::Local)).unwrap();
     }
 
@@ -474,8 +516,15 @@ fn exclusive_tx_overlay_scopes_same_row_uuid_by_table() {
         .unwrap();
     let tx = db.exclusive_tx().unwrap();
     let pending_a = cells("selected", "table A pending");
-    tx.insert_with_id("table_a", shared_row, pending_a.clone())
-        .unwrap();
+    tx.insert(
+        "table_a",
+        pending_a.clone(),
+        crate::db::InsertOptions {
+            row_id: Some(shared_row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     assert_reads(
         &tx,
@@ -491,8 +540,15 @@ fn exclusive_tx_overlay_scopes_same_row_uuid_by_table() {
     );
 
     let pending_b = cells("selected", "table B pending");
-    tx.insert_with_id("table_b", shared_row, pending_b.clone())
-        .unwrap();
+    tx.insert(
+        "table_b",
+        pending_b.clone(),
+        crate::db::InsertOptions {
+            row_id: Some(shared_row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert_reads(
         &tx,
         "table_a",
@@ -524,18 +580,21 @@ fn upsert_merges_existing_rows_but_writes_absent_rows_directly() {
         "todos",
         existing,
         doctest_support::todo_cells("draft", false),
+        Default::default(),
     )
     .unwrap();
     db.upsert(
         "todos",
         existing,
         BTreeMap::from([("title".to_owned(), Value::String("renamed".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     db.upsert(
         "todos",
         absent,
         BTreeMap::from([("title".to_owned(), Value::String("created".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
 
@@ -566,10 +625,24 @@ fn mergeable_tx_commits_multiple_writes_under_one_tx_id() {
     let row_two = row(2);
     let tx = db.mergeable_tx().unwrap();
 
-    tx.insert_with_id("todos", row_one, doctest_support::todo_cells("one", false))
-        .unwrap();
-    tx.insert_with_id("todos", row_two, doctest_support::todo_cells("two", true))
-        .unwrap();
+    tx.insert(
+        "todos",
+        doctest_support::todo_cells("one", false),
+        crate::db::InsertOptions {
+            row_id: Some(row_one),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    tx.insert(
+        "todos",
+        doctest_support::todo_cells("two", true),
+        crate::db::InsertOptions {
+            row_id: Some(row_two),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     let tx_id = tx.commit().unwrap();
 
     let rows = prepared_read(&db, &db.table("todos"))
@@ -600,12 +673,20 @@ fn mergeable_tx_coalesces_insert_then_update_for_same_row() {
     let row = row(1);
     let tx = db.mergeable_tx().unwrap();
 
-    tx.insert_with_id("todos", row, doctest_support::todo_cells("draft", false))
-        .unwrap();
+    tx.insert(
+        "todos",
+        doctest_support::todo_cells("draft", false),
+        crate::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     tx.update(
         "todos",
         row,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+        Default::default(),
     )
     .unwrap();
     let tx_id = tx.commit().unwrap();
@@ -633,18 +714,31 @@ fn mergeable_tx_coalesces_restore_then_update_for_same_row() {
     let table = &doctest_support::schema().tables[0];
     let row = row(1);
 
-    db.insert_with_id("todos", row, doctest_support::todo_cells("archived", false))
-        .unwrap();
-    db.delete("todos", row).unwrap();
+    db.insert(
+        "todos",
+        doctest_support::todo_cells("archived", false),
+        crate::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    db.delete("todos", row, Default::default()).unwrap();
     assert!(prepared_read(&db, &db.table("todos")).is_empty());
 
     let tx = db.mergeable_tx().unwrap();
-    tx.restore("todos", row, doctest_support::todo_cells("restored", false))
-        .unwrap();
+    tx.restore(
+        "todos",
+        row,
+        Some(doctest_support::todo_cells("restored", false)),
+        Default::default(),
+    )
+    .unwrap();
     tx.update(
         "todos",
         row,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+        Default::default(),
     )
     .unwrap();
     let tx_id = tx.commit().unwrap();
@@ -687,18 +781,27 @@ fn mergeable_tx_coalesces_repeated_same_row_updates() {
     let row = row(1);
     let tx = db.mergeable_tx().unwrap();
 
-    tx.insert_with_id("todos", row, doctest_support::todo_cells("first", false))
-        .unwrap();
+    tx.insert(
+        "todos",
+        doctest_support::todo_cells("first", false),
+        crate::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     tx.update(
         "todos",
         row,
         BTreeMap::from([("title".to_owned(), Value::String("second".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
     tx.update(
         "todos",
         row,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+        Default::default(),
     )
     .unwrap();
     let tx_id = tx.commit().unwrap();
@@ -725,16 +828,24 @@ fn mergeable_tx_coalesces_update_then_delete_for_same_row() {
     let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
     let row = row(1);
 
-    db.insert_with_id("todos", row, doctest_support::todo_cells("base", false))
-        .unwrap();
+    db.insert(
+        "todos",
+        doctest_support::todo_cells("base", false),
+        crate::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     let tx = db.mergeable_tx().unwrap();
     tx.update(
         "todos",
         row,
         BTreeMap::from([("title".to_owned(), Value::String("ignored".to_owned()))]),
+        Default::default(),
     )
     .unwrap();
-    tx.delete("todos", row).unwrap();
+    tx.delete("todos", row, Default::default()).unwrap();
     let tx_id = tx.commit().unwrap();
 
     assert!(prepared_read(&db, &db.table("todos")).is_empty());
@@ -756,17 +867,23 @@ fn mergeable_tx_and_ref_have_identical_restore_and_reinsert_results() {
     let reinserted = row(2);
 
     for db in [&builder, &handle] {
-        db.insert_with_id(
+        db.insert(
             "todos",
-            restored,
             doctest_support::todo_cells("archived", false),
+            crate::db::InsertOptions {
+                row_id: Some(restored),
+                ..Default::default()
+            },
         )
         .unwrap();
-        db.delete("todos", restored).unwrap();
-        db.insert_with_id(
+        db.delete("todos", restored, Default::default()).unwrap();
+        db.insert(
             "todos",
-            reinserted,
             doctest_support::todo_cells("original", false),
+            crate::db::InsertOptions {
+                row_id: Some(reinserted),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -776,7 +893,8 @@ fn mergeable_tx_and_ref_have_identical_restore_and_reinsert_results() {
         .restore(
             "todos",
             restored,
-            doctest_support::todo_cells("restored", false),
+            Some(doctest_support::todo_cells("restored", false)),
+            Default::default(),
         )
         .unwrap();
     builder_tx
@@ -784,14 +902,20 @@ fn mergeable_tx_and_ref_have_identical_restore_and_reinsert_results() {
             "todos",
             restored,
             BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
         )
         .unwrap();
-    builder_tx.delete("todos", reinserted).unwrap();
     builder_tx
-        .insert_with_id(
+        .delete("todos", reinserted, Default::default())
+        .unwrap();
+    builder_tx
+        .insert(
             "todos",
-            reinserted,
             doctest_support::todo_cells("reinserted", true),
+            crate::db::InsertOptions {
+                row_id: Some(reinserted),
+                ..Default::default()
+            },
         )
         .unwrap();
     builder_tx.commit().unwrap();
@@ -803,20 +927,25 @@ fn mergeable_tx_and_ref_have_identical_restore_and_reinsert_results() {
         tx.restore(
             "todos",
             restored,
-            doctest_support::todo_cells("restored", false),
+            Some(doctest_support::todo_cells("restored", false)),
+            Default::default(),
         )
         .unwrap();
         tx.update(
             "todos",
             restored,
             BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
         )
         .unwrap();
-        tx.delete("todos", reinserted).unwrap();
-        tx.insert_with_id(
+        tx.delete("todos", reinserted, Default::default()).unwrap();
+        tx.insert(
             "todos",
-            reinserted,
             doctest_support::todo_cells("reinserted", true),
+            crate::db::InsertOptions {
+                row_id: Some(reinserted),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -872,17 +1001,30 @@ fn mergeable_tx_read_observes_its_staged_restore() {
     let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
     let row = row(1);
 
-    db.insert_with_id("todos", row, doctest_support::todo_cells("archived", false))
-        .unwrap();
-    db.delete("todos", row).unwrap();
+    db.insert(
+        "todos",
+        doctest_support::todo_cells("archived", false),
+        crate::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    db.delete("todos", row, Default::default()).unwrap();
 
     let tx = db.mergeable_tx().unwrap();
-    tx.restore("todos", row, doctest_support::todo_cells("restored", false))
-        .unwrap();
+    tx.restore(
+        "todos",
+        row,
+        Some(doctest_support::todo_cells("restored", false)),
+        Default::default(),
+    )
+    .unwrap();
     tx.update(
         "todos",
         row,
         BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+        Default::default(),
     )
     .unwrap();
 
@@ -898,8 +1040,15 @@ fn exclusive_tx_ref_survives_handle_reconstruction_until_explicit_commit() {
     let table = &doctest_support::schema().tables[0];
     let row = row(1);
 
-    db.insert_with_id("todos", row, doctest_support::todo_cells("base", false))
-        .unwrap();
+    db.insert(
+        "todos",
+        doctest_support::todo_cells("base", false),
+        crate::db::InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let open_tx = OpenTransactionId::new();
     db.begin_exclusive(open_tx).unwrap();
@@ -913,6 +1062,7 @@ fn exclusive_tx_ref_survives_handle_reconstruction_until_explicit_commit() {
             "todos",
             row,
             BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
         )
         .unwrap();
     }
@@ -945,7 +1095,14 @@ fn identity_bound_exclusive_transaction_rejects_cross_identity_reads_and_commits
 
     db.begin_exclusive_for_identity(open, alice).unwrap();
     db.exclusive_tx_ref(open)
-        .insert_with_id("todos", row, doctest_support::todo_cells("alice", false))
+        .insert(
+            "todos",
+            doctest_support::todo_cells("alice", false),
+            InsertOptions {
+                row_id: Some(row),
+                ..Default::default()
+            },
+        )
         .unwrap();
 
     // Planted positive: the bound identity can read the transaction overlay.
@@ -999,10 +1156,24 @@ fn mergeable_transaction_identity_reads_are_not_forced_to_begin_author() {
     );
     let alice_row = row(0xa3);
     let bob_row = row(0xb3);
-    db.insert_with_id("todos", alice_row, cells("alice", false, alice))
-        .unwrap();
-    db.insert_with_id("todos", bob_row, cells("bob", false, bob))
-        .unwrap();
+    db.insert(
+        "todos",
+        cells("alice", false, alice),
+        InsertOptions {
+            row_id: Some(alice_row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    db.insert(
+        "todos",
+        cells("bob", false, bob),
+        InsertOptions {
+            row_id: Some(bob_row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     assert_eq!(
         block_on(db.all_for_identity(&prepared, ReadOpts::default(), alice))
@@ -1131,10 +1302,13 @@ fn mergeable_tx_emits_one_subscription_delta_for_many_writes() {
 
     let tx = db.mergeable_tx().unwrap();
     for index in 0..100u8 {
-        tx.insert_with_id(
+        tx.insert(
             "todos",
-            RowUuid::from_bytes([index + 1; 16]),
             doctest_support::todo_cells(&format!("todo {index}"), false),
+            crate::db::InsertOptions {
+                row_id: Some(RowUuid::from_bytes([index + 1; 16])),
+                ..Default::default()
+            },
         )
         .unwrap();
     }

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -391,6 +391,112 @@ fn exclusive_overlay_reserves_stable_provenance_for_insert_and_update() {
     assert_eq!(provenance(&committed, existing), updated_overlay);
 }
 
+#[test]
+fn exclusive_crud_preserves_explicit_updated_at() {
+    let db = block_on(doctest_support::open_todos_db()).unwrap();
+    let inserted = row(0xc1);
+    let upserted = row(0xc2);
+    let deleted = row(0xc3);
+    let restored = row(0xc4);
+
+    for (row, title, updated_at_ms) in [
+        (upserted, "upsert base", 10),
+        (deleted, "delete base", 20),
+        (restored, "restore base", 30),
+    ] {
+        db.insert(
+            "todos",
+            doctest_support::todo_cells(title, false),
+            InsertOptions {
+                row_id: Some(row),
+                updated_at_ms: Some(updated_at_ms),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+    db.delete(
+        "todos",
+        restored,
+        DeleteOptions {
+            updated_at_ms: Some(40),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let tx = db.exclusive_tx().unwrap();
+    tx.insert(
+        "todos",
+        doctest_support::todo_cells("inserted", false),
+        InsertOptions {
+            row_id: Some(inserted),
+            updated_at_ms: Some(100),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    tx.upsert(
+        "todos",
+        upserted,
+        BTreeMap::from([("title".to_owned(), Value::String("upserted".to_owned()))]),
+        UpsertOptions {
+            updated_at_ms: Some(200),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    tx.delete(
+        "todos",
+        deleted,
+        DeleteOptions {
+            updated_at_ms: Some(300),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    tx.restore(
+        "todos",
+        restored,
+        Some(doctest_support::todo_cells("restored", true)),
+        RestoreOptions {
+            updated_at_ms: Some(400),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    tx.commit().unwrap();
+
+    let query = db
+        .prepare_query(
+            &db.table("todos")
+                .select(["title", "$createdAt", "$updatedAt"]),
+        )
+        .unwrap();
+    let rows = block_on(db.all(
+        &query,
+        ReadOpts {
+            include_deleted: true,
+            ..Default::default()
+        },
+    ))
+    .unwrap();
+    let updated_at = |row_id| {
+        rows.iter()
+            .find(|row| row.row_uuid() == row_id)
+            .unwrap()
+            .provenance()
+            .unwrap()
+            .unwrap()
+            .updated_at
+    };
+
+    assert_eq!(updated_at(inserted), TxTime(100));
+    assert_eq!(updated_at(upserted), TxTime(200));
+    assert_eq!(updated_at(deleted), TxTime(300));
+    assert_eq!(updated_at(restored), TxTime(400));
+}
+
 /// This stays internal because transaction overlays are not sync-visible. The
 /// point, table, and prepared-query paths are separate overlay consumers, so
 /// exercise all three with the same row UUID present in two logical tables.

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -69,6 +69,31 @@ fn exclusive_transactions_lower_oversized_scalars_before_publication() {
     });
     assert_eq!(physical, after_update, "unchanged locators must be stable");
 
+    let upsert = db.exclusive_tx().unwrap();
+    upsert
+        .upsert(
+            "todos",
+            row,
+            BTreeMap::from([("done".to_owned(), Value::Bool(false))]),
+            Default::default(),
+        )
+        .unwrap();
+    upsert.commit().unwrap();
+    let after_upsert = block_on(async {
+        db.node
+            .node
+            .lock()
+            .await
+            .current_physical_cell_in_schema(db.schema_version_id, "todos", row, "title")
+            .await
+            .unwrap()
+            .unwrap()
+    });
+    assert_eq!(
+        physical, after_upsert,
+        "upserting unrelated cells must preserve unchanged locators"
+    );
+
     let mergeable = db.mergeable_tx().unwrap();
     assert_eq!(
         mergeable.read("todos", row).unwrap().unwrap().get("title"),

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -623,33 +623,6 @@ where
             .map_err(Into::into)
     }
 
-    pub(super) async fn stage_exclusive_update(
-        &self,
-        tx_id: OpenTransactionId,
-        table: &str,
-        row: RowUuid,
-        patch: RowCells,
-    ) -> Result<(), Error> {
-        let now_ms = self.next_now_ms();
-        let mut node = self.node.node.lock().await;
-        let mut cells = node
-            .tx_read_in_schema(tx_id, self.schema_version_id, table, row)
-            .await?
-            .unwrap_or_default();
-        cells.extend(patch);
-        node.tx_write_in_schema_at_ms(
-            tx_id,
-            self.schema_version_id,
-            table,
-            row,
-            cells,
-            None,
-            Some(now_ms),
-        )
-        .await?;
-        Ok(())
-    }
-
     pub(super) async fn stage_exclusive_delete(
         &self,
         tx_id: OpenTransactionId,

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -623,6 +623,34 @@ where
             .map_err(Into::into)
     }
 
+    pub(super) async fn stage_exclusive_update(
+        &self,
+        tx_id: OpenTransactionId,
+        table: &str,
+        row: RowUuid,
+        patch: RowCells,
+        updated_at_ms: Option<u64>,
+    ) -> Result<(), Error> {
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        let mut node = self.node.node.lock().await;
+        let mut cells = node
+            .tx_read_in_schema(tx_id, self.schema_version_id, table, row)
+            .await?
+            .unwrap_or_default();
+        cells.extend(patch);
+        node.tx_write_in_schema_at_ms(
+            tx_id,
+            self.schema_version_id,
+            table,
+            row,
+            cells,
+            None,
+            Some(now_ms),
+        )
+        .await?;
+        Ok(())
+    }
+
     pub(super) async fn stage_exclusive_delete(
         &self,
         tx_id: OpenTransactionId,

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -652,6 +652,35 @@ where
         Ok(())
     }
 
+    pub(super) async fn stage_exclusive_upsert(
+        &self,
+        tx_id: OpenTransactionId,
+        table: &str,
+        row: RowUuid,
+        patch: RowCells,
+        updated_at_ms: Option<u64>,
+    ) -> Result<(), Error> {
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        let mut node = self.node.node.lock().await;
+        let mut cells = node
+            .tx_read_in_schema(tx_id, self.schema_version_id, table, row)
+            .await?
+            .unwrap_or_default();
+        cells.extend(patch);
+        let cells = self.apply_insert_defaults(table, cells)?;
+        node.tx_write_in_schema_at_ms(
+            tx_id,
+            self.schema_version_id,
+            table,
+            row,
+            cells,
+            None,
+            Some(now_ms),
+        )
+        .await?;
+        Ok(())
+    }
+
     pub(super) async fn stage_exclusive_delete(
         &self,
         tx_id: OpenTransactionId,

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -603,8 +603,9 @@ where
         table: &str,
         row: RowUuid,
         cells: RowCells,
+        updated_at_ms: Option<u64>,
     ) -> Result<(), Error> {
-        let now_ms = self.next_now_ms();
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
         let cells = self.apply_insert_defaults(table, cells)?;
         self.node
             .node
@@ -656,8 +657,9 @@ where
         tx_id: OpenTransactionId,
         table: &str,
         row: RowUuid,
+        updated_at_ms: Option<u64>,
     ) -> Result<(), Error> {
-        let now_ms = self.next_now_ms();
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
         self.node
             .node
             .lock()
@@ -681,8 +683,9 @@ where
         table: &str,
         row: RowUuid,
         cells: RowCells,
+        updated_at_ms: Option<u64>,
     ) -> Result<(), Error> {
-        let now_ms = self.next_now_ms();
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
         let cells = self.apply_insert_defaults(table, cells)?;
         let mut node = self.node.node.lock().await;
         // Restore needs one content version and one deletion-register version:

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -2938,7 +2938,7 @@ fn db_facade_current_rows_match_seeded_create_delete_sequence() {
     let table = &crate::db::doctest_support::schema().tables[0];
 
     let write = db
-        .insert("todos", crate::db::doctest_support::todo_cells("a1", false))
+        .insert("todos", crate::db::doctest_support::todo_cells("a1", false), Default::default())
         .unwrap();
     let row_a = write.row_uuid();
     crate::db::doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -2949,7 +2949,7 @@ fn db_facade_current_rows_match_seeded_create_delete_sequence() {
     );
 
     let write = db
-        .insert("todos", crate::db::doctest_support::todo_cells("b1", false))
+        .insert("todos", crate::db::doctest_support::todo_cells("b1", false), Default::default())
         .unwrap();
     let row_b = write.row_uuid();
     crate::db::doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -2964,7 +2964,7 @@ fn db_facade_current_rows_match_seeded_create_delete_sequence() {
     );
 
     crate::db::doctest_support::block_on(
-        db.delete("todos", row_a)
+        db.delete("todos", row_a, Default::default())
             .unwrap()
             .wait(DurabilityTier::Local),
     )
@@ -2972,11 +2972,7 @@ fn db_facade_current_rows_match_seeded_create_delete_sequence() {
     assert_eq!(db_facade_row_ids(&db.read(&prepared).unwrap()), vec![row_b]);
 
     crate::db::doctest_support::block_on(
-        db.restore(
-            "todos",
-            row_a,
-            crate::db::doctest_support::todo_cells("a2", true),
-        )
+        db.restore("todos", row_a, Some(crate::db::doctest_support::todo_cells("a2", true)), Default::default())
         .unwrap()
         .wait(DurabilityTier::Local),
     )
@@ -2992,7 +2988,7 @@ fn db_facade_current_rows_match_seeded_create_delete_sequence() {
     );
 
     crate::db::doctest_support::block_on(
-        db.delete("todos", row_b)
+        db.delete("todos", row_b, Default::default())
             .unwrap()
             .wait(DurabilityTier::Local),
     )
@@ -3017,7 +3013,7 @@ fn db_facade_multi_row_query_matches_seeded_create_delete_sequence_via_write_han
     let table = &crate::db::doctest_support::schema().tables[0];
 
     let write = db
-        .insert("todos", crate::db::doctest_support::todo_cells("a1", false))
+        .insert("todos", crate::db::doctest_support::todo_cells("a1", false), Default::default())
         .unwrap();
     let row_a = write.row_uuid();
     crate::db::doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -3029,7 +3025,7 @@ fn db_facade_multi_row_query_matches_seeded_create_delete_sequence_via_write_han
     );
 
     let write = db
-        .insert("todos", crate::db::doctest_support::todo_cells("b1", false))
+        .insert("todos", crate::db::doctest_support::todo_cells("b1", false), Default::default())
         .unwrap();
     let row_b = write.row_uuid();
     crate::db::doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
@@ -3038,7 +3034,7 @@ fn db_facade_multi_row_query_matches_seeded_create_delete_sequence_via_write_han
             .unwrap();
     assert_eq!(db_facade_row_ids(&rows), vec![row_a, row_b]);
 
-    let write = db.delete("todos", row_a).unwrap();
+    let write = db.delete("todos", row_a, Default::default()).unwrap();
     crate::db::doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
     let rows = db.read(&prepared).unwrap();
     assert_eq!(db_facade_row_ids(&rows), vec![row_b]);
@@ -3048,11 +3044,7 @@ fn db_facade_multi_row_query_matches_seeded_create_delete_sequence_via_write_han
     );
 
     let write = db
-        .restore(
-            "todos",
-            row_a,
-            crate::db::doctest_support::todo_cells("a2", true),
-        )
+        .restore("todos", row_a, Some(crate::db::doctest_support::todo_cells("a2", true)), Default::default())
         .unwrap();
     crate::db::doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
     let rows = db.read(&prepared).unwrap();
@@ -3072,7 +3064,7 @@ fn db_facade_multi_row_query_matches_seeded_create_delete_sequence_via_write_han
         Some(Value::Bool(true))
     );
 
-    let write = db.delete("todos", row_b).unwrap();
+    let write = db.delete("todos", row_b, Default::default()).unwrap();
     crate::db::doctest_support::block_on(write.wait(DurabilityTier::Local)).unwrap();
     let rows =
         crate::db::doctest_support::block_on(db.all(&prepared, crate::db::ReadOpts::default()))

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -284,7 +284,7 @@ impl Backend {
         table: &str,
         cells: crate::db::RowCells,
     ) -> std::result::Result<(CoreRowUuid, CoreTxId), CoreDbError> {
-        let write = crate::db::block_on(self.0.insert(table, cells))?;
+        let write = crate::db::block_on(self.0.insert(table, cells, Default::default()))?;
         Ok((write.row_uuid(), write.mergeable_tx_id()))
     }
 
@@ -294,7 +294,14 @@ impl Backend {
         table: &str,
         cells: crate::db::RowCells,
     ) -> std::result::Result<(CoreRowUuid, CoreTxId), CoreDbError> {
-        let write = crate::db::block_on(self.0.insert_for_identity(identity, table, cells))?;
+        let write = crate::db::block_on(self.0.insert(
+            table,
+            cells,
+            crate::db::InsertOptions {
+                identity: crate::db::WriteIdentity::Session(identity),
+                ..Default::default()
+            },
+        ))?;
         Ok((write.row_uuid(), write.mergeable_tx_id()))
     }
 
@@ -304,7 +311,15 @@ impl Backend {
         row_id: CoreRowUuid,
         cells: crate::db::RowCells,
     ) -> std::result::Result<CoreTxId, CoreDbError> {
-        Ok(crate::db::block_on(self.0.insert_with_id(table, row_id, cells))?.mergeable_tx_id())
+        Ok(crate::db::block_on(self.0.insert(
+            table,
+            cells,
+            crate::db::InsertOptions {
+                row_id: Some(row_id),
+                ..Default::default()
+            },
+        ))?
+        .mergeable_tx_id())
     }
 
     fn insert_with_id_for_identity(
@@ -314,10 +329,15 @@ impl Backend {
         row_id: CoreRowUuid,
         cells: crate::db::RowCells,
     ) -> std::result::Result<CoreTxId, CoreDbError> {
-        Ok(crate::db::block_on(
-            self.0
-                .insert_with_id_for_identity(identity, table, row_id, cells),
-        )?
+        Ok(crate::db::block_on(self.0.insert(
+            table,
+            cells,
+            crate::db::InsertOptions {
+                row_id: Some(row_id),
+                identity: crate::db::WriteIdentity::Session(identity),
+                ..Default::default()
+            },
+        ))?
         .mergeable_tx_id())
     }
 
@@ -327,7 +347,10 @@ impl Backend {
         row_id: CoreRowUuid,
         cells: crate::db::RowCells,
     ) -> std::result::Result<CoreTxId, CoreDbError> {
-        Ok(crate::db::block_on(self.0.upsert(table, row_id, cells))?.mergeable_tx_id())
+        Ok(
+            crate::db::block_on(self.0.upsert(table, row_id, cells, Default::default()))?
+                .mergeable_tx_id(),
+        )
     }
 
     fn upsert_for_identity(
@@ -337,10 +360,16 @@ impl Backend {
         row_id: CoreRowUuid,
         cells: crate::db::RowCells,
     ) -> std::result::Result<CoreTxId, CoreDbError> {
-        Ok(
-            crate::db::block_on(self.0.upsert_for_identity(identity, table, row_id, cells))?
-                .mergeable_tx_id(),
-        )
+        Ok(crate::db::block_on(self.0.upsert(
+            table,
+            row_id,
+            cells,
+            crate::db::UpsertOptions {
+                identity: crate::db::WriteIdentity::Session(identity),
+                ..Default::default()
+            },
+        ))?
+        .mergeable_tx_id())
     }
 
     fn update(
@@ -349,7 +378,10 @@ impl Backend {
         row_id: CoreRowUuid,
         cells: crate::db::RowCells,
     ) -> std::result::Result<CoreTxId, CoreDbError> {
-        Ok(crate::db::block_on(self.0.update(table, row_id, cells))?.mergeable_tx_id())
+        Ok(
+            crate::db::block_on(self.0.update(table, row_id, cells, Default::default()))?
+                .mergeable_tx_id(),
+        )
     }
 
     fn delete_for_identity(
@@ -358,10 +390,15 @@ impl Backend {
         table: &str,
         row_id: CoreRowUuid,
     ) -> std::result::Result<CoreTxId, CoreDbError> {
-        Ok(
-            crate::db::block_on(self.0.delete_for_identity(identity, table, row_id))?
-                .mergeable_tx_id(),
-        )
+        Ok(crate::db::block_on(self.0.delete(
+            table,
+            row_id,
+            crate::db::DeleteOptions {
+                identity: crate::db::WriteIdentity::Session(identity),
+                ..Default::default()
+            },
+        ))?
+        .mergeable_tx_id())
     }
 
     fn delete(
@@ -369,7 +406,10 @@ impl Backend {
         table: &str,
         row_id: CoreRowUuid,
     ) -> std::result::Result<CoreTxId, CoreDbError> {
-        Ok(crate::db::block_on(self.0.delete(table, row_id))?.mergeable_tx_id())
+        Ok(
+            crate::db::block_on(self.0.delete(table, row_id, Default::default()))?
+                .mergeable_tx_id(),
+        )
     }
 
     fn prepare_query(
@@ -453,11 +493,15 @@ impl Backend {
         row_id: CoreRowUuid,
         cells: crate::db::RowCells,
     ) -> std::result::Result<(), CoreDbError> {
-        crate::db::block_on(
-            self.0
-                .exclusive_tx_ref(tx_id)
-                .insert_with_id(table, row_id, cells),
-        )
+        crate::db::block_on(self.0.exclusive_tx_ref(tx_id).insert(
+            table,
+            cells,
+            crate::db::InsertOptions {
+                row_id: Some(row_id),
+                ..Default::default()
+            },
+        ))
+        .map(|_| ())
     }
 
     fn exclusive_update(
@@ -467,7 +511,12 @@ impl Backend {
         row_id: CoreRowUuid,
         cells: crate::db::RowCells,
     ) -> std::result::Result<(), CoreDbError> {
-        crate::db::block_on(self.0.exclusive_tx_ref(tx_id).update(table, row_id, cells))
+        crate::db::block_on(self.0.exclusive_tx_ref(tx_id).update(
+            table,
+            row_id,
+            cells,
+            Default::default(),
+        ))
     }
 
     fn exclusive_delete(
@@ -476,7 +525,11 @@ impl Backend {
         table: &str,
         row_id: CoreRowUuid,
     ) -> std::result::Result<(), CoreDbError> {
-        crate::db::block_on(self.0.exclusive_tx_ref(tx_id).delete(table, row_id))
+        crate::db::block_on(self.0.exclusive_tx_ref(tx_id).delete(
+            table,
+            row_id,
+            Default::default(),
+        ))
     }
 
     fn commit_exclusive_handle(

--- a/crates/jazz/tests/async_open.rs
+++ b/crates/jazz/tests/async_open.rs
@@ -82,6 +82,7 @@ fn concurrent_cold_reads_and_subscription_wait_for_the_async_node_owner() {
     block_on(db.insert(
         "todos",
         [("title".to_owned(), Value::String("cold read".to_owned()))].into(),
+        Default::default(),
     ))
     .expect("seed todo");
     let prepared = db

--- a/crates/jazz/tests/authorization_scope_reentry.rs
+++ b/crates/jazz/tests/authorization_scope_reentry.rs
@@ -4,8 +4,9 @@ mod common;
 
 use jazz::block_on;
 use jazz::db::{
-    Db, DbConfig, DbIdentity, ErrorCode, LocalUpdates, MergeableTxOps, Propagation, ReadOpts,
-    SeededRowIdSource, SubscriptionEvent, SubscriptionStream,
+    Db, DbConfig, DbIdentity, ErrorCode, InsertOptions, LocalUpdates, MergeableTxOps, Propagation,
+    ReadOpts, SeededRowIdSource, SubscriptionEvent, SubscriptionStream, UpdateOptions,
+    UpsertOptions, WriteIdentity,
 };
 use jazz::groove::records::Value;
 use jazz::groove::storage::TestStorage;
@@ -94,25 +95,31 @@ fn opts() -> ReadOpts {
 }
 
 fn insert_document(db: &Db<TestStorage>, id: RowUuid, team: RowUuid, rank: u64) {
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         DOCUMENTS,
-        id,
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(team.0)),
             ("rank".to_owned(), Value::U64(rank)),
         ]),
+        InsertOptions {
+            row_id: Some(id),
+            ..Default::default()
+        },
     ))
     .expect("insert document");
 }
 
 fn insert_membership(db: &Db<TestStorage>, id: RowUuid, team: RowUuid, user: AuthorId) {
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         MEMBERSHIPS,
-        id,
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(team.0)),
             ("user".to_owned(), Value::Uuid(user.0)),
         ]),
+        InsertOptions {
+            row_id: Some(id),
+            ..Default::default()
+        },
     ))
     .expect("insert membership");
 }
@@ -133,9 +140,25 @@ fn upsert_applies_insert_policy_only_to_a_genuinely_absent_target() {
         ("rank".to_owned(), Value::U64(1)),
     ]);
 
-    block_on(db.upsert_for_identity(READER, DOCUMENTS, document, cells.clone()))
-        .expect("absent target follows public insert policy");
-    let error = match block_on(db.upsert_for_identity(READER, DOCUMENTS, document, cells)) {
+    block_on(db.upsert(
+        DOCUMENTS,
+        document,
+        cells.clone(),
+        UpsertOptions {
+            identity: WriteIdentity::Session(READER),
+            ..Default::default()
+        },
+    ))
+    .expect("absent target follows public insert policy");
+    let error = match block_on(db.upsert(
+        DOCUMENTS,
+        document,
+        cells,
+        UpsertOptions {
+            identity: WriteIdentity::Session(READER),
+            ..Default::default()
+        },
+    )) {
         Ok(_) => panic!("hidden existing target requires read permission"),
         Err(error) => error,
     };
@@ -236,10 +259,13 @@ fn write_only_full_row_update_succeeds_but_partial_update_and_upsert_are_denied(
     let second = row(0x22);
     let refill = row(0x23);
 
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         TEAMS,
-        authorized_team,
         BTreeMap::from([("name".to_owned(), Value::String("authorized".to_owned()))]),
+        InsertOptions {
+            row_id: Some(authorized_team),
+            ..Default::default()
+        },
     ))
     .expect("insert team");
     insert_membership(&db, row(0x31), authorized_team, READER);
@@ -255,23 +281,29 @@ fn write_only_full_row_update_succeeds_but_partial_update_and_upsert_are_denied(
         )
         .expect("prepare exact ordered page");
 
-    block_on(db.update_for_identity(
-        WRITER,
+    block_on(db.update(
         DOCUMENTS,
         winner,
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(authorized_team.0)),
             ("rank".to_owned(), Value::U64(5)),
         ]),
+        UpdateOptions {
+            identity: WriteIdentity::Session(WRITER),
+            ..Default::default()
+        },
     ))
     .expect("write-only principal can issue a full-row update");
     assert_eq!(ordered_page(&db, READER, &prepared), vec![second, refill]);
 
-    let partial_error = match block_on(db.update_for_identity(
-        WRITER,
+    let partial_error = match block_on(db.update(
         DOCUMENTS,
         winner,
         BTreeMap::from([("rank".to_owned(), Value::U64(40))]),
+        UpdateOptions {
+            identity: WriteIdentity::Session(WRITER),
+            ..Default::default()
+        },
     )) {
         Ok(_) => panic!("write-only principal's partial update must be denied"),
         Err(error) => error,
@@ -284,14 +316,17 @@ fn write_only_full_row_update_succeeds_but_partial_update_and_upsert_are_denied(
     );
     assert_eq!(ordered_page(&db, READER, &prepared), vec![second, refill]);
 
-    let upsert_error = match block_on(db.upsert_for_identity(
-        WRITER,
+    let upsert_error = match block_on(db.upsert(
         DOCUMENTS,
         winner,
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(authorized_team.0)),
             ("rank".to_owned(), Value::U64(40)),
         ]),
+        UpsertOptions {
+            identity: WriteIdentity::Session(WRITER),
+            ..Default::default()
+        },
     )) {
         Ok(_) => panic!("write-only principal's upsert must be denied"),
         Err(error) => error,
@@ -311,12 +346,14 @@ fn write_only_full_row_update_succeeds_but_partial_update_and_upsert_are_denied(
         DOCUMENTS,
         winner,
         BTreeMap::from([("rank".to_owned(), Value::U64(41))]),
+        Default::default(),
     ))
     .expect("client-local partial update stages optimistically");
     block_on(db.upsert(
         DOCUMENTS,
         winner,
         BTreeMap::from([("rank".to_owned(), Value::U64(42))]),
+        Default::default(),
     ))
     .expect("client-local upsert stages optimistically");
 }
@@ -334,10 +371,13 @@ fn maintained_authorization_restores_an_ordered_page_after_scope_reentry() {
         (authorized_team, "authorized"),
         (unauthorized_team, "unauthorized"),
     ] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             TEAMS,
-            team,
             BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            InsertOptions {
+                row_id: Some(team),
+                ..Default::default()
+            },
         ))
         .expect("insert team");
     }
@@ -374,11 +414,14 @@ fn maintained_authorization_restores_an_ordered_page_after_scope_reentry() {
          is only meaningful for a write-only principal"
     );
 
-    let denied = match block_on(db.update_for_identity(
-        WRITER,
+    let denied = match block_on(db.update(
         DOCUMENTS,
         winner,
         BTreeMap::from([("team".to_owned(), Value::Uuid(unauthorized_team.0))]),
+        UpdateOptions {
+            identity: WriteIdentity::Session(WRITER),
+            ..Default::default()
+        },
     )) {
         Ok(_) => {
             panic!("write-only partial update must be denied before it can corrupt omitted cells")
@@ -390,11 +433,14 @@ fn maintained_authorization_restores_an_ordered_page_after_scope_reentry() {
     assert_eq!(reader_page(), vec![winner, second]);
     assert!(stream.try_next_event().is_none());
 
-    block_on(db.update_for_identity(
-        MAINTAINER,
+    block_on(db.update(
         DOCUMENTS,
         winner,
         BTreeMap::from([("team".to_owned(), Value::Uuid(unauthorized_team.0))]),
+        UpdateOptions {
+            identity: WriteIdentity::Session(MAINTAINER),
+            ..Default::default()
+        },
     ))
     .expect("reader-authorized principal moves winning document out of scope");
     let move_out_delta = exact_delta(&mut stream);
@@ -416,6 +462,7 @@ fn maintained_authorization_restores_an_ordered_page_after_scope_reentry() {
             DOCUMENTS,
             winner,
             BTreeMap::from([("team".to_owned(), Value::Uuid(authorized_team.0))]),
+            Default::default(),
         )
         .await?;
         // The authority re-entry and this ordinary content update share one
@@ -425,6 +472,7 @@ fn maintained_authorization_restores_an_ordered_page_after_scope_reentry() {
             DOCUMENTS,
             second,
             BTreeMap::from([("rank".to_owned(), Value::U64(21))]),
+            Default::default(),
         )
         .await?;
         Ok(())

--- a/crates/jazz/tests/branch_views.rs
+++ b/crates/jazz/tests/branch_views.rs
@@ -174,20 +174,28 @@ fn indexed_branch_view_masks_base_before_applying_the_predicate() {
     let overridden = RowUuid::from_bytes([0x7f; 16]);
     let inherited = RowUuid::from_bytes([0x80; 16]);
     for row in [overridden, inherited] {
-        db.insert_with_id_in_branch(
+        db.insert(
             "todos",
-            base.clone(),
-            row,
             BTreeMap::from([("title".to_owned(), Value::String("needle".to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
-    db.update_in_branch_view(
+    db.update(
         "todos",
-        head.clone(),
-        Some(BranchViewBase::Current(base.clone())),
         overridden,
         BTreeMap::from([("title".to_owned(), Value::String("hidden".to_owned()))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: Some(BranchViewBase::Current(base.clone())),
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -222,27 +230,38 @@ fn branch_view_reduction_precedes_aggregation_and_ordered_windows() {
     let inherited = RowUuid::from_bytes([0x9a; 16]);
     let added = RowUuid::from_bytes([0x9b; 16]);
     for (row, title) in [(replaced, "alpha"), (inherited, "bravo")] {
-        db.insert_with_id_in_branch(
+        db.insert(
             "todos",
-            base.clone(),
-            row,
             BTreeMap::from([("title".to_owned(), Value::String(title.to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
-    db.update_in_branch_view(
+    db.update(
         "todos",
-        head.clone(),
-        Some(BranchViewBase::Current(base.clone())),
         replaced,
         BTreeMap::from([("title".to_owned(), Value::String("zulu".to_owned()))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: Some(BranchViewBase::Current(base.clone())),
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id_in_branch(
+    db.insert(
         "todos",
-        head.clone(),
-        added,
         BTreeMap::from([("title".to_owned(), Value::String("charlie".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(added),
+            target: jazz::db::ExactWriteTarget::Branch(head.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
     let opts = ReadOpts::default().branch_view(head, Some(BranchViewBase::Current(base)));
@@ -306,37 +325,52 @@ fn branch_view_join_projects_branch_column_subsets_and_shared_tables() {
     let workspace = uuid::Uuid::from_bytes([0x84; 16]);
     let branch = uuid::Uuid::from_bytes([0x85; 16]);
     let owner = RowUuid::from_bytes([0x86; 16]);
-    db.insert_with_id(
+    db.insert(
         "workspaces",
-        RowUuid(workspace),
         BTreeMap::from([("name".to_owned(), Value::String("shared".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(RowUuid(workspace)),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id(
+    db.insert(
         "users",
-        owner,
         BTreeMap::from([("name".to_owned(), Value::String("shared".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(owner),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id_in_branch(
+    db.insert(
         "memberships",
-        BranchSelector::new([("workspace_id", Value::Uuid(workspace))]),
-        RowUuid::from_bytes([0x87; 16]),
         BTreeMap::from([("role".to_owned(), Value::String("editor".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(RowUuid::from_bytes([0x87; 16])),
+            target: jazz::db::ExactWriteTarget::Branch(BranchSelector::new([(
+                "workspace_id",
+                Value::Uuid(workspace),
+            )])),
+            ..Default::default()
+        },
     )
     .unwrap();
     let document = RowUuid::from_bytes([0x88; 16]);
-    db.insert_with_id_in_branch(
+    db.insert(
         "documents",
-        BranchSelector::new([
-            ("workspace_id", Value::Uuid(workspace)),
-            ("branch_id", Value::Uuid(branch)),
-        ]),
-        document,
         BTreeMap::from([
             ("owner".to_owned(), Value::Uuid(owner.0)),
             ("title".to_owned(), Value::String("draft".to_owned())),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(document),
+            target: jazz::db::ExactWriteTarget::Branch(BranchSelector::new([
+                ("workspace_id", Value::Uuid(workspace)),
+                ("branch_id", Value::Uuid(branch)),
+            ])),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -413,28 +447,37 @@ fn branch_view_reachability_consumes_effective_sources() {
     let allowed_team = uuid::Uuid::from_bytes([0xa2; 16]);
     let denied_team = uuid::Uuid::from_bytes([0xa3; 16]);
     for (team, name) in [(allowed_team, "allowed"), (denied_team, "denied")] {
-        db.insert_with_id(
+        db.insert(
             "teams",
-            RowUuid(team),
             BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(RowUuid(team)),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
-    db.insert_with_id_in_branch(
+    db.insert(
         "documents",
-        base.clone(),
-        document,
         BTreeMap::from([("title".to_owned(), Value::String("reachable".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(document),
+            target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
-    db.insert_with_id_in_branch(
+    db.insert(
         "access",
-        base.clone(),
-        access,
         BTreeMap::from([
             ("document".to_owned(), Value::Uuid(document.0)),
             ("team".to_owned(), Value::Uuid(allowed_team)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(access),
+            target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
     let query = db
@@ -456,12 +499,17 @@ fn branch_view_reachability_consumes_effective_sources() {
         1
     );
 
-    db.update_in_branch_view(
+    db.update(
         "access",
-        head.clone(),
-        Some(BranchViewBase::Current(base.clone())),
         access,
         BTreeMap::from([("team".to_owned(), Value::Uuid(denied_team))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: Some(BranchViewBase::Current(base.clone())),
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(
@@ -518,14 +566,17 @@ fn branch_column_reference_policy_controls_effective_reads() {
     let outsider = AuthorId::from_bytes([0x77; 16]);
     let branch = RowUuid::from_bytes([0x78; 16]);
     let selector = BranchSelector::new([("branch_id", Value::Uuid(branch.0))]);
-    db.insert_with_id(
+    db.insert(
         "branches",
-        branch,
         BTreeMap::from([
             ("branch_key".to_owned(), Value::Uuid(branch.0)),
             ("name".to_owned(), Value::String("draft".to_owned())),
             ("owner".to_owned(), Value::Uuid(owner.0)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(branch),
+            ..Default::default()
+        },
     )
     .unwrap();
     let branches = db.prepare_query(&db.table("branches")).unwrap();
@@ -543,12 +594,15 @@ fn branch_column_reference_policy_controls_effective_reads() {
     );
 
     let todo = RowUuid::from_bytes([0x79; 16]);
-    db.insert_with_id_in_branch_for_identity(
-        owner,
+    db.insert(
         "todos",
-        selector.clone(),
-        todo,
         BTreeMap::from([("title".to_owned(), Value::String("allowed".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(todo),
+            identity: jazz::db::WriteIdentity::Session(owner),
+            target: jazz::db::ExactWriteTarget::Branch(selector.clone()),
+            ..Default::default()
+        },
     )
     .expect("the ordinary referenced branch row authorizes its owner");
     let joined = db
@@ -635,26 +689,32 @@ fn frozen_base_applies_one_cut_to_policy_dependencies() {
     let base = BranchSelector::new([("branch_id", Value::Uuid(base_branch.0))]);
     let head = BranchSelector::new([("branch_id", Value::Uuid(head_branch.0))]);
     for branch in [base_branch, head_branch] {
-        db.insert_with_id_in_branch(
+        db.insert(
             "branches",
-            base.clone(),
-            branch,
             BTreeMap::from([
                 ("branch_key".to_owned(), Value::Uuid(branch.0)),
                 ("name".to_owned(), Value::String("branch".to_owned())),
                 ("owner".to_owned(), Value::Uuid(before.0)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(branch),
+                target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
     let row = RowUuid::from_bytes([0xac; 16]);
     let authored = db
-        .insert_with_id_in_branch_for_identity(
-            before,
+        .insert(
             "todos",
-            base.clone(),
-            row,
             BTreeMap::from([("title".to_owned(), Value::String("frozen".to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                identity: jazz::db::WriteIdentity::Session(before),
+                target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+                ..Default::default()
+            },
         )
         .unwrap()
         .mergeable_tx_id();
@@ -664,11 +724,17 @@ fn frozen_base_applies_one_cut_to_policy_dependencies() {
         local_base: authored.time,
         dots: Vec::new(),
     };
-    db.update_in_branch(
+    db.update(
         "branches",
-        base.clone(),
         head_branch,
         BTreeMap::from([("owner".to_owned(), Value::Uuid(after.0))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: base.clone(),
+                base: None,
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -728,23 +794,29 @@ fn branch_view_subscription_tracks_reference_policy_revoke_and_grant() {
     let outsider = AuthorId::from_bytes([0xb6; 16]);
     let branch = RowUuid::from_bytes([0xb7; 16]);
     let selector = BranchSelector::new([("branch_id", Value::Uuid(branch.0))]);
-    db.insert_with_id(
+    db.insert(
         "branches",
-        branch,
         BTreeMap::from([
             ("branch_key".to_owned(), Value::Uuid(branch.0)),
             ("name".to_owned(), Value::String("draft".to_owned())),
             ("owner".to_owned(), Value::Uuid(owner.0)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(branch),
+            ..Default::default()
+        },
     )
     .unwrap();
     let row = RowUuid::from_bytes([0xb8; 16]);
-    db.insert_with_id_in_branch_for_identity(
-        owner,
+    db.insert(
         "todos",
-        selector.clone(),
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("visible".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            identity: jazz::db::WriteIdentity::Session(owner),
+            target: jazz::db::ExactWriteTarget::Branch(selector.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
     let query = db.prepare_query(&db.table("todos")).unwrap();
@@ -764,6 +836,7 @@ fn branch_view_subscription_tracks_reference_policy_revoke_and_grant() {
         "branches",
         branch,
         BTreeMap::from([("owner".to_owned(), Value::Uuid(outsider.0))]),
+        Default::default(),
     )
     .unwrap();
     assert!(matches!(
@@ -776,6 +849,7 @@ fn branch_view_subscription_tracks_reference_policy_revoke_and_grant() {
         "branches",
         branch,
         BTreeMap::from([("owner".to_owned(), Value::Uuid(owner.0))]),
+        Default::default(),
     )
     .unwrap();
     assert!(matches!(
@@ -793,18 +867,24 @@ fn one_mergeable_transaction_can_atomically_write_multiple_branches() {
     let right = selector(0x73);
 
     let tx = db.mergeable_tx().unwrap();
-    tx.insert_with_id_in_branch(
+    tx.insert(
         "todos",
-        left.clone(),
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("left".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(left.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
-    tx.insert_with_id_in_branch(
+    tx.insert(
         "todos",
-        right.clone(),
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("right".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(right.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
     tx.commit().unwrap();
@@ -838,11 +918,14 @@ fn branch_move_is_explicit_source_delete_and_destination_restore() {
     let source = selector(0x94);
     let target = selector(0x95);
     let row = RowUuid::from_bytes([0x96; 16]);
-    db.insert_with_id_in_branch(
+    db.insert(
         "todos",
-        source.clone(),
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("move me".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(source.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -876,22 +959,39 @@ fn cross_branch_transaction_and_independent_winners_survive_reopen() {
     {
         let db = open_rocks_db(directory.path(), &schema);
         let tx = db.mergeable_tx().unwrap();
-        tx.insert_with_id_in_branch(
+        tx.insert(
             "todos",
-            left.clone(),
-            row,
             BTreeMap::from([("title".to_owned(), Value::String("left".to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                target: jazz::db::ExactWriteTarget::Branch(left.clone()),
+                ..Default::default()
+            },
         )
         .unwrap();
-        tx.insert_with_id_in_branch(
+        tx.insert(
             "todos",
-            right.clone(),
-            row,
             BTreeMap::from([("title".to_owned(), Value::String("right".to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                target: jazz::db::ExactWriteTarget::Branch(right.clone()),
+                ..Default::default()
+            },
         )
         .unwrap();
         tx.commit().unwrap();
-        db.delete_in_branch("todos", left.clone(), row).unwrap();
+        db.delete(
+            "todos",
+            row,
+            jazz::db::DeleteOptions {
+                target: jazz::db::WriteTarget::BranchView {
+                    head: left.clone(),
+                    base: None,
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
     }
 
     let db = open_rocks_db(directory.path(), &schema);
@@ -938,11 +1038,14 @@ fn sibling_branch_view_subscriptions_isolate_first_writes() {
     ));
 
     let row = RowUuid::from_bytes([0x8b; 16]);
-    db.insert_with_id_in_branch(
+    db.insert(
         "todos",
-        left,
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("left".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(left),
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(matches!(
@@ -955,11 +1058,14 @@ fn sibling_branch_view_subscriptions_isolate_first_writes() {
         "a sibling branch key must not receive the first-write delta"
     );
 
-    db.insert_with_id_in_branch(
+    db.insert(
         "todos",
-        right,
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("right".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(right),
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(matches!(
@@ -969,14 +1075,34 @@ fn sibling_branch_view_subscriptions_isolate_first_writes() {
     ));
     assert!(left_stream.try_next_event().is_none());
 
-    db.delete_in_branch("todos", selector(0x89), row).unwrap();
+    db.delete(
+        "todos",
+        row,
+        jazz::db::DeleteOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: selector(0x89),
+                base: None,
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert!(matches!(
         block_on(left_stream.next_event()).unwrap(),
         SubscriptionEvent::Delta { reset: false, ref removed, .. }
             if removed.iter().any(|candidate| candidate.row_uuid == row)
     ));
     assert!(right_stream.try_next_event().is_none());
-    db.restore_in_branch("todos", selector(0x89), row).unwrap();
+    db.restore(
+        "todos",
+        row,
+        None,
+        jazz::db::RestoreOptions {
+            target: jazz::db::ExactWriteTarget::Branch(selector(0x89)),
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert!(matches!(
         block_on(left_stream.next_event()).unwrap(),
         SubscriptionEvent::Delta { reset: false, ref added, .. }
@@ -1012,11 +1138,14 @@ fn seeded_branch_view_subscription_matches_one_shot_reduction() {
         .map(|index| RowUuid::from_bytes([index.wrapping_add(0xb1); 16]))
         .collect::<Vec<_>>();
     for (index, row) in rows.iter().enumerate() {
-        db.insert_with_id_in_branch(
+        db.insert(
             "todos",
-            base.clone(),
-            *row,
             BTreeMap::from([("title".to_owned(), Value::String(format!("seed-{index}")))]),
+            jazz::db::InsertOptions {
+                row_id: Some(*row),
+                target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+                ..Default::default()
+            },
         )
         .unwrap();
     }
@@ -1059,43 +1188,68 @@ fn seeded_branch_view_subscription_matches_one_shot_reduction() {
         seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
         let row = rows[(seed as usize) % rows.len()];
         let result = match (seed >> 32) % 5 {
-            0 => block_on(db.update_in_branch(
+            0 => block_on(db.update(
                 "todos",
-                base.clone(),
                 row,
                 BTreeMap::from([("title".to_owned(), Value::String(format!("base-{step}")))]),
+                jazz::db::UpdateOptions {
+                    target: jazz::db::WriteTarget::BranchView {
+                        head: base.clone(),
+                        base: None,
+                    },
+                    ..Default::default()
+                },
             ))
             .map(|_| ()),
-            1 => block_on(db.update_in_branch_view(
+            1 => block_on(db.update(
                 "todos",
-                head.clone(),
-                Some(BranchViewBase::Current(base.clone())),
                 row,
                 BTreeMap::from([("title".to_owned(), Value::String(format!("head-{step}")))]),
+                jazz::db::UpdateOptions {
+                    target: jazz::db::WriteTarget::BranchView {
+                        head: head.clone(),
+                        base: Some(BranchViewBase::Current(base.clone())),
+                    },
+                    ..Default::default()
+                },
             ))
             .map(|_| ()),
-            2 => block_on(db.delete_in_branch_view(
+            2 => block_on(db.delete(
                 "todos",
-                head.clone(),
-                Some(BranchViewBase::Current(base.clone())),
                 row,
+                jazz::db::DeleteOptions {
+                    target: jazz::db::WriteTarget::BranchView {
+                        head: head.clone(),
+                        base: Some(BranchViewBase::Current(base.clone())),
+                    },
+                    ..Default::default()
+                },
             ))
             .map(|_| ()),
-            3 => block_on(db.restore_with_cells_in_branch(
+            3 => block_on(db.restore(
                 "todos",
-                head.clone(),
                 row,
-                BTreeMap::from([(
+                Some(BTreeMap::from([(
                     "title".to_owned(),
                     Value::String(format!("restored-{step}")),
-                )]),
+                )])),
+                jazz::db::RestoreOptions {
+                    target: jazz::db::ExactWriteTarget::Branch(head.clone()),
+                    ..Default::default()
+                },
             ))
             .map(|_| ()),
-            _ => block_on(db.update_in_branch(
+            _ => block_on(db.update(
                 "todos",
-                head.clone(),
                 row,
                 BTreeMap::from([("title".to_owned(), Value::String(format!("exact-{step}")))]),
+                jazz::db::UpdateOptions {
+                    target: jazz::db::WriteTarget::BranchView {
+                        head: head.clone(),
+                        base: None,
+                    },
+                    ..Default::default()
+                },
             ))
             .map(|_| ()),
         };
@@ -1125,11 +1279,14 @@ fn db_exact_mutations_and_branch_view_reads_compose_head_over_base() {
     let row = RowUuid::from_bytes([0x64; 16]);
     let base = selector(0x65);
     let head = selector(0x66);
-    db.insert_with_id_in_branch(
+    db.insert(
         "todos",
-        base.clone(),
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("base".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -1165,11 +1322,17 @@ fn db_exact_mutations_and_branch_view_reads_compose_head_over_base() {
         SubscriptionEvent::Delta { reset: true, .. }
     ));
 
-    db.update_in_branch(
+    db.update(
         "todos",
-        selector(0x65),
         row,
         BTreeMap::from([("title".to_owned(), Value::String("base edited".to_owned()))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: selector(0x65),
+                base: None,
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
     let base_changed = block_on(subscription.next_event()).unwrap();
@@ -1181,12 +1344,17 @@ fn db_exact_mutations_and_branch_view_reads_compose_head_over_base() {
         "unexpected live-base subscription delta: {base_changed:?}"
     );
 
-    db.update_in_branch_view(
+    db.update(
         "todos",
-        head.clone(),
-        Some(BranchViewBase::Current(selector(0x65))),
         row,
         BTreeMap::from([("title".to_owned(), Value::String("draft".to_owned()))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: Some(BranchViewBase::Current(selector(0x65))),
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
     let changed = block_on(subscription.next_event()).unwrap();
@@ -1197,11 +1365,17 @@ fn db_exact_mutations_and_branch_view_reads_compose_head_over_base() {
         ),
         "unexpected branch subscription delta: {changed:?}"
     );
-    db.update_in_branch(
+    db.update(
         "todos",
-        head.clone(),
         row,
         BTreeMap::from([("title".to_owned(), Value::String("edited".to_owned()))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: None,
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
     let rows = block_on(db.all(&prepared, opts.clone())).unwrap();
@@ -1210,7 +1384,18 @@ fn db_exact_mutations_and_branch_view_reads_compose_head_over_base() {
         Some(Value::String("edited".to_owned()))
     );
 
-    db.delete_in_branch("todos", head, row).unwrap();
+    db.delete(
+        "todos",
+        row,
+        jazz::db::DeleteOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head,
+                base: None,
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert!(block_on(db.all(&prepared, opts)).unwrap().is_empty());
 }
 
@@ -1220,11 +1405,14 @@ fn inherited_delete_is_a_head_register_and_can_be_restored() {
     let row = RowUuid::from_bytes([0x67; 16]);
     let base = selector(0x68);
     let head = selector(0x69);
-    db.insert_with_id_in_branch(
+    db.insert(
         "todos",
-        base.clone(),
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("base".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
     let prepared = db.prepare_query(&db.table("todos")).unwrap();
@@ -1243,14 +1431,19 @@ fn inherited_delete_is_a_head_register_and_can_be_restored() {
         SubscriptionEvent::Delta { reset: true, .. }
     ));
 
-    db.delete_in_branch_view(
+    db.delete(
         "todos",
-        head.clone(),
-        match &opts.read_view.source {
-            ReadViewSourceSpec::BranchView { base, .. } => base.clone(),
-            _ => unreachable!(),
-        },
         row,
+        jazz::db::DeleteOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: match &opts.read_view.source {
+                    ReadViewSourceSpec::BranchView { base, .. } => base.clone(),
+                    _ => unreachable!(),
+                },
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
     let deleted = block_on(subscription.next_event()).unwrap();
@@ -1267,11 +1460,17 @@ fn inherited_delete_is_a_head_register_and_can_be_restored() {
             .is_empty()
     );
 
-    db.restore_with_cells_in_branch(
+    db.restore(
         "todos",
-        head.clone(),
         row,
-        BTreeMap::from([("title".to_owned(), Value::String("restored".to_owned()))]),
+        Some(BTreeMap::from([(
+            "title".to_owned(),
+            Value::String("restored".to_owned()),
+        )])),
+        jazz::db::RestoreOptions {
+            target: jazz::db::ExactWriteTarget::Branch(head.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
     let restored = block_on(subscription.next_event()).unwrap();
@@ -1297,11 +1496,14 @@ fn frozen_base_subscription_keeps_the_base_fixed_and_the_head_live() {
     let base = selector(0x75);
     let head = selector(0x76);
     let seeded = db
-        .insert_with_id_in_branch(
+        .insert(
             "todos",
-            base.clone(),
-            row,
             BTreeMap::from([("title".to_owned(), Value::String("base".to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                target: jazz::db::ExactWriteTarget::Branch(base.clone()),
+                ..Default::default()
+            },
         )
         .unwrap()
         .mergeable_tx_id();
@@ -1325,24 +1527,35 @@ fn frozen_base_subscription_keeps_the_base_fixed_and_the_head_live() {
         SubscriptionEvent::Delta { reset: true, .. }
     ));
 
-    db.update_in_branch(
+    db.update(
         "todos",
-        base,
         row,
         BTreeMap::from([("title".to_owned(), Value::String("later base".to_owned()))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: base,
+                base: None,
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(subscription.try_next_event().is_none());
 
-    db.update_in_branch_view(
+    db.update(
         "todos",
-        head.clone(),
-        match &opts.read_view.source {
-            ReadViewSourceSpec::BranchView { base, .. } => base.clone(),
-            _ => unreachable!(),
-        },
         row,
         BTreeMap::from([("title".to_owned(), Value::String("live head".to_owned()))]),
+        jazz::db::UpdateOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: match &opts.read_view.source {
+                    ReadViewSourceSpec::BranchView { base, .. } => base.clone(),
+                    _ => unreachable!(),
+                },
+            },
+            ..Default::default()
+        },
     )
     .unwrap();
     let changed = block_on(subscription.next_event()).unwrap();
@@ -1356,19 +1569,33 @@ fn frozen_base_subscription_keeps_the_base_fixed_and_the_head_live() {
         Some(Value::String("live head".to_owned()))
     );
 
-    db.delete_in_branch("todos", head.clone(), row).unwrap();
+    db.delete(
+        "todos",
+        row,
+        jazz::db::DeleteOptions {
+            target: jazz::db::WriteTarget::BranchView {
+                head: head.clone(),
+                base: None,
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert!(matches!(
         block_on(subscription.next_event()).unwrap(),
         SubscriptionEvent::Delta { reset: false, ref removed, .. } if removed.len() == 1
     ));
-    db.restore_with_cells_in_branch(
+    db.restore(
         "todos",
-        head,
         row,
-        BTreeMap::from([(
+        Some(BTreeMap::from([(
             "title".to_owned(),
             Value::String("restored head".to_owned()),
-        )]),
+        )])),
+        jazz::db::RestoreOptions {
+            target: jazz::db::ExactWriteTarget::Branch(head),
+            ..Default::default()
+        },
     )
     .unwrap();
     assert!(matches!(
@@ -1383,11 +1610,14 @@ fn db_contribution_merge_is_an_ordinary_retry_safe_transaction() {
     let source = selector(0x91);
     let target = selector(0x92);
     let row = RowUuid::from_bytes([0x93; 16]);
-    db.insert_with_id_in_branch(
+    db.insert(
         "todos",
-        source.clone(),
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("source".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            target: jazz::db::ExactWriteTarget::Branch(source.clone()),
+            ..Default::default()
+        },
     )
     .unwrap();
 

--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -195,6 +195,7 @@ fn non_durable_browser_client_waits_for_worker_local_ack() {
                 "title".to_owned(),
                 Value::String("persist me in the worker".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("insert optimistic todo");
     let tx_id = write.mergeable_tx_id();
@@ -281,6 +282,7 @@ fn browser_worker_initial_view_preserves_newer_optimistic_membership() {
         .insert(
             "todos",
             BTreeMap::from([("title".to_owned(), Value::String("open".to_owned()))]),
+            Default::default(),
         )
         .expect("insert optimistic open todo");
     let row = insert.row_uuid();
@@ -329,6 +331,7 @@ fn browser_worker_initial_view_preserves_newer_optimistic_membership() {
             "todos",
             row,
             BTreeMap::from([("title".to_owned(), Value::String("done".to_owned()))]),
+            Default::default(),
         )
         .expect("move optimistic todo out of filtered subscription");
     assert!(
@@ -381,6 +384,7 @@ fn worker_relay_forwards_authority_fate_to_browser_client() {
                 "title".to_owned(),
                 Value::String("relay me unchanged".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("insert relayed todo");
     let tx_id = write.mergeable_tx_id();
@@ -459,6 +463,7 @@ fn worker_relay_forwards_authority_fate_to_browser_client() {
             "todos",
             row,
             BTreeMap::from([("title".to_owned(), Value::String("relay update".to_owned()))]),
+            Default::default(),
         )
         .expect("update through settled relay");
     let update_tx = update.mergeable_tx_id();
@@ -498,6 +503,7 @@ fn browser_client_hydrates_local_subscription_from_worker_relay() {
                 "title".to_owned(),
                 Value::String("persisted before main thread opens".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("seed worker-local todo");
 
@@ -554,6 +560,7 @@ fn reopened_browser_worker_hydrates_local_subscription_without_query_warmup() {
                 "title".to_owned(),
                 Value::String("persisted before worker restart".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("seed worker-local todo");
     first_worker.tick().expect("persist worker-local todo");
@@ -609,6 +616,7 @@ fn worker_baseline_arriving_during_cold_main_hydration_is_delivered_exactly_once
             .insert(
                 "todos",
                 BTreeMap::from([("title".to_owned(), Value::String(title.to_owned()))]),
+                Default::default(),
             )
             .expect("seed worker-local todo");
     }
@@ -678,11 +686,13 @@ fn browser_client_local_only_subscription_stops_at_worker() {
         .insert(
             "todos",
             BTreeMap::from([("title".to_owned(), Value::String("worker-local".to_owned()))]),
+            Default::default(),
         )
         .expect("seed worker-local todo");
     core.insert(
         "todos",
         BTreeMap::from([("title".to_owned(), Value::String("server-only".to_owned()))]),
+        Default::default(),
     )
     .expect("seed server-only todo");
 
@@ -755,6 +765,7 @@ fn browser_relay_does_not_publish_a_premature_settled_snapshot() {
                 "title".to_owned(),
                 Value::String("already settled at the authority".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("seed authority todo");
     let seeded_tx = seeded.mergeable_tx_id();
@@ -854,6 +865,7 @@ fn browser_relay_hydrates_fresh_included_edge_subscription_from_authority() {
         .insert(
             "profiles",
             BTreeMap::from([("name".to_owned(), Value::String("Alice".to_owned()))]),
+            Default::default(),
         )
         .expect("seed included profile");
     let message = seeder
@@ -867,6 +879,7 @@ fn browser_relay_hydrates_fresh_included_edge_subscription_from_authority() {
                 ),
                 ("created".to_owned(), Value::U64(1)),
             ]),
+            Default::default(),
         )
         .expect("seed included message");
     seeder.tick().expect("upload seeded relation");
@@ -1011,6 +1024,7 @@ fn browser_relay_replays_causal_ancestors_before_pending_write_fates() {
                 "title".to_owned(),
                 Value::String("accepted parent".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("insert base row");
     let row = base.row_uuid();
@@ -1055,6 +1069,7 @@ fn browser_relay_replays_causal_ancestors_before_pending_write_fates() {
                 "title".to_owned(),
                 Value::String("pending child".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("update accepted row offline");
     let update_tx = update.mergeable_tx_id();
@@ -1123,6 +1138,7 @@ fn worker_relay_forwards_authority_rejection_to_browser_client() {
                 "title".to_owned(),
                 Value::String("reject after local persistence".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("insert optimistic todo");
     let tx_id = write.mergeable_tx_id();
@@ -1171,6 +1187,7 @@ fn reopened_worker_replays_pending_commit_before_later_fate() {
                 "title".to_owned(),
                 Value::String("pending across worker restart".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("insert pending todo");
     let tx_id = write.mergeable_tx_id();
@@ -1236,6 +1253,7 @@ fn reopened_worker_routes_later_rejection_to_same_main_thread_identity() {
                 "title".to_owned(),
                 Value::String("reject after worker restart".to_owned()),
             )]),
+            Default::default(),
         )
         .expect("insert pending todo");
     let tx_id = write.mergeable_tx_id();

--- a/crates/jazz/tests/column_defaults.rs
+++ b/crates/jazz/tests/column_defaults.rs
@@ -90,10 +90,13 @@ fn stored_row(db: &Db<TestStorage>, row_id: RowUuid) -> BTreeMap<String, Value> 
 fn core_insert_applies_literal_defaults_for_omitted_columns() {
     let db = open_db();
 
-    jazz::block_on(db.insert_with_id(
+    jazz::block_on(db.insert(
         "events",
-        row(1),
         cells([("title", Value::String("created".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(1)),
+            ..Default::default()
+        },
     ))
     .expect("insert row");
 
@@ -119,13 +122,16 @@ fn core_insert_applies_literal_defaults_for_omitted_columns() {
 fn core_insert_preserves_explicit_null_instead_of_using_default() {
     let db = open_db();
 
-    jazz::block_on(db.insert_with_id(
+    jazz::block_on(db.insert(
         "events",
-        row(2),
         cells([
             ("title", Value::String("created".to_owned())),
             ("note", Value::Nullable(None)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(2)),
+            ..Default::default()
+        },
     ))
     .expect("insert row");
 
@@ -138,9 +144,8 @@ fn core_insert_preserves_explicit_null_instead_of_using_default() {
 fn core_insert_keeps_explicit_values_for_defaulted_columns() {
     let db = open_db();
 
-    jazz::block_on(db.insert_with_id(
+    jazz::block_on(db.insert(
         "events",
-        row(3),
         cells([
             ("title", Value::String("created".to_owned())),
             ("count", Value::I64(7)),
@@ -150,6 +155,10 @@ fn core_insert_keeps_explicit_values_for_defaulted_columns() {
                 Value::Nullable(Some(Box::new(Value::String("explicit note".to_owned())))),
             ),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(3)),
+            ..Default::default()
+        },
     ))
     .expect("insert row");
 

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -44,10 +44,27 @@ fn rocksdb_writes_are_resident_before_the_sync_call_returns() {
     db.set_non_durable_client();
     let row_id = jazz::ids::RowUuid::from_bytes([0; 16]);
 
-    block_on(db.insert_with_id_at_ms("todos", row_id, row! { title: "first" }, 1))
-        .expect("first insert");
+    block_on(db.insert(
+        "todos",
+        row! { title: "first" },
+        jazz::db::InsertOptions {
+            row_id: Some(row_id),
+            updated_at_ms: Some(1),
+            ..Default::default()
+        },
+    ))
+    .expect("first insert");
     assert!(
-        block_on(db.insert_with_id_at_ms("todos", row_id, row! { title: "duplicate" }, 2)).is_err(),
+        block_on(db.insert(
+            "todos",
+            row! { title: "duplicate" },
+            jazz::db::InsertOptions {
+                row_id: Some(row_id),
+                updated_at_ms: Some(2),
+                ..Default::default()
+            }
+        ))
+        .is_err(),
         "a second synchronous write must observe the resident first write",
     );
 }
@@ -70,18 +87,25 @@ fn deferred_persistence_keeps_resident_write_sync_and_local_durability_pending()
     db.set_deferred_local_persistence(true);
 
     control.pause_on(TestStorageOperation::WriteMany);
-    let write = block_on(db.insert("todos", row! { title: "resident now" }))
+    let write = block_on(db.insert("todos", row! { title: "resident now" }, Default::default()))
         .expect("resident insert does not await persistence");
 
     let query = db.prepare_query(&db.table("todos")).expect("prepare query");
     let rows = block_on(db.all(&query, ReadOpts::default())).expect("read resident rows");
     assert_eq!(rows.len(), 1, "the write is immediately query-visible");
     assert!(
-        block_on(db.insert_with_id("todos", write.row_uuid(), row! { title: "duplicate" },))
-            .is_err(),
+        block_on(db.insert(
+            "todos",
+            row! { title: "duplicate" },
+            jazz::db::InsertOptions {
+                row_id: Some(write.row_uuid()),
+                ..Default::default()
+            }
+        ))
+        .is_err(),
         "resident currency checks must reject a duplicate before persistence",
     );
-    block_on(db.delete("todos", write.row_uuid()))
+    block_on(db.delete("todos", write.row_uuid(), Default::default()))
         .expect("resident row can be deleted before insert persistence");
     assert!(
         block_on(db.all(&query, ReadOpts::default()))
@@ -89,8 +113,13 @@ fn deferred_persistence_keeps_resident_write_sync_and_local_durability_pending()
             .is_empty(),
         "the deletion is immediately query-visible",
     );
-    block_on(db.restore("todos", write.row_uuid(), row! { title: "restored now" }))
-        .expect("restore observes the resident deletion before persistence");
+    block_on(db.restore(
+        "todos",
+        write.row_uuid(),
+        Some(row! { title: "restored now" }),
+        Default::default(),
+    ))
+    .expect("restore observes the resident deletion before persistence");
     assert_eq!(
         block_on(db.all(&query, ReadOpts::default()))
             .expect("read resident restoration")

--- a/crates/jazz/tests/dynamic_schema_views.rs
+++ b/crates/jazz/tests/dynamic_schema_views.rs
@@ -166,12 +166,26 @@ fn registered_schema_views_share_one_open_batch() {
         owner.begin_mergeable(batch).await.unwrap();
         old_view
             .mergeable_tx_ref(batch)
-            .insert_with_id("items", RowUuid::from_bytes([1; 16]), Default::default())
+            .insert(
+                "items",
+                Default::default(),
+                jazz::db::InsertOptions {
+                    row_id: Some(RowUuid::from_bytes([1; 16])),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         new_view
             .mergeable_tx_ref(batch)
-            .insert_with_id("items", RowUuid::from_bytes([2; 16]), Default::default())
+            .insert(
+                "items",
+                Default::default(),
+                jazz::db::InsertOptions {
+                    row_id: Some(RowUuid::from_bytes([2; 16])),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         owner.commit_mergeable_handle(batch).await.unwrap();
@@ -278,7 +292,14 @@ fn empty_owner_accepts_first_typed_schema_view() {
         owner.begin_mergeable(batch).await.unwrap();
         let view = owner.register_schema_view(schema("first")).await.unwrap();
         view.mergeable_tx_ref(batch)
-            .insert_with_id("items", RowUuid::from_bytes([3; 16]), Default::default())
+            .insert(
+                "items",
+                Default::default(),
+                jazz::db::InsertOptions {
+                    row_id: Some(RowUuid::from_bytes([3; 16])),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         let prepared = view.prepare_query(&view.table("items")).unwrap();
@@ -304,7 +325,14 @@ fn one_batch_accepts_writes_from_structurally_distinct_views() {
         let first = owner.register_schema_view(schema("same")).await.unwrap();
         first
             .mergeable_tx_ref(batch)
-            .insert_with_id("items", RowUuid::from_bytes([4; 16]), Default::default())
+            .insert(
+                "items",
+                Default::default(),
+                jazz::db::InsertOptions {
+                    row_id: Some(RowUuid::from_bytes([4; 16])),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         let second = owner
@@ -313,7 +341,14 @@ fn one_batch_accepts_writes_from_structurally_distinct_views() {
             .unwrap();
         second
             .mergeable_tx_ref(batch)
-            .insert_with_id("items", RowUuid::from_bytes([5; 16]), Default::default())
+            .insert(
+                "items",
+                Default::default(),
+                jazz::db::InsertOptions {
+                    row_id: Some(RowUuid::from_bytes([5; 16])),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
 
@@ -340,7 +375,14 @@ fn typed_view_reads_and_updates_preexisting_snapshot_rows() {
         let seed = OpenTransactionId::new();
         owner.begin_mergeable(seed).await.unwrap();
         view.mergeable_tx_ref(seed)
-            .insert_with_id("items", row, Default::default())
+            .insert(
+                "items",
+                Default::default(),
+                jazz::db::InsertOptions {
+                    row_id: Some(row),
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         owner.commit_mergeable_handle(seed).await.unwrap();
@@ -372,6 +414,7 @@ fn typed_view_reads_and_updates_preexisting_snapshot_rows() {
             "items",
             row,
             [("label".to_owned(), Value::String("updated".to_owned()))].into(),
+            Default::default(),
         )
         .await
         .unwrap();
@@ -393,9 +436,16 @@ fn ordinary_view_write_does_not_enter_open_owner_snapshot() {
         owner.begin_exclusive(batch).await.unwrap();
         let view = owner.register_schema_view(schema("direct")).await.unwrap();
         let row = RowUuid::from_bytes([7; 16]);
-        view.insert_with_id("items", row, Default::default())
-            .await
-            .unwrap();
+        view.insert(
+            "items",
+            Default::default(),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
         let prepared = view.prepare_query(&view.table("items")).unwrap();
         assert!(
@@ -418,9 +468,16 @@ fn exclusive_view_commit_rejects_concurrent_local_row_change() {
         let owner = open_owner(empty_schema()).await;
         let view = owner.register_schema_view(schema("base")).await.unwrap();
         let row = RowUuid::from_bytes([8; 16]);
-        view.insert_with_id("items", row, Default::default())
-            .await
-            .unwrap();
+        view.insert(
+            "items",
+            Default::default(),
+            jazz::db::InsertOptions {
+                row_id: Some(row),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
         let batch = OpenTransactionId::new();
         owner.begin_exclusive(batch).await.unwrap();
@@ -430,6 +487,7 @@ fn exclusive_view_commit_rejects_concurrent_local_row_change() {
             "items",
             row,
             [("label".to_owned(), Value::String("alice".to_owned()))].into(),
+            Default::default(),
         )
         .await
         .unwrap();
@@ -437,6 +495,7 @@ fn exclusive_view_commit_rejects_concurrent_local_row_change() {
             "items",
             row,
             [("label".to_owned(), Value::String("bob".to_owned()))].into(),
+            Default::default(),
         )
         .await
         .unwrap();

--- a/crates/jazz/tests/edge_fate_authority.rs
+++ b/crates/jazz/tests/edge_fate_authority.rs
@@ -206,6 +206,7 @@ fn edge_shell_does_not_report_global_or_serve_global_before_core_ack() {
     let write = block_on(alice.insert(
         "todos",
         BTreeMap::from([("title".to_owned(), Value::String("edge only".to_owned()))]),
+        Default::default(),
     ))
     .unwrap();
     pump_client_edge(&alice, &alice_wire, &mut edge, alice_session);
@@ -271,6 +272,7 @@ fn core_shell_client_upload_still_reports_global_immediately() {
     let write = block_on(alice.insert(
         "todos",
         BTreeMap::from([("title".to_owned(), Value::String("core global".to_owned()))]),
+        Default::default(),
     ))
     .unwrap();
     pump_client_edge(&alice, &alice_wire, &mut core, alice_session);
@@ -326,6 +328,7 @@ fn core_authority_rejects_omitted_insert_after_read_policy_closes_table() {
             ("title".to_owned(), Value::String("forged write".to_owned())),
             ("completed".to_owned(), Value::Bool(false)),
         ]),
+        Default::default(),
     ))
     .unwrap();
     pump_client_edge(&alice, &wire, &mut core, session);
@@ -360,14 +363,17 @@ fn explicit_unchanged_partial_write_survives_sync_and_wins_lww() {
     // Keep every transaction identity distinct and the LWW order explicit:
     // TxId includes each client's already-distinct node id plus this HLC time.
     let row = RowUuid::from_bytes([0xd2; 16]);
-    block_on(alice.insert_with_id_at_ms(
+    block_on(alice.insert(
         "todos",
-        row,
         BTreeMap::from([
             ("title".to_owned(), Value::String("base".to_owned())),
             ("completed".to_owned(), Value::Bool(false)),
         ]),
-        100,
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            updated_at_ms: Some(100),
+            ..Default::default()
+        },
     ))
     .unwrap();
     pump_client_edge(&alice, &alice_wire, &mut core, alice_session);
@@ -382,28 +388,42 @@ fn explicit_unchanged_partial_write_survives_sync_and_wins_lww() {
 
     // Neither client is pumped after these writes until both heads exist, so
     // they remain concurrent children of the shared t=100 base.
-    block_on(alice.update_at_ms(
+    block_on(alice.update(
         "todos",
         row,
         BTreeMap::from([
             ("title".to_owned(), Value::String("alice-change".to_owned())),
             ("completed".to_owned(), Value::Bool(true)),
         ]),
-        200,
+        jazz::db::UpdateOptions {
+            updated_at_ms: Some(200),
+            ..Default::default()
+        },
     ))
     .unwrap();
-    let explicit_write = block_on(bob.update_at_ms(
+    let explicit_write = block_on(bob.update(
         "todos",
         row,
         BTreeMap::from([("title".to_owned(), Value::String("base".to_owned()))]),
-        300,
+        jazz::db::UpdateOptions {
+            updated_at_ms: Some(300),
+            ..Default::default()
+        },
     ))
     .unwrap();
     // An empty partial update is not a content mutation. It reuses the current
     // write identity instead of emitting a newer legacy "all materialized cells
     // authored" version that could clobber Alice's cells during reconciliation.
-    let no_op = block_on(bob.update_at_ms("todos", row, BTreeMap::new(), 400))
-        .expect("empty patch remains a safe no-op");
+    let no_op = block_on(bob.update(
+        "todos",
+        row,
+        BTreeMap::new(),
+        jazz::db::UpdateOptions {
+            updated_at_ms: Some(400),
+            ..Default::default()
+        },
+    ))
+    .expect("empty patch remains a safe no-op");
     assert_eq!(no_op.mergeable_tx_id(), explicit_write.mergeable_tx_id());
 
     pump_client_edge(&alice, &alice_wire, &mut core, alice_session);

--- a/crates/jazz/tests/incremental_delivery_canary.rs
+++ b/crates/jazz/tests/incremental_delivery_canary.rs
@@ -198,9 +198,8 @@ fn relation_query() -> Query {
 
 fn seed_relation_fixture(db: &Db<TestStorage>, child_rows: usize) -> RowUuid {
     let parent = row(1);
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         "parents",
-        parent,
         BTreeMap::from([
             (
                 "label".to_owned(),
@@ -208,18 +207,25 @@ fn seed_relation_fixture(db: &Db<TestStorage>, child_rows: usize) -> RowUuid {
             ),
             ("ordinal".to_owned(), Value::I32(0)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(parent),
+            ..Default::default()
+        },
     ))
     .expect("insert parent");
 
     for index in 0..child_rows {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             "children",
-            row(1_000 + index as u64),
             BTreeMap::from([
                 ("parent_id".to_owned(), Value::Uuid(parent.0)),
                 ("label".to_owned(), Value::String(format!("child-{index}"))),
                 ("ordinal".to_owned(), Value::I32(index as i32)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(row(1_000 + index as u64)),
+                ..Default::default()
+            },
         ))
         .unwrap_or_else(|err| panic!("insert child {index}: {err}"));
     }
@@ -319,9 +325,8 @@ fn measure_single_child_insert(scale: usize) -> AllocSnapshot {
     );
 
     reset_alloc_counter();
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         "children",
-        row(10_000_000 + scale as u64),
         BTreeMap::from([
             ("parent_id".to_owned(), Value::Uuid(parent.0)),
             (
@@ -330,6 +335,10 @@ fn measure_single_child_insert(scale: usize) -> AllocSnapshot {
             ),
             ("ordinal".to_owned(), Value::I32((scale + 1) as i32)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(10_000_000 + scale as u64)),
+            ..Default::default()
+        },
     ))
     .expect("insert measured child");
     expect_parent_snapshot(
@@ -439,13 +448,16 @@ fn write_cells(parent: RowUuid, index: usize) -> BTreeMap<String, Value> {
 
 fn seed_rocks_write_fixture(db: &Db<RocksDbStorage>, child_rows: usize) -> RowUuid {
     let parent = row(50_000_000);
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         "parents",
-        parent,
         BTreeMap::from([
             ("label".to_owned(), Value::String("write-parent".to_owned())),
             ("ordinal".to_owned(), Value::I32(0)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(parent),
+            ..Default::default()
+        },
     ))
     .expect("insert write parent");
 
@@ -455,10 +467,13 @@ fn seed_rocks_write_fixture(db: &Db<RocksDbStorage>, child_rows: usize) -> RowUu
         let end = (start + 200).min(child_rows);
         block_on(db.transaction(async |tx| {
             for index in start..end {
-                tx.insert_with_id(
+                tx.insert(
                     "children",
-                    row(60_000_000 + index as u64),
                     write_cells(parent, index),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row(60_000_000 + index as u64)),
+                        ..Default::default()
+                    },
                 )
                 .await?;
             }
@@ -480,8 +495,13 @@ fn measure_rocks_write_transaction(existing_rows: usize) -> TxMeasurement {
     block_on(db.transaction(async |tx| {
         for offset in 0..200 {
             let index = start_index + offset;
-            tx.update("children", row(index as u64), write_cells(parent, index))
-                .await?;
+            tx.update(
+                "children",
+                row(index as u64),
+                write_cells(parent, index),
+                Default::default(),
+            )
+            .await?;
         }
         Ok(())
     }))

--- a/crates/jazz/tests/parameterized_subscription_routing.rs
+++ b/crates/jazz/tests/parameterized_subscription_routing.rs
@@ -59,13 +59,16 @@ fn row(seed: u64) -> RowUuid {
 }
 
 fn insert_document(db: &Db<TestStorage>, document: RowUuid, team: RowUuid, updated_at: u64) {
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         "documents",
-        document,
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(team.0)),
             ("updated_at".to_owned(), Value::U64(updated_at)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(document),
+            ..Default::default()
+        },
     ))
     .expect("insert document");
 }

--- a/crates/jazz/tests/prepared_claim_routing.rs
+++ b/crates/jazz/tests/prepared_claim_routing.rs
@@ -408,10 +408,13 @@ fn opts() -> ReadOpts {
 
 fn seed(db: &BenchDb, team_a: RowUuid, team_b: RowUuid, region_a: &str, region_b: &str) {
     for (team, name) in [(team_a, "Team A"), (team_b, "Team B")] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             TEAMS,
-            team,
             BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(team),
+                ..Default::default()
+            },
         ))
         .expect("seed team");
     }
@@ -419,25 +422,31 @@ fn seed(db: &BenchDb, team_a: RowUuid, team_b: RowUuid, region_a: &str, region_b
         (row(0x31), team_a, USER_A, region_a),
         (row(0x32), team_b, USER_B, region_b),
     ] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             MEMBERSHIPS,
-            membership,
             BTreeMap::from([
                 ("team".to_owned(), Value::Uuid(team.0)),
                 ("user".to_owned(), Value::Uuid(user.0)),
                 ("region".to_owned(), Value::String(region.to_owned())),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(membership),
+                ..Default::default()
+            },
         ))
         .expect("seed membership");
     }
     for (document, team, updated_at) in [(row(0x41), team_a, 10), (row(0x42), team_b, 20)] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             DOCUMENTS,
-            document,
             BTreeMap::from([
                 ("team".to_owned(), Value::Uuid(team.0)),
                 ("updated_at".to_owned(), Value::U64(updated_at)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(document),
+                ..Default::default()
+            },
         ))
         .expect("seed document");
     }
@@ -452,31 +461,40 @@ fn seed_two_hop_reachability_policy(db: &BenchDb) -> (RowUuid, RowUuid, RowUuid,
     let group_b = row(0x72);
 
     for (project, name) in [(project_a, "project-a"), (project_b, "project-b")] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             PROJECTS,
-            project,
             BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(project),
+                ..Default::default()
+            },
         ))
         .expect("seed project");
     }
     for (group, name) in [(group_a, "group-a"), (group_b, "group-b")] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             GROUPS,
-            group,
             BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            jazz::db::InsertOptions {
+                row_id: Some(group),
+                ..Default::default()
+            },
         ))
         .expect("seed group");
     }
     for (document, project, updated_at) in
         [(document_a, project_a, 10), (document_b, project_b, 20)]
     {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             DOCUMENTS,
-            document,
             BTreeMap::from([
                 ("project".to_owned(), Value::Uuid(project.0)),
                 ("updated_at".to_owned(), Value::U64(updated_at)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(document),
+                ..Default::default()
+            },
         ))
         .expect("seed document");
     }
@@ -484,13 +502,16 @@ fn seed_two_hop_reachability_policy(db: &BenchDb) -> (RowUuid, RowUuid, RowUuid,
         (row(0x81), document_a, project_a),
         (row(0x82), document_b, project_b),
     ] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             MEMBERSHIPS,
-            membership,
             BTreeMap::from([
                 ("document".to_owned(), Value::Uuid(document.0)),
                 ("project".to_owned(), Value::Uuid(project.0)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(membership),
+                ..Default::default()
+            },
         ))
         .expect("seed membership");
     }
@@ -498,24 +519,30 @@ fn seed_two_hop_reachability_policy(db: &BenchDb) -> (RowUuid, RowUuid, RowUuid,
         (row(0x91), project_a, group_a),
         (row(0x92), project_b, group_b),
     ] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             PROJECT_ACCESS,
-            access,
             BTreeMap::from([
                 ("project".to_owned(), Value::Uuid(project.0)),
                 ("group".to_owned(), Value::Uuid(group.0)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(access),
+                ..Default::default()
+            },
         ))
         .expect("seed project access");
     }
     for (membership, group, user) in [(row(0xa1), group_a, USER_A), (row(0xa2), group_b, USER_B)] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             GROUP_MEMBERS,
-            membership,
             BTreeMap::from([
                 ("group".to_owned(), Value::Uuid(group.0)),
                 ("user".to_owned(), Value::Uuid(user.0)),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(membership),
+                ..Default::default()
+            },
         ))
         .expect("seed reachability seed membership");
     }
@@ -626,34 +653,43 @@ fn prepared_policy_claim_routing_preserves_claimless_union_branches() {
         USER_B,
         BTreeMap::from([("region".to_owned(), Value::String("region-b".to_owned()))]),
     );
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         DOCUMENTS,
-        public,
         BTreeMap::from([
             ("visibility".to_owned(), Value::String("public".to_owned())),
             ("owner".to_owned(), Value::Uuid(WRITER.0)),
             ("region".to_owned(), Value::String("other".to_owned())),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(public),
+            ..Default::default()
+        },
     ))
     .expect("seed public document");
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         DOCUMENTS,
-        private,
         BTreeMap::from([
             ("visibility".to_owned(), Value::String("private".to_owned())),
             ("owner".to_owned(), Value::Uuid(USER_A.0)),
             ("region".to_owned(), Value::String("other".to_owned())),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(private),
+            ..Default::default()
+        },
     ))
     .expect("seed private document");
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         DOCUMENTS,
-        regional,
         BTreeMap::from([
             ("visibility".to_owned(), Value::String("private".to_owned())),
             ("owner".to_owned(), Value::Uuid(WRITER.0)),
             ("region".to_owned(), Value::String("region-a".to_owned())),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(regional),
+            ..Default::default()
+        },
     ))
     .expect("seed regional document");
 
@@ -800,9 +836,8 @@ fn prepared_nested_claim_routes_keep_two_bindings_isolated_through_live_membersh
         (chat_a, "chat-a", join_code_a),
         (chat_b, "chat-b", join_code_b),
     ] {
-        block_on(db.insert_with_id(
+        block_on(db.insert(
             CHATS,
-            chat,
             BTreeMap::from([
                 ("name".to_owned(), Value::String(name.to_owned())),
                 (
@@ -810,6 +845,10 @@ fn prepared_nested_claim_routes_keep_two_bindings_isolated_through_live_membersh
                     Value::Nullable(Some(Box::new(Value::String(format!("stored-{join_code}"))))),
                 ),
             ]),
+            jazz::db::InsertOptions {
+                row_id: Some(chat),
+                ..Default::default()
+            },
         ))
         .expect("seed invite chat");
     }
@@ -858,13 +897,16 @@ fn prepared_nested_claim_routes_keep_two_bindings_isolated_through_live_membersh
         "a chat without its membership must not be visible"
     );
 
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         CHAT_MEMBERS,
-        row(0xc3),
         BTreeMap::from([
             ("chatId".to_owned(), Value::Uuid(chat_a.0)),
             ("userId".to_owned(), Value::String(user_id_a.to_owned())),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(0xc3)),
+            ..Default::default()
+        },
     ))
     .expect("commit membership for binding A");
     let added_rows = |event| match event {
@@ -892,13 +934,16 @@ fn prepared_nested_claim_routes_keep_two_bindings_isolated_through_live_membersh
         "binding A's CommitUnit must not leak into binding B"
     );
 
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         CHAT_MEMBERS,
-        row(0xc4),
         BTreeMap::from([
             ("chatId".to_owned(), Value::Uuid(chat_b.0)),
             ("userId".to_owned(), Value::String(user_id_b.to_owned())),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(0xc4)),
+            ..Default::default()
+        },
     ))
     .expect("commit membership for binding B");
     assert_eq!(
@@ -1053,16 +1098,22 @@ fn mutually_referential_dependency_policies_do_not_recurse() {
     let db = open_db_with_schema(policy_proof_cycle_schema());
     let a = row(0xb1);
     let b = row(0xb2);
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         CYCLE_A,
-        a,
         BTreeMap::from([("b".to_owned(), Value::Uuid(b.0))]),
+        jazz::db::InsertOptions {
+            row_id: Some(a),
+            ..Default::default()
+        },
     ))
     .expect("seed cycle A");
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         CYCLE_B,
-        b,
         BTreeMap::from([("a".to_owned(), Value::Uuid(a.0))]),
+        jazz::db::InsertOptions {
+            row_id: Some(b),
+            ..Default::default()
+        },
     ))
     .expect("seed cycle B");
 
@@ -1285,12 +1336,14 @@ fn rebuilt_subscription_drop_releases_rehydrated_handle_without_touching_peer() 
         DOCUMENTS,
         row(0x41),
         BTreeMap::from([("updated_at".to_owned(), Value::U64(11))]),
+        Default::default(),
     ))
     .expect("trigger A subscription rehydration");
     block_on(db.update(
         DOCUMENTS,
         row(0x42),
         BTreeMap::from([("updated_at".to_owned(), Value::U64(21))]),
+        Default::default(),
     ))
     .expect("trigger B subscription rehydration");
     assert!(matches!(
@@ -1316,13 +1369,16 @@ fn rebuilt_subscription_drop_releases_rehydrated_handle_without_touching_peer() 
     // must be retired by the next node owner turn, without touching Bob's.
     block_on(db.tick()).expect("drain A finalization after runtime rebuild");
     assert_eq!(db.active_groove_subscriptions_for_test(), 1);
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         DOCUMENTS,
-        row(0x43),
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(team_b.0)),
             ("updated_at".to_owned(), Value::U64(30)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(row(0x43)),
+            ..Default::default()
+        },
     ))
     .expect("write after dropping A");
     assert!(matches!(
@@ -1347,19 +1403,25 @@ fn prepared_join_handle_recompiles_after_catalogue_runtime_rebuild() {
     let db = open_db_with_schema_as(v1.clone(), AuthorId::SYSTEM);
     let team = row(0xa1);
     let document = row(0xa2);
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         TEAMS,
-        team,
         BTreeMap::from([("name".to_owned(), Value::String("Team A".to_owned()))]),
+        jazz::db::InsertOptions {
+            row_id: Some(team),
+            ..Default::default()
+        },
     ))
     .expect("seed team");
-    block_on(db.insert_with_id(
+    block_on(db.insert(
         DOCUMENTS,
-        document,
         BTreeMap::from([
             ("team".to_owned(), Value::Uuid(team.0)),
             ("updated_at".to_owned(), Value::U64(1)),
         ]),
+        jazz::db::InsertOptions {
+            row_id: Some(document),
+            ..Default::default()
+        },
     ))
     .expect("seed document");
     let join = Query::from(DOCUMENTS).join_via_column(

--- a/crates/jazz/tests/row_provenance.rs
+++ b/crates/jazz/tests/row_provenance.rs
@@ -50,19 +50,25 @@ fn row_provenance_preserves_created_fields_and_advances_updated_at() {
     let row = RowUuid::from_bytes([0x33; 16]);
     let db = open_db(alice);
 
-    jazz::block_on(db.insert_with_id_at_ms(
+    jazz::block_on(db.insert(
         "todos",
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("first".to_owned()))]),
-        1_000,
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            updated_at_ms: Some(1_000),
+            ..Default::default()
+        },
     ))
     .expect("insert row");
 
-    jazz::block_on(db.update_at_ms(
+    jazz::block_on(db.update(
         "todos",
         row,
         BTreeMap::from([("title".to_owned(), Value::String("second".to_owned()))]),
-        2_000,
+        jazz::db::UpdateOptions {
+            updated_at_ms: Some(2_000),
+            ..Default::default()
+        },
     ))
     .expect("update row");
 
@@ -109,14 +115,25 @@ fn deletion_advances_updated_provenance_without_replacing_creation_provenance() 
     let row = RowUuid::from_bytes([0x44; 16]);
     let db = open_db(alice);
 
-    jazz::block_on(db.insert_with_id_at_ms(
+    jazz::block_on(db.insert(
         "todos",
-        row,
         BTreeMap::from([("title".to_owned(), Value::String("first".to_owned()))]),
-        1_000,
+        jazz::db::InsertOptions {
+            row_id: Some(row),
+            updated_at_ms: Some(1_000),
+            ..Default::default()
+        },
     ))
     .expect("insert row");
-    jazz::block_on(db.delete_at_ms("todos", row, 3_000)).expect("delete row");
+    jazz::block_on(db.delete(
+        "todos",
+        row,
+        jazz::db::DeleteOptions {
+            updated_at_ms: Some(3_000),
+            ..Default::default()
+        },
+    ))
+    .expect("delete row");
 
     let prepared = db.prepare_query(&db.table("todos")).expect("prepare query");
     let rows = jazz::block_on(db.all(
@@ -159,6 +176,7 @@ fn empty_batched_update_still_validates_handle_and_target() {
         "todos",
         row,
         BTreeMap::new(),
+        Default::default(),
     ))
     .expect_err("stale batch handle must be rejected");
     assert!(stale_error.message.contains("open transaction"));
@@ -169,6 +187,7 @@ fn empty_batched_update_still_validates_handle_and_target() {
         "todos",
         row,
         BTreeMap::new(),
+        Default::default(),
     ))
     .expect_err("absent target must be rejected");
     assert!(

--- a/crates/jazz/tests/shared_coverage_differential.rs
+++ b/crates/jazz/tests/shared_coverage_differential.rs
@@ -333,21 +333,29 @@ fn run_scenario(mode: CoverageMode) -> ScenarioReceipt {
             "title".to_owned(),
             Value::String("alpha-updated".to_owned()),
         )]),
+        Default::default(),
     ))
     .expect("update visible row");
-    block_on(server.insert_with_id(
+    block_on(server.insert(
         "beta_items",
-        row(310),
         cells("beta-inserted-visible", visible_owner),
+        jazz::db::InsertOptions {
+            row_id: Some(row(310)),
+            ..Default::default()
+        },
     ))
     .expect("insert visible row");
-    block_on(server.insert_with_id(
+    block_on(server.insert(
         "gamma_items",
-        row(320),
         cells("gamma-inserted-hidden", hidden_owner),
+        jazz::db::InsertOptions {
+            row_id: Some(row(320)),
+            ..Default::default()
+        },
     ))
     .expect("insert hidden row");
-    block_on(server.delete("delta_items", row(103))).expect("delete visible row");
+    block_on(server.delete("delta_items", row(103), Default::default()))
+        .expect("delete visible row");
 
     drive(&server, &client, &mut streams, &table_schemas, &mut traces);
 

--- a/crates/jazz/tests/structured_result_tree.rs
+++ b/crates/jazz/tests/structured_result_tree.rs
@@ -87,6 +87,7 @@ fn nested_tree_preserves_projection_order_offset_and_reset() {
             ("title".to_owned(), Value::String("parent".to_owned())),
             ("rank".to_owned(), Value::I32(0)),
         ]),
+        Default::default(),
     ))
     .expect("insert parent")
     .row_uuid();
@@ -100,6 +101,7 @@ fn nested_tree_preserves_projection_order_offset_and_reset() {
                     ("label".to_owned(), Value::String(label.to_owned())),
                     ("rank".to_owned(), Value::I32(rank)),
                 ]),
+                Default::default(),
             ))
             .expect("insert child")
             .row_uuid(),
@@ -113,6 +115,7 @@ fn nested_tree_preserves_projection_order_offset_and_reset() {
                 ("label".to_owned(), Value::String(label.to_owned())),
                 ("rank".to_owned(), Value::I32(rank)),
             ]),
+            Default::default(),
         ))
         .expect("insert grandchild");
     }
@@ -213,6 +216,7 @@ fn maintained_array_subscription_with_root_parameter_lowers_and_delivers() {
             ("title".to_owned(), Value::String("matching".to_owned())),
             ("rank".to_owned(), Value::I32(7)),
         ]),
+        Default::default(),
     ))
     .expect("insert matching parent")
     .row_uuid();
@@ -222,6 +226,7 @@ fn maintained_array_subscription_with_root_parameter_lowers_and_delivers() {
             ("title".to_owned(), Value::String("other".to_owned())),
             ("rank".to_owned(), Value::I32(8)),
         ]),
+        Default::default(),
     ))
     .expect("insert non-matching parent");
     let initial_child = block_on(db.insert(
@@ -231,6 +236,7 @@ fn maintained_array_subscription_with_root_parameter_lowers_and_delivers() {
             ("label".to_owned(), Value::String("initial".to_owned())),
             ("rank".to_owned(), Value::I32(0)),
         ]),
+        Default::default(),
     ))
     .expect("insert initial child")
     .row_uuid();
@@ -275,6 +281,7 @@ fn maintained_array_subscription_with_root_parameter_lowers_and_delivers() {
             ("label".to_owned(), Value::String("later".to_owned())),
             ("rank".to_owned(), Value::I32(1)),
         ]),
+        Default::default(),
     ))
     .expect("insert later child")
     .row_uuid();
@@ -314,6 +321,7 @@ fn omitted_array_limit_is_unbounded_for_prepare_read_and_subscribe() {
             ("title".to_owned(), Value::String("parent".to_owned())),
             ("rank".to_owned(), Value::I32(0)),
         ]),
+        Default::default(),
     ))
     .expect("insert parent")
     .row_uuid();
@@ -324,6 +332,7 @@ fn omitted_array_limit_is_unbounded_for_prepare_read_and_subscribe() {
             ("label".to_owned(), Value::String("child".to_owned())),
             ("rank".to_owned(), Value::I32(0)),
         ]),
+        Default::default(),
     ))
     .expect("insert child");
 
@@ -381,6 +390,7 @@ fn large_parent_is_materialized_atomically_without_a_frame_bound() {
             ("title".to_owned(), Value::String("parent".to_owned())),
             ("rank".to_owned(), Value::I32(0)),
         ]),
+        Default::default(),
     ))
     .expect("insert parent")
     .row_uuid();
@@ -393,6 +403,7 @@ fn large_parent_is_materialized_atomically_without_a_frame_bound() {
                 ("label".to_owned(), Value::String(payload.clone())),
                 ("rank".to_owned(), Value::I32(rank)),
             ]),
+            Default::default(),
         ))
         .expect("insert individually valid child");
     }

--- a/crates/jazz/tests/warm_reopen_differential.rs
+++ b/crates/jazz/tests/warm_reopen_differential.rs
@@ -138,14 +138,51 @@ fn child_cells(parent: RowUuid, label: &str, rank: i32) -> BTreeMap<String, Valu
 
 fn seed_store(dir: &tempfile::TempDir, schema: &JazzSchema, node_byte: u8) {
     let db = open_db(dir, schema, node_byte, node_byte as u64);
-    block_on(db.insert_with_id("parents", row(1), parent_cells("alpha", 1))).expect("insert alpha");
-    block_on(db.insert_with_id("parents", row(2), parent_cells("beta", 2))).expect("insert beta");
-    block_on(db.insert_with_id("children", row(101), child_cells(row(1), "a-1", 1)))
-        .expect("insert a-1");
-    block_on(db.insert_with_id("children", row(102), child_cells(row(1), "a-2", 2)))
-        .expect("insert a-2");
-    block_on(db.insert_with_id("children", row(201), child_cells(row(2), "b-1", 1)))
-        .expect("insert b-1");
+    block_on(db.insert(
+        "parents",
+        parent_cells("alpha", 1),
+        jazz::db::InsertOptions {
+            row_id: Some(row(1)),
+            ..Default::default()
+        },
+    ))
+    .expect("insert alpha");
+    block_on(db.insert(
+        "parents",
+        parent_cells("beta", 2),
+        jazz::db::InsertOptions {
+            row_id: Some(row(2)),
+            ..Default::default()
+        },
+    ))
+    .expect("insert beta");
+    block_on(db.insert(
+        "children",
+        child_cells(row(1), "a-1", 1),
+        jazz::db::InsertOptions {
+            row_id: Some(row(101)),
+            ..Default::default()
+        },
+    ))
+    .expect("insert a-1");
+    block_on(db.insert(
+        "children",
+        child_cells(row(1), "a-2", 2),
+        jazz::db::InsertOptions {
+            row_id: Some(row(102)),
+            ..Default::default()
+        },
+    ))
+    .expect("insert a-2");
+    block_on(db.insert(
+        "children",
+        child_cells(row(2), "b-1", 1),
+        jazz::db::InsertOptions {
+            row_id: Some(row(201)),
+            ..Default::default()
+        },
+    ))
+    .expect("insert b-1");
     block_on(db.close()).expect("close seeded db");
 }
 
@@ -397,14 +434,22 @@ fn reopen_from_rebuild_and_persisted_placeholder_are_incrementally_equivalent() 
         (
             "related row insert",
             Box::new(|db| {
-                block_on(db.insert_with_id("children", row(103), child_cells(row(1), "a-3", 3)))
-                    .expect("insert child");
+                block_on(db.insert(
+                    "children",
+                    child_cells(row(1), "a-3", 3),
+                    jazz::db::InsertOptions {
+                        row_id: Some(row(103)),
+                        ..Default::default()
+                    },
+                ))
+                .expect("insert child");
             }),
         ),
         (
             "related row delete",
             Box::new(|db| {
-                block_on(db.delete("children", row(201))).expect("delete child");
+                block_on(db.delete("children", row(201), Default::default()))
+                    .expect("delete child");
             }),
         ),
     ];

--- a/examples/band-chat/benchmarks/src/lib.rs
+++ b/examples/band-chat/benchmarks/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeMap;
 
-use jazz::db::{Db, DbConfig, DbIdentity, PreparedQuery, block_on};
+use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, PreparedQuery, block_on};
 use jazz::groove::records::Value;
 use jazz::groove::storage::MemoryStorage;
 use jazz::ids::{AuthorId, NodeUuid, RowUuid};
@@ -239,7 +239,15 @@ fn open_db() -> (BenchDb, TableSchema, TableSchema) {
 }
 
 fn insert(db: &BenchDb, table: &str, id: RowUuid, cells: BTreeMap<String, Value>) {
-    let write = block_on(db.insert_with_id(table, id, cells)).expect("insert BandChat fixture row");
+    let write = block_on(db.insert(
+        table,
+        cells,
+        InsertOptions {
+            row_id: Some(id),
+            ..Default::default()
+        },
+    ))
+    .expect("insert BandChat fixture row");
     block_on(write.wait(DurabilityTier::Local)).expect("fixture row reaches local durability");
 }
 

--- a/examples/big-label/benchmarks/src/lib.rs
+++ b/examples/big-label/benchmarks/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeMap;
 
-use jazz::db::{Db, DbConfig, DbIdentity, PreparedQuery, block_on};
+use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, PreparedQuery, block_on};
 use jazz::groove::records::Value;
 use jazz::groove::storage::MemoryStorage;
 use jazz::ids::{AuthorId, NodeUuid, RowUuid};
@@ -215,7 +215,15 @@ fn open_db() -> (BenchDb, TableSchema) {
 }
 
 fn insert(db: &BenchDb, table: &str, id: RowUuid, cells: BTreeMap<String, Value>) {
-    let write = block_on(db.insert_with_id(table, id, cells)).expect("insert BigLabel fixture row");
+    let write = block_on(db.insert(
+        table,
+        cells,
+        InsertOptions {
+            row_id: Some(id),
+            ..Default::default()
+        },
+    ))
+    .expect("insert BigLabel fixture row");
     block_on(write.wait(DurabilityTier::Local)).expect("fixture row reaches local durability");
 }
 

--- a/examples/music-agent/benchmarks/src/lib.rs
+++ b/examples/music-agent/benchmarks/src/lib.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::io::Cursor;
 
-use jazz::db::{Db, DbConfig, DbIdentity, PreparedQuery, block_on};
+use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, PreparedQuery, block_on};
 use jazz::groove::large_values::{INLINE_VALUE_MAX_BYTES, LargeValueKind};
 use jazz::groove::records::Value;
 use jazz::groove::storage::TestStorage;
@@ -193,8 +193,15 @@ fn table(schema: &JazzSchema, name: &str) -> TableSchema {
 }
 
 fn insert(db: &BenchDb, table: &str, row: RowUuid, cells: BTreeMap<String, Value>) {
-    let write =
-        block_on(db.insert_with_id(table, row, cells)).expect("insert MusicAgent fixture row");
+    let write = block_on(db.insert(
+        table,
+        cells,
+        InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    ))
+    .expect("insert MusicAgent fixture row");
     block_on(write.wait(DurabilityTier::Local)).expect("durable fixture row");
 }
 

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -533,6 +533,53 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     ]);
   });
 
+  it("allocates clock-backed ordered UUIDv7 ids in Rust for ordinary and staged inserts", async () => {
+    const { NapiDb } = await loadNapiModule();
+    const runtime = new NativeRuntimeAdapter(
+      { openMemory: (schema, config) => NapiDb.openMemory(schema, config) as never },
+      TEST_SCHEMA,
+      deterministicBytes("jazz-napi-native-runtime:uuidv7-node"),
+      deterministicBytes("jazz-napi-native-runtime:uuidv7-author"),
+      1,
+      true,
+    );
+    runtimes.push(runtime);
+
+    const insert = (title: string, writeContext?: string) =>
+      runtime.insert(
+        "todos",
+        {
+          title: { type: "Text", value: title },
+          done: { type: "Boolean", value: false },
+        },
+        writeContext,
+      );
+
+    const first = insert("first");
+    const second = insert("second");
+    const openBatchId = beginTestBatch(runtime);
+    const writeContext = JSON.stringify({ batch_id: openBatchId });
+    const third = insert("third", writeContext);
+    const fourth = insert("fourth", writeContext);
+
+    for (const row of [first, second, third, fourth]) {
+      expect(row.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
+    }
+
+    const generatedAtMs = Number.parseInt(first.id.replaceAll("-", "").slice(0, 12), 16);
+    expect(Math.abs(Date.now() - generatedAtMs)).toBeLessThan(60_000);
+    const ids = [first.id, second.id, third.id, fourth.id];
+    expect(ids).toEqual([...ids].sort());
+
+    await runtime.commitTransaction(openBatchId);
+    const rows = (await runtime.query(JSON.stringify({ table: "todos" }))) as Array<{
+      id: string;
+    }>;
+    expect(rows.map((row) => row.id)).toEqual([first.id, second.id, third.id, fourth.id]);
+  });
+
   it("applies column defaults for direct napi inserts with omitted cells", async () => {
     const { NapiDb } = await loadNapiModule();
     const runtime = new NativeRuntimeAdapter(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -127,6 +127,20 @@ type NativeDb = {
     author: Uint8Array,
     opts: unknown,
   ): ReadableStream<unknown> | Subscription;
+  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): Write;
+  insertEncodedForIdentity(
+    table: string,
+    cells: Uint8Array,
+    author: Uint8Array,
+    updatedAtMs?: number | null,
+  ): Write;
+  insertEncodedInBranch?(table: string, cells: Uint8Array, branch: unknown): Write;
+  insertEncodedInBranchForIdentity?(
+    table: string,
+    cells: Uint8Array,
+    branch: unknown,
+    author: Uint8Array,
+  ): Write;
   insertWithIdEncoded(table: string, rowId: Uint8Array, cells: Uint8Array): Write;
   insertWithIdEncodedForIdentity(
     table: string,
@@ -357,7 +371,8 @@ type Subscription = {
 
 type Write = {
   readonly batchId: string;
-  payload: Uint8Array;
+  readonly payload: Uint8Array;
+  readonly rowId: Uint8Array;
   wait(tier: string): Promise<void>;
   writeState(): unknown;
   close?(): boolean;
@@ -366,6 +381,8 @@ type Write = {
 type Tx = {
   commit(): Write;
   rollback(): void;
+  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): Uint8Array;
+  insertEncodedInBranch?(table: string, cells: Uint8Array, branch: unknown): Uint8Array;
   insertWithIdEncoded(
     table: string,
     rowId: Uint8Array,
@@ -616,7 +633,8 @@ export class NativeRuntimeAdapter implements Runtime {
     private readonly schema: WasmSchema,
     private readonly node: Uint8Array,
     author: Uint8Array,
-    sourceId: number,
+    // Retained for constructor compatibility; production row IDs must use the core clock source.
+    _sourceId: number,
     historyComplete: boolean,
     opts?: {
       persistentPath?: string;
@@ -641,7 +659,7 @@ export class NativeRuntimeAdapter implements Runtime {
     this.configBytes = openConfig(
       node,
       author,
-      sourceId,
+      undefined,
       historyComplete,
       opts?.initialSyncFlushEvery,
     );
@@ -946,7 +964,7 @@ export class NativeRuntimeAdapter implements Runtime {
     _writeContext?: string | null,
     objectId?: string | null,
   ): InsertResult {
-    const rowId = objectId ? parseUuid(objectId) : crypto.getRandomValues(new Uint8Array(16));
+    const suppliedRowId = objectId ? parseUuid(objectId) : undefined;
     const cells = encodeCellsForRow(this.table(table), values);
     const writeSession = sessionFromWriteContext(_writeContext);
     this.applySessionClaims(writeSession);
@@ -956,13 +974,25 @@ export class NativeRuntimeAdapter implements Runtime {
     const tx = this.currentTx(_writeContext, "Insert");
     if (tx) {
       const nativeTx = this.txForWrite(tx, writeIdentity);
+      let rowId: Uint8Array;
       if (branchView) {
-        requireBranchMethod(
-          nativeTx.insertWithIdEncodedInBranch,
-          "transaction branch inserts",
-        ).call(nativeTx, table, rowId, cells, branchView.head);
+        if (suppliedRowId) {
+          rowId = suppliedRowId;
+          requireBranchMethod(
+            nativeTx.insertWithIdEncodedInBranch,
+            "transaction branch inserts",
+          ).call(nativeTx, table, rowId, cells, branchView.head);
+        } else {
+          rowId = requireBranchMethod(
+            nativeTx.insertEncodedInBranch,
+            "transaction generated-id branch inserts",
+          ).call(nativeTx, table, cells, branchView.head);
+        }
       } else {
-        nativeTx.insertWithIdEncoded(table, rowId, cells, updatedAtMs);
+        rowId = suppliedRowId ?? nativeTx.insertEncoded(table, cells, updatedAtMs);
+        if (suppliedRowId) {
+          nativeTx.insertWithIdEncoded(table, rowId, cells, updatedAtMs);
+        }
       }
       const row = this.rowStateFromValues(table, rowId, values);
       tx.writes.push({ table, rowId, row });
@@ -975,22 +1005,43 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     const write = writeOrNormalizeRejection("Insert", () =>
       branchView
-        ? writeIdentity
-          ? requireBranchMethod(
-              this.db.insertWithIdEncodedInBranchForIdentity,
-              "identity-scoped branch inserts",
-            ).call(this.db, table, rowId, cells, branchView.head, writeIdentity)
-          : requireBranchMethod(this.db.insertWithIdEncodedInBranch, "branch inserts").call(
-              this.db,
-              table,
-              rowId,
-              cells,
-              branchView.head,
-            )
+        ? suppliedRowId
+          ? writeIdentity
+            ? requireBranchMethod(
+                this.db.insertWithIdEncodedInBranchForIdentity,
+                "identity-scoped branch inserts",
+              ).call(this.db, table, suppliedRowId, cells, branchView.head, writeIdentity)
+            : requireBranchMethod(this.db.insertWithIdEncodedInBranch, "branch inserts").call(
+                this.db,
+                table,
+                suppliedRowId,
+                cells,
+                branchView.head,
+              )
+          : writeIdentity
+            ? requireBranchMethod(
+                this.db.insertEncodedInBranchForIdentity,
+                "identity-scoped generated-id branch inserts",
+              ).call(this.db, table, cells, branchView.head, writeIdentity)
+            : requireBranchMethod(
+                this.db.insertEncodedInBranch,
+                "generated-id branch inserts",
+              ).call(this.db, table, cells, branchView.head)
         : writeIdentity
-          ? this.db.insertWithIdEncodedForIdentity(table, rowId, cells, writeIdentity, updatedAtMs)
-          : this.db.insertWithIdEncoded(table, rowId, cells, updatedAtMs),
+          ? suppliedRowId
+            ? this.db.insertWithIdEncodedForIdentity(
+                table,
+                suppliedRowId,
+                cells,
+                writeIdentity,
+                updatedAtMs,
+              )
+            : this.db.insertEncodedForIdentity(table, cells, writeIdentity, updatedAtMs)
+          : suppliedRowId
+            ? this.db.insertWithIdEncoded(table, suppliedRowId, cells, updatedAtMs)
+            : this.db.insertEncoded(table, cells, updatedAtMs),
     );
+    const rowId = suppliedRowId ?? write.rowId;
     return this.finishInsert(table, rowId, values, write);
   }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -84,6 +84,28 @@ type NativeDbConstructor = {
   openPersistent?(dataPath: string, schema: Uint8Array, config: Uint8Array): NativeDb;
 };
 
+type NativeWriteOptions = {
+  author?: Uint8Array;
+  updatedAtMs?: number;
+};
+
+type NativeInsertOptions = NativeWriteOptions & {
+  rowId?: Uint8Array;
+  branch?: unknown;
+};
+
+type NativeUpdateOptions = NativeWriteOptions & {
+  head?: unknown;
+  base?: unknown;
+};
+
+type NativeUpsertOptions = NativeWriteOptions & {
+  branch?: unknown;
+};
+
+type NativeDeleteOptions = NativeUpdateOptions;
+type NativeRestoreOptions = NativeUpsertOptions;
+
 type NativeDb = {
   // Native runtime adapters may close synchronously or asynchronously and may
   // report whether they transitioned state. The adapter awaits either form and
@@ -127,33 +149,25 @@ type NativeDb = {
     author: Uint8Array,
     opts: unknown,
   ): ReadableStream<unknown> | Subscription;
-  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): Write;
-  insertEncodedForIdentity(
+  insertEncoded(table: string, cells: Uint8Array, options?: NativeInsertOptions): Write;
+  updateEncoded(
     table: string,
-    cells: Uint8Array,
-    author: Uint8Array,
-    updatedAtMs?: number | null,
+    rowId: Uint8Array,
+    patch: Uint8Array,
+    options?: NativeUpdateOptions,
   ): Write;
-  insertEncodedInBranch?(table: string, cells: Uint8Array, branch: unknown): Write;
-  insertEncodedInBranchForIdentity?(
-    table: string,
-    cells: Uint8Array,
-    branch: unknown,
-    author: Uint8Array,
-  ): Write;
-  insertWithIdEncoded(table: string, rowId: Uint8Array, cells: Uint8Array): Write;
-  insertWithIdEncodedForIdentity(
+  upsertEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
-    author: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: NativeUpsertOptions,
   ): Write;
-  insertWithIdEncoded(
+  deleteEncoded(table: string, rowId: Uint8Array, options?: NativeDeleteOptions): Write;
+  restoreEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: NativeRestoreOptions,
   ): Write;
   beginStreamingMutationEncoded?(
     table: string,
@@ -167,112 +181,6 @@ type NativeDb = {
     head?: unknown,
     base?: unknown,
   ): NativeStreamingMutation;
-  insertWithIdEncodedInBranch?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    branch: unknown,
-  ): Write;
-  insertWithIdEncodedInBranchForIdentity?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    branch: unknown,
-    author: Uint8Array,
-  ): Write;
-  restoreEncoded(table: string, rowId: Uint8Array, cells: Uint8Array): Write;
-  restoreEncodedForIdentity(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    author: Uint8Array,
-    updatedAtMs?: number | null,
-  ): Write;
-  restoreEncoded(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): Write;
-  restoreInBranch?(table: string, rowId: Uint8Array, branch: unknown): Write;
-  restoreEncodedInBranch?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    branch: unknown,
-  ): Write;
-  restoreEncodedInBranchForIdentity?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    branch: unknown,
-    author: Uint8Array,
-  ): Write;
-  updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array): Write;
-  updateEncodedForIdentity(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    author: Uint8Array,
-    updatedAtMs?: number | null,
-  ): Write;
-  updateEncoded(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    updatedAtMs?: number | null,
-  ): Write;
-  updateEncodedInBranch?(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    branch: unknown,
-  ): Write;
-  updateEncodedInBranchView?(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    head: unknown,
-    base?: unknown,
-  ): Write;
-  updateEncodedInBranchViewForIdentity?(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    head: unknown,
-    base: unknown,
-    author: Uint8Array,
-  ): Write;
-  upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array): Write;
-  upsertEncodedForIdentity(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    author: Uint8Array,
-    updatedAtMs?: number | null,
-  ): Write;
-  upsertEncoded(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): Write;
-  delete(table: string, rowId: Uint8Array, updatedAtMs?: number | null): Write;
-  deleteForIdentity(
-    table: string,
-    rowId: Uint8Array,
-    author: Uint8Array,
-    updatedAtMs?: number | null,
-  ): Write;
-  deleteInBranch?(table: string, rowId: Uint8Array, branch: unknown): Write;
-  deleteInBranchView?(table: string, rowId: Uint8Array, head: unknown, base?: unknown): Write;
-  deleteInBranchViewForIdentity?(
-    table: string,
-    rowId: Uint8Array,
-    head: unknown,
-    base: unknown,
-    author: Uint8Array,
-  ): Write;
   requestInsertPermissionAdviceEncoded?(
     table: string,
     cells: Uint8Array,
@@ -381,53 +289,26 @@ type Write = {
 type Tx = {
   commit(): Write;
   rollback(): void;
-  insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): Uint8Array;
-  insertEncodedInBranch?(table: string, cells: Uint8Array, branch: unknown): Uint8Array;
-  insertWithIdEncoded(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
-  insertWithIdEncodedInBranch?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    branch: unknown,
-  ): void;
-  restoreEncoded(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
-  restoreEncodedInBranch?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    branch: unknown,
-  ): void;
+  insertEncoded(table: string, cells: Uint8Array, options?: NativeInsertOptions): Uint8Array;
   updateEncoded(
     table: string,
     rowId: Uint8Array,
     patch: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
-  updateEncodedInBranchView?(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    head: unknown,
-    base?: unknown,
+    options?: NativeUpdateOptions,
   ): void;
   upsertEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: NativeUpsertOptions,
   ): void;
-  delete(table: string, rowId: Uint8Array, updatedAtMs?: number | null): void;
-  deleteInBranchView?(table: string, rowId: Uint8Array, head: unknown, base?: unknown): void;
+  deleteEncoded(table: string, rowId: Uint8Array, options?: NativeDeleteOptions): void;
+  restoreEncoded(
+    table: string,
+    rowId: Uint8Array,
+    cells: Uint8Array,
+    options?: NativeRestoreOptions,
+  ): void;
 };
 
 export type Transport = {
@@ -974,26 +855,11 @@ export class NativeRuntimeAdapter implements Runtime {
     const tx = this.currentTx(_writeContext, "Insert");
     if (tx) {
       const nativeTx = this.txForWrite(tx, writeIdentity);
-      let rowId: Uint8Array;
-      if (branchView) {
-        if (suppliedRowId) {
-          rowId = suppliedRowId;
-          requireBranchMethod(
-            nativeTx.insertWithIdEncodedInBranch,
-            "transaction branch inserts",
-          ).call(nativeTx, table, rowId, cells, branchView.head);
-        } else {
-          rowId = requireBranchMethod(
-            nativeTx.insertEncodedInBranch,
-            "transaction generated-id branch inserts",
-          ).call(nativeTx, table, cells, branchView.head);
-        }
-      } else {
-        rowId = suppliedRowId ?? nativeTx.insertEncoded(table, cells, updatedAtMs);
-        if (suppliedRowId) {
-          nativeTx.insertWithIdEncoded(table, rowId, cells, updatedAtMs);
-        }
-      }
+      const rowId = nativeTx.insertEncoded(table, cells, {
+        rowId: suppliedRowId,
+        branch: branchView?.head,
+        updatedAtMs: updatedAtMs ?? undefined,
+      });
       const row = this.rowStateFromValues(table, rowId, values);
       tx.writes.push({ table, rowId, row });
       return {
@@ -1004,45 +870,14 @@ export class NativeRuntimeAdapter implements Runtime {
       };
     }
     const write = writeOrNormalizeRejection("Insert", () =>
-      branchView
-        ? suppliedRowId
-          ? writeIdentity
-            ? requireBranchMethod(
-                this.db.insertWithIdEncodedInBranchForIdentity,
-                "identity-scoped branch inserts",
-              ).call(this.db, table, suppliedRowId, cells, branchView.head, writeIdentity)
-            : requireBranchMethod(this.db.insertWithIdEncodedInBranch, "branch inserts").call(
-                this.db,
-                table,
-                suppliedRowId,
-                cells,
-                branchView.head,
-              )
-          : writeIdentity
-            ? requireBranchMethod(
-                this.db.insertEncodedInBranchForIdentity,
-                "identity-scoped generated-id branch inserts",
-              ).call(this.db, table, cells, branchView.head, writeIdentity)
-            : requireBranchMethod(
-                this.db.insertEncodedInBranch,
-                "generated-id branch inserts",
-              ).call(this.db, table, cells, branchView.head)
-        : writeIdentity
-          ? suppliedRowId
-            ? this.db.insertWithIdEncodedForIdentity(
-                table,
-                suppliedRowId,
-                cells,
-                writeIdentity,
-                updatedAtMs,
-              )
-            : this.db.insertEncodedForIdentity(table, cells, writeIdentity, updatedAtMs)
-          : suppliedRowId
-            ? this.db.insertWithIdEncoded(table, suppliedRowId, cells, updatedAtMs)
-            : this.db.insertEncoded(table, cells, updatedAtMs),
+      this.db.insertEncoded(table, cells, {
+        rowId: suppliedRowId,
+        author: writeIdentity,
+        branch: branchView?.head,
+        updatedAtMs: updatedAtMs ?? undefined,
+      }),
     );
-    const rowId = suppliedRowId ?? write.rowId;
-    return this.finishInsert(table, rowId, values, write);
+    return this.finishInsert(table, suppliedRowId ?? write.rowId, values, write);
   }
 
   async streamingMutation(
@@ -1148,17 +983,10 @@ export class NativeRuntimeAdapter implements Runtime {
     const tx = this.currentTx(writeContext, "Restore");
     if (tx) {
       const nativeTx = this.txForWrite(tx, writeIdentity);
-      if (branchView) {
-        requireBranchMethod(nativeTx.restoreEncodedInBranch, "transaction branch restores").call(
-          nativeTx,
-          table,
-          rowId,
-          cells,
-          branchView.head,
-        );
-      } else {
-        nativeTx.restoreEncoded(table, rowId, cells, updatedAtMs);
-      }
+      nativeTx.restoreEncoded(table, rowId, cells, {
+        branch: branchView?.head,
+        updatedAtMs: updatedAtMs ?? undefined,
+      });
       const row = this.rowStateFromValues(table, rowId, values);
       tx.writes.push({ table, rowId, row });
       return {
@@ -1169,22 +997,11 @@ export class NativeRuntimeAdapter implements Runtime {
       };
     }
     const write = writeOrNormalizeRejection("Restore", () =>
-      branchView
-        ? writeIdentity
-          ? requireBranchMethod(
-              this.db.restoreEncodedInBranchForIdentity,
-              "identity-scoped branch restores",
-            ).call(this.db, table, rowId, cells, branchView.head, writeIdentity)
-          : requireBranchMethod(this.db.restoreEncodedInBranch, "branch restores").call(
-              this.db,
-              table,
-              rowId,
-              cells,
-              branchView.head,
-            )
-        : writeIdentity
-          ? this.db.restoreEncodedForIdentity(table, rowId, cells, writeIdentity, updatedAtMs)
-          : this.db.restoreEncoded(table, rowId, cells, updatedAtMs),
+      this.db.restoreEncoded(table, rowId, cells, {
+        author: writeIdentity,
+        branch: branchView?.head,
+        updatedAtMs: updatedAtMs ?? undefined,
+      }),
     );
     return this.finishInsert(table, rowId, values, write);
   }
@@ -1205,18 +1022,11 @@ export class NativeRuntimeAdapter implements Runtime {
     const tx = this.currentTx(writeContext, "Update");
     if (tx) {
       const nativeTx = this.txForWrite(tx, writeIdentity);
-      if (branchView) {
-        requireBranchMethod(nativeTx.updateEncodedInBranchView, "transaction branch updates").call(
-          nativeTx,
-          table,
-          rowId,
-          patch,
-          branchView.head,
-          branchView.base,
-        );
-      } else {
-        nativeTx.updateEncoded(table, rowId, patch, updatedAtMs);
-      }
+      nativeTx.updateEncoded(table, rowId, patch, {
+        head: branchView?.head,
+        base: branchView?.base,
+        updatedAtMs: updatedAtMs ?? undefined,
+      });
       tx.writes.push({
         table,
         rowId,
@@ -1225,31 +1035,12 @@ export class NativeRuntimeAdapter implements Runtime {
       return { kind: "staged", openBatchId: txIdFromContext(writeContext)! };
     }
     const write = writeOrNormalizeRejection("Update", () =>
-      branchView
-        ? writeIdentity
-          ? requireBranchMethod(
-              this.db.updateEncodedInBranchViewForIdentity,
-              "identity-scoped branch updates",
-            ).call(this.db, table, rowId, patch, branchView.head, branchView.base, writeIdentity)
-          : branchView.base === undefined
-            ? requireBranchMethod(this.db.updateEncodedInBranch, "exact branch updates").call(
-                this.db,
-                table,
-                rowId,
-                patch,
-                branchView.head,
-              )
-            : requireBranchMethod(this.db.updateEncodedInBranchView, "branch-view updates").call(
-                this.db,
-                table,
-                rowId,
-                patch,
-                branchView.head,
-                branchView.base,
-              )
-        : writeIdentity
-          ? this.db.updateEncodedForIdentity(table, rowId, patch, writeIdentity, updatedAtMs)
-          : this.db.updateEncoded(table, rowId, patch, updatedAtMs),
+      this.db.updateEncoded(table, rowId, patch, {
+        author: writeIdentity,
+        head: branchView?.head,
+        base: branchView?.base,
+        updatedAtMs: updatedAtMs ?? undefined,
+      }),
     );
     return this.finishMutation(write);
   }
@@ -1266,6 +1057,7 @@ export class NativeRuntimeAdapter implements Runtime {
     this.applySessionClaims(writeSession);
     const writeIdentity = this.trustedWriteIdentity(writeSession);
     const updatedAtMs = effectiveUpdatedAtMs(writeContext);
+    const branchView = branchViewFromWriteContext(writeContext);
     const tx = this.currentTx(writeContext, "Upsert");
     const existing = tx
       ? (this.stagedRowForWriteMerge(tx, table, rowId) ?? this.readRowForWriteMerge(table, rowId))
@@ -1279,7 +1071,10 @@ export class NativeRuntimeAdapter implements Runtime {
       throw writeError("Upsert", normalizeWriteSetupMessage(errorMessage(error)));
     }
     if (tx) {
-      this.txForWrite(tx, writeIdentity).upsertEncoded(table, rowId, cells, updatedAtMs);
+      this.txForWrite(tx, writeIdentity).upsertEncoded(table, rowId, cells, {
+        branch: branchView?.head,
+        updatedAtMs: updatedAtMs ?? undefined,
+      });
       tx.writes.push({
         table,
         rowId,
@@ -1290,9 +1085,11 @@ export class NativeRuntimeAdapter implements Runtime {
       return { kind: "staged", openBatchId: txIdFromContext(writeContext)! };
     }
     const write = writeOrNormalizeRejection("Upsert", () =>
-      writeIdentity
-        ? this.db.upsertEncodedForIdentity(table, rowId, cells, writeIdentity, updatedAtMs)
-        : this.db.upsertEncoded(table, rowId, cells, updatedAtMs),
+      this.db.upsertEncoded(table, rowId, cells, {
+        author: writeIdentity,
+        branch: branchView?.head,
+        updatedAtMs: updatedAtMs ?? undefined,
+      }),
     );
     return this.finishMutation(write);
   }
@@ -1308,44 +1105,21 @@ export class NativeRuntimeAdapter implements Runtime {
     const tx = this.currentTx(writeContext, "Delete");
     if (tx) {
       const nativeTx = this.txForWrite(tx, writeIdentity);
-      if (branchView) {
-        requireBranchMethod(nativeTx.deleteInBranchView, "transaction branch deletes").call(
-          nativeTx,
-          table,
-          rowId,
-          branchView.head,
-          branchView.base,
-        );
-      } else {
-        nativeTx.delete(table, rowId, updatedAtMs);
-      }
+      nativeTx.deleteEncoded(table, rowId, {
+        head: branchView?.head,
+        base: branchView?.base,
+        updatedAtMs: updatedAtMs ?? undefined,
+      });
       tx.writes.push({ table, rowId, deleted: true });
       return { kind: "staged", openBatchId: txIdFromContext(writeContext)! };
     }
     const write = writeOrNormalizeRejection("Delete", () =>
-      branchView
-        ? writeIdentity
-          ? requireBranchMethod(
-              this.db.deleteInBranchViewForIdentity,
-              "identity-scoped branch deletes",
-            ).call(this.db, table, rowId, branchView.head, branchView.base, writeIdentity)
-          : branchView.base === undefined
-            ? requireBranchMethod(this.db.deleteInBranch, "exact branch deletes").call(
-                this.db,
-                table,
-                rowId,
-                branchView.head,
-              )
-            : requireBranchMethod(this.db.deleteInBranchView, "branch-view deletes").call(
-                this.db,
-                table,
-                rowId,
-                branchView.head,
-                branchView.base,
-              )
-        : writeIdentity
-          ? this.db.deleteForIdentity(table, rowId, writeIdentity, updatedAtMs)
-          : this.db.delete(table, rowId, updatedAtMs),
+      this.db.deleteEncoded(table, rowId, {
+        author: writeIdentity,
+        head: branchView?.head,
+        base: branchView?.base,
+        updatedAtMs: updatedAtMs ?? undefined,
+      }),
     );
     return this.finishMutation(write);
   }
@@ -3048,11 +2822,6 @@ function branchViewFromWriteContext(writeContext?: string | null): EncodedBranch
   } catch {
     return undefined;
   }
-}
-
-function requireBranchMethod<T>(method: T | undefined, name: string): T {
-  if (method === undefined) throw new Error(`native runtime does not support ${name}`);
-  return method;
 }
 
 function sessionFromWriteContext(writeContext?: string | null): RuntimeSession | null {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -109,11 +109,11 @@ function fakeTx(overrides: Partial<TxForTest> = {}): TxForTest {
   return {
     commit: () => fakeWrite(),
     rollback: () => undefined,
-    insertWithIdEncoded: () => undefined,
+    insertEncoded: (_table, _cells, options) => options?.rowId ?? new Uint8Array(16),
     restoreEncoded: () => undefined,
     updateEncoded: () => undefined,
     upsertEncoded: () => undefined,
-    delete: () => undefined,
+    deleteEncoded: () => undefined,
     ...overrides,
   };
 }
@@ -130,31 +130,34 @@ function fakeWrite() {
 type TxForTest = {
   commit(): ReturnType<typeof fakeWrite>;
   rollback(): void;
-  insertWithIdEncoded(
+  insertEncoded(
     table: string,
-    rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
+    options?: { rowId?: Uint8Array; branch?: unknown; updatedAtMs?: number },
+  ): Uint8Array;
   restoreEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: { branch?: unknown; updatedAtMs?: number },
   ): void;
   updateEncoded(
     table: string,
     rowId: Uint8Array,
     patch: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: { head?: unknown; base?: unknown; updatedAtMs?: number },
   ): void;
   upsertEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: { branch?: unknown; updatedAtMs?: number },
   ): void;
-  delete(table: string, rowId: Uint8Array, updatedAtMs?: number | null): void;
+  deleteEncoded(
+    table: string,
+    rowId: Uint8Array,
+    options?: { head?: unknown; base?: unknown; updatedAtMs?: number },
+  ): void;
 };
 
 function uuidBytes(value: string): Uint8Array {
@@ -178,12 +181,9 @@ it("stages authenticated client mutations through the optimistic local core path
         fakeDb({
           all: () => encodeRows([]),
           allForIdentity: () => encodeRows([]),
-          insertWithIdEncoded: (table: string) => {
+          insertEncoded: (table: string, _cells: Uint8Array, options?: { rowId?: Uint8Array }) => {
             staged.push(table);
-            return fakeWrite();
-          },
-          insertWithIdEncodedForIdentity: () => {
-            throw new Error("ordinary client mutation must not use trusted serving");
+            return { ...fakeWrite(), rowId: options?.rowId ?? new Uint8Array(16) };
           },
           prepareQuery: () => ({}),
           tick: () => undefined,
@@ -224,7 +224,14 @@ it("preserves logical user columns that share names with native storage metadata
       openMemory: () =>
         fakeDb({
           all: () => encodeRows([]),
-          insertWithIdEncoded: () => fakeWrite(),
+          insertEncoded: (
+            _table: string,
+            _cells: Uint8Array,
+            options?: { rowId?: Uint8Array },
+          ) => ({
+            ...fakeWrite(),
+            rowId: options?.rowId ?? new Uint8Array(16),
+          }),
           prepareQuery: () => ({}),
           tick: () => undefined,
         }),
@@ -265,7 +272,10 @@ it("uses identity-aware core txs only on an explicit trusted-serving host", () =
           mergeableTxForIdentity: (_openBatchId: string, author: Uint8Array) => {
             authors.push(formatUuidForTest(author));
             return fakeTx({
-              insertWithIdEncoded: (table: string) => staged.push(table),
+              insertEncoded: (table, _cells, options) => {
+                staged.push(table);
+                return options?.rowId ?? new Uint8Array(16);
+              },
             });
           },
           prepareQuery: () => ({}),
@@ -428,7 +438,12 @@ it("rejects a duplicate live OpenBatchId without replacing its staged transactio
           mergeableTx: () => {
             const staged: string[] = [];
             stagedTransactions.push(staged);
-            return fakeTx({ insertWithIdEncoded: (table: string) => staged.push(table) });
+            return fakeTx({
+              insertEncoded: (table, _cells, options) => {
+                staged.push(table);
+                return options?.rowId ?? new Uint8Array(16);
+              },
+            });
           },
         }),
       openBrowser: async () => {
@@ -523,7 +538,7 @@ it("emits an onMutationError event for an unawaited rejected write", async () =>
     {
       openMemory: () =>
         fakeDb({
-          insertWithIdEncoded: () => write,
+          insertEncoded: () => write,
           onMutationError: (callback: (event: MutationErrorEvent) => void) => {
             mutationErrorCallback = callback;
           },
@@ -599,7 +614,7 @@ it("does not emit onMutationError when an active wait handles the rejection", as
     {
       openMemory: () =>
         fakeDb({
-          insertWithIdEncoded: () => write,
+          insertEncoded: () => write,
           onMutationError: () => undefined,
         }),
     } as never,
@@ -643,15 +658,18 @@ it("passes caller-supplied updatedAt into staged mergeable transaction writes", 
           all: () => encodeRows([]),
           mergeableTx: () =>
             fakeTx({
-              insertWithIdEncoded: (_table, _rowId, _cells, updatedAtMs) =>
-                staged.push({ op: "insert", updatedAtMs }),
-              updateEncoded: (_table, _rowId, _patch, updatedAtMs) =>
-                staged.push({ op: "update", updatedAtMs }),
-              upsertEncoded: (_table, _rowId, _cells, updatedAtMs) =>
-                staged.push({ op: "upsert", updatedAtMs }),
-              restoreEncoded: (_table, _rowId, _cells, updatedAtMs) =>
-                staged.push({ op: "restore", updatedAtMs }),
-              delete: (_table, _rowId, updatedAtMs) => staged.push({ op: "delete", updatedAtMs }),
+              insertEncoded: (_table, _cells, options) => {
+                staged.push({ op: "insert", updatedAtMs: options?.updatedAtMs });
+                return options?.rowId ?? new Uint8Array(16);
+              },
+              updateEncoded: (_table, _rowId, _patch, options) =>
+                staged.push({ op: "update", updatedAtMs: options?.updatedAtMs }),
+              upsertEncoded: (_table, _rowId, _cells, options) =>
+                staged.push({ op: "upsert", updatedAtMs: options?.updatedAtMs }),
+              restoreEncoded: (_table, _rowId, _cells, options) =>
+                staged.push({ op: "restore", updatedAtMs: options?.updatedAtMs }),
+              deleteEncoded: (_table, _rowId, options) =>
+                staged.push({ op: "delete", updatedAtMs: options?.updatedAtMs }),
             }),
           prepareQuery: () => ({}),
           tick: () => undefined,

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -185,6 +185,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     const write = {
       batchId: "00000000000070008000000000000007",
       payload: new Uint8Array(),
+      rowId: new Uint8Array(16),
       wait: () => (settled ? Promise.resolve() : new Promise<void>(() => {})),
       writeState: () => ({}),
     };
@@ -192,7 +193,7 @@ describe("NativeRuntimeAdapter server transport", () => {
       {
         openMemory: () =>
           fakeDb({
-            insertWithIdEncoded: () => write,
+            insertEncoded: () => write,
             connectUpstream: () => transport,
             tick: () => undefined,
           }),
@@ -248,6 +249,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     const write = {
       batchId: "00000000000070008000000000000007",
       payload: new Uint8Array(),
+      rowId: new Uint8Array(16),
       wait: () => (settled ? Promise.resolve() : new Promise<void>(() => {})),
       writeState: () => ({}),
       nextWriteStateChange: () => new Promise<void>(() => {}),
@@ -256,7 +258,7 @@ describe("NativeRuntimeAdapter server transport", () => {
       {
         openMemory: () =>
           fakeDb({
-            insertWithIdEncoded: () => write,
+            insertEncoded: () => write,
             connectUpstream: () => transport,
             tick: () => undefined,
           }),
@@ -844,11 +846,11 @@ function fakeTx(overrides: Partial<TxForTest> = {}): TxForTest {
   return {
     commit: () => fakeWrite(),
     rollback: () => undefined,
-    insertWithIdEncoded: () => undefined,
+    insertEncoded: (_table, _cells, options) => options?.rowId ?? new Uint8Array(16),
     restoreEncoded: () => undefined,
     updateEncoded: () => undefined,
     upsertEncoded: () => undefined,
-    delete: () => undefined,
+    deleteEncoded: () => undefined,
     ...overrides,
   };
 }
@@ -857,6 +859,7 @@ function fakeWrite() {
   return {
     batchId: "00000000000070008000000000000001",
     payload: new Uint8Array(0),
+    rowId: new Uint8Array(16),
     wait: async () => undefined,
     writeState: () => ({}),
   };
@@ -865,29 +868,9 @@ function fakeWrite() {
 type TxForTest = {
   commit(): ReturnType<typeof fakeWrite>;
   rollback(): void;
-  insertWithIdEncoded(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
-  restoreEncoded(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
-  updateEncoded(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
-  upsertEncoded(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
-  delete(table: string, rowId: Uint8Array, updatedAtMs?: number | null): void;
+  insertEncoded(table: string, cells: Uint8Array, options?: { rowId?: Uint8Array }): Uint8Array;
+  restoreEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, options?: unknown): void;
+  updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array, options?: unknown): void;
+  upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, options?: unknown): void;
+  deleteEncoded(table: string, rowId: Uint8Array, options?: unknown): void;
 };

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -541,7 +541,7 @@ describe("NativeRuntimeAdapter server transport", () => {
               calls.push(["update", table, rowId, patch]);
               return write;
             },
-            delete: (table: string, rowId: Uint8Array) => {
+            deleteEncoded: (table: string, rowId: Uint8Array) => {
               calls.push(["delete", table, rowId]);
               return write;
             },
@@ -596,8 +596,12 @@ describe("NativeRuntimeAdapter server transport", () => {
                 },
               ]),
             prepareQuery: () => ({}),
-            insertWithIdEncoded: (_table: string, rowId: Uint8Array) => {
-              insertedRowIds.push(rowId);
+            insertEncoded: (
+              _table: string,
+              _cells: Uint8Array,
+              options?: { rowId?: Uint8Array },
+            ) => {
+              insertedRowIds.push(options?.rowId ?? new Uint8Array(16));
               return write;
             },
             tick: () => undefined,
@@ -645,11 +649,11 @@ describe("NativeRuntimeAdapter server transport", () => {
       {
         openMemory: () =>
           fakeDb({
-            insertWithIdEncodedInBranch: (...args: unknown[]) => {
+            insertEncoded: (...args: unknown[]) => {
               calls.push(["insert", ...args]);
               return fakeWrite();
             },
-            updateEncodedInBranchView: (...args: unknown[]) => {
+            updateEncoded: (...args: unknown[]) => {
               calls.push(["update", ...args]);
               return fakeWrite();
             },
@@ -681,9 +685,9 @@ describe("NativeRuntimeAdapter server transport", () => {
     );
 
     expect(calls[0]?.[0]).toBe("insert");
-    expect(calls[0]?.at(-1)).toEqual(head);
+    expect(calls[0]?.at(-1)).toMatchObject({ branch: head });
     expect(calls[1]?.[0]).toBe("update");
-    expect(calls[1]?.slice(-2)).toEqual([head, base]);
+    expect(calls[1]?.at(-1)).toMatchObject({ head, base });
   });
 
   it("runs scheduled core ticks before post-wait edge reads", async () => {
@@ -726,7 +730,7 @@ describe("NativeRuntimeAdapter server transport", () => {
               ];
             },
           }),
-          insertWithIdEncoded: () => {
+          insertEncoded: () => {
             schedulerCallback?.("deferred");
             return fakeWrite();
           },
@@ -5642,11 +5646,11 @@ function fakeTx(overrides: Partial<TxForTest> = {}): TxForTest {
   return {
     commit: () => fakeWrite(),
     rollback: () => undefined,
-    insertWithIdEncoded: () => undefined,
+    insertEncoded: (_table, _cells, options) => options?.rowId ?? new Uint8Array(16),
     restoreEncoded: () => undefined,
     updateEncoded: () => undefined,
     upsertEncoded: () => undefined,
-    delete: () => undefined,
+    deleteEncoded: () => undefined,
     ...overrides,
   };
 }
@@ -5663,31 +5667,34 @@ function fakeWrite() {
 type TxForTest = {
   commit(): ReturnType<typeof fakeWrite>;
   rollback(): void;
-  insertWithIdEncoded(
+  insertEncoded(
     table: string,
-    rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
-  ): void;
+    options?: { rowId?: Uint8Array; branch?: unknown; updatedAtMs?: number },
+  ): Uint8Array;
   restoreEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: { branch?: unknown; updatedAtMs?: number },
   ): void;
   updateEncoded(
     table: string,
     rowId: Uint8Array,
     patch: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: { head?: unknown; base?: unknown; updatedAtMs?: number },
   ): void;
   upsertEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
-    updatedAtMs?: number | null,
+    options?: { branch?: unknown; updatedAtMs?: number },
   ): void;
-  delete(table: string, rowId: Uint8Array, updatedAtMs?: number | null): void;
+  deleteEncoded(
+    table: string,
+    rowId: Uint8Array,
+    options?: { head?: unknown; base?: unknown; updatedAtMs?: number },
+  ): void;
 };
 
 function uuidBytes(value: string): Uint8Array {

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -27,6 +27,7 @@ declare module "jazz-wasm" {
   export class WasmWrite {
     readonly batchId: string;
     readonly payload: Uint8Array;
+    readonly rowId: Uint8Array;
     writeState(): unknown;
     wait(tier: string): Promise<void>;
     close(): boolean;
@@ -47,11 +48,19 @@ declare module "jazz-wasm" {
   }
 
   export class WasmTx {
+    insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): Uint8Array;
+    insertEncodedInBranch(table: string, cells: Uint8Array, branch: unknown): Uint8Array;
     insertWithIdEncoded(
       table: string,
       rowId: Uint8Array,
       cells: Uint8Array,
       updatedAtMs?: number | null,
+    ): void;
+    insertWithIdEncodedInBranch(
+      table: string,
+      rowId: Uint8Array,
+      cells: Uint8Array,
+      branch: unknown,
     ): void;
     updateEncoded(
       table: string,
@@ -166,19 +175,51 @@ declare module "jazz-wasm" {
       opts: unknown,
     ): ReadableStream<unknown>;
 
-    insertEncoded(table: string, cells: Uint8Array): WasmWrite;
+    insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): WasmWrite;
+    insertEncodedForIdentity(
+      table: string,
+      cells: Uint8Array,
+      author: Uint8Array,
+      updatedAtMs?: number | null,
+    ): WasmWrite;
+    insertEncodedInBranch(table: string, cells: Uint8Array, branch: unknown): WasmWrite;
+    insertEncodedInBranchForIdentity(
+      table: string,
+      cells: Uint8Array,
+      branch: unknown,
+      author: Uint8Array,
+    ): WasmWrite;
     canInsertEncoded(table: string, cells: Uint8Array): "allowed" | "denied" | "unknown";
     requestInsertPermissionAdviceEncoded(
       table: string,
       cells: Uint8Array,
     ): WasmPermissionAdviceRequest;
     requestReadPermissionAdvice(table: string, rowId: Uint8Array): WasmPermissionAdviceRequest;
-    insertWithIdEncoded(table: string, rowId: Uint8Array, cells: Uint8Array): WasmWrite;
+    insertWithIdEncoded(
+      table: string,
+      rowId: Uint8Array,
+      cells: Uint8Array,
+      updatedAtMs?: number | null,
+    ): WasmWrite;
+    insertWithIdEncodedInBranch(
+      table: string,
+      rowId: Uint8Array,
+      cells: Uint8Array,
+      branch: unknown,
+    ): WasmWrite;
+    insertWithIdEncodedInBranchForIdentity(
+      table: string,
+      rowId: Uint8Array,
+      cells: Uint8Array,
+      branch: unknown,
+      author: Uint8Array,
+    ): WasmWrite;
     insertWithIdEncodedForIdentity(
       table: string,
       rowId: Uint8Array,
       cells: Uint8Array,
       author: Uint8Array,
+      updatedAtMs?: number | null,
     ): WasmWrite;
     updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array): WasmWrite;
     updateEncodedForIdentity(

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -47,39 +47,48 @@ declare module "jazz-wasm" {
     close(): boolean;
   }
 
+  export type WriteOptions = {
+    author?: Uint8Array;
+    updatedAtMs?: number;
+  };
+
+  export type InsertOptions = WriteOptions & {
+    rowId?: Uint8Array;
+    branch?: unknown;
+  };
+
+  export type UpdateOptions = WriteOptions & {
+    head?: unknown;
+    base?: unknown;
+  };
+
+  export type UpsertOptions = WriteOptions & {
+    branch?: unknown;
+  };
+
+  export type DeleteOptions = UpdateOptions;
+  export type RestoreOptions = UpsertOptions;
+
   export class WasmTx {
-    insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): Uint8Array;
-    insertEncodedInBranch(table: string, cells: Uint8Array, branch: unknown): Uint8Array;
-    insertWithIdEncoded(
-      table: string,
-      rowId: Uint8Array,
-      cells: Uint8Array,
-      updatedAtMs?: number | null,
-    ): void;
-    insertWithIdEncodedInBranch(
-      table: string,
-      rowId: Uint8Array,
-      cells: Uint8Array,
-      branch: unknown,
-    ): void;
+    insertEncoded(table: string, cells: Uint8Array, options?: InsertOptions): Uint8Array;
     updateEncoded(
       table: string,
       rowId: Uint8Array,
       patch: Uint8Array,
-      updatedAtMs?: number | null,
+      options?: UpdateOptions,
     ): void;
     upsertEncoded(
       table: string,
       rowId: Uint8Array,
       cells: Uint8Array,
-      updatedAtMs?: number | null,
+      options?: UpsertOptions,
     ): void;
-    delete(table: string, rowId: Uint8Array, updatedAtMs?: number | null): void;
+    deleteEncoded(table: string, rowId: Uint8Array, options?: DeleteOptions): void;
     restoreEncoded(
       table: string,
       rowId: Uint8Array,
       cells: Uint8Array,
-      updatedAtMs?: number | null,
+      options?: RestoreOptions,
     ): void;
     commit(): WasmWrite;
     rollback(): void;
@@ -175,58 +184,18 @@ declare module "jazz-wasm" {
       opts: unknown,
     ): ReadableStream<unknown>;
 
-    insertEncoded(table: string, cells: Uint8Array, updatedAtMs?: number | null): WasmWrite;
-    insertEncodedForIdentity(
-      table: string,
-      cells: Uint8Array,
-      author: Uint8Array,
-      updatedAtMs?: number | null,
-    ): WasmWrite;
-    insertEncodedInBranch(table: string, cells: Uint8Array, branch: unknown): WasmWrite;
-    insertEncodedInBranchForIdentity(
-      table: string,
-      cells: Uint8Array,
-      branch: unknown,
-      author: Uint8Array,
-    ): WasmWrite;
+    insertEncoded(table: string, cells: Uint8Array, options?: InsertOptions): WasmWrite;
     canInsertEncoded(table: string, cells: Uint8Array): "allowed" | "denied" | "unknown";
     requestInsertPermissionAdviceEncoded(
       table: string,
       cells: Uint8Array,
     ): WasmPermissionAdviceRequest;
     requestReadPermissionAdvice(table: string, rowId: Uint8Array): WasmPermissionAdviceRequest;
-    insertWithIdEncoded(
-      table: string,
-      rowId: Uint8Array,
-      cells: Uint8Array,
-      updatedAtMs?: number | null,
-    ): WasmWrite;
-    insertWithIdEncodedInBranch(
-      table: string,
-      rowId: Uint8Array,
-      cells: Uint8Array,
-      branch: unknown,
-    ): WasmWrite;
-    insertWithIdEncodedInBranchForIdentity(
-      table: string,
-      rowId: Uint8Array,
-      cells: Uint8Array,
-      branch: unknown,
-      author: Uint8Array,
-    ): WasmWrite;
-    insertWithIdEncodedForIdentity(
-      table: string,
-      rowId: Uint8Array,
-      cells: Uint8Array,
-      author: Uint8Array,
-      updatedAtMs?: number | null,
-    ): WasmWrite;
-    updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array): WasmWrite;
-    updateEncodedForIdentity(
+    updateEncoded(
       table: string,
       rowId: Uint8Array,
       patch: Uint8Array,
-      author: Uint8Array,
+      options?: UpdateOptions,
     ): WasmWrite;
     requestUpdatePermissionAdviceEncoded(
       table: string,
@@ -234,26 +203,18 @@ declare module "jazz-wasm" {
       patch: Uint8Array,
     ): WasmPermissionAdviceRequest;
     requestDeletePermissionAdvice(table: string, rowId: Uint8Array): WasmPermissionAdviceRequest;
-    upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array): WasmWrite;
-    upsertEncodedForIdentity(
+    upsertEncoded(
       table: string,
       rowId: Uint8Array,
       cells: Uint8Array,
-      author: Uint8Array,
+      options?: UpsertOptions,
     ): WasmWrite;
-    delete(table: string, rowId: Uint8Array, updatedAtMs?: number | null): WasmWrite;
-    deleteForIdentity(
-      table: string,
-      rowId: Uint8Array,
-      author: Uint8Array,
-      updatedAtMs?: number | null,
-    ): WasmWrite;
-    restoreEncoded(table: string, rowId: Uint8Array, cells: Uint8Array): WasmWrite;
-    restoreEncodedForIdentity(
+    deleteEncoded(table: string, rowId: Uint8Array, options?: DeleteOptions): WasmWrite;
+    restoreEncoded(
       table: string,
       rowId: Uint8Array,
       cells: Uint8Array,
-      author: Uint8Array,
+      options?: RestoreOptions,
     ): WasmWrite;
     setTickScheduler(
       callback: (urgency: "immediate" | "deferred" | `after:${number}`) => void,

--- a/packages/jazz-tools/tests/browser/db.all.test.ts
+++ b/packages/jazz-tools/tests/browser/db.all.test.ts
@@ -416,6 +416,38 @@ describe("db.all browser integration", () => {
     expect(Array.from(rows[0]?.payload ?? [])).toEqual([0, 1, 2, 255]);
   });
 
+  it("generates clock-backed UUIDv7 row ids and returns them in insertion order by default", async () => {
+    const db = track(
+      await createDb({
+        appId: "db-all-test",
+        driver: { type: "persistent", dbName: uniqueDbName("uuidv7-order") },
+      }),
+    );
+
+    const ids: string[] = [];
+    for (const title of ["first", "second", "third"]) {
+      const result = await db.insert(todos, {
+        title,
+        done: false,
+        priority: undefined,
+        owner_id: undefined,
+        tags: [],
+        payload: undefined,
+      });
+      ids.push(result.value.id);
+    }
+
+    for (const id of ids) {
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    }
+    const generatedAtMs = Number.parseInt(ids[0]!.replaceAll("-", "").slice(0, 12), 16);
+    expect(Math.abs(Date.now() - generatedAtMs)).toBeLessThan(60_000);
+    expect(ids).toEqual([...ids].sort());
+
+    const rows = await db.all<Todo>(makeQuery<Todo>("todos", {}));
+    expect(rows.map((row) => row.id)).toEqual(ids);
+  });
+
   it("supports orderBy + limit + offset", async () => {
     const db = track(
       await createDb({


### PR DESCRIPTION
## Description

Rows created through the TS client without an explicit id were using a non-uuidv7 id generated on the TS side. This meant that rows were not sorted by creation time when using the default query ordering (id asc).

This PR also fixes the proliferation of CRUD methods across the TS<>Rust boundary, instead keeping one insert, update, delete and restore method with an options param.