### PR TITLE
Lower nested correlated policy clauses

### DIFF
--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -987,6 +987,164 @@ fn join_policy_authorizes_writes_reads_and_next_emission_revocation() {
     // output-row policies into the subscription graph.
 }
 
+/// The authority accepts Alice's editor insert only when the candidate's
+/// canvas agrees with the referenced layer; changing only the candidate canvas
+/// must produce the ordinary authorization-denied fate.
+///
+/// This stays at the node boundary because only the authority's settled fate
+/// proves that the compiled policy joins constrain an incoming candidate.
+///
+/// ```text
+/// alice ──shape(layer A, canvas A)──► authority ──► Accepted
+/// alice ──shape(layer A, canvas B)──► authority ──► AuthorizationDenied
+/// ```
+#[test]
+fn nested_correlated_exists_insert_policy_rejects_cross_canvas_candidates() {
+    let alice = user(0xa3);
+    let canvas_a = row(0xa4);
+    let canvas_b = row(0xa5);
+    let layer_a = row(0xa6);
+    let editor_membership = row(0xa7);
+    let accepted_shape = row(0xa8);
+    let rejected_shape = row(0xa9);
+
+    let insert_policy = PublicPolicyExpr::Exists {
+        table: "layers".to_owned(),
+        condition: Box::new(PublicPolicyExpr::And(vec![
+            PublicPolicyExpr::Cmp {
+                column: "id".to_owned(),
+                op: PublicCmpOp::Eq,
+                value: PublicPolicyValue::SessionRef(vec![
+                    "__jazz_outer_row".to_owned(),
+                    "layer_id".to_owned(),
+                ]),
+            },
+            PublicPolicyExpr::Cmp {
+                column: "canvas_id".to_owned(),
+                op: PublicCmpOp::Eq,
+                value: PublicPolicyValue::SessionRef(vec![
+                    "__jazz_outer_row".to_owned(),
+                    "canvas_id".to_owned(),
+                ]),
+            },
+            PublicPolicyExpr::Exists {
+                table: "canvas_members".to_owned(),
+                condition: Box::new(PublicPolicyExpr::And(vec![
+                    PublicPolicyExpr::Cmp {
+                        column: "canvas_id".to_owned(),
+                        op: PublicCmpOp::Eq,
+                        value: PublicPolicyValue::SessionRef(vec![
+                            "__jazz_outer_row".to_owned(),
+                            "canvas_id".to_owned(),
+                        ]),
+                    },
+                    public_claim_eq("user_id", "sub"),
+                    public_literal_eq("role", PublicValue::Text("editor".to_owned())),
+                ])),
+            },
+        ])),
+    };
+    let schema = build_public_test_schema(
+        PublicSchemaBuilder::new()
+            .table(
+                PublicTableSchemaBuilder::new("canvases")
+                    .column("title", PublicColumnType::Text),
+            )
+            .table(PublicTableSchemaBuilder::new("layers").fk_column("canvas_id", "canvases"))
+            .table(
+                PublicTableSchemaBuilder::new("canvas_members")
+                    .fk_column("canvas_id", "canvases")
+                    .column("user_id", PublicColumnType::Uuid)
+                    .column("role", PublicColumnType::Text),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("shapes")
+                    .fk_column("layer_id", "layers")
+                    .fk_column("canvas_id", "canvases")
+                    .policies(PublicTablePolicies::new().with_insert(insert_policy)),
+            ),
+    );
+    let (_alice_dir, mut alice_node) = open_node_with_schema(node(3), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+    install_test_uuid_sub_claim(&mut core, alice);
+
+    accept_global(
+        &mut core,
+        MergeableCommit::new("canvases", canvas_a, 10).cells(BTreeMap::from([(
+            "title".to_owned(),
+            Value::String("canvas A".to_owned()),
+        )])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("canvases", canvas_b, 11).cells(BTreeMap::from([(
+            "title".to_owned(),
+            Value::String("canvas B".to_owned()),
+        )])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("layers", layer_a, 12).cells(BTreeMap::from([(
+            "canvas_id".to_owned(),
+            Value::Uuid(canvas_a.0),
+        )])),
+    );
+    accept_global(
+        &mut core,
+        MergeableCommit::new("canvas_members", editor_membership, 13).cells(BTreeMap::from([
+            ("canvas_id".to_owned(), Value::Uuid(canvas_a.0)),
+            ("user_id".to_owned(), Value::Uuid(alice.test_uuid())),
+            ("role".to_owned(), Value::String("editor".to_owned())),
+        ])),
+    );
+
+    let accepted = alice_node
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("shapes", accepted_shape, 14)
+                .made_by(alice)
+                .cells(BTreeMap::from([
+                    ("layer_id".to_owned(), Value::Uuid(layer_a.0)),
+                    ("canvas_id".to_owned(), Value::Uuid(canvas_a.0)),
+                ])),
+        )
+        .unwrap();
+    let [accepted_fate] = core
+        .apply_sync_message_settled(accepted.1)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    assert!(matches!(
+        accepted_fate,
+        SyncMessage::FateUpdate {
+            fate: Fate::Accepted,
+            ..
+        }
+    ));
+
+    let rejected = alice_node
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("shapes", rejected_shape, 15)
+                .made_by(alice)
+                .cells(BTreeMap::from([
+                    ("layer_id".to_owned(), Value::Uuid(layer_a.0)),
+                    ("canvas_id".to_owned(), Value::Uuid(canvas_b.0)),
+                ])),
+        )
+        .unwrap();
+    let [rejected_fate] = core
+        .apply_sync_message_settled(rejected.1)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    assert!(matches!(
+        rejected_fate,
+        SyncMessage::FateUpdate {
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            ..
+        }
+    ));
+}
+
 /// `allowedTo.insert(release)` composes the release INSERT policy with the
 /// assignment's tenant-correlated existence checks: an eligible owner is
 /// accepted while that same owner cannot attach a foreign membership. The

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -1300,13 +1300,11 @@ fn append_exists_policy_clause(
 
     let mut outer_correlations = Vec::new();
     let mut filters = Vec::new();
+    let mut nested_exists = Vec::new();
+    let mut conditions = Vec::new();
+    collect_policy_conjuncts(condition, &mut conditions);
 
-    let conditions = match condition {
-        PolicyExpr::And(exprs) => exprs.as_slice(),
-        expr => std::slice::from_ref(expr),
-    };
-
-    for (index, expr) in conditions.iter().enumerate() {
+    for (index, expr) in conditions.into_iter().enumerate() {
         match expr {
             PolicyExpr::Cmp {
                 column,
@@ -1318,6 +1316,10 @@ fn append_exists_policy_clause(
                     source_column: path_segments[1].clone(),
                 });
             }
+            PolicyExpr::Exists {
+                table: nested_table,
+                condition: nested_condition,
+            } => nested_exists.push((index, nested_table.as_str(), nested_condition.as_ref())),
             other => filters.push(convert_policy_predicate(
                 &exists_table_name,
                 &format!("{path}.Exists[{index}]"),
@@ -1341,23 +1343,52 @@ fn append_exists_policy_clause(
     let source_column = primary.source_column;
     let correlated_filters = outer_correlations;
 
-    if join_column == "id" {
-        Ok(query.join_via_row_id_with_correlations(
+    let query = if join_column == "id" {
+        query.join_via_row_id_with_correlations(
             exists_table,
             source_column,
             correlated_filters,
             filters,
-        ))
+        )
     } else if correlated_filters.is_empty() {
-        Ok(query.join_via_column(exists_table, join_column, source_column, filters))
+        query.join_via_column(exists_table, join_column, source_column, filters)
     } else {
-        Ok(query.join_via_column_with_correlations(
+        query.join_via_column_with_correlations(
             exists_table,
             join_column,
             source_column,
             correlated_filters,
             filters,
-        ))
+        )
+    };
+
+    // Legacy `Exists` has one outer-row scope, even when an all-of nests
+    // another EXISTS. Each nested existential is therefore an additional
+    // proof about the protected row, not a join relative to the first proof
+    // row. Lower it through this same correlated-join path so every declared
+    // FK edge remains independently validated by the core query contract.
+    nested_exists
+        .into_iter()
+        .try_fold(query, |query, (index, nested_table, nested_condition)| {
+            append_exists_policy_clause(
+                schema,
+                table,
+                &format!("{path}.Exists[{index}]"),
+                query,
+                nested_table,
+                nested_condition,
+            )
+        })
+}
+
+fn collect_policy_conjuncts<'a>(expr: &'a PolicyExpr, output: &mut Vec<&'a PolicyExpr>) {
+    match expr {
+        PolicyExpr::And(children) => {
+            for child in children {
+                collect_policy_conjuncts(child, output);
+            }
+        }
+        other => output.push(other),
     }
 }
 
@@ -3675,6 +3706,97 @@ mod tests {
                 Operand::Claim(DIRECT_USER_ID_CLAIM.to_owned()),
             )]
         );
+    }
+
+    // This conversion-boundary test stays internal because its purpose is to
+    // prove that legacy public-policy syntax is normalized into the same core
+    // join representation as relation-backed policies before any runtime
+    // schema can be admitted.
+    #[test]
+    fn converts_nested_correlated_exists_conjunction_to_independent_joins() {
+        let schema = SchemaBuilder::new()
+            .table(TableSchemaBuilder::new("canvases"))
+            .table(TableSchemaBuilder::new("layers").fk_column("canvas_id", "canvases"))
+            .table(
+                TableSchemaBuilder::new("canvas_members")
+                    .fk_column("canvas_id", "canvases")
+                    .column("user_id", ColumnType::Text)
+                    .column("role", ColumnType::Text),
+            )
+            .table(
+                TableSchemaBuilder::new("shapes")
+                    .fk_column("layer_id", "layers")
+                    .fk_column("canvas_id", "canvases")
+                    .policies(TablePolicies::new().with_insert(PolicyExpr::Exists {
+                        table: "layers".to_owned(),
+                        condition: Box::new(PolicyExpr::And(vec![
+                            PolicyExpr::Cmp {
+                                column: "id".to_owned(),
+                                op: CmpOp::Eq,
+                                value: PolicyValue::SessionRef(vec![
+                                    "__jazz_outer_row".to_owned(),
+                                    "layer_id".to_owned(),
+                                ]),
+                            },
+                            PolicyExpr::Cmp {
+                                column: "canvas_id".to_owned(),
+                                op: CmpOp::Eq,
+                                value: PolicyValue::SessionRef(vec![
+                                    "__jazz_outer_row".to_owned(),
+                                    "canvas_id".to_owned(),
+                                ]),
+                            },
+                            PolicyExpr::Exists {
+                                table: "canvas_members".to_owned(),
+                                condition: Box::new(PolicyExpr::And(vec![
+                                    PolicyExpr::Cmp {
+                                        column: "canvas_id".to_owned(),
+                                        op: CmpOp::Eq,
+                                        value: PolicyValue::SessionRef(vec![
+                                            "__jazz_outer_row".to_owned(),
+                                            "canvas_id".to_owned(),
+                                        ]),
+                                    },
+                                    PolicyExpr::Cmp {
+                                        column: "user_id".to_owned(),
+                                        op: CmpOp::Eq,
+                                        value: PolicyValue::SessionRef(vec!["user_id".to_owned()]),
+                                    },
+                                    PolicyExpr::Cmp {
+                                        column: "role".to_owned(),
+                                        op: CmpOp::Eq,
+                                        value: PolicyValue::Literal(Value::Text(
+                                            "editor".to_owned(),
+                                        )),
+                                    },
+                                ])),
+                            },
+                        ])),
+                    })),
+            )
+            .build();
+
+        let converted = convert_public_schema(&schema)
+            .expect("nested correlated EXISTS conjunction must compile");
+        let shapes = converted
+            .tables
+            .iter()
+            .find(|table| table.name == "shapes")
+            .unwrap();
+        let policy = shapes.write_policies.insert_check.as_ref().unwrap();
+        assert_eq!(policy.joins.len(), 2);
+        assert_eq!(policy.joins[0].table, "layers");
+        assert_eq!(policy.joins[0].source_column.as_deref(), Some("layer_id"));
+        assert_eq!(
+            policy.joins[0].correlated_filters,
+            vec![JoinCorrelation {
+                join_column: "canvas_id".to_owned(),
+                source_column: "canvas_id".to_owned(),
+            }]
+        );
+        assert_eq!(policy.joins[1].table, "canvas_members");
+        assert_eq!(policy.joins[1].on_column, "canvas_id");
+        assert_eq!(policy.joins[1].source_column.as_deref(), Some("canvas_id"));
     }
 
     #[test]


### PR DESCRIPTION
🤖 ## Before

The public policy DSL can express an insert rule whose conjunction contains more than one correlated `exists` clause, but server-shell conversion only lowered the outer clause. It handed a nested `PolicyExpr::Exists` to scalar conversion, which rejected valid policies as unsupported. Attempting to rewrite the rule as an FK chain instead produced `JoinNotRefCompatible`.

This prevented policies such as: a shape's layer must belong to the same canvas named by the shape, and the session must be a member of that canvas.

## After

Conversion flattens associative `AND` expressions and lowers each nested `exists` as an independent join correlated to the protected/root row. Every join continues through the existing FK, schema, claims, normalization, and authorization path; there is no app-specific branch or second evaluator.

## Example

- `shape(layer=A-layer, canvas=A)` plus Alice's qualifying membership in A is admitted.
- The same layer paired with `canvas=B` is rejected, even if Alice otherwise has access to A.
- Removing the declared layer-to-canvas reference makes conversion fail rather than weakening the policy.

## Boundaries

- This supports nested correlated clauses under associative `AND`.
- Arbitrary nested `OR` or `NOT` inside legacy `exists` remains unsupported.
- Duplicate target tables retain distinct path-derived aliases.
- Session/claim filters and protected-row correlations remain independently validated for every join.

## Verification

- Focused conversion receipt
- Authority-fate receipt proving same-canvas acceptance and cross-canvas denial
- Existing correlated-`exists` and OR-branch receipts
- Independent adversarial review planted non-recursive conjunction lowering and a missing root FK; both failed at the intended boundary and were restored cleanly.
