### PR TITLE
perf(jazz): scope parent validation by table

### DIFF
--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -542,6 +542,78 @@ where
         Ok(versions)
     }
 
+    /// Return the versions authored by one transaction for one logical table.
+    ///
+    /// Unlike [`Self::query_versions_for_tx`], this deliberately visits only
+    /// the requested table's physical history sources. It still uses the
+    /// transaction index rather than a branch-local primary key so callers
+    /// validating a causal parent can observe versions from every branch.
+    pub(super) async fn query_versions_for_tx_table(
+        &mut self,
+        tx_id: TxId,
+        schema_version: SchemaVersionId,
+        table: &str,
+    ) -> Result<Vec<VersionRow>, Error> {
+        let requested_table_id = self.physical_table_id_for_schema(schema_version, table)?;
+        if let Some(cached) = self.query.tx_versions_cache.get(&tx_id) {
+            let table_aliases = self
+                .catalogue
+                .physical_mappings
+                .iter()
+                .flat_map(|(schema_version, mapping)| {
+                    let schema_alias = self.catalogue.schema_version_aliases.get(schema_version);
+                    mapping.tables.iter().filter_map(move |(table, mapping)| {
+                        (mapping.table_id == requested_table_id)
+                            .then(|| schema_alias.copied().map(|alias| (alias, table.clone())))
+                            .flatten()
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut versions = Vec::new();
+            for version in cached {
+                if table_aliases.iter().any(|(schema_alias, table)| {
+                    table == version.table() && *schema_alias == version.schema_version_alias()
+                }) {
+                    versions.push(version.clone());
+                }
+            }
+            return Ok(versions);
+        }
+        let Some(tx) = self.query_transaction(tx_id).await? else {
+            return Ok(Vec::new());
+        };
+        let mut versions = Vec::new();
+        for storage_table in [
+            physical_history_table_name(requested_table_id),
+            SHARED_DELETION_HISTORY_TABLE.to_owned(),
+        ] {
+            let raws = self
+                .database
+                .index_scan_raw(
+                    &storage_table,
+                    "by_tx",
+                    &[Value::U64(tx_id.time.0), Value::U64(tx.node_alias.0)],
+                )
+                .await?
+                .into_iter()
+                .map(|raw| raw.owned_record())
+                .collect::<Vec<_>>();
+            for raw in raws {
+                let requested_table = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+                    ""
+                } else {
+                    table
+                };
+                let version =
+                    self.decode_history_owned_record(requested_table, &storage_table, raw)?;
+                if self.physical_table_id_for_version(&version)? == requested_table_id {
+                    versions.push(version);
+                }
+            }
+        }
+        Ok(versions)
+    }
+
     pub(super) async fn query_versions_for_tx_rows_by_alias(
         &mut self,
         tx_id: TxId,

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -330,11 +330,16 @@ where
                 &table_schema.name,
             )?;
             for parent in &commit.parents {
-                let parent_versions = self.query_versions_for_tx(*parent).await?;
-                let same_row = parent_versions.iter().filter(|version| {
-                    version.row_uuid() == commit.row_uuid
-                        && self.physical_table_id_for_version(version).ok() == Some(table_id)
-                });
+                let parent_versions = self
+                    .query_versions_for_tx_table(
+                        *parent,
+                        write_schema_version,
+                        &table_schema.name,
+                    )
+                    .await?;
+                let same_row = parent_versions
+                    .iter()
+                    .filter(|version| self.physical_table_id_for_version(version).ok() == Some(table_id));
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
                 {

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -339,7 +339,10 @@ where
                     .await?;
                 let same_row = parent_versions
                     .iter()
-                    .filter(|version| self.physical_table_id_for_version(version).ok() == Some(table_id));
+                    .filter(|version| {
+                        version.row_uuid() == commit.row_uuid
+                            && self.physical_table_id_for_version(version).ok() == Some(table_id)
+                    });
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
                 {

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -455,6 +455,88 @@ fn version_parents_cannot_cross_branch_keys() {
 }
 
 #[test]
+fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
+    let schema = branch_view_schema();
+    let (_dir, mut node) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x56; 16]), schema);
+    let target = row(0x57);
+    let sibling = row(0x58);
+    let branch_a = branch_selector(0x59);
+    let branch_b = branch_selector(0x5a);
+    let owner = AuthorSubject::for_test_bytes([0x5b; 16]);
+    let cells = |title: &str| {
+        BTreeMap::from([
+            ("title".to_owned(), v(title)),
+            ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+        ])
+    };
+
+    // A same-table multi-row transaction can legitimately contain a parent
+    // for the target and an unrelated sibling under another branch.
+    let valid_parent = node
+        .commit_mergeable_many_settled(vec![
+            MergeableCommit::new("todos", target, 10)
+                .branch(branch_a.clone())
+                .cells(cells("target base")),
+            MergeableCommit::new("todos", sibling, 11)
+                .branch(branch_b.clone())
+                .cells(cells("sibling other branch")),
+        ])
+        .unwrap();
+    let valid_child = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", target, 20)
+                .branch(branch_a.clone())
+                .parents(vec![valid_parent])
+                .cells(cells("target child")),
+        )
+        .unwrap();
+
+    // Deletion and restore parents use the shared deletion history table, so
+    // retain the normal same-row/branch chain through both lifecycle layers.
+    let deletion_parent = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", target, 30)
+                .branch(branch_a.clone())
+                .parents(vec![valid_child])
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", target, 40)
+            .branch(branch_a.clone())
+            .parents(vec![deletion_parent])
+            .deletion(DeletionEvent::Restored),
+    )
+    .unwrap();
+
+    // This transaction contains the target only under branch B, plus a
+    // sibling deletion under branch A. A table-only lookup would see branch A
+    // and wrongly bless the foreign target parent.
+    let foreign_parent = node
+        .commit_mergeable_many_settled(vec![
+            MergeableCommit::new("todos", target, 50)
+                .branch(branch_b)
+                .cells(cells("foreign target parent")),
+            MergeableCommit::new("todos", sibling, 51)
+                .branch(branch_a.clone())
+                .deletion(DeletionEvent::Deleted),
+        ])
+        .unwrap();
+    let error = node
+        .commit_mergeable(
+            MergeableCommit::new("todos", target, 60)
+                .branch(branch_a)
+                .parents(vec![foreign_parent])
+                .cells(cells("must reject foreign target parent")),
+        )
+        .resolve()
+        .err()
+        .expect("a sibling under the requested branch cannot validate a foreign target parent");
+    assert!(matches!(error, Error::InvalidMergeableCommit(_)));
+}
+
+#[test]
 fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     let schema = branch_view_schema();
     let (_dir, mut node) =

