### PR TITLE
Hydrate large values across NAPI public reads

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -79,11 +79,11 @@ export declare class NapiDb {
   setTickScheduler(callback: ((err: Error | null, arg: string) => void)): void
   onMutationError(callback: (event: any) => void): void
   prepareQuery(query: Uint8Array): PreparedQuery
-  all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   /** Read through an open transaction using the identity bound at begin. */
   allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
-  allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
   allRelationSnapshotForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
   allRelationQuery(queryJson: string, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
@@ -138,6 +138,11 @@ export declare class Subscription {
   readAll(): Array<SubscriptionEvent>
   drain(): Array<SubscriptionEvent>
   close(): boolean
+}
+
+/** A thread-affine Rust read suspended on local or routed chunk I/O. */
+export declare class PendingNativeRead {
+  poll(): Uint8Array | null
 }
 
 export declare class TestJwtIssuer {

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -104,7 +104,7 @@ export declare class NapiDb {
   evictExpiredStagedLargeValues(): number
   readValueRange(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array | PendingNativeRead
   readTextUtf16Range(table: string, rowId: Uint8Array, column: string, start: number, end: number): string | PendingNativeRead
-  readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): string | null
+  readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): string | null | PendingNativeRead
   appendValue(table: string, rowId: Uint8Array, column: string, bytes: Uint8Array): Write
   spliceValue(table: string, rowId: Uint8Array, column: string, offset: number, deleteLength: number, insert: Uint8Array): Write
   setNonDurableClient(): void

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -81,7 +81,7 @@ export declare class NapiDb {
   prepareQuery(query: Uint8Array): PreparedQuery
   all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   /** Read through an open transaction using the identity bound at begin. */
-  allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
   allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -130,7 +130,11 @@ export declare class PendingNativeRead {
  * waiting for chunk I/O. Call `readAll` again after transport progress.
  */
 export declare class PendingNativeSubscriptionBatch {
-
+  /**
+   * The host should wait this bounded delay before asking the subscription
+   * to retry a retained chunk-hydration batch.
+   */
+  retryAfterMs(): number | null
 }
 
 /**

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -135,8 +135,8 @@ export declare class StreamingMutation {
 }
 
 export declare class Subscription {
-  readAll(): Array<SubscriptionEvent>
-  drain(): Array<SubscriptionEvent>
+  readAll(): Array<SubscriptionEvent> | PendingNativeSubscriptionBatch
+  drain(): Array<SubscriptionEvent> | PendingNativeSubscriptionBatch
   close(): boolean
 }
 
@@ -144,6 +144,9 @@ export declare class Subscription {
 export declare class PendingNativeRead {
   poll(): Uint8Array | null
 }
+
+/** A bounded native subscription batch waiting for large-value chunk I/O. */
+export declare class PendingNativeSubscriptionBatch {}
 
 export declare class TestJwtIssuer {
   static start(): Promise<TestJwtIssuer>

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -104,7 +104,7 @@ export declare class NapiDb {
   evictExpiredStagedLargeValues(): number
   readValueRange(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array | PendingNativeRead
   readTextUtf16Range(table: string, rowId: Uint8Array, column: string, start: number, end: number): string | PendingNativeRead
-  readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): string | null | PendingNativeRead
+  readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): string | undefined | null | PendingNativeRead
   appendValue(table: string, rowId: Uint8Array, column: string, bytes: Uint8Array): Write | PendingNativeWrite
   spliceValue(table: string, rowId: Uint8Array, column: string, offset: number, deleteLength: number, insert: Uint8Array): Write | PendingNativeWrite
   setNonDurableClient(): void
@@ -113,6 +113,32 @@ export declare class NapiDb {
   mergeableTx(openBatchId: string): Tx
   mergeableTxForIdentity(openBatchId: string, author: Uint8Array): Tx
   close(): Promise<undefined>
+}
+
+/**
+ * A JavaScript-thread-owned binding read which suspended on asynchronous
+ * large-value storage. NAPI promises execute on a Send worker pool, whereas
+ * a Jazz runtime is deliberately `Rc`/thread-affine. The adapter drives this
+ * object after its peer transport makes progress instead of blocking Node.
+ */
+export declare class PendingNativeRead {
+  poll(): Uint8Array | null
+}
+
+/**
+ * Opaque marker returned while the next bounded native subscription batch is
+ * waiting for chunk I/O. Call `readAll` again after transport progress.
+ */
+export declare class PendingNativeSubscriptionBatch {
+
+}
+
+/**
+ * Thread-affine large-value mutation setup which is waiting for local or
+ * routed chunks. The completed value is the ordinary write receipt.
+ */
+export declare class PendingNativeWrite {
+  poll(): Write | null
 }
 
 export declare class PreparedQuery {
@@ -138,19 +164,6 @@ export declare class Subscription {
   readAll(): Array<SubscriptionEvent> | PendingNativeSubscriptionBatch
   drain(): Array<SubscriptionEvent> | PendingNativeSubscriptionBatch
   close(): boolean
-}
-
-/** A thread-affine Rust read suspended on local or routed chunk I/O. */
-export declare class PendingNativeRead {
-  poll(): Uint8Array | null
-}
-
-/** A bounded native subscription batch waiting for large-value chunk I/O. */
-export declare class PendingNativeSubscriptionBatch {}
-
-/** A thread-affine mutation setup waiting for large-value chunk I/O. */
-export declare class PendingNativeWrite {
-  poll(): Write | null
 }
 
 export declare class TestJwtIssuer {

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -84,10 +84,10 @@ export declare class NapiDb {
   allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
   allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
-  allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  allRelationSnapshotForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  allRelationQuery(queryJson: string, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
-  allRelationQueryForIdentity(queryJson: string, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array
+  allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  allRelationSnapshotForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  allRelationQuery(queryJson: string, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  allRelationQueryForIdentity(queryJson: string, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   localCurrentRow(table: string, rowId: Uint8Array): Uint8Array
   attachQuery(query: PreparedQuery, opts?: any | undefined | null): QueryAttachment
   attachQueryForIdentity(query: PreparedQuery, author: Uint8Array, opts?: any | undefined | null): QueryAttachment

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -105,8 +105,8 @@ export declare class NapiDb {
   readValueRange(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array | PendingNativeRead
   readTextUtf16Range(table: string, rowId: Uint8Array, column: string, start: number, end: number): string | PendingNativeRead
   readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): string | null | PendingNativeRead
-  appendValue(table: string, rowId: Uint8Array, column: string, bytes: Uint8Array): Write
-  spliceValue(table: string, rowId: Uint8Array, column: string, offset: number, deleteLength: number, insert: Uint8Array): Write
+  appendValue(table: string, rowId: Uint8Array, column: string, bytes: Uint8Array): Write | PendingNativeWrite
+  spliceValue(table: string, rowId: Uint8Array, column: string, offset: number, deleteLength: number, insert: Uint8Array): Write | PendingNativeWrite
   setNonDurableClient(): void
   connectUpstream(): Transport
   connectUpstreamWithSession(protocolVersion: number, features: number, remoteNode: Buffer, remoteEpoch: bigint, localNode: Buffer, localEpoch: bigint): Transport
@@ -147,6 +147,11 @@ export declare class PendingNativeRead {
 
 /** A bounded native subscription batch waiting for large-value chunk I/O. */
 export declare class PendingNativeSubscriptionBatch {}
+
+/** A thread-affine mutation setup waiting for large-value chunk I/O. */
+export declare class PendingNativeWrite {
+  poll(): Write | null
+}
 
 export declare class TestJwtIssuer {
   static start(): Promise<TestJwtIssuer>

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -102,8 +102,8 @@ export declare class NapiDb {
   setLargeValueStagingPolicy(incomingBytesPerWindow: number, windowMs: number, maxAgeMs?: number | undefined | null): void
   /** Run one idempotent expiry pass; native hosts normally call this on a timer. */
   evictExpiredStagedLargeValues(): number
-  readValueRange(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array
-  readTextUtf16Range(table: string, rowId: Uint8Array, column: string, start: number, end: number): string
+  readValueRange(table: string, rowId: Uint8Array, column: string, start: number, end: number): Uint8Array | PendingNativeRead
+  readTextUtf16Range(table: string, rowId: Uint8Array, column: string, start: number, end: number): string | PendingNativeRead
   readJsonPointer(table: string, rowId: Uint8Array, column: string, pointer: string): string | null
   appendValue(table: string, rowId: Uint8Array, column: string, bytes: Uint8Array): Write
   spliceValue(table: string, rowId: Uint8Array, column: string, offset: number, deleteLength: number, insert: Uint8Array): Write

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -322,46 +322,107 @@ struct PendingSubscriptionBatchCompletion {
     layouts: HashSet<String>,
 }
 
+/// A retryable chunk miss is not a subscription failure: retain the exact raw
+/// batch so the next host turn can re-run hydration after the peer pump has
+/// supplied the requested content.
+enum PendingSubscriptionBatchOutcome {
+    Complete(PendingSubscriptionBatchCompletion),
+    Retryable {
+        events: Vec<CoreSubscriptionEvent>,
+        retry_after_ms: u32,
+    },
+}
+
+enum PendingSubscriptionBatchState {
+    Future(LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchOutcome>>),
+    /// The raw events have been returned to the subscription queue. Keep this
+    /// marker visible to JavaScript for one turn so it can honor the retry
+    /// delay rather than tight-polling an immediately retryable resolver.
+    Retryable {
+        retry_after_ms: u32,
+    },
+}
+
+enum PendingSubscriptionBatchPoll {
+    Pending,
+    Complete(PendingSubscriptionBatchCompletion),
+    /// `Some` is the first observation of the retryable future completion and
+    /// owns events which must be restored to the front of the queue. `None`
+    /// is the following host turn, which clears the marker and retries them.
+    Retryable {
+        events: Option<Vec<CoreSubscriptionEvent>>,
+    },
+}
+
 /// Opaque marker returned while the next bounded native subscription batch is
 /// waiting for chunk I/O. Call `readAll` again after transport progress.
 #[napi]
 pub struct PendingNativeSubscriptionBatch {
-    future: Rc<
-        RefCell<Option<LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchCompletion>>>>,
-    >,
+    state: Rc<RefCell<Option<PendingSubscriptionBatchState>>>,
 }
 
 impl Clone for PendingNativeSubscriptionBatch {
     fn clone(&self) -> Self {
         Self {
-            future: Rc::clone(&self.future),
+            state: Rc::clone(&self.state),
         }
     }
 }
 
 impl PendingNativeSubscriptionBatch {
-    fn new(
-        future: LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchCompletion>>,
-    ) -> Self {
+    fn new(future: LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchOutcome>>) -> Self {
         Self {
-            future: Rc::new(RefCell::new(Some(future))),
+            state: Rc::new(RefCell::new(Some(PendingSubscriptionBatchState::Future(
+                future,
+            )))),
         }
     }
 
-    fn poll_once(&self) -> napi::Result<Option<PendingSubscriptionBatchCompletion>> {
-        let Some(mut future) = self.future.borrow_mut().take() else {
+    fn poll_once(&self) -> napi::Result<PendingSubscriptionBatchPoll> {
+        let Some(state) = self.state.borrow_mut().take() else {
             return Err(napi::Error::from_reason(
                 "native pending subscription batch is already complete",
             ));
         };
+        let PendingSubscriptionBatchState::Future(mut future) = state else {
+            let PendingSubscriptionBatchState::Retryable { retry_after_ms } = state else {
+                unreachable!("subscription batch state is exhaustive");
+            };
+            *self.state.borrow_mut() =
+                Some(PendingSubscriptionBatchState::Retryable { retry_after_ms });
+            return Ok(PendingSubscriptionBatchPoll::Retryable { events: None });
+        };
         let waker = Waker::noop();
         let mut context = Context::from_waker(waker);
         match Pin::new(&mut future).poll(&mut context) {
-            Poll::Ready(result) => result.map(Some),
+            Poll::Ready(result) => result.map(|outcome| match outcome {
+                PendingSubscriptionBatchOutcome::Complete(completion) => {
+                    PendingSubscriptionBatchPoll::Complete(completion)
+                }
+                PendingSubscriptionBatchOutcome::Retryable {
+                    events,
+                    retry_after_ms,
+                } => {
+                    *self.state.borrow_mut() =
+                        Some(PendingSubscriptionBatchState::Retryable { retry_after_ms });
+                    PendingSubscriptionBatchPoll::Retryable {
+                        events: Some(events),
+                    }
+                }
+            }),
             Poll::Pending => {
-                *self.future.borrow_mut() = Some(future);
-                Ok(None)
+                *self.state.borrow_mut() = Some(PendingSubscriptionBatchState::Future(future));
+                Ok(PendingSubscriptionBatchPoll::Pending)
             }
+        }
+    }
+
+    fn retry_after_ms(&self) -> Option<u32> {
+        match self.state.borrow().as_ref() {
+            Some(PendingSubscriptionBatchState::Retryable { retry_after_ms }) => {
+                Some(*retry_after_ms)
+            }
+            _ => None,
         }
     }
 }
@@ -388,6 +449,16 @@ impl PendingNativeRead {
                 Ok(None)
             }
         }
+    }
+}
+
+#[napi]
+impl PendingNativeSubscriptionBatch {
+    /// The host should wait this bounded delay before asking the subscription
+    /// to retry a retained chunk-hydration batch.
+    #[napi(js_name = "retryAfterMs")]
+    pub fn retry_after_ms_for_js(&self) -> Option<u32> {
+        self.retry_after_ms()
     }
 }
 
@@ -954,6 +1025,15 @@ impl Subscription {
 
 const MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS: usize = 256;
 
+fn requeue_retryable_subscription_batch(
+    pending_events: &mut VecDeque<CoreSubscriptionEvent>,
+    events: Vec<CoreSubscriptionEvent>,
+) {
+    for event in events.into_iter().rev() {
+        pending_events.push_front(event);
+    }
+}
+
 fn read_or_start_subscription_batch<S>(
     db: &Rc<CoreDb<S>>,
     stream: &mut SubscriptionStream,
@@ -966,12 +1046,22 @@ where
 {
     if let Some(batch) = pending_batch.as_ref() {
         match batch.poll_once()? {
-            Some(completion) => {
+            PendingSubscriptionBatchPoll::Complete(completion) => {
                 *pending_batch = None;
                 *published_terminal_layouts = completion.layouts;
                 return Ok(Some(completion.events));
             }
-            None => return Ok(None),
+            PendingSubscriptionBatchPoll::Pending => return Ok(None),
+            PendingSubscriptionBatchPoll::Retryable {
+                events: Some(events),
+                ..
+            } => {
+                requeue_retryable_subscription_batch(pending_events, events);
+                return Ok(None);
+            }
+            PendingSubscriptionBatchPoll::Retryable { events: None, .. } => {
+                *pending_batch = None;
+            }
         }
     }
     let mut raw_events = Vec::with_capacity(MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS);
@@ -992,30 +1082,49 @@ where
     let batch = PendingNativeSubscriptionBatch::new(Box::pin(async move {
         let mut raw_events = raw_events;
         for event in &mut raw_events {
-            db.hydrate_subscription_event_for_binding_outcome(event)
+            match db
+                .hydrate_subscription_event_for_binding_outcome(event)
                 .await
-                .map_err(|error| match error {
-                    jazz::db::BindingHydrationError::RetryableChunkUnavailable { .. } => {
-                        napi::Error::from_reason(
-                            "large-value chunk remains temporarily unavailable",
-                        )
-                    }
-                    jazz::db::BindingHydrationError::Error(error) => napi_error(error),
-                })?;
+            {
+                Ok(()) => {}
+                Err(jazz::db::BindingHydrationError::RetryableChunkUnavailable {
+                    retry_after_ms,
+                }) => {
+                    // Preserve the whole batch below rather than making a
+                    // retryable absence terminal at the NAPI boundary.
+                    return Ok(PendingSubscriptionBatchOutcome::Retryable {
+                        events: raw_events,
+                        retry_after_ms,
+                    });
+                }
+                Err(jazz::db::BindingHydrationError::Error(error)) => {
+                    return Err(napi_error(error));
+                }
+            }
         }
         let mut layouts = layouts;
         let events = raw_events
             .iter()
             .map(|event| core_subscription_event_to_napi(event, &mut layouts))
             .collect::<napi::Result<Vec<_>>>()?;
-        Ok(PendingSubscriptionBatchCompletion { events, layouts })
+        Ok(PendingSubscriptionBatchOutcome::Complete(
+            PendingSubscriptionBatchCompletion { events, layouts },
+        ))
     }));
     match batch.poll_once()? {
-        Some(completion) => {
+        PendingSubscriptionBatchPoll::Complete(completion) => {
             *published_terminal_layouts = completion.layouts;
             Ok(Some(completion.events))
         }
-        None => {
+        PendingSubscriptionBatchPoll::Pending
+        | PendingSubscriptionBatchPoll::Retryable { events: None } => {
+            *pending_batch = Some(batch);
+            Ok(None)
+        }
+        PendingSubscriptionBatchPoll::Retryable {
+            events: Some(events),
+        } => {
+            requeue_retryable_subscription_batch(pending_events, events);
             *pending_batch = Some(batch);
             Ok(None)
         }
@@ -4673,19 +4782,21 @@ pub fn verify_local_first_identity_proof_napi(
 mod tests {
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::{BTreeMap, HashSet, VecDeque};
     use std::rc::Rc;
 
     use futures::channel::oneshot;
 
     use crate::{
         CoreOpenDbConfig, CoreSelfSignedClientProof, InsertOptions, NapiDb, NapiDbInnerStorage,
-        NapiTxKind, PreparedQuery, RestoreOptions, Tx, UpdateOptions, UpsertOptions,
-        authority_epoch_from_bigint, core_author_id_from_bytes, core_block_on,
-        core_claim_value_from_json, core_insert_options, core_open_backend_identity,
-        core_open_identity, core_read_opts_from_json, core_read_tier_from_str,
-        core_restore_options, core_subscription_event_to_napi, core_update_options,
-        core_upsert_options, encode_core_subscription_delta, terminal_bytes_to_numbers,
+        NapiTxKind, PendingNativeRead, PendingNativeSubscriptionBatch,
+        PendingSubscriptionBatchOutcome, PendingSubscriptionBatchPoll, PreparedQuery,
+        RestoreOptions, Tx, UpdateOptions, UpsertOptions, authority_epoch_from_bigint,
+        core_author_id_from_bytes, core_block_on, core_claim_value_from_json, core_insert_options,
+        core_open_backend_identity, core_open_identity, core_read_opts_from_json,
+        core_read_tier_from_str, core_restore_options, core_subscription_event_to_napi,
+        core_update_options, core_upsert_options, encode_core_subscription_delta,
+        requeue_retryable_subscription_batch, terminal_bytes_to_numbers,
         unknown_transaction_kind_message,
     };
 
@@ -4702,14 +4813,68 @@ mod tests {
             pending.poll_once().unwrap().is_none(),
             "planted suspension is retained"
         );
-        sender
-            .send(Uint8Array::new(vec![7, 11]))
-            .expect("complete the retained future");
+        assert!(
+            sender.send(Uint8Array::new(vec![7, 11])).is_ok(),
+            "complete the retained future"
+        );
         assert_eq!(pending.poll_once().unwrap().unwrap().to_vec(), vec![7, 11]);
         assert!(
             pending.poll_once().is_err(),
             "completed reads cannot be replayed or double-encoded"
         );
+    }
+
+    // Internal because this asserts the NAPI object's one-turn retry marker;
+    // public transport topology tests separately prove that routed chunks are
+    // eventually delivered. The marker is what prevents the binding from
+    // dropping an otherwise retryable subscription batch between those turns.
+    #[test]
+    fn pending_subscription_batch_retains_retryable_marker_for_the_next_js_turn() {
+        let batch = PendingNativeSubscriptionBatch::new(Box::pin(async {
+            Ok(PendingSubscriptionBatchOutcome::Retryable {
+                events: Vec::new(),
+                retry_after_ms: 37,
+            })
+        }));
+
+        assert!(matches!(
+            batch.poll_once().unwrap(),
+            PendingSubscriptionBatchPoll::Retryable {
+                events: Some(events),
+            } if events.is_empty()
+        ));
+        assert_eq!(batch.retry_after_ms(), Some(37));
+        assert!(matches!(
+            batch.poll_once().unwrap(),
+            PendingSubscriptionBatchPoll::Retryable { events: None }
+        ));
+    }
+
+    #[test]
+    fn retryable_subscription_batch_returns_raw_events_to_the_front_in_fifo_order() {
+        let mut queued = VecDeque::from([CoreSubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
+        }]);
+        requeue_retryable_subscription_batch(
+            &mut queued,
+            vec![CoreSubscriptionEvent::Closed, CoreSubscriptionEvent::Closed],
+        );
+
+        assert!(matches!(
+            queued.pop_front(),
+            Some(CoreSubscriptionEvent::Closed)
+        ));
+        assert!(matches!(
+            queued.pop_front(),
+            Some(CoreSubscriptionEvent::Closed)
+        ));
+        assert!(matches!(
+            queued.pop_front(),
+            Some(CoreSubscriptionEvent::Rejected {
+                reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
+            })
+        ));
+        assert!(queued.is_empty());
     }
 
     /// Binding read choices lower without widening the write durability parser.
@@ -4748,7 +4913,7 @@ mod tests {
     use jazz::ids::{
         AuthorSubject as CoreAuthorSubject, NodeUuid as CoreNodeUuid, RowUuid as CoreRowUuid,
     };
-    use jazz::protocol::ReadViewSpec as CoreReadViewSpec;
+    use jazz::protocol::{ReadViewSpec as CoreReadViewSpec, SubscribeRejectReason};
     use jazz::tools::OpenTransactionId as CoreOpenBatchId;
     use jazz::tools::{
         ColumnType, PolicyExpr, Schema, SchemaBuilder, TableName, TablePolicies, TableSchema, Value,

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2190,24 +2190,46 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_relation_snapshot(&query.inner, opts))
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_snapshot(&query.inner, opts))
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_relation_snapshot(&snapshot)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationSnapshotForIdentity")]
@@ -2219,25 +2241,47 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let author = core_author_id_from_bytes(&author)?;
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_relation_snapshot_for_identity(&query.inner, opts, author))
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot_for_identity(&query, opts, author)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_snapshot_for_identity(&query.inner, opts, author))
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_snapshot_for_identity(&query, opts, author)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_relation_snapshot(&snapshot)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_relation_snapshot(&snapshot)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationQuery")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -286,6 +286,55 @@ pub struct PendingNativeRead {
     future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Uint8Array>>>>>,
 }
 
+struct PendingSubscriptionBatchCompletion {
+    events: Vec<SubscriptionEvent>,
+    layouts: HashSet<String>,
+}
+
+/// Opaque marker returned while the next bounded native subscription batch is
+/// waiting for chunk I/O. Call `readAll` again after transport progress.
+#[napi]
+pub struct PendingNativeSubscriptionBatch {
+    future: Rc<
+        RefCell<Option<LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchCompletion>>>>,
+    >,
+}
+
+impl Clone for PendingNativeSubscriptionBatch {
+    fn clone(&self) -> Self {
+        Self {
+            future: Rc::clone(&self.future),
+        }
+    }
+}
+
+impl PendingNativeSubscriptionBatch {
+    fn new(
+        future: LocalBoxFuture<'static, napi::Result<PendingSubscriptionBatchCompletion>>,
+    ) -> Self {
+        Self {
+            future: Rc::new(RefCell::new(Some(future))),
+        }
+    }
+
+    fn poll_once(&self) -> napi::Result<Option<PendingSubscriptionBatchCompletion>> {
+        let Some(mut future) = self.future.borrow_mut().take() else {
+            return Err(napi::Error::from_reason(
+                "native pending subscription batch is already complete",
+            ));
+        };
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        match Pin::new(&mut future).poll(&mut context) {
+            Poll::Ready(result) => result.map(Some),
+            Poll::Pending => {
+                *self.future.borrow_mut() = Some(future);
+                Ok(None)
+            }
+        }
+    }
+}
+
 impl PendingNativeRead {
     fn new(future: LocalBoxFuture<'static, napi::Result<Uint8Array>>) -> Self {
         Self {
@@ -562,8 +611,18 @@ impl NapiTransportInner {
 }
 
 enum NapiSubscription {
-    Memory(SubscriptionStream),
-    Persistent(SubscriptionStream),
+    Memory {
+        db: Rc<CoreDb<CoreMemoryStorage>>,
+        stream: SubscriptionStream,
+        pending_events: VecDeque<CoreSubscriptionEvent>,
+        pending_batch: Option<PendingNativeSubscriptionBatch>,
+    },
+    Persistent {
+        db: Rc<CoreDb<CoreRocksDbStorage>>,
+        stream: SubscriptionStream,
+        pending_events: VecDeque<CoreSubscriptionEvent>,
+        pending_batch: Option<PendingNativeSubscriptionBatch>,
+    },
 }
 
 #[napi(js_name = "Tx")]
@@ -780,36 +839,137 @@ impl Transport {
 #[napi]
 impl Subscription {
     #[napi(js_name = "readAll")]
-    pub fn read_all(&mut self) -> napi::Result<Vec<SubscriptionEvent>> {
+    pub fn read_all(
+        &mut self,
+    ) -> napi::Result<Either<Vec<SubscriptionEvent>, PendingNativeSubscriptionBatch>> {
         let subscription = self
             .inner
             .as_mut()
             .ok_or_else(|| napi::Error::from_reason("subscription is closed"))?;
-        let mut events = Vec::new();
-        loop {
-            let event = match subscription {
-                NapiSubscription::Memory(stream) => stream.try_next_event(),
-                NapiSubscription::Persistent(stream) => stream.try_next_event(),
-            };
-            let Some(event) = event else {
-                break;
-            };
-            events.push(core_subscription_event_to_napi(
-                &event,
+        let result = match subscription {
+            NapiSubscription::Memory {
+                db,
+                stream,
+                pending_events,
+                pending_batch,
+            } => read_or_start_subscription_batch(
+                db,
+                stream,
+                pending_events,
+                pending_batch,
                 &mut self.published_terminal_layouts,
-            )?);
+            ),
+            NapiSubscription::Persistent {
+                db,
+                stream,
+                pending_events,
+                pending_batch,
+            } => read_or_start_subscription_batch(
+                db,
+                stream,
+                pending_events,
+                pending_batch,
+                &mut self.published_terminal_layouts,
+            ),
+        };
+        match result {
+            Ok(Some(events)) => Ok(Either::A(events)),
+            Ok(None) => match subscription {
+                NapiSubscription::Memory { pending_batch, .. }
+                | NapiSubscription::Persistent { pending_batch, .. } => Ok(Either::B(
+                    pending_batch
+                        .as_ref()
+                        .expect("suspended batch is retained")
+                        .clone(),
+                )),
+            },
+            Err(error) => {
+                self.inner.take();
+                Err(error)
+            }
         }
-        Ok(events)
     }
 
     #[napi]
-    pub fn drain(&mut self) -> napi::Result<Vec<SubscriptionEvent>> {
+    pub fn drain(
+        &mut self,
+    ) -> napi::Result<Either<Vec<SubscriptionEvent>, PendingNativeSubscriptionBatch>> {
         self.read_all()
     }
 
     #[napi]
     pub fn close(&mut self) -> bool {
         self.inner.take().is_some()
+    }
+}
+
+const MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS: usize = 256;
+
+fn read_or_start_subscription_batch<S>(
+    db: &Rc<CoreDb<S>>,
+    stream: &mut SubscriptionStream,
+    pending_events: &mut VecDeque<CoreSubscriptionEvent>,
+    pending_batch: &mut Option<PendingNativeSubscriptionBatch>,
+    published_terminal_layouts: &mut HashSet<String>,
+) -> napi::Result<Option<Vec<SubscriptionEvent>>>
+where
+    S: CoreOrderedKvStorage + CoreReopenableStorage + 'static,
+{
+    if let Some(batch) = pending_batch.as_ref() {
+        match batch.poll_once()? {
+            Some(completion) => {
+                *pending_batch = None;
+                *published_terminal_layouts = completion.layouts;
+                return Ok(Some(completion.events));
+            }
+            None => return Ok(None),
+        }
+    }
+    let mut raw_events = Vec::with_capacity(MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS);
+    while raw_events.len() < MAX_RETAINED_SUBSCRIPTION_BATCH_EVENTS {
+        let Some(event) = pending_events
+            .pop_front()
+            .or_else(|| stream.try_next_event())
+        else {
+            break;
+        };
+        raw_events.push(event);
+    }
+    if raw_events.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let db = Rc::clone(db);
+    let layouts = published_terminal_layouts.clone();
+    let batch = PendingNativeSubscriptionBatch::new(Box::pin(async move {
+        let mut raw_events = raw_events;
+        for event in &mut raw_events {
+            db.hydrate_subscription_event_for_binding_outcome(event)
+                .await
+                .map_err(|error| match error {
+                    jazz::db::BindingHydrationError::RetryableChunkUnavailable { .. } => {
+                        napi::Error::from_reason(
+                            "large-value chunk remains temporarily unavailable",
+                        )
+                    }
+                    jazz::db::BindingHydrationError::Error(error) => napi_error(error),
+                })?;
+        }
+        let mut layouts = layouts;
+        let events = raw_events
+            .iter()
+            .map(|event| core_subscription_event_to_napi(event, &mut layouts))
+            .collect::<napi::Result<Vec<_>>>()?;
+        Ok(PendingSubscriptionBatchCompletion { events, layouts })
+    }));
+    match batch.poll_once()? {
+        Some(completion) => {
+            *published_terminal_layouts = completion.layouts;
+            Ok(Some(completion.events))
+        }
+        None => {
+            *pending_batch = Some(batch);
+            Ok(None)
+        }
     }
 }
 
@@ -2494,14 +2654,18 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe(&query.inner, opts))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe(&query.inner, opts))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe(&query.inner, opts)).map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe(&query.inner, opts)).map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),
@@ -2526,14 +2690,20 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
+                    .map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_for_identity(&query.inner, opts, author))
+                    .map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),
@@ -2557,14 +2727,20 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe_relation_query(&query, opts))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe_relation_query(&query, opts))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_relation_query(&query, opts))
+                    .map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(db.subscribe_relation_query(&query, opts))
+                    .map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),
@@ -2590,14 +2766,24 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         let inner = match db {
-            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory(
-                core_block_on(db.subscribe_relation_query_for_identity(&query, opts, author))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent(
-                core_block_on(db.subscribe_relation_query_for_identity(&query, opts, author))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => NapiSubscription::Memory {
+                db: Rc::clone(db),
+                stream: core_block_on(
+                    db.subscribe_relation_query_for_identity(&query, opts, author),
+                )
+                .map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
+            NapiDbInnerStorage::Persistent(db) => NapiSubscription::Persistent {
+                db: Rc::clone(db),
+                stream: core_block_on(
+                    db.subscribe_relation_query_for_identity(&query, opts, author),
+                )
+                .map_err(napi_error)?,
+                pending_events: VecDeque::new(),
+                pending_batch: None,
+            },
         };
         Ok(Subscription {
             inner: Some(inner),

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2907,23 +2907,33 @@ impl NapiDb {
         column: String,
         start: f64,
         end: f64,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let range = checked_u64_range(start, end)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let bytes = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.read_value_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_value_range(&table, row_id, &column, range)
+                        .await
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.read_value_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_value_range(&table, row_id, &column, range)
+                        .await
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        Ok(Uint8Array::new(bytes))
     }
 
     #[napi(js_name = "readTextUtf16Range")]
@@ -2934,22 +2944,39 @@ impl NapiDb {
         column: String,
         start: f64,
         end: f64,
-    ) -> napi::Result<String> {
+    ) -> napi::Result<Either<String, PendingNativeRead>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let range = checked_u64_range(start, end)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        match db {
+        let bytes = match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.read_text_utf16_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_text_utf16_range(&table, row_id, &column, range)
+                        .await
+                        .map(|value| Uint8Array::new(value.into_bytes()))
+                        .map_err(napi_error)
+                }))?
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.read_text_utf16_range(&table, row_id, &column, range))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    db.read_text_utf16_range(&table, row_id, &column, range)
+                        .await
+                        .map(|value| Uint8Array::new(value.into_bytes()))
+                        .map_err(napi_error)
+                }))?
             }
-        }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))
+        };
+        Ok(match bytes {
+            Either::A(bytes) => {
+                Either::A(String::from_utf8(bytes.to_vec()).expect("Rust String is valid UTF-8"))
+            }
+            Either::B(pending) => Either::B(pending),
+        })
     }
 
     #[napi(js_name = "readJsonPointer")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -43,13 +43,15 @@ pub type JsonValue = serde_json::Value;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::future::Future;
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Mutex;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use futures::future::LocalBoxFuture;
 use futures::lock::Mutex as LocalMutex;
 use jazz::db::StreamingMutationKind as CoreStreamingMutationKind;
 use jazz::db::{
@@ -273,6 +275,62 @@ pub struct Write {
     row_id: CoreRowUuid,
     batch_id: TransactionId,
     inner: Option<NapiWrite>,
+}
+
+/// A JavaScript-thread-owned binding read which suspended on asynchronous
+/// large-value storage. NAPI promises execute on a Send worker pool, whereas
+/// a Jazz runtime is deliberately `Rc`/thread-affine. The adapter drives this
+/// object after its peer transport makes progress instead of blocking Node.
+#[napi]
+pub struct PendingNativeRead {
+    future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Uint8Array>>>>>,
+}
+
+impl PendingNativeRead {
+    fn new(future: LocalBoxFuture<'static, napi::Result<Uint8Array>>) -> Self {
+        Self {
+            future: Rc::new(RefCell::new(Some(future))),
+        }
+    }
+
+    fn poll_once(&self) -> napi::Result<Option<Uint8Array>> {
+        let Some(mut future) = self.future.borrow_mut().take() else {
+            return Err(napi::Error::from_reason(
+                "native pending read is already complete",
+            ));
+        };
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        match Pin::new(&mut future).poll(&mut context) {
+            Poll::Ready(result) => result.map(Some),
+            Poll::Pending => {
+                *self.future.borrow_mut() = Some(future);
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[napi]
+impl PendingNativeRead {
+    #[napi]
+    pub fn poll(&self) -> napi::Result<Option<Uint8Array>> {
+        self.poll_once()
+    }
+}
+
+fn native_read_or_pending(
+    future: LocalBoxFuture<'static, napi::Result<Uint8Array>>,
+) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
+    let pending = PendingNativeRead::new(future);
+    match pending.poll_once()? {
+        Some(bytes) => Ok(Either::A(bytes)),
+        None => Ok(Either::B(pending)),
+    }
+}
+
+fn napi_error(error: impl std::fmt::Display) -> napi::Error {
+    napi::Error::from_reason(error.to_string())
 }
 
 #[napi(js_name = "Transport")]
@@ -1969,20 +2027,40 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let rows = match db {
-            NapiDbInnerStorage::Memory(db) => core_block_on(db.all(&query.inner, opts)),
-            NapiDbInnerStorage::Persistent(db) => core_block_on(db.all(&query.inner, opts)),
+        match db {
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db.all(&query, opts).await.map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db.all(&query, opts).await.map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     /// Read through an open transaction using the identity bound at begin.
@@ -2061,25 +2139,47 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let author = core_author_id_from_bytes(&author)?;
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let rows = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_for_identity(&query.inner, opts, author))
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .all_for_identity(&query, opts, author)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_for_identity(&query.inner, opts, author))
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .all_for_identity(&query, opts, author)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationSnapshot")]
@@ -4134,6 +4234,8 @@ mod tests {
     use std::collections::{BTreeMap, HashSet};
     use std::rc::Rc;
 
+    use futures::channel::oneshot;
+
     use crate::{
         CoreOpenDbConfig, CoreSelfSignedClientProof, InsertOptions, NapiDb, NapiDbInnerStorage,
         NapiTxKind, PreparedQuery, RestoreOptions, Tx, UpdateOptions, UpsertOptions,
@@ -4144,6 +4246,29 @@ mod tests {
         core_upsert_options, encode_core_subscription_delta, terminal_bytes_to_numbers,
         unknown_transaction_kind_message,
     };
+
+    #[test]
+    fn pending_native_read_retains_a_suspended_future_until_the_next_js_turn() {
+        let (sender, receiver) = oneshot::channel::<Uint8Array>();
+        let pending = PendingNativeRead::new(Box::pin(async move {
+            receiver
+                .await
+                .map_err(|_| napi::Error::from_reason("planned sender drop"))
+        }));
+
+        assert!(
+            pending.poll_once().unwrap().is_none(),
+            "planted suspension is retained"
+        );
+        sender
+            .send(Uint8Array::new(vec![7, 11]))
+            .expect("complete the retained future");
+        assert_eq!(pending.poll_once().unwrap().unwrap().to_vec(), vec![7, 11]);
+        assert!(
+            pending.poll_once().is_err(),
+            "completed reads cannot be replayed or double-encoded"
+        );
+    }
 
     /// Binding read choices lower without widening the write durability parser.
     #[test]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2986,25 +2986,51 @@ impl NapiDb {
         row_id: Uint8Array,
         column: String,
         pointer: String,
-    ) -> napi::Result<Option<String>> {
+    ) -> napi::Result<Either<Option<String>, PendingNativeRead>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let value = match db {
+        let bytes = match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.read_json_pointer(&table, row_id, &column, &pointer))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let value = db
+                        .read_json_pointer(&table, row_id, &column, &pointer)
+                        .await
+                        .map_err(napi_error)?;
+                    let text = value
+                        .map(|value| serde_json::to_string(&value))
+                        .transpose()
+                        .map_err(napi_error)?
+                        .unwrap_or_default();
+                    Ok(Uint8Array::new(text.into_bytes()))
+                }))?
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.read_json_pointer(&table, row_id, &column, &pointer))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let value = db
+                        .read_json_pointer(&table, row_id, &column, &pointer)
+                        .await
+                        .map_err(napi_error)?;
+                    let text = value
+                        .map(|value| serde_json::to_string(&value))
+                        .transpose()
+                        .map_err(napi_error)?
+                        .unwrap_or_default();
+                    Ok(Uint8Array::new(text.into_bytes()))
+                }))?
             }
-        }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        value
-            .map(|value| serde_json::to_string(&value))
-            .transpose()
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
+        };
+        Ok(match bytes {
+            Either::A(bytes) => {
+                let text = String::from_utf8(bytes.to_vec()).expect("JSON is UTF-8");
+                Either::A((!text.is_empty()).then_some(text))
+            }
+            Either::B(pending) => Either::B(pending),
+        })
     }
 
     #[napi(js_name = "appendValue")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2500,23 +2500,45 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let query = core_relation_query_from_json(&query_json)?;
         let opts = core_read_opts_from_json(opts)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
-            NapiDbInnerStorage::Memory(db) => core_block_on(db.all_relation_query(&query, opts)),
+        match db {
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_query(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_query(&query, opts))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_query(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&snapshot.rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "allRelationQueryForIdentity")]
@@ -2528,7 +2550,7 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let query = core_relation_query_from_json(&query_json)?;
         let author = core_author_id_from_bytes(&author)?;
         let opts = core_read_opts_from_json(opts)?;
@@ -2536,18 +2558,38 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
-        let snapshot = match db {
+        match db {
             NapiDbInnerStorage::Memory(db) => {
-                core_block_on(db.all_relation_query_for_identity(&query, opts, author))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_query_for_identity(&query, opts, author)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
             NapiDbInnerStorage::Persistent(db) => {
-                core_block_on(db.all_relation_query_for_identity(&query, opts, author))
+                let db = Rc::clone(db);
+                native_read_or_pending(Box::pin(async move {
+                    let mut snapshot = db
+                        .all_relation_query_for_identity(&query, opts, author)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_relation_snapshot_for_binding(&mut snapshot)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&snapshot.rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
             }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&snapshot.rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "localCurrentRow")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2073,7 +2073,7 @@ impl NapiDb {
             ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
         )]
         opts: Option<JsonValue>,
-    ) -> napi::Result<Uint8Array> {
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let db = self.inner.borrow();
         let db = db
             .as_ref()
@@ -2085,28 +2085,76 @@ impl NapiDb {
         }
         let opts = core_read_opts_from_json(opts)?;
         let open_tx = tx.open_tx()?;
-        let rows = match (db, tx.kind) {
-            (NapiDbInnerStorage::Memory(db), NapiTxKind::Mergeable) => core_block_on(
-                db.mergeable_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
-            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Mergeable) => core_block_on(
-                db.mergeable_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
-            (NapiDbInnerStorage::Memory(db), NapiTxKind::Exclusive) => core_block_on(
-                db.exclusive_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
-            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Exclusive) => core_block_on(
-                db.exclusive_tx_ref(open_tx)
-                    .all_prepared_with_opts(&query.inner, opts),
-            ),
+        match (db, tx.kind) {
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Mergeable) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .mergeable_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Mergeable) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .mergeable_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Exclusive) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .exclusive_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Exclusive) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .exclusive_tx_ref(open_tx)
+                        .all_prepared_with_opts(&query, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
         }
-        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-        encode_core_rows(&rows)
-            .map(Uint8Array::new)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))
     }
 
     #[napi(js_name = "setIdentityClaims")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -286,6 +286,37 @@ pub struct PendingNativeRead {
     future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Uint8Array>>>>>,
 }
 
+/// Thread-affine large-value mutation setup which is waiting for local or
+/// routed chunks. The completed value is the ordinary write receipt.
+#[napi]
+pub struct PendingNativeWrite {
+    future: Rc<RefCell<Option<LocalBoxFuture<'static, napi::Result<Write>>>>>,
+}
+
+impl PendingNativeWrite {
+    fn new(future: LocalBoxFuture<'static, napi::Result<Write>>) -> Self {
+        Self {
+            future: Rc::new(RefCell::new(Some(future))),
+        }
+    }
+    fn poll_once(&self) -> napi::Result<Option<Write>> {
+        let Some(mut future) = self.future.borrow_mut().take() else {
+            return Err(napi::Error::from_reason(
+                "native pending write is already complete",
+            ));
+        };
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        match Pin::new(&mut future).poll(&mut context) {
+            Poll::Ready(result) => result.map(Some),
+            Poll::Pending => {
+                *self.future.borrow_mut() = Some(future);
+                Ok(None)
+            }
+        }
+    }
+}
+
 struct PendingSubscriptionBatchCompletion {
     events: Vec<SubscriptionEvent>,
     layouts: HashSet<String>,
@@ -361,6 +392,14 @@ impl PendingNativeRead {
 }
 
 #[napi]
+impl PendingNativeWrite {
+    #[napi]
+    pub fn poll(&self) -> napi::Result<Option<Write>> {
+        self.poll_once()
+    }
+}
+
+#[napi]
 impl PendingNativeRead {
     #[napi]
     pub fn poll(&self) -> napi::Result<Option<Uint8Array>> {
@@ -374,6 +413,16 @@ fn native_read_or_pending(
     let pending = PendingNativeRead::new(future);
     match pending.poll_once()? {
         Some(bytes) => Ok(Either::A(bytes)),
+        None => Ok(Either::B(pending)),
+    }
+}
+
+fn native_write_or_pending(
+    future: LocalBoxFuture<'static, napi::Result<Write>>,
+) -> napi::Result<Either<Write, PendingNativeWrite>> {
+    let pending = PendingNativeWrite::new(future);
+    match pending.poll_once()? {
+        Some(write) => Ok(Either::A(write)),
         None => Ok(Either::B(pending)),
     }
 }
@@ -3040,23 +3089,33 @@ impl NapiDb {
         row_id: Uint8Array,
         column: String,
         bytes: Uint8Array,
-    ) -> napi::Result<Write> {
+    ) -> napi::Result<Either<Write, PendingNativeWrite>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let db = self.inner.borrow();
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.append_value(&table, row_id, &column, bytes.to_vec()))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.append_value(&table, row_id, &column, bytes.to_vec()))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .append_value(&table, row_id, &column, bytes.to_vec())
+                        .await
+                        .map_err(napi_error)?;
+                    core_write_memory(db, write)
+                }))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .append_value(&table, row_id, &column, bytes.to_vec())
+                        .await
+                        .map_err(napi_error)?;
+                    core_write_persistent(db, write)
+                }))
+            }
         }
     }
 
