### PR TITLE
Preserve correlated policy result carriers

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -1987,6 +1987,23 @@ fn lower_relation_key_ref(
             {
                 return Ok(field);
             }
+            if let Some(LinearStep::Project(columns)) = linear.steps.last()
+                && let NormalizedValueRef::RowId(RowIdRef::Source(value_source)) = value
+                && linear.root.source() == Some(value_source)
+                && let Some(column) = columns.iter().find(|column| {
+                    matches!(
+                        &column.value,
+                        NormalizedValueRef::RowId(RowIdRef::Source(column_source))
+                            if column_source == value_source
+                    )
+                })
+            {
+                // Relation-backed policy expressions commonly project their
+                // source row ID as public `id`. Subsequent outer joins must
+                // consume that projected private proof field, rather than
+                // asking the graph for the pre-projection `row_uuid` name.
+                return Ok(column.output.name.clone());
+            }
             if let Some(source) = &output.root_source {
                 if let Some(source_id) = linear.root.source() {
                     if let Ok(key) = lower_join_key_ref(value, source_id, source, request) {

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -1879,6 +1879,23 @@ fn authorization_subplan_with_correlated_allowed_to_joins_lowers_without_occurre
         .iter()
         .find(|terminal| matches!(terminal.output, OutputTerminalSchema::AppRows(_)))
         .expect("public app-rows terminal");
+    let public_graph = format!("{:#?}", public_terminal.graph);
+    assert!(
+        !public_graph.contains("__policy_join_source_"),
+        "policy-proof carriers must not reach a public query terminal: {public_graph}"
+    );
+    let OutputTerminalSchema::AppRows(public_schema) = &public_terminal.output else {
+        panic!("public app-rows terminal must retain its public descriptor");
+    };
+    assert!(
+        public_schema
+            .descriptor
+            .fields()
+            .iter()
+            .filter_map(|field| field.name.as_deref())
+            .all(|field| !field.starts_with("__policy_join_source_")),
+        "private policy carriers must not appear in the public descriptor: {public_schema:#?}"
+    );
     let collector_inputs = BTreeSet::from([
         "__collect_root___flat_join_source_0_row_uuid".to_owned(),
         "__collect_root___flat_join_source_1_row_uuid".to_owned(),

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -1,6 +1,12 @@
 // Write attribution, ownership, joins, rejection, and cleanup.
 
 use crate::query::{Include, JoinMode, OrderDirection};
+use crate::tools::public_api::relation_ir::{
+    ColumnRef as PublicRelColumnRef, JoinCondition as PublicRelJoinCondition,
+    JoinKind as PublicRelJoinKind, PredicateCmpOp as PublicRelPredicateCmpOp,
+    PredicateExpr as PublicRelPredicateExpr, RelExpr as PublicRelExpr,
+    ValueRef as PublicRelValueRef,
+};
 use std::cell::Cell;
 use std::rc::Rc;
 
@@ -914,6 +920,194 @@ fn join_policy_authorizes_writes_reads_and_next_emission_revocation() {
 /// assignment's tenant-correlated existence checks: an eligible owner is
 /// accepted while that same owner cannot attach a foreign membership. The
 /// compiler-plan regression separately asserts occurrence-carrier suppression.
+/// A relation-backed `exists` must prove both the denormalized workspace and
+/// the referenced block together.  The same owner is deliberately a member of
+/// both workspaces, so authorizing the block reference without its workspace
+/// correlation would accept the cross-workspace write.
+#[test]
+fn correlated_exists_rel_keeps_workspace_and_referenced_row_together_for_insert_and_update() {
+    let owner = user(0xa1);
+    let workspace_a = row(0xb1);
+    let workspace_b = row(0xb2);
+    let owner_membership_a = row(0xc1);
+    let owner_membership_b = row(0xc2);
+    let block_a = row(0xd1);
+    let block_b = row(0xd2);
+    let accepted_task = row(0xe1);
+    let rejected_task = row(0xe2);
+
+    let column = |scope: &str, name: &str| PublicRelColumnRef {
+        scope: Some(scope.to_owned()),
+        column: name.to_owned(),
+    };
+    let outer = |scope: &str, name: &str, outer_name: &str| PublicRelPredicateExpr::Cmp {
+        left: column(scope, name),
+        op: PublicRelPredicateCmpOp::Eq,
+        right: PublicRelValueRef::OuterColumn(PublicRelColumnRef::unscoped(outer_name)),
+    };
+    let task_policy = PublicPolicyExpr::ExistsRel {
+        rel: PublicRelExpr::Filter {
+            input: Box::new(PublicRelExpr::Join {
+                left: Box::new(PublicRelExpr::TableScan {
+                    table: "blocks".into(),
+                    alias: Some("blocks".to_owned()),
+                }),
+                right: Box::new(PublicRelExpr::Filter {
+                    input: Box::new(PublicRelExpr::TableScan {
+                        table: "members".into(),
+                        alias: Some("members".to_owned()),
+                    }),
+                    predicate: PublicRelPredicateExpr::And(vec![
+                        outer("members", "workspace", "workspace"),
+                        PublicRelPredicateExpr::Cmp {
+                            left: column("members", "subject"),
+                            op: PublicRelPredicateCmpOp::Eq,
+                            right: PublicRelValueRef::SessionRef(vec![
+                                "claims".to_owned(),
+                                "sub".to_owned(),
+                            ]),
+                        },
+                    ]),
+                }),
+                on: vec![PublicRelJoinCondition {
+                    left: column("blocks", "workspace"),
+                    right: column("members", "workspace"),
+                }],
+                join_kind: PublicRelJoinKind::Inner,
+            }),
+            // The FK correlation is separate from the nested membership
+            // conjunction, mirroring `allOf([exists, workspaceId + FK])`.
+            predicate: PublicRelPredicateExpr::And(vec![outer("blocks", "id", "block")]),
+        },
+    };
+    let schema = build_public_test_schema(
+        PublicSchemaBuilder::new()
+            .table(
+                PublicTableSchemaBuilder::new("workspaces")
+                    .column("name", PublicColumnType::Text),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("members")
+                    .fk_column("workspace", "workspaces")
+                    .column("subject", PublicColumnType::Uuid),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("blocks")
+                    .fk_column("workspace", "workspaces"),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("tasks")
+                    .fk_column("workspace", "workspaces")
+                    .fk_column("block", "blocks")
+                    .column("title", PublicColumnType::Text)
+                    .policies(
+                        PublicTablePolicies::new()
+                            .with_insert(task_policy.clone())
+                            .with_update(Some(task_policy.clone()), task_policy),
+                    ),
+            ),
+    );
+    let (_core_dir, mut core) = open_node_with_schema(node(0x9a), schema);
+    for (table, row_uuid, time, cells) in [
+        (
+            "workspaces",
+            workspace_a,
+            1,
+            BTreeMap::from([("name".to_owned(), Value::String("A".to_owned()))]),
+        ),
+        (
+            "workspaces",
+            workspace_b,
+            2,
+            BTreeMap::from([("name".to_owned(), Value::String("B".to_owned()))]),
+        ),
+        (
+            "members",
+            owner_membership_a,
+            3,
+            BTreeMap::from([
+                ("workspace".to_owned(), Value::Uuid(workspace_a.0)),
+                ("subject".to_owned(), Value::Uuid(owner.0)),
+            ]),
+        ),
+        (
+            "members",
+            owner_membership_b,
+            4,
+            BTreeMap::from([
+                ("workspace".to_owned(), Value::Uuid(workspace_b.0)),
+                ("subject".to_owned(), Value::Uuid(owner.0)),
+            ]),
+        ),
+        (
+            "blocks",
+            block_a,
+            5,
+            BTreeMap::from([("workspace".to_owned(), Value::Uuid(workspace_a.0))]),
+        ),
+        (
+            "blocks",
+            block_b,
+            6,
+            BTreeMap::from([("workspace".to_owned(), Value::Uuid(workspace_b.0))]),
+        ),
+    ] {
+        accept_global(&mut core, MergeableCommit::new(table, row_uuid, time).cells(cells));
+    }
+    core.set_session_claims(owner, BTreeMap::from([("sub".to_owned(), Value::Uuid(owner.0))]));
+
+    let accepted = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("tasks", accepted_task, 7)
+                .made_by(owner)
+                .cells(BTreeMap::from([
+                    ("workspace".to_owned(), Value::Uuid(workspace_a.0)),
+                    ("block".to_owned(), Value::Uuid(block_a.0)),
+                    ("title".to_owned(), Value::String("same workspace".to_owned())),
+                ])),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(accepted).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(accepted),
+        Some((Fate::Accepted, Some(_), DurabilityTier::Global))
+    ));
+
+    let denied_insert = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("tasks", rejected_task, 8)
+                .made_by(owner)
+                .cells(BTreeMap::from([
+                    ("workspace".to_owned(), Value::Uuid(workspace_a.0)),
+                    ("block".to_owned(), Value::Uuid(block_b.0)),
+                    ("title".to_owned(), Value::String("cross workspace".to_owned())),
+                ])),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(denied_insert).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(denied_insert),
+        Some((Fate::Rejected(RejectionReason::AuthorizationDenied), None, DurabilityTier::Local))
+    ));
+
+    let denied_update = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("tasks", accepted_task, 9)
+                .made_by(owner)
+                .cells(BTreeMap::from([
+                    ("workspace".to_owned(), Value::Uuid(workspace_a.0)),
+                    ("block".to_owned(), Value::Uuid(block_b.0)),
+                    ("title".to_owned(), Value::String("foreign replacement".to_owned())),
+                ])),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(denied_update).unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(denied_update),
+        Some((Fate::Rejected(RejectionReason::AuthorizationDenied), None, DurabilityTier::Local))
+    ));
+}
+
 #[test]
 fn correlated_inherited_insert_policy_accepts_owner_and_denies_cross_tenant_membership() {
     let owner = user(0xa1);

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -1003,7 +1003,8 @@ fn correlated_exists_rel_keeps_workspace_and_referenced_row_together_for_insert_
                     .policies(
                         PublicTablePolicies::new()
                             .with_insert(task_policy.clone())
-                            .with_update(Some(task_policy.clone()), task_policy),
+                            .with_update(Some(task_policy.clone()), task_policy.clone())
+                            .with_delete(task_policy),
                     ),
             ),
     );
