### PR TITLE
Bound client outbox discovery and terminal replay

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1970,8 +1970,12 @@ impl UploadOutbox {
         true
     }
 
-    fn iter(&self) -> impl Iterator<Item = &PendingUpload> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = &PendingUpload> + ExactSizeIterator {
         self.entries.iter()
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
     }
 
     fn is_empty(&self) -> bool {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1953,7 +1953,38 @@ struct ServedAuthorizationScopeClause {
 
 /// Locally-authored transactions awaiting upload, oldest first. Shared with
 /// upstream [`PeerConnection`]s, each of which tracks how far it has shipped.
-type Outbox = Rc<RefCell<Vec<PendingUpload>>>;
+type Outbox = Rc<RefCell<UploadOutbox>>;
+
+#[derive(Default)]
+struct UploadOutbox {
+    entries: Vec<PendingUpload>,
+    tx_ids: HashSet<TxId>,
+}
+
+impl UploadOutbox {
+    fn push(&mut self, pending: PendingUpload) -> bool {
+        if !self.tx_ids.insert(pending.tx_id) {
+            return false;
+        }
+        self.entries.push(pending);
+        true
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &PendingUpload> {
+        self.entries.iter()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn retain(&mut self, mut keep: impl FnMut(&PendingUpload) -> bool) {
+        self.entries.retain(|pending| keep(pending));
+        self.tx_ids.clear();
+        self.tx_ids
+            .extend(self.entries.iter().map(|pending| pending.tx_id));
+    }
+}
 
 #[derive(Clone)]
 struct PendingUpload {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1957,7 +1957,7 @@ type Outbox = Rc<RefCell<UploadOutbox>>;
 
 #[derive(Default)]
 struct UploadOutbox {
-    entries: Vec<PendingUpload>,
+    entries: VecDeque<PendingUpload>,
     tx_ids: HashSet<TxId>,
 }
 
@@ -1966,7 +1966,7 @@ impl UploadOutbox {
         if !self.tx_ids.insert(pending.tx_id) {
             return false;
         }
-        self.entries.push(pending);
+        self.entries.push_back(pending);
         true
     }
 
@@ -1978,15 +1978,29 @@ impl UploadOutbox {
         self.entries.len()
     }
 
-    fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
     fn retain(&mut self, mut keep: impl FnMut(&PendingUpload) -> bool) {
         self.entries.retain(|pending| keep(pending));
         self.tx_ids.clear();
         self.tx_ids
             .extend(self.entries.iter().map(|pending| pending.tx_id));
+    }
+
+    fn remove_released(&mut self, released: &mut HashSet<TxId>) {
+        while self
+            .entries
+            .front()
+            .is_some_and(|pending| released.remove(&pending.tx_id))
+        {
+            let pending = self
+                .entries
+                .pop_front()
+                .expect("released outbox front remains present");
+            self.tx_ids.remove(&pending.tx_id);
+        }
+        if released.is_empty() {
+            return;
+        }
+        self.retain(|pending| !released.contains(&pending.tx_id));
     }
 }
 

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -81,7 +81,7 @@ where
             node: Rc::new(futures::lock::Mutex::new(node)),
             receives_commits_as_local,
             subscriptions: Rc::new(RefCell::new(Vec::new())),
-            outbox: Rc::new(RefCell::new(Vec::new())),
+            outbox: Rc::new(RefCell::new(UploadOutbox::default())),
             pending_local_publications: Rc::new(RefCell::new(VecDeque::new())),
             local_publication_settler: Rc::new(futures::lock::Mutex::new(())),
             upstream_subscriptions: Rc::new(RefCell::new(Vec::new())),
@@ -193,10 +193,9 @@ where
 
     pub(super) fn queue_pending_upload(&self, tx_id: TxId, unit: Option<SyncMessage>) {
         let mut outbox = self.outbox.borrow_mut();
-        if outbox.iter().any(|pending| pending.tx_id == tx_id) {
+        if !outbox.push(PendingUpload { tx_id, unit }) {
             return;
         }
-        outbox.push(PendingUpload { tx_id, unit });
         drop(outbox);
         self.mark_subscriber_connections_dirty();
         self.schedule_tick(TickUrgency::Deferred);
@@ -805,15 +804,11 @@ where
                 drop(routes);
                 let mut outbox = self.outbox.borrow_mut();
                 for tx_id in routed_txs {
-                    if !outbox.iter().any(|pending| pending.tx_id == tx_id) {
-                        outbox.push(PendingUpload {
-                            tx_id,
-                            unit: crate::db::block_on(
-                                self.node.borrow_mut().commit_unit_for(tx_id),
-                            )
+                    outbox.push(PendingUpload {
+                        tx_id,
+                        unit: crate::db::block_on(self.node.borrow_mut().commit_unit_for(tx_id))
                             .ok(),
-                        });
-                    }
+                    });
                 }
             }
         }
@@ -1407,15 +1402,13 @@ where
                         for tx_id in &routed_txs {
                             uploaded.remove(tx_id);
                             let mut outbox = outbox.borrow_mut();
-                            if !outbox.iter().any(|pending| pending.tx_id == *tx_id) {
-                                outbox.push(PendingUpload {
-                                    tx_id: *tx_id,
-                                    unit: crate::db::block_on(
-                                        self.node.borrow_mut().commit_unit_for(*tx_id),
-                                    )
-                                    .ok(),
-                                });
-                            }
+                            outbox.push(PendingUpload {
+                                tx_id: *tx_id,
+                                unit: crate::db::block_on(
+                                    self.node.borrow_mut().commit_unit_for(*tx_id),
+                                )
+                                .ok(),
+                            });
                         }
                     }
                     self.schedule_tick(TickUrgency::Immediate);

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -955,6 +955,7 @@ where
             observed_session_claim_revision: Cell::new(0),
             connection_epoch,
             startup_error: None,
+            released_outbox_tx_ids: Vec::new(),
             link: ConnectionLink::Upstream(UpstreamConnectionState {
                 local_receiver,
                 pending,
@@ -1186,6 +1187,7 @@ where
             observed_session_claim_revision: Cell::new(session_claim_revision),
             connection_epoch,
             startup_error,
+            released_outbox_tx_ids: Vec::new(),
             link: ConnectionLink::Subscriber(SubscriberConnectionState {
                 peer,
                 ingest_context,
@@ -1451,6 +1453,7 @@ where
                 .set(chunk_completion_generation);
         }
         let mut remote_sync_applied = false;
+        let mut released_outbox_tx_ids = HashSet::new();
         // A later subscriber can mutate Core state after an earlier peer link
         // has already had its turn in this pass.  Remember that generation so
         // the post-receive serve pass below reaches that earlier link too;
@@ -1459,7 +1462,9 @@ where
         let subscriber_dirty_epoch_before = self.subscriber_dirty_epoch.get();
         let connections = self.connections.borrow().clone();
         for connection in &connections {
-            let next = connection.lock().await.tick().await?;
+            let mut connection = connection.lock().await;
+            let next = connection.tick().await?;
+            released_outbox_tx_ids.extend(connection.take_released_outbox_tx_ids());
             stats.subscription_events += next.subscription_events;
             stats.remote_sync_applied += next.remote_sync_applied;
             remote_sync_applied |= next.remote_sync_applied > 0;
@@ -1473,7 +1478,9 @@ where
                     connection.mark_subscriber_dirty() || subscriber_state_changed
                 };
                 if should_tick {
-                    let next = connection.lock().await.tick().await?;
+                    let mut connection = connection.lock().await;
+                    let next = connection.tick().await?;
+                    released_outbox_tx_ids.extend(connection.take_released_outbox_tx_ids());
                     stats.subscription_events += next.subscription_events;
                     stats.remote_sync_applied += next.remote_sync_applied;
                 }
@@ -1490,41 +1497,21 @@ where
                 .enforce_edge_cache_budget(&pins, budget)
                 .await?;
         }
-        self.prune_settled_outbox_uploads();
+        if !released_outbox_tx_ids.is_empty() {
+            self.release_outbox_uploads(released_outbox_tx_ids);
+        }
         Ok(stats)
     }
 
-    fn prune_settled_outbox_uploads(&self) {
-        // With no peer connection, no transaction in the upload outbox can
-        // advance to Global during this tick. Keep every entry for a future
-        // reconnect without re-reading its unchanged fate from storage. This
-        // also prevents an offline host that ticks after each local write from
-        // turning the outbox into an O(writes²) transaction-state scan.
-        if self.connections.borrow().is_empty() {
-            return;
-        }
+    fn release_outbox_uploads(&self, released_tx_ids: HashSet<TxId>) {
         let mut outbox = self.outbox.borrow_mut();
-        if outbox.is_empty() {
-            return;
-        }
-        let mut node = self.node.borrow_mut();
-        let mut released_tx_ids = BTreeSet::new();
-        outbox.retain(|pending| {
-            let state = crate::db::block_on(node.transaction_state(pending.tx_id));
-            let Some((fate, _, durability)) = state else {
-                return true;
-            };
-            let retain = matches!(fate, Fate::Pending | Fate::Accepted)
-                && durability < DurabilityTier::Global;
-            if !retain {
-                released_tx_ids.insert(pending.tx_id);
-            }
-            retain
-        });
-        drop(node);
+        let mut remaining = released_tx_ids.clone();
+        outbox.remove_released(&mut remaining);
         drop(outbox);
-        if released_tx_ids.is_empty() {
-            return;
+        for connection in self.connections.borrow().iter() {
+            connection
+                .borrow_mut()
+                .forget_released_outbox_tx_ids(&released_tx_ids);
         }
         self.large_value_upload_retry_deadlines
             .borrow_mut()

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -318,6 +318,8 @@ where
     /// Fresh non-resumable epoch binding authorization receipts to this link.
     pub(super) connection_epoch: u64,
     pub(super) startup_error: Option<Error>,
+    /// Exact uploads whose applied fate made them globally settled or rejected.
+    pub(super) released_outbox_tx_ids: Vec<TxId>,
     pub(super) link: ConnectionLink,
     pub(super) last_resume_bytes: Option<usize>,
     pub(super) auxiliary_pump: PeerIoPump,
@@ -504,6 +506,20 @@ impl<S> PeerConnection<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
+    pub(super) fn take_released_outbox_tx_ids(&mut self) -> Vec<TxId> {
+        std::mem::take(&mut self.released_outbox_tx_ids)
+    }
+
+    pub(super) fn forget_released_outbox_tx_ids(&mut self, released: &HashSet<TxId>) {
+        let ConnectionLink::Upstream(UpstreamConnectionState { uploaded, .. }) = &mut self.link
+        else {
+            return;
+        };
+        for tx_id in released {
+            uploaded.remove(tx_id);
+        }
+    }
+
     /// Clone the binding-driven auxiliary I/O endpoint for this peer link.
     pub fn io_pump(&self) -> PeerIoPump {
         self.auxiliary_pump.clone()
@@ -1945,6 +1961,20 @@ where
                                     }
                                     _ => None,
                                 };
+                                let released_outbox_tx_id = match &message {
+                                    SyncMessage::FateUpdate {
+                                        tx_id,
+                                        fate,
+                                        durability,
+                                        ..
+                                    } if matches!(fate, Fate::Rejected(_))
+                                        || durability
+                                            .is_some_and(|tier| tier >= DurabilityTier::Global) =>
+                                    {
+                                        Some(*tx_id)
+                                    }
+                                    _ => None,
+                                };
                                 if !pending_view_updates.is_empty() {
                                     apply_pending_authority_view_updates(
                                         &self.node,
@@ -2014,6 +2044,9 @@ where
                                     }
                                     drop(routes);
                                     route_local_fate(&self.local_fate_routes, tx_id, &fate);
+                                }
+                                if let Some(tx_id) = released_outbox_tx_id {
+                                    self.released_outbox_tx_ids.push(tx_id);
                                 }
                             }
                         }

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1123,13 +1123,30 @@ where
                             pending.remove(pending_index);
                         }
                         // Upload locally-authored commits not yet shipped on this link.
-                        let to_upload: Vec<TxId> = outbox
-                            .borrow()
-                            .iter()
-                            .map(|pending| pending.tx_id)
-                            .filter(|tx_id| !uploaded.contains(tx_id))
-                            .collect();
-                        for tx_id in to_upload {
+                        let to_upload: Vec<(TxId, Option<SyncMessage>)> = {
+                            let outbox = outbox.borrow();
+                            let expected_missing = outbox.len().checked_sub(uploaded.len());
+                            let mut suffix = outbox
+                                .iter()
+                                .rev()
+                                .take_while(|pending| !uploaded.contains(&pending.tx_id))
+                                .map(|pending| (pending.tx_id, pending.unit.clone()))
+                                .collect::<Vec<_>>();
+                            if expected_missing == Some(suffix.len()) {
+                                suffix.reverse();
+                                suffix
+                            } else {
+                                // Fate cleanup and authority handoff can leave
+                                // holes in this link's uploaded set. Preserve
+                                // the general set-difference behavior there.
+                                outbox
+                                    .iter()
+                                    .filter(|pending| !uploaded.contains(&pending.tx_id))
+                                    .map(|pending| (pending.tx_id, pending.unit.clone()))
+                                    .collect()
+                            }
+                        };
+                        for (tx_id, staged) in to_upload {
                             if failed_large_value_uploads.contains(&tx_id)
                                 || awaiting_large_value_uploads.contains_key(&tx_id)
                                 || !awaiting_large_value_uploads.is_empty()
@@ -1149,11 +1166,6 @@ where
                             self.large_value_upload_retry_deadlines
                                 .borrow_mut()
                                 .remove(&tx_id);
-                            let staged = outbox
-                                .borrow()
-                                .iter()
-                                .find(|pending| pending.tx_id == tx_id)
-                                .and_then(|pending| pending.unit.clone());
                             let unit = if let Some(unit) = staged {
                                 unit
                             } else {

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2991,11 +2991,10 @@ where
                             }
                             if let Some((tx_id, unit)) = local_upload {
                                 let mut outbox = outbox.borrow_mut();
-                                if !outbox.iter().any(|pending| pending.tx_id == tx_id) {
-                                    outbox.push(PendingUpload {
+                                if outbox.push(PendingUpload {
                                         tx_id,
                                         unit: Some(unit),
-                                    });
+                                    }) {
                                     schedule_tick_in(&self.scheduler, TickUrgency::Deferred);
                                 }
                             }

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -1801,11 +1801,14 @@ fn upload_is_not_marked_sent_after_one_shot_backpressure_and_retries() {
                 .cells(cells("retry", false, client_author)),
         )
         .unwrap();
-    client
-        .node
-        .outbox
-        .borrow_mut()
-        .push(PendingUpload { tx_id, unit: None });
+    assert!(
+        client
+            .node
+            .outbox
+            .borrow_mut()
+            .push(PendingUpload { tx_id, unit: None }),
+        "test setup queues the retry upload once"
+    );
 
     client.tick().unwrap();
     assert!(outbound.borrow().is_empty());
@@ -1828,6 +1831,63 @@ fn upload_is_not_marked_sent_after_one_shot_backpressure_and_retries() {
     assert!(outbound.borrow_mut().pop_front().is_none());
 }
 
+/// A terminal authority rejection releases its upload from the shared outbox,
+/// so reconnecting the client cannot replay a transaction whose user-visible
+/// outcome is already final.
+///
+/// writer ──CommitUnit──► authority
+/// writer ◄─rejected fate── authority
+/// writer ──reconnect──► replacement authority (no replay)
+#[test]
+fn rejected_upload_is_not_replayed_after_reconnect() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xe1; 16]);
+    let client = open_db(0xe1, author, &schema);
+    let (client_transport, mut authority_transport) = duplex();
+    let upstream = crate::db::block_on(client.connect_upstream(client_transport));
+
+    let write = client
+        .insert(
+            "todos",
+            cells("rejected", false, author),
+            Default::default(),
+        )
+        .expect("stage local upload");
+    client.tick().expect("send initial upload");
+    let uploaded = std::iter::from_fn(|| authority_transport.try_recv()).find_map(|message| {
+        matches!(message, SyncMessage::CommitUnit { ref tx, .. } if tx.tx_id == write.mergeable_tx_id())
+            .then_some(message)
+    });
+    assert!(
+        uploaded.is_some(),
+        "authority receives the staged upload once"
+    );
+
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id: write.mergeable_tx_id(),
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_time: None,
+            durability: None,
+        })
+        .expect("return terminal rejection");
+    client.tick().expect("apply terminal rejection");
+    let rejected = crate::db::block_on(write.wait(DurabilityTier::Global))
+        .expect_err("rejected upload stays terminal");
+    assert_eq!(rejected.code, ErrorCode::WriteRejected);
+
+    assert!(client.detach_connection(&upstream));
+    let (reconnected_transport, mut replacement_authority) = duplex();
+    let _reconnected = crate::db::block_on(client.connect_upstream(reconnected_transport));
+    client.tick().expect("tick replacement connection");
+    assert!(
+        std::iter::from_fn(|| replacement_authority.try_recv()).all(
+            |message| !matches!(message, SyncMessage::CommitUnit { tx, .. } if tx.tx_id == write.mergeable_tx_id())
+        ),
+        "replacement authority must not replay a terminally rejected upload"
+    );
+}
+
 #[test]
 fn local_missing_upload_body_still_kills_sync_driver() {
     let schema = schema();
@@ -1839,10 +1899,13 @@ fn local_missing_upload_body_still_kills_sync_driver() {
         crate::time::TxTime::from(client.next_now_ms()),
         NodeUuid::from_bytes([0xee; 16]),
     );
-    client.node.outbox.borrow_mut().push(PendingUpload {
-        tx_id: missing_tx,
-        unit: None,
-    });
+    assert!(
+        client.node.outbox.borrow_mut().push(PendingUpload {
+            tx_id: missing_tx,
+            unit: None,
+        }),
+        "test setup queues the missing upload once"
+    );
 
     let error = client.tick().unwrap_err();
     assert_eq!(error.code, ErrorCode::Protocol);


### PR DESCRIPTION
🤖 Reconstructs the still-valid outbox optimizations from stale old-core #2032 directly on current main.

Before:

- pending upload membership required linear scans;
- reconnect upload discovery could rescan broad local history even when the upstream cursor described a contiguous known suffix;
- terminal acceptance or rejection did not prune exact settled transaction IDs from the pending outbox immediately.

After:

- an indexed set provides O(1) pending-membership checks;
- each link discovers only the contiguous suffix after its known cursor, with a conservative fallback when history contains a hole;
- applied terminal fates release the exact settled uploads;
- a rejected upload followed by reconnect is proven not to replay.

The fallback preserves correctness for sparse or incomplete local history; this is not a new reconciliation semantic. Focused retry, missing-body, reconnect, and fate receipts pass. A planted removal of fate-to-outbox release makes the new reconnect test fail by replaying the rejected transaction.

The legacy `multi-table-ingest` benchmark from #2032 was intentionally removed from current main, so this PR does not revive obsolete benchmark infrastructure. A current example-based outbox benchmark can follow separately.