### PR TITLE
fix: align native declaration guard

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -17,12 +17,23 @@ export declare class NapiDb {
   upsertEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, options?: UpsertOptions | undefined | null): Write
   deleteEncoded(table: string, rowId: Uint8Array, options?: DeleteOptions | undefined | null): Write
   restoreEncoded(table: string, rowId: Uint8Array, cells?: Uint8Array | undefined | null, options?: RestoreOptions | undefined | null): Write
+  /**
+   * Backend-only root mutation entrypoints. They deliberately do not take
+   * branch selectors: attributed branch writes fail closed until #1881's
+   * split transaction/branch representation is designed.
+   */
   insertWithIdEncodedAttributed(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array): Write
   updateEncodedAttributed(table: string, rowId: Uint8Array, patch: Uint8Array, author: Uint8Array): Write
   upsertEncodedAttributed(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array): Write
   deleteAttributed(table: string, rowId: Uint8Array, author: Uint8Array): Write
   restoreEncodedAttributed(table: string, rowId: Uint8Array, cells: Uint8Array, author: Uint8Array): Write
   beginStreamingMutationEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, column: string, kind: string, mutation?: string | undefined | null, author?: Uint8Array | undefined | null, updatedAtMs?: number | undefined | null, head?: JsonValue | undefined | null, base?: JsonValue | undefined | null): StreamingMutation
+  /**
+   * Trusted-backend streaming counterpart: SYSTEM remains the admission
+   * identity and `attribution` is retained only for final row provenance.
+   * Branch streaming is intentionally unsupported until its split state is
+   * designed, so it fails closed rather than silently losing attribution.
+   */
   beginStreamingMutationAttributedEncoded(table: string, rowId: Uint8Array, cells: Uint8Array, column: string, kind: string, mutation: string | undefined | null, author: Uint8Array | undefined | null, attribution: Uint8Array, updatedAtMs?: number | undefined | null, head?: JsonValue | undefined | null, base?: JsonValue | undefined | null): StreamingMutation
   static openMemory(schema: Uint8Array, config: Uint8Array): NapiDb
   /**
@@ -55,7 +66,11 @@ export declare class NapiDb {
   attachExclusiveTx(openBatchId: string): Tx
   /** Begin one owner-wide transaction without creating an owning per-schema Tx. */
   beginTransaction(openBatchId: string, kind: string, author?: Uint8Array | undefined | null): void
-  /** Begin the only supported backend-attributed transaction shape: mergeable root writes. */
+  /**
+   * Begin the only supported attributed transaction shape. Keeping this a
+   * distinct native ABI makes an older binding fail closed rather than
+   * silently treating provenance as ordinary SYSTEM authorship.
+   */
   beginTransactionAttributed(openBatchId: string, attribution: Uint8Array): void
   /** Commit an owner-wide transaction by id and optional kind. */
   commitTransaction(openBatchId: string, kind?: string | undefined | null): Write

--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -280,6 +280,33 @@ function assertRealNapiGeneration(path, expectedBinding, { sealed = true } = {})
   if (sealed) required.push([join(path, ".jazz-artifact-manifest.json"), "sealed manifest"]);
   for (const [candidate, label] of required) realRegularFile(candidate, label);
 }
+function displayArtifactPath(path) {
+  return relative(root, path).replaceAll("\\\\", "/");
+}
+function declarationMismatchDiagnostic(stablePath, generatedPath, stable, generated) {
+  const stableLines = stable.split("\n");
+  const generatedLines = generated.split("\n");
+  const firstDifference = stableLines.findIndex((line, index) => line !== generatedLines[index]);
+  const line =
+    firstDifference === -1 ? Math.min(stableLines.length, generatedLines.length) : firstDifference;
+  const start = Math.max(0, line - 2);
+  const end = Math.min(Math.max(stableLines.length, generatedLines.length), line + 3);
+  const render = (lines, prefix) =>
+    lines
+      .slice(start, end)
+      .map((value, index) => `${prefix}${String(start + index + 1).padStart(5)} | ${value}`)
+      .join("\n");
+  return [
+    "NAPI build generated declarations that differ from the public package type surface; update the checked-in declaration before activating.",
+    `checked-in declarations: ${displayArtifactPath(stablePath)}`,
+    `generated declarations: ${displayArtifactPath(generatedPath)}`,
+    `first difference near line ${line + 1}:`,
+    "--- checked-in",
+    render(stableLines, "-"),
+    "+++ generated",
+    render(generatedLines, "+"),
+  ].join("\n");
+}
 function publishExpectedFingerprint(kind, fingerprint) {
   // Producer tasks never mutate jazz-tools source. Release assembly derives
   // its expectation modules from the sealed downloaded manifests.
@@ -343,9 +370,16 @@ export function validateNapiStage(
   const loader = join(stagePath, "index.js");
   const declarations = join(stagePath, "index.d.ts");
   assertRealNapiGeneration(stagePath, expectedBinding, { sealed: false });
-  if (readFileSync(declarations, "utf8") !== readFileSync(stableDeclarationsPath, "utf8"))
+  const generatedDeclarations = readFileSync(declarations, "utf8");
+  const stableDeclarations = readFileSync(stableDeclarationsPath, "utf8");
+  if (generatedDeclarations !== stableDeclarations)
     throw new Error(
-      "NAPI build generated declarations that differ from the public package type surface; update the checked-in declaration before activating",
+      declarationMismatchDiagnostic(
+        stableDeclarationsPath,
+        declarations,
+        stableDeclarations,
+        generatedDeclarations,
+      ),
     );
   if (target !== hostTarget) return;
   const receipt = spawnSync(

--- a/dev/artifacts/napi-build-contract.test.mjs
+++ b/dev/artifacts/napi-build-contract.test.mjs
@@ -173,13 +173,23 @@ test("a newly generated public export absent from the stable package declaration
       join(staged, "index.d.ts"),
       "export declare class NapiDb { tick(): void }\nexport declare function newlyGeneratedExport(): void\n",
     );
-    assert.throws(
-      () =>
-        validateNapiStage(staged, "jazz-napi.linux-x64-gnu.node", "next", "cross-target", {
-          stableDeclarationsPath: stableDeclarations,
-        }),
+    let error;
+    try {
+      validateNapiStage(staged, "jazz-napi.linux-x64-gnu.node", "next", "cross-target", {
+        stableDeclarationsPath: stableDeclarations,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    assert.match(
+      error.message,
       /generated declarations that differ from the public package type surface/,
     );
+    assert.match(error.message, /checked-in declarations: /);
+    assert.match(error.message, /generated declarations: /);
+    assert.match(error.message, /first difference near line 2/);
+    assert.match(error.message, /--- checked-in/);
+    assert.match(error.message, /\+\s*2 \| export declare function newlyGeneratedExport/);
     assert.equal(existsSync(join(root, "native-binding.pointer.cjs")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
🤖 Fixes the current-main NAPI declaration freshness failure exposed by #1984 and #1985.

The generated native declarations contained three Rust doc-comment blocks added with attributed writes, while the checked-in public declaration surface was stale. ABI signatures were already identical.

This also makes future failures actionable by reporting the checked-in/generated paths and a bounded first-difference excerpt.

Verification:
- `pnpm --filter jazz-napi build`
- artifact contract tests: 24/24
- CI workflow contracts: 95/95 plus ignored-test self-test