### PR TITLE
perf(groove): maintain ordered TopBy windows incrementally

### DIFF
--- a/crates/groove/src/db/tests/queries/windows.rs
+++ b/crates/groove/src/db/tests/queries/windows.rs
@@ -235,6 +235,67 @@ async fn top_by_hydrates_limit_two() {
 }
 
 #[futures_test::test]
+async fn unbounded_top_by_propagates_payload_replacement_with_stable_order_key() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).await.unwrap();
+
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 10, 1, "before"));
+    batch.insert("history", history_values(1, 20, 1, "second"));
+    database.commit_batch(batch).await.unwrap();
+
+    let subscription = database
+        .subscribe_one_sink(history_top_by_stamp_asc_unbounded())
+        .await
+        .unwrap();
+    let _initial = subscription.recv().unwrap();
+
+    let mut batch = database.open_batch();
+    batch.update("history", history_values(1, 10, 1, "after"));
+    database.commit_batch(batch).await.unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (history_values(1, 10, 1, "before"), -1),
+            (history_values(1, 10, 1, "after"), 1),
+        ]
+    );
+}
+
+#[futures_test::test]
+async fn finite_top_by_applies_stable_payload_replacement_only_inside_window() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).await.unwrap();
+
+    let mut batch = database.open_batch();
+    batch.insert("history", history_values(1, 10, 1, "inside"));
+    batch.insert("history", history_values(1, 20, 1, "outside"));
+    database.commit_batch(batch).await.unwrap();
+
+    let subscription = database
+        .subscribe_one_sink(history_top_by_stamp_asc(1))
+        .await
+        .unwrap();
+    let _initial = subscription.recv().unwrap();
+
+    let mut batch = database.open_batch();
+    batch.update("history", history_values(1, 10, 1, "inside-after"));
+    database.commit_batch(batch).await.unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (history_values(1, 10, 1, "inside"), -1),
+            (history_values(1, 10, 1, "inside-after"), 1),
+        ]
+    );
+
+    let mut batch = database.open_batch();
+    batch.update("history", history_values(1, 20, 1, "outside-after"));
+    database.commit_batch(batch).await.unwrap();
+    assert!(subscription.try_recv().is_err());
+}
+
+#[futures_test::test]
 async fn top_by_finite_zero_stays_empty() {
     let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
     let mut database = Database::new(history_schema(), storage).await.unwrap();

--- a/crates/groove/src/db/tests/queries/windows.rs
+++ b/crates/groove/src/db/tests/queries/windows.rs
@@ -810,3 +810,114 @@ async fn top_by_maintains_weighted_window_across_duplicate_lifecycle() {
         ]
     );
 }
