### PR TITLE
Encode Expo SecureStore scope keys safely

### DIFF
--- a/.changeset/expo-securestore-scoped-keys.md
+++ b/.changeset/expo-securestore-scoped-keys.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Encode Expo SecureStore scope values into valid, collision-resistant key segments.

--- a/packages/jazz-tools/src/expo/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.test.ts
@@ -9,9 +9,9 @@ vi.mock("expo-secure-store", () => ({
 import { ExpoAuthSecretStore, type ExpoSecureStoreLike } from "./auth-secret-store.js";
 
 function recordingStore() {
-  const getItemAsync = vi.fn(async () => null);
-  const setItemAsync = vi.fn(async () => {});
-  const deleteItemAsync = vi.fn(async () => {});
+  const getItemAsync = vi.fn<ExpoSecureStoreLike["getItemAsync"]>(async () => null);
+  const setItemAsync = vi.fn<ExpoSecureStoreLike["setItemAsync"]>(async () => {});
+  const deleteItemAsync = vi.fn<ExpoSecureStoreLike["deleteItemAsync"]>(async () => {});
   const secureStore: ExpoSecureStoreLike = { getItemAsync, setItemAsync, deleteItemAsync };
   return { secureStore, getItemAsync, setItemAsync, deleteItemAsync };
 }

--- a/packages/jazz-tools/src/expo/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("expo-crypto", () => ({ getRandomBytes: vi.fn() }));
+vi.mock("expo-secure-store", () => ({
+  deleteItemAsync: vi.fn(),
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+}));
+import { ExpoAuthSecretStore, type ExpoSecureStoreLike } from "./auth-secret-store.js";
+
+function recordingStore() {
+  const getItemAsync = vi.fn(async () => null);
+  const setItemAsync = vi.fn(async () => {});
+  const deleteItemAsync = vi.fn(async () => {});
+  const secureStore: ExpoSecureStoreLike = { getItemAsync, setItemAsync, deleteItemAsync };
+  return { secureStore, getItemAsync, setItemAsync, deleteItemAsync };
+}
+
+describe("ExpoAuthSecretStore scoped keys", () => {
+  it("uses only Expo SecureStore-compatible characters for scoped defaults", async () => {
+    const { secureStore, setItemAsync } = recordingStore();
+    const store = new ExpoAuthSecretStore({
+      secureStore,
+      appId: "app:one/%",
+      userId: "user@example.com",
+      sessionId: "session/東京",
+    });
+
+    await store.saveSecret("secret");
+
+    const key = setItemAsync.mock.calls[0]?.[0];
+    expect(key).toMatch(/^[A-Za-z0-9._-]+$/);
+    expect(key).not.toContain(":");
+    expect(key).not.toContain("%");
+  });
+
+  it("keeps app, user, and session scopes distinct", async () => {
+    const { secureStore, getItemAsync } = recordingStore();
+
+    await new ExpoAuthSecretStore({ secureStore, appId: "same" }).loadSecret();
+    await new ExpoAuthSecretStore({ secureStore, userId: "same" }).loadSecret();
+    await new ExpoAuthSecretStore({ secureStore, sessionId: "same" }).loadSecret();
+
+    const keys = getItemAsync.mock.calls.map(([key]) => key);
+    expect(new Set(keys)).toHaveProperty("size", 3);
+  });
+
+  it("preserves the unscoped default key", async () => {
+    const { secureStore, getItemAsync } = recordingStore();
+
+    await new ExpoAuthSecretStore({ secureStore }).loadSecret();
+
+    expect(getItemAsync).toHaveBeenCalledWith("jazz-auth-secret");
+  });
+});

--- a/packages/jazz-tools/src/expo/auth-secret-store.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.ts
@@ -23,13 +23,23 @@ export interface ExpoAuthSecretStoreOptions {
   secureStore?: ExpoSecureStoreLike;
 }
 
-function normalizeScopeSegment(value?: string | null): string | null {
+function encodeScopeSegment(label: string, value?: string | null): string | null {
   if (typeof value !== "string") {
     return null;
   }
 
   const trimmed = value.trim();
-  return trimmed.length > 0 ? encodeURIComponent(trimmed) : null;
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const bytes = new TextEncoder().encode(trimmed);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const encoded = btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `${label}-${encoded}`;
 }
 
 function resolveExpoAuthSecretKey(options: ExpoAuthSecretStoreOptions = {}): string {
@@ -38,12 +48,12 @@ function resolveExpoAuthSecretKey(options: ExpoAuthSecretStoreOptions = {}): str
   }
 
   const scopeSegments = [
-    normalizeScopeSegment(options.appId),
-    normalizeScopeSegment(options.userId),
-    normalizeScopeSegment(options.sessionId),
+    encodeScopeSegment("app", options.appId),
+    encodeScopeSegment("user", options.userId),
+    encodeScopeSegment("session", options.sessionId),
   ].filter((segment): segment is string => segment !== null);
 
-  return scopeSegments.length === 0 ? DEFAULT_KEY : `${DEFAULT_KEY}:${scopeSegments.join(":")}`;
+  return scopeSegments.length === 0 ? DEFAULT_KEY : `${DEFAULT_KEY}.${scopeSegments.join(".")}`;
 }
 
 export class ExpoAuthSecretStore implements AuthSecretStore {


### PR DESCRIPTION
## Summary
- encode app, user and session scope values as labelled base64url segments that Expo SecureStore accepts
- keep equal values in different scope types distinct and preserve custom and unscoped keys
- change the generated scoped-key format; existing scoped secrets are not migrated, so affected users may need to authenticate again

Before, a scoped key could contain rejected characters such as `:` and `%`. After, each UTF-8 scope is encoded using only letters, numbers, `_` and `-`.

## Testing
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/expo/auth-secret-store.test.ts` — 3 tests passed