### PR TITLE
Wire trusted React Native relay admission

### DIFF
--- a/crates/jazz-native-relay/include/jazz_native_relay.h
+++ b/crates/jazz-native-relay/include/jazz_native_relay.h
@@ -42,27 +42,11 @@ jazz_native_relay_status jazz_native_relay_host_execute(
     size_t request_len,
     jazz_native_relay_bytes *out);
 
-/* Admit a postcard RelayScopeAdmissionRequest supplied by trusted platform
- * code. JavaScript receives only the resulting opaque random capability. */
-jazz_native_relay_status jazz_native_relay_host_admit_scope(
-    jazz_native_relay_host *host,
-    const uint8_t *request,
-    size_t request_len,
-    jazz_native_relay_bytes *out);
-
 /* Admit strict JSON from trusted Kotlin/Swift platform code. This is not a
  * JavaScript command: unknown fields, malformed config, SYSTEM identity, and
  * bearer-token claims are rejected by Rust. On success `out` is exactly the
  * opaque 32-byte admission capability, never a config or claim echo. */
 jazz_native_relay_status jazz_native_relay_host_admit_scope_json(
-    jazz_native_relay_host *host,
-    const uint8_t *request,
-    size_t request_len,
-    jazz_native_relay_bytes *out);
-
-/* Revoke a postcard RelayScopeRevocationRequest from trusted platform code.
- * This closes every relay and UI-client alias opened by that capability. */
-jazz_native_relay_status jazz_native_relay_host_revoke_scope(
     jazz_native_relay_host *host,
     const uint8_t *request,
     size_t request_len,

--- a/crates/jazz-native-relay/include/jazz_native_relay.h
+++ b/crates/jazz-native-relay/include/jazz_native_relay.h
@@ -50,6 +50,16 @@ jazz_native_relay_status jazz_native_relay_host_admit_scope(
     size_t request_len,
     jazz_native_relay_bytes *out);
 
+/* Admit strict JSON from trusted Kotlin/Swift platform code. This is not a
+ * JavaScript command: unknown fields, malformed config, SYSTEM identity, and
+ * bearer-token claims are rejected by Rust. On success `out` is exactly the
+ * opaque 32-byte admission capability, never a config or claim echo. */
+jazz_native_relay_status jazz_native_relay_host_admit_scope_json(
+    jazz_native_relay_host *host,
+    const uint8_t *request,
+    size_t request_len,
+    jazz_native_relay_bytes *out);
+
 /* Revoke a postcard RelayScopeRevocationRequest from trusted platform code.
  * This closes every relay and UI-client alias opened by that capability. */
 jazz_native_relay_status jazz_native_relay_host_revoke_scope(
@@ -57,6 +67,13 @@ jazz_native_relay_status jazz_native_relay_host_revoke_scope(
     const uint8_t *request,
     size_t request_len,
     jazz_native_relay_bytes *out);
+
+/* Revoke a raw opaque 32-byte admission capability held by trusted platform
+ * lifecycle code. This is intentionally not exposed through execute. */
+jazz_native_relay_status jazz_native_relay_host_revoke_scope_capability(
+    jazz_native_relay_host *host,
+    const uint8_t *capability,
+    size_t capability_len);
 
 /*
  * Execute one complete postcard RelayCommandRequest. On success, response

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -100,11 +100,10 @@ pub struct RelayScopeRequest {
     pub auth_scope: Option<String>,
 }
 
-/// Configuration admitted by trusted platform code before JavaScript may open
-/// a relay. This uses a separate C ABI entry point and is deliberately not a
-/// [`RelayCommandRequest`] variant.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RelayScopeAdmissionRequest {
+/// Normalized configuration admitted internally after the strict trusted JSON
+/// boundary. It is deliberately not a [`RelayCommandRequest`] variant.
+#[derive(Clone, Debug, PartialEq)]
+struct RelayScopeAdmissionRequest {
     pub scope: RelayScopeRequest,
     pub sqlite_path: String,
     pub schema_json: String,
@@ -198,15 +197,10 @@ fn reject_bearer_claims(claims: &BTreeMap<String, Value>) -> Result<(), JazzNati
     Ok(())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-pub struct RelayScopeAdmissionResponse {
-    pub admitted_scope: AdmissionCapability,
-}
-
 /// Unguessable authority to open one host-admitted native scope.
 ///
 /// Its representation is opaque to JavaScript and platform bindings. They
-/// carry the postcard bytes returned by trusted admission unchanged.
+/// carry its raw 32 bytes only as a handle for ordinary relay commands.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
 pub struct AdmissionCapability([u8; 32]);
 
@@ -214,16 +208,6 @@ impl std::fmt::Debug for AdmissionCapability {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("AdmissionCapability([redacted])")
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-pub struct RelayScopeRevocationRequest {
-    pub admitted_scope: AdmissionCapability,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-pub struct RelayScopeRevocationResponse {
-    pub revoked: bool,
 }
 
 impl From<RelayScopeRequest> for RelayScope {
@@ -534,7 +518,7 @@ impl NativeRelayHost {
     fn admit_scope(
         &mut self,
         request: RelayScopeAdmissionRequest,
-    ) -> Result<RelayScopeAdmissionResponse, JazzNativeRelayStatus> {
+    ) -> Result<AdmissionCapability, JazzNativeRelayStatus> {
         RelayScope::from(request.scope.clone())
             .validate()
             .map_err(relay_status)?;
@@ -578,9 +562,7 @@ impl NativeRelayHost {
                 claims: request.claims,
             },
         );
-        Ok(RelayScopeAdmissionResponse {
-            admitted_scope: handle,
-        })
+        Ok(handle)
     }
 
     fn revoke_scope(&mut self, admitted_scope: AdmissionCapability) -> bool {
@@ -792,61 +774,6 @@ pub unsafe extern "C" fn jazz_native_relay_host_execute(
     JazzNativeRelayStatus::Ok
 }
 
-/// Admit one persistence/authentication scope from trusted platform code.
-///
-/// This entry point is intentionally separate from the opaque JavaScript
-/// command channel. JNI/Swift derive the path, schema, database identity, and
-/// opaque authentication scope, admit them here, then reveal only the returned
-/// handle to JavaScript.
-///
-/// # Safety
-/// `host`, request bytes, and `out` follow the same rules as
-/// [`jazz_native_relay_host_execute`].
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn jazz_native_relay_host_admit_scope(
-    host: *mut JazzNativeRelayHost,
-    request: *const u8,
-    request_len: usize,
-    out: *mut JazzNativeRelayBytes,
-) -> JazzNativeRelayStatus {
-    if out.is_null() {
-        return JazzNativeRelayStatus::InvalidArgument;
-    }
-    unsafe { *out = JazzNativeRelayBytes::EMPTY };
-    if host.is_null() || (request.is_null() && request_len != 0) {
-        return JazzNativeRelayStatus::InvalidArgument;
-    }
-    let request = if request_len == 0 {
-        &[]
-    } else {
-        unsafe { std::slice::from_raw_parts(request, request_len) }
-    };
-    let request = match postcard::from_bytes::<RelayScopeAdmissionRequest>(request) {
-        Ok(request) => request,
-        Err(_) => return JazzNativeRelayStatus::InvalidCommand,
-    };
-    let mut host = match unsafe { (&*host).inner.lock() } {
-        Ok(host) => host,
-        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
-    };
-    let response = match host.admit_scope(request) {
-        Ok(response) => response,
-        Err(status) => return status,
-    };
-    let bytes = match postcard::to_allocvec(&response) {
-        Ok(bytes) => bytes,
-        Err(_) => return JazzNativeRelayStatus::EncodeFailure,
-    };
-    let boxed = bytes.into_boxed_slice();
-    unsafe {
-        *out = JazzNativeRelayBytes {
-            len: boxed.len(),
-            data: Box::into_raw(boxed).cast(),
-        };
-    }
-    JazzNativeRelayStatus::Ok
-}
-
 /// Admit one complete trusted scope described as strict JSON by Kotlin or
 /// Swift/Objective-C. This is intentionally a separate platform-only entry
 /// point: generic JavaScript `execute` accepts only [`RelayCommandRequest`]
@@ -890,11 +817,11 @@ pub unsafe extern "C" fn jazz_native_relay_host_admit_scope_json(
         Ok(host) => host,
         Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
     };
-    let response = match host.admit_scope(request) {
-        Ok(response) => response,
+    let capability = match host.admit_scope(request) {
+        Ok(capability) => capability,
         Err(status) => return status,
     };
-    let mut capability = response.admitted_scope.0.to_vec();
+    let mut capability = capability.0.to_vec();
     unsafe {
         *out = JazzNativeRelayBytes {
             len: capability.len(),
@@ -902,56 +829,6 @@ pub unsafe extern "C" fn jazz_native_relay_host_admit_scope_json(
         };
     }
     std::mem::forget(capability);
-    JazzNativeRelayStatus::Ok
-}
-
-/// Revoke one trusted admission capability and close every relay/client alias
-/// opened through it. Unknown or already-revoked capabilities are idempotent.
-///
-/// # Safety
-/// `host`, request bytes, and `out` follow the same rules as
-/// [`jazz_native_relay_host_execute`].
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn jazz_native_relay_host_revoke_scope(
-    host: *mut JazzNativeRelayHost,
-    request: *const u8,
-    request_len: usize,
-    out: *mut JazzNativeRelayBytes,
-) -> JazzNativeRelayStatus {
-    if out.is_null() {
-        return JazzNativeRelayStatus::InvalidArgument;
-    }
-    unsafe { *out = JazzNativeRelayBytes::EMPTY };
-    if host.is_null() || (request.is_null() && request_len != 0) {
-        return JazzNativeRelayStatus::InvalidArgument;
-    }
-    let request = if request_len == 0 {
-        &[]
-    } else {
-        unsafe { std::slice::from_raw_parts(request, request_len) }
-    };
-    let request = match postcard::from_bytes::<RelayScopeRevocationRequest>(request) {
-        Ok(request) => request,
-        Err(_) => return JazzNativeRelayStatus::InvalidCommand,
-    };
-    let mut host = match unsafe { (&*host).inner.lock() } {
-        Ok(host) => host,
-        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
-    };
-    let response = RelayScopeRevocationResponse {
-        revoked: host.revoke_scope(request.admitted_scope),
-    };
-    let bytes = match postcard::to_allocvec(&response) {
-        Ok(bytes) => bytes,
-        Err(_) => return JazzNativeRelayStatus::EncodeFailure,
-    };
-    let boxed = bytes.into_boxed_slice();
-    unsafe {
-        *out = JazzNativeRelayBytes {
-            len: boxed.len(),
-            data: Box::into_raw(boxed).cast(),
-        };
-    }
     JazzNativeRelayStatus::Ok
 }
 
@@ -2189,25 +2066,8 @@ mod tests {
             identity,
             claims: BTreeMap::new(),
         };
-        let admission_bytes = postcard::to_allocvec(&admission).unwrap();
-        let mut admission_output = JazzNativeRelayBytes::EMPTY;
-        assert_eq!(
-            unsafe {
-                jazz_native_relay_host_admit_scope(
-                    host,
-                    admission_bytes.as_ptr(),
-                    admission_bytes.len(),
-                    &mut admission_output,
-                )
-            },
-            JazzNativeRelayStatus::Ok
-        );
-        let admitted_scope = postcard::from_bytes::<RelayScopeAdmissionResponse>(unsafe {
-            std::slice::from_raw_parts(admission_output.data, admission_output.len)
-        })
-        .unwrap()
-        .admitted_scope;
-        unsafe { jazz_native_relay_bytes_free(&mut admission_output) };
+        let admitted_scope = unsafe { (*host).inner.lock().unwrap().admit_scope(admission) }
+            .expect("test admission is valid");
         let open = RelayCommandRequest::Open {
             supported_abi_minimum: NATIVE_RELAY_ABI_VERSION,
             supported_abi_maximum: NATIVE_RELAY_ABI_VERSION,
@@ -2332,7 +2192,6 @@ mod tests {
                     claims: BTreeMap::new(),
                 })
                 .unwrap()
-                .admitted_scope
         };
         let request = |minimum, maximum| RelayCommandRequest::Open {
             supported_abi_minimum: minimum,
@@ -2449,11 +2308,16 @@ mod tests {
             JazzNativeRelayStatus::InvalidCommand
         );
 
-        let bearer = serde_json::to_vec(&request(BTreeMap::from([(
+        let mut bearer = request(BTreeMap::from([(
             "access_token".to_owned(),
             Value::String("never-persist-a-bearer".to_owned()),
-        )])))
-        .unwrap();
+        )]));
+        // Keep this otherwise-valid request outside the already-admitted
+        // scope, so rejection proves the credential filter rather than the
+        // immutable-scope configuration check below.
+        bearer["scope"]["auth_scope"] =
+            serde_json::Value::String("different-valid-subject".to_owned());
+        let bearer = serde_json::to_vec(&bearer).unwrap();
         assert_eq!(
             unsafe {
                 jazz_native_relay_host_admit_scope_json(
@@ -2548,25 +2412,8 @@ mod tests {
             host: *mut JazzNativeRelayHost,
             request: RelayScopeAdmissionRequest,
         ) -> AdmissionCapability {
-            let request = postcard::to_allocvec(&request).unwrap();
-            let mut output = JazzNativeRelayBytes::EMPTY;
-            assert_eq!(
-                unsafe {
-                    jazz_native_relay_host_admit_scope(
-                        host,
-                        request.as_ptr(),
-                        request.len(),
-                        &mut output,
-                    )
-                },
-                JazzNativeRelayStatus::Ok
-            );
-            let response = postcard::from_bytes::<RelayScopeAdmissionResponse>(unsafe {
-                std::slice::from_raw_parts(output.data, output.len)
-            })
-            .unwrap();
-            unsafe { jazz_native_relay_bytes_free(&mut output) };
-            response.admitted_scope
+            unsafe { (*host).inner.lock().unwrap().admit_scope(request) }
+                .expect("test admission is valid")
         }
         let alice = unsafe { admit(host, admission("alice", 0xa1)) };
         let bob = unsafe { admit(host, admission("bob", 0xb1)) };
@@ -2605,30 +2452,7 @@ mod tests {
             Err(JazzNativeRelayStatus::InvalidHandle)
         );
 
-        let request = postcard::to_allocvec(&RelayScopeRevocationRequest {
-            admitted_scope: alice,
-        })
-        .unwrap();
-        let mut output = JazzNativeRelayBytes::EMPTY;
-        assert_eq!(
-            unsafe {
-                jazz_native_relay_host_revoke_scope(
-                    host,
-                    request.as_ptr(),
-                    request.len(),
-                    &mut output,
-                )
-            },
-            JazzNativeRelayStatus::Ok
-        );
-        assert!(
-            postcard::from_bytes::<RelayScopeRevocationResponse>(unsafe {
-                std::slice::from_raw_parts(output.data, output.len)
-            })
-            .unwrap()
-            .revoked
-        );
-        unsafe { jazz_native_relay_bytes_free(&mut output) };
+        assert!(unsafe { (*host).inner.lock().unwrap().revoke_scope(alice) });
 
         assert_eq!(
             execute(open(alice)),

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -37,6 +37,9 @@ const NATIVE_RELAY_QUEUE_MAX_BYTES: usize = MAX_LOGICAL_MESSAGE_BYTES;
 const NATIVE_RELAY_DRAIN_MAX_MESSAGES: usize = 64;
 const NATIVE_RELAY_DRAIN_TARGET_BYTES: usize = 8 * 1024 * 1024;
 const NATIVE_RELAY_PUMP_MAX_CLIENTS: usize = 64;
+/// Trusted platform admission carries schema and validated claims, but must
+/// remain bounded independently of the generic peer-frame budget.
+const NATIVE_RELAY_ADMISSION_MAX_BYTES: usize = 1024 * 1024;
 
 /// Codec-owned commands accepted by the native relay C ABI.
 ///
@@ -107,6 +110,92 @@ pub struct RelayScopeAdmissionRequest {
     pub schema_json: String,
     pub identity: DbIdentity,
     pub claims: BTreeMap<String, Value>,
+}
+
+/// JSON-shaped form accepted only by the platform-owned admission C entry
+/// point. Keeping this separate from the postcard command codec makes the
+/// platform integration practical without letting JavaScript construct scope
+/// configuration. Rust still owns validation and normalization.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TrustedRelayScopeAdmissionJson {
+    scope: TrustedRelayScopeJson,
+    sqlite_path: String,
+    schema_json: String,
+    identity: TrustedRelayIdentityJson,
+    claims: BTreeMap<String, Value>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TrustedRelayScopeJson {
+    app_namespace: String,
+    storage_namespace: String,
+    auth_scope: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TrustedRelayIdentityJson {
+    node: jazz::ids::NodeUuid,
+    author: jazz::ids::AuthorSubject,
+}
+
+impl TrustedRelayScopeAdmissionJson {
+    fn normalize(self) -> Result<RelayScopeAdmissionRequest, JazzNativeRelayStatus> {
+        if self.sqlite_path.trim().is_empty() {
+            return Err(JazzNativeRelayStatus::LifecycleFailure);
+        }
+        let scope = RelayScopeRequest {
+            app_namespace: self.scope.app_namespace,
+            storage_namespace: self.scope.storage_namespace,
+            auth_scope: self.scope.auth_scope,
+        };
+        RelayScope::from(scope.clone())
+            .validate()
+            .map_err(relay_status)?;
+        if matches!(self.identity.author, jazz::ids::AuthorSubject::System) {
+            return Err(JazzNativeRelayStatus::LifecycleFailure);
+        }
+        reject_bearer_claims(&self.claims)?;
+        // Parse and reserialize before storing so the trusted boundary has one
+        // normalized schema spelling and malformed JSON cannot reach admission.
+        let schema_value = serde_json::from_str::<serde_json::Value>(&self.schema_json)
+            .map_err(|_| JazzNativeRelayStatus::LifecycleFailure)?;
+        let schema_json = serde_json::to_string(&schema_value)
+            .map_err(|_| JazzNativeRelayStatus::LifecycleFailure)?;
+        Ok(RelayScopeAdmissionRequest {
+            scope,
+            sqlite_path: self.sqlite_path,
+            schema_json,
+            identity: DbIdentity {
+                node: self.identity.node,
+                author: self.identity.author,
+            },
+            claims: self.claims,
+        })
+    }
+}
+
+fn reject_bearer_claims(claims: &BTreeMap<String, Value>) -> Result<(), JazzNativeRelayStatus> {
+    // These values belong exclusively to upstream-session negotiation. The
+    // relay receives validated identity claims, never a bearer credential that
+    // could be persisted or exposed through diagnostics.
+    const CREDENTIAL_CLAIMS: &[&str] = &[
+        "authorization",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "bearer_token",
+        "token",
+    ];
+    if claims.keys().any(|key| {
+        let normalized = key.to_ascii_lowercase();
+        CREDENTIAL_CLAIMS.contains(&normalized.as_str())
+    }) {
+        return Err(JazzNativeRelayStatus::LifecycleFailure);
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -446,26 +535,46 @@ impl NativeRelayHost {
         &mut self,
         request: RelayScopeAdmissionRequest,
     ) -> Result<RelayScopeAdmissionResponse, JazzNativeRelayStatus> {
+        RelayScope::from(request.scope.clone())
+            .validate()
+            .map_err(relay_status)?;
+        if matches!(request.identity.author, jazz::ids::AuthorSubject::System) {
+            return Err(JazzNativeRelayStatus::LifecycleFailure);
+        }
+        reject_bearer_claims(&request.claims)?;
         let public_schema = serde_json::from_str(&request.schema_json)
             .map_err(|_| JazzNativeRelayStatus::LifecycleFailure)?;
         let schema =
             JazzSchema::new(&public_schema).map_err(|_| JazzNativeRelayStatus::LifecycleFailure)?;
+        let config = RelayOpenConfig {
+            supported_abi: NativeRelayAbiRange {
+                minimum: NATIVE_RELAY_ABI_VERSION,
+                maximum: NATIVE_RELAY_ABI_VERSION,
+            },
+            scope: request.scope.into(),
+            sqlite_path: PathBuf::from(request.sqlite_path),
+            schema,
+            identity: request.identity,
+            #[cfg(test)]
+            thread_start_counter: self.thread_start_counter.clone(),
+        };
+        // A scope is immutable once trusted code has admitted it. Reject a
+        // conflicting second configuration before JavaScript can receive a
+        // capability, even if no relay alias has been opened yet.
+        if self.admitted_scopes.values().any(|admitted| {
+            admitted.config.scope == config.scope
+                && (admitted.config.sqlite_path != config.sqlite_path
+                    || admitted.config.schema.version_id() != config.schema.version_id()
+                    || admitted.config.identity != config.identity
+                    || admitted.claims != request.claims)
+        }) {
+            return Err(JazzNativeRelayStatus::LifecycleFailure);
+        }
         let handle = self.allocate_admission_capability().map_err(relay_status)?;
         self.admitted_scopes.insert(
             handle,
             AdmittedRelayScope {
-                config: RelayOpenConfig {
-                    supported_abi: NativeRelayAbiRange {
-                        minimum: NATIVE_RELAY_ABI_VERSION,
-                        maximum: NATIVE_RELAY_ABI_VERSION,
-                    },
-                    scope: request.scope.into(),
-                    sqlite_path: PathBuf::from(request.sqlite_path),
-                    schema,
-                    identity: request.identity,
-                    #[cfg(test)]
-                    thread_start_counter: self.thread_start_counter.clone(),
-                },
+                config,
                 claims: request.claims,
             },
         );
@@ -738,6 +847,64 @@ pub unsafe extern "C" fn jazz_native_relay_host_admit_scope(
     JazzNativeRelayStatus::Ok
 }
 
+/// Admit one complete trusted scope described as strict JSON by Kotlin or
+/// Swift/Objective-C. This is intentionally a separate platform-only entry
+/// point: generic JavaScript `execute` accepts only [`RelayCommandRequest`]
+/// and can never carry paths, schema, claims, or bearer credentials.
+///
+/// The returned bytes are exactly one random 256-bit capability. They are
+/// opaque to JavaScript; the platform host may hand them to foreground code,
+/// but only the native relay can interpret them.
+///
+/// # Safety
+/// `host`, request bytes, and `out` follow the same rules as
+/// [`jazz_native_relay_host_execute`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_admit_scope_json(
+    host: *mut JazzNativeRelayHost,
+    request: *const u8,
+    request_len: usize,
+    out: *mut JazzNativeRelayBytes,
+) -> JazzNativeRelayStatus {
+    if out.is_null() {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    unsafe { *out = JazzNativeRelayBytes::EMPTY };
+    if host.is_null()
+        || request.is_null()
+        || request_len == 0
+        || request_len > NATIVE_RELAY_ADMISSION_MAX_BYTES
+    {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    let request = unsafe { std::slice::from_raw_parts(request, request_len) };
+    let request = match serde_json::from_slice::<TrustedRelayScopeAdmissionJson>(request) {
+        Ok(request) => request,
+        Err(_) => return JazzNativeRelayStatus::InvalidCommand,
+    };
+    let request = match request.normalize() {
+        Ok(request) => request,
+        Err(status) => return status,
+    };
+    let mut host = match unsafe { (&*host).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    let response = match host.admit_scope(request) {
+        Ok(response) => response,
+        Err(status) => return status,
+    };
+    let mut capability = response.admitted_scope.0.to_vec();
+    unsafe {
+        *out = JazzNativeRelayBytes {
+            len: capability.len(),
+            data: capability.as_mut_ptr(),
+        };
+    }
+    std::mem::forget(capability);
+    JazzNativeRelayStatus::Ok
+}
+
 /// Revoke one trusted admission capability and close every relay/client alias
 /// opened through it. Unknown or already-revoked capabilities are idempotent.
 ///
@@ -785,6 +952,33 @@ pub unsafe extern "C" fn jazz_native_relay_host_revoke_scope(
             data: Box::into_raw(boxed).cast(),
         };
     }
+    JazzNativeRelayStatus::Ok
+}
+
+/// Revoke exactly one opaque 256-bit admission capability held by trusted
+/// platform lifecycle code. This avoids making Kotlin/Swift encode a postcard
+/// revocation request and remains deliberately unavailable to JavaScript.
+///
+/// # Safety
+/// `host` must be a live host pointer. When non-null, `capability` must point
+/// to exactly 32 readable bytes for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_revoke_scope_capability(
+    host: *mut JazzNativeRelayHost,
+    capability: *const u8,
+    capability_len: usize,
+) -> JazzNativeRelayStatus {
+    if host.is_null() || capability.is_null() || capability_len != 32 {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    let capability = unsafe { std::slice::from_raw_parts(capability, capability_len) };
+    let mut bytes = [0_u8; 32];
+    bytes.copy_from_slice(capability);
+    let mut host = match unsafe { (&*host).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    let _ = host.revoke_scope(AdmissionCapability(bytes));
     JazzNativeRelayStatus::Ok
 }
 
@@ -2188,6 +2382,144 @@ mod tests {
         assert!(output.data.is_null());
         assert_eq!(output.len, 0);
         unsafe { jazz_native_relay_host_free(host) };
+    }
+
+    // This is necessarily an internal ABI-boundary test: Kotlin/Swift do not
+    // run in this Rust target, but the production C entry proves their only
+    // permitted admission path rejects malformed/credential-bearing config
+    // before a JavaScript-visible capability exists.
+    #[test]
+    fn trusted_json_admission_is_strict_bounded_and_never_echoes_config() {
+        let directory = tempfile::tempdir().unwrap();
+        let host = jazz_native_relay_host_new();
+        let identity = DbIdentity {
+            node: NodeUuid::from_bytes([0x91; 16]),
+            author: AuthorSubject::for_test_bytes([0x92; 16]),
+        };
+        let request = |claims: BTreeMap<String, Value>| {
+            serde_json::json!({
+                "scope": {
+                    "app_namespace": "trusted-host",
+                    "storage_namespace": "primary",
+                    "auth_scope": "opaque-validated-subject",
+                },
+                "sqlite_path": directory.path().join("trusted.sqlite").display().to_string(),
+                "schema_json": serde_json::to_string(schema().public_schema()).unwrap(),
+                "identity": serde_json::to_value(identity).unwrap(),
+                "claims": serde_json::to_value(claims).unwrap(),
+            })
+        };
+        let encoded = serde_json::to_vec(&request(BTreeMap::from([(
+            "role".to_owned(),
+            Value::String("member".to_owned()),
+        )])))
+        .unwrap();
+        let mut output = JazzNativeRelayBytes::EMPTY;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_admit_scope_json(
+                    host,
+                    encoded.as_ptr(),
+                    encoded.len(),
+                    &mut output,
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert_eq!(output.len, 32, "only the opaque capability crosses out");
+        assert_ne!(
+            unsafe { std::slice::from_raw_parts(output.data, output.len) },
+            encoded.as_slice(),
+            "the trusted config must never be reflected to JavaScript"
+        );
+        unsafe { jazz_native_relay_bytes_free(&mut output) };
+
+        let mut unknown = request(BTreeMap::new());
+        unknown["unexpected"] = serde_json::Value::Bool(true);
+        let unknown = serde_json::to_vec(&unknown).unwrap();
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_admit_scope_json(
+                    host,
+                    unknown.as_ptr(),
+                    unknown.len(),
+                    &mut output,
+                )
+            },
+            JazzNativeRelayStatus::InvalidCommand
+        );
+
+        let bearer = serde_json::to_vec(&request(BTreeMap::from([(
+            "access_token".to_owned(),
+            Value::String("never-persist-a-bearer".to_owned()),
+        )])))
+        .unwrap();
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_admit_scope_json(
+                    host,
+                    bearer.as_ptr(),
+                    bearer.len(),
+                    &mut output,
+                )
+            },
+            JazzNativeRelayStatus::LifecycleFailure
+        );
+
+        let oversized = vec![b'x'; NATIVE_RELAY_ADMISSION_MAX_BYTES + 1];
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_admit_scope_json(
+                    host,
+                    oversized.as_ptr(),
+                    oversized.len(),
+                    &mut output,
+                )
+            },
+            JazzNativeRelayStatus::InvalidArgument
+        );
+        assert!(output.data.is_null());
+        assert_eq!(output.len, 0);
+        unsafe { jazz_native_relay_host_free(host) };
+    }
+
+    #[test]
+    fn trusted_admission_rejects_conflicting_scope_before_open() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut host = NativeRelayHost::default();
+        let admission =
+            |sqlite_path: &str, claims: BTreeMap<String, Value>| RelayScopeAdmissionRequest {
+                scope: RelayScopeRequest {
+                    app_namespace: "trusted-host".to_owned(),
+                    storage_namespace: "primary".to_owned(),
+                    auth_scope: Some("opaque-validated-subject".to_owned()),
+                },
+                sqlite_path: sqlite_path.to_owned(),
+                schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
+                identity: DbIdentity {
+                    node: NodeUuid::from_bytes([0xa1; 16]),
+                    author: AuthorSubject::for_test_bytes([0xa2; 16]),
+                },
+                claims,
+            };
+        let primary = directory
+            .path()
+            .join("primary.sqlite")
+            .display()
+            .to_string();
+        host.admit_scope(admission(&primary, BTreeMap::new()))
+            .unwrap();
+        let other = directory.path().join("other.sqlite").display().to_string();
+        assert_eq!(
+            host.admit_scope(admission(&other, BTreeMap::new())),
+            Err(JazzNativeRelayStatus::LifecycleFailure),
+            "a scope cannot mint a second capability with different trusted storage"
+        );
+        assert_eq!(
+            host.admitted_scopes.len(),
+            1,
+            "failed admission must not leave a usable capability"
+        );
     }
 
     #[test]

--- a/crates/jazz-native-relay/tests/c_abi_probe.c
+++ b/crates/jazz-native-relay/tests/c_abi_probe.c
@@ -39,6 +39,24 @@ int main(void) {
     fprintf(stderr, "invalid host did not reset output\n");
     return 1;
   }
+  /* Trusted scope admission is a dedicated ABI, not an execute command. An
+   * invalid JSON fixture proves the symbol is linked without placing config or
+   * credentials on the generic command channel. */
+  const uint8_t invalid_admission[] = {'{'};
+  if (jazz_native_relay_host_admit_scope_json(host, invalid_admission,
+                                               sizeof(invalid_admission), &response) !=
+          JAZZ_NATIVE_RELAY_INVALID_COMMAND ||
+      response.data != NULL || response.len != 0) {
+    fprintf(stderr, "trusted admission JSON did not fail closed\n");
+    return 1;
+  }
+  uint8_t capability[32] = {0};
+  if (jazz_native_relay_host_revoke_scope_capability(host, capability,
+                                                      sizeof(capability)) !=
+      JAZZ_NATIVE_RELAY_OK) {
+    fprintf(stderr, "trusted capability revocation ABI failed\n");
+    return 1;
+  }
   jazz_native_relay_host_free(host);
   if (jazz_native_relay_execute((const uint8_t *)"\xff", 1, &response) !=
       JAZZ_NATIVE_RELAY_INVALID_COMMAND) {

--- a/crates/jazz-rn/README.md
+++ b/crates/jazz-rn/README.md
@@ -37,11 +37,14 @@ nor CocoaPods, so Gradle configuration/build and `pod install` must run on the
 respective Blacksmith runners before claiming platform or device support.
 The shared host codec now stages trusted native scope admission/revocation via
 random 256-bit capabilities, client open-close, bounded `Pump`, directional
-bounded peer-frame send/drain, and handle/queue diagnostics. The thin JNI and
-Objective-C++ wrappers forward the
-opaque command channel when their staged artifacts are present; platform-owned
-scope admission remains part of the device integration. This is still a
-platform checkpoint, not device support: there is no assembled release-package
+bounded peer-frame send/drain, and handle/queue diagnostics. Kotlin and
+Swift/Objective-C application authentication code supplies the complete strict
+scope configuration to a dedicated native entrypoint; Rust validates and
+normalizes it, then returns only the opaque 32-byte capability. The generic
+TurboModule `execute` channel never accepts scope configuration, claims, or
+bearer tokens. On auth switch, trusted code revokes the old capability (closing
+all of its relay/client aliases) before admitting the new scope. This is still
+a platform checkpoint, not device support: there is no assembled release-package
 or Expo development-build receipt yet.
 
 The shared artifact seam is `jazz_native_relay_abi_version` from

--- a/crates/jazz-rn/android/cpp-relay.cpp
+++ b/crates/jazz-rn/android/cpp-relay.cpp
@@ -2,6 +2,24 @@
 
 #include "jazz_native_relay.h"
 
+namespace {
+jbyteArray copy_response(JNIEnv *env, jazz_native_relay_bytes *output,
+                         jazz_native_relay_status status,
+                         const char *failure_message) {
+  if (status != JAZZ_NATIVE_RELAY_OK) {
+    env->ThrowNew(env->FindClass("java/lang/IllegalStateException"), failure_message);
+    return nullptr;
+  }
+  auto result = env->NewByteArray(static_cast<jsize>(output->len));
+  if (result != nullptr) {
+    env->SetByteArrayRegion(result, 0, static_cast<jsize>(output->len),
+                            reinterpret_cast<const jbyte *>(output->data));
+  }
+  jazz_native_relay_bytes_free(output);
+  return result;
+}
+}  // namespace
+
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_jazzrn_JazzRelayBridge_nativeCreate(JNIEnv *, jclass) {
   return reinterpret_cast<jlong>(jazz_native_relay_host_new());
@@ -27,15 +45,34 @@ Java_com_jazzrn_JazzRelayBridge_nativeExecute(
       reinterpret_cast<jazz_native_relay_host *>(host),
       reinterpret_cast<const uint8_t *>(input), static_cast<size_t>(length), &output);
   env->ReleaseByteArrayElements(command, input, JNI_ABORT);
+  return copy_response(env, &output, status, "Jazz native relay command failed");
+}
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_jazzrn_JazzRelayBridge_nativeAdmitTrustedScopeJson(
+    JNIEnv *env, jclass, jlong host, jbyteArray admission_json) {
+  const jsize length = env->GetArrayLength(admission_json);
+  jbyte *input = env->GetByteArrayElements(admission_json, nullptr);
+  jazz_native_relay_bytes output{};
+  const auto status = jazz_native_relay_host_admit_scope_json(
+      reinterpret_cast<jazz_native_relay_host *>(host),
+      reinterpret_cast<const uint8_t *>(input), static_cast<size_t>(length), &output);
+  env->ReleaseByteArrayElements(admission_json, input, JNI_ABORT);
+  return copy_response(env, &output, status,
+                       "Jazz trusted relay admission was rejected");
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_jazzrn_JazzRelayBridge_nativeRevokeTrustedScope(
+    JNIEnv *env, jclass, jlong host, jbyteArray capability) {
+  const jsize length = env->GetArrayLength(capability);
+  jbyte *input = env->GetByteArrayElements(capability, nullptr);
+  const auto status = jazz_native_relay_host_revoke_scope_capability(
+      reinterpret_cast<jazz_native_relay_host *>(host),
+      reinterpret_cast<const uint8_t *>(input), static_cast<size_t>(length));
+  env->ReleaseByteArrayElements(capability, input, JNI_ABORT);
   if (status != JAZZ_NATIVE_RELAY_OK) {
-    env->ThrowNew(env->FindClass("java/lang/IllegalStateException"), "Jazz native relay command failed");
-    return nullptr;
+    env->ThrowNew(env->FindClass("java/lang/IllegalStateException"),
+                  "Jazz trusted relay revocation failed");
   }
-  auto result = env->NewByteArray(static_cast<jsize>(output.len));
-  if (result != nullptr) {
-    env->SetByteArrayRegion(result, 0, static_cast<jsize>(output.len),
-                            reinterpret_cast<const jbyte *>(output.data));
-  }
-  jazz_native_relay_bytes_free(&output);
-  return result;
 }

--- a/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayBridge.kt
+++ b/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayBridge.kt
@@ -1,24 +1,122 @@
 package com.jazzrn
 
 import android.util.Base64
+import org.json.JSONObject
 
 /** Opaque JNI carrier for the shared C ABI; it owns no Jazz semantics. */
 internal object JazzRelayBridge {
-  private val host: Long
+  private var host: Long = 0
+  private var runtimeReferences = 0
+  private val trustedCapabilities = mutableSetOf<String>()
 
-  init {
+  private fun ensureHost(): Long {
+    if (host != 0L) return host
     System.loadLibrary("jazzrelay")
     host = nativeCreate()
     check(host != 0L) { "Jazz native relay failed to create its host" }
+    return host
   }
 
-  fun abiVersion(): Double = nativeAbiVersion().toDouble()
+  @Synchronized
+  fun acquireRuntime() {
+    ensureHost()
+    runtimeReferences += 1
+  }
 
-  fun execute(commandBase64: String): String =
-    Base64.encodeToString(nativeExecute(host, Base64.decode(commandBase64, Base64.NO_WRAP)), Base64.NO_WRAP)
+  @Synchronized
+  fun releaseRuntime() {
+    check(runtimeReferences > 0) { "Jazz native relay runtime lease underflow" }
+    runtimeReferences -= 1
+    destroyIfUnused()
+  }
+
+  @Synchronized
+  fun abiVersion(): Double {
+    ensureHost()
+    return nativeAbiVersion().toDouble()
+  }
+
+  @Synchronized
+  fun execute(commandBase64: String): String = Base64.encodeToString(
+    nativeExecute(ensureHost(), Base64.decode(commandBase64, Base64.NO_WRAP)),
+    Base64.NO_WRAP
+  )
+
+  /**
+   * The only Android entry for trusted scope configuration. It is deliberately
+   * not part of the TurboModule: JS gets the returned random capability but
+   * cannot supply path/schema/identity/claims to the generic command channel.
+   */
+  @Synchronized
+  fun admitTrustedScope(config: TrustedRelayScopeConfig): ByteArray {
+    val payload = JSONObject().apply {
+      put("scope", JSONObject().apply {
+        put("app_namespace", config.appNamespace)
+        put("storage_namespace", config.storageNamespace)
+        put("auth_scope", config.authScope ?: JSONObject.NULL)
+      })
+      put("sqlite_path", config.sqlitePath)
+      put("schema_json", config.schemaJson)
+      put("identity", JSONObject(config.identityJson))
+      put("claims", JSONObject(config.claimsJson))
+    }.toString().encodeToByteArray()
+    return nativeAdmitTrustedScopeJson(ensureHost(), payload).also {
+      check(it.size == 32) { "Jazz native relay returned an invalid admission capability" }
+      trustedCapabilities += Base64.encodeToString(it, Base64.NO_WRAP)
+    }
+  }
+
+  @Synchronized
+  fun revokeTrustedScope(capability: ByteArray) {
+    check(capability.size == 32) { "Jazz admission capabilities are exactly 32 bytes" }
+    nativeRevokeTrustedScope(ensureHost(), capability)
+    trustedCapabilities -= Base64.encodeToString(capability, Base64.NO_WRAP)
+    destroyIfUnused()
+  }
+
+  private fun destroyIfUnused() {
+    if (host != 0L && runtimeReferences == 0 && trustedCapabilities.isEmpty()) {
+      nativeDestroy(host)
+      host = 0
+    }
+  }
 
   @JvmStatic private external fun nativeCreate(): Long
   @JvmStatic private external fun nativeDestroy(host: Long)
   @JvmStatic private external fun nativeAbiVersion(): Int
   @JvmStatic private external fun nativeExecute(host: Long, command: ByteArray): ByteArray
+  @JvmStatic private external fun nativeAdmitTrustedScopeJson(host: Long, admissionJson: ByteArray): ByteArray
+  @JvmStatic private external fun nativeRevokeTrustedScope(host: Long, capability: ByteArray)
+}
+
+/**
+ * Complete, validated input owned by Android application/authentication code.
+ * The JSON identity and claims use the Rust relay's typed transport shape and
+ * are parsed and validated in Rust; bearer-token claim names are rejected.
+ * This type is intentionally Kotlin-only and never generated into JS.
+ */
+data class TrustedRelayScopeConfig(
+  val appNamespace: String,
+  val storageNamespace: String,
+  val authScope: String?,
+  val sqlitePath: String,
+  val schemaJson: String,
+  val identityJson: String,
+  val claimsJson: String = "{}",
+)
+
+/**
+ * Android auth lifecycle seam. Providers derive the complete configuration
+ * after validation, retain only the opaque return value for JS, and revoke the
+ * old value before admitting a changed authenticated scope.
+ */
+object JazzRelayTrustedAdmission {
+  fun admit(config: TrustedRelayScopeConfig): ByteArray = JazzRelayBridge.admitTrustedScope(config)
+
+  fun replace(previous: ByteArray?, next: TrustedRelayScopeConfig): ByteArray {
+    previous?.let(JazzRelayBridge::revokeTrustedScope)
+    return JazzRelayBridge.admitTrustedScope(next)
+  }
+
+  fun revoke(capability: ByteArray) = JazzRelayBridge.revokeTrustedScope(capability)
 }

--- a/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayModule.kt
+++ b/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayModule.kt
@@ -15,7 +15,10 @@ import com.facebook.react.module.annotations.ReactModule
  */
 @ReactModule(name = JazzRelayModule.NAME)
 class JazzRelayModule(reactContext: ReactApplicationContext) : NativeJazzRelaySpec(reactContext) {
-  private val bridge = runCatching { JazzRelayBridge }.getOrNull()
+  private val bridge = runCatching {
+    JazzRelayBridge.acquireRuntime()
+    JazzRelayBridge
+  }.getOrNull()
 
   override fun getAbiVersion(): Double = bridge?.abiVersion() ?: 0.0
 
@@ -28,6 +31,14 @@ class JazzRelayModule(reactContext: ReactApplicationContext) : NativeJazzRelaySp
     runCatching { bridge.execute(encodedCommand) }
       .onSuccess(promise::resolve)
       .onFailure { promise.reject("E_JAZZ_RELAY_COMMAND", it) }
+  }
+
+  override fun invalidate() {
+    // Runtime leases make `nativeDestroy` deterministic without destroying a
+    // shared process host while another RN runtime still uses it. Trusted
+    // admissions keep their host alive until explicit logout/revocation.
+    bridge?.let { JazzRelayBridge.releaseRuntime() }
+    super.invalidate()
   }
 
   companion object {

--- a/crates/jazz-rn/ios/JazzRelay.h
+++ b/crates/jazz-rn/ios/JazzRelay.h
@@ -9,3 +9,18 @@
 #endif
 
 @end
+
+/**
+ * Swift/Objective-C authentication lifecycle seam. This is intentionally not
+ * a React Native module: trusted platform code supplies strict JSON to Rust
+ * and receives only a random opaque capability for foreground JavaScript.
+ */
+@interface JazzRelayTrustedAdmission : NSObject
++ (nullable NSData *)admitScopeJSON:(NSData *)configuration
+                              error:(NSError * _Nullable * _Nullable)error;
++ (BOOL)revokeCapability:(NSData *)capability
+                   error:(NSError * _Nullable * _Nullable)error;
++ (nullable NSData *)replaceCapability:(nullable NSData *)previous
+                    withScopeJSON:(NSData *)configuration
+                            error:(NSError * _Nullable * _Nullable)error;
+@end

--- a/crates/jazz-rn/ios/JazzRelay.mm
+++ b/crates/jazz-rn/ios/JazzRelay.mm
@@ -16,9 +16,41 @@
 
 #if JAZZ_RELAY_ARTIFACT_AVAILABLE
 static jazz_native_relay_host *relayHost = NULL;
+static NSUInteger relayRuntimeReferences = 0;
+static NSMutableSet<NSData *> *trustedCapabilities = nil;
+
+static jazz_native_relay_host *EnsureRelayHost(void) {
+  if (relayHost == NULL) relayHost = jazz_native_relay_host_new();
+  return relayHost;
+}
+
+static void DestroyRelayHostIfUnused(void) {
+  if (relayHost != NULL && relayRuntimeReferences == 0 && trustedCapabilities.count == 0) {
+    jazz_native_relay_host_free(relayHost);
+    relayHost = NULL;
+  }
+}
+
+static NSError *RelayLifecycleError(NSString *message) {
+  return [NSError errorWithDomain:@"JazzRelay" code:1
+                          userInfo:@{NSLocalizedDescriptionKey: message}];
+}
 #endif
 
 RCT_EXPORT_MODULE(JazzRelay)
+
+- (instancetype)init {
+  self = [super init];
+#if JAZZ_RELAY_ARTIFACT_AVAILABLE
+  if (self != nil) {
+    @synchronized([JazzRelay class]) {
+      EnsureRelayHost();
+      relayRuntimeReferences += 1;
+    }
+  }
+#endif
+  return self;
+}
 
 - (NSNumber *)getAbiVersion {
   // ABI zero is the stable unavailable sentinel. The autolinked host exists,
@@ -34,7 +66,6 @@ RCT_EXPORT_MODULE(JazzRelay)
          resolve:(RCTPromiseResolveBlock)resolve
           reject:(RCTPromiseRejectBlock)reject {
 #if JAZZ_RELAY_ARTIFACT_AVAILABLE
-  if (relayHost == NULL) relayHost = jazz_native_relay_host_new();
   NSData *request = [[NSData alloc] initWithBase64EncodedString:commandBase64 options:0];
   jazz_native_relay_bytes output = {0};
   jazz_native_relay_status status = jazz_native_relay_host_execute(
@@ -51,11 +82,82 @@ RCT_EXPORT_MODULE(JazzRelay)
 #endif
 }
 
+- (void)invalidate {
+#if JAZZ_RELAY_ARTIFACT_AVAILABLE
+  @synchronized([JazzRelay class]) {
+    if (relayRuntimeReferences > 0) relayRuntimeReferences -= 1;
+    DestroyRelayHostIfUnused();
+  }
+#endif
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params {
   return std::make_shared<facebook::react::NativeJazzRelaySpecJSI>(params);
 }
 #endif
+
+@end
+
+@implementation JazzRelayTrustedAdmission
+
++ (NSData *)admitScopeJSON:(NSData *)configuration
+                     error:(NSError **)error {
+#if JAZZ_RELAY_ARTIFACT_AVAILABLE
+  @synchronized([JazzRelay class]) {
+    jazz_native_relay_bytes output = {0};
+    jazz_native_relay_status status = jazz_native_relay_host_admit_scope_json(
+        EnsureRelayHost(), (const uint8_t *)configuration.bytes, configuration.length, &output);
+    if (status != JAZZ_NATIVE_RELAY_OK) {
+      if (error != NULL) *error = RelayLifecycleError(@"Jazz trusted relay admission was rejected");
+      return nil;
+    }
+    NSData *capability = [NSData dataWithBytes:output.data length:output.len];
+    jazz_native_relay_bytes_free(&output);
+    if (capability.length != 32) {
+      if (error != NULL) *error = RelayLifecycleError(@"Jazz relay returned an invalid admission capability");
+      return nil;
+    }
+    if (trustedCapabilities == nil) trustedCapabilities = [NSMutableSet set];
+    [trustedCapabilities addObject:capability];
+    return capability;
+  }
+#else
+  if (error != NULL) *error = [NSError errorWithDomain:@"JazzRelay" code:2 userInfo:@{NSLocalizedDescriptionKey: @"Jazz native relay requires a matching development or release build."}];
+  return nil;
+#endif
+}
+
++ (BOOL)revokeCapability:(NSData *)capability
+                   error:(NSError **)error {
+#if JAZZ_RELAY_ARTIFACT_AVAILABLE
+  @synchronized([JazzRelay class]) {
+    if (capability.length != 32) {
+      if (error != NULL) *error = RelayLifecycleError(@"Jazz admission capabilities are exactly 32 bytes");
+      return NO;
+    }
+    jazz_native_relay_status status = jazz_native_relay_host_revoke_scope_capability(
+        EnsureRelayHost(), (const uint8_t *)capability.bytes, capability.length);
+    if (status != JAZZ_NATIVE_RELAY_OK) {
+      if (error != NULL) *error = RelayLifecycleError(@"Jazz trusted relay revocation failed");
+      return NO;
+    }
+    [trustedCapabilities removeObject:capability];
+    DestroyRelayHostIfUnused();
+    return YES;
+  }
+#else
+  if (error != NULL) *error = [NSError errorWithDomain:@"JazzRelay" code:2 userInfo:@{NSLocalizedDescriptionKey: @"Jazz native relay requires a matching development or release build."}];
+  return NO;
+#endif
+}
+
++ (NSData *)replaceCapability:(NSData *)previous
+                 withScopeJSON:(NSData *)configuration
+                         error:(NSError **)error {
+  if (previous != nil && ![self revokeCapability:previous error:error]) return nil;
+  return [self admitScopeJSON:configuration error:error];
+}
 
 @end

--- a/crates/jazz/SPEC/19_native_relays.md
+++ b/crates/jazz/SPEC/19_native_relays.md
@@ -50,6 +50,50 @@ chooses either
 retention or deletion through a separate, user-visible storage-lifecycle API.
 No current host may reuse a relay after an auth-scope change.
 
+#### Trusted platform admission codec
+
+The host admission ABI is deliberately separate from the generic relay command
+ABI. Kotlin and Swift/Objective-C pass one complete strict JSON object to
+`jazz_native_relay_host_admit_scope_json`; JavaScript never receives that
+object or a method that accepts it. Its exact top-level fields are:
+
+```text
+{
+  scope: { app_namespace, storage_namespace, auth_scope },
+  sqlite_path,
+  schema_json,
+  identity: { node, author },
+  claims
+}
+```
+
+Unknown fields at the top level, scope, or identity level fail closed. Rust
+parses the schema JSON, serializes it to its normalized JSON spelling, builds
+the `JazzSchema`, validates scope and the non-`SYSTEM` author, and validates
+the typed claims before it admits the scope. Admission input is bounded to
+1 MiB independently of peer-frame limits. Credential-bearing claims named
+`authorization`, `access_token`, `refresh_token`, `id_token`,
+`bearer_token`, or `token` (case-insensitive) fail closed. This is a boundary
+rule, not a replacement for JWT verification: platform authentication verifies
+a credential first, derives `auth_scope` and validated claims, then discards
+the bearer material from this admission call.
+
+On success the ABI returns exactly 32 random bytes: the opaque admission
+capability. The trusted platform layer owns its lifetime and may hand that
+opaque value to foreground JavaScript only for relay lifecycle commands. It
+never logs, derives storage names from, or decodes the capability. A second
+admission for the same scope with different SQLite path, schema, durable
+identity, or claims fails before minting a capability, including when no relay
+alias has yet been opened.
+
+Auth switching is ordered: revoke every capability for the old authenticated
+scope (which atomically closes its relay and UI-client aliases), then admit the
+new complete scope. A revoked or guessed capability cannot open or attach a
+client. Platform host destruction occurs only after its foreground runtime
+leases and trusted capabilities are both gone, at which point it calls
+`jazz_native_relay_host_free`; it does not retain Rust `Db` pointers across
+that lifecycle.
+
 `Db` and its peer connections are executor-local. A native relay therefore owns
 all core values on one dedicated native owner thread. Host calls are encoded
 commands with responses; JSI/JNI/Swift must never retain or dereference a Rust
@@ -91,6 +135,13 @@ separate source of queue depth. Receive calls drain a
 bounded batch, and each pump services a bounded round-robin subset of UI peers.
 Callers retry after draining or scheduling another pump rather than spinning an
 unbounded native turn.
+
+`execute` and the `JazzRelay` TurboModule expose only the opaque postcard
+`RelayCommandRequest` command/frame vocabulary. Neither admits nor revokes a
+scope, and neither accepts claims, tokens, storage paths, schema, or durable
+identity. The dedicated trusted admission/revocation C entries are callable
+only by platform lifecycle code; this prohibition is source-contract tested in
+the RN package in addition to the Rust ABI tests.
 
 ### 19.3 SQLite backend contract
 
@@ -150,6 +201,10 @@ and Maven/Kotlin packages consume the same relay core and artifact slices.
    deltas, flush/close, and planted negative checks.
 2. Native relay contracts: two UI clients sharing one relay, distinct scopes,
    auth switch/logout, upstream reconnect, reload/reopen, and corrupted store.
+   The exact host receipt
+   `jazz_native_relay::tests::admitted_scope_capabilities_are_unguessable_and_revocation_closes_all_aliases`
+   proves that revocation closes every alias and that the old capability cannot
+   be reused; do not duplicate this lifecycle assertion in binding-only tests.
 3. First-party RN test app: scenarios emit structured machine-readable
    results; the app itself is not a Maestro test script.
 4. Linux Blacksmith: Rust/TS contracts, Android native artifact build, Android

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -170,6 +170,39 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
   assert.match(androidRelay, /E_JAZZ_RELAY_UNAVAILABLE/);
 });
 
+test("trusted relay admission stays outside the JavaScript command channel", async () => {
+  const nativeSpec = await readFile(
+    new URL("../../../crates/jazz-rn/src/NativeJazzRelay.ts", import.meta.url),
+    "utf8",
+  );
+  const androidBridge = await readFile(
+    new URL(
+      "../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayBridge.kt",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const iosRelay = await readFile(
+    new URL("../../../crates/jazz-rn/ios/JazzRelay.mm", import.meta.url),
+    "utf8",
+  );
+  const header = await readFile(
+    new URL("../../../crates/jazz-native-relay/include/jazz_native_relay.h", import.meta.url),
+    "utf8",
+  );
+
+  assert.doesNotMatch(nativeSpec, /admit|revoke|claims|token/i);
+  assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
+  assert.match(androidBridge, /nativeAdmitTrustedScopeJson/);
+  assert.match(androidBridge, /nativeRevokeTrustedScope/);
+  assert.match(androidBridge, /releaseRuntime/);
+  assert.match(iosRelay, /JazzRelayTrustedAdmission/);
+  assert.match(iosRelay, /jazz_native_relay_host_admit_scope_json/);
+  assert.match(iosRelay, /jazz_native_relay_host_revoke_scope_capability/);
+  assert.match(header, /jazz_native_relay_host_admit_scope_json/);
+  assert.match(header, /jazz_native_relay_host_revoke_scope_capability/);
+});
+
 test("relay artifact staging targets every Android ABI and iOS framework slice", async () => {
   const script = await readFile(
     new URL("../../../crates/jazz-rn/scripts/build-relay-artifacts.sh", import.meta.url),


### PR DESCRIPTION
🤖 Implements the trusted platform admission boundary from #1973 on top of the native relay foundation in #1832.

Before, Rust could admit and revoke native relay scopes, but Android and iOS exposed only the generic command channel and could not construct the private postcard request. A platform host therefore had no supported way to establish a durable authenticated relay without routing trusted configuration through JavaScript.

After, a dedicated versioned C ABI accepts a strict, length-bounded JSON admission document from trusted Kotlin/Objective-C host code. Rust canonicalizes and validates schema, scope, database identity, and claims before minting an opaque 32-byte capability. Unknown fields, SYSTEM identity, bearer-token claim names, malformed input, and same-scope configuration mismatch fail closed. Revocation closes every alias before a new auth scope is admitted.

The generic execute/TurboModule channel cannot admit or revoke scopes and never receives configuration, claims, or tokens. JavaScript receives only the opaque capability needed by the future foreground-client relay bridge (#2166).

Includes Android/iOS lifecycle APIs, ref-counted native destruction, C ABI probes, malformed/boundary/mismatch tests, source-contract checks, and normative SPEC 19 documentation. Actual platform linking is stacked conceptually with artifact packaging #2167; device acceptance remains #1974.