### PR TITLE
Mirror requested CORS preflight headers

### DIFF
--- a/crates/jazz-server/src/server/routes/mod.rs
+++ b/crates/jazz-server/src/server/routes/mod.rs
@@ -23,7 +23,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowHeaders, CorsLayer};
 use tower_http::trace::TraceLayer;
 
 use crate::server::ServerState;
@@ -112,7 +112,10 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route("/health", get(health_handler))
         .route("/internal/shutdown", post(internal_shutdown_handler))
         .nest("/apps/{app_id}", traced_routes)
-        .layer(CorsLayer::permissive())
+        // `*` does not authorize `Authorization` in a browser CORS preflight.
+        // Mirror the requested names while retaining the intentionally
+        // credential-free permissive policy.
+        .layer(CorsLayer::permissive().allow_headers(AllowHeaders::mirror_request()))
         .with_state(state)
 }
 
@@ -122,7 +125,7 @@ mod tests {
     use super::*;
 
     use axum::extract::{Path, Query};
-    use axum::http::{HeaderMap, StatusCode, Uri};
+    use axum::http::{HeaderMap, Method, StatusCode, Uri, header};
     use axum::response::Json;
 
     use jazz::tools::AppId;
@@ -262,6 +265,60 @@ mod tests {
 
     fn named_test_app_route(path: &str) -> String {
         format!("/apps/test-app/{}", path.trim_start_matches('/'))
+    }
+
+    #[tokio::test]
+    async fn cors_preflight_mirrors_requested_auth_headers_without_credentials() {
+        let app = make_test_router(make_sync_test_state("test-backend-secret").await);
+        let requested_headers = "authorization, x-jazz-admin-secret";
+
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri(test_app_route("/admin/schemas"))
+                    .header(header::ORIGIN, "http://localhost:3000")
+                    .header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+                    .header(header::ACCESS_CONTROL_REQUEST_HEADERS, requested_headers)
+                    .body(axum::body::Body::empty())
+                    .expect("valid CORS preflight"),
+            )
+            .await
+            .expect("CORS layer handles preflight");
+
+        assert!(response.status().is_success());
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+                .and_then(|value| value.to_str().ok()),
+            Some(requested_headers),
+            "preflight must explicitly allow the requested authorization headers"
+        );
+        assert!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                .is_none(),
+            "the shared server CORS policy must not enable cookie credentials"
+        );
+
+        let vary = response
+            .headers()
+            .get(header::VARY)
+            .and_then(|value| value.to_str().ok())
+            .expect("CORS response must vary by preflight inputs");
+        for required in [
+            "origin",
+            "access-control-request-method",
+            "access-control-request-headers",
+        ] {
+            assert!(
+                vary.split(',')
+                    .any(|value| value.trim().eq_ignore_ascii_case(required)),
+                "Vary must include {required}; got {vary:?}"
+            );
+        }
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
🤖 Replaces #908 on the current jazz-server Axum router.

Browsers do not interpret Access-Control-Allow-Headers: * as authorizing the Authorization header. The server now mirrors the requested preflight header names while retaining its permissive origin/method policy and keeping credentials disabled.

A current-route regression test asserts exact header reflection, absence of Access-Control-Allow-Credentials, and all required Vary dimensions. A planted reversion to wildcard headers makes the test fail. Independently adversarially reviewed.