### PR TITLE
perf(groove): cache stored record descriptors during scans

### DIFF
--- a/crates/groove/src/db/encoding.rs
+++ b/crates/groove/src/db/encoding.rs
@@ -206,30 +206,41 @@ pub(super) fn primary_key_bytes(
     Ok(bytes)
 }
 
-pub(super) fn decode_stored_table_record(
-    table: &TableSchema,
-    stored: Vec<u8>,
-) -> Result<VariantRecord, Error> {
-    let (variant_tag, payload) = split_variant_record(&stored)?;
-    let descriptor = table
-        .record_schema_for_variant(variant_tag)
-        .ok_or_else(|| Error::UnknownTableVariant {
-            table: table.name.clone(),
-            version: u64::from(variant_tag),
-        })?;
-    let record = OwnedRecord::new(payload.to_vec(), descriptor);
-    Ok(VariantRecord::new(variant_tag, record))
-}
-
-pub(super) fn decode_stored_key_value<'a>(
-    table: &TableSchema,
-    key: Vec<u8>,
-    stored: Vec<u8>,
-) -> Result<EncodedKeyValue<'a>, Error> {
-    Ok(EncodedKeyValue::from_variant(
-        key,
-        decode_stored_table_record(table, stored)?,
-    ))
+impl Database {
+    pub(super) fn decode_stored_key_value<'a>(
+        &self,
+        table: &TableSchema,
+        key: Vec<u8>,
+        stored: Vec<u8>,
+    ) -> Result<EncodedKeyValue<'a>, Error> {
+        let (variant_tag, payload) = split_variant_record(&stored)?;
+        let cached = self
+            .stored_record_descriptors
+            .borrow()
+            .get(&table.name)
+            .and_then(|variants| variants.get(&variant_tag))
+            .copied();
+        let descriptor = if let Some(descriptor) = cached {
+            descriptor
+        } else {
+            let descriptor = table
+                .record_schema_for_variant(variant_tag)
+                .ok_or_else(|| Error::UnknownTableVariant {
+                    table: table.name.clone(),
+                    version: u64::from(variant_tag),
+                })?;
+            self.stored_record_descriptors
+                .borrow_mut()
+                .entry(table.name.clone())
+                .or_default()
+                .insert(variant_tag, descriptor);
+            descriptor
+        };
+        Ok(EncodedKeyValue::from_variant(
+            key,
+            VariantRecord::new(variant_tag, OwnedRecord::new(payload.to_vec(), descriptor)),
+        ))
+    }
 }
 
 pub(crate) fn persisted_index_primary_key(

--- a/crates/groove/src/db/facade.rs
+++ b/crates/groove/src/db/facade.rs
@@ -93,6 +93,7 @@ impl Database {
             last_commit_metrics: None,
             last_tick_metrics: None,
             storage_read_metrics: Rc::new(RefCell::new(StorageReadMetrics::default())),
+            stored_record_descriptors: RefCell::new(BTreeMap::new()),
             next_publication_id: 1,
             durable_publication_frontier: None,
             resident_publications: BTreeMap::new(),

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -387,6 +387,10 @@ pub struct Database {
     last_commit_metrics: Option<CommitMetrics>,
     last_tick_metrics: Option<TickMetrics>,
     storage_read_metrics: Rc<RefCell<StorageReadMetrics>>,
+    /// Dense record descriptors are invariant for one table variant. Keep the
+    /// interned handles beside the database schema so scans do not rebuild and
+    /// re-hash the same logical field list once per stored row.
+    stored_record_descriptors: RefCell<BTreeMap<String, BTreeMap<u32, RecordDescriptor>>>,
     next_publication_id: u64,
     durable_publication_frontier: Option<PublicationId>,
     resident_publications: BTreeMap<PublicationId, Rc<RefCell<StagedWriteState>>>,

--- a/crates/groove/src/db/primary_storage.rs
+++ b/crates/groove/src/db/primary_storage.rs
@@ -297,7 +297,7 @@ impl Database {
             return store
                 .get_raw(&encoded_key)
                 .await?
-                .map(|value| decode_stored_key_value(table_schema, encoded_key, value))
+                .map(|value| self.decode_stored_key_value(table_schema, encoded_key, value))
                 .transpose();
         }
 
@@ -309,7 +309,7 @@ impl Database {
         store
             .get_raw(&encoded_key)
             .await?
-            .map(|value| decode_stored_key_value(table_schema, encoded_key, value))
+            .map(|value| self.decode_stored_key_value(table_schema, encoded_key, value))
             .transpose()
     }
 
@@ -345,7 +345,7 @@ impl Database {
         store
             .get_raw(&encoded_key)
             .await?
-            .map(|value| decode_stored_key_value(table_schema, encoded_key, value))
+            .map(|value| self.decode_stored_key_value(table_schema, encoded_key, value))
             .transpose()
     }
 
@@ -382,7 +382,7 @@ impl Database {
             .prefix(&key_prefix)
             .await?
             .into_iter()
-            .map(|(key, value)| decode_stored_key_value(table_schema, key, value))
+            .map(|(key, value)| self.decode_stored_key_value(table_schema, key, value))
             .collect()
     }
 
@@ -418,7 +418,7 @@ impl Database {
         store
             .last_with_prefix(&key_prefix)
             .await?
-            .map(|(key, value)| decode_stored_key_value(table_schema, key, value))
+            .map(|(key, value)| self.decode_stored_key_value(table_schema, key, value))
             .transpose()
     }
 
@@ -470,7 +470,7 @@ impl Database {
             .range(&start_key, &end_key)
             .await?
             .into_iter()
-            .map(|(key, value)| decode_stored_key_value(table_schema, key, value))
+            .map(|(key, value)| self.decode_stored_key_value(table_schema, key, value))
             .collect()
     }
 
@@ -560,7 +560,7 @@ impl Database {
         store
             .last_with_prefix_before_or_at(&key_prefix, &upper_key)
             .await?
-            .map(|(key, value)| decode_stored_key_value(table_schema, key, value))
+            .map(|(key, value)| self.decode_stored_key_value(table_schema, key, value))
             .transpose()
     }
 
@@ -753,7 +753,7 @@ impl Database {
                 &index_record.get("value")?,
             )?;
             if let Some(record) = store.get_raw(&primary_key).await? {
-                records.push(decode_stored_key_value(table_schema, primary_key, record)?);
+                records.push(self.decode_stored_key_value(table_schema, primary_key, record)?);
             } else if table_schema.primary_key.is_some() {
                 return Err(Error::InvalidPersistedIndex(index_name.to_owned()));
             }


### PR DESCRIPTION
Follow-up to #2098.

## Before / after

Before, every decoded stored row called `TableSchema::record_schema_for_variant`. That rebuilt the same logical field vector and called `RecordDescriptor::new`, re-hashing and interning an invariant table/variant descriptor once per row. Recovery scans therefore paid schema construction and allocator cost proportional to row count.

After, each `Database` memoizes the interned `RecordDescriptor` handle by table name and variant tag. The first row of a variant validates/builds the descriptor; subsequent rows reuse the `Copy` intern handle without cloning the table name or reconstructing fields.

Exact local A/B on the same persisted W4 profile-S store, composed with the current read + graceful-shutdown work (five reopen cycles):

- before: 639.6 ms total p50; 631.3 ms open; 8.0 ms first query
- after: 475.8 ms total p50; 468.0 ms open; 7.8 ms first query
- improvement: **25.6% total / 25.9% open**; query unchanged

## Invariants

- Stored bytes and descriptors are interpreted exactly as before.
- Unknown variant tags still fail through `UnknownTableVariant` before caching.
- Existing table variants are immutable. Live registration may add a new table or a new variant tag; both naturally miss the cache and are validated on first decode.
- Cache ownership is per `Database`, so no descriptor from another schema/runtime can leak into a lookup.
- The cache key uses borrowed table-name lookup on hits; table-name allocation occurs only on the first variant decode.

## Worked cases

Ordinary table: the first tag-0 row builds the descriptor; all remaining scan rows reuse it.

Versioned physical table: each distinct variant tag gets its own descriptor entry. Repeated rows for that schema version reuse the matching handle.

New live variant: registration adds a previously unseen tag. Its first stored row misses and builds from the updated live table schema; existing tag entries remain valid because registered variants are immutable.

Invalid tag: lookup misses, schema lookup fails, and no cache entry is installed.

## Tests

- full Groove lib suite: 536 passed, 2 ignored
- pre-commit Groove clippy, rustfmt, sensitive-data guard
- exact five-cycle W4 A/B receipt above

## Non-goals

This does not remove the recovery scans themselves, lazily rebuild ahead-current indexes, or alter storage/WAL policy. It removes repeated schema work inside all stored-row decodes, so it should also help ordinary large scans outside recovery.
