### PR TITLE
fix(groove): reconcile chunk metadata after staged install failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
  "base64 0.22.1",
  "console_error_panic_hook",
  "ed25519-dalek",
+ "futures-channel",
  "futures-util",
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/crates/groove/src/chunks.rs
+++ b/crates/groove/src/chunks.rs
@@ -727,13 +727,23 @@ where
                     Ok(bytes)
                 }
                 Err(ChunkStorageError::Unavailable) => {
+                    let bytes = self.resolver.resolve(request.clone()).await?;
+                    // Resolver failure has no byte-store side effect, so do
+                    // not create a durable recovery obligation until it has
+                    // supplied mechanically valid bytes. This keeps a
+                    // disconnected/cancelled fetch from leaking journal
+                    // entries for chunks that were never staged.
+                    if bytes.len() > crate::large_values::MAX_ENCODED_NODE_BYTES
+                        || object_hash(&bytes) != node_ref.object_hash
+                    {
+                        return Err(ChunkError::Integrity);
+                    }
                     // This durable marker is deliberately written before the
                     // independent byte store.  If either staging or metadata
                     // installation is interrupted, a later exact read knows
                     // that it must finish the install rather than treating
                     // resident bytes as a complete mapping.
                     self.journal.mark_pending(node_ref.clone()).await?;
-                    let bytes = self.resolver.resolve(request.clone()).await?;
                     self.storage
                         .stage(vec![StagedChunk {
                             node_ref: node_ref.clone(),
@@ -2384,6 +2394,35 @@ mod tests {
         assert_eq!(block_on(provider.get(request.clone())), Ok(bytes.clone()));
         assert_eq!(block_on(provider.get(request)), Ok(bytes));
         assert_eq!(observer.calls.get(), 2);
+    }
+
+    #[test]
+    fn failed_remote_resolution_does_not_leave_a_pending_install_marker() {
+        let bytes = Bytes::from_static(b"the resolver will not provide this chunk");
+        let request = ChunkRequest {
+            object_hash: object_hash(&bytes).0,
+            locator: Locator::from_seed(b"failed-resolution-has-no-staged-bytes"),
+        };
+        let journal = Rc::new(MemoryInstallJournal::default());
+        let provider = StorageChunkProvider::with_resolver_observer_and_journal(
+            Rc::new(MemoryChunkStorage::new()),
+            Rc::new(UnavailableChunkResolver),
+            Rc::new(CountingInstallObserver::default()),
+            journal.clone(),
+        );
+
+        assert_eq!(
+            block_on(provider.get(request.clone())),
+            Err(ChunkError::Unavailable)
+        );
+        assert!(
+            !block_on(journal.is_pending(crate::large_values::NodeRef {
+                object_hash: ContentHash(request.object_hash),
+                locator: request.locator,
+            }))
+            .unwrap(),
+            "only a byte-store staging attempt creates a durable recovery obligation"
+        );
     }
 
     #[test]

--- a/crates/groove/src/chunks.rs
+++ b/crates/groove/src/chunks.rs
@@ -224,6 +224,40 @@ pub trait ChunkInstallObserver {
         node_ref: crate::large_values::NodeRef,
         encoded: Bytes,
     ) -> ChunkFuture<'_, Result<(), ChunkError>>;
+
+    /// Whether this observer atomically consumes the pending-install journal
+    /// entry as part of its own metadata durability boundary. Groove's
+    /// database observer does this so a resident publication cannot clear the
+    /// recovery obligation before its staged metadata is persisted.
+    fn completes_install_journal(&self) -> bool {
+        false
+    }
+}
+
+/// Groove-owned durable recovery marker for a remotely staged chunk whose
+/// metadata installation has not completed yet.
+///
+/// The byte backend deliberately knows nothing about this state: it can be a
+/// blob service shared by many databases.  Groove records the marker before
+/// staging bytes, retries the policy-blind metadata installation while it is
+/// present, and removes it only after that installation succeeds.  A crash at
+/// any point therefore leaves either no bytes or a marker that makes the next
+/// exact read reconcile the metadata.
+pub trait ChunkInstallJournal {
+    fn mark_pending(
+        &self,
+        node_ref: crate::large_values::NodeRef,
+    ) -> ChunkFuture<'_, Result<(), ChunkError>>;
+
+    fn is_pending(
+        &self,
+        node_ref: crate::large_values::NodeRef,
+    ) -> ChunkFuture<'_, Result<bool, ChunkError>>;
+
+    fn complete(
+        &self,
+        node_ref: crate::large_values::NodeRef,
+    ) -> ChunkFuture<'_, Result<(), ChunkError>>;
 }
 
 #[derive(Clone, Default)]
@@ -234,6 +268,35 @@ impl ChunkInstallObserver for NoopChunkInstallObserver {
         &self,
         _node_ref: crate::large_values::NodeRef,
         _encoded: Bytes,
+    ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+/// The standalone provider constructor has no durable Groove metadata plane.
+/// Database construction supplies a real journal; this no-op implementation
+/// retains the former behavior for embedders that only need byte retrieval.
+#[derive(Clone, Default)]
+pub struct NoopChunkInstallJournal;
+
+impl ChunkInstallJournal for NoopChunkInstallJournal {
+    fn mark_pending(
+        &self,
+        _node_ref: crate::large_values::NodeRef,
+    ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn is_pending(
+        &self,
+        _node_ref: crate::large_values::NodeRef,
+    ) -> ChunkFuture<'_, Result<bool, ChunkError>> {
+        Box::pin(async { Ok(false) })
+    }
+
+    fn complete(
+        &self,
+        _node_ref: crate::large_values::NodeRef,
     ) -> ChunkFuture<'_, Result<(), ChunkError>> {
         Box::pin(async { Ok(()) })
     }
@@ -570,6 +633,11 @@ pub struct StorageChunkProvider<S> {
     storage: S,
     resolver: Rc<dyn MissingChunkResolver>,
     observer: Rc<dyn ChunkInstallObserver>,
+    journal: Rc<dyn ChunkInstallJournal>,
+    /// A successful reconciliation is immutable.  Remembering it makes the
+    /// normal resident path purely a byte read after the first post-reopen
+    /// journal probe; it never reacquires the metadata lifecycle lock.
+    settled_installs: Rc<RefCell<BTreeSet<ChunkRequest>>>,
 }
 
 impl<S> StorageChunkProvider<S> {
@@ -578,6 +646,8 @@ impl<S> StorageChunkProvider<S> {
             storage,
             resolver: Rc::new(UnavailableChunkResolver),
             observer: Rc::new(NoopChunkInstallObserver),
+            journal: Rc::new(NoopChunkInstallJournal),
+            settled_installs: Rc::new(RefCell::new(BTreeSet::new())),
         }
     }
 
@@ -586,6 +656,8 @@ impl<S> StorageChunkProvider<S> {
             storage,
             resolver,
             observer: Rc::new(NoopChunkInstallObserver),
+            journal: Rc::new(NoopChunkInstallJournal),
+            settled_installs: Rc::new(RefCell::new(BTreeSet::new())),
         }
     }
 
@@ -594,10 +666,28 @@ impl<S> StorageChunkProvider<S> {
         resolver: Rc<dyn MissingChunkResolver>,
         observer: Rc<dyn ChunkInstallObserver>,
     ) -> Self {
+        Self::with_resolver_observer_and_journal(
+            storage,
+            resolver,
+            observer,
+            Rc::new(NoopChunkInstallJournal),
+        )
+    }
+
+    /// Construct a provider whose byte plane is independent from the
+    /// Groove-owned journal that records incomplete metadata installation.
+    pub fn with_resolver_observer_and_journal(
+        storage: S,
+        resolver: Rc<dyn MissingChunkResolver>,
+        observer: Rc<dyn ChunkInstallObserver>,
+        journal: Rc<dyn ChunkInstallJournal>,
+    ) -> Self {
         Self {
             storage,
             resolver,
             observer,
+            journal,
+            settled_installs: Rc::new(RefCell::new(BTreeSet::new())),
         }
     }
 }
@@ -616,54 +706,88 @@ where
         observer: Rc<dyn ChunkInstallObserver>,
     ) -> ChunkFuture<'_, Result<Bytes, ChunkError>> {
         Box::pin(async move {
+            let node_ref = crate::large_values::NodeRef {
+                object_hash: ContentHash(request.object_hash),
+                locator: request.locator,
+            };
             match self
                 .storage
                 .get(request.locator, ContentHash(request.object_hash))
                 .await
             {
-                // A previous remote resolution may have made the immutable
-                // bytes durable just before its metadata observer failed. Do
-                // not let a subsequent local hit turn that failed install
-                // into a permanently invisible accounting hole: the observer
-                // is deliberately idempotent and reconciles this mapping on
-                // every provider load that reaches storage.
                 Ok(bytes) => {
-                    observer
-                        .installed(
-                            crate::large_values::NodeRef {
-                                object_hash: ContentHash(request.object_hash),
-                                locator: request.locator,
-                            },
-                            bytes.clone(),
-                        )
-                        .await?;
+                    self.reconcile_pending_install(
+                        request.clone(),
+                        node_ref,
+                        bytes.clone(),
+                        observer,
+                        false,
+                    )
+                    .await?;
                     Ok(bytes)
                 }
                 Err(ChunkStorageError::Unavailable) => {
+                    // This durable marker is deliberately written before the
+                    // independent byte store.  If either staging or metadata
+                    // installation is interrupted, a later exact read knows
+                    // that it must finish the install rather than treating
+                    // resident bytes as a complete mapping.
+                    self.journal.mark_pending(node_ref.clone()).await?;
                     let bytes = self.resolver.resolve(request.clone()).await?;
                     self.storage
                         .stage(vec![StagedChunk {
-                            node_ref: crate::large_values::NodeRef {
-                                object_hash: ContentHash(request.object_hash),
-                                locator: request.locator,
-                            },
+                            node_ref: node_ref.clone(),
                             encoded: bytes.to_vec(),
                         }])
                         .await
                         .map_err(ChunkError::from)?;
-                    observer
-                        .installed(
-                            crate::large_values::NodeRef {
-                                object_hash: ContentHash(request.object_hash),
-                                locator: request.locator,
-                            },
-                            bytes.clone(),
-                        )
-                        .await?;
+                    self.reconcile_pending_install(
+                        request,
+                        node_ref,
+                        bytes.clone(),
+                        observer,
+                        true,
+                    )
+                    .await?;
                     Ok(bytes)
                 }
                 Err(error) => Err(ChunkError::from(error)),
             }
+        })
+    }
+}
+
+impl<S> StorageChunkProvider<S>
+where
+    S: ChunkStorage,
+{
+    fn reconcile_pending_install(
+        &self,
+        request: ChunkRequest,
+        node_ref: crate::large_values::NodeRef,
+        bytes: Bytes,
+        observer: Rc<dyn ChunkInstallObserver>,
+        newly_staged: bool,
+    ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+        Box::pin(async move {
+            if self.settled_installs.borrow().contains(&request) {
+                return Ok(());
+            }
+            // A regular resident chunk has no journal marker, so it must not
+            // call the observer or enter the database lifecycle mutex.
+            if !newly_staged && !self.journal.is_pending(node_ref.clone()).await? {
+                self.settled_installs.borrow_mut().insert(request);
+                return Ok(());
+            }
+            observer.installed(node_ref.clone(), bytes).await?;
+            // If the process stops after metadata is durable but before this
+            // compare-and-delete, the next opener retries an idempotent
+            // install.  It can never lose the recovery obligation.
+            if !observer.completes_install_journal() {
+                self.journal.complete(node_ref).await?;
+            }
+            self.settled_installs.borrow_mut().insert(request);
+            Ok(())
         })
     }
 }
