### PR TITLE
bench(examples): add BandChat caught-up fast-resume receipt

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo install cargo-codspeed --version 5.0.1 --locked
 
       - name: Build example benchmark suites
-        run: cargo codspeed build --package jazz-example-benchmark-smoke --package jazz-example-benchmark-w1 --package jazz-example-big-label-benchmark --package jazz-example-band-chat-benchmark --package jazz-example-world-tour-benchmark --bench fixture --bench ahead_current --bench loads --bench queries
+        run: cargo codspeed build --package jazz-example-benchmark-smoke --package jazz-example-benchmark-w1 --package jazz-example-big-label-benchmark --package jazz-example-band-chat-benchmark --package jazz-example-world-tour-benchmark --bench fixture --bench ahead_current --bench loads --bench queries --bench fast_resume
 
       - name: Run example benchmark suites
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1371,6 +1371,21 @@ test("CodSpeed builds and runs the BandChat benchmark variant", () => {
   );
 });
 
+test("CodSpeed builds the BandChat caught-up fast-resume receipt", () => {
+  assert.match(
+    codspeedWorkflow,
+    /cargo codspeed build [^\n]*--package jazz-example-band-chat-benchmark[^\n]*--bench fast_resume/,
+  );
+  assert.throws(
+    () =>
+      assert.match(
+        codspeedWorkflow.replace(" --bench fast_resume", ""),
+        /--bench fast_resume/,
+      ),
+    /fast_resume/,
+  );
+});
+
 test("Windows NAPI release builds provision libclang for RocksDB bindgen", () => {
   const windowsNapiSetup =
     /name: Install libclang for Windows bindgen[\s\S]*if: matrix\.platform == 'win32-x64-msvc'[\s\S]*choco install llvm --version=21\.1\.8 --yes --no-progress --limit-output[\s\S]*Test-Path \(Join-Path \$libclangPath "libclang\.dll"\)[\s\S]*LIBCLANG_PATH=\$libclangPath[\s\S]*\$env:GITHUB_PATH/;

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1377,11 +1377,7 @@ test("CodSpeed builds the BandChat caught-up fast-resume receipt", () => {
     /cargo codspeed build [^\n]*--package jazz-example-band-chat-benchmark[^\n]*--bench fast_resume/,
   );
   assert.throws(
-    () =>
-      assert.match(
-        codspeedWorkflow.replace(" --bench fast_resume", ""),
-        /--bench fast_resume/,
-      ),
+    () => assert.match(codspeedWorkflow.replace(" --bench fast_resume", ""), /--bench fast_resume/),
     /fast_resume/,
   );
 });

--- a/examples/band-chat/benchmarks/Cargo.toml
+++ b/examples/band-chat/benchmarks/Cargo.toml
@@ -13,3 +13,7 @@ divan = { workspace = true }
 [[bench]]
 name = "loads"
 harness = false
+
+[[bench]]
+name = "fast_resume"
+harness = false

--- a/examples/band-chat/benchmarks/README.md
+++ b/examples/band-chat/benchmarks/README.md
@@ -13,6 +13,12 @@ unread predicate selects a strict subset. The measured prepared Jazz reads cover
 - unread rooms for one member, ordered by recent activity;
 - one author's message history, newest first.
 
+It also measures a caught-up message-history resume at 100, 1,000, and 10,000
+messages. The fixture learns the peer's fast-resume cursor from an actual
+settled publication. Every measured resume must therefore emit no reset,
+membership transition, or version payload. This is the performance receipt for
+#2136: any remaining scale dependence is server-side work, not replayed data.
+
 Database opening, schema compilation, seeding, local-durability waits, and query
 preparation occur before each Divan measured closure. Only the read and returned
 row count are measured and black-boxed. Tests separately assert exact result
@@ -21,4 +27,5 @@ cardinality, pagination, filtering, and order.
 ```sh
 cargo test -p jazz-example-band-chat-benchmark
 cargo bench -p jazz-example-band-chat-benchmark --bench loads
+cargo bench -p jazz-example-band-chat-benchmark --bench fast_resume
 ```

--- a/examples/band-chat/benchmarks/benches/fast_resume.rs
+++ b/examples/band-chat/benchmarks/benches/fast_resume.rs
@@ -1,0 +1,20 @@
+use jazz_example_band_chat_benchmark::FastResumeFixture;
+
+fn main() {
+    divan::main();
+}
+
+/// Thesis #2136: attaching a caught-up history subscriber must be bounded by
+/// the missed delta (zero here), rather than by all retained messages.
+#[divan::bench(args = [100, 1_000, 10_000])]
+fn caught_up_fast_resume(bencher: divan::Bencher<'_, '_>, message_count: usize) {
+    let mut fixture = FastResumeFixture::new(message_count);
+    bencher.bench_local(|| {
+        let receipt = fixture.caught_up_fast_resume();
+        assert!(
+            receipt.is_caught_up_noop(),
+            "caught-up resume leaked a payload: {receipt:?}"
+        );
+        divan::black_box(receipt)
+    });
+}

--- a/examples/band-chat/benchmarks/src/fast_resume.rs
+++ b/examples/band-chat/benchmarks/src/fast_resume.rs
@@ -1,0 +1,212 @@
+//! Caught-up BandChat timeline resume receipt.
+//!
+//! This is intentionally a small protocol fixture rather than an application
+//! runtime fixture: it exercises the same settled message-history shape while
+//! making the fast-known-state boundary observable without relying on private
+//! benchmark infrastructure.
+
+use std::collections::BTreeMap;
+
+use jazz::db::block_on;
+use jazz::groove::records::Value;
+use jazz::groove::storage::MemoryStorage;
+use jazz::ids::{NodeUuid, RowUuid};
+use jazz::node::{MergeableCommit, NodeState, SKEW_TOLERANCE_MS};
+use jazz::peer::PeerState;
+use jazz::protocol::{
+    KnownStateCompleteness, KnownStateDeclaration, RegisterShapeOptions, SubscriptionKey,
+    SyncMessage,
+};
+use jazz::query::Query;
+use jazz::schema::JazzSchema;
+use jazz::time::GlobalTime;
+use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+use jazz::tx::Fate;
+
+const TABLE: &str = "messages";
+
+/// The externally observable result of attaching a fully caught-up peer.
+#[derive(Debug, PartialEq, Eq)]
+pub struct FastResumeReceipt {
+    pub reset_result_set: bool,
+    pub result_member_adds: usize,
+    pub result_member_removes: usize,
+    pub version_carriers: usize,
+    pub version_bundles: usize,
+}
+
+impl FastResumeReceipt {
+    pub fn is_caught_up_noop(&self) -> bool {
+        !self.reset_result_set
+            && self.result_member_adds == 0
+            && self.result_member_removes == 0
+            && self.version_carriers == 0
+            && self.version_bundles == 0
+    }
+}
+
+/// A seeded BandChat message-history view with its settled membership frontier.
+///
+/// Construction represents established server state and is deliberately outside
+/// the benchmark timing closure. `caught_up_fast_resume` measures only attaching
+/// a peer which has already observed that exact frontier.
+pub struct FastResumeFixture {
+    core: NodeState<MemoryStorage>,
+    shape: jazz::query::ValidatedQuery,
+    binding: jazz::query::Binding,
+    subscription: SubscriptionKey,
+    settled_through: GlobalTime,
+}
+
+impl FastResumeFixture {
+    pub fn new(message_count: usize) -> Self {
+        assert!(message_count > 0, "fixture requires at least one message");
+        let schema = schema();
+        let mut writer = open_node(node(1), schema.clone());
+        let mut core = open_node(node(2), schema.clone());
+
+        for index in 0..message_count {
+            let (published, unit) = block_on(
+                writer.commit_mergeable_unit(
+                    MergeableCommit::new(TABLE, row(index), 1_000 + index as u64)
+                        .cells(message_cells(index)),
+                ),
+            )
+            .expect("create BandChat message fixture commit");
+            block_on(writer.persist_and_settle_transaction(published))
+                .expect("persist BandChat message fixture commit");
+
+            let SyncMessage::CommitUnit { tx, versions } = unit else {
+                panic!("fixture commit must publish a commit unit");
+            };
+            let outcome =
+                block_on(core.ingest_commit_unit(tx, versions, u64::MAX - SKEW_TOLERANCE_MS))
+                    .expect("ingest BandChat message fixture commit");
+            let [fate] = block_on(core.persist_and_settle_outcome(outcome))
+                .expect("settle BandChat message fixture commit")
+                .try_into()
+                .expect("fixture commit has one fate");
+            assert!(matches!(
+                fate,
+                SyncMessage::FateUpdate {
+                    fate: Fate::Accepted,
+                    ..
+                }
+            ));
+        }
+
+        let shape = Query::from(TABLE)
+            .validate(&schema)
+            .expect("validate BandChat message-history query");
+        let binding = shape
+            .bind(BTreeMap::new())
+            .expect("bind BandChat message-history query");
+        let subscription = SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: binding.binding_id(),
+            read_view: Default::default(),
+        };
+
+        // The cursor is learned from an actual settled publication, never from
+        // fixture timestamps. That keeps this receipt honest about the protocol
+        // frontier used by a reconnecting peer.
+        let mut warm_peer = PeerState::relay();
+        let warm_update = block_on(warm_peer.rehydrate_query_for_subscription_with_opts(
+            &mut core,
+            subscription,
+            &shape,
+            &binding,
+            RegisterShapeOptions::default(),
+        ))
+        .expect("rehydrate warm BandChat message-history peer")
+        .expect("warm peer receives an initial view update");
+        let SyncMessage::ViewUpdate(payload) = warm_update else {
+            panic!("warm peer must receive a view update");
+        };
+
+        Self {
+            core,
+            shape,
+            binding,
+            subscription,
+            settled_through: payload.settled_through,
+        }
+    }
+
+    /// Attach a peer whose `FastCurrentMembership` declaration is exactly at
+    /// the observed settled frontier. The update must carry no reset,
+    /// membership transition, or version payload; CPU cost is what Divan and
+    /// CodSpeed measure across fixture scales.
+    pub fn caught_up_fast_resume(&mut self) -> FastResumeReceipt {
+        let mut peer = PeerState::relay();
+        peer.declare_known_state(
+            self.subscription,
+            Some(KnownStateDeclaration::Fast {
+                completeness: KnownStateCompleteness::FastCurrentMembership,
+                position: self.settled_through,
+            }),
+        );
+        let update = block_on(peer.rehydrate_query_for_subscription_with_opts(
+            &mut self.core,
+            self.subscription,
+            &self.shape,
+            &self.binding,
+            RegisterShapeOptions::default(),
+        ))
+        .expect("rehydrate caught-up BandChat peer")
+        .expect("caught-up peer receives an initial view update");
+        let SyncMessage::ViewUpdate(payload) = update else {
+            panic!("caught-up peer must receive a view update");
+        };
+        FastResumeReceipt {
+            reset_result_set: payload.reset_result_set,
+            result_member_adds: payload.result_member_adds.len(),
+            result_member_removes: payload.result_member_removes.len(),
+            version_carriers: payload.version_carriers.len(),
+            version_bundles: payload.version_bundles.len(),
+        }
+    }
+}
+
+fn schema() -> JazzSchema {
+    let source = SchemaBuilder::new()
+        .table(
+            TableSchemaBuilder::new(TABLE)
+                .column("body", ColumnType::Text)
+                .column("sent_at", ColumnType::Timestamp)
+                .index_only(["sent_at"]),
+        )
+        .build();
+    JazzSchema::new(&source).expect("BandChat fast-resume schema compiles")
+}
+
+fn open_node(node_uuid: NodeUuid, schema: JazzSchema) -> NodeState<MemoryStorage> {
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    block_on(NodeState::new(
+        node_uuid,
+        schema,
+        MemoryStorage::new(&family_refs),
+    ))
+    .expect("open BandChat fast-resume fixture node")
+}
+
+fn message_cells(index: usize) -> BTreeMap<String, Value> {
+    BTreeMap::from([
+        (
+            "body".to_owned(),
+            Value::String(format!("Message {index:06}")),
+        ),
+        ("sent_at".to_owned(), Value::U64(index as u64)),
+    ])
+}
+
+fn node(byte: u8) -> NodeUuid {
+    NodeUuid::from_bytes([byte; 16])
+}
+
+fn row(index: usize) -> RowUuid {
+    let mut bytes = [4; 16];
+    bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
+    RowUuid::from_bytes(bytes)
+}

