### PR TITLE
perf: bound point policy authorization by target row

### DIFF
--- a/crates/jazz/src/node/query_eval/authorization.rs
+++ b/crates/jazz/src/node/query_eval/authorization.rs
@@ -264,6 +264,27 @@ where
         if let Some(graph) = self.query.policy_authorization_graph_cache.get(&cache_key) {
             return Ok(graph.clone());
         }
+        self.policy_authorization_row_id_graph_inner(request, None, true)
+            .await
+    }
+
+    pub(super) async fn point_policy_authorization_row_id_graph(
+        &mut self,
+        request: QueryProgramRequest,
+        access_paths: BTreeMap<SourceId, CurrentAccessPath>,
+    ) -> Result<PolicyAuthorizationGraph, Error> {
+        self.query_engine_read_metrics.policy_authorization_graphs += 1;
+        self.policy_authorization_row_id_graph_inner(request, Some(access_paths), false)
+            .await
+    }
+
+    async fn policy_authorization_row_id_graph_inner(
+        &mut self,
+        request: QueryProgramRequest,
+        forced_access_paths: Option<BTreeMap<SourceId, CurrentAccessPath>>,
+        cache: bool,
+    ) -> Result<PolicyAuthorizationGraph, Error> {
+        let cache_key = policy_authorization_graph_cache_key(&request);
         let proof_table = match &request.policy {
             PolicyContext::AuthorizationSubplan {
                 protected_source, ..
@@ -287,11 +308,24 @@ where
         }
 
         let result = async {
-            let access_paths = self.query_program_access_paths(&request)?;
-            let program = Box::pin(
-                self.compile_query_program_request_with_access_paths(request, access_paths.clone()),
-            )
-            .await?;
+            let access_paths = match forced_access_paths {
+                Some(access_paths) => access_paths,
+                None => self.query_program_access_paths(&request)?,
+            };
+            let program =
+                if cache {
+                    Box::pin(self.compile_query_program_request_with_access_paths(
+                        request,
+                        access_paths.clone(),
+                    ))
+                    .await?
+                } else {
+                    Box::pin(self.compile_query_program_request_with_shared_access_paths(
+                        request,
+                        access_paths.clone(),
+                    ))
+                    .await?
+                };
             let graph = lowered_terminal_graph(&program, "policy.authorized_rows")?;
             let route_fields = program
                 .lowered
@@ -311,9 +345,11 @@ where
                 route_fields,
                 access_paths,
             };
-            self.query
-                .policy_authorization_graph_cache
-                .insert(cache_key, graph.clone());
+            if cache {
+                self.query
+                    .policy_authorization_graph_cache
+                    .insert(cache_key, graph.clone());
+            }
             Ok(graph)
         }
         .await;

--- a/crates/jazz/src/node/query_eval/lowering.rs
+++ b/crates/jazz/src/node/query_eval/lowering.rs
@@ -436,7 +436,39 @@ where
         inline_sources: BTreeMap<SourceId, Vec<CurrentRow>>,
         access_paths: BTreeMap<SourceId, CurrentAccessPath>,
     ) -> Result<QueryProgram, Error> {
-        Box::pin(self.prepare_query_program_policy_dependencies(&request)).await?;
+        self.compile_query_program_request_with_inline_sources_and_access_paths_inner(
+            request,
+            inline_sources,
+            access_paths,
+            true,
+        )
+        .await
+    }
+
+    pub(super) async fn compile_query_program_request_with_shared_access_paths(
+        &mut self,
+        request: QueryProgramRequest,
+        access_paths: BTreeMap<SourceId, CurrentAccessPath>,
+    ) -> Result<QueryProgram, Error> {
+        self.compile_query_program_request_with_inline_sources_and_access_paths_inner(
+            request,
+            BTreeMap::new(),
+            access_paths,
+            false,
+        )
+        .await
+    }
+
+    async fn compile_query_program_request_with_inline_sources_and_access_paths_inner(
+        &mut self,
+        request: QueryProgramRequest,
+        inline_sources: BTreeMap<SourceId, Vec<CurrentRow>>,
+        access_paths: BTreeMap<SourceId, CurrentAccessPath>,
+        count_access_path_metrics: bool,
+    ) -> Result<QueryProgram, Error> {
+        let replaced_policy_graphs =
+            Box::pin(self.prepare_query_program_policy_dependencies(&request, &access_paths))
+                .await?;
         let trace_request = capability_trace_enabled().then(|| request.clone());
         let read_view = request.reads.primary.clone();
         let mut resolver = JazzSourceGraphPreparer {
@@ -444,11 +476,15 @@ where
             read_view: &read_view,
             inline_sources,
             access_paths,
+            count_access_path_metrics,
             current_projection_targets: BTreeMap::new(),
         };
         let node_uuid = resolver.node.node_uuid;
         let node_alias = resolver.node.self_node_alias;
         let result = Box::pin(prepare_and_lower_query_program(request, &mut resolver)).await;
+        resolver
+            .node
+            .restore_policy_authorization_graphs(replaced_policy_graphs);
         if let Some(request) = trace_request {
             trace_capability_compile(
                 node_uuid,
@@ -463,7 +499,8 @@ where
     async fn prepare_query_program_policy_dependencies(
         &mut self,
         request: &QueryProgramRequest,
-    ) -> Result<(), Error> {
+        outer_access_paths: &BTreeMap<SourceId, CurrentAccessPath>,
+    ) -> Result<BTreeMap<String, Option<PolicyAuthorizationGraph>>, Error> {
         let source_requests = query_program_source_requests(request)
             .map_err(|report| Error::QueryCapability(format!("{report:?}")))?;
         let read_view = request.reads.primary.clone();
@@ -473,6 +510,7 @@ where
                 read_view: &read_view,
                 inline_sources: BTreeMap::new(),
                 access_paths: BTreeMap::new(),
+                count_access_path_metrics: true,
                 current_projection_targets: BTreeMap::new(),
             };
             source_requests
@@ -492,26 +530,108 @@ where
                 )
             })
             .collect::<BTreeMap<_, _>>();
