### PR TITLE
Retain UNION occurrence carriers for shared aliases

### DIFF
--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -1018,6 +1018,11 @@ fn lower_linear_plan_steps_cached(
     // subsequent join. Keep their source-qualified field addresses so the
     // final flat-join projection can still name every contributing source.
     let mut accumulated_join_fields = BTreeMap::<(SourceId, String), (String, usize)>::new();
+    // UNION inputs have an occurrence identity which is not source-qualified:
+    // it is the complete `(arm, row)` pair. Keep its public terminal names
+    // while flattening a consecutive inner join so the final projection can
+    // retain the pair for result-membership.
+    let mut accumulated_union_occurrence_fields = BTreeSet::<String>::new();
     let mut available_route_fields = if matches!(plan.root, LinearRoot::Source { .. }) {
         root_source.routing_fields.clone()
     } else {
@@ -1205,6 +1210,17 @@ fn lower_linear_plan_steps_cached(
                                 .to_owned(),
                         )
                     })?;
+                    let mut union_occurrence_outputs = BTreeMap::new();
+                    if !policy_subplan && matches!(right.as_ref(), RelationInputPlan::Union(_)) {
+                        if let Some((arm_field, row_field)) =
+                            &lowered_right.union_occurrence_carrier
+                        {
+                            union_occurrence_outputs
+                                .insert(arm_field.clone(), format!("__root_join_arm_{step_index}"));
+                            union_occurrence_outputs
+                                .insert(row_field.clone(), format!("__root_join_row_{step_index}"));
+                        }
+                    }
                     let mut projection = fields
                         .iter()
                         .map(|field| ProjectField::renamed(left_field(field), field.clone()))
@@ -1213,12 +1229,20 @@ fn lower_linear_plan_steps_cached(
                     let mut next_nullable = nullable_fields.clone();
                     let mut next_depths = nullable_field_depths.clone();
                     for field in right_fields {
-                        let output = if policy_subplan {
-                            format!("__policy_join_source_{step_index}_{field}")
-                        } else {
-                            format!("__flat_join_source_{step_index}_{field}")
-                        };
+                        let output = union_occurrence_outputs
+                            .get(&field)
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                if policy_subplan {
+                                    format!("__policy_join_source_{step_index}_{field}")
+                                } else {
+                                    format!("__flat_join_source_{step_index}_{field}")
+                                }
+                            });
                         projection.push(ProjectField::renamed(right_field(&field), output.clone()));