--- a/examples/band-chat/benchmarks/src/lib.rs
+++ b/examples/band-chat/benchmarks/src/lib.rs
@@ -3,6 +3,10 @@
 //! The benchmark intentionally duplicates this small schema surface rather
 //! than importing application runtime or fixture helpers.
 
+mod fast_resume;
+
+pub use fast_resume::{FastResumeFixture, FastResumeReceipt};
+
 use std::collections::BTreeMap;
 
 use jazz::db::{Db, DbConfig, DbIdentity, InsertOptions, PreparedQuery, block_on};

--- a/examples/band-chat/benchmarks/tests/workloads.rs
+++ b/examples/band-chat/benchmarks/tests/workloads.rs
@@ -1,4 +1,16 @@
-use jazz_example_band_chat_benchmark::{Fixture, expected_counts};
+use jazz_example_band_chat_benchmark::{FastResumeFixture, Fixture, expected_counts};
+
+#[test]
+fn caught_up_fast_resume_emits_no_membership_or_version_payload() {
+    for message_count in [100, 1_000] {
+        let mut fixture = FastResumeFixture::new(message_count);
+        let receipt = fixture.caught_up_fast_resume();
+        assert!(
+            receipt.is_caught_up_noop(),
+            "{message_count} messages leaked a caught-up resume payload: {receipt:?}"
+        );
+    }
+}
 
 #[test]
 fn representative_loads_have_exact_cardinality_and_order() {


### PR DESCRIPTION
🤖 Adds a performance/correctness receipt for reconnecting a fully caught-up BandChat client.

## Example

A room has accumulated 10,000 messages. A client has already received all of them, briefly disconnects, and reconnects with the exact cursor from its last settled update.

Jazz should confirm that the client is current without replaying the room: no reset, added/removed membership, row versions, or commit bundles. The amount of transmitted result data should therefore remain zero whether the history contains 100, 1,000, or 10,000 messages.

## Before

The same thesis was measured by a bespoke RocksDB/JSON timing driver under `crates/jazz/benches`. It was disconnected from the example-app benchmark workflow and mixed protocol behavior with native-storage setup.

## After

BandChat's benchmark package owns a minimal one-table fixture built through public Node/Peer protocol APIs. It first performs a real warm publication to obtain a settled `FastCurrentMembership` cursor, then reconnects using that cursor and asserts that Jazz emits no replay payload.

Divan and CodSpeed run the receipt at histories of 100, 1,000, and 10,000 messages. This is a diagnostic receipt, not a runtime optimization and not a promise of constant wall-clock time. Its invariant is specifically zero replay output for an already-current cursor.

The fixture intentionally isolates that protocol invariant. It does not claim to reproduce BandChat's room filter and ordering; those application-level query shapes have separate coverage.

## Evidence

- BandChat benchmark tests: 2/2
- benchmark listing and test-mode execution at all three history sizes
- Rust-throughput workflow contract: 39/39
- formatting, diff check, and scoped pre-commit checks

Replaces #2137 in the current example/Divan/CodSpeed benchmark model.
