### PR TITLE
Source create-jazz starters from immutable release snapshots

### DIFF
--- a/.changeset/immutable-create-jazz-snapshots.md
+++ b/.changeset/immutable-create-jazz-snapshots.md
@@ -1,0 +1,5 @@
+---
+"create-jazz": patch
+---
+
+Scaffold starters and workspace dependencies from the immutable source snapshot matching the installed release.

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -24,7 +24,7 @@ on:
           - publish
           - dry-run
       version:
-        description: "Optional exact manual version override (for example 2.0.0-alpha.6)."
+        description: "Optional expected source version. It must match the checked-out release snapshot."
         required: false
         type: string
 
@@ -407,7 +407,7 @@ jobs:
       )
     permissions:
       actions: read
-      contents: read
+      contents: write
       id-token: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -546,35 +546,12 @@ jobs:
 
       - name: Resolve lock-stepped npm package versions
         run: |
-          set_pkg_version_if_needed() {
-            local pkg_dir="$1"
-            local current_version
-
-            current_version=$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version' "${pkg_dir}/package.json")
-
-            if [ "${current_version}" != "${VERSION}" ]; then
-              npm --prefix "${pkg_dir}" version "${VERSION}" --no-git-tag-version
-            fi
-          }
-
-          if [ "${RELEASE_MODE}" = "dry-run" ]; then
-            VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/jazz-tools/package.json","utf8")).version')
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version || '' }}"
-            if [ -n "${VERSION}" ]; then
-              set_pkg_version_if_needed packages/jazz-tools
-              set_pkg_version_if_needed crates/jazz-wasm
-              set_pkg_version_if_needed crates/jazz-napi
-              set_pkg_version_if_needed packages/create-jazz
-            else
-              pnpm release:version
-              VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/jazz-tools/package.json","utf8")).version')
-              set_pkg_version_if_needed crates/jazz-wasm
-              set_pkg_version_if_needed crates/jazz-napi
-              set_pkg_version_if_needed packages/create-jazz
-            fi
-          else
-            VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/jazz-tools/package.json","utf8")).version')
+          VERSION=$(git show "${GITHUB_SHA}:packages/jazz-tools/package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>console.log(JSON.parse(s).version))')
+          EXPECTED_VERSION="${{ github.event.inputs.version || '' }}"
+          if [ -n "${EXPECTED_VERSION}" ] && [ "${EXPECTED_VERSION}" != "${VERSION}" ]; then
+            echo "Manual version ${EXPECTED_VERSION} does not match checked-out source version ${VERSION}."
+            echo "Publish a committed release snapshot first; release workflows never rewrite versions in place."
+            exit 1
           fi
 
           echo "Resolved publish version: ${VERSION}"
@@ -597,6 +574,23 @@ jobs:
       - name: Guard alpha-only lock-stepped publish versions
         run: |
           EXPECTED_VERSION="${{ github.event.inputs.version || '' }}" node -e 'const fs=require("fs");const path=require("path");const expected=process.env.EXPECTED_VERSION;const alphaVersion=/^2\.0\.0-alpha\.[0-9A-Za-z.-]+$/;const tools=JSON.parse(fs.readFileSync("packages/jazz-tools/package.json","utf8"));const wasm=JSON.parse(fs.readFileSync("crates/jazz-wasm/package.json","utf8"));const napi=JSON.parse(fs.readFileSync("crates/jazz-napi/package.json","utf8"));const createJazz=JSON.parse(fs.readFileSync("packages/create-jazz/package.json","utf8"));if(expected){if(!alphaVersion.test(expected)){throw new Error(`Version override must match 2.0.0-alpha.*, got ${expected}`);}if(tools.version!==expected){throw new Error(`Version override mismatch: expected ${expected}, got ${tools.version}`);}}for(const pkg of [tools,wasm,napi,createJazz]){if(!alphaVersion.test(pkg.version)){throw new Error(`${pkg.name} version must match 2.0.0-alpha.*, got ${pkg.version}`);}const tag=pkg.publishConfig&&pkg.publishConfig.tag;if(tag&&tag!=="alpha"&&pkg.name!=="create-jazz"){throw new Error(`${pkg.name} publishConfig.tag must be alpha, got ${tag}`);}}if(!(tools.version===wasm.version&&tools.version===napi.version&&napi.version===createJazz.version)){throw new Error(`Versions diverged: tools=${tools.version} wasm=${wasm.version} napi=${napi.version} create-jazz=${createJazz.version}`);}for(const [name,version] of Object.entries(napi.optionalDependencies||{})){if(version!==napi.version){throw new Error(`napi optional dep ${name} is ${version}, expected ${napi.version}`);}}for(const entry of fs.readdirSync("crates/jazz-napi/npm",{withFileTypes:true})){if(!entry.isDirectory())continue;const pkgPath=path.join("crates/jazz-napi/npm",entry.name,"package.json");const pkg=JSON.parse(fs.readFileSync(pkgPath,"utf8"));if(!alphaVersion.test(pkg.version)){throw new Error(`${pkg.name} version must match 2.0.0-alpha.*, got ${pkg.version}`);}if(pkg.version!==napi.version){throw new Error(`${pkg.name} version ${pkg.version} must match jazz-napi ${napi.version}`);}}console.log(`Alpha-only publish guard passed at ${tools.version}`);'
+
+      - name: Verify immutable release source snapshot
+        run: |
+          PUBLISHED_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
+          for package_json in \
+            packages/create-jazz/package.json \
+            packages/jazz-tools/package.json \
+            crates/jazz-wasm/package.json \
+            crates/jazz-napi/package.json; do
+            SOURCE_VERSION=$(git show "${GITHUB_SHA}:${package_json}" | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>console.log(JSON.parse(s).version))')
+            if [ "${SOURCE_VERSION}" != "${PUBLISHED_VERSION}" ]; then
+              echo "${package_json} is ${SOURCE_VERSION} at ${GITHUB_SHA}, but this workflow would publish ${PUBLISHED_VERSION}."
+              echo "Publish a committed release snapshot first; source tags must exactly match the published packages."
+              exit 1
+            fi
+          done
+          echo "Source snapshot ${GITHUB_SHA} exactly matches ${PUBLISHED_VERSION}."
 
       - name: Verify packed jazz-wasm payload
         run: |
@@ -712,6 +706,29 @@ jobs:
           fi
 
           npm dist-tag add "create-jazz@${CREATE_JAZZ_VERSION}" latest
+
+      - name: Tag published source snapshot
+        if: env.RELEASE_MODE == 'publish'
+        run: |
+          VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
+          TAG="v${VERSION}"
+          SOURCE_COMMIT=$(git rev-parse "${GITHUB_SHA}^{commit}")
+          EXISTING_TAG_TARGET=$(git ls-remote --tags origin "refs/tags/${TAG}" "refs/tags/${TAG}^{}" | awk -v tag="${TAG}" '
+            $2 == "refs/tags/" tag "^{}" { peeled = $1 }
+            $2 == "refs/tags/" tag { direct = $1 }
+            END { print peeled ? peeled : direct }
+          ')
+
+          if [ -n "${EXISTING_TAG_TARGET}" ]; then
+            if [ "${EXISTING_TAG_TARGET}" != "${SOURCE_COMMIT}" ]; then
+              echo "${TAG} already points to ${EXISTING_TAG_TARGET}, not the published source ${SOURCE_COMMIT}."
+              exit 1
+            fi
+            echo "${TAG} already points at the published source snapshot."
+          else
+            git tag "${TAG}" "${SOURCE_COMMIT}"
+            git push origin "refs/tags/${TAG}"
+          fi
 
   deploy-inspector-production:
     name: Promote inspector production

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -592,6 +592,29 @@ jobs:
           done
           echo "Source snapshot ${GITHUB_SHA} exactly matches ${PUBLISHED_VERSION}."
 
+      - name: Ensure release source tag
+        if: env.RELEASE_MODE == 'publish'
+        run: |
+          VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
+          TAG="v${VERSION}"
+          SOURCE_COMMIT=$(git rev-parse "${GITHUB_SHA}^{commit}")
+          EXISTING_TAG_TARGET=$(git ls-remote --tags origin "refs/tags/${TAG}" "refs/tags/${TAG}^{}" | awk -v tag="${TAG}" '
+            $2 == "refs/tags/" tag "^{}" { peeled = $1 }
+            $2 == "refs/tags/" tag { direct = $1 }
+            END { print peeled ? peeled : direct }
+          ')
+
+          if [ -n "${EXISTING_TAG_TARGET}" ]; then
+            if [ "${EXISTING_TAG_TARGET}" != "${SOURCE_COMMIT}" ]; then
+              echo "${TAG} already points to ${EXISTING_TAG_TARGET}, not the release source ${SOURCE_COMMIT}."
+              exit 1
+            fi
+            echo "${TAG} already points at the release source snapshot."
+          else
+            git tag "${TAG}" "${SOURCE_COMMIT}"
+            git push origin "refs/tags/${TAG}"
+          fi
+
       - name: Verify packed jazz-wasm payload
         run: |
           TMP_DIR=$(mktemp -d)
@@ -706,29 +729,6 @@ jobs:
           fi
 
           npm dist-tag add "create-jazz@${CREATE_JAZZ_VERSION}" latest
-
-      - name: Tag published source snapshot
-        if: env.RELEASE_MODE == 'publish'
-        run: |
-          VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
-          TAG="v${VERSION}"
-          SOURCE_COMMIT=$(git rev-parse "${GITHUB_SHA}^{commit}")
-          EXISTING_TAG_TARGET=$(git ls-remote --tags origin "refs/tags/${TAG}" "refs/tags/${TAG}^{}" | awk -v tag="${TAG}" '
-            $2 == "refs/tags/" tag "^{}" { peeled = $1 }
-            $2 == "refs/tags/" tag { direct = $1 }
-            END { print peeled ? peeled : direct }
-          ')
-
-          if [ -n "${EXISTING_TAG_TARGET}" ]; then
-            if [ "${EXISTING_TAG_TARGET}" != "${SOURCE_COMMIT}" ]; then
-              echo "${TAG} already points to ${EXISTING_TAG_TARGET}, not the published source ${SOURCE_COMMIT}."
-              exit 1
-            fi
-            echo "${TAG} already points at the published source snapshot."
-          else
-            git tag "${TAG}" "${SOURCE_COMMIT}"
-            git push origin "refs/tags/${TAG}"
-          fi
 
   deploy-inspector-production:
     name: Promote inspector production

--- a/packages/create-jazz/README.md
+++ b/packages/create-jazz/README.md
@@ -46,9 +46,12 @@ zero-config local sync.
 
 ## A note on versioning
 
-Every version of `create-jazz` fetches the starter, the workspace config, and
-package versions from the `main` branch of
-[`garden-co/jazz2`](https://github.com/garden-co/jazz2) at scaffold time —
-regardless of which CLI version you install. In other words, `npm create
-jazz@0.0.1` and `npm create jazz@latest` will produce the same output on any
-given day, and that output tracks whatever is on `main` right now.
+New `create-jazz` releases fetch their starter, workspace config, and package
+versions from an immutable `v<create-jazz-version>` source tag in
+[`garden-co/jazz`](https://github.com/garden-co/jazz). That keeps an installed
+CLI and the generated app on the same release snapshot.
+
+Releases from before immutable source snapshots retain their historical
+behaviour of reading `main`. Snapshot-aware releases never fall back to `main`:
+if their matching tag is unavailable, the CLI fails with an upgrade hint rather
+than silently scaffolding a potentially incompatible app.

--- a/packages/create-jazz/src/deps.ts
+++ b/packages/create-jazz/src/deps.ts
@@ -213,10 +213,10 @@ async function fetchOnce(url: string): Promise<Response> {
 
 export async function resolveRemoteDeps(
   manifest: PackageManifest,
-  repoConfig: { repo: string; branch: string },
+  repoConfig: { repo: string; ref: string },
   onProgress?: ResolveProgressCallback,
 ): Promise<PackageManifest> {
-  const rawBase = `https://raw.githubusercontent.com/${repoConfig.repo}/refs/heads/${repoConfig.branch}`;
+  const rawBase = `https://raw.githubusercontent.com/${repoConfig.repo}/${repoConfig.ref}`;
   const workspaceUrl = `${rawBase}/pnpm-workspace.yaml`;
 
   const wsRes = await fetchOnce(workspaceUrl);

--- a/packages/create-jazz/src/release-config.test.ts
+++ b/packages/create-jazz/src/release-config.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
 
@@ -24,5 +25,30 @@ describe("release config", () => {
     for (const packageName of jazzFixedGroup) {
       expect(preState.initialVersions?.[packageName]).toBe("2.0.0-alpha.6");
     }
+  });
+
+  it("establishes the exact source tag before publishing any package", () => {
+    const workflow = parseYaml(
+      fs.readFileSync(
+        path.join(repoRoot, ".github", "workflows", "publish-jazz-tools-alpha.yml"),
+        "utf8",
+      ),
+    ) as {
+      jobs: {
+        "publish-npm": {
+          steps: Array<{ name?: string; run?: string }>;
+        };
+      };
+    };
+    const steps = workflow.jobs["publish-npm"].steps;
+    const sourceTagIndex = steps.findIndex((step) => step.name === "Ensure release source tag");
+    const firstPublishIndex = steps.findIndex((step) => step.name?.startsWith("Publish "));
+
+    expect(sourceTagIndex).toBeGreaterThan(-1);
+    expect(firstPublishIndex).toBeGreaterThan(-1);
+    expect(sourceTagIndex).toBeLessThan(firstPublishIndex);
+    expect(steps[sourceTagIndex]?.run).toContain("EXISTING_TAG_TARGET");
+    expect(steps[sourceTagIndex]?.run).toContain("SOURCE_COMMIT");
+    expect(steps[sourceTagIndex]?.run).toContain('git push origin "refs/tags/${TAG}"');
   });
 });

--- a/packages/create-jazz/src/scaffold-release.test.ts
+++ b/packages/create-jazz/src/scaffold-release.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { scaffold } from "./scaffold.js";
+
+const { tigedMock } = vi.hoisted(() => ({ tigedMock: vi.fn() }));
+
+vi.mock("tiged", () => ({ default: tigedMock }));
+
+const packageVersion = (
+  JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf8")) as {
+    version: string;
+  }
+).version;
+
+describe("scaffold() release source snapshots", () => {
+  let tmpRoot: string;
+  let targetDir: string;
+  let previousStarterPath: string | undefined;
+
+  beforeEach(() => {
+    previousStarterPath = process.env.JAZZ_STARTER_PATH;
+    delete process.env.JAZZ_STARTER_PATH;
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "create-jazz-release-"));
+    targetDir = path.join(tmpRoot, "app");
+    tigedMock.mockImplementation(() => ({
+      clone: async (dir: string) => {
+        await fs.promises.writeFile(
+          path.join(dir, "package.json"),
+          JSON.stringify({ name: "release-starter" }),
+        );
+      },
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("packages: []\n")),
+    );
+  });
+
+  afterEach(() => {
+    if (previousStarterPath === undefined) delete process.env.JAZZ_STARTER_PATH;
+    else process.env.JAZZ_STARTER_PATH = previousStarterPath;
+    vi.unstubAllGlobals();
+    tigedMock.mockReset();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("uses the installed release for both starter and workspace metadata", async () => {
+    await scaffold({
+      appName: "release-app",
+      targetDir,
+      pm: null,
+      starter: "next-betterauth",
+      git: false,
+    });
+
+    const releaseRef = `v${packageVersion}`;
+    expect(tigedMock).toHaveBeenCalledWith(
+      `garden-co/jazz/starters/next-betterauth#${releaseRef}`,
+      { disableCache: true },
+    );
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      `https://raw.githubusercontent.com/garden-co/jazz/refs/tags/${releaseRef}/pnpm-workspace.yaml`,
+      expect.anything(),
+    );
+  });
+
+  it("fails clearly instead of falling back to main when the release tag is unavailable", async () => {
+    tigedMock.mockImplementation(() => ({
+      clone: async () => {
+        throw new Error("could not find commit hash");
+      },
+    }));
+
+    await expect(
+      scaffold({
+        appName: "unavailable-release",
+        targetDir,
+        pm: null,
+        starter: "next-betterauth",
+        git: false,
+      }),
+    ).rejects.toThrow(/immutable source snapshot.*does not fall back to main/i);
+    expect(fs.existsSync(targetDir)).toBe(false);
+  });
+
+  it("fails clearly when the release tag lacks workspace metadata", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not found", { status: 404 })),
+    );
+
+    await expect(
+      scaffold({
+        appName: "missing-workspace",
+        targetDir,
+        pm: null,
+        starter: "next-betterauth",
+        git: false,
+      }),
+    ).rejects.toThrow(/immutable source snapshot.*does not fall back to main/i);
+    expect(fs.existsSync(targetDir)).toBe(false);
+  });
+});

--- a/packages/create-jazz/src/scaffold.ts
+++ b/packages/create-jazz/src/scaffold.ts
@@ -10,7 +10,12 @@ import {
 import { installJazzSkills } from "./agent-skills.js";
 
 const REPO = "garden-co/jazz";
-const BRANCH = "main";
+const CREATE_JAZZ_VERSION = (
+  JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf-8")) as {
+    version: string;
+  }
+).version;
+const RELEASE_REF = `v${CREATE_JAZZ_VERSION}`;
 const DEFAULT_STARTER = "next-betterauth";
 
 export const KNOWN_STARTERS = [
@@ -68,6 +73,15 @@ export interface ScaffoldOptions {
 
 const SCAFFOLD_COPY_SKIP = new Set(["node_modules", ".next", ".jazz", ".turbo", ".env", ".git"]);
 
+function sourceSnapshotError(action: string, cause: unknown): Error {
+  return new Error(
+    `Could not ${action} from immutable source snapshot ${RELEASE_REF} for create-jazz@${CREATE_JAZZ_VERSION}. ` +
+      "Jazz deliberately does not fall back to main, because that could scaffold code incompatible with the installed CLI. " +
+      "This release snapshot may be unavailable; upgrade with `npm create jazz@latest` and try again.",
+    { cause },
+  );
+}
+
 async function fetchStarter(starter: StarterName, dir: string): Promise<void> {
   const localPath = process.env.JAZZ_STARTER_PATH;
   if (localPath) {
@@ -78,8 +92,12 @@ async function fetchStarter(starter: StarterName, dir: string): Promise<void> {
     return;
   }
   const tiged = (await import("tiged")).default;
-  const emitter = tiged(`${REPO}/starters/${starter}#${BRANCH}`, { disableCache: true });
-  await emitter.clone(dir);
+  const emitter = tiged(`${REPO}/starters/${starter}#${RELEASE_REF}`, { disableCache: true });
+  try {
+    await emitter.clone(dir);
+  } catch (cause) {
+    throw sourceSnapshotError(`fetch starter "${starter}"`, cause);
+  }
 }
 
 async function resolveManifest(
@@ -90,7 +108,15 @@ async function resolveManifest(
   if (localPath) {
     return resolveLocalDeps(manifest, path.resolve(localPath, "../.."), onProgress);
   }
-  return resolveRemoteDeps(manifest, { repo: REPO, branch: BRANCH }, onProgress);
+  try {
+    return await resolveRemoteDeps(
+      manifest,
+      { repo: REPO, ref: `refs/tags/${RELEASE_REF}` },
+      onProgress,
+    );
+  } catch (cause) {
+    throw sourceSnapshotError("resolve starter dependencies", cause);
+  }
 }
 
 export async function scaffold(options: ScaffoldOptions): Promise<void> {


### PR DESCRIPTION
🤖 Replaces #1137 with immutable, version-matched release source snapshots.

create-jazz fetches starter sources and workspace metadata from the exact v<installed-version> tag, with an explicit failure and transactional cleanup when no snapshot exists. Historical already-published CLIs retain their bundled behavior.

Release automation validates committed lockstep package versions, rejects conflicting tags, and creates or verifies the exact source tag before any npm publication. This prevents publishing or promoting a snapshot-aware CLI without its required source; exact-target reruns remain idempotent.

Focused create-jazz suite: 79 passed, 1 skipped. Independently adversarially reviewed.