### PR TITLE
Add deterministic topology envelope fault scheduling

### DIFF
--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -5,6 +5,38 @@ bounded named phases, disconnect/reconnect/restart/failure callbacks, receipts,
 and replay commands. App scenarios continue to own schemas, fixtures,
 operations, and assertions.
 
+## Envelope faults
+
+The same module also provides `TopologyEnvelopeScheduler`, a test-only virtual
+time boundary around an app test transport's _delivery callback_. It does not
+instrument, patch, or otherwise change Jazz's runtime transport. Give messages
+stable endpoint names and non-sensitive test labels, then wrap delivery:
+
+```ts
+const envelopes = new TopologyEnvelopeScheduler(seed);
+await envelopes.intercept(
+  { from: "browser", to: "edge", label: "write" },
+  encodedMessage,
+  (message) => testTransport.deliver(message),
+);
+```
+
+Arm faults before the next intercepted envelope with
+`duplicateNext`, `delayNext(ticks)`, `reorderNext`, or
+`dropNextThenRetry(ticks)`. `partition(a, b)` holds traffic in both directions;
+`heal(a, b)` releases ready traffic. `advance(ticks)` moves only virtual time,
+so tests never need wall-clock sleeps to reproduce a schedule. Delivery order,
+attempt number, virtual tick, endpoint names, labels, and every fault action
+are retained in the payload-free scheduler receipt. Pass each scheduler through
+`envelopeSchedulers` on `runTopologyScenario`; the runner closes it after app
+cleanup and records discarded held envelopes, preventing a test fault from
+leaking into another scenario.
+
+The scheduler deliberately models message delivery only. Connection lifecycle,
+real transport retry policy, and application assertions remain app-owned. An
+app should use an explicit test transport seam (or its existing simulation
+link), rather than adding app-specific production hooks just for topology tests.
+
 Register a scenario in `dev/example-topology-scenarios.json` with a stable id,
 topology labels, working directory, and an argv array. Run the bounded smoke
 locally with:

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -32,9 +32,13 @@ are retained in the payload-free scheduler receipt. Pass each scheduler through
 cleanup and records discarded held envelopes, preventing a test fault from
 leaking into another scenario. Delivery callbacks receive an `AbortSignal` and
 must stop work when it aborts: teardown awaits all in-flight callbacks up to
-the scenario's bounded fault timeout. A callback that ignores cancellation
-causes a visible cleanup-timeout receipt and scenario failure rather than a
-quiet cross-test leak.
+the scenario's bounded fault timeout. If a callback ignores cancellation, that
+timeout is recorded as a cleanup failure, but teardown still drains the callback
+before returning so it cannot quietly mutate a later scenario.
+Callbacks that need to enqueue a follow-up use their scoped
+`deliveryContext.intercept(...)`; ordinary concurrent callers continue to use
+the scheduler directly and their promise does not settle before their ready
+delivery has run.
 
 Envelope descriptors are deliberately narrow, immutable snapshots of
 `{ from, to, label? }`: endpoint names and labels are bounded, unknown metadata
@@ -45,7 +49,9 @@ outstanding work, partition links, and receipt activities to keep a bad randomiz
 envelope id remains stable across copies/retry while each actual delivery has a
 separate sequence and attempt; retry is recorded when the retry is delivered,
 not merely scheduled. A callback failure fail-stops the scheduler and records
-discarded remaining deliveries deterministically.
+discarded remaining deliveries deterministically. Delivery failures are recorded
+only as a bounded `error`/`non-error` classification; exception messages and
+payload values never enter scheduler receipts.
 
 The scheduler deliberately models message delivery only. Connection lifecycle,
 real transport retry policy, and application assertions remain app-owned. An

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -30,7 +30,22 @@ attempt number, virtual tick, endpoint names, labels, and every fault action
 are retained in the payload-free scheduler receipt. Pass each scheduler through
 `envelopeSchedulers` on `runTopologyScenario`; the runner closes it after app
 cleanup and records discarded held envelopes, preventing a test fault from
-leaking into another scenario.
+leaking into another scenario. Delivery callbacks receive an `AbortSignal` and
+must stop work when it aborts: teardown awaits all in-flight callbacks up to
+the scenario's bounded fault timeout. A callback that ignores cancellation
+causes a visible cleanup-timeout receipt and scenario failure rather than a
+quiet cross-test leak.
+
+Envelope descriptors are deliberately narrow, immutable snapshots of
+`{ from, to, label? }`: endpoint names and labels are bounded, unknown metadata
+and NUL-containing endpoint names are rejected, and payloads are never recorded.
+Only one fault kind can be armed for an envelope (multiple duplicate copies are
+the sole composable case). The scheduler also bounds copies, virtual ticks, and
+outstanding work, partition links, and receipt activities to keep a bad randomized soak schedule finite. A logical
+envelope id remains stable across copies/retry while each actual delivery has a
+separate sequence and attempt; retry is recorded when the retry is delivered,
+not merely scheduled. A callback failure fail-stops the scheduler and records
+discarded remaining deliveries deterministically.
 
 The scheduler deliberately models message delivery only. Connection lifecycle,
 real transport retry policy, and application assertions remain app-owned. An

--- a/dev/EXAMPLE_TOPOLOGY_HARNESS.md
+++ b/dev/EXAMPLE_TOPOLOGY_HARNESS.md
@@ -38,7 +38,9 @@ before returning so it cannot quietly mutate a later scenario.
 Callbacks that need to enqueue a follow-up use their scoped
 `deliveryContext.intercept(...)`; ordinary concurrent callers continue to use
 the scheduler directly and their promise does not settle before their ready
-delivery has run.
+delivery has run. A synchronous callback loses that capability immediately on
+return, before any microtask it queued can run; an async callback retains it
+until its returned promise settles.
 
 Envelope descriptors are deliberately narrow, immutable snapshots of
 `{ from, to, label? }`: endpoint names and labels are bounded, unknown metadata

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -245,6 +245,14 @@ describe("shared example topology harness", () => {
     expect(() => scheduler.reorderNext()).toThrow("only one envelope fault kind");
   });
 