@@ -1468,6 +1592,53 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Default)]
+    struct MemoryInstallJournal {
+        pending: Rc<RefCell<BTreeSet<crate::large_values::NodeRef>>>,
+    }
+
+    impl ChunkInstallJournal for MemoryInstallJournal {
+        fn mark_pending(
+            &self,
+            node_ref: crate::large_values::NodeRef,
+        ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+            self.pending.borrow_mut().insert(node_ref);
+            Box::pin(async { Ok(()) })
+        }
+
+        fn is_pending(
+            &self,
+            node_ref: crate::large_values::NodeRef,
+        ) -> ChunkFuture<'_, Result<bool, ChunkError>> {
+            let pending = self.pending.borrow().contains(&node_ref);
+            Box::pin(async move { Ok(pending) })
+        }
+
+        fn complete(
+            &self,
+            node_ref: crate::large_values::NodeRef,
+        ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+            self.pending.borrow_mut().remove(&node_ref);
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingInstallObserver {
+        calls: Cell<usize>,
+    }
+
+    impl ChunkInstallObserver for CountingInstallObserver {
+        fn installed(
+            &self,
+            _node_ref: crate::large_values::NodeRef,
+            _encoded: Bytes,
+        ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+            self.calls.set(self.calls.get().saturating_add(1));
+            Box::pin(async { Ok(()) })
+        }
+    }
+
     struct CountingProvider {
         calls: Cell<usize>,
         bytes: Bytes,
@@ -2073,10 +2244,12 @@ mod tests {
             attempts: Cell::new(0),
             installed: Cell::new(0),
         });
-        let provider = StorageChunkProvider::with_resolver_and_observer(
+        let journal = Rc::new(MemoryInstallJournal::default());
+        let provider = StorageChunkProvider::with_resolver_observer_and_journal(
             storage.clone(),
             Rc::new(StaticResolver(bytes.clone())),
             observer.clone(),
+            journal.clone(),
         );
 
         // The bytes are already resident when metadata durability fails.
@@ -2092,14 +2265,77 @@ mod tests {
         // A reconstructed provider models reopen: its first load is now a
         // local hit, but it must still reconcile the missing install exactly
         // once instead of silently returning the resident bytes.
-        let reopened = StorageChunkProvider::with_resolver_and_observer(
+        let reopened = StorageChunkProvider::with_resolver_observer_and_journal(
             storage,
             Rc::new(StaticResolver(bytes.clone())),
             observer.clone(),
+            journal,
         );
         assert_eq!(block_on(reopened.get(request)), Ok(bytes));
         assert_eq!(observer.attempts.get(), 2);
         assert_eq!(observer.installed.get(), 1);
+    }
+
+    #[test]
+    fn ordinary_resident_chunk_hits_do_not_reenter_metadata_installation() {
+        let storage = Rc::new(MemoryChunkStorage::new());
+        let bytes = Bytes::from_static(b"already complete local chunk bytes");
+        let request = ChunkRequest {
+            object_hash: object_hash(&bytes).0,
+            locator: Locator::from_seed(b"complete-resident-install"),
+        };
+        block_on(storage.stage(vec![StagedChunk {
+            node_ref: crate::large_values::NodeRef {
+                object_hash: ContentHash(request.object_hash),
+                locator: request.locator,
+            },
+            encoded: bytes.to_vec(),
+        }]))
+        .unwrap();
+        let observer = Rc::new(CountingInstallObserver::default());
+        let provider = StorageChunkProvider::with_resolver_observer_and_journal(
+            storage,
+            Rc::new(StaticResolver(bytes.clone())),
+            observer.clone(),
+            Rc::new(MemoryInstallJournal::default()),
+        );
+
+        assert_eq!(block_on(provider.get(request.clone())), Ok(bytes.clone()));
+        assert_eq!(block_on(provider.get(request)), Ok(bytes));
+        assert_eq!(
+            observer.calls.get(),
+            0,
+            "a fully installed resident mapping must not call the lifecycle-bound observer"
+        );
+    }
+
+    #[test]
+    fn concurrent_pending_install_consumers_run_one_metadata_observer() {
+        let storage = Rc::new(MemoryChunkStorage::new());
+        let bytes = Bytes::from_static(b"one remote chunk, one metadata install");
+        let request = ChunkRequest {
+            object_hash: object_hash(&bytes).0,
+            locator: Locator::from_seed(b"coalesced-pending-install"),
+        };
+        let observer = Rc::new(CountingInstallObserver::default());
+        let provider = Rc::new(StorageChunkProvider::with_resolver_observer_and_journal(
+            storage,
+            Rc::new(StaticResolver(bytes.clone())),
+            observer.clone(),
+            Rc::new(MemoryInstallJournal::default()),
+        ));
+        let owned = OwnedChunkProvider::new(provider);
+
+        let (first, second) = block_on(async {
+            futures::join!(owned.get(request.clone()), owned.get(request.clone()))
+        });
+        assert_eq!(first.unwrap(), bytes);
+        assert_eq!(second.unwrap(), bytes);
+        assert_eq!(
+            observer.calls.get(),
+            1,
+            "coalesced consumers must share one pending metadata installation"
+        );
     }
 
     #[test]

--- a/crates/groove/src/chunks.rs
+++ b/crates/groove/src/chunks.rs
@@ -621,7 +621,24 @@ where
                 .get(request.locator, ContentHash(request.object_hash))
                 .await
             {
-                Ok(bytes) => Ok(bytes),
+                // A previous remote resolution may have made the immutable
+                // bytes durable just before its metadata observer failed. Do
+                // not let a subsequent local hit turn that failed install
+                // into a permanently invisible accounting hole: the observer
+                // is deliberately idempotent and reconciles this mapping on
+                // every provider load that reaches storage.
+                Ok(bytes) => {
+                    observer
+                        .installed(
+                            crate::large_values::NodeRef {
+                                object_hash: ContentHash(request.object_hash),
+                                locator: request.locator,
+                            },
+                            bytes.clone(),
+                        )
+                        .await?;
+                    Ok(bytes)
+                }
                 Err(ChunkStorageError::Unavailable) => {
                     let bytes = self.resolver.resolve(request.clone()).await?;
                     self.storage
@@ -1427,6 +1444,30 @@ mod tests {
         }
     }
 
+    struct FailOnceInstallObserver {
+        attempts: Cell<usize>,
+        installed: Cell<usize>,
+    }
+
+    impl ChunkInstallObserver for FailOnceInstallObserver {
+        fn installed(
+            &self,
+            _node_ref: crate::large_values::NodeRef,
+            _encoded: Bytes,
+        ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+            self.attempts.set(self.attempts.get().saturating_add(1));
+            if self.attempts.get() == 1 {
+                return Box::pin(async {
+                    Err(ChunkError::Backend(
+                        "injected metadata WriteMany failure".to_owned(),
+                    ))
+                });
+            }
+            self.installed.set(self.installed.get().saturating_add(1));
+            Box::pin(async { Ok(()) })
+        }
+    }
+
     struct CountingProvider {
         calls: Cell<usize>,
         bytes: Bytes,
@@ -2018,6 +2059,47 @@ mod tests {
             block_on(managed.get(locator, ContentHash([7; 32]))),
             Err(ChunkStorageError::Integrity)
         );
+    }
+
+    #[test]
+    fn resident_remote_chunk_retries_its_failed_metadata_install_after_reopen() {
+        let storage = Rc::new(MemoryChunkStorage::new());
+        let bytes = Bytes::from_static(b"authenticated remote branch bytes");
+        let request = ChunkRequest {
+            object_hash: object_hash(&bytes).0,
+            locator: Locator::from_seed(b"retry-resident-install"),
+        };
+        let observer = Rc::new(FailOnceInstallObserver {
+            attempts: Cell::new(0),
+            installed: Cell::new(0),
+        });
+        let provider = StorageChunkProvider::with_resolver_and_observer(
+            storage.clone(),
+            Rc::new(StaticResolver(bytes.clone())),
+            observer.clone(),
+        );
+
+        // The bytes are already resident when metadata durability fails.
+        assert!(matches!(
+            block_on(provider.get(request.clone())),
+            Err(ChunkError::Backend(message)) if message.contains("WriteMany")
+        ));
+        assert_eq!(
+            block_on(storage.get(request.locator, ContentHash(request.object_hash))).unwrap(),
+            bytes
+        );
+
+        // A reconstructed provider models reopen: its first load is now a
+        // local hit, but it must still reconcile the missing install exactly
+        // once instead of silently returning the resident bytes.
+        let reopened = StorageChunkProvider::with_resolver_and_observer(
+            storage,
+            Rc::new(StaticResolver(bytes.clone())),
+            observer.clone(),
+        );
+        assert_eq!(block_on(reopened.get(request)), Ok(bytes));
+        assert_eq!(observer.attempts.get(), 2);
+        assert_eq!(observer.installed.get(), 1);
     }
 
     #[test]

--- a/crates/groove/src/chunks.rs
+++ b/crates/groove/src/chunks.rs
@@ -770,7 +770,10 @@ where
         newly_staged: bool,
     ) -> ChunkFuture<'_, Result<(), ChunkError>> {
         Box::pin(async move {
-            if self.settled_installs.borrow().contains(&request) {
+            // A miss which was subsequently re-staged must not be hidden by
+            // an earlier ordinary-resident cache entry.  The journal has just
+            // acquired a new durability obligation in that case.
+            if !newly_staged && self.settled_installs.borrow().contains(&request) {
                 return Ok(());
             }
             // A regular resident chunk has no journal marker, so it must not
@@ -784,9 +787,19 @@ where
             // compare-and-delete, the next opener retries an idempotent
             // install.  It can never lose the recovery obligation.
             if !observer.completes_install_journal() {
-                self.journal.complete(node_ref).await?;
+                self.journal.complete(node_ref.clone()).await?;
             }
-            self.settled_installs.borrow_mut().insert(request);
+            // A resident publication may have staged the metadata operation
+            // without persisting it yet.  Its observer legitimately reports
+            // success so the publication can continue, but its physical
+            // journal marker remains until that publication reaches the
+            // durable frontier.  Do not cache that provisional result: a
+            // later read in the same process must still see the marker and
+            // retry after a failed/cancelled publication, rather than waiting
+            // for a process restart to recover it.
+            if !self.journal.is_pending(node_ref).await? {
+                self.settled_installs.borrow_mut().insert(request);
+            }
             Ok(())
         })
     }
@@ -1639,6 +1652,29 @@ mod tests {
         }
     }
 
+    /// Models a resident publication observer: it has staged its metadata
+    /// mutation successfully, but the shared journal remains physically
+    /// pending until the publication is persisted.
+    #[derive(Default)]
+    struct DeferredInstallObserver {
+        calls: Cell<usize>,
+    }
+
+    impl ChunkInstallObserver for DeferredInstallObserver {
+        fn installed(
+            &self,
+            _node_ref: crate::large_values::NodeRef,
+            _encoded: Bytes,
+        ) -> ChunkFuture<'_, Result<(), ChunkError>> {
+            self.calls.set(self.calls.get().saturating_add(1));
+            Box::pin(async { Ok(()) })
+        }
+
+        fn completes_install_journal(&self) -> bool {
+            true
+        }
+    }
+
     struct CountingProvider {
         calls: Cell<usize>,
         bytes: Bytes,
@@ -2307,6 +2343,47 @@ mod tests {
             0,
             "a fully installed resident mapping must not call the lifecycle-bound observer"
         );
+    }
+
+    #[test]
+    fn pending_marker_is_not_hidden_by_a_provisional_same_process_install() {
+        let storage = Rc::new(MemoryChunkStorage::new());
+        let bytes = Bytes::from_static(b"publication metadata not durable yet");
+        let request = ChunkRequest {
+            object_hash: object_hash(&bytes).0,
+            locator: Locator::from_seed(b"provisional-install-marker"),
+        };
+        let observer = Rc::new(DeferredInstallObserver::default());
+        let journal = Rc::new(MemoryInstallJournal::default());
+        let provider = StorageChunkProvider::with_resolver_observer_and_journal(
+            storage,
+            Rc::new(StaticResolver(bytes.clone())),
+            observer.clone(),
+            journal.clone(),
+        );
+
+        // The first read stages bytes and metadata into a resident
+        // publication. It is usable immediately, but it must not be cached as
+        // durable while the physical marker remains.
+        assert_eq!(block_on(provider.get(request.clone())), Ok(bytes.clone()));
+        assert_eq!(observer.calls.get(), 1);
+
+        // Model a failed/cancelled publication without a process restart.
+        // The next reader must re-run the installer rather than treating its
+        // earlier in-memory success as proof that metadata survived.
+        assert_eq!(block_on(provider.get(request.clone())), Ok(bytes.clone()));
+        assert_eq!(observer.calls.get(), 2);
+
+        // Once the actual durable boundary clears the marker, a regular hit
+        // becomes cacheable and later reads never re-enter metadata lifecycle.
+        let node_ref = crate::large_values::NodeRef {
+            object_hash: ContentHash(request.object_hash),
+            locator: request.locator,
+        };
+        block_on(journal.complete(node_ref)).unwrap();
+        assert_eq!(block_on(provider.get(request.clone())), Ok(bytes.clone()));
+        assert_eq!(block_on(provider.get(request)), Ok(bytes));
+        assert_eq!(observer.calls.get(), 2);
     }
 
     #[test]

--- a/crates/groove/src/db/facade.rs
+++ b/crates/groove/src/db/facade.rs
@@ -75,13 +75,16 @@ impl Database {
             Rc::new(crate::chunks::UnavailableChunkResolver);
         let large_value_lifecycle = std::sync::Arc::new(futures::lock::Mutex::new(()));
         ivm_runtime.set_chunk_provider(Rc::new(
-            crate::chunks::StorageChunkProvider::with_resolver_and_observer(
+            crate::chunks::StorageChunkProvider::with_resolver_observer_and_journal(
                 chunk_storage.clone(),
                 chunk_resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&storage),
                     lifecycle: std::sync::Arc::downgrade(&large_value_lifecycle),
                     resident_install: None,
+                }),
+                Rc::new(MetadataChunkInstallJournal {
+                    storage: Rc::downgrade(&storage),
                 }),
             ),
         ));
