### PR TITLE
Reject ambiguous generated relation names

### DIFF
--- a/.changeset/reject-ambiguous-relation-names.md
+++ b/.changeset/reject-ambiguous-relation-names.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Reject schemas whose reference columns generate ambiguous relation names instead of silently selecting one relation.
+Reject schemas whose generated relation names are ambiguous or shadow another stored/public output column instead of silently selecting or overwriting a value.

--- a/.changeset/reject-ambiguous-relation-names.md
+++ b/.changeset/reject-ambiguous-relation-names.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reject schemas whose reference columns generate ambiguous relation names instead of silently selecting one relation.

--- a/packages/jazz-tools/src/codegen/relation-analyzer.ts
+++ b/packages/jazz-tools/src/codegen/relation-analyzer.ts
@@ -29,15 +29,40 @@ export interface Relation {
 
 export class AmbiguousRelationNameError extends Error {}
 
-function addRelation(relations: Map<string, Relation[]>, relation: Relation): void {
+function relationProvenance(relation: Relation): string {
+  const referenceColumn = relation.type === "forward" ? relation.fromColumn : relation.toColumn;
+  const referenceTable = relation.type === "forward" ? relation.fromTable : relation.toTable;
+  const referencedTable = relation.type === "forward" ? relation.toTable : relation.fromTable;
+
+  return `${relation.type} relation generated from reference column "${referenceTable}.${referenceColumn}" to "${referencedTable}.id"`;
+}
+
+function addRelation(
+  relations: Map<string, Relation[]>,
+  outputColumnsByTable: Map<string, Set<string>>,
+  relation: Relation,
+): void {
   const tableRelations = relations.get(relation.fromTable);
   if (!tableRelations) {
     throw new Error(`Unknown relation source table "${relation.fromTable}"`);
   }
+
+  // A scalar reference may intentionally use its own relation name (for
+  // example `team: ref("teams")`). The typed include API replaces that one
+  // reference value with the joined row. Every other output-column collision
+  // would instead make two independently-addressable public values share a
+  // key, so reject it.
+  const isOwnReferenceColumn = relation.type === "forward" && relation.fromColumn === relation.name;
+  if (!isOwnReferenceColumn && outputColumnsByTable.get(relation.fromTable)?.has(relation.name)) {
+    throw new AmbiguousRelationNameError(
+      `Generated relation name "${relation.name}" on table "${relation.fromTable}" (${relationProvenance(relation)}) collides with the stored/public output column "${relation.fromTable}.${relation.name}". Rename the reference column or the output column.`,
+    );
+  }
+
   const existing = tableRelations.find((candidate) => candidate.name === relation.name);
   if (existing) {
     throw new AmbiguousRelationNameError(
-      `Generated relation name "${relation.name}" is ambiguous on table "${relation.fromTable}" between columns "${existing.fromColumn}/${existing.toColumn}" and "${relation.fromColumn}/${relation.toColumn}". Rename one of the reference columns.`,
+      `Generated relation name "${relation.name}" is ambiguous on table "${relation.fromTable}" between ${relationProvenance(existing)} and ${relationProvenance(relation)}. Rename one of the reference columns.`,
     );
   }
   tableRelations.push(relation);
@@ -70,10 +95,15 @@ function forwardRefNameFromFK(columnName: string): string {
  */
 export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
   const relations = new Map<string, Relation[]>();
+  const outputColumnsByTable = new Map<string, Set<string>>();
 
   // Initialize empty arrays for all tables
-  for (const tableName of Object.keys(schema)) {
+  for (const [tableName, table] of Object.entries(schema)) {
     relations.set(tableName, []);
+    // `id` is implicit in every public row even though it is not a stored
+    // descriptor. Includes are materialized onto the same public row object,
+    // so relation names must not shadow either it or a stored column.
+    outputColumnsByTable.set(tableName, new Set(["id", ...table.columns.map((col) => col.name)]));
   }
 
   for (const [tableName, table] of Object.entries(schema)) {
@@ -101,7 +131,7 @@ export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
           isArray: isForwardArray,
           nullable: col.nullable,
         };
-        addRelation(relations, forwardRelation);
+        addRelation(relations, outputColumnsByTable, forwardRelation);
 
         // Verify the referenced table exists
         if (!relations.has(col.references)) {
@@ -122,7 +152,7 @@ export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
           isArray: true,
           nullable: false, // Arrays are not nullable, just empty
         };
-        addRelation(relations, reverseRelation);
+        addRelation(relations, outputColumnsByTable, reverseRelation);
       }
     }
   }

--- a/packages/jazz-tools/src/codegen/relation-analyzer.ts
+++ b/packages/jazz-tools/src/codegen/relation-analyzer.ts
@@ -28,6 +28,31 @@ export interface Relation {
 }
 
 export class AmbiguousRelationNameError extends Error {}
+export class DuplicateColumnNameError extends Error {}
+
+function columnDescriptorProvenance(
+  index: number,
+  column: WasmSchema[string]["columns"][number],
+): string {
+  const reference = column.references ? ` referencing "${column.references}"` : "";
+  return `descriptor #${index + 1} (${column.column_type.type}${reference})`;
+}
+
+function validateUniqueColumnDescriptors(schema: WasmSchema): void {
+  for (const [tableName, table] of Object.entries(schema)) {
+    const seen = new Map<string, number>();
+    for (const [index, column] of table.columns.entries()) {
+      const previousIndex = seen.get(column.name);
+      if (previousIndex !== undefined) {
+        const previous = table.columns[previousIndex]!;
+        throw new DuplicateColumnNameError(
+          `Table "${tableName}" has duplicate column descriptor "${column.name}": ${columnDescriptorProvenance(previousIndex, previous)} conflicts with ${columnDescriptorProvenance(index, column)}. Column names must be unique before relation names are derived.`,
+        );
+      }
+      seen.set(column.name, index);
+    }
+  }
+}
 
 function relationProvenance(relation: Relation): string {
   const referenceColumn = relation.type === "forward" ? relation.fromColumn : relation.toColumn;
@@ -94,6 +119,8 @@ function forwardRefNameFromFK(columnName: string): string {
  * @returns Map from table name to array of relations on that table
  */
 export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
+  validateUniqueColumnDescriptors(schema);
+
   const relations = new Map<string, Relation[]>();
   const outputColumnsByTable = new Map<string, Set<string>>();
 

--- a/packages/jazz-tools/src/codegen/relation-analyzer.ts
+++ b/packages/jazz-tools/src/codegen/relation-analyzer.ts
@@ -27,6 +27,22 @@ export interface Relation {
   nullable: boolean;
 }
 
+export class AmbiguousRelationNameError extends Error {}
+
+function addRelation(relations: Map<string, Relation[]>, relation: Relation): void {
+  const tableRelations = relations.get(relation.fromTable);
+  if (!tableRelations) {
+    throw new Error(`Unknown relation source table "${relation.fromTable}"`);
+  }
+  const existing = tableRelations.find((candidate) => candidate.name === relation.name);
+  if (existing) {
+    throw new AmbiguousRelationNameError(
+      `Generated relation name "${relation.name}" is ambiguous on table "${relation.fromTable}" between columns "${existing.fromColumn}/${existing.toColumn}" and "${relation.fromColumn}/${relation.toColumn}". Rename one of the reference columns.`,
+    );
+  }
+  tableRelations.push(relation);
+}
+
 /**
  * Capitalize the first letter of a string.
  */
@@ -85,7 +101,7 @@ export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
           isArray: isForwardArray,
           nullable: col.nullable,
         };
-        relations.get(tableName)!.push(forwardRelation);
+        addRelation(relations, forwardRelation);
 
         // Verify the referenced table exists
         if (!relations.has(col.references)) {
@@ -106,7 +122,7 @@ export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
           isArray: true,
           nullable: false, // Arrays are not nullable, just empty
         };
-        relations.get(col.references)!.push(reverseRelation);
+        addRelation(relations, reverseRelation);
       }
     }
   }

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -23,6 +23,7 @@ import type {
   PolicyValue,
   Value,
 } from "../drivers/types.js";
