### PR TITLE
Bound and reap create-jazz package receipts

### DIFF
--- a/packages/create-jazz/src/package-contents.test.ts
+++ b/packages/create-jazz/src/package-contents.test.ts
@@ -1,12 +1,18 @@
 import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = path.resolve(import.meta.dirname, "..");
 // `npm pack` performs filesystem traversal and can contend with the parallel
-// browser suite in the TypeScript CI partition. Keep that one child operation
-// bounded without making the whole test runner's timeout permissive.
+// browser suite in the TypeScript CI partition. A cold complete partition took
+// 11.7s and concurrent load exceeded the former 15s whole-test budget, so 30s
+// gives that phase bounded contention headroom without making Vitest global.
 const NPM_PACK_TIMEOUT_MS = 30_000;
+const TEST_CLEANUP_MARGIN_MS = 5_000;
+const TERMINATION_GRACE_MS = 1_000;
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const bundledSkillFiles = [
   "skills/jazz/SKILL.md",
   "skills/jazz/references/application-data.md",
@@ -29,54 +35,80 @@ function runBoundedChild(
     child.stdout.on("data", (chunk) => stdout.push(String(chunk)));
     child.stderr.on("data", (chunk) => stderr.push(String(chunk)));
 
-    let settled = false;
-    const finish = (result: () => void) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      result();
-    };
+    let spawnError: Error | undefined;
+    let timedOut = false;
+    let forceKillTimer: NodeJS.Timeout | undefined;
     const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-      finish(() => reject(new Error(`${description} timed out after ${timeoutMs}ms`)));
+      timedOut = true;
+      // Request graceful termination first so package-manager cleanup can run.
+      // The close handler below is the only settlement point: it guarantees
+      // both output streams have drained and the child has been reaped.
+      child.kill("SIGTERM");
+      forceKillTimer = setTimeout(() => child.kill("SIGKILL"), TERMINATION_GRACE_MS);
     }, timeoutMs);
 
