### PR TITLE
perf(jazz): bound flat subscription delta bookkeeping

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -89,7 +89,10 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')
     name: W1 read wall time (memory + RocksDB)
     runs-on: codspeed-macro
-    timeout-minutes: 20
+    # A cold macro runner currently spends ~14 minutes rebuilding RocksDB and
+    # another ~11 minutes measuring both backends. Keep enough headroom for the
+    # complete pair so a successful memory suite cannot starve RocksDB.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/crates/jazz/benches/observer_write_path.rs
+++ b/crates/jazz/benches/observer_write_path.rs
@@ -100,7 +100,7 @@ fn all_documents_query(db: &BenchDb) -> jazz::db::PreparedQuery {
 fn update_write_path_with_and_without_observer(c: &mut Criterion) {
     let mut group = c.benchmark_group("observer_write_path/update_content");
 
-    for scale in [1_000usize] {
+    for scale in [100usize, 1_000, 5_000] {
         group.throughput(Throughput::Elements(1));
 
         group.bench_with_input(

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -4234,37 +4234,29 @@ fn apply_maintained_update_to_snapshot(
         }
     }
 
-    let mut index = 0;
-    while index < snapshot.root_count {
-        let occurrence_id = snapshot_index
-            .roots
-            .iter()
-            .find_map(|(occurrence, position)| (*position == index).then(|| occurrence.clone()))
-            .expect("every maintained root row has an occurrence index");
-        if update_removed.contains(&occurrence_id)
-            && !update_added
-                .iter()
-                .any(|(added, _)| *added == occurrence_id)
-        {
-            let row = snapshot.rows.remove(index);
-            snapshot.root_count -= 1;
-            snapshot_index.roots.remove(&occurrence_id);
-            for position in snapshot_index.roots.values_mut() {
-                if *position > index {
-                    *position -= 1;
-                }
-            }
-            for position in snapshot_index.related.values_mut() {
+    for occurrence_id in &update_removed {
+        if update_added.iter().any(|(added, _)| added == occurrence_id) {
+            continue;
+        }
+        let Some(index) = snapshot_index.roots.get(occurrence_id).copied() else {
+            continue;
+        };
+        let row = snapshot.rows.remove(index);
+        snapshot.root_count -= 1;
+        snapshot_index.roots.remove(occurrence_id);
+        for position in snapshot_index.roots.values_mut() {
+            if *position > index {
                 *position -= 1;
             }
-            removed.push(RemovedRow {
-                table: row.table().to_owned(),
-                row_uuid: row.row_uuid(),
-                occurrence_id,
-            });
-        } else {
-            index += 1;
         }
+        for position in snapshot_index.related.values_mut() {
+            *position -= 1;
+        }
+        removed.push(RemovedRow {
+            table: row.table().to_owned(),
+            row_uuid: row.row_uuid(),
+            occurrence_id: occurrence_id.clone(),
+        });
     }
 
     if !update_removed_edges.is_empty() {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -2475,10 +2475,11 @@ where
                         continue;
                     } else {
                         let state_ref = &mut refresh;
-                        let previous_snapshot = state_ref.snapshot.clone();
-                        let previous_snapshot_index = state_ref.snapshot_index.clone();
                         let authoritative_membership_changed =
                             update.authoritative_membership_changed;
+                        let previous = authoritative_membership_changed.then(|| {
+                            (state_ref.snapshot.clone(), state_ref.snapshot_index.clone())
+                        });
                         let mut event = apply_maintained_update_to_snapshot(
                             &mut state_ref.snapshot,
                             &mut state_ref.snapshot_index,
@@ -2488,6 +2489,8 @@ where
                             terminal_rows,
                         );
                         if authoritative_membership_changed {
+                            let (previous_snapshot, previous_snapshot_index) = previous
+                                .expect("authoritative membership changes retain prior snapshot");
                             order_maintained_snapshot_roots(
                                 &node.borrow(),
                                 &shape.query(),


### PR DESCRIPTION
## Summary

Stacked on #2027. This removes two result-cardinality-sized bookkeeping operations from ordinary flat maintained subscription deltas and extends the existing observer benchmark across 100, 1,000, and 5,000 retained rows.

Closes #2086.

## Before / after

Before, every maintained flat delta cloned the complete public `RelationSnapshot` and `RelationSnapshotIndex`, even though the copies are only needed for an authoritative membership reconciliation. Removal handling then walked every root and reverse-looked-up its occurrence identity, including updates with no actual removal.

After:

- the previous snapshot/index are retained only for authoritative membership changes;
- removals iterate the delta's removed occurrence ids and use the existing occurrence-to-position index;
- normal add/update/remove event semantics and the retained snapshot remain unchanged.

Example: a content update to one row in an ordinary `subscribe(all documents)` stream updates that one occurrence without copying or reverse-scanning every retained root. An actual removal still removes the indexed occurrence and shifts later positions exactly as before. Authority reconciliation still captures the complete pre-change snapshot before mutation and uses it to publish the ordered suffix.

## Performance receipt

Local memory `[profile.perf]`, same branch/harness:

- 1,000 retained rows: ~69.15 ms median before -> ~41.15 ms after (1.68x)
- 5,000 retained rows after: ~215.65 ms
- no-observer update control remains ~0.74-0.91 ms

This is a useful first checkpoint, not the end-state. Tick diagnostics show exactly 40 processed delta records at both 1k and 5k, while latency and retained evaluator payload remain linear (7.3 MB -> 36.5 MB). The next thesis is O(retained-state) runtime bookkeeping around an otherwise bounded incremental tick; CodSpeed wall-time should identify the exact owner.

## Correctness receipts

- flat subscription update with nullable sort payload: pass
- offset window after leading-row deletion: pass
- authoritative reset occurrence/order/count rebuild: pass
- benchmark target compile and pre-commit clippy/rustfmt/sensitive-data guard: pass

Browser async-storage delivery gates are required before landing because #2077 showed that a semantically plausible maintained-path optimization can miss asynchronous first-match delivery.

## Non-goals

- no maintained query planning or index-selection change;
- no wire protocol or subscription event shape change;
- no change to structured/terminal-row materialization;
- no claim yet that delta latency is result-size-independent.
