### PR TITLE
Bound large-value DAG traversal and refcounts

### DIFF
--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -286,76 +286,15 @@ impl Database {
                 })?,
             });
         }
-        let mut node_updates =
-            BTreeMap::<crate::large_values::NodeRef, LargeValueNodeReferences>::new();
-        let mut pending = node_transitions;
-        while let Some((node_ref, delta)) = pending.pop() {
-            let mut metadata = if let Some(metadata) = node_updates.remove(&node_ref) {
-                metadata
-            } else {
-                let encoded = self
-                    .storage
-                    .get(
-                        LARGE_VALUE_METADATA_CF.to_owned(),
-                        large_value_node_key(&node_ref)?,
-                    )
-                    .await?
-                    .ok_or_else(|| {
-                        Error::InvalidLargeValueMetadata(
-                            "active node reference metadata is missing".to_owned(),
-                        )
-                    })?;
-                postcard::from_bytes(&encoded).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot decode node references: {error}"
-                    ))
-                })?
-            };
-            let crossed_zero = if delta > 0 {
-                let crossed = metadata.references == 0;
-                metadata.references = metadata.references.checked_add(1).ok_or_else(|| {
-                    Error::InvalidLargeValueMetadata("node reference count overflow".to_owned())
-                })?;
-                crossed
-            } else {
-                metadata.references = metadata.references.checked_sub(1).ok_or_else(|| {
-                    Error::InvalidLargeValueMetadata("node reference count underflow".to_owned())
-                })?;
-                metadata.references == 0
-            };
-            if crossed_zero {
-                pending.extend(
-                    metadata
-                        .children
-                        .iter()
-                        .cloned()
-                        .map(|child| (child, delta)),
-                );
-            }
-            node_updates.insert(node_ref, metadata);
-        }
-        for (node_ref, metadata) in node_updates {
-            staged_operations.push(OwnedWriteOperation::Set {
-                cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                key: large_value_node_key(&node_ref)?,
-                value: postcard::to_allocvec(&metadata).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot encode node references: {error}"
-                    ))
-                })?,
-            });
-            if metadata.references == 0 {
-                staged_operations.push(OwnedWriteOperation::Set {
-                    cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                    key: large_value_reclaim_key(&node_ref)?,
-                    value: postcard::to_allocvec(&node_ref).map_err(|error| {
-                        Error::InvalidLargeValueMetadata(format!(
-                            "cannot encode reclaim entry: {error}"
-                        ))
-                    })?,
-                });
-            }
-        }
+        staged_operations.extend(
+            large_value_node_transition_operations(
+                &self.storage,
+                BTreeMap::new(),
+                node_transitions,
+                false,
+            )
+            .await?,
+        );
         let resident_overlay = Rc::new(StagedWriteOverlay::new_owned(
             Rc::clone(&self.storage),
             Rc::clone(&self.resident_writes),

--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -227,74 +227,6 @@ impl Database {
             .chain(accepted_roots.keys())
             .cloned()
             .collect::<BTreeSet<_>>();
-        let mut node_transitions = Vec::<(crate::large_values::NodeRef, i8)>::new();
-        for root in roots {
-            let key = large_value_root_key(&root)?;
-            let mut references = match self
-                .storage
-                .get(LARGE_VALUE_METADATA_CF.to_owned(), key.clone())
-                .await?
-            {
-                Some(encoded) => postcard::from_bytes(&encoded).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot decode root references: {error}"
-                    ))
-                })?,
-                None => LargeValueRootReferences::default(),
-            };
-            let previous_total = references.durable.saturating_add(references.staged);
-            let durable_delta = durable_root_deltas.get(&root).copied().unwrap_or_default();
-            references.durable = if durable_delta >= 0 {
-                references.durable.checked_add(durable_delta as u64)
-            } else {
-                references.durable.checked_sub(durable_delta.unsigned_abs())
-            }
-            .ok_or_else(|| {
-                Error::InvalidLargeValueMetadata("durable root count overflow/underflow".to_owned())
-            })?;
-            references.staged = references
-                .staged
-                .checked_sub(accepted_roots.get(&root).copied().unwrap_or_default())
-                .ok_or_else(|| {
-                    Error::InvalidLargeValueMetadata("staged root count underflow".to_owned())
-                })?;
-            let next_total = references.durable.saturating_add(references.staged);
-            if previous_total == 0 && next_total > 0 && !references.node_active {
-                if self
-                    .storage
-                    .get(
-                        LARGE_VALUE_METADATA_CF.to_owned(),
-                        large_value_node_key(&root)?,
-                    )
-                    .await?
-                    .is_some()
-                {
-                    references.node_active = true;
-                    node_transitions.push((root.clone(), 1));
-                }
-            } else if previous_total > 0 && next_total == 0 && references.node_active {
-                references.node_active = false;
-                node_transitions.push((root.clone(), -1));
-            }
-            staged_operations.push(OwnedWriteOperation::Set {
-                cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                key,
-                value: postcard::to_allocvec(&references).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot encode root references: {error}"
-                    ))
-                })?,
-            });
-        }
-        staged_operations.extend(
-            large_value_node_transition_operations(
-                &self.storage,
-                BTreeMap::new(),
-                node_transitions,
-                false,
-            )
-            .await?,
-        );
         let resident_overlay = Rc::new(StagedWriteOverlay::new_owned(
             Rc::clone(&self.storage),
             Rc::clone(&self.resident_writes),
@@ -323,6 +255,88 @@ impl Database {
                 return Err(Error::IvmRuntime(error));
             }
         };
+        // The tick may request missing chunks, which can install metadata via
+        // the same lifecycle. Only acquire it after ticking, then retain the
+        // owned guard in AppliedBatch until this publication's ordered write
+        // commits the root/node transition snapshot.
+        let large_value_lifecycle_guard = if roots.is_empty() {
+            None
+        } else {
+            let guard = self.large_value_lifecycle.clone().lock_owned().await;
+            let mut node_transitions = Vec::<(crate::large_values::NodeRef, i8)>::new();
+            let mut lifecycle_operations = Vec::new();
+            for root in roots {
+                let key = large_value_root_key(&root)?;
+                let mut references = match self
+                    .storage
+                    .get(LARGE_VALUE_METADATA_CF.to_owned(), key.clone())
+                    .await?
+                {
+                    Some(encoded) => postcard::from_bytes(&encoded).map_err(|error| {
+                        Error::InvalidLargeValueMetadata(format!(
+                            "cannot decode root references: {error}"
+                        ))
+                    })?,
+                    None => LargeValueRootReferences::default(),
+                };
+                let previous_total = references.durable.saturating_add(references.staged);
+                let durable_delta = durable_root_deltas.get(&root).copied().unwrap_or_default();
+                references.durable = if durable_delta >= 0 {
+                    references.durable.checked_add(durable_delta as u64)
+                } else {
+                    references.durable.checked_sub(durable_delta.unsigned_abs())
+                }
+                .ok_or_else(|| {
+                    Error::InvalidLargeValueMetadata(
+                        "durable root count overflow/underflow".to_owned(),
+                    )
+                })?;
+                references.staged = references
+                    .staged
+                    .checked_sub(accepted_roots.get(&root).copied().unwrap_or_default())
+                    .ok_or_else(|| {
+                        Error::InvalidLargeValueMetadata("staged root count underflow".to_owned())
+                    })?;
+                let next_total = references.durable.saturating_add(references.staged);
+                if previous_total == 0 && next_total > 0 && !references.node_active {
+                    if self
+                        .storage
+                        .get(
+                            LARGE_VALUE_METADATA_CF.to_owned(),
+                            large_value_node_key(&root)?,
+                        )
+                        .await?
+                        .is_some()
+                    {
+                        references.node_active = true;
+                        node_transitions.push((root.clone(), 1));
+                    }
+                } else if previous_total > 0 && next_total == 0 && references.node_active {
+                    references.node_active = false;
+                    node_transitions.push((root.clone(), -1));
+                }
+                lifecycle_operations.push(OwnedWriteOperation::Set {
+                    cf: LARGE_VALUE_METADATA_CF.to_owned(),
+                    key,
+                    value: postcard::to_allocvec(&references).map_err(|error| {
+                        Error::InvalidLargeValueMetadata(format!(
+                            "cannot encode root references: {error}"
+                        ))
+                    })?,
+                });
+            }
+            lifecycle_operations.extend(
+                large_value_node_transition_operations(
+                    &self.storage,
+                    BTreeMap::new(),
+                    node_transitions,
+                    false,
+                )
+                .await?,
+            );
+            staged_state.borrow_mut().extend(lifecycle_operations);
+            Some(guard)
+        };
         let ivm_tick_time = tick_start.elapsed();
         let staged_operations = std::mem::take(&mut *staged_state.borrow_mut()).into_operations();
         let operations = staged_operations
@@ -346,6 +360,7 @@ impl Database {
             tick,
             notifications_deferred: defer_notifications_until_durable,
             lifecycle: Rc::new(Cell::new(AppliedBatchLifecycle::Applied)),
+            large_value_lifecycle_guard: Rc::new(RefCell::new(large_value_lifecycle_guard)),
             abandoned_application: Rc::clone(&self.abandoned_application),
         })
     }

--- a/crates/groove/src/db/facade.rs
+++ b/crates/groove/src/db/facade.rs
@@ -73,12 +73,14 @@ impl Database {
             )));
         let chunk_resolver: Rc<dyn crate::chunks::MissingChunkResolver> =
             Rc::new(crate::chunks::UnavailableChunkResolver);
+        let large_value_lifecycle = Rc::new(futures::lock::Mutex::new(()));
         ivm_runtime.set_chunk_provider(Rc::new(
             crate::chunks::StorageChunkProvider::with_resolver_and_observer(
                 chunk_storage.clone(),
                 chunk_resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&storage),
+                    lifecycle: Rc::downgrade(&large_value_lifecycle),
                 }),
             ),
         ));