-    child.on("error", (error) => finish(() => reject(error)));
+    child.on("error", (error) => {
+      spawnError = error;
+    });
     child.on("close", (code, signal) => {
-      if (code === 0) {
-        finish(() => resolve(stdout.join("")));
+      clearTimeout(timer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      const output = `${stdout.join("")}${stderr.join("")}`;
+      if (timedOut) {
+        reject(new Error(`${description} timed out after ${timeoutMs}ms\n${output}`));
         return;
       }
-      finish(() =>
-        reject(
-          new Error(
-            `${description} exited with code=${code} signal=${signal ?? "none"}\n${stdout.join("")}${stderr.join("")}`,
-          ),
-        ),
+      if (spawnError) {
+        reject(new Error(`${spawnError.message}\n${output}`));
+        return;
+      }
+      if (code === 0) {
+        resolve(stdout.join(""));
+        return;
+      }
+      reject(
+        new Error(`${description} exited with code=${code} signal=${signal ?? "none"}\n${output}`),
       );
     });
   });
 }
 
 describe("create-jazz package contents", () => {
-  it("terminates a hung package command with the phase watchdog", { timeout: 1_000 }, async () => {
-    await expect(
-      runBoundedChild(
-        process.execPath,
-        ["-e", "setTimeout(() => {}, 10_000)"],
-        packageRoot,
-        50,
-        "package watchdog probe",
-      ),
-    ).rejects.toThrow("package watchdog probe timed out after 50ms");
-  });
+  it(
+    "prevents a timed-out child from performing a delayed side effect",
+    { timeout: 2_000 },
+    async () => {
+      const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-jazz-pack-watchdog-"));
+      const marker = path.join(probeDir, "late-side-effect");
+      try {
+        await expect(
+          runBoundedChild(
+            process.execPath,
+            [
+              "-e",
+              "const fs = require('node:fs'); setTimeout(() => { fs.writeFileSync(process.argv[1], process.pid.toString()); }, 250);",
+              marker,
+            ],
+            packageRoot,
+            50,
+            "package watchdog probe",
+          ),
+        ).rejects.toThrow("package watchdog probe timed out after 50ms");
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        expect(fs.existsSync(marker)).toBe(false);
+      } finally {
+        fs.rmSync(probeDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it(
     "ships the bundled agent skills in npm pack output",
-    { timeout: NPM_PACK_TIMEOUT_MS + 5_000 },
+    { timeout: NPM_PACK_TIMEOUT_MS + TEST_CLEANUP_MARGIN_MS },
     async () => {
       const output = await runBoundedChild(
-        "npm",
+        npmCommand,
         ["pack", "--json", "--dry-run", "--ignore-scripts"],
         packageRoot,
         NPM_PACK_TIMEOUT_MS,

--- a/packages/create-jazz/src/package-contents.test.ts
+++ b/packages/create-jazz/src/package-contents.test.ts
@@ -12,7 +12,8 @@ const packageRoot = path.resolve(import.meta.dirname, "..");
 const NPM_PACK_TIMEOUT_MS = 30_000;
 const TEST_CLEANUP_MARGIN_MS = 5_000;
 const TERMINATION_GRACE_MS = 1_000;
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmPackArgs = ["pack", "--json", "--dry-run", "--ignore-scripts"];
+const windowsNpmPackCommand = "npm.cmd pack --json --dry-run --ignore-scripts";
 const bundledSkillFiles = [
   "skills/jazz/SKILL.md",
   "skills/jazz/references/application-data.md",
@@ -73,7 +74,30 @@ function runBoundedChild(
   });
 }
 
+function npmPackInvocation(
+  platform = process.platform,
+  comSpec = process.env.ComSpec,
+): { command: string; args: string[] } {
+  if (platform === "win32") {
+    // Node requires .cmd files to run through cmd.exe. The command string is
+    // deliberately fixed (rather than formed from values) before it reaches
+    // cmd.exe, while ComSpec stays a direct executable argument to spawn.
+    return {
+      command: comSpec || "cmd.exe",
+      args: ["/d", "/s", "/c", windowsNpmPackCommand],
+    };
+  }
+  return { command: "npm", args: npmPackArgs };
+}
+
 describe("create-jazz package contents", () => {
+  it("constructs the Windows npm invocation through cmd.exe without interpolation", () => {
+    expect(npmPackInvocation("win32", "C:\\Windows\\System32\\cmd.exe")).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "npm.cmd pack --json --dry-run --ignore-scripts"],
+    });
+  });
+
   it(
     "prevents a timed-out child from performing a delayed side effect",
     { timeout: 2_000 },
@@ -107,9 +131,10 @@ describe("create-jazz package contents", () => {
     "ships the bundled agent skills in npm pack output",
     { timeout: NPM_PACK_TIMEOUT_MS + TEST_CLEANUP_MARGIN_MS },
     async () => {
+      const npm = npmPackInvocation();
       const output = await runBoundedChild(
-        npmCommand,
-        ["pack", "--json", "--dry-run", "--ignore-scripts"],
+        npm.command,
+        npm.args,
         packageRoot,
         NPM_PACK_TIMEOUT_MS,
         "npm pack --dry-run",

--- a/packages/create-jazz/src/package-contents.test.ts
+++ b/packages/create-jazz/src/package-contents.test.ts
@@ -1,8 +1,12 @@
-import { execFileSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const packageRoot = path.resolve(import.meta.dirname, "..");
+// `npm pack` performs filesystem traversal and can contend with the parallel
+// browser suite in the TypeScript CI partition. Keep that one child operation
+// bounded without making the whole test runner's timeout permissive.
+const NPM_PACK_TIMEOUT_MS = 30_000;
 const bundledSkillFiles = [
   "skills/jazz/SKILL.md",
   "skills/jazz/references/application-data.md",
@@ -11,17 +15,79 @@ const bundledSkillFiles = [
   "skills/jazz/references/testing.md",
 ];
 
-describe("create-jazz package contents", () => {
-  it("ships the bundled agent skills in npm pack output", () => {
-    const output = execFileSync("npm", ["pack", "--json", "--dry-run", "--ignore-scripts"], {
-      cwd: packageRoot,
-      encoding: "utf8",
-    });
-    const packed = JSON.parse(output) as Array<{ files?: Array<{ path: string }> }>;
-    const paths = new Set(packed[0]?.files?.map((file) => file.path));
+function runBoundedChild(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+  description: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    child.stdout.on("data", (chunk) => stdout.push(String(chunk)));
+    child.stderr.on("data", (chunk) => stderr.push(String(chunk)));
 
-    for (const file of bundledSkillFiles) {
-      expect(paths).toContain(file);
-    }
-  }, 15_000);
+    let settled = false;
+    const finish = (result: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      result();
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(() => reject(new Error(`${description} timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+
+    child.on("error", (error) => finish(() => reject(error)));
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        finish(() => resolve(stdout.join("")));
+        return;
+      }
+      finish(() =>
+        reject(
+          new Error(
+            `${description} exited with code=${code} signal=${signal ?? "none"}\n${stdout.join("")}${stderr.join("")}`,
+          ),
+        ),
+      );
+    });
+  });
+}
+
+describe("create-jazz package contents", () => {
+  it("terminates a hung package command with the phase watchdog", { timeout: 1_000 }, async () => {
+    await expect(
+      runBoundedChild(
+        process.execPath,
+        ["-e", "setTimeout(() => {}, 10_000)"],
+        packageRoot,
+        50,
+        "package watchdog probe",
+      ),
+    ).rejects.toThrow("package watchdog probe timed out after 50ms");
+  });
+
+  it(
+    "ships the bundled agent skills in npm pack output",
+    { timeout: NPM_PACK_TIMEOUT_MS + 5_000 },
+    async () => {
+      const output = await runBoundedChild(
+        "npm",
+        ["pack", "--json", "--dry-run", "--ignore-scripts"],
+        packageRoot,
+        NPM_PACK_TIMEOUT_MS,
+        "npm pack --dry-run",
+      );
+      const packed = JSON.parse(output) as Array<{ files?: Array<{ path: string }> }>;
+      const paths = new Set(packed[0]?.files?.map((file) => file.path));
+
+      for (const file of bundledSkillFiles) {
+        expect(paths).toContain(file);
+      }
+    },
+  );
 });


### PR DESCRIPTION
🤖 ## Before

The create-jazz package-contents receipt ran `npm pack --dry-run` synchronously under Vitest's generic 15-second test timeout. A cold full partition took 11.7 seconds and exceeded 15 seconds under concurrent TypeScript/browser load, even though focused execution was healthy. When the outer timeout fired it provided no phase-specific diagnosis or child cleanup guarantee.

## After

`npm pack` runs as an explicit child with a measured 30-second phase watchdog. Timeout requests SIGTERM, escalates to SIGKILL after one second, and settles only after the child's `close` event and output streams drain. A 35-second outer test timeout is only cleanup margin. Normal nonzero/spawn/timeout errors retain buffered stdout and stderr.

Windows invokes the fixed npm command through `ComSpec /d /s /c`; no runtime value is interpolated into the command string. Other platforms continue to spawn npm directly.

## Examples

- A healthy cold package receipt taking 12 seconds is allowed to complete.
- A hung pack child is terminated and reaped; its delayed marker never appears after timeout.
- Removing the initial termination call makes the marker sensitivity test fail.

## Non-goals

- This does not relax package-content assertions.
- The watchdog remains finite and does not convert a real hang into an unbounded wait.
- It does not use a general shell on non-Windows platforms.

## Verification

- create-jazz package receipts: 3/3
- create-jazz TypeScript check
- CI workflow contracts: 114/114 plus ignored-test self-test
- Formatting, lint, diff and sensitive-data gates
- Independent adversarial review planted missing termination and command-construction changes; both failed at the intended receipts and were restored cleanly.
