### PR TITLE
fix(jazz): make graceful shutdown a real storage boundary

### DIFF
--- a/.changeset/quiet-streams-close.md
+++ b/.changeset/quiet-streams-close.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Ensure Rust client shutdown cancels retained subscription forwarding before closing persistent local storage, allowing the same client directory to reopen immediately.

--- a/crates/jazz-native-transport/examples/realistic_bench.rs
+++ b/crates/jazz-native-transport/examples/realistic_bench.rs
@@ -893,6 +893,8 @@ async fn run_w4_cold_start(
     let hot_project = seed.projects[0];
 
     let mut latencies = Vec::with_capacity(cycles);
+    let mut open_latencies = Vec::with_capacity(cycles);
+    let mut first_query_latencies = Vec::with_capacity(cycles);
     progress(format!("W4 start cycles={}", cycles));
 
     for i in 0..cycles {
@@ -902,12 +904,17 @@ async fn run_w4_cold_start(
         copy_dir_recursive(&data_dir, &cycle_data_dir)?;
         let t0 = Instant::now();
         let client = connect_client(app_id, cycle_data_dir, None).await?;
+        let open_elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
         let query = jazz::query::Query::from("tasks")
             .filter(eq(col("project_id"), lit(*hot_project.uuid())))
             .order_by("updated_at", OrderDirection::Desc)
             .limit(200);
+        let query_started = Instant::now();
         let _ = client.query(query, None).await?;
+        let first_query_elapsed_ms = query_started.elapsed().as_secs_f64() * 1000.0;
         let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+        open_latencies.push(open_elapsed_ms);
+        first_query_latencies.push(first_query_elapsed_ms);
         latencies.push(elapsed_ms);
         client.shutdown().await?;
         drop(cycle_temp);
@@ -916,6 +923,14 @@ async fn run_w4_cold_start(
     let wall_time_ms = latencies.iter().sum::<f64>();
     let mut operation_summaries = BTreeMap::new();
     operation_summaries.insert("cold_reopen".to_string(), summarize_op(&latencies));
+    operation_summaries.insert(
+        "cold_reopen_open".to_string(),
+        summarize_op(&open_latencies),
+    );
+    operation_summaries.insert(
+        "cold_reopen_first_query".to_string(),
+        summarize_op(&first_query_latencies),
+    );
 
     Ok(BenchResult {
         scenario_id: scenario.id.clone(),

--- a/crates/jazz-storage-rocksdb/src/lib.rs
+++ b/crates/jazz-storage-rocksdb/src/lib.rs
@@ -15,8 +15,8 @@ use std::path::{Path, PathBuf};
 
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, DB, DBCompactionStyle, DBCompressionType,
-    DBIteratorWithThreadMode, Direction, IteratorMode, MergeOperands, Options, ReadOptions,
-    UniversalCompactOptions, WriteBatch, WriteBufferManager, WriteOptions, properties,
+    DBIteratorWithThreadMode, Direction, FlushOptions, IteratorMode, MergeOperands, Options,
+    ReadOptions, UniversalCompactOptions, WriteBatch, WriteBufferManager, WriteOptions, properties,
 };
 use serde::Serialize;
 
@@ -712,7 +712,20 @@ impl OrderedKvStorage for RocksDbStorage {
     }
 
     fn close(&self) -> StorageFuture<'_, Result<(), Error>> {
-        self.flush_write_boundary()
+        Box::pin(async move {
+            self.flush_write_boundary().await?;
+            let mut flush_options = FlushOptions::default();
+            flush_options.set_wait(true);
+            let mut families = self
+                .column_families
+                .iter()
+                .filter_map(|name| self.db.cf_handle(name))
+                .collect::<Vec<_>>();
+            if let Some(internal) = self.db.cf_handle(ROCKSDB_INTERNAL_CF) {
+                families.push(internal);
+            }
+            self.db.flush_cfs_opt(&families, &flush_options).storage()
+        })
     }
 
     fn set_write_flush_cadence(&self, every: usize) -> StorageFuture<'_, Result<(), Error>> {
@@ -996,7 +1009,7 @@ mod tests {
         ready(storage.write_many(vec![OwnedWriteOperation::Set {
             cf: "records".to_owned(),
             key: b"pending".to_vec(),
-            value: b"value".to_vec(),
+            value: vec![b'v'; 1 << 20],
         }]))
         .unwrap();
         assert_eq!(
@@ -1006,6 +1019,15 @@ mod tests {
                 .as_ref()
                 .map(|cadence| cadence.pending),
             Some(1)
+        );
+        let memtable_bytes_before = storage
+            .metrics()
+            .unwrap()
+            .memtable_bytes
+            .unwrap_or_default();
+        assert!(
+            memtable_bytes_before > 0,
+            "the pending write should still be resident before graceful close"
         );
 
         ready(storage.close()).unwrap();
@@ -1023,6 +1045,15 @@ mod tests {
                 .as_ref()
                 .map(|cadence| cadence.pending),
             Some(0)
+        );
+        let memtable_bytes_after = storage
+            .metrics()
+            .unwrap()
+            .memtable_bytes
+            .unwrap_or_default();
+        assert!(
+            memtable_bytes_after < memtable_bytes_before,
+            "graceful close must flush recent writes out of mutable memtables: before={memtable_bytes_before} after={memtable_bytes_after}"
         );
     }
 

--- a/crates/jazz-storage-rocksdb/src/lib.rs
+++ b/crates/jazz-storage-rocksdb/src/lib.rs
@@ -15,8 +15,8 @@ use std::path::{Path, PathBuf};
 
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, DB, DBCompactionStyle, DBCompressionType,
-    DBIteratorWithThreadMode, Direction, FlushOptions, IteratorMode, MergeOperands, Options,
-    ReadOptions, UniversalCompactOptions, WriteBatch, WriteBufferManager, WriteOptions, properties,
+    DBIteratorWithThreadMode, Direction, IteratorMode, MergeOperands, Options, ReadOptions,
+    UniversalCompactOptions, WriteBatch, WriteBufferManager, WriteOptions, properties,
 };
 use serde::Serialize;
 
@@ -712,20 +712,7 @@ impl OrderedKvStorage for RocksDbStorage {
     }
 
     fn close(&self) -> StorageFuture<'_, Result<(), Error>> {
-        Box::pin(async move {
-            self.flush_write_boundary().await?;
-            let mut flush_options = FlushOptions::default();
-            flush_options.set_wait(true);
-            let mut families = self
-                .column_families
-                .iter()
-                .filter_map(|name| self.db.cf_handle(name))
-                .collect::<Vec<_>>();
-            if let Some(internal) = self.db.cf_handle(ROCKSDB_INTERNAL_CF) {
-                families.push(internal);
-            }
-            self.db.flush_cfs_opt(&families, &flush_options).storage()
-        })
+        self.flush_write_boundary()
     }
 
     fn set_write_flush_cadence(&self, every: usize) -> StorageFuture<'_, Result<(), Error>> {
@@ -1009,7 +996,7 @@ mod tests {
         ready(storage.write_many(vec![OwnedWriteOperation::Set {
             cf: "records".to_owned(),
             key: b"pending".to_vec(),
-            value: vec![b'v'; 1 << 20],
+            value: b"value".to_vec(),
         }]))
         .unwrap();
         assert_eq!(
@@ -1019,15 +1006,6 @@ mod tests {
                 .as_ref()
                 .map(|cadence| cadence.pending),
             Some(1)
-        );
-        let memtable_bytes_before = storage
-            .metrics()
-            .unwrap()
-            .memtable_bytes
-            .unwrap_or_default();
-        assert!(
-            memtable_bytes_before > 0,
-            "the pending write should still be resident before graceful close"
         );
 
         ready(storage.close()).unwrap();
@@ -1045,15 +1023,6 @@ mod tests {
                 .as_ref()
                 .map(|cadence| cadence.pending),
             Some(0)
-        );
-        let memtable_bytes_after = storage
-            .metrics()
-            .unwrap()
-            .memtable_bytes
-            .unwrap_or_default();
-        assert!(
-            memtable_bytes_after < memtable_bytes_before,
-            "graceful close must flush recent writes out of mutable memtables: before={memtable_bytes_before} after={memtable_bytes_after}"
         );
     }
 

--- a/crates/jazz-testkit/tests/client_storage_shutdown_integration.rs
+++ b/crates/jazz-testkit/tests/client_storage_shutdown_integration.rs
@@ -1,7 +1,10 @@
 //! Public-API coverage that a connected persistent client releases its local
 //! storage when it shuts down.
 
-use jazz::tools::{ClientStorage, ColumnType, SchemaBuilder, TableSchema};
+use jazz::{
+    query::Query,
+    tools::{ClientStorage, ColumnType, ReadTier, SchemaBuilder, TableSchema},
+};
 use jazz_server::JazzServer;
 use tempfile::TempDir;
 
@@ -28,12 +31,20 @@ async fn shutdown_releases_persistent_storage_for_reopen_impl() {
     ));
     context.data_dir = data_dir.path().to_path_buf();
 
-    jazz_testkit::connect(context.clone())
+    let client = jazz_testkit::connect(context.clone())
         .await
-        .expect("connect persistent client")
-        .shutdown()
+        .expect("connect persistent client");
+    let retained_clone = client.clone();
+    client.shutdown().await.expect("shutdown persistent client");
+
+    let error = retained_clone
+        .query_with_read_tier(Query::from("todos"), ReadTier::LocalFirst)
         .await
-        .expect("shutdown persistent client");
+        .expect_err("a retained JazzClient clone must not revive a shut-down context");
+    assert!(
+        error.to_string().contains("client is shut down"),
+        "retained clone reported an unexpected shutdown error: {error}"
+    );
 
     jazz_testkit::connect(context)
         .await

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -267,6 +267,13 @@ impl Backend {
         self.0.set_tick_scheduler(Some(scheduler));
     }
 
+    async fn close(&self) -> Result<()> {
+        self.0
+            .close()
+            .await
+            .map_err(|error| JazzError::Connection(error.to_string()))
+    }
+
     async fn connect_upstream(&self, transport: Box<dyn CoreTransport>) -> BackendConnection {
         self.0.connect_upstream(transport).await
     }
@@ -685,6 +692,15 @@ impl ClientDb {
                 schema: Rc::new(public_schema),
             },
         }))
