### PR TITLE
Preserve caller-owned starter work directories

### DIFF
--- a/packages/create-jazz-e2e/package.json
+++ b/packages/create-jazz-e2e/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",
+    "test": "tsx --test src/run-starter.test.ts",
     "e2e": "tsx src/cli.ts",
     "e2e:all": "tsx src/cli.ts --all"
   },

--- a/packages/create-jazz-e2e/src/run-starter.test.ts
+++ b/packages/create-jazz-e2e/src/run-starter.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+
+import { runStarter } from "./run-starter.js";
+
+function missingTarballDir(): string {
+  return path.join(os.tmpdir(), `create-jazz-e2e-missing-${randomUUID()}`);
+}
+
+test("cleanup preserves a caller-provided work directory", async (t) => {
+  const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-jazz-e2e-caller-test-"));
+  const workDir = path.join(testDir, "caller-owned");
+  const sentinel = path.join(workDir, "sentinel.txt");
+  fs.mkdirSync(workDir);
+  fs.writeFileSync(sentinel, "caller data");
+  t.after(() => fs.rmSync(testDir, { recursive: true, force: true }));
+
+  const result = await runStarter({
+    starter: "react-localfirst",
+    repoRoot: process.cwd(),
+    workDir,
+    tarballDir: missingTarballDir(),
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.errorMessage ?? "", /does not exist/);
+  assert.equal(fs.existsSync(workDir), true);
+  assert.equal(fs.readFileSync(sentinel, "utf8"), "caller data");
+});
+
+test("cleanup removes a harness-created temporary work directory", async (t) => {
+  const result = await runStarter({
+    starter: "react-localfirst",
+    repoRoot: process.cwd(),
+    tarballDir: missingTarballDir(),
+  });
+  const workDir = path.dirname(result.appDir);
+  t.after(() => fs.rmSync(workDir, { recursive: true, force: true }));
+
+  assert.equal(result.success, false);
+  assert.match(result.errorMessage ?? "", /does not exist/);
+  assert.equal(fs.existsSync(workDir), false);
+});

--- a/packages/create-jazz-e2e/src/run-starter.ts
+++ b/packages/create-jazz-e2e/src/run-starter.ts
@@ -21,7 +21,7 @@ const PACKAGES_TO_PACK = ["jazz-tools", "jazz-napi", "jazz-wasm"] as const;
 export interface RunStarterOptions {
   starter: StarterName;
   repoRoot: string;
-  /** If provided, scaffold under here; else mkdtemp. */
+  /** If provided, scaffold under this caller-owned directory without removing it; else mkdtemp. */
   workDir?: string;
   /** Skip the playwright step (build-only). Useful for a fast smoke pass. */
   skipE2E?: boolean;
@@ -303,6 +303,7 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
   const config = getStarterConfig(opts.starter);
   const durations: PhaseTiming[] = [];
   let server: LocalJazzServerHandle | undefined;
+  const ownsWorkDir = opts.workDir === undefined;
   const workDir = opts.workDir ?? fs.mkdtempSync(path.join(os.tmpdir(), `cje2e-${opts.starter}-`));
   fs.mkdirSync(workDir, { recursive: true });
   const tarballDir = path.join(workDir, "_tarballs");
@@ -435,7 +436,7 @@ export async function runStarter(opts: RunStarterOptions): Promise<RunStarterRes
         // Best-effort.
       }
     }
-    if (!opts.keepTempDir) {
+    if (ownsWorkDir && !opts.keepTempDir) {
       try {
         fs.rmSync(workDir, { recursive: true, force: true });
       } catch {


### PR DESCRIPTION
## Summary

- track whether `runStarter` created its work directory
- recursively remove only harness-created temporary directories
- preserve caller-supplied directories and their existing contents
- add the focused cleanup tests to the package's normal `test` task

## Before and after

Before, `runStarter({ workDir })` treated a supplied directory like an internally created temporary directory. Unless `keepTempDir` was true, final cleanup recursively removed the whole directory.

After, cleanup follows directory ownership. A directory created with `mkdtemp` is still removed by default. A directory supplied by the caller is left intact.

## Governing invariants

- `runStarter` deletes a directory only when it created that directory.
- `keepTempDir: true` continues to retain harness-created temporary directories.
- Caller-owned directories are not partially cleaned because the harness cannot reliably distinguish generated files from caller files.

## Worked examples

### Caller-owned directory

A caller supplies `/tmp/shared-run`, which already contains `keep.txt`. The starter run fails during setup. Cleanup leaves `/tmp/shared-run` and `keep.txt` in place.

### Harness-owned directory

A caller does not supply `workDir`. The harness creates a temporary directory, the run finishes or fails, and default cleanup removes that directory recursively.

## Unchanged behaviour

Starter scaffolding, packing, phase timing, and `keepTempDir` semantics are unchanged.

## Red/green commits

1. `288716cef768d1454d78a45c7376ff3de5b61a72` adds ownership regressions and wires the package test task.
2. `530817367f28dc196fa94e61ba4e5b1246192db2` makes cleanup ownership-aware.

## Verification

- `pnpm --filter create-jazz-e2e test`
- 2 passed
