### PR TITLE
Inline published jazz-tools runtime sources

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -121,7 +121,7 @@
   },
   "scripts": {
     "build": "pnpm build:runtime && pnpm build:test && pnpm build:svelte && pnpm build:solid",
-    "build:runtime": "node scripts/clean-dist.mjs && tsc && node scripts/bundle-broker-worker.mjs",
+    "build:runtime": "node scripts/clean-dist.mjs && tsc && node scripts/bundle-broker-worker.mjs && node scripts/verify-runtime-sourcemaps.mjs",
     "build:svelte": "svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json && node scripts/cleanup-generated-src-types.mjs",
     "build:solid": "vite build --config vite.config.solid.ts --mode solid-dom && vite build --config vite.config.solid.ts --mode solid-ssr && tsc --project tsconfig.solid.json --emitDeclarationOnly",
     "check": "tsc --noEmit",

--- a/packages/jazz-tools/scripts/verify-runtime-sourcemaps.mjs
+++ b/packages/jazz-tools/scripts/verify-runtime-sourcemaps.mjs
@@ -1,0 +1,58 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const distRoot = resolve(packageRoot, "dist");
+const sourceRoot = resolve(packageRoot, "src");
+
+function fail(message) {
+  throw new Error(`Runtime sourcemap verification failed: ${message}`);
+}
+
+function findMaps(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = resolve(directory, entry.name);
+    if (entry.isDirectory()) return findMaps(entryPath);
+    return entry.name.endsWith(".js.map") ? [entryPath] : [];
+  });
+}
+
+if (!existsSync(distRoot)) fail("missing dist directory");
+
+const maps = findMaps(distRoot);
+if (maps.length === 0) fail("no emitted JavaScript maps found");
+
+for (const mapPath of maps) {
+  const map = JSON.parse(readFileSync(mapPath, "utf8"));
+  const sourcePath = mapPath.slice(0, -4);
+
+  if (!existsSync(sourcePath)) {
+    fail(`${relative(packageRoot, mapPath)} has no emitted JavaScript file`);
+  }
+  if (!Array.isArray(map.sources) || map.sources.length === 0) {
+    fail(`${relative(packageRoot, mapPath)} has no sources`);
+  }
+  if (!Array.isArray(map.sourcesContent) || map.sourcesContent.length !== map.sources.length) {
+    fail(`${relative(packageRoot, mapPath)} has incomplete sourcesContent`);
+  }
+
+  map.sources.forEach((source, index) => {
+    if (typeof source !== "string" || typeof map.sourcesContent[index] !== "string") {
+      fail(`${relative(packageRoot, mapPath)} has a non-text source entry`);
+    }
+
+    const resolvedSource = resolve(dirname(mapPath), map.sourceRoot || "", source);
+    const sourceRelativeToRoot = relative(sourceRoot, resolvedSource);
+    if (
+      sourceRelativeToRoot.startsWith(`..${sep}`) ||
+      sourceRelativeToRoot === ".." ||
+      !existsSync(resolvedSource)
+    ) {
+      fail(`${relative(packageRoot, mapPath)} points outside emitted package sources: ${source}`);
+    }
+    if (readFileSync(resolvedSource, "utf8") !== map.sourcesContent[index]) {
+      fail(`${relative(packageRoot, mapPath)} embeds stale source content for ${source}`);
+    }
+  });
+}

--- a/packages/jazz-tools/tsconfig.json
+++ b/packages/jazz-tools/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/packages/jazz-tools/tsconfig.tests.json
+++ b/packages/jazz-tools/tsconfig.tests.json
@@ -8,6 +8,7 @@
     "noEmit": true,
     "rootDir": ".",
     "sourceMap": false,
+    "inlineSources": false,
     "paths": {
       "jazz-tools": ["./src/index.ts"],
       "jazz-tools/*": ["./src/*"]


### PR DESCRIPTION
🤖 Replaces #721 on current main.

Embeds the original TypeScript sources in published jazz-tools runtime source maps, so debuggers can resolve package frames without shipping a separate source tree.

The runtime build now verifies every emitted JavaScript map has a paired artifact, complete source content, source paths contained within the package source tree, and byte-for-byte current source content.

Focused runtime build, test-config typecheck, and packed-artifact inspection pass.