+                        if union_occurrence_outputs.contains_key(&field) {
+                            accumulated_union_occurrence_fields.insert(output.clone());
+                        }
                         let nullable_depth = right_depths.get(&field).copied().unwrap_or(0);
                         accumulated_join_fields.insert(
                             (right_source.clone(), field.clone()),
@@ -1252,6 +1276,15 @@ fn lower_linear_plan_steps_cached(
                     );
                     let mut occurrence_fields = BTreeSet::new();
                     if !omits_public_occurrence_carriers(request) {
+                        // Earlier consecutive UNION joins already flattened
+                        // their complete occurrence pair into the left input.
+                        // Retain both fields under their terminal names; row
+                        // identity without its union arm is ambiguous.
+                        for output in &accumulated_union_occurrence_fields {
+                            projection
+                                .push(ProjectField::renamed(left_field(output), output.clone()));
+                            occurrence_fields.insert(output.clone());
+                        }
                         // A trailing semi-join filters the complete public
                         // tuple but contributes no occurrence of its own.
                         // Preserve the earlier inner-join row IDs from the

--- a/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/lowering/graph_lowering.rs
@@ -1271,7 +1271,29 @@ fn lower_linear_plan_steps_cached(
                         }
                     }
                     if *mode == JoinMode::Inner && !omits_public_occurrence_carriers(request) {
-                        if let Some(right_source_id) = right.root_source() {
+                        // A union's root source is one of its arms, but its
+                        // public occurrence is the `(arm, row)` pair. Check
+                        // the relation shape before inspecting that source so
+                        // an aliased common arm cannot make us drop the union
+                        // carrier that result-membership terminals require.
+                        if matches!(right.as_ref(), RelationInputPlan::Union(_)) {
+                            if let Some((arm_field, row_field)) =
+                                &lowered_right.union_occurrence_carrier
+                            {
+                                let arm_output = format!("__root_join_arm_{step_index}");
+                                let row_output = format!("__root_join_row_{step_index}");
+                                projection.push(ProjectField::renamed(
+                                    right_field(arm_field),
+                                    arm_output.clone(),
+                                ));
+                                projection.push(ProjectField::renamed(
+                                    right_field(row_field),
+                                    row_output.clone(),
+                                ));
+                                occurrence_fields.insert(arm_output);
+                                occurrence_fields.insert(row_output);
+                            }
+                        } else if let Some(right_source_id) = right.root_source() {
                             let right_source = resolved_sources.get(right_source_id).ok_or_else(|| {
                                 UnsupportedReason::Operator(format!(
                                     "inner join occurrence source {right_source_id:?} was not resolved"
@@ -1294,21 +1316,6 @@ fn lower_linear_plan_steps_cached(
                                 ));
                                 occurrence_fields.insert(output);
                             }
-                        } else if let Some((arm_field, row_field)) =
-                            &lowered_right.union_occurrence_carrier
-                        {
-                            let arm_output = format!("__root_join_arm_{step_index}");
-                            let row_output = format!("__root_join_row_{step_index}");
-                            projection.push(ProjectField::renamed(
-                                right_field(arm_field),
-                                arm_output.clone(),
-                            ));
-                            projection.push(ProjectField::renamed(
-                                right_field(row_field),
-                                row_output.clone(),
-                            ));
-                            occurrence_fields.insert(arm_output);
-                            occurrence_fields.insert(row_output);
                         }
                     }
                     graph = graph.project_fields(projection);

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -537,6 +537,7 @@ fn current_join_via_can_use_union_relation_input() {
     assert_current_join_via_union_relation_input(
         source("todo_tags", SourceRole::Policy("direct".to_owned())),
         source("todo_tags", SourceRole::Policy("inherited".to_owned())),
+        false,
     );
 }
 
@@ -546,12 +547,21 @@ fn current_join_via_can_use_union_relation_input() {
 #[test]
 fn current_join_via_shared_alias_union_keeps_arm_and_row_carriers() {
     let shared = source("todo_tags", SourceRole::Alias("policy_branch".to_owned()));
-    assert_current_join_via_union_relation_input(shared.clone(), shared);
+    assert_current_join_via_union_relation_input(shared.clone(), shared, false);
+}
+
+/// The shared-alias UNION must retain its full `(arm, row)` occurrence identity
+/// when an additional INNER JOIN causes the first join input to be flattened.
+#[test]
+fn current_join_via_shared_alias_union_keeps_carriers_through_consecutive_inner_join() {
+    let shared = source("todo_tags", SourceRole::Alias("policy_branch".to_owned()));
+    assert_current_join_via_union_relation_input(shared.clone(), shared, true);
 }
 
 fn assert_current_join_via_union_relation_input(
     direct_source: SourceId,
     inherited_source: SourceId,
+    consecutive_inner_join: bool,
 ) {
     let root = RowSetNodeId("root".to_owned());
     let direct_source_node = RowSetNodeId("direct-source".to_owned());
@@ -560,26 +570,37 @@ fn assert_current_join_via_union_relation_input(
     let inherited_project = RowSetNodeId("inherited-project".to_owned());
     let union_node = RowSetNodeId("authorized-union".to_owned());
     let join_node = RowSetNodeId("join".to_owned());
+    let ordinary_source_node = RowSetNodeId("ordinary-source".to_owned());
+    let ordinary_project = RowSetNodeId("ordinary-project".to_owned());
+    let terminal_join = RowSetNodeId("terminal-join".to_owned());
     let root_source = source("todos", SourceRole::Root);
+    let ordinary_source = source("todo_tags", SourceRole::Alias("ordinary".to_owned()));
+    let mut sources = BTreeMap::from([
+        (
+            root_source.clone(),
+            requested_current_source(DurabilityTier::Global),
+        ),
+        (
+            direct_source.clone(),
+            requested_current_source(DurabilityTier::Global),
+        ),
+        (
+            inherited_source.clone(),
+            requested_current_source(DurabilityTier::Global),
+        ),
+    ]);
+    if consecutive_inner_join {
+        sources.insert(
+            ordinary_source.clone(),
+            requested_current_source(DurabilityTier::Global),
+        );
+    }
     let request = QueryProgramRequest {
         authorization_mode: QueryAuthorizationMode::TrustedServing,
         reads: QueryReadSet::primary(ReadView {
             read_schema: schema(0x10),
             policy_schema: schema(0x11),
-            sources: BTreeMap::from([
-                (
-                    root_source.clone(),
-                    requested_current_source(DurabilityTier::Global),
-                ),
-                (
-                    direct_source.clone(),
-                    requested_current_source(DurabilityTier::Global),
-                ),
-                (
-                    inherited_source.clone(),
-                    requested_current_source(DurabilityTier::Global),
-                ),
-            ]),
+            sources,
         }),
         policy: system_policy_context(),
         input: RowSetProgramInput {
@@ -588,7 +609,11 @@ fn assert_current_join_via_union_relation_input(
                     shape_id: shape(0x7a),
                     canonical: vec![0x7a],
                 },
-                root: join_node.clone(),
+                root: if consecutive_inner_join {
+                    terminal_join.clone()
+                } else {
+                    join_node.clone()
+                },
                 result: ResultId::RealRow {
                     table: "todos".to_owned(),
                     row: ResultRowRef::Source(root_source.clone()),
@@ -597,94 +622,140 @@ fn assert_current_join_via_union_relation_input(
                 closure_paths: Vec::new(),
                 join_contributions: Vec::new(),
                 reachable_contributions: Vec::new(),
-                nodes: BTreeMap::from([
-                    (
-                        root.clone(),
-                        RowSetExpr::Source {
-                            source: root_source.clone(),
-                            visibility: RowVisibility::Visible,
-                        },
-                    ),
-                    (
-                        direct_source_node.clone(),
-                        RowSetExpr::Source {
-                            source: direct_source.clone(),
-                            visibility: RowVisibility::Visible,
-                        },
-                    ),
-                    (
-                        direct_project.clone(),
-                        RowSetExpr::Project {
-                            input: direct_source_node,
-                            columns: vec![RowProjection {
-                                output: TypedOutputField {
-                                    name: "todo".to_owned(),
-                                    ty: ColumnType::Uuid,
-                                },
-                                value: NormalizedValueRef::SourceField {
-                                    source: direct_source,
-                                    field: "todo".to_owned(),
-                                },
-                            }],
-                        },
-                    ),
-                    (
-                        inherited_source_node.clone(),
-                        RowSetExpr::Source {
-                            source: inherited_source.clone(),
-                            visibility: RowVisibility::Visible,
-                        },
-                    ),
-                    (
-                        inherited_project.clone(),
-                        RowSetExpr::Project {
-                            input: inherited_source_node,
-                            columns: vec![RowProjection {
-                                output: TypedOutputField {
-                                    name: "todo".to_owned(),
-                                    ty: ColumnType::Uuid,
-                                },
-                                value: NormalizedValueRef::SourceField {
-                                    source: inherited_source,
-                                    field: "todo".to_owned(),
-                                },
-                            }],
-                        },
-                    ),
-                    (
-                        union_node.clone(),
-                        RowSetExpr::Union {
-                            inputs: vec![
-                                UnionInput {
-                                    node: direct_project,
-                                    label: "direct".to_owned(),
-                                },
-                                UnionInput {
-                                    node: inherited_project,
-                                    label: "inherited".to_owned(),
-                                },
-                            ],
-                        },
-                    ),
-                    (
-                        join_node,
-                        RowSetExpr::Join {
-                            left: root,
-                            right: union_node,
-                            mode: JoinMode::Inner,
-                            on: PredicateExpr::Compare {
-                                left: NormalizedValueRef::RowId(RowIdRef::Source(
-                                    root_source.clone(),
-                                )),
-                                op: ComparisonOp::Eq,
-                                right: NormalizedValueRef::SourceField {
-                                    source: root_source.clone(),
-                                    field: "todo".to_owned(),
+                nodes: {
+                    let mut nodes = BTreeMap::from([
+                        (
+                            root.clone(),
+                            RowSetExpr::Source {
+                                source: root_source.clone(),
+                                visibility: RowVisibility::Visible,
+                            },
+                        ),
+                        (
+                            direct_source_node.clone(),
+                            RowSetExpr::Source {
+                                source: direct_source.clone(),
+                                visibility: RowVisibility::Visible,
+                            },
+                        ),
+                        (
+                            direct_project.clone(),
+                            RowSetExpr::Project {
+                                input: direct_source_node,
+                                columns: vec![RowProjection {
+                                    output: TypedOutputField {
+                                        name: "todo".to_owned(),
+                                        ty: ColumnType::Uuid,
+                                    },
+                                    value: NormalizedValueRef::SourceField {
+                                        source: direct_source.clone(),
+                                        field: "todo".to_owned(),
+                                    },
+                                }],
+                            },
+                        ),
+                        (
+                            inherited_source_node.clone(),
+                            RowSetExpr::Source {
+                                source: inherited_source.clone(),
+                                visibility: RowVisibility::Visible,
+                            },
+                        ),
+                        (
+                            inherited_project.clone(),
+                            RowSetExpr::Project {
+                                input: inherited_source_node,
+                                columns: vec![RowProjection {
+                                    output: TypedOutputField {
+                                        name: "todo".to_owned(),
+                                        ty: ColumnType::Uuid,
+                                    },
+                                    value: NormalizedValueRef::SourceField {
+                                        source: inherited_source.clone(),
+                                        field: "todo".to_owned(),
+                                    },
+                                }],
+                            },
+                        ),
+                        (
+                            union_node.clone(),
+                            RowSetExpr::Union {
+                                inputs: vec![
+                                    UnionInput {
+                                        node: direct_project,
+                                        label: "direct".to_owned(),
+                                    },
+                                    UnionInput {
+                                        node: inherited_project,
+                                        label: "inherited".to_owned(),
+                                    },
+                                ],
+                            },
+                        ),
+                        (
+                            join_node.clone(),
+                            RowSetExpr::Join {
+                                left: root,
+                                right: union_node,
+                                mode: JoinMode::Inner,
+                                on: PredicateExpr::Compare {
+                                    left: NormalizedValueRef::RowId(RowIdRef::Source(
+                                        root_source.clone(),
+                                    )),
+                                    op: ComparisonOp::Eq,
+                                    right: NormalizedValueRef::SourceField {
+                                        source: root_source.clone(),
+                                        field: "todo".to_owned(),
+                                    },
                                 },
                             },
-                        },
-                    ),
-                ]),
+                        ),
+                    ]);
+                    if consecutive_inner_join {
+                        nodes.insert(
+                            ordinary_source_node.clone(),
+                            RowSetExpr::Source {
+                                source: ordinary_source.clone(),
+                                visibility: RowVisibility::Visible,
+                            },
+                        );
+                        nodes.insert(
+                            ordinary_project.clone(),
+                            RowSetExpr::Project {
+                                input: ordinary_source_node,
+                                columns: vec![RowProjection {
+                                    output: TypedOutputField {
+                                        name: "todo".to_owned(),
+                                        ty: ColumnType::Uuid,
+                                    },
+                                    value: NormalizedValueRef::SourceField {
+                                        source: ordinary_source.clone(),
+                                        field: "todo".to_owned(),
+                                    },
+                                }],
+                            },
+                        );
+                        nodes.insert(
+                            terminal_join,
+                            RowSetExpr::Join {
+                                left: join_node,
+                                right: ordinary_project,
+                                mode: JoinMode::Inner,
+                                on: PredicateExpr::Compare {
+                                    left: NormalizedValueRef::RowId(RowIdRef::Source(
+                                        root_source.clone(),
+                                    )),
+                                    op: ComparisonOp::Eq,
+                                    right: NormalizedValueRef::SourceField {
+                                        source: ordinary_source,
+                                        field: "todo".to_owned(),
+                                    },
+                                },
+                            },
+                        );
+                    }
+                    nodes
+                },
             },
             binding: ProgramBinding {
                 id: BindingId(uuid::Uuid::from_bytes([0x7a; 16])),
@@ -753,6 +824,16 @@ fn assert_current_join_via_union_relation_input(
             if fields.iter().any(|field| field.output_name == "__root_join_arm_0")
                 && fields.iter().any(|field| field.output_name == "__root_join_row_0")
     )));
+    if consecutive_inner_join {
+        assert!(graph_any(&membership.graph, &|graph| matches!(
+            graph,
+            GraphBuilder::Project { input, fields }
+                if fields.iter().any(|field| field.output_name == "__root_join_arm_0")
+                    && fields.iter().any(|field| field.output_name == "__root_join_row_0")
+                    && matches!(input.as_ref(), GraphBuilder::Join { right, .. }
+                        if !matches!(right.as_ref(), GraphBuilder::Union { .. }))
+        )));
+    }
 }
 
 #[test]

--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -534,6 +534,25 @@ fn current_join_via_lowers_as_left_deep_semijoin() {
 
 #[test]
 fn current_join_via_can_use_union_relation_input() {
+    assert_current_join_via_union_relation_input(
+        source("todo_tags", SourceRole::Policy("direct".to_owned())),
+        source("todo_tags", SourceRole::Policy("inherited".to_owned())),
+    );
+}
+
+/// A UNION may have a common aliased source even when each arm has different
+/// predicates. The root source is then available, but must not be mistaken
+/// for a non-union join occurrence.
+#[test]
+fn current_join_via_shared_alias_union_keeps_arm_and_row_carriers() {
+    let shared = source("todo_tags", SourceRole::Alias("policy_branch".to_owned()));
+    assert_current_join_via_union_relation_input(shared.clone(), shared);
+}
+
+fn assert_current_join_via_union_relation_input(
+    direct_source: SourceId,
+    inherited_source: SourceId,
+) {
     let root = RowSetNodeId("root".to_owned());
     let direct_source_node = RowSetNodeId("direct-source".to_owned());
     let direct_project = RowSetNodeId("direct-project".to_owned());
@@ -542,8 +561,6 @@ fn current_join_via_can_use_union_relation_input() {
     let union_node = RowSetNodeId("authorized-union".to_owned());
     let join_node = RowSetNodeId("join".to_owned());
     let root_source = source("todos", SourceRole::Root);
-    let direct_source = source("todo_tags", SourceRole::Policy("direct".to_owned()));
-    let inherited_source = source("todo_tags", SourceRole::Policy("inherited".to_owned()));
     let request = QueryProgramRequest {
         authorization_mode: QueryAuthorizationMode::TrustedServing,
         reads: QueryReadSet::primary(ReadView {


### PR DESCRIPTION
🤖 Reconstructs and supersedes #1888 directly atop #2045, preserving the original attributable commit without the obsolete historical stack mechanics.

## Before

A `RelationInputPlan::Union` whose arms shared the same aliased source could report that alias as its `root_source()`. Inner-join lowering then selected the ordinary-source path first and omitted the UNION `(arm, row)` occurrence pair, even though result-membership metadata requested `__root_join_arm_0` and `__root_join_row_0`. Downstream evaluation could fail with `graph field not found`.

## After

- Lowering recognizes a UNION before inspecting `root_source()`.
- It projects both hidden arm and row carrier fields and registers both in occurrence metadata.
- The ordinary source-root path remains the fallback for non-UNION inputs.

## Examples

- Direct and inherited UNION arms sharing the `todo_tags` alias now retain both arm and row identity.
- A heterogeneous UNION continues to retain the same carrier pair.
- An ordinary left-deep source-column semi-join keeps its existing source-row behavior.

## Invariant and non-goals

A public inner join to a UNION preserves its complete `(arm, row)` occurrence identity even when every arm shares an alias. Policy-proof and authorization subplans still omit public occurrence carriers. This does not change authorization semantics, alter #2045 correlated-inheritance behavior, or repair the separate browser/edge empty-workspace symptom tracked in #1871.

## Verification

- Shared-alias UNION, heterogeneous UNION, and ordinary left-deep join receipts passed.
- Planted unreachable UNION dispatch made the shared-alias receipt fail with both carrier fields missing; restoration passed.
- `cargo fmt --check` and `git diff --check` passed.

Original attribution is retained with a `-x` trailer for commit `43d1154dd`.
