### PR TITLE
fix(sync): bound subscriber admission async stack

### DIFF
--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2503,12 +2503,17 @@ where
                             shape_registrations.insert(registration_key, registration);
                         }
                         SyncMessage::Subscribe(subscribe) => {
+                            // Subscription admission has a substantially larger async state
+                            // machine than ordinary peer messages. Keep that state on the heap
+                            // so a commit uploaded on this same connection does not carry the
+                            // inactive Subscribe arm on a normal two-megabyte executor stack.
+                            let should_continue = Box::pin(async {
                             if let Err(message) =
                                 validate_known_state_declaration(&subscribe.known_state)
                             {
                                 let _ = message;
                                 drop_peer_request(&self.node);
-                                continue;
+                                return Ok::<bool, Error>(true);
                             }
                             let shape_id = subscribe.shape_id;
                             let subscription = subscribe.subscription;
@@ -2519,7 +2524,7 @@ where
                                 shape_registrations.get(&registration_key).cloned()
                             else {
                                 drop_peer_request(&self.node);
-                                continue;
+                                return Ok::<bool, Error>(true);
                             };
                             let pending_catalogue_admission = matches!(
                                 &registration,
@@ -2533,7 +2538,7 @@ where
                                     // already served by this connection flush first. A rejected
                                     // shape must not starve unrelated subscriptions.
                                     deferred_subscribe_rejections.push_back((subscription, detail));
-                                    continue;
+                                    return Ok::<bool, Error>(true);
                                 }
                                 SubscriberShapeRegistration::Registered(opts)
                                 | SubscriberShapeRegistration::PendingCatalogueAdmission(opts) => {
@@ -2551,7 +2556,7 @@ where
                                 } else {
                                     drop_peer_request(&self.node);
                                 }
-                                continue;
+                                return Ok::<bool, Error>(true);
                             };
                             if pending_catalogue_admission {
                                 shape_registrations.insert(
@@ -2569,7 +2574,7 @@ where
                                 Ok(binding) => binding,
                                 Err(_) => {
                                     drop_peer_request(&self.node);
-                                    continue;
+                                    return Ok::<bool, Error>(true);
                                 }
                             };
                             if ensure_supported_register_shape_options(
@@ -2580,7 +2585,7 @@ where
                             .is_err()
                             {
                                 drop_peer_request(&self.node);
-                                continue;
+                                return Ok::<bool, Error>(true);
                             }
                             let scope_purpose = if let Some(purpose) = scope_purpose {
                                 let expected_result =
@@ -2592,7 +2597,7 @@ where
                                     Ok(expected) => expected,
                                     Err(_) => {
                                         drop_peer_request(&self.node);
-                                        continue;
+                                        return Ok::<bool, Error>(true);
                                     }
                                 };
                                 let exact_support = subscription.shape_id == shape.shape_id()
@@ -2611,7 +2616,7 @@ where
                                     );
                                 if !exact_support {
                                     drop_peer_request(&self.node);
-                                    continue;
+                                    return Ok::<bool, Error>(true);
                                 }
                                 Some(AuthorizedScopePurpose {
                                     key: expected.key,
@@ -2633,7 +2638,7 @@ where
                                 && existing != purpose
                             {
                                 drop_peer_request(&self.node);
-                                continue;
+                                return Ok::<bool, Error>(true);
                             }
                             let supported = self
                                 .node
@@ -2655,7 +2660,7 @@ where
                                     detail,
                                 )
                                 .map_err(transport_error)?;
-                                continue;
+                                return Ok::<bool, Error>(true);
                             } else if let Err(error) = supported {
                                 reject_server_subscription_failure(
                                     &mut *self.transport,
@@ -2663,7 +2668,7 @@ where
                                     &error,
                                 )
                                 .map_err(transport_error)?;
-                                continue;
+                                return Ok::<bool, Error>(true);
                             }
                             let coverage = coverage_key(&shape, &binding, opts.clone());
                             let group_subscription = SubscriptionKey {
@@ -2766,7 +2771,7 @@ where
                                     )
                                 {
                                     drop_peer_request(&self.node);
-                                    continue;
+                                    return Ok::<bool, Error>(true);
                                 }
                                 scope_purposes.insert(subscription, purpose);
                             }
@@ -2865,6 +2870,12 @@ where
                             }
                             schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
                             scheduled_immediate = true;
+                            Ok::<bool, Error>(false)
+                            })
+                            .await?;
+                            if should_continue {
+                                continue;
+                            }
                         }
                         SyncMessage::Unsubscribe { subscription } => {
                             self.node.borrow_mut().apply_unsubscribe(subscription);

--- a/crates/jazz/src/db/tests/subscriptions/structured.rs
+++ b/crates/jazz/src/db/tests/subscriptions/structured.rs
@@ -257,6 +257,14 @@ fn structured_subscription_splices_in_terminal_root_order_after_insert() {
     assert!(terminal_operations.is_empty());
 }
 
+/// A normal reader rehydrates a structured message subscription after a
+/// separately invite-scoped connection writes its membership.
+///
+/// Alice's invite-scoped connection ──membership──► server ──coverage──►
+/// Alice's normal connection ──structured subscribe──► message + sender.
+///
+/// This also exercises the bounded-stack peer admission path: the server must
+/// process the membership commit without carrying inactive Subscribe-arm state.
 #[test]
 fn propagated_structured_subscription_rehydrates_after_membership_scoped_one_shot() {
     let schema = membership_scoped_relation_schema();


### PR DESCRIPTION
🤖 Fixes a reproducible default-test-thread stack overflow in subscriber admission.

Before:
- processing a membership CommitUnit retained the inactive, roughly 361 KiB Subscribe admission future on the stack;
- that combined with dispatch, ingest, source preparation, and the structured rehydration test state to exceed Rust default 2 MiB test stacks;
- the named test passed at 3 MiB but aborted at the default size.

After:
- only the Subscribe admission arm crosses a boxed suspension boundary;
- early-exit behavior returns explicitly to the inbound loop, preserving admission semantics;
- non-Subscribe message paths are unchanged.

Evidence:
- the exact structured rehydration receipt passes at the default stack size;
- all 106 subscription tests pass;
- replacing the boxed boundary with the former inline async state reproduces the exact stack overflow;
- focused Clippy, formatting, diff, and sensitive-data gates pass.