--- a/examples/benchmarks/w1/benches/reads_memory_walltime.rs
+++ b/examples/benchmarks/w1/benches/reads_memory_walltime.rs
@@ -88,6 +88,30 @@ fn resubscribe_activity_point_profile_s_memory(bencher: divan::Bencher<'_, '_>) 
     bencher.bench_local(|| fixture.subscribe_point_activity_once());
 }
 
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn delete_task_point_scaling_memory(bencher: divan::Bencher<'_, '_>, activity_events: usize) {
+    bencher
+        .with_inputs(|| Fixture::<MemoryStorage>::memory(300, 1_200, activity_events))
+        .bench_local_values(|fixture| {
+            fixture.delete_target_task();
+            fixture
+        });
+}
+
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn restore_task_point_scaling_memory(bencher: divan::Bencher<'_, '_>, activity_events: usize) {
+    bencher
+        .with_inputs(|| {
+            let fixture = Fixture::<MemoryStorage>::memory(300, 1_200, activity_events);
+            fixture.delete_target_task();
+            fixture
+        })
+        .bench_local_values(|fixture| {
+            fixture.restore_target_task();
+            fixture
+        });
+}
+
 /// Fixed-result scaling receipt exposing query-engine candidate hydration.
 #[divan::bench(args = [(300, 1_200, 900), (3_000, 12_000, 9_000)], sample_count = 5)]
 fn query_comments_scaling_memory(

--- a/examples/benchmarks/w1/src/lib.rs
+++ b/examples/benchmarks/w1/src/lib.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 
 use jazz::db::{
-    Db, DbConfig, DbIdentity, InsertOptions, LocalUpdates, MergeableTxOps, PreparedQuery,
-    Propagation, ReadOpts, SubscriptionEvent, SubscriptionStream, UpdateOptions, WriteIdentity,
-    block_on,
+    Db, DbConfig, DbIdentity, DeleteOptions, InsertOptions, LocalUpdates, MergeableTxOps,
+    PreparedQuery, Propagation, ReadOpts, RestoreOptions, SubscriptionEvent, SubscriptionStream,
+    UpdateOptions, WriteIdentity, block_on,
 };
 use jazz::groove::records::Value;
 use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
@@ -38,6 +38,7 @@ pub struct Fixture<S: OrderedKvStorage> {
     maintained_activity: PreparedQuery,
     point_activity: PreparedQuery,
     activity_transition_row: RowUuid,
+    task_transition_row: RowUuid,
     activity_transition_matching: bool,
     activity_update_identity: WriteIdentity,
 }
@@ -266,6 +267,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
             maintained_activity,
             point_activity,
             activity_transition_row: row_id(4, PROJECTS),
+            task_transition_row: task_ids[0],
             activity_transition_matching: false,
             activity_update_identity,
         };
