### PR TITLE
Validate browser helper command contracts

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -135,6 +135,7 @@
     "typecheck:react-native": "tsc --project tsconfig.react-native-tests.json",
     "test:browser": "node ../../dev/artifacts/verify-correctness-test-artifacts.mjs && vitest run --config vitest.config.browser.ts",
     "test:browser:focused": "node scripts/test-browser-focused.mjs",
+    "typecheck:browser-helpers": "tsc --project tests/browser/tsconfig.browser-helpers.json",
     "test:browser:contract": "node scripts/test-browser-focused.test.mjs",
     "test:terminal-layout-contract": "vitest run --config vitest.config.ts src/runtime/terminal-layout-contract-matrix.test.ts --reporter=verbose --passWithNoTests=false",
     "bench:abstract:node": "JAZZ_ABSTRACT_BENCH=1 vitest run --config vitest.config.ts src/runtime/schema-marshalling.abstract-bench.test.ts",

--- a/packages/jazz-tools/tests/browser/browser-commands.ts
+++ b/packages/jazz-tools/tests/browser/browser-commands.ts
@@ -1,0 +1,67 @@
+import { commands } from "vitest/browser";
+
+import type { JazzServerInfo } from "./testing-server.js";
+
+export interface JazzServerBrowserCommands {
+  jazzServerInfo(appId?: string, schema?: number[]): Promise<JazzServerInfo>;
+  jazzServerBlockNetwork(serverUrl: string): Promise<void>;
+  jazzServerUnblockNetwork(serverUrl: string): Promise<void>;
+  jazzServerJwtForUser(
+    userId: string,
+    claims?: Record<string, unknown>,
+    appId?: string,
+  ): Promise<string>;
+}
+
+export interface JazzTopologyBrowserCommands {
+  jazzBrowserTopologyLog(
+    status: "start" | "complete" | "failed",
+    label: string,
+    elapsedMs: number,
+  ): Promise<void>;
+}
+
+function hasFunction(value: object, key: string): boolean {
+  return key in value && typeof Reflect.get(value, key) === "function";
+}
+
+function isJazzServerBrowserCommands(value: unknown): value is JazzServerBrowserCommands {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    hasFunction(value, "jazzServerInfo") &&
+    hasFunction(value, "jazzServerBlockNetwork") &&
+    hasFunction(value, "jazzServerUnblockNetwork") &&
+    hasFunction(value, "jazzServerJwtForUser")
+  );
+}
+
+function isJazzTopologyBrowserCommands(value: unknown): value is JazzTopologyBrowserCommands {
+  return (
+    typeof value === "object" && value !== null && hasFunction(value, "jazzBrowserTopologyLog")
+  );
+}
+
+/**
+ * Read the commands configured by the current browser-test project.
+ *
+ * Vitest's browser entrypoint re-exports commands through peer dependencies,
+ * so test helpers deliberately validate the runtime command contract instead
+ * of relying on ambient augmentation from a particular package installation.
+ */
+export function jazzServerBrowserCommands(): JazzServerBrowserCommands {
+  if (!isJazzServerBrowserCommands(commands)) {
+    throw new Error(
+      "Browser test project is missing Jazz server commands. Configure jazzServerInfo, " +
+        "jazzServerBlockNetwork, jazzServerUnblockNetwork, and jazzServerJwtForUser.",
+    );
+  }
+  return commands;
+}
+
+export function jazzTopologyBrowserCommands(): JazzTopologyBrowserCommands {
+  if (!isJazzTopologyBrowserCommands(commands)) {
+    throw new Error("Browser test project is missing the jazzBrowserTopologyLog command.");
+  }
+  return commands;
+}

--- a/packages/jazz-tools/tests/browser/browser-helpers.typecheck.ts
+++ b/packages/jazz-tools/tests/browser/browser-helpers.typecheck.ts
@@ -1,0 +1,13 @@
+import {
+  blockJazzServerNetwork,
+  getJazzServerInfo,
+  getJazzServerJwtForUser,
+  unblockJazzServerNetwork,
+} from "./testing-server.js";
+import { browserTopologyReporter } from "./topology-harness.js";
+
+void getJazzServerInfo;
+void getJazzServerJwtForUser;
+void blockJazzServerNetwork;
+void unblockJazzServerNetwork;
+void browserTopologyReporter;

