### PR TITLE
Compare subscription rows by logical content

### DIFF
--- a/crates/jazz-testkit/tests/policies_integration/inherited_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/inherited_policies.rs
@@ -1905,7 +1905,6 @@ async fn inherited_referencing_scalar_paths_grant_visibility_and_compose_with_or
 /// Verifies that reverse inheritance invalidates active subscriptions when
 /// referencing rows are created, deleted, or retargeted.
 #[tokio::test]
-#[ignore = "#1764: deleting the last reverse-inheritance reference does not emit the required target-row removal delta"]
 async fn inherited_referencing_scalar_subscription_updates_follow_create_delete_and_retarget() {
     tokio::task::LocalSet::new().run_until(inherited_referencing_scalar_subscription_updates_follow_create_delete_and_retarget_inner()).await;
 }
@@ -2024,7 +2023,6 @@ async fn inherited_referencing_scalar_subscription_updates_follow_create_delete_
 /// Verifies that reverse inheritance over `UUID[] REFERENCES` grants access
 /// and that reordering or duplicating the array does not change semantics.
 #[tokio::test]
-#[ignore = "#1764: reordering a reverse-inherited UUID array emits spurious target-row update deltas despite unchanged set membership"]
 async fn inherited_referencing_array_membership_preserves_set_semantics() {
     tokio::task::LocalSet::new()
         .run_until(inherited_referencing_array_membership_preserves_set_semantics_inner())

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -3625,7 +3625,7 @@ fn subscription_terminal_delta_event(
         .iter()
         .zip(&current_roots[..common_prefix])
         .zip(&current_occurrences[..common_prefix])
-        .filter(|((previous, current), _)| previous != current)
+        .filter(|((previous, current), _)| !previous.subscription_equivalent(current))
         .map(|((_, current), occurrence_id)| SubscriptionOutputRow {
             occurrence_id: occurrence_id.clone(),
             row: current.clone(),
@@ -3709,7 +3709,7 @@ fn subscription_delta_event_with_reset(
     for (key, row) in &current_by_id {
         match previous_by_id.get(key) {
             None => added.push(subscription_output_row((*row).clone())),
-            Some(previous_row) if *previous_row != *row => {
+            Some(previous_row) if !previous_row.subscription_equivalent(row) => {
                 updated.push(subscription_output_row((*row).clone()))
             }
             Some(_) => {}
@@ -3853,7 +3853,7 @@ fn apply_maintained_update_to_snapshot(
 
     for (key, row) in &update_added {
         if let Some(position) = snapshot_index.roots.get(&key).copied() {
-            if snapshot.rows[position] != *row {
+            if !snapshot.rows[position].subscription_equivalent(row) {
                 snapshot.rows[position] = row.clone();
                 updated.push(SubscriptionOutputRow {
                     occurrence_id: key.clone(),

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1290,6 +1290,87 @@ impl CurrentRow {
         Some((TxTime(time), NodeAlias(alias)))
     }
 
+    /// Compare the row data visible to a subscription, independent of the
+    /// physical descriptor that happened to materialize it.
+    ///
+    /// A maintained view may carry an unchanged row first from its physical
+    /// current relation and then from a public policy/query projection. The
+    /// storage-only fields differ between those descriptors, but emitting an
+    /// update for that representation change would turn a policy no-op (such
+    /// as reordering an array used only as a reverse-inheritance grant) into a
+    /// spurious application-visible row update.
+    pub(crate) fn subscription_equivalent(&self, other: &Self) -> bool {
+        let provenance_matches = match (self.provenance(), other.provenance()) {
+            // Some physical current-row carriers retain no provenance fields.
+            // Their absence is representational rather than a statement that
+            // the public provenance changed, so compare it only when both
+            // sides can express it.
+            (Ok(Some(left)), Ok(Some(right))) => left == right,
+            (Ok(_), Ok(_)) => true,
+            _ => false,
+        };
+        let left_cells = self.subscription_cells();
+        let right_cells = other.subscription_cells();
+        self.table == other.table
+            && self.row_uuid() == other.row_uuid()
+            && self.deleted == other.deleted
+            && left_cells == right_cells
+            && provenance_matches
+    }
+
+    fn subscription_cells(&self) -> BTreeMap<String, Option<Value>> {
+        let descriptor = self.record.descriptor();
+        let physical_current = descriptor.field_index("schema_version").is_some()
+            && descriptor.field_index("created_by").is_some()
+            && descriptor.field_index("updated_by").is_some();
+        descriptor
+            .fields()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, field)| {
+                let name = field.name.as_ref()?.as_str();
+                let name = if name.starts_with("user_") {
+                    let name = self::query_engine::logical_user_column(name);
+                    self::query_engine::aggregate_output_logical_name(name)
+                        .unwrap_or(name)
+                        .to_owned()
+                } else if let Some(name) = self::query_engine::aggregate_output_logical_name(name) {
+                    name.to_owned()
+                } else if matches!(
+                    name,
+                    "$createdBy"
+                        | "$createdAt"
+                        | "$updatedBy"
+                        | "$updatedAt"
+                        | "branch_key"
+                        | "row_uuid"
+                        | "tx_time"
+                        | "tx_node_id"
+                        | "schema_version"
+                        | "parents"
+                        | "authored_columns"
+                        | "global_time"
+                        | "settle_position"
+                ) || name.starts_with("__jazz_")
+                    || (physical_current
+                        && matches!(
+                            name,
+                            "created_by" | "created_at" | "updated_by" | "updated_at"
+                        ))
+                {
+                    return None;
+                } else {
+                    name.to_owned()
+                };
+                let value = match self.record.borrowed().get_idx(idx).ok()? {
+                    Value::Nullable(value) => value.map(|value| *value),
+                    value => Some(value),
+                };
+                Some((name, value))
+            })
+            .collect()
+    }
+
     #[cfg(test)]
     pub(crate) fn test_cells_by_descriptor(&self) -> BTreeMap<String, Value> {
         let user_cells = self

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1183,16 +1183,33 @@ impl CurrentRow {
     pub(crate) fn provenance(&self) -> Result<Option<RowProvenance>, Error> {
         let descriptor = self.record.descriptor();
         let borrowed = self.record.borrowed();
-        let Some(created_by_idx) = descriptor.field_index("$createdBy") else {
-            return Ok(None);
+        let indices = match (
+            descriptor.field_index("$createdBy"),
+            descriptor.field_index("$createdAt"),
+            descriptor.field_index("$updatedBy"),
+            descriptor.field_index("$updatedAt"),
+        ) {
+            (Some(created_by), Some(created_at), Some(updated_by), Some(updated_at)) => {
+                Some((created_by, created_at, updated_by, updated_at))
+            }
+            _ if descriptor.field_index("schema_version").is_some()
+                && descriptor.field_index("branch_key").is_some() =>
+            {
+                match (
+                    descriptor.field_index("created_by"),
+                    descriptor.field_index("created_at"),
+                    descriptor.field_index("updated_by"),
+                    descriptor.field_index("updated_at"),
+                ) {
+                    (Some(created_by), Some(created_at), Some(updated_by), Some(updated_at)) => {
+                        Some((created_by, created_at, updated_by, updated_at))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
         };
-        let Some(created_at_idx) = descriptor.field_index("$createdAt") else {
-            return Ok(None);
-        };
-        let Some(updated_by_idx) = descriptor.field_index("$updatedBy") else {
-            return Ok(None);
-        };
-        let Some(updated_at_idx) = descriptor.field_index("$updatedAt") else {
+        let Some((created_by_idx, created_at_idx, updated_by_idx, updated_at_idx)) = indices else {
             return Ok(None);
         };
         Ok(Some(RowProvenance {
@@ -1301,25 +1318,31 @@ impl CurrentRow {
     /// spurious application-visible row update.
     pub(crate) fn subscription_equivalent(&self, other: &Self) -> bool {
         let provenance_matches = match (self.provenance(), other.provenance()) {
-            // Some physical current-row carriers retain no provenance fields.
-            // Their absence is representational rather than a statement that
-            // the public provenance changed, so compare it only when both
-            // sides can express it.
-            (Ok(Some(left)), Ok(Some(right))) => left == right,
-            (Ok(_), Ok(_)) => true,
+            (Ok(left), Ok(right)) => left == right,
             _ => false,
         };
-        let left_cells = self.subscription_cells();
-        let right_cells = other.subscription_cells();
         self.table == other.table
             && self.row_uuid() == other.row_uuid()
             && self.deleted == other.deleted
-            && left_cells == right_cells
+            && self.subscription_cells_equivalent(other)
             && provenance_matches
     }
 
-    fn subscription_cells(&self) -> BTreeMap<String, Option<Value>> {
+    fn subscription_cells_equivalent(&self, other: &Self) -> bool {
+        let right_count = other.subscription_cells().count();
+        let mut left_count = 0_usize;
+        let all_left_match = self.subscription_cells().all(|(left_name, left_value)| {
+            left_count += 1;
+            other.subscription_cells().any(|(right_name, right_value)| {
+                left_name == right_name && left_value == right_value
+            })
+        });
+        all_left_match && left_count == right_count
+    }
+
+    fn subscription_cells(&self) -> impl Iterator<Item = (&str, Option<Value>)> + '_ {
         let descriptor = self.record.descriptor();
+        let borrowed = self.record.borrowed();
         let physical_current = descriptor.field_index("schema_version").is_some()
             && descriptor.field_index("created_by").is_some()
             && descriptor.field_index("updated_by").is_some();
@@ -1327,15 +1350,13 @@ impl CurrentRow {
             .fields()
             .iter()
             .enumerate()
-            .filter_map(|(idx, field)| {
+            .filter_map(move |(idx, field)| {
                 let name = field.name.as_ref()?.as_str();
                 let name = if name.starts_with("user_") {
                     let name = self::query_engine::logical_user_column(name);
-                    self::query_engine::aggregate_output_logical_name(name)
-                        .unwrap_or(name)
-                        .to_owned()
+                    self::query_engine::aggregate_output_logical_name(name).unwrap_or(name)
                 } else if let Some(name) = self::query_engine::aggregate_output_logical_name(name) {
-                    name.to_owned()
+                    name
                 } else if matches!(
                     name,
                     "$createdBy"
@@ -1360,15 +1381,14 @@ impl CurrentRow {
                 {
                     return None;
                 } else {
-                    name.to_owned()
+                    name
                 };
-                let value = match self.record.borrowed().get_idx(idx).ok()? {
+                let value = match borrowed.get_idx(idx).ok()? {
                     Value::Nullable(value) => value.map(|value| *value),
                     value => Some(value),
                 };
                 Some((name, value))
             })
-            .collect()
     }
 
     #[cfg(test)]

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1329,15 +1329,14 @@ impl CurrentRow {
     }
 
     fn subscription_cells_equivalent(&self, other: &Self) -> bool {
-        let right_count = other.subscription_cells().count();
-        let mut left_count = 0_usize;
-        let all_left_match = self.subscription_cells().all(|(left_name, left_value)| {
-            left_count += 1;
-            other.subscription_cells().any(|(right_name, right_value)| {
-                left_name == right_name && left_value == right_value
-            })
-        });
-        all_left_match && left_count == right_count
+        // Decode each cell exactly once. Descriptor order differs between a
+        // physical current row and its public projection, so canonicalize the
+        // borrowed logical names instead of repeatedly rescanning either row.
+        let mut left = self.subscription_cells().collect::<Vec<_>>();
+        let mut right = other.subscription_cells().collect::<Vec<_>>();
+        left.sort_unstable_by_key(|(name, _)| *name);
+        right.sort_unstable_by_key(|(name, _)| *name);
+        left == right
     }
 
     fn subscription_cells(&self) -> impl Iterator<Item = (&str, Option<Value>)> + '_ {

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1332,11 +1332,25 @@ impl CurrentRow {
         // Decode each cell exactly once. Descriptor order differs between a
         // physical current row and its public projection, so canonicalize the
         // borrowed logical names instead of repeatedly rescanning either row.
-        let mut left = self.subscription_cells().collect::<Vec<_>>();
-        let mut right = other.subscription_cells().collect::<Vec<_>>();
-        left.sort_unstable_by_key(|(name, _)| *name);
-        right.sort_unstable_by_key(|(name, _)| *name);
-        left == right
+        match (
+            self.canonical_subscription_cells(),
+            other.canonical_subscription_cells(),
+        ) {
+            (Some(left), Some(right)) => left == right,
+            _ => false,
+        }
+    }
+
+    fn canonical_subscription_cells(&self) -> Option<Vec<(&str, Vec<u8>)>> {
+        let mut cells = self
+            .subscription_cells()
+            .map(|(name, value)| Some((name, postcard::to_allocvec(&value).ok()?)))
+            .collect::<Option<Vec<_>>>()?;
+        // Logical names may legally collide (for example a group column and
+        // an aggregate alias). The canonical Value bytes preserve multiset
+        // semantics without making equality depend on descriptor order.
+        cells.sort_unstable();
+        Some(cells)
     }
 
     fn subscription_cells(&self) -> impl Iterator<Item = (&str, Option<Value>)> + '_ {

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -129,6 +129,55 @@ fn subscription_equivalence_canonicalizes_wide_rows_without_repeated_decoding() 
 }
 
 #[test]
+fn subscription_equivalence_canonicalizes_duplicate_logical_names_by_value() {
+    fn query_row(fields: Vec<(String, records::ValueType)>, values: Vec<Value>) -> CurrentRow {
+        let descriptor = records::RecordDescriptor::new(
+            [("row_uuid".to_owned(), records::ValueType::Uuid)]
+                .into_iter()
+                .chain(fields)
+                .chain([
+                    ("$createdBy".to_owned(), records::ValueType::String),
+                    ("$createdAt".to_owned(), records::ValueType::U64),
+                    ("$updatedBy".to_owned(), records::ValueType::String),
+                    ("$updatedAt".to_owned(), records::ValueType::U64),
+                ]),
+        );
+        let values = [Value::Uuid(row(0x6c).0)]
+            .into_iter()
+            .chain(values)
+            .chain([
+                Value::String(AuthorSubject::SYSTEM.canonical().to_owned()),
+                Value::U64(10),
+                Value::String(AuthorSubject::SYSTEM.canonical().to_owned()),
+                Value::U64(20),
+            ])
+            .collect::<Vec<_>>();
+        let raw = descriptor.create(&values).unwrap();
+        CurrentRow::new("scores", OwnedRecord::new(raw, descriptor))
+    }
+
+    let aggregate_layout = query_row(
+        vec![
+            ("foo".to_owned(), records::ValueType::U64),
+            ("__jazz_aggregate_foo".to_owned(), records::ValueType::U64),
+        ],
+        vec![Value::U64(1), Value::U64(2)],
+    );
+    let public_layout = query_row(
+        vec![
+            (
+                "user___jazz_aggregate_foo".to_owned(),
+                records::ValueType::U64,
+            ),
+            ("user_foo".to_owned(), records::ValueType::U64),
+        ],
+        vec![Value::U64(2), Value::U64(1)],
+    );
+
+    assert!(aggregate_layout.subscription_equivalent(&public_layout));
+}
+
+#[test]
 fn ordinary_oversized_scalar_write_is_staged_indirect_and_reads_logically_inline() {
     let schema = two_column_schema();
     let node_uuid = node(0x71);

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -173,8 +173,17 @@ fn subscription_equivalence_canonicalizes_duplicate_logical_names_by_value() {
         ],
         vec![Value::U64(2), Value::U64(1)],
     );
+    let foo = query_row(
+        vec![("foo".to_owned(), records::ValueType::U64)],
+        vec![Value::U64(1)],
+    );
+    let bar = query_row(
+        vec![("bar".to_owned(), records::ValueType::U64)],
+        vec![Value::U64(1)],
+    );
 
     assert!(aggregate_layout.subscription_equivalent(&public_layout));
+    assert!(!foo.subscription_equivalent(&bar));
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -1,4 +1,72 @@
 #[test]
+fn subscription_equivalence_preserves_physical_to_public_provenance_changes() {
+    fn current_row(
+        physical: bool,
+        created_by: AuthorSubject,
+        created_at: u64,
+        updated_by: AuthorSubject,
+        updated_at: u64,
+    ) -> CurrentRow {
+        let row_uuid = row(0x68);
+        let (descriptor, values) = if physical {
+            (
+                records::RecordDescriptor::new([
+                    ("branch_key".to_owned(), records::ValueType::Bytes),
+                    ("row_uuid".to_owned(), records::ValueType::Uuid),
+                    ("schema_version".to_owned(), records::ValueType::U64),
+                    ("created_by".to_owned(), records::ValueType::String),
+                    ("created_at".to_owned(), records::ValueType::U64),
+                    ("updated_by".to_owned(), records::ValueType::String),
+                    ("updated_at".to_owned(), records::ValueType::U64),
+                    ("user_title".to_owned(), records::ValueType::String),
+                ]),
+                vec![
+                    Value::Bytes(Vec::new()),
+                    Value::Uuid(row_uuid.0),
+                    Value::U64(1),
+                    Value::String(created_by.canonical().to_owned()),
+                    Value::U64(created_at),
+                    Value::String(updated_by.canonical().to_owned()),
+                    Value::U64(updated_at),
+                    Value::String("same title".to_owned()),
+                ],
+            )
+        } else {
+            (
+                records::RecordDescriptor::new([
+                    ("row_uuid".to_owned(), records::ValueType::Uuid),
+                    ("title".to_owned(), records::ValueType::String),
+                    ("$createdBy".to_owned(), records::ValueType::String),
+                    ("$createdAt".to_owned(), records::ValueType::U64),
+                    ("$updatedBy".to_owned(), records::ValueType::String),
+                    ("$updatedAt".to_owned(), records::ValueType::U64),
+                ]),
+                vec![
+                    Value::Uuid(row_uuid.0),
+                    Value::String("same title".to_owned()),
+                    Value::String(created_by.canonical().to_owned()),
+                    Value::U64(created_at),
+                    Value::String(updated_by.canonical().to_owned()),
+                    Value::U64(updated_at),
+                ],
+            )
+        };
+        let raw = descriptor.create(&values).unwrap();
+        CurrentRow::new("todos", OwnedRecord::new(raw, descriptor))
+    }
+
+    let created_by = AuthorSubject::for_test_uuid(uuid::Uuid::from_bytes([0x68; 16]));
+    let original_updated_by = AuthorSubject::for_test_uuid(uuid::Uuid::from_bytes([0x69; 16]));
+    let changed_updated_by = AuthorSubject::for_test_uuid(uuid::Uuid::from_bytes([0x6a; 16]));
+    let physical = current_row(true, created_by, 10, original_updated_by, 20);
+    let same_public = current_row(false, created_by, 10, original_updated_by, 20);
+    let changed_public = current_row(false, created_by, 10, changed_updated_by, 21);
+
+    assert!(physical.subscription_equivalent(&same_public));
+    assert!(!physical.subscription_equivalent(&changed_public));
+}
+
+#[test]
 fn ordinary_oversized_scalar_write_is_staged_indirect_and_reads_logically_inline() {
     let schema = two_column_schema();
     let node_uuid = node(0x71);

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -6,6 +6,7 @@ fn subscription_equivalence_preserves_physical_to_public_provenance_changes() {
         created_at: u64,
         updated_by: AuthorSubject,
         updated_at: u64,
+        title: &str,
     ) -> CurrentRow {
         let row_uuid = row(0x68);
         let (descriptor, values) = if physical {
@@ -28,7 +29,7 @@ fn subscription_equivalence_preserves_physical_to_public_provenance_changes() {
                     Value::U64(created_at),
                     Value::String(updated_by.canonical().to_owned()),
                     Value::U64(updated_at),
-                    Value::String("same title".to_owned()),
+                    Value::String(title.to_owned()),
                 ],
             )
         } else {
@@ -43,7 +44,7 @@ fn subscription_equivalence_preserves_physical_to_public_provenance_changes() {
                 ]),
                 vec![
                     Value::Uuid(row_uuid.0),
-                    Value::String("same title".to_owned()),
+                    Value::String(title.to_owned()),
                     Value::String(created_by.canonical().to_owned()),
                     Value::U64(created_at),
                     Value::String(updated_by.canonical().to_owned()),
@@ -58,12 +59,73 @@ fn subscription_equivalence_preserves_physical_to_public_provenance_changes() {
     let created_by = AuthorSubject::for_test_uuid(uuid::Uuid::from_bytes([0x68; 16]));
     let original_updated_by = AuthorSubject::for_test_uuid(uuid::Uuid::from_bytes([0x69; 16]));
     let changed_updated_by = AuthorSubject::for_test_uuid(uuid::Uuid::from_bytes([0x6a; 16]));
-    let physical = current_row(true, created_by, 10, original_updated_by, 20);
-    let same_public = current_row(false, created_by, 10, original_updated_by, 20);
-    let changed_public = current_row(false, created_by, 10, changed_updated_by, 21);
+    let physical = current_row(true, created_by, 10, original_updated_by, 20, "same title");
+    let same_public = current_row(false, created_by, 10, original_updated_by, 20, "same title");
+    let changed_provenance = current_row(false, created_by, 10, changed_updated_by, 21, "same title");
+    let changed_content = current_row(false, created_by, 10, original_updated_by, 20, "new title");
 
     assert!(physical.subscription_equivalent(&same_public));
-    assert!(!physical.subscription_equivalent(&changed_public));
+    assert!(!physical.subscription_equivalent(&changed_provenance));
+    assert!(!physical.subscription_equivalent(&changed_content));
+}
+
+#[test]
+fn subscription_equivalence_canonicalizes_wide_rows_without_repeated_decoding() {
+    const CELL_COUNT: usize = 512;
+    let row_uuid = row(0x6b);
+    let mut physical_fields = vec![
+        ("branch_key".to_owned(), records::ValueType::Bytes),
+        ("row_uuid".to_owned(), records::ValueType::Uuid),
+        ("schema_version".to_owned(), records::ValueType::U64),
+        ("created_by".to_owned(), records::ValueType::String),
+        ("created_at".to_owned(), records::ValueType::U64),
+        ("updated_by".to_owned(), records::ValueType::String),
+        ("updated_at".to_owned(), records::ValueType::U64),
+    ];
+    let mut physical_values = vec![
+        Value::Bytes(Vec::new()),
+        Value::Uuid(row_uuid.0),
+        Value::U64(1),
+        Value::String(AuthorSubject::SYSTEM.canonical().to_owned()),
+        Value::U64(10),
+        Value::String(AuthorSubject::SYSTEM.canonical().to_owned()),
+        Value::U64(20),
+    ];
+    let mut public_fields = vec![
+        ("row_uuid".to_owned(), records::ValueType::Uuid),
+        ("$createdBy".to_owned(), records::ValueType::String),
+        ("$createdAt".to_owned(), records::ValueType::U64),
+        ("$updatedBy".to_owned(), records::ValueType::String),
+        ("$updatedAt".to_owned(), records::ValueType::U64),
+    ];
+    let mut public_values = vec![
+        Value::Uuid(row_uuid.0),
+        Value::String(AuthorSubject::SYSTEM.canonical().to_owned()),
+        Value::U64(10),
+        Value::String(AuthorSubject::SYSTEM.canonical().to_owned()),
+        Value::U64(20),
+    ];
+    for idx in 0..CELL_COUNT {
+        physical_fields.push((format!("user_column_{idx}"), records::ValueType::U64));
+        physical_values.push(Value::U64(idx as u64));
+    }
+    // Reverse public descriptor order to ensure equality is independent of
+    // layout while still decoding only the two linear cell iterators once.
+    for idx in (0..CELL_COUNT).rev() {
+        public_fields.push((format!("column_{idx}"), records::ValueType::U64));
+        public_values.push(Value::U64(idx as u64));
+    }
+    let physical_descriptor = records::RecordDescriptor::new(physical_fields);
+    let public_descriptor = records::RecordDescriptor::new(public_fields);
+    let physical_raw = physical_descriptor.create(&physical_values).unwrap();
+    let public_raw = public_descriptor.create(&public_values).unwrap();
+    let physical = CurrentRow::new(
+        "todos",
+        OwnedRecord::new(physical_raw, physical_descriptor),
+    );
+    let public = CurrentRow::new("todos", OwnedRecord::new(public_raw, public_descriptor));
+
+    assert!(physical.subscription_equivalent(&public));
 }
 
 #[test]


### PR DESCRIPTION
🤖 Reconstructs the live subscription-equivalence fix isolated while retiring #1678, without restoring its obsolete global-watermark scans.

## Before

Subscription diffs compared physical CurrentRow records. The same logical public row can have different physical carrier names or layout after relational policy lowering, causing spurious updated events when an inherited array was reordered or contained duplicates.

## After

Rows compare by externally visible subscription identity: table, UUID, deletion state, canonical logical cell multiset, and normalized provenance. Each row is decoded once; logical name plus canonical value bytes are sorted and compared in O(total encoded bytes + n log n).

## Examples

- Reordering or duplicating inherited policy dependency rows emits no target-row update when public content is unchanged.
- Physical and public provenance carriers compare equal only when their visible created/updated provenance agrees.
- A changed title, changed updated author/time, or equal value under a different logical name remains a meaningful update.
- Aggregate and grouped-source fields may share a logical name; their values compare as a multiset independent of physical layout.

## Invariants and non-goals

Malformed cell or provenance decoding fails closed and cannot suppress an update. Scalar policy-dependency create, delete, and retarget changes still deliver visibility deltas. This does not reintroduce the historical per-subscription global watermark scan; current maintained runtime already delivers those scalar changes.

## Verification

- Three comparator receipts cover provenance/content, 512-column reversed layout, duplicate logical names, and name sensitivity.
- Three inherited-policy integration receipts cover scalar visibility, scalar create/delete/retarget, and array reorder/duplicate semantics.
- Planted raw-record, ignored-value, ignored-name, ignored-provenance, and missing-sort regressions are detected.
- Independent adversarial review found no remaining correctness or asymptotic issue.
- Clippy, rustfmt, diff, and sensitive-data gates pass.