### PR TITLE
Preserve exclusive view fragments across sibling queries

### DIFF
--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -1001,8 +1001,19 @@ where
         let mut loaded_tx_ids = BTreeSet::new();
         for (tx_id, tx_bundles) in bundles_by_tx {
             let first = tx_bundles[0];
+            let view_scoped = first.scope == crate::protocol::VersionBundleScope::ViewScoped;
+            // Each view-scoped bundle declares only its own redacted fragment
+            // cardinality. Compare the immutable transaction identity here and
+            // synthesize the receiver-local authorized cardinality only after
+            // exact version deduplication below.
+            let mut first_tx_identity = first.tx.clone();
+            first_tx_identity.n_total_writes = 0;
             if tx_bundles.iter().any(|bundle| {
-                bundle.tx != first.tx
+                let mut tx_identity = bundle.tx.clone();
+                tx_identity.n_total_writes = 0;
+                tx_identity != first_tx_identity
+                    || (bundle.scope == crate::protocol::VersionBundleScope::ViewScoped)
+                        != view_scoped
                     || bundle.fate != first.fate
                     || bundle.global_time != first.global_time
                     || bundle.durability != first.durability
@@ -1033,7 +1044,7 @@ where
                         version.deletion().is_some(),
                     );
                     match unique_versions.get(&key) {
-                        Some(existing) if existing.record().raw() != version.record().raw() => {
+                        Some(existing) if *existing != version => {
                             duplicate_conflict = true;
                             break;
                         }
@@ -1052,6 +1063,7 @@ where
             }
             let version_count = unique_versions.len();
             if first.tx.kind == TxKind::Exclusive
+                && !view_scoped
                 && usize::try_from(first.tx.n_total_writes).ok() != Some(version_count)
             {
                 continue;
@@ -1070,7 +1082,13 @@ where
                 continue;
             }
             if loaded_tx_ids.insert(tx_id) {
-                eligible.push(tx_bundles);
+                let mut local_tx = first.tx.clone();
+                if view_scoped {
+                    local_tx.n_total_writes = version_count
+                        .try_into()
+                        .map_err(|_| Error::InvalidStoredValue("view payload is too large"))?;
+                }
+                eligible.push((tx_bundles, local_tx, view_scoped));
             }
         }
         if eligible.is_empty() {
@@ -1078,7 +1096,9 @@ where
         }
         let eligible_versions = eligible
             .iter()
-            .flat_map(|tx_bundles| tx_bundles.iter().flat_map(|bundle| bundle.versions))
+            .flat_map(|(tx_bundles, _, _)| {
+                tx_bundles.iter().flat_map(|bundle| bundle.versions)
+            })
             .cloned()
             .collect::<Vec<_>>();
         self.prepare_authored_schema_variants_for_commit(&eligible_versions).await?;
@@ -1088,7 +1108,7 @@ where
         let mut batch = self.database.open_batch();
         let version_count = eligible
             .iter()
-            .flatten()
+            .flat_map(|(tx_bundles, _, _)| tx_bundles)
             .map(|bundle| bundle.versions.len())
             .sum::<usize>();
         batch.reserve(eligible.len() + version_count.saturating_mul(2));
@@ -1101,9 +1121,9 @@ where
             BTreeSet::<(PhysicalTableId, String, BranchKey, RowUuid)>::new();
         let mut applied_global_times = Vec::with_capacity(eligible.len());
 
-        for tx_bundles in eligible {
+        for (tx_bundles, local_tx, view_scoped) in eligible {
             let first = tx_bundles[0];
-            let tx = first.tx;
+            let tx = &local_tx;
             let tx_node_alias = self.ensure_node_alias(tx.tx_id.node).await?;
             let global_time = first.global_time.expect("checked above");
             applied_global_times.push(global_time);
@@ -1119,7 +1139,7 @@ where
                     (*first.fate).clone(),
                     first.global_time,
                     first.durability,
-                    first.scope == crate::protocol::VersionBundleScope::ViewScoped,
+                    view_scoped,
                 ),
             );
 

--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -1109,12 +1109,17 @@ where
             applied_global_times.push(global_time);
             batch.insert(
                 "jazz_transactions",
-                transaction_values(
+                // A reset may bulk-load only the view-authorized rows of an
+                // exclusive transaction. Preserve that scope marker even when
+                // the redacted write count equals this fragment's length, so a
+                // later sibling view can extend the same local projection.
+                transaction_values_with_cardinality_scope(
                     tx_node_alias,
                     tx,
                     (*first.fate).clone(),
                     first.global_time,
                     first.durability,
+                    first.scope == crate::protocol::VersionBundleScope::ViewScoped,
                 ),
             );
 

--- a/crates/jazz/src/node/tests/sync/receiver_batches.rs
+++ b/crates/jazz/src/node/tests/sync/receiver_batches.rs
@@ -226,6 +226,10 @@ fn receiver_batch_preloads_peer_inventory_bundles_before_membership() {
     assert_eq!(reader.sync_metrics().parked_orphans, 0);
 }
 
+/// Two independently authorized reset fragments from one exclusive transaction
+/// are coalesced into one atomic local current projection.
+///
+/// core ──todo fragment + sibling fragment──► alice's relay
 #[test]
 fn receiver_batch_coalesces_partial_bundles_for_same_tx() {
     let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
@@ -320,9 +324,201 @@ fn receiver_batch_coalesces_partial_bundles_for_same_tx() {
             .iter()
             .any(|version| version.table() == "todos" && version.row_uuid() == row(2))
     );
-    assert_eq!(reader.sync_metrics().receiver_bulk_ingest_commits, 0);
-    assert_eq!(reader.sync_metrics().receiver_bulk_bundle_ingests, 0);
-    assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 2);
+    let stored_tx = reader.query_transaction(tx_id).unwrap().unwrap();
+    assert!(stored_tx.view_scoped_cardinality);
+    assert_eq!(stored_tx.tx.n_total_writes, 2);
+    for (title, expected_row) in [("one", row(1)), ("two", row(2))] {
+        let shape = Query::from("todos")
+            .filter(eq(col("title"), lit(title)))
+            .validate(&schema())
+            .unwrap();
+        assert_eq!(
+            reader
+                .query_rows(
+                    &shape,
+                    &shape.bind(BTreeMap::new()).unwrap(),
+                    DurabilityTier::Global,
+                )
+                .unwrap()
+                .into_iter()
+                .map(current_row_pair)
+                .collect::<BTreeMap<_, _>>(),
+            BTreeMap::from([(expected_row, title_cells(title))])
+        );
+    }
+    let hidden = Query::from("todos")
+        .filter(eq(col("title"), lit("not shipped")))
+        .validate(&schema())
+        .unwrap();
+    assert!(
+        reader
+            .query_rows(
+                &hidden,
+                &hidden.bind(BTreeMap::new()).unwrap(),
+                DurabilityTier::Global,
+            )
+            .unwrap()
+            .is_empty(),
+        "coalescing may expose only the exact authorized fragments in the frame"
+    );
+    assert_eq!(reader.sync_metrics().receiver_bulk_ingest_commits, 1);
+    assert_eq!(reader.sync_metrics().receiver_bulk_bundle_ingests, 1);
+    assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);
+}
+
+/// Reordered and duplicate view-scoped fragments coalesce by exact version
+/// identity without changing the authorized current projection.
+///
+/// core ──row 2, row 1, row 1 replay──► alice's relay
+#[test]
+fn receiver_batch_coalesces_reordered_and_duplicate_view_scoped_fragments() {
+    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let tx_id = TxId::new(TxTime::from(10), node(1));
+    let tx = Transaction {
+        tx_id,
+        kind: TxKind::Exclusive,
+        n_total_writes: 1,
+        made_by: AuthorSubject::SYSTEM,
+        permission_subject: None,
+        base_snapshot: None,
+        row_read_set: None,
+        absent_read_set: None,
+        predicate_read_set: None,
+        user_metadata_json: None,
+        contribution_merge: None,
+    };
+    let first = version_record(row(1), Vec::new(), title_cells("one"), None);
+    let second = version_record(row(2), Vec::new(), title_cells("two"), None);
+    let update = |version: VersionRecord, result_row| ViewUpdateParts {
+        subscription,
+        settled_through: GlobalTime(1),
+        defer_settlement: false,
+        reset_result_set: true,
+        version_carriers: Vec::new(),
+        version_bundles: vec![VersionBundle {
+            scope: crate::protocol::VersionBundleScope::ViewScoped,
+            tx: tx.clone(),
+            versions: vec![version],
+            fate: Fate::Accepted,
+            global_time: Some(GlobalTime(1)),
+            durability: DurabilityTier::Global,
+        }],
+        peer_complete_tx_payload_refs: Vec::new(),
+        authorization_progress: None,
+        opening_pending: false,
+        result_member_adds: vec![ResultMemberEntry::row((
+            "todos".to_owned().into(),
+            result_row,
+            tx_id,
+        ))],
+        result_member_removes: Vec::new(),
+        terminal_operations: Vec::new(),
+        program_fact_adds: Vec::new(),
+        program_fact_removes: Vec::new(),
+    };
+
+    reader
+        .apply_view_updates_in_batch(vec![
+            update(second, row(2)),
+            update(first.clone(), row(1)),
+            update(first, row(1)),
+        ])
+        .unwrap();
+
+    assert_eq!(reader.query_all_versions().unwrap().len(), 2);
+    for (title, expected_row) in [("one", row(1)), ("two", row(2))] {
+        let shape = Query::from("todos")
+            .filter(eq(col("title"), lit(title)))
+            .validate(&schema())
+            .unwrap();
+        assert_eq!(
+            reader
+                .query_rows(
+                    &shape,
+                    &shape.bind(BTreeMap::new()).unwrap(),
+                    DurabilityTier::Global,
+                )
+                .unwrap()
+                .into_iter()
+                .map(current_row_pair)
+                .collect::<BTreeMap<_, _>>(),
+            BTreeMap::from([(expected_row, title_cells(title))])
+        );
+    }
+    assert_eq!(reader.sync_metrics().receiver_bulk_ingest_commits, 1);
+}
+
+/// Conflicting transaction identity or row bytes in coalesced view-scoped
+/// fragments reject the complete receiver frame before any row becomes visible.
+///
+/// mallory ──conflicting sibling fragments──✗──► alice's relay
+#[test]
+fn receiver_batch_rejects_conflicting_view_scoped_fragments_atomically() {
+    let tx_id = TxId::new(TxTime::from(10), node(1));
+    let base_tx = Transaction {
+        tx_id,
+        kind: TxKind::Exclusive,
+        n_total_writes: 1,
+        made_by: AuthorSubject::SYSTEM,
+        permission_subject: None,
+        base_snapshot: None,
+        row_read_set: None,
+        absent_read_set: None,
+        predicate_read_set: None,
+        user_metadata_json: None,
+        contribution_merge: None,
+    };
+    let run = |identity_conflict: bool| {
+        let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+        let subscription = reader.whole_table_subscription_key("todos").unwrap();
+        let mut conflicting_tx = base_tx.clone();
+        if identity_conflict {
+            conflicting_tx.made_by = AuthorSubject::for_test_bytes([0x55; 16]);
+        }
+        let first = version_record(row(1), Vec::new(), title_cells("one"), None);
+        let conflicting = if identity_conflict {
+            version_record(row(2), Vec::new(), title_cells("two"), None)
+        } else {
+            version_record(row(1), Vec::new(), title_cells("changed"), None)
+        };
+        let update = |tx: Transaction, version: VersionRecord| ViewUpdateParts {
+            subscription,
+            settled_through: GlobalTime(1),
+            defer_settlement: false,
+            reset_result_set: true,
+            version_carriers: Vec::new(),
+            version_bundles: vec![VersionBundle {
+                scope: crate::protocol::VersionBundleScope::ViewScoped,
+                tx,
+                versions: vec![version],
+                fate: Fate::Accepted,
+                global_time: Some(GlobalTime(1)),
+                durability: DurabilityTier::Global,
+            }],
+            peer_complete_tx_payload_refs: Vec::new(),
+            authorization_progress: None,
+            opening_pending: false,
+            result_member_adds: Vec::new(),
+            result_member_removes: Vec::new(),
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        };
+        let result = reader.apply_view_updates_in_batch(vec![
+            update(base_tx.clone(), first),
+            update(conflicting_tx, conflicting),
+        ]);
+        assert!(matches!(result.resolve(), Err(Error::ConflictingCommitUnit(id)) if id == tx_id));
+        assert!(reader.query_all_versions().unwrap().is_empty());
+        assert!(reader
+            .current_rows("todos", DurabilityTier::Global)
+            .unwrap()
+            .is_empty());
+    };
+
+    run(false);
+    run(true);
 }
 
 // This stays internal because it directly exercises the protocol receiver's

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1325,7 +1325,15 @@ where
         }
         if bundle.scope == crate::protocol::VersionBundleScope::ViewScoped {
             let tx_id = bundle.tx.tx_id;
-            let mut known_keys = if self.query_transaction(tx_id).await?.is_some() {
+            let stored_tx = self.query_transaction(tx_id).await?;
+            // A bulk reset installs its authorized fragment as locally current
+            // so a relay can serve it onward. Further authorized siblings from
+            // that same view-scoped transaction must extend that projection;
+            // fragments first learned outside such a reset remain history-only.
+            let extend_current_view = stored_tx
+                .as_ref()
+                .is_some_and(|stored| stored.view_scoped_cardinality);
+            let mut known_keys = if stored_tx.is_some() {
                 self.query_versions_for_tx(tx_id)
                     .await?
                     .iter()
@@ -1340,15 +1348,25 @@ where
                 .len()
                 .try_into()
                 .map_err(|_| Error::InvalidStoredValue("view payload is too large"))?;
-            return self
-                .ingest_transaction_fragment_without_current_indexes(
+            return if extend_current_view {
+                self.ingest_view_scoped_transaction_with_current_indexes(
                     redacted_tx,
                     bundle.versions,
                     bundle.fate,
                     bundle.global_time,
                     bundle.durability,
                 )
-                .await;
+                .await
+            } else {
+                self.ingest_transaction_fragment_without_current_indexes(
+                    redacted_tx,
+                    bundle.versions,
+                    bundle.fate,
+                    bundle.global_time,
+                    bundle.durability,
+                )
+                .await
+            };
         }
         let complete_len = usize::try_from(bundle.tx.n_total_writes).map_err(|_| {
             Error::InvalidStoredValue("exclusive transaction write count does not fit usize")

--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -7,8 +7,8 @@ use std::rc::Rc;
 mod common;
 
 use jazz::db::{
-    Db, DbConfig, DbIdentity, Propagation, ReadOpts, SubscriptionEvent, TickScheduler, TickUrgency,
-    Transport, block_on,
+    Db, DbConfig, DbIdentity, ExclusiveTxOps, Propagation, ReadOpts, SubscriptionEvent,
+    TickScheduler, TickUrgency, Transport, block_on,
 };
 use jazz::groove::records::Value;
 use jazz::groove::storage::{TestStorage, TestStorageOperation};
@@ -1398,6 +1398,198 @@ fn browser_relay_does_not_publish_a_premature_settled_snapshot() {
         )),
         "expected settled authority row, got {settled:?}"
     );
+}
+
+#[test]
+fn view_scoped_exclusive_sibling_edge_reads_extend_relay_projection() {
+    let schema = compile_schema(
+        &SchemaBuilder::new()
+            .table(TableSchemaBuilder::new("orgs").column("name", ColumnType::Text))
+            .table(TableSchemaBuilder::new("todos").fk_column("org_id", "orgs"))
+            .table(
+                TableSchemaBuilder::new("checks")
+                    .fk_column("org_id", "orgs")
+                    .fk_column("todo_id", "todos"),
+            )
+            .table(
+                TableSchemaBuilder::new("notes")
+                    .fk_column("org_id", "orgs")
+                    .fk_column("check_id", "checks"),
+            )
+            .build(),
+    );
+    let alice = AuthorSubject::for_test_bytes([0xd1; 16]);
+    let main_thread = open_db(0x41, alice, &schema);
+    let worker = open_db(0x42, alice, &schema);
+    let core = open_core(0x43, &schema);
+    let seeder = open_db(0x44, alice, &schema);
+    main_thread.set_non_durable_client();
+
+    let (main_transport, worker_subscriber_transport) = duplex();
+    let _main_connection = block_on(main_thread.connect_upstream(main_transport));
+    let _worker_subscriber = worker.accept_subscriber(worker_subscriber_transport, alice);
+    let (worker_upstream_transport, core_transport) = duplex();
+    let _worker_upstream = block_on(worker.connect_upstream(worker_upstream_transport));
+    let _core_subscriber = core.accept_subscriber(core_transport, alice);
+    let (seed_transport, core_seed_transport) = duplex();
+    let _seed_upstream = block_on(seeder.connect_upstream(seed_transport));
+    let _core_seed = core.accept_subscriber(core_seed_transport, alice);
+
+    let tx = seeder
+        .exclusive_tx()
+        .expect("open exclusive seed transaction");
+    let org = tx
+        .insert(
+            "orgs",
+            BTreeMap::from([("name".to_owned(), Value::String("north".to_owned()))]),
+            Default::default(),
+        )
+        .expect("seed org");
+    let todo = tx
+        .insert(
+            "todos",
+            BTreeMap::from([("org_id".to_owned(), Value::Uuid(org.0))]),
+            Default::default(),
+        )
+        .expect("seed todo");
+    let check = tx
+        .insert(
+            "checks",
+            BTreeMap::from([
+                ("org_id".to_owned(), Value::Uuid(org.0)),
+                ("todo_id".to_owned(), Value::Uuid(todo.0)),
+            ]),
+            Default::default(),
+        )
+        .expect("seed check");
+    let note = tx
+        .insert(
+            "notes",
+            BTreeMap::from([
+                ("org_id".to_owned(), Value::Uuid(org.0)),
+                ("check_id".to_owned(), Value::Uuid(check.0)),
+            ]),
+            Default::default(),
+        )
+        .expect("seed note");
+    tx.commit().expect("commit exclusive sibling rows");
+    for _ in 0..4 {
+        seeder.tick().expect("upload sibling rows");
+        core.tick().expect("accept sibling rows");
+        seeder.tick().expect("apply sibling fates");
+    }
+
+    let opts = ReadOpts {
+        tier: DurabilityTier::Edge,
+        ..ReadOpts::default()
+    };
+    for (table, expected_row) in [("todos", todo), ("checks", check), ("notes", note)] {
+        let query = main_thread
+            .prepare_query(&Query::from(table).filter(eq(col("org_id"), lit(org.0))))
+            .expect("prepare sibling query");
+        let attachment = main_thread
+            .attach_query_with_opts(&query, opts.clone())
+            .expect("attach sibling query");
+        for _ in 0..12 {
+            main_thread.tick().expect("register sibling query");
+            worker.tick().expect("forward sibling query");
+            core.tick().expect("serve sibling query");
+            worker.tick().expect("relay sibling result");
+            main_thread.tick().expect("apply sibling result");
+            if main_thread.query_attachment_is_covered(&attachment) {
+                break;
+            }
+        }
+        assert!(main_thread.query_attachment_is_covered(&attachment));
+        let rows = block_on(main_thread.all(&query, opts.clone())).unwrap();
+        assert_eq!(rows.len(), 1, "covered {table} query returned false-empty");
+        assert_eq!(rows[0].row_uuid(), expected_row);
+        main_thread.detach_query(attachment);
+        main_thread.tick().expect("send sibling unsubscribe");
+        worker.tick().expect("retire sibling relay coverage");
+        core.tick().expect("retire sibling authority coverage");
+        worker.tick().expect("apply sibling retirement");
+        main_thread
+            .tick()
+            .expect("apply sibling retirement locally");
+    }
+
+    // Control: the same relay lifecycle already works when every row has its
+    // own mergeable transaction identity. Keep it beside the exclusive case
+    // so the receipt specifically protects fragment extension, rather than a
+    // broader change to strict-Edge attachment semantics.
+    let merge_org = seeder
+        .insert(
+            "orgs",
+            BTreeMap::from([("name".to_owned(), Value::String("south".to_owned()))]),
+            Default::default(),
+        )
+        .expect("seed mergeable org");
+    let merge_org_id = merge_org.row_uuid();
+    let merge_todo = seeder
+        .insert(
+            "todos",
+            BTreeMap::from([("org_id".to_owned(), Value::Uuid(merge_org_id.0))]),
+            Default::default(),
+        )
+        .expect("seed mergeable todo");
+    let merge_todo_id = merge_todo.row_uuid();
+    let merge_check = seeder
+        .insert(
+            "checks",
+            BTreeMap::from([
+                ("org_id".to_owned(), Value::Uuid(merge_org_id.0)),
+                ("todo_id".to_owned(), Value::Uuid(merge_todo_id.0)),
+            ]),
+            Default::default(),
+        )
+        .expect("seed mergeable check");
+    let merge_check_id = merge_check.row_uuid();
+    let merge_note = seeder
+        .insert(
+            "notes",
+            BTreeMap::from([
+                ("org_id".to_owned(), Value::Uuid(merge_org_id.0)),
+                ("check_id".to_owned(), Value::Uuid(merge_check_id.0)),
+            ]),
+            Default::default(),
+        )
+        .expect("seed mergeable note");
+    let merge_note_id = merge_note.row_uuid();
+    for _ in 0..8 {
+        seeder.tick().expect("upload mergeable sibling rows");
+        core.tick().expect("accept mergeable sibling rows");
+        seeder.tick().expect("apply mergeable sibling fates");
+    }
+    for (table, expected_row) in [
+        ("todos", merge_todo_id),
+        ("checks", merge_check_id),
+        ("notes", merge_note_id),
+    ] {
+        let query = main_thread
+            .prepare_query(&Query::from(table).filter(eq(col("org_id"), lit(merge_org_id.0))))
+            .expect("prepare mergeable control query");
+        let attachment = main_thread
+            .attach_query_with_opts(&query, opts.clone())
+            .expect("attach mergeable control query");
+        for _ in 0..12 {
+            main_thread
+                .tick()
+                .expect("register mergeable control query");
+            worker.tick().expect("forward mergeable control query");
+            core.tick().expect("serve mergeable control query");
+            worker.tick().expect("relay mergeable control result");
+            main_thread.tick().expect("apply mergeable control result");
+            if main_thread.query_attachment_is_covered(&attachment) {
+                break;
+            }
+        }
+        assert!(main_thread.query_attachment_is_covered(&attachment));
+        let rows = block_on(main_thread.all(&query, opts.clone())).unwrap();
+        assert_eq!(rows.len(), 1, "covered mergeable {table} query was empty");
+        assert_eq!(rows[0].row_uuid(), expected_row);
+        main_thread.detach_query(attachment);
+    }
 }
 
 /// A fresh browser main thread receives the worker's authority-owned reset as

--- a/packages/jazz-tools/tests/browser/db.include-subscriptions.server.test.ts
+++ b/packages/jazz-tools/tests/browser/db.include-subscriptions.server.test.ts
@@ -21,10 +21,12 @@ const app = schema.defineApp({
     org_id: schema.ref("orgs"),
   }),
   user_checks: schema.table({
+    org_id: schema.ref("orgs"),
     todo_id: schema.ref("todos"),
   }),
   check_notes: schema.table({
     body: schema.string(),
+    org_id: schema.ref("orgs"),
     user_check_id: schema.ref("user_checks"),
   }),
 });
