### PR TITLE
Fix correlated inherited policy lowering

### DIFF
--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -11,7 +11,7 @@ use std::hash::{BuildHasher, Hash, Hasher};
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use crate::records::{RecordDescriptor, Value, ValueType};
+use crate::records::{RecordDescriptor, Value, ValueType, collect_by_ordered_scalar};
 use thiserror::Error;
 
 use super::op_types::*;
@@ -2011,25 +2011,6 @@ fn expect_arrangement_inputs(inputs: &[NodeOutput]) -> Result<(), GraphValidatio
         Ok(())
     } else {
         Err(GraphValidationError::InvalidNodeOutput)
-    }
-}
-
-fn collect_by_ordered_scalar(value_type: &ValueType) -> bool {
-    match value_type {
-        ValueType::Nullable(inner) => collect_by_ordered_scalar(inner),
-        ValueType::U8
-        | ValueType::U16
-        | ValueType::U32
-        | ValueType::U64
-        | ValueType::I32
-        | ValueType::I64
-        | ValueType::F64
-        | ValueType::Bool
-        | ValueType::String
-        | ValueType::Bytes
-        | ValueType::Uuid
-        | ValueType::EnumTag(_) => true,
-        _ => false,
     }
 }
 

--- a/crates/groove/src/ivm/runtime/record_projection.rs
+++ b/crates/groove/src/ivm/runtime/record_projection.rs
@@ -1,6 +1,7 @@
 //! Record descriptors, projection, enum remapping, and operator shape validation.
 
 use super::*;