@@ -100,7 +102,7 @@ impl Database {
                 waiters: BTreeMap::new(),
                 failure: None,
             })),
-            large_value_lifecycle: Rc::new(futures::lock::Mutex::new(())),
+            large_value_lifecycle,
             abandoned_application: Rc::new(Cell::new(false)),
             poisoned: false,
         })
@@ -187,6 +189,7 @@ impl Database {
                 self.chunk_resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&self.storage),
+                    lifecycle: Rc::downgrade(&self.large_value_lifecycle),
                 }),
             ),
         ));
@@ -203,6 +206,7 @@ impl Database {
                 resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&self.storage),
+                    lifecycle: Rc::downgrade(&self.large_value_lifecycle),
                 }),
             ),
         ));
@@ -1025,7 +1029,6 @@ impl Database {
                 "staged receipt id is already bound to a different descriptor".to_owned(),
             ));
         }
-        let kind = value_ref.kind;
         let staged = crate::large_values::StagedLargeValue {
             id,
             value_ref,
@@ -1073,70 +1076,16 @@ impl Database {
                 value: references,
             },
         ];
-        let mut node_updates =
-            BTreeMap::<crate::large_values::NodeRef, LargeValueNodeReferences>::new();
-        let mut pending = if activate_root {
-            vec![staged.value_ref.root.clone()]
-        } else {
-            Vec::new()
-        };
-        while let Some(node_ref) = pending.pop() {
-            let mut metadata = if let Some(metadata) = node_updates.remove(&node_ref) {
-                metadata
-            } else if let Some(encoded) = self
-                .storage
-                .get(
-                    LARGE_VALUE_METADATA_CF.to_owned(),
-                    large_value_node_key(&node_ref)?,
+        if activate_root {
+            operations.extend(
+                large_value_node_transition_operations(
+                    &self.storage,
+                    BTreeMap::new(),
+                    vec![(staged.value_ref.root.clone(), 1)],
+                    false,
                 )
-                .await?
-            {
-                postcard::from_bytes(&encoded).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot decode node references: {error}"
-                    ))
-                })?
-            } else {
-                let encoded = self
-                    .chunk_storage
-                    .get(node_ref.locator, node_ref.object_hash)
-                    .await
-                    .map_err(crate::chunks::ChunkError::from)
-                    .map_err(crate::ivm::runtime::IvmRuntimeError::from)?;
-                let children =
-                    match crate::large_values::decode_node(kind, node_ref.object_hash, &encoded)
-                        .map_err(crate::ivm::runtime::IvmRuntimeError::from)?
-                    {
-                        crate::large_values::ChunkNode::Leaf { .. } => Vec::new(),
-                        crate::large_values::ChunkNode::Branch { children, .. } => {
-                            children.into_iter().map(|child| child.node_ref).collect()
-                        }
-                    };
-                LargeValueNodeReferences {
-                    references: 0,
-                    upload_references: 0,
-                    children,
-                }
-            };
-            let activate_children = metadata.references == 0;
-            metadata.references = metadata.references.checked_add(1).ok_or_else(|| {
-                Error::InvalidLargeValueMetadata("node reference count overflow".to_owned())
-            })?;
-            if activate_children {
-                pending.extend(metadata.children.iter().cloned());
-            }
-            node_updates.insert(node_ref, metadata);
-        }
-        for (node_ref, metadata) in node_updates {
-            operations.push(OwnedWriteOperation::Set {
-                cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                key: large_value_node_key(&node_ref)?,
-                value: postcard::to_allocvec(&metadata).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot encode node references: {error}"
-                    ))
-                })?,
-            });
+                .await?,
+            );
         }
         self.storage.write_many(operations).await?;
         Ok(staged)
@@ -1225,54 +1174,16 @@ impl Database {
                 })?,
             },
         ];
-        let mut pending = if deactivate_root {
-            vec![staged.value_ref.root.clone()]
-        } else {
-            Vec::new()
-        };
-        while let Some(node_ref) = pending.pop() {
-            let key = large_value_node_key(&node_ref)?;
-            let encoded = self
-                .storage
-                .get(LARGE_VALUE_METADATA_CF.to_owned(), key.clone())
-                .await?
-                .ok_or_else(|| {
-                    Error::InvalidLargeValueMetadata(
-                        "reachable node reference metadata is missing".to_owned(),
-                    )
-                })?;
-            let mut metadata: LargeValueNodeReferences =
-                postcard::from_bytes(&encoded).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot decode node references: {error}"
-                    ))
-                })?;
-            metadata.references = metadata.references.checked_sub(1).ok_or_else(|| {
-                Error::InvalidLargeValueMetadata("node reference count underflow".to_owned())
-            })?;
-            if metadata.references == 0 {
-                pending.extend(metadata.children.iter().cloned());
-            }
-            operations.push(OwnedWriteOperation::Set {
-                cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                key,
-                value: postcard::to_allocvec(&metadata).map_err(|error| {
-                    Error::InvalidLargeValueMetadata(format!(
-                        "cannot encode node references: {error}"
-                    ))
-                })?,
-            });
-            if metadata.references == 0 {
-                operations.push(OwnedWriteOperation::Set {
-                    cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                    key: large_value_reclaim_key(&node_ref)?,
-                    value: postcard::to_allocvec(&node_ref).map_err(|error| {
-                        Error::InvalidLargeValueMetadata(format!(
-                            "cannot encode reclaim entry: {error}"
-                        ))
-                    })?,
-                });
-            }
+        if deactivate_root {
+            operations.extend(
+                large_value_node_transition_operations(
+                    &self.storage,
+                    BTreeMap::new(),
+                    vec![(staged.value_ref.root.clone(), -1)],
+                    false,
+                )
+                .await?,
+            );
         }
         self.storage.write_many(operations).await?;
         Ok(true)

--- a/crates/groove/src/db/facade.rs
+++ b/crates/groove/src/db/facade.rs
@@ -402,12 +402,7 @@ impl Database {
                         "cannot decode pushed chunk metadata: {error}"
                     ))
                 })?;
-                let children = match node {
-                    crate::large_values::ChunkNode::Leaf { .. } => Vec::new(),
-                    crate::large_values::ChunkNode::Branch { children, .. } => {
-                        children.into_iter().map(|child| child.node_ref).collect()
-                    }
-                };
+                let children = unique_large_value_children(&node);
                 LargeValueNodeReferences {
                     references: 0,
                     upload_references: 1,

--- a/crates/groove/src/db/facade.rs
+++ b/crates/groove/src/db/facade.rs
@@ -73,14 +73,14 @@ impl Database {
             )));
         let chunk_resolver: Rc<dyn crate::chunks::MissingChunkResolver> =
             Rc::new(crate::chunks::UnavailableChunkResolver);
-        let large_value_lifecycle = Rc::new(futures::lock::Mutex::new(()));
+        let large_value_lifecycle = std::sync::Arc::new(futures::lock::Mutex::new(()));
         ivm_runtime.set_chunk_provider(Rc::new(
             crate::chunks::StorageChunkProvider::with_resolver_and_observer(
                 chunk_storage.clone(),
                 chunk_resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&storage),
-                    lifecycle: Rc::downgrade(&large_value_lifecycle),
+                    lifecycle: std::sync::Arc::downgrade(&large_value_lifecycle),
                 }),
             ),
         ));
@@ -189,7 +189,7 @@ impl Database {
                 self.chunk_resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&self.storage),
-                    lifecycle: Rc::downgrade(&self.large_value_lifecycle),
+                    lifecycle: std::sync::Arc::downgrade(&self.large_value_lifecycle),
                 }),
             ),
         ));
@@ -206,7 +206,7 @@ impl Database {
                 resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&self.storage),
