### PR TITLE
Restore frozen base rows after head restores

### DIFF
--- a/.changeset/calm-owls-restore.md
+++ b/.changeset/calm-owls-restore.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Restore inherited frozen-branch rows when a head deletion is restored.

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -538,7 +538,7 @@ where
                 // entirely in maintained table inputs so pending rejection,
                 // replacement, deletion and restoration cannot leak into the
                 // frozen relation.
-                let frozen_base_rows = self
+                let (frozen_base_rows, frozen_base_deleted_rows) = self
                     .node
                     .branch_snapshot_rows_for_schema(
                         &request.source.table,
@@ -564,7 +564,21 @@ where
                         branch_witness_field.map(|field| (field, frozen_base_key)),
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
-                if descriptor != opening_descriptor || metadata != opening_metadata {
+                let (frozen_base_deletions, deletion_descriptor, deletion_metadata) =
+                    inline_current_graph_with_source_metadata_and_branch_witness(
+                        &table,
+                        frozen_base_deleted_rows,
+                        schema_version_alias,
+                        "frozen-branch-base-deletions",
+                        &request.requirements,
+                        branch_witness_field.map(|field| (field, frozen_base_key)),
+                    )
+                    .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+                if descriptor != opening_descriptor
+                    || metadata != opening_metadata
+                    || descriptor != deletion_descriptor
+                    || metadata != deletion_metadata
+                {
                     return Err(source_resolution_error(
                         request,
                         SourceGap::SchemaProjection,
@@ -576,17 +590,25 @@ where
                     ["row_uuid"],
                     ["row_uuid"],
                 );
+                let inherited_without_frozen_deletions = GraphBuilder::anti_join(
+                    inherited.clone(),
+                    frozen_base_deletions.project(["row_uuid"]),
+                    ["row_uuid"],
+                    ["row_uuid"],
+                );
                 // A deletion-register winner is explicit for both states. Use
                 // its positive Restored row as a positive maintained input;
                 // relying only on retraction from a filtered Deleted relation
                 // would not publish a deletion-only restore transition.
                 let inherited = GraphBuilder::union([
                     GraphBuilder::anti_join(
-                        inherited.clone(),
+                        inherited_without_frozen_deletions,
                         head_deletion_presence,
                         ["row_uuid"],
                         ["row_uuid"],
                     ),
+                    // A head Restored winner deliberately also reveals a
+                    // base row whose frozen deletion winner was Deleted.
                     GraphBuilder::semi_join(inherited, restored, ["row_uuid"], ["row_uuid"]),
                 ]);
                 let unfiltered = GraphBuilder::union([live_head, inherited]);

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -478,8 +478,8 @@ where
                 let branch_witness_field =
                     (!table.branch_by.is_empty()).then_some("supplying_branch_key");
                 let tier = graph_tier.expect("branch view has a current tier");
-                let frozen_base_key = match base {
-                    Some(BranchViewSourceBase::Snapshot(key, _)) => key,
+                let (frozen_base_key, frozen_snapshot) = match base {
+                    Some(BranchViewSourceBase::Snapshot(key, snapshot)) => (key, snapshot),
                     _ => unreachable!("guarded frozen branch base"),
                 };
                 let head_keys = self
@@ -497,8 +497,13 @@ where
                     .projected_branch_deletion_source_graph(request, tier, &head_keys)
                     .await?;
                 let head_content_presence = head_content.clone().project(["row_uuid"]);
+                let head_deletion_presence = head_deletions.clone().project(["row_uuid"]);
                 let deleted = head_deletions
+                    .clone()
                     .filter(PredicateExpr::eq("_deletion", Value::EnumTag(0)))
+                    .project(["row_uuid"]);
+                let restored = head_deletions
+                    .filter(PredicateExpr::eq("_deletion", Value::EnumTag(1)))
                     .project(["row_uuid"]);
                 let selected_head = GraphBuilder::anti_join(
                     head_content.clone(),
@@ -529,17 +534,18 @@ where
                     &metadata,
                     branch_witness_field.is_some(),
                 );
-                // Capture the full opening view once. Anti-joining it against
-                // live head presence leaves only inherited frozen rows; all
-                // subsequent head changes remain maintained table inputs.
-                let opening_rows = self
+                // Capture only the base snapshot once. The live head is kept
+                // entirely in maintained table inputs so pending rejection,
+                // replacement, deletion and restoration cannot leak into the
+                // frozen relation.
+                let frozen_base_rows = self
                     .node
-                    .branch_view_rows_for_schema(
+                    .branch_snapshot_rows_for_schema(
                         &request.source.table,
                         self.read_view.read_schema,
-                        tier,
                         head,
-                        base,
+                        frozen_base_key,
+                        frozen_snapshot,
                     )
                     .await
                     .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
@@ -551,7 +557,7 @@ where
                 let (opening, opening_descriptor, opening_metadata) =
                     inline_current_graph_with_source_metadata_and_branch_witness(
                         &table,
-                        opening_rows,
+                        frozen_base_rows,
                         schema_version_alias,
                         "frozen-branch-base",
                         &request.requirements,
@@ -570,8 +576,19 @@ where
                     ["row_uuid"],
                     ["row_uuid"],
                 );
-                let inherited =
-                    GraphBuilder::anti_join(inherited, deleted, ["row_uuid"], ["row_uuid"]);
+                // A deletion-register winner is explicit for both states. Use
+                // its positive Restored row as a positive maintained input;
+                // relying only on retraction from a filtered Deleted relation
+                // would not publish a deletion-only restore transition.
+                let inherited = GraphBuilder::union([
+                    GraphBuilder::anti_join(
+                        inherited.clone(),
+                        head_deletion_presence,
+                        ["row_uuid"],
+                        ["row_uuid"],
+                    ),
+                    GraphBuilder::semi_join(inherited, restored, ["row_uuid"], ["row_uuid"]),
+                ]);
                 let unfiltered = GraphBuilder::union([live_head, inherited]);
                 let graph = match &authorization {
                     SourceAuthorizationRequest::System => unfiltered,

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -564,21 +564,7 @@ where
                         branch_witness_field.map(|field| (field, frozen_base_key)),
                     )
                     .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
-                let (frozen_base_deletions, deletion_descriptor, deletion_metadata) =
-                    inline_current_graph_with_source_metadata_and_branch_witness(
-                        &table,
-                        frozen_base_deleted_rows,
-                        schema_version_alias,
-                        "frozen-branch-base-deletions",
-                        &request.requirements,
-                        branch_witness_field.map(|field| (field, frozen_base_key)),
-                    )
-                    .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
-                if descriptor != opening_descriptor
-                    || metadata != opening_metadata
-                    || descriptor != deletion_descriptor
-                    || metadata != deletion_metadata
-                {
+                if descriptor != opening_descriptor || metadata != opening_metadata {
                     return Err(source_resolution_error(
                         request,
                         SourceGap::SchemaProjection,
@@ -590,27 +576,58 @@ where
                     ["row_uuid"],
                     ["row_uuid"],
                 );
-                let inherited_without_frozen_deletions = GraphBuilder::anti_join(
-                    inherited.clone(),
-                    frozen_base_deletions.project(["row_uuid"]),
-                    ["row_uuid"],
-                    ["row_uuid"],
-                );
                 // A deletion-register winner is explicit for both states. Use
                 // its positive Restored row as a positive maintained input;
                 // relying only on retraction from a filtered Deleted relation
                 // would not publish a deletion-only restore transition.
-                let inherited = GraphBuilder::union([
-                    GraphBuilder::anti_join(
-                        inherited_without_frozen_deletions,
-                        head_deletion_presence,
+                let inherited = if frozen_base_deleted_rows.is_empty() {
+                    // Do not add an empty static anti-join to the maintained
+                    // path: its static witness cannot publish the inherited
+                    // row when a pending head content winner retracts.
+                    GraphBuilder::union([
+                        GraphBuilder::anti_join(
+                            inherited.clone(),
+                            head_deletion_presence,
+                            ["row_uuid"],
+                            ["row_uuid"],
+                        ),
+                        GraphBuilder::semi_join(inherited, restored, ["row_uuid"], ["row_uuid"]),
+                    ])
+                } else {
+                    let (frozen_base_deletions, deletion_descriptor, deletion_metadata) =
+                        inline_current_graph_with_source_metadata_and_branch_witness(
+                            &table,
+                            frozen_base_deleted_rows,
+                            schema_version_alias,
+                            "frozen-branch-base-deletions",
+                            &request.requirements,
+                            branch_witness_field.map(|field| (field, frozen_base_key)),
+                        )
+                        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+                    if descriptor != deletion_descriptor || metadata != deletion_metadata {
+                        return Err(source_resolution_error(
+                            request,
+                            SourceGap::SchemaProjection,
+                        ));
+                    }
+                    let inherited_without_frozen_deletions = GraphBuilder::anti_join(
+                        inherited.clone(),
+                        frozen_base_deletions.project(["row_uuid"]),
                         ["row_uuid"],
                         ["row_uuid"],
-                    ),
-                    // A head Restored winner deliberately also reveals a
-                    // base row whose frozen deletion winner was Deleted.
-                    GraphBuilder::semi_join(inherited, restored, ["row_uuid"], ["row_uuid"]),
-                ]);
+                    );
+                    GraphBuilder::union([
+                        GraphBuilder::anti_join(
+                            inherited_without_frozen_deletions,
+                            head_deletion_presence,
+                            ["row_uuid"],
+                            ["row_uuid"],
+                        ),
+                        // A head Restored winner deliberately also reveals a
+                        // base row whose frozen deletion winner was Deleted.
+                        GraphBuilder::semi_join(inherited, restored, ["row_uuid"], ["row_uuid"]),
+                    ])
+                };
                 let unfiltered = GraphBuilder::union([live_head, inherited]);
                 let graph = match &authorization {
                     SourceAuthorizationRequest::System => unfiltered,

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -497,13 +497,12 @@ where
                     .projected_branch_deletion_source_graph(request, tier, &head_keys)
                     .await?;
                 let head_content_presence = head_content.clone().project(["row_uuid"]);
-                let head_deletion_presence = head_deletions.clone().project(["row_uuid"]);
                 let deleted = head_deletions
                     .filter(PredicateExpr::eq("_deletion", Value::EnumTag(0)))
                     .project(["row_uuid"]);
                 let selected_head = GraphBuilder::anti_join(
                     head_content.clone(),
-                    deleted,
+                    deleted.clone(),
                     ["row_uuid"],
                     ["row_uuid"],
                 )
@@ -571,12 +570,8 @@ where
                     ["row_uuid"],
                     ["row_uuid"],
                 );
-                let inherited = GraphBuilder::anti_join(
-                    inherited,
-                    head_deletion_presence,
-                    ["row_uuid"],
-                    ["row_uuid"],
-                );
+                let inherited =
+                    GraphBuilder::anti_join(inherited, deleted, ["row_uuid"], ["row_uuid"]);
                 let unfiltered = GraphBuilder::union([live_head, inherited]);
                 let graph = match &authorization {
                     SourceAuthorizationRequest::System => unfiltered,

--- a/crates/jazz/src/node/source_resolution.rs
+++ b/crates/jazz/src/node/source_resolution.rs
@@ -264,7 +264,6 @@ where
         head: &BranchKey,
         base: Option<&BranchViewSourceBase>,
     ) -> Result<Vec<CurrentRow>, Error> {
-        let read_table = self.table_in_schema(table, read_schema_version)?;
         let (head_content, head_deletions) = self
             .branch_winners_for_schema(table, read_schema_version, tier, head, None)
             .await?;
@@ -291,6 +290,59 @@ where
                 .await?
             }
         };
+        self.materialize_branch_view_winners(
+            table,
+            read_schema_version,
+            head,
+            head_content,
+            head_deletions,
+            base_content,
+            base_deletions,
+        )
+    }
+
+    /// Materialize only the frozen base relation for a snapshot-backed branch
+    /// view. The live head is deliberately absent: query lowering overlays its
+    /// maintained content and deletion registers separately.
+    pub(super) async fn branch_snapshot_rows_for_schema(
+        &mut self,
+        table: &str,
+        read_schema_version: SchemaVersionId,
+        output_branch: &BranchKey,
+        base_branch: &BranchKey,
+        snapshot: &SnapshotRef,
+    ) -> Result<Vec<CurrentRow>, Error> {
+        let (base_content, base_deletions) = self
+            .branch_winners_for_schema(
+                table,
+                read_schema_version,
+                DurabilityTier::Local,
+                base_branch,
+                Some(snapshot),
+            )
+            .await?;
+        self.materialize_branch_view_winners(
+            table,
+            read_schema_version,
+            output_branch,
+            BTreeMap::new(),
+            BTreeMap::new(),
+            base_content,
+            base_deletions,
+        )
+    }
+
+    fn materialize_branch_view_winners(
+        &mut self,
+        table: &str,
+        read_schema_version: SchemaVersionId,
+        output_branch: &BranchKey,
+        head_content: BTreeMap<RowUuid, VersionRow>,
+        head_deletions: BTreeMap<RowUuid, VersionRow>,
+        base_content: BTreeMap<RowUuid, VersionRow>,
+        base_deletions: BTreeMap<RowUuid, VersionRow>,
+    ) -> Result<Vec<CurrentRow>, Error> {
+        let read_table = self.table_in_schema(table, read_schema_version)?;
         let row_ids = head_content
             .keys()
             .chain(base_content.keys())
@@ -330,7 +382,7 @@ where
                 continue;
             }
             for column_name in &read_table.branch_by {
-                let (_, encoded) = head
+                let (_, encoded) = output_branch
                     .values
                     .iter()
                     .find(|(name, _)| name == column_name)

--- a/crates/jazz/src/node/source_resolution.rs
+++ b/crates/jazz/src/node/source_resolution.rs
@@ -311,7 +311,7 @@ where
         output_branch: &BranchKey,
         base_branch: &BranchKey,
         snapshot: &SnapshotRef,
-    ) -> Result<Vec<CurrentRow>, Error> {
+    ) -> Result<(Vec<CurrentRow>, Vec<CurrentRow>), Error> {
         let (base_content, base_deletions) = self
             .branch_winners_for_schema(
                 table,
@@ -321,15 +321,30 @@ where
                 Some(snapshot),
             )
             .await?;
-        self.materialize_branch_view_winners(
+        // Keep the frozen content and deletion layers distinct. A live head
+        // `Restored` winner can reveal base content even when the frozen base
+        // itself had a `Deleted` winner.
+        let deleted_row_ids = base_deletions
+            .iter()
+            .filter_map(|(row_uuid, version)| {
+                (version.deletion() == Some(DeletionEvent::Deleted)).then_some(*row_uuid)
+            })
+            .collect::<BTreeSet<_>>();
+        let base_rows = self.materialize_branch_view_winners(
             table,
             read_schema_version,
             output_branch,
             BTreeMap::new(),
             BTreeMap::new(),
             base_content,
-            base_deletions,
-        )
+            BTreeMap::new(),
+        )?;
+        let deleted_base_rows = base_rows
+            .iter()
+            .filter(|row| deleted_row_ids.contains(&row.row_uuid()))
+            .cloned()
+            .collect();
+        Ok((base_rows, deleted_base_rows))
     }
 
     fn materialize_branch_view_winners(

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -204,17 +204,11 @@ fn frozen_base_row_reappears_after_head_deletion_is_restored() {
             .deletion(DeletionEvent::Deleted),
     )
     .unwrap();
-    node.commit_mergeable_settled(
-        MergeableCommit::new("todos", row_uuid, 30)
-            .branch(head.clone())
-            .deletion(DeletionEvent::Restored),
-    )
-    .unwrap();
 
     let read_view = crate::protocol::ReadViewSpec::branch_view(
-        head,
+        head.clone(),
         Some(crate::protocol::BranchViewBase::snapshot(
-            base,
+            base.clone(),
             crate::protocol::SnapshotRef {
                 owner: node_id,
                 global_base: GlobalTime(0),
@@ -225,7 +219,35 @@ fn frozen_base_row_reappears_after_head_deletion_is_restored() {
     );
     let shape = Query::from("todos").validate(&schema).unwrap();
     let binding = shape.bind(BTreeMap::new()).unwrap();
-    let snapshot = node
+    let (shape, binding, plan) = node
+        .prepare_query_binding_for_link_in_authorization_mode(
+            &shape,
+            &binding,
+            DurabilityTier::Local,
+            AuthorSubject::SYSTEM,
+            QueryAuthorizationMode::ClientLocal,
+        )
+        .unwrap();
+    let (mut maintained, initial) = node
+        .open_maintained_view_subscription_in_authorization_mode(
+            &shape,
+            &binding,
+            AuthorSubject::SYSTEM,
+            DurabilityTier::Local,
+            &read_view,
+            Some(plan),
+            QueryAuthorizationMode::ClientLocal,
+        )
+        .unwrap();
+    assert_eq!(initial.root_count, 0);
+
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", row_uuid, 30)
+            .branch(head)
+            .deletion(DeletionEvent::Restored),
+    )
+    .unwrap();
+    let fresh = node
         .query_relation_snapshot_for_serving_in_read_view(
             &shape,
             &binding,
@@ -234,9 +256,133 @@ fn frozen_base_row_reappears_after_head_deletion_is_restored() {
             &read_view,
         )
         .unwrap();
+    assert_eq!(fresh.root_count, 1, "fresh evaluation must see the restoration");
+    let update = node
+        .drain_local_maintained_view_subscription(&mut maintained, None)
+        .unwrap()
+        .expect("restoration must publish the frozen base row");
 
-    assert_eq!(snapshot.root_count, 1);
-    assert_eq!(snapshot.rows[0].row_uuid(), row_uuid);
+    assert_eq!(update.added.len(), 1);
+    assert_eq!(update.added[0].1.row_uuid(), row_uuid);
+    assert!(update.removed.is_empty());
+}
+
+#[test]
+fn frozen_base_subscription_does_not_capture_pending_head_content() {
+    let schema = branch_view_schema();
+    let node_id = NodeUuid::from_bytes([0x3a; 16]);
+    let (_dir, mut node) = open_history_complete_node_with_schema(node_id, schema.clone());
+    let row_uuid = row(0x3b);
+    let base = branch_selector(0x3c);
+    let head = branch_selector(0x3d);
+    let base_tx = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 10)
+                .branch(base.clone())
+                .cells(BTreeMap::from([
+                    ("title".to_owned(), v("frozen base")),
+                    ("owner".to_owned(), Value::Uuid(uuid::Uuid::nil())),
+                ])),
+        )
+        .unwrap();
+    let (pending, _) = node
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", row_uuid, 20)
+                .branch(head.clone())
+                .cells(BTreeMap::from([
+                    ("title".to_owned(), v("pending head")),
+                    ("owner".to_owned(), Value::Uuid(uuid::Uuid::nil())),
+                ])),
+        )
+        .unwrap();
+    let read_view = crate::protocol::ReadViewSpec::branch_view(
+        head,
+        Some(crate::protocol::BranchViewBase::snapshot(
+            base.clone(),
+            crate::protocol::SnapshotRef {
+                owner: node_id,
+                global_base: GlobalTime(0),
+                local_base: base_tx.time,
+                dots: Vec::new(),
+            },
+        )),
+    );
+    let shape = Query::from("todos").validate(&schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let (shape, binding, plan) = node
+        .prepare_query_binding_for_link_in_authorization_mode(
+            &shape,
+            &binding,
+            DurabilityTier::Local,
+            AuthorSubject::SYSTEM,
+            QueryAuthorizationMode::ClientLocal,
+        )
+        .unwrap();
+    let (mut maintained, initial) = node
+        .open_maintained_view_subscription_in_authorization_mode(
+            &shape,
+            &binding,
+            AuthorSubject::SYSTEM,
+            DurabilityTier::Local,
+            &read_view,
+            Some(plan),
+            QueryAuthorizationMode::ClientLocal,
+        )
+        .unwrap();
+    let table = schema.tables.iter().find(|table| table.name == "todos").unwrap();
+    assert_eq!(initial.rows[0].cell(table, "title"), Some(v("pending head")));
+
+    node.apply_sync_message_settled(SyncMessage::FateUpdate {
+        tx_id: pending,
+        fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+        global_time: None,
+        durability: None,
+    })
+    .unwrap();
+    let update = node
+        .drain_local_maintained_view_subscription(&mut maintained, None)
+        .unwrap()
+        .expect("head rejection must restore the frozen base payload");
+    assert_eq!(update.removed.len(), 1);
+    assert_eq!(update.added.len(), 1);
+    assert_eq!(update.added[0].1.cell(table, "title"), Some(v("frozen base")));
+
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", row_uuid, 30)
+            .branch(base)
+            .parents(vec![base_tx])
+            .cells(BTreeMap::from([
+                ("title".to_owned(), v("later base")),
+                ("owner".to_owned(), Value::Uuid(uuid::Uuid::nil())),
+            ])),
+    )
+    .unwrap();
+    assert!(
+        node.drain_local_maintained_view_subscription(&mut maintained, None)
+            .unwrap()
+            .is_none(),
+        "later base changes must remain outside the frozen relation"
+    );
+
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", row_uuid, 40)
+            .branch(branch_selector(0x3d))
+            .cells(BTreeMap::from([
+                ("title".to_owned(), v("replacement head")),
+                ("owner".to_owned(), Value::Uuid(uuid::Uuid::nil())),
+            ])),
+    )
+    .unwrap();
+    let replacement = node
+        .drain_local_maintained_view_subscription(&mut maintained, None)
+        .unwrap()
+        .expect("replacement head content must remain live");
+    assert_eq!(replacement.removed.len(), 1);
+    assert_eq!(replacement.added.len(), 1);
+    assert_eq!(
+        replacement.added[0].1.cell(table, "title"),
+        Some(v("replacement head"))
+    );
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -353,6 +353,19 @@ fn frozen_base_subscription_does_not_capture_pending_head_content() {
         durability: None,
     })
     .unwrap();
+    let fresh = node
+        .query_relation_snapshot_for_serving_in_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Local,
+            AuthorSubject::SYSTEM,
+            &read_view,
+        )
+        .unwrap();
+    assert_eq!(
+        fresh.root_count, 1,
+        "fresh rejection evaluation must restore the frozen base"
+    );
     let update = node
         .drain_local_maintained_view_subscription(&mut maintained, None)
         .unwrap()

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -180,7 +180,13 @@ fn branch_view_selects_head_then_base_and_keeps_unbranched_tables_shared() {
 }
 
 #[test]
-fn frozen_base_row_reappears_after_head_deletion_is_restored() {
+/// Frozen-base lowering keeps the base content and deletion registers separate.
+/// This internal test is needed because it verifies the maintained graph's
+/// frozen input and its live head fate transition in one evaluation boundary.
+///
+/// alice writes and deletes base content at the snapshot, then the head's
+/// `Restored` winner reveals that frozen content without a head content write.
+fn frozen_base_deleted_row_reappears_after_head_deletion_is_restored() {
     let schema = branch_view_schema();
     let node_id = NodeUuid::from_bytes([0x4a; 16]);
     let (_dir, mut node) = open_history_complete_node_with_schema(node_id, schema.clone());
@@ -198,6 +204,14 @@ fn frozen_base_row_reappears_after_head_deletion_is_restored() {
                 ])),
         )
         .unwrap();
+    let base_delete = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 15)
+                .branch(base.clone())
+                .parents(vec![base_tx])
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
     node.commit_mergeable_settled(
         MergeableCommit::new("todos", row_uuid, 20)
             .branch(head.clone())
@@ -212,7 +226,7 @@ fn frozen_base_row_reappears_after_head_deletion_is_restored() {
             crate::protocol::SnapshotRef {
                 owner: node_id,
                 global_base: GlobalTime(0),
-                local_base: base_tx.time,
+                local_base: base_delete.time,
                 dots: Vec::new(),
             },
         )),

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -180,6 +180,66 @@ fn branch_view_selects_head_then_base_and_keeps_unbranched_tables_shared() {
 }
 
 #[test]
+fn frozen_base_row_reappears_after_head_deletion_is_restored() {
+    let schema = branch_view_schema();
+    let node_id = NodeUuid::from_bytes([0x4a; 16]);
+    let (_dir, mut node) = open_history_complete_node_with_schema(node_id, schema.clone());
+    let row_uuid = row(0x4b);
+    let base = branch_selector(0x4c);
+    let head = branch_selector(0x4d);
+    let owner = AuthorSubject::for_test_bytes([0x4e; 16]);
+    let base_tx = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 10)
+                .branch(base.clone())
+                .cells(BTreeMap::from([
+                    ("title".to_owned(), v("frozen base")),
+                    ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+                ])),
+        )
+        .unwrap();
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", row_uuid, 20)
+            .branch(head.clone())
+            .deletion(DeletionEvent::Deleted),
+    )
+    .unwrap();
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", row_uuid, 30)
+            .branch(head.clone())
+            .deletion(DeletionEvent::Restored),
+    )
+    .unwrap();
+
+    let read_view = crate::protocol::ReadViewSpec::branch_view(
+        head,
+        Some(crate::protocol::BranchViewBase::snapshot(
+            base,
+            crate::protocol::SnapshotRef {
+                owner: node_id,
+                global_base: GlobalTime(0),
+                local_base: base_tx.time,
+                dots: Vec::new(),
+            },
+        )),
+    );
+    let shape = Query::from("todos").validate(&schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let snapshot = node
+        .query_relation_snapshot_for_serving_in_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Local,
+            AuthorSubject::SYSTEM,
+            &read_view,
+        )
+        .unwrap();
+
+    assert_eq!(snapshot.root_count, 1);
+    assert_eq!(snapshot.rows[0].row_uuid(), row_uuid);
+}
+
+#[test]
 fn version_parents_cannot_cross_branch_keys() {
     let schema = branch_view_schema();
     let (_dir, mut node) =


### PR DESCRIPTION
## Summary
- distinguish live head content from active head deletions when resolving frozen branch views
- keep head content authoritative while allowing an inherited opening row to reappear after its head deletion is restored
- preserve the fixed opening snapshot instead of rereading later base changes

Before, restoring a head deletion could leave the inherited row permanently hidden. After, the frozen opening row becomes visible again unless the head supplies replacement content.

## Testing
- `cargo test -p jazz --features testing frozen_base_row_reappears_after_head_deletion_is_restored` — passed