### PR TITLE
Avoid quadratic merge-head replay across deep histories

### DIFF
--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -1,6 +1,9 @@
 //! Canonical indirect representation for large logical scalar values.
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
@@ -2055,6 +2058,8 @@ pub fn prepare_reusing(
 /// record codecs. The containing schema supplies the declared kind, including
 /// the backing primitive type and the expected kind of every referenced node.
 pub fn encode_stored_scalar(kind: LargeValueKind, value: &StoredScalar) -> Result<Vec<u8>, Error> {
+    #[cfg(test)]
+    STORED_SCALAR_ENCODE_CALLS.with(|calls| calls.set(calls.get() + 1));
     let schema = stored_scalar_schema(kind);
     let enum_value = match value {
         StoredScalar::Primitive(bytes) => {
@@ -2081,9 +2086,28 @@ pub fn encode_stored_scalar(kind: LargeValueKind, value: &StoredScalar) -> Resul
     };
     crate::records::encode_single_field_value(
         &Value::Enum(enum_value),
-        &ValueType::Enum(Box::new(schema)),
+        stored_scalar_value_type(kind),
     )
     .map_err(|_| Error::MalformedScalar)
+}
+
+// A structural receipt for the current-row materialization fast path. This is
+// deliberately test-only: the production contract is that inline values are
+// returned verbatim without entering the scalar encoder, not that callers pay
+// for metrics bookkeeping.
+#[cfg(test)]
+std::thread_local! {
+    static STORED_SCALAR_ENCODE_CALLS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+fn reset_stored_scalar_encode_calls() {
+    STORED_SCALAR_ENCODE_CALLS.with(|calls| calls.set(0));
+}
+
+#[cfg(test)]
+fn stored_scalar_encode_calls() -> usize {
+    STORED_SCALAR_ENCODE_CALLS.with(|calls| calls.get())
 }
 
 /// Decode and canonically validate the internal stored-scalar enum. The
@@ -2091,21 +2115,18 @@ pub fn encode_stored_scalar(kind: LargeValueKind, value: &StoredScalar) -> Resul
 /// interpreted directly through that schema; indirect values authenticate the
 /// expected kind when their content-addressed nodes are decoded.
 pub fn decode_stored_scalar(kind: LargeValueKind, encoded: &[u8]) -> Result<StoredScalar, Error> {
-    let schema = stored_scalar_schema(kind);
-    let decoded = crate::records::decode_single_field_value(
-        encoded,
-        &ValueType::Enum(Box::new(schema.clone())),
-    )
-    .map_err(|error| match error {
-        crate::records::Error::InvalidUtf8 => Error::InvalidUtf8,
-        _ => Error::MalformedScalar,
-    })?;
+    let decoded =
+        crate::records::decode_single_field_value(encoded, stored_scalar_value_type(kind))
+            .map_err(|error| match error {
+                crate::records::Error::InvalidUtf8 => Error::InvalidUtf8,
+                _ => Error::MalformedScalar,
+            })?;
     let Value::Enum(value) = decoded else {
         return Err(Error::MalformedScalar);
     };
     let canonical = crate::records::encode_single_field_value(
         &Value::Enum(value.clone()),
-        &ValueType::Enum(Box::new(schema.clone())),
+        stored_scalar_value_type(kind),
     )
     .map_err(|_| Error::MalformedScalar)?;
     if canonical != encoded {
@@ -2163,7 +2184,41 @@ pub fn inline_scalar_bytes(kind: LargeValueKind, encoded: &[u8]) -> Result<&[u8]
     }
 }
 
-fn stored_scalar_schema(kind: LargeValueKind) -> EnumSchema {
+fn stored_scalar_schema(kind: LargeValueKind) -> &'static EnumSchema {
+    // Current-row evaluation decodes this ordinary scalar envelope on every
+    // affected record. Building its nested descriptors repeatedly re-hashes
+    // their layouts even though `RecordDescriptor` later interns them, making
+    // a rapid stream of revisions pay avoidable work proportional to every
+    // historical update. The schema is immutable and kind-parametric, so one
+    // process-wide instance per declared kind is the canonical interpretation.
+    static BYTES: OnceLock<EnumSchema> = OnceLock::new();
+    static STRING: OnceLock<EnumSchema> = OnceLock::new();
+    static JSON: OnceLock<EnumSchema> = OnceLock::new();
+
+    let schema = match kind {
+        LargeValueKind::Bytes => &BYTES,
+        LargeValueKind::String => &STRING,
+        LargeValueKind::Json => &JSON,
+    };
+    schema.get_or_init(|| build_stored_scalar_schema(kind))
+}
+
+fn stored_scalar_value_type(kind: LargeValueKind) -> &'static ValueType {
+    // `ValueType::Enum` owns its schema. Cache this wrapper as well so the
+    // ordinary scalar codec does not deep-clone the schema for every cell.
+    static BYTES: OnceLock<ValueType> = OnceLock::new();
+    static STRING: OnceLock<ValueType> = OnceLock::new();
+    static JSON: OnceLock<ValueType> = OnceLock::new();
+
+    let value_type = match kind {
+        LargeValueKind::Bytes => &BYTES,
+        LargeValueKind::String => &STRING,
+        LargeValueKind::Json => &JSON,
+    };
+    value_type.get_or_init(|| ValueType::Enum(Box::new(stored_scalar_schema(kind).clone())))
+}
+
+fn build_stored_scalar_schema(kind: LargeValueKind) -> EnumSchema {
     let primitive = RecordDescriptor::new([(
         "value",
         match kind {
@@ -3235,13 +3290,18 @@ pub(crate) fn materialize_record_attempt(
 ) -> Result<Vec<u8>, IvmRuntimeError> {
     let mut values = descriptor.bind(raw).to_values()?;
     let mut blocked = false;
+    let mut changed = false;
     for value in &mut values {
-        materialize_value_attempt(value, inputs, &mut blocked)?;
+        changed |= materialize_value_attempt(value, inputs, &mut blocked)?;
     }
     if blocked {
         return Err(IvmRuntimeError::EvaluationBlocked);
     }
-    Ok(descriptor.create(&values)?)
+    if changed {
+        Ok(descriptor.create(&values)?)
+    } else {
+        Ok(raw.to_vec())
+    }
 }
 
 /// Materialize only the logical fields an operator will inspect. Unselected
@@ -3254,6 +3314,7 @@ pub(crate) fn materialize_record_fields_attempt(
 ) -> Result<Vec<u8>, IvmRuntimeError> {
     let mut values = descriptor.bind(raw).to_values()?;
     let mut blocked = false;
+    let mut changed = false;
     for index in field_indices {
         let value = values
             .get_mut(*index)
@@ -3261,19 +3322,23 @@ pub(crate) fn materialize_record_fields_attempt(
                 index: *index,
                 len: descriptor.fields().len(),
             })?;
-        materialize_value_attempt(value, inputs, &mut blocked)?;
+        changed |= materialize_value_attempt(value, inputs, &mut blocked)?;
     }
     if blocked {
         return Err(IvmRuntimeError::EvaluationBlocked);
     }
-    Ok(descriptor.create(&values)?)
+    if changed {
+        Ok(descriptor.create(&values)?)
+    } else {
+        Ok(raw.to_vec())
+    }
 }
 
 fn materialize_value_attempt(
     value: &mut Value,
     inputs: &mut EvaluationInputs,
     blocked: &mut bool,
-) -> Result<(), IvmRuntimeError> {
+) -> Result<bool, IvmRuntimeError> {
     match value {
         Value::Large(large) => match materialize_attempt(large, inputs) {
             Ok(bytes) => {
@@ -3286,19 +3351,20 @@ fn materialize_value_attempt(
                         Value::String(String::from_utf8(bytes).map_err(|_| Error::InvalidUtf8)?)
                     }
                 };
-                Ok(())
+                Ok(true)
             }
             Err(IvmRuntimeError::EvaluationBlocked) => {
                 *blocked = true;
-                Ok(())
+                Ok(false)
             }
             Err(error) => Err(error),
         },
         Value::Tuple(values) | Value::Array(values) => {
+            let mut changed = false;
             for value in values {
-                materialize_value_attempt(value, inputs, blocked)?;
+                changed |= materialize_value_attempt(value, inputs, blocked)?;
             }
-            Ok(())
+            Ok(changed)
         }
         Value::Nullable(Some(value)) => materialize_value_attempt(value, inputs, blocked),
         Value::Record(record) => {
@@ -3306,12 +3372,13 @@ fn materialize_value_attempt(
             let materialized = materialize_record_attempt(&descriptor, record.raw(), inputs);
             match materialized {
                 Ok(raw) => {
+                    let changed = raw.as_slice() != record.raw();
                     *record = crate::records::OwnedRecord::new(raw, descriptor);
-                    Ok(())
+                    Ok(changed)
                 }
                 Err(IvmRuntimeError::EvaluationBlocked) => {
                     *blocked = true;
-                    Ok(())
+                    Ok(false)
                 }
                 Err(error) => Err(error),
             }
@@ -3321,17 +3388,21 @@ fn materialize_value_attempt(
             let descriptor = *enum_value.record().descriptor();
             match materialize_record_attempt(&descriptor, enum_value.record().raw(), inputs) {
                 Ok(raw) => {
+                    let changed = raw.as_slice() != enum_value.record().raw();
                     *enum_value = crate::records::EnumValue::new(
                         tag,
                         crate::records::OwnedRecord::new(raw, descriptor),
                     );
+                    Ok(changed)
                 }
-                Err(IvmRuntimeError::EvaluationBlocked) => *blocked = true,
-                Err(error) => return Err(error),
+                Err(IvmRuntimeError::EvaluationBlocked) => {
+                    *blocked = true;
+                    Ok(false)
+                }
+                Err(error) => Err(error),
             }
-            Ok(())
         }
-        _ => Ok(()),
+        _ => Ok(false),
     }
 }
 
@@ -5572,6 +5643,61 @@ mod tests {
     }
 
     #[test]
+    fn stored_scalar_schema_is_cached_per_declared_kind() {
+        let bytes = stored_scalar_schema(LargeValueKind::Bytes);
+        let string = stored_scalar_schema(LargeValueKind::String);
+        let json = stored_scalar_schema(LargeValueKind::Json);
+
+        assert!(std::ptr::eq(
+            bytes,
+            stored_scalar_schema(LargeValueKind::Bytes)
+        ));
+        assert!(std::ptr::eq(
+            string,
+            stored_scalar_schema(LargeValueKind::String)
+        ));
+        assert!(std::ptr::eq(
+            json,
+            stored_scalar_schema(LargeValueKind::Json)
+        ));
+        assert!(!std::ptr::eq(bytes, string));
+        assert!(!std::ptr::eq(bytes, json));
+        assert!(!std::ptr::eq(string, json));
+    }
+
+    #[test]
+    fn materializing_inline_projected_fields_does_not_reencode_the_current_row() {
+        // Point reads in policy evaluation and projected subscriptions use this
+        // path for each current row. Inline scalar values cannot need chunk
+        // resolution, so rebuilding the surrounding record would only replay
+        // its scalar codec once per historical update.
+        let descriptor = RecordDescriptor::new([
+            ("title", ValueType::String),
+            ("body", ValueType::String),
+            ("revision", ValueType::U64),
+        ]);
+        let raw = descriptor
+            .create(&[
+                Value::String("current title".to_owned()),
+                Value::String("current body".to_owned()),
+                Value::U64(500),
+            ])
+            .unwrap();
+        let mut inputs = EvaluationInputs::default();
+
+        reset_stored_scalar_encode_calls();
+        let materialized =
+            materialize_record_fields_attempt(&descriptor, &raw, &[0], &mut inputs).unwrap();
+
+        assert_eq!(materialized, raw);
+        assert_eq!(
+            stored_scalar_encode_calls(),
+            0,
+            "an already-inline current row must pass through without scalar re-encoding"
+        );
+    }
+
+    #[test]
     fn stored_scalar_is_a_canonical_generic_enum_for_each_declared_kind() {
         for prefix in 0..=u8::MAX {
             let logical = vec![prefix, 1, 2, 3];
@@ -5586,7 +5712,9 @@ mod tests {
             );
             let generic = crate::records::decode_single_field_value(
                 &encoded,
-                &ValueType::Enum(Box::new(stored_scalar_schema(LargeValueKind::Bytes))),
+                &ValueType::Enum(Box::new(
+                    stored_scalar_schema(LargeValueKind::Bytes).clone(),
+                )),
             )
             .unwrap();
             assert!(matches!(generic, Value::Enum(ref value) if value.tag() == 2));
@@ -5683,7 +5811,7 @@ mod tests {
             assert_eq!(decoded, StoredScalar::Chunked(value));
             let generic = crate::records::decode_single_field_value(
                 &encoded,
-                &ValueType::Enum(Box::new(stored_scalar_schema(kind))),
+                &ValueType::Enum(Box::new(stored_scalar_schema(kind).clone())),
             )
             .unwrap();
             assert!(matches!(generic, Value::Enum(ref value) if value.tag() == 3));

--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -14,10 +14,25 @@ use crate::protocol_limits::{
 };
 use crate::schema::{ColumnSchema, MERGE_HEADS_TABLE};
 use groove::records::ValueType;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub(super) const MAX_SCHEMA_LINEAGE_DECLARATIONS: usize = 4096;
 pub(super) const MAX_SCHEMA_LINEAGE_NAME_BYTES: usize = 1024;
 pub(super) const MAX_SCHEMA_LINEAGE_OPS: usize = 16_384;
+
+#[cfg(test)]
+static MERGE_HEAD_REACHABILITY_WALKS: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(super) fn reset_merge_head_reachability_walks_for_test() {
+    MERGE_HEAD_REACHABILITY_WALKS.store(0, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+pub(super) fn merge_head_reachability_walks_for_test() -> usize {
+    MERGE_HEAD_REACHABILITY_WALKS.load(Ordering::Relaxed)
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct CommitUnitParkMode {

--- a/crates/jazz/src/node/ingest/fates.rs
+++ b/crates/jazz/src/node/ingest/fates.rs
@@ -76,6 +76,7 @@ where
         let mut global_current_updates = Vec::new();
         let cleanup_rejected_versions = matches!(stored.fate, Fate::Rejected(_));
         let tx_versions = self.query_versions_for_tx(tx_id).await?;
+        #[cfg(test)]
         let content_versions = tx_versions
             .iter()
             .filter(|version| version.layer() == VersionLayer::Content)
@@ -117,12 +118,15 @@ where
                 stored.view_scoped_cardinality,
             ),
         );
-        if !matches!(stored.fate, Fate::Rejected(_)) {
-            for version in &content_versions {
-                self.update_merge_heads_for_content_version(&mut batch, version, false)
-                    .await?;
-            }
-        }
+        // Pending and accepted content versions both participate in local
+        // merge-head state. Ingest already installed this transaction's
+        // versions while it was pending, so advancing the fate must not replay
+        // reachability maintenance over its history. Besides being redundant,
+        // fate updates can arrive newest-first and turn that replay into a
+        // quadratic walk of one row's causal chain.
+        //
+        // Rejections are handled by `remove_rejected_local_versions`, which
+        // rebuilds the affected derived state after removing the rows.
         if let Some(global_time) = stored.global_time {
             for version in &global_current_updates {
                 self.write_global_current_update(&mut batch, version, global_time)?;

--- a/crates/jazz/src/node/ingest/view_updates.rs
+++ b/crates/jazz/src/node/ingest/view_updates.rs
@@ -757,6 +757,8 @@ where
         start: TxId,
         target: TxId,
     ) -> Result<bool, Error> {
+        #[cfg(test)]
+        MERGE_HEAD_REACHABILITY_WALKS.fetch_add(1, Ordering::Relaxed);
         let mut stack = vec![start];
         let mut seen = BTreeSet::new();
         while let Some(tx_id) = stack.pop() {
@@ -789,6 +791,8 @@ where
         start: TxId,
         target: TxId,
     ) -> Result<bool, Error> {
+        #[cfg(test)]
+        MERGE_HEAD_REACHABILITY_WALKS.fetch_add(1, Ordering::Relaxed);
         let mut stack = vec![start];
         let mut seen = BTreeSet::new();
         while let Some(tx_id) = stack.pop() {

--- a/crates/jazz/src/node/tests/merge_heads.rs
+++ b/crates/jazz/src/node/tests/merge_heads.rs
@@ -162,6 +162,45 @@ fn merge_heads_match_history_for_relay_pending_then_edge_fate() {
 }
 
 #[test]
+fn accepting_pending_history_does_not_rewalk_the_merge_chain() {
+    // A relay installs pending versions into current/merge-head state. Their
+    // later accepted fates do not alter head membership, even when transport
+    // delivers the fates newest-first. Rewalking the chain here made a 500
+    // revision subscription starve unrelated query tests.
+    let schema = two_column_schema();
+    let (_edge_dir, mut edge) = open_node_with_schema(node(0xfb), schema);
+    let row = row(0xfb);
+    let mut versions = Vec::new();
+    let mut parent = None;
+
+    for _ in 0..32 {
+        let mut commit = MergeableCommit::new("todos", row, 10)
+            .cells(BTreeMap::from([("title".to_owned(), "revision".to_owned())]));
+        if let Some(parent) = parent {
+            commit = commit.parents(vec![parent]);
+        }
+        let published = edge.commit_mergeable(commit).unwrap();
+        let tx_id = settle_published(&mut edge, published).unwrap();
+        parent = Some(tx_id);
+        versions.push(tx_id);
+    }
+
+    super::super::ingest::reset_merge_head_reachability_walks_for_test();
+    for tx_id in versions.into_iter().rev() {
+        edge.apply_fate_update(tx_id, Fate::Accepted, None, Some(DurabilityTier::Edge))
+            .unwrap();
+    }
+
+    assert_eq!(
+        super::super::ingest::merge_head_reachability_walks_for_test(),
+        0,
+        "accepting a pending chain must not replay historical reachability"
+    );
+    edge.assert_merge_heads_match_history_for_test("todos", row)
+        .unwrap();
+}
+
+#[test]
 fn merge_heads_match_history_after_parked_unit_resolves() {
     let schema = two_column_schema();
     let (_parent_dir, mut parent_writer) = open_node_with_schema(node(0xb1), schema.clone());


### PR DESCRIPTION
🤖 ## Before

Published writes can place pending row versions into merge-head and current derived state before their final fates arrive. When each later Accepted fate arrived, Jazz replayed merge-head reachability even though Pending and Accepted have identical membership. Fates may arrive newest-first, so accepting older revisions repeatedly walked the newest head's full parent chain: quadratic work in history depth.

Under the CI-shaped query suite, a 500-update subscription exceeded a 90-second focused watchdog and starved an unrelated projected-join subscription past CI's 180-second limit.

Inline projected materialization also cloned scalar schemas and re-encoded records even when it resolved no indirect large value.

## After

- Accepted fate transitions retain the pending merge-head/current membership without replaying reachability. Rejection still rebuilds derived state because it changes membership.
- Inline materialization returns the existing stored record when no indirect large value was resolved, avoiding scalar re-encoding and schema cloning.

No query, fate, merge-head, or history semantics change.

## Verification

- A 32-revision reverse-fate structural receipt observes zero redundant reachability walks and retains the existing history/head oracle.
- Scalar-only materialization observes zero encode calls.
- CI-shaped `jazz-testkit --test query`: 29/29 pass; the collateral projected join completes in about 0.65 seconds and the rapid bulk receipt completes in about 39 seconds under contention.
- Focused merge-head/materialization tests and Clippy pass.

This fixes the base failure exposed while validating #2097.
