### PR TITLE
Retain complete scans for disjunctive policy proofs

### DIFF
--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -932,6 +932,179 @@ fn db_sync_surface_edge_session_read_policy_filters_private_table_query() {
     assert!(prepared_all(&reader, &query, edge_subscribe_opts()).is_empty());
 }
 
+/// A real client commonly reads its self-membership grant before querying the
+/// resource that grant authorizes. The second subscription must publish a
+/// result membership even when the first subscription already delivered the
+/// resource as policy support.
+fn membership_grant_then_parent_query_keeps_disjunctive_read_proof(indexed: bool) {
+    let member_exists = public_exists(
+        "members",
+        [
+            public_outer_eq("workspace_id", "id"),
+            public_session_eq("subject", &["claims", "user_id"]),
+        ],
+    );
+    let workspaces = PublicTableSchemaBuilder::new("workspaces")
+        .column("owner_subject", PublicColumnType::Text)
+        .policies(
+            PublicTablePolicies::new()
+                .with_select(PublicPolicyExpr::Or(vec![
+                    public_session_eq("owner_subject", &["claims", "user_id"]),
+                    member_exists,
+                ]))
+                .with_insert(PublicPolicyExpr::True),
+        );
+    let members = PublicTableSchemaBuilder::new("members")
+        .fk_column("workspace_id", "workspaces")
+        .column("subject", PublicColumnType::Text)
+        .column("role", PublicColumnType::Text)
+        .policies(
+            PublicTablePolicies::new()
+                .with_select(PublicPolicyExpr::Or(vec![
+                    public_session_eq("subject", &["claims", "user_id"]),
+                    PublicPolicyExpr::Inherits {
+                        operation: PublicOperation::Select,
+                        via_column: "workspace_id".to_owned(),
+                        max_depth: None,
+                    },
+                ]))
+                .with_insert(PublicPolicyExpr::True),
+        );
+    let workspaces = if indexed {
+        workspaces.index_only(["owner_subject"])
+    } else {
+        workspaces
+    };
+    let members = if indexed {
+        members.index_only(["workspace_id", "subject", "role"])
+    } else {
+        members
+    };
+    let schema =
+        build_public_db_test_schema(PublicSchemaBuilder::new().table(workspaces).table(members));
+    let manager = AuthorSubject::for_test_bytes([0xa1; 16]);
+    let owner = AuthorSubject::for_test_bytes([0xb2; 16]);
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0xa1, manager, &schema);
+    let owner_client = open_db(0xb2, owner, &schema);
+    let (owner_transport, server_owner_transport) = duplex();
+    let _owner_upstream = crate::db::block_on(owner_client.connect_upstream(owner_transport));
+    let _owner_subscriber = server.accept_subscriber_with_claims(
+        server_owner_transport,
+        owner,
+        BTreeMap::from([(
+            "user_id".to_owned(),
+            Value::String(owner.test_uuid().to_string()),
+        )]),
+    );
+    let (client_transport, server_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber_with_claims(
+        server_transport,
+        manager,
+        BTreeMap::from([(
+            "user_id".to_owned(),
+            Value::String(manager.test_uuid().to_string()),
+        )]),
+    );
+    let workspace = owner_client
+        .insert(
+            "workspaces",
+            BTreeMap::from([(
+                "owner_subject".to_owned(),
+                Value::String(owner.test_uuid().to_string()),
+            )]),
+            Default::default(),
+        )
+        .unwrap();
+    let grant = owner_client
+        .insert(
+            "members",
+            BTreeMap::from([
+                (
+                    "workspace_id".to_owned(),
+                    Value::Uuid(workspace.row_uuid().0),
+                ),
+                (
+                    "subject".to_owned(),
+                    Value::String(manager.test_uuid().to_string()),
+                ),
+                ("role".to_owned(), Value::String("member".to_owned())),
+            ]),
+            Default::default(),
+        )
+        .unwrap();
+    for _ in 0..16 {
+        owner_client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        if server.read(&server.table("members")).unwrap().len() == 1 {
+            break;
+        }
+    }
+    assert_eq!(server.read(&server.table("workspaces")).unwrap().len(), 1);
+    assert_eq!(server.read(&server.table("members")).unwrap().len(), 1);
+    let grant_query =
+        Query::from("members").filter(eq(col("id"), lit(Value::Uuid(grant.row_uuid().0))));
+    let mut grant_subscription =
+        prepared_subscribe(&client, &grant_query, edge_subscribe_opts()).unwrap();
+    for _ in 0..16 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        if !prepared_all(&client, &grant_query, edge_subscribe_opts()).is_empty() {
+            break;
+        }
+    }
+    if indexed {
+        assert_eq!(
+            server
+                .node()
+                .borrow()
+                .query_engine_read_metrics()
+                .source_index_probes,
+            0,
+            "the disjunctive policy must retain a complete source path",
+        );
+    }
+    assert_eq!(
+        prepared_all(&client, &grant_query, edge_subscribe_opts()).len(),
+        1
+    );
+    while grant_subscription.try_next_event().is_some() {}
+
+    let workspace_query =
+        Query::from("workspaces").filter(eq(col("id"), lit(Value::Uuid(workspace.row_uuid().0))));
+    let mut workspace_subscription =
+        prepared_subscribe(&client, &workspace_query, edge_subscribe_opts()).unwrap();
+    for _ in 0..16 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        if !prepared_all(&client, &workspace_query, edge_subscribe_opts()).is_empty() {
+            break;
+        }
+    }
+    assert_eq!(
+        prepared_all(&client, &workspace_query, edge_subscribe_opts())
+            .iter()
+            .map(CurrentRow::row_uuid)
+            .collect::<Vec<_>>(),
+        vec![workspace.row_uuid()],
+    );
+    assert!(workspace_subscription.try_next_event().is_some());
+}
+
+#[test]
+fn db_sync_surface_membership_grant_then_parent_query_keeps_disjunctive_read_proof() {
+    membership_grant_then_parent_query_keeps_disjunctive_read_proof(false);
+}
+
+#[test]
+fn db_sync_surface_indexed_membership_grant_then_parent_query_keeps_disjunctive_read_proof() {
+    membership_grant_then_parent_query_keeps_disjunctive_read_proof(true);
+}
+
 /// A prepared trusted-serving read binds each request session's text `user_id`
 /// independently: Alice receives her seeded message while Bob receives none.
 ///

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -2807,6 +2807,23 @@ where
         &self,
         request: &QueryProgramRequest,
     ) -> Result<BTreeMap<SourceId, CurrentAccessPath>, Error> {
+        // A policy proof may contain both an owner arm and a correlated
+        // membership arm for the same protected source. Walking its nested
+        // nodes independently would see the owner's claim equality and apply
+        // that index path to the entire union, incorrectly excluding rows
+        // that only the membership arm authorizes. The small planner does not
+        // prove per-arm coverage, so any alternative or relational proof
+        // retains full source scans.
+        if request.input.shape.nodes.values().any(|node| {
+            matches!(
+                node,
+                RowSetExpr::Union { .. }
+                    | RowSetExpr::Join { .. }
+                    | RowSetExpr::RecursiveRelation { .. }
+            )
+        }) {
+            return Ok(BTreeMap::new());
+        }
         self.normalized_program_access_paths(
             &request.input,
             &request.reads.primary,


### PR DESCRIPTION
🤖 Reconstructs and supersedes #1903 atop #2048, retaining the deterministic authorization-planning fix and original attribution while omitting obsolete historical browser/stack mechanics.

## Before

Policy-proof access-path derivation walked every normalized node. An owner equality found in one UNION arm could narrow the protected source for all arms, even though another membership/EXISTS arm authorized different rows. A non-owner member could therefore be excluded only when the relevant indexes existed.

## After

- A proof program containing `Union`, `Join`, or `RecursiveRelation` advertises no derived current-source access path.
- The already-lowered authorization graph evaluates those alternative/relational proofs against a complete source scan.
- Simple conjunctive scalar proofs continue using sound indexes.

## Examples

- A manager receives self-membership and queries a workspace authorized through membership EXISTS. Indexed and unindexed schemas now return the same workspace.
- The owner equality from a different UNION arm is no longer treated as globally valid for the membership arm.
- A simple indexed conjunctive read policy still probes its index and retains its final policy predicate.

## Invariant and non-goals

Under INV-LOWER-22, an authorization access path may narrow the protected source only when it is sound for every proof route. This does not alter authorization predicates/evaluation, ordinary query planning, ordering/bounds, or introduce a per-arm optimizer.

## Verification

- Unindexed membership delivery receipt passed.
- Indexed membership receipt passed and recorded zero unsound source probes.
- Existing indexed conjunctive-policy receipt passed.
- Planted removal of the relational bailout produced 10 probes where zero are required; restoration passed.
- Formatting, Clippy, diff, and sensitive-data checks passed.

Original attribution is retained with `-x` trailers for commits `84df02049`, `18522c626`, and `52b9d6298`.
