### PR TITLE
Add Inspector detach window

### DIFF
--- a/.changeset/inspectorDetachedWindow.md
+++ b/.changeset/inspectorDetachedWindow.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Let the in-app inspector move into a separate window that matches the dock dimensions and returns to the dock when the window closes.

--- a/.changeset/inspectorDetachedWindow.md
+++ b/.changeset/inspectorDetachedWindow.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Let the in-app inspector move into a separate window that matches the dock dimensions and returns to the dock when the window closes.
+Let the in-app inspector move into a separate window that matches the dock dimensions and returns to the dock when the window closes. The detached window opens with Alt+Shift+D, and its toolbar button can be hidden in settings.

--- a/packages/inspector/src/components/inspector-layout/index.test.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.test.tsx
@@ -1,6 +1,11 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { SettingsPage } from "../../pages/settings/index.js";
+import {
+  DETACH_SHORTCUT_TOOLTIP,
+  OVERLAY_SHOW_DETACH_BUTTON_STORAGE_KEY,
+} from "../../utility/overlay-settings.js";
 import { InspectorLayout } from "./index";
 
 const mockUseStandaloneContext = vi.fn();
@@ -17,16 +22,24 @@ vi.mock("../../contexts/devtools-context.js", () => ({
 }));
 
 vi.mock("../../utility/overlay-settings.js", () => ({
+  DETACH_SHORTCUT_KEYS: ["Alt", "Shift", "D"],
+  DETACH_SHORTCUT_TOOLTIP: "Open in separate window Alt+Shift+D",
+  OVERLAY_HIDE_LAUNCHER_STORAGE_KEY: "jazz-inspector-overlay:hide-toggle",
+  OVERLAY_SHOW_DETACH_BUTTON_STORAGE_KEY: "jazz-inspector-overlay:show-detach-button",
   isDetachedInspector: () => mockIsDetachedInspector(),
+  isBoolean: (value: unknown) => typeof value === "boolean",
   requestCloseOverlay: vi.fn(),
   requestDetachOverlay: (...args: unknown[]) => mockRequestDetachOverlay(...args),
+  setOverlayActiveRoute: vi.fn(),
 }));
 
 describe("InspectorLayout", () => {
   beforeEach(() => {
+    localStorage.clear();
     mockUseStandaloneContext.mockReset();
     mockUseDevtoolsContext.mockReset();
     mockIsDetachedInspector.mockReset();
+    mockRequestDetachOverlay.mockReset();
     mockIsDetachedInspector.mockReturnValue(false);
     mockUseDevtoolsContext.mockReturnValue({ runtime: "extension" });
   });
@@ -199,6 +212,35 @@ describe("InspectorLayout", () => {
     const detach = screen.getByRole("button", { name: "Open inspector in separate window" });
     fireEvent.click(detach);
     expect(mockRequestDetachOverlay).toHaveBeenCalledWith("/data-explorer/todos/data");
+    expect(screen.getByText(DETACH_SHORTCUT_TOOLTIP)).not.toBeNull();
+
+    fireEvent.keyDown(window, { altKey: true, shiftKey: true, code: "KeyD" });
+    expect(mockRequestDetachOverlay).toHaveBeenNthCalledWith(2, "/data-explorer/todos/data");
+  });
+
+  it("shows the detach button by default and lets settings hide it", () => {
+    mockUseStandaloneContext.mockReturnValue(null);
+    mockUseDevtoolsContext.mockReturnValue({ runtime: "overlay" });
+
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <Routes>
+          <Route element={<InspectorLayout />}>
+            <Route path="settings" element={<SettingsPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const visibility = screen.getByRole("switch", { name: "Show the detach button" });
+    expect(
+      screen.getByRole("button", { name: "Open inspector in separate window" }),
+    ).not.toBeNull();
+
+    fireEvent.click(visibility);
+
+    expect(screen.queryByRole("button", { name: "Open inspector in separate window" })).toBeNull();
+    expect(localStorage.getItem(OVERLAY_SHOW_DETACH_BUTTON_STORAGE_KEY)).toBe("false");
   });
 
   it("hides overlay window actions in a detached inspector", () => {

--- a/packages/inspector/src/components/inspector-layout/index.test.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.test.tsx
@@ -5,6 +5,8 @@ import { InspectorLayout } from "./index";
 
 const mockUseStandaloneContext = vi.fn();
 const mockUseDevtoolsContext = vi.fn();
+const mockIsDetachedInspector = vi.fn();
+const mockRequestDetachOverlay = vi.fn();
 
 vi.mock("../../contexts/standalone-context.js", () => ({
   useStandaloneContext: () => mockUseStandaloneContext(),
@@ -14,10 +16,18 @@ vi.mock("../../contexts/devtools-context.js", () => ({
   useDevtoolsContext: () => mockUseDevtoolsContext(),
 }));
 
+vi.mock("../../utility/overlay-settings.js", () => ({
+  isDetachedInspector: () => mockIsDetachedInspector(),
+  requestCloseOverlay: vi.fn(),
+  requestDetachOverlay: (...args: unknown[]) => mockRequestDetachOverlay(...args),
+}));
+
 describe("InspectorLayout", () => {
   beforeEach(() => {
     mockUseStandaloneContext.mockReset();
     mockUseDevtoolsContext.mockReset();
+    mockIsDetachedInspector.mockReset();
+    mockIsDetachedInspector.mockReturnValue(false);
     mockUseDevtoolsContext.mockReturnValue({ runtime: "extension" });
   });
 
@@ -174,5 +184,35 @@ describe("InspectorLayout", () => {
 
     expect(screen.queryByRole("button", { name: "Connections" })).toBeNull();
     expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("opens the active route in a separate window from overlay mode", () => {
+    mockUseStandaloneContext.mockReturnValue(null);
+    mockUseDevtoolsContext.mockReturnValue({ runtime: "overlay" });
+
+    render(
+      <MemoryRouter initialEntries={["/data-explorer/todos/data"]}>
+        <InspectorLayout />
+      </MemoryRouter>,
+    );
+
+    const detach = screen.getByRole("button", { name: "Open inspector in separate window" });
+    fireEvent.click(detach);
+    expect(mockRequestDetachOverlay).toHaveBeenCalledWith("/data-explorer/todos/data");
+  });
+
+  it("hides overlay window actions in a detached inspector", () => {
+    mockUseStandaloneContext.mockReturnValue(null);
+    mockUseDevtoolsContext.mockReturnValue({ runtime: "overlay" });
+    mockIsDetachedInspector.mockReturnValue(true);
+
+    render(
+      <MemoryRouter>
+        <InspectorLayout />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Open inspector in separate window" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close inspector" })).toBeNull();
   });
 });

--- a/packages/inspector/src/components/inspector-layout/index.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import { useStandaloneContext } from "../../contexts/standalone-context.js";
@@ -6,9 +7,13 @@ import {
   type SchemaHashInfo,
 } from "../../utility/schema-hash-display.js";
 import {
+  DETACH_SHORTCUT_TOOLTIP,
+  OVERLAY_SHOW_DETACH_BUTTON_STORAGE_KEY,
+  isBoolean,
   isDetachedInspector,
   requestCloseOverlay,
   requestDetachOverlay,
+  setOverlayActiveRoute,
 } from "../../utility/overlay-settings.js";
 import { useLocalStorageState } from "../../utility/use-local-storage-state.js";
 import { Tooltip } from "../tooltip/Tooltip.js";
@@ -89,8 +94,27 @@ export function InspectorLayout() {
     TABLES_PANEL_OPEN_STORAGE_KEY,
     true,
   );
+  const [showDetachButton, setShowDetachButton] = useLocalStorageState<boolean>(
+    OVERLAY_SHOW_DETACH_BUTTON_STORAGE_KEY,
+    true,
+    { isValid: isBoolean },
+  );
 
   const isDataExplorerRoute = location.pathname.startsWith("/data-explorer");
+  const activeRoute = `${location.pathname}${location.search}`;
+
+  useEffect(() => {
+    if (!isOverlay || isDetached) return;
+    setOverlayActiveRoute(activeRoute);
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!event.altKey || !event.shiftKey || event.code !== "KeyD") return;
+      event.preventDefault();
+      requestDetachOverlay(activeRoute);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeRoute, isDetached, isOverlay]);
 
   const onToggleTablesPanel = () => {
     setIsTablesPanelOpen((isOpen) => !isOpen);
@@ -158,16 +182,18 @@ export function InspectorLayout() {
           ) : null}
           {isOverlay && !isDetached ? (
             <>
-              <Tooltip label="Open in separate window">
-                <button
-                  type="button"
-                  onClick={() => requestDetachOverlay(`${location.pathname}${location.search}`)}
-                  className={styles.iconButton}
-                  aria-label="Open inspector in separate window"
-                >
-                  <PictureInPictureIcon />
-                </button>
-              </Tooltip>
+              {showDetachButton ? (
+                <Tooltip label={DETACH_SHORTCUT_TOOLTIP}>
+                  <button
+                    type="button"
+                    onClick={() => requestDetachOverlay(activeRoute)}
+                    className={styles.iconButton}
+                    aria-label="Open inspector in separate window"
+                  >
+                    <PictureInPictureIcon />
+                  </button>
+                </Tooltip>
+              ) : null}
               <Tooltip label="Close (Esc)">
                 <button
                   type="button"
@@ -183,7 +209,7 @@ export function InspectorLayout() {
         </div>
       </header>
       <section className={styles.content}>
-        <Outlet context={{ isTablesPanelOpen }} />
+        <Outlet context={{ isTablesPanelOpen, showDetachButton, setShowDetachButton }} />
       </section>
     </main>
   );

--- a/packages/inspector/src/components/inspector-layout/index.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.tsx
@@ -5,7 +5,11 @@ import {
   formatSchemaHashOptionLabel,
   type SchemaHashInfo,
 } from "../../utility/schema-hash-display.js";
-import { requestCloseOverlay } from "../../utility/overlay-settings.js";
+import {
+  isDetachedInspector,
+  requestCloseOverlay,
+  requestDetachOverlay,
+} from "../../utility/overlay-settings.js";
 import { useLocalStorageState } from "../../utility/use-local-storage-state.js";
 import { Tooltip } from "../tooltip/Tooltip.js";
 import styles from "./index.module.css";
@@ -53,9 +57,32 @@ function CloseIcon() {
   );
 }
 
+function PictureInPictureIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 10h6V4" />
+      <path d="m2 4 6 6" />
+      <path d="M21 10V7a2 2 0 0 0-2-2h-7" />
+      <path d="M3 14v2a2 2 0 0 0 2 2h3" />
+      <rect x="12" y="14" width="10" height="7" rx="1" />
+    </svg>
+  );
+}
+
 export function InspectorLayout() {
   const { runtime } = useDevtoolsContext();
   const isOverlay = runtime === "overlay";
+  const isDetached = isOverlay && isDetachedInspector();
   const standaloneContext = useStandaloneContext();
   const location = useLocation();
   const [isTablesPanelOpen, setIsTablesPanelOpen] = useLocalStorageState(
@@ -129,17 +156,29 @@ export function InspectorLayout() {
               </button>
             </>
           ) : null}
-          {isOverlay ? (
-            <Tooltip label="Close (Esc)">
-              <button
-                type="button"
-                onClick={requestCloseOverlay}
-                className={styles.iconButton}
-                aria-label="Close inspector"
-              >
-                <CloseIcon />
-              </button>
-            </Tooltip>
+          {isOverlay && !isDetached ? (
+            <>
+              <Tooltip label="Open in separate window">
+                <button
+                  type="button"
+                  onClick={() => requestDetachOverlay(`${location.pathname}${location.search}`)}
+                  className={styles.iconButton}
+                  aria-label="Open inspector in separate window"
+                >
+                  <PictureInPictureIcon />
+                </button>
+              </Tooltip>
+              <Tooltip label="Close (Esc)">
+                <button
+                  type="button"
+                  onClick={requestCloseOverlay}
+                  className={styles.iconButton}
+                  aria-label="Close inspector"
+                >
+                  <CloseIcon />
+                </button>
+              </Tooltip>
+            </>
           ) : null}
         </div>
       </header>

--- a/packages/inspector/src/contexts/host-link.test.tsx
+++ b/packages/inspector/src/contexts/host-link.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { INSPECTOR_HOST_GLOBAL } from "jazz-tools";
 import {
@@ -23,6 +23,7 @@ function installHost(subs: unknown[] = []) {
 
 afterEach(() => {
   delete (window as unknown as Record<string, unknown>)[INSPECTOR_HOST_GLOBAL];
+  Object.defineProperty(window, "opener", { configurable: true, value: null });
 });
 
 describe("host-link", () => {
@@ -42,6 +43,7 @@ describe("host-link", () => {
       window.dispatchEvent(
         new MessageEvent("message", {
           data: { type: "jazz-inspector:subscriptions", list: [{ id: "s2", table: "projects" }] },
+          origin: window.location.origin,
           // Real cross-window postMessage sets event.source to the sender;
           // window.parent === window in jsdom, so that's `window` here.
           source: window,
@@ -77,5 +79,56 @@ describe("host-link", () => {
       window.dispatchEvent(new MessageEvent("message", { data: { type: "other" } }));
     });
     expect(result.current).toEqual([]);
+  });
+
+  it("reads from and registers a detached window with its opener host", () => {
+    const registerInspectorWindow = vi.fn();
+    const unregisterInspectorWindow = vi.fn();
+    const opener = {
+      [INSPECTOR_HOST_GLOBAL]: {
+        getConnectionConfig: () => ({ appId: "detached" }),
+        getWasmSchema: () => ({ todos: { columns: [] } }),
+        getActiveSubscriptions: () => [{ id: "s1", table: "todos" }],
+        registerInspectorWindow,
+        unregisterInspectorWindow,
+      },
+    } as unknown as Window;
+    const previousOpener = window.opener;
+    Object.defineProperty(window, "opener", { configurable: true, value: opener });
+
+    const { result, unmount } = renderHook(() => useHostSubscriptions());
+
+    expect(readInspectorHostConfig()).toMatchObject({ appId: "detached" });
+    expect(result.current).toEqual([{ id: "s1", table: "todos" }]);
+    expect(registerInspectorWindow).toHaveBeenCalledWith(window);
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "jazz-inspector:subscriptions", list: [{ id: "s2", table: "projects" }] },
+          origin: window.location.origin,
+          source: opener,
+        }),
+      );
+    });
+    expect(result.current).toEqual([{ id: "s2", table: "projects" }]);
+
+    unmount();
+    expect(unregisterInspectorWindow).toHaveBeenCalledWith(window);
+    Object.defineProperty(window, "opener", { configurable: true, value: previousOpener });
+  });
+
+  it("falls back to the parent host when an opener's parent is cross-origin", () => {
+    installHost();
+    const opener = Object.create(null, {
+      parent: {
+        get() {
+          throw new DOMException("Blocked", "SecurityError");
+        },
+      },
+    }) as Window;
+    Object.defineProperty(window, "opener", { configurable: true, value: opener });
+
+    expect(readInspectorHostConfig()).toMatchObject({ appId: "app1" });
   });
 });

--- a/packages/inspector/src/contexts/host-link.ts
+++ b/packages/inspector/src/contexts/host-link.ts
@@ -24,29 +24,39 @@ export interface InspectorRuntimeSession {
 }
 
 /**
- * Reads the host handle the overlay loader publishes on the parent window
- * (`window.__jazzInspectorHost`). Same-origin only; returns null in the
- * standalone build (no parent) or if reading the parent throws.
+ * Reads the host handle from the dock's parent or the detached window's opener.
+ * Same-origin only; returns null in the standalone build.
  */
-function readHost(): JazzInspectorHost | null {
+function readHost(): { handle: JazzInspectorHost; window: Window } | null {
+  const candidates = [window.opener];
   try {
-    const host = (window.parent as unknown as Record<string, unknown>)[INSPECTOR_HOST_GLOBAL];
-    return (host as JazzInspectorHost | undefined) ?? null;
+    candidates.push(window.opener?.parent ?? null);
   } catch {
-    return null;
+    // A cross-origin opener may deny access to its parent.
   }
+  candidates.push(window.parent);
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const host = (candidate as unknown as Record<string, unknown>)[INSPECTOR_HOST_GLOBAL];
+      if (host) return { handle: host as JazzInspectorHost, window: candidate };
+    } catch {
+      // An opener candidate may cross an origin boundary.
+    }
+  }
+  return null;
 }
 
 export function readInspectorHostConfig(): DbConfig | null {
   const host = readHost();
-  return host ? host.getConnectionConfig() : null;
+  return host ? host.handle.getConnectionConfig() : null;
 }
 
 export function readInspectorHostSchema(): WasmSchema | null {
   const host = readHost();
   if (!host) return null;
   try {
-    return host.getWasmSchema();
+    return host.handle.getWasmSchema();
   } catch {
     // getWasmSchema throws while no schema exists anywhere yet (no client and
     // no defineApp) — treat that as "not ready" and let the poll retry.
@@ -57,7 +67,7 @@ export function readInspectorHostSchema(): WasmSchema | null {
 export async function openInspectorRuntimeSession(): Promise<InspectorRuntimeSession | null> {
   const host = readHost();
   if (!host) return null;
-  const control = await host.openControlPort();
+  const control = await host.handle.openControlPort();
   control.start();
   let nextId = 1;
 
@@ -110,15 +120,16 @@ export async function openInspectorRuntimeSession(): Promise<InspectorRuntimeSes
  */
 export function useHostSubscriptions(): InspectorSubscription[] {
   const [list, setList] = useState<InspectorSubscription[]>(
-    () => readHost()?.getActiveSubscriptions() ?? [],
+    () => readHost()?.handle.getActiveSubscriptions() ?? [],
   );
 
   useEffect(() => {
+    const host = readHost();
+    const isDetached = window.parent === window && window.opener !== null;
+    if (isDetached) host?.handle.registerInspectorWindow(window);
     const onMessage = (event: MessageEvent) => {
-      // The host handle push always comes from the parent window (same-origin,
-      // per readHost() above) — mirror the deleted bridge's event.source guard
-      // so an unrelated same-origin frame/tab can't spoof a subscription push.
-      if (event.source !== window.parent) return;
+      // Accept pushes only from the window that owns the host handle.
+      if (event.origin !== window.location.origin || event.source !== host?.window) return;
       const data = event.data as InspectorSubscriptionsMessage | undefined;
       if (data?.type === INSPECTOR_SUBSCRIPTIONS_MESSAGE && Array.isArray(data.list)) {
         setList(data.list);
@@ -126,9 +137,12 @@ export function useHostSubscriptions(): InspectorSubscription[] {
     };
     window.addEventListener("message", onMessage);
     // Re-read in case a push landed between initial render and listener attach.
-    const current = readHost()?.getActiveSubscriptions();
+    const current = host?.handle.getActiveSubscriptions();
     if (current) setList(current);
-    return () => window.removeEventListener("message", onMessage);
+    return () => {
+      window.removeEventListener("message", onMessage);
+      if (isDetached) host?.handle.unregisterInspectorWindow(window);
+    };
   }, []);
 
   return list;

--- a/packages/inspector/src/inspector-app.tsx
+++ b/packages/inspector/src/inspector-app.tsx
@@ -198,6 +198,7 @@ export function InspectorApp() {
 }
 
 function InspectorRuntime({ config, wasmSchema }: { config: DbConfig; wasmSchema: WasmSchema }) {
+  const initialRoute = new URLSearchParams(window.location.search).get("route") ?? "/";
   return (
     <InspectorConnectionErrorBoundary>
       <JazzProvider
@@ -206,7 +207,7 @@ function InspectorRuntime({ config, wasmSchema }: { config: DbConfig; wasmSchema
         fallback={<p style={{ padding: 16 }}>Connecting…</p>}
       >
         <DevtoolsProvider wasmSchema={wasmSchema} runtime="overlay">
-          <MemoryRouter>
+          <MemoryRouter initialEntries={[initialRoute]}>
             <InspectorRoutes />
           </MemoryRouter>
         </DevtoolsProvider>

--- a/packages/inspector/src/pages/settings/index.tsx
+++ b/packages/inspector/src/pages/settings/index.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from "react";
+import { useOutletContext } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import { useLocalStorageState } from "../../utility/use-local-storage-state.js";
-import { OVERLAY_HIDE_LAUNCHER_STORAGE_KEY, isBoolean } from "../../utility/overlay-settings.js";
+import {
+  DETACH_SHORTCUT_KEYS,
+  OVERLAY_HIDE_LAUNCHER_STORAGE_KEY,
+  isBoolean,
+} from "../../utility/overlay-settings.js";
 import styles from "./index.module.css";
 
 // macOS spells the shortcut with glyphs; everything else uses words. Computed
@@ -29,15 +34,21 @@ interface Shortcut {
   overlayOnly?: boolean;
 }
 
-// Mirrors the bindings wired in the overlay loader (Alt+Shift+J / Esc) and the
+// Mirrors the bindings wired in the overlay loader (Alt+Shift+J / Alt+Shift+D / Esc) and the
 // data grid (double-click / Del / Shift-click). Keep in sync if those change.
 const SHORTCUTS: Shortcut[] = [
   { keys: OPEN_SHORTCUT_KEYS, label: "Open or close the inspector", overlayOnly: true },
+  { keys: DETACH_SHORTCUT_KEYS, label: "Open in a separate window", overlayOnly: true },
   { keys: ["Esc"], label: "Close the inspector", overlayOnly: true },
   { keys: ["Double-click"], label: "Edit a cell" },
   { keys: ["Del"], label: "Delete the focused row" },
   { keys: ["Shift", "Click"], label: "Select a range of rows" },
 ];
+
+interface SettingsOutletContext {
+  showDetachButton: boolean;
+  setShowDetachButton: (show: boolean) => void;
+}
 
 interface ToggleRowProps {
   id: string;
@@ -80,6 +91,7 @@ function ToggleRow({ id, label, description, checked, onChange }: ToggleRowProps
 export function SettingsPage() {
   const { runtime } = useDevtoolsContext();
   const isOverlay = runtime === "overlay";
+  const { showDetachButton, setShowDetachButton } = useOutletContext<SettingsOutletContext>();
   const [hideLauncher, setHideLauncher] = useLocalStorageState<boolean>(
     OVERLAY_HIDE_LAUNCHER_STORAGE_KEY,
     false,
@@ -108,6 +120,18 @@ export function SettingsPage() {
                 }
                 checked={hideLauncher}
                 onChange={setHideLauncher}
+              />
+              <ToggleRow
+                id="show-detach-button"
+                label="Show the detach button"
+                description={
+                  <>
+                    Display the separate-window action in the inspector toolbar. You can always use{" "}
+                    <KeyCombo keys={DETACH_SHORTCUT_KEYS} />.
+                  </>
+                }
+                checked={showDetachButton}
+                onChange={setShowDetachButton}
               />
             </div>
           </section>

--- a/packages/inspector/src/test/setup.ts
+++ b/packages/inspector/src/test/setup.ts
@@ -1,6 +1,21 @@
 const dialogPrototype =
   globalThis.HTMLDialogElement?.prototype ?? globalThis.HTMLElement?.prototype;
 
+const localStorageValues = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    clear: () => localStorageValues.clear(),
+    getItem: (key: string) => localStorageValues.get(key) ?? null,
+    key: (index: number) => [...localStorageValues.keys()][index] ?? null,
+    get length() {
+      return localStorageValues.size;
+    },
+    removeItem: (key: string) => localStorageValues.delete(key),
+    setItem: (key: string, value: string) => localStorageValues.set(key, value),
+  } satisfies Storage,
+});
+
 if (typeof globalThis.confirm !== "function") {
   globalThis.confirm = () => false;
 }

--- a/packages/inspector/src/utility/overlay-settings.test.ts
+++ b/packages/inspector/src/utility/overlay-settings.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requestCloseOverlay, requestDetachOverlay } from "./overlay-settings.js";
+
+const initialUrl = window.location.href;
+
+describe("requestDetachOverlay", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState(null, "", initialUrl);
+    delete (window as unknown as Record<string, unknown>).__jazzInspectorOverlay;
+  });
+
+  it("detaches synchronously through the parent overlay", () => {
+    const detach = vi.fn(() => true);
+    (window as unknown as Record<string, unknown>).__jazzInspectorOverlay = { detach };
+    const trigger = document.createElement("button");
+    document.body.append(trigger);
+    trigger.focus();
+
+    requestDetachOverlay("/data-explorer/todos/data?filter=open");
+
+    expect(detach).toHaveBeenCalledWith("/data-explorer/todos/data?filter=open");
+    expect(document.activeElement).not.toBe(trigger);
+    trigger.remove();
+  });
+
+  it("keeps focus when the popup is blocked", () => {
+    const detach = vi.fn(() => false);
+    (window as unknown as Record<string, unknown>).__jazzInspectorOverlay = { detach };
+    const trigger = document.createElement("button");
+    document.body.append(trigger);
+    trigger.focus();
+
+    requestDetachOverlay("/data-explorer");
+
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  it("closes a detached inspector window", () => {
+    const close = vi.spyOn(window, "close").mockImplementation(() => {});
+    window.history.replaceState(null, "", "?detached=1");
+
+    requestCloseOverlay();
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/inspector/src/utility/overlay-settings.test.ts
+++ b/packages/inspector/src/utility/overlay-settings.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { requestCloseOverlay, requestDetachOverlay } from "./overlay-settings.js";
+import {
+  requestCloseOverlay,
+  requestDetachOverlay,
+  setOverlayActiveRoute,
+} from "./overlay-settings.js";
 
 const initialUrl = window.location.href;
 
@@ -35,6 +39,15 @@ describe("requestDetachOverlay", () => {
 
     expect(document.activeElement).toBe(trigger);
     trigger.remove();
+  });
+
+  it("synchronizes the active route with the parent overlay", () => {
+    const setActiveRoute = vi.fn();
+    (window as unknown as Record<string, unknown>).__jazzInspectorOverlay = { setActiveRoute };
+
+    setOverlayActiveRoute("/settings");
+
+    expect(setActiveRoute).toHaveBeenCalledWith("/settings");
   });
 
   it("closes a detached inspector window", () => {

--- a/packages/inspector/src/utility/overlay-settings.ts
+++ b/packages/inspector/src/utility/overlay-settings.ts
@@ -11,6 +11,14 @@
  * literal `true` / `false`, which the loader reads as `raw === "true"`.
  */
 export const OVERLAY_HIDE_LAUNCHER_STORAGE_KEY = "jazz-inspector-overlay:hide-toggle";
+export const OVERLAY_SHOW_DETACH_BUTTON_STORAGE_KEY = "jazz-inspector-overlay:show-detach-button";
+
+const IS_APPLE =
+  typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+export const DETACH_SHORTCUT_KEYS = IS_APPLE ? ["⌥", "⇧", "D"] : ["Alt", "Shift", "D"];
+export const DETACH_SHORTCUT_TOOLTIP = IS_APPLE
+  ? "Open in separate window ⌥⇧D"
+  : "Open in separate window Alt+Shift+D";
 
 export function isBoolean(value: unknown): value is boolean {
   return typeof value === "boolean";
@@ -23,6 +31,7 @@ const OVERLAY_CONTROL_GLOBAL = "__jazzInspectorOverlay";
 
 interface InspectorOverlayControl {
   detach(route: string): boolean;
+  setActiveRoute(route: string): void;
 }
 
 export function isDetachedInspector(): boolean {
@@ -39,6 +48,17 @@ export function requestDetachOverlay(route: string): void {
     }
   } catch {
     // No parent / cross-origin (e.g. standalone app) — nothing to detach.
+  }
+}
+
+export function setOverlayActiveRoute(route: string): void {
+  try {
+    const control = (window.parent as unknown as Record<string, unknown>)[OVERLAY_CONTROL_GLOBAL] as
+      | InspectorOverlayControl
+      | undefined;
+    control?.setActiveRoute(route);
+  } catch {
+    // No parent / cross-origin (e.g. standalone app) — nothing to synchronize.
   }
 }
 

--- a/packages/inspector/src/utility/overlay-settings.ts
+++ b/packages/inspector/src/utility/overlay-settings.ts
@@ -16,15 +16,39 @@ export function isBoolean(value: unknown): value is boolean {
   return typeof value === "boolean";
 }
 
-// postMessage type the overlay chrome (jazz-tools loader.ts) listens for to
-// dismiss the dock. The chrome owns no close button anymore — Close lives in the
-// inspector's top bar and asks the chrome to close via this message. Duplicated
-// in the loader on purpose (separate package); keep the two in sync.
+// The close message and direct overlay control are duplicated in jazz-tools'
+// loader on purpose (separate package); keep them in sync.
 const OVERLAY_CLOSE_MESSAGE_TYPE = "jazz-inspector-overlay:close";
+const OVERLAY_CONTROL_GLOBAL = "__jazzInspectorOverlay";
 
-/** Ask the overlay chrome (parent window) to close the inspector dock. */
+interface InspectorOverlayControl {
+  detach(route: string): boolean;
+}
+
+export function isDetachedInspector(): boolean {
+  return new URLSearchParams(window.location.search).get("detached") === "1";
+}
+
+export function requestDetachOverlay(route: string): void {
+  try {
+    const control = (window.parent as unknown as Record<string, unknown>)[OVERLAY_CONTROL_GLOBAL] as
+      | InspectorOverlayControl
+      | undefined;
+    if (control?.detach(route) && document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  } catch {
+    // No parent / cross-origin (e.g. standalone app) — nothing to detach.
+  }
+}
+
+/** Close a detached window or ask the overlay chrome to close the inspector dock. */
 export function requestCloseOverlay(): void {
   try {
+    if (isDetachedInspector()) {
+      window.close();
+      return;
+    }
     window.parent.postMessage({ type: OVERLAY_CLOSE_MESSAGE_TYPE }, window.location.origin);
   } catch {
     // No parent / cross-origin (e.g. standalone app) — nothing to close.

--- a/packages/inspector/src/utility/use-local-storage-state.test.tsx
+++ b/packages/inspector/src/utility/use-local-storage-state.test.tsx
@@ -46,4 +46,18 @@ describe("useLocalStorageState", () => {
 
     expect(screen.getByRole("button", { name: "5" })).not.toBeNull();
   });
+
+  it("updates when another window changes localStorage", () => {
+    render(<LocalStorageNumberProbe storageKey="test.storage.number" />);
+    localStorage.setItem("test.storage.number", "12");
+
+    fireEvent(
+      window,
+      new StorageEvent("storage", {
+        key: "test.storage.number",
+      }),
+    );
+
+    expect(screen.getByRole("button", { name: "12" })).not.toBeNull();
+  });
 });

--- a/packages/inspector/src/utility/use-local-storage-state.ts
+++ b/packages/inspector/src/utility/use-local-storage-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type Dispatch, type SetStateAction } from "react";
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
 
 interface UseLocalStorageStateOptions<T> {
   /**
@@ -54,6 +54,15 @@ export function useLocalStorageState<T>(
 ): [T, Dispatch<SetStateAction<T>>] {
   const { isValid } = options;
   const [value, setValue] = useState(() => readLocalStorageState(key, defaultValue, options));
+
+  useEffect(() => {
+    const syncStoredValue = (event: StorageEvent) => {
+      if (event.key !== null && event.key !== key) return;
+      setValue(readLocalStorageState(key, defaultValue, { isValid }));
+    };
+    window.addEventListener("storage", syncStoredValue);
+    return () => window.removeEventListener("storage", syncStoredValue);
+  }, [defaultValue, isValid, key]);
 
   const setStoredValue = useCallback<Dispatch<SetStateAction<T>>>(
     (nextValue) => {

--- a/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.test.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.test.ts
@@ -76,6 +76,48 @@ describe("installInspectorHost", () => {
     expect(posts).toHaveLength(2);
   });
 
+  it("pushes subscriptions to a registered detached inspector window", () => {
+    const iframePosts: any[] = [];
+    const popupPosts: any[] = [];
+    const iframeWindow = { postMessage: (m: any) => iframePosts.push(m) } as unknown as Window;
+    const popupWindow = { postMessage: (m: any) => popupPosts.push(m) } as unknown as Window;
+    const fake = makeFakeDb();
+
+    installInspectorHost(fake.db, iframeWindow, "http://localhost");
+    const handle = (window as any)[INSPECTOR_HOST_GLOBAL];
+    handle.registerInspectorWindow(popupWindow);
+    fake.fireChange();
+
+    expect(iframePosts).toHaveLength(2);
+    expect(popupPosts).toHaveLength(1);
+
+    handle.unregisterInspectorWindow(popupWindow);
+    fake.fireChange();
+    expect(popupPosts).toHaveLength(1);
+  });
+
+  it("keeps detached inspector windows across host rebinding", () => {
+    const inspectorWindows = new Set<Window>();
+    const iframeWindow = { postMessage: vi.fn() } as unknown as Window;
+    const popupWindow = { postMessage: vi.fn() } as unknown as Window;
+    const first = makeFakeDb();
+    const dispose = installInspectorHost(
+      first.db,
+      iframeWindow,
+      "http://localhost",
+      inspectorWindows,
+    );
+    const handle = (window as any)[INSPECTOR_HOST_GLOBAL];
+    handle.registerInspectorWindow(popupWindow);
+
+    dispose();
+    const second = makeFakeDb();
+    installInspectorHost(second.db, iframeWindow, "http://localhost", inspectorWindows);
+    second.fireChange();
+
+    expect(popupWindow.postMessage).toHaveBeenCalled();
+  });
+
   it("dispose() removes the listener and the global", () => {
     const iframeWindow = { postMessage: () => {} } as unknown as Window;
     const stop = vi.fn();

--- a/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
@@ -39,8 +39,14 @@ function buildOverlayDbConfig(config: DbConfig): DbConfig {
  * Publish the same-origin host handle and the one-way active-subscription feed.
  * No live Db crosses the iframe boundary and no devtools protocol is involved.
  */
-export function installInspectorHost(db: Db, iframeWindow: Window, origin: string): () => void {
+export function installInspectorHost(
+  db: Db,
+  iframeWindow: Window,
+  origin: string,
+  inspectorWindows = new Set<Window>(),
+): () => void {
   db.setDevMode(true);
+  inspectorWindows.add(iframeWindow);
 
   const handle: JazzInspectorHost = {
     getConnectionConfig() {
@@ -59,22 +65,34 @@ export function installInspectorHost(db: Db, iframeWindow: Window, origin: strin
     getActiveSubscriptions() {
       return serializeActiveSubscriptions(db.getActiveQuerySubscriptions());
     },
+    registerInspectorWindow(target) {
+      inspectorWindows.add(target);
+    },
+    unregisterInspectorWindow(target) {
+      inspectorWindows.delete(target);
+    },
   };
   (window as unknown as Record<string, unknown>)[INSPECTOR_HOST_GLOBAL] = handle;
 
   const push = () => {
-    iframeWindow.postMessage(
-      {
-        type: INSPECTOR_SUBSCRIPTIONS_MESSAGE,
-        list: handle.getActiveSubscriptions(),
-      },
-      origin,
-    );
+    const message = {
+      type: INSPECTOR_SUBSCRIPTIONS_MESSAGE,
+      list: handle.getActiveSubscriptions(),
+    };
+    for (const target of inspectorWindows) {
+      try {
+        if (target.closed) inspectorWindows.delete(target);
+        else target.postMessage(message, origin);
+      } catch {
+        inspectorWindows.delete(target);
+      }
+    }
   };
   const stop = db.onActiveQuerySubscriptionsChange(push);
 
   return () => {
     stop();
+    inspectorWindows.delete(iframeWindow);
     delete (window as unknown as Record<string, unknown>)[INSPECTOR_HOST_GLOBAL];
   };
 }

--- a/packages/jazz-tools/src/dev/inspector-overlay/inspector-host-types.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/inspector-host-types.ts
@@ -19,6 +19,8 @@ export interface JazzInspectorHost {
   getWasmSchema(): WasmSchema;
   /** Current active subscriptions, without JS stacks. */
   getActiveSubscriptions(): InspectorSubscription[];
+  registerInspectorWindow(target: Window): void;
+  unregisterInspectorWindow(target: Window): void;
 }
 
 export const INSPECTOR_HOST_GLOBAL = "__jazzInspectorHost" as const;

--- a/packages/jazz-tools/src/dev/inspector-overlay/loader.test.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/loader.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./host-bridge.js", () => ({
+  installInspectorHost: vi.fn(() => vi.fn()),
+}));
+
+class TestStyleSheet {
+  replaceSync() {}
+}
+
+describe("inspector overlay detached window", () => {
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    });
+    vi.useFakeTimers();
+    localStorage.setItem("jazz-inspector-overlay:open", "1");
+    vi.stubGlobal("CSSStyleSheet", TestStyleSheet);
+  });
+
+  afterEach(() => {
+    document.querySelector("jazz-inspector-overlay")?.remove();
+    localStorage.clear();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens at the dock size and restores the dock when the popup closes", async () => {
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      focus: vi.fn(),
+    } as unknown as Window;
+    const open = vi.spyOn(window, "open").mockReturnValue(popup);
+    const { startInspectorOverlay } = await import("./loader.js");
+
+    startInspectorOverlay({} as import("../../runtime/db.js").Db);
+    const overlay = document.querySelector("jazz-inspector-overlay");
+    const dock = overlay?.shadowRoot?.querySelector<HTMLElement>(".jzov-dock");
+    expect(dock?.dataset.open).toBe("true");
+    vi.spyOn(dock!, "getBoundingClientRect").mockReturnValue({
+      width: 1024,
+      height: 420,
+    } as DOMRect);
+
+    const control = (
+      window as unknown as { __jazzInspectorOverlay: { detach(route: string): boolean } }
+    ).__jazzInspectorOverlay;
+    expect(control.detach("/settings")).toBe(true);
+
+    expect(open).toHaveBeenCalledOnce();
+    const url = new URL(String(open.mock.calls[0]?.[0]));
+    expect(url.searchParams.get("detached")).toBe("1");
+    expect(url.searchParams.get("route")).toBe("/settings");
+    expect(open.mock.calls[0]?.[2]).toContain("width=1024,height=420");
+    expect(dock?.dataset.open).toBe("false");
+    expect(localStorage.getItem("jazz-inspector-overlay:open")).toBe("1");
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { altKey: true, shiftKey: true, code: "KeyJ" }),
+    );
+    expect(popup.focus).toHaveBeenCalledTimes(2);
+    expect(dock?.dataset.open).toBe("false");
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(localStorage.getItem("jazz-inspector-overlay:open")).toBe("1");
+
+    Object.defineProperty(popup, "closed", { value: true });
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { altKey: true, shiftKey: true, code: "KeyJ" }),
+    );
+
+    expect(dock?.dataset.open).toBe("true");
+    expect(localStorage.getItem("jazz-inspector-overlay:open")).toBe("1");
+
+    open.mockReturnValueOnce(null);
+    expect(control.detach("/settings")).toBe(false);
+    expect(dock?.dataset.open).toBe("true");
+
+    const replacementPopup = {
+      closed: false,
+      close: vi.fn(),
+      focus: vi.fn(),
+    } as unknown as Window;
+    open.mockReturnValue(replacementPopup);
+    control.detach("/settings");
+    window.dispatchEvent(new PageTransitionEvent("pagehide"));
+    expect(replacementPopup.close).toHaveBeenCalledOnce();
+    expect(dock?.dataset.open).toBe("true");
+  });
+});

--- a/packages/jazz-tools/src/dev/inspector-overlay/loader.test.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/loader.test.ts
@@ -9,6 +9,11 @@ class TestStyleSheet {
   replaceSync() {}
 }
 
+interface InspectorOverlayControl {
+  detach(route: string): boolean;
+  setActiveRoute(route: string): void;
+}
+
 describe("inspector overlay detached window", () => {
   beforeEach(() => {
     const values = new Map<string, string>();
@@ -48,10 +53,16 @@ describe("inspector overlay detached window", () => {
       height: 420,
     } as DOMRect);
 
-    const control = (
-      window as unknown as { __jazzInspectorOverlay: { detach(route: string): boolean } }
-    ).__jazzInspectorOverlay;
-    expect(control.detach("/settings")).toBe(true);
+    let control = (window as unknown as { __jazzInspectorOverlay: InspectorOverlayControl })
+      .__jazzInspectorOverlay;
+    control.setActiveRoute("/settings");
+    overlay?.remove();
+    document.body.append(overlay!);
+    control = (window as unknown as { __jazzInspectorOverlay: InspectorOverlayControl })
+      .__jazzInspectorOverlay;
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { altKey: true, shiftKey: true, code: "KeyD" }),
+    );
 
     expect(open).toHaveBeenCalledOnce();
     const url = new URL(String(open.mock.calls[0]?.[0]));

--- a/packages/jazz-tools/src/dev/inspector-overlay/loader.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/loader.ts
@@ -10,9 +10,11 @@ const TOGGLE_POS_KEY = "jazz-inspector-overlay:toggle-pos";
 // button is hidden and the overlay opens only via the keyboard shortcut. Stored
 // as JSON by the iframe, hence the `=== "true"` parse below.
 const HIDE_TOGGLE_KEY = "jazz-inspector-overlay:hide-toggle";
-// postMessage type the inspector's in-iframe Close button posts to the top
-// window to dismiss the dock; see packages/inspector/src/utility/overlay-settings.ts.
+// postMessage types the inspector iframe sends to dismiss the dock; see
+// packages/inspector/src/utility/overlay-settings.ts.
 const CLOSE_MESSAGE_TYPE = "jazz-inspector-overlay:close";
+const OVERLAY_CONTROL_GLOBAL = "__jazzInspectorOverlay";
+const DETACHED_WINDOW_NAME = "jazz-inspector-detached";
 const MIN_HEIGHT = 200;
 const DEFAULT_RATIO = 0.42;
 const TOGGLE_SIZE = 44;
@@ -226,6 +228,7 @@ const TEMPLATE = `
 class HostBinding {
   #db: InspectorHostDb | undefined;
   #iframeWindow: Window | undefined;
+  #inspectorWindows = new Set<Window>();
   #bound: { db: InspectorHostDb; iframeWindow: Window; dispose: () => void } | undefined;
 
   setDb(db: InspectorHostDb): void {
@@ -242,6 +245,7 @@ class HostBinding {
   unbind(): void {
     this.#iframeWindow = undefined;
     this.#dispose();
+    this.#inspectorWindows.clear();
   }
 
   #rebind(): void {
@@ -257,7 +261,12 @@ class HostBinding {
     this.#bound = {
       db: this.#db,
       iframeWindow: this.#iframeWindow,
-      dispose: installInspectorHost(this.#db, this.#iframeWindow, window.location.origin),
+      dispose: installInspectorHost(
+        this.#db,
+        this.#iframeWindow,
+        window.location.origin,
+        this.#inspectorWindows,
+      ),
     };
   }
 
@@ -322,13 +331,16 @@ class JazzInspectorOverlay extends HTMLElement {
     applyTogglePos(togglePos);
 
     let open = readOpen();
+    let detachedWindow: Window | null = null;
+    let detachedWindowCheck: ReturnType<typeof setInterval> | undefined;
     // When the user opts into keyboard-only mode, the toggle stays hidden even
     // while the dock is closed; the shortcut is then the only way to open it.
     let hideToggle = readHideToggle();
     const apply = (): void => {
-      dock.dataset.open = open ? "true" : "false";
-      toggle.hidden = open || hideToggle;
-      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+      const dockOpen = open && detachedWindow === null;
+      dock.dataset.open = dockOpen ? "true" : "false";
+      toggle.hidden = dockOpen || detachedWindow !== null || hideToggle;
+      toggle.setAttribute("aria-expanded", dockOpen ? "true" : "false");
     };
     const setOpen = (next: boolean): void => {
       if (open === next) return;
@@ -338,6 +350,57 @@ class JazzInspectorOverlay extends HTMLElement {
       // Return focus to the toggle on close, but only if it's actually visible.
       if (!open && !toggle.hidden) toggle.focus();
     };
+    const stopDetachedWindowCheck = (): void => {
+      if (detachedWindowCheck === undefined) return;
+      clearInterval(detachedWindowCheck);
+      detachedWindowCheck = undefined;
+    };
+    const restoreDockIfDetachedWindowClosed = (): boolean => {
+      if (!detachedWindow?.closed) return false;
+      detachedWindow = null;
+      stopDetachedWindowCheck();
+      apply();
+      return true;
+    };
+    const closeDetachedWindow = (): void => {
+      stopDetachedWindowCheck();
+      detachedWindow?.close();
+      detachedWindow = null;
+      apply();
+    };
+    const openDetachedWindow = (route: string): boolean => {
+      const url = new URL(iframe.src);
+      url.searchParams.set("detached", "1");
+      url.searchParams.set("route", route);
+      const rect = dock.getBoundingClientRect();
+      const width = Math.round(rect.width || window.innerWidth);
+      const height = Math.round(rect.height || readHeight() || MIN_HEIGHT);
+      const top = Math.round(window.screenY + window.outerHeight - height);
+      const popup = window.open(
+        url,
+        DETACHED_WINDOW_NAME,
+        `popup,width=${width},height=${height},left=${window.screenX},top=${top}`,
+      );
+      if (!popup) return false;
+      detachedWindow = popup;
+      popup.focus();
+      apply();
+      stopDetachedWindowCheck();
+      detachedWindowCheck = setInterval(restoreDockIfDetachedWindowClosed, 250);
+      return true;
+    };
+    signal.addEventListener("abort", closeDetachedWindow, { once: true });
+    window.addEventListener("pagehide", closeDetachedWindow, { signal });
+    const overlayControl = { detach: openDetachedWindow };
+    (window as unknown as Record<string, unknown>)[OVERLAY_CONTROL_GLOBAL] = overlayControl;
+    signal.addEventListener(
+      "abort",
+      () => {
+        const host = window as unknown as Record<string, unknown>;
+        if (host[OVERLAY_CONTROL_GLOBAL] === overlayControl) delete host[OVERLAY_CONTROL_GLOBAL];
+      },
+      { once: true },
+    );
 
     // Drag to reposition; a click that didn't drag opens the inspector.
     let dragMoved = false;
@@ -391,8 +454,13 @@ class JazzInspectorOverlay extends HTMLElement {
         // "j". `e.code === "KeyJ"` is layout- and modifier-independent.
         if (e.altKey && e.shiftKey && e.code === "KeyJ") {
           e.preventDefault();
+          if (restoreDockIfDetachedWindowClosed()) return;
+          if (detachedWindow && !detachedWindow.closed) {
+            detachedWindow.focus();
+            return;
+          }
           setOpen(!open);
-        } else if (e.key === "Escape" && open) {
+        } else if (e.key === "Escape" && open && detachedWindow === null) {
           setOpen(false);
         }
       },
@@ -449,16 +517,14 @@ class JazzInspectorOverlay extends HTMLElement {
     hostBinding.setIframeWindow(iframe.contentWindow ?? undefined);
     signal.addEventListener("abort", () => hostBinding.unbind(), { once: true });
 
-    // The in-iframe Close button posts up here (same-origin).
+    // The iframe posts here when the dock closes.
     window.addEventListener(
       "message",
       (event) => {
-        if (
-          event.origin === window.location.origin &&
-          (event.data as { type?: unknown } | null)?.type === CLOSE_MESSAGE_TYPE
-        ) {
-          setOpen(false);
-        }
+        if (event.origin !== window.location.origin || event.source !== iframe.contentWindow)
+          return;
+        const data = event.data as { type?: unknown } | null;
+        if (data?.type === CLOSE_MESSAGE_TYPE) setOpen(false);
       },
       { signal },
     );

--- a/packages/jazz-tools/src/dev/inspector-overlay/loader.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/loader.ts
@@ -283,6 +283,7 @@ const hostBinding = new HostBinding();
 // registered against #ac.signal so disconnectedCallback() removes them at once.
 class JazzInspectorOverlay extends HTMLElement {
   #ac: AbortController | undefined;
+  #activeRoute = "/data-explorer";
 
   // Constructed once and shared by adoptedStyleSheets, so the (large) CSS is
   // parsed a single time rather than re-injected as a <style> per mount.
@@ -391,7 +392,12 @@ class JazzInspectorOverlay extends HTMLElement {
     };
     signal.addEventListener("abort", closeDetachedWindow, { once: true });
     window.addEventListener("pagehide", closeDetachedWindow, { signal });
-    const overlayControl = { detach: openDetachedWindow };
+    const overlayControl = {
+      detach: openDetachedWindow,
+      setActiveRoute: (route: string) => {
+        this.#activeRoute = route;
+      },
+    };
     (window as unknown as Record<string, unknown>)[OVERLAY_CONTROL_GLOBAL] = overlayControl;
     signal.addEventListener(
       "abort",
@@ -460,6 +466,14 @@ class JazzInspectorOverlay extends HTMLElement {
             return;
           }
           setOpen(!open);
+        } else if (e.altKey && e.shiftKey && e.code === "KeyD") {
+          e.preventDefault();
+          restoreDockIfDetachedWindowClosed();
+          if (detachedWindow && !detachedWindow.closed) {
+            detachedWindow.focus();
+            return;
+          }
+          if (openDetachedWindow(this.#activeRoute)) setOpen(true);
         } else if (e.key === "Escape" && open && detachedWindow === null) {
           setOpen(false);
         }


### PR DESCRIPTION
## Summary

Adds a detachable in-app inspector window and controls for opening it without keeping the toolbar action visible.

### Behavior before

- The inspector was available only as a docked overlay.
- The toolbar had no detach shortcut or visibility preference.
- Inspector routes existed only inside the docked iframe.

### Behavior after

- The toolbar can open the inspector in a separate browser window.
- The detached window matches the dock dimensions and opens on the active inspector route.
- Closing the detached window restores the dock.
- `Alt+Shift+D` opens the detached window from either the host page or inspector iframe.
- The Settings page can hide the detach button while keeping the shortcut available.
- Route and preference state remain synchronized across the host, docked iframe, detached window, and overlay reconnects.

### Validation

- `pnpm build:core`
- `pnpm --filter jazz-tools build`
- `pnpm --filter inspector build`
- `pnpm --filter inspector test`
- `pnpm --filter jazz-tools test:node -- src/dev/inspector-overlay/loader.test.ts`
- Browser manual test: Helium and brave (Chronium-based); Orion (Safari-based)

### Examples

https://github.com/user-attachments/assets/5bc0382a-a09b-4d61-81a0-d66f3c041074

**Detach from the toolbar**

1. Open a table in Data Explorer.
2. Select the separate-window toolbar action.
3. The dock hides and a window opens on the same table route.
4. Close the window.
5. The dock returns.

**Detach with the shortcut**

1. Navigate within the inspector.
2. Press Alt+Shift+D while focus is in either the host page or inspector.
3. The detached window opens on the active route.
4. Press the shortcut again to focus the existing window.

**Hide the toolbar action**

1. Open Inspector Settings.
2. Disable “Show the detach button.”
3. The toolbar action disappears and the preference persists.
4. Alt+Shift+D remains available.