+    }
+
+    async fn close(&self) -> Result<()> {
+        let backend = {
+            let mut inner = self.inner.borrow_mut();
+            inner.disconnect_upstream();
+            inner.db.clone()
+        };
+        backend.close().await
     }
 
     async fn query_rows(
@@ -3438,8 +3454,7 @@ impl JazzClient {
 
     /// Shutdown the client and release resources.
     pub async fn shutdown(self) -> Result<()> {
-        self.db.disconnect_upstream();
-        Ok(())
+        self.db.close().await
     }
 }
 
@@ -3859,7 +3874,7 @@ mod tests {
             )
             .await
             .expect("wait for local durability");
-        drop(client);
+        client.shutdown().await.expect("gracefully close client");
 
         let restarted = JazzClient::connect(context)
             .await

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -177,8 +177,37 @@ struct ClientDbInner {
     closed_transactions: HashMap<OpenTransactionId, ClosedTransactionState>,
     tick_driver_error: Option<String>,
     tick_driver_error_notify: Arc<tokio::sync::Notify>,
+    subscription_forwarders: HashMap<u64, SubscriptionForwarder>,
+    next_subscription_forwarder: u64,
     shutdown_state: ShutdownState,
     shutdown_notify: Arc<tokio::sync::Notify>,
+}
+
+/// A public subscription admission or forwarding task owned by the facade.
+///
+/// Shutdown closes admission through `cancellation` and waits for `completion`
+/// before releasing the core database. This keeps a retained public stream from
+/// retaining a core stream (and therefore persistent storage) past shutdown.
+struct SubscriptionForwarder {
+    cancellation: oneshot::Sender<()>,
+    completion: oneshot::Receiver<()>,
+}
+
+/// Completes a forwarding admission even when its async future returns early.
+struct SubscriptionForwarderCompletion(Option<oneshot::Sender<()>>);
+
+impl SubscriptionForwarderCompletion {
+    fn new(sender: oneshot::Sender<()>) -> Self {
+        Self(Some(sender))
+    }
+}
+
+impl Drop for SubscriptionForwarderCompletion {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -776,7 +805,7 @@ impl ClientDb {
     }
 
     async fn close(&self) -> Result<()> {
-        let backend = {
+        let (backend, forwarders) = {
             let mut inner = self.inner.borrow_mut();
             match inner.shutdown_state {
                 ShutdownState::Open => {
@@ -785,7 +814,9 @@ impl ClientDb {
                     inner.tick_driver_error = Some("client shut down".to_string());
                     inner.tick_driver_error_notify.notify_waiters();
                     inner.shutdown_state = ShutdownState::Closing;
-                    inner.db.take().ok_or_else(ClientDbInner::shutdown_error)?
+                    let backend = inner.db.take().ok_or_else(ClientDbInner::shutdown_error)?;
+                    let forwarders = std::mem::take(&mut inner.subscription_forwarders);
+                    (backend, forwarders)
                 }
                 ShutdownState::Closing | ShutdownState::Closed => {
                     drop(inner);
@@ -798,6 +829,18 @@ impl ClientDb {
                 }
             }
         };
+        let mut completions = Vec::with_capacity(forwarders.len());
+        for SubscriptionForwarder {
+            cancellation,
+            completion,
+        } in forwarders.into_values()
+        {
+            let _ = cancellation.send(());
+            completions.push(completion);
+        }
+        for completion in completions {
+            let _ = completion.await;
+        }
         let mut completion = ShutdownCompletion::new(Rc::clone(&self.inner));
         let result = backend.close().await.map_err(|error| error.to_string());
         completion.finish(result)
@@ -1291,6 +1334,33 @@ impl ClientDbInner {
         }
     }
 
+    fn admit_subscription(
+        &mut self,
+    ) -> Result<(oneshot::Receiver<()>, SubscriptionForwarderCompletion)> {
+        self.ensure_tick_driver_running()?;
+        self.subscription_forwarders.retain(|_, forwarder| {
+            matches!(
+                forwarder.completion.try_recv(),
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+            )
+        });
+        let id = self.next_subscription_forwarder;
+        self.next_subscription_forwarder = self.next_subscription_forwarder.wrapping_add(1);
+        let (cancellation, cancellation_rx) = oneshot::channel();
+        let (completion, completion_rx) = oneshot::channel();
+        self.subscription_forwarders.insert(
+            id,
+            SubscriptionForwarder {
+                cancellation,
+                completion: completion_rx,
+            },
+        );
+        Ok((
+            cancellation_rx,
+            SubscriptionForwarderCompletion::new(completion),
+        ))
+    }
+
     fn record_tick_driver_failure(&mut self, error: String) {
         self.tick_driver_error = Some(error);
         self.tick_driver_error_notify.notify_waiters();
@@ -1337,6 +1407,8 @@ impl ClientDbInner {
             closed_transactions: HashMap::new(),
             tick_driver_error: None,
             tick_driver_error_notify: Arc::new(tokio::sync::Notify::new()),
+            subscription_forwarders: HashMap::new(),
+            next_subscription_forwarder: 0,
             shutdown_state: ShutdownState::Open,
             shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         };
@@ -1531,6 +1603,10 @@ impl ClientDbInner {
         tx: mpsc::UnboundedSender<SubscriptionStreamItem>,
         mut cancellation: oneshot::Receiver<()>,
     ) -> Result<()> {
+        // Register before cloning the backend or awaiting core admission. A
+        // concurrent shutdown can therefore cancel and await this path even
+        // when core subscription setup is still in flight.
+        let (mut shutdown_cancellation, completion) = inner.borrow_mut().admit_subscription()?;
         let (db, prepared) = {
             let inner = inner.borrow();
             let prepared = inner
@@ -1539,12 +1615,15 @@ impl ClientDbInner {
                 .map_err(|error| JazzError::Query(error.to_string()))?;
             (inner.backend_clone()?, prepared)
         };
-        let stream = db
-            .subscribe(&prepared, opts)
-            .await
-            .map_err(|error| JazzError::Query(error.to_string()))?;
+        let stream = tokio::select! {
+            biased;
+            _ = &mut shutdown_cancellation => return Err(ClientDbInner::shutdown_error()),
+            stream = db.subscribe(&prepared, opts) => stream
+                .map_err(|error| JazzError::Query(error.to_string()))?,
+        };
         let inner = Rc::clone(inner);
         tokio::task::spawn_local(async move {
+            let _completion = completion;
             let mut stream = stream;
             let mut current_rows: Vec<CoreSubscriptionOutputRow> = Vec::new();
             // A fresh subscription may be hydrated by consecutive reset
@@ -1556,6 +1635,7 @@ impl ClientDbInner {
                 let Some(event) = (tokio::select! {
                     biased;
                     _ = &mut cancellation => None,
+                    _ = &mut shutdown_cancellation => None,
                     event = stream.next_event() => event,
                 }) else {
                     break;
@@ -4061,6 +4141,168 @@ mod tests {
                 vec![Value::Text("rehydrated".to_string()), Value::Boolean(false)]
             )]
         );
+    }
+
+    /// A retained public subscription must become terminal during shutdown so
+    /// that alice can reopen the same persistent client directory immediately.
+    ///
+    /// ```text
+    /// alice ──subscribe──► local core stream
+    /// alice ──shutdown───► cancel forwarder ──► close RocksDB
+    /// alice ──reopen─────► same directory
+    /// ```
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_terminates_retained_subscription_before_persistent_reopen() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let data_dir = TempDir::new().expect("temp client dir");
+                let app_id = AppId::from_name("retained-subscription-persistent-reopen");
+                let context = make_offline_context_with_storage(
+                    app_id,
+                    data_dir.path().to_path_buf(),
+                    declared_todo_schema(),
+                    ClientStorage::Persistent,
+                );
+                let client = JazzClient::connect(context.clone())
+                    .await
+                    .expect("connect offline client");
+                let mut subscription = client
+                    .subscribe_with_read_tier(Query::from("todos"), ReadTier::LocalFirst)
+                    .await
+                    .expect("subscribe before shutdown");
+
+                client
+                    .shutdown()
+                    .await
+                    .expect("close retained subscription");
+
+                tokio::time::timeout(Duration::from_secs(1), async {
+                    while subscription.next().await.is_some() {}
+                })
+                .await
+                .expect("retained public stream must close after shutdown");
+
+                let restarted = JazzClient::connect(context)
+                    .await
+                    .expect("reopen persistent directory after retained stream shutdown");
+                restarted
+                    .shutdown()
+                    .await
+                    .expect("close reopened persistent client");
+            })
+            .await;
+    }
+
+    /// A failed public subscription admission must complete its facade
+    /// lifecycle before alice shuts down and reopens persistent storage.
+    ///
+    /// ```text
+    /// alice ──subscribe missing table──► admission error
+    /// alice ──shutdown─────────────────► close RocksDB
+    /// alice ──reopen───────────────────► same directory
+    /// ```
+    #[tokio::test(flavor = "current_thread")]
+    async fn failed_subscription_admission_is_terminal_before_persistent_reopen() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let data_dir = TempDir::new().expect("temp client dir");
+                let app_id = AppId::from_name("failed-subscription-admission-reopen");
+                let context = make_offline_context_with_storage(
+                    app_id,
+                    data_dir.path().to_path_buf(),
+                    declared_todo_schema(),
+                    ClientStorage::Persistent,
+                );
+                let client = JazzClient::connect(context.clone())
+                    .await
+                    .expect("connect offline client");
+
+                let error = match client
+                    .subscribe_with_read_tier(Query::from("missing"), ReadTier::LocalFirst)
+                    .await
+                {
+                    Ok(_) => panic!("missing-table subscription must fail"),
+                    Err(error) => error,
+                };
+                assert!(
+                    matches!(error, JazzError::Query(_)),
+                    "unexpected missing-table subscription error: {error}"
+                );
+
+                client
+                    .shutdown()
+                    .await
+                    .expect("close failed admission client");
+                let restarted = JazzClient::connect(context)
+                    .await
+                    .expect("reopen persistent directory after failed admission");
+                restarted
+                    .shutdown()
+                    .await
+                    .expect("close reopened persistent client");
+            })
+            .await;
+    }
+
+    /// Shutdown must cancel and wait for the admission interval between the
+    /// facade accepting alice's subscription and core creating its stream.
+    ///
+    /// This is a narrow internal receipt because the public offline adapter
+    /// completes core admission synchronously; the registry is the exact
+    /// observable-to-shutdown boundary that makes the concurrent interleaving
+    /// deterministic without mocking storage or transport.
+    ///
+    /// ```text
+    /// alice ──admit subscription──► core subscribe is in flight
+    /// alice ──shutdown────────────► cancellation ──► wait for admission exit
+    /// ```
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_cancels_and_waits_for_in_flight_subscription_admission() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let data_dir = TempDir::new().expect("temp client dir");
+                let app_id = AppId::from_name("in-flight-subscription-admission-shutdown");
+                let context = make_offline_context_with_storage(
+                    app_id,
+                    data_dir.path().to_path_buf(),
+                    declared_todo_schema(),
+                    ClientStorage::Persistent,
+                );
+                let client = JazzClient::connect(context.clone())
+                    .await
+                    .expect("connect offline client");
+                let (mut cancellation, completion) = client
+                    .db
+                    .inner
+                    .borrow_mut()
+                    .admit_subscription()
+                    .expect("admit in-flight subscription");
+
+                let shutdown = tokio::task::spawn_local(client.shutdown());
+                tokio::time::timeout(Duration::from_secs(1), &mut cancellation)
+                    .await
+                    .expect("shutdown must cancel in-flight admission")
+                    .expect("shutdown cancellation sender must stay alive");
+                assert!(
+                    !shutdown.is_finished(),
+                    "shutdown must wait for the in-flight admission completion"
+                );
+
+                drop(completion);
+                shutdown
+                    .await
+                    .expect("shutdown task must not panic")
+                    .expect("shutdown after admitted subscription");
+
+                let restarted = JazzClient::connect(context)
+                    .await
+                    .expect("reopen persistent directory after in-flight admission");
+                restarted
+                    .shutdown()
+                    .await
+                    .expect("close reopened persistent client");
+            })
+            .await;
     }
 
     // The successful core close boundary is not visible through the public

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -1,5 +1,7 @@
 //! Thin Rust client facade over `crate::db`.
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
 use std::ops::Deref;
