### PR TITLE
Fan out shared structured collector updates

### DIFF
--- a/.changeset/structured-collector-fanout.md
+++ b/.changeset/structured-collector-fanout.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Deliver structured collector updates to every subscription and sink sharing the same terminal node.

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -457,10 +457,10 @@ impl TickEvaluator<'_> {
         Ok(())
     }
 
-    pub(super) fn take_terminal_deltas_for_output(
-        &mut self,
+    pub(super) fn terminal_delta_node_for_output(
+        &self,
         node: NodeId,
-    ) -> Result<Option<TerminalDeltas>, IvmRuntimeError> {
+    ) -> Result<Option<NodeId>, IvmRuntimeError> {
         let mut pending = vec![node];
         let mut seen = HashSet::new();
         let mut fallback = None;
@@ -480,16 +480,25 @@ impl TickEvaluator<'_> {
             has_public_root |= is_public_root;
             if self.terminal_deltas.contains_key(&node) {
                 if is_public_root {
-                    return Ok(self.terminal_deltas.remove(&node));
+                    return Ok(Some(node));
                 }
                 fallback.get_or_insert(node);
             }
             pending.extend(graph_node.descriptor.inputs.iter().copied());
         }
-        Ok((!has_public_root)
-            .then_some(fallback)
-            .flatten()
-            .and_then(|node| self.terminal_deltas.remove(&node)))
+        Ok((!has_public_root).then_some(fallback).flatten())
+    }
+
+    pub(super) fn terminal_deltas_for_consumer(
+        &mut self,
+        node: NodeId,
+        last_consumer: bool,
+    ) -> Option<TerminalDeltas> {
+        if last_consumer {
+            self.terminal_deltas.remove(&node)
+        } else {
+            self.terminal_deltas.get(&node).cloned()
+        }
     }
 
     pub(super) fn output_is_structured_collect_by(

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -582,6 +582,25 @@ impl IncrementalEvaluation<'_> {
             return self.poll(runtime, cx);
         }
 
+        let mut terminal_consumers = HashMap::<NodeId, usize>::default();
+        for subscription_id in &self.affected_subscriptions {
+            let Some(subscription) = runtime.multisink_subscriptions.get(subscription_id) else {
+                continue;
+            };
+            if subscription.failed || self.published_subscriptions.contains(subscription_id) {
+                continue;
+            }
+            for output in subscription
+                .outputs
+                .values()
+                .filter(|output| self.affected_nodes.contains(&output.node))
+            {
+                if let Some(node) = evaluator.terminal_delta_node_for_output(output.node)? {
+                    *terminal_consumers.entry(node).or_default() += 1;
+                }
+            }
+        }
+
         for subscription_id in &self.affected_subscriptions {
             let Some(subscription) = runtime.multisink_subscriptions.get(subscription_id) else {
                 continue;
@@ -601,8 +620,7 @@ impl IncrementalEvaluation<'_> {
             {
                 continue;
             }
-            let mut sinks = BTreeMap::new();
-            let mut terminal_sinks = BTreeMap::new();
+            let mut prepared_outputs = Vec::new();
             for (sink, output) in &subscription.outputs {
                 if !self.affected_nodes.contains(&output.node) {
                     continue;
@@ -666,6 +684,12 @@ impl IncrementalEvaluation<'_> {
                     }
                     Err(error) => return Poll::Ready(Err(error.into())),
                 };
+                prepared_outputs.push((sink, output, records));
+            }
+
+            let mut sinks = BTreeMap::new();
+            let mut terminal_sinks = BTreeMap::new();
+            for (sink, output, records) in prepared_outputs {
                 if !records.deltas.is_empty()
                     && !records.descriptor.registry_compatible_with(&output.output)
                 {
@@ -677,10 +701,12 @@ impl IncrementalEvaluation<'_> {
                 let records = records.as_ref().clone();
                 if terminal_owned {
                     let terminal = if structured {
-                        if let Some(terminal) =
-                            evaluator.take_terminal_deltas_for_output(output.node)?
-                        {
-                            Some(terminal)
+                        if let Some(node) = evaluator.terminal_delta_node_for_output(output.node)? {
+                            let remaining = terminal_consumers
+                                .get_mut(&node)
+                                .expect("terminal consumer counted before publication");
+                            *remaining -= 1;
+                            evaluator.terminal_deltas_for_consumer(node, *remaining == 0)
                         } else if !public_root && !records.is_empty() {
                             Some(terminal_deltas_from_record_deltas(&records)?)
                         } else if output.root_ordering_node.is_some() {

--- a/crates/groove/tests/multisink_subscription.rs
+++ b/crates/groove/tests/multisink_subscription.rs
@@ -6,7 +6,7 @@
 use std::sync::mpsc::TryRecvError;
 
 use groove::db::{Database, GraphBuilder, RoutedMultisinkTerminal};
-use groove::ivm::ProjectField;
+use groove::ivm::{CollectByField, ProjectField, TopByLimit};
 use groove::records::{RecordDescriptor, Value};
 use groove::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema,
@@ -406,6 +406,43 @@ async fn multisink_subscription_delivers_initial_and_tick_deltas_for_all_sinks()
         tick.get("years").unwrap().to_values().unwrap(),
         [(vec![Value::U64(2), Value::U64(1957)], 1)]
     );
+}
+
+#[futures_test::test]
+async fn shared_structured_output_delivers_terminal_deltas_to_every_subscription() {
+    let mut db = database().await;
+    let graph = GraphBuilder::collect_root_ordered(
+        GraphBuilder::table("albums"),
+        ["id"],
+        [
+            CollectByField::named("id"),
+            CollectByField::named("title"),
+            CollectByField::named("year"),
+        ],
+        Vec::new(),
+        Vec::<String>::new(),
+        0,
+        TopByLimit::Unbounded,
+    );
+    let first = db.subscribe([("rows", graph.clone())]).unwrap();
+    let second = db.subscribe([("rows", graph)]).unwrap();
+    first.try_recv().expect("first initial snapshot");
+    second.try_recv().expect("second initial snapshot");
+
+    insert_album(&mut db, 1, "Kind of Blue", 1959).await;
+
+    let first_tick = first.try_recv().expect("first subscription tick");
+    let second_tick = second.try_recv().expect("second subscription tick");
+    let first_terminal = first_tick
+        .terminal_sinks
+        .get("rows")
+        .expect("first subscription receives structured terminal deltas");
+    let second_terminal = second_tick
+        .terminal_sinks
+        .get("rows")
+        .expect("second subscription receives structured terminal deltas");
+    assert!(!first_terminal.is_empty());
+    assert_eq!(second_terminal, first_terminal);
 }
 
 #[futures_test::test]


### PR DESCRIPTION
## Summary
- Deliver structured collector updates to every subscription and sink sharing the same terminal node.
- Avoid unnecessary copies and preserve pending updates when a sink pauses for storage.

## Before
Reading a terminal update removed it from the evaluator. The first shared consumer received the update, while later consumers could see nothing. Moving the payload too early could also lose it if another sink paused before publication.

## After
Groove counts all consumers of each terminal update, clones only for non-final consumers, and moves the original to the last one. It materialises every sink before consuming terminal state, so a paused sink can retry safely.

## Test plan
- [x] Run `cargo test -p groove --test multisink_subscription` — 7 passed.
- [x] Run `cargo fmt --check`.