@@ -3069,7 +3128,7 @@ impl NapiDb {
         offset: f64,
         delete_length: f64,
         insert: Uint8Array,
-    ) -> napi::Result<Write> {
+    ) -> napi::Result<Either<Write, PendingNativeWrite>> {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let offset = checked_u64(offset, "offset")?;
         let delete_length = checked_u64(delete_length, "deleteLength")?;
@@ -3078,30 +3137,40 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.splice_value(
-                    &table,
-                    row_id,
-                    &column,
-                    offset,
-                    delete_length,
-                    insert.to_vec(),
-                ))
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.splice_value(
-                    &table,
-                    row_id,
-                    &column,
-                    offset,
-                    delete_length,
-                    insert.to_vec(),
-                ))
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .splice_value(
+                            &table,
+                            row_id,
+                            &column,
+                            offset,
+                            delete_length,
+                            insert.to_vec(),
+                        )
+                        .await
+                        .map_err(napi_error)?;
+                    core_write_memory(db, write)
+                }))
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let db = Rc::clone(db);
+                native_write_or_pending(Box::pin(async move {
+                    let write = db
+                        .splice_value(
+                            &table,
+                            row_id,
+                            &column,
+                            offset,
+                            delete_length,
+                            insert.to_vec(),
+                        )
+                        .await
+                        .map_err(napi_error)?;
+                    core_write_persistent(db, write)
+                }))
+            }
         }
     }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -125,7 +125,7 @@ type NativeWriteOptions = {
 
 type PendingNativeRead = { poll(): Uint8Array | null };
 type NativeReadResult = Uint8Array | PendingNativeRead;
-type PendingNativeSubscriptionBatch = object;
+type PendingNativeSubscriptionBatch = { retryAfterMs?(): number | null };
 type PendingNativeWrite = { poll(): Write | null };
 
 function isPendingNativeRead(value: unknown): value is PendingNativeRead {
@@ -2256,7 +2256,7 @@ export class NativeRuntimeAdapter implements Runtime {
         attachment = await this.attachQueryIfNeeded("edge", null, query, session);
         if (this.closed) return;
         const opts = readOptions("edge", false, null);
-        this.readRowsForHost(query, opts, session?.identity);
+        await this.readRowsForHostAsync(query, opts, session?.identity);
       } finally {
         if (attachment !== undefined && !this.closed) this.db.detachQuery?.(attachment);
       }
@@ -2437,7 +2437,7 @@ export class NativeRuntimeAdapter implements Runtime {
         if (peerHasResponded && this.db.queryAttachmentIsCovered(attachment)) return;
       }
       try {
-        this.readRowsForHost(query, opts, identity);
+        await this.readRowsForHostAsync(query, opts, identity);
         if (!this.db.queryAttachmentIsCovered) return;
       } catch (error) {
         if (!isPendingCoverageError(error)) throw error;
@@ -2704,7 +2704,8 @@ export class NativeRuntimeAdapter implements Runtime {
         const batch = source.source.readAll();
         if (!Array.isArray(batch)) {
           await this.pumpServerTransport();
-          await sleep(0);
+          const retryAfterMs = batch.retryAfterMs?.() ?? 0;
+          await sleep(Math.max(0, retryAfterMs));
           continue;
         }
         for (const event of batch) {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -123,6 +123,13 @@ type NativeWriteOptions = {
   updatedAtMs?: number;
 };
 
+type PendingNativeRead = { poll(): Uint8Array | null };
+type NativeReadResult = Uint8Array | PendingNativeRead;
+
+function isPendingNativeRead(value: unknown): value is PendingNativeRead {
+  return typeof (value as PendingNativeRead | null)?.poll === "function";
+}
+
 type NativeInsertOptions = NativeWriteOptions & {
   rowId?: Uint8Array;
   branch?: unknown;
@@ -152,26 +159,29 @@ type NativeDb = {
   rollbackTransaction(openBatchId: string): void;
   attachMergeableTx(openBatchId: string): Tx;
   attachExclusiveTx?(openBatchId: string): Tx;
-  all(query: PreparedQuery, opts: unknown): Uint8Array;
-  allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): Uint8Array;
+  all(query: PreparedQuery, opts: unknown): NativeReadResult;
+  allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): NativeReadResult;
   allAsync?(query: PreparedQuery, opts: unknown): Uint8Array | Promise<Uint8Array>;
   allForIdentityAsync?(
     query: PreparedQuery,
     author: Uint8Array,
     opts: unknown,
   ): Uint8Array | Promise<Uint8Array>;
-  allRelationQuery?(queryJson: string, opts: unknown): Uint8Array | Promise<Uint8Array>;
+  allRelationQuery?(queryJson: string, opts: unknown): NativeReadResult | Promise<NativeReadResult>;
   allRelationQueryForIdentity?(
     queryJson: string,
     author: Uint8Array,
     opts: unknown,
-  ): Uint8Array | Promise<Uint8Array>;
-  allRelationSnapshot?(query: PreparedQuery, opts: unknown): Uint8Array | Promise<Uint8Array>;
+  ): NativeReadResult | Promise<NativeReadResult>;
+  allRelationSnapshot?(
+    query: PreparedQuery,
+    opts: unknown,
+  ): NativeReadResult | Promise<NativeReadResult>;
   allRelationSnapshotForIdentity?(
     query: PreparedQuery,
     author: Uint8Array,
     opts: unknown,
-  ): Uint8Array | Promise<Uint8Array>;
+  ): NativeReadResult | Promise<NativeReadResult>;
   setIdentityClaims?(author: Uint8Array, claims: Record<string, unknown> | undefined | null): void;
   attachQuery?(query: PreparedQuery, opts: unknown): unknown;
   attachQueryForIdentity?(query: PreparedQuery, author: Uint8Array, opts: unknown): unknown;
@@ -1627,17 +1637,19 @@ export class NativeRuntimeAdapter implements Runtime {
         if (!this.db.allRelationQueryForIdentity) {
           throw new Error("Native runtime does not support trusted-serving relation queries");
         }
-        const payload = await this.db.allRelationQueryForIdentity(
-          coreQueryJson,
-          session?.identity ?? this.peerIdentity,
-          opts,
+        const payload = await this.awaitNativeRead(
+          this.db.allRelationQueryForIdentity(
+            coreQueryJson,
+            session?.identity ?? this.peerIdentity,
+            opts,
+          ),
         );
         return rowsFromBatches(readRowBatches(payload), this.schema);
       }
       if (!this.db.allRelationQuery) {
         throw new Error("Native runtime does not support relation queries");
       }
-      const payload = await this.db.allRelationQuery(coreQueryJson, opts);
+      const payload = await this.awaitNativeRead(this.db.allRelationQuery(coreQueryJson, opts));
       return rowsFromBatches(readRowBatches(payload), this.schema);
     }
     const query = this.prepareQuery(coreQueryJson);
@@ -1650,10 +1662,12 @@ export class NativeRuntimeAdapter implements Runtime {
           if (!this.db.allRelationSnapshotForIdentity) {
             throw new Error("Native runtime does not support trusted-serving relation snapshots");
           }
-          const payload = await this.db.allRelationSnapshotForIdentity(
-            query,
-            session?.identity ?? this.peerIdentity,
-            opts,
+          const payload = await this.awaitNativeRead(
+            this.db.allRelationSnapshotForIdentity(
+              query,
+              session?.identity ?? this.peerIdentity,
+              opts,
+            ),
           );
           return rowsFromRelationSnapshot(
             readRelationSnapshot(payload),
@@ -1664,7 +1678,7 @@ export class NativeRuntimeAdapter implements Runtime {
         if (!this.db.allRelationSnapshot) {
           throw new Error("Native runtime does not support relation snapshots");
         }
-        const payload = await this.db.allRelationSnapshot(query, opts);
+        const payload = await this.awaitNativeRead(this.db.allRelationSnapshot(query, opts));
         return rowsFromRelationSnapshot(
           readRelationSnapshot(payload),
           this.schema,
@@ -2015,6 +2029,11 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     const query = this.prepareQuery(JSON.stringify({ table }));
     const rows = this.db.all(query, readOptions());
+    if (isPendingNativeRead(rows)) {
+      throw new Error(
+        "write merge cannot synchronously hydrate a large value; use the exact local row reader",
+      );
+    }
     return rowsFromBatches(readRowBatches(rows), this.schema).find(
       (row) => row.table === table && row.id === formatUuid(rowId),
     );
@@ -2081,10 +2100,16 @@ export class NativeRuntimeAdapter implements Runtime {
    * point, with a request session supplying its subject when present.
    */
   private readRowsForHost(query: PreparedQuery, opts: unknown, identity?: Uint8Array): Uint8Array {
-    if (this.trustedBackend && identity === undefined) return this.db.all(query, opts);
-    return this.readAuthorizationHost === "trusted-serving"
-      ? this.db.allForIdentity(query, identity ?? this.peerIdentity, opts)
-      : this.db.all(query, opts);
+    const result =
+      this.trustedBackend && identity === undefined
+        ? this.db.all(query, opts)
+        : this.readAuthorizationHost === "trusted-serving"
+          ? this.db.allForIdentity(query, identity ?? this.peerIdentity, opts)
+          : this.db.all(query, opts);
+    if (isPendingNativeRead(result)) {
+      throw new Error("large-value hydration is pending; use the asynchronous read boundary");
+    }
+    return result;
   }
 
   private async readRowsForHostAsync(
@@ -2093,14 +2118,35 @@ export class NativeRuntimeAdapter implements Runtime {
     identity?: Uint8Array,
   ): Promise<Uint8Array> {
     if (this.trustedBackend && identity === undefined) {
-      return await (this.db.allAsync?.(query, opts) ?? this.db.all(query, opts));
+      return this.awaitNativeRead(this.db.allAsync?.(query, opts) ?? this.db.all(query, opts));
     }
     if (this.readAuthorizationHost === "trusted-serving") {
       const author = identity ?? this.peerIdentity;
-      return await (this.db.allForIdentityAsync?.(query, author, opts) ??
-        this.db.allForIdentity(query, author, opts));
+      return this.awaitNativeRead(
+        this.db.allForIdentityAsync?.(query, author, opts) ??
+          this.db.allForIdentity(query, author, opts),
+      );
     }
-    return await (this.db.allAsync?.(query, opts) ?? this.db.all(query, opts));
+    return this.awaitNativeRead(this.db.allAsync?.(query, opts) ?? this.db.all(query, opts));
+  }
+
+  /**
+   * Native NAPI reads may suspend on a routed large-value chunk.  Keep the
+   * thread-affine Rust future in the binding and let the existing peer pump
+   * deliver the missing chunk between polls; never block the JS event loop.
+   */
+  private async awaitNativeRead(
+    started: NativeReadResult | Promise<NativeReadResult>,
+  ): Promise<Uint8Array> {
+    const result = await started;
+    if (!isPendingNativeRead(result)) return result;
+    for (;;) {
+      const bytes = result.poll();
+      if (bytes !== null) return bytes;
+      if (this.closed) throw new Error("large-value hydration was cancelled by runtime shutdown");
+      await this.pumpServerTransport();
+      await sleep(0);
+    }
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -280,7 +280,7 @@ type NativeDb = {
   mergeableTx(openBatchId: OpenBatchId): Tx;
   mergeableTxForIdentity?(openBatchId: OpenBatchId, author: Uint8Array): Tx;
   exclusiveTx?(openBatchId: OpenBatchId): Tx;
-  allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): Uint8Array;
+  allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): NativeReadResult;
   setTickScheduler(
     callback:
       | ((urgency: "immediate" | "deferred") => void)
@@ -2091,7 +2091,7 @@ export class NativeRuntimeAdapter implements Runtime {
     if (!this.db.allInTransaction) {
       throw new Error("Native runtime does not support transaction reads");
     }
-    return this.db.allInTransaction(query, this.txForRead(pendingTx), opts);
+    return this.awaitNativeRead(this.db.allInTransaction(query, this.txForRead(pendingTx), opts));
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -126,9 +126,14 @@ type NativeWriteOptions = {
 type PendingNativeRead = { poll(): Uint8Array | null };
 type NativeReadResult = Uint8Array | PendingNativeRead;
 type PendingNativeSubscriptionBatch = object;
+type PendingNativeWrite = { poll(): Write | null };
 
 function isPendingNativeRead(value: unknown): value is PendingNativeRead {
   return typeof (value as PendingNativeRead | null)?.poll === "function";
+}
+
+function isPendingNativeWrite(value: unknown): value is PendingNativeWrite {
+  return typeof (value as PendingNativeWrite | null)?.poll === "function";
 }
 
 type NativeInsertOptions = NativeWriteOptions & {
@@ -320,7 +325,7 @@ type NativeDb = {
     rowId: Uint8Array,
     column: string,
     bytes: Uint8Array,
-  ): Write | Promise<Write>;
+  ): Write | PendingNativeWrite | Promise<Write | PendingNativeWrite>;
   spliceValue?(
     table: string,
     rowId: Uint8Array,
@@ -328,7 +333,7 @@ type NativeDb = {
     offset: number,
     deleteLength: number,
     insert: Uint8Array,
-  ): Write | Promise<Write>;
+  ): Write | PendingNativeWrite | Promise<Write | PendingNativeWrite>;
   connectUpstream(): Transport;
   connectUpstreamWithSession?(
     protocolVersion: number,
@@ -924,8 +929,9 @@ export class NativeRuntimeAdapter implements Runtime {
       return await this.ownerRuntime.appendValue(table, objectId, column, bytes);
     }
     if (!this.db.appendValue) throw new Error("Native runtime does not expose value append");
+    const write = await this.db.appendValue(table, parseUuid(objectId), column, bytes);
     return this.finishMutation(
-      await this.db.appendValue(table, parseUuid(objectId), column, bytes),
+      isPendingNativeWrite(write) ? await this.awaitNativeWrite(write) : write,
     );
   }
 
@@ -948,8 +954,16 @@ export class NativeRuntimeAdapter implements Runtime {
       );
     }
     if (!this.db.spliceValue) throw new Error("Native runtime does not expose value splice");
+    const write = await this.db.spliceValue(
+      table,
+      parseUuid(objectId),
+      column,
+      offset,
+      deleteLength,
+      insert,
+    );
     return this.finishMutation(
-      await this.db.spliceValue(table, parseUuid(objectId), column, offset, deleteLength, insert),
+      isPendingNativeWrite(write) ? await this.awaitNativeWrite(write) : write,
     );
   }
 
@@ -2153,6 +2167,16 @@ export class NativeRuntimeAdapter implements Runtime {
       const bytes = result.poll();
       if (bytes !== null) return bytes;
       if (this.closed) throw new Error("large-value hydration was cancelled by runtime shutdown");
+      await this.pumpServerTransport();
+      await sleep(0);
+    }
+  }
+
+  private async awaitNativeWrite(pending: PendingNativeWrite): Promise<Write> {
+    for (;;) {
+      const write = pending.poll();
+      if (write !== null) return write;
+      if (this.closed) throw new Error("large-value mutation was cancelled by runtime shutdown");
       await this.pumpServerTransport();
       await sleep(0);
     }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -125,6 +125,7 @@ type NativeWriteOptions = {
 
 type PendingNativeRead = { poll(): Uint8Array | null };
 type NativeReadResult = Uint8Array | PendingNativeRead;
+type PendingNativeSubscriptionBatch = object;
 
 function isPendingNativeRead(value: unknown): value is PendingNativeRead {
   return typeof (value as PendingNativeRead | null)?.poll === "function";
@@ -357,8 +358,8 @@ type NativePermissionAdviceRequest = {
 type PreparedQuery = object;
 
 type Subscription = {
-  readAll(): unknown[];
-  drain?(): unknown[];
+  readAll(): unknown[] | PendingNativeSubscriptionBatch;
+  drain?(): unknown[] | PendingNativeSubscriptionBatch;
   close?(): boolean;
 };
 
@@ -2625,7 +2626,9 @@ export class NativeRuntimeAdapter implements Runtime {
     if (subscription.cancelled) return;
     for (const source of subscription.sources) {
       if (!isReadableSubscriptionReader(source.source)) {
-        this.drainNativeSubscription(handle, subscription, source);
+        if (source.reading) continue;
+        source.reading = true;
+        void this.drainNativeSubscription(handle, subscription, source);
         continue;
       }
       if (source.reading) continue;
@@ -2658,22 +2661,35 @@ export class NativeRuntimeAdapter implements Runtime {
     }
   }
 
-  private drainNativeSubscription(
+  private async drainNativeSubscription(
     handle: number,
     subscription: SubscriptionState,
     source: SubscriptionSourceState,
-  ): void {
+  ): Promise<void> {
     if (isReadableSubscriptionReader(source.source)) return;
-    for (const event of source.source.readAll()) {
-      if (subscription.cancelled || this.subscriptions.get(handle) !== subscription) return;
-      try {
-        this.applySubscriptionChunk(subscription, event);
-      } catch (error) {
-        this.failSubscription(
-          subscription,
-          error instanceof Error ? error : new Error(String(error)),
-        );
+    try {
+      while (!subscription.cancelled && this.subscriptions.get(handle) === subscription) {
+        const batch = source.source.readAll();
+        if (!Array.isArray(batch)) {
+          await this.pumpServerTransport();
+          await sleep(0);
+          continue;
+        }
+        for (const event of batch) {
+          if (subscription.cancelled || this.subscriptions.get(handle) !== subscription) return;
+          try {
+            this.applySubscriptionChunk(subscription, event);
+          } catch (error) {
+            this.failSubscription(
+              subscription,
+              error instanceof Error ? error : new Error(String(error)),
+            );
+          }
+        }
+        if (batch.length === 0) return;
       }
+    } finally {
+      source.reading = false;
     }
   }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -167,7 +167,7 @@ type NativeDb = {
     query: PreparedQuery,
     author: Uint8Array,
     opts: unknown,
-  ): Uint8Array | Promise<Uint8Array>;
+  ): NativeReadResult | Promise<NativeReadResult>;
   allRelationQuery?(queryJson: string, opts: unknown): NativeReadResult | Promise<NativeReadResult>;
   allRelationQueryForIdentity?(
     queryJson: string,
@@ -301,14 +301,14 @@ type NativeDb = {
     column: string,
     start: number,
     end: number,
-  ): Uint8Array | Promise<Uint8Array>;
+  ): NativeReadResult | Promise<NativeReadResult>;
   readTextUtf16Range?(
     table: string,
     rowId: Uint8Array,
     column: string,
     start: number,
     end: number,
-  ): string | Promise<string>;
+  ): string | PendingNativeRead | Promise<string | PendingNativeRead>;
   readJsonPointer?(
     table: string,
     rowId: Uint8Array,
@@ -873,7 +873,9 @@ export class NativeRuntimeAdapter implements Runtime {
       return await this.ownerRuntime.readValueRange(table, objectId, column, start, end);
     }
     if (!this.db.readValueRange) throw new Error("Native runtime does not expose value ranges");
-    return await this.db.readValueRange(table, parseUuid(objectId), column, start, end);
+    return this.awaitNativeRead(
+      this.db.readValueRange(table, parseUuid(objectId), column, start, end),
+    );
   }
 
   async readTextUtf16Range(
@@ -889,7 +891,10 @@ export class NativeRuntimeAdapter implements Runtime {
     if (!this.db.readTextUtf16Range) {
       throw new Error("Native runtime does not expose UTF-16 value ranges");
     }
-    return await this.db.readTextUtf16Range(table, parseUuid(objectId), column, start, end);
+    const result = await this.db.readTextUtf16Range(table, parseUuid(objectId), column, start, end);
+    return isPendingNativeRead(result)
+      ? new TextDecoder().decode(await this.awaitNativeRead(result))
+      : result;
   }
 
   async readJsonPointer(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -314,7 +314,7 @@ type NativeDb = {
     rowId: Uint8Array,
     column: string,
     pointer: string,
-  ): unknown | Promise<unknown>;
+  ): unknown | PendingNativeRead | Promise<unknown | PendingNativeRead>;
   appendValue?(
     table: string,
     rowId: Uint8Array,
@@ -907,7 +907,10 @@ export class NativeRuntimeAdapter implements Runtime {
       return await this.ownerRuntime.readJsonPointer(table, objectId, column, pointer);
     }
     if (!this.db.readJsonPointer) throw new Error("Native runtime does not expose JSON pointers");
-    const value = await this.db.readJsonPointer(table, parseUuid(objectId), column, pointer);
+    let value = await this.db.readJsonPointer(table, parseUuid(objectId), column, pointer);
+    if (isPendingNativeRead(value)) {
+      value = new TextDecoder().decode(await this.awaitNativeRead(value));
+    }
     return typeof value === "string" ? JSON.parse(value) : value;
   }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2164,9 +2164,9 @@ export class NativeRuntimeAdapter implements Runtime {
     const result = await started;
     if (!isPendingNativeRead(result)) return result;
     for (;;) {
+      if (this.closed) throw new Error("large-value hydration was cancelled by runtime shutdown");
       const bytes = result.poll();
       if (bytes !== null) return bytes;
-      if (this.closed) throw new Error("large-value hydration was cancelled by runtime shutdown");
       await this.pumpServerTransport();
       await sleep(0);
     }
@@ -2174,9 +2174,9 @@ export class NativeRuntimeAdapter implements Runtime {
 
   private async awaitNativeWrite(pending: PendingNativeWrite): Promise<Write> {
     for (;;) {
+      if (this.closed) throw new Error("large-value mutation was cancelled by runtime shutdown");
       const write = pending.poll();
       if (write !== null) return write;
-      if (this.closed) throw new Error("large-value mutation was cancelled by runtime shutdown");
       await this.pumpServerTransport();
       await sleep(0);
     }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -167,7 +167,7 @@ type NativeDb = {
   attachExclusiveTx?(openBatchId: string): Tx;
   all(query: PreparedQuery, opts: unknown): NativeReadResult;
   allForIdentity(query: PreparedQuery, author: Uint8Array, opts: unknown): NativeReadResult;
-  allAsync?(query: PreparedQuery, opts: unknown): Uint8Array | Promise<Uint8Array>;
+  allAsync?(query: PreparedQuery, opts: unknown): NativeReadResult | Promise<NativeReadResult>;
   allForIdentityAsync?(
     query: PreparedQuery,
     author: Uint8Array,

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -5749,6 +5749,9 @@ function runtimeWithNativeSubscriptionChunk(
   chunk: unknown,
   schema: WasmSchema = testSchema,
 ): NativeRuntimeAdapter {
+  // Native readAll drains its queue; returning the same non-empty batch forever
+  // would make the adapter's bounded drain loop spin rather than model NAPI.
+  const chunks = [chunk];
   return new NativeRuntimeAdapter(
     {
       openMemory: () =>
@@ -5756,7 +5759,7 @@ function runtimeWithNativeSubscriptionChunk(
           all: () => new Uint8Array([0]),
           prepareQuery: () => ({}),
           subscribe: () => ({
-            readAll: () => [chunk],
+            readAll: () => chunks.splice(0),
             close: () => true,
           }),
           tick: () => undefined,
@@ -5782,7 +5785,7 @@ function runtimeWithNativeRelationSubscriptionChunks(
       openMemory: () =>
         fakeDb({
           subscribeRelationQuery: () => ({
-            readAll: () => chunks,
+            readAll: () => chunks.splice(0),
             close: () => true,
           }),
           tick: () => undefined,

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -6798,6 +6798,55 @@ function writeTeamGatherBatches(
   );
 }
 
+it("awaits pending native large-value hydration while checking edge coverage", async () => {
+  let polls = 0;
+  let runtime!: NativeRuntimeAdapter;
+  const pending = {
+    poll: () => {
+      if (polls++ === 0) {
+        (runtime as unknown as { peerTransportActivityEpoch: number }).peerTransportActivityEpoch =
+          2;
+        return null;
+      }
+      return new Uint8Array();
+    },
+  };
+  runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          all: () => pending,
+          prepareQuery: () => ({}),
+          queryAttachmentIsCovered: () => true,
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+
+  const waitForCoverage = (
+    runtime as unknown as {
+      waitForQueryCoverage(
+        attachment: unknown,
+        query: object,
+        opts: object,
+        identity?: Uint8Array,
+        minimumPeerActivityEpoch?: number,
+      ): Promise<void>;
+    }
+  ).waitForQueryCoverage.bind(runtime);
+
+  await expect(waitForCoverage({}, {}, { tier: "edge" }, undefined, 1)).resolves.toBeUndefined();
+  expect(polls).toBe(2);
+});
+
 function typedOccurrenceKey(label: string): Uint8Array {
   const labelBytes = inlineScalar(label);
   const key = new Uint8Array(1 + 16 + 4 + 16 + 4 + 4 + 4 + labelBytes.length);

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -6800,6 +6800,9 @@ function writeTeamGatherBatches(
 
 it("awaits pending native large-value hydration while checking edge coverage", async () => {
   let polls = 0;
+  let peerPumps = 0;
+  let asyncReads = 0;
+  let syncReads = 0;
   let runtime!: NativeRuntimeAdapter;
   const pending = {
     poll: () => {
@@ -6815,7 +6818,14 @@ it("awaits pending native large-value hydration while checking edge coverage", a
     {
       openMemory: () =>
         fakeDb({
-          all: () => pending,
+          all: () => {
+            syncReads += 1;
+            throw new Error("coverage bypassed the async native read boundary");
+          },
+          allAsync: async () => {
+            asyncReads += 1;
+            return pending;
+          },
           prepareQuery: () => ({}),
           queryAttachmentIsCovered: () => true,
           tick: () => undefined,
@@ -6830,6 +6840,13 @@ it("awaits pending native large-value hydration while checking edge coverage", a
     1,
     true,
   );
+  (
+    runtime as unknown as {
+      pumpServerTransport(): Promise<void>;
+    }
+  ).pumpServerTransport = async () => {
+    peerPumps += 1;
+  };
 
   const waitForCoverage = (
     runtime as unknown as {
@@ -6845,6 +6862,84 @@ it("awaits pending native large-value hydration while checking edge coverage", a
 
   await expect(waitForCoverage({}, {}, { tier: "edge" }, undefined, 1)).resolves.toBeUndefined();
   expect(polls).toBe(2);
+  expect(asyncReads).toBe(1);
+  expect(syncReads).toBe(0);
+  expect(peerPumps).toBeGreaterThanOrEqual(2);
+});
+
+it("cancels a suspended native read before polling it again after close", async () => {
+  let polls = 0;
+  let runtime!: NativeRuntimeAdapter;
+  runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          readValueRange: () => ({
+            poll: () => {
+              polls += 1;
+              if (polls > 1) throw new Error("native read was polled after close");
+              queueMicrotask(() => void runtime.close());
+              return null;
+            },
+          }),
+          close: () => undefined,
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+
+  await expect(
+    runtime.readValueRange("todos", "00000000-0000-0000-0000-000000000001", "title", 0, 1),
+  ).rejects.toThrow("large-value hydration was cancelled by runtime shutdown");
+  expect(polls).toBe(1);
+});
+
+it("cancels a suspended native write before polling it again after close", async () => {
+  let polls = 0;
+  let runtime!: NativeRuntimeAdapter;
+  runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          appendValue: async () => ({
+            poll: () => {
+              polls += 1;
+              if (polls > 1) throw new Error("native write was polled after close");
+              queueMicrotask(() => void runtime.close());
+              return null;
+            },
+          }),
+          close: () => undefined,
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+
+  await expect(
+    runtime.appendValue(
+      "todos",
+      "00000000-0000-0000-0000-000000000001",
+      "title",
+      new Uint8Array([1]),
+    ),
+  ).rejects.toThrow("large-value mutation was cancelled by runtime shutdown");
+  expect(polls).toBe(1);
 });
 
 function typedOccurrenceKey(label: string): Uint8Array {

--- a/packages/jazz-tools/src/runtime/native-runtime/server-convergence.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/server-convergence.test.ts
@@ -314,7 +314,13 @@ describe("NativeRuntimeAdapter server convergence", () => {
         const rows = await reader.query(JSON.stringify({ table: "values" }), { tier: "edge" });
         return rows.length === 2 ? rows : undefined;
       }, 15_000);
-      const values = new Map(received.map((row) => [row.values[0]?.value, row.values]));
+      const values = new Map(
+        received.map((row) => {
+          const kind = row.values[0];
+          if (kind?.type !== "Text") throw new Error("expected a Text kind discriminator");
+          return [kind.value, row.values] as const;
+        }),
+      );
       expect(values.get("text")?.[1]).toEqual({ type: "Text", value: text });
       expect(values.get("bytes")?.[2]).toEqual({ type: "Bytea", value: bytes });
 
@@ -324,7 +330,13 @@ describe("NativeRuntimeAdapter server convergence", () => {
           JSON.stringify({ table: "values" }),
           (delta) => {
             const rows = normalizeTestDelta(delta, largeValueSchema);
-            if (rows.some((change) => "row" in change && change.row?.values[0]?.value === "bytes"))
+            if (
+              rows.some((change) => {
+                if (!("row" in change) || !change.row) return false;
+                const kind = change.row.values[0];
+                return kind?.type === "Text" && kind.value === "bytes";
+              })
+            )
               resolve();
           },
           { tier: "edge" },

--- a/packages/jazz-tools/src/runtime/native-runtime/server-convergence.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/server-convergence.test.ts
@@ -8,11 +8,16 @@ import { fetchSchemaHashes, fetchStoredWasmSchema, publishStoredSchema } from ".
 import { startLocalJazzServer, type LocalJazzServerHandle } from "../../testing/index.js";
 import { JazzClient } from "../client.js";
 import { createWasmRuntime, hasJazzWasmBuild } from "../testing/wasm-runtime-test-utils.js";
+import {
+  createNapiNativeRuntimeAdapter,
+  hasJazzNapiBuild,
+} from "../testing/napi-runtime-test-utils.js";
 import { encodeSchema } from "./native-runtime-adapter.js";
 import { decodeNativeDelta, isNativeRowDelta } from "../subscription-manager.js";
 import type { SubscriptionWireDelta } from "../../drivers/types.js";
 
 const maybeIt = hasJazzWasmBuild() ? it : it.skip;
+const maybeNapiIt = hasJazzNapiBuild() ? it : it.skip;
 const previousWebSocket = globalThis.WebSocket;
 
 const schema = {
@@ -26,7 +31,8 @@ const schema = {
 
 function normalizeTestDelta(delta: SubscriptionWireDelta, testSchema: WasmSchema) {
   if (isNativeRowDelta(delta)) {
-    const columns = testSchema.todos?.columns ?? testSchema.arrays?.columns;
+    const columns =
+      testSchema.todos?.columns ?? testSchema.arrays?.columns ?? testSchema.values?.columns;
     if (!columns) throw new Error("test schema has no decodable subscription table");
     return decodeNativeDelta(delta, columns);
   }
@@ -48,6 +54,16 @@ const writableTodoSchema = {
 const arraySchema = {
   arrays: {
     columns: [{ name: "data", column_type: { type: "Bytea" }, nullable: false }],
+  },
+} satisfies WasmSchema;
+
+const largeValueSchema = {
+  values: {
+    columns: [
+      { name: "kind", column_type: { type: "Text" }, nullable: false },
+      { name: "text", column_type: { type: "Text" }, nullable: true },
+      { name: "bytes", column_type: { type: "Bytea" }, nullable: true },
+    ],
   },
 } satisfies WasmSchema;
 
@@ -260,6 +276,65 @@ describe("NativeRuntimeAdapter server convergence", () => {
     20_000,
   );
 
+  maybeNapiIt(
+    "hydrates routed large-value chunks before NAPI query and subscription encoding",
+    async () => {
+      globalThis.WebSocket ??= WebSocket as unknown as typeof globalThis.WebSocket;
+      const appId = "00000000-0000-0000-0000-00000000c005";
+      server = await startLocalJazzServer({
+        appId,
+        inMemory: true,
+        adminSecret: "native-runtime-large-value-admin",
+        schema: encodeSchema(largeValueSchema),
+      });
+      const writer = await createNapiClient({ appId, serverUrl: server.url, peer: "large-writer" });
+      const reader = await createNapiClient({ appId, serverUrl: server.url, peer: "large-reader" });
+      clients.push(writer, reader);
+      writer.connectTransport(server.url, { admin_secret: server.adminSecret });
+      reader.connectTransport(server.url, { admin_secret: server.adminSecret });
+
+      const text = "routed text ".repeat(9_000);
+      const bytes = Uint8Array.from({ length: 90_000 }, (_, index) => index % 251);
+
+      const textWrite = await writer.insertStreaming(
+        "values",
+        { kind: { type: "Text", value: "text" } },
+        "text",
+        streamOf(text),
+      );
+      await waitForPromise(textWrite.wait({ tier: "edge" }), "streamed Text did not settle");
+      const bytesWrite = await writer.insertStreaming(
+        "values",
+        { kind: { type: "Text", value: "bytes" } },
+        "bytes",
+        streamOf(bytes),
+      );
+      await waitForPromise(bytesWrite.wait({ tier: "edge" }), "streamed Bytea did not settle");
+      const received = await waitFor(async () => {
+        const rows = await reader.query(JSON.stringify({ table: "values" }), { tier: "edge" });
+        return rows.length === 2 ? rows : undefined;
+      }, 15_000);
+      const values = new Map(received.map((row) => [row.values[0]?.value, row.values]));
+      expect(values.get("text")?.[1]).toEqual({ type: "Text", value: text });
+      expect(values.get("bytes")?.[2]).toEqual({ type: "Bytea", value: bytes });
+
+      // The NAPI subscription is independently encoded from one-shot rows.
+      const subscription = new Promise<void>((resolve) => {
+        reader.subscribe(
+          JSON.stringify({ table: "values" }),
+          (delta) => {
+            const rows = normalizeTestDelta(delta, largeValueSchema);
+            if (rows.some((change) => "row" in change && change.row?.values[0]?.value === "bytes"))
+              resolve();
+          },
+          { tier: "edge" },
+        );
+      });
+      await waitForPromise(subscription, "NAPI subscription did not publish hydrated large values");
+    },
+    30_000,
+  );
+
   maybeIt("replays accepted BYTEA rows to a fresh websocket subscriber", async () => {
     globalThis.WebSocket ??= WebSocket as unknown as typeof globalThis.WebSocket;
 
@@ -447,6 +522,28 @@ async function createClient({
     appId,
     schema: clientSchema,
     serverUrl,
+  });
+}
+
+async function createNapiClient({
+  appId,
+  serverUrl,
+  peer,
+}: {
+  appId: string;
+  serverUrl: string;
+  peer: string;
+}): Promise<JazzClient> {
+  const runtime = await createNapiNativeRuntimeAdapter(largeValueSchema, { appId, peerId: peer });
+  return JazzClient.connectWithRuntime(runtime, { appId, schema: largeValueSchema, serverUrl });
+}
+
+function streamOf(...chunks: Array<string | Uint8Array>): ReadableStream<string | Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
   });
 }
 


### PR DESCRIPTION
🤖 ## Replacement scope

This reconstructs and supersedes #1863 on current `main`, retaining only the remaining public-binding gap.

## Before

Current WASM/browser paths already support async large-value hydration and relay recovery. NAPI public reads, relation/transaction outputs, subscriptions, and partial-value helpers could block through the core or encode unresolved descriptors. The old #1863 branch would also have regressed current retry/terminal behavior by hydrating inside `Db::all`.

## After

- The NAPI boundary exposes thread-affine pollable read/write handles; the native adapter pumps peers and yields between polls.
- Ordinary, identity, relation snapshot/query, transaction, and subscription outputs hydrate before public encoding.
- Byte, UTF-16 text, and JSON pointer reads plus append/splice setup use the same async boundary.
- Coverage attachment and refresh await pending hydration rather than synchronously re-entering it.
- Retryable subscription chunk misses retain and replay the exact raw batch FIFO; only terminal outcomes close it.
- Closing a runtime between polls yields the stable cancellation error without polling a closed native future.

Core semantics, existing WASM behavior, and #1857 direct-WASM insertion remain unchanged.

## Verification

- Two-runtime routed NAPI receipt streams large text and bytes through a writer and materializes them through an independent reader; subscription encoding is independently verified.
- Focused scheduling/cancellation receipts force multiple polls, peer pumping, no synchronous fallback, and close-between-polls behavior.
- `cargo test -p jazz-napi`: 21/21.
- Exact `pnpm build:test-artifacts` passes end to end, including release NAPI, fast WASM, Jazz Tools/RN/framework type builds, provenance and load checks.
- Planted synchronous coverage re-entry, dropped retry batch, and poll-after-close regressions fail at their intended boundaries and were restored.
- Independent adversarial review completed after two repair cycles.
