### PR TITLE
fix(ci): build Jazz Tools before parallel TS suites

### DIFF
--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -18,7 +18,11 @@ browser_tests_log="${log_dir}/jazz-browser-tests-$$.log"
 # them once before either suite starts: otherwise an example's fallback build
 # can clean that shared directory while a sibling browser suite imports it.
 if [[ "${JAZZ_SKIP_JAZZ_TOOLS_BUILD:-0}" != "1" ]]; then
-  pnpm --filter jazz-tools build
+  pnpm --filter jazz-tools build || {
+    status=$?
+    echo "jazz-tools prebuild failed; refusing to launch suites against stale exports" >&2
+    exit "${status}"
+  }
 fi
 
 terminate_children() {

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -14,6 +14,13 @@ log_dir=${RUNNER_TEMP:-/tmp}
 node_tests_log="${log_dir}/jazz-node-tests-$$.log"
 browser_tests_log="${log_dir}/jazz-browser-tests-$$.log"
 
+# Every example resolves the public `jazz-tools/*` exports from `dist`. Build
+# them once before either suite starts: otherwise an example's fallback build
+# can clean that shared directory while a sibling browser suite imports it.
+if [[ "${JAZZ_SKIP_JAZZ_TOOLS_BUILD:-0}" != "1" ]]; then
+  pnpm --filter jazz-tools build
+fi
+
 terminate_children() {
   trap - INT TERM
   for child_pid in "${node_tests_pid}" "${browser_tests_pid}"; do

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1450,6 +1450,11 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   );
   assert.match(typescript, /name: Run Node and browser test suites in parallel/);
   assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
+  assert.match(runner, /pnpm --filter jazz-tools build/);
+  assert.match(
+    runner,
+    /Every example resolves the public `jazz-tools\/\*` exports from `dist`/,
+  );
   assert.match(runner, /--concurrency=2/);
   assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
   assert.match(
@@ -1488,6 +1493,7 @@ test("parallel TypeScript runner waits for both suites and combines their failur
       encoding: "utf8",
       env: {
         ...process.env,
+        JAZZ_SKIP_JAZZ_TOOLS_BUILD: "1",
         JAZZ_NODE_TEST_COMMAND: `sleep 0.05; touch ${JSON.stringify(nodeMarker)}; exit ${testCase.node}`,
         JAZZ_BROWSER_TEST_COMMAND: `sleep 0.1; touch ${JSON.stringify(browserMarker)}; exit ${testCase.browser}`,
       },
@@ -1509,6 +1515,7 @@ test("parallel TypeScript runner terminates both child process groups", async ()
     cwd: root,
     env: {
       ...process.env,
+      JAZZ_SKIP_JAZZ_TOOLS_BUILD: "1",
       JAZZ_NODE_TEST_COMMAND: `sleep 0.5; touch ${JSON.stringify(nodeMarker)}`,
       JAZZ_BROWSER_TEST_COMMAND: `sleep 0.5; touch ${JSON.stringify(browserMarker)}`,
     },

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1507,6 +1507,33 @@ test("parallel TypeScript runner waits for both suites and combines their failur
   }
 });
 
+test("a failed jazz-tools prebuild prevents both TypeScript suites from starting", () => {
+  const runner = path.join(root, "dev/gates/run-ts-tests.sh");
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-prebuild-"));
+  const fakePnpm = path.join(fixture, "pnpm");
+  const nodeMarker = path.join(fixture, "node");
+  const browserMarker = path.join(fixture, "browser");
+  try {
+    fs.writeFileSync(fakePnpm, "#!/bin/sh\nexit 23\n", { mode: 0o755 });
+    const result = spawnSync("bash", [runner], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture}:${process.env.PATH}`,
+        JAZZ_NODE_TEST_COMMAND: `touch ${JSON.stringify(nodeMarker)}`,
+        JAZZ_BROWSER_TEST_COMMAND: `touch ${JSON.stringify(browserMarker)}`,
+      },
+    });
+    assert.equal(result.status, 23, result.stderr);
+    assert.equal(fs.existsSync(nodeMarker), false, "node suite started after failed prebuild");
+    assert.equal(fs.existsSync(browserMarker), false, "browser suite started after failed prebuild");
+    assert.match(result.stderr, /refusing to launch suites against stale exports/);
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
 test("parallel TypeScript runner terminates both child process groups", async () => {
   const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-interrupt-"));
   const nodeMarker = path.join(fixture, "node-orphan");

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1451,10 +1451,7 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(typescript, /name: Run Node and browser test suites in parallel/);
   assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
   assert.match(runner, /pnpm --filter jazz-tools build/);
-  assert.match(
-    runner,
-    /Every example resolves the public `jazz-tools\/\*` exports from `dist`/,
-  );
+  assert.match(runner, /Every example resolves the public `jazz-tools\/\*` exports from `dist`/);
   assert.match(runner, /--concurrency=2/);
   assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
   assert.match(
@@ -1527,7 +1524,11 @@ test("a failed jazz-tools prebuild prevents both TypeScript suites from starting
     });
     assert.equal(result.status, 23, result.stderr);
     assert.equal(fs.existsSync(nodeMarker), false, "node suite started after failed prebuild");
-    assert.equal(fs.existsSync(browserMarker), false, "browser suite started after failed prebuild");
+    assert.equal(
+      fs.existsSync(browserMarker),
+      false,
+      "browser suite started after failed prebuild",
+    );
     assert.match(result.stderr, /refusing to launch suites against stale exports/);
   } finally {
     fs.rmSync(fixture, { recursive: true, force: true });


### PR DESCRIPTION
🤖 Fixes the current-main TypeScript CI race exposed by #1984 and likely shared by #1985.

The docs server fallback could rebuild `jazz-tools` while browser example tests were importing `jazz-tools/testing`; that build cleans the shared `dist` tree, so concurrent suites intermittently observed a missing testing entrypoint.

The runner now builds Jazz Tools once before launching the still-parallel Node and browser process groups. The prebuild fails closed with its exact exit status and launches neither group on failure.

Verification:
- CI runner contracts: 32/32
- planted prebuild exit 23 is preserved and launches neither suite
- parallel docs Todo server: 13/13
- parallel React browser Todo: 11/11

The candidate passed independent review.