@@ -66,6 +68,76 @@ afterEach(async () => {
 });
 
 describe("websocket include subscriptions", () => {
+  /**
+   * A client may attach several independently bound strict-edge reads after an
+   * authority has accepted an exclusive transaction. Each attachment
+   * needs its own current authority receipt; one must not strand the others.
+   *
+   * owner ──exclusive todo──► server
+   * observer ──three Edge attachments──► server ──current receipts──► observer
+   */
+  it("covers concurrent edge queries attached after an exclusive commit", async () => {
+    const { appId, serverUrl, adminSecret } = await getJazzServerInfo(
+      uniqueDbName("exclusive-then-edge-coverage"),
+    );
+    await publishSchemaAndPermissions(appId, serverUrl, adminSecret, permissions);
+
+    const sharedSecret = generateAuthSecret();
+    const owner = await openDb(
+      appId,
+      serverUrl,
+      adminSecret,
+      "exclusive-then-edge-owner",
+      sharedSecret,
+    );
+    const observer = await openDb(
+      appId,
+      serverUrl,
+      adminSecret,
+      "exclusive-then-edge-observer",
+      sharedSecret,
+    );
+    await ensureNativeRuntimeAdapterReady(owner);
+    await ensureNativeRuntimeAdapterReady(observer);
+
+    const org = await owner.insert(app.orgs, { name: "North" }).wait({ tier: "edge" });
+    expect(await observer.all(app.orgs.where({ id: org.id }), { tier: "edge" })).toMatchObject([
+      { id: org.id },
+    ]);
+    const write = await owner.exclusiveTransaction((transaction) => {
+      const todo = transaction.insert(app.todos, { title: "Ship", org_id: org.id });
+      const check = transaction.insert(app.user_checks, { org_id: org.id, todo_id: todo.id });
+      const note = transaction.insert(app.check_notes, {
+        body: "ready",
+        org_id: org.id,
+        user_check_id: check.id,
+      });
+      return { todo, check, note };
+    });
+    const { todo, check, note } = await withTimeout(
+      write.wait(),
+      15_000,
+      "exclusive transaction did not reach the authority",
+    );
+
+    const [todos, checks, notes] = await withTimeout(
+      Promise.all([
+        observer.all(app.todos.where({ org_id: org.id }), { tier: "edge" }),
+        observer.all(app.user_checks.where({ todo_id: todo.id }), { tier: "edge" }),
+        observer.all(app.check_notes.where({ user_check_id: check.id }), { tier: "edge" }),
+      ]),
+      20_000,
+      "concurrent strict-edge query coverage did not settle",
+    );
+    expect(todos.map((row) => row.id)).toEqual([todo.id]);
+    expect(checks.map((row) => ({ id: row.id, todoId: row.todo_id }))).toEqual([
+      { id: check.id, todoId: todo.id },
+    ]);
+    expect(notes.map((row) => ({ id: row.id, checkId: row.user_check_id }))).toEqual([
+      { id: note.id, checkId: check.id },
+    ]);
+  }, 45_000);
+
   it("delivers depth-3 reverse include material from client A to client B subscribeAll", async () => {
     const { appId, serverUrl, adminSecret } = await getJazzServerInfo(
       uniqueDbName("include-subscriptions"),
@@ -124,7 +196,7 @@ describe("websocket include subscriptions", () => {
       "client A todo insert did not reach the server",
     );
     const userCheck = await withTimeout(
-      dbA.insert(app.user_checks, { todo_id: todo.id }).wait({ tier: "global" }),
+      dbA.insert(app.user_checks, { org_id: org.id, todo_id: todo.id }).wait({ tier: "global" }),
       10_000,
       "client A user_check insert did not reach the server",
     );
@@ -133,6 +205,7 @@ describe("websocket include subscriptions", () => {
       dbA
         .insert(app.check_notes, {
           body: "looks good",
+          org_id: org.id,
           user_check_id: userCheck.id,
         })
         .wait({ tier: "global" }),


### PR DESCRIPTION
🤖 ## Before

When an exclusive transaction inserted several rows, a relay could ingest the first authorized view-scoped fragment as though its redacted cardinality described the complete transaction. Later sibling fragments joined history but did not extend the current indexes. A strict Edge query attached afterward could therefore receive the first row while equally authorized sibling queries were reported as covered-empty.

Example: one accepted transaction inserts a todo, its check, and a note. The first attached sibling query returns its row; the other two incorrectly return empty depending only on attachment order.

## After

Bulk ingestion preserves the view-scoped cardinality marker. When later authorized fragments of that same transaction arrive, they extend an already-current view-scoped projection's current indexes. This does not serialize query attachment or weaken Edge tier semantics.

## Verification

- Rust main → persistent worker → core receipt asserts exact todo/check/note identities for one exclusive transaction, with independent mergeable transactions as a control.
- Browser receipt asserts the same exact identities and relations under concurrent attachment.
- All 20 browser relay durability tests pass.
- A planted loss of the scope marker deterministically makes the second sibling query covered-empty.

Fixes #2089 and unblocks #2082.