-                    lifecycle: Rc::downgrade(&self.large_value_lifecycle),
+                    lifecycle: std::sync::Arc::downgrade(&self.large_value_lifecycle),
                 }),
             ),
         ));

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -128,11 +128,18 @@ async fn large_value_node_transition_operations(
     mut pending: Vec<(crate::large_values::NodeRef, i8)>,
     allow_missing_positive_metadata: bool,
 ) -> Result<Vec<OwnedWriteOperation>, Error> {
+    let mut node_budget = crate::large_values::PhysicalTraversalNodeBudget::new();
+    node_budget
+        .consume_many(node_updates.len())
+        .map_err(crate::ivm::runtime::IvmRuntimeError::from)?;
     let mut reclaim_candidates = BTreeSet::new();
     while let Some((node_ref, delta)) = pending.pop() {
         let mut metadata = if let Some(metadata) = node_updates.remove(&node_ref) {
             metadata
         } else {
+            node_budget
+                .consume()
+                .map_err(crate::ivm::runtime::IvmRuntimeError::from)?;
             match storage
                 .get(
                     LARGE_VALUE_METADATA_CF.to_owned(),

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -93,9 +93,118 @@ struct LargeValueNodeReferences {
     children: Vec<crate::large_values::NodeRef>,
 }
 
+fn unique_large_value_children(
+    node: &crate::large_values::ChunkNode,
+) -> Vec<crate::large_values::NodeRef> {
+    match node {
+        crate::large_values::ChunkNode::Leaf { .. } => Vec::new(),
+        crate::large_values::ChunkNode::Branch { children, .. } => children
+            .iter()
+            .map(|child| child.node_ref.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+    }
+}
+
+/// Apply physical-node ownership transitions against one read-your-own-write
+/// overlay. Each active parent contributes one reference to each distinct
+/// child node, regardless of how many logical occurrences that child has.
+async fn large_value_node_transition_operations(
+    storage: &LayoutStorage,
+    mut node_updates: BTreeMap<crate::large_values::NodeRef, LargeValueNodeReferences>,
+    mut pending: Vec<(crate::large_values::NodeRef, i8)>,
+    allow_missing_positive_metadata: bool,
+) -> Result<Vec<OwnedWriteOperation>, Error> {
+    let mut reclaim_candidates = BTreeSet::new();
+    while let Some((node_ref, delta)) = pending.pop() {
+        let mut metadata = if let Some(metadata) = node_updates.remove(&node_ref) {
+            metadata
+        } else {
+            match storage
+                .get(
+                    LARGE_VALUE_METADATA_CF.to_owned(),
+                    large_value_node_key(&node_ref)?,
+                )
+                .await?
+            {
+                Some(encoded) => postcard::from_bytes(&encoded).map_err(|error| {
+                    Error::InvalidLargeValueMetadata(format!(
+                        "cannot decode node references: {error}"
+                    ))
+                })?,
+                None if delta > 0 && allow_missing_positive_metadata => {
+                    LargeValueNodeReferences::default()
+                }
+                None => {
+                    return Err(Error::InvalidLargeValueMetadata(
+                        "active node reference metadata is missing".to_owned(),
+                    ));
+                }
+            }
+        };
+        metadata.children = metadata
+            .children
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let crossed_zero = if delta > 0 {
+            let crossed = metadata.references == 0;
+            metadata.references = metadata.references.checked_add(1).ok_or_else(|| {
+                Error::InvalidLargeValueMetadata("node reference count overflow".to_owned())
+            })?;
+            reclaim_candidates.remove(&node_ref);
+            crossed
+        } else {
+            metadata.references = metadata.references.checked_sub(1).ok_or_else(|| {
+                Error::InvalidLargeValueMetadata("node reference count underflow".to_owned())
+            })?;
+            let crossed = metadata.references == 0;
+            if crossed {
+                reclaim_candidates.insert(node_ref.clone());
+            }
+            crossed
+        };
+        if crossed_zero {
+            pending.extend(
+                metadata
+                    .children
+                    .iter()
+                    .cloned()
+                    .map(|child| (child, delta)),
+            );
+        }
+        node_updates.insert(node_ref, metadata);
+    }
+    let mut operations = Vec::new();
+    for (node_ref, metadata) in node_updates {
+        operations.push(OwnedWriteOperation::Set {
+            cf: LARGE_VALUE_METADATA_CF.to_owned(),
+            key: large_value_node_key(&node_ref)?,
+            value: postcard::to_allocvec(&metadata).map_err(|error| {
+                Error::InvalidLargeValueMetadata(format!("cannot encode node references: {error}"))
+            })?,
+        });
+        if metadata.references == 0 && reclaim_candidates.contains(&node_ref) {
+            operations.push(OwnedWriteOperation::Set {
+                cf: LARGE_VALUE_METADATA_CF.to_owned(),
+                key: large_value_reclaim_key(&node_ref)?,
+                value: postcard::to_allocvec(&node_ref).map_err(|error| {
+                    Error::InvalidLargeValueMetadata(format!(
+                        "cannot encode reclaim entry: {error}"
+                    ))
+                })?,
+            });
+        }
+    }
+    Ok(operations)
+}
+
 #[derive(Clone)]
 struct MetadataChunkInstallObserver {
     storage: std::rc::Weak<LayoutStorage>,
+    lifecycle: std::rc::Weak<AsyncMutex<()>>,
 }
 
 impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
@@ -110,16 +219,18 @@ impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
                     "database storage closed during chunk installation".to_owned(),
                 )
             })?;
-            let node =
-                crate::large_values::decode_authenticated_node(node_ref.object_hash, &encoded)
-                    .map_err(|_| crate::chunks::ChunkError::Integrity)?;
-            let children = match node {
-                crate::large_values::ChunkNode::Leaf { .. } => Vec::new(),
-                crate::large_values::ChunkNode::Branch { children, .. } => children
-                    .into_iter()
-                    .map(|child| child.node_ref)
-                    .collect::<Vec<_>>(),
-            };
+            let lifecycle = self.lifecycle.upgrade().ok_or_else(|| {
+                crate::chunks::ChunkError::Backend(
+                    "database lifecycle closed during chunk installation".to_owned(),
+                )
+            })?;
+            let _lifecycle = lifecycle.lock().await;
+            let node = crate::large_values::decode_node_untyped_authenticated(
+                node_ref.object_hash,
+                &encoded,
+            )
+            .map_err(|_| crate::chunks::ChunkError::Integrity)?;
+            let children = unique_large_value_children(&node);
             let node_key = large_value_node_key(&node_ref)
                 .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
             let existing = storage
@@ -158,18 +269,23 @@ impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
                 && !root_references.node_active;
             if activate_root {
                 root_references.node_active = true;
-                metadata.references = metadata.references.checked_add(1).ok_or_else(|| {
-                    crate::chunks::ChunkError::Backend("node reference count overflow".to_owned())
-                })?;
             }
-            let activate_children =
-                newly_discovered_active_children || (activate_root && metadata.references == 1);
-            let mut operations = vec![OwnedWriteOperation::Set {
-                cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                key: node_key,
-                value: postcard::to_allocvec(&metadata)
-                    .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?,
-            }];
+            let mut initial = BTreeMap::from([(node_ref.clone(), metadata)]);
+            let mut transitions = Vec::new();
+            if activate_root {
+                transitions.push((node_ref.clone(), 1));
+            }
+            if newly_discovered_active_children {
+                transitions.extend(children.into_iter().map(|child| (child, 1)));
+            }
+            let mut operations = large_value_node_transition_operations(
+                &storage,
+                std::mem::take(&mut initial),
+                transitions,
+                true,
+            )
+            .await
+            .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
             if activate_root {
                 operations.push(OwnedWriteOperation::Set {
                     cf: LARGE_VALUE_METADATA_CF.to_owned(),
@@ -177,35 +293,6 @@ impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
                     value: postcard::to_allocvec(&root_references)
                         .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?,
                 });
-            }
-            if activate_children {
-                for child in children {
-                    let child_key = large_value_node_key(&child)
-                        .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
-                    let encoded = storage
-                        .get(LARGE_VALUE_METADATA_CF.to_owned(), child_key.clone())
-                        .await
-                        .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
-                    let mut child_metadata: LargeValueNodeReferences = encoded
-                        .as_deref()
-                        .map(postcard::from_bytes)
-                        .transpose()
-                        .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?
-                        .unwrap_or_default();
-                    child_metadata.references =
-                        child_metadata.references.checked_add(1).ok_or_else(|| {
-                            crate::chunks::ChunkError::Backend(
-                                "child reference count overflow".to_owned(),
-                            )
-                        })?;
-                    operations.push(OwnedWriteOperation::Set {
-                        cf: LARGE_VALUE_METADATA_CF.to_owned(),
-                        key: child_key,
-                        value: postcard::to_allocvec(&child_metadata).map_err(|error| {
-                            crate::chunks::ChunkError::Backend(error.to_string())
-                        })?,
-                    });
-                }
             }
             storage
                 .write_many(operations)

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -13,6 +13,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 use std::str;
+use std::sync::{Arc, Weak};
 use std::task::{Poll, Waker};
 
 use futures::lock::Mutex as AsyncMutex;
@@ -204,7 +205,7 @@ async fn large_value_node_transition_operations(
 #[derive(Clone)]
 struct MetadataChunkInstallObserver {
     storage: std::rc::Weak<LayoutStorage>,
-    lifecycle: std::rc::Weak<AsyncMutex<()>>,
+    lifecycle: Weak<AsyncMutex<()>>,
 }
 
 impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
@@ -328,7 +329,7 @@ pub struct Database {
     /// promotion, and reclamation lifecycle. The blob backend may be separate
     /// from metadata storage, so this boundary prevents both intent eviction
     /// during an in-flight put and lost reference-count updates across uploads.
-    large_value_lifecycle: Rc<AsyncMutex<()>>,
+    large_value_lifecycle: Arc<AsyncMutex<()>>,
     abandoned_application: Rc<Cell<bool>>,
     poisoned: bool,
 }
@@ -355,6 +356,10 @@ pub struct AppliedBatch {
     tick: TickMetrics,
     notifications_deferred: bool,
     lifecycle: Rc<Cell<AppliedBatchLifecycle>>,
+    /// Retains the large-value metadata lifecycle through the matching
+    /// ordered storage write. This is acquired after the IVM tick, whose
+    /// chunk resolution may itself install metadata through that lifecycle.
+    large_value_lifecycle_guard: Rc<RefCell<Option<futures::lock::OwnedMutexGuard<()>>>>,
     abandoned_application: Rc<Cell<bool>>,
 }
 
@@ -371,6 +376,8 @@ impl AppliedBatch {
         );
         let mut attempt = PersistenceAttempt {
             lifecycle: Rc::clone(&self.lifecycle),
+            large_value_lifecycle_guard: self.large_value_lifecycle_guard.borrow_mut().take(),
+            large_value_lifecycle_guard_slot: Rc::clone(&self.large_value_lifecycle_guard),
             completed: false,
         };
         let turn = std::future::poll_fn(|cx| {
@@ -443,6 +450,8 @@ impl AppliedBatch {
 
 struct PersistenceAttempt {
     lifecycle: Rc<Cell<AppliedBatchLifecycle>>,
+    large_value_lifecycle_guard: Option<futures::lock::OwnedMutexGuard<()>>,
+    large_value_lifecycle_guard_slot: Rc<RefCell<Option<futures::lock::OwnedMutexGuard<()>>>>,
     completed: bool,
 }
 
@@ -450,6 +459,8 @@ impl Drop for PersistenceAttempt {
     fn drop(&mut self) {
         if !self.completed && self.lifecycle.get() == AppliedBatchLifecycle::Persisting {
             self.lifecycle.set(AppliedBatchLifecycle::Applied);
+            *self.large_value_lifecycle_guard_slot.borrow_mut() =
+                self.large_value_lifecycle_guard.take();
         }
     }
 }

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -99,13 +99,24 @@ fn unique_large_value_children(
 ) -> Vec<crate::large_values::NodeRef> {
     match node {
         crate::large_values::ChunkNode::Leaf { .. } => Vec::new(),
-        crate::large_values::ChunkNode::Branch { children, .. } => children
-            .iter()
-            .map(|child| child.node_ref.clone())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect(),
+        crate::large_values::ChunkNode::Branch { children, .. } => {
+            canonical_large_value_children(children.iter().map(|child| child.node_ref.clone()))
+        }
     }
+}
+
+/// Metadata child edges describe physical ownership rather than a logical
+/// byte order. Normalize them on every read/write boundary so historical
+/// logical-order vectors and duplicate child occurrences retain their exact
+/// one-edge-per-physical-child meaning.
+fn canonical_large_value_children(
+    children: impl IntoIterator<Item = crate::large_values::NodeRef>,
+) -> Vec<crate::large_values::NodeRef> {
+    children
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 /// Apply physical-node ownership transitions against one read-your-own-write
@@ -144,12 +155,7 @@ async fn large_value_node_transition_operations(
                 }
             }
         };
-        metadata.children = metadata
-            .children
-            .into_iter()
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
+        metadata.children = canonical_large_value_children(metadata.children);
         let crossed_zero = if delta > 0 {
             let crossed = metadata.references == 0;
             metadata.references = metadata.references.checked_add(1).ok_or_else(|| {
@@ -244,11 +250,13 @@ impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
                 .transpose()
                 .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?
                 .unwrap_or_default();
-            if !metadata.children.is_empty() && metadata.children != children {
+            let existing_children =
+                canonical_large_value_children(std::mem::take(&mut metadata.children));
+            if !existing_children.is_empty() && existing_children != children {
                 return Err(crate::chunks::ChunkError::Integrity);
             }
             let newly_discovered_active_children =
-                metadata.references > 0 && metadata.children.is_empty() && !children.is_empty();
+                metadata.references > 0 && existing_children.is_empty() && !children.is_empty();
             metadata.children = children.clone();
 
             let root_key = large_value_root_key(&node_ref)

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -1068,6 +1068,121 @@ async fn resolver_installed_shared_dag_recursively_activates_and_reclaims_descen
     assert_eq!(chunks.len(), 0);
 }
 
+// Root/node transitions are included in an ordered publication, while a
+// resolver can install a newly available root through an independently held
+// provider. The publication must retain the lifecycle after it snapshots the
+// root count and until that ordered write is durable; otherwise an observer
+// that read the old active parent can overwrite the last-root deactivation.
+#[futures_test::test]
+async fn last_root_publication_blocks_descendant_install_until_its_refcount_write_is_durable() {
+    let schema = DatabaseSchema::new([TableSchema::new(
+        "objects",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("payload", ColumnType::Bytes),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let storage = MemoryStorage::new(&schema.column_families());
+    let chunks = Rc::new(crate::chunks::MemoryChunkStorage::new());
+    let mut database = Database::new(schema, storage).await.unwrap();
+    database.set_chunk_storage(chunks.clone());
+    let prepared = crate::large_values::repeated_child_dag_fixture(1, 4);
+    let root_chunk = prepared
+        .staged_chunks
+        .iter()
+        .find(|chunk| chunk.node_ref == prepared.value_ref.root)
+        .unwrap()
+        .clone();
+    let child = prepared
+        .staged_chunks
+        .iter()
+        .find(|chunk| chunk.node_ref != prepared.value_ref.root)
+        .unwrap()
+        .node_ref
+        .clone();
+    let staged = database
+        .stage_large_value_preparation(prepared.clone())
+        .await
+        .unwrap();
+    let mut insert = database.open_batch();
+    insert.insert(
+        "objects",
+        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+    );
+    insert.accept_large_value(staged.id);
+    database.commit_batch(insert).await.unwrap();
+
+    // Model a root fetched from a peer after its durable root record already
+    // became active but before its child metadata was learned. This is the
+    // state the resolver observer repairs.
+    database
+        .storage
+        .write_many(vec![
+            OwnedWriteOperation::Set {
+                cf: LARGE_VALUE_METADATA_CF.to_owned(),
+                key: large_value_node_key(&prepared.value_ref.root).unwrap(),
+                value: postcard::to_allocvec(&LargeValueNodeReferences {
+                    references: 1,
+                    upload_references: 0,
+                    children: Vec::new(),
+                })
+                .unwrap(),
+            },
+            OwnedWriteOperation::Set {
+                cf: LARGE_VALUE_METADATA_CF.to_owned(),
+                key: large_value_node_key(&child).unwrap(),
+                value: postcard::to_allocvec(&LargeValueNodeReferences::default()).unwrap(),
+            },
+        ])
+        .await
+        .unwrap();
+    crate::chunks::ChunkStorage::delete(
+        &*chunks,
+        root_chunk.node_ref.locator,
+        root_chunk.node_ref.object_hash,
+    )
+    .await
+    .unwrap();
+    database.set_missing_chunk_resolver(Rc::new(FixtureChunkResolver {
+        chunks: Rc::new(std::collections::BTreeMap::from([(
+            crate::chunks::ChunkRequest {
+                object_hash: root_chunk.node_ref.object_hash.0,
+                locator: root_chunk.node_ref.locator,
+            },
+            Bytes::from(root_chunk.encoded.clone()),
+        )])),
+    }));
+
+    let mut delete = database.open_batch();
+    delete.delete("objects", PrimaryKeyValue::U64(1));
+    let applied = database.apply_batch(delete).await.unwrap();
+
+    let provider = database.owned_chunk_provider();
+    let request = crate::chunks::ChunkRequest {
+        object_hash: root_chunk.node_ref.object_hash.0,
+        locator: root_chunk.node_ref.locator,
+    };
+    let mut installation = Box::pin(provider.get(request));
+    assert!(futures::poll!(installation.as_mut()).is_pending());
+
+    let persisted = applied.persist().await;
+    database.finish_persistence(persisted).unwrap();
+    installation.await.unwrap();
+
+    let encoded = database
+        .storage
+        .get(
+            LARGE_VALUE_METADATA_CF.to_owned(),
+            large_value_node_key(&child).unwrap(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let metadata: LargeValueNodeReferences = postcard::from_bytes(&encoded).unwrap();
+    assert_eq!(metadata.references, 0);
+}
+
 #[futures_test::test]
 async fn root_first_upload_requests_only_authenticated_missing_frontier() {
     let schema = DatabaseSchema::new([TableSchema::new(

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -7,6 +7,25 @@ use std::cell::Cell;
 use std::task::{Poll, Waker};
 
 #[derive(Clone)]
+struct FixtureChunkResolver {
+    chunks: Rc<std::collections::BTreeMap<crate::chunks::ChunkRequest, Bytes>>,
+}
+
+impl crate::chunks::MissingChunkResolver for FixtureChunkResolver {
+    fn resolve(
+        &self,
+        request: crate::chunks::ChunkRequest,
+    ) -> crate::chunks::ChunkFuture<'_, Result<Bytes, crate::chunks::ChunkError>> {
+        Box::pin(async move {
+            self.chunks
+                .get(&request)
+                .cloned()
+                .ok_or(crate::chunks::ChunkError::Unavailable)
+        })
+    }
+}
+
+#[derive(Clone)]
 struct CrashAfterChunkPut {
     storage: Rc<crate::chunks::MemoryChunkStorage>,
     fail_after_successes: Cell<Option<usize>>,
@@ -884,6 +903,167 @@ async fn shared_durable_root_is_reclaimed_only_after_its_last_physical_record() 
             .await
             .unwrap()
             > 0
+    );
+    assert_eq!(chunks.len(), 0);
+}
+
+// This internal storage-lifecycle receipt uses a non-canonical but valid shared
+// DAG that an authenticated peer may upload. It proves physical ownership and
+// finalization are graph-aware even though logical materialization preserves
+// every repeated child occurrence.
+#[futures_test::test]
+async fn repeated_child_dag_finalizes_once_per_node_and_reclaims_without_leaks() {
+    let schema = DatabaseSchema::new([TableSchema::new(
+        "objects",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("payload", ColumnType::Bytes),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let storage = MemoryStorage::new(&schema.column_families());
+    let chunks = Rc::new(crate::chunks::MemoryChunkStorage::new());
+    let mut database = Database::new(schema, storage).await.unwrap();
+    database.set_chunk_storage(chunks.clone());
+    let prepared = crate::large_values::repeated_child_dag_fixture(
+        crate::large_values::MAX_TREE_DEPTH,
+        crate::large_values::BRANCH_MAX_CHILDREN,
+    );
+    let physical_nodes = prepared.staged_chunks.len();
+
+    let staged = database
+        .stage_large_value_preparation(prepared.clone())
+        .await
+        .unwrap();
+    assert_eq!(chunks.len(), physical_nodes);
+    for chunk in &prepared.staged_chunks {
+        let encoded = database
+            .storage
+            .get(
+                LARGE_VALUE_METADATA_CF.to_owned(),
+                large_value_node_key(&chunk.node_ref).unwrap(),
+            )
+            .await
+            .unwrap()
+            .expect("every finalized physical node has metadata");
+        let metadata: LargeValueNodeReferences = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(
+            metadata.references, 1,
+            "one active physical parent/root contributes one reference"
+        );
+        assert!(
+            metadata.children.len() <= 1,
+            "repeated logical child occurrences are one physical ownership edge"
+        );
+    }
+
+    assert!(database.evict_staged_large_value(staged.id).await.unwrap());
+    assert_eq!(
+        database
+            .reclaim_orphaned_large_value_chunks(usize::MAX)
+            .await
+            .unwrap(),
+        physical_nodes
+    );
+    assert_eq!(chunks.len(), 0);
+}
+
+// Resolver installation happens before the complete graph is resident. This
+// receipt proves an active newly authenticated branch recursively activates a
+// distinct shared child once, even when the child occurs many times.
+#[futures_test::test]
+async fn resolver_installed_shared_dag_recursively_activates_and_reclaims_descendants() {
+    let schema = DatabaseSchema::new([TableSchema::new(
+        "objects",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("payload", ColumnType::Bytes),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let storage = MemoryStorage::new(&schema.column_families());
+    let chunks = Rc::new(crate::chunks::MemoryChunkStorage::new());
+    let mut database = Database::new(schema, storage).await.unwrap();
+    database.set_chunk_storage(chunks.clone());
+    let prepared = crate::large_values::repeated_child_dag_fixture(
+        2,
+        crate::large_values::BRANCH_MAX_CHILDREN,
+    );
+    let resolver_chunks = prepared
+        .staged_chunks
+        .iter()
+        .map(|chunk| {
+            (
+                crate::chunks::ChunkRequest {
+                    object_hash: chunk.node_ref.object_hash.0,
+                    locator: chunk.node_ref.locator,
+                },
+                Bytes::copy_from_slice(&chunk.encoded),
+            )
+        })
+        .collect();
+    database.set_missing_chunk_resolver(Rc::new(FixtureChunkResolver {
+        chunks: Rc::new(resolver_chunks),
+    }));
+
+    let staged = crate::large_values::StagedLargeValue {
+        id: crate::large_values::StagedLargeValueId([0x5d; 16]),
+        value_ref: prepared.value_ref.clone(),
+        accounting: Default::default(),
+        created_at_ms: 1,
+    };
+    database
+        .storage
+        .write_many(vec![
+            OwnedWriteOperation::Set {
+                cf: LARGE_VALUE_METADATA_CF.to_owned(),
+                key: staged_large_value_key(staged.id),
+                value: postcard::to_allocvec(&staged).unwrap(),
+            },
+            OwnedWriteOperation::Set {
+                cf: LARGE_VALUE_METADATA_CF.to_owned(),
+                key: large_value_root_key(&staged.value_ref.root).unwrap(),
+                value: postcard::to_allocvec(&LargeValueRootReferences {
+                    durable: 0,
+                    staged: 1,
+                    node_active: false,
+                })
+                .unwrap(),
+            },
+        ])
+        .await
+        .unwrap();
+
+    let provider = database.owned_chunk_provider();
+    for chunk in prepared.staged_chunks.iter().rev() {
+        let request = crate::chunks::ChunkRequest {
+            object_hash: chunk.node_ref.object_hash.0,
+            locator: chunk.node_ref.locator,
+        };
+        drop(provider.get(request).await.unwrap());
+    }
+    for chunk in &prepared.staged_chunks {
+        let encoded = database
+            .storage
+            .get(
+                LARGE_VALUE_METADATA_CF.to_owned(),
+                large_value_node_key(&chunk.node_ref).unwrap(),
+            )
+            .await
+            .unwrap()
+            .expect("resolver-installed active node has metadata");
+        let metadata: LargeValueNodeReferences = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(metadata.references, 1);
+        assert!(metadata.children.len() <= 1);
+    }
+
+    assert!(database.evict_staged_large_value(staged.id).await.unwrap());
+    assert_eq!(
+        database
+            .reclaim_orphaned_large_value_chunks(usize::MAX)
+            .await
+            .unwrap(),
+        prepared.staged_chunks.len()
     );
     assert_eq!(chunks.len(), 0);
 }

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -1068,6 +1068,117 @@ async fn resolver_installed_shared_dag_recursively_activates_and_reclaims_descen
     assert_eq!(chunks.len(), 0);
 }
 
+// Older metadata stored the branch's logical child order, including every
+// repeated occurrence. A missing byte plane must be repairable from that
+// metadata: the resolver normalizes it to the one physical ownership edge
+// without treating the historical representation as an integrity failure.
+#[futures_test::test]
+async fn resolver_reinstalls_legacy_duplicate_child_metadata_after_byte_loss() {
+    let schema = DatabaseSchema::new([TableSchema::new(
+        "objects",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("payload", ColumnType::Bytes),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let storage = MemoryStorage::new(&schema.column_families());
+    let chunks = Rc::new(crate::chunks::MemoryChunkStorage::new());
+    let mut database = Database::new(schema, storage).await.unwrap();
+    database.set_chunk_storage(chunks.clone());
+    let prepared = crate::large_values::repeated_child_dag_fixture(1, 4);
+    let root_chunk = prepared
+        .staged_chunks
+        .iter()
+        .find(|chunk| chunk.node_ref == prepared.value_ref.root)
+        .unwrap()
+        .clone();
+    let child = prepared
+        .staged_chunks
+        .iter()
+        .find(|chunk| chunk.node_ref != prepared.value_ref.root)
+        .unwrap()
+        .node_ref
+        .clone();
+    let staged = database
+        .stage_large_value_preparation(prepared.clone())
+        .await
+        .unwrap();
+    let mut insert = database.open_batch();
+    insert.insert(
+        "objects",
+        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+    );
+    insert.accept_large_value(staged.id);
+    database.commit_batch(insert).await.unwrap();
+
+    let legacy_children = match crate::large_values::decode_node(
+        crate::large_values::LargeValueKind::Bytes,
+        root_chunk.node_ref.object_hash,
+        &root_chunk.encoded,
+    )
+    .unwrap()
+    {
+        crate::large_values::ChunkNode::Branch { children, .. } => children
+            .into_iter()
+            .map(|child| child.node_ref)
+            .collect::<Vec<_>>(),
+        crate::large_values::ChunkNode::Leaf { .. } => panic!("fixture root must branch"),
+    };
+    assert_eq!(legacy_children, vec![child.clone(); 4]);
+    database
+        .storage
+        .write_many(vec![OwnedWriteOperation::Set {
+            cf: LARGE_VALUE_METADATA_CF.to_owned(),
+            key: large_value_node_key(&root_chunk.node_ref).unwrap(),
+            value: postcard::to_allocvec(&LargeValueNodeReferences {
+                references: 1,
+                upload_references: 0,
+                children: legacy_children,
+            })
+            .unwrap(),
+        }])
+        .await
+        .unwrap();
+    crate::chunks::ChunkStorage::delete(
+        &*chunks,
+        root_chunk.node_ref.locator,
+        root_chunk.node_ref.object_hash,
+    )
+    .await
+    .unwrap();
+    database.set_missing_chunk_resolver(Rc::new(FixtureChunkResolver {
+        chunks: Rc::new(std::collections::BTreeMap::from([(
+            crate::chunks::ChunkRequest {
+                object_hash: root_chunk.node_ref.object_hash.0,
+                locator: root_chunk.node_ref.locator,
+            },
+            Bytes::from(root_chunk.encoded.clone()),
+        )])),
+    }));
+
+    database
+        .owned_chunk_provider()
+        .get(crate::chunks::ChunkRequest {
+            object_hash: root_chunk.node_ref.object_hash.0,
+            locator: root_chunk.node_ref.locator,
+        })
+        .await
+        .unwrap();
+    let encoded = database
+        .storage
+        .get(
+            LARGE_VALUE_METADATA_CF.to_owned(),
+            large_value_node_key(&root_chunk.node_ref).unwrap(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let metadata: LargeValueNodeReferences = postcard::from_bytes(&encoded).unwrap();
+    assert_eq!(metadata.references, 1);
+    assert_eq!(metadata.children, vec![child]);
+}
+
 // Root/node transitions are included in an ordered publication, while a
 // resolver can install a newly available root through an independently held
 // provider. The publication must retain the lifecycle after it snapshots the

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -33,6 +33,15 @@ pub const MAX_TREE_DEPTH: usize = 32;
 /// small authenticated DAG with zero-length metrics from turning one
 /// materialization attempt into exponential CPU or memory work.
 pub const MAX_LOGICAL_TRAVERSAL_STEPS: usize = 128 * 1024;
+/// Maximum number of distinct immutable nodes a graph-oriented operation may
+/// retain while authenticating one descriptor. This matches the logical-work
+/// budget while still admitting multi-gigabyte canonical values: even at the
+/// minimum leaf size, a normally shaped tree can represent well over 1 GiB.
+///
+/// Physical traversals must remember every discovered node to deduplicate DAG
+/// edges and validate repeated references consistently, so this is also their
+/// memory boundary.
+pub const MAX_PHYSICAL_TRAVERSAL_NODES: usize = MAX_LOGICAL_TRAVERSAL_STEPS;
 /// JSON syntax validation retains one frame per open array/object. Keep this
 /// separate from the immutable-tree bound: a small logical value can otherwise
 /// use arbitrarily deep JSON nesting to grow validator memory.
@@ -1463,6 +1472,8 @@ pub enum Error {
     InvalidTree,
     #[error("large-value logical traversal exceeded its deterministic work limit")]
     TraversalWorkLimitExceeded,
+    #[error("large-value physical traversal exceeded its distinct-node limit")]
+    PhysicalTraversalNodeLimitExceeded,
     #[error("malformed physical scalar encoding")]
     MalformedScalar,
     #[error("indirect scalar requires interruptible evaluation")]
@@ -1501,6 +1512,7 @@ struct PhysicalNodeState {
 struct PhysicalTraversal {
     pending: Vec<PhysicalTraversalEntry>,
     nodes: BTreeMap<NodeRef, PhysicalNodeState>,
+    node_budget: PhysicalTraversalNodeBudget,
 }
 
 impl PhysicalTraversal {
@@ -1509,7 +1521,24 @@ impl PhysicalTraversal {
         expected_metrics: Option<NodeMetrics>,
         expected_logical_hash: ContentHash,
     ) -> Self {
-        Self {
+        Self::new_with_node_limit(
+            root,
+            expected_metrics,
+            expected_logical_hash,
+            MAX_PHYSICAL_TRAVERSAL_NODES,
+        )
+        .expect("the configured physical traversal node limit is non-zero")
+    }
+
+    fn new_with_node_limit(
+        root: NodeRef,
+        expected_metrics: Option<NodeMetrics>,
+        expected_logical_hash: ContentHash,
+        max_nodes: usize,
+    ) -> Result<Self, Error> {
+        let mut node_budget = PhysicalTraversalNodeBudget::with_limit(max_nodes);
+        node_budget.consume()?;
+        Ok(Self {
             pending: vec![PhysicalTraversalEntry {
                 node_ref: root.clone(),
                 ancestors: Vec::new(),
@@ -1522,7 +1551,8 @@ impl PhysicalTraversal {
                     actual_metrics: None,
                 },
             )]),
-        }
+            node_budget,
+        })
     }
 
     fn pop(&mut self) -> Option<PhysicalTraversalEntry> {
@@ -1576,6 +1606,7 @@ impl PhysicalTraversal {
                 state.expected_metrics = Some(child.metrics);
             }
             std::collections::btree_map::Entry::Vacant(entry) => {
+                self.node_budget.consume()?;
                 entry.insert(PhysicalNodeState {
                     expected_logical_hash: child.logical_hash,
                     expected_metrics: Some(child.metrics),
@@ -1598,6 +1629,37 @@ impl PhysicalTraversal {
         for child in children.into_iter().rev() {
             self.discover_child(parent, child)?;
         }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct PhysicalTraversalNodeBudget {
+    remaining: usize,
+}
+
+impl PhysicalTraversalNodeBudget {
+    pub(crate) fn new() -> Self {
+        Self::with_limit(MAX_PHYSICAL_TRAVERSAL_NODES)
+    }
+
+    fn with_limit(limit: usize) -> Self {
+        Self { remaining: limit }
+    }
+
+    pub(crate) fn consume(&mut self) -> Result<(), Error> {
+        self.remaining = self
+            .remaining
+            .checked_sub(1)
+            .ok_or(Error::PhysicalTraversalNodeLimitExceeded)?;
+        Ok(())
+    }
+
+    pub(crate) fn consume_many(&mut self, count: usize) -> Result<(), Error> {
+        self.remaining = self
+            .remaining
+            .checked_sub(count)
+            .ok_or(Error::PhysicalTraversalNodeLimitExceeded)?;
         Ok(())
     }
 }
@@ -4128,6 +4190,44 @@ mod tests {
         Locator(hash.0)
     }
 
+    fn traverse_fixture_with_node_limit(
+        prepared: &PreparedLargeValue,
+        max_nodes: usize,
+    ) -> Result<usize, Error> {
+        let root_metrics = Some(NodeMetrics {
+            byte_length: prepared.value_ref.byte_length,
+            utf16_length: prepared.value_ref.utf16_length,
+        });
+        let chunks = prepared
+            .staged_chunks
+            .iter()
+            .map(|chunk| (chunk.node_ref.clone(), chunk))
+            .collect::<BTreeMap<_, _>>();
+        let mut traversal = PhysicalTraversal::new_with_node_limit(
+            prepared.value_ref.root.clone(),
+            root_metrics,
+            prepared.value_ref.logical_hash,
+            max_nodes,
+        )?;
+        let mut visited = 0;
+        while let Some(entry) = traversal.pop() {
+            let chunk = chunks
+                .get(&entry.node_ref)
+                .expect("fixture has every reachable physical node");
+            let node = decode_node(
+                prepared.value_ref.kind,
+                entry.node_ref.object_hash,
+                &chunk.encoded,
+            )?;
+            traversal.validate_node(prepared.value_ref.kind, &entry.node_ref, &node)?;
+            if let ChunkNode::Branch { children, .. } = node {
+                traversal.discover_children(&entry, children)?;
+            }
+            visited += 1;
+        }
+        Ok(visited)
+    }
+
     fn encode_v12_primitive_bytes(bytes: &[u8]) -> Vec<u8> {
         let primitive = RecordDescriptor::new([("value", ValueType::raw_bytes())]);
         let chunked = RecordDescriptor::new(Vec::<(String, ValueType)>::new());
@@ -4238,6 +4338,27 @@ mod tests {
         .unwrap();
         assert_eq!(count as usize, prepared.staged_chunks.len());
         assert_eq!(visited.len(), prepared.staged_chunks.len());
+    }
+
+    #[test]
+    fn physical_traversal_budget_allows_the_exact_distinct_node_boundary_for_shared_dag() {
+        let prepared = repeated_child_dag_fixture(2, BRANCH_MAX_CHILDREN);
+        assert_eq!(prepared.staged_chunks.len(), 3);
+        assert_eq!(
+            traverse_fixture_with_node_limit(&prepared, prepared.staged_chunks.len()),
+            Ok(prepared.staged_chunks.len()),
+            "repeated logical child edges consume one physical-node slot"
+        );
+    }
+
+    #[test]
+    fn physical_traversal_budget_rejects_one_distinct_node_over_the_boundary() {
+        let prepared = repeated_child_dag_fixture(3, BRANCH_MAX_CHILDREN);
+        assert_eq!(prepared.staged_chunks.len(), 4);
+        assert_eq!(
+            traverse_fixture_with_node_limit(&prepared, prepared.staged_chunks.len() - 1),
+            Err(Error::PhysicalTraversalNodeLimitExceeded)
+        );
     }
 
     struct WindowReader<'a> {

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -1,5 +1,7 @@
 //! Canonical indirect representation for large logical scalar values.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 mod json_syntax;
@@ -25,6 +27,12 @@ pub const BRANCH_MIN_CHILDREN: usize = 4;
 pub const BRANCH_TARGET_CHILDREN: usize = 16;
 pub const BRANCH_MAX_CHILDREN: usize = 64;
 pub const MAX_TREE_DEPTH: usize = 32;
+/// Maximum number of logical tree-edge occurrences one synchronous scalar
+/// operation may expand. Physical graph walks deduplicate shared nodes, but a
+/// shared node can occur at many logical positions. This bound prevents a
+/// small authenticated DAG with zero-length metrics from turning one
+/// materialization attempt into exponential CPU or memory work.
+pub const MAX_LOGICAL_TRAVERSAL_STEPS: usize = 128 * 1024;
 /// JSON syntax validation retains one frame per open array/object. Keep this
 /// separate from the immutable-tree bound: a small logical value can otherwise
 /// use arbitrarily deep JSON nesting to grow validator memory.
@@ -1453,6 +1461,8 @@ pub enum Error {
     DescriptorMismatch,
     #[error("large-value tree contains a cycle or exceeds its depth bound")]
     InvalidTree,
+    #[error("large-value logical traversal exceeded its deterministic work limit")]
+    TraversalWorkLimitExceeded,
     #[error("malformed physical scalar encoding")]
     MalformedScalar,
     #[error("indirect scalar requires interruptible evaluation")]
@@ -1465,6 +1475,156 @@ pub enum ReachabilityError {
     LargeValue(#[from] Error),
     #[error(transparent)]
     Chunk(#[from] crate::chunks::ChunkError),
+}
+
+#[derive(Clone)]
+struct PhysicalTraversalEntry {
+    node_ref: NodeRef,
+    /// Exact ancestors on this occurrence's path. Shared descendants are
+    /// legal; encountering an ancestor again is a cycle even when that node
+    /// was already authenticated through another path.
+    ancestors: Vec<NodeRef>,
+}
+
+#[derive(Clone, Copy)]
+struct PhysicalNodeState {
+    expected_logical_hash: ContentHash,
+    expected_metrics: Option<NodeMetrics>,
+    actual_metrics: Option<NodeMetrics>,
+}
+
+/// A physical graph traversal visits each immutable node once while retaining
+/// enough per-edge evidence to reject inconsistent shared references and
+/// cycles. Logical readers deliberately do not use this deduplication: every
+/// edge occurrence contributes bytes to the scalar and is instead protected by
+/// [`MAX_LOGICAL_TRAVERSAL_STEPS`].
+struct PhysicalTraversal {
+    pending: Vec<PhysicalTraversalEntry>,
+    nodes: BTreeMap<NodeRef, PhysicalNodeState>,
+}
+
+impl PhysicalTraversal {
+    fn new(
+        root: NodeRef,
+        expected_metrics: Option<NodeMetrics>,
+        expected_logical_hash: ContentHash,
+    ) -> Self {
+        Self {
+            pending: vec![PhysicalTraversalEntry {
+                node_ref: root.clone(),
+                ancestors: Vec::new(),
+            }],
+            nodes: BTreeMap::from([(
+                root,
+                PhysicalNodeState {
+                    expected_logical_hash,
+                    expected_metrics,
+                    actual_metrics: None,
+                },
+            )]),
+        }
+    }
+
+    fn pop(&mut self) -> Option<PhysicalTraversalEntry> {
+        self.pending.pop()
+    }
+
+    fn validate_node(
+        &mut self,
+        kind: LargeValueKind,
+        node_ref: &NodeRef,
+        node: &ChunkNode,
+    ) -> Result<(), Error> {
+        let state = self.nodes.get_mut(node_ref).ok_or(Error::InvalidTree)?;
+        if node_logical_hash(node) != state.expected_logical_hash {
+            return Err(Error::DescriptorMismatch);
+        }
+        let actual_metrics = node_metrics(kind, node)?;
+        if state
+            .expected_metrics
+            .is_some_and(|expected| expected != actual_metrics)
+        {
+            return Err(Error::DescriptorMismatch);
+        }
+        state.actual_metrics = Some(actual_metrics);
+        Ok(())
+    }
+
+    fn discover_child(
+        &mut self,
+        parent: &PhysicalTraversalEntry,
+        child: BranchChild,
+    ) -> Result<(), Error> {
+        let mut ancestors = parent.ancestors.clone();
+        ancestors.push(parent.node_ref.clone());
+        if ancestors.len() > MAX_TREE_DEPTH || ancestors.contains(&child.node_ref) {
+            return Err(Error::InvalidTree);
+        }
+        match self.nodes.entry(child.node_ref.clone()) {
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+                if state.expected_logical_hash != child.logical_hash
+                    || state
+                        .expected_metrics
+                        .is_some_and(|metrics| metrics != child.metrics)
+                    || state
+                        .actual_metrics
+                        .is_some_and(|metrics| metrics != child.metrics)
+                {
+                    return Err(Error::DescriptorMismatch);
+                }
+                state.expected_metrics = Some(child.metrics);
+            }
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(PhysicalNodeState {
+                    expected_logical_hash: child.logical_hash,
+                    expected_metrics: Some(child.metrics),
+                    actual_metrics: None,
+                });
+                self.pending.push(PhysicalTraversalEntry {
+                    node_ref: child.node_ref,
+                    ancestors,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn discover_children(
+        &mut self,
+        parent: &PhysicalTraversalEntry,
+        children: Vec<BranchChild>,
+    ) -> Result<(), Error> {
+        for child in children.into_iter().rev() {
+            self.discover_child(parent, child)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LogicalTraversalBudget {
+    remaining: usize,
+}
+
+impl LogicalTraversalBudget {
+    fn new() -> Self {
+        Self {
+            remaining: MAX_LOGICAL_TRAVERSAL_STEPS,
+        }
+    }
+
+    fn consume(&mut self) -> Result<(), Error> {
+        self.consume_many(1)
+    }
+
+    fn consume_many(&mut self, count: usize) -> Result<(), Error> {
+        self.remaining = self
+            .remaining
+            .checked_sub(count)
+            .ok_or(Error::TraversalWorkLimitExceeded)?;
+        Ok(())
+    }
 }
 
 /// Authenticate and visit every immutable node reachable from one descriptor.
@@ -1482,57 +1642,22 @@ pub async fn visit_reachable_chunks(
         byte_length: value.byte_length,
         utf16_length: value.utf16_length,
     });
-    let mut pending = vec![(
-        value.root.clone(),
-        0_usize,
-        root_metrics,
-        value.logical_hash,
-    )];
+    let mut traversal =
+        PhysicalTraversal::new(value.root.clone(), root_metrics, value.logical_hash);
     let mut visited = 0_u64;
-    while let Some((node_ref, depth, expected_metrics, expected_logical_hash)) = pending.pop() {
-        if depth > MAX_TREE_DEPTH {
-            return Err(Error::InvalidTree.into());
-        }
+    while let Some(entry) = traversal.pop() {
+        let node_ref = &entry.node_ref;
         let request = ChunkRequest {
             object_hash: node_ref.object_hash.0,
             locator: node_ref.locator,
         };
         let encoded = provider.get(request.clone()).await?;
         let node = decode_node(value.kind, node_ref.object_hash, &encoded)?;
-        if node_logical_hash(&node) != expected_logical_hash {
-            return Err(Error::DescriptorMismatch.into());
-        }
-        match &node {
-            ChunkNode::Leaf { bytes, .. } => {
-                if expected_metrics
-                    .is_some_and(|expected| metrics(value.kind, bytes).ok() != Some(expected))
-                {
-                    return Err(Error::DescriptorMismatch.into());
-                }
-            }
-            ChunkNode::Branch { children, .. } => {
-                if let Some(expected) = expected_metrics {
-                    let mut child_metrics = children.iter().map(|child| child.metrics);
-                    let Some(first) = child_metrics.next() else {
-                        return Err(Error::MalformedNode.into());
-                    };
-                    if child_metrics.try_fold(first, add_metrics)? != expected {
-                        return Err(Error::DescriptorMismatch.into());
-                    }
-                }
-            }
-        }
+        traversal.validate_node(value.kind, node_ref, &node)?;
         visit(&request);
         visited = visited.checked_add(1).ok_or(Error::MetricOverflow)?;
         if let ChunkNode::Branch { children, .. } = node {
-            for child in children.into_iter().rev() {
-                pending.push((
-                    child.node_ref,
-                    depth + 1,
-                    Some(child.metrics),
-                    child.logical_hash,
-                ));
-            }
+            traversal.discover_children(&entry, children)?;
         }
     }
     Ok(visited)
@@ -1542,7 +1667,7 @@ pub async fn visit_reachable_chunks(
 pub struct LargeValueUploadCursor {
     kind: LargeValueKind,
     provider: crate::chunks::OwnedChunkProvider,
-    pending: Vec<(NodeRef, usize, Option<NodeMetrics>, ContentHash)>,
+    traversal: PhysicalTraversal,
 }
 
 impl LargeValueUploadCursor {
@@ -1558,7 +1683,7 @@ impl LargeValueUploadCursor {
         Ok(Self {
             kind: value.kind,
             provider,
-            pending: vec![(value.root.clone(), 0, root_metrics, value.logical_hash)],
+            traversal: PhysicalTraversal::new(value.root.clone(), root_metrics, value.logical_hash),
         })
     }
 
@@ -1570,55 +1695,22 @@ impl LargeValueUploadCursor {
     ) -> Result<Vec<StagedChunk>, ReachabilityError> {
         let mut batch = Vec::new();
         while batch.len() < limit.max(1) {
-            let Some((node_ref, depth, expected_metrics, expected_logical_hash)) =
-                self.pending.pop()
-            else {
+            let Some(entry) = self.traversal.pop() else {
                 break;
             };
-            if depth > MAX_TREE_DEPTH {
-                return Err(Error::InvalidTree.into());
-            }
+            let node_ref = &entry.node_ref;
             let request = ChunkRequest {
                 object_hash: node_ref.object_hash.0,
                 locator: node_ref.locator,
             };
             let encoded = self.provider.get(request).await?;
             let node = decode_node(self.kind, node_ref.object_hash, encoded.bytes())?;
-            if node_logical_hash(&node) != expected_logical_hash {
-                return Err(Error::DescriptorMismatch.into());
-            }
-            match &node {
-                ChunkNode::Leaf { bytes, .. } => {
-                    if expected_metrics
-                        .is_some_and(|expected| metrics(self.kind, bytes).ok() != Some(expected))
-                    {
-                        return Err(Error::DescriptorMismatch.into());
-                    }
-                }
-                ChunkNode::Branch { children, .. } => {
-                    if let Some(expected) = expected_metrics {
-                        let mut child_metrics = children.iter().map(|child| child.metrics);
-                        let Some(first) = child_metrics.next() else {
-                            return Err(Error::MalformedNode.into());
-                        };
-                        if child_metrics.try_fold(first, add_metrics)? != expected {
-                            return Err(Error::DescriptorMismatch.into());
-                        }
-                    }
-                }
-            }
+            self.traversal.validate_node(self.kind, node_ref, &node)?;
             if let ChunkNode::Branch { children, .. } = node {
-                for child in children.into_iter().rev() {
-                    self.pending.push((
-                        child.node_ref,
-                        depth + 1,
-                        Some(child.metrics),
-                        child.logical_hash,
-                    ));
-                }
+                self.traversal.discover_children(&entry, children)?;
             }
             batch.push(StagedChunk {
-                node_ref,
+                node_ref: entry.node_ref,
                 encoded: encoded.bytes().to_vec(),
             });
         }
@@ -1639,22 +1731,16 @@ pub(crate) async fn missing_upload_frontier(
         byte_length: value.byte_length,
         utf16_length: value.utf16_length,
     });
-    let mut pending = vec![(
-        value.root.clone(),
-        0_usize,
-        root_metrics,
-        value.logical_hash,
-    )];
+    let mut traversal =
+        PhysicalTraversal::new(value.root.clone(), root_metrics, value.logical_hash);
     let mut missing = Vec::new();
-    while let Some((node_ref, depth, expected_metrics, expected_logical_hash)) = pending.pop() {
-        if depth > MAX_TREE_DEPTH {
-            return Err(Error::InvalidTree.into());
-        }
+    while let Some(entry) = traversal.pop() {
+        let node_ref = &entry.node_ref;
         let encoded = match reader.get(node_ref.locator, node_ref.object_hash).await {
             Ok(encoded) => encoded,
             Err(crate::chunks::ChunkStorageError::Unavailable) => {
-                missing.push(node_ref);
-                if missing.len() == limit {
+                missing.push(entry.node_ref);
+                if missing.len() >= limit.max(1) {
                     break;
                 }
                 continue;
@@ -1662,38 +1748,9 @@ pub(crate) async fn missing_upload_frontier(
             Err(error) => return Err(crate::chunks::ChunkError::from(error).into()),
         };
         let node = decode_node(value.kind, node_ref.object_hash, &encoded)?;
-        if node_logical_hash(&node) != expected_logical_hash {
-            return Err(Error::DescriptorMismatch.into());
-        }
-        match &node {
-            ChunkNode::Leaf { bytes, .. } => {
-                if expected_metrics
-                    .is_some_and(|expected| metrics(value.kind, bytes).ok() != Some(expected))
-                {
-                    return Err(Error::DescriptorMismatch.into());
-                }
-            }
-            ChunkNode::Branch { children, .. } => {
-                if let Some(expected) = expected_metrics {
-                    let mut child_metrics = children.iter().map(|child| child.metrics);
-                    let Some(first) = child_metrics.next() else {
-                        return Err(Error::MalformedNode.into());
-                    };
-                    if child_metrics.try_fold(first, add_metrics)? != expected {
-                        return Err(Error::DescriptorMismatch.into());
-                    }
-                }
-            }
-        }
+        traversal.validate_node(value.kind, node_ref, &node)?;
         if let ChunkNode::Branch { children, .. } = node {
-            for child in children.into_iter().rev() {
-                pending.push((
-                    child.node_ref,
-                    depth + 1,
-                    Some(child.metrics),
-                    child.logical_hash,
-                ));
-            }
+            traversal.discover_children(&entry, children)?;
         }
     }
     Ok(missing)
@@ -1715,22 +1772,16 @@ pub(crate) async fn validate_finalized_upload(
         byte_length: value.byte_length,
         utf16_length: value.utf16_length,
     });
-    let mut pending = vec![(
-        value.root.clone(),
-        0_usize,
-        root_metrics,
-        value.logical_hash,
-    )];
-    while let Some((node_ref, depth, expected_metrics, expected_logical_hash)) = pending.pop() {
-        if depth > MAX_TREE_DEPTH {
-            return Err(Error::InvalidTree.into());
-        }
+    let mut traversal =
+        PhysicalTraversal::new(value.root.clone(), root_metrics, value.logical_hash);
+    while let Some(entry) = traversal.pop() {
+        let node_ref = &entry.node_ref;
         // Descriptor-keyed peer uploads may legitimately discover that an
         // identical descriptor was completed by another connection. Once its
         // pending record was bound to that exact descriptor at `begin`, local
         // immutable nodes are safe to reuse. Unbound/raw uploads, in contrast,
         // must prove every reachable node was journaled by this upload.
-        if !descriptor_was_bound_before_completion && !uploaded_chunks.contains(&node_ref) {
+        if !descriptor_was_bound_before_completion && !uploaded_chunks.contains(node_ref) {
             return Err(Error::DescriptorMismatch.into());
         }
         let encoded = reader
@@ -1738,36 +1789,9 @@ pub(crate) async fn validate_finalized_upload(
             .await
             .map_err(crate::chunks::ChunkError::from)?;
         let node = decode_node(value.kind, node_ref.object_hash, &encoded)?;
-        if node_logical_hash(&node) != expected_logical_hash {
-            return Err(Error::DescriptorMismatch.into());
-        }
-        match &node {
-            ChunkNode::Leaf { bytes, .. } => {
-                if expected_metrics
-                    .is_some_and(|expected| metrics(value.kind, bytes).ok() != Some(expected))
-                {
-                    return Err(Error::DescriptorMismatch.into());
-                }
-            }
-            ChunkNode::Branch { children, .. } => {
-                if let Some(expected) = expected_metrics {
-                    let mut child_metrics = children.iter().map(|child| child.metrics);
-                    let Some(first) = child_metrics.next() else {
-                        return Err(Error::MalformedNode.into());
-                    };
-                    if child_metrics.try_fold(first, add_metrics)? != expected {
-                        return Err(Error::DescriptorMismatch.into());
-                    }
-                }
-                for child in children.iter().rev() {
-                    pending.push((
-                        child.node_ref.clone(),
-                        depth + 1,
-                        Some(child.metrics),
-                        child.logical_hash,
-                    ));
-                }
-            }
+        traversal.validate_node(value.kind, node_ref, &node)?;
+        if let ChunkNode::Branch { children, .. } = node {
+            traversal.discover_children(&entry, children)?;
         }
     }
     Ok(())
@@ -2610,6 +2634,16 @@ pub(crate) fn decode_authenticated_node(
     expected_hash: ContentHash,
     encoded: &[u8],
 ) -> Result<ChunkNode, Error> {
+    decode_node_untyped_authenticated(expected_hash, encoded)
+}
+
+/// Authenticate and canonically decode an immutable-node envelope before a
+/// referencing descriptor is available. Descriptor-bound reads additionally
+/// apply [`decode_node`]'s kind check.
+pub(crate) fn decode_node_untyped_authenticated(
+    expected_hash: ContentHash,
+    encoded: &[u8],
+) -> Result<ChunkNode, Error> {
     if object_hash(encoded) != expected_hash {
         return Err(Error::ObjectHashMismatch);
     }
@@ -2977,7 +3011,9 @@ pub(crate) fn materialize_attempt(
     )];
     let mut leaves = Vec::<(NodeRef, Vec<u8>)>::new();
     let mut blocked = false;
+    let mut budget = LogicalTraversalBudget::new();
     while let Some((node_ref, depth, expected_metrics, expected_logical_hash)) = pending.pop() {
+        budget.consume()?;
         if depth > MAX_TREE_DEPTH {
             return Err(Error::InvalidTree.into());
         }
@@ -3013,6 +3049,7 @@ pub(crate) fn materialize_attempt(
                         return Err(Error::DescriptorMismatch.into());
                     }
                 }
+                budget.consume_many(children.len())?;
                 for child in children.into_iter().rev() {
                     pending.push((
                         child.node_ref,
@@ -3307,7 +3344,9 @@ fn base_utf16_range_attempt(
     )];
     let mut slices = Vec::new();
     let mut blocked = false;
+    let mut budget = LogicalTraversalBudget::new();
     while let Some((node_ref, hash, start, length, depth)) = pending.pop() {
+        budget.consume()?;
         if depth > MAX_TREE_DEPTH {
             return Err(Error::InvalidTree.into());
         }
@@ -3332,6 +3371,7 @@ fn base_utf16_range_attempt(
                 slices.push((start, part));
             }
             ChunkNode::Branch { children, .. } => {
+                budget.consume_many(children.len())?;
                 let mut child_start = start;
                 let mut next = Vec::with_capacity(children.len());
                 for child in children {
@@ -3467,7 +3507,9 @@ fn base_utf16_length_for_byte_range_attempt(
     )];
     let mut total = 0_u64;
     let mut blocked = false;
+    let mut budget = LogicalTraversalBudget::new();
     while let Some((node_ref, expected_hash, start, bytes_len, utf16_len, depth)) = pending.pop() {
+        budget.consume()?;
         if depth > MAX_TREE_DEPTH {
             return Err(Error::InvalidTree.into());
         }
@@ -3503,6 +3545,7 @@ fn base_utf16_length_for_byte_range_attempt(
                     .ok_or(Error::MetricOverflow)?;
             }
             ChunkNode::Branch { children, .. } => {
+                budget.consume_many(children.len())?;
                 let mut child_start = start;
                 let mut next = Vec::with_capacity(children.len());
                 for child in children {
@@ -3759,7 +3802,9 @@ fn base_range_attempt(
     )];
     let mut slices = Vec::<(u64, Vec<u8>)>::new();
     let mut blocked = false;
+    let mut budget = LogicalTraversalBudget::new();
     while let Some((node_ref, expected_hash, start, length, depth)) = pending.pop() {
+        budget.consume()?;
         if depth > MAX_TREE_DEPTH {
             return Err(Error::InvalidTree.into());
         }
@@ -3796,6 +3841,7 @@ fn base_range_attempt(
                 if total != length {
                     return Err(Error::DescriptorMismatch.into());
                 }
+                budget.consume_many(children.len())?;
                 let mut child_start = start;
                 let mut children_with_offsets = Vec::with_capacity(children.len());
                 for child in children {
@@ -3969,6 +4015,69 @@ fn gear(byte: u8) -> u64 {
     value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
     value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
     value ^ (value >> 31)
+}
+
+/// Build a valid bottom-up DAG whose every branch repeats the same child.
+/// Empty bytes keep all aggregate metrics at zero, so depth/fanout checks alone
+/// cannot bound its logical expansion. This is crate-private test scaffolding
+/// because canonical construction deliberately emits trees, not shared DAGs.
+#[cfg(test)]
+pub(crate) fn repeated_child_dag_fixture(depth: usize, fanout: usize) -> PreparedLargeValue {
+    assert!(depth <= MAX_TREE_DEPTH);
+    assert!((1..=BRANCH_MAX_CHILDREN).contains(&fanout));
+    let mut staged_chunks = Vec::new();
+    let mut nonce = 0_u64;
+    let mut locator = |hash: ContentHash| {
+        let mut seed = hash.0.to_vec();
+        seed.extend_from_slice(&nonce.to_le_bytes());
+        nonce += 1;
+        Locator::from_seed(&seed)
+    };
+    let leaf = ChunkNode::Leaf {
+        format: FORMAT_VERSION,
+        kind: LargeValueKind::Bytes,
+        bytes: Vec::new(),
+    };
+    let mut current = stage_node(
+        leaf.clone(),
+        node_metrics(LargeValueKind::Bytes, &leaf).unwrap(),
+        &mut locator,
+        &mut staged_chunks,
+    )
+    .unwrap();
+    for _ in 0..depth {
+        let node = ChunkNode::Branch {
+            format: FORMAT_VERSION,
+            kind: LargeValueKind::Bytes,
+            children: vec![
+                BranchChild {
+                    node_ref: current.node_ref.clone(),
+                    metrics: current.metrics,
+                    logical_hash: current.structural_hash,
+                };
+                fanout
+            ],
+        };
+        current = stage_node(
+            node.clone(),
+            node_metrics(LargeValueKind::Bytes, &node).unwrap(),
+            &mut locator,
+            &mut staged_chunks,
+        )
+        .unwrap();
+    }
+    PreparedLargeValue {
+        value_ref: LargeValueRef {
+            kind: LargeValueKind::Bytes,
+            format_version: FORMAT_VERSION,
+            logical_hash: current.structural_hash,
+            root: current.node_ref,
+            byte_length: 0,
+            utf16_length: None,
+            edit_tail: Vec::new(),
+        },
+        staged_chunks,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🤖 Makes large-value chunk traversal explicitly DAG-aware and bounds traversal/refcount work while preserving canonical node decoding and storage-format semantics.

This is the base of a three-PR correctness stack. It prevents shared descendants from being traversed or accounted as if every incoming edge introduced a new subtree.

Verification: focused DAG/lifecycle tests; Groove library suite; Clippy. Independently reviewed with planted root-accounting regression sensitivity.