+  it("rejects non-numeric virtual-time requests before they can schedule a delivery", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(42);
+    await expect(scheduler.advance("one" as never)).rejects.toThrow("positive safe integer");
+    expect(() => scheduler.delayNext(Number.NaN)).toThrow("positive safe integer");
+    expect(() => scheduler.dropNextThenRetry(1.5)).toThrow("positive safe integer");
+    expect(scheduler.receipt()).toMatchObject({ tick: 0, pending: 0 });
+  });
+
   it("fail-stops after a callback failure and discards remaining duplicate deliveries", async () => {
     const scheduler = new TopologyEnvelopeScheduler(43);
     scheduler.duplicateNext(2);

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -235,6 +235,7 @@ describe("shared example topology harness", () => {
       "parent",
       async (_, context) => {
         staleIntercept = context.intercept;
+        await Promise.resolve();
         await context.intercept(
           { from: "a", to: "b", label: "child" },
           "child",
@@ -253,6 +254,31 @@ describe("shared example topology harness", () => {
     await expect(staleIntercept({ from: "a", to: "b" }, "stale", () => undefined)).rejects.toThrow(
       "topology delivery intercept is no longer active",
     );
+  });
+
+  it("invalidates a synchronous callback intercept before its queued microtasks run", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(39);
+    let escaped!: Promise<void>;
+    await scheduler.intercept(
+      { from: "a", to: "b", label: "sync-parent" },
+      "sync-parent",
+      (_, context) => {
+        queueMicrotask(() => {
+          escaped = context.intercept(
+            { from: "a", to: "b", label: "escaped-child" },
+            "escaped-child",
+            () => undefined,
+          );
+        });
+      },
+    );
+    await expect(escaped).rejects.toThrow("topology delivery intercept is no longer active");
+    expect(
+      scheduler
+        .receipt()
+        .activities.filter(({ action }) => action === "delivered")
+        .map(({ label }) => label),
+    ).toEqual(["sync-parent"]);
   });
 
   it("snapshots bounded descriptors and rejects receipt-field or payload injection", async () => {

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -55,6 +55,10 @@ describe("shared example topology harness", () => {
     expect(receipt.activities.map(({ action }) => action)).toContain("dropped");
     expect(receipt.activities.map(({ action }) => action)).toContain("retried");
     expect(receipt.activities.map(({ action }) => action)).toContain("partitioned");
+    const retry = receipt.activities.find(({ action }) => action === "retried");
+    const dropped = receipt.activities.find(({ action }) => action === "dropped");
+    expect(retry?.envelopeId).toBe(dropped?.envelopeId);
+    expect(retry?.sequence).toBe(dropped?.sequence);
   });
 
   it("closes held envelopes after scenario cleanup, proving faults cannot leak between cases", async () => {
@@ -79,6 +83,182 @@ describe("shared example topology harness", () => {
     await expect(
       scheduler.intercept({ from: "a", to: "b" }, "late", () => undefined),
     ).rejects.toThrow("scheduler is closed");
+  });
+
+  it("waits for an in-flight delivery to finish before the scenario returns", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(19);
+    let deliveryFinished = false;
+    void scheduler.intercept(
+      { from: "a", to: "b", label: "in-flight" },
+      "in-flight",
+      (_, { signal }) =>
+        new Promise<void>((resolve) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              deliveryFinished = true;
+              resolve();
+            },
+            { once: true },
+          );
+        }),
+    );
+    await Promise.resolve();
+
+    const receipt = await runTopologyScenario({
+      id: "harness.fixture.in-flight-cleanup",
+      topology: ["fixture"],
+      seed: 19,
+      phaseTimeoutMs: 50,
+      faultTimeoutMs: 50,
+      targets: {},
+      replay: "in-flight-cleanup-fixture",
+      envelopeSchedulers: [scheduler],
+      phases: [],
+    });
+    expect(deliveryFinished).toBe(true);
+    expect(receipt.envelopes[0]).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
+    expect(receipt.envelopes[0]?.cleanup?.status).toBe("completed");
+  });
+
+  it("records a rejected delivery without retaining it for cleanup", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(23);
+    await expect(
+      scheduler.intercept({ from: "a", to: "b", label: "reject" }, "reject", () =>
+        Promise.reject(new Error("planted delivery rejection")),
+      ),
+    ).rejects.toThrow("planted delivery rejection");
+    await scheduler.close(20);
+    const receipt = scheduler.receipt();
+    expect(receipt).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
+    expect(receipt.activities.find(({ action }) => action === "deliveryFailed")?.error).toContain(
+      "planted delivery rejection",
+    );
+  });
+
+  it("bounds a delivery that ignores cancellation and retains an explicit timeout receipt", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(31);
+    let release!: () => void;
+    const delivery = scheduler.intercept(
+      { from: "a", to: "b", label: "ignores-abort" },
+      "ignores-abort",
+      () => new Promise<void>((resolve) => (release = resolve)),
+    );
+    await Promise.resolve();
+    let failure: unknown;
+    try {
+      await runTopologyScenario({
+        id: "harness.fixture.in-flight-timeout",
+        topology: ["fixture"],
+        seed: 31,
+        phaseTimeoutMs: 50,
+        faultTimeoutMs: 5,
+        targets: {},
+        replay: "in-flight-timeout-fixture",
+        envelopeSchedulers: [scheduler],
+        phases: [],
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(TopologyScenarioError);
+    const receipt = (failure as TopologyScenarioError).receipt.envelopes[0];
+    expect(receipt).toMatchObject({ closed: true, inFlight: 1, cleanup: { status: "failed" } });
+    expect(receipt?.activities.at(-1)?.action).toBe("closeTimedOut");
+    release();
+    await delivery;
+  });
+
+  it("serializes concurrent intercepts and permits a delivery to enqueue a follow-up", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(37);
+    let releaseFirst!: () => void;
+    const delivered: string[] = [];
+    const first = scheduler.intercept(
+      { from: "a", to: "b", label: "first" },
+      "first",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = () => {
+            delivered.push("first");
+            resolve();
+          };
+        }),
+    );
+    await Promise.resolve();
+    const second = scheduler.intercept(
+      { from: "a", to: "b", label: "second" },
+      "second",
+      () => void delivered.push("second"),
+    );
+    expect(delivered).toEqual([]);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(delivered).toEqual(["first", "second"]);
+
+    await scheduler.intercept({ from: "a", to: "b", label: "parent" }, "parent", async () => {
+      await scheduler.intercept(
+        { from: "a", to: "b", label: "child" },
+        "child",
+        () => void delivered.push("child"),
+      );
+      delivered.push("parent");
+    });
+    expect(delivered).toEqual(["first", "second", "parent", "child"]);
+    expect(
+      scheduler
+        .receipt()
+        .activities.filter(({ action }) => action === "delivered")
+        .map(({ label }) => label),
+    ).toEqual(["first", "second", "parent", "child"]);
+  });
+
+  it("snapshots bounded descriptors and rejects receipt-field or payload injection", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(41);
+    const envelope = { from: "a", to: "b", label: "before" };
+    scheduler.delayNext();
+    await scheduler.intercept(envelope, "value", () => undefined);
+    envelope.label = "after";
+    await scheduler.advance();
+    expect(
+      scheduler
+        .receipt()
+        .activities.filter(({ action }) => action === "delivered")
+        .map(({ label }) => label),
+    ).toEqual(["before"]);
+    await expect(
+      scheduler.intercept(
+        {
+          from: "a",
+          to: "b",
+          label: "safe",
+          action: "delivered",
+          payload: "not-a-receipt",
+        } as never,
+        "value",
+        () => undefined,
+      ),
+    ).rejects.toThrow("unsupported metadata");
+    await expect(
+      scheduler.intercept({ from: "a", to: "b", label: "x".repeat(257) }, "value", () => undefined),
+    ).rejects.toThrow("at most 256");
+    scheduler.delayNext();
+    expect(() => scheduler.reorderNext()).toThrow("only one envelope fault kind");
+  });
+
+  it("fail-stops after a callback failure and discards remaining duplicate deliveries", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(43);
+    scheduler.duplicateNext(2);
+    await expect(
+      scheduler.intercept({ from: "a", to: "b", label: "fail" }, "value", () => {
+        throw new Error("planted terminal delivery failure");
+      }),
+    ).rejects.toThrow("planted terminal delivery failure");
+    const receipt = scheduler.receipt();
+    expect(receipt.activities.filter(({ action }) => action === "deliveryFailed")).toHaveLength(1);
+    expect(receipt.activities.filter(({ action }) => action === "discarded")).toHaveLength(2);
+    await expect(
+      scheduler.intercept({ from: "a", to: "b" }, "later", () => undefined),
+    ).rejects.toThrow("scheduler is failed");
   });
 
   it("runs deterministic phases and every fault callback with a replayable receipt", async () => {

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  TopologyEnvelopeScheduler,
   TopologyScenarioError,
   deterministicRandom,
   runTopologyScenario,
@@ -7,6 +8,79 @@ import {
 } from "./harness.js";
 
 describe("shared example topology harness", () => {
+  it("deterministically plants envelope duplicates, delay, reordering, retry, and a healed partition", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(73);
+    const delivered: Array<{ value: string; attempt: number; tick: number }> = [];
+    const send = (value: string) =>
+      scheduler.intercept(
+        { from: "browser", to: "edge", label: value },
+        value,
+        (received, context) => void delivered.push({ value: received, ...context }),
+      );
+
+    scheduler.duplicateNext();
+    await send("duplicate");
+    scheduler.delayNext(2);
+    await send("delayed");
+    scheduler.reorderNext();
+    await send("first");
+    await send("second");
+    scheduler.dropNextThenRetry(3);
+    await send("retry");
+
+    expect(delivered.map(({ value, attempt }) => `${value}:${attempt}`)).toEqual([
+      "duplicate:1",
+      "duplicate:2",
+      "second:1",
+      "first:1",
+    ]);
+    await scheduler.advance(2);
+    expect(delivered.map(({ value }) => value)).toEqual([
+      "duplicate",
+      "duplicate",
+      "second",
+      "first",
+      "delayed",
+    ]);
+    await scheduler.advance();
+    expect(delivered.some(({ value }) => value === "retry")).toBe(true);
+    scheduler.partition("browser", "edge");
+    await send("partitioned");
+    expect(delivered.some(({ value }) => value === "partitioned")).toBe(false);
+    await scheduler.heal("browser", "edge");
+    expect(delivered.map(({ value }) => value)).toContain("partitioned");
+
+    const receipt = scheduler.receipt();
+    expect(receipt).toMatchObject({ seed: 73, tick: 3, pending: 0, closed: false });
+    expect(receipt.activities.map(({ action }) => action)).toContain("dropped");
+    expect(receipt.activities.map(({ action }) => action)).toContain("retried");
+    expect(receipt.activities.map(({ action }) => action)).toContain("partitioned");
+  });
+
+  it("closes held envelopes after scenario cleanup, proving faults cannot leak between cases", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(17);
+    scheduler.delayNext(10);
+    await scheduler.intercept({ from: "a", to: "b", label: "held" }, "held", () => undefined);
+
+    const receipt = await runTopologyScenario({
+      id: "harness.fixture.envelope-cleanup",
+      topology: ["fixture"],
+      seed: 17,
+      phaseTimeoutMs: 50,
+      faultTimeoutMs: 50,
+      targets: {},
+      replay: "envelope-cleanup-fixture",
+      envelopeSchedulers: [scheduler],
+      phases: [],
+    });
+    expect(receipt.envelopes).toHaveLength(1);
+    expect(receipt.envelopes[0]).toMatchObject({ closed: true, pending: 0 });
+    expect(receipt.envelopes[0]?.activities.at(-1)?.action).toBe("discarded");
+    await expect(
+      scheduler.intercept({ from: "a", to: "b" }, "late", () => undefined),
+    ).rejects.toThrow("scheduler is closed");
+  });
+
   it("runs deterministic phases and every fault callback with a replayable receipt", async () => {
     const seed = Number(process.env.JAZZ_EXAMPLE_TOPOLOGY_SEED ?? 29);
     const calls: string[] = [];

--- a/packages/jazz-tools/tests/topology/harness.test.ts
+++ b/packages/jazz-tools/tests/topology/harness.test.ts
@@ -4,6 +4,7 @@ import {
   TopologyScenarioError,
   deterministicRandom,
   runTopologyScenario,
+  type TopologyEnvelopeDelivery,
   type TopologyFaultTarget,
 } from "./harness.js";
 
@@ -123,53 +124,71 @@ describe("shared example topology harness", () => {
 
   it("records a rejected delivery without retaining it for cleanup", async () => {
     const scheduler = new TopologyEnvelopeScheduler(23);
+    const secret = "credential-shaped-secret-value";
     await expect(
       scheduler.intercept({ from: "a", to: "b", label: "reject" }, "reject", () =>
-        Promise.reject(new Error("planted delivery rejection")),
+        Promise.reject(new Error(secret)),
       ),
-    ).rejects.toThrow("planted delivery rejection");
+    ).rejects.toThrow(secret);
     await scheduler.close(20);
     const receipt = scheduler.receipt();
     expect(receipt).toMatchObject({ closed: true, pending: 0, inFlight: 0 });
-    expect(receipt.activities.find(({ action }) => action === "deliveryFailed")?.error).toContain(
-      "planted delivery rejection",
+    expect(receipt.activities.find(({ action }) => action === "deliveryFailed")?.error).toBe(
+      "error",
     );
+    const serialized = JSON.stringify(receipt);
+    expect(serialized).not.toContain(secret);
+    expect(serialized.length).toBeLessThan(2_000);
   });
 
-  it("bounds a delivery that ignores cancellation and retains an explicit timeout receipt", async () => {
+  it("records a bounded timeout but drains an abort-ignoring delivery before returning", async () => {
     const scheduler = new TopologyEnvelopeScheduler(31);
     let release!: () => void;
+    let observeAbort!: () => void;
+    const abortObserved = new Promise<void>((resolve) => (observeAbort = resolve));
     const delivery = scheduler.intercept(
       { from: "a", to: "b", label: "ignores-abort" },
       "ignores-abort",
-      () => new Promise<void>((resolve) => (release = resolve)),
+      (_, { signal }) =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+          signal.addEventListener("abort", observeAbort, { once: true });
+        }),
     );
     await Promise.resolve();
+    let scenarioSettled = false;
+    const scenario = runTopologyScenario({
+      id: "harness.fixture.in-flight-timeout",
+      topology: ["fixture"],
+      seed: 31,
+      phaseTimeoutMs: 200,
+      faultTimeoutMs: 50,
+      targets: {},
+      replay: "in-flight-timeout-fixture",
+      envelopeSchedulers: [scheduler],
+      phases: [],
+    }).finally(() => (scenarioSettled = true));
+    await abortObserved;
+    while (!scheduler.receipt().activities.some(({ action }) => action === "closeTimedOut")) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    expect(scenarioSettled).toBe(false);
+    release();
     let failure: unknown;
     try {
-      await runTopologyScenario({
-        id: "harness.fixture.in-flight-timeout",
-        topology: ["fixture"],
-        seed: 31,
-        phaseTimeoutMs: 50,
-        faultTimeoutMs: 5,
-        targets: {},
-        replay: "in-flight-timeout-fixture",
-        envelopeSchedulers: [scheduler],
-        phases: [],
-      });
+      await scenario;
     } catch (error) {
       failure = error;
     }
     expect(failure).toBeInstanceOf(TopologyScenarioError);
     const receipt = (failure as TopologyScenarioError).receipt.envelopes[0];
-    expect(receipt).toMatchObject({ closed: true, inFlight: 1, cleanup: { status: "failed" } });
-    expect(receipt?.activities.at(-1)?.action).toBe("closeTimedOut");
-    release();
+    expect(receipt).toMatchObject({ closed: true, inFlight: 0, cleanup: { status: "failed" } });
+    expect(receipt?.activities.map(({ action }) => action)).toContain("closeTimedOut");
+    expect(receipt?.activities.at(-1)?.action).toBe("delivered");
     await delivery;
   });
 
-  it("serializes concurrent intercepts and permits a delivery to enqueue a follow-up", async () => {
+  it("keeps an independent concurrent intercept pending until its held callback is delivered", async () => {
     const scheduler = new TopologyEnvelopeScheduler(37);
     let releaseFirst!: () => void;
     const delivered: string[] = [];
@@ -190,26 +209,50 @@ describe("shared example topology harness", () => {
       "second",
       () => void delivered.push("second"),
     );
+    let secondSettled = false;
+    void second.then(() => (secondSettled = true));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(delivered).toEqual([]);
+    expect(secondSettled).toBe(false);
     releaseFirst();
     await Promise.all([first, second]);
     expect(delivered).toEqual(["first", "second"]);
-
-    await scheduler.intercept({ from: "a", to: "b", label: "parent" }, "parent", async () => {
-      await scheduler.intercept(
-        { from: "a", to: "b", label: "child" },
-        "child",
-        () => void delivered.push("child"),
-      );
-      delivered.push("parent");
-    });
-    expect(delivered).toEqual(["first", "second", "parent", "child"]);
+    expect(secondSettled).toBe(true);
     expect(
       scheduler
         .receipt()
         .activities.filter(({ action }) => action === "delivered")
         .map(({ label }) => label),
-    ).toEqual(["first", "second", "parent", "child"]);
+    ).toEqual(["first", "second"]);
+  });
+
+  it("permits a callback-scoped reentrant intercept without releasing independent callers", async () => {
+    const scheduler = new TopologyEnvelopeScheduler(38);
+    const delivered: string[] = [];
+    let staleIntercept!: Parameters<TopologyEnvelopeDelivery<string>>[1]["intercept"];
+    await scheduler.intercept(
+      { from: "a", to: "b", label: "parent" },
+      "parent",
+      async (_, context) => {
+        staleIntercept = context.intercept;
+        await context.intercept(
+          { from: "a", to: "b", label: "child" },
+          "child",
+          () => void delivered.push("child"),
+        );
+        delivered.push("parent");
+      },
+    );
+    expect(delivered).toEqual(["parent", "child"]);
+    expect(
+      scheduler
+        .receipt()
+        .activities.filter(({ action }) => action === "delivered")
+        .map(({ label }) => label),
+    ).toEqual(["parent", "child"]);
+    await expect(staleIntercept({ from: "a", to: "b" }, "stale", () => undefined)).rejects.toThrow(
+      "topology delivery intercept is no longer active",
+    );
   });
 
   it("snapshots bounded descriptors and rejects receipt-field or payload injection", async () => {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -660,9 +660,9 @@ export class TopologyEnvelopeScheduler {
     return this.#partitions.has(linkKey(envelope.from, envelope.to));
   }
 
-  private recordPending(
+  private recordPending<T>(
     action: TopologyEnvelopeAction,
-    pending: PendingEnvelope<unknown>,
+    pending: PendingEnvelope<T>,
     error?: unknown,
   ): void {
     this.record({
@@ -801,7 +801,12 @@ function assertEndpoint(name: string, value: unknown): asserts value is string {
 }
 
 function assertTopologyTicks(name: string, ticks: unknown): asserts ticks is number {
-  if (!Number.isSafeInteger(ticks) || ticks < 1 || ticks > MAX_TOPOLOGY_TICKS) {
+  if (
+    typeof ticks !== "number" ||
+    !Number.isSafeInteger(ticks) ||
+    ticks < 1 ||
+    ticks > MAX_TOPOLOGY_TICKS
+  ) {
     throw new Error(`${name} ticks must be a positive safe integer at most ${MAX_TOPOLOGY_TICKS}`);
   }
 }

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -654,29 +654,39 @@ export class TopologyEnvelopeScheduler {
 
   private async deliver(pending: PendingEnvelope<unknown>): Promise<void> {
     const controller = new AbortController();
-    const promise = Promise.resolve().then(async () => {
+    const promise = Promise.resolve().then(() => {
       let callbackActive = true;
+      const context: TopologyEnvelopeDeliveryContext = {
+        envelopeId: pending.envelopeId,
+        attempt: pending.attempt,
+        tick: this.#tick,
+        sequence: pending.sequence,
+        signal: controller.signal,
+        intercept: async <T>(
+          envelope: TopologyTransportEnvelope,
+          value: T,
+          deliver: TopologyEnvelopeDelivery<T>,
+        ) => {
+          if (!callbackActive) {
+            throw new Error("topology delivery intercept is no longer active");
+          }
+          await this.interceptInternal(envelope, value, deliver, true);
+        },
+      };
+      let result: Promise<void> | void;
       try {
-        await pending.deliver(pending.value, {
-          envelopeId: pending.envelopeId,
-          attempt: pending.attempt,
-          tick: this.#tick,
-          sequence: pending.sequence,
-          signal: controller.signal,
-          intercept: async <T>(
-            envelope: TopologyTransportEnvelope,
-            value: T,
-            deliver: TopologyEnvelopeDelivery<T>,
-          ) => {
-            if (!callbackActive) {
-              throw new Error("topology delivery intercept is no longer active");
-            }
-            await this.interceptInternal(envelope, value, deliver, true);
-          },
-        });
-      } finally {
+        result = pending.deliver(pending.value, context);
+      } catch (error) {
         callbackActive = false;
+        throw error;
       }
+      if (result === undefined) {
+        callbackActive = false;
+        return;
+      }
+      return Promise.resolve(result).finally(() => {
+        callbackActive = false;
+      });
     });
     this.#inFlight.set(pending.sequence, { pending, controller, promise });
     try {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -288,6 +288,15 @@ export interface TopologyEnvelopeDeliveryContext {
   tick: number;
   sequence: number;
   signal: AbortSignal;
+  /**
+   * Enqueue a follow-up from this delivery without waiting on the drain which
+   * is currently awaiting this callback. Valid only until the callback settles.
+   */
+  intercept<T>(
+    envelope: TopologyTransportEnvelope,
+    value: T,
+    deliver: TopologyEnvelopeDelivery<T>,
+  ): Promise<void>;
 }
 
 export type TopologyEnvelopeDelivery<T> = (
@@ -385,7 +394,6 @@ export class TopologyEnvelopeScheduler {
   #closePromise: Promise<void> | undefined;
   #cleanup: TopologyActivityReceipt | undefined;
   #pumpPromise: Promise<void> | undefined;
-  #deliveryDepth = 0;
   #failure: unknown;
 
   constructor(seed: number) {
@@ -482,6 +490,15 @@ export class TopologyEnvelopeScheduler {
     value: T,
     deliver: TopologyEnvelopeDelivery<T>,
   ): Promise<void> {
+    await this.interceptInternal(envelope, value, deliver, false);
+  }
+
+  private async interceptInternal<T>(
+    envelope: TopologyTransportEnvelope,
+    value: T,
+    deliver: TopologyEnvelopeDelivery<T>,
+    reentrant: boolean,
+  ): Promise<void> {
     this.assertOpen();
     const descriptor = snapshotEnvelope(envelope);
     const pending: PendingEnvelope<T> = {
@@ -530,7 +547,7 @@ export class TopologyEnvelopeScheduler {
         this.#pending.push(duplicate as PendingEnvelope<unknown>);
       }
     }
-    await this.pump();
+    await this.pump(reentrant);
   }
 
   /**
@@ -587,25 +604,34 @@ export class TopologyEnvelopeScheduler {
       await waitForSettlement(
         [...this.#inFlight.values()].map(({ promise }) => promise),
         timeoutMs,
+        (timeoutError) => {
+          const message = errorMessage(timeoutError);
+          Object.assign(this.#cleanup!, {
+            status: "failed",
+            elapsedMs: elapsed(started),
+            error: message,
+          });
+          this.record({ action: "closeTimedOut", error: message });
+        },
       );
       Object.assign(this.#cleanup, { status: "completed", elapsedMs: elapsed(started) });
     } catch (error) {
       const message = errorMessage(error);
-      Object.assign(this.#cleanup, {
-        status: "failed",
-        elapsedMs: elapsed(started),
-        error: message,
-      });
-      this.record({ action: "closeTimedOut", error: message });
+      if (this.#cleanup.status !== "failed") {
+        Object.assign(this.#cleanup, {
+          status: "failed",
+          elapsedMs: elapsed(started),
+          error: message,
+        });
+      }
       throw error;
     }
   }
 
-  private async pump(): Promise<void> {
-    // A delivery callback may await `intercept` to enqueue a follow-up. Do not
-    // make it await its own serialized drain; the outer drain will pick up the
-    // follow-up after the callback returns. Other callers still join the drain.
-    if (this.#pumpPromise) return this.#deliveryDepth > 0 ? undefined : this.#pumpPromise;
+  private async pump(reentrant = false): Promise<void> {
+    // Only the callback-scoped intercept below may avoid joining its own drain.
+    // Independent concurrent callers always await the active serialized pump.
+    if (this.#pumpPromise) return reentrant ? undefined : this.#pumpPromise;
     this.#pumpPromise = this.pumpInternal();
     try {
       await this.#pumpPromise;
@@ -629,7 +655,7 @@ export class TopologyEnvelopeScheduler {
   private async deliver(pending: PendingEnvelope<unknown>): Promise<void> {
     const controller = new AbortController();
     const promise = Promise.resolve().then(async () => {
-      this.#deliveryDepth++;
+      let callbackActive = true;
       try {
         await pending.deliver(pending.value, {
           envelopeId: pending.envelopeId,
@@ -637,9 +663,19 @@ export class TopologyEnvelopeScheduler {
           tick: this.#tick,
           sequence: pending.sequence,
           signal: controller.signal,
+          intercept: async <T>(
+            envelope: TopologyTransportEnvelope,
+            value: T,
+            deliver: TopologyEnvelopeDelivery<T>,
+          ) => {
+            if (!callbackActive) {
+              throw new Error("topology delivery intercept is no longer active");
+            }
+            await this.interceptInternal(envelope, value, deliver, true);
+          },
         });
       } finally {
-        this.#deliveryDepth--;
+        callbackActive = false;
       }
     });
     this.#inFlight.set(pending.sequence, { pending, controller, promise });
@@ -673,7 +709,7 @@ export class TopologyEnvelopeScheduler {
       from: pending.envelope.from,
       to: pending.envelope.to,
       ...(pending.envelope.label === undefined ? {} : { label: pending.envelope.label }),
-      ...(error === undefined ? {} : { error: errorMessage(error) }),
+      ...(error === undefined ? {} : { error: topologyEnvelopeErrorClass(error) }),
     });
   }
 
@@ -689,7 +725,7 @@ export class TopologyEnvelopeScheduler {
   private assertOpen(): void {
     if (this.#closed) throw new Error("topology envelope scheduler is closed");
     if (this.#failure !== undefined) {
-      throw new Error(`topology envelope scheduler is failed: ${errorMessage(this.#failure)}`);
+      throw new Error("topology envelope scheduler is failed after a delivery error");
     }
   }
 
@@ -814,22 +850,37 @@ function assertTopologyTicks(name: string, ticks: unknown): asserts ticks is num
 async function waitForSettlement(
   promises: readonly Promise<void>[],
   timeoutMs: number,
+  onTimeout: (error: Error) => void,
 ): Promise<void> {
   if (promises.length === 0) return;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutError = new Error(`topology envelope cleanup timed out after ${timeoutMs}ms`);
+  const settlement = Promise.allSettled(promises).then(() => undefined);
+  let timedOut = false;
   try {
     await Promise.race([
-      Promise.allSettled(promises).then(() => undefined),
+      settlement,
       new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`topology envelope cleanup timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
+        timer = setTimeout(() => {
+          timedOut = true;
+          onTimeout(timeoutError);
+          reject(timeoutError);
+        }, timeoutMs);
       }),
     ]);
+  } catch (error) {
+    if (!timedOut) throw error;
+    // A timeout is diagnostic, not permission for the scheduler to leak a
+    // still-mutating delivery into the next scenario.
+    await settlement;
+    throw timeoutError;
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+function topologyEnvelopeErrorClass(error: unknown): "error" | "non-error" {
+  return error instanceof Error ? "error" : "non-error";
 }
 
 export class TopologyScenarioError extends Error {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -53,6 +53,11 @@ export interface TopologyScenario {
   targets: Readonly<Record<string, TopologyFaultTarget>>;
   phases: readonly TopologyPhase[];
   replay: string;
+  /**
+   * Test-only transport schedulers owned by this scenario. The runner closes
+   * them after app cleanup so a held packet cannot leak into a later test.
+   */
+  envelopeSchedulers?: readonly TopologyEnvelopeScheduler[];
   cleanup?: (context: TopologyCleanupContext) => Promise<void>;
   cleanupTimeoutMs?: number;
 }
@@ -75,6 +80,7 @@ export interface TopologyReceipt {
   phases: Array<TopologyActivityReceipt & { name: string }>;
   faults: Array<TopologyActivityReceipt & { kind: TopologyFaultKind; target: string }>;
   compensations: Array<TopologyActivityReceipt & { name: string }>;
+  envelopes: TopologyEnvelopeSchedulerReceipt[];
   cleanup?: TopologyActivityReceipt;
   replay: string;
   error?: string;
@@ -101,6 +107,7 @@ export async function runTopologyScenario(
     phases: [],
     faults: [],
     compensations: [],
+    envelopes: scenario.envelopeSchedulers?.map((scheduler) => scheduler.receipt()) ?? [],
     replay: scenario.replay,
   };
   const scenarioStarted = now();
@@ -249,10 +256,294 @@ export async function runTopologyScenario(
         scenarioError ??= cleanupError;
       }
     }
+    for (const scheduler of scenario.envelopeSchedulers ?? []) {
+      try {
+        scheduler.close();
+      } catch (closeError) {
+        const message = `envelope scheduler cleanup failed: ${errorMessage(closeError)}`;
+        receipt.status = "failed";
+        receipt.error = receipt.error ? `${receipt.error}; ${message}` : message;
+        scenarioError ??= closeError;
+      }
+    }
+    receipt.envelopes = scenario.envelopeSchedulers?.map((scheduler) => scheduler.receipt()) ?? [];
     receipt.elapsedMs = elapsed(scenarioStarted);
   }
   if (receipt.status === "failed") throw new TopologyScenarioError(receipt, scenarioError);
   return receipt;
+}
+
+/** A small, app-owned description of a message at a test transport boundary. */
+export interface TopologyTransportEnvelope {
+  from: string;
+  to: string;
+  /** Stable test-only label; never inspect production payloads just to fault them. */
+  label?: string;
+}
+
+export interface TopologyEnvelopeDeliveryContext {
+  attempt: number;
+  tick: number;
+  sequence: number;
+}
+
+export type TopologyEnvelopeDelivery<T> = (
+  value: T,
+  context: TopologyEnvelopeDeliveryContext,
+) => Promise<void> | void;
+
+export type TopologyEnvelopeAction =
+  | "queued"
+  | "delivered"
+  | "duplicated"
+  | "delayed"
+  | "reordered"
+  | "dropped"
+  | "retried"
+  | "partitioned"
+  | "healed"
+  | "discarded";
+
+export interface TopologyEnvelopeActivity {
+  action: TopologyEnvelopeAction;
+  sequence?: number;
+  from?: string;
+  to?: string;
+  label?: string;
+  tick: number;
+  attempt?: number;
+}
+
+export interface TopologyEnvelopeSchedulerReceipt {
+  seed: number;
+  tick: number;
+  closed: boolean;
+  pending: number;
+  activities: readonly TopologyEnvelopeActivity[];
+}
+
+interface PendingEnvelope<T> {
+  sequence: number;
+  envelope: TopologyTransportEnvelope;
+  value: T;
+  deliver: TopologyEnvelopeDelivery<T>;
+  dueTick: number;
+  attempt: number;
+}
+
+interface NextEnvelopeFault {
+  duplicate: number;
+  delayTicks: number;
+  reorder: boolean;
+  dropThenRetryTicks: number | undefined;
+}
+
+/**
+ * Deterministic, virtual-time transport envelope scheduler for example E2Es.
+ *
+ * Wrap only an app test transport's delivery callback with `intercept`; no
+ * Jazz runtime transport is altered. Normal envelopes deliver immediately.
+ * Faults are armed before the next matching envelope, then `advance`/`heal`
+ * releases held work in a deterministic order. Its receipt is intentionally
+ * payload-free, making it safe to include in scenario reports and replays.
+ */
+export class TopologyEnvelopeScheduler {
+  readonly seed: number;
+  #tick = 0;
+  #sequence = 0;
+  #closed = false;
+  #pending: PendingEnvelope<unknown>[] = [];
+  #heldForReorder: PendingEnvelope<unknown> | undefined;
+  #partitions = new Set<string>();
+  #next: NextEnvelopeFault = {
+    duplicate: 0,
+    delayTicks: 0,
+    reorder: false,
+    dropThenRetryTicks: undefined,
+  };
+  #activities: TopologyEnvelopeActivity[] = [];
+
+  constructor(seed: number) {
+    this.seed = seed;
+  }
+
+  /** Deliver the next matching envelope more than once (one duplicate by default). */
+  duplicateNext(copies = 1): void {
+    this.assertOpen();
+    if (!Number.isInteger(copies) || copies < 1)
+      throw new Error("duplicate copies must be a positive integer");
+    this.#next.duplicate += copies;
+  }
+
+  /** Hold the next matching envelope for virtual `ticks`; `advance` releases it. */
+  delayNext(ticks = 1): void {
+    this.assertOpen();
+    if (!Number.isInteger(ticks) || ticks < 1)
+      throw new Error("delay ticks must be a positive integer");
+    this.#next.delayTicks = Math.max(this.#next.delayTicks, ticks);
+  }
+
+  /** Reverse the next pair of envelopes, retaining the first until the second arrives. */
+  reorderNext(): void {
+    this.assertOpen();
+    this.#next.reorder = true;
+  }
+
+  /** Drop the next envelope, then make exactly one retry available after virtual `ticks`. */
+  dropNextThenRetry(ticks = 1): void {
+    this.assertOpen();
+    if (!Number.isInteger(ticks) || ticks < 1)
+      throw new Error("retry ticks must be a positive integer");
+    this.#next.dropThenRetryTicks = ticks;
+  }
+
+  /** Block both directions between two named endpoints until `heal` is called. */
+  partition(first: string, second: string): void {
+    this.assertOpen();
+    this.#partitions.add(linkKey(first, second));
+    this.record({ action: "partitioned", from: first, to: second });
+  }
+
+  /** Heal one link (or all links) and immediately deliver every now-ready envelope. */
+  async heal(first?: string, second?: string): Promise<void> {
+    this.assertOpen();
+    if ((first === undefined) !== (second === undefined)) {
+      throw new Error("heal requires both endpoints or neither");
+    }
+    if (first === undefined) this.#partitions.clear();
+    else this.#partitions.delete(linkKey(first, second!));
+    this.record({ action: "healed", from: first, to: second });
+    await this.pump();
+  }
+
+  /** Advance deterministic virtual time and release due, non-partitioned envelopes. */
+  async advance(ticks = 1): Promise<void> {
+    this.assertOpen();
+    if (!Number.isInteger(ticks) || ticks < 1)
+      throw new Error("advance ticks must be a positive integer");
+    this.#tick += ticks;
+    await this.pump();
+  }
+
+  /**
+   * Intercept one transport-envelope delivery. The caller retains ownership of
+   * transport connection/retry semantics; this models only message delivery.
+   */
+  async intercept<T>(
+    envelope: TopologyTransportEnvelope,
+    value: T,
+    deliver: TopologyEnvelopeDelivery<T>,
+  ): Promise<void> {
+    this.assertOpen();
+    const pending: PendingEnvelope<T> = {
+      sequence: ++this.#sequence,
+      envelope,
+      value,
+      deliver,
+      dueTick: this.#tick,
+      attempt: 1,
+    };
+    this.recordPending("queued", pending);
+    const fault = this.takeNextFault();
+    if (fault.dropThenRetryTicks !== undefined) {
+      this.recordPending("dropped", pending);
+      pending.attempt = 2;
+      pending.dueTick += fault.dropThenRetryTicks;
+      this.recordPending("retried", pending);
+      this.#pending.push(pending as PendingEnvelope<unknown>);
+    } else if (this.#heldForReorder || fault.reorder) {
+      if (!this.#heldForReorder) {
+        this.#heldForReorder = pending as PendingEnvelope<unknown>;
+        this.recordPending("reordered", pending);
+      } else {
+        this.recordPending("reordered", pending);
+        this.#pending.push(pending as PendingEnvelope<unknown>, this.#heldForReorder);
+        this.#heldForReorder = undefined;
+      }
+    } else {
+      pending.dueTick += fault.delayTicks;
+      if (fault.delayTicks) this.recordPending("delayed", pending);
+      this.#pending.push(pending as PendingEnvelope<unknown>);
+      for (let copy = 0; copy < fault.duplicate; copy++) {
+        const duplicate = { ...pending, sequence: ++this.#sequence, attempt: copy + 2 };
+        this.recordPending("duplicated", duplicate);
+        this.#pending.push(duplicate as PendingEnvelope<unknown>);
+      }
+    }
+    await this.pump();
+  }
+
+  /** Discard undelivered envelopes, including an incomplete reorder pair. Idempotent. */
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const pending of [
+      ...this.#pending,
+      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
+    ]) {
+      this.recordPending("discarded", pending);
+    }
+    this.#pending = [];
+    this.#heldForReorder = undefined;
+    this.#partitions.clear();
+  }
+
+  receipt(): TopologyEnvelopeSchedulerReceipt {
+    return {
+      seed: this.seed,
+      tick: this.#tick,
+      closed: this.#closed,
+      pending: this.#pending.length + Number(this.#heldForReorder !== undefined),
+      activities: this.#activities.map((activity) => ({ ...activity })),
+    };
+  }
+
+  private takeNextFault(): NextEnvelopeFault {
+    const next = this.#next;
+    this.#next = { duplicate: 0, delayTicks: 0, reorder: false, dropThenRetryTicks: undefined };
+    return next;
+  }
+
+  private async pump(): Promise<void> {
+    while (true) {
+      const index = this.#pending.findIndex(
+        (pending) => pending.dueTick <= this.#tick && !this.isPartitioned(pending.envelope),
+      );
+      if (index === -1) return;
+      const [pending] = this.#pending.splice(index, 1);
+      await pending.deliver(pending.value, {
+        attempt: pending.attempt,
+        tick: this.#tick,
+        sequence: pending.sequence,
+      });
+      this.recordPending("delivered", pending);
+    }
+  }
+
+  private isPartitioned(envelope: TopologyTransportEnvelope): boolean {
+    return this.#partitions.has(linkKey(envelope.from, envelope.to));
+  }
+
+  private recordPending(action: TopologyEnvelopeAction, pending: PendingEnvelope<unknown>): void {
+    this.record({
+      action,
+      sequence: pending.sequence,
+      attempt: pending.attempt,
+      ...pending.envelope,
+    });
+  }
+
+  private record(activity: Omit<TopologyEnvelopeActivity, "tick">): void {
+    this.#activities.push({ ...activity, tick: this.#tick });
+  }
+
+  private assertOpen(): void {
+    if (this.#closed) throw new Error("topology envelope scheduler is closed");
+  }
+}
+
+function linkKey(first: string, second: string): string {
+  return first < second ? `${first}\u0000${second}` : `${second}\u0000${first}`;
 }
 
 export class TopologyScenarioError extends Error {

--- a/packages/jazz-tools/tests/topology/harness.ts
+++ b/packages/jazz-tools/tests/topology/harness.ts
@@ -58,6 +58,7 @@ export interface TopologyScenario {
    * them after app cleanup so a held packet cannot leak into a later test.
    */
   envelopeSchedulers?: readonly TopologyEnvelopeScheduler[];
+  envelopeCleanupTimeoutMs?: number;
   cleanup?: (context: TopologyCleanupContext) => Promise<void>;
   cleanupTimeoutMs?: number;
 }
@@ -258,7 +259,7 @@ export async function runTopologyScenario(
     }
     for (const scheduler of scenario.envelopeSchedulers ?? []) {
       try {
-        scheduler.close();
+        await scheduler.close(scenario.envelopeCleanupTimeoutMs ?? scenario.faultTimeoutMs);
       } catch (closeError) {
         const message = `envelope scheduler cleanup failed: ${errorMessage(closeError)}`;
         receipt.status = "failed";
@@ -275,16 +276,18 @@ export async function runTopologyScenario(
 
 /** A small, app-owned description of a message at a test transport boundary. */
 export interface TopologyTransportEnvelope {
-  from: string;
-  to: string;
+  readonly from: string;
+  readonly to: string;
   /** Stable test-only label; never inspect production payloads just to fault them. */
-  label?: string;
+  readonly label?: string;
 }
 
 export interface TopologyEnvelopeDeliveryContext {
+  envelopeId: number;
   attempt: number;
   tick: number;
   sequence: number;
+  signal: AbortSignal;
 }
 
 export type TopologyEnvelopeDelivery<T> = (
@@ -302,16 +305,21 @@ export type TopologyEnvelopeAction =
   | "retried"
   | "partitioned"
   | "healed"
-  | "discarded";
+  | "discarded"
+  | "deliveryFailed"
+  | "deliveryAborted"
+  | "closeTimedOut";
 
 export interface TopologyEnvelopeActivity {
   action: TopologyEnvelopeAction;
+  envelopeId?: number;
   sequence?: number;
   from?: string;
   to?: string;
   label?: string;
   tick: number;
   attempt?: number;
+  error?: string;
 }
 
 export interface TopologyEnvelopeSchedulerReceipt {
@@ -319,16 +327,20 @@ export interface TopologyEnvelopeSchedulerReceipt {
   tick: number;
   closed: boolean;
   pending: number;
+  inFlight: number;
+  cleanup?: TopologyActivityReceipt;
   activities: readonly TopologyEnvelopeActivity[];
 }
 
 interface PendingEnvelope<T> {
+  envelopeId: number;
   sequence: number;
   envelope: TopologyTransportEnvelope;
   value: T;
   deliver: TopologyEnvelopeDelivery<T>;
   dueTick: number;
   attempt: number;
+  retry: boolean;
 }
 
 interface NextEnvelopeFault {
@@ -336,6 +348,12 @@ interface NextEnvelopeFault {
   delayTicks: number;
   reorder: boolean;
   dropThenRetryTicks: number | undefined;
+}
+
+interface InFlightEnvelope {
+  pending: PendingEnvelope<unknown>;
+  controller: AbortController;
+  promise: Promise<void>;
 }
 
 /**
@@ -351,6 +369,7 @@ export class TopologyEnvelopeScheduler {
   readonly seed: number;
   #tick = 0;
   #sequence = 0;
+  #envelopeId = 0;
   #closed = false;
   #pending: PendingEnvelope<unknown>[] = [];
   #heldForReorder: PendingEnvelope<unknown> | undefined;
@@ -362,44 +381,67 @@ export class TopologyEnvelopeScheduler {
     dropThenRetryTicks: undefined,
   };
   #activities: TopologyEnvelopeActivity[] = [];
+  #inFlight = new Map<number, InFlightEnvelope>();
+  #closePromise: Promise<void> | undefined;
+  #cleanup: TopologyActivityReceipt | undefined;
+  #pumpPromise: Promise<void> | undefined;
+  #deliveryDepth = 0;
+  #failure: unknown;
 
   constructor(seed: number) {
+    if (!Number.isSafeInteger(seed) || seed < 0 || seed > 0xffff_ffff) {
+      throw new Error("topology envelope scheduler seed must be a uint32");
+    }
     this.seed = seed;
   }
 
   /** Deliver the next matching envelope more than once (one duplicate by default). */
   duplicateNext(copies = 1): void {
     this.assertOpen();
-    if (!Number.isInteger(copies) || copies < 1)
-      throw new Error("duplicate copies must be a positive integer");
+    this.assertArmedOnly("duplicate");
+    if (!Number.isSafeInteger(copies) || copies < 1 || copies > MAX_TOPOLOGY_COPIES)
+      throw new Error(`duplicate copies must be a positive integer at most ${MAX_TOPOLOGY_COPIES}`);
+    if (this.#next.duplicate + copies > MAX_TOPOLOGY_COPIES)
+      throw new Error(`duplicate copies must not exceed ${MAX_TOPOLOGY_COPIES}`);
     this.#next.duplicate += copies;
   }
 
   /** Hold the next matching envelope for virtual `ticks`; `advance` releases it. */
   delayNext(ticks = 1): void {
     this.assertOpen();
-    if (!Number.isInteger(ticks) || ticks < 1)
-      throw new Error("delay ticks must be a positive integer");
-    this.#next.delayTicks = Math.max(this.#next.delayTicks, ticks);
+    this.assertArmedOnly("delay");
+    assertTopologyTicks("delay", ticks);
+    this.#next.delayTicks = ticks;
   }
 
   /** Reverse the next pair of envelopes, retaining the first until the second arrives. */
   reorderNext(): void {
     this.assertOpen();
+    this.assertArmedOnly("reorder");
     this.#next.reorder = true;
   }
 
   /** Drop the next envelope, then make exactly one retry available after virtual `ticks`. */
   dropNextThenRetry(ticks = 1): void {
     this.assertOpen();
-    if (!Number.isInteger(ticks) || ticks < 1)
-      throw new Error("retry ticks must be a positive integer");
+    this.assertArmedOnly("drop-then-retry");
+    assertTopologyTicks("retry", ticks);
     this.#next.dropThenRetryTicks = ticks;
   }
 
   /** Block both directions between two named endpoints until `heal` is called. */
   partition(first: string, second: string): void {
     this.assertOpen();
+    assertEndpoint("first partition endpoint", first);
+    assertEndpoint("second partition endpoint", second);
+    if (
+      !this.#partitions.has(linkKey(first, second)) &&
+      this.#partitions.size >= MAX_TOPOLOGY_PARTITIONS
+    ) {
+      throw new Error(
+        `topology envelope scheduler partition capacity is ${MAX_TOPOLOGY_PARTITIONS}`,
+      );
+    }
     this.#partitions.add(linkKey(first, second));
     this.record({ action: "partitioned", from: first, to: second });
   }
@@ -410,6 +452,10 @@ export class TopologyEnvelopeScheduler {
     if ((first === undefined) !== (second === undefined)) {
       throw new Error("heal requires both endpoints or neither");
     }
+    if (first !== undefined) {
+      assertEndpoint("first heal endpoint", first);
+      assertEndpoint("second heal endpoint", second!);
+    }
     if (first === undefined) this.#partitions.clear();
     else this.#partitions.delete(linkKey(first, second!));
     this.record({ action: "healed", from: first, to: second });
@@ -419,8 +465,10 @@ export class TopologyEnvelopeScheduler {
   /** Advance deterministic virtual time and release due, non-partitioned envelopes. */
   async advance(ticks = 1): Promise<void> {
     this.assertOpen();
-    if (!Number.isInteger(ticks) || ticks < 1)
-      throw new Error("advance ticks must be a positive integer");
+    assertTopologyTicks("advance", ticks);
+    if (this.#tick + ticks > MAX_TOPOLOGY_TICKS) {
+      throw new Error(`topology virtual time must not exceed ${MAX_TOPOLOGY_TICKS} ticks`);
+    }
     this.#tick += ticks;
     await this.pump();
   }
@@ -435,37 +483,49 @@ export class TopologyEnvelopeScheduler {
     deliver: TopologyEnvelopeDelivery<T>,
   ): Promise<void> {
     this.assertOpen();
+    const descriptor = snapshotEnvelope(envelope);
     const pending: PendingEnvelope<T> = {
-      sequence: ++this.#sequence,
-      envelope,
+      envelopeId: this.allocateEnvelopeId(),
+      sequence: this.allocateSequence(),
+      envelope: descriptor,
       value,
       deliver,
       dueTick: this.#tick,
       attempt: 1,
+      retry: false,
     };
     this.recordPending("queued", pending);
     const fault = this.takeNextFault();
     if (fault.dropThenRetryTicks !== undefined) {
       this.recordPending("dropped", pending);
       pending.attempt = 2;
+      pending.retry = true;
       pending.dueTick += fault.dropThenRetryTicks;
-      this.recordPending("retried", pending);
+      this.ensureCapacity(1);
       this.#pending.push(pending as PendingEnvelope<unknown>);
     } else if (this.#heldForReorder || fault.reorder) {
       if (!this.#heldForReorder) {
+        this.ensureCapacity(1);
         this.#heldForReorder = pending as PendingEnvelope<unknown>;
         this.recordPending("reordered", pending);
       } else {
         this.recordPending("reordered", pending);
+        this.ensureCapacity(2);
         this.#pending.push(pending as PendingEnvelope<unknown>, this.#heldForReorder);
         this.#heldForReorder = undefined;
       }
     } else {
       pending.dueTick += fault.delayTicks;
       if (fault.delayTicks) this.recordPending("delayed", pending);
+      this.ensureCapacity(1 + fault.duplicate);
       this.#pending.push(pending as PendingEnvelope<unknown>);
       for (let copy = 0; copy < fault.duplicate; copy++) {
-        const duplicate = { ...pending, sequence: ++this.#sequence, attempt: copy + 2 };
+        const duplicate = {
+          ...pending,
+          sequence: this.allocateSequence(),
+          attempt: copy + 2,
+          retry: false,
+        };
         this.recordPending("duplicated", duplicate);
         this.#pending.push(duplicate as PendingEnvelope<unknown>);
       }
@@ -473,19 +533,18 @@ export class TopologyEnvelopeScheduler {
     await this.pump();
   }
 
-  /** Discard undelivered envelopes, including an incomplete reorder pair. Idempotent. */
-  close(): void {
-    if (this.#closed) return;
-    this.#closed = true;
-    for (const pending of [
-      ...this.#pending,
-      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
-    ]) {
-      this.recordPending("discarded", pending);
+  /**
+   * Abort and await in-flight delivery before returning. A callback which
+   * ignores its signal produces a bounded, visible cleanup failure rather
+   * than silently leaking into a later scenario. Idempotent.
+   */
+  close(timeoutMs: number): Promise<void> {
+    if (this.#closePromise) return this.#closePromise;
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 1) {
+      return Promise.reject(new Error("envelope cleanup timeout must be positive"));
     }
-    this.#pending = [];
-    this.#heldForReorder = undefined;
-    this.#partitions.clear();
+    this.#closePromise = this.closeInternal(timeoutMs);
+    return this.#closePromise;
   }
 
   receipt(): TopologyEnvelopeSchedulerReceipt {
@@ -494,6 +553,8 @@ export class TopologyEnvelopeScheduler {
       tick: this.#tick,
       closed: this.#closed,
       pending: this.#pending.length + Number(this.#heldForReorder !== undefined),
+      inFlight: this.#inFlight.size,
+      cleanup: this.#cleanup && { ...this.#cleanup },
       activities: this.#activities.map((activity) => ({ ...activity })),
     };
   }
@@ -504,19 +565,94 @@ export class TopologyEnvelopeScheduler {
     return next;
   }
 
+  private async closeInternal(timeoutMs: number): Promise<void> {
+    this.#closed = true;
+    for (const pending of [
+      ...this.#pending,
+      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
+    ]) {
+      this.recordPending("discarded", pending);
+    }
+    this.#pending = [];
+    this.#heldForReorder = undefined;
+    this.#partitions.clear();
+    const started = now();
+    this.#cleanup = { status: "attempted", elapsedMs: 0 };
+    const abort = new Error("topology envelope scheduler closed");
+    for (const inFlight of this.#inFlight.values()) {
+      inFlight.controller.abort(abort);
+      this.recordPending("deliveryAborted", inFlight.pending, abort);
+    }
+    try {
+      await waitForSettlement(
+        [...this.#inFlight.values()].map(({ promise }) => promise),
+        timeoutMs,
+      );
+      Object.assign(this.#cleanup, { status: "completed", elapsedMs: elapsed(started) });
+    } catch (error) {
+      const message = errorMessage(error);
+      Object.assign(this.#cleanup, {
+        status: "failed",
+        elapsedMs: elapsed(started),
+        error: message,
+      });
+      this.record({ action: "closeTimedOut", error: message });
+      throw error;
+    }
+  }
+
   private async pump(): Promise<void> {
+    // A delivery callback may await `intercept` to enqueue a follow-up. Do not
+    // make it await its own serialized drain; the outer drain will pick up the
+    // follow-up after the callback returns. Other callers still join the drain.
+    if (this.#pumpPromise) return this.#deliveryDepth > 0 ? undefined : this.#pumpPromise;
+    this.#pumpPromise = this.pumpInternal();
+    try {
+      await this.#pumpPromise;
+    } finally {
+      this.#pumpPromise = undefined;
+    }
+  }
+
+  private async pumpInternal(): Promise<void> {
     while (true) {
+      if (this.#closed) return;
       const index = this.#pending.findIndex(
         (pending) => pending.dueTick <= this.#tick && !this.isPartitioned(pending.envelope),
       );
       if (index === -1) return;
       const [pending] = this.#pending.splice(index, 1);
-      await pending.deliver(pending.value, {
-        attempt: pending.attempt,
-        tick: this.#tick,
-        sequence: pending.sequence,
-      });
+      await this.deliver(pending);
+    }
+  }
+
+  private async deliver(pending: PendingEnvelope<unknown>): Promise<void> {
+    const controller = new AbortController();
+    const promise = Promise.resolve().then(async () => {
+      this.#deliveryDepth++;
+      try {
+        await pending.deliver(pending.value, {
+          envelopeId: pending.envelopeId,
+          attempt: pending.attempt,
+          tick: this.#tick,
+          sequence: pending.sequence,
+          signal: controller.signal,
+        });
+      } finally {
+        this.#deliveryDepth--;
+      }
+    });
+    this.#inFlight.set(pending.sequence, { pending, controller, promise });
+    try {
+      if (pending.retry) this.recordPending("retried", pending);
+      await promise;
       this.recordPending("delivered", pending);
+    } catch (error) {
+      this.recordPending("deliveryFailed", pending, error);
+      this.failStop(error);
+      throw error;
+    } finally {
+      this.#inFlight.delete(pending.sequence);
     }
   }
 
@@ -524,26 +660,171 @@ export class TopologyEnvelopeScheduler {
     return this.#partitions.has(linkKey(envelope.from, envelope.to));
   }
 
-  private recordPending(action: TopologyEnvelopeAction, pending: PendingEnvelope<unknown>): void {
+  private recordPending(
+    action: TopologyEnvelopeAction,
+    pending: PendingEnvelope<unknown>,
+    error?: unknown,
+  ): void {
     this.record({
       action,
+      envelopeId: pending.envelopeId,
       sequence: pending.sequence,
       attempt: pending.attempt,
-      ...pending.envelope,
+      from: pending.envelope.from,
+      to: pending.envelope.to,
+      ...(pending.envelope.label === undefined ? {} : { label: pending.envelope.label }),
+      ...(error === undefined ? {} : { error: errorMessage(error) }),
     });
   }
 
   private record(activity: Omit<TopologyEnvelopeActivity, "tick">): void {
+    if (this.#activities.length >= MAX_TOPOLOGY_ACTIVITIES) {
+      throw new Error(
+        `topology envelope scheduler activity capacity is ${MAX_TOPOLOGY_ACTIVITIES}`,
+      );
+    }
     this.#activities.push({ ...activity, tick: this.#tick });
   }
 
   private assertOpen(): void {
     if (this.#closed) throw new Error("topology envelope scheduler is closed");
+    if (this.#failure !== undefined) {
+      throw new Error(`topology envelope scheduler is failed: ${errorMessage(this.#failure)}`);
+    }
+  }
+
+  private assertArmedOnly(kind: string): void {
+    const armed =
+      this.#next.duplicate > 0 ||
+      this.#next.delayTicks > 0 ||
+      this.#next.reorder ||
+      this.#next.dropThenRetryTicks !== undefined;
+    const duplicateOnly =
+      this.#next.duplicate > 0 &&
+      !this.#next.delayTicks &&
+      !this.#next.reorder &&
+      this.#next.dropThenRetryTicks === undefined;
+    if (armed && !(kind === "duplicate" && duplicateOnly)) {
+      throw new Error("only one envelope fault kind may be armed for the next envelope");
+    }
+  }
+
+  private allocateSequence(): number {
+    if (this.#sequence >= Number.MAX_SAFE_INTEGER)
+      throw new Error("topology delivery sequence exhausted");
+    return ++this.#sequence;
+  }
+
+  private allocateEnvelopeId(): number {
+    if (this.#envelopeId >= Number.MAX_SAFE_INTEGER)
+      throw new Error("topology envelope id exhausted");
+    return ++this.#envelopeId;
+  }
+
+  private ensureCapacity(additional: number): void {
+    if (
+      this.#pending.length +
+        Number(this.#heldForReorder !== undefined) +
+        this.#inFlight.size +
+        additional >
+      MAX_TOPOLOGY_ENVELOPES
+    ) {
+      throw new Error(`topology envelope scheduler capacity is ${MAX_TOPOLOGY_ENVELOPES}`);
+    }
+  }
+
+  private failStop(error: unknown): void {
+    if (this.#failure !== undefined) return;
+    this.#failure = error;
+    for (const queued of [
+      ...this.#pending,
+      ...(this.#heldForReorder ? [this.#heldForReorder] : []),
+    ]) {
+      this.recordPending("discarded", queued, error);
+    }
+    this.#pending = [];
+    this.#heldForReorder = undefined;
   }
 }
 
 function linkKey(first: string, second: string): string {
   return first < second ? `${first}\u0000${second}` : `${second}\u0000${first}`;
+}
+
+const MAX_TOPOLOGY_ENDPOINT_LENGTH = 128;
+const MAX_TOPOLOGY_LABEL_LENGTH = 256;
+const MAX_TOPOLOGY_COPIES = 16;
+const MAX_TOPOLOGY_TICKS = 1_000_000;
+const MAX_TOPOLOGY_ENVELOPES = 4_096;
+const MAX_TOPOLOGY_PARTITIONS = 4_096;
+const MAX_TOPOLOGY_ACTIVITIES = 32_768;
+const ENVELOPE_KEYS = new Set(["from", "to", "label"]);
+
+function snapshotEnvelope(envelope: TopologyTransportEnvelope): TopologyTransportEnvelope {
+  if (
+    typeof envelope !== "object" ||
+    envelope === null ||
+    ![Object.prototype, null].includes(Object.getPrototypeOf(envelope))
+  ) {
+    throw new Error("topology envelope must be a plain descriptor");
+  }
+  for (const key of Reflect.ownKeys(envelope)) {
+    if (typeof key !== "string" || !ENVELOPE_KEYS.has(key)) {
+      throw new Error(`topology envelope contains unsupported metadata: ${String(key)}`);
+    }
+  }
+  const { from, to, label } = envelope;
+  assertEndpoint("from", from);
+  assertEndpoint("to", to);
+  if (
+    label !== undefined &&
+    (typeof label !== "string" || label.length > MAX_TOPOLOGY_LABEL_LENGTH)
+  ) {
+    throw new Error(
+      `topology envelope label must be a string at most ${MAX_TOPOLOGY_LABEL_LENGTH} characters`,
+    );
+  }
+  return label === undefined ? { from, to } : { from, to, label };
+}
+
+function assertEndpoint(name: string, value: unknown): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_TOPOLOGY_ENDPOINT_LENGTH ||
+    value.includes("\u0000")
+  ) {
+    throw new Error(
+      `topology envelope ${name} must be a non-empty string at most ${MAX_TOPOLOGY_ENDPOINT_LENGTH} characters without NUL`,
+    );
+  }
+}
+
+function assertTopologyTicks(name: string, ticks: unknown): asserts ticks is number {
+  if (!Number.isSafeInteger(ticks) || ticks < 1 || ticks > MAX_TOPOLOGY_TICKS) {
+    throw new Error(`${name} ticks must be a positive safe integer at most ${MAX_TOPOLOGY_TICKS}`);
+  }
+}
+
+async function waitForSettlement(
+  promises: readonly Promise<void>[],
+  timeoutMs: number,
+): Promise<void> {
+  if (promises.length === 0) return;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.allSettled(promises).then(() => undefined),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`topology envelope cleanup timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export class TopologyScenarioError extends Error {


### PR DESCRIPTION
🤖 Reconstructs and supersedes #1883 atop the current topology harness, preserving deterministic planted transport failures while fixing its concurrency, cleanup, and receipt boundaries.

## Before

The shared example topology harness could not deterministically schedule duplicate, delay, reorder, retry, drop, and partition-heal behavior at the envelope boundary. Tests either depended on timing or each invented partial fault machinery.

## After

- `TopologyEnvelopeScheduler` deterministically scripts envelope actions and bounded receipts.
- Independent concurrent intercepts remain serialized and settle only after delivery.
- Delivery callbacks receive a scoped reentrant intercept capability, avoiding self-deadlock without allowing unrelated callers through.
- Synchronous callback scopes expire before queued microtasks; async scopes remain valid only until their promise settles.
- Close aborts work, records a bounded diagnostic timeout, and still drains abort-ignoring callbacks before returning.
- Receipts record bounded stable error classes and never callback exception messages or envelope payloads.
- Terminal cleanup integrates with the current `TopologyScenario` registrar contract.

## Examples

- Duplicate then delayed envelopes replay in deterministic order.
- A callback can await a nested intercept without deadlocking; an external caller arriving during that callback still waits.
- A synchronous callback cannot save its intercept capability and use it from a queued microtask.
- A callback that ignores abort cannot mutate state after the scenario has returned.
- An exception containing sensitive text produces only a bounded `error` receipt classification.

## Invariants and non-goals

Fault scheduling is test-only and does not change production transport semantics. Receipts are bounded and payload-free. `close()` is terminal: no callback or scheduled action escapes into the next scenario. This PR establishes the shared harness; individual example applications adopt it in follow-ups.

## Verification

- Focused topology harness typecheck and tests: 19/19.
- Planted failures cover missing pump loops, independent-concurrency early settlement, disabled reentrancy, callback leakage, raw error messages, synchronous capability escape, and premature async expiry.
- Independent adversarial review found no remaining blocker.
- Formatting, lint, diff, and sensitive-data gates pass.