### PR TITLE
Bound browser auxiliary relay batches

### DIFF
--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3158,6 +3158,135 @@ mod dynamic_schema_view_tests {
         assert_eq!(opts.propagation, Propagation::Full);
     }
 
+    /// The host-visible transport boundary must honor both parts of its
+    /// auxiliary drain budget. This lives here rather than in the core pump
+    /// receipts because wasm-bindgen's optional-number ABI is part of the
+    /// browser worker contract: a stale generated package can otherwise hide
+    /// the count/byte arguments behind TypeScript mocks.
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    async fn wasm_auxiliary_drain_bounds_count_and_bytes_with_fifo_remainder() {
+        let schema = JazzSchema::new(&SchemaBuilder::new().build())
+            .expect("empty public schema compiles for transport receipt");
+        let refs = schema.column_families();
+        let refs = refs.iter().map(String::as_str).collect::<Vec<_>>();
+        let db = Rc::new(
+            Db::open(DbConfig::new(
+                schema,
+                MemoryStorage::new(&refs),
+                DbIdentity {
+                    node: jazz::ids::NodeUuid::from_bytes([0x63; 16]),
+                    author: AuthorId::from_bytes([0xc3; 16]),
+                },
+            ))
+            .await
+            .expect("open memory-backed wasm transport"),
+        );
+        let binding = WasmDb {
+            inner: WasmDbInner::Memory(db),
+            owns_runtime: false,
+        };
+        let transport = binding
+            .accept_subscriber(vec![0x73; 16], JsValue::NULL)
+            .expect("accept a real wasm subscriber transport");
+
+        let features = jazz::wire::current_wire_features()
+            & !(jazz::wire::FEATURE_PAYLOAD_LZ4 | jazz::wire::FEATURE_PAYLOAD_ZSTD);
+        let request = |request_id| jazz::protocol::ChunkRequestEntry {
+            request_id,
+            locator: vec![request_id as u8; 16],
+            expected_hash: [request_id as u8; 32],
+            // A hop-exhausted request has a deterministic immediate result,
+            // so the receipt exercises the binding drain without another
+            // transport or a semantic tick.
+            remaining_hops: 0,
+        };
+        let incoming =
+            jazz::protocol::SyncMessage::ChunkRequestBatch(jazz::protocol::ChunkRequestBatch {
+                requests: (1..=5).map(request).collect(),
+            });
+        let payload = jazz::wire::encode_sync_message_for_features(&incoming, features)
+            .expect("encode auxiliary chunk request batch");
+        let incoming_frame = jazz::wire::encode_frame(&jazz::wire::WireFrame::Message(
+            jazz::wire::WireEnvelope::new(jazz::wire::WIRE_PROTOCOL_VERSION, features, payload),
+        ))
+        .expect("frame auxiliary chunk request batch");
+        wasm_bindgen_futures::JsFuture::from(transport.route_auxiliary_wire_frame(incoming_frame))
+            .await
+            .expect("route actual auxiliary request through wasm binding");
+
+        let one_response =
+            jazz::protocol::SyncMessage::ChunkResponseBatch(jazz::protocol::ChunkResponseBatch {
+                responses: vec![jazz::protocol::ChunkResponseEntry {
+                    request_id: 1,
+                    result: jazz::protocol::ChunkResponse::Unavailable,
+                }],
+            });
+        let one_response_bytes =
+            jazz::wire::encode_sync_message_for_features(&one_response, features)
+                .expect("encode expected auxiliary response");
+        let one_response_frame = jazz::wire::encode_frame(&jazz::wire::WireFrame::Message(
+            jazz::wire::WireEnvelope::new(
+                jazz::wire::WIRE_PROTOCOL_VERSION,
+                features,
+                one_response_bytes,
+            ),
+        ))
+        .expect("frame expected auxiliary response");
+        let byte_budget = one_response_frame.len() as u32;
+
+        let decode_ids = |frames: js_sys::Array| {
+            frames
+                .iter()
+                .map(|frame| {
+                    let bytes = js_sys::Uint8Array::new(&frame).to_vec();
+                    assert!(
+                        bytes.len() <= byte_budget as usize,
+                        "each actual WASM result stays within the requested byte budget"
+                    );
+                    let jazz::wire::WireFrame::Message(envelope) = jazz::wire::decode_frame(&bytes)
+                        .expect("decode actual wasm response frame")
+                    else {
+                        panic!("auxiliary output remains a complete message frame");
+                    };
+                    let response =
+                        jazz::wire::decode_sync_message_for_features(&envelope.payload, features)
+                            .expect("decode actual wasm auxiliary response");
+                    let jazz::protocol::SyncMessage::ChunkResponseBatch(batch) = response else {
+                        panic!("subscriber sends a chunk response on the auxiliary lane");
+                    };
+                    assert_eq!(batch.responses.len(), 1);
+                    batch.responses[0].request_id
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let first = transport
+            .recv_auxiliary_wire_frames(Some(8), Some(byte_budget))
+            .expect("drain byte-bounded real wasm response batch");
+        assert_eq!(first.length(), 1, "byte budget admits only one frame");
+        assert_eq!(decode_ids(first), vec![1]);
+
+        let second = transport
+            .recv_auxiliary_wire_frames(Some(2), Some(byte_budget * 2))
+            .expect("drain count-bounded real wasm response batch");
+        assert_eq!(second.length(), 2, "count budget admits exactly two frames");
+        assert_eq!(decode_ids(second), vec![2, 3]);
+
+        let tail = transport
+            .recv_auxiliary_wire_frames(Some(8), Some(byte_budget * 8))
+            .expect("drain retained real wasm response remainder");
+        assert_eq!(decode_ids(tail), vec![4, 5], "remainder stays FIFO");
+        assert_eq!(
+            transport
+                .recv_auxiliary_wire_frames(Some(1), Some(byte_budget))
+                .expect("empty auxiliary drain")
+                .length(),
+            0,
+            "all queued frames are eventually drained"
+        );
+    }
+
     #[test]
     fn transaction_binding_diagnostics_use_transaction_vocabulary() {
         assert_eq!(

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -2147,13 +2147,30 @@ impl WasmTransport {
         })
     }
 
-    /// Drain complete auxiliary wire frames independently of semantic ticks.
+    /// Drain a bounded FIFO batch of complete auxiliary wire frames
+    /// independently of semantic ticks. Browser bindings choose a small
+    /// MessagePort batch so a burst of legal chunk responses cannot become one
+    /// giant structured-clone allocation.
     #[wasm_bindgen(js_name = recvAuxiliaryWireFrames)]
-    pub fn recv_auxiliary_wire_frames(&self) -> Result<js_sys::Array, JsValue> {
+    pub fn recv_auxiliary_wire_frames(
+        &self,
+        max_frames: Option<u32>,
+        max_bytes: Option<u32>,
+    ) -> Result<js_sys::Array, JsValue> {
+        let max_frames = max_frames.unwrap_or(1).max(1) as usize;
+        let max_bytes = max_bytes
+            .unwrap_or(jazz::protocol_limits::MAX_WIRE_FRAME_BYTES as u32)
+            .max(1) as usize;
         let frames = js_sys::Array::new();
-        while let Some(frame) = self
+        for frame in self
             .auxiliary_pump
-            .take_outbound_wire_frame(self.protocol_version, self.features, None)
+            .take_outbound_wire_frames(
+                self.protocol_version,
+                self.features,
+                None,
+                max_frames,
+                max_bytes,
+            )
             .map_err(|error| JsValue::from_str(&error))?
         {
             frames.push(&js_sys::Uint8Array::from(frame.as_slice()).into());

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -555,9 +555,69 @@ impl PeerIoPump {
         negotiated_features: crate::wire::WireFeatures,
         session: Option<crate::wire::WireSession>,
     ) -> Result<Option<Vec<u8>>, String> {
-        let Some(message) = self.take_outbound(1) else {
-            return Ok(None);
-        };
+        let mut frames = self.take_outbound_wire_frames(
+            protocol_version,
+            negotiated_features,
+            session,
+            1,
+            crate::protocol_limits::MAX_WIRE_FRAME_BYTES,
+        )?;
+        Ok(frames.pop())
+    }
+
+    /// Drain a bounded FIFO prefix of the auxiliary lane into complete wire
+    /// frames. If the next complete frame would exceed `max_bytes`, it remains
+    /// queued for a later drain; no response is dropped merely because a host
+    /// transport chooses a smaller batch boundary.
+    pub fn take_outbound_wire_frames(
+        &self,
+        protocol_version: u16,
+        negotiated_features: crate::wire::WireFeatures,
+        session: Option<crate::wire::WireSession>,
+        max_frames: usize,
+        max_bytes: usize,
+    ) -> Result<Vec<Vec<u8>>, String> {
+        if max_frames == 0 || max_bytes == 0 {
+            return Ok(Vec::new());
+        }
+        let mut frames = Vec::new();
+        let mut total_bytes: usize = 0;
+        while frames.len() < max_frames {
+            let Some(message) = self.take_outbound(1) else {
+                break;
+            };
+            let frame = Self::encode_outbound_wire_frame(
+                message.clone(),
+                protocol_version,
+                negotiated_features,
+                session.clone(),
+            )?;
+            let Some(next_total) = total_bytes.checked_add(frame.len()) else {
+                self.restore_outbound(message);
+                break;
+            };
+            if next_total > max_bytes {
+                self.restore_outbound(message);
+                if frames.is_empty() {
+                    return Err(format!(
+                        "auxiliary wire frame exceeds bounded drain budget: frame={} budget={max_bytes}",
+                        frame.len()
+                    ));
+                }
+                break;
+            }
+            total_bytes = next_total;
+            frames.push(frame);
+        }
+        Ok(frames)
+    }
+
+    fn encode_outbound_wire_frame(
+        message: SyncMessage,
+        protocol_version: u16,
+        negotiated_features: crate::wire::WireFeatures,
+        session: Option<crate::wire::WireSession>,
+    ) -> Result<Vec<u8>, String> {
         let payload = crate::wire::encode_sync_message_for_features(&message, negotiated_features)
             .map_err(|error| format!("cannot encode auxiliary sync payload: {error:?}"))?;
         let active_features = negotiated_features
@@ -568,7 +628,6 @@ impl PeerIoPump {
             envelope = envelope.with_session(session);
         }
         crate::wire::encode_frame(&crate::wire::WireFrame::Message(envelope))
-            .map(Some)
             .map_err(|error| format!("cannot encode auxiliary wire frame: {error}"))
     }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -249,12 +249,19 @@ impl PeerChunkResolver {
         state.outbound.drain(..count).collect()
     }
 
-    fn take_relay_responses(&self, connection: u64) -> Vec<ChunkResponseEntry> {
-        self.state
-            .borrow_mut()
-            .relay_responses
-            .remove(&connection)
-            .unwrap_or_default()
+    fn take_relay_responses(&self, connection: u64, limit: usize) -> Vec<ChunkResponseEntry> {
+        let mut state = self.state.borrow_mut();
+        let (responses, exhausted) = match state.relay_responses.get_mut(&connection) {
+            Some(queued) => {
+                let count = limit.min(queued.len());
+                (queued.drain(..count).collect(), queued.is_empty())
+            }
+            None => return Vec::new(),
+        };
+        if exhausted {
+            state.relay_responses.remove(&connection);
+        }
+        responses
     }
 
     fn is_active_upstream(&self, connection: u64) -> bool {
@@ -575,7 +582,7 @@ impl PeerIoPump {
                 ))
             }
             PeerIoPumpRole::Subscriber => {
-                let responses = self.resolver.take_relay_responses(self.connection);
+                let responses = self.resolver.take_relay_responses(self.connection, limit);
                 (!responses.is_empty()).then_some(SyncMessage::ChunkResponseBatch(
                     ChunkResponseBatch { responses },
                 ))

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -115,6 +115,70 @@ fn auxiliary_pump_completes_a_suspended_groove_chunk_read_without_a_semantic_tic
 }
 
 #[test]
+fn subscriber_auxiliary_responses_are_bounded_to_one_chunk_per_wire_frame() {
+    let resolver = PeerChunkResolver::default();
+    let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());
+    let database = crate::db::block_on(groove::db::Database::new(
+        schema,
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    let subscriber = PeerIoPump::new(
+        resolver.clone(),
+        database.local_chunk_reader(),
+        23,
+        PeerIoPumpRole::Subscriber,
+    );
+    let response_count = 10;
+    let chunk_bytes = vec![0x5a; groove::large_values::LEAF_MAX_BYTES];
+    resolver.state.borrow_mut().relay_responses.insert(
+        23,
+        (0..response_count)
+            .map(|request_id| ChunkResponseEntry {
+                request_id,
+                result: ChunkResponse::Found(chunk_bytes.clone()),
+            })
+            .collect(),
+    );
+
+    let features = crate::wire::current_wire_features();
+    let mut observed_request_ids = Vec::new();
+    for _ in 0..response_count {
+        let frame = subscriber
+            .take_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
+            .unwrap()
+            .expect("each queued response has its own wire frame");
+        assert!(
+            frame.len() <= crate::protocol_limits::MAX_WIRE_FRAME_BYTES,
+            "one auxiliary frame stays below the wire allocation limit"
+        );
+        let crate::wire::WireFrame::Message(envelope) = crate::wire::decode_frame(&frame).unwrap()
+        else {
+            panic!("auxiliary output is a complete message frame");
+        };
+        let payload =
+            crate::wire::decompress_sync_payload(&envelope.payload, envelope.features).unwrap();
+        let SyncMessage::ChunkResponseBatch(batch) =
+            crate::wire::decode_sync_message_for_features(&payload, features).unwrap()
+        else {
+            panic!("subscriber emits chunk responses");
+        };
+        assert_eq!(batch.responses.len(), 1, "the requested bound is honored");
+        observed_request_ids.push(batch.responses[0].request_id);
+    }
+    assert_eq!(
+        observed_request_ids,
+        (0..response_count).collect::<Vec<_>>()
+    );
+    assert!(
+        subscriber
+            .take_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
 fn dropping_the_last_suspended_consumer_cancels_unsent_chunk_demand() {
     let resolver = PeerChunkResolver::default();
     let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -179,6 +179,81 @@ fn subscriber_auxiliary_responses_are_bounded_to_one_chunk_per_wire_frame() {
 }
 
 #[test]
+fn bounded_auxiliary_drain_keeps_large_response_batches_fifo_and_within_bytes() {
+    let resolver = PeerChunkResolver::default();
+    let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());
+    let database = crate::db::block_on(groove::db::Database::new(
+        schema,
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    let subscriber = PeerIoPump::new(
+        resolver.clone(),
+        database.local_chunk_reader(),
+        24,
+        PeerIoPumpRole::Subscriber,
+    );
+    let response_count = 32_u64;
+    let chunk_bytes = vec![0x3c; groove::large_values::LEAF_MAX_BYTES];
+    resolver.state.borrow_mut().relay_responses.insert(
+        24,
+        (0..response_count)
+            .map(|request_id| ChunkResponseEntry {
+                request_id,
+                result: ChunkResponse::Found(chunk_bytes.clone()),
+            })
+            .collect(),
+    );
+
+    let features = crate::wire::current_wire_features();
+    let byte_budget = groove::large_values::LEAF_MAX_BYTES * 4;
+    let mut observed_request_ids = Vec::new();
+    loop {
+        let frames = subscriber
+            .take_outbound_wire_frames(
+                crate::wire::WIRE_PROTOCOL_VERSION,
+                features,
+                None,
+                8,
+                byte_budget,
+            )
+            .unwrap();
+        if frames.is_empty() {
+            break;
+        }
+        assert!(
+            frames.len() <= 8,
+            "frame-count budget bounds every host batch"
+        );
+        assert!(
+            frames.iter().map(Vec::len).sum::<usize>() <= byte_budget,
+            "byte budget bounds every host batch"
+        );
+        for frame in frames {
+            let crate::wire::WireFrame::Message(envelope) =
+                crate::wire::decode_frame(&frame).unwrap()
+            else {
+                panic!("auxiliary output is a complete message frame");
+            };
+            let payload =
+                crate::wire::decompress_sync_payload(&envelope.payload, envelope.features).unwrap();
+            let SyncMessage::ChunkResponseBatch(batch) =
+                crate::wire::decode_sync_message_for_features(&payload, features).unwrap()
+            else {
+                panic!("subscriber emits chunk responses");
+            };
+            assert_eq!(batch.responses.len(), 1, "per-frame bound remains intact");
+            observed_request_ids.push(batch.responses[0].request_id);
+        }
+    }
+    assert_eq!(
+        observed_request_ids,
+        (0..response_count).collect::<Vec<_>>(),
+        "each bounded drain preserves the queued response order and reaches the tail"
+    );
+}
+
+#[test]
 fn dropping_the_last_suspended_consumer_cancels_unsent_chunk_demand() {
     let resolver = PeerChunkResolver::default();
     let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());

--- a/dev/artifacts/verify-correctness-test-artifacts.mjs
+++ b/dev/artifacts/verify-correctness-test-artifacts.mjs
@@ -96,6 +96,26 @@ export function verifyCorrectnessTestArtifacts(rootDir = root) {
           `WASM ABI drift for WasmDb.${method}: consumer=${sourceArity}, d.ts=${typeArity}, glue=${glueArity}`,
         );
     }
+    const expectedTransport = classBody(
+      text("packages/jazz-tools/src/types/jazz-wasm.d.ts", rootDir),
+      "WasmTransport",
+    );
+    const generatedTransportTypes = classBody(
+      text("crates/jazz-wasm/pkg/jazz_wasm.d.ts", rootDir),
+      "WasmTransport",
+    );
+    const generatedTransportGlue = classBody(
+      text("crates/jazz-wasm/pkg/jazz_wasm.js", rootDir),
+      "WasmTransport",
+    );
+    const transportMethod = "recvAuxiliaryWireFrames";
+    const sourceArity = arityFromDeclaration(expectedTransport, transportMethod);
+    const typeArity = arityFromDeclaration(generatedTransportTypes, transportMethod);
+    const glueArity = arityFromGlue(generatedTransportGlue, transportMethod);
+    if (sourceArity !== typeArity || sourceArity !== glueArity)
+      failures.push(
+        `WASM ABI drift for WasmTransport.${transportMethod}: consumer=${sourceArity}, d.ts=${typeArity}, glue=${glueArity}`,
+      );
     const workerWasm = resolve(rootDir, "packages/jazz-tools/dist/worker/jazz_wasm_bg.wasm");
     const workerGlue = resolve(rootDir, "packages/jazz-tools/dist/worker/jazz-broker-worker.js");
     if (!existsSync(workerWasm) || !existsSync(workerGlue)) {

--- a/dev/artifacts/verify-correctness-test-artifacts.test.mjs
+++ b/dev/artifacts/verify-correctness-test-artifacts.test.mjs
@@ -18,15 +18,15 @@ function fixture() {
   // checks and prove their planted drift is reported alongside provenance.
   writeFileSync(
     join(root, "packages/jazz-tools/src/types/jazz-wasm.d.ts"),
-    `declare module "jazz-wasm" { export class WasmDb {\nconnectUpstream(): any;\nconnectUpstreamWithSession(a: number): any;\nacceptSubscriber(a: Uint8Array, claims: Record<string, (value: unknown, source: string) => void>): any;\n} }`,
+    `declare module "jazz-wasm" { export class WasmDb {\nconnectUpstream(): any;\nconnectUpstreamWithSession(a: number): any;\nacceptSubscriber(a: Uint8Array, claims: Record<string, (value: unknown, source: string) => void>): any;\n}\nexport class WasmTransport {\nrecvAuxiliaryWireFrames(maxFrames?: number, maxBytes?: number): Uint8Array[];\n} }`,
   );
   writeFileSync(
     join(root, "crates/jazz-wasm/pkg/jazz_wasm.d.ts"),
-    `export class WasmDb {\nconnectUpstream(): any;\nconnectUpstreamWithSession(a: number): any;\nacceptSubscriber(a: Uint8Array, claims: Record<string, (value: unknown, source: string) => void>): any;\n}`,
+    `export class WasmDb {\nconnectUpstream(): any;\nconnectUpstreamWithSession(a: number): any;\nacceptSubscriber(a: Uint8Array, claims: Record<string, (value: unknown, source: string) => void>): any;\n}\nexport class WasmTransport {\nrecvAuxiliaryWireFrames(max_frames?: number, max_bytes?: number): Array<any>;\n}`,
   );
   writeFileSync(
     join(root, "crates/jazz-wasm/pkg/jazz_wasm.js"),
-    `export class WasmDb {\nconnectUpstream() {}\nconnectUpstreamWithSession(a) {}\nacceptSubscriber(a, claims) {}\n}`,
+    `export class WasmDb {\nconnectUpstream() {}\nconnectUpstreamWithSession(a) {}\nacceptSubscriber(a, claims) {}\n}\nexport class WasmTransport {\nrecvAuxiliaryWireFrames(max_frames, max_bytes) {}\n}`,
   );
   writeFileSync(
     join(root, "crates/jazz/src/wire.rs"),
@@ -61,6 +61,19 @@ test("reports a wire-version mismatch", () => {
   assert.match(
     verifyCorrectnessTestArtifacts(root).join("\n"),
     /wire protocol version mismatch: Rust=9, TS=8/,
+  );
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("reports stale generated bounded auxiliary transport arguments", () => {
+  const root = fixture();
+  writeFileSync(
+    join(root, "crates/jazz-wasm/pkg/jazz_wasm.js"),
+    `export class WasmDb {\nconnectUpstream() {}\nconnectUpstreamWithSession(a) {}\nacceptSubscriber(a, claims) {}\n}\nexport class WasmTransport {\nrecvAuxiliaryWireFrames() {}\n}`,
+  );
+  assert.match(
+    verifyCorrectnessTestArtifacts(root).join("\n"),
+    /WasmTransport\.recvAuxiliaryWireFrames: consumer=2, d\.ts=2, glue=0/,
   );
   rmSync(root, { recursive: true, force: true });
 });

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
@@ -103,7 +103,7 @@ describe("BrowserWorkerTransportPump", () => {
     const auxiliary = Uint8Array.from([7, 7]);
     const semantic = Uint8Array.from([8, 8]);
     const sendWireFrame = vi.fn();
-    let releaseAuxiliaryRoute!: () => void;
+    let releaseAuxiliaryRoute!: (value: undefined) => void;
     const routeAuxiliaryWireFrame = vi.fn((frame: Uint8Array) => {
       if (frame[0] === 7) {
         return new Promise<undefined>((resolve) => (releaseAuxiliaryRoute = resolve));
@@ -121,7 +121,7 @@ describe("BrowserWorkerTransportPump", () => {
     await Promise.resolve();
     expect(sendWireFrame).not.toHaveBeenCalled();
 
-    releaseAuxiliaryRoute();
+    releaseAuxiliaryRoute(undefined);
     await vi.waitFor(() => expect(sendWireFrame).toHaveBeenCalledWith(semantic));
     expect(routeAuxiliaryWireFrame.mock.calls.map(([frame]) => frame)).toEqual([
       auxiliary,

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
@@ -95,6 +95,26 @@ describe("BrowserWorkerTransportPump", () => {
     pump.close();
   });
 
+  it("publishes an auxiliary chunk request while semantic evaluation is suspended", async () => {
+    const request = Uint8Array.from([9, 4]);
+    const sendFrames = vi.fn();
+    let resolveAuxiliaryReady!: () => void;
+    let auxiliaryFrames: Uint8Array[] = [];
+    const peer = transport({
+      tick: () => new Promise<number>(() => undefined),
+      recvAuxiliaryWireFrames: () => auxiliaryFrames.splice(0),
+      auxiliaryOutboundReady: () =>
+        new Promise<void>((resolve) => (resolveAuxiliaryReady = resolve)),
+    });
+    const pump = new BrowserWorkerTransportPump(runtime(peer), peer, sendFrames, vi.fn());
+
+    auxiliaryFrames = [request];
+    resolveAuxiliaryReady();
+
+    await vi.waitFor(() => expect(sendFrames).toHaveBeenCalledWith([request]));
+    pump.close();
+  });
+
   it("publishes an already-produced peer request before awaiting suspended evaluation", async () => {
     let release!: () => void;
     const request = Uint8Array.from([9, 3]);

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
@@ -95,6 +95,37 @@ describe("BrowserWorkerTransportPump", () => {
     pump.close();
   });
 
+  it("preserves FIFO across MessagePort batches while auxiliary routing is pending", async () => {
+    const auxiliary = Uint8Array.from([7, 7]);
+    const semantic = Uint8Array.from([8, 8]);
+    const sendWireFrame = vi.fn();
+    let releaseAuxiliaryRoute!: () => void;
+    const routeAuxiliaryWireFrame = vi.fn((frame: Uint8Array) => {
+      if (frame[0] === 7) {
+        return new Promise<undefined>((resolve) => (releaseAuxiliaryRoute = resolve));
+      }
+      return Promise.resolve(frame);
+    });
+    const peer = transport({ routeAuxiliaryWireFrame, sendWireFrame });
+    const pump = new BrowserWorkerTransportPump(runtime(peer), peer, () => undefined, vi.fn());
+
+    // A later port delivery must not overtake an earlier chunk response while
+    // the latter is still resolving through the dedicated auxiliary lane.
+    pump.receive([auxiliary]);
+    await vi.waitFor(() => expect(routeAuxiliaryWireFrame).toHaveBeenCalledWith(auxiliary));
+    pump.receive([semantic]);
+    await Promise.resolve();
+    expect(sendWireFrame).not.toHaveBeenCalled();
+
+    releaseAuxiliaryRoute();
+    await vi.waitFor(() => expect(sendWireFrame).toHaveBeenCalledWith(semantic));
+    expect(routeAuxiliaryWireFrame.mock.calls.map(([frame]) => frame)).toEqual([
+      auxiliary,
+      semantic,
+    ]);
+    pump.close();
+  });
+
   it("publishes an auxiliary chunk request while semantic evaluation is suspended", async () => {
     const request = Uint8Array.from([9, 4]);
     const sendFrames = vi.fn();

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
@@ -72,6 +72,29 @@ describe("BrowserWorkerTransportPump", () => {
     pump.close();
   });
 
+  it("routes worker chunk responses through the auxiliary lane", async () => {
+    const chunkResponse = Uint8Array.from([7, 7]);
+    const semanticFrame = Uint8Array.from([8, 8]);
+    const sendWireFrame = vi.fn();
+    const routeAuxiliaryWireFrame = vi.fn(async (frame: Uint8Array) => {
+      if (frame[0] === 7) return undefined;
+      return frame;
+    });
+    const peer = transport({
+      routeAuxiliaryWireFrame,
+      sendWireFrame,
+    });
+    const pump = new BrowserWorkerTransportPump(runtime(peer), peer, () => undefined, vi.fn());
+
+    // The chunk response is consumed by the dedicated auxiliary lane; only
+    // the following canonical frame reaches the normal transport queue.
+    pump.receive([chunkResponse, semanticFrame]);
+
+    await vi.waitFor(() => expect(routeAuxiliaryWireFrame).toHaveBeenCalledTimes(2));
+    expect(sendWireFrame).toHaveBeenCalledWith(semanticFrame);
+    pump.close();
+  });
+
   it("publishes an already-produced peer request before awaiting suspended evaluation", async () => {
     let release!: () => void;
     const request = Uint8Array.from([9, 3]);

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { BrowserWorkerTransportPump } from "./browser-worker-transport.js";
+import {
+  BrowserWorkerTransportPump,
+  MAX_AUXILIARY_BYTES_PER_PORT_MESSAGE,
+  MAX_AUXILIARY_FRAMES_PER_PORT_MESSAGE,
+} from "./browser-worker-transport.js";
 import type { Transport } from "./native-runtime-adapter.js";
 
 function runtime(peer: Transport) {
@@ -144,6 +148,134 @@ describe("BrowserWorkerTransportPump", () => {
 
     await vi.waitFor(() => expect(sendFrames).toHaveBeenCalledWith([request]));
     pump.close();
+  });
+
+  it("bounds auxiliary MessagePort batches, drains their FIFO tail, and yields to semantics", async () => {
+    vi.useFakeTimers();
+    try {
+      const sent: string[] = [];
+      const batches: Uint8Array[][] = [];
+      const frames = Array.from({ length: 10 }, (_, index) => {
+        const frame = new Uint8Array(400_000);
+        frame[0] = index + 1;
+        return frame;
+      });
+      let auxiliaryReady = false;
+      let releaseAuxiliaryReady!: () => void;
+      const recvAuxiliaryWireFrames = vi.fn((maxFrames = Infinity, maxBytes = Infinity) => {
+        if (!auxiliaryReady) return [];
+        const batch: Uint8Array[] = [];
+        let bytes = 0;
+        while (frames.length > 0 && batch.length < maxFrames) {
+          const frame = frames[0]!;
+          if (batch.length > 0 && bytes + frame.byteLength > maxBytes) break;
+          frames.shift();
+          batch.push(frame);
+          bytes += frame.byteLength;
+        }
+        return batch;
+      });
+      const peer = transport({
+        recvAuxiliaryWireFrames,
+        auxiliaryOutboundReady: () =>
+          auxiliaryReady
+            ? Promise.resolve()
+            : new Promise<void>((resolve) => (releaseAuxiliaryReady = resolve)),
+        tick: () => new Promise<number>(() => undefined),
+      });
+      const pump = new BrowserWorkerTransportPump(
+        {
+          onPeerTransportWork: () => () => undefined,
+          progressPeerTransport: () => new Promise<void>(() => undefined),
+          retirePeerTransport: async () => undefined,
+        },
+        peer,
+        (batch) => {
+          batches.push(batch);
+          sent.push(`aux:${batch.map((frame) => frame[0]).join(",")}`);
+        },
+        vi.fn(),
+      );
+
+      // Let the constructor's semantic pump enter its suspended tick before
+      // making auxiliary traffic available; the watch path below is then the
+      // only auxiliary drainer and its task yield is observable.
+      await Promise.resolve();
+      await Promise.resolve();
+      auxiliaryReady = true;
+      releaseAuxiliaryReady();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(batches).toHaveLength(1);
+      expect(recvAuxiliaryWireFrames).toHaveBeenLastCalledWith(
+        MAX_AUXILIARY_FRAMES_PER_PORT_MESSAGE,
+        MAX_AUXILIARY_BYTES_PER_PORT_MESSAGE,
+      );
+
+      const sendWireFrame = vi.fn((frame: Uint8Array) => sent.push(`semantic:${frame[0]}`));
+      peer.sendWireFrame = sendWireFrame;
+      pump.receive([Uint8Array.from([99])]);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(sent).toEqual(["aux:1,2", "semantic:99"]);
+
+      while (frames.length > 0) await vi.advanceTimersToNextTimerAsync();
+      expect(batches.flat().map((frame) => frame[0])).toEqual(
+        Array.from({ length: 10 }, (_, index) => index + 1),
+      );
+      for (const batch of batches) {
+        expect(batch).toHaveLength(2);
+        expect(batch.reduce((total, frame) => total + frame.byteLength, 0)).toBeLessThanOrEqual(
+          MAX_AUXILIARY_BYTES_PER_PORT_MESSAGE,
+        );
+      }
+      expect(sent[2]).toBe("aux:3,4");
+      pump.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops a scheduled bounded auxiliary continuation when closed", async () => {
+    vi.useFakeTimers();
+    try {
+      const sent = vi.fn();
+      const frames = [Uint8Array.from([1]), Uint8Array.from([2])];
+      let auxiliaryReady = false;
+      let releaseAuxiliaryReady!: () => void;
+      const peer = transport({
+        recvAuxiliaryWireFrames: () => (auxiliaryReady ? frames.splice(0, 1) : []),
+        auxiliaryOutboundReady: () =>
+          auxiliaryReady
+            ? Promise.resolve()
+            : new Promise<void>((resolve) => (releaseAuxiliaryReady = resolve)),
+        tick: () => new Promise<number>(() => undefined),
+      });
+      const pump = new BrowserWorkerTransportPump(
+        {
+          onPeerTransportWork: () => () => undefined,
+          progressPeerTransport: () => new Promise<void>(() => undefined),
+          retirePeerTransport: async () => undefined,
+        },
+        peer,
+        sent,
+        vi.fn(),
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+      auxiliaryReady = true;
+      releaseAuxiliaryReady();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(sent).toHaveBeenCalledTimes(1);
+      pump.close();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sent).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("publishes an already-produced peer request before awaiting suspended evaluation", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.ts
@@ -13,6 +13,10 @@ export class BrowserWorkerTransportPump {
   private runAgain = false;
   private closed = false;
   private outboundDrainScheduled = false;
+  // A MessagePort can deliver several batches before a WASM auxiliary routing
+  // promise settles. Keep their wire order: a later semantic frame must not
+  // overtake an earlier chunk response that wakes a suspended evaluator.
+  private inboundRouting: Promise<void> = Promise.resolve();
   private requestedGeneration = 0;
   private completedGeneration = 0;
   private readonly flushWaiters = new Set<{ target: number; resolve: () => void }>();
@@ -33,15 +37,10 @@ export class BrowserWorkerTransportPump {
 
   receive(frames: readonly Uint8Array[]): void {
     if (this.closed || frames.length === 0) return;
-    if (this.transport.sendWireFrames) {
-      this.transport.sendWireFrames(frames);
-    } else {
-      for (const frame of frames) this.transport.sendWireFrame(frame);
-    }
-    // Coverage waiters need evidence of a peer response, not merely evidence
-    // that our own pump ran after sending a request.
-    this.runtime.notifyPeerTransportActivity?.();
-    this.schedule();
+    const operation = this.inboundRouting.then(() => this.routeInboundFrames(frames));
+    this.inboundRouting = operation.catch((error) => {
+      if (!this.closed) this.onError(error);
+    });
   }
 
   schedule(runAgainIfRunning = true): void {
@@ -118,6 +117,30 @@ export class BrowserWorkerTransportPump {
       this.schedule();
     }
   }
+
+  private async routeInboundFrames(frames: readonly Uint8Array[]): Promise<void> {
+    if (this.closed) return;
+    const canonical: Uint8Array[] = [];
+    for (const frame of frames) {
+      const routed = this.transport.routeAuxiliaryWireFrame
+        ? await this.transport.routeAuxiliaryWireFrame(frame)
+        : frame;
+      if (routed != null) canonical.push(normalizeTransportFrame(routed));
+    }
+    if (this.closed) return;
+    if (canonical.length > 0) {
+      if (this.transport.sendWireFrames) {
+        this.transport.sendWireFrames(canonical);
+      } else {
+        for (const frame of canonical) this.transport.sendWireFrame(frame);
+      }
+    }
+    // Coverage waiters need evidence of a peer response, not merely evidence
+    // that our own pump ran after sending a request. Auxiliary frames count:
+    // they can be the response that resumes a blocked query evaluation.
+    this.runtime.notifyPeerTransportActivity?.();
+    this.schedule();
+  }
 }
 
 export function transferableFrames(frames: readonly Uint8Array[]): Uint8Array[] {
@@ -125,12 +148,14 @@ export function transferableFrames(frames: readonly Uint8Array[]): Uint8Array[] 
 }
 
 function normalizeTransportFrames(frames: unknown[]): Uint8Array[] {
-  return frames.map((frame) => {
-    if (frame instanceof Uint8Array) return frame;
-    if (frame instanceof ArrayBuffer) return new Uint8Array(frame);
-    if (ArrayBuffer.isView(frame)) {
-      return new Uint8Array(frame.buffer, frame.byteOffset, frame.byteLength);
-    }
-    throw new Error("Browser worker transport received a non-binary wire frame");
-  });
+  return frames.map(normalizeTransportFrame);
+}
+
+function normalizeTransportFrame(frame: unknown): Uint8Array {
+  if (frame instanceof Uint8Array) return frame;
+  if (frame instanceof ArrayBuffer) return new Uint8Array(frame);
+  if (ArrayBuffer.isView(frame)) {
+    return new Uint8Array(frame.buffer, frame.byteOffset, frame.byteLength);
+  }
+  throw new Error("Browser worker transport received a non-binary wire frame");
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.ts
@@ -32,6 +32,9 @@ export class BrowserWorkerTransportPump {
     // must not recursively request another identical pass.
     this.removeWorkListener = runtime.onPeerTransportWork(() => this.schedule(false));
     this.transport.setOutboundScheduler?.(() => this.scheduleOutboundDrain());
+    void this.watchAuxiliaryOutbound().catch((error) => {
+      if (!this.closed) this.onError(error);
+    });
     this.schedule(true);
   }
 
@@ -82,6 +85,10 @@ export class BrowserWorkerTransportPump {
     if (this.closed) return;
     const frames = normalizeTransportFrames(this.transport.recvWireFrames());
     if (frames.length > 0) this.sendFrames(frames);
+    const auxiliary = this.transport.recvAuxiliaryWireFrames;
+    if (!auxiliary) return;
+    const auxiliaryFrames = normalizeTransportFrames(auxiliary.call(this.transport));
+    if (auxiliaryFrames.length > 0) this.sendFrames(auxiliaryFrames);
   }
 
   private scheduleOutboundDrain(): void {
@@ -140,6 +147,18 @@ export class BrowserWorkerTransportPump {
     // they can be the response that resumes a blocked query evaluation.
     this.runtime.notifyPeerTransportActivity?.();
     this.schedule();
+  }
+
+  private async watchAuxiliaryOutbound(): Promise<void> {
+    while (!this.closed) {
+      const readiness = this.transport.auxiliaryOutboundReady?.();
+      if (!readiness || typeof readiness === "boolean") return;
+      await readiness;
+      if (this.closed) return;
+      // This path is deliberately independent of progressPeerTransport(): a
+      // root evaluator may be suspended on this very chunk request.
+      this.drainOutboundFrames();
+    }
   }
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-transport.ts
@@ -1,5 +1,11 @@
 import type { Transport } from "./native-runtime-adapter.js";
 
+// Keep auxiliary chunk traffic below a bounded structured-clone allocation.
+// A host may emit 256 KiB content-tree nodes, so this leaves room for several
+// complete frames without giving one MessagePort task an unbounded payload.
+export const MAX_AUXILIARY_FRAMES_PER_PORT_MESSAGE = 8;
+export const MAX_AUXILIARY_BYTES_PER_PORT_MESSAGE = 1024 * 1024;
+
 export interface PeerTransportRuntime {
   onPeerTransportWork(listener: () => void): () => void;
   notifyPeerTransportActivity?(): void;
@@ -81,14 +87,21 @@ export class BrowserWorkerTransportPump {
     await new Promise<void>((resolve) => this.flushWaiters.add({ target, resolve }));
   }
 
-  drainOutboundFrames(): void {
-    if (this.closed) return;
+  drainOutboundFrames(): boolean {
+    if (this.closed) return false;
     const frames = normalizeTransportFrames(this.transport.recvWireFrames());
     if (frames.length > 0) this.sendFrames(frames);
     const auxiliary = this.transport.recvAuxiliaryWireFrames;
-    if (!auxiliary) return;
-    const auxiliaryFrames = normalizeTransportFrames(auxiliary.call(this.transport));
+    if (!auxiliary) return false;
+    const auxiliaryFrames = normalizeTransportFrames(
+      auxiliary.call(
+        this.transport,
+        MAX_AUXILIARY_FRAMES_PER_PORT_MESSAGE,
+        MAX_AUXILIARY_BYTES_PER_PORT_MESSAGE,
+      ),
+    );
     if (auxiliaryFrames.length > 0) this.sendFrames(auxiliaryFrames);
+    return auxiliaryFrames.length > 0;
   }
 
   private scheduleOutboundDrain(): void {
@@ -157,7 +170,11 @@ export class BrowserWorkerTransportPump {
       if (this.closed) return;
       // This path is deliberately independent of progressPeerTransport(): a
       // root evaluator may be suspended on this very chunk request.
-      this.drainOutboundFrames();
+      const drainedAuxiliary = this.drainOutboundFrames();
+      // `auxiliaryOutboundReady()` remains immediately ready while a bounded
+      // drain leaves a remainder. Yield a browser task between batches so an
+      // upload burst cannot spin in microtasks or starve MessagePort input.
+      if (drainedAuxiliary) await yieldToBrowserTask();
     }
   }
 }
@@ -177,4 +194,8 @@ function normalizeTransportFrame(frame: unknown): Uint8Array {
     return new Uint8Array(frame.buffer, frame.byteOffset, frame.byteLength);
   }
   throw new Error("Browser worker transport received a non-binary wire frame");
+}
+
+function yieldToBrowserTask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -319,7 +319,7 @@ export type Transport = {
   setOutboundScheduler?(callback: () => void): void;
   clearOutboundScheduler?(): void;
   routeAuxiliaryWireFrame?(frame: Uint8Array): unknown | Promise<unknown>;
-  recvAuxiliaryWireFrames?(): unknown[];
+  recvAuxiliaryWireFrames?(maxFrames?: number, maxBytes?: number): unknown[];
   auxiliaryOutboundReady?(): boolean | Promise<void>;
   tick(): number | Promise<number>;
   updateAuthenticatedClaims?(claims: Record<string, unknown>): void | Promise<void>;

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -42,6 +42,9 @@ declare module "jazz-wasm" {
   export class WasmTransport {
     sendWireFrame(frame: Uint8Array): void;
     recvWireFrames(): Uint8Array[];
+    routeAuxiliaryWireFrame(frame: Uint8Array): Promise<Uint8Array | undefined>;
+    recvAuxiliaryWireFrames(maxFrames?: number, maxBytes?: number): Uint8Array[];
+    auxiliaryOutboundReady(): Promise<void>;
     tick(): Promise<number>;
     updateAuthenticatedClaims(claims: Record<string, unknown>): Promise<void>;
     close(): boolean;


### PR DESCRIPTION
🤖 This makes browser SharedWorker auxiliary/chunk traffic bounded and correctly routed without folding it into semantic subscription ticks.

Before:

- auxiliary chunk frames could enter the semantic tick path;
- multiple asynchronous MessagePort batches could reorder their frames;
- outbound auxiliary draining could build an unbounded `postMessage` batch;
- generated WASM glue could silently drift from the TypeScript consumer ABI.

After:

- auxiliary frames use their own inbound and outbound routes;
- complete inbound batches are serialized, preserving FIFO across asynchronous routing;
- each outbound drain is bounded to 8 frames or 1 MiB and yields between batches while retaining the queued tail;
- core chunk responses preserve FIFO when the next frame exceeds the current byte budget;
- a real WASM receipt and artifact-freshness guard verify the optional bounded-drain arguments through generated glue.

The bounds limit each handoff, not the total payload: remaining frames stay queued and are drained fairly by later browser tasks. A separate follow-up tracks bounding the number of inbound batches waiting behind asynchronous work.

Verification includes browser transport tests, Rust chunk-pump tests, Node WASM tests, TypeScript checks, and the generated-artifact guard. An independent adversarial review found no correctness issue.
