### PR TITLE
Isolate broker worker bundle test outputs

### DIFF
--- a/packages/jazz-tools/scripts/bundle-broker-worker.mjs
+++ b/packages/jazz-tools/scripts/bundle-broker-worker.mjs
@@ -3,40 +3,91 @@
 // not reliably discover and bundle its imports themselves.
 import { build } from "esbuild";
 import { existsSync } from "node:fs";
-import { copyFile, readFile, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertWasmGlueInstantiates } from "../../../dev/artifacts/wasm-glue-abi.mjs";
 
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 const entry = fileURLToPath(new URL("../src/worker/jazz-broker-worker.ts", import.meta.url));
-const outfile = fileURLToPath(new URL("../dist/worker/jazz-broker-worker.js", import.meta.url));
+const canonicalOutputDir = fileURLToPath(new URL("../dist/worker", import.meta.url));
 const wasmSource = fileURLToPath(
   new URL("../../../crates/jazz-wasm/pkg/jazz_wasm_bg.wasm", import.meta.url),
 );
-const wasmOutfile = fileURLToPath(new URL("../dist/worker/jazz_wasm_bg.wasm", import.meta.url));
 
-await build({
-  entryPoints: [entry],
-  outfile,
-  bundle: true,
-  format: "esm",
-  platform: "browser",
-  target: "es2022",
-  legalComments: "none",
-});
+export function brokerWorkerOutputDir(args = process.argv.slice(2)) {
+  if (args.length === 0) return canonicalOutputDir;
+  if (args.length === 2 && args[0] === "--out-dir" && args[1]) return resolve(packageRoot, args[1]);
+  throw new Error("Usage: node scripts/bundle-broker-worker.mjs [--out-dir directory]");
+}
 
-// `runtimeSources.wasmUrl` can deliberately point a worker at a package-level
-// asset. Refuse to publish a worker whose embedded wasm-bindgen glue cannot
-// instantiate the binary it is built alongside: the browser otherwise reports
-// an opaque missing-import error only after the SharedWorker has started.
-await assertWasmGlueInstantiates(await readFile(wasmSource), await readFile(outfile, "utf8"));
+function assertOutputMayBePublished(outputDir) {
+  // The CI parent publishes this directory before it starts concurrent suites.
+  // A test that needs to exercise bundling must use its own output directory:
+  // overwriting the public one makes a browser fetch observe a missing or
+  // partially copied .wasm file even though the preflight was initially valid.
+  if (
+    process.env.JAZZ_TEST_SEALED_TOOLS_DIST === "1" &&
+    resolve(outputDir) === resolve(canonicalOutputDir)
+  )
+    throw new Error(
+      "jazz-tools worker output is sealed for concurrent tests; bundle into a private --out-dir",
+    );
+}
 
