### PR TITLE
Bound retained auxiliary chunk relay obligations

### DIFF
--- a/.changeset/bound-chunk-relay-obligations.md
+++ b/.changeset/bound-chunk-relay-obligations.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bound retained auxiliary chunk relay obligations and stop the native upstream pump cleanly after disconnection.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -144,6 +144,9 @@ fn storage_error_kind(error: &groove::chunks::ChunkStorageError) -> &'static str
         groove::chunks::ChunkStorageError::Backend(_) => "backend",
     }
 }
+// Relay correlation entries and their queued responses share one global
+// budget while in-process consumers remain outside peer admission.
+const MAX_RELAY_CHUNK_OBLIGATIONS: usize = MAX_PENDING_CHUNK_DEMANDS;
 
 enum ChunkDemandWaiter {
     Local {
@@ -166,6 +169,7 @@ struct PendingChunkDemand {
 struct ChunkDemandState {
     next_request_id: u64,
     next_waiter_id: u64,
+    relay_chunk_obligations: usize,
     pending_by_chunk: BTreeMap<groove::chunks::ChunkRequest, PendingChunkDemand>,
     chunk_by_upstream_id: BTreeMap<u64, groove::chunks::ChunkRequest>,
     outbound: VecDeque<ChunkRequestEntry>,
@@ -267,6 +271,40 @@ impl PeerChunkResolver {
         }
     }
 
+    fn queue_relay_response(
+        state: &mut ChunkDemandState,
+        connection: u64,
+        response: ChunkResponseEntry,
+        reserved: bool,
+    ) -> bool {
+        if !reserved {
+            if state.relay_chunk_obligations >= MAX_RELAY_CHUNK_OBLIGATIONS {
+                return false;
+            }
+            state.relay_chunk_obligations += 1;
+        }
+        state
+            .relay_responses
+            .entry(connection)
+            .or_default()
+            .push(response);
+        Self::wake_connection(state, connection);
+        true
+    }
+
+    fn enqueue_relay_responses(
+        &self,
+        connection: u64,
+        responses: impl IntoIterator<Item = ChunkResponseEntry>,
+    ) {
+        let mut state = self.state.borrow_mut();
+        for response in responses {
+            if !Self::queue_relay_response(&mut state, connection, response, false) {
+                break;
+            }
+        }
+    }
+
     fn enqueue(
         &self,
         request: groove::chunks::ChunkRequest,
@@ -274,8 +312,13 @@ impl PeerChunkResolver {
         waiter: ChunkDemandWaiter,
     ) -> Result<(), ChunkDemandWaiter> {
         let mut state = self.state.borrow_mut();
+        let relay_waiter = matches!(&waiter, ChunkDemandWaiter::Relay { .. });
+        if relay_waiter && state.relay_chunk_obligations >= MAX_RELAY_CHUNK_OBLIGATIONS {
+            return Err(waiter);
+        }
         if let Some(pending) = state.pending_by_chunk.get_mut(&request) {
             pending.waiters.push(waiter);
+            state.relay_chunk_obligations += usize::from(relay_waiter);
             return Ok(());
         }
         if state.pending_by_chunk.len() >= MAX_PENDING_CHUNK_DEMANDS {
@@ -300,6 +343,7 @@ impl PeerChunkResolver {
                 waiters: vec![waiter],
             },
         );
+        state.relay_chunk_obligations += usize::from(relay_waiter);
         if let Some(connection) = state.upstream_connection {
             Self::wake_connection(&mut state, connection);
         }
@@ -309,15 +353,15 @@ impl PeerChunkResolver {
     fn enqueue_relay(&self, connection: u64, request: ChunkRequestEntry) {
         if request.remaining_hops == 0 {
             let mut state = self.state.borrow_mut();
-            state
-                .relay_responses
-                .entry(connection)
-                .or_default()
-                .push(ChunkResponseEntry {
+            Self::queue_relay_response(
+                &mut state,
+                connection,
+                ChunkResponseEntry {
                     request_id: request.request_id,
                     result: ChunkResponse::Unavailable,
-                });
-            Self::wake_connection(&mut state, connection);
+                },
+                false,
+            );
             return;
         }
         if let Err(ChunkDemandWaiter::Relay {
@@ -335,15 +379,15 @@ impl PeerChunkResolver {
             },
         ) {
             let mut state = self.state.borrow_mut();
-            state
-                .relay_responses
-                .entry(connection)
-                .or_default()
-                .push(ChunkResponseEntry {
+            Self::queue_relay_response(
+                &mut state,
+                connection,
+                ChunkResponseEntry {
                     request_id,
                     result: ChunkResponse::Retryable { retry_after_ms: 25 },
-                });
-            Self::wake_connection(&mut state, connection);
+                },
+                false,
+            );
         }
     }
 
@@ -363,13 +407,17 @@ impl PeerChunkResolver {
         let (responses, exhausted) = match state.relay_responses.get_mut(&connection) {
             Some(queued) => {
                 let count = limit.min(queued.len());
-                (queued.drain(..count).collect(), queued.is_empty())
+                (queued.drain(..count).collect::<Vec<_>>(), queued.is_empty())
             }
             None => return Vec::new(),
         };
         if exhausted {
             state.relay_responses.remove(&connection);
         }
+        state.relay_chunk_obligations = state
+            .relay_chunk_obligations
+            .checked_sub(responses.len())
+            .expect("drained relay responses are accounted");
         responses
     }
 
@@ -405,18 +453,19 @@ impl PeerChunkResolver {
                     connection,
                     request_id,
                 } => {
-                    state
-                        .relay_responses
-                        .entry(connection)
-                        .or_default()
-                        .push(ChunkResponseEntry {
+                    Self::queue_relay_response(
+                        &mut state,
+                        connection,
+                        ChunkResponseEntry {
                             request_id,
                             result: response.result.clone(),
-                        });
-                    Self::wake_connection(&mut state, connection);
+                        },
+                        true,
+                    );
                 }
             }
         }
+        debug_assert!(state.relay_chunk_obligations <= MAX_RELAY_CHUNK_OBLIGATIONS);
     }
 
     fn cancel_local(&self, request: &groove::chunks::ChunkRequest, waiter_id: u64) {
@@ -443,7 +492,14 @@ impl PeerChunkResolver {
         state.trace_by_connection.remove(&connection);
         state.traced_connections.remove(&connection);
         let disconnected_waker = state.outbound_wakers.remove(&connection);
-        state.relay_responses.remove(&connection);
+        let queued_responses = state
+            .relay_responses
+            .remove(&connection)
+            .map_or(0, |responses| responses.len());
+        state.relay_chunk_obligations = state
+            .relay_chunk_obligations
+            .checked_sub(queued_responses)
+            .expect("disconnected relay responses are accounted");
         if upstream {
             state.upstream_connections.remove(&connection);
             if state.upstream_connection == Some(connection) {
@@ -480,11 +536,24 @@ impl PeerChunkResolver {
             let Some(pending) = state.pending_by_chunk.get_mut(&request) else {
                 continue;
             };
+            let mut removed_relay_waiters = 0;
             pending.waiters.retain(|waiter| {
-                !matches!(waiter, ChunkDemandWaiter::Relay { connection: relay, .. } if *relay == connection)
+                let remove = matches!(
+                    waiter,
+                    ChunkDemandWaiter::Relay {
+                        connection: relay,
+                        ..
+                    } if *relay == connection
+                );
+                removed_relay_waiters += usize::from(remove);
+                !remove
             });
-            if pending.waiters.is_empty() {
-                let upstream_id = pending.upstream_id;
+            let emptied_upstream_id = pending.waiters.is_empty().then_some(pending.upstream_id);
+            state.relay_chunk_obligations = state
+                .relay_chunk_obligations
+                .checked_sub(removed_relay_waiters)
+                .expect("disconnected relay waiters are accounted");
+            if let Some(upstream_id) = emptied_upstream_id {
                 state.pending_by_chunk.remove(&request);
                 state.chunk_by_upstream_id.remove(&upstream_id);
                 state
@@ -619,6 +688,9 @@ impl PeerIoPump {
             (PeerIoPumpRole::Subscriber, SyncMessage::ChunkRequestBatch(batch)) => {
                 let mut responses = Vec::new();
                 for request in batch.requests {
+                    if self.is_disconnected() {
+                        break;
+                    }
                     self.resolver.record_request(
                         self.connection,
                         self.role,
@@ -627,14 +699,17 @@ impl PeerIoPump {
                         None,
                         None,
                     );
-                    match self
+                    let result = self
                         .local_chunks
                         .get(
                             request.locator.clone(),
                             groove::large_values::ContentHash(request.expected_hash),
                         )
-                        .await
-                    {
+                        .await;
+                    if self.is_disconnected() {
+                        break;
+                    }
+                    match result {
                         Ok(bytes) => {
                             self.resolver.record_request(
                                 self.connection,
@@ -676,14 +751,9 @@ impl PeerIoPump {
                         }
                     }
                 }
-                if !responses.is_empty() {
-                    let mut state = self.resolver.state.borrow_mut();
-                    state
-                        .relay_responses
-                        .entry(self.connection)
-                        .or_default()
-                        .extend(responses);
-                    PeerChunkResolver::wake_connection(&mut state, self.connection);
+                if !responses.is_empty() && !self.is_disconnected() {
+                    self.resolver
+                        .enqueue_relay_responses(self.connection, responses);
                 }
                 Ok(())
             }
@@ -852,6 +922,11 @@ impl PeerIoPump {
                 }
             }
             (PeerIoPumpRole::Subscriber, SyncMessage::ChunkResponseBatch(batch)) => {
+                state.relay_chunk_obligations = state
+                    .relay_chunk_obligations
+                    .checked_add(batch.responses.len())
+                    .filter(|count| *count <= MAX_RELAY_CHUNK_OBLIGATIONS)
+                    .expect("restored relay responses retain their admission");
                 let queued = state.relay_responses.entry(self.connection).or_default();
                 queued.splice(0..0, batch.responses);
             }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -977,7 +977,7 @@ impl PeerIoPump {
         }
     }
 
-    fn is_disconnected(&self) -> bool {
+    pub(crate) fn is_disconnected(&self) -> bool {
         self.resolver
             .state
             .borrow()

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1176,6 +1176,7 @@ where
             ),
             ConnectionLink::Subscriber(_) => (None, None, None),
         };
+        connection_ref.auxiliary_pump.disconnect();
         drop(connection_ref);
         let mut connections = self.connections.borrow_mut();
         connections.retain(|candidate| !Rc::ptr_eq(candidate, connection));

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2071,6 +2071,9 @@ where
                         SyncMessage::ChunkRequestBatch(batch) => {
                             let mut responses = Vec::new();
                             for request in batch.requests {
+                                if self.auxiliary_pump.is_disconnected() {
+                                    break;
+                                }
                                 let local = self
                                     .node
                                     .lock()
@@ -2080,6 +2083,9 @@ where
                                         groove::large_values::ContentHash(request.expected_hash),
                                     )
                                     .await;
+                                if self.auxiliary_pump.is_disconnected() {
+                                    break;
+                                }
                                 match local {
                                     Ok(bytes) => responses.push(ChunkResponseEntry {
                                         request_id: request.request_id,
@@ -2095,7 +2101,9 @@ where
                                     }),
                                 }
                             }
-                            if !responses.is_empty() {
+                            if !responses.is_empty()
+                                && !self.auxiliary_pump.is_disconnected()
+                            {
                                 self.transport
                                     .send(SyncMessage::ChunkResponseBatch(ChunkResponseBatch {
                                         responses,

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -1,11 +1,100 @@
+use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 
 use groove::chunks::{ChunkKvStorage, ChunkProvider, ChunkStorage, MissingChunkResolver};
 
 use super::super::*;
+use super::{duplex, open_db, schema};
+
+#[derive(Default)]
+struct DeferredChunkStorage {
+    backend: groove::chunks::MemoryChunkStorage,
+    outcome: RefCell<
+        Option<Result<bytes::Bytes, groove::chunks::ChunkStorageError>>,
+    >,
+    waiter: RefCell<Option<Waker>>,
+}
+
+impl DeferredChunkStorage {
+    fn release(&self, outcome: Result<bytes::Bytes, groove::chunks::ChunkStorageError>) {
+        *self.outcome.borrow_mut() = Some(outcome);
+        if let Some(waiter) = self.waiter.borrow_mut().take() {
+            waiter.wake();
+        }
+    }
+}
+
+impl ChunkStorage for DeferredChunkStorage {
+    fn get(
+        &self,
+        _locator: groove::large_values::Locator,
+        _expected_hash: groove::large_values::ContentHash,
+    ) -> groove::chunks::ChunkFuture<
+        '_,
+        Result<bytes::Bytes, groove::chunks::ChunkStorageError>,
+    > {
+        Box::pin(std::future::poll_fn(|context| {
+            if let Some(outcome) = self.outcome.borrow_mut().take() {
+                Poll::Ready(outcome)
+            } else {
+                *self.waiter.borrow_mut() = Some(context.waker().clone());
+                Poll::Pending
+            }
+        }))
+    }
+
+    fn stage(
+        &self,
+        chunks: Vec<groove::large_values::StagedChunk>,
+    ) -> groove::chunks::ChunkFuture<
+        '_,
+        Result<
+            groove::large_values::StagedLargeValueAccounting,
+            groove::chunks::ChunkStorageError,
+        >,
+    > {
+        self.backend.stage(chunks)
+    }
+
+    fn delete(
+        &self,
+        locator: groove::large_values::Locator,
+        expected_hash: groove::large_values::ContentHash,
+    ) -> groove::chunks::ChunkFuture<'_, Result<(), groove::chunks::ChunkStorageError>> {
+        self.backend.delete(locator, expected_hash)
+    }
+}
+
+fn deferred_local_chunk_reader() -> (
+    groove::chunks::LocalChunkReader,
+    Rc<DeferredChunkStorage>,
+) {
+    let storage = Rc::new(DeferredChunkStorage::default());
+    let mut database = crate::db::block_on(groove::db::Database::new(
+        groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new()),
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    database.set_chunk_storage(storage.clone());
+    (database.local_chunk_reader(), storage)
+}
+
+fn retained_relay_obligations(state: &ChunkDemandState) -> usize {
+    state
+        .pending_by_chunk
+        .values()
+        .flat_map(|pending| &pending.waiters)
+        .filter(|waiter| matches!(waiter, ChunkDemandWaiter::Relay { .. }))
+        .count()
+        + state
+            .relay_responses
+            .values()
+            .map(Vec::len)
+            .sum::<usize>()
+}
 
 #[test]
 fn auxiliary_pump_completes_a_suspended_groove_chunk_read_without_a_semantic_tick() {
@@ -280,6 +369,539 @@ fn dropping_the_last_suspended_consumer_cancels_unsent_chunk_demand() {
     ));
     drop(pending);
     assert!(pump.take_outbound(64).is_none());
+}
+
+#[test]
+fn completed_relay_responses_hold_capacity_until_drained() {
+    let resolver = PeerChunkResolver::default();
+    let connection = 30;
+    let request = groove::chunks::ChunkRequest {
+        object_hash: [0x30; 32],
+        locator: groove::large_values::Locator::random(),
+    };
+    for request_id in 0..MAX_PENDING_CHUNK_DEMANDS as u64 {
+        resolver.enqueue_relay(
+            connection,
+            ChunkRequestEntry {
+                request_id,
+                locator: request.locator.clone(),
+                expected_hash: request.object_hash,
+                remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+            },
+        );
+    }
+    let upstream_id = resolver.take_outbound(1)[0].request_id;
+    resolver.complete(ChunkResponseEntry {
+        request_id: upstream_id,
+        result: ChunkResponse::Found(vec![0x30]),
+    });
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        MAX_PENDING_CHUNK_DEMANDS
+    );
+
+    resolver.enqueue_relay(
+        connection,
+        ChunkRequestEntry {
+            request_id: MAX_PENDING_CHUNK_DEMANDS as u64,
+            locator: request.locator.clone(),
+            expected_hash: request.object_hash,
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        },
+    );
+    let state = resolver.state.borrow();
+    assert_eq!(
+        retained_relay_obligations(&state),
+        MAX_PENDING_CHUNK_DEMANDS,
+        "undrained responses retain admission capacity"
+    );
+    assert!(
+        !state.pending_by_chunk.contains_key(&request),
+        "refill is rejected while completed responses own the budget"
+    );
+    drop(state);
+
+    let responses = resolver.take_relay_responses(connection, usize::MAX);
+    assert_eq!(responses.len(), MAX_PENDING_CHUNK_DEMANDS);
+    resolver.enqueue_relay(
+        connection,
+        ChunkRequestEntry {
+            request_id: MAX_PENDING_CHUNK_DEMANDS as u64 + 1,
+            locator: request.locator.clone(),
+            expected_hash: request.object_hash,
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        },
+    );
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        1,
+        "draining responses releases their admission capacity"
+    );
+}
+
+#[test]
+fn immediate_overload_responses_cannot_bypass_the_relay_obligation_bound() {
+    let ordinary = PeerChunkResolver::default();
+    for request_id in [1, 2] {
+        ordinary.enqueue_relay(
+            31,
+            ChunkRequestEntry {
+                request_id,
+                locator: groove::large_values::Locator::random(),
+                expected_hash: [0x31; 32],
+                remaining_hops: 0,
+            },
+        );
+    }
+    assert_eq!(
+        ordinary.take_relay_responses(31, usize::MAX),
+        vec![
+            ChunkResponseEntry {
+                request_id: 1,
+                result: ChunkResponse::Unavailable,
+            },
+            ChunkResponseEntry {
+                request_id: 2,
+                result: ChunkResponse::Unavailable,
+            },
+        ],
+        "ordinary immediate responses preserve request correlation"
+    );
+
+    let resolver = PeerChunkResolver::default();
+    let connection = 31;
+    for request_id in 0..MAX_PENDING_CHUNK_DEMANDS as u64 {
+        resolver.enqueue_relay(
+            connection,
+            ChunkRequestEntry {
+                request_id,
+                locator: groove::large_values::Locator::random(),
+                expected_hash: [0x31; 32],
+                remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+            },
+        );
+    }
+    for request_id in
+        MAX_PENDING_CHUNK_DEMANDS as u64..MAX_PENDING_CHUNK_DEMANDS as u64 + 64
+    {
+        resolver.enqueue_relay(
+            connection,
+            ChunkRequestEntry {
+                request_id,
+                locator: groove::large_values::Locator::random(),
+                expected_hash: [0x31; 32],
+                remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+            },
+        );
+        resolver.enqueue_relay(
+            connection,
+            ChunkRequestEntry {
+                request_id: request_id + 64,
+                locator: groove::large_values::Locator::random(),
+                expected_hash: [0x31; 32],
+                remaining_hops: 0,
+            },
+        );
+    }
+    let state = resolver.state.borrow();
+    assert_eq!(
+        retained_relay_obligations(&state),
+        MAX_PENDING_CHUNK_DEMANDS,
+        "Retryable and zero-hop responses share the existing global budget"
+    );
+    assert!(
+        state.relay_responses.get(&connection).is_none(),
+        "overload responses are dropped instead of retained past capacity"
+    );
+}
+
+#[test]
+fn draining_restoring_and_disconnecting_transfer_relay_response_capacity_exactly() {
+    let resolver = PeerChunkResolver::default();
+    let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());
+    let database = crate::db::block_on(groove::db::Database::new(
+        schema,
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    let pump = PeerIoPump::new(
+        resolver.clone(),
+        database.local_chunk_reader(),
+        32,
+        PeerIoPumpRole::Subscriber,
+    );
+    resolver.enqueue_relay(
+        32,
+        ChunkRequestEntry {
+            request_id: 32,
+            locator: groove::large_values::Locator::random(),
+            expected_hash: [0x32; 32],
+            remaining_hops: 0,
+        },
+    );
+    let response = pump.take_outbound(1).expect("one immediate response");
+    assert_eq!(retained_relay_obligations(&resolver.state.borrow()), 0);
+    pump.restore_outbound(response);
+    assert_eq!(retained_relay_obligations(&resolver.state.borrow()), 1);
+
+    let request = groove::chunks::ChunkRequest {
+        object_hash: [0x32; 32],
+        locator: groove::large_values::Locator::random(),
+    };
+    for request_id in 0..MAX_PENDING_CHUNK_DEMANDS as u64 - 1 {
+        resolver.enqueue_relay(
+            32,
+            ChunkRequestEntry {
+                request_id,
+                locator: request.locator.clone(),
+                expected_hash: request.object_hash,
+                remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+            },
+        );
+    }
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        MAX_PENDING_CHUNK_DEMANDS
+    );
+    resolver.enqueue_relay(
+        32,
+        ChunkRequestEntry {
+            request_id: MAX_PENDING_CHUNK_DEMANDS as u64,
+            locator: request.locator.clone(),
+            expected_hash: request.object_hash,
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        },
+    );
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        MAX_PENDING_CHUNK_DEMANDS
+    );
+
+    drop(pump.take_outbound(1).expect("restored response drains"));
+    resolver.enqueue_relay(
+        32,
+        ChunkRequestEntry {
+            request_id: MAX_PENDING_CHUNK_DEMANDS as u64 + 1,
+            locator: request.locator.clone(),
+            expected_hash: request.object_hash,
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        },
+    );
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        MAX_PENDING_CHUNK_DEMANDS
+    );
+    pump.disconnect();
+    let state = resolver.state.borrow();
+    assert_eq!(retained_relay_obligations(&state), 0);
+    assert!(!state.pending_by_chunk.contains_key(&request));
+    assert!(state.relay_responses.get(&32).is_none());
+}
+
+// This stays at the auxiliary-pump boundary because relay admission and
+// hop-local request-id correlation are not observable through database APIs.
+#[test]
+fn duplicate_relay_chunk_waiters_are_bounded_and_release_capacity() {
+    let schema = schema();
+    let server = open_db(0x25, AuthorSubject::SYSTEM, &schema);
+    let (_client_transport, server_transport) = duplex();
+    let subscriber = server.accept_subscriber(server_transport, AuthorSubject::SYSTEM);
+    let pump = subscriber.borrow().io_pump();
+    let resolver = server.node.chunk_resolver.clone();
+    let connection = pump.connection;
+    let request = groove::chunks::ChunkRequest {
+        object_hash: [0x25; 32],
+        locator: groove::large_values::Locator::random(),
+    };
+    let route = |pump: &PeerIoPump, request_ids: std::ops::Range<u64>| {
+        for first in request_ids
+            .clone()
+            .step_by(crate::protocol_limits::MAX_CHUNK_REQUEST_BATCH_ENTRIES)
+        {
+            let end = (first
+                + crate::protocol_limits::MAX_CHUNK_REQUEST_BATCH_ENTRIES as u64)
+                .min(request_ids.end);
+            crate::db::block_on(pump.route_incoming(SyncMessage::ChunkRequestBatch(
+                ChunkRequestBatch {
+                    requests: (first..end)
+                        .map(|request_id| ChunkRequestEntry {
+                            request_id,
+                            locator: request.locator.clone(),
+                            expected_hash: request.object_hash,
+                            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+                        })
+                        .collect(),
+                },
+            )))
+            .unwrap();
+        }
+    };
+
+    route(&pump, 0..MAX_PENDING_CHUNK_DEMANDS as u64 + 1);
+
+    let upstream_id = resolver.take_outbound(1)[0].request_id;
+    {
+        let state = resolver.state.borrow();
+        let pending = state
+            .pending_by_chunk
+            .get(&request)
+            .expect("the coalesced upstream demand remains pending");
+        assert_eq!(
+            pending.waiters.len(),
+            MAX_PENDING_CHUNK_DEMANDS,
+            "duplicate relay waiters share the global pending-demand ceiling"
+        );
+        assert!(
+            state.relay_responses.get(&connection).is_none(),
+            "a full obligation budget does not retain an overload response"
+        );
+    }
+
+    resolver.complete(ChunkResponseEntry {
+        request_id: upstream_id,
+        result: ChunkResponse::Found(vec![0x25]),
+    });
+    let responses = resolver.take_relay_responses(connection, usize::MAX);
+    assert_eq!(responses.len(), MAX_PENDING_CHUNK_DEMANDS);
+    for (request_id, response) in responses.iter().enumerate() {
+        assert_eq!(
+            response,
+            &ChunkResponseEntry {
+                request_id: request_id as u64,
+                result: ChunkResponse::Found(vec![0x25]),
+            },
+            "ordinary relay fan-out preserves every distinct request id"
+        );
+    }
+
+    route(
+        &pump,
+        MAX_PENDING_CHUNK_DEMANDS as u64..MAX_PENDING_CHUNK_DEMANDS as u64 + 1,
+    );
+    assert_eq!(
+        resolver.state.borrow().pending_by_chunk[&request]
+            .waiters
+            .len(),
+        1,
+        "completing a demand releases relay-waiter admission capacity"
+    );
+    route(
+        &pump,
+        MAX_PENDING_CHUNK_DEMANDS as u64 + 1..MAX_PENDING_CHUNK_DEMANDS as u64 * 2,
+    );
+    assert_eq!(
+        resolver.state.borrow().pending_by_chunk[&request]
+            .waiters
+            .len(),
+        MAX_PENDING_CHUNK_DEMANDS
+    );
+
+    assert!(server.detach_connection(&subscriber));
+    assert!(
+        !resolver.state.borrow().pending_by_chunk.contains_key(&request),
+        "standard database detach removes every relay waiter owned by the session"
+    );
+
+    let (_replacement_client, replacement_transport) = duplex();
+    let replacement = server.accept_subscriber(replacement_transport, AuthorSubject::SYSTEM);
+    let replacement_pump = replacement.borrow().io_pump();
+    route(&replacement_pump, 0..1);
+    let state = resolver.state.borrow();
+    assert_eq!(
+        state.pending_by_chunk[&request].waiters.len(),
+        1,
+        "detaching a relay releases its global waiter capacity"
+    );
+    assert!(
+        state
+            .relay_responses
+            .get(&replacement_pump.connection)
+            .is_none(),
+        "the replacement session is admitted rather than rejected"
+    );
+}
+
+#[test]
+fn detach_during_missing_chunk_lookup_cannot_restore_relay_demand() {
+    let schema = schema();
+    let server = open_db(0x26, AuthorSubject::SYSTEM, &schema);
+    let (_client_transport, server_transport) = duplex();
+    let subscriber = server.accept_subscriber(server_transport, AuthorSubject::SYSTEM);
+    let resolver = server.node.chunk_resolver.clone();
+    let (local_chunks, storage) = deferred_local_chunk_reader();
+    let pump = PeerIoPump::new(
+        resolver.clone(),
+        local_chunks,
+        subscriber.borrow().connection_epoch,
+        PeerIoPumpRole::Subscriber,
+    );
+    subscriber.borrow_mut().auxiliary_pump = pump.clone();
+    let request = ChunkRequestEntry {
+        request_id: 26,
+        locator: groove::large_values::Locator::random(),
+        expected_hash: [0x26; 32],
+        remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+    };
+    let chunk = groove::chunks::ChunkRequest {
+        locator: request.locator.clone(),
+        object_hash: request.expected_hash,
+    };
+    let mut routing = Box::pin(pump.route_incoming(SyncMessage::ChunkRequestBatch(
+        ChunkRequestBatch {
+            requests: vec![request],
+        },
+    )));
+    let waker = futures::task::noop_waker();
+    let mut context = Context::from_waker(&waker);
+    assert!(matches!(routing.as_mut().poll(&mut context), Poll::Pending));
+
+    assert!(server.detach_connection(&subscriber));
+    storage.release(Err(groove::chunks::ChunkStorageError::Unavailable));
+    assert!(matches!(
+        routing.as_mut().poll(&mut context),
+        Poll::Ready(Ok(()))
+    ));
+    let state = resolver.state.borrow();
+    assert!(
+        !state.pending_by_chunk.contains_key(&chunk),
+        "a missing result that resumes after detach cannot restore relay demand"
+    );
+    assert!(
+        state.relay_responses.get(&pump.connection).is_none(),
+        "the detached session retains no auxiliary output"
+    );
+}
+
+#[test]
+fn detach_during_found_chunk_lookup_cannot_restore_relay_response() {
+    let schema = schema();
+    let server = open_db(0x27, AuthorSubject::SYSTEM, &schema);
+    let (_client_transport, server_transport) = duplex();
+    let subscriber = server.accept_subscriber(server_transport, AuthorSubject::SYSTEM);
+    let resolver = server.node.chunk_resolver.clone();
+    let (local_chunks, storage) = deferred_local_chunk_reader();
+    let pump = PeerIoPump::new(
+        resolver.clone(),
+        local_chunks,
+        subscriber.borrow().connection_epoch,
+        PeerIoPumpRole::Subscriber,
+    );
+    subscriber.borrow_mut().auxiliary_pump = pump.clone();
+    let request = ChunkRequestEntry {
+        request_id: 27,
+        locator: groove::large_values::Locator::random(),
+        expected_hash: [0x27; 32],
+        remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+    };
+    let mut routing = Box::pin(pump.route_incoming(SyncMessage::ChunkRequestBatch(
+        ChunkRequestBatch {
+            requests: vec![request],
+        },
+    )));
+    let waker = futures::task::noop_waker();
+    let mut context = Context::from_waker(&waker);
+    assert!(matches!(routing.as_mut().poll(&mut context), Poll::Pending));
+
+    assert!(server.detach_connection(&subscriber));
+    storage.release(Ok(bytes::Bytes::from_static(b"found after detach")));
+    assert!(matches!(
+        routing.as_mut().poll(&mut context),
+        Poll::Ready(Ok(()))
+    ));
+    let state = resolver.state.borrow();
+    assert!(
+        state.relay_responses.get(&pump.connection).is_none(),
+        "a found result that resumes after detach cannot restore relay output"
+    );
+    assert!(
+        state
+            .pending_by_chunk
+            .values()
+            .all(|pending| pending.waiters.iter().all(|waiter| {
+                !matches!(
+                    waiter,
+                    ChunkDemandWaiter::Relay { connection, .. }
+                        if *connection == pump.connection
+                )
+            })),
+        "the detached session retains no relay waiter"
+    );
+}
+
+#[test]
+fn detach_during_peer_tick_chunk_lookup_drops_missing_and_found_outcomes() {
+    for found in [false, true] {
+        let schema = schema();
+        let server = open_db(
+            if found { 0x29 } else { 0x28 },
+            AuthorSubject::SYSTEM,
+            &schema,
+        );
+        let storage = Rc::new(DeferredChunkStorage::default());
+        crate::db::block_on(async {
+            server
+                .node
+                .node
+                .lock()
+                .await
+                .set_chunk_storage(storage.clone());
+        });
+        let (mut client_transport, server_transport) = duplex();
+        let subscriber = server.accept_subscriber(server_transport, AuthorSubject::SYSTEM);
+        let resolver = server.node.chunk_resolver.clone();
+        let pump = subscriber.borrow().io_pump();
+        let request = ChunkRequestEntry {
+            request_id: if found { 29 } else { 28 },
+            locator: groove::large_values::Locator::random(),
+            expected_hash: if found { [0x29; 32] } else { [0x28; 32] },
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        };
+        let chunk = groove::chunks::ChunkRequest {
+            locator: request.locator.clone(),
+            object_hash: request.expected_hash,
+        };
+        client_transport
+            .send(SyncMessage::ChunkRequestBatch(ChunkRequestBatch {
+                requests: vec![request],
+            }))
+            .unwrap();
+
+        let mut connection = subscriber.borrow_mut();
+        let mut ticking = Box::pin(connection.tick());
+        let waker = futures::task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        assert!(matches!(
+            ticking.as_mut().poll(&mut context),
+            Poll::Pending
+        ));
+
+        pump.disconnect();
+        storage.release(if found {
+            Ok(bytes::Bytes::from_static(b"peer tick found after detach"))
+        } else {
+            Err(groove::chunks::ChunkStorageError::Unavailable)
+        });
+        assert!(matches!(
+            ticking.as_mut().poll(&mut context),
+            Poll::Ready(Ok(_))
+        ));
+        drop(ticking);
+        drop(connection);
+
+        let state = resolver.state.borrow();
+        assert!(
+            !state.pending_by_chunk.contains_key(&chunk),
+            "peer tick cannot restore missing relay demand after detach"
+        );
+        assert!(
+            state.relay_responses.get(&pump.connection).is_none(),
+            "peer tick cannot queue auxiliary output after detach"
+        );
+        assert!(
+            client_transport.try_recv().is_none(),
+            "peer tick cannot send a found response after detach"
+        );
+    }
 }
 
 // This stays at the auxiliary-pump boundary because the batch split is a

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -12,9 +12,7 @@ use super::{duplex, open_db, schema};
 #[derive(Default)]
 struct DeferredChunkStorage {
     backend: groove::chunks::MemoryChunkStorage,
-    outcome: RefCell<
-        Option<Result<bytes::Bytes, groove::chunks::ChunkStorageError>>,
-    >,
+    outcome: RefCell<Option<Result<bytes::Bytes, groove::chunks::ChunkStorageError>>>,
     waiter: RefCell<Option<Waker>>,
 }
 
@@ -32,10 +30,8 @@ impl ChunkStorage for DeferredChunkStorage {
         &self,
         _locator: groove::large_values::Locator,
         _expected_hash: groove::large_values::ContentHash,
-    ) -> groove::chunks::ChunkFuture<
-        '_,
-        Result<bytes::Bytes, groove::chunks::ChunkStorageError>,
-    > {
+    ) -> groove::chunks::ChunkFuture<'_, Result<bytes::Bytes, groove::chunks::ChunkStorageError>>
+    {
         Box::pin(std::future::poll_fn(|context| {
             if let Some(outcome) = self.outcome.borrow_mut().take() {
                 Poll::Ready(outcome)
@@ -51,10 +47,7 @@ impl ChunkStorage for DeferredChunkStorage {
         chunks: Vec<groove::large_values::StagedChunk>,
     ) -> groove::chunks::ChunkFuture<
         '_,
-        Result<
-            groove::large_values::StagedLargeValueAccounting,
-            groove::chunks::ChunkStorageError,
-        >,
+        Result<groove::large_values::StagedLargeValueAccounting, groove::chunks::ChunkStorageError>,
     > {
         self.backend.stage(chunks)
     }
@@ -68,10 +61,7 @@ impl ChunkStorage for DeferredChunkStorage {
     }
 }
 
-fn deferred_local_chunk_reader() -> (
-    groove::chunks::LocalChunkReader,
-    Rc<DeferredChunkStorage>,
-) {
+fn deferred_local_chunk_reader() -> (groove::chunks::LocalChunkReader, Rc<DeferredChunkStorage>) {
     let storage = Rc::new(DeferredChunkStorage::default());
     let mut database = crate::db::block_on(groove::db::Database::new(
         groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new()),
@@ -89,11 +79,7 @@ fn retained_relay_obligations(state: &ChunkDemandState) -> usize {
         .flat_map(|pending| &pending.waiters)
         .filter(|waiter| matches!(waiter, ChunkDemandWaiter::Relay { .. }))
         .count()
-        + state
-            .relay_responses
-            .values()
-            .map(Vec::len)
-            .sum::<usize>()
+        + state.relay_responses.values().map(Vec::len).sum::<usize>()
 }
 
 #[test]
@@ -219,14 +205,12 @@ fn subscriber_auxiliary_responses_are_bounded_to_one_chunk_per_wire_frame() {
     );
     let response_count = 10;
     let chunk_bytes = vec![0x5a; groove::large_values::LEAF_MAX_BYTES];
-    resolver.state.borrow_mut().relay_responses.insert(
+    resolver.enqueue_relay_responses(
         23,
-        (0..response_count)
-            .map(|request_id| ChunkResponseEntry {
-                request_id,
-                result: ChunkResponse::Found(chunk_bytes.clone()),
-            })
-            .collect(),
+        (0..response_count).map(|request_id| ChunkResponseEntry {
+            request_id,
+            result: ChunkResponse::Found(chunk_bytes.clone()),
+        }),
     );
 
     let features = crate::wire::current_wire_features();
@@ -283,14 +267,12 @@ fn bounded_auxiliary_drain_keeps_large_response_batches_fifo_and_within_bytes() 
     );
     let response_count = 32_u64;
     let chunk_bytes = vec![0x3c; groove::large_values::LEAF_MAX_BYTES];
-    resolver.state.borrow_mut().relay_responses.insert(
+    resolver.enqueue_relay_responses(
         24,
-        (0..response_count)
-            .map(|request_id| ChunkResponseEntry {
-                request_id,
-                result: ChunkResponse::Found(chunk_bytes.clone()),
-            })
-            .collect(),
+        (0..response_count).map(|request_id| ChunkResponseEntry {
+            request_id,
+            result: ChunkResponse::Found(chunk_bytes.clone()),
+        }),
     );
 
     let features = crate::wire::current_wire_features();
@@ -481,9 +463,7 @@ fn immediate_overload_responses_cannot_bypass_the_relay_obligation_bound() {
             },
         );
     }
-    for request_id in
-        MAX_PENDING_CHUNK_DEMANDS as u64..MAX_PENDING_CHUNK_DEMANDS as u64 + 64
-    {
+    for request_id in MAX_PENDING_CHUNK_DEMANDS as u64..MAX_PENDING_CHUNK_DEMANDS as u64 + 64 {
         resolver.enqueue_relay(
             connection,
             ChunkRequestEntry {
@@ -618,11 +598,10 @@ fn duplicate_relay_chunk_waiters_are_bounded_and_release_capacity() {
             .clone()
             .step_by(crate::protocol_limits::MAX_CHUNK_REQUEST_BATCH_ENTRIES)
         {
-            let end = (first
-                + crate::protocol_limits::MAX_CHUNK_REQUEST_BATCH_ENTRIES as u64)
+            let end = (first + crate::protocol_limits::MAX_CHUNK_REQUEST_BATCH_ENTRIES as u64)
                 .min(request_ids.end);
-            crate::db::block_on(pump.route_incoming(SyncMessage::ChunkRequestBatch(
-                ChunkRequestBatch {
+            crate::db::block_on(
+                pump.route_incoming(SyncMessage::ChunkRequestBatch(ChunkRequestBatch {
                     requests: (first..end)
                         .map(|request_id| ChunkRequestEntry {
                             request_id,
@@ -631,8 +610,8 @@ fn duplicate_relay_chunk_waiters_are_bounded_and_release_capacity() {
                             remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
                         })
                         .collect(),
-                },
-            )))
+                })),
+            )
             .unwrap();
         }
     };
@@ -698,7 +677,11 @@ fn duplicate_relay_chunk_waiters_are_bounded_and_release_capacity() {
 
     assert!(server.detach_connection(&subscriber));
     assert!(
-        !resolver.state.borrow().pending_by_chunk.contains_key(&request),
+        !resolver
+            .state
+            .borrow()
+            .pending_by_chunk
+            .contains_key(&request),
         "standard database detach removes every relay waiter owned by the session"
     );
 
@@ -870,10 +853,7 @@ fn detach_during_peer_tick_chunk_lookup_drops_missing_and_found_outcomes() {
         let mut ticking = Box::pin(connection.tick());
         let waker = futures::task::noop_waker();
         let mut context = Context::from_waker(&waker);
-        assert!(matches!(
-            ticking.as_mut().poll(&mut context),
-            Poll::Pending
-        ));
+        assert!(matches!(ticking.as_mut().poll(&mut context), Poll::Pending));
 
         pump.disconnect();
         storage.release(if found {

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -359,8 +359,12 @@ async fn drive_upstream_wire(
         let auxiliary_wake = io.pump.outbound_ready();
         futures::pin_mut!(external_wake, auxiliary_wake);
         match futures::future::select(external_wake, auxiliary_wake).await {
-            futures::future::Either::Left((Some(()), _))
-            | futures::future::Either::Right(((), _)) => {}
+            futures::future::Either::Left((Some(()), _)) => {}
+            futures::future::Either::Right(((), _)) => {
+                if io.pump.is_disconnected() {
+                    return;
+                }
+            }
             futures::future::Either::Left((None, _)) => {
                 io.pump.disconnect();
                 return;


### PR DESCRIPTION
## Stack dependency

This PR is stacked on #1985, which keeps browser large-value relays live across facade rebuilds. It preserves that PR's local-reader retargeting and bounded diagnostic tracing while adding retained-state admission and detach safety.

## Summary

- cap pending remote relay waiters and queued relay responses under one 4,096-entry budget
- retain request correlation for admitted relay work
- release capacity only when a response drains or its connection disconnects
- prevent storage lookups that finish after detach from recreating relay work or responses
- stop a disconnected native upstream pump instead of repeatedly resolving its readiness future
- cover both the auxiliary pump and direct `PeerConnection::tick` subscriber paths

## Before and after

Before, the 4,096 limit counted unique missing chunks. Repeated requests for one missing chunk could append unlimited waiter IDs. Completing those waiters moved them to an unbounded response queue, so repeated fill-and-complete cycles could still grow memory indefinitely.

A detached native upstream pump also treated its cancellation wake as ordinary outbound readiness. Its local executor loop stayed continuously ready, preventing the shell owner from receiving its storage-shutdown command and leaving the catalogue RocksDB lock held.

After, one counter covers the complete retained relay obligation: pending remote waiters plus queued responses. Moving a waiter into the response queue transfers its reservation instead of releasing it. A cancellation wake now terminates the native pump, allowing the owner thread to close storage deterministically.

## Governing invariants

- `relay_chunk_obligations = pending remote waiters + queued relay responses` in stable state.
- The total never exceeds 4,096.
- Local in-process chunk consumers do not consume remote relay capacity.
- Completion transfers a reservation from waiter to response.
- Draining or disconnecting releases reservations.
- Restoring an unsent response batch reacquires exactly the slots released by its drain.
- When already saturated, a new overload response may be dropped rather than retained without bound.
- Disconnect readiness terminates native upstream pumping; it is not another work notification.

## Worked examples

### Coalesced demand

Two downstream requests ask for the same missing chunk with different request IDs. Jazz sends one upstream chunk request, retains two bounded waiter obligations, and returns one correctly correlated response for each admitted request.

### Undrained responses

A peer fills 4,096 waiter slots and the upstream completes them. The resulting queued responses continue to occupy all 4,096 slots. Further requests cannot grow retained state until responses drain or the connection disconnects.

### Detach during storage lookup

A downstream connection closes while its local chunk lookup is awaiting storage. Whether storage later reports found or missing, Jazz drops the outcome and does not recreate a relay waiter or send a response to the detached connection. The native owner pump exits on that disconnect, so server shutdown can join the owner and release RocksDB.

## Unchanged behaviour

Wire batch limits, request IDs, local chunk reads, upstream coalescing, retry delay values, PR #1985's facade retargeting, and its redacted trace format remain unchanged.

## Red/green commits

1. `82baad3e5` adds the admission, response-backlog, accounting, and detach-race regressions.
2. `7f0fadad2` implements total-obligation accounting and detach fencing on top of #1985.
3. `b747a0fe3` makes the native owner pump observe that detach as terminal.

## Verification

- `cargo test -p jazz --no-default-features --features testing,transport-compression-zstd --lib db::tests::chunk_io_pump` — 14 passed
- `cargo nextest run --profile jazz-ci -p jazz-testkit --test catalogue_sync_integration` — 26 passed
- pre-commit `cargo clippy --package jazz -- -D warnings` — passed