+        let mut replaced = BTreeMap::new();
         for (cache_key, dependency) in dependencies {
-            match Box::pin(self.policy_authorization_row_id_graph(dependency)).await {
-                Ok(_) => {}
-                Err(Error::QueryCapability(error)) if error.contains("PolicyProofCycle") => {
-                    return Err(Error::QueryCapability(error));
+            let point_path = match &dependency.policy {
+                PolicyContext::AuthorizationSubplan {
+                    protected_source, ..
+                } => outer_access_paths
+                    .get(protected_source)
+                    .cloned()
+                    .map(|path| BTreeMap::from([(protected_source.clone(), path)])),
+                _ => None,
+            };
+            if let Some(access_paths) = point_path {
+                let previous = self
+                    .query
+                    .policy_authorization_graph_cache
+                    .remove(&cache_key);
+                match Box::pin(
+                    self.point_policy_authorization_row_id_graph(dependency, access_paths),
+                )
+                .await
+                {
+                    Ok(graph) => {
+                        self.query
+                            .policy_authorization_graph_cache
+                            .insert(cache_key.clone(), graph);
+                        replaced.insert(cache_key, previous);
+                    }
+                    Err(Error::QueryCapability(error)) if error.contains("PolicyProofCycle") => {
+                        self.restore_policy_authorization_graphs(replaced);
+                        if let Some(previous) = previous {
+                            self.query
+                                .policy_authorization_graph_cache
+                                .insert(cache_key, previous);
+                        }
+                        return Err(Error::QueryCapability(error));
+                    }
+                    Err(Error::QueryCapability(_)) => {
+                        self.query.policy_authorization_graph_cache.insert(
+                            cache_key.clone(),
+                            PolicyAuthorizationGraph {
+                                graph: empty_authorized_row_id_graph(),
+                                route_fields: BTreeSet::new(),
+                                access_paths: BTreeMap::new(),
+                            },
+                        );
+                        replaced.insert(cache_key, previous);
+                    }
+                    Err(error) => {
+                        self.restore_policy_authorization_graphs(replaced);
+                        if let Some(previous) = previous {
+                            self.query
+                                .policy_authorization_graph_cache
+                                .insert(cache_key, previous);
+                        }
+                        return Err(error);
+                    }
                 }
-                Err(Error::QueryCapability(_)) => {
-                    self.query.policy_authorization_graph_cache.insert(
-                        cache_key,
-                        PolicyAuthorizationGraph {
-                            graph: empty_authorized_row_id_graph(),
-                            route_fields: BTreeSet::new(),
-                            access_paths: BTreeMap::new(),
-                        },
-                    );
+            } else {
+                match Box::pin(self.policy_authorization_row_id_graph(dependency)).await {
+                    Ok(_) => {}
+                    Err(Error::QueryCapability(error)) if error.contains("PolicyProofCycle") => {
+                        self.restore_policy_authorization_graphs(replaced);
+                        return Err(Error::QueryCapability(error));
+                    }
+                    Err(Error::QueryCapability(_)) => {
+                        self.query.policy_authorization_graph_cache.insert(
+                            cache_key,
+                            PolicyAuthorizationGraph {
+                                graph: empty_authorized_row_id_graph(),
+                                route_fields: BTreeSet::new(),
+                                access_paths: BTreeMap::new(),
+                            },
+                        );
+                    }
+                    Err(error) => {
+                        self.restore_policy_authorization_graphs(replaced);
+                        return Err(error);
+                    }
                 }
-                Err(error) => return Err(error),
             }
         }
-        Ok(())
+        Ok(replaced)
+    }
+
+    fn restore_policy_authorization_graphs(
+        &mut self,
+        replaced: BTreeMap<String, Option<PolicyAuthorizationGraph>>,
+    ) {
+        for (cache_key, previous) in replaced {
+            match previous {
+                Some(graph) => {
+                    self.query
+                        .policy_authorization_graph_cache
+                        .insert(cache_key, graph);
+                }
+                None => {
+                    self.query
+                        .policy_authorization_graph_cache
+                        .remove(&cache_key);
+                }
+            }
+        }
     }
 
     pub(super) async fn prepared_query_plan_from_program(

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -12,6 +12,11 @@ pub(super) struct JazzSourceGraphPreparer<'a, S> {
     pub(super) read_view: &'a ReadView<RequestedSourceStage>,
     pub(super) inline_sources: BTreeMap<SourceId, Vec<CurrentRow>>,
     pub(super) access_paths: BTreeMap<SourceId, CurrentAccessPath>,
+    /// Whether access-path metrics should account for this logical graph
+    /// fragment. A policy proof specialized from its outer source reuses the
+    /// same deduplicated physical source node, so only the outer fragment owns
+    /// that source-plan receipt.
+    pub(super) count_access_path_metrics: bool,
     /// Query-local enum boundary targets, keyed by logical source.  Defining
     /// a variant target invalidates table inputs, so reuse it across the main
     /// source, access path, and metadata sidecars of one compiled program.
@@ -1366,7 +1371,9 @@ where
     ) -> Result<Option<GraphBuilder>, SourceResolutionError> {
         match access_path {
             CurrentAccessPath::PrimaryKey(prefix) => {
-                self.node.query_engine_read_metrics.source_primary_key_scans += 1;
+                if self.count_access_path_metrics {
+                    self.node.query_engine_read_metrics.source_primary_key_scans += 1;
+                }
                 Ok(Some(selected_visible_current_primary_key_graph(
                     table, tier, prefix,
                 )))
@@ -1665,7 +1672,9 @@ where
             let projection_target = self.current_projection_target(request, read_table)?;
             let content = match self.access_paths.get(&request.source).cloned() {
                 Some(CurrentAccessPath::PrimaryKey(prefix)) => {
-                    self.node.query_engine_read_metrics.source_primary_key_scans += 1;
+                    if self.count_access_path_metrics {
+                        self.node.query_engine_read_metrics.source_primary_key_scans += 1;
+                    }
                     self.node
                         .physical_current_source_scan_graph_with_projection_target(
                             self.read_view.read_schema,
@@ -1758,7 +1767,9 @@ where
         let access_path = self.access_paths.get(&request.source).cloned();
         let global = match &access_path {
             Some(CurrentAccessPath::PrimaryKey(prefix)) => {
-                self.node.query_engine_read_metrics.source_primary_key_scans += 1;
+                if self.count_access_path_metrics {
+                    self.node.query_engine_read_metrics.source_primary_key_scans += 1;
+                }
                 self.node
                     .physical_current_source_scan_graph_with_projection_target(
                         self.read_view.read_schema,

--- a/crates/jazz/src/node/query_eval/tests/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/tests/read_sources.rs
@@ -145,6 +145,7 @@ fn reverse_table_lens_projects_membership_and_content_version_sources() {
         read_view: &read_view,
         inline_sources: BTreeMap::new(),
         access_paths: BTreeMap::new(),
+        count_access_path_metrics: true,
         current_projection_targets: BTreeMap::new(),
     };
 

--- a/crates/jazz/src/node/tests/policies_rls/includes.rs
+++ b/crates/jazz/src/node/tests/policies_rls/includes.rs
@@ -107,6 +107,19 @@ fn point_read_authorization_keeps_using_physical_row_uuid_with_declared_id() {
         .unwrap();
     core.accept_global_for_test(tx.0).unwrap();
 
+    let generic = Query::from("documents")
+        .validate(&core.catalogue.schema)
+        .unwrap();
+    let generic_binding = generic.bind(BTreeMap::new()).unwrap();
+    core.query_rows_for_link(&generic, &generic_binding, DurabilityTier::Global, alice)
+        .unwrap();
+    let cached_policy_graphs = core
+        .query
+        .policy_authorization_graph_cache
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
     core.reset_query_engine_read_metrics();
     assert!(
         core.dry_run_read_current_allows("documents", physical_row, alice)
@@ -116,6 +129,15 @@ fn point_read_authorization_keeps_using_physical_row_uuid_with_declared_id() {
         core.query_engine_read_metrics().source_primary_key_scans,
         1,
         "the authorization probe must point-scan the physical row"
+    );
+    assert_eq!(
+        core.query
+            .policy_authorization_graph_cache
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        cached_policy_graphs,
+        "point authorization must preserve the reusable generic policy graph"
     );
     assert!(
         core.dry_run_write_current_allows("documents", physical_row, alice)

--- a/crates/jazz/src/node/tests/policies_rls/includes.rs
+++ b/crates/jazz/src/node/tests/policies_rls/includes.rs
@@ -75,6 +75,7 @@ fn parent_ref_join_matches_a_declared_id_column_instead_of_the_physical_row_uuid
 #[test]
 fn point_read_authorization_keeps_using_physical_row_uuid_with_declared_id() {
     let alice = user(0xa1);
+    let bob = user(0xa2);
     let schema = build_public_test_schema(PublicSchemaBuilder::new().table(
         PublicTableSchemaBuilder::new("documents")
             .column("id", PublicColumnType::Uuid)
@@ -95,7 +96,12 @@ fn point_read_authorization_keeps_using_physical_row_uuid_with_declared_id() {
         alice,
         BTreeMap::from([("sub".to_owned(), Value::Uuid(alice.test_uuid()))]),
     );
+    core.set_session_claims(
+        bob,
+        BTreeMap::from([("sub".to_owned(), Value::Uuid(bob.test_uuid()))]),
+    );
     let physical_row = row(0xc1);
+    let other_physical_row = row(0xc2);
     let declared_id = row(0xd1);
     let tx = core
         .commit_mergeable_unit_settled(
@@ -106,13 +112,29 @@ fn point_read_authorization_keeps_using_physical_row_uuid_with_declared_id() {
         )
         .unwrap();
     core.accept_global_for_test(tx.0).unwrap();
+    let other_tx = core
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("documents", other_physical_row, 11).cells(BTreeMap::from([
+                ("id".to_owned(), Value::Uuid(row(0xd2).0)),
+                ("owner".to_owned(), Value::Uuid(alice.test_uuid())),
+            ])),
+        )
+        .unwrap();
+    core.accept_global_for_test(other_tx.0).unwrap();
 
     let generic = Query::from("documents")
         .validate(&core.catalogue.schema)
         .unwrap();
     let generic_binding = generic.bind(BTreeMap::new()).unwrap();
-    core.query_rows_for_link(&generic, &generic_binding, DurabilityTier::Global, alice)
-        .unwrap();
+    assert_eq!(
+        core.query_rows_for_link(&generic, &generic_binding, DurabilityTier::Global, alice)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([physical_row, other_physical_row]),
+        "the generic policy graph must initially authorize both of Alice's documents"
+    );
     let cached_policy_graphs = core
         .query
         .policy_authorization_graph_cache
@@ -142,6 +164,92 @@ fn point_read_authorization_keeps_using_physical_row_uuid_with_declared_id() {
     assert!(
         core.dry_run_write_current_allows("documents", physical_row, alice)
             .unwrap()
+    );
+    assert!(
+        !core
+            .dry_run_read_current_allows("documents", physical_row, bob)
+            .unwrap(),
+        "a point-specialized policy proof must retain its session scope"
+    );
+    assert_eq!(
+        core.query
+            .policy_authorization_graph_cache
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
+        cached_policy_graphs,
+        "a denied point proof must not retain another identity's specialization"
+    );
+    assert_eq!(
+        core.query_rows_for_link(&generic, &generic_binding, DurabilityTier::Global, alice)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([physical_row, other_physical_row]),
+        "a generic query after a point proof must not inherit that point's bound"
+    );
+
+    let ownership_change = core
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("documents", physical_row, 20)
+                .cells(BTreeMap::from([("owner".to_owned(), Value::Uuid(bob.test_uuid()))])),
+        )
+        .unwrap();
+    core.accept_global_for_test(ownership_change.0).unwrap();
+    assert!(
+        !core
+            .dry_run_read_current_allows("documents", physical_row, alice)
+            .unwrap(),
+        "policy-dependency changes must revoke the former owner's point access"
+    );
+    assert!(
+        core.dry_run_read_current_allows("documents", physical_row, bob)
+            .unwrap(),
+        "policy-dependency changes must grant the new owner's point access"
+    );
+    assert_eq!(
+        core.query_rows_for_link(&generic, &generic_binding, DurabilityTier::Global, bob)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([physical_row]),
+        "a generic query after a point proof must use its generic policy graph"
+    );
+    assert_eq!(
+        core.query_rows_for_link(&generic, &generic_binding, DurabilityTier::Global, alice)
+            .unwrap()
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([other_physical_row]),
+        "the former owner keeps only the separately authorized generic result"
+    );
+
+    let deletion = core
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("documents", physical_row, 30).deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    core.accept_global_for_test(deletion.0).unwrap();
+    assert!(
+        !core
+            .dry_run_read_current_allows("documents", physical_row, bob)
+            .unwrap(),
+        "a deleted target must be a point-authorization miss"
+    );
+    let restoration = core
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("documents", physical_row, 40)
+                .deletion(DeletionEvent::Restored),
+        )
+        .unwrap();
+    core.accept_global_for_test(restoration.0).unwrap();
+    assert!(
+        core.dry_run_read_current_allows("documents", physical_row, bob)
+            .unwrap(),
+        "restoring the target must restore point authorization from current policy evidence"
     );
 }
 


### PR DESCRIPTION
Closes #2069.

Stacked on #2115; review only `c4492849d` for this thesis.

## Before

A trusted point operation could select its target row through a physical primary-key path, then compile the row-policy authorization dependency as a generic reusable graph. The generic proof scanned the protected table, so a fixed-row update grew from 16.5 ms at 900 rows to 150.3 ms at 9,000 rows.

## After

When the outer query has a concrete protected-source access path, policy dependency preparation builds a query-local specialization with the same access path. The compiled graph retains that specialization, while the node's generic policy graph cache is restored immediately for later unbounded queries and subscriptions.

W1-derived memory walltime median:

| activity rows | before | after |
|---:|---:|---:|
| 900 | 16.53 ms | 4.85 ms |
| 9,000 | 150.3 ms | 5.95 ms |

The 9k case is ~25x faster and 10x state now costs ~1.23x.

## Invariants

- Authorization still evaluates the complete row policy; only candidate sourcing changes.
- Physical row UUID remains authoritative even when a user-declared `id` column differs.
- The outer point query and specialized proof share the deduplicated physical source-plan receipt.
- Query-local specialization never replaces or poisons the reusable generic policy graph cache.
- Policy proof cycles and capability failures preserve the prior fail-closed behavior.

## Worked cases

Normal: updating one policy-protected activity row at 9k table depth point-selects that row for both the serving operation and its authorization proof, then evaluates the unchanged predicate.

Declared-id edge: a row whose public `id` differs from its physical UUID is still authorized by the physical UUID lookup.

Reuse edge: after a generic policy graph is cached, a point authorization compiles its specialization and restores the exact generic cache keys for subsequent subscriptions.

## Non-goals

- This does not fix cold maintained point-subscription hydration. W1 controls are 137 ms→1.077 s without policy and 136 ms→1.074 s with policy; #2119 tracks the table-proportional bootstrap separately.
- It does not add new policy planner inference through unions, joins, or recursive proofs.

## Receipts

- `point_read_authorization_keeps_using_physical_row_uuid_with_declared_id`
- all three `incremental_delivery_canary` tests
- `cargo check -p jazz`
- `cargo clippy -p jazz --lib -- -D warnings`
- rustfmt, diff check, and sensitive-data hook