@@ -364,6 +366,27 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
         .expect("toggle W1 indexed predicate");
         block_on(write.wait(DurabilityTier::Local)).expect("settle W1 indexed predicate toggle");
         self.activity_transition_matching = !self.activity_transition_matching;
+    }
+
+    pub fn delete_target_task(&self) {
+        let write = block_on(self.db.delete(
+            "tasks",
+            self.task_transition_row,
+            DeleteOptions::default(),
+        ))
+        .expect("delete W1 target task");
+        block_on(write.wait(DurabilityTier::Local)).expect("settle W1 target deletion");
+    }
+
+    pub fn restore_target_task(&self) {
+        let write = block_on(self.db.restore(
+            "tasks",
+            self.task_transition_row,
+            None,
+            RestoreOptions::default(),
+        ))
+        .expect("restore W1 target task");
+        block_on(write.wait(DurabilityTier::Local)).expect("settle W1 target restore");
     }
 }
 


### PR DESCRIPTION
## Summary

Stacks on #2121. Fixes the first checkpoint of #2122.

### Before

A local mergeable update/delete validates each explicit parent by calling `query_versions_for_tx`. When the parent transaction is cached, that clones and sorts every version in the transaction before filtering for the one touched physical table and row. A realistic W1 seed transaction contains tasks, comments, and activity, so deleting one task became slower as unrelated activity rows grew.

### After

Parent validation asks for versions from the touched physical table only:

- cache hit: map the physical table across known schema aliases, reject unrelated versions by interned logical name before reading the schema tag, and clone only matching-table versions;
- cache miss: scan `by_tx` only in that physical content-history table plus shared deletion history, filtering the latter by physical table id.

The existing validation then checks the same row and rejects any parent found solely under a different branch.

## Governing invariants

- A causal parent for the same physical table/row under another branch remains invalid.
- Schema-renamed logical tables that map to the same physical table remain visible to validation.
- Deletion parents remain visible through shared deletion history.
- Missing/pending parents retain the existing behavior.

## Non-goals / residual

- This does not add a `(tx,row)` storage index. On a cache hit it still performs cheap interned-name comparisons across the transaction, so the algorithm is not strictly O(1) in total transaction width even though the W1 cross-table measurement is flat.
- Same-table transaction width is not yet bounded by the touched row.
- No subscription, query-result, fate, or persistence semantics change.

## Worked examples

Normal path: one transaction inserts 300 tasks, 1,200 comments, and 9,000 activity rows. A later delete of one task now filters the cached parent transaction by the task physical table before cloning records.

Branch edge: a task version authored under branch A is named as a parent of a version under branch B. Table-scoped lookup still discovers the branch-A version, and the existing `version_parents_cannot_cross_branch_keys` rejection fires.

Cache-miss edge: after tx-version cache eviction, the lookup reads the requested physical history table and shared deletion history through their transaction indices; it does not assume the default branch.

## Performance receipt (local MemoryStorage, W1)

| sibling activity rows in seed transaction | before | after |
|---:|---:|---:|
| 900 | 1.15 ms | 0.68 ms |
| 9,000 | 3.92 ms | 0.64 ms |

~6.1x faster at 9k; observed cross-table slope removed. Restore control remains flat (~0.43–0.52 ms).

The benchmark returns its consumed fixture from the timed Divan closure so whole-database destruction is excluded.

## Tests

- `dev/t version_parents_cannot_cross_branch_keys`
- all three `incremental_delivery_canary` tests
- `JAZZ_SEED_COUNT=30 dev/t --exact node::tests::harness::m3_maintained_one_shot_differential_oracle -- --ignored`
- `cargo clippy -p jazz --no-default-features --features testing,transport-compression-zstd --lib -- -D warnings`
- `cargo check -p jazz-example-w1-benchmark --bench reads_memory_walltime`
- pre-commit rustfmt, Clippy, and sensitive-data guard
