### PR TITLE
fix(ci): seal Jazz Tools output during parallel tests

### DIFF
--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -23,16 +23,10 @@ if [[ "${JAZZ_SKIP_JAZZ_TOOLS_BUILD:-0}" != "1" ]]; then
     echo "prepared release jazz-napi artifact did not load; run pnpm build:test-artifacts before test-ts" >&2
     exit 1
   fi
-  for required in \
-    packages/jazz-tools/dist/cli.js \
-    packages/jazz-tools/dist/testing/index.js \
-    packages/jazz-tools/dist/runtime/client-session.js \
-    packages/jazz-tools/dist/backend/request-auth.js; do
-    if [[ ! -f "${required}" ]]; then
-      echo "jazz-tools prebuild omitted required test export ${required}; refusing to launch suites" >&2
-      exit 1
-    fi
-  done
+  if ! node dev/gates/verify-jazz-tools-exports.mjs; then
+    echo "prepared jazz-tools public export surface is incomplete; refusing to launch suites" >&2
+    exit 1
+  fi
   # Test children share this prepared public surface. A child that tries to
   # rebuild it fails before clean-dist can remove files another suite imports.
   export JAZZ_TEST_SEALED_TOOLS_DIST=1

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -14,15 +14,15 @@ log_dir=${RUNNER_TEMP:-/tmp}
 node_tests_log="${log_dir}/jazz-node-tests-$$.log"
 browser_tests_log="${log_dir}/jazz-browser-tests-$$.log"
 
-# Every example resolves the public `jazz-tools/*` exports from `dist`. Build
-# them once before either suite starts: otherwise an example's fallback build
-# can clean that shared directory while a sibling browser suite imports it.
+# The workflow's top-level artifact gate prepares the release NAPI loader and
+# Jazz Tools public exports before either suite starts. Test children only
+# consume those immutable artifacts: allowing an example pretest to rebuild
+# either package races a sibling importer and can delete its dist files.
 if [[ "${JAZZ_SKIP_JAZZ_TOOLS_BUILD:-0}" != "1" ]]; then
-  pnpm --filter jazz-tools build || {
-    status=$?
-    echo "jazz-tools prebuild failed; refusing to launch suites against stale exports" >&2
-    exit "${status}"
-  }
+  if ! node -e "require('./crates/jazz-napi')"; then
+    echo "prepared release jazz-napi artifact did not load; run pnpm build:test-artifacts before test-ts" >&2
+    exit 1
+  fi
   for required in \
     packages/jazz-tools/dist/cli.js \
     packages/jazz-tools/dist/testing/index.js \

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -23,6 +23,19 @@ if [[ "${JAZZ_SKIP_JAZZ_TOOLS_BUILD:-0}" != "1" ]]; then
     echo "jazz-tools prebuild failed; refusing to launch suites against stale exports" >&2
     exit "${status}"
   }
+  for required in \
+    packages/jazz-tools/dist/cli.js \
+    packages/jazz-tools/dist/testing/index.js \
+    packages/jazz-tools/dist/runtime/client-session.js \
+    packages/jazz-tools/dist/backend/request-auth.js; do
+    if [[ ! -f "${required}" ]]; then
+      echo "jazz-tools prebuild omitted required test export ${required}; refusing to launch suites" >&2
+      exit 1
+    fi
+  done
+  # Test children share this prepared public surface. A child that tries to
+  # rebuild it fails before clean-dist can remove files another suite imports.
+  export JAZZ_TEST_SEALED_TOOLS_DIST=1
 fi
 
 terminate_children() {

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1563,7 +1563,11 @@ test("a missing prepared native artifact prevents both TypeScript suites from st
       },
     });
     assert.equal(result.status, 1, result.stderr);