+import { analyzeRelations } from "./relation-analyzer.js";
 import { toValue } from "../runtime/value-converter.js";
 
 const map: Record<ScalarSqlType, ColumnType> = {
@@ -297,5 +298,9 @@ export function schemaToWasm(schema: Schema): WasmSchema {
     };
   }
 
+  // Relation names become keys in the public row shape when an include is
+  // materialized. Validate their namespace while compiling a schema rather
+  // than allowing consumers to discover a collision later during lowering.
+  analyzeRelations(tables);
   return tables;
 }

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -369,17 +369,17 @@ const creatorCondition = {
 };
 
 describe("permissions DSL", () => {
-  it("rejects ambiguous generated relation names before policy construction", () => {
-    const ambiguousApp = s.defineApp({
-      users: s.table({ name: s.string() }),
-      todos: s.table({
-        ownerId: s.ref("users"),
-        owner_id: s.ref("users"),
+  it("rejects duplicate generated relation names while compiling the schema", () => {
+    expect(() =>
+      s.defineApp({
+        users: s.table({ name: s.string() }),
+        todos: s.table({
+          ownerId: s.ref("users"),
+          owner_id: s.ref("users"),
+        }),
       }),
-    });
-
-    expect(() => definePermissions(ambiguousApp, () => {})).toThrow(
-      /Generated relation name "owner" is ambiguous on table "todos"/,
+    ).toThrow(
+      /Generated relation name "owner" is ambiguous on table "todos".*"todos.ownerId".*"todos.owner_id"/,
     );
   });
 

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -6,6 +6,7 @@ import {
   type PermissionRelation,
 } from "./index.js";
 import type { PolicyExpr } from "../schema.js";
+import { schema as s } from "../index.js";
 import { canonicalAuthorSubject } from "../runtime/author-id.js";
 import {
   toAssertionPolicyExprWithRelForTest,
@@ -368,6 +369,20 @@ const creatorCondition = {
 };
 
 describe("permissions DSL", () => {
+  it("rejects ambiguous generated relation names before policy construction", () => {
+    const ambiguousApp = s.defineApp({
+      users: s.table({ name: s.string() }),
+      todos: s.table({
+        ownerId: s.ref("users"),
+        owner_id: s.ref("users"),
+      }),
+    });
+
+    expect(() => definePermissions(ambiguousApp, () => {})).toThrow(
+      /Generated relation name "owner" is ambiguous on table "todos"/,
+    );
+  });
+
   it("compiles read/insert/update/delete policies", () => {
     const compiled = definePermissions(app, ({ policy, allOf, allowedTo, session }) => [
       policy.todos.allowRead.where({ ownerId: session.userId }),

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -9,6 +9,7 @@ import type {
 import type { WasmSchema } from "../drivers/types.js";
 import {
   AmbiguousRelationNameError,
+  DuplicateColumnNameError,
   analyzeRelations,
   type Relation,
 } from "../codegen/relation-analyzer.js";
@@ -909,7 +910,7 @@ function collectRelationsByTable(app: AppLike): Map<string, Relation[]> {
   try {
     return analyzeRelations(typedSchema);
   } catch (error) {
-    if (error instanceof AmbiguousRelationNameError) {
+    if (error instanceof AmbiguousRelationNameError || error instanceof DuplicateColumnNameError) {
       throw error;
     }
     // Keep permissive behavior for partially-specified schemas used in tests/tooling.

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -1322,18 +1322,13 @@ function resolveNamedRelation(
   table: string,
   relationName: string,
 ): Relation {
-  const matches = (relationsByTable.get(table) ?? []).filter(
+  const relation = (relationsByTable.get(table) ?? []).find(
     (candidate) => candidate.name === relationName,
   );
-  if (matches.length === 0) {
+  if (!relation) {
     throw new Error(`Unknown relation "${relationName}" on table "${table}".`);
   }
-  if (matches.length > 1) {
-    throw new AmbiguousRelationNameError(
-      `Relation "${relationName}" is ambiguous on table "${table}". Rename one of the reference columns.`,
-    );
-  }
-  return matches[0]!;
+  return relation;
 }
 
 function isRecursiveCurrentFilter(raw: unknown, token: RecursiveCurrentValue): boolean {

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -7,7 +7,11 @@ import type {
   TablePolicies,
 } from "../schema.js";
 import type { WasmSchema } from "../drivers/types.js";
-import { analyzeRelations, type Relation } from "../codegen/relation-analyzer.js";
+import {
+  AmbiguousRelationNameError,
+  analyzeRelations,
+  type Relation,
+} from "../codegen/relation-analyzer.js";
 import type {
   RelColumnRef,
   RelExpr,
@@ -904,7 +908,10 @@ function collectRelationsByTable(app: AppLike): Map<string, Relation[]> {
   const typedSchema = schema as WasmSchema;
   try {
     return analyzeRelations(typedSchema);
-  } catch {
+  } catch (error) {
+    if (error instanceof AmbiguousRelationNameError) {
+      throw error;
+    }
     // Keep permissive behavior for partially-specified schemas used in tests/tooling.
     // hopTo/gather callers still receive explicit unknown-relation errors.
     return new Map();
@@ -1315,12 +1322,18 @@ function resolveNamedRelation(
   table: string,
   relationName: string,
 ): Relation {
-  const relations = relationsByTable.get(table) ?? [];
-  const relation = relations.find((candidate) => candidate.name === relationName);
-  if (!relation) {
+  const matches = (relationsByTable.get(table) ?? []).filter(
+    (candidate) => candidate.name === relationName,
+  );
+  if (matches.length === 0) {
     throw new Error(`Unknown relation "${relationName}" on table "${table}".`);
   }
-  return relation;
+  if (matches.length > 1) {
+    throw new AmbiguousRelationNameError(
+      `Relation "${relationName}" is ambiguous on table "${table}". Rename one of the reference columns.`,
+    );
+  }
+  return matches[0]!;
 }
 
 function isRecursiveCurrentFilter(raw: unknown, token: RecursiveCurrentValue): boolean {

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -52,6 +52,29 @@ describe("translateQuery", () => {
     );
   });
 
+  it("rejects duplicate external descriptors before allowing a reference-name alias", () => {
+    const duplicateDescriptorSchema = {
+      users: {
+        columns: [{ name: "name", column_type: { type: "Text" as const }, nullable: false }],
+      },
+      todos: {
+        columns: [
+          { name: "owner", column_type: { type: "Text" as const }, nullable: false },
+          {
+            name: "owner",
+            column_type: { type: "Uuid" as const },
+            nullable: false,
+            references: "users",
+          },
+        ],
+      },
+    };
+
+    expect(() => translateQuery(app.todos._build(), duplicateDescriptorSchema)).toThrow(
+      /Table "todos" has duplicate column descriptor "owner": descriptor #1 \(Text\) conflicts with descriptor #2 \(Uuid referencing "users"\)/,
+    );
+  });
+
   it("rejects a forward relation that would shadow a stored output column", () => {
     expect(() =>
       s.defineApp({

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -23,21 +23,86 @@ const app = s.defineApp({
   }),
 });
 
-const ambiguousRelationsApp = s.defineApp({
-  users: s.table({
-    name: s.string(),
-  }),
-  todos: s.table({
-    ownerId: s.ref("users"),
-    owner_id: s.ref("users"),
-  }),
-});
-
 describe("translateQuery", () => {
-  it("rejects reference columns that generate the same relation name", () => {
+  it("rejects colliding externally supplied relation schemas during query lowering", () => {
+    const ambiguousRelationsSchema = {
+      users: {
+        columns: [{ name: "name", column_type: { type: "Text" as const }, nullable: false }],
+      },
+      todos: {
+        columns: [
+          {
+            name: "ownerId",
+            column_type: { type: "Uuid" as const },
+            nullable: false,
+            references: "users",
+          },
+          {
+            name: "owner_id",
+            column_type: { type: "Uuid" as const },
+            nullable: false,
+            references: "users",
+          },
+        ],
+      },
+    };
+
+    expect(() => translateQuery(app.todos._build(), ambiguousRelationsSchema)).toThrow(
+      /Generated relation name "owner" is ambiguous on table "todos".*"todos.ownerId".*"todos.owner_id"/,
+    );
+  });
+
+  it("rejects a forward relation that would shadow a stored output column", () => {
     expect(() =>
-      translateQuery(ambiguousRelationsApp.todos._build(), ambiguousRelationsApp.wasmSchema),
-    ).toThrow(/Generated relation name "owner" is ambiguous on table "todos"/);
+      s.defineApp({
+        users: s.table({ name: s.string() }),
+        todos: s.table({
+          owner: s.string(),
+          ownerId: s.ref("users"),
+        }),
+      }),
+    ).toThrow(
+      /Generated relation name "owner" on table "todos".*forward relation generated from reference column "todos.ownerId".*stored\/public output column "todos.owner"/,
+    );
+  });
+
+  it("rejects a generated relation that would shadow the implicit public id", () => {
+    expect(() =>
+      s.defineApp({
+        users: s.table({ name: s.string() }),
+        todos: s.table({
+          idId: s.ref("users"),
+        }),
+      }),
+    ).toThrow(
+      /Generated relation name "id" on table "todos".*forward relation generated from reference column "todos.idId".*stored\/public output column "todos.id"/,
+    );
+  });
+
+  it("rejects a nested reverse relation that would shadow a stored output column", () => {
+    expect(() =>
+      s.defineApp({
+        users: s.table({
+          todosViaOwner: s.string(),
+        }),
+        todos: s.table({
+          ownerId: s.ref("users"),
+        }),
+      }),
+    ).toThrow(
+      /Generated relation name "todosViaOwner" on table "users".*reverse relation generated from reference column "todos.ownerId".*stored\/public output column "users.todosViaOwner"/,
+    );
+  });
+
+  it("preserves the established reference-column relation alias", () => {
+    expect(() =>
+      s.defineApp({
+        users: s.table({ name: s.string() }),
+        todos: s.table({
+          owner: s.ref("users"),
+        }),
+      }),
+    ).not.toThrow();
   });
 
   it("emits ordinary table queries on the flat Query path", () => {

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -23,7 +23,23 @@ const app = s.defineApp({
   }),
 });
 
+const ambiguousRelationsApp = s.defineApp({
+  users: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    ownerId: s.ref("users"),
+    owner_id: s.ref("users"),
+  }),
+});
+
 describe("translateQuery", () => {
+  it("rejects reference columns that generate the same relation name", () => {
+    expect(() =>
+      translateQuery(ambiguousRelationsApp.todos._build(), ambiguousRelationsApp.wasmSchema),
+    ).toThrow(/Generated relation name "owner" is ambiguous on table "todos"/);
+  });
+
   it("emits ordinary table queries on the flat Query path", () => {
     const query = app.todos
       .includeDeleted()


### PR DESCRIPTION
## Summary
- detect reference columns that generate the same relation name on a table
- propagate a dedicated ambiguity error through policy and runtime query construction
- require affected schemas to rename a reference column instead of resolving by declaration order

Before, an ambiguous relation could silently select the first match. After, schema and query construction fail with an actionable error.

## Testing
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/permissions/index.test.ts src/runtime/query-adapter.test.ts` — 67 tests passed