### PR TITLE
Document secure invite links

### DIFF
--- a/docs/content/docs/recipes/access-control/invite-links.mdx
+++ b/docs/content/docs/recipes/access-control/invite-links.mdx
@@ -1,0 +1,117 @@
+---
+title: "Invite links"
+description: Let users share a URL that grants another user access to a private resource without knowing their identity in advance.
+reviewedAt: "9712a744f"
+---
+
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+
+Invite links are a pattern that let a resource owner share a URL that grants access to anyone who
+has it without knowing the recipient's identity in advance. The URL carries the resource ID plus a
+secret that the owner stores in a private invite row.
+
+When an invitee opens the URL, your backend validates the code and inserts a membership row for
+their already-authenticated session. From that point on, access flows through the normal membership
+rule.
+
+This recipe deliberately keeps redemption on a backend. A link is a bearer capability: it must be
+checked at the same authority that performs the membership write. Do not model the code as a
+client-supplied session claim or authorize the write from a one-off read; that would let the read
+and write run under different credentials.
+
+## Schema
+
+Keep invite codes in their own table, not on the resource row. Jazz permissions are row-level, so a
+`joinCode` on the chat would be visible to every chat member. This table has no client read rule;
+only the backend checks its code. The members table records which invite each user used to join, so
+you can audit or revoke individual memberships later.
+
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-schema
+</include>
+
+## Permissions
+
+A user can read a chat once they have a membership row. A chat creator can bootstrap their own
+membership and create or revoke invite links, but no client can write a membership for somebody
+else. The only way for an invitee to join is the server route below. The server has a
+[backend identity](/docs/getting-started/server-setup#backend-identity-pattern) and inserts the row
+on their behalf after validating the join code.
+
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-permissions
+</include>
+
+See [Permissions](/docs/auth/permissions) for more on `exists.where`, `allOf`, and `anyOf`, and [Session identity and authorship](/docs/auth/sessions#session-identity-and-authorship) for how the backend stamps the user as the row's author while keeping backend permissions.
+
+## Generating a link
+
+The creator inserts the chat, their own membership, and a private invite row client-side. These
+writes are allowed by the permission rules above&hairsp;—&hairsp;the chat row is open to insert, and
+the membership and invite rules let the creator bootstrap resources that match their
+`$createdBy`. The code goes only in the invite row and URL.
+
+<include cwd lang="ts" meta='title="createInviteLink.ts"'>
+  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-create-link
+</include>
+
+<Callout type="warn">
+  The code lives in the URL fragment (after `#`) to keep it out of server access logs, CDN logs, and
+  `Referer` headers. Don't pass the code as a route parameter or query string&hairsp;—&hairsp;those
+  land in server logs.
+</Callout>
+
+## Accepting an invite
+
+The invitee opens the link while signed in. The client posts the chat ID and code to a server route.
+The server reads the private invite with backend privileges, checks the code, and inserts the
+membership row. The route is idempotent&hairsp;—&hairsp;it skips the insert if the user already has a
+membership, so re-opening the link or retrying after a transient error won't create duplicate rows.
+
+### Server route
+
+The route reads and writes as the backend: the invitee has no read access to the chat until they're
+a member, and the `chatMembers.allowInsert` rule only admits the chat's creator, so they can't
+insert their own membership directly. Your normal auth middleware resolves the caller to a Jazz
+`Session` first. `withAttributionForSession` then keeps backend permissions while stamping the
+membership's edit metadata to that exact issuer/subject pair.
+
+The `context` referenced below is the backend Jazz context for your app&hairsp;—&hairsp;see [Backend context setup](/docs/getting-started/server-setup#backend-context-setup) for how to create one.
+
+<include cwd lang="ts" meta='title="api/invite/redeem.ts"'>
+  ../examples/docs/todo-server-ts/src/invite-snippets.ts#invite-redeem-route
+</include>
+
+<Accordions type="single">
+<Accordion title="Single-use, expiring, or role-scoped codes">
+
+For single-use codes, rotate the code in your server route after a successful redeem. For richer requirements (expiry, codes that grant specific roles, audit metadata), put codes in their own table alongside the data you need to colocate with each one&hairsp;—&hairsp;creation date, granted role, expiry timestamp, and so on.
+
+The example uses the full `crypto.randomUUID()` value. Keep at least that much entropy for a link
+that is not single-use or expiring.
+
+</Accordion>
+</Accordions>
+
+### Client handler
+
+Route `/#/invite/:chatId/:code` to a component that calls the server route and then redirects.
+
+<include cwd lang="tsx" meta='title="InviteHandler.tsx"'>
+  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-handler-primary
+</include>
+
+Once the route returns, the user's subscription picks the chat up via the membership rule, and access persists for as long as the membership row exists.
+
+## Revoking access
+
+Delete a member's row to revoke their access immediately. The server stops syncing the resource to
+them as soon as the row is gone.
+
+<include cwd lang="ts" meta='title="revokeMember.ts"'>
+  ../examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx#invite-revoke
+</include>
+
+An invite link is a bearer capability: deleting a membership alone does not stop somebody who kept
+the link from redeeming it again. Delete or rotate the private invite row too when you need to
+invalidate the link for future redeemers.

--- a/docs/content/docs/recipes/access-control/invite-links.mdx
+++ b/docs/content/docs/recipes/access-control/invite-links.mdx
@@ -64,9 +64,10 @@ the membership and invite rules let the creator bootstrap resources that match t
 ## Accepting an invite
 
 The invitee opens the link while signed in. The client posts the chat ID and code to a server route.
-The server reads the private invite with backend privileges, checks the code, and inserts the
-membership row. The route is idempotent&hairsp;—&hairsp;it skips the insert if the user already has a
-membership, so re-opening the link or retrying after a transient error won't create duplicate rows.
+The server uses one exclusive transaction to read the private invite, check whether the user is
+already a member, insert their membership, and consume a single-use invite. The route is
+idempotent&hairsp;—&hairsp;it skips the insert if the user already has a membership, so re-opening the
+link or retrying after a transient error won't create duplicate rows.
 
 ### Server route
 
@@ -75,6 +76,13 @@ a member, and the `chatMembers.allowInsert` rule only admits the chat's creator,
 insert their own membership directly. Your normal auth middleware resolves the caller to a Jazz
 `Session` first. `withAttributionForSession` then keeps backend permissions while stamping the
 membership's edit metadata to that exact issuer/subject pair.
+
+The transaction is what makes redemption correct under concurrency. A multi-use invite stays in
+the table, so it is deliberately replayable by anyone holding the link. A single-use invite is
+deleted in the same exclusive transaction as the membership insert: two simultaneous redeems
+cannot both succeed. If the authority rejects the transaction because another redemption won the
+race, report that failure to the client and let it retry only if that remains appropriate for your
+UI.
 
 The `context` referenced below is the backend Jazz context for your app&hairsp;—&hairsp;see [Backend context setup](/docs/getting-started/server-setup#backend-context-setup) for how to create one.
 
@@ -85,7 +93,9 @@ The `context` referenced below is the backend Jazz context for your app&hairsp;�
 <Accordions type="single">
 <Accordion title="Single-use, expiring, or role-scoped codes">
 
-For single-use codes, rotate the code in your server route after a successful redeem. For richer requirements (expiry, codes that grant specific roles, audit metadata), put codes in their own table alongside the data you need to colocate with each one&hairsp;—&hairsp;creation date, granted role, expiry timestamp, and so on.
+Pass `{ singleUse: true }` when creating a link to consume it atomically on successful redemption.
+For richer requirements (expiry, codes that grant specific roles, audit metadata), add those fields
+to the invite table and check them in the same exclusive transaction.
 
 The example uses the full `crypto.randomUUID()` value. Keep at least that much entropy for a link
 that is not single-use or expiring.

--- a/docs/content/docs/recipes/access-control/meta.json
+++ b/docs/content/docs/recipes/access-control/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Access Control",
-  "pages": ["user-owned-data", "shared-access", "group-permissions"]
+  "pages": ["user-owned-data", "shared-access", "invite-links", "group-permissions"]
 }

--- a/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import { schema as s } from "jazz-tools";
+import { useDb } from "jazz-tools/react";
+
+const schema = {
+  chats: s.table({}),
+  chatMembers: s.table({
+    chatId: s.ref("chats"),
+    user_id: s.string(),
+    inviteId: s.string().optional(),
+  }),
+  chatInvites: s.table({
+    chatId: s.ref("chats"),
+    code: s.string(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+// Stand-in for the reader's router. With React Router, this would be
+// `const navigate = useNavigate()` inside the component.
+function navigate(to: string) {
+  window.location.hash = to;
+}
+
+// #region invite-create-link
+export function createInviteLink(db: ReturnType<typeof useDb>, userId: string): string {
+  const joinCode = crypto.randomUUID();
+
+  const { value: chat } = db.insert(app.chats, {});
+
+  db.insert(app.chatMembers, { chatId: chat.id, user_id: userId });
+  db.insert(app.chatInvites, { chatId: chat.id, code: joinCode });
+
+  return `${window.location.origin}/#/invite/${chat.id}/${joinCode}`;
+}
+// #endregion invite-create-link
+
+// #region invite-revoke
+export function revokeMember(db: ReturnType<typeof useDb>, memberId: string) {
+  db.delete(app.chatMembers, memberId);
+}
+// #endregion invite-revoke
+
+// #region invite-handler-primary
+export function InviteHandler({ chatId, code }: { chatId: string; code: string }) {
+  const handled = useRef(false);
+
+  useEffect(() => {
+    if (handled.current) return;
+    handled.current = true;
+
+    fetch("/api/invite/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatId, code }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`redeem failed: ${res.status}`);
+        navigate(`/chat/${chatId}`);
+      })
+      .catch((err) => {
+        console.error("failed to join", err);
+        handled.current = false;
+      });
+  }, [chatId, code]);
+
+  return <p>Joining…</p>;
+}
+// #endregion invite-handler-primary

--- a/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/invite-snippets.tsx
@@ -12,6 +12,7 @@ const schema = {
   chatInvites: s.table({
     chatId: s.ref("chats"),
     code: s.string(),
+    singleUse: s.boolean(),
   }),
 };
 
@@ -25,13 +26,17 @@ function navigate(to: string) {
 }
 
 // #region invite-create-link
-export function createInviteLink(db: ReturnType<typeof useDb>, userId: string): string {
+export function createInviteLink(
+  db: ReturnType<typeof useDb>,
+  userId: string,
+  { singleUse = false }: { singleUse?: boolean } = {},
+): string {
   const joinCode = crypto.randomUUID();
 
   const { value: chat } = db.insert(app.chats, {});
 
   db.insert(app.chatMembers, { chatId: chat.id, user_id: userId });
-  db.insert(app.chatInvites, { chatId: chat.id, code: joinCode });
+  db.insert(app.chatInvites, { chatId: chat.id, code: joinCode, singleUse });
 
   return `${window.location.origin}/#/invite/${chat.id}/${joinCode}`;
 }

--- a/examples/docs/todo-server-ts/src/invite-snippets.ts
+++ b/examples/docs/todo-server-ts/src/invite-snippets.ts
@@ -12,6 +12,7 @@ const schema = {
   chatInvites: s.table({
     chatId: s.ref("chats"),
     code: s.string(),
+    singleUse: s.boolean(),
   }),
 };
 // #endregion invite-schema
@@ -82,21 +83,25 @@ export async function POST(req: AuthenticatedRequest): Promise<Response> {
 
   const { chatId, code } = (await req.json()) as { chatId: string; code: string };
 
-  const backend = context.asBackend(app);
-  const invite = await backend.one(app.chatInvites.where({ chatId, code }));
-  if (!invite) {
-    return new Response("invalid invite", { status: 400 });
-  }
+  // This handle has backend permissions but attributes writes to the authenticated session.
+  const backendDb = context.withAttributionForSession(session, app);
+  const result = await backendDb.exclusiveTransaction(async (tx) => {
+    // Checking membership first keeps re-opening a successfully redeemed link idempotent,
+    // even after a single-use invite has been consumed.
+    const existing = await tx.one(app.chatMembers.where({ chatId, user_id: session.user_id }));
+    if (existing) return "already-member" as const;
 
-  // Idempotent: a repeated redeem (link reopened, retry after a transient error)
-  // must not insert a second membership row.
-  const existing = await backend.one(app.chatMembers.where({ chatId, user_id: session.user_id }));
-  if (existing) return Response.json({ ok: true });
+    const invite = await tx.one(app.chatInvites.where({ chatId, code }));
+    if (!invite) return "invalid" as const;
 
-  await context
-    .withAttributionForSession(session, app)
-    .insert(app.chatMembers, { chatId, user_id: session.user_id, inviteId: invite.id })
-    .wait({ tier: "edge" });
+    tx.insert(app.chatMembers, { chatId, user_id: session.user_id, inviteId: invite.id });
+    if (invite.singleUse) tx.delete(app.chatInvites, invite.id);
+    return "joined" as const;
+  });
+
+  // Exclusive transactions settle at the authority, so wait() takes no tier.
+  await result.wait();
+  if (result.value === "invalid") return new Response("invalid invite", { status: 400 });
 
   return Response.json({ ok: true });
 }

--- a/examples/docs/todo-server-ts/src/invite-snippets.ts
+++ b/examples/docs/todo-server-ts/src/invite-snippets.ts
@@ -1,0 +1,103 @@
+import { schema as s } from "jazz-tools";
+import type { JazzContext } from "jazz-tools/backend";
+
+// #region invite-schema
+const schema = {
+  chats: s.table({}),
+  chatMembers: s.table({
+    chatId: s.ref("chats"),
+    user_id: s.string(),
+    inviteId: s.string().optional(),
+  }),
+  chatInvites: s.table({
+    chatId: s.ref("chats"),
+    code: s.string(),
+  }),
+};
+// #endregion invite-schema
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+// #region invite-permissions
+s.definePermissions(app, ({ policy, allOf, anyOf, session }) => {
+  policy.chats.allowRead.where((chat) =>
+    policy.chatMembers.exists.where({ chatId: chat.id, user_id: session.user_id }),
+  );
+  policy.chats.allowInsert.always();
+
+  // Users can read their own membership row; chat creators can read every
+  // member of their chats.
+  policy.chatMembers.allowRead.where((member) =>
+    anyOf([
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.author }),
+    ]),
+  );
+
+  // The creator can insert their own membership in their own chat. Everyone
+  // else must come through the server route, which writes with backend
+  // privileges.
+  policy.chatMembers.allowInsert.where((member) =>
+    allOf([
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.author }),
+    ]),
+  );
+
+  // Users can leave; chat creators can remove any member.
+  policy.chatMembers.allowDelete.where((member) =>
+    anyOf([
+      { user_id: session.user_id },
+      policy.chats.exists.where({ id: member.chatId, $createdBy: session.author }),
+    ]),
+  );
+
+  // Invite codes are bearer capabilities. They never sync back down to a client.
+  policy.chatInvites.allowRead.never();
+  policy.chatInvites.allowInsert.where((invite) =>
+    policy.chats.exists.where({ id: invite.chatId, $createdBy: session.author }),
+  );
+  policy.chatInvites.allowDelete.where((invite) =>
+    policy.chats.exists.where({ id: invite.chatId, $createdBy: session.author }),
+  );
+});
+// #endregion invite-permissions
+
+declare const context: JazzContext;
+
+// Supplied by your authentication middleware after it has verified the caller.
+type AuthenticatedRequest = Request & {
+  session: {
+    issuer: string;
+    user_id: string;
+    authMode: "external" | "local-first";
+    claims: Record<string, unknown>;
+  };
+};
+
+// #region invite-redeem-route
+export async function POST(req: AuthenticatedRequest): Promise<Response> {
+  const { session } = req;
+
+  const { chatId, code } = (await req.json()) as { chatId: string; code: string };
+
+  const backend = context.asBackend(app);
+  const invite = await backend.one(app.chatInvites.where({ chatId, code }));
+  if (!invite) {
+    return new Response("invalid invite", { status: 400 });
+  }
+
+  // Idempotent: a repeated redeem (link reopened, retry after a transient error)
+  // must not insert a second membership row.
+  const existing = await backend.one(app.chatMembers.where({ chatId, user_id: session.user_id }));
+  if (existing) return Response.json({ ok: true });
+
+  await context
+    .withAttributionForSession(session, app)
+    .insert(app.chatMembers, { chatId, user_id: session.user_id, inviteId: invite.id })
+    .wait({ tier: "edge" });
+
+  return Response.json({ ok: true });
+}
+// #endregion invite-redeem-route


### PR DESCRIPTION
🤖 Replaces #927 with a server-backed, capability-safe invite recipe.

Invite codes live only in a private table and URL fragments; redemption runs on an authenticated backend with canonical session attribution. One exclusive transaction covers membership existence, invite validation, membership insertion, and optional single-use consumption, preventing duplicate and double-redemption races. Multi-use links remain explicitly replayable.

Docs, client snippets, and standalone server snippets typecheck. The full server-doc example retains unrelated pre-existing API-drift errors. The authorization and concurrency boundary was independently adversarially reviewed.