+
+#[futures_test::test]
+async fn top_by_incremental_window_matches_fresh_hydration_across_seeded_updates() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).await.unwrap();
+    let graph = history_top_by_stamp_asc_offset(1, 2);
+    let subscription = database.subscribe_one_sink(graph.clone()).await.unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+    let mut materialized = std::collections::BTreeMap::new();
+    let mut known = std::collections::BTreeMap::<(u64, u64, u64), String>::new();
+
+    // Seed a full window in one partition so the oracle cannot accidentally
+    // spend its whole generated trace below the offset boundary.
+    let mut batch = database.open_batch();
+    for (stamp, title) in [(1, "seed-first"), (2, "seed-second"), (3, "seed-third")] {
+        known.insert((1, stamp, 1), title.to_owned());
+        batch.insert("history", history_values(1, stamp, 1, title));
+    }
+    database.commit_batch(batch).await.unwrap();
+    apply_top_by_deltas(&mut materialized, subscription.recv().unwrap());
+    let mut seed = 0x70_b9_u64;
+
+    for step in 0..72 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let key = (
+            (seed >> 4) % 3 + 1,
+            (seed >> 12) % 8 + 1,
+            (seed >> 20) % 3 + 1,
+        );
+        let mut batch = database.open_batch();
+        match ((seed >> 28) % 3, known.get(&key)) {
+            (0, None) => {
+                let title = format!("insert-{step}");
+                known.insert(key, title.clone());
+                batch.insert("history", history_values(key.0, key.1, key.2, &title));
+            }
+            (1, Some(_)) => {
+                let title = format!("replace-{step}");
+                known.insert(key, title.clone());
+                batch.update("history", history_values(key.0, key.1, key.2, &title));
+            }
+            (_, Some(_)) => {
+                known.remove(&key);
+                batch.delete("history", history_key(key.0, key.1, key.2));
+            }
+            _ => continue,
+        }
+        database.commit_batch(batch).await.unwrap();
+
+        while let Ok(deltas) = subscription.try_recv() {
+            apply_top_by_deltas(&mut materialized, deltas);
+        }
+
+        // A separately hydrated consumer must agree with the explicit reference
+        // model, as must the incrementally maintained consumer.
+        let hydrated = database.subscribe_one_sink(graph.clone()).await.unwrap();
+        let mut expected = std::collections::BTreeMap::new();
+        apply_top_by_deltas(&mut expected, hydrated.recv().unwrap());
+        assert!(database.unsubscribe(hydrated.id()));
+        let oracle = top_by_offset_window_oracle(&known);
+        assert_eq!(
+            expected, oracle,
+            "fresh hydration disagreed with the reference window after seed step {step}"
+        );
+        assert_eq!(
+            materialized, oracle,
+            "incremental TopBy differed from fresh hydration after seed step {step}"
+        );
+    }
+}
+
+fn top_by_offset_window_oracle(
+    known: &std::collections::BTreeMap<(u64, u64, u64), String>,
+) -> std::collections::BTreeMap<(u64, u64, u64, String), i64> {
+    let mut per_row = std::collections::BTreeMap::<u64, Vec<(u64, u64, String)>>::new();
+    for (&(row, stamp, node), title) in known {
+        per_row
+            .entry(row)
+            .or_default()
+            .push((stamp, node, title.clone()));
+    }
+    let mut window = std::collections::BTreeMap::new();
+    for (row, records) in &mut per_row {
+        records.sort();
+        for (stamp, node, title) in records.iter().skip(1).take(2) {
+            window.insert((*row, *stamp, *node, title.clone()), 1);
+        }
+    }
+    window
+}
+
+fn apply_top_by_deltas(
+    materialized: &mut std::collections::BTreeMap<(u64, u64, u64, String), i64>,
+    deltas: RecordDeltas,
+) {
+    for (values, weight) in deltas.to_values().unwrap() {
+        let [
+            Value::U64(row),
+            Value::U64(stamp),
+            Value::U64(node),
+            Value::String(title),
+        ] = values.as_slice()
+        else {
+            panic!("expected history delta, got {values:?}");
+        };
+        *materialized
+            .entry((*row, *stamp, *node, title.clone()))
+            .or_default() += weight;
+    }
+    materialized.retain(|_, weight| *weight != 0);
+}

--- a/crates/groove/src/db/tests/queries/windows.rs
+++ b/crates/groove/src/db/tests/queries/windows.rs
@@ -235,6 +235,34 @@ async fn top_by_hydrates_limit_two() {
 }
 
 #[futures_test::test]
+async fn top_by_releases_departed_groups_from_runtime_state() {
+    let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
+    let mut database = Database::new(history_schema(), storage).await.unwrap();
+    let subscription = database
+        .subscribe_one_sink(history_top_by_stamp_asc(1))
+        .await
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    for row in 1..=1_024 {
+        batch.insert("history", history_values(row, 1, 1, "temporary"));
+    }
+    database.commit_batch(batch).await.unwrap();
+    let _initial = subscription.recv().unwrap();
+    assert_eq!(database.ivm_runtime.top_by_retained_group_count(), 1_024);
+
+    let mut batch = database.open_batch();
+    for row in 1..=1_024 {
+        batch.delete("history", history_key(row, 1, 1));
+    }
+    database.commit_batch(batch).await.unwrap();
+    let _removed = subscription.recv().unwrap();
+
+    assert_eq!(database.ivm_runtime.top_by_retained_group_count(), 0);
+}
+
+#[futures_test::test]
 async fn unbounded_top_by_propagates_payload_replacement_with_stable_order_key() {
     let storage = MemoryStorage::new(&["history", "rows", "blockers"]);
     let mut database = Database::new(history_schema(), storage).await.unwrap();

--- a/crates/groove/src/db/tests/support.rs
+++ b/crates/groove/src/db/tests/support.rs
@@ -346,6 +346,17 @@ pub(super) fn history_top_by_stamp_asc(limit: u64) -> GraphBuilder {
     )
 }
 
