### PR TITLE
fix(backend): separate trusted host authority from sync credentials

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -3464,9 +3464,10 @@ where
     if config.history_complete {
         let db = if trusted_backend {
             // SAFETY: `trusted_backend` is true only after this NAPI open
-            // configuration carried a non-empty backend credential. This is
-            // the binding's intentionally narrow trusted in-process boundary;
-            // it is not inferred from SYSTEM or a caller-supplied author.
+            // configuration carried the binding's private backend-runtime
+            // marker. This is the intentionally narrow trusted in-process
+            // boundary; it is not inferred from an upstream credential,
+            // SYSTEM identity, or a caller-supplied author.
             unsafe {
                 core_block_on(CoreDb::open_history_complete_with_backend_attribution(
                     db_config,
@@ -3481,8 +3482,8 @@ where
         Ok(db)
     } else {
         let db = if trusted_backend {
-            // SAFETY: see the history-complete branch above. The credential
-            // gate is checked before this unsafe core opt-in.
+            // SAFETY: see the history-complete branch above. The private
+            // backend-runtime marker is checked before this unsafe core opt-in.
             unsafe { core_block_on(CoreDb::open_with_backend_attribution(db_config)) }
         } else {
             core_block_on(CoreDb::open(db_config))

--- a/packages/jazz-tools/src/backend/create-jazz-context.test.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.test.ts
@@ -287,6 +287,19 @@ describe("backend/create-jazz-context", () => {
     ).toThrow(/jwksUrl.*jwtPublicKey|jwtPublicKey.*jwksUrl/i);
   });
 
+  it("BC-U01c: rejects an empty upstream backend secret", () => {
+    expect(() =>
+      createJazzContext({
+        appId: "server-app",
+        app: { wasmSchema: SCHEMA_A },
+        permissions: {},
+        driver: { type: "persistent", dataPath: "/tmp/jazz.db" },
+        serverUrl: "http://localhost:1625",
+        backendSecret: "  ",
+      }),
+    ).toThrow("backendSecret must be non-empty when provided");
+  });
+
   it("BC-U02: supports high-level db/backend/request/session/attribution helpers", async () => {
     const context = createJazzContext({
       appId: "server-app",
@@ -343,6 +356,13 @@ describe("backend/create-jazz-context", () => {
     expect(mocks.clients).toHaveLength(1);
     expect(mocks.clients[0]!.asBackend).toHaveBeenCalledTimes(6);
     expect(mocks.connectWithRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.nativeRuntimeCtor.mock.calls[0]?.[6]).toMatchObject({
+      trustedBackendHost: true,
+    });
+    expect(mocks.nativeRuntimeCtor.mock.calls[0]?.[6]).not.toHaveProperty("backendCredential");
+    expect(mocks.connectWithRuntime.mock.calls[0]?.[1]).toMatchObject({
+      backendSecret: "secret",
+    });
   });
 
   it("BC-U03: request/session/attribution helpers work locally without backend sync config", async () => {

--- a/packages/jazz-tools/src/backend/create-jazz-context.test.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.test.ts
@@ -221,6 +221,7 @@ describe("backend/create-jazz-context", () => {
       {
         persistentPath: "/tmp/jazz.db",
         readAuthorizationHost: "trusted-serving",
+        isBackend: true,
       },
     );
   });
@@ -357,15 +358,18 @@ describe("backend/create-jazz-context", () => {
     expect(mocks.clients[0]!.asBackend).toHaveBeenCalledTimes(6);
     expect(mocks.connectWithRuntime).toHaveBeenCalledTimes(1);
     expect(mocks.nativeRuntimeCtor.mock.calls[0]?.[6]).toMatchObject({
-      trustedBackendHost: true,
+      isBackend: true,
     });
+    // Local backend authority is an application-runtime capability. The
+    // upstream transport secret is forwarded only to the connected client and
+    // never used as the native capability marker.
     expect(mocks.nativeRuntimeCtor.mock.calls[0]?.[6]).not.toHaveProperty("backendCredential");
     expect(mocks.connectWithRuntime.mock.calls[0]?.[1]).toMatchObject({
       backendSecret: "secret",
     });
   });
 
-  it("BC-U03: request/session/attribution helpers work locally without backend sync config", async () => {
+  it("BC-U03: disconnected backend runtime keeps request/session authority without credentials", async () => {
     const context = createJazzContext({
       appId: "server-app",
       app: { wasmSchema: SCHEMA_A },
@@ -624,7 +628,7 @@ describe("backend/create-jazz-context", () => {
       expect.any(Uint8Array),
       1,
       true,
-      { readAuthorizationHost: "trusted-serving" },
+      { readAuthorizationHost: "trusted-serving", isBackend: true },
     );
   });
 

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -125,12 +125,10 @@ class BackendRuntimeSource extends RuntimeSource<DbConfig> {
             persistentPath: this.config.driver.dataPath,
             readAuthorizationHost: "trusted-serving",
             trustedBackendHost: true,
-            backendCredential: this.config.backendSecret,
           }
         : {
             readAuthorizationHost: "trusted-serving",
             trustedBackendHost: true,
-            backendCredential: this.config.backendSecret,
           },
     );
 
@@ -224,6 +222,10 @@ function deterministicBytes(seed: string): Uint8Array {
 function assertValidBackendConfig(config: BackendContextConfig): void {
   if (config.driver.type === "memory" && !config.serverUrl) {
     throw new Error("driver.type='memory' requires serverUrl.");
+  }
+
+  if (config.backendSecret !== undefined && config.backendSecret.trim() === "") {
+    throw new Error("backendSecret must be non-empty when provided.");
   }
 
   if (config.jwksUrl !== undefined && config.jwtPublicKey !== undefined) {

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -124,10 +124,12 @@ class BackendRuntimeSource extends RuntimeSource<DbConfig> {
         ? {
             persistentPath: this.config.driver.dataPath,
             readAuthorizationHost: "trusted-serving",
+            trustedBackendHost: true,
             backendCredential: this.config.backendSecret,
           }
         : {
             readAuthorizationHost: "trusted-serving",
+            trustedBackendHost: true,
             backendCredential: this.config.backendSecret,
           },
     );

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -124,11 +124,11 @@ class BackendRuntimeSource extends RuntimeSource<DbConfig> {
         ? {
             persistentPath: this.config.driver.dataPath,
             readAuthorizationHost: "trusted-serving",
-            trustedBackendHost: true,
+            isBackend: true,
           }
         : {
             readAuthorizationHost: "trusted-serving",
-            trustedBackendHost: true,
+            isBackend: true,
           },
     );
 

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -257,7 +257,7 @@ it("runs every supported backend-attributed mutation family through real NAPI pr
     testAuthorBytes("napi-attribution:matrix-owner"),
     1,
     true,
-    { trustedBackendHost: true },
+    { isBackend: true },
   );
   const provenance = JSON.stringify(["https://issuer.example", "matrix-author"]);
   const context = (attribution: string | null = provenance, batchId?: string) =>
@@ -374,7 +374,7 @@ it("retains trusted-process attribution when a real NAPI schema view is register
     testAuthorBytes("napi-attribution:view-owner"),
     1,
     true,
-    { trustedBackendHost: true },
+    { isBackend: true },
   );
   const view = runtime.registerSchemaView(TEST_SCHEMA);
   const provenance = JSON.stringify(["https://issuer.example", "view-author"]);

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -257,7 +257,7 @@ it("runs every supported backend-attributed mutation family through real NAPI pr
     testAuthorBytes("napi-attribution:matrix-owner"),
     1,
     true,
-    { backendCredential: "test-backend-credential" },
+    { trustedBackendHost: true },
   );
   const provenance = JSON.stringify(["https://issuer.example", "matrix-author"]);
   const context = (attribution: string | null = provenance, batchId?: string) =>
@@ -374,7 +374,7 @@ it("retains trusted-process attribution when a real NAPI schema view is register
     testAuthorBytes("napi-attribution:view-owner"),
     1,
     true,
-    { backendCredential: "test-backend-credential" },
+    { trustedBackendHost: true },
   );
   const view = runtime.registerSchemaView(TEST_SCHEMA);
   const provenance = JSON.stringify(["https://issuer.example", "view-author"]);

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -1644,6 +1644,41 @@ describe("NAPI integration", () => {
     }
   }, 30_000);
 
+  it("allows local backend writes without an upstream secret but rejects public SYSTEM forgery", async () => {
+    const { createJazzContext } = await import("../backend/create-jazz-context.js");
+    const dataRoot = await createTempDir("jazz-napi-local-backend-");
+    const context = createJazzContext({
+      appId: randomUUID(),
+      app: { wasmSchema: TEST_SCHEMA },
+      permissions: {},
+      driver: { type: "persistent", dataPath: join(dataRoot, "runtime.db") },
+    });
+
+    try {
+      const created = await context
+        .asBackend()
+        .insert(simpleTodosTable, { title: "trusted-local-backend", done: false })
+        .wait({ tier: "local" });
+      expect(created).toMatchObject({ title: "trusted-local-backend", done: false });
+
+      const forgedSystemSession = context.forSession({
+        issuer: "urn:jazz:system",
+        user_id: "system",
+        claims: {},
+        authMode: "external",
+      });
+      expect(() =>
+        forgedSystemSession.insert(simpleTodosTable, {
+          title: "forged-system",
+          done: false,
+        }),
+      ).toThrow(/reserved issuer/);
+    } finally {
+      await context.shutdown();
+      await rm(dataRoot, { recursive: true, force: true });
+    }
+  });
+
   it("accepts modern epoch-millisecond timestamps from the TS value converter on backend durable writes", async () => {
     const dataRoot = await createTempDir("jazz-napi-timestamp-");
     const dataPath = join(dataRoot, "runtime.db");

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -1661,6 +1661,27 @@ describe("NAPI integration", () => {
         .wait({ tier: "local" });
       expect(created).toMatchObject({ title: "trusted-local-backend", done: false });
 
+      const authoredQuery: QueryBuilder<SimpleTodo & { $createdBy: string }> = {
+        _table: "todos",
+        _schema: TEST_SCHEMA,
+        _rowType: undefined as unknown as SimpleTodo & { $createdBy: string },
+        _build: () =>
+          JSON.stringify({
+            table: "todos",
+            conditions: [{ column: "id", op: "eq", value: created.id }],
+            select: ["title", "$createdBy"],
+            includes: {},
+            orderBy: [],
+            offset: 0,
+          }),
+      };
+      await expect(
+        context.asBackend().one(authoredQuery, { tier: "local" }),
+      ).resolves.toMatchObject({
+        title: "trusted-local-backend",
+        $createdBy: JSON.stringify(["urn:jazz:system", "system"]),
+      });
+
       const forgedSystemSession = context.forSession({
         issuer: "urn:jazz:system",
         user_id: "system",

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -658,7 +658,7 @@ function openMemoryDb(
   );
 }
 
-const NATIVE_TRUSTED_BACKEND_MODE_MARKER = "jazz:trusted-backend-host";
+const NATIVE_BACKEND_RUNTIME_MARKER = "jazz:backend-runtime";
 
 export class NativeRuntimeAdapter implements Runtime {
   private readonly db: NativeDb;
@@ -666,7 +666,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private readonly configBytes: Uint8Array;
   private readonly peerIdentity: Uint8Array;
   private readonly schemaHash: string;
-  private readonly trustedBackend: boolean;
+  private readonly isBackend: boolean;
   private readonly preparedQueries = new Map<string, PreparedQuery>();
   private readonly transactionOwner: TransactionOwnerState;
   private readonly pendingTxs: Map<string, PendingTx>;
@@ -726,7 +726,7 @@ export class NativeRuntimeAdapter implements Runtime {
     return new NativeRuntimeAdapter(null, schema, this.node, this.peerIdentity, 1, true, {
       db: this.db.registerSchema(encodeSchema(schema)),
       owner: this,
-      trustedBackendHost: this.trustedBackend,
+      isBackend: this.isBackend,
     });
   }
 
@@ -743,8 +743,13 @@ export class NativeRuntimeAdapter implements Runtime {
       initialSyncFlushEvery?: number;
       selfSignedClientProof?: NativeSelfSignedClientProof;
       readAuthorizationHost?: ReadAuthorizationHost;
-      /** Internal server-host authority; never derived from a public session. */
-      trustedBackendHost?: boolean;
+      /**
+       * Internal application-backend capability. This identifies an
+       * application-controlled trusted runtime that may perform backend/SYSTEM
+       * operations and evaluate request-scoped identities. It is not upstream
+       * connection state, a credential, or edge/core fate authority.
+       */
+      isBackend?: boolean;
       owner?: NativeRuntimeAdapter;
     },
   ) {
@@ -760,21 +765,18 @@ export class NativeRuntimeAdapter implements Runtime {
     this.completedTxs = this.transactionOwner.completedTxs;
     this.writes = this.transactionOwner.writes;
     this.schemaBytes = encodeSchema(schema);
-    this.trustedBackend = opts?.owner?.trustedBackend ?? opts?.trustedBackendHost ?? false;
-    // The current native ABI selects its trusted open path by presence of a
-    // credential. Keep that mode marker private to this adapter: callers use
-    // the explicit host-authority option; actual upstream credentials never
-    // cross this storage boundary.
-    const nativeBackendCredential = this.trustedBackend
-      ? NATIVE_TRUSTED_BACKEND_MODE_MARKER
-      : undefined;
+    this.isBackend = opts?.owner?.isBackend ?? opts?.isBackend ?? false;
+    // The current native ABI selects this application-runtime capability via
+    // its credential-shaped slot. Pass only the private marker: backendSecret
+    // authenticates upstream transport and must never confer local authority.
+    const nativeBackendMarker = this.isBackend ? NATIVE_BACKEND_RUNTIME_MARKER : undefined;
     this.configBytes = openConfig(
       node,
       author,
       sourceId,
       historyComplete,
       opts?.initialSyncFlushEvery,
-      nativeBackendCredential,
+      nativeBackendMarker,
     );
     this.peerIdentity = author;
     this.schemaHash = serializeRuntimeSchema(schema);
@@ -2205,8 +2207,7 @@ export class NativeRuntimeAdapter implements Runtime {
    * point, with a request session supplying its subject when present.
    */
   private readRowsForHost(query: PreparedQuery, opts: unknown, identity?: Uint8Array): Uint8Array {
-    if (this.trustedBackend && identity && isSystemIdentity(identity))
-      return this.db.all(query, opts);
+    if (this.isBackend && identity && isSystemIdentity(identity)) return this.db.all(query, opts);
     return this.readAuthorizationHost === "trusted-serving"
       ? this.db.allForIdentity(query, identity ?? this.peerIdentity, opts)
       : this.db.all(query, opts);
@@ -2217,17 +2218,17 @@ export class NativeRuntimeAdapter implements Runtime {
    * an ordinary client mutation into a policy-enforcing local admission.
    */
   private trustedWriteIdentity(session: RuntimeSession | null | undefined): Uint8Array | undefined {
-    if (this.trustedBackend && session && isSystemIdentity(session.identity)) return undefined;
+    if (this.isBackend && session && isSystemIdentity(session.identity)) return undefined;
     return this.readAuthorizationHost === "trusted-serving"
       ? (session?.identity ?? this.peerIdentity)
       : undefined;
   }
 
   /**
-   * A backend credential admits the write as SYSTEM; the public canonical
-   * attribution is provenance only.  Keep those two identities separate so
-   * an attributed backend write cannot accidentally become a user-authorized
-   * write (or vice versa).
+   * An application-controlled backend runtime may admit the write as SYSTEM;
+   * the public canonical attribution is provenance only. Keep local backend
+   * capability separate from upstream credentials so an attributed backend
+   * write cannot accidentally become a user-authorized write (or vice versa).
    */
   private backendAttribution(
     writeContext: string | null | undefined,
@@ -2245,7 +2246,7 @@ export class NativeRuntimeAdapter implements Runtime {
   }
 
   private isBackendSystemSession(session: RuntimeSession | null | undefined): boolean {
-    return this.trustedBackend && !!session && isSystemIdentity(session.identity);
+    return this.isBackend && !!session && isSystemIdentity(session.identity);
   }
 
   private stagedRowForWriteMerge(
@@ -2401,7 +2402,7 @@ export class NativeRuntimeAdapter implements Runtime {
     ) {
       return;
     }
-    if (this.trustedBackend && isSystemIdentity(session.identity)) return;
+    if (this.isBackend && isSystemIdentity(session.identity)) return;
     this.db.setIdentityClaims(session.identity, session.claims);
   }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -745,7 +745,6 @@ export class NativeRuntimeAdapter implements Runtime {
       readAuthorizationHost?: ReadAuthorizationHost;
       /** Internal server-host authority; never derived from a public session. */
       trustedBackendHost?: boolean;
-      backendCredential?: string;
       owner?: NativeRuntimeAdapter;
     },
   ) {
@@ -761,17 +760,14 @@ export class NativeRuntimeAdapter implements Runtime {
     this.completedTxs = this.transactionOwner.completedTxs;
     this.writes = this.transactionOwner.writes;
     this.schemaBytes = encodeSchema(schema);
-    this.trustedBackend =
-      opts?.owner?.trustedBackend ??
-      opts?.trustedBackendHost ??
-      opts?.backendCredential !== undefined;
+    this.trustedBackend = opts?.owner?.trustedBackend ?? opts?.trustedBackendHost ?? false;
     // The current native ABI selects its trusted open path by presence of a
     // credential. Keep that mode marker private to this adapter: callers use
-    // the explicit host-authority option, while backendCredential remains the
-    // real optional upstream credential.
-    const nativeBackendCredential =
-      opts?.backendCredential ??
-      (this.trustedBackend ? NATIVE_TRUSTED_BACKEND_MODE_MARKER : undefined);
+    // the explicit host-authority option; actual upstream credentials never
+    // cross this storage boundary.
+    const nativeBackendCredential = this.trustedBackend
+      ? NATIVE_TRUSTED_BACKEND_MODE_MARKER
+      : undefined;
     this.configBytes = openConfig(
       node,
       author,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -658,6 +658,8 @@ function openMemoryDb(
   );
 }
 
+const NATIVE_TRUSTED_BACKEND_MODE_MARKER = "jazz:trusted-backend-host";
+
 export class NativeRuntimeAdapter implements Runtime {
   private readonly db: NativeDb;
   private readonly schemaBytes: Uint8Array;
@@ -724,7 +726,7 @@ export class NativeRuntimeAdapter implements Runtime {
     return new NativeRuntimeAdapter(null, schema, this.node, this.peerIdentity, 1, true, {
       db: this.db.registerSchema(encodeSchema(schema)),
       owner: this,
-      backendCredential: this.trustedBackend ? "inherited-backend-capability" : undefined,
+      trustedBackendHost: this.trustedBackend,
     });
   }
 
@@ -741,6 +743,8 @@ export class NativeRuntimeAdapter implements Runtime {
       initialSyncFlushEvery?: number;
       selfSignedClientProof?: NativeSelfSignedClientProof;
       readAuthorizationHost?: ReadAuthorizationHost;
+      /** Internal server-host authority; never derived from a public session. */
+      trustedBackendHost?: boolean;
       backendCredential?: string;
       owner?: NativeRuntimeAdapter;
     },
@@ -757,14 +761,24 @@ export class NativeRuntimeAdapter implements Runtime {
     this.completedTxs = this.transactionOwner.completedTxs;
     this.writes = this.transactionOwner.writes;
     this.schemaBytes = encodeSchema(schema);
-    this.trustedBackend = opts?.owner?.trustedBackend ?? opts?.backendCredential !== undefined;
+    this.trustedBackend =
+      opts?.owner?.trustedBackend ??
+      opts?.trustedBackendHost ??
+      opts?.backendCredential !== undefined;
+    // The current native ABI selects its trusted open path by presence of a
+    // credential. Keep that mode marker private to this adapter: callers use
+    // the explicit host-authority option, while backendCredential remains the
+    // real optional upstream credential.
+    const nativeBackendCredential =
+      opts?.backendCredential ??
+      (this.trustedBackend ? NATIVE_TRUSTED_BACKEND_MODE_MARKER : undefined);
     this.configBytes = openConfig(
       node,
       author,
       sourceId,
       historyComplete,
       opts?.initialSyncFlushEvery,
-      opts?.backendCredential,
+      nativeBackendCredential,
     );
     this.peerIdentity = author;
     this.schemaHash = serializeRuntimeSchema(schema);

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -1341,7 +1341,7 @@ describe("NativeRuntimeAdapter server transport", () => {
       1,
       true,
       {
-        trustedBackendHost: true,
+        isBackend: true,
         readAuthorizationHost: "trusted-serving",
       },
     );
@@ -5062,7 +5062,7 @@ describe("NativeRuntimeAdapter streaming inserts", () => {
       new TextEncoder().encode(JSON.stringify(["urn:jazz:test", "backend-owner"])),
       1,
       true,
-      { trustedBackendHost: true },
+      { isBackend: true },
     );
     const context = JSON.stringify({
       session: {
@@ -5131,7 +5131,7 @@ describe("NativeRuntimeAdapter streaming inserts", () => {
       new TextEncoder().encode(JSON.stringify(["urn:jazz:test", "backend-owner"])),
       1,
       true,
-      { trustedBackendHost: true },
+      { isBackend: true },
     );
     const batch = createOpenBatchId();
     const context = (attribution?: string) =>
@@ -5173,7 +5173,7 @@ describe("NativeRuntimeAdapter streaming inserts", () => {
       new TextEncoder().encode(JSON.stringify(["urn:jazz:test", "backend-owner"])),
       1,
       true,
-      { trustedBackendHost: true },
+      { isBackend: true },
     );
     const context = JSON.stringify({
       session: {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -1341,7 +1341,7 @@ describe("NativeRuntimeAdapter server transport", () => {
       1,
       true,
       {
-        backendCredential: "backend-only-test-capability",
+        trustedBackendHost: true,
         readAuthorizationHost: "trusted-serving",
       },
     );
@@ -5062,7 +5062,7 @@ describe("NativeRuntimeAdapter streaming inserts", () => {
       new TextEncoder().encode(JSON.stringify(["urn:jazz:test", "backend-owner"])),
       1,
       true,
-      { backendCredential: "backend-only-test-capability" },
+      { trustedBackendHost: true },
     );
     const context = JSON.stringify({
       session: {
@@ -5131,7 +5131,7 @@ describe("NativeRuntimeAdapter streaming inserts", () => {
       new TextEncoder().encode(JSON.stringify(["urn:jazz:test", "backend-owner"])),
       1,
       true,
-      { backendCredential: "backend-only-test-capability" },
+      { trustedBackendHost: true },
     );
     const batch = createOpenBatchId();
     const context = (attribution?: string) =>
@@ -5173,7 +5173,7 @@ describe("NativeRuntimeAdapter streaming inserts", () => {
       new TextEncoder().encode(JSON.stringify(["urn:jazz:test", "backend-owner"])),
       1,
       true,
-      { backendCredential: "backend-only-test-capability" },
+      { trustedBackendHost: true },
     );
     const context = JSON.stringify({
       session: {


### PR DESCRIPTION
🤖 Fixes #1938.

## Decision: backend capability is not a credential

`isBackend` identifies an application-controlled trusted runtime that may perform backend/SYSTEM operations and evaluate request-scoped identities. It does **not** mean that the runtime is connected upstream, possesses credentials, or acts as an edge/core fate authority.

`backendSecret` has one separate purpose: authenticating that backend when it connects to an upstream server. Possessing a credential must never confer local backend capability.

The distinction is observable for a disconnected backend: it still needs local SYSTEM/request-scoped behavior even though it has no upstream and therefore no `backendSecret`. Connected backends normally have both properties, but they remain independent security boundaries.

## Before

`createJazzContext().asBackend()` correctly selected Jazz's private SYSTEM session, but native runtime construction accidentally used presence of `backendSecret` as its trusted-runtime selector. A local-only backend has no upstream secret, so SYSTEM was serialized through public identity ingress and rejected as a forged reserved issuer. Todo Server consequently returned 500 for ordinary CRUD and passed only 2/11 integration tests.

## After

- `createJazzContext` internally constructs its runtime with `isBackend: true`; this is not exposed through public client configuration.
- `NativeRuntimeAdapter` never accepts an upstream credential or infers local capability from one. `isBackend` selects only the private `jazz:backend-runtime` native marker.
- Schema views inherit their owner's backend status and cannot elevate an untrusted runtime.
- The real `backendSecret` flows only into JazzClient transport authentication.
- Empty or whitespace-only upstream secrets fail configuration rather than producing divergent TS/native behavior.
- Public reserved-issuer parsing and rejection are unchanged.

## Verification

- Todo Server integration: 11/11.
- A disconnected secretless persistent backend writes with exact `$createdBy` provenance `["urn:jazz:system","system"]`.
- A public session forging that reserved issuer is rejected.
- Backend unit receipts prove native construction receives `isBackend` but no transport credential, while JazzClient receives the real secret.
- Native schema-view attribution and reserved-issuer suites pass.
- Focused backend context and native adapter suite: 122 passed / 1 skipped.
- Real NAPI core suite: 36 passed / 1 skipped.
- Formatting, lint, diff, and sensitive-data gates pass.

This is stacked on #1939 and preserves the existing backend-versus-public-session semantics.
