### PR TITLE
Serialize concurrent streaming finalization

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -609,6 +609,11 @@ export class NativeRuntimeAdapter implements Runtime {
   private readonly completedTxs: Map<string, CompletedTx>;
   private readonly writes: Map<string, Write>;
   private readonly pendingLocalSettlements = new Set<Promise<void>>();
+  // Streaming sources can be consumed concurrently, but native `finish()`
+  // mutates the owner runtime. WASM evaluates that runtime behind one async
+  // borrow, so overlapping finalization can deadlock. Keep only this atomic
+  // publication boundary FIFO; ordinary writes and source reads stay parallel.
+  private streamingFinalization: Promise<void> = Promise.resolve();
   private readonly ownerRuntime: NativeRuntimeAdapter;
   private readonly readAuthorizationHost: ReadAuthorizationHost;
   private readonly subscriptions = new Map<number, SubscriptionState>();
@@ -1196,7 +1201,20 @@ export class NativeRuntimeAdapter implements Runtime {
         }
       }
       if (pendingHighSurrogate) await pushBounded(encoder.encode(pendingHighSurrogate));
-      const receipt = this.finishMutation(await upload.finish());
+      const owner = this.ownerRuntime;
+      const previousFinalization = owner.streamingFinalization;
+      let releaseFinalization!: () => void;
+      const finalization = new Promise<void>((resolve) => {
+        releaseFinalization = resolve;
+      });
+      owner.streamingFinalization = previousFinalization.then(() => finalization);
+      await previousFinalization;
+      let receipt: MutationResult;
+      try {
+        receipt = this.finishMutation(await upload.finish());
+      } finally {
+        releaseFinalization();
+      }
       return { id: formatUuid(rowId), ...receipt };
     } catch (error) {
       await upload.abort();

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -5071,6 +5071,138 @@ describe("NativeRuntimeAdapter server transport", () => {
 });
 
 describe("NativeRuntimeAdapter streaming inserts", () => {
+  it("serializes finalization across schema views while source ingestion stays concurrent", async () => {
+    type Deferred<T> = {
+      promise: Promise<T>;
+      resolve(value: T): void;
+      reject(error: Error): void;
+    };
+    const deferred = <T>(): Deferred<T> => {
+      let resolve!: (value: T) => void;
+      let reject!: (error: Error) => void;
+      const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+      });
+      return { promise, resolve, reject };
+    };
+    const completions = [
+      deferred<ReturnType<typeof fakeWrite>>(),
+      deferred<ReturnType<typeof fakeWrite>>(),
+    ];
+    const pushed: string[] = [];
+    const started: number[] = [];
+    let nextCompletion = 0;
+    let nativeDb!: NativeDbForTest;
+    const beginStreamingMutationEncoded = vi.fn(() => ({
+      push(chunk: Uint8Array) {
+        pushed.push(new TextDecoder().decode(chunk));
+      },
+      finish() {
+        const completion = nextCompletion++;
+        started.push(completion);
+        return completions[completion]!.promise;
+      },
+      abort: vi.fn(),
+    }));
+    nativeDb = fakeDb({
+      beginStreamingMutationEncoded,
+      registerSchema: () => nativeDb,
+    });
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () => nativeDb,
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const view = runtime.registerSchemaView(testSchema);
+    const source = async function* (value: string) {
+      yield value;
+    };
+
+    const first = runtime.streamingMutation("insert", "todos", {}, "title", source("first"));
+    const second = view.streamingMutation("insert", "todos", {}, "title", source("second"));
+
+    await vi.waitFor(() => expect(pushed).toEqual(expect.arrayContaining(["first", "second"])));
+    await vi.waitFor(() => expect(started).toEqual([0]));
+    completions[0]!.resolve(fakeWrite());
+    await vi.waitFor(() => expect(started).toEqual([0, 1]));
+    completions[1]!.resolve(fakeWrite());
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  });
+
+  it("releases the next streaming finalization after a failed finish", async () => {
+    type Deferred<T> = {
+      promise: Promise<T>;
+      resolve(value: T): void;
+      reject(error: Error): void;
+    };
+    const deferred = <T>(): Deferred<T> => {
+      let resolve!: (value: T) => void;
+      let reject!: (error: Error) => void;
+      const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+      });
+      return { promise, resolve, reject };
+    };
+    const completions = [
+      deferred<ReturnType<typeof fakeWrite>>(),
+      deferred<ReturnType<typeof fakeWrite>>(),
+    ];
+    const started: number[] = [];
+    const aborts = [vi.fn(), vi.fn()];
+    let nextCompletion = 0;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            beginStreamingMutationEncoded: () => {
+              const upload = nextCompletion++;
+              return {
+                push: () => undefined,
+                finish() {
+                  started.push(upload);
+                  return completions[upload]!.promise;
+                },
+                abort: aborts[upload]!,
+              };
+            },
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const source = async function* () {
+      yield "value";
+    };
+
+    const first = runtime.streamingMutation("insert", "todos", {}, "title", source());
+    const second = runtime.streamingMutation("insert", "todos", {}, "title", source());
+
+    await vi.waitFor(() => expect(started).toEqual([0]));
+    completions[0]!.reject(new Error("native finish failed"));
+    await expect(first).rejects.toThrow("native finish failed");
+    expect(aborts[0]).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(started).toEqual([0, 1]));
+    completions[1]!.resolve(fakeWrite());
+    await expect(second).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+  });
+
   it("infers the physical kind and applies backpressure to async chunks", async () => {
     const pushed: Uint8Array[] = [];
     let finished = false;

--- a/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
@@ -169,8 +169,9 @@ describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
         ]),
         "concurrent streamed WASM publication",
       );
