### PR TITLE
bench: isolate anonymized ingest depth scaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,6 +2110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jazz-example-multi-table-ingest-benchmark"
+version = "0.1.0"
+dependencies = [
+ "codspeed-divan-compat",
+ "jazz",
+ "jazz-storage-rocksdb",
+ "tempfile",
+]
+
+[[package]]
 name = "jazz-example-music-agent-benchmark"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "examples/band-chat/benchmarks",
   "examples/music-agent/benchmarks",
   "examples/benchmarks/smoke",
+  "examples/benchmarks/multi-table-ingest",
   "dev/benchmarks/storage/bench-core",
 ]
 exclude = ["examples/todo-server-rs", "examples/docs/todo-server-rs"]

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -1,6 +1,7 @@
 //! Canonical indirect representation for large logical scalar values.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
@@ -2164,6 +2165,18 @@ pub fn inline_scalar_bytes(kind: LargeValueKind, encoded: &[u8]) -> Result<&[u8]
 }
 
 fn stored_scalar_schema(kind: LargeValueKind) -> EnumSchema {
+    static BYTES: OnceLock<EnumSchema> = OnceLock::new();
+    static STRING: OnceLock<EnumSchema> = OnceLock::new();
+    static JSON: OnceLock<EnumSchema> = OnceLock::new();
+    match kind {
+        LargeValueKind::Bytes => BYTES.get_or_init(|| build_stored_scalar_schema(kind)),
+        LargeValueKind::String => STRING.get_or_init(|| build_stored_scalar_schema(kind)),
+        LargeValueKind::Json => JSON.get_or_init(|| build_stored_scalar_schema(kind)),
+    }
+    .clone()
+}
+
+fn build_stored_scalar_schema(kind: LargeValueKind) -> EnumSchema {
     let primitive = RecordDescriptor::new([(
         "value",
         match kind {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1970,8 +1970,12 @@ impl UploadOutbox {
         true
     }
 
-    fn iter(&self) -> impl Iterator<Item = &PendingUpload> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = &PendingUpload> + ExactSizeIterator {
         self.entries.iter()
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
     }
 
     fn is_empty(&self) -> bool {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1953,7 +1953,38 @@ struct ServedAuthorizationScopeClause {
 
 /// Locally-authored transactions awaiting upload, oldest first. Shared with
 /// upstream [`PeerConnection`]s, each of which tracks how far it has shipped.
-type Outbox = Rc<RefCell<Vec<PendingUpload>>>;
+type Outbox = Rc<RefCell<UploadOutbox>>;
+
+#[derive(Default)]
+struct UploadOutbox {
+    entries: Vec<PendingUpload>,
+    tx_ids: HashSet<TxId>,
+}
+
+impl UploadOutbox {
+    fn push(&mut self, pending: PendingUpload) -> bool {
+        if !self.tx_ids.insert(pending.tx_id) {
+            return false;
+        }
+        self.entries.push(pending);
+        true
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &PendingUpload> {
+        self.entries.iter()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn retain(&mut self, mut keep: impl FnMut(&PendingUpload) -> bool) {
+        self.entries.retain(|pending| keep(pending));
+        self.tx_ids.clear();
+        self.tx_ids
+            .extend(self.entries.iter().map(|pending| pending.tx_id));
+    }
+}
 
 #[derive(Clone)]
 struct PendingUpload {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1957,7 +1957,7 @@ type Outbox = Rc<RefCell<UploadOutbox>>;
 
 #[derive(Default)]
 struct UploadOutbox {
-    entries: Vec<PendingUpload>,
+    entries: VecDeque<PendingUpload>,
     tx_ids: HashSet<TxId>,
 }
 
@@ -1966,7 +1966,7 @@ impl UploadOutbox {
         if !self.tx_ids.insert(pending.tx_id) {
             return false;
         }
-        self.entries.push(pending);
+        self.entries.push_back(pending);
         true
     }
 
@@ -1978,15 +1978,29 @@ impl UploadOutbox {
         self.entries.len()
     }
 
-    fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
     fn retain(&mut self, mut keep: impl FnMut(&PendingUpload) -> bool) {
         self.entries.retain(|pending| keep(pending));
         self.tx_ids.clear();
         self.tx_ids
             .extend(self.entries.iter().map(|pending| pending.tx_id));
+    }
+
+    fn remove_released(&mut self, released: &mut HashSet<TxId>) {
+        while self
+            .entries
+            .front()
+            .is_some_and(|pending| released.remove(&pending.tx_id))
+        {
+            let pending = self
+                .entries
+                .pop_front()
+                .expect("released outbox front remains present");
+            self.tx_ids.remove(&pending.tx_id);
+        }
+        if released.is_empty() {
+            return;
+        }
+        self.retain(|pending| !released.contains(&pending.tx_id));
     }
 }
 

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -81,7 +81,7 @@ where
             node: Rc::new(futures::lock::Mutex::new(node)),
             receives_commits_as_local,
             subscriptions: Rc::new(RefCell::new(Vec::new())),
-            outbox: Rc::new(RefCell::new(Vec::new())),
+            outbox: Rc::new(RefCell::new(UploadOutbox::default())),
             pending_local_publications: Rc::new(RefCell::new(VecDeque::new())),
             local_publication_settler: Rc::new(futures::lock::Mutex::new(())),
             upstream_subscriptions: Rc::new(RefCell::new(Vec::new())),
@@ -193,10 +193,9 @@ where
 
     pub(super) fn queue_pending_upload(&self, tx_id: TxId, unit: Option<SyncMessage>) {
         let mut outbox = self.outbox.borrow_mut();
-        if outbox.iter().any(|pending| pending.tx_id == tx_id) {
+        if !outbox.push(PendingUpload { tx_id, unit }) {
             return;
         }
-        outbox.push(PendingUpload { tx_id, unit });
         drop(outbox);
         self.mark_subscriber_connections_dirty();
         self.schedule_tick(TickUrgency::Deferred);
@@ -805,15 +804,11 @@ where
                 drop(routes);
                 let mut outbox = self.outbox.borrow_mut();
                 for tx_id in routed_txs {
-                    if !outbox.iter().any(|pending| pending.tx_id == tx_id) {
-                        outbox.push(PendingUpload {
-                            tx_id,
-                            unit: crate::db::block_on(
-                                self.node.borrow_mut().commit_unit_for(tx_id),
-                            )
+                    outbox.push(PendingUpload {
+                        tx_id,
+                        unit: crate::db::block_on(self.node.borrow_mut().commit_unit_for(tx_id))
                             .ok(),
-                        });
-                    }
+                    });
                 }
             }
         }
@@ -1407,15 +1402,13 @@ where
                         for tx_id in &routed_txs {
                             uploaded.remove(tx_id);
                             let mut outbox = outbox.borrow_mut();
-                            if !outbox.iter().any(|pending| pending.tx_id == *tx_id) {
-                                outbox.push(PendingUpload {
-                                    tx_id: *tx_id,
-                                    unit: crate::db::block_on(
-                                        self.node.borrow_mut().commit_unit_for(*tx_id),
-                                    )
-                                    .ok(),
-                                });
-                            }
+                            outbox.push(PendingUpload {
+                                tx_id: *tx_id,
+                                unit: crate::db::block_on(
+                                    self.node.borrow_mut().commit_unit_for(*tx_id),
+                                )
+                                .ok(),
+                            });
                         }
                     }
                     self.schedule_tick(TickUrgency::Immediate);

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1497,7 +1497,13 @@ where
                 .enforce_edge_cache_budget(&pins, budget)
                 .await?;
         }
-        self.prune_settled_outbox_uploads();
+        // Outbox fates can only advance during this host tick when remote
+        // sync input was applied. A connected-but-silent upstream otherwise
+        // made every local write rescan every older pending upload, producing
+        // quadratic ingest while offline-but-connected.
+        if remote_sync_applied {
+            self.prune_settled_outbox_uploads();
+        }
         Ok(stats)
     }
 

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -955,6 +955,7 @@ where
             observed_session_claim_revision: Cell::new(0),
             connection_epoch,
             startup_error: None,
+            released_outbox_tx_ids: Vec::new(),
             link: ConnectionLink::Upstream(UpstreamConnectionState {
                 local_receiver,
                 pending,
@@ -1186,6 +1187,7 @@ where
             observed_session_claim_revision: Cell::new(session_claim_revision),
             connection_epoch,
             startup_error,
+            released_outbox_tx_ids: Vec::new(),
             link: ConnectionLink::Subscriber(SubscriberConnectionState {
                 peer,
                 ingest_context,
@@ -1451,6 +1453,7 @@ where
                 .set(chunk_completion_generation);
         }
         let mut remote_sync_applied = false;
+        let mut released_outbox_tx_ids = HashSet::new();
         // A later subscriber can mutate Core state after an earlier peer link
         // has already had its turn in this pass.  Remember that generation so
         // the post-receive serve pass below reaches that earlier link too;
@@ -1459,7 +1462,9 @@ where
         let subscriber_dirty_epoch_before = self.subscriber_dirty_epoch.get();
         let connections = self.connections.borrow().clone();
         for connection in &connections {
-            let next = connection.lock().await.tick().await?;
+            let mut connection = connection.lock().await;
+            let next = connection.tick().await?;
+            released_outbox_tx_ids.extend(connection.take_released_outbox_tx_ids());
             stats.subscription_events += next.subscription_events;
             stats.remote_sync_applied += next.remote_sync_applied;
             remote_sync_applied |= next.remote_sync_applied > 0;
@@ -1473,7 +1478,9 @@ where
                     connection.mark_subscriber_dirty() || subscriber_state_changed
                 };
                 if should_tick {
-                    let next = connection.lock().await.tick().await?;
+                    let mut connection = connection.lock().await;
+                    let next = connection.tick().await?;
+                    released_outbox_tx_ids.extend(connection.take_released_outbox_tx_ids());
                     stats.subscription_events += next.subscription_events;
                     stats.remote_sync_applied += next.remote_sync_applied;
                 }
@@ -1490,47 +1497,21 @@ where
                 .enforce_edge_cache_budget(&pins, budget)
                 .await?;
         }
-        // Outbox fates can only advance during this host tick when remote
-        // sync input was applied. A connected-but-silent upstream otherwise
-        // made every local write rescan every older pending upload, producing
-        // quadratic ingest while offline-but-connected.
-        if remote_sync_applied {
-            self.prune_settled_outbox_uploads();
+        if !released_outbox_tx_ids.is_empty() {
+            self.release_outbox_uploads(released_outbox_tx_ids);
         }
         Ok(stats)
     }
 
-    fn prune_settled_outbox_uploads(&self) {
-        // With no peer connection, no transaction in the upload outbox can
-        // advance to Global during this tick. Keep every entry for a future
-        // reconnect without re-reading its unchanged fate from storage. This
-        // also prevents an offline host that ticks after each local write from
-        // turning the outbox into an O(writes²) transaction-state scan.
-        if self.connections.borrow().is_empty() {
-            return;
-        }
+    fn release_outbox_uploads(&self, released_tx_ids: HashSet<TxId>) {
         let mut outbox = self.outbox.borrow_mut();
-        if outbox.is_empty() {
-            return;
-        }
-        let mut node = self.node.borrow_mut();
-        let mut released_tx_ids = BTreeSet::new();
-        outbox.retain(|pending| {
-            let state = crate::db::block_on(node.transaction_state(pending.tx_id));
-            let Some((fate, _, durability)) = state else {
-                return true;
-            };
-            let retain = matches!(fate, Fate::Pending | Fate::Accepted)
-                && durability < DurabilityTier::Global;
-            if !retain {
-                released_tx_ids.insert(pending.tx_id);
-            }
-            retain
-        });
-        drop(node);
+        let mut remaining = released_tx_ids.clone();
+        outbox.remove_released(&mut remaining);
         drop(outbox);
-        if released_tx_ids.is_empty() {
-            return;
+        for connection in self.connections.borrow().iter() {
+            connection
+                .borrow_mut()
+                .forget_released_outbox_tx_ids(&released_tx_ids);
         }
         self.large_value_upload_retry_deadlines
             .borrow_mut()

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1502,6 +1502,14 @@ where
     }
 
     fn prune_settled_outbox_uploads(&self) {
+        // With no peer connection, no transaction in the upload outbox can
+        // advance to Global during this tick. Keep every entry for a future
+        // reconnect without re-reading its unchanged fate from storage. This
+        // also prevents an offline host that ticks after each local write from
+        // turning the outbox into an O(writes²) transaction-state scan.
+        if self.connections.borrow().is_empty() {
+            return;
+        }
         let mut outbox = self.outbox.borrow_mut();
         if outbox.is_empty() {
             return;

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -318,6 +318,8 @@ where
     /// Fresh non-resumable epoch binding authorization receipts to this link.
     pub(super) connection_epoch: u64,
     pub(super) startup_error: Option<Error>,
+    /// Exact uploads whose applied fate made them globally settled or rejected.
+    pub(super) released_outbox_tx_ids: Vec<TxId>,
     pub(super) link: ConnectionLink,
     pub(super) last_resume_bytes: Option<usize>,
     pub(super) auxiliary_pump: PeerIoPump,
@@ -504,6 +506,20 @@ impl<S> PeerConnection<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
+    pub(super) fn take_released_outbox_tx_ids(&mut self) -> Vec<TxId> {
+        std::mem::take(&mut self.released_outbox_tx_ids)
+    }
+
+    pub(super) fn forget_released_outbox_tx_ids(&mut self, released: &HashSet<TxId>) {
+        let ConnectionLink::Upstream(UpstreamConnectionState { uploaded, .. }) = &mut self.link
+        else {
+            return;
+        };
+        for tx_id in released {
+            uploaded.remove(tx_id);
+        }
+    }
+
     /// Clone the binding-driven auxiliary I/O endpoint for this peer link.
     pub fn io_pump(&self) -> PeerIoPump {
         self.auxiliary_pump.clone()
@@ -1945,6 +1961,20 @@ where
                                     }
                                     _ => None,
                                 };
+                                let released_outbox_tx_id = match &message {
+                                    SyncMessage::FateUpdate {
+                                        tx_id,
+                                        fate,
+                                        durability,
+                                        ..
+                                    } if matches!(fate, Fate::Rejected(_))
+                                        || durability
+                                            .is_some_and(|tier| tier >= DurabilityTier::Global) =>
+                                    {
+                                        Some(*tx_id)
+                                    }
+                                    _ => None,
+                                };
                                 if !pending_view_updates.is_empty() {
                                     apply_pending_authority_view_updates(
                                         &self.node,
@@ -2014,6 +2044,9 @@ where
                                     }
                                     drop(routes);
                                     route_local_fate(&self.local_fate_routes, tx_id, &fate);
+                                }
+                                if let Some(tx_id) = released_outbox_tx_id {
+                                    self.released_outbox_tx_ids.push(tx_id);
                                 }
                             }
                         }

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1123,13 +1123,30 @@ where
                             pending.remove(pending_index);
                         }
                         // Upload locally-authored commits not yet shipped on this link.
-                        let to_upload: Vec<TxId> = outbox
-                            .borrow()
-                            .iter()
-                            .map(|pending| pending.tx_id)
-                            .filter(|tx_id| !uploaded.contains(tx_id))
-                            .collect();
-                        for tx_id in to_upload {
+                        let to_upload: Vec<(TxId, Option<SyncMessage>)> = {
+                            let outbox = outbox.borrow();
+                            let expected_missing = outbox.len().checked_sub(uploaded.len());
+                            let mut suffix = outbox
+                                .iter()
+                                .rev()
+                                .take_while(|pending| !uploaded.contains(&pending.tx_id))
+                                .map(|pending| (pending.tx_id, pending.unit.clone()))
+                                .collect::<Vec<_>>();
+                            if expected_missing == Some(suffix.len()) {
+                                suffix.reverse();
+                                suffix
+                            } else {
+                                // Fate cleanup and authority handoff can leave
+                                // holes in this link's uploaded set. Preserve
+                                // the general set-difference behavior there.
+                                outbox
+                                    .iter()
+                                    .filter(|pending| !uploaded.contains(&pending.tx_id))
+                                    .map(|pending| (pending.tx_id, pending.unit.clone()))
+                                    .collect()
+                            }
+                        };
+                        for (tx_id, staged) in to_upload {
                             if failed_large_value_uploads.contains(&tx_id)
                                 || awaiting_large_value_uploads.contains_key(&tx_id)
                                 || !awaiting_large_value_uploads.is_empty()
@@ -1149,11 +1166,6 @@ where
                             self.large_value_upload_retry_deadlines
                                 .borrow_mut()
                                 .remove(&tx_id);
-                            let staged = outbox
-                                .borrow()
-                                .iter()
-                                .find(|pending| pending.tx_id == tx_id)
-                                .and_then(|pending| pending.unit.clone());
                             let unit = if let Some(unit) = staged {
                                 unit
                             } else {

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2991,11 +2991,10 @@ where
                             }
                             if let Some((tx_id, unit)) = local_upload {
                                 let mut outbox = outbox.borrow_mut();
-                                if !outbox.iter().any(|pending| pending.tx_id == tx_id) {
-                                    outbox.push(PendingUpload {
+                                if outbox.push(PendingUpload {
                                         tx_id,
                                         unit: Some(unit),
-                                    });
+                                    }) {
                                     schedule_tick_in(&self.scheduler, TickUrgency::Deferred);
                                 }
                             }

--- a/crates/jazz/src/node/physical/bindings.rs
+++ b/crates/jazz/src/node/physical/bindings.rs
@@ -204,39 +204,6 @@ pub(super) fn physical_history_storage_table(
     Ok(physical_history_table_name(mapping.table_id))
 }
 
-pub(super) fn physical_current_binding(
-    catalogue_schemas: &BTreeMap<SchemaVersionId, SchemaVersion>,
-    physical_mappings: &BTreeMap<SchemaVersionId, SchemaPhysicalMapping>,
-    schema_version: SchemaVersionId,
-    logical_table: &str,
-    class: PhysicalCurrentClass,
-) -> Result<PhysicalHistoryBinding, Error> {
-    let schema = catalogue_schemas
-        .get(&schema_version)
-        .ok_or(Error::InvalidStoredValue("physical current schema missing"))?;
-    let table = schema
-        .schema
-        .tables
-        .iter()
-        .find(|table| table.name == logical_table)
-        .ok_or_else(|| Error::TableNotFound(logical_table.to_owned()))?;
-    let mapping = physical_mappings
-        .get(&schema_version)
-        .and_then(|mapping| mapping.tables.get(logical_table))
-        .ok_or(Error::InvalidStoredValue(
-            "physical current table mapping missing",
-        ))?;
-    Ok(PhysicalHistoryBinding {
-        storage_table: physical_current_storage_table(
-            physical_mappings,
-            schema_version,
-            logical_table,
-            class,
-        )?,
-        descriptor: physical_current_descriptor(table, mapping)?,
-    })
-}
-
 pub(super) fn physical_current_storage_table(
     physical_mappings: &BTreeMap<SchemaVersionId, SchemaPhysicalMapping>,
     schema_version: SchemaVersionId,

--- a/crates/jazz/src/node/physical/projections.rs
+++ b/crates/jazz/src/node/physical/projections.rs
@@ -75,15 +75,14 @@ where
             .ok_or(Error::InvalidStoredValue(
                 "physical current source schema alias missing",
             ))?;
-        let binding = physical_current_binding(
-            &self.catalogue.catalogue_schemas,
+        let storage_table = physical_current_storage_table(
             &self.catalogue.physical_mappings,
             schema_version,
             logical_table,
             class,
         )?;
         Ok(GraphBuilder::variant_source_scan(
-            binding.storage_table,
+            storage_table,
             physical_current_projection_target(alias, logical_table),
             shared_branch_scan(None),
         ))
@@ -96,15 +95,14 @@ where
         class: PhysicalCurrentClass,
         projection_target: impl Into<String>,
     ) -> Result<GraphBuilder, Error> {
-        let binding = physical_current_binding(
-            &self.catalogue.catalogue_schemas,
+        let storage_table = physical_current_storage_table(
             &self.catalogue.physical_mappings,
             schema_version,
             logical_table,
             class,
         )?;
         Ok(GraphBuilder::variant_source_scan(
-            binding.storage_table,
+            storage_table,
             projection_target,
             shared_branch_scan(None),
         ))
@@ -118,15 +116,14 @@ where
         projection_target: impl Into<String>,
         branch_key: &BranchKey,
     ) -> Result<GraphBuilder, Error> {
-        let binding = physical_current_binding(
-            &self.catalogue.catalogue_schemas,
+        let storage_table = physical_current_storage_table(
             &self.catalogue.physical_mappings,
             schema_version,
             logical_table,
             class,
         )?;
         Ok(GraphBuilder::variant_source_scan(
-            binding.storage_table,
+            storage_table,
             projection_target,
             branch_scan(branch_key, None),
         ))
@@ -147,15 +144,14 @@ where
             .ok_or(Error::InvalidStoredValue(
                 "physical current source schema alias missing",
             ))?;
-        let binding = physical_current_binding(
-            &self.catalogue.catalogue_schemas,
+        let storage_table = physical_current_storage_table(
             &self.catalogue.physical_mappings,
             schema_version,
             logical_table,
             class,
         )?;
         Ok(GraphBuilder::variant_source_scan(
-            binding.storage_table,
+            storage_table,
             physical_current_projection_target(alias, logical_table),
             shared_branch_scan(Some(scan)),
         ))
@@ -169,15 +165,14 @@ where
         projection_target: impl Into<String>,
         scan: groove::ivm::StaticScanSpec,
     ) -> Result<GraphBuilder, Error> {
-        let binding = physical_current_binding(
-            &self.catalogue.catalogue_schemas,
+        let storage_table = physical_current_storage_table(
             &self.catalogue.physical_mappings,
             schema_version,
             logical_table,
             class,
         )?;
         Ok(GraphBuilder::variant_source_scan(
-            binding.storage_table,
+            storage_table,
             projection_target,
             shared_branch_scan(Some(scan)),
         ))

--- a/examples/benchmarks/multi-table-ingest/Cargo.toml
+++ b/examples/benchmarks/multi-table-ingest/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-jazz = { workspace = true }
+jazz = { workspace = true, features = ["runtime"] }
 jazz-storage-rocksdb = { workspace = true }
 tempfile = "3.27.0"
 

--- a/examples/benchmarks/multi-table-ingest/Cargo.toml
+++ b/examples/benchmarks/multi-table-ingest/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "jazz-example-multi-table-ingest-benchmark"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+jazz = { workspace = true }
+jazz-storage-rocksdb = { workspace = true }
+tempfile = "3.27.0"
+
+[dev-dependencies]
+divan = { workspace = true }
+
+[[bench]]
+name = "ingest_memory_walltime"
+harness = false
+
+[[bench]]
+name = "ingest_rocksdb_walltime"
+harness = false

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
@@ -1,0 +1,14 @@
+use jazz::groove::storage::MemoryStorage;
+use jazz_example_multi_table_ingest_benchmark::IngestFixture;
+
+fn main() {
+    divan::main();
+}
+
+/// Thesis #2030: the next fixed 1k insert batch should not depend on table depth.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_memory(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| IngestFixture::<MemoryStorage>::memory(existing_jobs))
+        .bench_local_values(IngestFixture::insert_next_1k);
+}

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
@@ -44,6 +44,18 @@ fn next_1k_jobs_memory_with_write_state_check(
         .bench_local_values(IngestFixture::insert_next_1k);
 }
 
+/// Connected-but-stalled differential: each host tick currently rechecks the
+/// fate of every pending upload in the outbox.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_memory_with_stalled_upstream(
+    bencher: divan::Bencher<'_, '_>,
+    existing_jobs: usize,
+) {
+    bencher
+        .with_inputs(|| IngestFixture::<MemoryStorage>::memory_with_stalled_upstream(existing_jobs))
+        .bench_local_values(IngestFixture::insert_next_1k);
+}
+
 /// Exact public Rust client execution-model differential.
 #[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
 fn next_1k_jobs_public_client_memory(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
@@ -20,3 +20,13 @@ fn next_1k_jobs_memory_attributed(bencher: divan::Bencher<'_, '_>, existing_jobs
         .with_inputs(|| IngestFixture::<MemoryStorage>::memory_attributed(existing_jobs))
         .bench_local_values(IngestFixture::insert_next_1k);
 }
+
+/// Differential for an indexed correlated EXISTS insert policy.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_memory_attributed_exists(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| {
+            IngestFixture::<MemoryStorage>::memory_attributed_with_exists_policy(existing_jobs)
+        })
+        .bench_local_values(IngestFixture::insert_next_1k);
+}

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
@@ -44,8 +44,8 @@ fn next_1k_jobs_memory_with_write_state_check(
         .bench_local_values(IngestFixture::insert_next_1k);
 }
 
-/// Connected-but-stalled differential: each host tick currently rechecks the
-/// fate of every pending upload in the outbox.
+/// Connected-but-stalled differential after the existing backlog has been
+/// shipped once: each measured host tick should do work only for the new row.
 #[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
 fn next_1k_jobs_memory_with_stalled_upstream(
     bencher: divan::Bencher<'_, '_>,

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
@@ -12,3 +12,11 @@ fn next_1k_jobs_memory(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
         .with_inputs(|| IngestFixture::<MemoryStorage>::memory(existing_jobs))
         .bench_local_values(IngestFixture::insert_next_1k);
 }
+
+/// Differential receipt for the trusted-backend attribution path.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_memory_attributed(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| IngestFixture::<MemoryStorage>::memory_attributed(existing_jobs))
+        .bench_local_values(IngestFixture::insert_next_1k);
+}

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
@@ -1,5 +1,5 @@
 use jazz::groove::storage::MemoryStorage;
-use jazz_example_multi_table_ingest_benchmark::IngestFixture;
+use jazz_example_multi_table_ingest_benchmark::{ClientIngestFixture, IngestFixture};
 
 fn main() {
     divan::main();
@@ -29,4 +29,25 @@ fn next_1k_jobs_memory_attributed_exists(bencher: divan::Bencher<'_, '_>, existi
             IngestFixture::<MemoryStorage>::memory_attributed_with_exists_policy(existing_jobs)
         })
         .bench_local_values(IngestFixture::insert_next_1k);
+}
+
+/// Differential for the synchronous fate check performed by `JazzClient`.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_memory_with_write_state_check(
+    bencher: divan::Bencher<'_, '_>,
+    existing_jobs: usize,
+) {
+    bencher
+        .with_inputs(|| {
+            IngestFixture::<MemoryStorage>::memory_with_write_state_check(existing_jobs)
+        })
+        .bench_local_values(IngestFixture::insert_next_1k);
+}
+
+/// Exact public Rust client execution-model differential.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_public_client_memory(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| ClientIngestFixture::memory(existing_jobs))
+        .bench_local_values(ClientIngestFixture::insert_next_1k);
 }

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_memory_walltime.rs
@@ -56,6 +56,15 @@ fn next_1k_jobs_memory_with_stalled_upstream(
         .bench_local_values(IngestFixture::insert_next_1k);
 }
 
+/// Active-but-slow authority differential: one previously uploaded transaction
+/// receives Global fate per measured host tick.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_memory_with_trickling_fates(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| IngestFixture::<MemoryStorage>::memory_with_trickling_fates(existing_jobs))
+        .bench_local_values(IngestFixture::insert_next_1k);
+}
+
 /// Exact public Rust client execution-model differential.
 #[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
 fn next_1k_jobs_public_client_memory(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_rocksdb_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_rocksdb_walltime.rs
@@ -1,0 +1,14 @@
+use jazz_example_multi_table_ingest_benchmark::IngestFixture;
+use jazz_storage_rocksdb::RocksDbStorage;
+
+fn main() {
+    divan::main();
+}
+
+/// Persistent-backend companion to the fixed-batch scaling receipt.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_rocksdb(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| IngestFixture::<RocksDbStorage>::rocksdb(existing_jobs))
+        .bench_local_values(|(_dir, fixture)| fixture.insert_next_1k());
+}

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_rocksdb_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_rocksdb_walltime.rs
@@ -20,3 +20,11 @@ fn next_1k_jobs_public_client_persistent(bencher: divan::Bencher<'_, '_>, existi
         .with_inputs(|| ClientIngestFixture::persistent(existing_jobs))
         .bench_local_values(ClientIngestFixture::insert_next_1k);
 }
+
+/// Adopter-profile reproduction: one host-driven tick per offline write.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_rocksdb_tick_per_write(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| IngestFixture::<RocksDbStorage>::rocksdb_with_tick(existing_jobs))
+        .bench_local_values(|(_dir, fixture)| fixture.insert_next_1k());
+}

--- a/examples/benchmarks/multi-table-ingest/benches/ingest_rocksdb_walltime.rs
+++ b/examples/benchmarks/multi-table-ingest/benches/ingest_rocksdb_walltime.rs
@@ -1,4 +1,4 @@
-use jazz_example_multi_table_ingest_benchmark::IngestFixture;
+use jazz_example_multi_table_ingest_benchmark::{ClientIngestFixture, IngestFixture};
 use jazz_storage_rocksdb::RocksDbStorage;
 
 fn main() {
@@ -11,4 +11,12 @@ fn next_1k_jobs_rocksdb(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
     bencher
         .with_inputs(|| IngestFixture::<RocksDbStorage>::rocksdb(existing_jobs))
         .bench_local_values(|(_dir, fixture)| fixture.insert_next_1k());
+}
+
+/// Public-client companion, including its persistent-driver scheduling path.
+#[divan::bench(args = [0, 1_000, 3_000, 5_000], sample_count = 1)]
+fn next_1k_jobs_public_client_persistent(bencher: divan::Bencher<'_, '_>, existing_jobs: usize) {
+    bencher
+        .with_inputs(|| ClientIngestFixture::persistent(existing_jobs))
+        .bench_local_values(ClientIngestFixture::insert_next_1k);
 }

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -7,7 +7,9 @@ use jazz::groove::records::Value;
 use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
 use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
 use jazz::schema::JazzSchema;
-use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+use jazz::tools::{
+    CmpOp, ColumnType, PolicyExpr, PolicyValue, SchemaBuilder, TablePolicies, TableSchemaBuilder,
+};
 use jazz::tx::DurabilityTier;
 use jazz_storage_rocksdb::{Durability, RocksDbStorage};
 use tempfile::TempDir;
@@ -30,8 +32,15 @@ impl IngestFixture<MemoryStorage> {
         Self::memory_with_attribution(existing_jobs, true)
     }
 
+    pub fn memory_attributed_with_exists_policy(existing_jobs: usize) -> Self {
+        let schema = schema(true);
+        let families = schema.column_families();
+        let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+        Self::new(schema, MemoryStorage::new(&refs), existing_jobs, true)
+    }
+
     fn memory_with_attribution(existing_jobs: usize, attributed: bool) -> Self {
-        let schema = schema();
+        let schema = schema(false);
         let families = schema.column_families();
         let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
         Self::new(schema, MemoryStorage::new(&refs), existing_jobs, attributed)
@@ -40,7 +49,7 @@ impl IngestFixture<MemoryStorage> {
 
 impl IngestFixture<RocksDbStorage> {
     pub fn rocksdb(existing_jobs: usize) -> (TempDir, Self) {
-        let schema = schema();
+        let schema = schema(false);
         let families = schema.column_families();
         let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
         let dir = tempfile::tempdir().expect("create ingest benchmark directory");
@@ -168,6 +177,10 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
             let mut cells = BTreeMap::from([
                 ("tenant".to_owned(), tenant(job)),
                 (
+                    "group_id".to_owned(),
+                    Value::Uuid(row_id(1, job % GROUPS).0),
+                ),
+                (
                     "status".to_owned(),
                     Value::String(["OPEN", "ASSIGNED", "DONE", "VERIFIED"][job % 4].into()),
                 ),
@@ -205,7 +218,22 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
     }
 }
 
-fn schema() -> JazzSchema {
+fn schema(with_exists_policy: bool) -> JazzSchema {
+    let jobs_policies = if with_exists_policy {
+        TablePolicies::new().with_insert(PolicyExpr::Exists {
+            table: "groups".to_owned(),
+            condition: Box::new(PolicyExpr::Cmp {
+                column: "id".to_owned(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec![
+                    "__jazz_outer_row".to_owned(),
+                    "group_id".to_owned(),
+                ]),
+            }),
+        })
+    } else {
+        TablePolicies::new()
+    };
     let public = SchemaBuilder::new()
         .table(
             TableSchemaBuilder::new("groups")
@@ -240,6 +268,7 @@ fn schema() -> JazzSchema {
         .table(
             TableSchemaBuilder::new("jobs")
                 .column("tenant", ColumnType::Text)
+                .fk_column("group_id", "groups")
                 .nullable_fk_column("resource_id", "resources")
                 .column(
                     "status",
@@ -248,7 +277,8 @@ fn schema() -> JazzSchema {
                 .column("title", ColumnType::Text)
                 .column("reward", ColumnType::Integer)
                 .column("external_key", ColumnType::Text)
-                .index_only(["tenant", "status", "resource_id"]),
+                .index_only(["tenant", "group_id", "status", "resource_id"])
+                .policies(jobs_policies),
         )
         .table(
             TableSchemaBuilder::new("sessions")

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -71,6 +71,10 @@ impl IngestFixture<MemoryStorage> {
     pub fn memory_with_stalled_upstream(existing_jobs: usize) -> Self {
         let mut fixture = Self::memory_with_attribution(existing_jobs, false);
         let _connection = block_on(fixture.db.connect_upstream(Box::new(StalledTransport)));
+        // Ship the pre-existing backlog outside the measured closure. The
+        // transport remains silent, so every row stays pending in the shared
+        // outbox while the benchmark isolates steady host-tick maintenance.
+        block_on(fixture.db.tick()).expect("prime stalled upstream backlog");
         fixture.tick_after_write = true;
         fixture
     }

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -2,16 +2,18 @@
 
 use std::collections::BTreeMap;
 
-use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, WriteIdentity, block_on};
+use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, Transport, WriteIdentity, block_on};
 use jazz::groove::records::Value;
 use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
 use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
+use jazz::protocol::SyncMessage;
 use jazz::schema::JazzSchema;
 use jazz::tools::{
     CmpOp, ColumnType, PolicyExpr, PolicyValue, Schema, SchemaBuilder, TablePolicies,
     TableSchemaBuilder,
 };
 use jazz::tx::DurabilityTier;
+use jazz::wire::TransportError;
 use jazz_storage_rocksdb::{Durability, RocksDbStorage};
 use tempfile::TempDir;
 
@@ -66,6 +68,13 @@ impl IngestFixture<MemoryStorage> {
         )
     }
 
+    pub fn memory_with_stalled_upstream(existing_jobs: usize) -> Self {
+        let mut fixture = Self::memory_with_attribution(existing_jobs, false);
+        let _connection = block_on(fixture.db.connect_upstream(Box::new(StalledTransport)));
+        fixture.tick_after_write = true;
+        fixture
+    }
+
     fn memory_with_attribution(existing_jobs: usize, attributed: bool) -> Self {
         let schema = schema(false);
         let families = schema.column_families();
@@ -78,6 +87,18 @@ impl IngestFixture<MemoryStorage> {
             false,
             false,
         )
+    }
+}
+
+struct StalledTransport;
+
+impl Transport for StalledTransport {
+    fn send(&mut self, _message: SyncMessage) -> Result<(), TransportError> {
+        Ok(())
+    }
+
+    fn try_recv(&mut self) -> Option<SyncMessage> {
+        None
     }
 }
 

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -1,0 +1,253 @@
+//! Neutral synthetic multi-table ingest fixture for thesis #2030.
+
+use std::collections::BTreeMap;
+
+use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, block_on};
+use jazz::groove::records::Value;
+use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
+use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
+use jazz::schema::JazzSchema;
+use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+use jazz::tx::DurabilityTier;
+use jazz_storage_rocksdb::{Durability, RocksDbStorage};
+use tempfile::TempDir;
+
+const GROUPS: usize = 32;
+const RESOURCES: usize = 1_000;
+
+pub struct IngestFixture<S: OrderedKvStorage> {
+    db: Db<S>,
+    next_job: usize,
+}
+
+impl IngestFixture<MemoryStorage> {
+    pub fn memory(existing_jobs: usize) -> Self {
+        let schema = schema();
+        let families = schema.column_families();
+        let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+        Self::new(schema, MemoryStorage::new(&refs), existing_jobs)
+    }
+}
+
+impl IngestFixture<RocksDbStorage> {
+    pub fn rocksdb(existing_jobs: usize) -> (TempDir, Self) {
+        let schema = schema();
+        let families = schema.column_families();
+        let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+        let dir = tempfile::tempdir().expect("create ingest benchmark directory");
+        let storage =
+            RocksDbStorage::open_with_durability(dir.path(), &refs, Durability::WalNoSync)
+                .expect("open ingest benchmark RocksDB");
+        (dir, Self::new(schema, storage, existing_jobs))
+    }
+}
+
+impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
+    fn new(schema: JazzSchema, storage: S, existing_jobs: usize) -> Self {
+        let db = block_on(Db::open(DbConfig::new(
+            schema,
+            storage,
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x83; 16]),
+                author: AuthorSubject::SYSTEM,
+            },
+        )))
+        .expect("open multi-table ingest database");
+        let mut fixture = Self { db, next_job: 0 };
+        fixture.seed_dimensions();
+        fixture.insert_jobs(existing_jobs);
+        fixture
+    }
+
+    pub fn insert_next_1k(mut self) -> usize {
+        self.insert_jobs(1_000);
+        self.next_job
+    }
+
+    fn seed_dimensions(&mut self) {
+        for group in 0..GROUPS {
+            self.insert(
+                "groups",
+                row_id(1, group),
+                BTreeMap::from([
+                    ("tenant".to_owned(), tenant(group)),
+                    (
+                        "label".to_owned(),
+                        Value::String(format!("Group {group:03}")),
+                    ),
+                ]),
+            );
+        }
+        for resource in 0..RESOURCES {
+            let mut cells = BTreeMap::from([
+                ("tenant".to_owned(), tenant(resource)),
+                (
+                    "label".to_owned(),
+                    Value::String(format!("Resource {resource:05}")),
+                ),
+                (
+                    "summary".to_owned(),
+                    Value::String(format!("Synthetic resource {resource:05}")),
+                ),
+                (
+                    "status".to_owned(),
+                    Value::String(["READY", "PAUSED", "ERROR", "ACTIVE"][resource % 4].into()),
+                ),
+                (
+                    "phase".to_owned(),
+                    Value::String(["IDLE", "HELD", "ASSIGNED", "WORKING"][resource % 4].into()),
+                ),
+                (
+                    "group_id".to_owned(),
+                    nullable(Value::Uuid(row_id(1, resource % GROUPS).0)),
+                ),
+                (
+                    "heartbeat_at".to_owned(),
+                    nullable(Value::U64(resource as u64)),
+                ),
+                (
+                    "version".to_owned(),
+                    Value::String(format!("v{}.{}", resource % 4, resource % 10)),
+                ),
+                (
+                    "latitude".to_owned(),
+                    nullable(Value::F64((resource % 90) as f64)),
+                ),
+                (
+                    "longitude".to_owned(),
+                    nullable(Value::F64((resource % 180) as f64)),
+                ),
+                (
+                    "capacity".to_owned(),
+                    nullable(Value::F64((resource % 100) as f64)),
+                ),
+                ("uptime".to_owned(), nullable(Value::I32(resource as i32))),
+            ]);
+            if resource % 3 == 0 {
+                cells.insert(
+                    "held_by".to_owned(),
+                    nullable(Value::String(format!("user-{}", resource % 20))),
+                );
+                cells.insert("held_at".to_owned(), nullable(Value::U64(resource as u64)));
+            }
+            self.insert("resources", row_id(2, resource), cells);
+        }
+    }
+
+    fn insert_jobs(&mut self, count: usize) {
+        let start = self.next_job;
+        for job in start..start + count {
+            let mut cells = BTreeMap::from([
+                ("tenant".to_owned(), tenant(job)),
+                (
+                    "status".to_owned(),
+                    Value::String(["OPEN", "ASSIGNED", "DONE", "VERIFIED"][job % 4].into()),
+                ),
+                ("title".to_owned(), Value::String(format!("Job {job:07}"))),
+                ("reward".to_owned(), Value::I32((job % 10_000) as i32)),
+                (
+                    "external_key".to_owned(),
+                    Value::String(format!("key-{job:07}")),
+                ),
+            ]);
+            if job % 4 == 0 {
+                cells.insert(
+                    "resource_id".to_owned(),
+                    nullable(Value::Uuid(row_id(2, job % RESOURCES).0)),
+                );
+            }
+            self.insert("jobs", row_id(3, job), cells);
+        }
+        self.next_job += count;
+    }
+
+    fn insert(&self, table: &str, row_id: RowUuid, cells: BTreeMap<String, Value>) {
+        let write = block_on(self.db.insert(
+            table,
+            cells,
+            InsertOptions {
+                row_id: Some(row_id),
+                ..Default::default()
+            },
+        ))
+        .unwrap_or_else(|error| panic!("insert synthetic {table} row: {error}"));
+        block_on(write.wait(DurabilityTier::Local))
+            .unwrap_or_else(|error| panic!("wait for synthetic {table} row: {error}"));
+    }
+}
+
+fn schema() -> JazzSchema {
+    let public = SchemaBuilder::new()
+        .table(
+            TableSchemaBuilder::new("groups")
+                .column("tenant", ColumnType::Text)
+                .column("label", ColumnType::Text)
+                .index_only(["tenant"]),
+        )
+        .table(
+            TableSchemaBuilder::new("resources")
+                .column("tenant", ColumnType::Text)
+                .column("label", ColumnType::Text)
+                .column("summary", ColumnType::Text)
+                .column(
+                    "status",
+                    string_enum(["READY", "PAUSED", "ERROR", "ACTIVE"]),
+                )
+                .column(
+                    "phase",
+                    string_enum(["IDLE", "HELD", "ASSIGNED", "WORKING"]),
+                )
+                .nullable_fk_column("group_id", "groups")
+                .nullable_column("held_by", ColumnType::Text)
+                .nullable_column("held_at", ColumnType::Timestamp)
+                .nullable_column("heartbeat_at", ColumnType::Timestamp)
+                .column("version", ColumnType::Text)
+                .nullable_column("latitude", ColumnType::Double)
+                .nullable_column("longitude", ColumnType::Double)
+                .nullable_column("capacity", ColumnType::Double)
+                .nullable_column("uptime", ColumnType::Integer)
+                .index_only(["tenant", "group_id", "phase", "held_by"]),
+        )
+        .table(
+            TableSchemaBuilder::new("jobs")
+                .column("tenant", ColumnType::Text)
+                .nullable_fk_column("resource_id", "resources")
+                .column(
+                    "status",
+                    string_enum(["OPEN", "ASSIGNED", "DONE", "VERIFIED"]),
+                )
+                .column("title", ColumnType::Text)
+                .column("reward", ColumnType::Integer)
+                .column("external_key", ColumnType::Text)
+                .index_only(["tenant", "status", "resource_id"]),
+        )
+        .table(
+            TableSchemaBuilder::new("sessions")
+                .fk_column("resource_id", "resources")
+                .column("user", ColumnType::Text)
+                .column("started_at", ColumnType::Timestamp),
+        )
+        .build();
+    JazzSchema::new(&public).expect("multi-table ingest schema compiles")
+}
+
+fn string_enum<const N: usize>(variants: [&str; N]) -> ColumnType {
+    ColumnType::Enum {
+        variants: variants.into_iter().map(str::to_owned).collect(),
+    }
+}
+
+fn tenant(index: usize) -> Value {
+    Value::String(format!("tenant-{}", index % 2))
+}
+
+fn nullable(value: Value) -> Value {
+    Value::Nullable(Some(Box::new(value)))
+}
+
+fn row_id(kind: u8, index: usize) -> RowUuid {
+    let mut bytes = [0_u8; 16];
+    bytes[0] = kind;
+    bytes[8..].copy_from_slice(&(index as u64).to_be_bytes());
+    RowUuid::from_bytes(bytes)
+}

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -1,6 +1,6 @@
 //! Neutral synthetic multi-table ingest fixture for thesis #2030.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, Transport, WriteIdentity, block_on};
 use jazz::groove::records::Value;
@@ -8,11 +8,12 @@ use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
 use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
 use jazz::protocol::SyncMessage;
 use jazz::schema::JazzSchema;
+use jazz::time::GlobalTime;
 use jazz::tools::{
     CmpOp, ColumnType, PolicyExpr, PolicyValue, Schema, SchemaBuilder, TablePolicies,
     TableSchemaBuilder,
 };
-use jazz::tx::DurabilityTier;
+use jazz::tx::{DurabilityTier, Fate};
 use jazz::wire::TransportError;
 use jazz_storage_rocksdb::{Durability, RocksDbStorage};
 use tempfile::TempDir;
@@ -79,6 +80,18 @@ impl IngestFixture<MemoryStorage> {
         fixture
     }
 
+    pub fn memory_with_trickling_fates(existing_jobs: usize) -> Self {
+        let mut fixture = Self::memory_with_attribution(existing_jobs, false);
+        let _connection = block_on(
+            fixture
+                .db
+                .connect_upstream(Box::new(TrickleFateTransport::default())),
+        );
+        block_on(fixture.db.tick()).expect("prime trickle-fate upstream backlog");
+        fixture.tick_after_write = true;
+        fixture
+    }
+
     fn memory_with_attribution(existing_jobs: usize, attributed: bool) -> Self {
         let schema = schema(false);
         let families = schema.column_families();
@@ -103,6 +116,37 @@ impl Transport for StalledTransport {
 
     fn try_recv(&mut self) -> Option<SyncMessage> {
         None
+    }
+}
+
+#[derive(Default)]
+struct TrickleFateTransport {
+    inbound: VecDeque<SyncMessage>,
+    receive_one: bool,
+    next_global_time: u64,
+}
+
+impl Transport for TrickleFateTransport {
+    fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
+        if let SyncMessage::CommitUnit { tx, .. } = message {
+            self.next_global_time += 1;
+            self.inbound.push_back(SyncMessage::FateUpdate {
+                tx_id: tx.tx_id,
+                fate: Fate::Accepted,
+                global_time: Some(GlobalTime(self.next_global_time)),
+                durability: Some(DurabilityTier::Global),
+            });
+            self.receive_one = true;
+        }
+        Ok(())
+    }
+
+    fn try_recv(&mut self) -> Option<SyncMessage> {
+        if !self.receive_one {
+            return None;
+        }
+        self.receive_one = false;
+        self.inbound.pop_front()
     }
 }
 

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -26,6 +26,7 @@ pub struct IngestFixture<S: OrderedKvStorage> {
     next_job: usize,
     write_identity: WriteIdentity,
     check_write_state: bool,
+    tick_after_write: bool,
 }
 
 impl IngestFixture<MemoryStorage> {
@@ -47,6 +48,7 @@ impl IngestFixture<MemoryStorage> {
             existing_jobs,
             true,
             false,
+            false,
         )
     }
 
@@ -60,6 +62,7 @@ impl IngestFixture<MemoryStorage> {
             existing_jobs,
             false,
             true,
+            false,
         )
     }
 
@@ -72,6 +75,7 @@ impl IngestFixture<MemoryStorage> {
             MemoryStorage::new(&refs),
             existing_jobs,
             attributed,
+            false,
             false,
         )
     }
@@ -86,7 +90,24 @@ impl IngestFixture<RocksDbStorage> {
         let storage =
             RocksDbStorage::open_with_durability(dir.path(), &refs, Durability::WalNoSync)
                 .expect("open ingest benchmark RocksDB");
-        (dir, Self::new(schema, storage, existing_jobs, false, false))
+        (
+            dir,
+            Self::new(schema, storage, existing_jobs, false, false, false),
+        )
+    }
+
+    pub fn rocksdb_with_tick(existing_jobs: usize) -> (TempDir, Self) {
+        let schema = schema(false);
+        let families = schema.column_families();
+        let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+        let dir = tempfile::tempdir().expect("create ingest benchmark directory");
+        let storage =
+            RocksDbStorage::open_with_durability(dir.path(), &refs, Durability::WalNoSync)
+                .expect("open ingest benchmark RocksDB");
+        (
+            dir,
+            Self::new(schema, storage, existing_jobs, false, false, true),
+        )
     }
 }
 
@@ -97,6 +118,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
         existing_jobs: usize,
         attributed: bool,
         check_write_state: bool,
+        tick_after_write: bool,
     ) -> Self {
         let config = DbConfig::new(
             schema,
@@ -127,6 +149,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
             next_job: 0,
             write_identity,
             check_write_state,
+            tick_after_write,
         };
         fixture.seed_dimensions();
         fixture.insert_jobs(existing_jobs);
@@ -257,6 +280,10 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
         }
         block_on(write.wait(DurabilityTier::Local))
             .unwrap_or_else(|error| panic!("wait for synthetic {table} row: {error}"));
+        if self.tick_after_write {
+            block_on(self.db.tick())
+                .unwrap_or_else(|error| panic!("tick after synthetic {table} row: {error}"));
+        }
     }
 }
 

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, block_on};
+use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, WriteIdentity, block_on};
 use jazz::groove::records::Value;
 use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
 use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
@@ -18,14 +18,23 @@ const RESOURCES: usize = 1_000;
 pub struct IngestFixture<S: OrderedKvStorage> {
     db: Db<S>,
     next_job: usize,
+    write_identity: WriteIdentity,
 }
 
 impl IngestFixture<MemoryStorage> {
     pub fn memory(existing_jobs: usize) -> Self {
+        Self::memory_with_attribution(existing_jobs, false)
+    }
+
+    pub fn memory_attributed(existing_jobs: usize) -> Self {
+        Self::memory_with_attribution(existing_jobs, true)
+    }
+
+    fn memory_with_attribution(existing_jobs: usize, attributed: bool) -> Self {
         let schema = schema();
         let families = schema.column_families();
         let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
-        Self::new(schema, MemoryStorage::new(&refs), existing_jobs)
+        Self::new(schema, MemoryStorage::new(&refs), existing_jobs, attributed)
     }
 }
 
@@ -38,22 +47,41 @@ impl IngestFixture<RocksDbStorage> {
         let storage =
             RocksDbStorage::open_with_durability(dir.path(), &refs, Durability::WalNoSync)
                 .expect("open ingest benchmark RocksDB");
-        (dir, Self::new(schema, storage, existing_jobs))
+        (dir, Self::new(schema, storage, existing_jobs, false))
     }
 }
 
 impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
-    fn new(schema: JazzSchema, storage: S, existing_jobs: usize) -> Self {
-        let db = block_on(Db::open(DbConfig::new(
+    fn new(schema: JazzSchema, storage: S, existing_jobs: usize, attributed: bool) -> Self {
+        let config = DbConfig::new(
             schema,
             storage,
             DbIdentity {
                 node: NodeUuid::from_bytes([0x83; 16]),
                 author: AuthorSubject::SYSTEM,
             },
-        )))
+        );
+        let db = if attributed {
+            // SAFETY: this synthetic process owns the isolated benchmark DB and
+            // never exposes its trusted-backend capability to another caller.
+            unsafe { block_on(Db::open_with_backend_attribution(config)) }
+        } else {
+            block_on(Db::open(config))
+        }
         .expect("open multi-table ingest database");
-        let mut fixture = Self { db, next_job: 0 };
+        let write_identity = if attributed {
+            WriteIdentity::Attribution(
+                AuthorSubject::authenticated("https://benchmark.invalid", "synthetic-writer")
+                    .expect("synthetic attributed identity"),
+            )
+        } else {
+            WriteIdentity::Database
+        };
+        let mut fixture = Self {
+            db,
+            next_job: 0,
+            write_identity,
+        };
         fixture.seed_dimensions();
         fixture.insert_jobs(existing_jobs);
         fixture
@@ -167,6 +195,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
             cells,
             InsertOptions {
                 row_id: Some(row_id),
+                identity: self.write_identity,
                 ..Default::default()
             },
         ))

--- a/examples/benchmarks/multi-table-ingest/src/lib.rs
+++ b/examples/benchmarks/multi-table-ingest/src/lib.rs
@@ -8,7 +8,8 @@ use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
 use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
 use jazz::schema::JazzSchema;
 use jazz::tools::{
-    CmpOp, ColumnType, PolicyExpr, PolicyValue, SchemaBuilder, TablePolicies, TableSchemaBuilder,
+    CmpOp, ColumnType, PolicyExpr, PolicyValue, Schema, SchemaBuilder, TablePolicies,
+    TableSchemaBuilder,
 };
 use jazz::tx::DurabilityTier;
 use jazz_storage_rocksdb::{Durability, RocksDbStorage};
@@ -17,10 +18,14 @@ use tempfile::TempDir;
 const GROUPS: usize = 32;
 const RESOURCES: usize = 1_000;
 
+mod public_client;
+pub use public_client::ClientIngestFixture;
+
 pub struct IngestFixture<S: OrderedKvStorage> {
     db: Db<S>,
     next_job: usize,
     write_identity: WriteIdentity,
+    check_write_state: bool,
 }
 
 impl IngestFixture<MemoryStorage> {
@@ -36,14 +41,39 @@ impl IngestFixture<MemoryStorage> {
         let schema = schema(true);
         let families = schema.column_families();
         let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
-        Self::new(schema, MemoryStorage::new(&refs), existing_jobs, true)
+        Self::new(
+            schema,
+            MemoryStorage::new(&refs),
+            existing_jobs,
+            true,
+            false,
+        )
+    }
+
+    pub fn memory_with_write_state_check(existing_jobs: usize) -> Self {
+        let schema = schema(false);
+        let families = schema.column_families();
+        let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+        Self::new(
+            schema,
+            MemoryStorage::new(&refs),
+            existing_jobs,
+            false,
+            true,
+        )
     }
 
     fn memory_with_attribution(existing_jobs: usize, attributed: bool) -> Self {
         let schema = schema(false);
         let families = schema.column_families();
         let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
-        Self::new(schema, MemoryStorage::new(&refs), existing_jobs, attributed)
+        Self::new(
+            schema,
+            MemoryStorage::new(&refs),
+            existing_jobs,
+            attributed,
+            false,
+        )
     }
 }
 
@@ -56,12 +86,18 @@ impl IngestFixture<RocksDbStorage> {
         let storage =
             RocksDbStorage::open_with_durability(dir.path(), &refs, Durability::WalNoSync)
                 .expect("open ingest benchmark RocksDB");
-        (dir, Self::new(schema, storage, existing_jobs, false))
+        (dir, Self::new(schema, storage, existing_jobs, false, false))
     }
 }
 
 impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
-    fn new(schema: JazzSchema, storage: S, existing_jobs: usize, attributed: bool) -> Self {
+    fn new(
+        schema: JazzSchema,
+        storage: S,
+        existing_jobs: usize,
+        attributed: bool,
+        check_write_state: bool,
+    ) -> Self {
         let config = DbConfig::new(
             schema,
             storage,
@@ -90,6 +126,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
             db,
             next_job: 0,
             write_identity,
+            check_write_state,
         };
         fixture.seed_dimensions();
         fixture.insert_jobs(existing_jobs);
@@ -213,12 +250,21 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> IngestFixture<S> {
             },
         ))
         .unwrap_or_else(|error| panic!("insert synthetic {table} row: {error}"));
+        if self.check_write_state {
+            self.db
+                .write_state(write.mergeable_tx_id())
+                .unwrap_or_else(|error| panic!("inspect synthetic {table} write fate: {error}"));
+        }
         block_on(write.wait(DurabilityTier::Local))
             .unwrap_or_else(|error| panic!("wait for synthetic {table} row: {error}"));
     }
 }
 
 fn schema(with_exists_policy: bool) -> JazzSchema {
+    JazzSchema::new(&public_schema(with_exists_policy)).expect("multi-table ingest schema compiles")
+}
+
+fn public_schema(with_exists_policy: bool) -> Schema {
     let jobs_policies = if with_exists_policy {
         TablePolicies::new().with_insert(PolicyExpr::Exists {
             table: "groups".to_owned(),
@@ -234,7 +280,7 @@ fn schema(with_exists_policy: bool) -> JazzSchema {
     } else {
         TablePolicies::new()
     };
-    let public = SchemaBuilder::new()
+    SchemaBuilder::new()
         .table(
             TableSchemaBuilder::new("groups")
                 .column("tenant", ColumnType::Text)
@@ -286,8 +332,7 @@ fn schema(with_exists_policy: bool) -> JazzSchema {
                 .column("user", ColumnType::Text)
                 .column("started_at", ColumnType::Timestamp),
         )
-        .build();
-    JazzSchema::new(&public).expect("multi-table ingest schema compiles")
+        .build()
 }
 
 fn string_enum<const N: usize>(variants: [&str; N]) -> ColumnType {

--- a/examples/benchmarks/multi-table-ingest/src/public_client.rs
+++ b/examples/benchmarks/multi-table-ingest/src/public_client.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use jazz::db::block_on;
+use jazz::tools::{AppContext, AppId, ClientStorage, JazzClient, ObjectId, Value};
+use tempfile::TempDir;
+
+use crate::{GROUPS, RESOURCES, public_schema, row_id};
+
+pub struct ClientIngestFixture {
+    _dir: TempDir,
+    client: JazzClient,
+    next_job: usize,
+}
+
+impl ClientIngestFixture {
+    pub fn memory(existing_jobs: usize) -> Self {
+        Self::new(existing_jobs, ClientStorage::Memory)
+    }
+
+    pub fn persistent(existing_jobs: usize) -> Self {
+        Self::new(existing_jobs, ClientStorage::Persistent)
+    }
+
+    fn new(existing_jobs: usize, storage: ClientStorage) -> Self {
+        let dir = tempfile::tempdir().expect("create public-client benchmark directory");
+        let storage_factory = matches!(storage, ClientStorage::Persistent)
+            .then(|| Arc::new(jazz_storage_rocksdb::RocksDbStorageFactory) as Arc<_>);
+        let client = block_on(JazzClient::connect(AppContext {
+            app_id: AppId::from_name("neutral-multi-table-ingest"),
+            client_id: None,
+            schema: public_schema(false),
+            server_url: String::new(),
+            data_dir: dir.path().to_path_buf(),
+            storage,
+            storage_factory,
+            jwt_token: None,
+            backend_secret: None,
+            admin_secret: None,
+        }))
+        .expect("open public JazzClient benchmark database");
+        let mut fixture = Self {
+            _dir: dir,
+            client,
+            next_job: 0,
+        };
+        fixture.seed_dimensions();
+        fixture.insert_jobs(existing_jobs);
+        fixture
+    }
+
+    pub fn insert_next_1k(mut self) -> usize {
+        self.insert_jobs(1_000);
+        self.next_job
+    }
+
+    fn seed_dimensions(&self) {
+        for group in 0..GROUPS {
+            self.insert(
+                "groups",
+                1,
+                group,
+                HashMap::from([
+                    ("tenant".to_owned(), tenant(group)),
+                    ("label".to_owned(), Value::Text(format!("Group {group:03}"))),
+                ]),
+            );
+        }
+        for resource in 0..RESOURCES {
+            self.insert(
+                "resources",
+                2,
+                resource,
+                HashMap::from([
+                    ("tenant".to_owned(), tenant(resource)),
+                    (
+                        "label".to_owned(),
+                        Value::Text(format!("Resource {resource:05}")),
+                    ),
+                    (
+                        "summary".to_owned(),
+                        Value::Text(format!("Synthetic resource {resource:05}")),
+                    ),
+                    (
+                        "status".to_owned(),
+                        Value::Text(["READY", "PAUSED", "ERROR", "ACTIVE"][resource % 4].into()),
+                    ),
+                    (
+                        "phase".to_owned(),
+                        Value::Text(["IDLE", "HELD", "ASSIGNED", "WORKING"][resource % 4].into()),
+                    ),
+                    (
+                        "group_id".to_owned(),
+                        Value::Uuid(ObjectId::from_uuid(row_id(1, resource % GROUPS).0)),
+                    ),
+                    ("held_by".to_owned(), Value::Null),
+                    ("held_at".to_owned(), Value::Null),
+                    ("heartbeat_at".to_owned(), Value::Timestamp(resource as u64)),
+                    (
+                        "version".to_owned(),
+                        Value::Text(format!("v{}.{}", resource % 4, resource % 10)),
+                    ),
+                    ("latitude".to_owned(), Value::Double((resource % 90) as f64)),
+                    (
+                        "longitude".to_owned(),
+                        Value::Double((resource % 180) as f64),
+                    ),
+                    (
+                        "capacity".to_owned(),
+                        Value::Double((resource % 100) as f64),
+                    ),
+                    ("uptime".to_owned(), Value::Integer(resource as i32)),
+                ]),
+            );
+        }
+    }
+
+    fn insert_jobs(&mut self, count: usize) {
+        for job in self.next_job..self.next_job + count {
+            self.insert(
+                "jobs",
+                3,
+                job,
+                HashMap::from([
+                    ("tenant".to_owned(), tenant(job)),
+                    (
+                        "group_id".to_owned(),
+                        Value::Uuid(ObjectId::from_uuid(row_id(1, job % GROUPS).0)),
+                    ),
+                    ("resource_id".to_owned(), Value::Null),
+                    (
+                        "status".to_owned(),
+                        Value::Text(["OPEN", "ASSIGNED", "DONE", "VERIFIED"][job % 4].into()),
+                    ),
+                    ("title".to_owned(), Value::Text(format!("Job {job:07}"))),
+                    ("reward".to_owned(), Value::Integer((job % 10_000) as i32)),
+                    (
+                        "external_key".to_owned(),
+                        Value::Text(format!("key-{job:07}")),
+                    ),
+                ]),
+            );
+        }
+        self.next_job += count;
+    }
+
+    fn insert(&self, table: &str, kind: u8, index: usize, cells: HashMap<String, Value>) {
+        let (_, _, transaction_id) = self
+            .client
+            .insert_with_id(table, row_id(kind, index).0, cells)
+            .unwrap_or_else(|error| panic!("public-client insert synthetic {table} row: {error}"));
+        block_on(self.client.wait_for_transaction(
+            transaction_id.expect("public-client insert commits immediately"),
+            jazz::tools::DurabilityTier::Local,
+        ))
+        .unwrap_or_else(|error| panic!("wait for public-client {table} row: {error}"));
+    }
+}
+
+fn tenant(index: usize) -> Value {
+    Value::Text(format!("tenant-{}", index % 2))
+}


### PR DESCRIPTION
## Thesis

Tracks #2030.

A fixed-size insert batch should have bounded amortized cost as the table and pending-upload outbox grow. The anonymized fixture first falsified ordinary core/schema/policy/storage causes, then reproduced the adopter curve through host-driven upload maintenance.

## Before

Every host tick could perform multiple O(outbox depth) operations:

1. prune every pending upload by re-reading transaction fate, even with no peer or with a connected peer that delivered no remote input;
2. linearly scan the ordered outbox to suppress duplicate enqueue;
3. for each upstream link, scan the full outbox to compute `outbox - uploaded`;
4. scan it again for each candidate to retrieve an optional staged commit unit.

A host that ticks after each local insert therefore accumulated O(writes²) work while disconnected or connected to a slow/silent upstream.

## After

- Fate pruning consumes exact successfully applied Global/rejected FateUpdate IDs; it no longer re-reads every pending transaction.
- Released oldest uploads pop from a deque in O(1), with stable fallback for out-of-order fates; every link forgets the same released IDs.
- The ordered upload vector has companion O(1) transaction-ID membership.
- A link visits only the contiguous unuploaded suffix when length accounting proves that suffix contains every missing ID, carrying each staged unit directly.
- Fate cleanup or authority handoff can create holes; the proof fails and preserves the original full set-difference fallback.

The benchmark primes the legitimate one-time upload of an existing backlog outside the measured closure, then measures steady next-1k host-tick maintenance while the transport accepts uploads but returns no fates.

## Receipts

Original connected-silent reproduction, next 1k at 0/1k/3k/5k pending depth:

- before remote-input gate: 7.224 / 12.22 / 20.44 / 30.86 s
- after remote-input gate: 1.243 / 1.249 / 1.657 / 1.847 s (the first measured tick still included backlog catch-up)

Controlled steady-state receipt after priming that catch-up:

| pending depth | membership-only | final suffix/unit fast path |
|---:|---:|---:|
| 0 | 412.7 ms | 396.0 ms |
| 1,000 | 439.6 ms | 396.5 ms |
| 3,000 | 499.2 ms | 407.3 ms |
| 5,000 | 544.4 ms | 407.3 ms |

The final 0→5k penalty is ~11 ms; steady accepting-but-silent ingest is approximately depth-flat.

For a slow active authority returning one Global fate per tick, exact fate-addressed pruning improves next-1k from 6.106/11.36 s at 0/1k depth (deeper stopped) to 0.738/0.749/0.752/0.797 s through 5k.

## Governing invariants

- The vector remains the source of upload order; membership does not reorder transactions.
- Exact duplicate tx IDs remain suppressed across local publication, replay, subscriber ingest, reconnect, and authority handoff.
- A connection marks an upload sent only after transport acceptance; backpressure retries the same unit.
- Rate-limited or failed large-value uploads retain their established retry behavior.
- Rejected/global-settled entries remain until durable fate is observed and are then removed from both vector and membership together.
- When unuploaded entries are not a contiguous suffix, discovery falls back to the prior general set difference.

## Worked examples

Disconnected seed: 5,000 writes remain queued. Per-write host ticks do not re-read 5,000 unchanged fates; reconnect later still sees the complete ordered outbox.

Silent connected seed: the transport accepts each new commit but returns no fate. The link checks only the new suffix entry, while the pending vector remains available for eventual fate/reconnect handling.

Backpressure: sending the suffix entry fails once. It is not inserted into `uploaded`; the next tick finds and retries it.

Authority handoff: removing an older tx from the successor link's `uploaded` set creates a hole. Suffix cardinality no longer equals the missing count, so discovery performs the original full scan and redrives that tx.

## Non-goals

- Initial upload of an N-entry backlog remains intentionally O(N).
- Initial upload of an N-entry backlog and genuinely out-of-order fate removal remain O(N); steady ordered fates are O(released IDs).
- No transaction, fate, durability, retry, or upload-order semantics change.

## Validation

- anonymized memory/RocksDB/core/public-client differential benchmark API
- exact backpressure retry
- exact authority-handoff redrive
- missing-upload fatal and detach coverage
- iteration-tier incremental-delivery canaries and low-seed differential oracle running
- clippy, rustfmt, sensitive-data guard