--- a/packages/jazz-tools/tests/browser/testing-server.ts
+++ b/packages/jazz-tools/tests/browser/testing-server.ts
@@ -1,4 +1,4 @@
-import { commands } from "vitest/browser";
+import { jazzServerBrowserCommands } from "./browser-commands.js";
 
 export interface JazzServerInfo {
   appId: string;
@@ -13,29 +13,16 @@ export interface JazzServerNetworkDebugState {
   activePatterns: string[];
 }
 
-declare module "vitest/internal/browser" {
-  interface BrowserCommands {
-    jazzServerInfo: (appId?: string, schema?: number[]) => Promise<JazzServerInfo>;
-    jazzServerBlockNetwork: (serverUrl: string) => Promise<void>;
-    jazzServerUnblockNetwork: (serverUrl: string) => Promise<void>;
-    jazzServerJwtForUser: (
-      userId: string,
-      claims?: Record<string, unknown>,
-      appId?: string,
-    ) => Promise<string>;
-  }
-}
-
 export function getJazzServerInfo(appId?: string, schema?: Uint8Array): Promise<JazzServerInfo> {
-  return commands.jazzServerInfo(appId, schema ? [...schema] : undefined);
+  return jazzServerBrowserCommands().jazzServerInfo(appId, schema ? [...schema] : undefined);
 }
 
 export function blockJazzServerNetwork(serverUrl: string): Promise<void> {
-  return commands.jazzServerBlockNetwork(serverUrl);
+  return jazzServerBrowserCommands().jazzServerBlockNetwork(serverUrl);
 }
 
 export function unblockJazzServerNetwork(serverUrl: string): Promise<void> {
-  return commands.jazzServerUnblockNetwork(serverUrl);
+  return jazzServerBrowserCommands().jazzServerUnblockNetwork(serverUrl);
 }
 
 export async function getJazzServerJwtForUser(
@@ -43,5 +30,5 @@ export async function getJazzServerJwtForUser(
   claims?: Record<string, unknown>,
   appId?: string,
 ): Promise<string> {
-  return commands.jazzServerJwtForUser(userId, claims, appId);
+  return jazzServerBrowserCommands().jazzServerJwtForUser(userId, claims, appId);
 }

--- a/packages/jazz-tools/tests/browser/topology-harness.ts
+++ b/packages/jazz-tools/tests/browser/topology-harness.ts
@@ -1,21 +1,13 @@
-import { commands } from "vitest/browser";
+import { jazzTopologyBrowserCommands } from "./browser-commands.js";
 import type { TopologyReporter } from "../topology/harness.js";
 export * from "../topology/harness.js";
-
-declare module "vitest/internal/browser" {
-  interface BrowserCommands {
-    jazzBrowserTopologyLog: (
-      status: "start" | "complete" | "failed",
-      label: string,
-      elapsedMs: number,
-    ) => Promise<void>;
-  }
-}
 
 /** Reporter which mirrors browser lifecycle phases to the Node test process. */
 export const browserTopologyReporter: TopologyReporter = {
   phase(status, label, elapsedMs) {
     console.info(`[jazz-browser-topology] ${status} ${label} (${elapsedMs}ms)`);
-    void commands.jazzBrowserTopologyLog(status, label, elapsedMs).catch(() => undefined);
+    void jazzTopologyBrowserCommands()
+      .jazzBrowserTopologyLog(status, label, elapsedMs)
+      .catch(() => undefined);
   },
 };

--- a/packages/jazz-tools/tests/browser/tsconfig.browser-helpers.json
+++ b/packages/jazz-tools/tests/browser/tsconfig.browser-helpers.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "files": [
+    "browser-commands.ts",
+    "testing-server.ts",
+    "topology-harness.ts",
+    "browser-helpers.typecheck.ts"
+  ]
+}


### PR DESCRIPTION
🤖 Reconstructs and supersedes #1902 atop #2046, preserving the original attributable browser-command contract while omitting unrelated historical topology-harness mechanics.

## Before

Browser helpers ambient-augmented `vitest/internal/browser`. A peer instance could satisfy that type augmentation even when the actual browser project had not registered the corresponding handler, so code compiled and later failed with `commands.<name> is not a function`.

## After

- Server and topology helpers use explicit command interfaces.
- Each adapter validates the runtime `vitest/browser` proxy before invoking it.
- A dedicated browser-helper TypeScript project checks both helper families against their configured surfaces.
- Application Vitest configs remain responsible for registering the handlers they use.

## Examples

- A configured Jazz browser project exposes `jazzServerInfo`, JWT, block/unblock, and topology-log commands through typed adapters.
- A project missing `jazzServerJwtForUser` now fails immediately at the helper boundary with “Browser test project is missing Jazz server commands…” rather than an indirect missing-function error later.

## Invariant and non-goals

A helper may call only a fully configured command surface belonging to its current browser-test project. This does not change Jazz runtime semantics, add handlers automatically, define a generic remote-browser protocol, or restore unrelated scheduler/envelope changes from the old stack.

## Verification

- Browser-helper TypeScript project passed.
- Browser contract suite: 8/8 passed.
- A temporary proxy-only browser probe passed with full configuration; renaming one configured command failed with the new direct boundary error, then restoration passed.
- Formatting, lint, diff, and sensitive-data checks passed.

Original attribution is retained with a `-x` trailer for commit `40f7e7bba`.
