### PR TITLE
Remove deprecated migration collector API

### DIFF
--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { StandardJSONSchemaV1 } from "@standard-schema/spec";
-import {
-  col,
-  getCollectedMigration,
-  getCollectedSchema,
-  migrate,
-  resetCollectedState,
-  table,
-} from "./dsl.js";
+import { col, getCollectedSchema, resetCollectedState, table } from "./dsl.js";
 import { schemaToWasm } from "./codegen/schema-reader.js";
 import { structuralSchemaHash } from "./dev/schema-utils.js";
 import type { AddOp } from "./schema.js";
@@ -411,35 +404,5 @@ describe("reserved magic-column namespace", () => {
         $canRead: col.boolean(),
       }),
     ).toThrow(/reserved for magic columns/i);
-  });
-
-  it("rejects introduced migration columns starting with $", () => {
-    resetCollectedState();
-    expect(() =>
-      migrate("todos", {
-        $canRead: col.add.boolean({ default: false }),
-      }),
-    ).toThrow(/reserved for magic columns/i);
-  });
-
-  it("allows dropping legacy $-prefixed columns", () => {
-    resetCollectedState();
-    expect(() =>
-      migrate("todos", {
-        $legacy: col.drop.boolean({ backwardsDefault: false }),
-      }),
-    ).not.toThrow();
-
-    expect(getCollectedMigration()).toEqual({
-      table: "todos",
-      operations: [
-        {
-          type: "drop",
-          column: "$legacy",
-          sqlType: "BOOLEAN",
-          value: false,
-        },
-      ],
-    });
   });
 });

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -13,13 +13,9 @@ import type {
   JsonSqlType,
   JsonSchema,
   JsonValue,
-  Lens,
-  LensOp,
   AddOp,
   DropOp,
   RenameOp,
-  MigrationOp,
-  TableMigration,
   ScalarSqlType,
   TSTypeFromSqlType,
 } from "./schema.js";
@@ -957,11 +953,6 @@ export const col = {
   drop: new DropBuilder(),
   /**
    * Rename a column in the table
-   * @deprecated Use {@link col.renameFrom} instead
-   */
-  rename: (oldName: string): RenameOp => ({ _type: "rename", oldName }),
-  /**
-   * Rename a column in the table
    */
   renameFrom: <const TOldName extends string>(oldName: TOldName): RenameOp<TOldName> => ({
     _type: "rename",
@@ -970,11 +961,10 @@ export const col = {
 };
 
 // ============================================================================
-// Side-effect collection
+// Schema side-effect collection
 // ============================================================================
 
 let collectedTables: Table[] = [];
-let collectedMigrations: TableMigration[] = [];
 
 type ScalarIdColumnError<K extends string> =
   `Invalid reference key '${K}'. Rename it to '${K}_id' or '${K}Id'`;
@@ -1019,81 +1009,12 @@ export function table<const T extends Record<string, ColumnBuilder>>(
   });
 }
 
-export function migrate(tableName: string, ops: Record<string, MigrationOp>): void {
-  const operations = Object.entries(ops).map(([column, op]) => {
-    if (op._type !== "drop") {
-      assertUserColumnNameAllowed(column);
-    }
-    return { column, op };
-  });
-  collectedMigrations.push({ table: tableName, operations });
-}
-
 export function getCollectedSchema(): Schema {
   const schema = { tables: [...collectedTables] };
   collectedTables = [];
   return schema;
 }
 
-export function getCollectedMigration(): Lens | null {
-  const migration = collectedMigrations.shift();
-  if (!migration) {
-    return null;
-  }
-
-  const operations: LensOp[] = migration.operations.map(({ column, op }) => {
-    switch (op._type) {
-      case "add":
-        return {
-          type: "introduce" as const,
-          column,
-          sqlType: op.sqlType,
-          value: op.default,
-        };
-      case "drop":
-        return {
-          type: "drop" as const,
-          column,
-          sqlType: op.sqlType,
-          value: op.backwardsDefault,
-        };
-      case "rename":
-        return { type: "rename" as const, column, value: op.oldName };
-    }
-  });
-
-  return { table: migration.table, operations };
-}
-
-export function getCollectedMigrations(): Lens[] {
-  const migrations = [...collectedMigrations];
-  collectedMigrations = [];
-  return migrations.map((migration) => {
-    const operations: LensOp[] = migration.operations.map(({ column, op }) => {
-      switch (op._type) {
-        case "add":
-          return {
-            type: "introduce" as const,
-            column,
-            sqlType: op.sqlType,
-            value: op.default,
-          };
-        case "drop":
-          return {
-            type: "drop" as const,
-            column,
-            sqlType: op.sqlType,
-            value: op.backwardsDefault,
-          };
-        case "rename":
-          return { type: "rename" as const, column, value: op.oldName };
-      }
-    });
-    return { table: migration.table, operations };
-  });
-}
-
 export function resetCollectedState(): void {
   collectedTables = [];
-  collectedMigrations = [];
 }

--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -2,9 +2,7 @@
 
 import {
   col,
-  getCollectedMigration,
   getCollectedSchema,
-  migrate,
   resetCollectedState,
   table,
   allowExternalProvenanceName,
@@ -37,9 +35,7 @@ import type {
 export {
   table,
   col,
-  migrate,
   getCollectedSchema,
-  getCollectedMigration,
   resetCollectedState,
   allowExternalProvenanceName,
 } from "./dsl.js";
@@ -61,7 +57,6 @@ export type {
   LensOp,
   SqlType,
   LensOpType,
-  MigrationOp,
   AddOp,
   DropOp,
   RenameOp,

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -271,19 +271,6 @@ export interface RenameTableFromOp<TOldName extends string = string> {
   oldName: TOldName;
 }
 
-export type MigrationOp = AddOp | DropOp | RenameOp;
-
-// Internal representation for a single-table migration
-export interface TableMigration {
-  table: string;
-  operations: MigrationOpEntry[];
-}
-
-export interface MigrationOpEntry {
-  column: string;
-  op: MigrationOp;
-}
-
 // Lens format for SQL generation
 export interface IntroduceLensOp {
   type: "introduce";


### PR DESCRIPTION
🤖 Removes the unused deprecated migration collector rather than repairing its backwards-compatible behavior.

## Before

Jazz Tools still exported `migrate()`, collector readers, collector-only operation types, and the deprecated `col.rename()` alias. No repository consumer used them; only their self-tests remained.

## After

The legacy collector surface and tests are gone. `s.defineMigration(...)`, `s.renameFrom(...)`, current migration generation, and migrations from older schema versions are unchanged.

## Example

Supported migrations continue to use `s.defineMigration({ ... })`; there is no side-effectful `migrate("table", operations)` alternative.

## Verification

- Jazz Tools check passed
- focused DSL and migration tests: 33/33
- public-surface type probe confirms legacy exports absent and supported exports present
- planted `schema.rename` reintroduction was detected
- independent adversarial review found no correctness issue