+      const batchIds = await Promise.all(writes.map(committedBatchId));
       await withWatchdog(
-        Promise.all(writes.map((write) => runtime.waitForTransaction!(write.batchId, "local"))),
+        Promise.all(batchIds.map((batchId) => runtime.waitForTransaction!(batchId, "local"))),
         "concurrent streamed WASM local settlement",
       );
 
@@ -199,7 +200,13 @@ describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
     }
     let cleanupError: unknown;
     try {
-      await withWatchdog(runtime.close(), "concurrent streamed WASM runtime cleanup", 1_000);
+      const closeRuntime = runtime.close;
+      if (!closeRuntime) throw new Error("WASM runtime does not expose close()");
+      await withWatchdog(
+        Promise.resolve().then(() => closeRuntime.call(runtime)),
+        "concurrent streamed WASM runtime cleanup",
+        1_000,
+      );
     } catch (error) {
       cleanupError = error;
     }

--- a/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
@@ -143,55 +143,69 @@ describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
       await Promise.resolve();
       yield `${prefix} second`;
     };
+    let bodyError: unknown;
 
-    const writes = await withWatchdog(
-      Promise.all([
-        runtime.streamingMutation!(
-          "insert",
-          "todos",
-          { done: { type: "Boolean", value: false } },
-          "title",
-          source("one"),
-          null,
-          "00000000-0000-4000-8000-000000000201",
-        ),
-        runtime.streamingMutation!(
-          "insert",
-          "todos",
-          { done: { type: "Boolean", value: true } },
-          "title",
-          source("two"),
-          null,
-          "00000000-0000-4000-8000-000000000202",
-        ),
-      ]),
-      "concurrent streamed WASM publication",
-    );
-    await withWatchdog(
-      Promise.all(writes.map((write) => runtime.waitForTransaction!(write.batchId, "local"))),
-      "concurrent streamed WASM local settlement",
-    );
+    try {
+      const writes = await withWatchdog(
+        Promise.all([
+          runtime.streamingMutation!(
+            "insert",
+            "todos",
+            { done: { type: "Boolean", value: false } },
+            "title",
+            source("one"),
+            null,
+            "00000000-0000-4000-8000-000000000201",
+          ),
+          runtime.streamingMutation!(
+            "insert",
+            "todos",
+            { done: { type: "Boolean", value: true } },
+            "title",
+            source("two"),
+            null,
+            "00000000-0000-4000-8000-000000000202",
+          ),
+        ]),
+        "concurrent streamed WASM publication",
+      );
+      await withWatchdog(
+        Promise.all(writes.map((write) => runtime.waitForTransaction!(write.batchId, "local"))),
+        "concurrent streamed WASM local settlement",
+      );
 
-    await expect(runtime.query(JSON.stringify({ table: "todos" }))).resolves.toEqual([
-      {
-        id: "00000000-0000-4000-8000-000000000201",
-        table: "todos",
-        values: [
-          { type: "Text", value: "one first one second" },
-          { type: "Boolean", value: false },
-          { type: "Null" },
-        ],
-      },
-      {
-        id: "00000000-0000-4000-8000-000000000202",
-        table: "todos",
-        values: [
-          { type: "Text", value: "two first two second" },
-          { type: "Boolean", value: true },
-          { type: "Null" },
-        ],
-      },
-    ]);
+      await expect(runtime.query(JSON.stringify({ table: "todos" }))).resolves.toEqual([
+        {
+          id: "00000000-0000-4000-8000-000000000201",
+          table: "todos",
+          values: [
+            { type: "Text", value: "one first one second" },
+            { type: "Boolean", value: false },
+            { type: "Null" },
+          ],
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000202",
+          table: "todos",
+          values: [
+            { type: "Text", value: "two first two second" },
+            { type: "Boolean", value: true },
+            { type: "Null" },
+          ],
+        },
+      ]);
+    } catch (error) {
+      bodyError = error;
+    }
+    let cleanupError: unknown;
+    try {
+      await withWatchdog(runtime.close(), "concurrent streamed WASM runtime cleanup", 1_000);
+    } catch (error) {
+      cleanupError = error;
+    }
+    // The publication failure is the actionable signal when both phases fail.
+    if (bodyError) throw bodyError;
+    if (cleanupError) throw cleanupError;
   });
 
   it("rejects fragmented invalid JSON without publishing a row", async () => {

--- a/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
@@ -16,6 +16,23 @@ async function committedBatchId(receipt: WriteReceipt): Promise<BatchId> {
   return await receipt.batchId;
 }
 
+async function withWatchdog<T>(promise: Promise<T>, label: string, timeoutMs = 3_000): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
   it("selects and filters public provenance authors as canonical text", async () => {
     const appId = "wasm-public-provenance";
@@ -110,6 +127,66 @@ describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
         table: "todos",
         values: [
           { type: "Text", value: "upserted" },
+          { type: "Boolean", value: true },
+          { type: "Null" },
+        ],
+      },
+    ]);
+  });
+
+  it("finishes concurrent streamed writes without wedging the shared WASM runtime", async () => {
+    const runtime = await createWasmRuntime(app.wasmSchema, {
+      appId: "wasm-concurrent-streaming-publication",
+    });
+    const source = async function* (prefix: string) {
+      yield `${prefix} first `;
+      await Promise.resolve();
+      yield `${prefix} second`;
+    };
+
+    const writes = await withWatchdog(
+      Promise.all([
+        runtime.streamingMutation!(
+          "insert",
+          "todos",
+          { done: { type: "Boolean", value: false } },
+          "title",
+          source("one"),
+          null,
+          "00000000-0000-4000-8000-000000000201",
+        ),
+        runtime.streamingMutation!(
+          "insert",
+          "todos",
+          { done: { type: "Boolean", value: true } },
+          "title",
+          source("two"),
+          null,
+          "00000000-0000-4000-8000-000000000202",
+        ),
+      ]),
+      "concurrent streamed WASM publication",
+    );
+    await withWatchdog(
+      Promise.all(writes.map((write) => runtime.waitForTransaction!(write.batchId, "local"))),
+      "concurrent streamed WASM local settlement",
+    );
+
+    await expect(runtime.query(JSON.stringify({ table: "todos" }))).resolves.toEqual([
+      {
+        id: "00000000-0000-4000-8000-000000000201",
+        table: "todos",
+        values: [
+          { type: "Text", value: "one first one second" },
+          { type: "Boolean", value: false },
+          { type: "Null" },
+        ],
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000202",
+        table: "todos",
+        values: [
+          { type: "Text", value: "two first two second" },
           { type: "Boolean", value: true },
           { type: "Null" },
         ],


### PR DESCRIPTION
🤖 ## Before

Concurrent streamed mutations could reach the shared native runtime's `upload.finish()` simultaneously. This is unsafe for WASM's single async runtime borrow and can wedge publication.

The earlier #2075 branch accumulated 169 commits of unrelated stack work, so it was not safe to merge as the owner of this fix.

## After

Streaming source consumption remains concurrent, while the atomic native finalization boundary is FIFO-serialized per owner runtime. Registered schema views share that owner queue. A failed finalization releases the following upload.

## Examples

- Two schema views can consume `first` and `second` sources concurrently; only the first native finish begins until it settles.
- If the first native finish rejects, its upload aborts and the second finish proceeds.
- Ordinary mutations are unchanged; this queue covers only streamed native finalization.

## Verification

- Focused adapter suite: 114 passed, one skipped.
- `jazz-tools` runtime build passes.
- Planted removal of the finalization wait makes both concurrency receipts fail.
- A real-WASM watchdog runs two concurrent streamed inserts through one runtime, waits for publication and local settlement, verifies exact rows, and always bounds `runtime.close()`.
- Bypassing serialization makes exactly that WASM receipt hit its intended publication watchdog; cleanup remains bounded and does not mask the primary error.

Supersedes #2075.
