### PR TITLE
ci: make local gates CI-equivalent

### DIFF
--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -57,12 +57,11 @@ jobs:
         with:
           sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
 
-      - run: pnpm format:check
-      - run: pnpm lint
-      # Keep workflow assertions required without adding another Rust build.
-      - run: pnpm test:ci-workflow
-      - name: Verify Turbo artifact cache inputs
-        run: pnpm test:turbo-cache-inputs
+      # This named partition is also the local source of truth. Do not copy
+      # individual commands here: local `--ci-equivalent` must execute the
+      # same complete partition rather than a drifting approximation.
+      - name: Run CI-equivalent lint and metadata partition
+        run: node dev/gates/local-ci-equivalent.mjs --ci-partition lint
       - name: Report sccache statistics
         if: always()
         run: sccache --show-stats
@@ -102,12 +101,8 @@ jobs:
       - uses: ./.github/actions/setup-blacksmith
         with:
           sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
-      - name: Workspace Rust tests (bounded, sharded, receipted)
-        run: node dev/gates/run-rust-tests.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features jazz/testing,jazz/transport-compression-zstd,jazz-server/test,jazz-cli/test
-      - name: Benchmark deterministic scenario smoke
-        run: dev/gates/benchmark-smoke.sh --ci
-      - name: Verify Nextest partition coverage
-        run: node --test dev/gates/test/nextest-partitions.test.mjs
+      - name: Run CI-equivalent workspace Rust partition
+        run: node dev/gates/local-ci-equivalent.mjs --ci-partition rust-workspace
       - name: Upload Rust test receipt
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -162,40 +157,10 @@ jobs:
         with:
           sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
           rust-cache: "false"
-      # Compile only the library test binary first. The semantic oracle timeout
-      # below must not charge a cold compile or unrelated integration binaries.
-      - name: Compile M3 differential oracle libtest
-        shell: bash
-        run: |
-          set -euo pipefail
-          test_binary="$(cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json | node -e '
-            const readline = require("node:readline");
-            let executable;
-            const lines = readline.createInterface({ input: process.stdin });
-            lines.on("line", (line) => {
-              try {
-                const message = JSON.parse(line);
-                if (message.reason === "compiler-artifact" && message.target.name === "jazz" && message.executable)
-                  executable = message.executable;
-              } catch {}
-            });
-            lines.on("close", () => {
-              if (!executable) process.exitCode = 1;
-              else console.log(executable);
-            });
-          ')"
-          test -x "${test_binary}"
-          echo "M3_ORACLE_TEST_BINARY=${test_binary}" >> "${GITHUB_ENV}"
-      # The smallest stable real oracle smoke: fixed seed 11, the two smallest
-      # aggregate churn depths, and the normal three differential steps.
-      - name: Run maintained-vs-one-shot differential oracle smoke
-        shell: bash
-        run: |
-          timeout 60s env \
-            JAZZ_SEED=11 \
-            JAZZ_DIFFERENTIAL_CHURN_DEPTHS=10,1000 \
-            JAZZ_DIFFERENTIAL_STEP_COUNT=3 \
-            "${M3_ORACLE_TEST_BINARY}" node::tests::harness::m3_maintained_one_shot_differential_oracle --exact --ignored
+      # The shared partition compiles the exact libtest first; its semantic
+      # watchdog still measures execution only, never a cold compile.
+      - name: Run CI-equivalent M3 differential partition
+        run: node dev/gates/local-ci-equivalent.mjs --ci-partition rust-differential
       - name: Report sccache statistics
         if: always()
         run: sccache --show-stats
@@ -277,23 +242,11 @@ jobs:
       # PR-level checks cannot catch two independently green PRs whose merged
       # tree no longer compiles. This runs on every push to the integration
       # branch before building the TypeScript correctness artifacts.
-      - name: Check integration workspace
-        run: cargo check --workspace --all-targets
-
-      # Correctness tests use an unoptimised, provenance-checked WASM build.
-      # Package/publish workflows continue to use jazz-wasm's release build.
-      # The script reuses the restored default Cargo target, runs NAPI alone,
-      # then overlaps CLI with fast WASM. Each deterministic build is a signed
-      # Turbo task; the nondeterministic test suites below remain uncached.
-      - name: Build correctness-test artifacts
-        run: pnpm build:test-artifacts
-      - name: Verify preinstalled Chromium
-        run: pnpm exec playwright install --dry-run chromium
-      # Both suites consume the already-built artifacts and do not write shared
-      # outputs. Running them together avoids extending the PR critical path
-      # while retaining the complete Node and browser coverage in this gate.
-      - name: Run Node and browser test suites in parallel
-        run: dev/gates/run-ts-tests.sh
+      # This starts with the exhaustive workspace target-class check, then
+      # builds provenance-checked test artifacts and retains parallel Node /
+      # browser suites. The local CI-equivalent gate calls this exact partition.
+      - name: Run CI-equivalent TypeScript and workspace partition
+        run: node dev/gates/local-ci-equivalent.mjs --ci-partition typescript
       - name: Report sccache statistics
         if: always()
         run: sccache --show-stats

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,19 @@ core gate's `-p jazz --no-default-features --features testing,transport-compress
 **Canonical gates:** do not let born-red or rotted targets accumulate silently.
 For ordinary Rust/core work, the full gate set is:
 
+**Local CI-equivalent gate.** `node dev/gates/local-ci-equivalent.mjs
+--ci-equivalent` is the only local command that may be described as
+_CI-equivalent_. It executes the exact named correctness/build command
+partitions invoked by `.github/workflows/ci-suite.yml` (serialized locally;
+CI schedules them in parallel). It fails closed on a missing partition and
+includes the exhaustive workspace `--lib --bins --tests --examples --benches`
+compile with CI's required features before TypeScript artifacts or suites.
+The default `node dev/gates/local-ci-equivalent.mjs` is deliberately a faster
+**focused** iteration mode and prints that it is **not CI-equivalent**. Lanes
+must never call a focused, crate-only, or partial-artifact receipt
+CI-equivalent. Use `--ci-partition <name>` only when reproducing one named CI
+job during diagnosis; it is likewise not a full CI-equivalent result.
+
 - `cargo test -p jazz`
 - `cargo test -p groove`
 - `cargo test -p jazz --no-default-features --features testing,transport-compression-zstd` (matches `crates/jazz/TESTING_GUIDELINES.md`).

