### PR TITLE
Read Rust shadow identities across container ownership

### DIFF
--- a/dev/gates/run-rust-tests.mjs
+++ b/dev/gates/run-rust-tests.mjs
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { sameTrackedSource, sourceIdentity } from "./source-identity.mjs";
+import { checkedOutCommit, sameTrackedSource, sourceIdentity } from "./source-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const now = () => new Date().toISOString();
@@ -131,7 +131,7 @@ const result = await new Promise((resolve) => {
 });
 clearTimeout(timer);
 const finishedAt = now();
-const observedSource = { commit: run("git", ["rev-parse", "HEAD"]), ...sourceIdentity(root) };
+const observedSource = { commit: checkedOutCommit(root), ...sourceIdentity(root) };
 const baselinePath = process.env.RUST_SHADOW_SOURCE_BASELINE;
 const baseline = baselinePath ? JSON.parse(fs.readFileSync(baselinePath, "utf8")) : null;
 if (baseline && !sameTrackedSource(baseline, observedSource))
@@ -161,7 +161,7 @@ const data = {
   },
   command: [command, ...commandArgs],
   source: {
-    commit: run("git", ["rev-parse", "HEAD"]),
+    commit: checkedOutCommit(root),
     ...source,
   },
   environment: {

--- a/dev/gates/rust-shadow-matrix.mjs
+++ b/dev/gates/rust-shadow-matrix.mjs
@@ -12,7 +12,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { sameTrackedSource, sourceIdentity } from "./source-identity.mjs";
+import { checkedOutCommit, sameTrackedSource, sourceIdentity } from "./source-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const testArgs = [
@@ -146,7 +146,7 @@ function cleanSourceBaseline(argv) {
   if (!receipt || !/^[0-9a-f]{40}$/.test(expectedCommit))
     fail("usage: clean-source-baseline RECEIPT EXPECTED_COMMIT");
   const source = {
-    commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+    commit: checkedOutCommit(root),
     ...sourceIdentity(root),
   };
   if (!validSourceIdentity(source))
@@ -162,7 +162,7 @@ function shadowSourceBaseline() {
   const source = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
   if (!validSourceIdentity(source)) fail("shadow source baseline is not a clean checkout");
   const observed = {
-    commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+    commit: checkedOutCommit(root),
     ...sourceIdentity(root),
   };
   if (!sameTrackedSource(source, observed))
@@ -195,7 +195,7 @@ function shard(argv) {
     phases,
     status: "failed",
     source: baseline ?? {
-      commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+      commit: checkedOutCommit(root),
       ...sourceIdentity(root),
     },
     environment: {
@@ -240,7 +240,7 @@ function shard(argv) {
     if (
       baseline &&
       !sameTrackedSource(baseline, {
-        commit: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+        commit: checkedOutCommit(root),
         ...sourceIdentity(root),
       })
     )

--- a/dev/gates/source-identity.mjs
+++ b/dev/gates/source-identity.mjs
@@ -4,7 +4,15 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 function git(root, args, options = {}) {
-  const result = spawnSync("git", ["-C", root, ...args], { encoding: null, ...options });
+  // CI container checkouts can be owned by the runner while commands execute
+  // as the container user. Scope this exception to each read rather than
+  // mutating the runner's global Git configuration. The identity still comes
+  // from the exact checked-out repository and remains fail-closed on any Git
+  // error.
+  const result = spawnSync("git", ["-c", `safe.directory=${root}`, "-C", root, ...args], {
+    encoding: null,
+    ...options,
+  });
   if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed`);
   return result.stdout;
 }
@@ -44,6 +52,10 @@ export function sourceIdentity(root) {
     ),
     dirty: headTree !== indexTree || unstaged !== sha256("") || untracked.length !== 0,
   };
+}
+
+export function checkedOutCommit(root) {
+  return git(root, ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
 }
 
 // Dependency setup is allowed to create ignored build products, but it must

--- a/dev/gates/test/run-rust-tests.test.mjs
+++ b/dev/gates/test/run-rust-tests.test.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
+import { checkedOutCommit, sourceIdentity } from "../source-identity.mjs";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const runner = path.join(root, "dev/gates/run-rust-tests.mjs");
@@ -27,6 +28,31 @@ test("writes source, command, cache, and failure metadata", () => {
   assert.ok("cargoTargetDir" in value.environment);
   assert.equal(value.environment.rustMinStack, String(4 * 1024 * 1024));
   assert.equal(value.nextestProfile, hasNextest ? "jazz" : null);
+});
+test("seals an actual nested receipt across a container ownership boundary", () => {
+  const dir = temp();
+  const receipt = path.join(dir, "receipt.json");
+  const baseline = path.join(dir, "baseline.json");
+  const source = { commit: checkedOutCommit(root), ...sourceIdentity(root) };
+  fs.writeFileSync(baseline, JSON.stringify(source));
+  const result = spawnSync(
+    "node",
+    [runner, "--receipt", receipt, "--", "--version"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_TEST_ASSUME_DIFFERENT_OWNER: "1",
+        RUST_SHADOW_SOURCE_BASELINE: baseline,
+      },
+    },
+  );
+  assert.notEqual(result.status, 0, "the intentionally invalid Nextest selection must still fail");
+  const value = JSON.parse(fs.readFileSync(receipt, "utf8"));
+  assert.equal(value.source.commit, source.commit);
+  assert.equal(value.source.fingerprint, source.fingerprint);
+  fs.rmSync(dir, { recursive: true, force: true });
 });
 test("forwards the requested Nextest profile and records it in the receipt", () => {
   const source = fs.readFileSync(runner, "utf8");

--- a/dev/gates/test/run-rust-tests.test.mjs
+++ b/dev/gates/test/run-rust-tests.test.mjs
@@ -35,19 +35,15 @@ test("seals an actual nested receipt across a container ownership boundary", () 
   const baseline = path.join(dir, "baseline.json");
   const source = { commit: checkedOutCommit(root), ...sourceIdentity(root) };
   fs.writeFileSync(baseline, JSON.stringify(source));
-  const result = spawnSync(
-    "node",
-    [runner, "--receipt", receipt, "--", "--version"],
-    {
-      cwd: root,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        GIT_TEST_ASSUME_DIFFERENT_OWNER: "1",
-        RUST_SHADOW_SOURCE_BASELINE: baseline,
-      },
+  const result = spawnSync("node", [runner, "--receipt", receipt, "--", "--version"], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_TEST_ASSUME_DIFFERENT_OWNER: "1",
+      RUST_SHADOW_SOURCE_BASELINE: baseline,
     },
-  );
+  });
   assert.notEqual(result.status, 0, "the intentionally invalid Nextest selection must still fail");
   const value = JSON.parse(fs.readFileSync(receipt, "utf8"));
   assert.equal(value.source.commit, source.commit);

--- a/dev/gates/test/source-identity.test.mjs
+++ b/dev/gates/test/source-identity.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { sourceIdentity } from "../source-identity.mjs";
+import { checkedOutCommit, sourceIdentity } from "../source-identity.mjs";
 
 const git = (root, args) => {
   const result = spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
@@ -54,3 +54,18 @@ for (const [name, secret, mutate, restore] of [
     assert.equal(JSON.stringify(dirty).includes(secret), false);
     restore(root);
   });
+
+test("identity reads survive a container checkout ownership boundary", () => {
+  const root = fixture();
+  const previous = process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER;
+  process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = "1";
+  try {
+    const identity = sourceIdentity(root);
+    assert.equal(identity.dirty, false);
+    assert.match(checkedOutCommit(root), /^[0-9a-f]{40}$/);
+  } finally {
+    if (previous === undefined) delete process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER;
+    else process.env.GIT_TEST_ASSUME_DIFFERENT_OWNER = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
🤖 ## Before

After #2054 allowed the Rust shadow jobs to instantiate, both shards still failed before running tests. Actions checked the repository out under the runner user, while the container executed Git identity reads as a different user; Git rejected `HEAD^{tree}` as dubious ownership. The missing baseline then caused receipt upload and aggregate failures. Nested test-receipt code had the same unsafe raw `git rev-parse HEAD` reads.

## After

Every shadow baseline, shard-observation, and serialized-receipt identity read uses one fail-closed helper. It invokes Git with a process-scoped `safe.directory` for the exact repository root. It does not modify global Git configuration, trust another path, or mutate source. Commit, tree, index, staged, unstaged, and untracked identity checks remain intact.

## Example

A Blacksmith runner owns the checkout and its pinned toolchain container runs the shard as another user. Raw Git rejects the checkout, but the scoped helper reads the exact checked-out commit and tree. The shard receipt must still match that sealed baseline; any source drift or mismatched commit is rejected.

## Non-goals

- This does not make the shadow workflow required CI.
- It does not weaken exact-inventory or source-identity aggregation.
- It does not set a global or wildcard safe directory.

## Verification

- Source/workflow contracts: 42/42
- Nested real receipt path under simulated ownership mismatch: 1/1
- Independent adversarial review verified every baseline/shard identity read and no global mutation.
- Planting one unwrapped nested `rev-parse` causes the baseline comparison to fail and prevents receipt emission.
