### PR TITLE
Export generated NAPI JsonValue type

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -191,6 +191,17 @@ export interface InsertOptions {
   updatedAtMs?: number
 }
 
+/**
+ * Any JSON-compatible value crossing the native JavaScript boundary.
+ *
+ * Keep this alias exported through napi-rs rather than relying on its Rust
+ * import name: exported methods use `JsonValue` throughout their generated
+ * declarations, so the package must define that name for TypeScript
+ * consumers.
+ */
+export type JsonValue =
+  any
+
 export declare function mintLocalFirstToken(seedB64: string, audience: string, ttlSeconds: number): string
 
 /** Exact build/ABI fingerprint for the generated native artifact. */

--- a/crates/jazz-napi/package.json
+++ b/crates/jazz-napi/package.json
@@ -36,10 +36,13 @@
     "build": "node scripts/build.js",
     "build:debug": "node scripts/build.js --debug",
     "build:perf": "node scripts/build.js --profile perf",
-    "build:perf:sccache": "RUSTC_WRAPPER=sccache node scripts/build.js --profile perf"
+    "build:perf:sccache": "RUSTC_WRAPPER=sccache node scripts/build.js --profile perf",
+    "test": "pnpm typecheck:consumer",
+    "typecheck:consumer": "tsc --project tests/types/tsconfig.json"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3"
+    "@napi-rs/cli": "^3",
+    "@types/node": "catalog:default"
   },
   "napi": {
     "binaryName": "jazz-napi",

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -32,7 +32,14 @@ use napi::sys;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
+/// Any JSON-compatible value crossing the native JavaScript boundary.
+///
+/// Keep this alias exported through napi-rs rather than relying on its Rust
+/// import name: exported methods use `JsonValue` throughout their generated
+/// declarations, so the package must define that name for TypeScript
+/// consumers.
+#[napi]
+pub type JsonValue = serde_json::Value;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::future::Future;

--- a/crates/jazz-napi/tests/types/package-consumer.ts
+++ b/crates/jazz-napi/tests/types/package-consumer.ts
@@ -1,0 +1,12 @@
+import { NapiDb, type JsonValue } from "jazz-napi";
+
+const branch: JsonValue = {
+  name: "draft",
+  parents: ["main"],
+  archived: false,
+};
+
+declare const db: NapiDb;
+declare const encodedRow: Uint8Array;
+
+db.insertEncoded("documents", encodedRow, { branch });

--- a/crates/jazz-napi/tests/types/tsconfig.json
+++ b/crates/jazz-napi/tests/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["package-consumer.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,10 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3
-        version: 3.5.1(@emnapi/runtime@1.8.1)(@types/node@25.6.0)
+        version: 3.5.1(@emnapi/runtime@1.8.1)(@types/node@22.19.13)
+      '@types/node':
+        specifier: catalog:default
+        version: 22.19.13
 
   crates/jazz-rn:
     dependencies:
@@ -15558,14 +15561,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/checkbox@5.1.0(@types/node@25.6.0)':
+  '@inquirer/checkbox@5.1.0(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/confirm@5.1.21(@types/node@25.6.0)':
     dependencies:
@@ -15574,12 +15577,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/confirm@6.0.8(@types/node@25.6.0)':
+  '@inquirer/confirm@6.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/core@10.3.2(@types/node@25.6.0)':
     dependencies:
@@ -15594,17 +15597,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/core@11.1.5(@types/node@25.6.0)':
+  '@inquirer/core@11.1.5(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/editor@4.2.23(@types/node@25.6.0)':
     dependencies:
@@ -15614,13 +15617,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/editor@5.0.8(@types/node@25.6.0)':
+  '@inquirer/editor@5.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/external-editor': 2.0.3(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/expand@4.0.23(@types/node@25.6.0)':
     dependencies:
@@ -15630,12 +15633,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/expand@5.0.8(@types/node@25.6.0)':
+  '@inquirer/expand@5.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
     dependencies:
@@ -15644,12 +15647,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/external-editor@2.0.3(@types/node@25.6.0)':
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.13)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/figures@1.0.15': {}
 
@@ -15662,12 +15665,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/input@5.0.8(@types/node@25.6.0)':
+  '@inquirer/input@5.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/number@3.0.23(@types/node@25.6.0)':
     dependencies:
@@ -15676,12 +15679,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/number@4.0.8(@types/node@25.6.0)':
+  '@inquirer/number@4.0.8(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/password@4.0.23(@types/node@25.6.0)':
     dependencies:
@@ -15691,13 +15694,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/password@5.0.8(@types/node@25.6.0)':
+  '@inquirer/password@5.0.8(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/prompts@7.10.1(@types/node@25.6.0)':
     dependencies:
@@ -15714,20 +15717,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/prompts@8.3.0(@types/node@25.6.0)':
+  '@inquirer/prompts@8.3.0(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/checkbox': 5.1.0(@types/node@25.6.0)
-      '@inquirer/confirm': 6.0.8(@types/node@25.6.0)
-      '@inquirer/editor': 5.0.8(@types/node@25.6.0)
-      '@inquirer/expand': 5.0.8(@types/node@25.6.0)
-      '@inquirer/input': 5.0.8(@types/node@25.6.0)
-      '@inquirer/number': 4.0.8(@types/node@25.6.0)
-      '@inquirer/password': 5.0.8(@types/node@25.6.0)
-      '@inquirer/rawlist': 5.2.4(@types/node@25.6.0)
-      '@inquirer/search': 4.1.4(@types/node@25.6.0)
-      '@inquirer/select': 5.1.0(@types/node@25.6.0)
+      '@inquirer/checkbox': 5.1.0(@types/node@22.19.13)
+      '@inquirer/confirm': 6.0.8(@types/node@22.19.13)
+      '@inquirer/editor': 5.0.8(@types/node@22.19.13)
+      '@inquirer/expand': 5.0.8(@types/node@22.19.13)
+      '@inquirer/input': 5.0.8(@types/node@22.19.13)
+      '@inquirer/number': 4.0.8(@types/node@22.19.13)
+      '@inquirer/password': 5.0.8(@types/node@22.19.13)
+      '@inquirer/rawlist': 5.2.4(@types/node@22.19.13)
+      '@inquirer/search': 4.1.4(@types/node@22.19.13)
+      '@inquirer/select': 5.1.0(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/rawlist@4.1.11(@types/node@25.6.0)':
     dependencies:
@@ -15737,12 +15740,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/rawlist@5.2.4(@types/node@25.6.0)':
+  '@inquirer/rawlist@5.2.4(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/search@3.2.2(@types/node@25.6.0)':
     dependencies:
@@ -15753,13 +15756,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/search@4.1.4(@types/node@25.6.0)':
+  '@inquirer/search@4.1.4(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/select@4.4.2(@types/node@25.6.0)':
     dependencies:
@@ -15771,22 +15774,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/select@5.1.0(@types/node@25.6.0)':
+  '@inquirer/select@5.1.0(@types/node@22.19.13)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@25.6.0)
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@25.6.0)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@inquirer/type@3.0.10(@types/node@25.6.0)':
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/type@4.0.3(@types/node@25.6.0)':
+  '@inquirer/type@4.0.3(@types/node@22.19.13)':
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.13
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -16056,9 +16059,9 @@ snapshots:
 
   '@multiavatar/multiavatar@1.0.7': {}
 
-  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.8.1)(@types/node@25.6.0)':
+  '@napi-rs/cli@3.5.1(@emnapi/runtime@1.8.1)(@types/node@22.19.13)':
     dependencies:
-      '@inquirer/prompts': 8.3.0(@types/node@25.6.0)
+      '@inquirer/prompts': 8.3.0(@types/node@22.19.13)
       '@napi-rs/cross-toolchain': 1.0.3
       '@napi-rs/wasm-tools': 1.0.1
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
🤖 Reconstructs and supersedes #1934 atop #2049, preserving the still-live generated NAPI type export while adapting its consumer receipt to the current branch API.

## Before

Generated `index.d.ts` referenced `JsonValue` in multiple public signatures but did not declare or export it because Rust kept the alias as a private import. A direct package consumer could neither import `JsonValue` nor typecheck APIs such as `InsertOptions.branch` without undeclared-name errors.

## After

- `#[napi] pub type JsonValue = serde_json::Value` generates an exported `JsonValue = any` alias.
- `jazz-napi` declares its own Node type dependency for generated `Buffer` references.
- A package-name consumer typechecks a JSON branch passed through the current `db.insertEncoded(..., { branch })` API.

## Examples

- A consumer imports `NapiDb` and `JsonValue`, constructs `{ name: "draft", parents: ["main"], archived: false }`, and passes it as the branch option.
- Removing only the generated alias produces both “no exported member `JsonValue`” and internal undeclared-`JsonValue` diagnostics.

## Invariant and non-goals

Every type named by the generated public declaration is self-contained and exportable by package consumers. Raw NAPI JSON remains `any` at this boundary. This does not change runtime JSON conversion, validation, storage, branch authorization, or higher-level Jazz types.

## Verification

- Package consumer typecheck passed.
- Planted alias removal failed with the expected export/undeclared diagnostics; restoration passed.
- NAPI build contract: 8/8 passed.
- Rust formatting, staged Clippy, diff, and sensitive-data checks passed.

The historical branch-specific insert call was intentionally replaced by the current equivalent API. Fresh declaration regeneration is left to canonical CI because the local disposable generation build was interrupted by shared native-build pressure.