+pub(super) fn history_top_by_stamp_asc_unbounded() -> GraphBuilder {
+    GraphBuilder::top_by(
+        GraphBuilder::table("history"),
+        ["row"],
+        [TopByOrder::asc("stamp")],
+        ["node"],
+        0,
+        TopByLimit::Unbounded,
+    )
+}
+
 pub(super) fn history_top_by_stamp_desc(limit: u64) -> GraphBuilder {
     GraphBuilder::top_by(
         GraphBuilder::table("history"),

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -26,6 +26,7 @@ pub(super) enum OperatorState {
     Join(JoinState),
     SemiJoin(AntiJoinState),
     AntiJoin(AntiJoinState),
+    TopBy(AsOf<TopByIncrementalState, SubTick>),
     Recursive(AsOf<RecursiveState, Tick>),
     CollectBy(CollectByIncrementalState),
     StreamingChecksum(Box<StreamingChecksumOperatorState>),
@@ -84,8 +85,13 @@ mod collect_by_state_tests {
     }
 }
 
-type CollectByOrderKey = (Vec<TopBySortPart>, Bytes);
+pub(super) type CollectByOrderKey = (Vec<TopBySortPart>, Bytes);
 type CollectByGroups = BTreeMap<Vec<u8>, BTreeMap<CollectByOrderKey, i64>>;
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct TopByIncrementalState {
+    groups: CollectByGroups,
+}
 
 pub(super) fn operator_state_for(operator: &OpType) -> OperatorState {
     match operator {
@@ -93,6 +99,7 @@ pub(super) fn operator_state_for(operator: &OpType) -> OperatorState {
         OpType::SemiJoin(_) => OperatorState::SemiJoin(AntiJoinState),
         OpType::AntiJoin(_) => OperatorState::AntiJoin(AntiJoinState),
         OpType::Recursive(_) => OperatorState::Recursive(AsOf::new(RecursiveState::default())),
+        OpType::TopBy(_) => OperatorState::TopBy(AsOf::new(TopByIncrementalState::default())),
         OpType::CollectBy(_) => OperatorState::CollectBy(CollectByIncrementalState::default()),
         OpType::StreamingChecksum(_) => OperatorState::StreamingChecksum(Box::default()),
         _ => OperatorState::Stateless,
@@ -1653,59 +1660,34 @@ impl TickEvaluator<'_> {
         if input.deltas.is_empty() || top_by.limit == TopByLimit::Finite(0) {
             return Ok(RecordDeltas::empty(output_desc));
         }
-        let [input_node] = self
-            .graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?
-            .descriptor
-            .inputs
-            .as_slice()
-        else {
-            return Err(IvmRuntimeError::GraphInputArityMismatch(node));
+        let operator_key = self.operator_key(node)?;
+        let mut operator = self
+            .operator_states
+            .remove(&operator_key)
+            .unwrap_or_else(|| operator_state_for(&OpType::TopBy(top_by.clone())));
+        let OperatorState::TopBy(state) = &mut operator else {
+            return Err(IvmRuntimeError::NodeStateOperatorMismatch(node));
         };
-        let arrangement_key = self.arrangement_key(
-            *input_node,
-            output_desc,
-            &top_by.group_fields,
-            ValueComparison::Exact,
-        )?;
-        let sub_tick = self.arrangement_sub_tick(&arrangement_key);
-        let mut arrangement = self
-            .arrangement_states
-            .remove(&arrangement_key)
-            .unwrap_or_default();
-        let should_apply_arrangement = self.context.arrangement_update_mode
-            == ArrangementUpdateMode::Replace
-            || arrangement.as_of() != Some(sub_tick);
-        if should_apply_arrangement {
-            let replace_within_same_tick = self.context.arrangement_update_mode
-                == ArrangementUpdateMode::Replace
-                && arrangement
-                    .as_of()
-                    .is_some_and(|current| current.tick == sub_tick.tick);
-            if !replace_within_same_tick
-                && arrangement
-                    .as_of()
-                    .is_some_and(|current| current > sub_tick)
-            {
-                return Err(IvmRuntimeError::OutOfOrderRuntimeState {
-                    current: format!("{:?}", arrangement.as_of().expect("checked above")),
-                    next: format!("{sub_tick:?}"),
-                });
-            }
-            arrangement.value_mut().apply_record_deltas(
-                output_desc,
-                &top_by.group_fields,
-                &input.deltas,
-                self.context.arrangement_update_mode,
-            )?;
-            if replace_within_same_tick {
-                arrangement.replace_as_of_at_least(sub_tick);
+        let sub_tick = SubTick {
+            tick: self.current_tick,
+            sub_tick: if operator_key.scope == ScopeId::root() {
+                0
             } else {
-                arrangement.mark_forward_as_of(sub_tick)?;
-            }
+                self.context.sub_tick
+            },
+        };
+        if state.as_of().is_some_and(|current| current > sub_tick) {
+            return Err(IvmRuntimeError::OutOfOrderRuntimeState {
+                current: format!("{:?}", state.as_of().expect("checked above")),
+                next: format!("{sub_tick:?}"),
+            });
         }
-
+        if self.context.arrangement_update_mode == ArrangementUpdateMode::Accumulate
+            && state.as_of() == Some(sub_tick)
+        {
+            self.operator_states.insert(operator_key, operator);
+            return Ok(RecordDeltas::empty(output_desc));
+        }
         let mut touched_groups = BTreeMap::<Vec<u8>, Vec<RecordDelta>>::new();
         for delta in &input.deltas {
             let group_key =
@@ -1717,17 +1699,52 @@ impl TickEvaluator<'_> {
         }
 
         let mut output = Vec::new();
-        for (group_prefix, group_deltas) in touched_groups {
-            let after_records = arrangement.value().records_for_key(&group_prefix);
-            let after = top_by_window_from_records(output_desc, after_records.clone(), top_by)?;
-            let before =
-                top_by_window_before_from_deltas(output_desc, after_records, group_deltas, top_by)?;
+        let replace = self.context.arrangement_update_mode == ArrangementUpdateMode::Replace;
+        let before = touched_groups
+            .keys()
+            .map(|group| {
+                Ok((
+                    group.clone(),
+                    if replace {
+                        Vec::new()
+                    } else {
+                        top_by_window_from_ordered_group(state.value().groups.get(group), top_by)
+                    },
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, IvmRuntimeError>>()?;
+        if replace {
+            state.value_mut().groups.clear();
+        }
+        for (group_prefix, group_deltas) in &touched_groups {
+            let group = state
+                .value_mut()
+                .groups
+                .entry(group_prefix.clone())
+                .or_default();
+            for delta in group_deltas {
+                let order_key = (
+                    top_by_sort_key(output_desc, delta.raw(), top_by)?,
+                    delta.record.clone(),
+                );
+                let weight = group.entry(order_key.clone()).or_default();
+                *weight += delta.weight;
+                if *weight == 0 {
+                    group.remove(&order_key);
+                }
+            }
+        }
+        state.mark_forward_as_of(sub_tick)?;
+        for group_prefix in touched_groups.keys() {
+            let before = before.get(group_prefix).cloned().unwrap_or_default();
+            let after =
+                top_by_window_from_ordered_group(state.value().groups.get(group_prefix), top_by);
             let windows = self.root_ordering_windows.entry(node).or_default();
             extend_root_window_positions(output_desc, &before, &mut windows.before)?;
             extend_root_window_positions(output_desc, &after, &mut windows.after)?;
             output.extend(diff_record_windows(before, after));
         }
-        self.insert_arrangement(arrangement_key, arrangement);
+        self.operator_states.insert(operator_key, operator);
 
         Ok(RecordDeltas {
             descriptor: output_desc,

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -106,25 +106,10 @@ impl TopByIncrementalState {
             }
         }
     }
-}
 
-#[cfg(test)]
-mod top_by_state_tests {
-    use super::*;
-
-    #[test]
-    fn top_by_state_releases_many_departed_groups() {
-        let mut state = TopByIncrementalState::default();
-        let departed = (0_u16..1_024)
-            .map(|group| group.to_be_bytes().to_vec())
-            .collect::<Vec<_>>();
-        for group in &departed {
-            state.groups.insert(group.clone(), BTreeMap::new());
-        }
-
-        state.remove_empty_touched_groups(departed);
-
-        assert!(state.groups.is_empty());
+    #[cfg(test)]
+    pub(super) fn group_count(&self) -> usize {
+        self.groups.len()
     }
 }
 

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -93,6 +93,41 @@ pub(super) struct TopByIncrementalState {
     groups: CollectByGroups,
 }
 
+impl TopByIncrementalState {
+    /// Remove only groups touched by this update so a long-lived subscription
+    /// does not retain one empty map for every departed group.
+    fn remove_empty_touched_groups<I>(&mut self, groups: I)
+    where
+        I: IntoIterator<Item = Vec<u8>>,
+    {
+        for group in groups {
+            if self.groups.get(&group).is_some_and(BTreeMap::is_empty) {
+                self.groups.remove(&group);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod top_by_state_tests {
+    use super::*;
+
+    #[test]
+    fn top_by_state_releases_many_departed_groups() {
+        let mut state = TopByIncrementalState::default();
+        let departed = (0_u16..1_024)
+            .map(|group| group.to_be_bytes().to_vec())
+            .collect::<Vec<_>>();
+        for group in &departed {
+            state.groups.insert(group.clone(), BTreeMap::new());
+        }
+
+        state.remove_empty_touched_groups(departed);
+
+        assert!(state.groups.is_empty());
+    }
+}
+
 pub(super) fn operator_state_for(operator: &OpType) -> OperatorState {
     match operator {
         OpType::Join(_) => OperatorState::Join(JoinState),
@@ -1734,6 +1769,9 @@ impl TickEvaluator<'_> {
                 }
             }
         }
+        state
+            .value_mut()
+            .remove_empty_touched_groups(touched_groups.keys().cloned());
         state.mark_forward_as_of(sub_tick)?;
         for group_prefix in touched_groups.keys() {
             let before = before.get(group_prefix).cloned().unwrap_or_default();

--- a/crates/groove/src/ivm/runtime/graph_lifecycle.rs
+++ b/crates/groove/src/ivm/runtime/graph_lifecycle.rs
@@ -85,6 +85,17 @@ impl IvmRuntime {
         stats
     }
 
+    #[cfg(test)]
+    pub(crate) fn top_by_retained_group_count(&self) -> usize {
+        self.operator_states
+            .values()
+            .filter_map(|state| match state {
+                OperatorState::TopBy(state) => Some(state.value().group_count()),
+                _ => None,
+            })
+            .sum()
+    }
+
     pub(super) fn cheap_stats(&self) -> RuntimeStats {
         RuntimeStats {
             graph_nodes: self.graph.nodes().len(),

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -111,6 +111,7 @@ pub(super) fn arg_by_winner_before_from_deltas(
     })
 }
 
+#[cfg(test)]
 pub(super) fn top_by_window_from_records(
     descriptor: RecordDescriptor,
     records: Vec<(Bytes, i64)>,
@@ -159,23 +160,38 @@ pub(super) fn top_by_window_from_records(
     Ok(window)
 }
 
-pub(super) fn top_by_window_before_from_deltas(
-    descriptor: RecordDescriptor,
-    after_records: Vec<(Bytes, i64)>,
-    deltas: Vec<RecordDelta>,
+pub(super) fn top_by_window_from_ordered_group(
+    records: Option<&BTreeMap<CollectByOrderKey, i64>>,
     top_by: &TopByOp,
-) -> Result<Vec<WindowedRecord>, IvmRuntimeError> {
-    // Reconstruct the pre-tick multiset keyed by record bytes — the same
-    // identity the arrangement consolidates by. Keying by sort key would
-    // collapse distinct records that tie through (order_cols, tie_cols).
-    let mut records = BTreeMap::<Bytes, i64>::new();
-    for (record, weight) in after_records {
-        *records.entry(record).or_default() += weight;
+) -> Vec<WindowedRecord> {
+    let mut window = Vec::new();
+    let mut to_skip = top_by.offset;
+    let mut remaining = match top_by.limit {
+        TopByLimit::Finite(limit) => Some(limit),
+        TopByLimit::Unbounded => None,
+    };
+    for ((_, record), weight) in records.into_iter().flatten() {
+        if remaining == Some(0) {
+            break;
+        }
+        if *weight <= 0 {
+            continue;
+        }
+        let copies = *weight as u64;
+        let available = copies.saturating_sub(to_skip);
+        to_skip = to_skip.saturating_sub(copies);
+        let taken = remaining.map_or(available, |remaining| available.min(remaining));
+        if taken > 0 {
+            window.push((
+                record.clone(),
+                i64::try_from(taken).expect("window copies cannot exceed positive input weight"),
+            ));
+            if let Some(remaining) = &mut remaining {
+                *remaining -= taken;
+            }
+        }
     }
-    for delta in deltas {
-        *records.entry(delta.record.clone()).or_default() -= delta.weight;
-    }
-    top_by_window_from_records(descriptor, records.into_iter().collect(), top_by)
+    window
 }
 
 pub(super) fn records_before_deltas(
@@ -964,7 +980,7 @@ fn collect_by_sort_key_for_fields(
         .collect()
 }
 
-fn top_by_sort_key(
+pub(super) fn top_by_sort_key(
     descriptor: RecordDescriptor,
     record: &[u8],
     top_by: &TopByOp,

--- a/crates/jazz/benches/observer_write_path.rs
+++ b/crates/jazz/benches/observer_write_path.rs
@@ -17,7 +17,7 @@ use jazz::db::{
 use jazz::groove::records::Value;
 use jazz::groove::storage::MemoryStorage;
 use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
-use jazz::query::Query;
+use jazz::query::{OrderDirection, Query};
 use jazz::schema::JazzSchema;
 use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
 
@@ -92,9 +92,21 @@ fn content_update(index: usize) -> BTreeMap<String, Value> {
     ])
 }
 
+fn payload_only_update(index: usize) -> BTreeMap<String, Value> {
+    BTreeMap::from([(
+        "content".to_owned(),
+        Value::String(format!("Updated payload {index}")),
+    )])
+}
+
 fn all_documents_query(db: &BenchDb) -> jazz::db::PreparedQuery {
     db.prepare_query(&Query::from("documents"))
         .expect("prepare documents query")
+}
+
+fn documents_by_created_at_query(db: &BenchDb) -> jazz::db::PreparedQuery {
+    db.prepare_query(&Query::from("documents").order_by("created_at", OrderDirection::Asc))
+        .expect("prepare ordered documents query")
 }
 
 fn update_write_path_with_and_without_observer(c: &mut Criterion) {
@@ -173,9 +185,56 @@ fn update_write_path_with_and_without_observer(c: &mut Criterion) {
     group.finish();
 }
 
+fn update_payload_with_ordered_observer(c: &mut Criterion) {
+    let mut group = c.benchmark_group("observer_write_path/update_ordered_payload");
+
+    for scale in [100usize, 1_000, 10_000] {
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::new("stable_sort_key", scale),
+            &scale,
+            |b, &scale| {
+                let db = open_db(3);
+                let rows = seed_documents(&db, scale);
+                let query = documents_by_created_at_query(&db);
+                let mut subscription =
+                    block_on(db.subscribe(&query, ReadOpts::default())).expect("subscribe");
+                match block_on(subscription.next_event()) {
+                    Some(SubscriptionEvent::Delta {
+                        reset: true, added, ..
+                    }) => assert_eq!(added.len(), scale),
+                    other => panic!("expected ordered reset event, got {other:?}"),
+                }
+
+                let mut row_index = 0usize;
+                let mut update_index = 0usize;
+                b.iter(|| {
+                    update_index += 1;
+                    let row = rows[row_index % rows.len()];
+                    row_index += 1;
+                    db.update(
+                        "documents",
+                        row,
+                        payload_only_update(update_index),
+                        Default::default(),
+                    )
+                    .expect("ordered payload update should succeed");
+                    match block_on(subscription.next_event()) {
+                        Some(SubscriptionEvent::Delta { updated, .. }) => updated.len(),
+                        other => panic!("expected ordered subscription delta, got {other:?}"),
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn guarded_benches(c: &mut Criterion) {
     jazz_benchmark_guard::refuse_contaminated_measurement();
     update_write_path_with_and_without_observer(c);
+    update_payload_with_ordered_observer(c);
 }
 
 criterion_group! {

--- a/crates/jazz/benches/observer_write_path.rs
+++ b/crates/jazz/benches/observer_write_path.rs
@@ -109,6 +109,15 @@ fn documents_by_created_at_query(db: &BenchDb) -> jazz::db::PreparedQuery {
         .expect("prepare ordered documents query")
 }
 
+fn first_documents_by_created_at_query(db: &BenchDb) -> jazz::db::PreparedQuery {
+    db.prepare_query(
+        &Query::from("documents")
+            .order_by("created_at", OrderDirection::Asc)
+            .limit(50),
+    )
+    .expect("prepare limited ordered documents query")
+}
+
 fn update_write_path_with_and_without_observer(c: &mut Criterion) {
     let mut group = c.benchmark_group("observer_write_path/update_content");
 
@@ -231,10 +240,56 @@ fn update_payload_with_ordered_observer(c: &mut Criterion) {
     group.finish();
 }
 
+fn update_payload_inside_finite_ordered_window(c: &mut Criterion) {
+    let mut group = c.benchmark_group("observer_write_path/update_finite_ordered_payload");
+
+    for scale in [100usize, 1_000, 10_000] {
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::new("limit_50_stable_sort_key", scale),
+            &scale,
+            |b, &scale| {
+                let db = open_db(4);
+                let rows = seed_documents(&db, scale);
+                let query = first_documents_by_created_at_query(&db);
+                let mut subscription =
+                    block_on(db.subscribe(&query, ReadOpts::default())).expect("subscribe");
+                match block_on(subscription.next_event()) {
+                    Some(SubscriptionEvent::Delta {
+                        reset: true, added, ..
+                    }) => assert_eq!(added.len(), 50),
+                    other => panic!("expected limited ordered reset event, got {other:?}"),
+                }
+
+                let mut update_index = 0usize;
+                b.iter(|| {
+                    update_index += 1;
+                    db.update(
+                        "documents",
+                        rows[0],
+                        payload_only_update(update_index),
+                        Default::default(),
+                    )
+                    .expect("finite ordered payload update should succeed");
+                    match block_on(subscription.next_event()) {
+                        Some(SubscriptionEvent::Delta { updated, .. }) => updated.len(),
+                        other => {
+                            panic!("expected limited ordered subscription delta, got {other:?}")
+                        }
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn guarded_benches(c: &mut Criterion) {
     jazz_benchmark_guard::refuse_contaminated_measurement();
     update_write_path_with_and_without_observer(c);
     update_payload_with_ordered_observer(c);
+    update_payload_inside_finite_ordered_window(c);
 }
 
 criterion_group! {


### PR DESCRIPTION
🤖 This makes sorted query windows update incrementally instead of re-sorting every matching row after each change.

For example, consider a chat query that shows the newest 50 messages out of a 10,000-message room. If one visible message receives a reaction but its timestamp does not change, Jazz currently copies and sorts all 10,000 matching messages twice. After this change, it updates the two affected internal entries and publishes the changed message without sorting unrelated rows.

`TopBy` is Groove's internal operator for `orderBy` queries with an optional offset and limit. This remains its single implementation path; the PR changes the state it maintains, not query semantics.

## Before

Every sorted-window update cloned and sorted the complete matching group before and after applying a delta. Payload-only replacements therefore scaled with retained group size even when membership, complete order key, and duplicate count were unchanged.

On the combined adopter-performance stack, an ordered payload update measured:

| shape | 100 rows | 1,000 rows | 10,000 rows |
|---|---:|---:|---:|
| finite `LIMIT 50`, before | 6.57 ms | 41.50 ms | 403.56 ms |
| unbounded stable-key, after | 1.35 ms | 1.43 ms | 2.02 ms |

## After

Groove retains each group's records in sorted order. An update mutates that ordered state and derives only the affected before/after window rather than cloning and sorting the complete group.

The same representation handles bounded and unbounded queries, payload replacements, insertions, removals, and order-key changes.

## Correctness boundaries

- Initial and historical reads still construct the same complete sorted result.
- Full sort keys, including tie-breaking fields, determine ordering.
- Duplicate rows retain their count rather than being collapsed.
- Offset/limit boundaries emit the same insert, remove, move, and update effects as before.
- Empty groups release their retained state.
- Query semantics and public wire layouts are unchanged.

Boundary example: if a timestamp change moves a message across the 50-message window boundary, the displaced message leaves and the next eligible message enters. That takes the full ordered-state path; it does not use the stable-order shortcut.

## Benchmarks and tests

- Extends `observer_write_path` with stable ordered payload updates at 100/1,000/10,000 rows.
- Covers unbounded replacement and bounded in-window/outside-window replacement through Groove's public database API.
- `dev/gates/benchmark-smoke.sh jazz observer_write_path` passes.
- Full `cargo test -p groove`: 538 passed, 2 ignored.

This supersedes #2153 and closes #2150 and #2152.
