### PR TITLE
perf: bound cold maintained physical point hydration

### DIFF
--- a/crates/jazz/src/db/tests/subscriptions/authorization.rs
+++ b/crates/jazz/src/db/tests/subscriptions/authorization.rs
@@ -3,6 +3,130 @@
 use super::*;
 
 #[test]
+fn maintained_physical_point_subscriptions_keep_policy_scopes_live() {
+    let schema = owner_read_schema();
+    let db = open_db(0xa0, AuthorSubject::SYSTEM, &schema);
+    let alice = AuthorSubject::for_test_bytes([0xa1; 16]);
+    let bob = AuthorSubject::for_test_bytes([0xb2; 16]);
+    for identity in [alice, bob] {
+        db.node
+            .node
+            .borrow_mut()
+            .set_session_claims(identity, test_provider_claims(identity));
+    }
+
+    let target = row(0x71);
+    let other = row(0x72);
+    for (row_id, title, owner) in [(target, "target", alice), (other, "other", bob)] {
+        db.insert(
+            "todos",
+            cells(title, false, owner),
+            crate::db::InsertOptions {
+                row_id: Some(row_id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let target_query = db
+        .prepare_query(&Query::from("todos").filter(eq(col("id"), lit(Value::Uuid(target.0)))))
+        .unwrap();
+    let other_query = db
+        .prepare_query(&Query::from("todos").filter(eq(col("id"), lit(Value::Uuid(other.0)))))
+        .unwrap();
+    let opts = ReadOpts::default();
+    let mut alice_target =
+        block_on(db.subscribe_for_identity(&target_query, opts.clone(), alice)).unwrap();
+    assert_eq!(
+        row_ids(&opened_rows(block_on(alice_target.next_raw()).unwrap())),
+        vec![target],
+        "the target's owner receives the maintained physical-point seed"
+    );
+    let mut bob_target =
+        block_on(db.subscribe_for_identity(&target_query, opts.clone(), bob)).unwrap();
+    assert!(
+        opened_rows(block_on(bob_target.next_raw()).unwrap()).is_empty(),
+        "a second identity must not inherit the first identity's point-policy result"
+    );
+    let mut bob_other = block_on(db.subscribe_for_identity(&other_query, opts, bob)).unwrap();
+    assert_eq!(
+        row_ids(&opened_rows(block_on(bob_other.next_raw()).unwrap())),
+        vec![other],
+        "independent point subscriptions retain their own physical target"
+    );
+
+    db.update(
+        "todos",
+        other,
+        BTreeMap::from([(
+            "title".to_owned(),
+            Value::String("other changed".to_owned()),
+        )]),
+        Default::default(),
+    )
+    .unwrap();
+    assert!(alice_target.try_next_event().is_none());
+    assert!(bob_target.try_next_event().is_none());
+    let (_, updated, removed) = delta_rows(block_on(bob_other.next_raw()).unwrap());
+    assert!(updated.iter().any(|row| row.row_uuid() == other));
+    assert!(removed.is_empty());
+
+    db.update(
+        "todos",
+        target,
+        BTreeMap::from([(
+            "title".to_owned(),
+            Value::String("target changed".to_owned()),
+        )]),
+        Default::default(),
+    )
+    .unwrap();
+    assert!(bob_target.try_next_event().is_none());
+    let (_, updated, removed) = delta_rows(block_on(alice_target.next_raw()).unwrap());
+    assert!(updated.iter().any(|row| row.row_uuid() == target));
+    assert!(removed.is_empty());
+
+    db.update(
+        "todos",
+        target,
+        BTreeMap::from([("owner".to_owned(), Value::Uuid(bob.test_uuid()))]),
+        Default::default(),
+    )
+    .unwrap();
+    let (_, updated, removed) = delta_rows(block_on(alice_target.next_raw()).unwrap());
+    assert!(updated.is_empty());
+    assert_eq!(
+        removed.iter().map(|row| row.row_uuid).collect::<Vec<_>>(),
+        vec![target]
+    );
+    let (added, updated, removed) = delta_rows(block_on(bob_target.next_raw()).unwrap());
+    assert_eq!(row_ids(&added), vec![target]);
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
+
+    db.delete("todos", target, Default::default()).unwrap();
+    let (_, updated, removed) = delta_rows(block_on(bob_target.next_raw()).unwrap());
+    assert!(updated.is_empty());
+    assert_eq!(
+        removed.iter().map(|row| row.row_uuid).collect::<Vec<_>>(),
+        vec![target]
+    );
+
+    db.restore(
+        "todos",
+        target,
+        Some(cells("target restored", false, bob)),
+        Default::default(),
+    )
+    .unwrap();
+    let (added, updated, removed) = delta_rows(block_on(bob_target.next_raw()).unwrap());
+    assert_eq!(row_ids(&added), vec![target]);
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
+}
+
+#[test]
 fn maintained_subscription_emits_created_by_scoped_insert_after_empty_seed() {
     let schema = created_by_read_schema();
     let alice = AuthorSubject::for_test_bytes([0xa1; 16]);

--- a/crates/jazz/src/db/tests/subscriptions/materialization.rs
+++ b/crates/jazz/src/db/tests/subscriptions/materialization.rs
@@ -3,6 +3,57 @@
 use super::*;
 
 #[test]
+fn maintained_physical_point_subscription_stays_live_for_only_its_row() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xc1; 16]);
+    let db = open_db(0xc1, author, &schema);
+    let target = row(0x71);
+    let other = row(0x72);
+    for (row_id, title) in [(target, "target"), (other, "other")] {
+        db.insert(
+            "todos",
+            cells(title, false, author),
+            crate::db::InsertOptions {
+                row_id: Some(row_id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let query = Query::from("todos").filter(eq(col("id"), lit(Value::Uuid(target.0))));
+    let mut subscription = prepared_subscribe(&db, &query, ReadOpts::default()).unwrap();
+    let SubscriptionEvent::Delta { added, .. } = block_on(subscription.next_raw()).unwrap() else {
+        panic!("expected opening point-subscription delta");
+    };
+    assert_eq!(added.len(), 1);
+    assert_eq!(added[0].row_uuid(), target);
+
+    db.update(
+        "todos",
+        other,
+        BTreeMap::from([("title".to_owned(), Value::String("unrelated".to_owned()))]),
+        Default::default(),
+    )
+    .unwrap();
+    assert!(subscription.try_next_event().is_none());
+
+    db.update(
+        "todos",
+        target,
+        BTreeMap::from([("title".to_owned(), Value::String("changed".to_owned()))]),
+        Default::default(),
+    )
+    .unwrap();
+    let SubscriptionEvent::Delta { updated, .. } = block_on(subscription.next_raw()).unwrap()
+    else {
+        panic!("expected target-row point-subscription delta");
+    };
+    assert_eq!(updated.len(), 1);
+    assert_eq!(updated[0].row_uuid(), target);
+}
+
+#[test]
 fn server_reset_subscription_materializes_without_local_snapshot_eval() {
     let schema = schema();
     let owner = AuthorSubject::for_test_bytes([0xa1; 16]);

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -422,9 +422,11 @@ where
             settled_binding_view,
             authorization_mode,
         )?;
-        // One-shot reads are the only compilation mode allowed to attach a
-        // physical source cap. Prepared/maintained and policy programs keep
-        // their ordinary unbounded access paths.
+        // One-shot reads can use every eligible access path. Maintained reads
+        // deliberately retain their ordinary source except for the separately
+        // proved physical primary-key path: secondary indexes can settle at a
+        // frontier distinct from their maintained source, while one immutable
+        // physical row has no such independent frontier.
         let access_paths = self.one_shot_access_paths(shape, binding, tier)?;
         self.compile_query_program_request_with_access_paths(request, access_paths)
             .await

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -394,11 +394,13 @@ where
             prepared_claim_binding_mode,
             false,
         )?;
-        // Maintained/prepared programs must retain their established source
-        // graph. Physical source bounds are a one-shot-only optimization: even
-        // an otherwise unbounded optimized index source can settle against a
-        // different persisted frontier than the maintained full source.
-        self.compile_query_program_request(request).await
+        // Maintained index scans retain their established full source because
+        // an index can settle against a different persisted frontier. A
+        // physical primary-key source has no independent index frontier and
+        // remains incrementally complete for that one immutable row identity.
+        let access_paths = self.current_query_primary_key_access_paths(shape, binding)?;
+        self.compile_query_program_request_with_access_paths(request, access_paths)
+            .await
     }
 
     async fn compile_current_query_program_for_one_shot_read(

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -2,6 +2,102 @@
 
 use super::*;
 
+fn graph_contains_point_scan(graph: &GraphBuilder) -> bool {
+    match graph {
+        GraphBuilder::Table {
+            scan: Some(groove::ivm::StaticScanSpec::Point(_)),
+            ..
+        } => true,
+        GraphBuilder::Recursive { seed, step, .. } => {
+            graph_contains_point_scan(seed) || graph_contains_point_scan(step)
+        }
+        GraphBuilder::Filter { input, .. }
+        | GraphBuilder::UnwrapNullable { input, .. }
+        | GraphBuilder::Unnest { input, .. }
+        | GraphBuilder::VariantProject { input, .. }
+        | GraphBuilder::Project { input, .. }
+        | GraphBuilder::StreamingChecksum { input, .. }
+        | GraphBuilder::ArgMaxBy { input, .. }
+        | GraphBuilder::ArgMinBy { input, .. }
+        | GraphBuilder::TopBy { input, .. }
+        | GraphBuilder::CollectBy { input, .. }
+        | GraphBuilder::Aggregate { input, .. } => graph_contains_point_scan(input),
+        GraphBuilder::Union { inputs } => inputs.iter().any(graph_contains_point_scan),
+        GraphBuilder::Join { left, right, .. }
+        | GraphBuilder::SemiJoin { left, right, .. }
+        | GraphBuilder::AntiJoin { left, right, .. } => {
+            graph_contains_point_scan(left) || graph_contains_point_scan(right)
+        }
+        GraphBuilder::Table { .. }
+        | GraphBuilder::InlineRecords { .. }
+        | GraphBuilder::Index { .. }
+        | GraphBuilder::FrontierSource { .. }
+        | GraphBuilder::BindingSource { .. } => false,
+    }
+}
+
+#[test]
+fn maintained_physical_point_hydration_uses_only_its_current_row_source() {
+    let (_dir, mut node) = open_node();
+    let alice = author(1);
+    let target = row(0);
+    commit_global_issue(&mut node, 0, "open", alice, 1);
+    commit_global_issue(&mut node, 1, "open", alice, 2);
+
+    let shape = Query::from("issues")
+        .filter(eq(col("id"), lit(Value::Uuid(target.0))))
+        .validate(&node.catalogue.schema)
+        .unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let program = node
+        .compile_current_query_program_for_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            AuthorSubject::SYSTEM,
+            CurrentQueryProgramOutput::MaintainedView,
+            &ReadViewSpec::default(),
+        )
+        .expect("compile maintained physical-point program");
+    assert!(
+        program
+            .lowered
+            .terminals
+            .iter()
+            .any(|terminal| graph_contains_point_scan(&terminal.graph)),
+        "a maintained physical-point program must retain an exact physical source cap"
+    );
+    let (receiver, maintained, _schemas, transitions, _tables, _incomplete) = node
+        .open_seeded_maintained_subscription_view(
+            &shape,
+            &binding,
+            AuthorSubject::SYSTEM,
+            DurabilityTier::Global,
+            &ReadViewSpec::default(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        maintained
+            .active_result_members()
+            .iter()
+            .filter_map(crate::protocol::ResultMemberEntry::as_row)
+            .map(|(_, row, _)| row)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([target])
+    );
+    assert_eq!(
+        transitions
+            .adds
+            .iter()
+            .filter_map(crate::protocol::ResultMemberEntry::as_row)
+            .map(|(_, row, _)| row)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([target])
+    );
+    node.unsubscribe_groove_subscription(receiver.id());
+}
+
 #[test]
 fn query_subscription_result_sets_track_bindings_and_rehydrate() {
     let (_server_dir, mut server) = open_node();

--- a/examples/benchmarks/w1/benches/reads_memory_walltime.rs
+++ b/examples/benchmarks/w1/benches/reads_memory_walltime.rs
@@ -61,6 +61,26 @@ fn update_activity_policy_scaling_memory(bencher: divan::Bencher<'_, '_>, activi
     bencher.bench_local(|| fixture.toggle_activity_indexed_predicate());
 }
 
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn subscribe_activity_point_scaling_memory(
+    bencher: divan::Bencher<'_, '_>,
+    activity_events: usize,
+) {
+    bencher
+        .with_inputs(|| Fixture::<MemoryStorage>::memory(300, 1_200, activity_events))
+        .bench_local_values(|fixture| fixture.subscribe_point_activity_once());
+}
+
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn subscribe_activity_policy_point_scaling_memory(
+    bencher: divan::Bencher<'_, '_>,
+    activity_events: usize,
+) {
+    bencher
+        .with_inputs(|| Fixture::<MemoryStorage>::memory_policy_update(300, 1_200, activity_events))
+        .bench_local_values(|fixture| fixture.subscribe_point_activity_once());
+}
+
 /// Fixed-result scaling receipt exposing query-engine candidate hydration.
 #[divan::bench(args = [(300, 1_200, 900), (3_000, 12_000, 9_000)], sample_count = 5)]
 fn query_comments_scaling_memory(

--- a/examples/benchmarks/w1/benches/reads_memory_walltime.rs
+++ b/examples/benchmarks/w1/benches/reads_memory_walltime.rs
@@ -81,6 +81,13 @@ fn subscribe_activity_policy_point_scaling_memory(
         .bench_local_values(|fixture| fixture.subscribe_point_activity_once());
 }
 
+#[divan::bench(sample_count = 5)]
+fn resubscribe_activity_point_profile_s_memory(bencher: divan::Bencher<'_, '_>) {
+    let fixture = Fixture::<MemoryStorage>::memory(300, 1_200, 9_000);
+    assert_eq!(fixture.subscribe_point_activity_once(), 1);
+    bencher.bench_local(|| fixture.subscribe_point_activity_once());
+}
+
 /// Fixed-result scaling receipt exposing query-engine candidate hydration.
 #[divan::bench(args = [(300, 1_200, 900), (3_000, 12_000, 9_000)], sample_count = 5)]
 fn query_comments_scaling_memory(

--- a/examples/benchmarks/w1/src/lib.rs
+++ b/examples/benchmarks/w1/src/lib.rs
@@ -36,6 +36,7 @@ pub struct Fixture<S: OrderedKvStorage> {
     activity: PreparedQuery,
     bounded_activity_page: PreparedQuery,
     maintained_activity: PreparedQuery,
+    point_activity: PreparedQuery,
     activity_transition_row: RowUuid,
     activity_transition_matching: bool,
     activity_update_identity: WriteIdentity,
@@ -249,6 +250,13 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
                     .filter(eq(col("kind"), lit("updated"))),
             )
             .expect("prepare W1 maintained two-equality activity query");
+        let point_activity = db
+            .prepare_query(
+                &Query::from("activity")
+                    .filter(eq(col("id"), lit(row_id(4, 0).0)))
+                    .limit(1),
+            )
+            .expect("prepare W1 point activity query");
         let fixture = Self {
             db,
             board,
@@ -256,6 +264,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
             activity: activity_query,
             bounded_activity_page,
             maintained_activity,
+            point_activity,
             activity_transition_row: row_id(4, PROJECTS),
             activity_transition_matching: false,
             activity_update_identity,
@@ -310,6 +319,24 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
         };
         while fixture.subscription.try_next_event().is_some() {}
         fixture
+    }
+
+    pub fn subscribe_point_activity_once(self) -> usize {
+        let mut subscription = block_on(self.db.subscribe(
+            &self.point_activity,
+            ReadOpts {
+                tier: DurabilityTier::Local,
+                local_updates: LocalUpdates::Deferred,
+                propagation: Propagation::LocalOnly,
+                ..ReadOpts::default()
+            },
+        ))
+        .expect("install W1 maintained point subscription");
+        let mut rows = 0;
+        while let Some(event) = subscription.try_next_event() {
+            rows += event_row_count(event);
+        }
+        rows
     }
 
     fn read_count(&self, query: &PreparedQuery) -> usize {

--- a/examples/benchmarks/w1/src/lib.rs
+++ b/examples/benchmarks/w1/src/lib.rs
@@ -321,7 +321,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
         fixture
     }
 
-    pub fn subscribe_point_activity_once(self) -> usize {
+    pub fn subscribe_point_activity_once(&self) -> usize {
         let mut subscription = block_on(self.db.subscribe(
             &self.point_activity,
             ReadOpts {


### PR DESCRIPTION
Closes #2119.

Stacked on #2120; review the two commits `81cadff0b` and `af043031f` for this thesis.

## Before

Maintained/prepared queries deliberately retained unbounded sources because secondary-index state can settle at a different persisted frontier from the underlying current-row table. That rule also covered physical primary-key equality, even though a physical row identity has no independent index frontier. A one-row cold subscription therefore hydrated table-proportional state.

W1-derived memory walltime:

| activity rows | no policy | row policy |
|---:|---:|---:|
| 900 | 137 ms | 136 ms |
| 9,000 | 1.077 s | 1.074 s |

## After

Maintained compilation selects an access path only through `current_query_primary_key_access_paths`. Secondary indexes, intersections, ranges, and source limits remain on the established full maintained source. A physical point source stays live for updates to that immutable row identity.

| activity rows | no policy | row policy |
|---:|---:|---:|
| 900 | 46.4 ms | 48.3 ms |
| 9,000 | 62.2 ms | 64.8 ms |

At 9k this is ~17x faster; 10x state now costs 1.34x rather than 7.9x. Reopening the same prepared point subscription is 41.4/45.7 ms at 900/9k (1.10x), showing the residual is predominantly fixed per-subscriber work.

## Invariants and worked cases

- Normal: subscribing to `activity where id = target` hydrates only the target and continues to deliver updates to it.
- Unrelated update: changing another activity row emits no point-subscription event.
- Target update: changing the target emits exactly one updated row.
- Policy case: the query-local point policy proof from #2120 remains bounded and does not replace the reusable generic policy cache.
- Declared-id edge: tables declaring user data named `id` do not receive the physical-PK optimization.
- Indexed query edge: maintained secondary-index queries retain the full source because index/data frontier equivalence is not proved.

## Non-goals

This does not optimize bounded secondary-index subscriptions, ordered windows, relations, or includes. Those require separate incremental/frontier proofs. It also does not claim the remaining ~42-46 ms repeated-subscribe fixed cost is optimal.

## Receipts

- public `Db` test `maintained_physical_point_subscription_stays_live_for_only_its_row`
- all three `incremental_delivery_canary` tests
- W1 cold and repeated point-subscription benchmarks
- W1 benchmark compile
- clippy for `jazz` and the W1 benchmark crate
- rustfmt, diff check, sensitive-data hook