-// The worker bundles wasm-bindgen's JS glue. Its default initializer resolves
-// `jazz_wasm_bg.wasm` relative to that glue, which esbuild places in this
-// worker bundle. Keep the binary beside the shipped worker so every consumer
-// bundler sees one complete, package-owned worker artifact; applications do
-// not need to copy Jazz assets into their own public directory.
-await copyFile(wasmSource, wasmOutfile);
+export async function bundleBrokerWorker(outputDir = canonicalOutputDir) {
+  assertOutputMayBePublished(outputDir);
+  await mkdir(outputDir, { recursive: true });
+  // Prepare the complete pair privately. Publication below only renames fully
+  // written files, so even an ordinary (unsealed) rebuild cannot expose a
+  // truncated WebAssembly response to a server that opens the final filename.
+  const staging = await mkdtemp(resolve(outputDir, ".broker-worker-stage-"));
+  const stagedWorker = resolve(staging, "jazz-broker-worker.js");
+  const stagedWasm = resolve(staging, "jazz_wasm_bg.wasm");
+  const outfile = resolve(outputDir, "jazz-broker-worker.js");
+  const wasmOutfile = resolve(outputDir, "jazz_wasm_bg.wasm");
+  try {
+    await build({
+      entryPoints: [entry],
+      outfile: stagedWorker,
+      bundle: true,
+      format: "esm",
+      platform: "browser",
+      target: "es2022",
+      legalComments: "none",
+    });
 
-for (const stale of [`${outfile}.map`, outfile.replace(/\.js$/, ".ts")]) {
-  if (existsSync(stale)) await rm(stale);
+    // `runtimeSources.wasmUrl` can deliberately point a worker at a package-level
+    // asset. Refuse to publish a worker whose embedded wasm-bindgen glue cannot
+    // instantiate the binary it is built alongside: the browser otherwise reports
+    // an opaque missing-import error only after the SharedWorker has started.
+    await assertWasmGlueInstantiates(
+      await readFile(wasmSource),
+      await readFile(stagedWorker, "utf8"),
+    );
+
+    // The worker bundles wasm-bindgen's JS glue. Its default initializer resolves
+    // `jazz_wasm_bg.wasm` relative to that glue, which esbuild places in this
+    // worker bundle. Keep the binary beside the shipped worker so every consumer
+    // bundler sees one complete, package-owned worker artifact; applications do
+    // not need to copy Jazz assets into their own public directory.
+    await copyFile(wasmSource, stagedWasm);
+    await rename(stagedWorker, outfile);
+    await rename(stagedWasm, wasmOutfile);
+
+    for (const stale of [`${outfile}.map`, outfile.replace(/\.js$/, ".ts")]) {
+      if (existsSync(stale)) await rm(stale);
+    }
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await bundleBrokerWorker(brokerWorkerOutputDir());
+  } catch (error) {
+    console.error(`Broker worker bundle: ${error.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
+++ b/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { execFile } from "node:child_process";
-import { access, readFile, rm, stat } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -12,28 +14,47 @@ describe("broker worker packaging", () => {
     const bundleScript = fileURLToPath(
       new URL("../../scripts/bundle-broker-worker.mjs", import.meta.url),
     );
-    const outfile = fileURLToPath(
-      new URL("../../dist/worker/jazz-broker-worker.js", import.meta.url),
-    );
-    const wasmOutfile = fileURLToPath(
-      new URL("../../dist/worker/jazz_wasm_bg.wasm", import.meta.url),
-    );
+    const outputDir = await mkdtemp(join(tmpdir(), "jazz-broker-worker-bundle-"));
+    const outfile = join(outputDir, "jazz-broker-worker.js");
+    const wasmOutfile = join(outputDir, "jazz_wasm_bg.wasm");
     const pkgPath = fileURLToPath(new URL("../../package.json", import.meta.url));
     const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
     expect(pkg.scripts["build:runtime"]).toContain("bundle-broker-worker");
 
-    // Delete the pre-existing build output so a no-op or broken script cannot
-    // false-green by inspecting an artifact produced by an earlier command.
-    await Promise.all([rm(outfile, { force: true }), rm(wasmOutfile, { force: true })]);
-    await execFileAsync(process.execPath, [bundleScript], { cwd: packageRoot });
+    try {
+      // Tests must not regenerate the public worker: TypeScript CI starts its
+      // browser consumers alongside this node suite. A private output also
+      // ensures this remains a genuine bundling receipt rather than inspecting
+      // a prior package build.
+      await execFileAsync(process.execPath, [bundleScript, "--out-dir", outputDir], {
+        cwd: packageRoot,
+      });
 
-    const source = await readFile(outfile, "utf8");
-    // Consumer bundlers copy this indirectly constructed SharedWorker URL
-    // verbatim, so any remaining relative import would 404 in production.
-    expect(source).not.toMatch(/\bfrom\s*["']\.\.?\//);
-    expect(source).not.toMatch(/\bimport\s*\(\s*["']\.\.?\//);
-    expect(source).toMatch(/onconnect/);
-    await expect(access(wasmOutfile)).resolves.toBeUndefined();
-    expect((await stat(wasmOutfile)).size).toBeGreaterThan(0);
+      const source = await readFile(outfile, "utf8");
+      // Consumer bundlers copy this indirectly constructed SharedWorker URL
+      // verbatim, so any remaining relative import would 404 in production.
+      expect(source).not.toMatch(/\bfrom\s*["']\.\.?\//);
+      expect(source).not.toMatch(/\bimport\s*\(\s*["']\.\.?\//);
+      expect(source).toMatch(/onconnect/);
+      await expect(access(wasmOutfile)).resolves.toBeUndefined();
+      expect((await stat(wasmOutfile)).size).toBeGreaterThan(0);
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a test child attempting to replace the sealed public worker", async () => {
+    const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const bundleScript = fileURLToPath(
+      new URL("../../scripts/bundle-broker-worker.mjs", import.meta.url),
+    );
+    await expect(
+      execFileAsync(process.execPath, [bundleScript], {
+        cwd: packageRoot,
+        env: { ...process.env, JAZZ_TEST_SEALED_TOOLS_DIST: "1" },
+      }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("worker output is sealed for concurrent tests"),
+    });
   });
 });


### PR DESCRIPTION
🤖 Prevents broker-worker bundle receipts from corrupting the canonical WASM/JS artifacts consumed concurrently by other CI suites.

## Before

`broker-worker-bundle.test.ts` deleted and regenerated `packages/jazz-tools/dist/worker` while the TypeScript CI partition ran browser and example suites in parallel. Those consumers could pass artifact preflight and then read the pair mid-replacement. Observed failures included:

- an HTML document where WASM magic bytes were expected;
- a truncated module whose code section extended past the remaining bytes;
- the failing example changing between identical reruns.

## After

- The bundle receipt writes only to a private output directory.
- Concurrent/sealed test mode rejects attempts to publish into canonical `dist/worker`.
- Real publication stages the JS/WASM outputs before atomically replacing each final filename.
- A negative receipt protects the sealed-output boundary.

## Examples

- Browser/example suites may consume the canonical worker pair while the bundle receipt runs without either process mutating the other's files.
- An accidental test invocation targeting canonical `dist/worker` now fails before deletion or generation.
- Production artifact generation still publishes the completed staged outputs to their canonical filenames.

## Unchanged

The worker bundle contents, ABI, runtime loading behavior, and freshness fingerprint contract are unchanged; only publication/isolation mechanics change.

## Verification

- Focused broker-worker bundle receipts: 2 passed.
- Artifact-pipeline gate receipts: 17 passed.
- Planted removal of the sealed-output guard made the negative receipt fail; restoration passed.
- Formatting, diff, pre-commit, and sensitive-data checks passed.

This addresses the repeated CI failures seen while validating #1985, #2011, #2048, and #2050.
