### PR TITLE
Apply rejection cascades iteratively

### DIFF
--- a/crates/jazz/src/node/ingest/fates.rs
+++ b/crates/jazz/src/node/ingest/fates.rs
@@ -10,6 +10,18 @@ where
         global_time: Option<GlobalTime>,
         durability: Option<DurabilityTier>,
     ) -> Result<(), Error> {
+        self.apply_fate_update_with_cascade(tx_id, fate, global_time, durability, true)
+            .await
+    }
+
+    async fn apply_fate_update_with_cascade(
+        &mut self,
+        tx_id: TxId,
+        fate: Fate,
+        global_time: Option<GlobalTime>,
+        durability: Option<DurabilityTier>,
+        cascade_descendants: bool,
+    ) -> Result<(), Error> {
         self.require_catalogue_ready()?;
         debug_assert!(
             global_time.is_none() || durability == Some(DurabilityTier::Global),
@@ -22,6 +34,7 @@ where
             global_time,
             durability,
             &mut terminal_fate_persisted,
+            cascade_descendants,
         ).await;
         if terminal_fate_persisted {
             self.open_tx.local_permission_subjects.remove(&tx_id);
@@ -36,6 +49,7 @@ where
         global_time: Option<GlobalTime>,
         durability: Option<DurabilityTier>,
         terminal_fate_persisted: &mut bool,
+        cascade_descendants: bool,
     ) -> Result<(), Error> {
         let mut stored = self
             .query_transaction(tx_id).await?
@@ -181,6 +195,10 @@ where
             self.prune_child_edges(tx_id);
         } else if let Some(root) = rejected_root {
             self.prune_child_edges(tx_id);
+            if !cascade_descendants {
+                self.rejections.child_txs_by_parent.remove(&tx_id);
+                return Ok(());
+            }
             let cascades = self.local_cascade_descendants(tx_id, root).await?;
             for descendant in cascades {
                 // Authority-side parking resolves parents before children, so
@@ -194,11 +212,12 @@ where
                                 if *existing == root
                         )
                 );
-                Box::pin(self.apply_fate_update(
+                Box::pin(self.apply_fate_update_with_cascade(
                     descendant,
                     Fate::Rejected(RejectionReason::Cascade { root }),
                     None,
                     None,
+                    false,
                 ))
                 .await?;
             }
@@ -692,7 +711,8 @@ where
         let mut updates = Vec::new();
         for descendant in descendants {
             let fate = Fate::Rejected(RejectionReason::Cascade { root });
-            self.apply_fate_update(descendant, fate.clone(), None, None).await?;
+            self.apply_fate_update_with_cascade(descendant, fate.clone(), None, None, false)
+                .await?;
             updates.push(SyncMessage::FateUpdate {
                 tx_id: descendant,
                 fate,

--- a/crates/jazz/src/node/tests/sync/commit_causality.rs
+++ b/crates/jazz/src/node/tests/sync/commit_causality.rs
@@ -273,6 +273,54 @@ fn client_side_rejection_cascades_to_local_mergeable_descendant() {
         Fate::Rejected(RejectionReason::Cascade { root: exclusive })
     );
 }
+
+// Stack safety is an implementation-level property. This NodeState integration
+// test arranges a deep speculative local chain, then asserts terminal states
+// and retracted local rows through its fate entry point.
+#[test]
+fn client_rejects_deep_local_causal_chain_without_recursing() {
+    const DEPTH: usize = 1_024;
+
+    let (_client_dir, mut client) = open_node_with_uuid(node(1));
+    let mut parent = None;
+    let mut tx_ids = Vec::with_capacity(DEPTH);
+
+    for time in 1..=DEPTH {
+        // Spread versions across rows so test-only history consistency checks
+        // do not turn this stack-safety regression into a quadratic soak.
+        let mut commit = MergeableCommit::new("todos", row((time % 251) as u8), time as u64)
+            .cells(title_cells(&format!("depth-{time}")));
+        if let Some(parent) = parent {
+            commit = commit.parents(vec![parent]);
+        }
+        let (tx_id, _) = client.commit_mergeable_unit_settled(commit).unwrap();
+        parent = Some(tx_id);
+        tx_ids.push(tx_id);
+    }
+
+    let root = tx_ids[0];
+    client
+        .apply_fate_update(
+            root,
+            Fate::Rejected(RejectionReason::ClientClockTooFarAhead),
+            None,
+            None,
+        )
+        .unwrap();
+
+    for tx_id in tx_ids {
+        assert_eq!(
+            client.transaction_state_settled(tx_id).unwrap().0,
+            if tx_id == root {
+                Fate::Rejected(RejectionReason::ClientClockTooFarAhead)
+            } else {
+                Fate::Rejected(RejectionReason::Cascade { root })
+            }
+        );
+    }
+    assert!(client.current_rows("todos", DurabilityTier::Local).unwrap().is_empty());
+}
+
 #[test]
 fn authority_unparks_child_after_unknown_parent_accepts() {
     let (_client_dir, mut client) = open_node_with_uuid(node(1));


### PR DESCRIPTION
🤖 Reconstructs the still-live rejection-cascade stack-safety fix isolated while retiring #1678.

## Before

Applying a rejected transaction recursively settled every causal descendant. A sufficiently deep but valid causal chain overflowed the Rust stack on both client and authority paths.

## After

Jazz collects transitive cascade descendants iteratively once, then settles each descendant with further discovery disabled. Client fate application and authority cascade rejection use the same bounded-stack path while retaining deterministic causal order and pending-edge cleanup.

## Examples

- Rejecting the root of a 1,024-transaction chain settles the whole chain without recursion.
- A cycle in pending-edge bookkeeping terminates through the seen set.
- A nested descendant is still discovered and settled; disabling nested discovery leaves it pending and fails the regression.

## Invariants and non-goals

Every causally dependent transaction is rejected exactly once in deterministic transaction-id order. Terminal permission-subject and inbound/outbound pending-edge cleanup remain per transaction. This does not change rejection policy or introduce a global scan.

## Verification

- 1,024-deep cascade regression passes in about four seconds.
- Re-enabling recursion makes the regression stack-overflow and abort.
- Disabling nested discovery makes the later descendant remain pending.
- Existing local, authority, causality-payload, root-cause, and recovery cleanup receipts pass.
- Independent adversarial review found no correctness issue.
- Formatting, clippy, diff, and sensitive-data gates pass.