-    assert.equal(fs.existsSync(nodeMarker), false, "node suite started after failed artifact check");
+    assert.equal(
+      fs.existsSync(nodeMarker),
+      false,
+      "node suite started after failed artifact check",
+    );
     assert.equal(
       fs.existsSync(browserMarker),
       false,
@@ -1640,7 +1644,10 @@ test("missing public root or framework exports prevent both TypeScript suites fr
       assert.equal(result.status, 1, `${relative}: ${result.stderr}`);
       assert.equal(fs.existsSync(nodeMarker), false, `${relative}: node suite started`);
       assert.equal(fs.existsSync(browserMarker), false, `${relative}: browser suite started`);
-      assert.match(`${result.stdout}\n${result.stderr}`, new RegExp(`public export is missing: ${relative}`));
+      assert.match(
+        `${result.stdout}\n${result.stderr}`,
+        new RegExp(`public export is missing: ${relative}`),
+      );
     } finally {
       if (fs.existsSync(backup)) fs.renameSync(backup, target);
       fs.rmSync(fixture, { recursive: true, force: true });

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { parse } from "yaml";
 import { cleanDist } from "../../../packages/jazz-tools/scripts/clean-dist.mjs";
+import { missingJazzToolsTestSurface } from "../verify-jazz-tools-exports.mjs";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const workflow = fs.readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
@@ -1453,8 +1454,8 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
   assert.match(runner, /require\('\.\/crates\/jazz-napi'\)/);
   assert.match(runner, /JAZZ_TEST_SEALED_TOOLS_DIST=1/);
-  assert.match(runner, /dist\/testing\/index\.js/);
-  assert.match(runner, /dist\/runtime\/client-session\.js/);
+  assert.match(runner, /verify-jazz-tools-exports\.mjs/);
+  assert.match(runner, /public export surface is incomplete/);
   assert.match(runner, /Test children only\s+# consume those immutable artifacts/);
   assert.match(runner, /--concurrency=2/);
   assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
@@ -1571,6 +1572,79 @@ test("a missing prepared native artifact prevents both TypeScript suites from st
     assert.match(result.stderr, /prepared release jazz-napi artifact did not load/);
   } finally {
     fs.rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("the Jazz Tools preflight derives public exports and keeps test-only entrypoints explicit", () => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-tools-test-surface-"));
+  const packageRoot = path.join(fixture, "packages/jazz-tools");
+  const write = (relative, contents = "export {};") => {
+    const target = path.join(packageRoot, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, contents);
+  };
+  try {
+    write(
+      "package.json",
+      JSON.stringify({
+        exports: {
+          ".": { types: "./dist/index.d.ts", default: "./dist/index.js" },
+          "./react": { types: "./dist/react/index.d.ts", default: "./dist/react/index.js" },
+          "./testing": { default: "./dist/testing/index.js" },
+        },
+      }),
+    );
+    for (const file of [
+      "dist/index.d.ts",
+      "dist/index.js",
+      "dist/react/index.d.ts",
+      "dist/react/index.js",
+      "dist/testing/index.js",
+      "dist/cli.js",
+      "dist/runtime/client-session.js",
+      "dist/backend/request-auth.js",
+    ])
+      write(file);
+    assert.deepEqual(missingJazzToolsTestSurface(fixture), []);
+
+    fs.rmSync(path.join(packageRoot, "dist/index.js"));
+    assert.deepEqual(missingJazzToolsTestSurface(fixture), ["dist/index.js"]);
+    write("dist/index.js");
+
+    fs.rmSync(path.join(packageRoot, "dist/react/index.js"));
+    assert.deepEqual(missingJazzToolsTestSurface(fixture), ["dist/react/index.js"]);
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("missing public root or framework exports prevent both TypeScript suites from starting", () => {
+  const runner = path.join(root, "dev/gates/run-ts-tests.sh");
+  for (const relative of ["dist/index.js", "dist/react/index.js"]) {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-public-export-"));
+    const target = path.join(root, "packages/jazz-tools", relative);
+    const backup = `${target}.preflight-backup-${process.pid}`;
+    const nodeMarker = path.join(fixture, "node-suite-ran");
+    const browserMarker = path.join(fixture, "browser-suite-ran");
+    try {
+      fs.renameSync(target, backup);
+      const result = spawnSync("bash", [runner], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          JAZZ_NODE_TEST_COMMAND: `touch ${JSON.stringify(nodeMarker)}`,
+          JAZZ_BROWSER_TEST_COMMAND: `touch ${JSON.stringify(browserMarker)}`,
+        },
+      });
+      assert.equal(result.status, 1, `${relative}: ${result.stderr}`);
+      assert.equal(fs.existsSync(nodeMarker), false, `${relative}: node suite started`);
+      assert.equal(fs.existsSync(browserMarker), false, `${relative}: browser suite started`);
+      assert.match(`${result.stdout}\n${result.stderr}`, new RegExp(`public export is missing: ${relative}`));
+    } finally {
+      if (fs.existsSync(backup)) fs.renameSync(backup, target);
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
   }
 });
 

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1494,6 +1494,24 @@ test("a sealed test surface rejects a child clean before it can delete prepared 
   }
 });
 
+test("Turbo preserves the sealed surface for the real Jazz Tools build task", () => {
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "turbo", "run", "build", "--filter=jazz-tools", "--only", "--force"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, JAZZ_TEST_SEALED_TOOLS_DIST: "1" },
+    },
+  );
+  assert.notEqual(result.status, 0, "a sealed Jazz Tools build must not clean dist");
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /jazz-tools dist is sealed for concurrent tests/,
+    "Turbo strict-env child dropped JAZZ_TEST_SEALED_TOOLS_DIST before clean-dist",
+  );
+});
+
 test("parallel TypeScript runner waits for both suites and combines their failures", () => {
   const runner = path.join(root, "dev/gates/run-ts-tests.sh");
   const cases = [

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { parse } from "yaml";
+import { cleanDist } from "../../../packages/jazz-tools/scripts/clean-dist.mjs";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const workflow = fs.readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8");
@@ -1451,6 +1452,9 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(typescript, /name: Run Node and browser test suites in parallel/);
   assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
   assert.match(runner, /pnpm --filter jazz-tools build/);
+  assert.match(runner, /JAZZ_TEST_SEALED_TOOLS_DIST=1/);
+  assert.match(runner, /dist\/testing\/index\.js/);
+  assert.match(runner, /dist\/runtime\/client-session\.js/);
   assert.match(runner, /Every example resolves the public `jazz-tools\/\*` exports from `dist`/);
   assert.match(runner, /--concurrency=2/);
   assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
@@ -1471,6 +1475,23 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(runner, /Browser test suite exit status:/);
   assert.match(runner, /node_tests_status.*-ne 0 \|\|.*browser_tests_status.*-ne 0/);
   assert.doesNotMatch(typescript, /rust-components: clippy,rustfmt/);
+});
+
+test("a sealed test surface rejects a child clean before it can delete prepared exports", async () => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-sealed-tools-dist-"));
+  const marker = path.join(fixture, "testing", "index.js");
+  fs.mkdirSync(path.dirname(marker), { recursive: true });
+  fs.writeFileSync(marker, "prepared export");
+  const previous = process.env.JAZZ_TEST_SEALED_TOOLS_DIST;
+  process.env.JAZZ_TEST_SEALED_TOOLS_DIST = "1";
+  try {
+    await assert.rejects(() => cleanDist(fixture), /sealed for concurrent tests/);
+    assert.equal(fs.existsSync(marker), true, "sealed child build deleted a prepared export");
+  } finally {
+    if (previous === undefined) delete process.env.JAZZ_TEST_SEALED_TOOLS_DIST;
+    else process.env.JAZZ_TEST_SEALED_TOOLS_DIST = previous;
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
 });
 
 test("parallel TypeScript runner waits for both suites and combines their failures", () => {

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1623,17 +1623,50 @@ test("the Jazz Tools preflight derives public exports and keeps test-only entryp
 });
 
 test("missing public root or framework exports prevent both TypeScript suites from starting", () => {
-  const runner = path.join(root, "dev/gates/run-ts-tests.sh");
-  for (const relative of ["dist/index.js", "dist/react/index.js"]) {
-    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-public-export-"));
-    const target = path.join(root, "packages/jazz-tools", relative);
-    const backup = `${target}.preflight-backup-${process.pid}`;
-    const nodeMarker = path.join(fixture, "node-suite-ran");
-    const browserMarker = path.join(fixture, "browser-suite-ran");
-    try {
-      fs.renameSync(target, backup);
-      const result = spawnSync("bash", [runner], {
-        cwd: root,
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-public-export-"));
+  const write = (relative, contents = "export {};") => {
+    const target = path.join(fixture, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, contents);
+  };
+  const packageFiles = [
+    "dist/index.d.ts",
+    "dist/index.js",
+    "dist/react/index.d.ts",
+    "dist/react/index.js",
+    "dist/testing/index.js",
+    "dist/cli.js",
+    "dist/runtime/client-session.js",
+    "dist/backend/request-auth.js",
+  ];
+  try {
+    // The real runner and verifier resolve from cwd, so this is a controlled
+    // checkout rather than a mutation of the developer's generated dist. Lint
+    // CI deliberately has no Jazz Tools build before it runs this contract.
+    for (const source of ["run-ts-tests.sh", "verify-jazz-tools-exports.mjs"])
+      write(`dev/gates/${source}`, fs.readFileSync(path.join(root, "dev/gates", source), "utf8"));
+    write("crates/jazz-napi/package.json", JSON.stringify({ type: "commonjs" }));
+    write("crates/jazz-napi/index.js", "module.exports = {};\n");
+    write(
+      "packages/jazz-tools/package.json",
+      JSON.stringify({
+        exports: {
+          ".": { types: "./dist/index.d.ts", default: "./dist/index.js" },
+          "./react": { types: "./dist/react/index.d.ts", default: "./dist/react/index.js" },
+          "./testing": { default: "./dist/testing/index.js" },
+        },
+      }),
+    );
+    for (const file of packageFiles) write(`packages/jazz-tools/${file}`);
+
+    for (const relative of ["dist/index.js", "dist/react/index.js"]) {
+      const nodeMarker = path.join(fixture, "node-suite-ran");
+      const browserMarker = path.join(fixture, "browser-suite-ran");
+      fs.rmSync(nodeMarker, { force: true });
+      fs.rmSync(browserMarker, { force: true });
+      fs.rmSync(path.join(fixture, "packages/jazz-tools", relative));
+      const result = spawnSync("bash", ["dev/gates/run-ts-tests.sh"], {
+        cwd: fixture,
         encoding: "utf8",
         env: {
           ...process.env,
@@ -1648,10 +1681,10 @@ test("missing public root or framework exports prevent both TypeScript suites fr
         `${result.stdout}\n${result.stderr}`,
         new RegExp(`public export is missing: ${relative}`),
       );
-    } finally {
-      if (fs.existsSync(backup)) fs.renameSync(backup, target);
-      fs.rmSync(fixture, { recursive: true, force: true });
+      write(`packages/jazz-tools/${relative}`);
     }
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
   }
 });
 

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1451,11 +1451,11 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   );
   assert.match(typescript, /name: Run Node and browser test suites in parallel/);
   assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
-  assert.match(runner, /pnpm --filter jazz-tools build/);
+  assert.match(runner, /require\('\.\/crates\/jazz-napi'\)/);
   assert.match(runner, /JAZZ_TEST_SEALED_TOOLS_DIST=1/);
   assert.match(runner, /dist\/testing\/index\.js/);
   assert.match(runner, /dist\/runtime\/client-session\.js/);
-  assert.match(runner, /Every example resolves the public `jazz-tools\/\*` exports from `dist`/);
+  assert.match(runner, /Test children only\s+# consume those immutable artifacts/);
   assert.match(runner, /--concurrency=2/);
   assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
   assert.match(
@@ -1525,14 +1525,14 @@ test("parallel TypeScript runner waits for both suites and combines their failur
   }
 });
 
-test("a failed jazz-tools prebuild prevents both TypeScript suites from starting", () => {
+test("a missing prepared native artifact prevents both TypeScript suites from starting", () => {
   const runner = path.join(root, "dev/gates/run-ts-tests.sh");
   const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-prebuild-"));
-  const fakePnpm = path.join(fixture, "pnpm");
-  const nodeMarker = path.join(fixture, "node");
+  const fakeNode = path.join(fixture, "node");
+  const nodeMarker = path.join(fixture, "node-suite-ran");
   const browserMarker = path.join(fixture, "browser");
   try {
-    fs.writeFileSync(fakePnpm, "#!/bin/sh\nexit 23\n", { mode: 0o755 });
+    fs.writeFileSync(fakeNode, "#!/bin/sh\nexit 23\n", { mode: 0o755 });
     const result = spawnSync("bash", [runner], {
       cwd: root,
       encoding: "utf8",
@@ -1543,17 +1543,25 @@ test("a failed jazz-tools prebuild prevents both TypeScript suites from starting
         JAZZ_BROWSER_TEST_COMMAND: `touch ${JSON.stringify(browserMarker)}`,
       },
     });
-    assert.equal(result.status, 23, result.stderr);
-    assert.equal(fs.existsSync(nodeMarker), false, "node suite started after failed prebuild");
+    assert.equal(result.status, 1, result.stderr);
+    assert.equal(fs.existsSync(nodeMarker), false, "node suite started after failed artifact check");
     assert.equal(
       fs.existsSync(browserMarker),
       false,
-      "browser suite started after failed prebuild",
+      "browser suite started after failed artifact check",
     );
-    assert.match(result.stderr, /refusing to launch suites against stale exports/);
+    assert.match(result.stderr, /prepared release jazz-napi artifact did not load/);
   } finally {
     fs.rmSync(fixture, { recursive: true, force: true });
   }
+});
+
+test("TypeScript test children do not retain obsolete artifact fallback builds", () => {
+  const todoServer = JSON.parse(
+    fs.readFileSync(path.join(root, "examples/docs/todo-server-ts/package.json"), "utf8"),
+  );
+  assert.equal(todoServer.scripts.pretest, undefined);
+  assert.doesNotMatch(JSON.stringify(todoServer.scripts), /jazz-napi build|jazz-tools build/);
 });
 
 test("parallel TypeScript runner terminates both child process groups", async () => {

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -534,6 +534,12 @@ test("CI uses the correctness artifact path while package builds keep release WA
       expectedLease,
       `${task} must preserve the aggregate parent's selected artifact lock`,
     );
+  for (const task of ["build", "jazz-tools#build", "test"])
+    assert.deepEqual(
+      turbo.tasks[task].passThroughEnv,
+      ["JAZZ_TEST_SEALED_TOOLS_DIST"],
+      `${task} must preserve the sealed shared test surface for child package scripts`,
+    );
 });
 
 test("Turbo invalidates each native artifact only for its Cargo closure", () => {

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -526,6 +526,7 @@ test("CI uses the correctness artifact path while package builds keep release WA
     "JAZZ_TEST_ARTIFACT_LOCK_PATH",
     "JAZZ_ARTIFACT_BUILD_LEASE",
     "JAZZ_ARTIFACT_BUILD_LOCK_PATH",
+    "JAZZ_TEST_SEALED_TOOLS_DIST",
   ];
   for (const task of ["jazz-napi#build", "jazz-wasm#build", "jazz-wasm#build:fast"])
     assert.deepEqual(

--- a/dev/gates/verify-jazz-tools-exports.mjs
+++ b/dev/gates/verify-jazz-tools-exports.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/** Verify the generated files named by Jazz Tools' public package contract. */
+import { lstatSync, readFileSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
+
+// These files are invoked by the test command graph without being package
+// exports themselves. Keep this list deliberately small: public exports stay
+// derived from package.json, so adding a new SDK surface cannot silently omit
+// it from the preflight.
+const internalTestEntrypoints = [
+  "dist/cli.js",
+  "dist/runtime/client-session.js",
+  "dist/backend/request-auth.js",
+];
+
+function exportedFiles(value, files) {
+  if (typeof value === "string") {
+    if (value.startsWith("./dist/")) files.add(value.slice(2));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const nested of Object.values(value)) exportedFiles(nested, files);
+}
+
+export function missingJazzToolsTestSurface(root = repositoryRoot) {
+  const packageRoot = resolve(root, "packages/jazz-tools");
+  const manifest = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+  const expected = new Set(internalTestEntrypoints);
+  exportedFiles(manifest.exports, expected);
+  return [...expected].sort().filter((relative) => {
+    const path = resolve(packageRoot, relative);
+    const withinPackage = !relativePathEscapes(packageRoot, path);
+    if (!withinPackage) return true;
+    try {
+      return !lstatSync(path).isFile();
+    } catch {
+      return true;
+    }
+  });
+}
+
+function relativePathEscapes(packageRoot, candidate) {
+  const pathFromRoot = relative(packageRoot, candidate);
+  return pathFromRoot === "" || pathFromRoot === ".." || pathFromRoot.startsWith(`..${sep}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const missing = missingJazzToolsTestSurface();
+  if (missing.length) {
+    for (const path of missing) console.error(`jazz-tools public export is missing: ${path}`);
+    console.error("Fix: pnpm build:test-artifacts");
+    process.exitCode = 1;
+  }
+}

--- a/examples/docs/todo-server-ts/package.json
+++ b/examples/docs/todo-server-ts/package.json
@@ -7,7 +7,6 @@
     "build": "tsc",
     "start": "tsx src/main.ts",
     "dev": "tsx watch src/main.ts",
-    "pretest": "test -f ../../../packages/jazz-tools/dist/cli.js && test -f ../../../crates/jazz-napi/index.js || (pnpm --filter jazz-napi build && pnpm --filter jazz-tools build)",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/jazz-tools/scripts/clean-dist.mjs
+++ b/packages/jazz-tools/scripts/clean-dist.mjs
@@ -3,4 +3,13 @@ import { fileURLToPath } from "node:url";
 
 const distDir = fileURLToPath(new URL("../dist", import.meta.url));
 
-await rm(distDir, { recursive: true, force: true });
+export async function cleanDist(path = distDir) {
+  if (process.env.JAZZ_TEST_SEALED_TOOLS_DIST === "1") {
+    throw new Error(
+      "jazz-tools dist is sealed for concurrent tests; rebuild it before launching suites, not from a test child",
+    );
+  }
+  await rm(path, { recursive: true, force: true });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await cleanDist();

--- a/turbo.json
+++ b/turbo.json
@@ -59,7 +59,8 @@
       "passThroughEnv": [
         "JAZZ_TEST_ARTIFACT_LOCK_PATH",
         "JAZZ_ARTIFACT_BUILD_LEASE",
-        "JAZZ_ARTIFACT_BUILD_LOCK_PATH"
+        "JAZZ_ARTIFACT_BUILD_LOCK_PATH",
+        "JAZZ_TEST_SEALED_TOOLS_DIST"
       ],
       "outputs": [
         "native-binding.pointer.cjs",
@@ -88,7 +89,8 @@
       "passThroughEnv": [
         "JAZZ_TEST_ARTIFACT_LOCK_PATH",
         "JAZZ_ARTIFACT_BUILD_LEASE",
-        "JAZZ_ARTIFACT_BUILD_LOCK_PATH"
+        "JAZZ_ARTIFACT_BUILD_LOCK_PATH",
+        "JAZZ_TEST_SEALED_TOOLS_DIST"
       ],
       "cache": false,
       "outputs": []
@@ -114,7 +116,8 @@
       "passThroughEnv": [
         "JAZZ_TEST_ARTIFACT_LOCK_PATH",
         "JAZZ_ARTIFACT_BUILD_LEASE",
-        "JAZZ_ARTIFACT_BUILD_LOCK_PATH"
+        "JAZZ_ARTIFACT_BUILD_LOCK_PATH",
+        "JAZZ_TEST_SEALED_TOOLS_DIST"
       ],
       "cache": false,
       "outputs": []

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "pkg/**"],
-      "env": ["JAZZ_NAPI_RELEASE"]
+      "env": ["JAZZ_NAPI_RELEASE"],
+      "passThroughEnv": ["JAZZ_TEST_SEALED_TOOLS_DIST"]
     },
     "inspector#build": {
       "dependsOn": ["^build"],
@@ -136,7 +137,8 @@
         "$TURBO_ROOT$/pnpm-workspace.yaml",
         "$TURBO_ROOT$/turbo.json"
       ],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "passThroughEnv": ["JAZZ_TEST_SEALED_TOOLS_DIST"]
     },
     "build:crates": {
       "dependsOn": ["^build:crates"],
@@ -167,7 +169,8 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["JAZZ_TEST_SEALED_TOOLS_DIST"]
     }
   }
 }


### PR DESCRIPTION
🤖 Completes #1988 by making the prepared Jazz Tools test surface immutable while parallel Node and browser suites run.

The serial prebuild alone was insufficient: child fallback/direct builds could still execute `clean-dist`, transiently deleting exports while sibling suites imported them. Turbo's strict environment handling could also omit the seal from nested Jazz Tools build and test tasks.

The runner now derives the complete public `./dist/**` surface recursively from `packages/jazz-tools/package.json`, verifies the three documented internal test entrypoints plus the canonical NAPI artifact, and only then launches either child suite. Missing files, non-regular files, and symlinks fail before any suite starts. The seal is explicitly propagated through the relevant Turbo build and test tasks; under it, cleanup fails before deleting a file. Ordinary builds outside the test runner remain unchanged.

Independent adversarial review verified both boundaries with real planted failures: a forced nested Turbo build received the seal and stopped before cleanup, while removing root, React, and Vue exports made the runner fail with exact diagnostics before either child marker appeared. The complete CI-workflow contract suite passes 101/101, and the focused artifact/Turbo contracts pass 62/62.
