### PR TITLE
Fix automatic test server port allocation

### DIFF
--- a/packages/jazz-tools/src/dev/dev-server.ts
+++ b/packages/jazz-tools/src/dev/dev-server.ts
@@ -1,4 +1,3 @@
-import { createServer as createNetServer } from "node:net";
 import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -8,18 +7,6 @@ import { JazzServer } from "jazz-napi";
 export { deploy, type DeployOptions } from "./catalogue.js";
 
 const DEFAULT_APP_ID = "00000000-0000-0000-0000-000000000001";
-// The 20000-40000 space is partitioned by process id: vitest runs test files
-// in separate worker processes whose module-global allocation state cannot
-// coordinate, and a shared range let one worker steal a port another worker's
-// reopen test had briefly released (the napi.integration reopen flakes).
-const AUTO_PORT_SLOTS = 64;
-const AUTO_PORT_SLOT = process.pid % AUTO_PORT_SLOTS;
-const AUTO_PORT_RANGE = Math.floor(20_000 / AUTO_PORT_SLOTS);
-const AUTO_PORT_MIN = 20_000 + AUTO_PORT_SLOT * AUTO_PORT_RANGE;
-
-const autoAllocatedPorts = new Set<number>();
-
-let nextAutoPort = AUTO_PORT_MIN + Math.floor(Math.random() * AUTO_PORT_RANGE);
 
 export interface StartLocalJazzServerOptions {
   appId?: string;
@@ -46,38 +33,6 @@ export interface LocalJazzServerHandle {
   stop: () => Promise<void>;
 }
 
-async function canBindPort(port: number): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
-    const server = createNetServer();
-    server.once("error", () => {
-      resolve(false);
-    });
-    server.listen(port, "127.0.0.1", () => {
-      server.close((error) => {
-        void error;
-        resolve(true);
-      });
-    });
-  });
-}
-
-async function allocateAutoPort(): Promise<number> {
-  for (let attempts = 0; attempts < AUTO_PORT_RANGE; attempts += 1) {
-    const candidate = nextAutoPort;
-    nextAutoPort = AUTO_PORT_MIN + ((nextAutoPort - AUTO_PORT_MIN + 1) % AUTO_PORT_RANGE);
-    if (autoAllocatedPorts.has(candidate)) {
-      continue;
-    }
-    if (!(await canBindPort(candidate))) {
-      continue;
-    }
-    autoAllocatedPorts.add(candidate);
-    return candidate;
-  }
-
-  throw new Error("Failed to allocate a local Jazz server port.");
-}
-
 async function createOwnedDataDir(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "jazz-dev-server-"));
 }
@@ -99,8 +54,10 @@ export async function startLocalJazzServer(
   options: StartLocalJazzServerOptions = {},
 ): Promise<LocalJazzServerHandle> {
   const appId = options.appId ?? DEFAULT_APP_ID;
-  const port = options.port ?? (await allocateAutoPort());
-  const ownsPort = options.port === undefined;
+  // Ask the server to bind port 0 when callers do not require a particular
+  // address. Unlike probing a candidate port first, this is atomic and remains
+  // safe across Vitest worker processes (and separate concurrent CI jobs).
+  const port = options.port ?? 0;
   const ownsDataDir = options.inMemory !== true && options.dataDir === undefined;
   const dataDir = ownsDataDir ? await createOwnedDataDir() : options.dataDir;
   const adminSecret = options.adminSecret ?? `jazz-test-admin-${randomUUID().slice(0, 8)}`;
@@ -122,9 +79,6 @@ export async function startLocalJazzServer(
       schema: options.schema ? [...options.schema] : undefined,
     });
   } catch (error) {
-    if (ownsPort) {
-      autoAllocatedPorts.delete(port);
-    }
     if (ownsDataDir && dataDir) {
       await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
     }
@@ -145,9 +99,6 @@ export async function startLocalJazzServer(
       try {
         await server.stop();
       } finally {
-        if (ownsPort) {
-          autoAllocatedPorts.delete(port);
-        }
         if (ownsDataDir && dataDir) {
           await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
         }

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -137,27 +137,30 @@ describe("startLocalJazzServer", () => {
     }
   }, 15_000);
 
-  it("allocates a fresh port when no explicit port is provided", async () => {
+  it("atomically assigns distinct ports to concurrent automatic servers", async () => {
     const firstRoot = await createTempRoot("jazz-tools-testing-auto-port-a-");
     const secondRoot = await createTempRoot("jazz-tools-testing-auto-port-b-");
 
-    const firstServer = await startTrackedLocalJazzServer({
-      appId: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
-      dataDir: join(firstRoot, "data-dir"),
-    });
-    const firstPort = firstServer.port;
-    await stopTrackedLocalJazzServer(firstServer);
-
-    const secondServer = await startTrackedLocalJazzServer({
-      appId: "ffffffff-ffff-ffff-ffff-ffffffffffff",
-      dataDir: join(secondRoot, "data-dir"),
-    });
+    const [firstServer, secondServer] = await Promise.all([
+      startTrackedLocalJazzServer({
+        appId: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+        dataDir: join(firstRoot, "data-dir"),
+      }),
+      startTrackedLocalJazzServer({
+        appId: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        dataDir: join(secondRoot, "data-dir"),
+      }),
+    ]);
 
     try {
-      expect(secondServer.port).not.toBe(firstPort);
-      const healthResponse = await fetch(`${secondServer.url}/health`);
-      expect(healthResponse.status).toBe(200);
+      expect(firstServer.port).not.toBe(secondServer.port);
+      const healthResponses = await Promise.all([
+        fetch(`${firstServer.url}/health`),
+        fetch(`${secondServer.url}/health`),
+      ]);
+      expect(healthResponses.map((response) => response.status)).toEqual([200, 200]);
     } finally {
+      await stopTrackedLocalJazzServer(firstServer);
       await stopTrackedLocalJazzServer(secondServer);
     }
   }, 20_000);


### PR DESCRIPTION
🤖 Fix CI-local server allocation races by letting Rust atomically bind port 0 whenever callers do not request a specific port.

The previous PID-partitioned probe selected and released a candidate before NAPI bound it, leaving a TOCTOU race between Vitest workers. Explicit ports retain their existing restart behavior.

Adds a NAPI-backed regression that starts two automatic servers concurrently, verifies distinct assigned ports, and reaches both health endpoints.

This was extracted after PR #2012 exposed an intermittent `bind server listener: Address already in use` panic in the parallel TypeScript suite.