### PR TITLE
Validate configured JWT issuer and audience

### DIFF
--- a/.changeset/brave-auth-domains.md
+++ b/.changeset/brave-auth-domains.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Validate configured JWT issuers and audiences in backend request authentication.

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -57,6 +57,10 @@ export type BackendContextConfig = Omit<AppContext, "schema" | "driver" | "clien
   jwksUrl?: string;
   /** Single JWK object or PEM/JWK string used to verify external bearer JWTs in `forRequest()`. */
   jwtPublicKey?: BackendJwtPublicKey;
+  /** Required issuer for external bearer JWTs accepted by `forRequest()`. */
+  jwtIssuer?: string;
+  /** Required audience, or audiences, for external bearer JWTs accepted by `forRequest()`. */
+  jwtAudience?: string | readonly string[];
   /** Whether local-first bearer JWTs are accepted in `forRequest()`. Defaults to `true`. */
   allowLocalFirstAuth?: boolean;
 } & BackendContextSchemaConfig;
@@ -401,6 +405,8 @@ export class JazzContext {
       appId: this.config.appId,
       jwksUrl: this.config.jwksUrl,
       jwtPublicKey: this.config.jwtPublicKey,
+      jwtIssuer: this.config.jwtIssuer,
+      jwtAudience: this.config.jwtAudience,
       allowLocalFirstAuth: this.config.allowLocalFirstAuth,
     });
   }

--- a/packages/jazz-tools/src/backend/request-auth.test.ts
+++ b/packages/jazz-tools/src/backend/request-auth.test.ts
@@ -260,6 +260,64 @@ describe("backend request auth", () => {
     });
   });
 
+  it("rejects a signed external JWT from a different configured issuer", async () => {
+    const token = signHs256Jwt({
+      sub: "user-subject",
+      iss: "https://other-issuer.example",
+      aud: "jazz-api",
+    });
+
+    await expect(
+      resolveRequestSession(
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        {
+          appId: "issuer-bound-app",
+          jwtPublicKey: {
+            kty: "oct",
+            kid: JWT_KID,
+            alg: "HS256",
+            k: base64Url(JWT_SECRET),
+          },
+          jwtIssuer: "https://issuer.example",
+          jwtAudience: "jazz-api",
+        },
+      ),
+    ).rejects.toThrow(/issuer/i);
+  });
+
+  it("rejects a signed external JWT for a different configured audience", async () => {
+    const token = signHs256Jwt({
+      sub: "user-subject",
+      iss: "https://issuer.example",
+      aud: "other-service",
+    });
+
+    await expect(
+      resolveRequestSession(
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        {
+          appId: "audience-bound-app",
+          jwtPublicKey: {
+            kty: "oct",
+            kid: JWT_KID,
+            alg: "HS256",
+            k: base64Url(JWT_SECRET),
+          },
+          jwtIssuer: "https://issuer.example",
+          jwtAudience: "jazz-api",
+        },
+      ),
+    ).rejects.toThrow(/audience/i);
+  });
+
   it("preserves exact signed external JWT issuer spelling after validation", async () => {
     const token = signHs256Jwt({
       sub: " user-subject ",

--- a/packages/jazz-tools/src/backend/request-auth.ts
+++ b/packages/jazz-tools/src/backend/request-auth.ts
@@ -23,6 +23,8 @@ export interface BackendRequestAuthConfig {
   appId: string;
   jwksUrl?: string;
   jwtPublicKey?: BackendJwtPublicKey;
+  jwtIssuer?: string;
+  jwtAudience?: string | readonly string[];
   allowLocalFirstAuth?: boolean;
 }
 
@@ -322,6 +324,26 @@ function ensureJwtNotExpired(payload: JwtPayload): void {
   }
 }
 
+function ensureJwtDomain(payload: JwtPayload, config: BackendRequestAuthConfig): void {
+  if (config.jwtIssuer !== undefined && payload.iss !== config.jwtIssuer) {
+    throw new Error("JWT issuer does not match the configured issuer");
+  }
+
+  if (config.jwtAudience === undefined) {
+    return;
+  }
+  const expected = Array.isArray(config.jwtAudience) ? config.jwtAudience : [config.jwtAudience];
+  const actual =
+    typeof payload.aud === "string"
+      ? [payload.aud]
+      : Array.isArray(payload.aud) && payload.aud.every((audience) => typeof audience === "string")
+        ? payload.aud
+        : [];
+  if (!expected.some((audience) => actual.includes(audience))) {
+    throw new Error("JWT audience does not match the configured audience");
+  }
+}
+
 async function verifyLocalFirstIdentityProof(token: string, appId: string): Promise<string> {
   const { verifyLocalFirstIdentityProof: verifyToken } = await import("jazz-napi");
   const result = verifyToken(token, appId);
@@ -332,7 +354,11 @@ async function verifyLocalFirstIdentityProof(token: string, appId: string): Prom
   return result.id;
 }
 
-async function verifyExternalJwt(token: string, config: BackendRequestAuthConfig): Promise<void> {
+async function verifyExternalJwt(
+  token: string,
+  payload: JwtPayload,
+  config: BackendRequestAuthConfig,
+): Promise<void> {
   if (config.jwtPublicKey !== undefined) {
     try {
       await verifyJwtSignatureWithStaticKey(token, config.jwtPublicKey);
@@ -341,7 +367,8 @@ async function verifyExternalJwt(token: string, config: BackendRequestAuthConfig
       throw new Error(`Invalid JWT: ${message}`);
     }
 
-    ensureJwtNotExpired(requireJwtPayload(token));
+    ensureJwtNotExpired(payload);
+    ensureJwtDomain(payload, config);
     return;
   }
 
@@ -359,7 +386,8 @@ async function verifyExternalJwt(token: string, config: BackendRequestAuthConfig
       }
     }
 
-    ensureJwtNotExpired(requireJwtPayload(token));
+    ensureJwtNotExpired(payload);
+    ensureJwtDomain(payload, config);
     return;
   }
 
@@ -396,6 +424,6 @@ export async function resolveRequestSession(
 
   const session = requireJwtSession(payload);
   rejectReservedExternalJwtIssuer(session);
-  await verifyExternalJwt(token, config);
+  await verifyExternalJwt(token, payload, config);
   return session;
 }

--- a/packages/jazz-tools/src/runtime/client-session.ts
+++ b/packages/jazz-tools/src/runtime/client-session.ts
@@ -90,6 +90,7 @@ export interface JwtPayload {
   sub?: unknown;
   iss?: unknown;
   claims?: unknown;
+  aud?: unknown;
   exp?: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Let backend request authentication optionally bind trusted JWT keys to an expected issuer and one or more audiences.
- Reject correctly signed tokens outside the configured domain without changing existing defaults.

## Before
`forRequest` verified an external token's signature and optional expiry but had no issuer or audience constraints. When signing material was shared, a valid token intended for another service could be accepted.

## After
Applications can opt into `jwtIssuer`, `jwtAudience`, or both. Configured constraints are checked after signature verification. When neither is configured, authentication behaves exactly as it does today: the trusted key or JWKS defines the token domain. Local-first JWT handling is unchanged.

## Test plan
- [x] Run the 9 backend request-auth tests.
- [x] Run the 16 backend-context tests.
- [x] Run `pnpm --filter jazz-tools check`.
- [x] Run targeted `oxfmt --check`.

Includes a patch changeset for `jazz-tools`.