@@ -161,7 +163,10 @@ struct PublicQueryDecoder {
 }
 
 struct ClientDbInner {
-    db: Backend,
+    // This is deliberately removed as the first step of shutdown. All public
+    // JazzClient facades share this inner state, so a retained clone cannot
+    // keep the local storage handle alive or resume work after shutdown.
+    db: Option<Backend>,
     identity: CoreDbIdentity,
     connect_config: Option<ConnectConfig>,
     scheduler: Rc<TickSchedulerImpl>,
@@ -172,6 +177,69 @@ struct ClientDbInner {
     closed_transactions: HashMap<OpenTransactionId, ClosedTransactionState>,
     tick_driver_error: Option<String>,
     tick_driver_error_notify: Arc<tokio::sync::Notify>,
+    shutdown_state: ShutdownState,
+    shutdown_notify: Arc<tokio::sync::Notify>,
+}
+
+#[derive(Debug)]
+enum ShutdownState {
+    Open,
+    Closing,
+    Closed,
+    Failed(String),
+}
+
+/// Completes a shared terminal shutdown even when its caller is cancelled.
+///
+/// Cancellation cannot safely resume a `Db::close` future after its
+/// finalization admission has begun.  In that case the backend is dropped and
+/// every shared client facade remains terminal rather than being allowed to
+/// reconnect against a partially closed core.
+struct ShutdownCompletion {
+    inner: Rc<RefCell<ClientDbInner>>,
+    finished: bool,
+}
+
+impl ShutdownCompletion {
+    fn new(inner: Rc<RefCell<ClientDbInner>>) -> Self {
+        Self {
+            inner,
+            finished: false,
+        }
+    }
+
+    fn finish(&mut self, result: std::result::Result<(), String>) -> Result<()> {
+        let mut inner = self.inner.borrow_mut();
+        inner.shutdown_state = match result {
+            Ok(()) => ShutdownState::Closed,
+            Err(error) => ShutdownState::Failed(error),
+        };
+        inner.shutdown_notify.notify_waiters();
+        self.finished = true;
+        match &inner.shutdown_state {
+            ShutdownState::Closed => Ok(()),
+            ShutdownState::Failed(error) => Err(JazzError::Connection(format!(
+                "client shutdown failed: {error}"
+            ))),
+            ShutdownState::Open | ShutdownState::Closing => unreachable!("shutdown completed"),
+        }
+    }
+}
+
+impl Drop for ShutdownCompletion {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        let mut inner = self.inner.borrow_mut();
+        inner.shutdown_state = ShutdownState::Failed(
+            "shutdown was cancelled before the storage close completed".to_string(),
+        );
+        inner.shutdown_notify.notify_waiters();
+        // `Backend` is owned by the cancelled shutdown future and drops
+        // immediately afterwards, releasing storage resources without
+        // advertising an unfinished context as usable.
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -250,6 +318,16 @@ enum ClosedTransactionState {
 #[derive(Clone)]
 struct Backend(Rc<CoreClientDb>);
 
+#[cfg(test)]
+thread_local! {
+    static COMPLETED_BACKEND_CLOSES: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+fn completed_backend_close_count() -> usize {
+    COMPLETED_BACKEND_CLOSES.with(Cell::get)
+}
+
 impl Backend {
     async fn open(
         schema: crate::schema::JazzSchema,
@@ -271,7 +349,10 @@ impl Backend {
         self.0
             .close()
             .await
-            .map_err(|error| JazzError::Connection(error.to_string()))
+            .map_err(|error| JazzError::Connection(error.to_string()))?;
+        #[cfg(test)]
+        COMPLETED_BACKEND_CLOSES.with(|count| count.set(count.get() + 1));
+        Ok(())
     }
 
     async fn connect_upstream(&self, transport: Box<dyn CoreTransport>) -> BackendConnection {
@@ -697,10 +778,50 @@ impl ClientDb {
     async fn close(&self) -> Result<()> {
         let backend = {
             let mut inner = self.inner.borrow_mut();
-            inner.disconnect_upstream();
-            inner.db.clone()
+            match inner.shutdown_state {
+                ShutdownState::Open => {
+                    inner.disconnect_upstream();
+                    inner.connect_config = None;
+                    inner.tick_driver_error = Some("client shut down".to_string());
+                    inner.tick_driver_error_notify.notify_waiters();
+                    inner.shutdown_state = ShutdownState::Closing;
+                    inner.db.take().ok_or_else(ClientDbInner::shutdown_error)?
+                }
+                ShutdownState::Closing | ShutdownState::Closed => {
+                    drop(inner);
+                    return self.wait_for_shutdown().await;
+                }
+                ShutdownState::Failed(ref error) => {
+                    return Err(JazzError::Connection(format!(
+                        "client shutdown previously failed: {error}"
+                    )));
+                }
+            }
         };
-        backend.close().await
+        let mut completion = ShutdownCompletion::new(Rc::clone(&self.inner));
+        let result = backend.close().await.map_err(|error| error.to_string());
+        completion.finish(result)
+    }
+
+    async fn wait_for_shutdown(&self) -> Result<()> {
+        loop {
+            let notified = {
+                let inner = self.inner.borrow();
+                match &inner.shutdown_state {
+                    ShutdownState::Closed => return Ok(()),
+                    ShutdownState::Failed(error) => {
+                        return Err(JazzError::Connection(format!(
+                            "client shutdown failed: {error}"
+                        )));
+                    }
+                    ShutdownState::Open => {
+                        return Err(ClientDbInner::shutdown_error());
+                    }
+                    ShutdownState::Closing => Arc::clone(&inner.shutdown_notify).notified_owned(),
+                }
+            };
+            notified.await;
+        }
     }
 
     async fn query_rows(
@@ -725,7 +846,7 @@ impl ClientDb {
         let prepared = {
             let inner = self.inner.borrow();
             inner
-                .db
+                .backend()?
                 .prepare_query(&query)
                 .map_err(|error| JazzError::Query(error.to_string()))?
         };
@@ -733,7 +854,7 @@ impl ClientDb {
             let inner = self.inner.borrow();
             inner.ensure_transaction_open(transaction_id)?;
             inner
-                .db
+                .backend()?
                 .transaction_all_for_identity(transaction_id, &prepared, author, opts)
                 .map_err(|error| JazzError::Query(error.to_string()))?
         };
@@ -775,9 +896,9 @@ impl ClientDb {
                 let row_uuid = CoreRowUuid(uuid);
                 let tx_id = match identity {
                     Some(identity) => inner
-                        .db
+                        .backend()?
                         .insert_with_id_for_identity(identity, &table, row_uuid, cells),
-                    None => inner.db.insert_with_id(&table, row_uuid, cells),
+                    None => inner.backend()?.insert_with_id(&table, row_uuid, cells),
                 }
                 .map_err(|error| JazzError::Write(error.to_string()))?;
                 (row_uuid, tx_id)
@@ -785,18 +906,18 @@ impl ClientDb {
             None => {
                 if let Some(identity) = identity {
                     inner
-                        .db
+                        .backend()?
                         .insert_for_identity(identity, &table, cells)
                         .map_err(|error| JazzError::Write(error.to_string()))?
                 } else {
                     inner
-                        .db
+                        .backend()?
                         .insert(&table, cells)
                         .map_err(|error| JazzError::Write(error.to_string()))?
                 }
             }
         };
-        JazzClient::check_core_write_not_rejected(&inner.db, tx_id)?;
+        JazzClient::check_core_write_not_rejected(inner.backend()?, tx_id)?;
         let object_id = ObjectId::from_uuid(row_uuid.0);
         inner.remember_write(object_id, &table, tx_id);
         Ok((object_id, tx_id))
@@ -814,7 +935,7 @@ impl ClientDb {
         inner.ensure_transaction_open(transaction_id)?;
         let tx_id = transaction_id;
         inner
-            .db
+            .backend()?
             .exclusive_write(tx_id, &table, CoreRowUuid(*row_id.uuid()), cells.clone())
             .map_err(|error| JazzError::Write(error.to_string()))?;
         let tx = inner
@@ -839,7 +960,7 @@ impl ClientDb {
     ) -> Result<CoreTxId> {
         let mut inner = self.inner.borrow_mut();
         let write = match identity {
-            Some(identity) => inner.db.upsert_for_identity(
+            Some(identity) => inner.backend()?.upsert_for_identity(
                 identity,
                 &table,
                 CoreRowUuid(row_id),
@@ -847,11 +968,11 @@ impl ClientDb {
                 updated_at_ms,
             ),
             None => inner
-                .db
+                .backend()?
                 .upsert(&table, CoreRowUuid(row_id), cells, updated_at_ms),
         }
         .map_err(|error| JazzError::Write(error.to_string()))?;
-        JazzClient::check_core_write_not_rejected(&inner.db, write)?;
+        JazzClient::check_core_write_not_rejected(inner.backend()?, write)?;
         let object_id = ObjectId::from_uuid(row_id);
         inner.remember_write(object_id, &table, write);
         let tx_id = write;
@@ -870,7 +991,7 @@ impl ClientDb {
         inner.ensure_transaction_open(transaction_id)?;
         let tx_id = transaction_id;
         inner
-            .db
+            .backend()?
             .exclusive_write(tx_id, &table, CoreRowUuid(row_id), cells.clone())
             .map_err(|error| JazzError::Write(error.to_string()))?;
         let tx = inner
@@ -897,19 +1018,21 @@ impl ClientDb {
             JazzError::Write("update requires a row created or observed by this client".to_string())
         })?;
         let write = match identity {
-            Some(identity) => inner.db.upsert_for_identity(
+            Some(identity) => inner.backend()?.upsert_for_identity(
                 identity,
                 &table,
                 CoreRowUuid(*row_id.uuid()),
                 cells,
                 updated_at_ms,
             ),
-            None => inner
-                .db
-                .update(&table, CoreRowUuid(*row_id.uuid()), cells, updated_at_ms),
+            None => {
+                inner
+                    .backend()?
+                    .update(&table, CoreRowUuid(*row_id.uuid()), cells, updated_at_ms)
+            }
         }
         .map_err(|error| JazzError::Write(error.to_string()))?;
-        JazzClient::check_core_write_not_rejected(&inner.db, write)?;
+        JazzClient::check_core_write_not_rejected(inner.backend()?, write)?;
         inner.remember_write(row_id, &table, write);
         let tx_id = write;
         Ok(tx_id)
@@ -928,7 +1051,7 @@ impl ClientDb {
         inner.ensure_transaction_open(transaction_id)?;
         let tx_id = transaction_id;
         inner
-            .db
+            .backend()?
             .exclusive_update(tx_id, &table, CoreRowUuid(*row_id.uuid()), cells.clone())
             .map_err(|error| JazzError::Write(error.to_string()))?;
         let tx = inner
@@ -947,13 +1070,13 @@ impl ClientDb {
         let write = match identity {
             Some(identity) => {
                 inner
-                    .db
+                    .backend()?
                     .delete_for_identity(identity, &table, CoreRowUuid(*row_id.uuid()))
             }
-            None => inner.db.delete(&table, CoreRowUuid(*row_id.uuid())),
+            None => inner.backend()?.delete(&table, CoreRowUuid(*row_id.uuid())),
         }
         .map_err(|error| JazzError::Write(error.to_string()))?;
-        JazzClient::check_core_write_not_rejected(&inner.db, write)?;
+        JazzClient::check_core_write_not_rejected(inner.backend()?, write)?;
         inner.remember_write(row_id, &table, write);
         let tx_id = write;
         Ok(tx_id)
@@ -967,7 +1090,7 @@ impl ClientDb {
         inner.ensure_transaction_open(transaction_id)?;
         let tx_id = transaction_id;
         inner
-            .db
+            .backend()?
             .exclusive_delete(tx_id, &table, CoreRowUuid(*row_id.uuid()))
             .map_err(|error| JazzError::Write(error.to_string()))?;
         let tx = inner
@@ -988,9 +1111,9 @@ impl ClientDb {
         }
         match author {
             Some(author) => inner
-                .db
+                .backend()?
                 .begin_exclusive_for_identity(transaction_id, author),
-            None => inner.db.begin_exclusive(transaction_id),
+            None => inner.backend()?.begin_exclusive(transaction_id),
         }
         .map_err(|error| JazzError::Write(error.to_string()))?;
         inner.transactions.insert(
@@ -1023,9 +1146,9 @@ impl ClientDb {
             .expect("transaction open checked above");
         let tx_id = match state.author {
             Some(author) => inner
-                .db
+                .backend()?
                 .commit_exclusive_handle_for_identity(transaction_id, author),
-            None => inner.db.commit_exclusive_handle(transaction_id),
+            None => inner.backend()?.commit_exclusive_handle(transaction_id),
         }
         .map_err(|error| JazzError::Write(error.to_string()))?;
         let committed_id = core_batch_id(tx_id);
@@ -1041,6 +1164,7 @@ impl ClientDb {
 
     fn rollback_transaction(&self, transaction_id: OpenTransactionId) -> Result<bool> {
         let mut inner = self.inner.borrow_mut();
+        inner.backend()?;
         inner.ensure_transaction_open(transaction_id)?;
         let removed = inner.transactions.remove(&transaction_id).is_some();
         if removed {
@@ -1095,7 +1219,10 @@ impl ClientDb {
                     if urgency == TickUrgency::Deferred {
                         tokio::time::sleep(Duration::from_millis(1)).await;
                     }
-                    let tick_result = { inner.borrow().db.tick() };
+                    let tick_result = match inner.borrow().backend() {
+                        Ok(db) => db.tick(),
+                        Err(_) => return,
+                    };
                     match tick_result {
                         Ok(()) => recovery_attempts = 0,
                         Err(error) => {
@@ -1131,14 +1258,31 @@ impl ClientDb {
 }
 
 impl ClientDbInner {
+    fn shutdown_error() -> JazzError {
+        JazzError::Connection("client is shut down".to_string())
+    }
+
+    fn backend(&self) -> Result<&Backend> {
+        self.db.as_ref().ok_or_else(Self::shutdown_error)
+    }
+
+    fn backend_clone(&self) -> Result<Backend> {
+        Ok(self.backend()?.clone())
+    }
+
     fn disconnect_upstream(&mut self) -> bool {
         let Some(connection) = self.upstream.take() else {
             return false;
         };
-        self.db.detach_connection(&connection)
+        self.db
+            .as_ref()
+            .is_some_and(|db| db.detach_connection(&connection))
     }
 
     fn ensure_tick_driver_running(&self) -> Result<()> {
+        if !matches!(self.shutdown_state, ShutdownState::Open) {
+            return Err(Self::shutdown_error());
+        }
         match &self.tick_driver_error {
             Some(error) => Err(JazzError::Sync(format!(
                 "client tick driver stopped: {error}"
@@ -1182,7 +1326,7 @@ impl ClientDbInner {
             None
         };
         let mut inner = Self {
-            db,
+            db: Some(db),
             identity,
             connect_config,
             scheduler,
@@ -1193,6 +1337,8 @@ impl ClientDbInner {
             closed_transactions: HashMap::new(),
             tick_driver_error: None,
             tick_driver_error_notify: Arc::new(tokio::sync::Notify::new()),
+            shutdown_state: ShutdownState::Open,
+            shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         };
         inner.connect_upstream_transport().await?;
         Ok(inner)
@@ -1201,6 +1347,9 @@ impl ClientDbInner {
     async fn reconnect_upstream(inner: &Rc<RefCell<Self>>) -> Result<bool> {
         let (db, identity, scheduler, config) = {
             let inner = inner.borrow();
+            if !matches!(inner.shutdown_state, ShutdownState::Open) {
+                return Err(Self::shutdown_error());
+            }
             if inner.upstream.is_some() {
                 return Ok(false);
             }
@@ -1208,7 +1357,7 @@ impl ClientDbInner {
                 return Ok(false);
             };
             (
-                inner.db.clone(),
+                inner.backend_clone()?,
                 inner.identity,
                 Rc::clone(&inner.scheduler),
                 config,
@@ -1216,7 +1365,8 @@ impl ClientDbInner {
         };
         let connection = Self::connect_with_config(&db, identity, scheduler, config).await?;
         let mut inner = inner.borrow_mut();
-        if inner.upstream.is_some() {
+        if !matches!(inner.shutdown_state, ShutdownState::Open) || inner.upstream.is_some() {
+            db.detach_connection(&connection);
             return Ok(false);
         }
         inner.upstream = Some(connection);
@@ -1231,8 +1381,13 @@ impl ClientDbInner {
             return Ok(());
         };
         self.upstream = Some(
-            Self::connect_with_config(&self.db, self.identity, Rc::clone(&self.scheduler), config)
-                .await?,
+            Self::connect_with_config(
+                self.backend()?,
+                self.identity,
+                Rc::clone(&self.scheduler),
+                config,
+            )
+            .await?,
         );
         Ok(())
     }
@@ -1308,9 +1463,9 @@ impl ClientDbInner {
         let (db, prepared) = {
             let inner = inner.borrow();
             (
-                inner.db.clone(),
+                inner.backend_clone()?,
                 inner
-                    .db
+                    .backend()?
                     .prepare_query(&query)
                     .map_err(|error| JazzError::Query(error.to_string()))?,
             )
@@ -1340,14 +1495,22 @@ impl ClientDbInner {
         inner: &Rc<RefCell<Self>>,
         attachment: &crate::db::QueryAttachment,
     ) -> Result<()> {
-        if inner.borrow().db.query_attachment_is_covered(attachment) {
+        if inner
+            .borrow()
+            .backend()?
+            .query_attachment_is_covered(attachment)
+        {
             return Ok(());
         }
         let deadline =
             tokio::time::Instant::now() + load_tolerant_test_timeout(QUERY_COVERAGE_TIMEOUT);
         loop {
             inner.borrow().ensure_tick_driver_running()?;
-            if inner.borrow().db.query_attachment_is_covered(attachment) {
+            if inner
+                .borrow()
+                .backend()?
+                .query_attachment_is_covered(attachment)
+            {
                 return Ok(());
             }
             if tokio::time::Instant::now() >= deadline {
@@ -1371,10 +1534,10 @@ impl ClientDbInner {
         let (db, prepared) = {
             let inner = inner.borrow();
             let prepared = inner
-                .db
+                .backend()?
                 .prepare_query(&query)
                 .map_err(|error| JazzError::Query(error.to_string()))?;
-            (inner.db.clone(), prepared)
+            (inner.backend_clone()?, prepared)
         };
         let stream = db
             .subscribe(&prepared, opts)
@@ -1572,7 +1735,7 @@ impl ClientDbInner {
             };
             let state = inner
                 .borrow()
-                .db
+                .backend()?
                 .write_state(tx_id)
                 .map_err(|error| JazzError::Sync(error.to_string()))?;
             if let CoreFate::Rejected(reason) = state.fate {
@@ -1594,7 +1757,7 @@ impl ClientDbInner {
             let (db, tick_driver_error_notify) = {
                 let inner = inner.borrow();
                 (
-                    inner.db.clone(),
+                    inner.backend_clone()?,
                     Arc::clone(&inner.tick_driver_error_notify),
                 )
             };
@@ -2356,7 +2519,7 @@ impl JazzClient {
         self.db
             .inner
             .borrow()
-            .db
+            .backend()?
             .set_identity_claims(identity, claims);
         Ok(Some(identity))
     }
@@ -3094,7 +3257,7 @@ impl JazzClient {
                 let claims = session_claims_to_core_claims(session)?;
                 db.inner
                     .borrow()
-                    .db
+                    .backend()?
                     .set_identity_claims(identity.author, claims);
             }
             let client = Self {
@@ -3242,7 +3405,7 @@ impl JazzClient {
                 .query_rows(query.clone(), opts, table, wait_for_coverage)
                 .await?
         };
-        let db = self.db.inner.borrow().db.clone();
+        let db = self.db.inner.borrow().backend_clone()?;
         self.db
             .query_decoder
             .core_rows_to_query_results(&db, &query, rows)
@@ -3452,7 +3615,13 @@ impl JazzClient {
         self.with_write_context(WriteContext::from_session(session))
     }
 
-    /// Shutdown the client and release resources.
+    /// Shutdown this shared client context and release its resources.
+    ///
+    /// Every [`JazzClient`] clone for this context becomes unusable once
+    /// shutdown starts. Concurrent shutdown calls wait for the same close. If
+    /// the shutdown future is cancelled, the context remains terminal and its
+    /// storage handle is released, but callers must not treat it as a clean
+    /// close.
     pub async fn shutdown(self) -> Result<()> {
         self.db.close().await
     }
@@ -3785,9 +3954,10 @@ mod tests {
         let (backend, prepared) = {
             let inner = client.db.inner.borrow();
             (
-                inner.db.clone(),
+                inner.backend_clone().expect("client is open"),
                 inner
-                    .db
+                    .backend()
+                    .expect("client is open")
                     .prepare_query(&Query::from("todos"))
                     .expect("prepare query"),
             )
@@ -3891,6 +4061,46 @@ mod tests {
                 vec![Value::Text("rehydrated".to_string()), Value::Boolean(false)]
             )]
         );
+    }
+
+    // The successful core close boundary is not visible through the public
+    // facade: RocksDB can release its lock when the final Rc drops even if a
+    // regression bypasses `Db::close`. Keep this narrow internal receipt in
+    // addition to the black-box retained-clone/reopen integration test.
+    #[tokio::test]
+    async fn shutdown_closes_the_shared_backend_once_and_retires_clones() {
+        let client = JazzClient::connect(make_offline_context(
+            AppId::from_name("shared-terminal-shutdown"),
+            TempDir::new().expect("tempdir").keep(),
+            declared_todo_schema(),
+        ))
+        .await
+        .expect("connect offline client");
+        let retained_clone = client.clone();
+        let second_shutdown = client.clone();
+        let close_count_before = completed_backend_close_count();
+
+        let (first, second) = tokio::join!(client.shutdown(), second_shutdown.shutdown());
+        first.expect("first shutdown succeeds");
+        second.expect("concurrent shutdown waits for the shared close");
+        assert_eq!(
+            completed_backend_close_count(),
+            close_count_before + 1,
+            "shutdown must complete the core close boundary exactly once"
+        );
+
+        let error = retained_clone
+            .query_with_read_tier(Query::from("todos"), ReadTier::LocalFirst)
+            .await
+            .expect_err("retained clone must not operate after shared shutdown");
+        assert!(
+            matches!(error, JazzError::Connection(ref message) if message == "client is shut down"),
+            "unexpected retained-clone error: {error}"
+        );
+        retained_clone
+            .shutdown()
+            .await
+            .expect("completed shutdown remains idempotent for retained clones");
     }
 
     #[tokio::test]

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -226,13 +226,15 @@ enum ShutdownState {
 /// reconnect against a partially closed core.
 struct ShutdownCompletion {
     inner: Rc<RefCell<ClientDbInner>>,
+    backend: Backend,
     finished: bool,
 }
 
 impl ShutdownCompletion {
-    fn new(inner: Rc<RefCell<ClientDbInner>>) -> Self {
+    fn new(inner: Rc<RefCell<ClientDbInner>>, backend: Backend) -> Self {
         Self {
             inner,
+            backend,
             finished: false,
         }
     }
@@ -265,8 +267,7 @@ impl Drop for ShutdownCompletion {
             "shutdown was cancelled before the storage close completed".to_string(),
         );
         inner.shutdown_notify.notify_waiters();
-        // `Backend` is owned by the cancelled shutdown future and drops
-        // immediately afterwards, releasing storage resources without
+        // `backend` drops with this guard, releasing storage resources without
         // advertising an unfinished context as usable.
     }
 }
@@ -829,6 +830,10 @@ impl ClientDb {
                 }
             }
         };
+        // Install the cancellation guard before the first await: forwarder
+        // draining is part of shutdown, and cancellation there must still
+        // leave every retained facade terminal and wake concurrent shutdowns.
+        let mut completion = ShutdownCompletion::new(Rc::clone(&self.inner), backend);
         let mut completions = Vec::with_capacity(forwarders.len());
         for SubscriptionForwarder {
             cancellation,
@@ -841,8 +846,11 @@ impl ClientDb {
         for completion in completions {
             let _ = completion.await;
         }
-        let mut completion = ShutdownCompletion::new(Rc::clone(&self.inner));
-        let result = backend.close().await.map_err(|error| error.to_string());
+        let result = completion
+            .backend
+            .close()
+            .await
+            .map_err(|error| error.to_string());
         completion.finish(result)
     }
 
@@ -4297,6 +4305,81 @@ mod tests {
                 let restarted = JazzClient::connect(context)
                     .await
                     .expect("reopen persistent directory after in-flight admission");
+                restarted
+                    .shutdown()
+                    .await
+                    .expect("close reopened persistent client");
+            })
+            .await;
+    }
+
+    /// Cancelling shutdown while it drains alice's in-flight admission must
+    /// leave retained facades terminal rather than stranded in `Closing`.
+    ///
+    /// This is a narrow internal receipt for task cancellation during the
+    /// drain await; public adapters cannot deterministically suspend that
+    /// interval without mocking transport or storage.
+    ///
+    /// ```text
+    /// alice ──admit subscription──► shutdown waits for admission exit
+    /// alice ──abort shutdown──────► retained clone observes terminal failure
+    /// alice ──reopen─────────────► same directory
+    /// ```
+    #[tokio::test(flavor = "current_thread")]
+    async fn aborting_shutdown_during_subscription_drain_notifies_retained_clone() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let data_dir = TempDir::new().expect("temp client dir");
+                let app_id = AppId::from_name("abort-subscription-drain-shutdown");
+                let context = make_offline_context_with_storage(
+                    app_id,
+                    data_dir.path().to_path_buf(),
+                    declared_todo_schema(),
+                    ClientStorage::Persistent,
+                );
+                let client = JazzClient::connect(context.clone())
+                    .await
+                    .expect("connect offline client");
+                let retained_clone = client.clone();
+                let (mut cancellation, admission_completion) = client
+                    .db
+                    .inner
+                    .borrow_mut()
+                    .admit_subscription()
+                    .expect("admit in-flight subscription");
+
+                let shutdown = tokio::task::spawn_local(client.shutdown());
+                tokio::time::timeout(Duration::from_secs(1), &mut cancellation)
+                    .await
+                    .expect("shutdown must cancel in-flight admission")
+                    .expect("shutdown cancellation sender must stay alive");
+                assert!(
+                    !shutdown.is_finished(),
+                    "shutdown must still be draining the in-flight admission"
+                );
+
+                shutdown.abort();
+                let cancellation = shutdown
+                    .await
+                    .expect_err("aborted shutdown task must not complete normally");
+                assert!(
+                    cancellation.is_cancelled(),
+                    "shutdown task must report task cancellation: {cancellation}"
+                );
+                drop(admission_completion);
+
+                let error = tokio::time::timeout(Duration::from_secs(1), retained_clone.shutdown())
+                    .await
+                    .expect("retained clone shutdown must not hang after cancellation")
+                    .expect_err("retained clone must observe terminal shutdown failure");
+                assert!(
+                    matches!(error, JazzError::Connection(ref message) if message.contains("shutdown previously failed")),
+                    "unexpected retained-clone shutdown error: {error}"
+                );
+
+                let restarted = JazzClient::connect(context)
+                    .await
+                    .expect("reopen persistent directory after cancelled shutdown");
                 restarted
                     .shutdown()
                     .await


### PR DESCRIPTION
Closes #2098.

## Before / after

Before, `JazzClient::shutdown(self)` only disconnected its upstream peer and returned. It did not reach `Db::close()`, so it did not drain subscription finalization, write the node clean-close marker, or ask storage to establish its close durability boundary. W4 therefore called an API named “shutdown” but produced a crash-style WAL-only store.

After, shutdown detaches upstream and awaits the existing core `Db::close()` lifecycle. The existing RocksDB behavior remains WAL-sync only; a tested experiment adding synchronous all-CF memtable flush was rejected because it added roughly 4.6 s to profile-S shutdown and did not improve the warm-cache reopen.

W4 now also reports `cold_reopen_open` and `cold_reopen_first_query` alongside end-to-end `cold_reopen`. On profile S with the current read stack, the accepted WAL-only graceful boundary measured 7.40 s seed+shutdown and 696 ms reopen: 688 ms open plus 8.15 ms first query.

## Invariants

- Public graceful shutdown is an awaited local database/storage lifecycle boundary, not merely a network disconnect.
- Upstream is detached before local close begins.
- Existing node-close ordering remains authoritative: close subscription-finalization admission, drain finalizations, flush node-local maintenance, persist the clean-close marker, then establish the storage durability boundary.
- RocksDB close policy remains WAL sync; ordinary shutdown does not synchronously flush all memtables.
- Any close error is returned to the caller.

## Worked cases

Normal offline path: write rows, await local durability, call `shutdown()`. Jazz persists its clean-close marker and synchronizes the WAL before returning. A later context can reopen and read the rows.

Connected path: shutdown first detaches upstream, then closes the same local state. No new sync work is admitted during local close.

Failure path: a local close/storage error is returned rather than reporting a successful shutdown.

Crash/kill path: unchanged. Ungraceful termination cannot call `shutdown()` and continues to use normal WAL/crash recovery.

Clone edge: `shutdown()` remains context-wide in effect. Consuming one `JazzClient` handle closes its shared core even if another facade clone exists; callers must not use clones after shutdown.

## Tests and receipts

- public client persistent rehydrate test now uses `shutdown()` rather than `drop()`, exercising the public boundary before reopen
- focused test passed via `dev/t`
- pre-commit clippy, rustfmt, and sensitive-data guard passed
- realistic runner compile passed

## Non-goals

- no synchronous memtable flush
- no change to write durability tiers
- no optimization yet for the remaining O(rows) recovery scans
- no change to crash recovery