+use crate::records::collect_by_ordered_scalar;
 
 pub(super) fn extend_root_window_positions(
     descriptor: RecordDescriptor,
@@ -510,31 +511,13 @@ pub(super) fn validate_collect_by_key_types(
     input: &RecordDescriptor,
     indices: &[usize],
 ) -> Result<(), IvmRuntimeError> {
-    fn ordered_scalar(value_type: &ValueType) -> bool {
-        match value_type {
-            ValueType::Nullable(inner) => ordered_scalar(inner),
-            ValueType::U8
-            | ValueType::U16
-            | ValueType::U32
-            | ValueType::U64
-            | ValueType::I32
-            | ValueType::I64
-            | ValueType::F64
-            | ValueType::Bool
-            | ValueType::String
-            | ValueType::Bytes
-            | ValueType::Uuid
-            | ValueType::EnumTag(_) => true,
-            _ => false,
-        }
-    }
     for &index in indices {
         let value_type = &input
             .fields()
             .get(index)
             .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(index))?
             .value_type;
-        let scalar = ordered_scalar(value_type);
+        let scalar = collect_by_ordered_scalar(value_type);
         if value_type.contains_record() || !scalar {
             return Err(IvmRuntimeError::InvalidCollectBy(
                 "group, order, and tie fields must be scalar ordered values without records".into(),

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -90,6 +90,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 pub use macros::{FieldKind, RecordField, assert_record_field_layout};
+pub use values::collect_by_ordered_scalar;
 pub use values::{
     EnumCase, EnumSchema, EnumValue, ScalarEnumSchema, SystemVariantRegistry, Value, ValueType,
     VariantRegistry, variant_registry_id_for_path,

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -425,6 +425,29 @@ enum InternalValueTypeRepr {
     StoredScalar(crate::large_values::LargeValueKind),
 }
 
+/// Whether a value can be used as an ordered `collect_by` key.
+///
+/// Nullable values retain the ordering of their inner scalar. Composite values
+/// deliberately do not: collector keys must be independently ordered values.
+pub fn collect_by_ordered_scalar(value_type: &ValueType) -> bool {
+    match value_type {
+        ValueType::Nullable(inner) => collect_by_ordered_scalar(inner),
+        ValueType::U8
+        | ValueType::U16
+        | ValueType::U32
+        | ValueType::U64
+        | ValueType::I32
+        | ValueType::I64
+        | ValueType::F64
+        | ValueType::Bool
+        | ValueType::String
+        | ValueType::Bytes
+        | ValueType::Uuid
+        | ValueType::EnumTag(_) => true,
+        _ => false,
+    }
+}
+
 impl ValueType {
     /// Whether this is an engine-only physical backing type. Public schema and
     /// binding layers use this predicate to reject it without gaining access to

--- a/crates/jazz-testkit/tests/policies_integration/complex_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/complex_policies.rs
@@ -185,13 +185,15 @@ fn mixed_complex_select_policy() -> PolicyExpr {
     pe::all_of([
         pe::eq("published", true),
         pe::in_session("team_slug", "claims.team_slugs"),
-        pe::exists(pe::table("document_flags").where_(pe::rel::all_of([
-            pe::rel::eq_outer("document_id", "id"),
-            pe::rel::eq_literal("flag", "allow"),
-        ]))),
         pe::all_of([
-            pe::is_not_null("folder_id"),
-            pe::allowed_to_read("folder_id"),
+            pe::exists(pe::table("document_flags").where_(pe::rel::all_of([
+                pe::rel::eq_outer("document_id", "id"),
+                pe::rel::eq_literal("flag", "allow"),
+            ]))),
+            pe::all_of([
+                pe::is_not_null("folder_id"),
+                pe::allowed_to_read("folder_id"),
+            ]),
         ]),
     ])
 }

--- a/crates/jazz-testkit/tests/policies_integration/complex_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/complex_policies.rs
@@ -757,7 +757,6 @@ async fn exists_rel_hop_grants_and_denies_correctly_inner() {
 /// alice(claims=sales) ───────────────────────────────► sees only sales-matching row
 /// ```
 #[tokio::test]
-#[ignore = "#1761: mixed SELECT policy stays closed once EXISTS / INHERITS composition is involved"]
 async fn mixed_predicates_claims_exists_and_inherits_fail_closed() {
     tokio::task::LocalSet::new()
         .run_until(mixed_predicates_claims_exists_and_inherits_fail_closed_inner())

--- a/crates/jazz/src/node/query_engine/lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering.rs
@@ -7,7 +7,7 @@ use groove::ivm::{
     PlanExpr as GroovePlanExpr, PredicateExpr as GroovePredicateExpr, PredicateKind, ProjectField,
     TopByLimit, TopByOrder,
 };
-use groove::records::ValueType;
+use groove::records::{ValueType, collect_by_ordered_scalar};
 
 mod closure;
 use closure::{
@@ -510,7 +510,9 @@ fn parameter_domain(shape: &NormalizedRowSetShape) -> ParameterDomain {
                                 ty: column.ty.clone(),
                             },
                         );
-                        domain.routing_params.insert(param);
+                        if claim_route_is_ordered_scalar(&column.ty) {
+                            domain.routing_params.insert(param);
+                        }
                     }
                 }
             }
@@ -534,6 +536,17 @@ fn parameter_domain(shape: &NormalizedRowSetShape) -> ParameterDomain {
         }
     }
     domain
+}
+
+#[cfg(test)]
+pub(crate) fn parameter_domain_for_shape_for_test(
+    shape: &NormalizedRowSetShape,
+) -> ParameterDomain {
+    parameter_domain(shape)
+}
+
+fn claim_route_is_ordered_scalar(ty: &ColumnType) -> bool {
+    collect_by_ordered_scalar(ty)
 }
 
 fn parameter_domain_for_request(
@@ -652,7 +665,9 @@ fn collect_binding_source_params(graph: &GraphBuilder, domain: &mut ParameterDom
                             path,
                             ty: field.value_type.clone(),
                         });
-                    domain.routing_params.insert(name.to_owned());
+                    if claim_route_is_ordered_scalar(&field.value_type) {
+                        domain.routing_params.insert(name.to_owned());
+                    }
                 } else {
                     domain
                         .user_params

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -2134,6 +2134,47 @@ fn missing_sub_claim_lowers_to_deny_predicate() {
     assert!(graph.contains("Or([])"), "{graph}");
 }
 
+/// This is deliberately a lowering-level receipt: the parameter domain is an
+/// internal compiler boundary, while the policy integration receipt exercises
+/// the corresponding public behavior.
+#[test]
+fn only_ordered_scalar_claims_enter_collector_routing() {
+    let scalar = ClaimPath(vec!["tier".to_owned()]);
+    let array = ClaimPath(vec!["teams".to_owned()]);
+    let mut input = row_set_input(0xd3);
+    let root = input.shape.root.clone();
+    input.shape.nodes.insert(
+        root,
+        RowSetExpr::ValueSource {
+            shape: "claim-routing".to_owned(),
+            columns: vec![
+                ValueSourceColumn {
+                    name: "tier".to_owned(),
+                    value: NormalizedValueRef::Claim(scalar.clone()),
+                    ty: ColumnType::String.nullable(),
+                },
+                ValueSourceColumn {
+                    name: "teams".to_owned(),
+                    value: NormalizedValueRef::Claim(array.clone()),
+                    ty: ColumnType::Array(Box::new(ColumnType::Uuid)),
+                },
+            ],
+            mode: ValueSourceMode::Binding,
+        },
+    );
+
+    let domain = super::super::lowering::parameter_domain_for_shape_for_test(&input.shape);
+    let scalar_field = claim_param_field(&scalar);
+    let array_field = claim_param_field(&array);
+    assert!(domain.claim_params.contains_key(&scalar_field));
+    assert!(domain.claim_params.contains_key(&array_field));
+    assert!(domain.routing_params.contains(&scalar_field));
+    assert!(
+        !domain.routing_params.contains(&array_field),
+        "compound claim stays a prepared predicate input and never becomes a collector key"
+    );
+}
+
 #[test]
 fn missing_claim_lowers_to_deny_predicate() {
     let request = QueryProgramRequest {

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -1054,6 +1054,21 @@ fn append_policy_clause(
     native_select_inherits: bool,
 ) -> Result<Query, SchemaConversionError> {
     match expr {
+        PolicyExpr::And(exprs) => {
+            let mut query = query;
+            for (index, expr) in exprs.iter().enumerate() {
+                query = append_policy_clause(
+                    schema,
+                    table_schema,
+                    table,
+                    &format!("{path}.And[{index}]"),
+                    query,
+                    expr,
+                    native_select_inherits,
+                )?;
+            }
+            Ok(query)
+        }
         PolicyExpr::Inherits {
             operation,
             via_column,

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -1023,13 +1023,15 @@ fn convert_policy_with_native_select_inherits(
 }
 
 fn is_core_policy_clause(expr: &PolicyExpr) -> bool {
-    matches!(
-        expr,
+    match expr {
         PolicyExpr::Inherits { max_depth: _, .. }
-            | PolicyExpr::InheritsReferencing { .. }
-            | PolicyExpr::Exists { .. }
-            | PolicyExpr::ExistsRel { .. }
-    )
+        | PolicyExpr::InheritsReferencing { .. }
+        | PolicyExpr::Exists { .. }
+        | PolicyExpr::ExistsRel { .. } => true,
+        PolicyExpr::And(exprs) | PolicyExpr::Or(exprs) => exprs.iter().any(is_core_policy_clause),
+        PolicyExpr::Not(expr) => is_core_policy_clause(expr),
+        _ => false,
+    }
 }
 
 fn policy_requires_branch(expr: &PolicyExpr) -> bool {
@@ -3936,6 +3938,52 @@ mod tests {
         let policy = documents.read_policy.as_ref().unwrap();
         assert!(policy.filters.is_empty());
         assert!(policy.joins.is_empty());
+        assert_eq!(policy.inherits.len(), 1);
+        assert_eq!(policy.inherits[0].parent_column, "folder_id");
+        assert_eq!(policy.inherits[0].operation, InheritsOperation::Select);
+    }
+
+    #[test]
+    fn preserves_inherits_nested_under_a_conjunction() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchemaBuilder::new("folders")
+                    .column("name", ColumnType::Text)
+                    .policies(TablePolicies::new().with_select(PolicyExpr::True)),
+            )
+            .table(
+                TableSchemaBuilder::new("documents")
+                    .column("published", ColumnType::Boolean)
+                    .nullable_fk_column("folder_id", "folders")
+                    .policies(TablePolicies::new().with_select(PolicyExpr::And(vec![
+                        PolicyExpr::Cmp {
+                            column: "published".to_owned(),
+                            op: CmpOp::Eq,
+                            value: PolicyValue::Literal(Value::Boolean(true)),
+                        },
+                        PolicyExpr::And(vec![PolicyExpr::Inherits {
+                            operation: Operation::Select,
+                            via_column: "folder_id".to_owned(),
+                            max_depth: None,
+                        }]),
+                    ]))),
+            )
+            .build();
+
+        let converted = convert_public_schema(&schema).unwrap();
+        let documents = converted
+            .tables
+            .iter()
+            .find(|table| table.name == "documents")
+            .unwrap();
+        let policy = documents.read_policy.as_ref().unwrap();
+        assert_eq!(
+            policy.filters,
+            vec![Predicate::Eq(
+                Operand::Column("published".to_owned()),
+                Operand::Literal(GrooveValue::Bool(true)),
+            )]
+        );
         assert_eq!(policy.inherits.len(), 1);
         assert_eq!(policy.inherits[0].parent_column, "folder_id");
         assert_eq!(policy.inherits[0].operation, InheritsOperation::Select);


### PR DESCRIPTION
🤖 Reconstructs and supersedes #1884 on current `main`, retaining the original attributable commits while omitting the obsolete canonical-token path.

## Before

A nested `And` inside a correlated SELECT policy fell through predicate-only conversion and rejected an `INHERITS Select` clause. Compound claim arrays could also be carried into `CollectBy` routing, even though collector keys must have an independent total order.

## After

- Recursive clause lowering preserves every nested core-policy conjunct.
- Claims remain available as prepared predicate inputs.
- Only nullable, independently ordered scalars can become collector routing keys.
- Graph validation, runtime validation, and Jazz lowering share one `collect_by_ordered_scalar` rule.

## Example

Given a policy combining publication state, a team-array claim, `EXISTS(flag)`, and inherited folder SELECT access, Alice can read the document only when every conjunct succeeds. Documents in Bob's folder, unpublished documents, and documents without the flag remain denied. The team array participates in predicate evaluation but is never exposed as a collector key.

## Invariant and non-goals

Collectors receive only independently ordered scalar keys; composite claims cannot become routing keys or leak into collector descriptors. This does not restore the obsolete canonical-token implementation, add a public claim-routing API, change #2033 collector provenance semantics, or revive unrelated native/large-value stack work.

## Verification

- `cargo fmt --check`
- Focused ordered-scalar lowering receipt: 1 passed.
- Correlated policy integration receipt: 1 passed.
- Full Groove suite: 525 passed, 2 ignored, with integration and doc tests passing.
- Planted removal of the scalar guard reproduced `invalid collect_by descriptor`; restoration passed.

Original attribution is retained with `-x` trailers for commits `505106695` and `a4080d71`.
