### PR TITLE
Avoid copying uncompressed inbound wire payloads

### DIFF
--- a/.changeset/borrow-uncompressed-wire-payloads.md
+++ b/.changeset/borrow-uncompressed-wire-payloads.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce peak memory use when decoding uncompressed inbound wire payloads by borrowing the assembled message bytes.

--- a/crates/jazz/src/db/wire_transport.rs
+++ b/crates/jazz/src/db/wire_transport.rs
@@ -347,7 +347,7 @@ where
         self.validate_inbound_session(&envelope)?;
         let payload = self
             .inbound_stream
-            .decode_message(&envelope.payload, envelope.features)
+            .decode_message_borrowed(&envelope.payload, envelope.features)
             .map_err(|message| {
                 WireError::new(WireErrorCode::MalformedFrame, WireRetry::Never, message)
             })?;

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -1260,6 +1260,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn uncompressed_stream_decoder_borrows_payload() {
+        let mut decoder = WireStreamDecoder::new(FEATURE_NONE).unwrap();
+        let message = b"uncompressed logical message".to_vec();
+
+        let decoded = decoder.decode_message(&message, FEATURE_NONE).unwrap();
+
+        assert_eq!(decoded.as_ptr(), message.as_ptr());
+    }
+
     #[cfg(feature = "transport-compression-zstd")]
     #[test]
     fn compressed_stream_decoder_accepts_raw_envelopes() {

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -8,6 +8,7 @@
 
 use postcard::{from_bytes, to_allocvec};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 use crate::ids::{AuthorSubject, NodeUuid};
 use crate::protocol::SyncMessage;
@@ -604,18 +605,27 @@ impl WireStreamDecoder {
         Ok(Self { codec })
     }
 
-    /// Decode one message's stream chunk into one semantic sync payload.
+    /// Decode one message's stream chunk into one owned semantic sync payload.
     pub fn decode_message(
         &mut self,
         payload: &[u8],
         envelope_features: WireFeatures,
     ) -> Result<Vec<u8>, String> {
+        self.decode_message_borrowed(payload, envelope_features)
+            .map(Cow::into_owned)
+    }
+
+    pub(crate) fn decode_message_borrowed<'a>(
+        &mut self,
+        payload: &'a [u8],
+        envelope_features: WireFeatures,
+    ) -> Result<Cow<'a, [u8]>, String> {
         let active = envelope_features & FEATURE_PAYLOAD_COMPRESSION_MASK;
         if active.count_ones() > 1 {
             return Err("wire frame declares more than one payload compression codec".to_owned());
         }
         if active == FEATURE_NONE {
-            return Ok(payload.to_vec());
+            return Ok(Cow::Borrowed(payload));
         }
         if WireCompression::from_features(active) != self.codec {
             return Err("wire frame compression codec changed within one connection".to_owned());
@@ -624,7 +634,7 @@ impl WireStreamDecoder {
         if decoded.len() > crate::protocol_limits::MAX_LOGICAL_MESSAGE_BYTES {
             return Err("decompressed logical message exceeds receiver budget".to_owned());
         }
-        Ok(decoded)
+        Ok(Cow::Owned(decoded))
     }
 }
 
@@ -1265,7 +1275,9 @@ mod tests {
         let mut decoder = WireStreamDecoder::new(FEATURE_NONE).unwrap();
         let message = b"uncompressed logical message".to_vec();
 
-        let decoded = decoder.decode_message(&message, FEATURE_NONE).unwrap();
+        let decoded = decoder
+            .decode_message_borrowed(&message, FEATURE_NONE)
+            .unwrap();
 
         assert_eq!(decoded.as_ptr(), message.as_ptr());
     }


### PR DESCRIPTION
## Summary
- Borrow uncompressed payload bytes during inbound semantic decoding instead of copying the complete message.
- Keep compressed payloads owned and preserve the existing public Rust decoder interface.

## Before
Fragment reassembly produced one contiguous payload, then the uncompressed decoder copied the whole buffer before semantic decoding. A legal 256 MiB message could therefore hold roughly 512 MiB of byte buffers before decoded allocations.

## After
The inbound transport uses a crate-private borrowed-or-owned decode path. Uncompressed messages borrow the assembled bytes, compressed messages own their decompressed bytes, and external callers still receive the original owned `Vec<u8>` API.

## Test plan
- [x] Run the 30 `wire::tests` cases with the maintained Jazz feature set.
- [x] Run `cargo fmt --check`.