### PR TITLE
Bound retained auxiliary chunk relay obligations

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -92,6 +92,10 @@ pub(crate) type SharedNodeState<S> = Rc<LocalMutex<NodeState<S>>>;
 
 const DEFAULT_CHUNK_FORWARD_HOPS: u8 = 8;
 const MAX_PENDING_CHUNK_DEMANDS: usize = 4096;
+// Downstream relay waiters and their response hand-offs share one budget. A
+// response remains reserved while a binding is deciding whether its send
+// succeeded, so a failed send can be restored without racing fresh admission.
+const MAX_RELAY_CHUNK_OBLIGATIONS: usize = MAX_PENDING_CHUNK_DEMANDS;
 // Auxiliary chunk routing crosses several independent transports in browser
 // persistent-worker mode. Retain only a small, redacted flight recorder so a
 // binding can explain a miss without ever exposing a capability locator.
@@ -166,10 +170,15 @@ struct PendingChunkDemand {
 struct ChunkDemandState {
     next_request_id: u64,
     next_waiter_id: u64,
+    relay_chunk_obligations: usize,
     pending_by_chunk: BTreeMap<groove::chunks::ChunkRequest, PendingChunkDemand>,
     chunk_by_upstream_id: BTreeMap<u64, groove::chunks::ChunkRequest>,
     outbound: VecDeque<ChunkRequestEntry>,
     relay_responses: BTreeMap<u64, Vec<ChunkResponseEntry>>,
+    // Batches removed by `take_relay_responses` but not yet either restored
+    // after a failed send or acknowledged as handed to the transport.
+    // They remain part of `relay_chunk_obligations`.
+    inflight_relay_responses: BTreeMap<u64, VecDeque<Vec<ChunkResponseEntry>>>,
     outbound_wakers: BTreeMap<u64, Waker>,
     disconnected_connections: BTreeSet<u64>,
     upstream_connection: Option<u64>,
@@ -298,6 +307,45 @@ impl PeerChunkResolver {
         state.outbound.extend(retries);
     }
 
+    fn reserve_relay_obligation(state: &mut ChunkDemandState) -> bool {
+        if state.relay_chunk_obligations >= MAX_RELAY_CHUNK_OBLIGATIONS {
+            return false;
+        }
+        state.relay_chunk_obligations += 1;
+        true
+    }
+
+    fn queue_relay_response(
+        state: &mut ChunkDemandState,
+        connection: u64,
+        response: ChunkResponseEntry,
+        reservation_transferred: bool,
+    ) -> bool {
+        if !reservation_transferred && !Self::reserve_relay_obligation(state) {
+            return false;
+        }
+        state
+            .relay_responses
+            .entry(connection)
+            .or_default()
+            .push(response);
+        Self::wake_connection(state, connection);
+        true
+    }
+
+    fn enqueue_relay_responses(
+        &self,
+        connection: u64,
+        responses: impl IntoIterator<Item = ChunkResponseEntry>,
+    ) {
+        let mut state = self.state.borrow_mut();
+        for response in responses {
+            if !Self::queue_relay_response(&mut state, connection, response, false) {
+                break;
+            }
+        }
+    }
+
     fn enqueue(
         &self,
         request: groove::chunks::ChunkRequest,
@@ -305,11 +353,16 @@ impl PeerChunkResolver {
         waiter: ChunkDemandWaiter,
     ) -> Result<(), ChunkDemandWaiter> {
         let mut state = self.state.borrow_mut();
+        let relay_waiter = matches!(&waiter, ChunkDemandWaiter::Relay { .. });
+        if relay_waiter && !Self::reserve_relay_obligation(&mut state) {
+            return Err(waiter);
+        }
         if let Some(pending) = state.pending_by_chunk.get_mut(&request) {
             pending.waiters.push(waiter);
             return Ok(());
         }
         if state.pending_by_chunk.len() >= MAX_PENDING_CHUNK_DEMANDS {
+            state.relay_chunk_obligations -= usize::from(relay_waiter);
             return Err(waiter);
         }
         state.next_request_id = state.next_request_id.wrapping_add(1).max(1);
@@ -340,15 +393,15 @@ impl PeerChunkResolver {
     fn enqueue_relay(&self, connection: u64, request: ChunkRequestEntry) {
         if request.remaining_hops == 0 {
             let mut state = self.state.borrow_mut();
-            state
-                .relay_responses
-                .entry(connection)
-                .or_default()
-                .push(ChunkResponseEntry {
+            Self::queue_relay_response(
+                &mut state,
+                connection,
+                ChunkResponseEntry {
                     request_id: request.request_id,
                     result: ChunkResponse::Unavailable,
-                });
-            Self::wake_connection(&mut state, connection);
+                },
+                false,
+            );
             return;
         }
         if let Err(ChunkDemandWaiter::Relay {
@@ -366,15 +419,15 @@ impl PeerChunkResolver {
             },
         ) {
             let mut state = self.state.borrow_mut();
-            state
-                .relay_responses
-                .entry(connection)
-                .or_default()
-                .push(ChunkResponseEntry {
+            Self::queue_relay_response(
+                &mut state,
+                connection,
+                ChunkResponseEntry {
                     request_id,
                     result: ChunkResponse::Retryable { retry_after_ms: 25 },
-                });
-            Self::wake_connection(&mut state, connection);
+                },
+                false,
+            );
         }
     }
 
@@ -394,14 +447,65 @@ impl PeerChunkResolver {
         let (responses, exhausted) = match state.relay_responses.get_mut(&connection) {
             Some(queued) => {
                 let count = limit.min(queued.len());
-                (queued.drain(..count).collect(), queued.is_empty())
+                (
+                    queued.drain(..count).collect::<Vec<ChunkResponseEntry>>(),
+                    queued.is_empty(),
+                )
             }
             None => return Vec::new(),
         };
         if exhausted {
             state.relay_responses.remove(&connection);
         }
+        state
+            .inflight_relay_responses
+            .entry(connection)
+            .or_default()
+            .push_back(responses.clone());
         responses
+    }
+
+    fn restore_relay_responses(&self, connection: u64, responses: Vec<ChunkResponseEntry>) {
+        let mut state = self.state.borrow_mut();
+        let inflight = state
+            .inflight_relay_responses
+            .get_mut(&connection)
+            .expect("restored relay response batch was handed out");
+        let position = inflight
+            .iter()
+            .position(|batch| batch == &responses)
+            .expect("restored relay response batch is still in flight");
+        inflight.remove(position);
+        if inflight.is_empty() {
+            state.inflight_relay_responses.remove(&connection);
+        }
+        state
+            .relay_responses
+            .entry(connection)
+            .or_default()
+            .splice(0..0, responses);
+    }
+
+    fn acknowledge_relay_response_send(&self, connection: u64, responses: &[ChunkResponseEntry]) {
+        let mut state = self.state.borrow_mut();
+        let inflight = state
+            .inflight_relay_responses
+            .get_mut(&connection)
+            .expect("acknowledged relay response batch was handed out");
+        let position = inflight
+            .iter()
+            .position(|batch| batch == responses)
+            .expect("acknowledged relay response batch is still in flight");
+        let released = inflight
+            .remove(position)
+            .expect("located relay response batch remains removable");
+        if inflight.is_empty() {
+            state.inflight_relay_responses.remove(&connection);
+        }
+        state.relay_chunk_obligations = state
+            .relay_chunk_obligations
+            .checked_sub(released.len())
+            .expect("acknowledged relay responses are accounted");
     }
 
     fn is_active_upstream(&self, connection: u64) -> bool {
@@ -436,18 +540,19 @@ impl PeerChunkResolver {
                     connection,
                     request_id,
                 } => {
-                    state
-                        .relay_responses
-                        .entry(connection)
-                        .or_default()
-                        .push(ChunkResponseEntry {
+                    Self::queue_relay_response(
+                        &mut state,
+                        connection,
+                        ChunkResponseEntry {
                             request_id,
                             result: response.result.clone(),
-                        });
-                    Self::wake_connection(&mut state, connection);
+                        },
+                        true,
+                    );
                 }
             }
         }
+        debug_assert!(state.relay_chunk_obligations <= MAX_RELAY_CHUNK_OBLIGATIONS);
     }
 
     fn cancel_local(&self, request: &groove::chunks::ChunkRequest, waiter_id: u64) {
@@ -474,7 +579,20 @@ impl PeerChunkResolver {
         state.trace_by_connection.remove(&connection);
         state.traced_connections.remove(&connection);
         let disconnected_waker = state.outbound_wakers.remove(&connection);
-        state.relay_responses.remove(&connection);
+        let queued_responses = state
+            .relay_responses
+            .remove(&connection)
+            .map_or(0, |responses| responses.len());
+        let inflight_responses = state
+            .inflight_relay_responses
+            .remove(&connection)
+            .map_or(0, |batches| {
+                batches.into_iter().map(|batch| batch.len()).sum()
+            });
+        state.relay_chunk_obligations = state
+            .relay_chunk_obligations
+            .checked_sub(queued_responses + inflight_responses)
+            .expect("disconnected relay responses are accounted");
         if upstream {
             state.upstream_connections.remove(&connection);
             if state.upstream_connection == Some(connection) {
@@ -492,14 +610,26 @@ impl PeerChunkResolver {
         }
         let requests = state.pending_by_chunk.keys().cloned().collect::<Vec<_>>();
         for request in requests {
-            let Some(pending) = state.pending_by_chunk.get_mut(&request) else {
-                continue;
+            let (removed_relay_waiters, emptied_upstream_id) = {
+                let Some(pending) = state.pending_by_chunk.get_mut(&request) else {
+                    continue;
+                };
+                let mut removed_relay_waiters = 0;
+                pending.waiters.retain(|waiter| {
+                    let remove = matches!(waiter, ChunkDemandWaiter::Relay { connection: relay, .. } if *relay == connection);
+                    removed_relay_waiters += usize::from(remove);
+                    !remove
+                });
+                (
+                    removed_relay_waiters,
+                    pending.waiters.is_empty().then_some(pending.upstream_id),
+                )
             };
-            pending.waiters.retain(|waiter| {
-                !matches!(waiter, ChunkDemandWaiter::Relay { connection: relay, .. } if *relay == connection)
-            });
-            if pending.waiters.is_empty() {
-                let upstream_id = pending.upstream_id;
+            state.relay_chunk_obligations = state
+                .relay_chunk_obligations
+                .checked_sub(removed_relay_waiters)
+                .expect("disconnected relay waiters are accounted");
+            if let Some(upstream_id) = emptied_upstream_id {
                 state.pending_by_chunk.remove(&request);
                 state.chunk_by_upstream_id.remove(&upstream_id);
                 state
@@ -634,6 +764,9 @@ impl PeerIoPump {
             (PeerIoPumpRole::Subscriber, SyncMessage::ChunkRequestBatch(batch)) => {
                 let mut responses = Vec::new();
                 for request in batch.requests {
+                    if self.is_disconnected() {
+                        break;
+                    }
                     self.resolver.record_request(
                         self.connection,
                         self.role,
@@ -642,14 +775,17 @@ impl PeerIoPump {
                         None,
                         None,
                     );
-                    match self
+                    let result = self
                         .local_chunks
                         .get(
                             request.locator.clone(),
                             groove::large_values::ContentHash(request.expected_hash),
                         )
-                        .await
-                    {
+                        .await;
+                    if self.is_disconnected() {
+                        break;
+                    }
+                    match result {
                         Ok(bytes) => {
                             self.resolver.record_request(
                                 self.connection,
@@ -691,14 +827,9 @@ impl PeerIoPump {
                         }
                     }
                 }
-                if !responses.is_empty() {
-                    let mut state = self.resolver.state.borrow_mut();
-                    state
-                        .relay_responses
-                        .entry(self.connection)
-                        .or_default()
-                        .extend(responses);
-                    PeerChunkResolver::wake_connection(&mut state, self.connection);
+                if !responses.is_empty() && !self.is_disconnected() {
+                    self.resolver
+                        .enqueue_relay_responses(self.connection, responses);
                 }
                 Ok(())
             }
@@ -790,7 +921,14 @@ impl PeerIoPump {
                 protocol_version,
                 negotiated_features,
                 session.clone(),
-            )?;
+            );
+            let frame = match frame {
+                Ok(frame) => frame,
+                Err(error) => {
+                    self.restore_outbound(message);
+                    return Err(error);
+                }
+            };
             let Some(next_total) = total_bytes.checked_add(frame.len()) else {
                 self.restore_outbound(message);
                 break;
@@ -806,6 +944,7 @@ impl PeerIoPump {
                 break;
             }
             total_bytes = next_total;
+            self.acknowledge_outbound(&message);
             frames.push(frame);
         }
         Ok(frames)
@@ -859,29 +998,48 @@ impl PeerIoPump {
     }
 
     fn restore_outbound(&self, message: SyncMessage) {
-        let mut state = self.resolver.state.borrow_mut();
         match (self.role, message) {
             (PeerIoPumpRole::Upstream, SyncMessage::ChunkRequestBatch(batch)) => {
+                let mut state = self.resolver.state.borrow_mut();
                 for request in batch.requests.into_iter().rev() {
                     state.outbound.push_front(request);
                 }
             }
             (PeerIoPumpRole::Subscriber, SyncMessage::ChunkResponseBatch(batch)) => {
-                let queued = state.relay_responses.entry(self.connection).or_default();
-                queued.splice(0..0, batch.responses);
+                self.resolver
+                    .restore_relay_responses(self.connection, batch.responses);
             }
             _ => {}
         }
     }
 
+    /// Confirm that an auxiliary batch has been handed to its binding. A
+    /// failed transport send must call `restore_outbound` instead, retaining
+    /// the reservation across that decision boundary.
+    pub(crate) fn acknowledge_outbound(&self, message: &SyncMessage) {
+        if let (PeerIoPumpRole::Subscriber, SyncMessage::ChunkResponseBatch(batch)) =
+            (self.role, message)
+        {
+            self.resolver
+                .acknowledge_relay_response_send(self.connection, &batch.responses);
+        }
+    }
+
     /// Encode one bounded auxiliary payload for a binding-owned socket channel.
     pub fn take_outbound_payload(&self, limit: usize) -> Result<Option<Vec<u8>>, String> {
-        self.take_outbound(limit)
-            .map(|message| {
-                crate::wire::encode_sync_message(&message)
-                    .map_err(|error| format!("cannot encode auxiliary chunk payload: {error}"))
-            })
-            .transpose()
+        let Some(message) = self.take_outbound(limit) else {
+            return Ok(None);
+        };
+        match crate::wire::encode_sync_message(&message) {
+            Ok(payload) => {
+                self.acknowledge_outbound(&message);
+                Ok(Some(payload))
+            }
+            Err(error) => {
+                self.restore_outbound(message);
+                Err(format!("cannot encode auxiliary chunk payload: {error}"))
+            }
+        }
     }
 
     /// Wait until auxiliary output is ready without polling or driving a Jazz
@@ -917,7 +1075,7 @@ impl PeerIoPump {
         }
     }
 
-    fn is_disconnected(&self) -> bool {
+    pub(crate) fn is_disconnected(&self) -> bool {
         self.resolver
             .state
             .borrow()

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1277,6 +1277,10 @@ where
                     (None, None, None, retired)
                 }
             };
+        // The auxiliary lane is independent of semantic ticks. Retire it for
+        // both upstream and subscriber links before releasing this connection
+        // so an in-flight local lookup cannot recreate relay state afterward.
+        connection_ref.auxiliary_pump.disconnect();
         drop(connection_ref);
         // A rejection can be queued by the upstream turn immediately before
         // this abrupt detach. Its downstream transport is gone, so retaining

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -923,6 +923,7 @@ where
                                 }
                                 return Err(transport_error(error));
                             }
+                            self.auxiliary_pump.acknowledge_outbound(&message);
                         }
                         pending.extend(upstream_subscriptions.borrow_mut().drain(..));
                         let claims = self.node.borrow().session_claims_with_revisions();
@@ -2167,6 +2168,7 @@ where
                         self.auxiliary_pump.restore_outbound(message);
                         return Err(transport_error(error));
                     }
+                    self.auxiliary_pump.acknowledge_outbound(&message);
                 }
                 while let Some(message) = self.transport.try_recv() {
                     // Authorization support is authority-owned in Phase 3.

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2190,6 +2190,9 @@ where
                         SyncMessage::ChunkRequestBatch(batch) => {
                             let mut responses = Vec::new();
                             for request in batch.requests {
+                                if self.auxiliary_pump.is_disconnected() {
+                                    break;
+                                }
                                 let local = self
                                     .node
                                     .lock()
@@ -2199,6 +2202,9 @@ where
                                         groove::large_values::ContentHash(request.expected_hash),
                                     )
                                     .await;
+                                if self.auxiliary_pump.is_disconnected() {
+                                    break;
+                                }
                                 match local {
                                     Ok(bytes) => responses.push(ChunkResponseEntry {
                                         request_id: request.request_id,
@@ -2214,7 +2220,9 @@ where
                                     }),
                                 }
                             }
-                            if !responses.is_empty() {
+                            if !responses.is_empty()
+                                && !self.auxiliary_pump.is_disconnected()
+                            {
                                 self.transport
                                     .send(SyncMessage::ChunkResponseBatch(ChunkResponseBatch {
                                         responses,

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -525,6 +525,49 @@ fn mixed_waiter_and_immediate_response_saturation_never_exceeds_the_shared_cap()
 }
 
 #[test]
+fn completion_transfers_a_relay_reservation_until_the_response_is_acknowledged() {
+    let resolver = PeerChunkResolver::default();
+    let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());
+    let database = crate::db::block_on(groove::db::Database::new(
+        schema,
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    let subscriber = PeerIoPump::new(
+        resolver.clone(),
+        database.local_chunk_reader(),
+        46,
+        PeerIoPumpRole::Subscriber,
+    );
+    resolver.enqueue_relay(
+        46,
+        ChunkRequestEntry {
+            request_id: 46,
+            locator: groove::large_values::Locator::random(),
+            expected_hash: [46; 32],
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        },
+    );
+    let upstream_id = resolver.take_outbound(1)[0].request_id;
+    assert_eq!(retained_relay_obligations(&resolver.state.borrow()), 1);
+    resolver.complete(ChunkResponseEntry {
+        request_id: upstream_id,
+        result: ChunkResponse::Found(vec![46]),
+    });
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        1,
+        "completion transfers rather than releases the relay reservation"
+    );
+    let response = subscriber
+        .take_outbound(1)
+        .expect("completed response is queued");
+    assert_eq!(retained_relay_obligations(&resolver.state.borrow()), 1);
+    subscriber.acknowledge_outbound(&response);
+    assert_eq!(retained_relay_obligations(&resolver.state.borrow()), 0);
+}
+
+#[test]
 fn disconnect_mid_batch_stops_later_lookup_and_drops_the_resumed_result() {
     let schema = schema();
     let server = open_db(0x44, AuthorSubject::SYSTEM, &schema);

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -609,6 +609,81 @@ fn disconnect_mid_batch_stops_later_lookup_and_drops_the_resumed_result() {
     assert!(state.relay_responses.get(&pump.connection).is_none());
 }
 
+#[test]
+fn detach_during_peer_tick_chunk_lookup_drops_missing_and_found_outcomes() {
+    for found in [false, true] {
+        let schema = schema();
+        let server = open_db(
+            if found { 0x49 } else { 0x48 },
+            AuthorSubject::SYSTEM,
+            &schema,
+        );
+        let storage = Rc::new(DeferredChunkStorage::default());
+        crate::db::block_on(async {
+            server
+                .node
+                .node
+                .lock()
+                .await
+                .set_chunk_storage(storage.clone());
+        });
+        let (mut client_transport, server_transport) = duplex();
+        let subscriber = server.accept_subscriber(server_transport, AuthorSubject::SYSTEM);
+        let resolver = server.node.chunk_resolver.clone();
+        let pump = subscriber.borrow().io_pump();
+        let request = ChunkRequestEntry {
+            request_id: if found { 49 } else { 48 },
+            locator: groove::large_values::Locator::random(),
+            expected_hash: if found { [0x49; 32] } else { [0x48; 32] },
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        };
+        let chunk = groove::chunks::ChunkRequest {
+            locator: request.locator.clone(),
+            object_hash: request.expected_hash,
+        };
+        client_transport
+            .send(SyncMessage::ChunkRequestBatch(ChunkRequestBatch {
+                requests: vec![request],
+            }))
+            .unwrap();
+
+        let mut connection = subscriber.borrow_mut();
+        let mut ticking = Box::pin(connection.tick());
+        let waker = futures::task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        assert!(matches!(ticking.as_mut().poll(&mut context), Poll::Pending));
+
+        // The connection's semantic tick owns its peer borrow. This is the
+        // binding-side close signal which must fence the suspended lookup.
+        pump.disconnect();
+        storage.release(if found {
+            Ok(bytes::Bytes::from_static(b"peer tick found after detach"))
+        } else {
+            Err(groove::chunks::ChunkStorageError::Unavailable)
+        });
+        assert!(matches!(
+            ticking.as_mut().poll(&mut context),
+            Poll::Ready(Ok(_))
+        ));
+        drop(ticking);
+        drop(connection);
+
+        let state = resolver.state.borrow();
+        assert!(
+            !state.pending_by_chunk.contains_key(&chunk),
+            "peer tick cannot restore missing relay demand after detach"
+        );
+        assert!(
+            state.relay_responses.get(&pump.connection).is_none(),
+            "peer tick cannot queue auxiliary output after detach"
+        );
+        assert!(
+            client_transport.try_recv().is_none(),
+            "peer tick cannot send a found response after detach"
+        );
+    }
+}
+
 // This stays at the auxiliary-pump boundary because the batch split is a
 // hop-local wire-protocol contract, not a user-visible database operation.
 #[test]

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -1,11 +1,80 @@
+use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 
 use groove::chunks::{ChunkKvStorage, ChunkProvider, ChunkStorage, MissingChunkResolver};
 
 use super::super::*;
+use super::{duplex, open_db, schema};
+
+#[derive(Default)]
+struct DeferredChunkStorage {
+    backend: groove::chunks::MemoryChunkStorage,
+    outcome: RefCell<Option<Result<bytes::Bytes, groove::chunks::ChunkStorageError>>>,
+    waiter: RefCell<Option<Waker>>,
+}
+
+impl DeferredChunkStorage {
+    fn release(&self, outcome: Result<bytes::Bytes, groove::chunks::ChunkStorageError>) {
+        *self.outcome.borrow_mut() = Some(outcome);
+        if let Some(waiter) = self.waiter.borrow_mut().take() {
+            waiter.wake();
+        }
+    }
+}
+
+impl ChunkStorage for DeferredChunkStorage {
+    fn get(
+        &self,
+        _locator: groove::large_values::Locator,
+        _expected_hash: groove::large_values::ContentHash,
+    ) -> groove::chunks::ChunkFuture<'_, Result<bytes::Bytes, groove::chunks::ChunkStorageError>>
+    {
+        Box::pin(std::future::poll_fn(|context| {
+            if let Some(outcome) = self.outcome.borrow_mut().take() {
+                Poll::Ready(outcome)
+            } else {
+                *self.waiter.borrow_mut() = Some(context.waker().clone());
+                Poll::Pending
+            }
+        }))
+    }
+
+    fn stage(
+        &self,
+        chunks: Vec<groove::large_values::StagedChunk>,
+    ) -> groove::chunks::ChunkFuture<
+        '_,
+        Result<groove::large_values::StagedLargeValueAccounting, groove::chunks::ChunkStorageError>,
+    > {
+        self.backend.stage(chunks)
+    }
+
+    fn delete(
+        &self,
+        locator: groove::large_values::Locator,
+        expected_hash: groove::large_values::ContentHash,
+    ) -> groove::chunks::ChunkFuture<'_, Result<(), groove::chunks::ChunkStorageError>> {
+        self.backend.delete(locator, expected_hash)
+    }
+}
+
+fn deferred_local_chunk_reader() -> (groove::chunks::LocalChunkReader, Rc<DeferredChunkStorage>) {
+    let storage = Rc::new(DeferredChunkStorage::default());
+    let mut database = crate::db::block_on(groove::db::Database::new(
+        groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new()),
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    database.set_chunk_storage(storage.clone());
+    (database.local_chunk_reader(), storage)
+}
+
+fn retained_relay_obligations(state: &ChunkDemandState) -> usize {
+    state.relay_chunk_obligations
+}
 
 #[test]
 fn auxiliary_pump_completes_a_suspended_groove_chunk_read_without_a_semantic_tick() {
@@ -130,15 +199,19 @@ fn subscriber_auxiliary_responses_are_bounded_to_one_chunk_per_wire_frame() {
     );
     let response_count = 10;
     let chunk_bytes = vec![0x5a; groove::large_values::LEAF_MAX_BYTES];
-    resolver.state.borrow_mut().relay_responses.insert(
-        23,
-        (0..response_count)
-            .map(|request_id| ChunkResponseEntry {
-                request_id,
-                result: ChunkResponse::Found(chunk_bytes.clone()),
-            })
-            .collect(),
-    );
+    {
+        let mut state = resolver.state.borrow_mut();
+        state.relay_responses.insert(
+            23,
+            (0..response_count)
+                .map(|request_id| ChunkResponseEntry {
+                    request_id,
+                    result: ChunkResponse::Found(chunk_bytes.clone()),
+                })
+                .collect(),
+        );
+        state.relay_chunk_obligations = response_count as usize;
+    }
 
     let features = crate::wire::current_wire_features();
     let mut observed_request_ids = Vec::new();
@@ -194,15 +267,19 @@ fn bounded_auxiliary_drain_keeps_large_response_batches_fifo_and_within_bytes() 
     );
     let response_count = 32_u64;
     let chunk_bytes = vec![0x3c; groove::large_values::LEAF_MAX_BYTES];
-    resolver.state.borrow_mut().relay_responses.insert(
-        24,
-        (0..response_count)
-            .map(|request_id| ChunkResponseEntry {
-                request_id,
-                result: ChunkResponse::Found(chunk_bytes.clone()),
-            })
-            .collect(),
-    );
+    {
+        let mut state = resolver.state.borrow_mut();
+        state.relay_responses.insert(
+            24,
+            (0..response_count)
+                .map(|request_id| ChunkResponseEntry {
+                    request_id,
+                    result: ChunkResponse::Found(chunk_bytes.clone()),
+                })
+                .collect(),
+        );
+        state.relay_chunk_obligations = response_count as usize;
+    }
 
     let features = crate::wire::current_wire_features();
     let byte_budget = groove::large_values::LEAF_MAX_BYTES * 4;
@@ -280,6 +357,213 @@ fn dropping_the_last_suspended_consumer_cancels_unsent_chunk_demand() {
     ));
     drop(pending);
     assert!(pump.take_outbound(64).is_none());
+}
+
+#[test]
+fn failed_send_restore_keeps_its_relay_reservation_across_later_admission() {
+    let resolver = PeerChunkResolver::default();
+    let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());
+    let database = crate::db::block_on(groove::db::Database::new(
+        schema,
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    let subscriber = PeerIoPump::new(
+        resolver.clone(),
+        database.local_chunk_reader(),
+        40,
+        PeerIoPumpRole::Subscriber,
+    );
+    let shared = ChunkRequestEntry {
+        request_id: 0,
+        locator: groove::large_values::Locator::random(),
+        expected_hash: [40; 32],
+        remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+    };
+    for request_id in 0..MAX_RELAY_CHUNK_OBLIGATIONS as u64 - 1 {
+        resolver.enqueue_relay(
+            40,
+            ChunkRequestEntry {
+                request_id,
+                ..shared.clone()
+            },
+        );
+    }
+    resolver.enqueue_relay(
+        40,
+        ChunkRequestEntry {
+            request_id: MAX_RELAY_CHUNK_OBLIGATIONS as u64,
+            remaining_hops: 0,
+            ..shared.clone()
+        },
+    );
+    let handed_out = subscriber
+        .take_outbound(1)
+        .expect("response is handed to send");
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        MAX_RELAY_CHUNK_OBLIGATIONS,
+        "a send in progress keeps its reservation"
+    );
+
+    resolver.enqueue_relay(
+        40,
+        ChunkRequestEntry {
+            request_id: MAX_RELAY_CHUNK_OBLIGATIONS as u64 + 1,
+            ..shared
+        },
+    );
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        MAX_RELAY_CHUNK_OBLIGATIONS,
+        "a later relay request cannot consume the failed send's slot"
+    );
+    subscriber.restore_outbound(handed_out);
+    assert_eq!(
+        retained_relay_obligations(&resolver.state.borrow()),
+        MAX_RELAY_CHUNK_OBLIGATIONS,
+        "restoring an unsent batch transfers no extra reservation"
+    );
+}
+
+#[test]
+fn partial_drain_then_disconnect_releases_only_that_connections_obligations() {
+    let resolver = PeerChunkResolver::default();
+    let schema = groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new());
+    let database = crate::db::block_on(groove::db::Database::new(
+        schema,
+        groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF]),
+    ))
+    .unwrap();
+    let first = PeerIoPump::new(
+        resolver.clone(),
+        database.local_chunk_reader(),
+        41,
+        PeerIoPumpRole::Subscriber,
+    );
+    let second = PeerIoPump::new(
+        resolver.clone(),
+        database.local_chunk_reader(),
+        42,
+        PeerIoPumpRole::Subscriber,
+    );
+    for (connection, request_id) in [(41, 1), (41, 2), (42, 3), (42, 4)] {
+        resolver.enqueue_relay(
+            connection,
+            ChunkRequestEntry {
+                request_id,
+                locator: groove::large_values::Locator::random(),
+                expected_hash: [41; 32],
+                remaining_hops: 0,
+            },
+        );
+    }
+    let handed_out = first.take_outbound(1).expect("partial response drain");
+    first.disconnect();
+    let state = resolver.state.borrow();
+    assert_eq!(retained_relay_obligations(&state), 2);
+    assert!(state.relay_responses.get(&41).is_none());
+    assert!(state.inflight_relay_responses.get(&41).is_none());
+    drop(state);
+    let sent = second.take_outbound(1).expect("other connection is intact");
+    second.acknowledge_outbound(&sent);
+    assert_eq!(retained_relay_obligations(&resolver.state.borrow()), 1);
+    drop(handed_out);
+}
+
+#[test]
+fn mixed_waiter_and_immediate_response_saturation_never_exceeds_the_shared_cap() {
+    let resolver = PeerChunkResolver::default();
+    let request = ChunkRequestEntry {
+        request_id: 0,
+        locator: groove::large_values::Locator::random(),
+        expected_hash: [43; 32],
+        remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+    };
+    for request_id in 0..MAX_RELAY_CHUNK_OBLIGATIONS as u64 - 2 {
+        resolver.enqueue_relay(
+            43,
+            ChunkRequestEntry {
+                request_id,
+                ..request.clone()
+            },
+        );
+    }
+    resolver.enqueue_relay(
+        43,
+        ChunkRequestEntry {
+            request_id: 9_000,
+            remaining_hops: 0,
+            ..request.clone()
+        },
+    );
+    resolver.enqueue_relay(
+        43,
+        ChunkRequestEntry {
+            request_id: 9_001,
+            ..request.clone()
+        },
+    );
+    resolver.enqueue_relay(
+        43,
+        ChunkRequestEntry {
+            request_id: 9_002,
+            remaining_hops: 0,
+            ..request
+        },
+    );
+    let state = resolver.state.borrow();
+    assert_eq!(
+        retained_relay_obligations(&state),
+        MAX_RELAY_CHUNK_OBLIGATIONS
+    );
+    assert_eq!(
+        state.relay_responses.get(&43).map_or(0, Vec::len),
+        1,
+        "both immediate unavailable and overload retry responses obey the same cap"
+    );
+}
+
+#[test]
+fn disconnect_mid_batch_stops_later_lookup_and_drops_the_resumed_result() {
+    let schema = schema();
+    let server = open_db(0x44, AuthorSubject::SYSTEM, &schema);
+    let (_client_transport, server_transport) = duplex();
+    let subscriber = server.accept_subscriber(server_transport, AuthorSubject::SYSTEM);
+    let resolver = server.node.chunk_resolver.clone();
+    let (local_chunks, storage) = deferred_local_chunk_reader();
+    let pump = PeerIoPump::new(
+        resolver.clone(),
+        local_chunks,
+        subscriber.borrow().connection_epoch,
+        PeerIoPumpRole::Subscriber,
+    );
+    subscriber.borrow_mut().auxiliary_pump = pump.clone();
+    let requests = [44_u64, 45]
+        .into_iter()
+        .map(|request_id| ChunkRequestEntry {
+            request_id,
+            locator: groove::large_values::Locator::random(),
+            expected_hash: [0x44; 32],
+            remaining_hops: DEFAULT_CHUNK_FORWARD_HOPS,
+        })
+        .collect();
+    let mut routing = Box::pin(pump.route_incoming(SyncMessage::ChunkRequestBatch(
+        ChunkRequestBatch { requests },
+    )));
+    let waker = futures::task::noop_waker();
+    let mut context = Context::from_waker(&waker);
+    assert!(matches!(routing.as_mut().poll(&mut context), Poll::Pending));
+    assert!(server.detach_connection(&subscriber));
+    assert!(pump.is_disconnected());
+    storage.release(Err(groove::chunks::ChunkStorageError::Unavailable));
+    assert!(matches!(
+        routing.as_mut().poll(&mut context),
+        Poll::Ready(Ok(()))
+    ));
+    let state = resolver.state.borrow();
+    assert_eq!(retained_relay_obligations(&state), 0);
+    assert!(state.relay_responses.get(&pump.connection).is_none());
 }
 
 // This stays at the auxiliary-pump boundary because the batch split is a

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -359,8 +359,14 @@ async fn drive_upstream_wire(
         let auxiliary_wake = io.pump.outbound_ready();
         futures::pin_mut!(external_wake, auxiliary_wake);
         match futures::future::select(external_wake, auxiliary_wake).await {
-            futures::future::Either::Left((Some(()), _))
-            | futures::future::Either::Right(((), _)) => {}
+            futures::future::Either::Left((Some(()), _)) => {}
+            futures::future::Either::Right(((), _)) => {
+                // Disconnect wakes `outbound_ready` to let the owner tear
+                // down cleanly; it is not another unit of socket work.
+                if io.pump.is_disconnected() {
+                    return;
+                }
+            }
             futures::future::Either::Left((None, _)) => {
                 io.pump.disconnect();
                 return;


### PR DESCRIPTION
🤖 ## Stack dependency

This replacement is stacked on #1985 and supersedes #1997. It reconstructs the bounded relay work on the current browser-relay base without rewriting the stale branch.

## Before

Repeated requests for the same missing chunk could retain unbounded waiter IDs even though only unique chunks were capped. Completing waiters could then move them into an unbounded response queue. A disconnect during an awaited lookup could also recreate a waiter or send a found response after the requesting peer had detached.

## After

One 4,096-entry budget covers pending remote waiters plus queued and in-flight responses. Completion transfers a reservation rather than releasing it early; drain or disconnect releases it. Both the auxiliary pump and direct `PeerConnection::tick` paths fence before and after async lookup and before sending. Native owner pumps treat disconnect as terminal.

## Examples

- Two request IDs for one missing chunk share one upstream request but retain two bounded response obligations.
- If 4,096 waiters complete before responses drain, the response backlog continues to occupy all 4,096 slots and further work cannot grow retained state.
- If a peer detaches during a local lookup, neither a missing result nor a found result may recreate work or emit a response.

## Invariants and non-goals

- Stable retained obligations equal pending remote waiters plus queued/in-flight responses and never exceed 4,096.
- Local in-process readers do not consume the remote relay budget.
- Failed sends restore exactly their drained reservations.
- Wire limits, retry delays, request IDs, upstream coalescing, and #1985 facade retargeting are unchanged.

## Verification

- Focused chunk I/O suite: 14/14
- Server runtime: 4/4
- `cargo check -p jazz-napi -p jazz-wasm`
- Clippy/rustfmt/sensitive-data gates
- Independent adversarial review planted reservation and detach-fence regressions; each failed at the intended assertion and was restored cleanly.