@@ -189,13 +192,16 @@ impl Database {
     /// evaluation reads directly through it.
     pub fn set_chunk_storage(&mut self, storage: Rc<dyn crate::chunks::ChunkStorage>) {
         self.ivm_runtime.set_chunk_provider(Rc::new(
-            crate::chunks::StorageChunkProvider::with_resolver_and_observer(
+            crate::chunks::StorageChunkProvider::with_resolver_observer_and_journal(
                 storage.clone(),
                 self.chunk_resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&self.storage),
                     lifecycle: std::sync::Arc::downgrade(&self.large_value_lifecycle),
                     resident_install: None,
+                }),
+                Rc::new(MetadataChunkInstallJournal {
+                    storage: Rc::downgrade(&self.storage),
                 }),
             ),
         ));
@@ -207,13 +213,16 @@ impl Database {
         resolver: Rc<dyn crate::chunks::MissingChunkResolver>,
     ) {
         self.ivm_runtime.set_chunk_provider(Rc::new(
-            crate::chunks::StorageChunkProvider::with_resolver_and_observer(
+            crate::chunks::StorageChunkProvider::with_resolver_observer_and_journal(
                 self.chunk_storage.clone(),
                 resolver.clone(),
                 Rc::new(MetadataChunkInstallObserver {
                     storage: Rc::downgrade(&self.storage),
                     lifecycle: std::sync::Arc::downgrade(&self.large_value_lifecycle),
                     resident_install: None,
+                }),
+                Rc::new(MetadataChunkInstallJournal {
+                    storage: Rc::downgrade(&self.storage),
                 }),
             ),
         ));

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -86,6 +86,20 @@ fn large_value_reclaim_key(node_ref: &crate::large_values::NodeRef) -> Result<Ve
     Ok(key)
 }
 
+/// Durable marker for a remotely hydrated immutable node whose byte write has
+/// happened but whose Groove reference metadata still needs installation.
+/// This lives in Groove's metadata plane rather than in the blob backend: a
+/// locator remains an opaque capability to that backend.
+fn large_value_pending_install_key(
+    node_ref: &crate::large_values::NodeRef,
+) -> Result<Vec<u8>, Error> {
+    let mut key = b"install/".to_vec();
+    key.extend(postcard::to_allocvec(node_ref).map_err(|error| {
+        Error::InvalidLargeValueMetadata(format!("cannot encode pending install identity: {error}"))
+    })?);
+    Ok(key)
+}
+
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 struct LargeValueNodeReferences {
     references: u64,
@@ -227,6 +241,84 @@ struct MetadataChunkInstallObserver {
     resident_install: Option<ResidentLifecycleInstall>,
 }
 
+/// The recovery journal is intentionally separate from byte storage and from
+/// metadata installation. It only answers whether a particular exact chunk
+/// needs reconciliation, allowing normal resident reads to avoid both the
+/// observer and the large-value lifecycle mutex.
+#[derive(Clone)]
+struct MetadataChunkInstallJournal {
+    storage: std::rc::Weak<LayoutStorage>,
+}
+
+impl crate::chunks::ChunkInstallJournal for MetadataChunkInstallJournal {
+    fn mark_pending(
+        &self,
+        node_ref: crate::large_values::NodeRef,
+    ) -> crate::chunks::ChunkFuture<'_, Result<(), crate::chunks::ChunkError>> {
+        Box::pin(async move {
+            let storage = self.storage.upgrade().ok_or_else(|| {
+                crate::chunks::ChunkError::Backend(
+                    "database storage closed while recording chunk installation".to_owned(),
+                )
+            })?;
+            let key = large_value_pending_install_key(&node_ref)
+                .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
+            let existing = storage
+                .put_if_absent(LARGE_VALUE_METADATA_CF.to_owned(), key, Vec::new())
+                .await
+                .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
+            if existing.is_some_and(|value| !value.is_empty()) {
+                return Err(crate::chunks::ChunkError::Integrity);
+            }
+            Ok(())
+        })
+    }
+
+    fn is_pending(
+        &self,
+        node_ref: crate::large_values::NodeRef,
+    ) -> crate::chunks::ChunkFuture<'_, Result<bool, crate::chunks::ChunkError>> {
+        Box::pin(async move {
+            let storage = self.storage.upgrade().ok_or_else(|| {
+                crate::chunks::ChunkError::Backend(
+                    "database storage closed while reading chunk installation journal".to_owned(),
+                )
+            })?;
+            let key = large_value_pending_install_key(&node_ref)
+                .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
+            match storage
+                .get(LARGE_VALUE_METADATA_CF.to_owned(), key)
+                .await
+                .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?
+            {
+                None => Ok(false),
+                Some(value) if value.is_empty() => Ok(true),
+                Some(_) => Err(crate::chunks::ChunkError::Integrity),
+            }
+        })
+    }
+
+    fn complete(
+        &self,
+        node_ref: crate::large_values::NodeRef,
+    ) -> crate::chunks::ChunkFuture<'_, Result<(), crate::chunks::ChunkError>> {
+        Box::pin(async move {
+            let storage = self.storage.upgrade().ok_or_else(|| {
+                crate::chunks::ChunkError::Backend(
+                    "database storage closed while completing chunk installation".to_owned(),
+                )
+            })?;
+            let key = large_value_pending_install_key(&node_ref)
+                .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
+            storage
+                .compare_and_delete(LARGE_VALUE_METADATA_CF.to_owned(), key, Vec::new())
+                .await
+                .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?;
+            Ok(())
+        })
+    }
+}
+
 #[derive(Clone)]
 struct ResidentLifecycleInstall {
     storage: OwnedStorage<'static>,
@@ -347,6 +439,16 @@ impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
                         .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?,
                 });
             }