--- a/dev/gates/local-ci-equivalent.mjs
+++ b/dev/gates/local-ci-equivalent.mjs
@@ -29,6 +29,12 @@ export const RUST_WORKSPACE_TARGETS = Object.freeze([
 export const RUST_CI_FEATURES =
   "jazz/testing,jazz/transport-compression-zstd,jazz-server/test,jazz-cli/test";
 
+// CI setup supplies this one coordination input. Every other JAZZ_* variable
+// is a test, fixture, benchmark, timeout, or assertion control and would make
+// a local exact-partition result mean something different from GitHub CI.
+export const ALLOWED_INHERITED_CI_JAZZ_ENV = Object.freeze(["JAZZ_TEST_ARTIFACT_LOCK_PATH"]);
+const allowedInheritedCiJazzEnv = new Set(ALLOWED_INHERITED_CI_JAZZ_ENV);
+
 /** The CI-suite job that invokes each named partition. */
 export const ciPartitionJobs = Object.freeze({
   lint: "lint",
@@ -182,18 +188,47 @@ export function assertArtifactBoundary(commands) {
     throw new Error("CI-equivalent TypeScript plan runs tests before correctness artifacts.");
 }
 
-export async function runPlan(commands, run = runCommand) {
-  for (const item of commands) await run(item);
+/**
+ * Reject ambient Jazz controls before any exact partition begins.  Command
+ * local controls are appended only after this check, so callers cannot smuggle
+ * an override through a child process environment.
+ */
+export function exactCiEnvironment(parentEnvironment = process.env) {
+  const forbidden = Object.keys(parentEnvironment)
+    .filter((name) => name.startsWith("JAZZ_") && !allowedInheritedCiJazzEnv.has(name))
+    .sort();
+  if (forbidden.length) {
+    throw new Error(
+      `CI-equivalent gate refuses inherited Jazz control(s): ${forbidden.join(", ")}. ` +
+        "Unset them; only JAZZ_TEST_ARTIFACT_LOCK_PATH is inherited from CI setup.",
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(parentEnvironment).filter(
+      ([name]) => !name.startsWith("JAZZ_") || allowedInheritedCiJazzEnv.has(name),
+    ),
+  );
 }
 
-export async function runCommand({ label, executable, args, env = {} }) {
+export function commandEnvironment(baseEnvironment, localEnvironment = {}) {
+  return { ...baseEnvironment, ...localEnvironment };
+}
+
+export async function runPlan(commands, run = runCommand, baseEnvironment = process.env) {
+  for (const item of commands) await run(item, baseEnvironment);
+}
+
+export async function runCommand(
+  { label, executable, args, env = {} },
+  baseEnvironment = process.env,
+) {
   const started = performance.now();
   console.log(`local-ci: start ${label}: ${[executable, ...args].join(" ")}`);
   const status = await new Promise((resolvePromise, reject) => {
     const child = spawn(executable, args, {
       cwd: root,
       stdio: "inherit",
-      env: { ...process.env, ...env },
+      env: commandEnvironment(baseEnvironment, env),
     });
     child.once("error", reject);
     child.once("exit", (code, signal) => resolvePromise({ code, signal }));
@@ -229,14 +264,19 @@ async function main(argv) {
   }
 
   const commands = planFor({ mode, partition });
-  if (mode === "ci-equivalent") {
-    assertFullWorkspaceCoverage(commands);
-    assertArtifactBoundary(commands);
-    console.log("local-ci: CI-equivalent mode; running every CI command partition serially.");
-  } else if (!partition) {
+  const isExactPartition = mode === "ci-equivalent" || partition !== undefined;
+  if (isExactPartition) {
+    const baseEnvironment = exactCiEnvironment();
+    if (mode === "ci-equivalent") {
+      assertFullWorkspaceCoverage(commands);
+      assertArtifactBoundary(commands);
+      console.log("local-ci: CI-equivalent mode; running every CI command partition serially.");
+    }
+    await runPlan(commands, runCommand, baseEnvironment);
+  } else {
     console.log("local-ci: focused mode only; this is NOT CI-equivalent.");
+    await runPlan(commands);
   }
-  await runPlan(commands);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/dev/gates/local-ci-equivalent.mjs
+++ b/dev/gates/local-ci-equivalent.mjs
@@ -88,6 +88,7 @@ export const ciPartitions = Object.freeze({
   "rust-workspace": Object.freeze([
     command("workspace Rust tests", "node", [
       "dev/gates/run-rust-tests.mjs",
+      "--require-nextest",
       "--timeout-seconds",
       "780",
       "--nextest-profile",
@@ -126,7 +127,12 @@ export const ciPartitions = Object.freeze({
       "--dry-run",
       "chromium",
     ]),
-    command("parallel Node and browser suites", "bash", ["dev/gates/run-ts-tests.sh"]),
+    command("parallel Node and browser suites", "bash", ["dev/gates/run-ts-tests.sh"], {
+      // The test runner intentionally supports command overrides for its own
+      // harness tests.  A CI-equivalent invocation must not inherit one from
+      // a developer shell and silently test a smaller/different suite.
+      env: { JAZZ_REQUIRE_CI_TEST_COMMANDS: "1" },
+    }),
   ]),
 });
 
@@ -180,11 +186,15 @@ export async function runPlan(commands, run = runCommand) {
   for (const item of commands) await run(item);
 }
 
-export async function runCommand({ label, executable, args }) {
+export async function runCommand({ label, executable, args, env = {} }) {
   const started = performance.now();
   console.log(`local-ci: start ${label}: ${[executable, ...args].join(" ")}`);
   const status = await new Promise((resolvePromise, reject) => {
-    const child = spawn(executable, args, { cwd: root, stdio: "inherit" });
+    const child = spawn(executable, args, {
+      cwd: root,
+      stdio: "inherit",
+      env: { ...process.env, ...env },
+    });
     child.once("error", reject);
     child.once("exit", (code, signal) => resolvePromise({ code, signal }));
   });

--- a/dev/gates/local-ci-equivalent.mjs
+++ b/dev/gates/local-ci-equivalent.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * The executable correctness/build commands shared by CI and local development.
+ *
+ * `--ci-equivalent` is deliberately strict: it runs every named command
+ * partition invoked by .github/workflows/ci-suite.yml. GitHub schedules those
+ * partitions concurrently; this local entry point serializes them so one
+ * checkout can reuse its Cargo/artifact caches safely. It is command-equivalent
+ * to CI, not a claim that it reproduces GitHub credentials or runner images.
+ *
+ * The default is `--focused`, which is intentionally smaller and prints that it
+ * is NOT CI-equivalent. Never describe it as a full CI result.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export const RUST_WORKSPACE_TARGETS = Object.freeze([
+  "--lib",
+  "--bins",
+  "--tests",
+  "--examples",
+  "--benches",
+]);
+export const RUST_CI_FEATURES =
+  "jazz/testing,jazz/transport-compression-zstd,jazz-server/test,jazz-cli/test";
+
+const command = (label, executable, args, options = {}) =>
+  Object.freeze({ label, executable, args: Object.freeze(args), ...options });
+
+const m3DifferentialCommand = command(
+  "bounded maintained-vs-one-shot differential oracle",
+  "bash",
+  [
+    "-lc",
+    String.raw`set -euo pipefail
+test_binary="$(cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json | node -e '
+  const readline = require("node:readline");
+  let executable;
+  const lines = readline.createInterface({ input: process.stdin });
+  lines.on("line", (line) => {
+    try {
+      const message = JSON.parse(line);
+      if (message.reason === "compiler-artifact" && message.target.name === "jazz" && message.executable)
+        executable = message.executable;
+    } catch {}
+  });
+  lines.on("close", () => {
+    if (!executable) process.exitCode = 1;
+    else console.log(executable);
+  });
+')"
+test -x "$test_binary"
+timeout 60s env \
+  JAZZ_SEED=11 \
+  JAZZ_DIFFERENTIAL_CHURN_DEPTHS=10,1000 \
+  JAZZ_DIFFERENTIAL_STEP_COUNT=3 \
+  "$test_binary" node::tests::harness::m3_maintained_one_shot_differential_oracle --exact --ignored`,
+  ],
+);
+
+/**
+ * CI partitions are the source of truth for both CI and `--ci-equivalent`.
+ * Keep the labels stable: contracts use them to prove a selected failure stops
+ * the partition before an unrelated later command can hide it.
+ */
+export const ciPartitions = Object.freeze({
+  lint: Object.freeze([
+    command("format check", "pnpm", ["format:check"]),
+    command("lint", "pnpm", ["lint"]),
+    command("CI workflow contracts", "pnpm", ["test:ci-workflow"]),
+    command("Turbo cache-input contracts", "pnpm", ["test:turbo-cache-inputs"]),
+    command("invariant registry", "bash", ["dev/gates/invariant-registry.sh"]),
+    command("ignored-test inventory", "node", ["dev/gates/ignored-tests.mjs"]),
+  ]),
+  "rust-workspace": Object.freeze([
+    command("workspace Rust tests", "node", [
+      "dev/gates/run-rust-tests.mjs",
+      "--timeout-seconds",
+      "780",
+      "--nextest-profile",
+      "jazz-ci",
+      "--",
+      "--workspace",
+      "--lib",
+      "--bins",
+      "--tests",
+      "--features",
+      RUST_CI_FEATURES,
+    ]),
+    command("benchmark deterministic scenario smoke", "bash", [
+      "dev/gates/benchmark-smoke.sh",
+      "--ci",
+    ]),
+    command("Nextest partition coverage", "node", [
+      "--test",
+      "dev/gates/test/nextest-partitions.test.mjs",
+    ]),
+  ]),
+  "rust-differential": Object.freeze([m3DifferentialCommand]),
+  typescript: Object.freeze([
+    command("all Rust workspace target classes", "cargo", [
+      "check",
+      "--workspace",
+      ...RUST_WORKSPACE_TARGETS,
+      "--features",
+      RUST_CI_FEATURES,
+    ]),
+    command("correctness-test artifacts", "pnpm", ["build:test-artifacts"]),
+    command("preinstalled Chromium", "pnpm", [
+      "exec",
+      "playwright",
+      "install",
+      "--dry-run",
+      "chromium",
+    ]),
+    command("parallel Node and browser suites", "bash", ["dev/gates/run-ts-tests.sh"]),
+  ]),
+});
+
+export const focusedCommands = Object.freeze([
+  command("format check", "pnpm", ["format:check"]),
+  command("invariant registry", "bash", ["dev/gates/invariant-registry.sh"]),
+  command("ignored-test validator self-test", "node", [
+    "dev/gates/ignored-tests.mjs",
+    "--self-test",
+  ]),
+  command("core Rust library compile", "cargo", ["check", "-p", "jazz", "--lib"]),
+  command("jazz-tools typecheck", "pnpm", ["--filter", "jazz-tools", "check"]),
+]);
+
+export function planFor({ mode, partition } = {}) {
+  if (partition !== undefined) {
+    const commands = ciPartitions[partition];
+    if (!commands) throw new Error(`unknown CI partition: ${partition}`);
+    return commands;
+  }
+  if (mode === "ci-equivalent") return Object.freeze(Object.values(ciPartitions).flat());
+  if (mode === "focused") return focusedCommands;
+  throw new Error(`unknown local CI mode: ${mode}`);
+}
+
+export function assertFullWorkspaceCoverage(commands) {
+  const workspaceCheck = commands.find(
+    ({ executable, args }) =>
+      executable === "cargo" && args[0] === "check" && args.includes("--workspace"),
+  );
+  if (!workspaceCheck)
+    throw new Error("CI-equivalent plan omits the workspace target-class check.");
+  for (const target of RUST_WORKSPACE_TARGETS)
+    if (!workspaceCheck.args.includes(target))
+      throw new Error(`CI-equivalent workspace check omits required target class ${target}.`);
+  const featureIndex = workspaceCheck.args.indexOf("--features");
+  if (featureIndex < 0 || workspaceCheck.args[featureIndex + 1] !== RUST_CI_FEATURES)
+    throw new Error("CI-equivalent workspace check omits the required CI feature selection.");
+}
+
+export function assertArtifactBoundary(commands) {
+  const artifacts = commands.find(({ label }) => label === "correctness-test artifacts");
+  const suites = commands.find(({ label }) => label === "parallel Node and browser suites");
+  if (!artifacts || !suites)
+    throw new Error("CI-equivalent TypeScript plan omits artifacts or test suites.");
+  if (commands.indexOf(artifacts) > commands.indexOf(suites))
+    throw new Error("CI-equivalent TypeScript plan runs tests before correctness artifacts.");
+}
+
+export async function runPlan(commands, run = runCommand) {
+  for (const item of commands) await run(item);
+}
+
+export async function runCommand({ label, executable, args }) {
+  const started = performance.now();
+  console.log(`local-ci: start ${label}: ${[executable, ...args].join(" ")}`);
+  const status = await new Promise((resolvePromise, reject) => {
+    const child = spawn(executable, args, { cwd: root, stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolvePromise({ code, signal }));
+  });
+  const elapsedSeconds = ((performance.now() - started) / 1000).toFixed(1);
+  if (status.code !== 0)
+    throw new Error(
+      `local-ci: ${label} failed with ${status.signal ?? `exit ${status.code ?? 1}`} after ${elapsedSeconds}s`,
+    );
+  console.log(`local-ci: done ${label} (${elapsedSeconds}s)`);
+}
+
+function usage() {
+  console.error(`Usage: node dev/gates/local-ci-equivalent.mjs [--focused | --ci-equivalent | --ci-partition NAME]
+
+Default: --focused (NOT CI-equivalent; targeted iteration only).
+--ci-equivalent: all exact command partitions invoked by CI, serialized locally.
+--ci-partition: one named CI partition for .github/workflows/ci-suite.yml.`);
+}
+
+async function main(argv) {
+  let mode = "focused";
+  let partition;
+  if (argv.length === 1 && ["--help", "-h"].includes(argv[0])) {
+    usage();
+    return;
+  } else if (argv.length === 1 && argv[0] === "--focused") mode = "focused";
+  else if (argv.length === 1 && argv[0] === "--ci-equivalent") mode = "ci-equivalent";
+  else if (argv.length === 2 && argv[0] === "--ci-partition") partition = argv[1];
+  else if (argv.length !== 0) {
+    usage();
+    throw new Error("invalid local CI mode");
+  }
+
+  const commands = planFor({ mode, partition });
+  if (mode === "ci-equivalent") {
+    assertFullWorkspaceCoverage(commands);
+    assertArtifactBoundary(commands);
+    console.log("local-ci: CI-equivalent mode; running every CI command partition serially.");
+  } else if (!partition) {
+    console.log("local-ci: focused mode only; this is NOT CI-equivalent.");
+  }
+  await runPlan(commands);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -6,6 +6,20 @@
 # script starts.
 set -u
 
+# The runner accepts small command overrides solely so its process-management
+# contract tests can use deterministic short-lived children.  The shared local
+# CI partition sets this guard, matching CI's unmodified environment: an
+# inherited override would otherwise let a local "CI-equivalent" receipt skip
+# the suites that GitHub will run.
+if [[ "${JAZZ_REQUIRE_CI_TEST_COMMANDS:-0}" == "1" ]]; then
+  for override in JAZZ_NODE_TEST_COMMAND JAZZ_BROWSER_TEST_COMMAND JAZZ_SKIP_JAZZ_TOOLS_BUILD; do
+    if [[ -v "${override}" ]]; then
+      echo "${override} is a test-harness override and is forbidden by the CI-equivalent partition" >&2
+      exit 1
+    fi
+  done
+fi
+
 node_tests_command=${JAZZ_NODE_TEST_COMMAND:-"pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!auth-simple-chat --filter=!auth-workos-chat --filter=!auth-betterauth-chat --filter=!chat-react --filter=!world-tour --filter=!jazz-rn --concurrency=2"}
 browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --filter jazz-tools test:browser"}
 node_tests_pid=""

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -91,7 +91,7 @@ const assertUsesBlacksmithRunner = (jobName, jobSource) => {
   assert.doesNotMatch(jobSource, /^    runs-on: jazz-ci$/m);
 };
 const integrationCheckStep = (typescriptJob) => {
-  const start = typescriptJob.indexOf("name: Check integration workspace");
+  const start = typescriptJob.indexOf("name: Run CI-equivalent TypeScript and workspace partition");
   assert.notEqual(start, -1, "missing integration workspace check");
   const end = typescriptJob.indexOf("\n      - ", start + 1);
   return typescriptJob.slice(start, end === -1 ? typescriptJob.length : end);
@@ -455,141 +455,39 @@ test("trusted runners consume the validated immutable tool bundle", () => {
   );
 });
 
-test("Rust CI splits a bounded real differential-oracle smoke behind a stable aggregate", () => {
+test("Rust CI keeps the bounded real differential oracle in its shared command partition", () => {
   const workspace = job("test-rust-workspace");
   const differential = job("test-rust-differential");
   const aggregate = job("test-rust");
-  const compileStepName = "name: Compile M3 differential oracle libtest";
-  const runStepName = "name: Run maintained-vs-one-shot differential oracle smoke";
-  const assertM3CompileThenRun = (source) => {
-    const compileStart = source.indexOf(compileStepName);
-    const runStart = source.indexOf(runStepName);
-    assert.ok(compileStart !== -1, "missing M3 libtest compile step");
-    assert.ok(runStart !== -1, "missing M3 semantic execution step");
-    assert.ok(compileStart < runStart, "compile the M3 libtest before its semantic execution");
-    assert.match(
-      source.slice(compileStart, runStart),
-      /shell: bash/,
-      "the M3 compile step must not inherit the container's sh default",
-    );
-    assert.doesNotMatch(
-      source.slice(compileStart, runStart),
-      /\btimeout\b/,
-      "cold compilation must not consume the semantic-execution timeout",
-    );
-    assert.match(
-      source.slice(runStart),
-      /timeout 60s env/,
-      "the direct libtest execution must remain bounded",
-    );
-    assert.match(
-      source.slice(runStart),
-      /shell: bash/,
-      "the M3 semantic execution step must not inherit the container's sh default",
-    );
-  };
+  const localCi = fs.readFileSync(path.join(root, "dev/gates/local-ci-equivalent.mjs"), "utf8");
 
+  assert.match(workspace, /local-ci-equivalent\.mjs --ci-partition rust-workspace/);
+  assert.match(differential, /local-ci-equivalent\.mjs --ci-partition rust-differential/);
   assert.match(
-    workspace,
-    /run-rust-tests\.mjs --timeout-seconds 780 --nextest-profile jazz-ci -- --workspace --lib --bins --tests --features jazz\/testing,jazz\/transport-compression-zstd,jazz-server\/test,jazz-cli\/test/,
+    localCi,
+    /run-rust-tests\.mjs[\s\S]*--timeout-seconds[\s\S]*780[\s\S]*--nextest-profile[\s\S]*jazz-ci/,
   );
-  for (const testTarget of [
-    "incremental_delivery_canary",
-    "shared_coverage_differential",
-    "warm_reopen_differential",
-  ]) {
-    assert.doesNotMatch(workspace, new RegExp(`cargo test -p jazz --test ${testTarget}`));
-  }
   assert.match(
-    differential,
+    localCi,
     /cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json/,
   );
-  assert.match(differential, /message\.target\.name === "jazz"/);
+  assert.match(localCi, /message\.target\.name === "jazz"/);
   assert.match(
-    differential,
-    /echo "M3_ORACLE_TEST_BINARY=\$\{test_binary\}" >> "\$\{GITHUB_ENV\}"/,
+    localCi,
+    /timeout 60s env[\s\S]*JAZZ_SEED=11[\s\S]*JAZZ_DIFFERENTIAL_CHURN_DEPTHS=10,1000[\s\S]*JAZZ_DIFFERENTIAL_STEP_COUNT=3[\s\S]*m3_maintained_one_shot_differential_oracle --exact --ignored/,
   );
-  assert.match(
-    differential,
-    /timeout 60s env[\s\\]+JAZZ_SEED=11[\s\\]+JAZZ_DIFFERENTIAL_CHURN_DEPTHS=10,1000[\s\\]+JAZZ_DIFFERENTIAL_STEP_COUNT=3[\s\\]+"\$\{M3_ORACLE_TEST_BINARY\}" node::tests::harness::m3_maintained_one_shot_differential_oracle --exact --ignored/,
-  );
-  assertM3CompileThenRun(differential);
-  assert.match(differential, /full randomized matrix[\s\S]*long-running manual soak/);
-  assert.doesNotMatch(differential, /tracked red debt/);
   assert.match(
     m3Differential,
     /#\[ignore = "#\d+: manual randomized differential soak; bounded seed 11 runs in CI"\]\n(?:pub )?fn m3_maintained_one_shot_differential_oracle/,
   );
-  assert.doesNotMatch(workspace, /m3_maintained_one_shot_differential_oracle/);
   assert.match(aggregate, /if: always\(\)/);
   assert.match(aggregate, /needs: \[test-rust-workspace, test-rust-differential\]/);
-  assert.match(aggregate, /WORKSPACE_RESULT: \$\{\{ needs\.test-rust-workspace\.result \}\}/);
-  assert.match(aggregate, /DIFFERENTIAL_RESULT: \$\{\{ needs\.test-rust-differential\.result \}\}/);
   assert.match(aggregate, /test "\$\{WORKSPACE_RESULT\}" = success/);
   assert.match(aggregate, /test "\$\{DIFFERENTIAL_RESULT\}" = success/);
   assert.match(differential, /rust-cache: "false"/);
   assert.throws(
-    () =>
-      assert.match(
-        differential.replace('rust-cache: "false"', 'rust-cache: "true"'),
-        /rust-cache: "false"/,
-      ),
-    /rust-cache/,
-  );
-  assert.throws(
-    () =>
-      assert.match(
-        differential.replace(
-          "cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json",
-          "cargo test -p jazz --no-run --message-format=json",
-        ),
-        /cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json/,
-      ),
-    /--lib/,
-  );
-  assert.throws(
-    () => assert.match(differential.replace("--exact --ignored", "--ignored"), /--exact --ignored/),
+    () => assert.match(localCi.replace("--exact --ignored", "--ignored"), /--exact --ignored/),
     /exact/,
-  );
-  assert.throws(
-    () =>
-      assertM3CompileThenRun(
-        differential.replace(
-          `${compileStepName}\n        shell: bash\n        run:`,
-          `${compileStepName}\n        run:`,
-        ),
-      ),
-    /compile step must not inherit the container's sh default/,
-  );
-  assert.throws(
-    () =>
-      assertM3CompileThenRun(
-        differential.replace(
-          `${runStepName}\n        shell: bash\n        run:`,
-          `${runStepName}\n        run:`,
-        ),
-      ),
-    /semantic execution step must not inherit the container's sh default/,
-  );
-  assert.throws(
-    () =>
-      assertM3CompileThenRun(
-        differential.replace(
-          "cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json",
-          "timeout 60s cargo test -p jazz --lib --features testing,transport-compression-zstd --no-run --message-format=json",
-        ),
-      ),
-    /cold compilation must not consume the semantic-execution timeout/,
-  );
-  assert.throws(
-    () =>
-      assertM3CompileThenRun(
-        differential
-          .replace(compileStepName, "__M3_STEP_SWAP__")
-          .replace(runStepName, compileStepName)
-          .replace("__M3_STEP_SWAP__", runStepName),
-      ),
-    /compile the M3 libtest before its semantic execution/,
   );
 });
 
@@ -909,13 +807,12 @@ test("the TypeScript CI job checks the integration workspace before TypeScript a
   assert.doesNotMatch(workflowSuite, /^  build-integration:/m);
   assert.match(
     typescript,
-    /name: Check integration workspace\s+run: cargo check --workspace --all-targets/,
+    /name: Run CI-equivalent TypeScript and workspace partition\s+run: node dev\/gates\/local-ci-equivalent\.mjs --ci-partition typescript/,
   );
   assertIntegrationCheckIsGating(typescript);
   assert.ok(
-    typescript.indexOf("name: Check integration workspace") <
-      typescript.indexOf("name: Build correctness-test artifacts"),
-    "workspace check must fail before the expensive correctness artifact build",
+    typescript.indexOf("name: Run CI-equivalent TypeScript and workspace partition") !== -1,
+    "workspace check and artifacts must use the shared CI-equivalent partition",
   );
   assertUsesBlacksmithRunner("test-ts", typescript);
 });
@@ -1124,7 +1021,7 @@ test("Blacksmith and cache trust contracts reject planted unsafe changes", () =>
 test("integration workspace check contract rejects planted failure suppression", () => {
   const typescript = job("test-ts");
   const check =
-    "name: Check integration workspace\n        run: cargo check --workspace --all-targets";
+    "name: Run CI-equivalent TypeScript and workspace partition\n        run: node dev/gates/local-ci-equivalent.mjs --ci-partition typescript";
 
   assert.throws(
     () =>
@@ -1147,7 +1044,7 @@ test("integration workspace check contract rejects planted failure suppression",
 
 test("lint keeps its one workspace Clippy invocation inside pnpm lint", () => {
   const lint = job("lint");
-  assert.match(lint, /run: pnpm lint/);
+  assert.match(lint, /local-ci-equivalent\.mjs --ci-partition lint/);
   assert.doesNotMatch(lint, /^\s*- run: cargo clippy/m);
 });
 
@@ -1155,9 +1052,9 @@ test("CI runs the workflow contract test through its package script", () => {
   const lint = job("lint");
   assert.equal(
     packageJson.scripts["test:ci-workflow"],
-    "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
+    "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/local-ci-equivalent.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
   );
-  assert.match(lint, /run: pnpm test:ci-workflow/);
+  assert.match(lint, /local-ci-equivalent\.mjs --ci-partition lint/);
 });
 
 test("CodSpeed caches the root-workspace Cargo target", () => {
@@ -1269,10 +1166,7 @@ test("benchmark correctness stays on ordinary CI while API compilation uses real
   const workspace = job("test-rust-workspace");
   const scenarioMode = benchmarkSmokeMode("ci");
   const compileMode = benchmarkSmokeMode("compile-ci");
-  assert.match(
-    workspace,
-    /name: Benchmark deterministic scenario smoke\s+run: dev\/gates\/benchmark-smoke\.sh --ci/,
-  );
+  assert.match(workspace, /local-ci-equivalent\.mjs --ci-partition rust-workspace/);
   assert.match(
     realisticWorkflow,
     /name: Compile maintained benchmark APIs\s+run: dev\/gates\/benchmark-smoke\.sh --compile-ci/,
@@ -1444,12 +1338,10 @@ test("Windows NAPI release builds provision libclang for RocksDB bindgen", () =>
 test("TypeScript CI overlaps independent Node and browser suites after one artifact build", () => {
   const typescript = job("test-ts");
   const runner = fs.readFileSync(path.join(root, "dev/gates/run-ts-tests.sh"), "utf8");
-  assert.match(
-    typescript,
-    /name: Build correctness-test artifacts\s+run: pnpm build:test-artifacts/,
-  );
-  assert.match(typescript, /name: Run Node and browser test suites in parallel/);
-  assert.match(typescript, /run: dev\/gates\/run-ts-tests\.sh/);
+  const localCi = fs.readFileSync(path.join(root, "dev/gates/local-ci-equivalent.mjs"), "utf8");
+  assert.match(typescript, /local-ci-equivalent\.mjs --ci-partition typescript/);
+  assert.match(localCi, /correctness-test artifacts[\s\S]*build:test-artifacts/);
+  assert.match(localCi, /parallel Node and browser suites[\s\S]*run-ts-tests\.sh/);
   assert.match(runner, /pnpm --filter jazz-tools build/);
   assert.match(runner, /Every example resolves the public `jazz-tools\/\*` exports from `dist`/);
   assert.match(runner, /--concurrency=2/);

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -8,10 +8,13 @@ import { parse } from "yaml";
 import {
   RUST_CI_FEATURES,
   RUST_WORKSPACE_TARGETS,
+  ALLOWED_INHERITED_CI_JAZZ_ENV,
   assertArtifactBoundary,
   assertFullWorkspaceCoverage,
   ciPartitionJobs,
   ciPartitions,
+  commandEnvironment,
+  exactCiEnvironment,
   planFor,
   runPlan,
 } from "../local-ci-equivalent.mjs";
@@ -219,6 +222,34 @@ test("the shared TypeScript runner rejects inherited suite overrides under the C
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /JAZZ_NODE_TEST_COMMAND.*forbidden by the CI-equivalent partition/);
+});
+
+test("exact partitions fail closed on ambient Jazz controls and retain only the CI artifact lock", () => {
+  assert.deepEqual(ALLOWED_INHERITED_CI_JAZZ_ENV, ["JAZZ_TEST_ARTIFACT_LOCK_PATH"]);
+  assert.throws(
+    () =>
+      exactCiEnvironment({
+        PATH: "/bin",
+        JAZZ_UPDATE_WIRE_FIXTURES: "1",
+        JAZZ_SKIP_BULK_INGEST_ASSERTS: "1",
+      }),
+    /JAZZ_SKIP_BULK_INGEST_ASSERTS, JAZZ_UPDATE_WIRE_FIXTURES/,
+    "fixture rewrites and assertion skips must fail before any partition starts",
+  );
+
+  const base = exactCiEnvironment({
+    PATH: "/bin",
+    JAZZ_TEST_ARTIFACT_LOCK_PATH: "/tmp/jazz-test-artifacts.lock",
+  });
+  assert.deepEqual(base, {
+    PATH: "/bin",
+    JAZZ_TEST_ARTIFACT_LOCK_PATH: "/tmp/jazz-test-artifacts.lock",
+  });
+  assert.deepEqual(commandEnvironment(base, { JAZZ_REQUIRE_CI_TEST_COMMANDS: "1" }), {
+    PATH: "/bin",
+    JAZZ_TEST_ARTIFACT_LOCK_PATH: "/tmp/jazz-test-artifacts.lock",
+    JAZZ_REQUIRE_CI_TEST_COMMANDS: "1",
+  });
 });
 
 test("planted bench/test/bin/example compile failures are surfaced rather than skipped", async () => {

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { isDeepStrictEqual } from "node:util";
 import { parse } from "yaml";
@@ -180,6 +181,44 @@ test("CI-equivalent workspace check compiles every target class with the require
       : item,
   );
   assert.throws(() => assertFullWorkspaceCoverage(missingFeature), /required CI feature selection/);
+});
+
+test("CI-equivalent partitions cannot silently substitute their Rust or TypeScript runners", () => {
+  const rust = planFor({ partition: "rust-workspace" }).find(
+    ({ label }) => label === "workspace Rust tests",
+  );
+  assert.ok(rust);
+  assert.ok(
+    rust.args.includes("--require-nextest"),
+    "CI-equivalent Rust must fail rather than silently switch to Cargo fallback",
+  );
+
+  const typescript = planFor({ partition: "typescript" }).find(
+    ({ label }) => label === "parallel Node and browser suites",
+  );
+  assert.ok(typescript);
+  assert.deepEqual(typescript.env, { JAZZ_REQUIRE_CI_TEST_COMMANDS: "1" });
+
+  const planted = { ...typescript, env: {} };
+  assert.notDeepEqual(
+    planted.env,
+    { JAZZ_REQUIRE_CI_TEST_COMMANDS: "1" },
+    "a missing guard would permit inherited suite overrides",
+  );
+});
+
+test("the shared TypeScript runner rejects inherited suite overrides under the CI guard", () => {
+  const result = spawnSync("bash", ["dev/gates/run-ts-tests.sh"], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      JAZZ_REQUIRE_CI_TEST_COMMANDS: "1",
+      JAZZ_NODE_TEST_COMMAND: "true",
+    },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JAZZ_NODE_TEST_COMMAND.*forbidden by the CI-equivalent partition/);
 });
 
 test("planted bench/test/bin/example compile failures are surfaced rather than skipped", async () => {

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
+import { isDeepStrictEqual } from "node:util";
 import { parse } from "yaml";
 import {
   RUST_CI_FEATURES,
@@ -20,15 +21,42 @@ const workflowModel = parse(workflow);
 
 const partitionCommand = (partition) =>
   `node dev/gates/local-ci-equivalent.mjs --ci-partition ${partition}`;
-const isSccacheExport = ({ name, run }) =>
-  name === "Export trusted sccache configuration" &&
-  run
-    .trim()
-    .split("\n")
-    .every((line) => /^echo "SCCACHE_[A-Z0-9_]+=.*" >> "\$\{GITHUB_ENV\}"$/.test(line));
-const isTurboExport = ({ name, run }) =>
-  name === "Export trusted Turbo cache signing key" &&
-  /^echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=.*" >> "\$\{GITHUB_ENV\}"$/.test(run.trim());
+const trustedSccacheCondition =
+  "inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '')";
+const trustedTurboCondition = "inputs.trusted-cache";
+const sccacheExportStep = Object.freeze({
+  name: "Export trusted sccache configuration",
+  if: trustedSccacheCondition,
+  env: {
+    CACHE_BUCKET: "${{ vars.SCCACHE_BUCKET }}",
+    CACHE_REGION: "${{ vars.SCCACHE_REGION }}",
+  },
+  run:
+    [
+      'echo "SCCACHE_BUCKET=${CACHE_BUCKET}" >> "${GITHUB_ENV}"',
+      'echo "SCCACHE_REGION=${CACHE_REGION}" >> "${GITHUB_ENV}"',
+      'echo "SCCACHE_S3_USE_SSL=true" >> "${GITHUB_ENV}"',
+      'echo "SCCACHE_S3_KEY_PREFIX=jazz-ci/v1/production/blacksmith-v1" >> "${GITHUB_ENV}"',
+    ].join("\n") + "\n",
+});
+const turboExportStep = Object.freeze({
+  name: "Export trusted Turbo cache signing key",
+  if: trustedTurboCondition,
+  env: { CACHE_SIGNATURE_KEY: "${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}" },
+  run: 'echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=${CACHE_SIGNATURE_KEY}" >> "${GITHUB_ENV}"',
+});
+
+function isExactStep(actual, expected) {
+  return (
+    Object.keys(actual).length === Object.keys(expected).length &&
+    Object.keys(expected).every(
+      (key) => Object.hasOwn(actual, key) && isDeepStrictEqual(actual[key], expected[key]),
+    )
+  );
+}
+
+const isKnownAdminExport = (step) =>
+  isExactStep(step, sccacheExportStep) || isExactStep(step, turboExportStep);
 
 function assertCiSuiteUsesOnlySharedCorrectnessPartitions(model) {
   const expectedJobs = new Set(Object.values(ciPartitionJobs));
@@ -43,12 +71,7 @@ function assertCiSuiteUsesOnlySharedCorrectnessPartitions(model) {
       `${jobName} must invoke its shared ${partition} partition exactly once`,
     );
     for (const step of runSteps) {
-      if (
-        step.run === expected ||
-        step.run === "sccache --show-stats" ||
-        isSccacheExport(step) ||
-        isTurboExport(step)
-      )
+      if (step.run === expected || step.run === "sccache --show-stats" || isKnownAdminExport(step))
         continue;
       assert.fail(`${jobName} has an unshared direct run step: ${step.name ?? step.run}`);
     }
@@ -79,6 +102,22 @@ test("CI invokes only shared partitions and rejects a direct correctness bypass"
   assert.throws(
     () => assertCiSuiteUsesOnlySharedCorrectnessPartitions(planted),
     /unshared direct run step: quiet bypass/,
+  );
+
+  const sccacheExploit = structuredClone(workflowModel);
+  sccacheExploit.jobs.lint.steps.find(({ name }) => name === sccacheExportStep.name).run =
+    'echo "SCCACHE_PROBE=$(cargo test -p jazz)" >> "${GITHUB_ENV}"';
+  assert.throws(
+    () => assertCiSuiteUsesOnlySharedCorrectnessPartitions(sccacheExploit),
+    /unshared direct run step: Export trusted sccache configuration/,
+  );
+
+  const turboExploit = structuredClone(workflowModel);
+  turboExploit.jobs["test-ts"].steps.find(({ name }) => name === turboExportStep.name).run =
+    'echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=$(cargo test -p jazz)" >> "${GITHUB_ENV}"';
+  assert.throws(
+    () => assertCiSuiteUsesOnlySharedCorrectnessPartitions(turboExploit),
+    /unshared direct run step: Export trusted Turbo cache signing key/,
   );
 
   assert.deepEqual(

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -45,6 +45,11 @@ const turboExportStep = Object.freeze({
   env: { CACHE_SIGNATURE_KEY: "${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}" },
   run: 'echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=${CACHE_SIGNATURE_KEY}" >> "${GITHUB_ENV}"',
 });
+const sccacheStatsStep = Object.freeze({
+  name: "Report sccache statistics",
+  if: "always()",
+  run: "sccache --show-stats",
+});
 
 function isExactStep(actual, expected) {
   return (
@@ -55,8 +60,10 @@ function isExactStep(actual, expected) {
   );
 }
 
-const isKnownAdminExport = (step) =>
-  isExactStep(step, sccacheExportStep) || isExactStep(step, turboExportStep);
+const isKnownAdminStep = (step) =>
+  isExactStep(step, sccacheExportStep) ||
+  isExactStep(step, turboExportStep) ||
+  isExactStep(step, sccacheStatsStep);
 
 function assertCiSuiteUsesOnlySharedCorrectnessPartitions(model) {
   const expectedJobs = new Set(Object.values(ciPartitionJobs));
@@ -71,8 +78,7 @@ function assertCiSuiteUsesOnlySharedCorrectnessPartitions(model) {
       `${jobName} must invoke its shared ${partition} partition exactly once`,
     );
     for (const step of runSteps) {
-      if (step.run === expected || step.run === "sccache --show-stats" || isKnownAdminExport(step))
-        continue;
+      if (step.run === expected || isKnownAdminStep(step)) continue;
       assert.fail(`${jobName} has an unshared direct run step: ${step.name ?? step.run}`);
     }
   }
@@ -118,6 +124,22 @@ test("CI invokes only shared partitions and rejects a direct correctness bypass"
   assert.throws(
     () => assertCiSuiteUsesOnlySharedCorrectnessPartitions(turboExploit),
     /unshared direct run step: Export trusted Turbo cache signing key/,
+  );
+
+  const statsShellExploit = structuredClone(workflowModel);
+  statsShellExploit.jobs.lint.steps.find(({ name }) => name === sccacheStatsStep.name).shell =
+    "bash -c 'cargo test -p jazz; bash {0}'";
+  assert.throws(
+    () => assertCiSuiteUsesOnlySharedCorrectnessPartitions(statsShellExploit),
+    /unshared direct run step: Report sccache statistics/,
+  );
+
+  const statsRunExploit = structuredClone(workflowModel);
+  statsRunExploit.jobs.lint.steps.find(({ name }) => name === sccacheStatsStep.name).run =
+    "sccache --show-stats; cargo test -p jazz";
+  assert.throws(
+    () => assertCiSuiteUsesOnlySharedCorrectnessPartitions(statsRunExploit),
+    /unshared direct run step: Report sccache statistics/,
   );
 
   assert.deepEqual(

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import {
+  RUST_CI_FEATURES,
+  RUST_WORKSPACE_TARGETS,
+  assertArtifactBoundary,
+  assertFullWorkspaceCoverage,
+  ciPartitions,
+  planFor,
+  runPlan,
+} from "../local-ci-equivalent.mjs";
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const workflow = fs.readFileSync(path.join(root, ".github/workflows/ci-suite.yml"), "utf8");
+
+test("CI invokes every shared partition and local CI-equivalent flattens exactly those partitions", () => {
+  for (const partition of Object.keys(ciPartitions))
+    assert.match(
+      workflow,
+      new RegExp(`local-ci-equivalent\\.mjs --ci-partition ${partition}`),
+      `CI omits shared ${partition} partition`,
+    );
+
+  assert.deepEqual(
+    planFor({ mode: "ci-equivalent" }),
+    Object.values(ciPartitions).flat(),
+    "local CI-equivalent must not quietly replace a CI partition with an approximation",
+  );
+});
+
+test("focused mode is explicitly smaller and cannot be mistaken for CI-equivalent", () => {
+  const focused = planFor({ mode: "focused" });
+  const complete = planFor({ mode: "ci-equivalent" });
+  assert.ok(focused.length < complete.length);
+  assert.notDeepEqual(focused, complete);
+  assert.throws(() => planFor({ mode: "everything" }), /unknown local CI mode/);
+  assert.throws(() => planFor({ partition: "made-up" }), /unknown CI partition/);
+});
+
+test("CI-equivalent workspace check compiles every target class with the required features", () => {
+  const complete = planFor({ mode: "ci-equivalent" });
+  assert.doesNotThrow(() => assertFullWorkspaceCoverage(complete));
+  for (const omitted of RUST_WORKSPACE_TARGETS) {
+    const planted = complete.map((item) =>
+      item.label === "all Rust workspace target classes"
+        ? { ...item, args: item.args.filter((arg) => arg !== omitted) }
+        : item,
+    );
+    assert.throws(
+      () => assertFullWorkspaceCoverage(planted),
+      new RegExp(`omits required target class ${omitted.replace("--", "\\-\\-")}`),
+      `a ${omitted} compile regression must be caught before calling the gate CI-equivalent`,
+    );
+  }
+
+  const missingFeature = complete.map((item) =>
+    item.label === "all Rust workspace target classes"
+      ? { ...item, args: item.args.filter((arg) => arg !== RUST_CI_FEATURES) }
+      : item,
+  );
+  assert.throws(() => assertFullWorkspaceCoverage(missingFeature), /required CI feature selection/);
+});
+
+test("planted bench/test/bin/example compile failures are surfaced rather than skipped", async () => {
+  const complete = planFor({ mode: "ci-equivalent" });
+  for (const [target, failure] of [
+    ["--benches", "bench-only compile failure"],
+    ["--tests", "test-only compile failure"],
+    ["--bins", "bin-only compile failure"],
+    ["--examples", "example-only compile failure"],
+  ]) {
+    const seen = [];
+    await assert.rejects(
+      () =>
+        runPlan(complete, async (item) => {
+          seen.push(item.label);
+          if (item.label === "all Rust workspace target classes" && item.args.includes(target))
+            throw new Error(failure);
+        }),
+      new RegExp(failure),
+      `${target} failure must fail the CI-equivalent gate`,
+    );
+    assert.ok(seen.includes("all Rust workspace target classes"));
+    assert.equal(
+      seen.includes("correctness-test artifacts"),
+      false,
+      "a target-class compile failure must stop before TS artifacts hide it",
+    );
+  }
+});
+
+test("the generated-artifact boundary fails before Node/browser tests can use stale outputs", async () => {
+  const typescript = planFor({ partition: "typescript" });
+  assert.doesNotThrow(() => assertArtifactBoundary(typescript));
+  const reversed = [...typescript].reverse();
+  assert.throws(() => assertArtifactBoundary(reversed), /runs tests before correctness artifacts/);
+
+  const seen = [];
+  await assert.rejects(
+    () =>
+      runPlan(typescript, async (item) => {
+        seen.push(item.label);
+        if (item.label === "correctness-test artifacts")
+          throw new Error("generated artifact failure");
+      }),
+    /generated artifact failure/,
+  );
+  assert.deepEqual(seen, ["all Rust workspace target classes", "correctness-test artifacts"]);
+});

--- a/dev/gates/test/test-artifact-pipeline.test.mjs
+++ b/dev/gates/test/test-artifact-pipeline.test.mjs
@@ -494,7 +494,9 @@ test("CI uses the correctness artifact path while package builds keep release WA
   );
   const packageJson = readFileSync(new URL("../../../package.json", import.meta.url), "utf8");
   const pipeline = readFileSync(new URL("../build-test-artifacts.mjs", import.meta.url), "utf8");
-  assert.match(workflow, /pnpm build:test-artifacts/);
+  const localCi = readFileSync(new URL("../local-ci-equivalent.mjs", import.meta.url), "utf8");
+  assert.match(workflow, /local-ci-equivalent\.mjs --ci-partition typescript/);
+  assert.match(localCi, /correctness-test artifacts[\s\S]*pnpm[\s\S]*build:test-artifacts/);
   assert.match(packageJson, /"build:test-artifacts": "node dev\/gates\/build-test-artifacts\.mjs"/);
   assert.match(
     packageJson,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:vercel-preview-skip": "node --test dev/scripts/skip-new-core-vercel-preview.test.mjs",
     "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
-    "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
+    "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/local-ci-equivalent.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
     "ensure:rust-toolchain": "rustup target add wasm32-unknown-unknown && (wasm-pack --version >/dev/null 2>&1 || cargo install wasm-pack@0.13.1 --locked)",
     "build:vercel-docs": "bash dev/scripts/install-vercel-deps.sh && turbo run --env-mode=loose build:crates --filter=@jazz/rust && turbo run --env-mode=loose build --filter=docs --only",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",


### PR DESCRIPTION
🤖 Makes the documented local CI-equivalent gate execute the same maintained correctness partitions as GitHub CI.

The CI workflow delegates lint, exhaustive Rust workspace targets, the M3 differential oracle, and TypeScript correctness to shared local-ci-equivalent partitions. dev/gates/smoke.sh --ci-equivalent executes those same partitions serially; the ordinary focused smoke remains intentionally smaller and is no longer described as CI-equivalent.

The workflow contract fails closed on drift: every correctness job must call exactly its named shared partition once, aggregate jobs may only consume their results, and the few setup/cache/statistics shell steps are exact modeled records. Direct correctness commands, extra commands, unknown fields, custom shells, and command substitutions are rejected.

Exactness also covers runner selection. The Rust partition requires cargo-nextest instead of silently falling back to Cargo, and the TypeScript partition rejects inherited node, browser, or artifact-skip test-harness overrides that could substitute a smaller suite. A temporary merge with #1991 reproduced the same stale Groove fixture failures as GitHub CI, proving the shared gate catches that class locally.

Independent adversarial review planted direct Cargo commands in ordinary steps, cache exports, Turbo exports, sccache statistics shells, and inherited suite overrides. Each bypass failed the structural contract. Exit 23, SIGTERM, fail-fast propagation, and exact runner selection were verified. The workflow contract suite passes 108/108; the real lint and bounded M3 partitions pass; exhaustive Rust checking covers libs, bins, tests, examples, and benches with the CI feature set.