### PR TITLE
Preserve dotenv lines when writing generated app IDs

### DIFF
--- a/.changeset/neat-lions-separate.md
+++ b/.changeset/neat-lions-separate.md
@@ -2,4 +2,5 @@
 "jazz-tools": patch
 ---
 
-Keep generated app IDs on a separate dotenv line.
+Keep generated app IDs on a separate dotenv line without replacing the `.env`
+file or losing concurrent edits.

--- a/.changeset/neat-lions-separate.md
+++ b/.changeset/neat-lions-separate.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep generated app IDs on a separate dotenv line.

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -155,6 +155,7 @@
     "@scure/bip39": "^2.0.1",
     "@standard-schema/spec": "^1.1.0",
     "esbuild": "^0.27.0",
+    "fs-native-extensions": "1.5.0",
     "jazz-wasm": "workspace:*",
     "jose": "^6.2.1",
     "json-schema-to-ts": "^3.1.1",

--- a/packages/jazz-tools/src/dev/managed-runtime.test.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.test.ts
@@ -396,6 +396,35 @@ describe("ManagedDevRuntime", () => {
     );
   });
 
+  it("retries an atomic replacement between opening .env and its first identity check", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-replaced-opening-");
+    const envPath = join(schemaDir, ".env");
+    const replacementPath = join(schemaDir, ".env.replacement");
+    await writeFile(envPath, "ORIGINAL=old\n");
+    let replaced = false;
+
+    expect(
+      ensureEnvAppId(envPath, "VITE_JAZZ_APP_ID", "generated", undefined, {
+        afterOpen() {
+          if (!replaced) {
+            writeFileSync(replacementPath, "REPLACED=visible\n");
+            renameSync(replacementPath, envPath);
+            replaced = true;
+          }
+        },
+        waitForLock: waitForLockSync,
+        unlock,
+        write: (descriptor, bytes, offset) =>
+          writeSync(descriptor, bytes, offset, bytes.byteLength - offset),
+        fsync: fsyncSync,
+      }),
+    ).toBe("generated");
+
+    await expect(readFile(envPath, "utf8")).resolves.toBe(
+      "REPLACED=visible\nVITE_JAZZ_APP_ID=generated\n",
+    );
+  });
+
   it("retries when .env is atomically replaced after the append", async () => {
     const schemaDir = await tempRoots.create("jazz-managed-dotenv-replaced-final-");
     const envPath = join(schemaDir, ".env");

--- a/packages/jazz-tools/src/dev/managed-runtime.test.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { join } from "node:path";
+import { promisify } from "node:util";
+import { execFile as execFileCallback } from "node:child_process";
 import { createTempRootTracker, todoSchema } from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
 import * as catalogueProject from "./catalogue-project.js";
 import * as schemaWatcher from "./schema-watcher.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
-import { readFile, writeFile } from "node:fs/promises";
+import { chmod, readFile, stat, writeFile } from "node:fs/promises";
+import { build } from "esbuild";
+
+const execFile = promisify(execFileCallback);
 
 const tempRoots = createTempRootTracker();
 
@@ -143,6 +148,90 @@ describe("ManagedDevRuntime", () => {
     await expect(readFile(join(schemaDir, ".env"), "utf8")).resolves.toBe(
       `# VITE_JAZZ_APP_ID=disabled\nMY_VITE_JAZZ_APP_ID=other\nVITE_JAZZ_APP_ID=${appId}\n`,
     );
+  });
+
+  it("uses dotenv quoting, comments, whitespace, and export syntax", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-syntax-");
+    await writeFile(
+      join(schemaDir, ".env"),
+      'OTHER=value\n  export VITE_JAZZ_APP_ID = "quoted app id" # comment\n',
+    );
+
+    expect(makeRuntime().prepareEnv({ schemaDir })).toBe("quoted app id");
+  });
+
+  it("rejects duplicate and empty exact assignments without exposing values", async () => {
+    const duplicateDir = await tempRoots.create("jazz-managed-dotenv-duplicate-");
+    await writeFile(
+      join(duplicateDir, ".env"),
+      "VITE_JAZZ_APP_ID=first-secret\nexport VITE_JAZZ_APP_ID=second-secret\n",
+    );
+    expect(() => makeRuntime().prepareEnv({ schemaDir: duplicateDir })).toThrow(
+      "VITE_JAZZ_APP_ID is assigned more than once in .env (lines 1, 2)",
+    );
+    try {
+      makeRuntime().prepareEnv({ schemaDir: duplicateDir });
+    } catch (error) {
+      expect(String(error)).not.toContain("first-secret");
+      expect(String(error)).not.toContain("second-secret");
+    }
+
+    const emptyDir = await tempRoots.create("jazz-managed-dotenv-empty-");
+    await writeFile(join(emptyDir, ".env"), "VITE_JAZZ_APP_ID= # intentionally empty\n");
+    expect(() => makeRuntime().prepareEnv({ schemaDir: emptyDir })).toThrow(
+      "VITE_JAZZ_APP_ID is empty in .env",
+    );
+  });
+
+  it("preserves CRLF and file mode when appending atomically", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-preserve-");
+    const envPath = join(schemaDir, ".env");
+    await writeFile(envPath, "FIRST=one\r\nSECOND=two");
+    await chmod(envPath, 0o640);
+    const appId = "00000000-0000-0000-0000-000000000127";
+
+    expect(makeRuntime().prepareEnv({ appId, schemaDir })).toBe(appId);
+    await expect(readFile(envPath, "utf8")).resolves.toBe(
+      `FIRST=one\r\nSECOND=two\r\nVITE_JAZZ_APP_ID=${appId}\r\n`,
+    );
+    expect((await stat(envPath)).mode & 0o777).toBe(0o640);
+  });
+
+  it("serializes concurrent process writers without lost updates", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-process-race-");
+    const bundlePath = join(schemaDir, "managed-runtime.mjs");
+    await build({
+      entryPoints: [join(import.meta.dirname, "managed-runtime.ts")],
+      outfile: bundlePath,
+      bundle: true,
+      format: "esm",
+      platform: "node",
+    });
+    const envPath = join(schemaDir, ".env");
+    await writeFile(envPath, "EXISTING=preserved");
+    const prefixes = ["VITE", "NEXT_PUBLIC", "EXPO_PUBLIC"];
+    const candidates = Array.from({ length: 9 }, (_, index) => ({
+      key: `${prefixes[index % prefixes.length]}_JAZZ_APP_ID`,
+      value: `00000000-0000-0000-0000-${String(index + 1).padStart(12, "0")}`,
+    }));
+    const workers = candidates.map(({ key, value }) =>
+      execFile(process.execPath, [
+        "--input-type=module",
+        "--eval",
+        `import { ensureEnvAppId } from ${JSON.stringify(bundlePath)}; process.stdout.write(ensureEnvAppId(${JSON.stringify(envPath)}, ${JSON.stringify(key)}, ${JSON.stringify(value)}, undefined));`,
+      ]),
+    );
+    const results = (await Promise.all(workers)).map(({ stdout }) => stdout);
+    const content = await readFile(envPath, "utf8");
+    expect(content).toContain("EXISTING=preserved\n");
+    for (const prefix of prefixes) {
+      const key = `${prefix}_JAZZ_APP_ID`;
+      const matchingResults = results.filter((_, index) => candidates[index]?.key === key);
+      expect(new Set(matchingResults).size).toBe(1);
+      expect(content.match(new RegExp(`^${key}=`, "gm"))).toHaveLength(1);
+      expect(content).toContain(`${key}=${matchingResults[0]}\n`);
+    }
+    await expect(stat(`${envPath}.jazz-lock`)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("does not print the local server banner when stdout is not interactive", async () => {

--- a/packages/jazz-tools/src/dev/managed-runtime.test.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.test.ts
@@ -10,7 +10,15 @@ import { ensureEnvAppId, ManagedDevRuntime } from "./managed-runtime.js";
 import { chmod, lstat, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { build } from "esbuild";
 import { unlock, waitForLockSync } from "fs-native-extensions";
-import { appendFileSync, closeSync, fsyncSync, openSync, writeSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 
 const execFile = promisify(execFileCallback);
 
@@ -356,6 +364,64 @@ describe("ManagedDevRuntime", () => {
     });
     await expect(readFile(envPath, "utf8")).resolves.toBe(
       "FIRST=one\nEXTERNAL=kept\nVITE_JAZZ_APP_ID=generated\n",
+    );
+  });
+
+  it("retries against an atomic replacement made after lock acquisition", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-replaced-locked-");
+    const envPath = join(schemaDir, ".env");
+    const replacementPath = join(schemaDir, ".env.replacement");
+    await writeFile(envPath, "ORIGINAL=old\n");
+    let replaced = false;
+
+    expect(
+      ensureEnvAppId(envPath, "VITE_JAZZ_APP_ID", "generated", undefined, {
+        waitForLock(descriptor) {
+          waitForLockSync(descriptor);
+          if (!replaced) {
+            writeFileSync(replacementPath, "REPLACED=visible\n");
+            renameSync(replacementPath, envPath);
+            replaced = true;
+          }
+        },
+        unlock,
+        write: (descriptor, bytes, offset) =>
+          writeSync(descriptor, bytes, offset, bytes.byteLength - offset),
+        fsync: fsyncSync,
+      }),
+    ).toBe("generated");
+
+    await expect(readFile(envPath, "utf8")).resolves.toBe(
+      "REPLACED=visible\nVITE_JAZZ_APP_ID=generated\n",
+    );
+  });
+
+  it("retries when .env is atomically replaced after the append", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-replaced-final-");
+    const envPath = join(schemaDir, ".env");
+    const replacementPath = join(schemaDir, ".env.replacement");
+    await writeFile(envPath, "ORIGINAL=old\n");
+    let replaced = false;
+
+    expect(
+      ensureEnvAppId(envPath, "VITE_JAZZ_APP_ID", "generated", undefined, {
+        waitForLock: waitForLockSync,
+        unlock,
+        write: (descriptor, bytes, offset) =>
+          writeSync(descriptor, bytes, offset, bytes.byteLength - offset),
+        fsync(descriptor) {
+          fsyncSync(descriptor);
+          if (!replaced) {
+            writeFileSync(replacementPath, "REPLACED=visible\n");
+            renameSync(replacementPath, envPath);
+            replaced = true;
+          }
+        },
+      }),
+    ).toBe("generated");
+
+    await expect(readFile(envPath, "utf8")).resolves.toBe(
+      "REPLACED=visible\nVITE_JAZZ_APP_ID=generated\n",
     );
   });
 

--- a/packages/jazz-tools/src/dev/managed-runtime.test.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { execFile as execFileCallback } from "node:child_process";
+import { execFile as execFileCallback, spawn } from "node:child_process";
 import { createTempRootTracker, todoSchema } from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
 import * as catalogueProject from "./catalogue-project.js";
 import * as schemaWatcher from "./schema-watcher.js";
-import { ManagedDevRuntime } from "./managed-runtime.js";
-import { chmod, readFile, stat, writeFile } from "node:fs/promises";
+import { ensureEnvAppId, ManagedDevRuntime } from "./managed-runtime.js";
+import { chmod, lstat, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { build } from "esbuild";
+import { unlock, waitForLockSync } from "fs-native-extensions";
+import { appendFileSync, closeSync, fsyncSync, openSync, writeSync } from "node:fs";
 
 const execFile = promisify(execFileCallback);
 
@@ -183,18 +185,45 @@ describe("ManagedDevRuntime", () => {
     );
   });
 
-  it("preserves CRLF and file mode when appending atomically", async () => {
+  it("preserves CRLF, inode, and file mode when appending", async () => {
     const schemaDir = await tempRoots.create("jazz-managed-dotenv-preserve-");
     const envPath = join(schemaDir, ".env");
     await writeFile(envPath, "FIRST=one\r\nSECOND=two");
     await chmod(envPath, 0o640);
     const appId = "00000000-0000-0000-0000-000000000127";
 
+    const before = await stat(envPath);
     expect(makeRuntime().prepareEnv({ appId, schemaDir })).toBe(appId);
     await expect(readFile(envPath, "utf8")).resolves.toBe(
       `FIRST=one\r\nSECOND=two\r\nVITE_JAZZ_APP_ID=${appId}\r\n`,
     );
     expect((await stat(envPath)).mode & 0o777).toBe(0o640);
+    expect((await stat(envPath)).ino).toBe(before.ino);
+  });
+
+  it("creates .env with ordinary umask-derived permissions", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-mode-");
+    const previousUmask = process.umask(0o027);
+    try {
+      makeRuntime().prepareEnv({ schemaDir, appId: "mode-id" });
+    } finally {
+      process.umask(previousUmask);
+    }
+    expect((await stat(join(schemaDir, ".env"))).mode & 0o777).toBe(0o640);
+  });
+
+  it("rejects a symlinked .env without changing its target", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-symlink-");
+    const target = join(schemaDir, "target.env");
+    const envPath = join(schemaDir, ".env");
+    await writeFile(target, "EXISTING=untouched\n");
+    await symlink(target, envPath);
+
+    expect(() => makeRuntime().prepareEnv({ schemaDir, appId: "not-written" })).toThrow(
+      "refusing to update symlinked .env",
+    );
+    await expect(readFile(target, "utf8")).resolves.toBe("EXISTING=untouched\n");
+    expect((await lstat(envPath)).isSymbolicLink()).toBe(true);
   });
 
   it("serializes concurrent process writers without lost updates", async () => {
@@ -206,6 +235,7 @@ describe("ManagedDevRuntime", () => {
       bundle: true,
       format: "esm",
       platform: "node",
+      external: ["fs-native-extensions"],
     });
     const envPath = join(schemaDir, ".env");
     await writeFile(envPath, "EXISTING=preserved");
@@ -231,7 +261,138 @@ describe("ManagedDevRuntime", () => {
       expect(content.match(new RegExp(`^${key}=`, "gm"))).toHaveLength(1);
       expect(content).toContain(`${key}=${matchingResults[0]}\n`);
     }
-    await expect(stat(`${envPath}.jazz-lock`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("recovers the advisory lock after a writer is killed", async () => {
+    if (process.platform === "win32") return;
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-crash-");
+    const envPath = join(schemaDir, ".env");
+    await writeFile(envPath, "EXISTING=preserved\n");
+    const worker = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `import { openSync } from "node:fs"; import { waitForLockSync } from "fs-native-extensions"; const fd=openSync(${JSON.stringify(envPath)}, "a+"); waitForLockSync(fd); process.stdout.write("locked\\n"); setInterval(()=>{}, 1000);`,
+      ],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+    await new Promise<void>((resolve, reject) => {
+      worker.once("error", reject);
+      worker.stdout.once("data", () => resolve());
+    });
+    worker.kill("SIGKILL");
+    await new Promise<void>((resolve) => worker.once("exit", () => resolve()));
+
+    expect(makeRuntime().prepareEnv({ schemaDir, appId: "after-crash" })).toBe("after-crash");
+    await expect(readFile(envPath, "utf8")).resolves.toContain("VITE_JAZZ_APP_ID=after-crash\n");
+  });
+
+  it("waits for a live lock owner instead of stealing its lock", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-live-owner-");
+    const envPath = join(schemaDir, ".env");
+    const bundlePath = join(schemaDir, "managed-runtime.mjs");
+    await writeFile(envPath, "EXISTING=preserved\n");
+    await build({
+      entryPoints: [join(import.meta.dirname, "managed-runtime.ts")],
+      outfile: bundlePath,
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      external: ["fs-native-extensions"],
+    });
+    const descriptor = openSync(envPath, "a+");
+    waitForLockSync(descriptor);
+    const worker = execFile(process.execPath, [
+      "--input-type=module",
+      "--eval",
+      `import { ensureEnvAppId } from ${JSON.stringify(bundlePath)}; process.stdout.write(ensureEnvAppId(${JSON.stringify(envPath)}, "VITE_JAZZ_APP_ID", "after-owner", undefined));`,
+    ]);
+    let settled = false;
+    void worker.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(settled).toBe(false);
+    } finally {
+      unlock(descriptor);
+      closeSync(descriptor);
+    }
+    await expect(worker).resolves.toMatchObject({ stdout: "after-owner" });
+  });
+
+  it("preserves external edits made before the locked append", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-external-");
+    const envPath = join(schemaDir, ".env");
+    await writeFile(envPath, "EXTERNAL=first\n");
+    await writeFile(envPath, "EXTERNAL=changed\nOTHER=kept\n");
+    ensureEnvAppId(envPath, "VITE_JAZZ_APP_ID", "generated", undefined);
+    await expect(readFile(envPath, "utf8")).resolves.toBe(
+      "EXTERNAL=changed\nOTHER=kept\nVITE_JAZZ_APP_ID=generated\n",
+    );
+  });
+
+  it("reparses an unrelated external append after acquiring the lock", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-dotenv-external-locked-");
+    const envPath = join(schemaDir, ".env");
+    await writeFile(envPath, "FIRST=one\n");
+    ensureEnvAppId(envPath, "VITE_JAZZ_APP_ID", "generated", undefined, {
+      waitForLock(descriptor) {
+        waitForLockSync(descriptor);
+        // Model a non-cooperating editor that appends after the Jazz process has
+        // opened the file but before it reparses the latest bytes.
+        appendFileSync(envPath, "EXTERNAL=kept\n");
+      },
+      unlock,
+      write: (descriptor, bytes, offset) =>
+        writeSync(descriptor, bytes, offset, bytes.byteLength - offset),
+      fsync: fsyncSync,
+    });
+    await expect(readFile(envPath, "utf8")).resolves.toBe(
+      "FIRST=one\nEXTERNAL=kept\nVITE_JAZZ_APP_ID=generated\n",
+    );
+  });
+
+  it("full-writes short writes and surfaces write, fsync, and unlock errors", async () => {
+    const makeOperations = () => ({
+      waitForLock: waitForLockSync,
+      unlock,
+      write: (descriptor: number, bytes: Uint8Array, offset: number) =>
+        writeSync(descriptor, bytes, offset, Math.min(2, bytes.byteLength - offset)),
+      fsync: fsyncSync,
+    });
+    const shortDir = await tempRoots.create("jazz-managed-dotenv-short-write-");
+    ensureEnvAppId(
+      join(shortDir, ".env"),
+      "VITE_JAZZ_APP_ID",
+      "short",
+      undefined,
+      makeOperations(),
+    );
+    await expect(readFile(join(shortDir, ".env"), "utf8")).resolves.toBe(
+      "VITE_JAZZ_APP_ID=short\n",
+    );
+
+    for (const failure of ["write", "fsync", "unlock"] as const) {
+      const schemaDir = await tempRoots.create(`jazz-managed-dotenv-${failure}-`);
+      const operations = makeOperations();
+      operations[failure] = (() => {
+        throw new Error(`${failure}-failed`);
+      }) as never;
+      expect(() =>
+        ensureEnvAppId(join(schemaDir, ".env"), "VITE_JAZZ_APP_ID", failure, undefined, operations),
+      ).toThrow(`${failure}-failed`);
+      // close(2) releases the OS lock even if explicit unlock reports an error.
+      expect(() =>
+        ensureEnvAppId(join(schemaDir, ".env"), "OTHER", "retry", undefined),
+      ).not.toThrow();
+    }
   });
 
   it("does not print the local server banner when stdout is not interactive", async () => {

--- a/packages/jazz-tools/src/dev/managed-runtime.test.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.test.ts
@@ -116,6 +116,35 @@ describe("ManagedDevRuntime", () => {
     }
   });
 
+  it("separates a generated app ID from a final unterminated env line", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-unterminated-env-");
+    const appId = "00000000-0000-0000-0000-000000000125";
+    await writeFile(join(schemaDir, ".env"), "EXISTING=value");
+
+    const runtime = makeRuntime();
+    expect(runtime.prepareEnv({ appId, schemaDir })).toBe(appId);
+
+    await expect(readFile(join(schemaDir, ".env"), "utf8")).resolves.toBe(
+      `EXISTING=value\nVITE_JAZZ_APP_ID=${appId}\n`,
+    );
+  });
+
+  it("does not mistake comments or longer variable names for the app ID", async () => {
+    const schemaDir = await tempRoots.create("jazz-managed-similar-env-");
+    const appId = "00000000-0000-0000-0000-000000000126";
+    await writeFile(
+      join(schemaDir, ".env"),
+      "# VITE_JAZZ_APP_ID=disabled\nMY_VITE_JAZZ_APP_ID=other\n",
+    );
+
+    const runtime = makeRuntime();
+    expect(runtime.prepareEnv({ appId, schemaDir })).toBe(appId);
+
+    await expect(readFile(join(schemaDir, ".env"), "utf8")).resolves.toBe(
+      `# VITE_JAZZ_APP_ID=disabled\nMY_VITE_JAZZ_APP_ID=other\nVITE_JAZZ_APP_ID=${appId}\n`,
+    );
+  });
+
   it("does not print the local server banner when stdout is not interactive", async () => {
     const schemaDir = await tempRoots.create("jazz-managed-noninteractive-banner-");
     await writeFile(join(schemaDir, "schema.ts"), todoSchema());

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -1,17 +1,18 @@
 import { randomUUID } from "node:crypto";
 import {
   closeSync,
+  constants,
+  fstatSync,
   fsyncSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
+  writeSync,
 } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { unlock, waitForLockSync } from "fs-native-extensions";
 import type { LocalJazzServerHandle } from "./dev-server.js";
 import type { JazzPluginOptions, JazzServerOptions } from "./vite.js";
 import { resolveTelemetryCollectorUrl, type TelemetryOptions } from "../runtime/sync-telemetry.js";
@@ -135,7 +136,6 @@ function normalizeServerOption(
     }, {});
 }
 
-const lockWaiter = new Int32Array(new SharedArrayBuffer(4));
 const dotenvLine =
   /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gm;
 
@@ -168,15 +168,6 @@ function parseDotenv(content: string): {
   return { values, assignmentLines };
 }
 
-function readEnvContent(envPath: string): string {
-  try {
-    return readFileSync(envPath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "";
-    throw error;
-  }
-}
-
 function parsedEnvValue(content: string, envKey: string): string | null {
   const parsed = parseDotenv(content);
   const assignments = parsed.assignmentLines.get(envKey) ?? [];
@@ -200,65 +191,71 @@ function parsedEnvValue(content: string, envKey: string): string | null {
   return value;
 }
 
-function withEnvLock<T>(envPath: string, action: () => T): T {
-  const lockPath = `${envPath}.jazz-lock`;
-  const deadline = Date.now() + 10_000;
-  let descriptor: number | null = null;
-  while (descriptor === null) {
-    try {
-      descriptor = openSync(lockPath, "wx", 0o600);
-      writeFileSync(descriptor, `${process.pid}\n`);
-      fsyncSync(descriptor);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      if (Date.now() >= deadline) {
-        throw new Error(`${LOG_PREFIX} timed out waiting to update .env safely.`);
-      }
-      Atomics.wait(lockWaiter, 0, 0, 10);
-    }
-  }
-  let result: T | undefined;
-  let actionError: unknown;
-  try {
-    result = action();
-  } catch (error) {
-    actionError = error;
-  }
-  try {
-    closeSync(descriptor);
-    unlinkSync(lockPath);
-  } catch (cleanupError) {
-    if (actionError === undefined && (cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw cleanupError;
-    }
-  }
-  if (actionError !== undefined) throw actionError;
-  return result as T;
+interface EnvFileOperations {
+  waitForLock(descriptor: number): void;
+  unlock(descriptor: number): void;
+  write(descriptor: number, bytes: Uint8Array, offset: number): number;
+  fsync(descriptor: number): void;
 }
 
-function atomicReplaceEnv(envPath: string, content: string, mode: number): void {
-  const tempPath = join(dirname(envPath), `.${randomUUID()}.jazz-env.tmp`);
-  let descriptor: number | null = null;
-  let writeError: unknown;
+const defaultEnvFileOperations: EnvFileOperations = {
+  waitForLock: waitForLockSync,
+  unlock,
+  write: (descriptor, bytes, offset) =>
+    writeSync(descriptor, bytes, offset, bytes.byteLength - offset),
+  fsync: fsyncSync,
+};
+
+function assertRegularEnvPath(envPath: string): void {
   try {
-    descriptor = openSync(tempPath, "wx", mode);
-    writeFileSync(descriptor, content, "utf8");
-    fsyncSync(descriptor);
-    closeSync(descriptor);
-    descriptor = null;
-    renameSync(tempPath, envPath);
-  } catch (error) {
-    writeError = error;
-  }
-  try {
-    if (descriptor !== null) closeSync(descriptor);
-    unlinkSync(tempPath);
-  } catch (cleanupError) {
-    if (writeError === undefined && (cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw cleanupError;
+    const metadata = lstatSync(envPath);
+    if (metadata.isSymbolicLink()) {
+      throw new Error(
+        `${LOG_PREFIX} refusing to update symlinked .env at ${envPath}; use a regular file instead.`,
+      );
     }
+    if (!metadata.isFile()) {
+      throw new Error(`${LOG_PREFIX} refusing to update non-file .env at ${envPath}.`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
-  if (writeError !== undefined) throw writeError;
+}
+
+function openEnvForAppend(envPath: string): number {
+  assertRegularEnvPath(envPath);
+  const descriptor = openSync(
+    envPath,
+    constants.O_CREAT | constants.O_RDWR | constants.O_APPEND | constants.O_NOFOLLOW,
+    0o666,
+  );
+  try {
+    const pathMetadata = lstatSync(envPath);
+    const descriptorMetadata = fstatSync(descriptor);
+    if (
+      pathMetadata.isSymbolicLink() ||
+      !descriptorMetadata.isFile() ||
+      pathMetadata.dev !== descriptorMetadata.dev ||
+      pathMetadata.ino !== descriptorMetadata.ino
+    ) {
+      throw new Error(`${LOG_PREFIX} .env changed while it was being opened; retry startup.`);
+    }
+    return descriptor;
+  } catch (error) {
+    closeSync(descriptor);
+    throw error;
+  }
+}
+
+function writeAll(descriptor: number, bytes: Uint8Array, operations: EnvFileOperations): void {
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const written = operations.write(descriptor, bytes, offset);
+    if (!Number.isSafeInteger(written) || written <= 0) {
+      throw new Error(`${LOG_PREFIX} failed to make progress while appending to .env.`);
+    }
+    offset += written;
+  }
 }
 
 export function ensureEnvAppId(
@@ -266,32 +263,50 @@ export function ensureEnvAppId(
   envKey: string,
   fallback: string,
   preferred: string | undefined,
+  operations: EnvFileOperations = defaultEnvFileOperations,
 ): string {
   mkdirSync(dirname(envPath), { recursive: true });
-  return withEnvLock(envPath, () => {
-    const content = readEnvContent(envPath);
+  const descriptor = openEnvForAppend(envPath);
+  let result: string | undefined;
+  let actionError: unknown;
+  let locked = false;
+  try {
+    operations.waitForLock(descriptor);
+    locked = true;
+    // The lock is on the .env inode itself. Reparse only after acquisition so
+    // every cooperating process observes the previous writer's complete append.
+    const content = readFileSync(descriptor, "utf8");
     const existing = parsedEnvValue(content, envKey);
-    if (existing !== null) return preferred ?? existing;
-
-    const newline = content.includes("\r\n") ? "\r\n" : "\n";
-    const separator = content && !content.endsWith("\n") ? newline : "";
-    const next = `${content}${separator}${envKey}=${fallback}${newline}`;
-    const mode = (() => {
-      try {
-        return statSync(envPath).mode & 0o7777;
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0o600;
-        throw error;
-      }
-    })();
-    // Re-read under the interprocess lock immediately before replacement so
-    // every cooperating writer derives its update from the latest whole file.
-    if (readEnvContent(envPath) !== content) {
-      throw new Error(`${LOG_PREFIX} .env changed outside the Jazz writer; retry startup.`);
+    if (existing !== null) {
+      result = preferred ?? existing;
+    } else {
+      const newline = content.includes("\r\n") ? "\r\n" : "\n";
+      const separator = content && !content.endsWith("\n") ? newline : "";
+      const addition = Buffer.from(`${separator}${envKey}=${fallback}${newline}`);
+      writeAll(descriptor, addition, operations);
+      operations.fsync(descriptor);
+      result = fallback;
     }
-    atomicReplaceEnv(envPath, next, mode);
-    return fallback;
-  });
+  } catch (error) {
+    actionError = error;
+  }
+
+  let cleanupError: unknown;
+  if (locked) {
+    try {
+      operations.unlock(descriptor);
+    } catch (error) {
+      cleanupError = error;
+    }
+  }
+  try {
+    closeSync(descriptor);
+  } catch (error) {
+    cleanupError ??= error;
+  }
+  if (actionError !== undefined) throw actionError;
+  if (cleanupError !== undefined) throw cleanupError;
+  return result as string;
 }
 
 export interface InitializeOptions extends JazzPluginOptions {

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -1,7 +1,17 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 import type { LocalJazzServerHandle } from "./dev-server.js";
 import type { JazzPluginOptions, JazzServerOptions } from "./vite.js";
 import { resolveTelemetryCollectorUrl, type TelemetryOptions } from "../runtime/sync-telemetry.js";
@@ -125,32 +135,151 @@ function normalizeServerOption(
     }, {});
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const lockWaiter = new Int32Array(new SharedArrayBuffer(4));
+const dotenvLine =
+  /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gm;
+
+// Keep this contract aligned with the dotenv parser used by Vite and Expo:
+// export syntax, whitespace, quotes, inline comments, and quoted newlines all
+// resolve exactly as they do when the framework later loads the same file.
+function parseDotenv(content: string): {
+  values: Record<string, string>;
+  assignmentLines: Map<string, number[]>;
+} {
+  const values: Record<string, string> = {};
+  const assignmentLines = new Map<string, number[]>();
+  const normalized = content.replace(/\r\n?/g, "\n");
+  dotenvLine.lastIndex = 0;
+  for (const match of normalized.matchAll(dotenvLine)) {
+    const key = match[1];
+    if (!key) continue;
+    const line = normalized.slice(0, match.index).split("\n").length;
+    const lines = assignmentLines.get(key) ?? [];
+    lines.push(line);
+    assignmentLines.set(key, lines);
+    let value = (match[2] ?? "").trim();
+    const quote = value[0];
+    value = value.replace(/^(['"`])([\s\S]*)\1$/gm, "$2");
+    if (quote === '"') {
+      value = value.replace(/\\n/g, "\n").replace(/\\r/g, "\r");
+    }
+    values[key] = value;
+  }
+  return { values, assignmentLines };
 }
 
-function readEnvAppId(envPath: string, envKey: string): string | null {
+function readEnvContent(envPath: string): string {
   try {
-    const content = readFileSync(envPath, "utf8");
-    const match = content.match(new RegExp(`^${escapeRegExp(envKey)}=(.+)$`, "m"));
-    return match?.[1]?.trim() ?? null;
-  } catch {
-    return null;
+    return readFileSync(envPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw error;
   }
 }
 
-function persistAppIdToEnv(envPath: string, envKey: string, appId: string): void {
-  let content = "";
-  try {
-    content = readFileSync(envPath, "utf8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+function parsedEnvValue(content: string, envKey: string): string | null {
+  const parsed = parseDotenv(content);
+  const assignments = parsed.assignmentLines.get(envKey) ?? [];
+  if (assignments.length > 1) {
+    throw new Error(
+      `${LOG_PREFIX} ${envKey} is assigned more than once in .env (lines ${assignments.join(
+        ", ",
+      )}). Keep exactly one assignment.`,
+    );
   }
-  if (new RegExp(`^${escapeRegExp(envKey)}=`, "m").test(content)) return;
-  const separator = content && !content.endsWith("\n") ? "\n" : "";
-  const line = `${separator}${envKey}=${appId}\n`;
-  mkdirSync(join(envPath, ".."), { recursive: true });
-  writeFileSync(envPath, content + line);
+  if (assignments.length === 0) return null;
+  const value = parsed.values[envKey];
+  if (value === undefined) {
+    throw new Error(`${LOG_PREFIX} ${envKey} has an invalid .env assignment.`);
+  }
+  if (value.length === 0) {
+    throw new Error(
+      `${LOG_PREFIX} ${envKey} is empty in .env. Remove the assignment to generate an app ID, or provide a non-empty value.`,
+    );
+  }
+  return value;
+}
+
+function withEnvLock<T>(envPath: string, action: () => T): T {
+  const lockPath = `${envPath}.jazz-lock`;
+  const deadline = Date.now() + 10_000;
+  let descriptor: number | null = null;
+  while (descriptor === null) {
+    try {
+      descriptor = openSync(lockPath, "wx", 0o600);
+      writeFileSync(descriptor, `${process.pid}\n`);
+      fsyncSync(descriptor);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (Date.now() >= deadline) {
+        throw new Error(`${LOG_PREFIX} timed out waiting to update .env safely.`);
+      }
+      Atomics.wait(lockWaiter, 0, 0, 10);
+    }
+  }
+  try {
+    return action();
+  } finally {
+    closeSync(descriptor);
+    try {
+      unlinkSync(lockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function atomicReplaceEnv(envPath: string, content: string, mode: number): void {
+  const tempPath = join(dirname(envPath), `.${randomUUID()}.jazz-env.tmp`);
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(tempPath, "wx", mode);
+    writeFileSync(descriptor, content, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = null;
+    renameSync(tempPath, envPath);
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+    try {
+      unlinkSync(tempPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+export function ensureEnvAppId(
+  envPath: string,
+  envKey: string,
+  fallback: string,
+  preferred: string | undefined,
+): string {
+  mkdirSync(dirname(envPath), { recursive: true });
+  return withEnvLock(envPath, () => {
+    const content = readEnvContent(envPath);
+    const existing = parsedEnvValue(content, envKey);
+    if (existing !== null) return preferred ?? existing;
+
+    const newline = content.includes("\r\n") ? "\r\n" : "\n";
+    const separator = content && !content.endsWith("\n") ? newline : "";
+    const next = `${content}${separator}${envKey}=${fallback}${newline}`;
+    const mode = (() => {
+      try {
+        return statSync(envPath).mode & 0o7777;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0o600;
+        throw error;
+      }
+    })();
+    // Re-read under the interprocess lock immediately before replacement so
+    // every cooperating writer derives its update from the latest whole file.
+    if (readEnvContent(envPath) !== content) {
+      throw new Error(`${LOG_PREFIX} .env changed outside the Jazz writer; retry startup.`);
+    }
+    atomicReplaceEnv(envPath, next, mode);
+    return fallback;
+  });
 }
 
 export interface InitializeOptions extends JazzPluginOptions {
@@ -185,14 +314,12 @@ export class ManagedDevRuntime {
     const schemaDir = options.schemaDir ?? process.cwd();
     const envPath = join(options.envDir ?? schemaDir, ".env");
     const serverConfig = typeof serverOpt === "object" ? serverOpt : {};
-    const appId =
-      process.env[this.envKeys.appId] ??
-      readEnvAppId(envPath, this.envKeys.appId) ??
-      serverConfig.appId ??
-      options.appId ??
-      randomUUID();
-    persistAppIdToEnv(envPath, this.envKeys.appId, appId);
-    return appId;
+    return ensureEnvAppId(
+      envPath,
+      this.envKeys.appId,
+      process.env[this.envKeys.appId] ?? serverConfig.appId ?? options.appId ?? randomUUID(),
+      process.env[this.envKeys.appId],
+    );
   }
 
   private getManagedRuntimeConfig(options: JazzPluginOptions): ManagedRuntimeConfig {
@@ -369,7 +496,7 @@ export class ManagedDevRuntime {
           });
         }
 
-        persistAppIdToEnv(envPath, this.envKeys.appId, appId);
+        ensureEnvAppId(envPath, this.envKeys.appId, appId, appId);
         if (telemetryCollectorUrl) {
           console.log(`${LOG_PREFIX} telemetry collector: ${telemetryCollectorUrl}`);
         }

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -198,6 +198,12 @@ interface EnvFileOperations {
   fsync(descriptor: number): void;
 }
 
+class EnvPathReplacedError extends Error {
+  constructor() {
+    super(`${LOG_PREFIX} .env changed while it was being updated; retry startup.`);
+  }
+}
+
 const defaultEnvFileOperations: EnvFileOperations = {
   waitForLock: waitForLockSync,
   unlock,
@@ -222,6 +228,40 @@ function assertRegularEnvPath(envPath: string): void {
   }
 }
 
+/**
+ * The advisory lock belongs to the inode, not the pathname. Revalidate after
+ * locking (and before returning) so an atomic rename cannot leave us appending
+ * to an unlinked file while reporting success for the replacement at envPath.
+ */
+function assertEnvPathMatchesDescriptor(envPath: string, descriptor: number): void {
+  let pathMetadata;
+  try {
+    pathMetadata = lstatSync(envPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new EnvPathReplacedError();
+    }
+    throw error;
+  }
+  if (pathMetadata.isSymbolicLink()) {
+    throw new Error(
+      `${LOG_PREFIX} refusing to update symlinked .env at ${envPath}; use a regular file instead.`,
+    );
+  }
+  if (!pathMetadata.isFile()) {
+    throw new Error(`${LOG_PREFIX} refusing to update non-file .env at ${envPath}.`);
+  }
+
+  const descriptorMetadata = fstatSync(descriptor);
+  if (
+    !descriptorMetadata.isFile() ||
+    pathMetadata.dev !== descriptorMetadata.dev ||
+    pathMetadata.ino !== descriptorMetadata.ino
+  ) {
+    throw new EnvPathReplacedError();
+  }
+}
+
 function openEnvForAppend(envPath: string): number {
   assertRegularEnvPath(envPath);
   const descriptor = openSync(
@@ -230,16 +270,7 @@ function openEnvForAppend(envPath: string): number {
     0o666,
   );
   try {
-    const pathMetadata = lstatSync(envPath);
-    const descriptorMetadata = fstatSync(descriptor);
-    if (
-      pathMetadata.isSymbolicLink() ||
-      !descriptorMetadata.isFile() ||
-      pathMetadata.dev !== descriptorMetadata.dev ||
-      pathMetadata.ino !== descriptorMetadata.ino
-    ) {
-      throw new Error(`${LOG_PREFIX} .env changed while it was being opened; retry startup.`);
-    }
+    assertEnvPathMatchesDescriptor(envPath, descriptor);
     return descriptor;
   } catch (error) {
     closeSync(descriptor);
@@ -266,47 +297,71 @@ export function ensureEnvAppId(
   operations: EnvFileOperations = defaultEnvFileOperations,
 ): string {
   mkdirSync(dirname(envPath), { recursive: true });
-  const descriptor = openEnvForAppend(envPath);
-  let result: string | undefined;
-  let actionError: unknown;
-  let locked = false;
-  try {
-    operations.waitForLock(descriptor);
-    locked = true;
-    // The lock is on the .env inode itself. Reparse only after acquisition so
-    // every cooperating process observes the previous writer's complete append.
-    const content = readFileSync(descriptor, "utf8");
-    const existing = parsedEnvValue(content, envKey);
-    if (existing !== null) {
-      result = preferred ?? existing;
-    } else {
-      const newline = content.includes("\r\n") ? "\r\n" : "\n";
-      const separator = content && !content.endsWith("\n") ? newline : "";
-      const addition = Buffer.from(`${separator}${envKey}=${fallback}${newline}`);
-      writeAll(descriptor, addition, operations);
-      operations.fsync(descriptor);
-      result = fallback;
+  // An external atomic writer can replace the pathname after we have locked
+  // its old inode. Retry a few times against the visible replacement; a path
+  // that keeps changing remains an explicit startup failure rather than a
+  // false success on an unlinked descriptor.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const descriptor = openEnvForAppend(envPath);
+    let result: string | undefined;
+    let actionError: unknown;
+    let locked = false;
+    try {
+      operations.waitForLock(descriptor);
+      locked = true;
+      // The lock is on the .env inode itself. Revalidate the pathname after
+      // acquisition, then reparse so every cooperating process observes the
+      // previous writer's complete append on the visible file.
+      assertEnvPathMatchesDescriptor(envPath, descriptor);
+      const content = readFileSync(descriptor, "utf8");
+      const existing = parsedEnvValue(content, envKey);
+      if (existing !== null) {
+        result = preferred ?? existing;
+      } else {
+        const newline = content.includes("\r\n") ? "\r\n" : "\n";
+        const separator = content && !content.endsWith("\n") ? newline : "";
+        const addition = Buffer.from(`${separator}${envKey}=${fallback}${newline}`);
+        writeAll(descriptor, addition, operations);
+        operations.fsync(descriptor);
+        result = fallback;
+      }
+      // A replacement after the append/fsync would otherwise make this call
+      // falsely report an ID that is absent from the visible .env.
+      assertEnvPathMatchesDescriptor(envPath, descriptor);
+    } catch (error) {
+      actionError = error;
     }
-  } catch (error) {
-    actionError = error;
+
+    let cleanupError: unknown;
+    if (locked) {
+      try {
+        operations.unlock(descriptor);
+      } catch (error) {
+        cleanupError = error;
+      }
+    }
+    try {
+      closeSync(descriptor);
+    } catch (error) {
+      cleanupError ??= error;
+    }
+    if (actionError !== undefined) {
+      if (
+        actionError instanceof EnvPathReplacedError &&
+        cleanupError === undefined &&
+        attempt < 2
+      ) {
+        continue;
+      }
+      throw actionError;
+    }
+    if (cleanupError !== undefined) throw cleanupError;
+    return result as string;
   }
 
-  let cleanupError: unknown;
-  if (locked) {
-    try {
-      operations.unlock(descriptor);
-    } catch (error) {
-      cleanupError = error;
-    }
-  }
-  try {
-    closeSync(descriptor);
-  } catch (error) {
-    cleanupError ??= error;
-  }
-  if (actionError !== undefined) throw actionError;
-  if (cleanupError !== undefined) throw cleanupError;
-  return result as string;
+  // The loop either returns or throws; this keeps TypeScript's control-flow
+  // analysis honest if its bounds change in the future.
+  throw new EnvPathReplacedError();
 }
 
 export interface InitializeOptions extends JazzPluginOptions {

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -217,21 +217,29 @@ function withEnvLock<T>(envPath: string, action: () => T): T {
       Atomics.wait(lockWaiter, 0, 0, 10);
     }
   }
+  let result: T | undefined;
+  let actionError: unknown;
   try {
-    return action();
-  } finally {
+    result = action();
+  } catch (error) {
+    actionError = error;
+  }
+  try {
     closeSync(descriptor);
-    try {
-      unlinkSync(lockPath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    unlinkSync(lockPath);
+  } catch (cleanupError) {
+    if (actionError === undefined && (cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw cleanupError;
     }
   }
+  if (actionError !== undefined) throw actionError;
+  return result as T;
 }
 
 function atomicReplaceEnv(envPath: string, content: string, mode: number): void {
   const tempPath = join(dirname(envPath), `.${randomUUID()}.jazz-env.tmp`);
   let descriptor: number | null = null;
+  let writeError: unknown;
   try {
     descriptor = openSync(tempPath, "wx", mode);
     writeFileSync(descriptor, content, "utf8");
@@ -239,14 +247,18 @@ function atomicReplaceEnv(envPath: string, content: string, mode: number): void 
     closeSync(descriptor);
     descriptor = null;
     renameSync(tempPath, envPath);
-  } finally {
+  } catch (error) {
+    writeError = error;
+  }
+  try {
     if (descriptor !== null) closeSync(descriptor);
-    try {
-      unlinkSync(tempPath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    unlinkSync(tempPath);
+  } catch (cleanupError) {
+    if (writeError === undefined && (cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw cleanupError;
     }
   }
+  if (writeError !== undefined) throw writeError;
 }
 
 export function ensureEnvAppId(

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -196,6 +196,8 @@ interface EnvFileOperations {
   unlock(descriptor: number): void;
   write(descriptor: number, bytes: Uint8Array, offset: number): number;
   fsync(descriptor: number): void;
+  /** Test seam for a pathname replacement after open(2), before fstat/lstat. */
+  afterOpen?(descriptor: number): void;
 }
 
 class EnvPathReplacedError extends Error {
@@ -262,7 +264,7 @@ function assertEnvPathMatchesDescriptor(envPath: string, descriptor: number): vo
   }
 }
 
-function openEnvForAppend(envPath: string): number {
+function openEnvForAppend(envPath: string, afterOpen?: (descriptor: number) => void): number {
   assertRegularEnvPath(envPath);
   const descriptor = openSync(
     envPath,
@@ -270,6 +272,7 @@ function openEnvForAppend(envPath: string): number {
     0o666,
   );
   try {
+    afterOpen?.(descriptor);
     assertEnvPathMatchesDescriptor(envPath, descriptor);
     return descriptor;
   } catch (error) {
@@ -302,11 +305,12 @@ export function ensureEnvAppId(
   // that keeps changing remains an explicit startup failure rather than a
   // false success on an unlinked descriptor.
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    const descriptor = openEnvForAppend(envPath);
+    let descriptor: number | undefined;
     let result: string | undefined;
     let actionError: unknown;
     let locked = false;
     try {
+      descriptor = openEnvForAppend(envPath, operations.afterOpen);
       operations.waitForLock(descriptor);
       locked = true;
       // The lock is on the .env inode itself. Revalidate the pathname after
@@ -333,17 +337,19 @@ export function ensureEnvAppId(
     }
 
     let cleanupError: unknown;
-    if (locked) {
+    if (locked && descriptor !== undefined) {
       try {
         operations.unlock(descriptor);
       } catch (error) {
         cleanupError = error;
       }
     }
-    try {
-      closeSync(descriptor);
-    } catch (error) {
-      cleanupError ??= error;
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch (error) {
+        cleanupError ??= error;
+      }
     }
     if (actionError !== undefined) {
       if (

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -125,10 +125,14 @@ function normalizeServerOption(
     }, {});
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function readEnvAppId(envPath: string, envKey: string): string | null {
   try {
     const content = readFileSync(envPath, "utf8");
-    const match = content.match(new RegExp(`^${envKey}=(.+)$`, "m"));
+    const match = content.match(new RegExp(`^${escapeRegExp(envKey)}=(.+)$`, "m"));
     return match?.[1]?.trim() ?? null;
   } catch {
     return null;
@@ -142,10 +146,11 @@ function persistAppIdToEnv(envPath: string, envKey: string, appId: string): void
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }
-  if (content.includes(`${envKey}=`)) return;
-  const line = `${envKey}=${appId}\n`;
+  if (new RegExp(`^${escapeRegExp(envKey)}=`, "m").test(content)) return;
+  const separator = content && !content.endsWith("\n") ? "\n" : "";
+  const line = `${separator}${envKey}=${appId}\n`;
   mkdirSync(join(envPath, ".."), { recursive: true });
-  writeFileSync(envPath, content ? content + line : line);
+  writeFileSync(envPath, content + line);
 }
 
 export interface InitializeOptions extends JazzPluginOptions {

--- a/packages/jazz-tools/src/fs-native-extensions.d.ts
+++ b/packages/jazz-tools/src/fs-native-extensions.d.ts
@@ -1,0 +1,4 @@
+declare module "fs-native-extensions" {
+  export function waitForLockSync(descriptor: number): void;
+  export function unlock(descriptor: number): void;
+}

--- a/packages/jazz-tools/src/fs-native-extensions.d.ts
+++ b/packages/jazz-tools/src/fs-native-extensions.d.ts
@@ -1,4 +1,0 @@
-declare module "fs-native-extensions" {
-  export function waitForLockSync(descriptor: number): void;
-  export function unlock(descriptor: number): void;
-}

--- a/packages/jazz-tools/src/types/fs-native-extensions.d.ts
+++ b/packages/jazz-tools/src/types/fs-native-extensions.d.ts
@@ -1,0 +1,8 @@
+/**
+ * The native addon does not currently publish TypeScript declarations. Keep
+ * its small locking API here so every package typecheck can import it safely.
+ */
+declare module "fs-native-extensions" {
+  export function waitForLockSync(descriptor: number): void;
+  export function unlock(descriptor: number): void;
+}

--- a/packages/jazz-tools/tsconfig.react-native-tests.json
+++ b/packages/jazz-tools/tsconfig.react-native-tests.json
@@ -12,6 +12,7 @@
     "src/expo/**/*.typecheck.tsx",
     "src/expo/vendor.d.ts",
     "src/dev/expo.typecheck.ts",
+    "src/types/fs-native-extensions.d.ts",
     "src/types/jazz-wasm-mutation-error.d.ts"
   ],
   "exclude": ["node_modules", "dist"]

--- a/packages/jazz-tools/tsconfig.svelte.json
+++ b/packages/jazz-tools/tsconfig.svelte.json
@@ -4,5 +4,5 @@
     "rootDir": "./src/svelte",
     "outDir": "./dist/svelte"
   },
-  "include": ["src/svelte/**/*"]
+  "include": ["src/svelte/**/*", "src/types/**/*.d.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1387,6 +1387,9 @@ importers:
       expo-secure-store:
         specifier: '>=14.0.0'
         version: 57.0.1(expo@57.0.7)
+      fs-native-extensions:
+        specifier: 1.5.0
+        version: 1.5.0
       jazz-rn:
         specifier: workspace:*
         version: link:../../crates/jazz-rn
@@ -7180,6 +7183,25 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-addon-resolve@1.10.1:
+    resolution: {integrity: sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
+  bare-module-resolve@1.12.4:
+    resolution: {integrity: sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
+  bare-semver@1.1.0:
+    resolution: {integrity: sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -8706,6 +8728,9 @@ packages:
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
+
+  fs-native-extensions@1.5.0:
+    resolution: {integrity: sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -11546,6 +11571,10 @@ packages:
   remark@15.0.1:
     resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
+  require-addon@1.2.0:
+    resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
+    engines: {bare: '>=1.10.0'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -12811,6 +12840,9 @@ packages:
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
+  which-runtime@1.4.0:
+    resolution: {integrity: sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==}
 
   which-typed-array@1.1.22:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
@@ -19081,6 +19113,17 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  bare-addon-resolve@1.10.1:
+    dependencies:
+      bare-module-resolve: 1.12.4
+      bare-semver: 1.1.0
+
+  bare-module-resolve@1.12.4:
+    dependencies:
+      bare-semver: 1.1.0
+
+  bare-semver@1.1.0: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
@@ -20864,6 +20907,13 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+
+  fs-native-extensions@1.5.0:
+    dependencies:
+      require-addon: 1.2.0
+      which-runtime: 1.4.0
+    transitivePeerDependencies:
+      - bare-url
 
   fs.realpath@1.0.0: {}
 
@@ -24697,6 +24747,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-addon@1.2.0:
+    dependencies:
+      bare-addon-resolve: 1.10.1
+    transitivePeerDependencies:
+      - bare-url
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -26176,6 +26232,8 @@ snapshots:
       is-weakset: 2.0.4
 
   which-module@2.0.1: {}
+
+  which-runtime@1.4.0: {}
 
   which-typed-array@1.1.22:
     dependencies:


### PR DESCRIPTION
## Summary
- add a line break before a generated app-ID assignment when an existing dotenv file has no final newline
- recognise only an exact assignment at the start of a line
- preserve existing dotenv content, including comments and similarly named variables

Before, the generated assignment could be appended to the previous value. After, it is always written as a separate dotenv entry.

## Testing
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/dev/managed-runtime.test.ts` — 7 tests passed