+            // The recovery marker and all node/root metadata share the same
+            // durability boundary. In particular, a resident publication
+            // keeps both staged until its persistence receipt settles; it
+            // cannot leave resident bytes with neither metadata nor a retry
+            // marker after a cancelled/failed publication.
+            operations.push(OwnedWriteOperation::Delete {
+                cf: LARGE_VALUE_METADATA_CF.to_owned(),
+                key: large_value_pending_install_key(&node_ref)
+                    .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))?,
+            });
             if let Some(install) = resident_install {
                 if install.durable.get() {
                     match storage.write_many(operations).await {
@@ -368,6 +470,10 @@ impl crate::chunks::ChunkInstallObserver for MetadataChunkInstallObserver {
                     .map_err(|error| crate::chunks::ChunkError::Backend(error.to_string()))
             }
         })
+    }
+
+    fn completes_install_journal(&self) -> bool {
+        true
     }
 }
 

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -46,12 +46,34 @@ impl Database {
     /// the runtime is either complete or waiting for storage.
     ///
     /// Unlike [`Self::drive_progress`], this does not hold an unrelated owner
-    /// loop open while cold inputs are being acquired. The storage futures are
-    /// still polled with the caller's waker, so their completion schedules the
-    /// next owner-loop turn.
+    /// loop open while cold inputs are being acquired. Hosts that need a wake
+    /// after this short turn can use [`Self::drive_ready_progress_with_waker`].
     pub async fn drive_ready_progress(&mut self) -> Result<(), Error> {
-        let progress =
-            std::future::poll_fn(|cx| std::task::Poll::Ready(self.poll_progress(cx))).await;
+        self.drive_ready_progress_with_waker(None).await
+    }
+
+    /// Drive currently runnable work without waiting for cold storage, using
+    /// `progress_waker` for any storage request that remains pending.
+    ///
+    /// A non-blocking owner turn returns immediately after it discovers cold
+    /// work. Its executor waker is therefore no longer a useful continuation
+    /// target. Runtime shells that can arrange another owner turn supply their
+    /// own durable wake bridge here; callers without one retain the historical
+    /// externally-driven polling behaviour.
+    pub async fn drive_ready_progress_with_waker(
+        &mut self,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<(), Error> {
+        let progress = match progress_waker {
+            Some(progress_waker) => {
+                std::future::poll_fn(|_| {
+                    let mut progress_cx = std::task::Context::from_waker(progress_waker);
+                    std::task::Poll::Ready(self.poll_progress(&mut progress_cx))
+                })
+                .await
+            }
+            None => std::future::poll_fn(|cx| std::task::Poll::Ready(self.poll_progress(cx))).await,
+        };
         match progress {
             std::task::Poll::Ready(result) => result,
             std::task::Poll::Pending => Ok(()),

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -1,6 +1,16 @@
 use super::*;
 
 impl Database {
+    /// Whether a suspended IVM evaluation still needs a future owner turn.
+    ///
+    /// An external chunk completion can wake an evaluation which then starts a
+    /// second asynchronous operation (for example, durable install metadata).
+    /// Once the chunk request itself is complete, callers must still keep
+    /// polling this work until the runtime reaches a terminal state.
+    pub fn has_pending_progress(&self) -> bool {
+        self.ivm_runtime.has_pending_incremental()
+    }
+
     /// Drive every suspended incremental evaluation until the runtime is
     /// either quiescent or waiting for storage.
     ///

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -25,6 +25,148 @@ impl crate::chunks::MissingChunkResolver for FixtureChunkResolver {
     }
 }
 
+/// The byte plane is deliberately separate from Groove metadata. This receipt
+/// fails the metadata observer after the immutable byte has been staged, then
+/// rebuilds the provider over the same metadata store. The pending marker must
+/// cause exactly one retry; a regular byte-store hit alone is not evidence that
+/// child/reference metadata exists.
+#[futures_test::test]
+async fn pending_remote_chunk_install_retries_after_provider_rebuild() {
+    struct FailOnceObserver {
+        attempts: Rc<Cell<usize>>,
+    }
+
+    impl crate::chunks::ChunkInstallObserver for FailOnceObserver {
+        fn installed(
+            &self,
+            _node_ref: crate::large_values::NodeRef,
+            _encoded: Bytes,
+        ) -> crate::chunks::ChunkFuture<'_, Result<(), crate::chunks::ChunkError>> {
+            let attempts = Rc::clone(&self.attempts);
+            Box::pin(async move {
+                let attempt = attempts.get().saturating_add(1);
+                attempts.set(attempt);
+                if attempt == 1 {
+                    Err(crate::chunks::ChunkError::Backend(
+                        "injected post-staging metadata failure".to_owned(),
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+        }
+    }
+
+    let backing = MemoryStorage::new(&[LARGE_VALUE_METADATA_CF]);
+    let metadata = Rc::new(
+        LayoutStorage::new(backing, StorageLayout::Identity)
+            .await
+            .unwrap(),
+    );
+    let chunks = Rc::new(crate::chunks::MemoryChunkStorage::new());
+    let prepared = crate::large_values::prepare(
+        crate::large_values::LargeValueKind::Bytes,
+        &vec![0x5a; crate::large_values::INLINE_VALUE_MAX_BYTES + 1],
+    )
+    .unwrap();
+    let root = prepared.value_ref.root.clone();
+    let bytes = Bytes::from(
+        prepared
+            .staged_chunks
+            .iter()
+            .find(|chunk| chunk.node_ref == root)
+            .expect("prepared root is staged")
+            .encoded
+            .clone(),
+    );
+    let request = crate::chunks::ChunkRequest {
+        object_hash: root.object_hash.0,
+        locator: root.locator,
+    };
+    let resolver = Rc::new(FixtureChunkResolver {
+        chunks: Rc::new(std::collections::BTreeMap::from([(
+            request.clone(),
+            bytes.clone(),
+        )])),
+    });
+    let attempts = Rc::new(Cell::new(0));
+    let provider = crate::chunks::StorageChunkProvider::with_resolver_observer_and_journal(
+        chunks.clone(),
+        resolver.clone(),
+        Rc::new(FailOnceObserver {
+            attempts: Rc::clone(&attempts),
+        }),
+        Rc::new(MetadataChunkInstallJournal {
+            storage: Rc::downgrade(&metadata),
+        }),
+    );
+
+    assert!(matches!(
+        crate::chunks::ChunkProvider::get(&provider, request.clone()).await,
+        Err(crate::chunks::ChunkError::Backend(message))
+            if message.contains("post-staging metadata failure")
+    ));
+    assert_eq!(
+        crate::chunks::ChunkStorage::get(
+            chunks.as_ref(),
+            request.locator,
+            crate::large_values::ContentHash(request.object_hash),
+        )
+        .await
+        .unwrap(),
+        bytes,
+        "the immutable blob is resident before metadata installation succeeds"
+    );
+
+    let lifecycle = Arc::new(AsyncMutex::new(()));
+    let reopened = crate::chunks::StorageChunkProvider::with_resolver_observer_and_journal(
+        chunks,
+        resolver,
+        Rc::new(MetadataChunkInstallObserver {
+            storage: Rc::downgrade(&metadata),
+            lifecycle: Arc::downgrade(&lifecycle),
+            resident_install: None,
+        }),
+        Rc::new(MetadataChunkInstallJournal {
+            storage: Rc::downgrade(&metadata),
+        }),
+    );
+    assert_eq!(
+        crate::chunks::ChunkProvider::get(&reopened, request.clone()).await,
+        Ok(bytes)
+    );
+    assert_eq!(
+        attempts.get(),
+        1,
+        "the first post-staging observer failed once"
+    );
+    assert!(
+        metadata
+            .get(
+                LARGE_VALUE_METADATA_CF.to_owned(),
+                large_value_node_key(&root).unwrap(),
+            )
+            .await
+            .unwrap()
+            .is_some(),
+        "the reopened retry installs the actual Groove node metadata"
+    );
+    assert!(
+        !crate::chunks::ChunkInstallJournal::is_pending(
+            &MetadataChunkInstallJournal {
+                storage: Rc::downgrade(&metadata),
+            },
+            crate::large_values::NodeRef {
+                object_hash: crate::large_values::ContentHash(request.object_hash),
+                locator: request.locator,
+            },
+        )
+        .await
+        .unwrap(),
+        "a successful observer completion clears its durable recovery marker"
+    );
+}
+
 #[derive(Clone)]
 struct CountingFixtureChunkResolver {
     chunks: Rc<std::collections::BTreeMap<crate::chunks::ChunkRequest, Bytes>>,

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -2357,9 +2357,28 @@ async fn late_publication_metadata_write_failure_is_fatal_and_observable() {
     assert!(subscription.try_recv().is_err());
     database.finish_persistence(second.persist().await).unwrap();
 
-    control.fail_next(TestStorageOperation::WriteMany);
+    // A cold install now journals before it stages bytes. Pause that first
+    // write so this receipt can inject the failure at the *later* metadata
+    // durability boundary it is intended to exercise, rather than turning a
+    // pre-staging journal write into an unrelated query-local failure.
+    control.take_observed();
+    control.pause_on(TestStorageOperation::WriteMany);
     resolver_ready.set(true);
-    let error = database.flush().await.unwrap_err();
+    let mut flush = Box::pin(database.flush());
+    assert!(futures::poll!(flush.as_mut()).is_pending());
+    assert_eq!(
+        control.take_observed(),
+        vec![TestStorageOperation::WriteMany]
+    );
+    control.release_one();
+    assert!(futures::poll!(flush.as_mut()).is_pending());
+    assert_eq!(
+        control.take_observed(),
+        vec![TestStorageOperation::WriteMany]
+    );
+    control.fail_next(TestStorageOperation::WriteMany);
+    control.release_one();
+    let error = flush.await.unwrap_err();
     assert!(matches!(
         error,
         Error::IvmRuntime(IvmRuntimeError::Chunk(

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -2,6 +2,93 @@
 
 use super::*;
 
+/// A non-blocking owner turn must leave a real wake route behind for cold
+/// hydration. Merely noticing pending work on a later manually-driven tick is
+/// insufficient for event-driven hosts: no unrelated transport activity is
+/// required to resume this subscription.
+#[futures_test::test]
+async fn cold_hydration_wakes_the_supplied_owner_once_without_polling() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let (storage, control) = TestStorage::controlled(&["albums"]);
+    let mut database = Database::new(albums_schema(), storage.clone())
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("wake bridge".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+    storage.evict_all();
+    control.pause_on(TestStorageOperation::ScanOpen);
+
+    let subscription = database
+        .subscribe_one_sink(GraphBuilder::table("albums"))
+        .await
+        .unwrap();
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert_eq!(wakes.0.load(Ordering::Acquire), 0);
+
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    assert_eq!(
+        wakes.0.load(Ordering::Acquire),
+        1,
+        "storage readiness schedules exactly one following owner turn"
+    );
+    let mut observed_wakes = wakes.0.load(Ordering::Acquire);
+    for _ in 0..32 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+        let next_wakes = wakes.0.load(Ordering::Acquire);
+        assert!(
+            next_wakes > observed_wakes,
+            "each further cold operation requests its own owner turn instead of polling hot"
+        );
+        observed_wakes = next_wakes;
+    }
+    assert!(!database.has_pending_progress());
+    assert_eq!(
+        expect_try_recv_vals(&subscription),
+        vec![(
+            vec![Value::U64(1), Value::String("wake bridge".to_owned())],
+            1
+        )]
+    );
+    let idle_wakes = wakes.0.load(Ordering::Acquire);
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+    assert_eq!(
+        wakes.0.load(Ordering::Acquire),
+        idle_wakes,
+        "quiescent runtimes retain no storage wake and do not schedule a hot follow-up"
+    );
+}
+
 #[futures_test::test]
 async fn subscribe_sends_empty_hydration_snapshot_without_writes() {
     let storage = MemoryStorage::new(&["albums"]);

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -162,6 +162,12 @@ impl std::fmt::Debug for PendingIncrementalEvaluation {
     }
 }
 
+impl PendingIncrementalEvaluation {
+    pub(super) fn is_pending(&self) -> bool {
+        !self.0.borrow().order.is_empty()
+    }
+}
+
 /// Discovers request-producing leaves for all reachable siblings without recursively
 /// evaluating through the first blocked branch. Hash-consed nodes enter the
 /// queue once, so discovery is linear in the reachable graph slice.
@@ -1638,6 +1644,10 @@ impl IvmRuntime {
         } else {
             Poll::Pending
         }
+    }
+
+    pub(crate) fn has_pending_incremental(&self) -> bool {
+        self.pending_incremental.is_pending()
     }
 
     /// Drop an uninstalled hydration when its subscription is cancelled.

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -53,6 +53,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use futures::future::LocalBoxFuture;
 use futures::lock::Mutex as LocalMutex;
+use futures::task::{ArcWake, waker};
 use jazz::db::StreamingMutationKind as CoreStreamingMutationKind;
 use jazz::db::{
     ConnectionSessionContext as CoreConnectionSessionContext, Db as CoreDb,
@@ -225,7 +226,20 @@ struct NapiWireTransport {
 }
 
 struct NapiTickScheduler {
-    callback: ThreadsafeFunction<String, ()>,
+    callback: std::sync::Arc<ThreadsafeFunction<String, ()>>,
+}
+
+struct NapiQueryRuntimeWake {
+    callback: std::sync::Arc<ThreadsafeFunction<String, ()>>,
+}
+
+impl ArcWake for NapiQueryRuntimeWake {
+    fn wake_by_ref(arc_self: &std::sync::Arc<Self>) {
+        let _ = arc_self.callback.call(
+            Ok("immediate".to_owned()),
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
+    }
 }
 
 impl CoreTickScheduler for NapiTickScheduler {
@@ -245,6 +259,12 @@ impl CoreTickScheduler for NapiTickScheduler {
             Ok(format!("after:{delay_ms}")),
             ThreadsafeFunctionCallMode::NonBlocking,
         );
+    }
+
+    fn query_runtime_waker(&self) -> Option<Waker> {
+        Some(waker(std::sync::Arc::new(NapiQueryRuntimeWake {
+            callback: self.callback.clone(),
+        })))
     }
 }
 
@@ -2229,7 +2249,9 @@ impl NapiDb {
 
     #[napi(js_name = "setTickScheduler")]
     pub fn set_tick_scheduler(&self, callback: ThreadsafeFunction<String, ()>) -> napi::Result<()> {
-        let scheduler = Rc::new(NapiTickScheduler { callback });
+        let scheduler = Rc::new(NapiTickScheduler {
+            callback: std::sync::Arc::new(callback),
+        });
         let db = self.inner.borrow();
         let db = db
             .as_ref()

--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.22"
 console_error_panic_hook = { version = "0.1", optional = true }
 ed25519-dalek = "2"
 futures-util = "0.3.31"
+futures-channel = "0.3.31"
 idb-tree = { path = "../idb-tree" }
 jazz = { path = "../jazz", default-features = false }
 js-sys = "0.3.82"

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3,13 +3,17 @@ use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use futures_channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::future::{AbortHandle, Abortable};
 use futures_util::lock::Mutex as LocalMutex;
 use futures_util::stream;
+use futures_util::task::{waker, ArcWake};
 use futures_util::{Stream, StreamExt};
 #[cfg(target_arch = "wasm32")]
 use idb_tree::IndexedDbPageStore;
@@ -588,6 +592,24 @@ struct WasmWireTransport {
 
 struct WasmTickScheduler {
     callback: js_sys::Function,
+    progress_wake: UnboundedSender<()>,
+    progress_wake_pending: Arc<AtomicBool>,
+}
+
+/// `Waker` itself must be Send + Sync, while a JS callback is deliberately
+/// thread-affine. Keep only a thread-safe channel in the waker and forward it
+/// back to the WASM local task before touching JS.
+struct WasmQueryRuntimeWake {
+    sender: UnboundedSender<()>,
+    pending: Arc<AtomicBool>,
+}
+
+impl ArcWake for WasmQueryRuntimeWake {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        if !arc_self.pending.swap(true, Ordering::AcqRel) {
+            let _ = arc_self.sender.unbounded_send(());
+        }
+    }
 }
 
 impl TickScheduler for WasmTickScheduler {
@@ -606,6 +628,13 @@ impl TickScheduler for WasmTickScheduler {
             &JsValue::NULL,
             &JsValue::from_str(&format!("after:{delay_ms}")),
         );
+    }
+
+    fn query_runtime_waker(&self) -> Option<Waker> {
+        Some(waker(Arc::new(WasmQueryRuntimeWake {
+            sender: self.progress_wake.clone(),
+            pending: Arc::clone(&self.progress_wake_pending),
+        })))
     }
 }
 
@@ -961,7 +990,21 @@ impl WasmDbInner {
     }
 
     fn set_tick_scheduler(&self, callback: js_sys::Function) {
-        let scheduler = Rc::new(WasmTickScheduler { callback });
+        let (progress_wake, mut progress_events) = unbounded();
+        let progress_wake_pending = Arc::new(AtomicBool::new(false));
+        let progress_callback = callback.clone();
+        let progress_pending = Arc::clone(&progress_wake_pending);
+        wasm_bindgen_futures::spawn_local(async move {
+            while progress_events.next().await.is_some() {
+                progress_pending.store(false, Ordering::Release);
+                let _ = progress_callback.call1(&JsValue::NULL, &JsValue::from_str("immediate"));
+            }
+        });
+        let scheduler = Rc::new(WasmTickScheduler {
+            callback,
+            progress_wake,
+            progress_wake_pending,
+        });
         with_wasm_db!(self, |db| db.set_tick_scheduler(Some(scheduler)))
     }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1204,6 +1204,16 @@ pub trait TickScheduler {
     /// microtask would create a resend hot loop. Every host therefore supplies
     /// a real timer implementation.
     fn schedule_tick_after(&self, delay_ms: u64);
+
+    /// A waker for cold query-runtime storage progress.
+    ///
+    /// A non-blocking database tick deliberately returns while a query waits
+    /// for storage. Hosts that can arrange a later owner turn provide a waker
+    /// which schedules precisely that turn when storage becomes ready. The
+    /// default keeps manually-driven hosts source-compatible.
+    fn query_runtime_waker(&self) -> Option<Waker> {
+        None
+    }
 }
 
 /// A locally-originated transaction rejection that was not consumed by an

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1442,6 +1442,7 @@ where
         let chunk_completion_generation = self.chunk_resolver.completion_generation();
         if self.chunk_resolver.has_pending_local_demand()
             || chunk_completion_generation != self.observed_chunk_completion_generation.get()
+            || self.node.lock().await.has_pending_query_runtime()
         {
             stats.subscription_events += Box::pin(refresh_subscriptions_in(
                 &self.node,

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -388,6 +388,18 @@ where
         schedule_tick_in(&self.scheduler, urgency);
     }
 
+    /// Obtain the host-owned waker that survives this short owner turn.
+    ///
+    /// It is passed only into Groove's non-blocking query-progress poll. A
+    /// later cold-storage completion therefore asks the host for one new tick
+    /// instead of making this runtime poll while the storage is still cold.
+    pub(super) fn query_runtime_waker(&self) -> Option<Waker> {
+        self.scheduler
+            .borrow()
+            .as_ref()
+            .and_then(|scheduler| scheduler.query_runtime_waker())
+    }
+
     /// Enqueue a stream-finalization command without touching the async node
     /// mutex. This is the only operation a stream's `Drop` implementation may
     /// perform. A closed node has already retired its runtime, so later
@@ -683,10 +695,12 @@ where
     }
 
     pub(super) async fn refresh_subscriptions(&self) -> Result<usize, Error> {
+        let progress_waker = self.query_runtime_waker();
         refresh_subscriptions_in(
             &self.node,
             &self.subscriptions,
             &self.active_authority_view_receipts,
+            progress_waker.as_ref(),
         )
         .await
     }
@@ -1439,6 +1453,7 @@ where
         self.drain_subscription_finalizations().await?;
         self.deliver_pending_mutation_errors();
         let mut stats = DbTickStats::default();
+        let progress_waker = self.query_runtime_waker();
         let chunk_completion_generation = self.chunk_resolver.completion_generation();
         if self.chunk_resolver.has_pending_local_demand()
             || chunk_completion_generation != self.observed_chunk_completion_generation.get()
@@ -1448,6 +1463,7 @@ where
                 &self.node,
                 &self.subscriptions,
                 &self.active_authority_view_receipts,
+                progress_waker.as_ref(),
             ))
             .await?;
             self.observed_chunk_completion_generation
@@ -1617,6 +1633,7 @@ pub(super) async fn refresh_subscriptions_in<S>(
     node: &SharedNodeState<S>,
     subscriptions: &SubscriptionList,
     active_authority_view_receipts: &ActiveAuthorityViewReceipts,
+    progress_waker: Option<&Waker>,
 ) -> Result<usize, Error>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
@@ -1629,7 +1646,10 @@ where
         .await
         .take_pending_authoritative_reset_binding_views();
     let mut consumed_authoritative_resets = BTreeSet::new();
-    node.lock().await.drive_ready_query_runtime().await?;
+    node.lock()
+        .await
+        .drive_ready_query_runtime_with_waker(progress_waker)
+        .await?;
     let live_subscriptions = subscriptions.borrow().clone();
     for weak in &live_subscriptions {
         let Some(state) = weak.upgrade() else {

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -40,6 +40,7 @@ async fn finish_peer_publication_outcome<S, T>(
     node: &SharedNodeState<S>,
     subscriptions: &SubscriptionList,
     active_authority_view_receipts: &ActiveAuthorityViewReceipts,
+    progress_waker: Option<&Waker>,
     outcome: PublicationOutcome<T>,
 ) -> Result<(T, usize), Error>
 where
@@ -49,6 +50,7 @@ where
         node,
         subscriptions,
         active_authority_view_receipts,
+        progress_waker,
         outcome,
         true,
     )
@@ -60,6 +62,7 @@ async fn finish_peer_publication_outcome_with_refresh<S, T>(
     node: &SharedNodeState<S>,
     subscriptions: &SubscriptionList,
     active_authority_view_receipts: &ActiveAuthorityViewReceipts,
+    progress_waker: Option<&Waker>,
     outcome: PublicationOutcome<T>,
     refresh: bool,
 ) -> Result<(T, usize, bool), Error>
@@ -77,9 +80,13 @@ where
         if !publications.is_empty() {
             published_any = true;
             if refresh {
-                changed +=
-                    refresh_subscriptions_in(node, subscriptions, active_authority_view_receipts)
-                        .await?;
+                changed += refresh_subscriptions_in(
+                    node,
+                    subscriptions,
+                    active_authority_view_receipts,
+                    progress_waker,
+                )
+                .await?;
             }
             let mut persisted = Vec::with_capacity(publications.len());
             for publication in &publications {
@@ -903,6 +910,11 @@ where
             return Err(error);
         }
         let mut stats = DbTickStats::default();
+        let progress_waker = self
+            .scheduler
+            .borrow()
+            .as_ref()
+            .and_then(|scheduler| scheduler.query_runtime_waker());
         let connection_epoch = self.connection_epoch;
         self.observe_shared_subscriber_dirty_epoch();
         self.bind_subscriber_session_claims();
@@ -990,6 +1002,7 @@ where
                                             &self.node,
                                             &self.subscriptions,
                                             &self.active_authority_view_receipts,
+                                            progress_waker.as_ref(),
                                             outcome,
                                         )
                                         .await?;
@@ -1048,6 +1061,7 @@ where
                                         &self.node,
                                         &self.subscriptions,
                                         &self.active_authority_view_receipts,
+                                        progress_waker.as_ref(),
                                         outcome,
                                     )
                                     .await?;
@@ -2077,6 +2091,7 @@ where
                             &self.node,
                             &self.subscriptions,
                             &self.active_authority_view_receipts,
+                            progress_waker.as_ref(),
                         )
                         .await?;
                         let mut persisted = Vec::with_capacity(publications.len());
@@ -2099,6 +2114,7 @@ where
                                 &self.node,
                                 &self.subscriptions,
                                 &self.active_authority_view_receipts,
+                                progress_waker.as_ref(),
                             )
                             .await?;
                         }
@@ -2750,6 +2766,7 @@ where
                                 &self.node,
                                 &self.subscriptions,
                                 &self.active_authority_view_receipts,
+                                progress_waker.as_ref(),
                                 outcome,
                                 false,
                             )
@@ -3022,6 +3039,7 @@ where
                                 &self.node,
                                 &self.subscriptions,
                                 &self.active_authority_view_receipts,
+                                progress_waker.as_ref(),
                                 outcome,
                                 false,
                             )
@@ -3066,6 +3084,7 @@ where
                         &self.node,
                         &self.subscriptions,
                         &self.active_authority_view_receipts,
+                        progress_waker.as_ref(),
                     )
                     .await?;
                 }

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -914,6 +914,11 @@ self.database.finish_persistence(persisted)?;
             .map_err(Error::Groove)
     }
 
+    /// Whether an earlier non-blocking query-runtime turn left resumable work.
+    pub(crate) fn has_pending_query_runtime(&self) -> bool {
+        self.database.has_pending_progress()
+    }
+
     pub(crate) async fn set_initial_sync_flush_cadence(
         &mut self,
         every: usize,

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -908,8 +908,17 @@ self.database.finish_persistence(persisted)?;
     /// Resume all query work that can make progress now, without holding the
     /// caller open for storage-blocked nodes.
     pub(crate) async fn drive_ready_query_runtime(&mut self) -> Result<(), Error> {
+        self.drive_ready_query_runtime_with_waker(None).await
+    }
+
+    /// Resume runnable query work and retain a host-owned wake bridge for any
+    /// cold storage operation that starts during this owner turn.
+    pub(crate) async fn drive_ready_query_runtime_with_waker(
+        &mut self,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<(), Error> {
         self.database
-            .drive_ready_progress()
+            .drive_ready_progress_with_waker(progress_waker)
             .await
             .map_err(Error::Groove)
     }

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -27,6 +27,7 @@ use futures::StreamExt;
 use futures::channel::mpsc;
 use futures::future::LocalBoxFuture;
 use futures::task::LocalSpawnExt;
+use futures::task::{ArcWake, waker};
 use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 
 /// Sendable handle for the thread that owns the in-memory server shell.
@@ -135,6 +136,19 @@ struct ServerShellTickState {
     delayed: AtomicBool,
 }
 
+/// A storage-future wake is translated back into one serialized shell turn.
+/// The callback contains no database state, so it remains safe for a backend
+/// to invoke through a normal cross-thread `Waker`.
+struct ServerShellQueryRuntimeWake {
+    scheduler: ServerShellTickScheduler,
+}
+
+impl ArcWake for ServerShellQueryRuntimeWake {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.scheduler.schedule_tick(TickUrgency::Immediate);
+    }
+}
+
 impl ServerShellTickScheduler {
     fn enqueue_tick(
         jobs: &mpsc::UnboundedSender<ServerShellCommand>,
@@ -193,6 +207,12 @@ impl TickScheduler for ServerShellTickScheduler {
             state.delayed.store(false, Ordering::Release);
             Self::enqueue_tick(&jobs, &activity_tx, &io_wakers, &state);
         });
+    }
+
+    fn query_runtime_waker(&self) -> Option<std::task::Waker> {
+        Some(waker(Arc::new(ServerShellQueryRuntimeWake {
+            scheduler: self.clone(),
+        })))
     }
 }
 

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use futures::task::{ArcWake, waker};
+
 use crate::db::{
     Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, Error as CoreDbError,
     ErrorCode as CoreDbErrorCode, ExclusiveTxOps, LocalUpdates as CoreLocalUpdates,
@@ -709,6 +711,21 @@ struct TickState {
     notify: tokio::sync::Notify,
 }
 
+/// Thread-safe wake bridge retained by cold Groove storage futures.
+///
+/// It does not poll the database itself. It only records one Immediate owner
+/// turn when an actually pending operation becomes ready.
+struct QueryRuntimeWake {
+    state: Arc<TickState>,
+}
+
+impl ArcWake for QueryRuntimeWake {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.state.immediate.store(true, Ordering::Release);
+        arc_self.state.notify.notify_one();
+    }
+}
+
 impl TickSchedulerImpl {
     fn take(&self) -> Option<TickUrgency> {
         if self.state.immediate.swap(false, Ordering::AcqRel) {
@@ -757,6 +774,12 @@ impl TickScheduler for TickSchedulerImpl {
 
     fn schedule_tick_after(&self, delay_ms: u64) {
         self.wake_after(delay_ms);
+    }
+
+    fn query_runtime_waker(&self) -> Option<std::task::Waker> {
+        Some(waker(Arc::new(QueryRuntimeWake {
+            state: Arc::clone(&self.state),
+        })))
     }
 }
 
@@ -3435,6 +3458,18 @@ mod tests {
     use crate::tools::{ClientStorage, ColumnType, SchemaBuilder, TableSchema};
     use serde_json::json;
     use tempfile::TempDir;
+
+    #[test]
+    fn query_runtime_waker_enqueues_one_immediate_owner_turn() {
+        let scheduler = TickSchedulerImpl::default();
+        assert_eq!(scheduler.take(), None);
+        let waker = scheduler
+            .query_runtime_waker()
+            .expect("client scheduler provides cold-query wake bridge");
+        waker.wake_by_ref();
+        assert_eq!(scheduler.take(), Some(TickUrgency::Immediate));
+        assert_eq!(scheduler.take(), None, "waking does not create a hot loop");
+    }
 
     /// Product read tiers lower to the unchanged facade durability contract,
     /// keeping write durability independent of the read API migration.


### PR DESCRIPTION
🤖 Fixes a crash-recovery hole when Jazz downloads part of a large value. It closes #2039.

## User-visible failure

Suppose a client opens a document whose next chunk is not local:

1. Jazz downloads and durably stores the chunk bytes.
2. Before recording how that chunk connects to the large-value tree, the app crashes or the metadata write fails.
3. On retry, Jazz sees that the bytes are already local and previously treated the download as complete.

The document could then remain unreadable, and Jazz could lack the child links and reference counts needed to traverse or eventually reclaim that chunk.

## New recovery rule

Before staging downloaded bytes, Groove writes a small durable `install/<chunk>` marker. It clears that marker only in the same durable metadata update that records the chunk's tree links and reference counts.

After a crash, a locally present chunk with a marker resumes the missing metadata step. A normal, fully installed local chunk does not re-enter installation logic.

If writing bytes returns an ambiguous error, Jazz keeps the marker because the bytes may nevertheless have reached storage. If the remote request fails before any byte write is attempted, Jazz creates no marker.

The byte/blob store remains unaware of permissions and tree metadata; Groove owns this recovery bookkeeping.

## Why the narrower trigger matters

An earlier repair retried metadata installation on every local chunk hit. That made ordinary reads re-enter the metadata lifecycle and deadlocked publication tests. This version reconciles only chunks that still carry the durable marker.

The extra asynchronous metadata step also exposed a scheduler bug: runtimes could stop polling once the raw bytes arrived even though Groove still needed to finish installation. The repair adds a one-shot readiness wake-up across Client, Server, NAPI, and WASM. Actual storage progress schedules one more owner turn; there is no timer or polling loop.

## Failure and concurrency coverage

- metadata failure after bytes are staged, followed by reopen and successful recovery
- crash points before and after the marker, byte stage, and metadata commit
- ambiguous byte-store failure retaining the recovery marker
- ordinary local reads never invoking the installer
- concurrent readers installing metadata once
- provisional same-process cache entries not hiding durable recovery markers
- one-shot scheduler wake-up in Client, Server, NAPI, and WASM paths
- planted missing-marker, install-on-every-hit, and no-op-waker regressions

Verification includes `cargo test -p groove --lib` (534 passed, 2 ignored) and the CI-profile Groove suite (602 passed, 4 skipped).

The current CodSpeed comparison incorrectly falls back to an older `main` because the actual stacked base has no baseline receipt; its reported policy-query regression therefore includes unrelated lower-stack changes and must be remeasured after the lower stack lands.
