### PR TITLE
fix: inspector not working on new browser architecture

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -34,7 +34,7 @@ export declare class NapiDb {
   onMutationError(callback: (event: any) => void): void
   prepareQuery(query: Uint8Array): PreparedQuery
   all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  /** Read an open transaction using the identity bound at begin. */
+  /** Read through an open transaction using the identity bound at begin. */
   allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
   allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array

--- a/packages/inspector/tests/browser/overlay.spec.ts
+++ b/packages/inspector/tests/browser/overlay.spec.ts
@@ -124,9 +124,22 @@ test.describe("inspector overlay (embedded, shared runtime peer end-to-end)", ()
     await expect(inspector.getByRole("link", { name: "View todos data" })).toBeVisible({
       timeout: 30_000,
     });
-    await expect(inspector.getByLabel("Runtime context")).toBeVisible({ timeout: 10_000 });
-    await expect(inspector.getByLabel("Runtime context").locator("option")).toHaveCount(2);
-    await inspector.getByLabel("Runtime context").selectOption({ index: 1 });
+    const runtimeSelect = inspector.getByLabel("Runtime context");
+    await expect(runtimeSelect).toBeVisible({ timeout: 10_000 });
+    const runtimeOptions = runtimeSelect.locator("option");
+    await expect(runtimeOptions).toHaveCount(2);
+    const primaryContext = runtimeOptions.filter({ hasNotText: "inspector-secondary-context" });
+    const secondaryContext = runtimeOptions.filter({ hasText: "inspector-secondary-context" });
+    const primaryContextValue = await primaryContext.getAttribute("value");
+    const secondaryContextValue = await secondaryContext.getAttribute("value");
+    expect(primaryContextValue).toBeTruthy();
+    expect(secondaryContextValue).toBeTruthy();
+
+    await runtimeSelect.selectOption(primaryContextValue!);
+    await inspector.getByRole("link", { name: "View todos data" }).click();
+    await expect(inspector.getByText("First seeded todo")).toBeVisible({ timeout: 30_000 });
+
+    await runtimeSelect.selectOption(secondaryContextValue!);
     await expect(inspector.getByRole("link", { name: "Data Explorer" })).toBeVisible({
       timeout: 10_000,
     });

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -234,6 +234,10 @@ function attachTab(context: RuntimeContext, tabId: string, port: MessagePort): v
   context.peers.set(tabId, peer);
   port.addEventListener("message", onMessage);
   port.addEventListener("messageerror", onMessageError);
+  // SharedWorker connection ports are started by `onconnect`, but inspector
+  // peers arrive as freshly transferred MessageChannel ports. Starting is
+  // idempotent and required before addEventListener-based delivery can begin.
+  port.start();
 }
 
 async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortRequest): Promise<void> {


### PR DESCRIPTION
## Description

Fixes the in-app Inspector showing no rows after the SharedWorker/IndexedDB refactor. Inspector peers use transferred `MessageChannel` ports, but the worker never started those ports, leaving initialization and query messages queued indefinitely.

The fix calls `port.start()` when attaching any worker peer and adds coverage at both the worker protocol and Inspector overlay levels.