### PR TITLE
Repair Rust shadow source receipts

### DIFF
--- a/.github/workflows/ci-rust-shadow.yml
+++ b/.github/workflows/ci-rust-shadow.yml
@@ -44,8 +44,12 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      RUST_SHADOW_SOURCE_BASELINE: ${{ runner.temp }}/rust-shadow-source.json
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Seal clean checked-out source baseline
+        run: node dev/gates/rust-shadow-matrix.mjs clean-source-baseline "$RUST_SHADOW_SOURCE_BASELINE" "${{ github.sha }}"
       - uses: ./.github/actions/setup-blacksmith
       - name: Run exact-inventory Rust shadow shard
         run: node dev/gates/rust-shadow-matrix.mjs shard ${{ matrix.index }} 2 "target/rust-shadow/shard-${{ matrix.index }}.json"

--- a/dev/gates/run-rust-tests.mjs
+++ b/dev/gates/run-rust-tests.mjs
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { sourceIdentity } from "./source-identity.mjs";
+import { sameTrackedSource, sourceIdentity } from "./source-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const now = () => new Date().toISOString();
@@ -131,7 +131,12 @@ const result = await new Promise((resolve) => {
 });
 clearTimeout(timer);
 const finishedAt = now();
-const source = sourceIdentity(root);
+const observedSource = { commit: run("git", ["rev-parse", "HEAD"]), ...sourceIdentity(root) };
+const baselinePath = process.env.RUST_SHADOW_SOURCE_BASELINE;
+const baseline = baselinePath ? JSON.parse(fs.readFileSync(baselinePath, "utf8")) : null;
+if (baseline && !sameTrackedSource(baseline, observedSource))
+  throw new Error("Rust test changed the checked-out source after the shadow baseline");
+const source = baseline ?? observedSource;
 const data = {
   schemaVersion: 1,
   kind: "rust-test-receipt",

--- a/dev/gates/rust-shadow-matrix.mjs
+++ b/dev/gates/rust-shadow-matrix.mjs
@@ -12,7 +12,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { sourceIdentity } from "./source-identity.mjs";
+import { sameTrackedSource, sourceIdentity } from "./source-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const testArgs = [
@@ -140,6 +140,28 @@ function writeJson(file, value) {
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function cleanSourceBaseline(argv) {
+  const receipt = argv[0];
+  const expectedCommit = argv[1];
+  if (!receipt || !/^[0-9a-f]{40}$/.test(expectedCommit))
+    fail("usage: clean-source-baseline RECEIPT EXPECTED_COMMIT");
+  const source = { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) };
+  if (!validSourceIdentity(source)) fail("checkout contains source changes before dependency setup");
+  if (source.commit !== expectedCommit) fail("checkout source commit does not match workflow event commit");
+  writeJson(receipt, source);
+}
+
+function shadowSourceBaseline() {
+  const baselinePath = process.env.RUST_SHADOW_SOURCE_BASELINE;
+  if (!baselinePath) return null;
+  const source = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+  if (!validSourceIdentity(source)) fail("shadow source baseline is not a clean checkout");
+  const observed = { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) };
+  if (!sameTrackedSource(source, observed))
+    fail("dependency setup changed the checked-out source after the shadow baseline");
+  return source;
+}
+
 function shard(argv) {
   const index = Number(argv[0]);
   const count = Number(argv[1]);
@@ -155,6 +177,7 @@ function shard(argv) {
   const startedAt = now();
   const phases = [];
   const partition = `hash:${index}/${count}`;
+  const baseline = shadowSourceBaseline();
   const value = {
     schemaVersion: 1,
     kind: "rust-shadow-shard-receipt",
@@ -163,7 +186,7 @@ function shard(argv) {
     testArgs,
     phases,
     status: "failed",
-    source: { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) },
+    source: baseline ?? { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) },
     environment: {
       platform: process.platform,
       arch: process.arch,
@@ -203,6 +226,14 @@ function shard(argv) {
       if (result.status !== 0) fail(`partition tests exited ${result.status}`);
     });
     value.testReceipt = JSON.parse(fs.readFileSync(testReceipt, "utf8"));
+    if (
+      baseline &&
+      !sameTrackedSource(
+        baseline,
+        { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) },
+      )
+    )
+      fail("shadow execution changed the checked-out source after the baseline");
     if (index === 1) {
       // This is the same maintained seed required by CI, folded into shard 1
       // after the complete ordinary workspace partition has run.
@@ -388,4 +419,5 @@ function aggregate(argv) {
 const [command, ...argv] = process.argv.slice(2);
 if (command === "shard") shard(argv);
 else if (command === "aggregate") aggregate(argv);
+else if (command === "clean-source-baseline") cleanSourceBaseline(argv);
 else fail("expected shard or aggregate command");

--- a/dev/gates/rust-shadow-matrix.mjs
+++ b/dev/gates/rust-shadow-matrix.mjs
@@ -145,9 +145,14 @@ function cleanSourceBaseline(argv) {
   const expectedCommit = argv[1];
   if (!receipt || !/^[0-9a-f]{40}$/.test(expectedCommit))
     fail("usage: clean-source-baseline RECEIPT EXPECTED_COMMIT");
-  const source = { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) };
-  if (!validSourceIdentity(source)) fail("checkout contains source changes before dependency setup");
-  if (source.commit !== expectedCommit) fail("checkout source commit does not match workflow event commit");
+  const source = {
+    commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+    ...sourceIdentity(root),
+  };
+  if (!validSourceIdentity(source))
+    fail("checkout contains source changes before dependency setup");
+  if (source.commit !== expectedCommit)
+    fail("checkout source commit does not match workflow event commit");
   writeJson(receipt, source);
 }
 
@@ -156,7 +161,10 @@ function shadowSourceBaseline() {
   if (!baselinePath) return null;
   const source = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
   if (!validSourceIdentity(source)) fail("shadow source baseline is not a clean checkout");
-  const observed = { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) };
+  const observed = {
+    commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+    ...sourceIdentity(root),
+  };
   if (!sameTrackedSource(source, observed))
     fail("dependency setup changed the checked-out source after the shadow baseline");
   return source;
@@ -186,7 +194,10 @@ function shard(argv) {
     testArgs,
     phases,
     status: "failed",
-    source: baseline ?? { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) },
+    source: baseline ?? {
+      commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+      ...sourceIdentity(root),
+    },
     environment: {
       platform: process.platform,
       arch: process.arch,
@@ -228,10 +239,10 @@ function shard(argv) {
     value.testReceipt = JSON.parse(fs.readFileSync(testReceipt, "utf8"));
     if (
       baseline &&
-      !sameTrackedSource(
-        baseline,
-        { commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(), ...sourceIdentity(root) },
-      )
+      !sameTrackedSource(baseline, {
+        commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+        ...sourceIdentity(root),
+      })
     )
       fail("shadow execution changed the checked-out source after the baseline");
     if (index === 1) {

--- a/dev/gates/source-identity.mjs
+++ b/dev/gates/source-identity.mjs
@@ -45,3 +45,16 @@ export function sourceIdentity(root) {
     dirty: headTree !== indexTree || unstaged !== sha256("") || untracked.length !== 0,
   };
 }
+
+// Dependency setup is allowed to create ignored build products, but it must
+// never alter the checked-out source used by a receipt.  A baseline captured
+// immediately after checkout therefore remains the source attestation when
+// the later measurement has the same tracked-source identity.
+export function sameTrackedSource(left, right) {
+  return (
+    left?.commit === right?.commit &&
+    left?.headTree === right?.headTree &&
+    left?.indexTree === right?.indexTree &&
+    left?.unstaged === right?.unstaged
+  );
+}

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -555,6 +555,11 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
   assert.match(rustShadowLauncher, /test belongs to more than one shard/);
   assert.match(rustShadowLauncher, /hash shards do not cover the exact executable inventory/);
   assert.match(rustShadowLauncher, /sourceIdentity\(root\)/);
+  assert.match(rustShadowLauncher, /clean-source-baseline RECEIPT EXPECTED_COMMIT/);
+  assert.match(rustShadowLauncher, /dependency setup changed the checked-out source after the shadow baseline/);
+  assert.match(rustShadowLauncher, /shadow execution changed the checked-out source after the baseline/);
+  assert.match(rustShadowWorkflow, /Seal clean checked-out source baseline/);
+  assert.match(rustShadowWorkflow, /RUST_SHADOW_SOURCE_BASELINE: \$\{\{ runner\.temp \}\}\/rust-shadow-source\.json/);
   assert.match(rustShadowLauncher, /shards disagree on the checked-out source identity/);
   assert.match(rustShadowLauncher, /workflow event commit/);
   assert.match(

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -556,10 +556,19 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
   assert.match(rustShadowLauncher, /hash shards do not cover the exact executable inventory/);
   assert.match(rustShadowLauncher, /sourceIdentity\(root\)/);
   assert.match(rustShadowLauncher, /clean-source-baseline RECEIPT EXPECTED_COMMIT/);
-  assert.match(rustShadowLauncher, /dependency setup changed the checked-out source after the shadow baseline/);
-  assert.match(rustShadowLauncher, /shadow execution changed the checked-out source after the baseline/);
+  assert.match(
+    rustShadowLauncher,
+    /dependency setup changed the checked-out source after the shadow baseline/,
+  );
+  assert.match(
+    rustShadowLauncher,
+    /shadow execution changed the checked-out source after the baseline/,
+  );
   assert.match(rustShadowWorkflow, /Seal clean checked-out source baseline/);
-  assert.match(rustShadowWorkflow, /RUST_SHADOW_SOURCE_BASELINE: \$\{\{ runner\.temp \}\}\/rust-shadow-source\.json/);
+  assert.match(
+    rustShadowWorkflow,
+    /RUST_SHADOW_SOURCE_BASELINE: \$\{\{ runner\.temp \}\}\/rust-shadow-source\.json/,
+  );
   assert.match(rustShadowLauncher, /shards disagree on the checked-out source identity/);
   assert.match(rustShadowLauncher, /workflow event commit/);
   assert.match(


### PR DESCRIPTION
🤖 Repairs the Rust throughput shadow's source receipt without weakening tracked-source integrity.

The failed main run proved both test shards passed, but the aggregate rejected them because runner-generated untracked files made the post-test worktrees appear dirty. This change seals a fully clean source identity immediately after checkout, then requires dependency setup and test execution to preserve the commit, HEAD tree, index tree, and unstaged patch before either shard may reuse that baseline. Untracked build residue is no longer mistaken for committed-source drift.

This remains a non-required measurement workflow. Before promotion, it still needs a fresh green run and comparison against the required Rust jobs; the shadow currently uses two 8-vCPU shards and folds M3 into shard 1, while required CI has separate 4-vCPU workspace/differential jobs and additional benchmark-smoke/partition verification.

Verification:
- `pnpm test:ci-workflow`: 101 passed
- focused CI workflow contract: 37 passed
- both Rust shards in main run 32884167165 passed; aggregate was the only failure