@@ -1106,6 +1107,163 @@ fn correlated_exists_rel_keeps_workspace_and_referenced_row_together_for_insert_
         core.transaction_state_settled(denied_update),
         Some((Fate::Rejected(RejectionReason::AuthorizationDenied), None, DurabilityTier::Local))
     ));
+
+    // DELETE evaluates the persisted old row through USING, rather than a
+    // candidate payload. The rejected UPDATE above must not replace that old
+    // same-workspace authority.
+    let accepted_delete = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("tasks", accepted_task, 10)
+                .made_by(owner)
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    core.finalize_local_mergeable_commit_settled(accepted_delete)
+        .unwrap();
+    assert!(matches!(
+        core.transaction_state_settled(accepted_delete),
+        Some((Fate::Accepted, Some(_), DurabilityTier::Global))
+    ));
+}
+
+#[test]
+fn exists_rel_rejects_nested_outer_correlation_off_the_join_key() {
+    let column = |scope: &str, name: &str| PublicRelColumnRef {
+        scope: Some(scope.to_owned()),
+        column: name.to_owned(),
+    };
+    let policy = PublicPolicyExpr::ExistsRel {
+        rel: PublicRelExpr::Filter {
+            input: Box::new(PublicRelExpr::Join {
+                left: Box::new(PublicRelExpr::TableScan {
+                    table: "blocks".into(),
+                    alias: Some("blocks".to_owned()),
+                }),
+                right: Box::new(PublicRelExpr::Filter {
+                    input: Box::new(PublicRelExpr::TableScan {
+                        table: "members".into(),
+                        alias: Some("members".to_owned()),
+                    }),
+                    predicate: PublicRelPredicateExpr::Cmp {
+                        // `subject` is not the blocks-members equality key;
+                        // accepting this would silently retarget the proof.
+                        left: column("members", "subject"),
+                        op: PublicRelPredicateCmpOp::Eq,
+                        right: PublicRelValueRef::OuterColumn(PublicRelColumnRef::unscoped(
+                            "workspace",
+                        )),
+                    },
+                }),
+                on: vec![PublicRelJoinCondition {
+                    left: column("blocks", "workspace"),
+                    right: column("members", "workspace"),
+                }],
+                join_kind: PublicRelJoinKind::Inner,
+            }),
+            predicate: PublicRelPredicateExpr::Cmp {
+                left: column("blocks", "id"),
+                op: PublicRelPredicateCmpOp::Eq,
+                right: PublicRelValueRef::OuterColumn(PublicRelColumnRef::unscoped("block")),
+            },
+        },
+    };
+    let public = PublicSchemaBuilder::new()
+        .table(PublicTableSchemaBuilder::new("workspaces"))
+        .table(
+            PublicTableSchemaBuilder::new("members")
+                .fk_column("workspace", "workspaces")
+                .column("subject", PublicColumnType::Uuid),
+        )
+        .table(
+            PublicTableSchemaBuilder::new("blocks").fk_column("workspace", "workspaces"),
+        )
+        .table(
+            PublicTableSchemaBuilder::new("tasks")
+                .fk_column("workspace", "workspaces")
+                .fk_column("block", "blocks")
+                .policies(PublicTablePolicies::new().with_insert(policy)),
+        )
+        .build();
+    let error = crate::schema::JazzSchema::new(&public)
+        .expect_err("mismatched nested correlation must fail closed");
+    assert!(error
+        .to_string()
+        .contains("nested outer correlation must use its join key"));
+}
+
+#[test]
+fn exists_rel_fails_closed_for_outer_correlation_beyond_one_nested_join() {
+    let column = |scope: &str, name: &str| PublicRelColumnRef {
+        scope: Some(scope.to_owned()),
+        column: name.to_owned(),
+    };
+    let policy = PublicPolicyExpr::ExistsRel {
+        rel: PublicRelExpr::Filter {
+            input: Box::new(PublicRelExpr::Join {
+                left: Box::new(PublicRelExpr::TableScan {
+                    table: "blocks".into(),
+                    alias: Some("blocks".to_owned()),
+                }),
+                right: Box::new(PublicRelExpr::Join {
+                    left: Box::new(PublicRelExpr::TableScan {
+                        table: "members".into(),
+                        alias: Some("members".to_owned()),
+                    }),
+                    right: Box::new(PublicRelExpr::Filter {
+                        input: Box::new(PublicRelExpr::TableScan {
+                            table: "grants".into(),
+                            alias: Some("grants".to_owned()),
+                        }),
+                        predicate: PublicRelPredicateExpr::Cmp {
+                            left: column("grants", "workspace"),
+                            op: PublicRelPredicateCmpOp::Eq,
+                            right: PublicRelValueRef::OuterColumn(PublicRelColumnRef::unscoped(
+                                "workspace",
+                            )),
+                        },
+                    }),
+                    on: vec![PublicRelJoinCondition {
+                        left: column("members", "workspace"),
+                        right: column("grants", "workspace"),
+                    }],
+                    join_kind: PublicRelJoinKind::Inner,
+                }),
+                on: vec![PublicRelJoinCondition {
+                    left: column("blocks", "workspace"),
+                    right: column("members", "workspace"),
+                }],
+                join_kind: PublicRelJoinKind::Inner,
+            }),
+            predicate: PublicRelPredicateExpr::Cmp {
+                left: column("blocks", "id"),
+                op: PublicRelPredicateCmpOp::Eq,
+                right: PublicRelValueRef::OuterColumn(PublicRelColumnRef::unscoped("block")),
+            },
+        },
+    };
+    let public = PublicSchemaBuilder::new()
+        .table(PublicTableSchemaBuilder::new("workspaces"))
+        .table(
+            PublicTableSchemaBuilder::new("blocks").fk_column("workspace", "workspaces"),
+        )
+        .table(
+            PublicTableSchemaBuilder::new("members").fk_column("workspace", "workspaces"),
+        )
+        .table(
+            PublicTableSchemaBuilder::new("grants").fk_column("workspace", "workspaces"),
+        )
+        .table(
+            PublicTableSchemaBuilder::new("tasks")
+                .fk_column("workspace", "workspaces")
+                .fk_column("block", "blocks")
+                .policies(PublicTablePolicies::new().with_insert(policy)),
+        )
+        .build();
+    let error = crate::schema::JazzSchema::new(&public)
+        .expect_err("deep outer correlation must fail closed until its scope is retained");
+    assert!(error
+        .to_string()
+        .contains("does not yet support outer correlations beyond one nested join"));
 }
 
 #[test]

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -1380,7 +1380,16 @@ fn append_exists_rel_policy_clause(
     let correlation_index = lowered
         .filters
         .iter()
-        .position(|filter| matches!(filter.value, Some(LoweredRelValue::OuterRow(_))))
+        .position(|filter| {
+            matches!(filter.value, Some(LoweredRelValue::OuterRow(_)))
+                && filter.column.as_deref() == Some("id")
+        })
+        .or_else(|| {
+            lowered
+                .filters
+                .iter()
+                .position(|filter| matches!(filter.value, Some(LoweredRelValue::OuterRow(_))))
+        })
         .ok_or_else(|| {
             err(
                 format!("$.{}.{}", table.as_str(), path),
@@ -1401,11 +1410,23 @@ fn append_exists_rel_policy_clause(
         ));
     };
 
-    let remaining_filters = lowered
-        .filters
-        .iter()
-        .map(|filter| filter.predicate.clone())
-        .collect::<Vec<_>>();
+    // An ExistsRel can correlate more than one key from the protected row.
+    // Keep every extra outer-row equality as part of the join predicate;
+    // lowering it as the placeholder `Predicate::All([])` would otherwise
+    // prove the referenced row but not that it belongs to the same workspace.
+    let mut correlated_filters = Vec::new();
+    let mut remaining_filters = Vec::new();
+    for filter in &lowered.filters {
+        match (&filter.column, &filter.value) {
+            (Some(join_column), Some(LoweredRelValue::OuterRow(source_column))) => {
+                correlated_filters.push(JoinCorrelation {
+                    join_column: join_column.clone(),
+                    source_column: source_column.clone(),
+                });
+            }
+            _ => remaining_filters.push(filter.predicate.clone()),
+        }
+    }
 
     for reachable in &mut lowered.reachable {
         if reachable.access_row_column == "__pending_outer_row" {
@@ -1441,17 +1462,47 @@ fn append_exists_rel_policy_clause(
     }
 
     if !lowered.joins.is_empty() {
-        if lowered.joins.len() != 1 {
-            return Err(err(
-                format!("$.{}.{}", table.as_str(), path),
-                "core schema ExistsRel policies support one join chain at the server shell boundary",
-            ));
+        // The relation's left-most scan is the row correlated to the
+        // protected row. Its joins remain nested beneath that root; replacing
+        // it with the first nested join loses the FK relation and produces a
+        // `JoinNotRefCompatible` plan (for example task.block -> member.id).
+        // Lift outer correlations on a nested join through its equality edge,
+        // so `member.workspace = outer.workspace` constrains the root block's
+        // workspace without publishing any proof carrier.
+        for nested in &mut lowered.joins {
+            let source_column = nested.source_column.clone().ok_or_else(|| {
+                err(
+                    format!("$.{}.{}", table.as_str(), path),
+                    "core schema ExistsRel nested join is missing its source column",
+                )
+            })?;
+            for correlation in std::mem::take(&mut nested.correlated_filters) {
+                if correlation.join_column != nested.on_column {
+                    return Err(err(
+                        format!("$.{}.{}", table.as_str(), path),
+                        "core schema ExistsRel nested outer correlation must use its join key",
+                    ));
+                }
+                correlated_filters.push(JoinCorrelation {
+                    join_column: source_column.clone(),
+                    source_column: correlation.source_column,
+                });
+            }
         }
-        let mut join = lowered.joins.remove(0);
-        join.source_column = Some(source_column);
-        join.on_column = correlation_column;
-        join.filters.extend(remaining_filters);
-        query.joins.push(join);
+        query.joins.push(JoinVia {
+            table: lowered.table,
+            on_column: correlation_column.clone(),
+            target: if correlation_column == "id" {
+                JoinTarget::RowId
+            } else {
+                JoinTarget::Column
+            },
+            source_column: Some(source_column),
+            source_lookup: None,
+            correlated_filters,
+            filters: remaining_filters,
+            nested_joins: lowered.joins,
+        });
         return Ok(query);
     }
 
@@ -1461,9 +1512,20 @@ fn append_exists_rel_policy_clause(
         .map(|filter| filter.predicate)
         .collect::<Vec<_>>();
     if correlation_column == "id" {
-        Ok(query.join_via_row_id(lowered.table, source_column, filters))
+        Ok(query.join_via_row_id_with_correlations(
+            lowered.table,
+            source_column,
+            correlated_filters,
+            filters,
+        ))
     } else {
-        Ok(query.join_via_column(lowered.table, correlation_column, source_column, filters))
+        Ok(query.join_via_column_with_correlations(
+            lowered.table,
+            correlation_column,
+            source_column,
+            correlated_filters,
+            filters,
+        ))
     }
 }
 
@@ -1557,6 +1619,21 @@ fn lower_exists_rel(
                 });
             }
 
+            let mut correlated_filters = Vec::new();
+            let filters = right
+                .filters
+                .into_iter()
+                .filter_map(|filter| match (filter.column, filter.value) {
+                    (Some(join_column), Some(LoweredRelValue::OuterRow(source_column))) => {
+                        correlated_filters.push(JoinCorrelation {
+                            join_column,
+                            source_column,
+                        });
+                        None
+                    }
+                    _ => Some(filter.predicate),
+                })
+                .collect();
             let join = JoinVia {
                 table: right.table,
                 on_column: on.right.column.clone(),
@@ -1567,12 +1644,8 @@ fn lower_exists_rel(
                 },
                 source_column: Some(on.left.column.clone()),
                 source_lookup: None,
-                correlated_filters: Vec::new(),
-                filters: right
-                    .filters
-                    .into_iter()
-                    .map(|filter| filter.predicate)
-                    .collect(),
+                correlated_filters,
+                filters,
                 nested_joins: right.joins,
             };
             left.joins.push(join);

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -1470,6 +1470,16 @@ fn append_exists_rel_policy_clause(
         // so `member.workspace = outer.workspace` constrains the root block's
         // workspace without publishing any proof carrier.
         for nested in &mut lowered.joins {
+            if nested
+                .nested_joins
+                .iter()
+                .any(|child| !child.correlated_filters.is_empty())
+            {
+                return Err(err(
+                    format!("$.{}.{}", table.as_str(), path),
+                    "core schema ExistsRel does not yet support outer correlations beyond one nested join",
+                ));
+            }
             let source_column = nested.source_column.clone().ok_or_else(|| {
                 err(
                     format!("$.{}.{}", table.as_str(), path),

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -783,6 +783,42 @@ describe("permissions DSL", () => {
     }
   });
 
+  it("keeps a filtered join RHS inside the ExistsRel relation", () => {
+    const compiled = definePermissions(socialApp, ({ policy, session }) => [
+      policy.profiles.allowRead.where((profile) =>
+        policy.exists(
+          policy.people
+            .where({ profileId: profile.id })
+            .join(policy.friendships.where({ personBId: session.personId }), {
+              left: "id",
+              right: "personAId",
+            }),
+        ),
+      ),
+    ]);
+
+    const using = compiled.profiles!.select?.using;
+    expect(using?.type).toBe("ExistsRel");
+    if (!using || using.type !== "ExistsRel") {
+      throw new Error("Expected filtered join policy to compile to ExistsRel.");
+    }
+    const rel = toAssertionRelExprForTest(using.rel);
+    expect(rel.type).toBe("Filter");
+    if (rel.type !== "Filter") {
+      throw new Error("Expected outer profile correlation filter.");
+    }
+    expect(rel.input.type).toBe("Join");
+    if (rel.input.type !== "Join") {
+      throw new Error("Expected joined relation.");
+    }
+    expect(rel.input.right.type).toBe("Filter");
+    if (rel.input.right.type !== "Filter") {
+      throw new Error("Expected filtered RHS relation to remain nested.");
+    }
+    expect(rel.input.right.predicate.type).toBe("Cmp");
+    expect(JSON.stringify(rel.input.right)).toContain('"personBId"');
+  });
+
   it("supports one-clause friend-profile chain style using hopTo(...).where(...)", () => {
     const compiled = definePermissions(socialApp, ({ policy, anyOf, session }) => [
       policy.profiles.allowRead.where((profile) =>

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -819,6 +819,102 @@ describe("permissions DSL", () => {
     expect(JSON.stringify(rel.input.right)).toContain('"personBId"');
   });
 
+  it("rejects filtered join RHS shapes the relation lowering cannot alias safely", () => {
+    expect(() =>
+      definePermissions(socialApp, ({ policy }) => [
+        policy.profiles.allowRead.where(
+          policy.exists(
+            policy.people
+              .where({})
+              .join(policy.friendships.where({}), { left: "id", right: "personAId" }),
+          ),
+        ),
+      ]),
+    ).toThrow(/must include where\(\.\.\.\).*pass policy\.<table> directly/i);
+
+    expect(() =>
+      definePermissions(socialApp, ({ policy, session }) => [
+        policy.profiles.allowRead.where(
+          policy.exists(
+            policy.people.where({}).join(policy.people.where({ profileId: session.personId }), {
+              left: "id",
+              right: "id",
+            }),
+          ),
+        ),
+      ]),
+    ).toThrow(/same-table RHS without an alias/i);
+
+    expect(() =>
+      definePermissions(socialApp, ({ policy, session }) => [
+        policy.profiles.allowRead.where(
+          policy.exists(
+            policy.people
+              .where({})
+              .join(
+                policy.friendships
+                  .where({ personBId: session.personId })
+                  .join(policy.people, { left: "personAId", right: "id" }),
+                { left: "id", right: "personAId" },
+              ),
+          ),
+        ),
+      ]),
+    ).toThrow(/nested join\(\.\.\.\) and hopTo\(\.\.\.\) RHS are unsupported/i);
+
+    expect(() =>
+      definePermissions(socialApp, ({ policy, session }) => [
+        policy.profiles.allowRead.where(
+          policy.exists(
+            policy.people
+              .where({})
+              .join(
+                policy.friendships
+                  .where({ personBId: session.personId })
+                  .select({ friend: "personAId" }),
+                { left: "id", right: "personAId" },
+              ),
+          ),
+        ),
+      ]),
+    ).toThrow(/select\(\.\.\.\) RHS are unsupported/i);
+
+    expect(() =>
+      definePermissions(socialApp, ({ policy, session }) => [
+        policy.profiles.allowRead.where(
+          policy.exists(
+            policy.people
+              .where({})
+              .join(
+                policy.union([
+                  policy.friendships.where({ personAId: session.personId }),
+                  policy.friendships.where({ personBId: session.personId }),
+                ]),
+                { left: "id", right: "personAId" },
+              ),
+          ),
+        ),
+      ]),
+    ).toThrow(/union\(\.\.\.\) and gather\(\.\.\.\) RHS are unsupported/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy }) => {
+        const reachableTeams = policy.teams.gather({
+          start: { kind: "individual" },
+          step: ({ current }) =>
+            policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
+        });
+        return [
+          policy.todos.allowRead.where(
+            policy.exists(
+              policy.projects.where({}).join(reachableTeams, { left: "id", right: "id" }),
+            ),
+          ),
+        ];
+      }),
+    ).toThrow(/union\(\.\.\.\) and gather\(\.\.\.\) RHS are unsupported/i);
+  });
+
   it("supports one-clause friend-profile chain style using hopTo(...).where(...)", () => {
     const compiled = definePermissions(socialApp, ({ policy, anyOf, session }) => [
       policy.profiles.allowRead.where((profile) =>

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -819,6 +819,39 @@ describe("permissions DSL", () => {
     expect(JSON.stringify(rel.input.right)).toContain('"personBId"');
   });
 
+  it("keeps distinct filtered RHS scopes and binds the next join to the previous RHS", () => {
+    const compiled = definePermissions(socialApp, ({ policy, session }) => [
+      policy.profiles.allowRead.where((profile) =>
+        policy.exists(
+          policy.people
+            .where({ profileId: profile.id })
+            .join(policy.friendships.where({ personAId: session.personId }), {
+              left: "id",
+              right: "personAId",
+            })
+            .join(policy.profiles.where({ id: session.personId }), {
+              left: "personBId",
+              right: "id",
+            }),
+        ),
+      ),
+    ]);
+
+    const using = compiled.profiles!.select?.using;
+    expect(using?.type).toBe("ExistsRel");
+    if (!using || using.type !== "ExistsRel") {
+      throw new Error("Expected filtered join policy to compile to ExistsRel.");
+    }
+    const rel = toAssertionRelExprForTest(using.rel);
+    expect(rel.type).toBe("Filter");
+    if (rel.type !== "Filter" || rel.input.type !== "Join") {
+      throw new Error("Expected correlated filter over the second filtered join.");
+    }
+    expect(rel.input.on[0]?.left.scope).toBe("friendships");
+    expect(rel.input.on[0]?.right.scope).toBe("profiles");
+    expect(rel.input.right.type).toBe("Filter");
+  });
+
   it("rejects filtered join RHS shapes the relation lowering cannot alias safely", () => {
     expect(() =>
       definePermissions(socialApp, ({ policy }) => [
@@ -843,7 +876,26 @@ describe("permissions DSL", () => {
           ),
         ),
       ]),
-    ).toThrow(/same-table RHS without an alias/i);
+    ).toThrow(/scope "people".*already present in the left relation/i);
+
+    expect(() =>
+      definePermissions(socialApp, ({ policy, session }) => [
+        policy.profiles.allowRead.where(
+          policy.exists(
+            policy.people
+              .where({})
+              .join(policy.friendships.where({ personBId: session.personId }), {
+                left: "id",
+                right: "personAId",
+              })
+              .join(policy.friendships.where({ personAId: session.personId }), {
+                left: "personBId",
+                right: "personAId",
+              }),
+          ),
+        ),
+      ]),
+    ).toThrow(/scope "friendships".*already present in the left relation/i);
 
     expect(() =>
       definePermissions(socialApp, ({ policy, session }) => [

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -852,6 +852,31 @@ describe("permissions DSL", () => {
     expect(rel.input.right.type).toBe("Filter");
   });
 
+  it("binds qualified filters after a filtered RHS to that relation's real scope", () => {
+    const compiled = definePermissions(socialApp, ({ policy, session }) => [
+      policy.profiles.allowRead.where((profile) =>
+        policy.exists(
+          policy.people
+            .where({ profileId: profile.id })
+            .join(policy.friendships.where({ personAId: session.personId }), {
+              left: "id",
+              right: "personAId",
+            })
+            .where({ "friendships.personBId": session.personId }),
+        ),
+      ),
+    ]);
+
+    const using = compiled.profiles!.select?.using;
+    expect(using?.type).toBe("ExistsRel");
+    if (!using || using.type !== "ExistsRel") {
+      throw new Error("Expected filtered join policy to compile to ExistsRel.");
+    }
+    const relation = JSON.stringify(toAssertionRelExprForTest(using.rel));
+    expect(relation).toContain('"scope":"friendships","column":"personBId"');
+    expect(relation).not.toContain('"scope":"__join_0","column":"personBId"');
+  });
+
   it("rejects filtered join RHS shapes the relation lowering cannot alias safely", () => {
     expect(() =>
       definePermissions(socialApp, ({ policy }) => [

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -226,7 +226,7 @@ class PermissionRelationBuilder implements PermissionRelation {
     }
     const relation = isPermissionRelation(target) ? target : undefined;
     const table = relation
-      ? getRelationState(relation).outputTable
+      ? validateFilteredJoinRelation(relation, this.state).outputTable
       : relationJoinTargetToTable(target);
     const leftScope = currentRelationScope(this.state);
     const joins = [
@@ -1266,6 +1266,45 @@ function relationJoinTargetToTable(target: RelationJoinTarget): string {
   throw new Error(
     "join(...) expects a table relation, table builder (policy.<table>), or table name string.",
   );
+}
+
+/**
+ * A relation target is deliberately narrower than a normal relation. The
+ * lowering embeds it directly as the right side of the join, so it has no
+ * opportunity to allocate aliases for another relation tree. Keep that
+ * contract explicit until the lowering grows fresh alias rebinding.
+ */
+function validateFilteredJoinRelation(
+  relation: PermissionRelation,
+  leftState: RelationExprState,
+): RelationExprState {
+  const state = getRelationState(relation);
+  if (state.kind !== "table") {
+    throw new Error(
+      "join(...) relation RHS must be a filtered single-table relation; union(...) and gather(...) RHS are unsupported.",
+    );
+  }
+  if (state.joins.length > 0) {
+    throw new Error(
+      "join(...) relation RHS must be a filtered single-table relation; nested join(...) and hopTo(...) RHS are unsupported.",
+    );
+  }
+  if (state.selectMap && Object.keys(state.selectMap).length > 0) {
+    throw new Error(
+      "join(...) relation RHS must be a filtered single-table relation; select(...) RHS are unsupported.",
+    );
+  }
+  if (state.filters.length === 0) {
+    throw new Error(
+      "join(...) relation RHS must include where(...); pass policy.<table> directly for an unfiltered join.",
+    );
+  }
+  if (state.initialScope === leftState.initialScope) {
+    throw new Error(
+      `join(...) cannot use filtered relation "${state.outputTable}" as a same-table RHS without an alias. Use a distinct table or wait for aliased relation joins.`,
+    );
+  }
+  return state;
 }
 
 function resolveNamedRelation(

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -1415,7 +1415,7 @@ function resolveQualifiedRelationFilterScope(
 
   state.joins.forEach((join, index) => {
     if (join.table === qualifiedTable) {
-      scopes.add(relationJoinAlias(state.kind, join, index));
+      scopes.add(relationJoinScope(state, join, index));
     }
   });
 

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -1299,9 +1299,9 @@ function validateFilteredJoinRelation(
       "join(...) relation RHS must include where(...); pass policy.<table> directly for an unfiltered join.",
     );
   }
-  if (state.initialScope === leftState.initialScope) {
+  if (accumulatedRelationScopes(leftState).has(state.initialScope)) {
     throw new Error(
-      `join(...) cannot use filtered relation "${state.outputTable}" as a same-table RHS without an alias. Use a distinct table or wait for aliased relation joins.`,
+      `join(...) cannot use filtered relation scope "${state.initialScope}" because that scope is already present in the left relation. Use a distinct scope or wait for aliased relation joins.`,
     );
   }
   return state;
@@ -1345,7 +1345,28 @@ function currentRelationScope(state: RelationExprState): string {
 
   const joinIndex = state.joins.length - 1;
   const join = state.joins[joinIndex]!;
-  return relationJoinAlias(state.kind, join, joinIndex);
+  return relationJoinScope(state, join, joinIndex);
+}
+
+function relationJoinScope(
+  state: RelationExprState,
+  join: RelationJoinSpec,
+  index: number,
+): string {
+  return join.relation
+    ? currentRelationScope(getRelationState(join.relation))
+    : relationJoinAlias(state.kind, join, index);
+}
+
+function accumulatedRelationScopes(state: RelationExprState): Set<string> {
+  const scopes = new Set<string>();
+  if (state.initialScope) {
+    scopes.add(state.initialScope);
+  }
+  state.joins.forEach((join, index) => {
+    scopes.add(relationJoinScope(state, join, index));
+  });
+  return scopes;
 }
 
 function extractRelationFilters(

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -1687,6 +1687,7 @@ function applyRelationTail(options: {
   joinAlias: (join: RelationJoinSpec, index: number) => string;
 }): RelExpr {
   let relation = options.base;
+  let defaultScope = options.initialScope;
   let hasHopJoin = false;
 
   for (let i = 0; i < options.joins.length; i += 1) {
@@ -1708,6 +1709,7 @@ function applyRelationTail(options: {
         join_kind: "Inner",
       },
     };
+    defaultScope = rightScope;
     hasHopJoin ||= Boolean(join.viaHop);
   }
 

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -114,6 +114,8 @@ interface RelationJoinSpec {
   leftScope: string;
   left: string;
   right: string;
+  /** A separately filtered relation used as the right side of this join. */
+  relation?: PermissionRelation;
   viaHop?: boolean;
 }
 
@@ -149,7 +151,7 @@ interface TableJoinTarget {
   readonly __jazzPermissionTable: string;
 }
 
-type RelationJoinTarget = string | TableJoinTarget;
+type RelationJoinTarget = string | TableJoinTarget | PermissionRelation;
 
 export interface PermissionRelation {
   where(input: unknown): PermissionRelation;
@@ -222,7 +224,10 @@ class PermissionRelationBuilder implements PermissionRelation {
     if (this.state.kind === "union") {
       throw new Error("join(...) does not support union(...) relations in MVP.");
     }
-    const table = relationJoinTargetToTable(target);
+    const relation = isPermissionRelation(target) ? target : undefined;
+    const table = relation
+      ? getRelationState(relation).outputTable
+      : relationJoinTargetToTable(target);
     const leftScope = currentRelationScope(this.state);
     const joins = [
       ...this.state.joins,
@@ -231,6 +236,7 @@ class PermissionRelationBuilder implements PermissionRelation {
         left: on.left,
         leftScope,
         right: on.right,
+        relation,
       },
     ];
     return new PermissionRelationBuilder(
@@ -1257,7 +1263,9 @@ function relationJoinTargetToTable(target: RelationJoinTarget): string {
   ) {
     return target.__jazzPermissionTable;
   }
-  throw new Error("join(...) expects a table builder (policy.<table>) or table name string.");
+  throw new Error(
+    "join(...) expects a table relation, table builder (policy.<table>), or table name string.",
+  );
 }
 
 function resolveNamedRelation(
@@ -1640,26 +1648,27 @@ function applyRelationTail(options: {
   joinAlias: (join: RelationJoinSpec, index: number) => string;
 }): RelExpr {
   let relation = options.base;
-  let defaultScope = options.initialScope;
   let hasHopJoin = false;
 
   for (let i = 0; i < options.joins.length; i += 1) {
     const join = options.joins[i]!;
-    const rightScope = options.joinAlias(join, i);
+    const rightState = join.relation ? getRelationState(join.relation) : undefined;
+    const rightScope = rightState ? currentRelationScope(rightState) : options.joinAlias(join, i);
     relation = {
       Join: {
         left: relation,
-        right: {
-          TableScan: {
-            table: join.table,
-            alias: rightScope,
-          },
-        },
+        right: rightState
+          ? relationStateToRelExpr(rightState)
+          : {
+              TableScan: {
+                table: join.table,
+                alias: rightScope,
+              },
+            },
         on: [joinConditionFromSpec(join, rightScope)],
         join_kind: "Inner",
       },
     };
-    defaultScope = rightScope;
     hasHopJoin ||= Boolean(join.viaHop);
   }
 


### PR DESCRIPTION
🤖 Supersedes #1868 with only the still-live correlated-policy/provenance work on current main; nine historical staging patches already represented in main are intentionally omitted.

## Behavior

Filtered relation joins preserve correlated keys and receipt carriers. Their real table scope is used consistently for later joins and qualified filters, while ordinary unfiltered joins retain synthetic aliases.

A filtered authorization join remains correlated to the outer person:

```ts
policy.people
  .where({ profileId: profile.id })
  .join(
    policy.friendships.where({ personBId: session.personId }),
    { left: "id", right: "personAId" },
  )
```

A qualified filter after that join resolves against the real `friendships` scope—not a nonexistent synthetic alias:

```ts
policy.people
  .where({ profileId: profile.id })
  .join(
    policy.friendships.where({ personAId: session.personId }),
    { left: "id", right: "personAId" },
  )
  .where({ "friendships.personBId": session.personId })
```

Ambiguous scope reuse fails closed. This is rejected because both filtered RHS relations would bind the same `friendships` scope:

```ts
policy.people
  .join(policy.friendships.where({ personBId: session.personId }), {
    left: "id",
    right: "personAId",
  })
  .join(policy.friendships.where({ personBId: session.personId }), {
    left: "id",
    right: "personAId",
  })
```

Distinct filtered RHS scopes remain valid. Cross-workspace correlated references remain denied, and receipt-carrier suppression remains intact.

## Verification

- Permissions DSL: 51/51
- Focused Rust correlation, authorization, and receipt tests
- TypeScript typecheck, formatting, and lint
- Two adversarial review rounds with planted repeated-scope and qualified-filter alias failures