### PR TITLE
fix(wire): retain messages behind pending backpressure

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2496,23 +2496,20 @@ where
     node.validate_shape_ast_for_registration(shape_id, ast)
 }
 
-fn send_unsupported_shape_capability_rejection(
-    transport: &mut dyn Transport,
+fn unsupported_shape_capability_rejection_message(
     subscription: SubscriptionKey,
     detail: String,
-) -> Result<(), TransportError> {
-    send_subscription_rejection(
-        transport,
+) -> SyncMessage {
+    subscription_rejection_message(
         subscription,
         SubscribeRejectReason::UnsupportedShapeCapability { detail },
     )
 }
 
-fn reject_server_subscription_failure(
-    transport: &mut dyn Transport,
+fn server_subscription_failure_rejection_message(
     subscription: SubscriptionKey,
     error: &crate::node::Error,
-) -> Result<(), TransportError> {
+) -> SyncMessage {
     // Keep the complete error on the serving process only. Subscription keys
     // provide a correlation handle without disclosing schema, policy, or
     // storage details to the peer.
@@ -2520,8 +2517,7 @@ fn reject_server_subscription_failure(
         "jazz subscription rejected: shape={} binding={} read_view={} server_error={error}",
         subscription.shape_id.0, subscription.binding_id.0, subscription.read_view.id,
     );
-    send_subscription_rejection(
-        transport,
+    subscription_rejection_message(
         subscription,
         SubscribeRejectReason::ServerFailure {
             code: server_failure_code(error),
@@ -2529,15 +2525,14 @@ fn reject_server_subscription_failure(
     )
 }
 
-fn send_subscription_rejection(
-    transport: &mut dyn Transport,
+fn subscription_rejection_message(
     subscription: SubscriptionKey,
     reason: SubscribeRejectReason,
-) -> Result<(), TransportError> {
-    transport.send(SyncMessage::SubscribeRejected {
+) -> SyncMessage {
+    SyncMessage::SubscribeRejected {
         subscription,
         reason,
-    })
+    }
 }
 
 fn server_failure_code(error: &crate::node::Error) -> SubscribeServerFailureCode {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -971,6 +971,7 @@ where
             startup_error: None,
             released_outbox_tx_ids: Vec::new(),
             pending_chunk_response: None,
+            pending_control_response: None,
             link: ConnectionLink::Upstream(UpstreamConnectionState {
                 local_receiver,
                 pending,
@@ -1204,6 +1205,7 @@ where
             startup_error,
             released_outbox_tx_ids: Vec::new(),
             pending_chunk_response: None,
+            pending_control_response: None,
             link: ConnectionLink::Subscriber(SubscriberConnectionState {
                 peer,
                 ingest_context,

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -970,6 +970,7 @@ where
             connection_epoch,
             startup_error: None,
             released_outbox_tx_ids: Vec::new(),
+            pending_chunk_response: None,
             link: ConnectionLink::Upstream(UpstreamConnectionState {
                 local_receiver,
                 pending,
@@ -1202,6 +1203,7 @@ where
             connection_epoch,
             startup_error,
             released_outbox_tx_ids: Vec::new(),
+            pending_chunk_response: None,
             link: ConnectionLink::Subscriber(SubscriberConnectionState {
                 peer,
                 ingest_context,

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -983,6 +983,7 @@ where
                 large_value_uploads: transferred_large_value_uploads,
                 awaiting_large_value_uploads: BTreeMap::new(),
                 failed_large_value_uploads: BTreeSet::new(),
+                pending_row_version_fetches: VecDeque::new(),
                 pending_row_version_repairs: VecDeque::new(),
                 scope_view_cuts: BTreeMap::new(),
                 scope_receipts: BTreeMap::new(),

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -971,7 +971,7 @@ where
             startup_error: None,
             released_outbox_tx_ids: Vec::new(),
             pending_chunk_response: None,
-            pending_control_response: None,
+            pending_control_responses: VecDeque::new(),
             link: ConnectionLink::Upstream(UpstreamConnectionState {
                 local_receiver,
                 pending,
@@ -1205,7 +1205,7 @@ where
             startup_error,
             released_outbox_tx_ids: Vec::new(),
             pending_chunk_response: None,
-            pending_control_response: None,
+            pending_control_responses: VecDeque::new(),
             link: ConnectionLink::Subscriber(SubscriberConnectionState {
                 peer,
                 ingest_context,

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -339,10 +339,143 @@ where
     /// consuming inbound work, and entries leave only after logical wire
     /// admission. A permanently stalled peer therefore cannot manufacture an
     /// independent unbounded response backlog.
-    pub(super) pending_control_responses: VecDeque<SyncMessage>,
+    pub(super) pending_control_responses: VecDeque<PendingSubscriberControlResponse>,
     pub(super) link: ConnectionLink,
     pub(super) last_resume_bytes: Option<usize>,
     pub(super) auxiliary_pump: PeerIoPump,
+}
+
+/// A connection-owned response that has been produced but not yet admitted by
+/// the bounded wire adapter.
+///
+/// Most control protocol frames intentionally bypass `send_with_sync_context`:
+/// unlike a replicated payload, they must not opportunistically inject a
+/// catalogue snapshot ahead of a rejection or proof receipt. Repair payloads
+/// retain the sync context because their normal send path carries its
+/// per-peer bookkeeping.
+#[derive(Clone)]
+pub(super) enum PendingSubscriberControlResponse {
+    Direct(SyncMessage),
+    WithSyncContext(SyncMessage),
+    AuthorizationScopeSequence(PendingAuthorizationScopeSequence),
+}
+
+/// Lazily emits one authorization-scope proof sequence. The clauses are the
+/// authority's already-derived semantic hydration state; retaining this plan
+/// avoids copying it into a second, expanded wire-message queue when a bounded
+/// adapter is full between any two proof frames.
+#[derive(Clone)]
+pub(super) struct PendingAuthorizationScopeSequence {
+    request_id: PermissionAdviceRequestId,
+    key: crate::protocol::AuthorizationSupportScopeKey,
+    hydration: ServedAuthorizationScopeHydration,
+    next_step: usize,
+}
+
+impl PendingAuthorizationScopeSequence {
+    fn next_message(&self) -> Option<SyncMessage> {
+        let clause_count = self.hydration.clauses.len();
+        let proof_steps = clause_count.checked_mul(3)?;
+        if self.next_step < proof_steps {
+            let clause = &self.hydration.clauses[self.next_step / 3];
+            return Some(match self.next_step % 3 {
+                0 => clause.register.clone(),
+                1 => clause.subscribe.clone(),
+                2 => SyncMessage::AuthorizationScopeView {
+                    request_id: self.request_id,
+                    key: self.key.clone(),
+                    clause_index: (self.next_step / 3) as u16,
+                    clause_count: clause_count as u16,
+                    view: crate::protocol::ViewUpdatePayload::from_view_update(clause.view.clone())
+                        .expect("authority scope clauses are view updates"),
+                },
+                _ => unreachable!("modulo three has only three cases"),
+            });
+        }
+        if self.next_step == proof_steps {
+            return Some(SyncMessage::AuthorizationScopeAggregateReceipt {
+                request_id: self.request_id,
+                receipt: self.hydration.receipt.clone(),
+            });
+        }
+        let unsubscribe_index = self.next_step.checked_sub(proof_steps + 1)?;
+        self.hydration
+            .clauses
+            .get(unsubscribe_index)
+            .map(|clause| SyncMessage::Unsubscribe {
+                subscription: clause.subscription,
+            })
+    }
+
+    fn advance(&mut self) {
+        self.next_step = self.next_step.saturating_add(1);
+    }
+}
+
+impl PendingSubscriberControlResponse {
+    fn direct(message: SyncMessage) -> Self {
+        Self::Direct(message)
+    }
+
+    fn with_sync_context(message: SyncMessage) -> Self {
+        Self::WithSyncContext(message)
+    }
+
+    #[cfg(test)]
+    pub(super) fn message(&self) -> &SyncMessage {
+        match self {
+            Self::Direct(message) | Self::WithSyncContext(message) => message,
+            Self::AuthorizationScopeSequence(_) => {
+                panic!("scope sequences generate messages lazily")
+            }
+        }
+    }
+}
+
+fn queue_direct_control(
+    pending: &mut VecDeque<PendingSubscriberControlResponse>,
+    message: SyncMessage,
+) {
+    pending.push_back(PendingSubscriberControlResponse::direct(message));
+}
+
+fn queue_sync_context_control(
+    pending: &mut VecDeque<PendingSubscriberControlResponse>,
+    message: SyncMessage,
+) {
+    pending.push_back(PendingSubscriberControlResponse::with_sync_context(message));
+}
+
+fn queue_authorization_scope_sequence(
+    pending: &mut VecDeque<PendingSubscriberControlResponse>,
+    request_id: PermissionAdviceRequestId,
+    key: crate::protocol::AuthorizationSupportScopeKey,
+    hydration: ServedAuthorizationScopeHydration,
+) {
+    pending.push_back(
+        PendingSubscriberControlResponse::AuthorizationScopeSequence(
+            PendingAuthorizationScopeSequence {
+                request_id,
+                key,
+                hydration,
+                next_step: 0,
+            },
+        ),
+    );
+}
+
+macro_rules! flush_subscriber_controls_or_stop {
+    ($connection:expr, $peer:expr) => {
+        if !flush_pending_control_responses(
+            &$connection.node,
+            $peer,
+            $connection.transport.as_mut(),
+            &mut $connection.pending_control_responses,
+            &$connection.scheduler,
+        )? {
+            return Ok(true);
+        }
+    };
 }
 
 pub(super) enum ConnectionLink {
@@ -361,6 +494,11 @@ pub(super) struct UpstreamConnectionState {
     pub(super) large_value_uploads: LargeValueUploadQueues,
     pub(super) awaiting_large_value_uploads: BTreeMap<TxId, groove::large_values::LargeValueRef>,
     pub(super) failed_large_value_uploads: BTreeSet<TxId>,
+    /// Exact repair fetches whose byte admission has not happened yet.
+    /// Kept separately from the paired repair payload so a bounded wire
+    /// adapter cannot lose the one-shot request between detecting a missing
+    /// version and recording the ViewUpdate that needs it.
+    pub(super) pending_row_version_fetches: VecDeque<Vec<crate::protocol::RowVersionRef>>,
     pub(super) pending_row_version_repairs: VecDeque<PendingRowVersionRepair>,
     pub(super) scope_view_cuts: BTreeMap<SubscriptionKey, crate::time::GlobalTime>,
     pub(super) scope_receipts: BTreeMap<SubscriptionKey, AuthorizationScopeReceipt>,
@@ -489,7 +627,7 @@ pub(super) struct SubscriberConnectionState {
     pub(super) served: BTreeMap<SubscriptionKey, CoverageKey>,
     pub(super) coverage_groups: BTreeMap<CoverageKey, CoverageGroup>,
     pub(super) shape_registrations: BTreeMap<ShapeRegistrationKey, SubscriberShapeRegistration>,
-    pub(super) deferred_subscribe_rejections: VecDeque<SyncMessage>,
+    pub(super) deferred_subscribe_rejections: VecDeque<PendingSubscriberControlResponse>,
     pub(super) served_current_rows: BTreeMap<SubscriptionKey, String>,
     pub(super) scope_purposes: BTreeMap<SubscriptionKey, AuthorizedScopePurpose>,
     pub(super) scope_aggregates:
@@ -694,12 +832,13 @@ where
                 });
                 send_with_sync_context(&self.node, peer, self.transport.as_mut(), update)?;
                 if let Some((subscription, receipt)) = receipt {
-                    self.transport
-                        .send(SyncMessage::AuthorizationScopeReceipt {
+                    queue_direct_control(
+                        &mut self.pending_control_responses,
+                        SyncMessage::AuthorizationScopeReceipt {
                             subscription,
                             receipt,
-                        })
-                        .map_err(transport_error)?;
+                        },
+                    );
                 }
             }
         }
@@ -881,12 +1020,13 @@ where
                 });
                 send_with_sync_context(&self.node, peer, self.transport.as_mut(), update)?;
                 if let Some((subscription, receipt)) = receipt {
-                    self.transport
-                        .send(SyncMessage::AuthorizationScopeReceipt {
+                    queue_direct_control(
+                        &mut self.pending_control_responses,
+                        SyncMessage::AuthorizationScopeReceipt {
                             subscription,
                             receipt,
-                        })
-                        .map_err(transport_error)?;
+                        },
+                    );
                 }
             }
         }
@@ -944,6 +1084,7 @@ where
                 large_value_uploads,
                 awaiting_large_value_uploads,
                 failed_large_value_uploads,
+                pending_row_version_fetches,
                 pending_row_version_repairs,
                 scope_view_cuts,
                 scope_receipts,
@@ -952,6 +1093,22 @@ where
             }) => {
                 let stop = Box::pin(async {
                     let outbound_stop = Box::pin(async {
+                        if let Some(requests) = pending_row_version_fetches.front().cloned() {
+                            if let Err(error) = self
+                                .transport
+                                .send(SyncMessage::FetchRowVersions { requests })
+                            {
+                                if handle_transport_backpressure(
+                                    &self.node,
+                                    &self.scheduler,
+                                    &error,
+                                ) {
+                                    return Ok(true);
+                                }
+                                return Err(transport_error(error));
+                            }
+                            pending_row_version_fetches.pop_front();
+                        }
                         if let Some(message) = self.auxiliary_pump.take_outbound(64) {
                             if let Err(error) = self.transport.send(message.clone()) {
                                 self.auxiliary_pump.restore_outbound(message);
@@ -1583,11 +1740,7 @@ where
                                         summarize_subscription_key(subscription),
                                         missing.len()
                                     ));
-                                    self.transport
-                                        .send(SyncMessage::FetchRowVersions {
-                                            requests: missing.clone(),
-                                        })
-                                        .map_err(transport_error)?;
+                                    pending_row_version_fetches.push_back(missing.clone());
                                     pending_row_version_repairs.push_back(
                                         PendingRowVersionRepair {
                                             requests: missing,
@@ -1595,6 +1748,8 @@ where
                                             authority_receipt_eligible,
                                         },
                                     );
+                                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                    return Ok(true);
                                 }
                             }
                             SyncMessage::SubscribeRejected {
@@ -2200,7 +2355,7 @@ where
                     // than asking the byte transport to retain another
                     // logical message after its one admitted backlog.
                     for subscription in active_subscriptions {
-                        self.pending_control_responses.push_back(
+                        queue_direct_control(&mut self.pending_control_responses,
                             SyncMessage::SubscribeRejected {
                                 subscription,
                                 reason: rejection.reason.clone(),
@@ -2255,6 +2410,8 @@ where
                     return Ok(true);
                 }
                 if !flush_pending_control_responses(
+                    &self.node,
+                    peer,
                     self.transport.as_mut(),
                     &mut self.pending_control_responses,
                     &self.scheduler,
@@ -2264,6 +2421,9 @@ where
                 if let Some(message) = self.auxiliary_pump.take_outbound(64) {
                     if let Err(error) = self.transport.send(message.clone()) {
                         self.auxiliary_pump.restore_outbound(message);
+                        if handle_transport_backpressure(&self.node, &self.scheduler, &error) {
+                            return Ok(true);
+                        }
                         return Err(transport_error(error));
                     }
                     self.auxiliary_pump.acknowledge_outbound(&message);
@@ -2350,7 +2510,7 @@ where
                             serve_authorization_scope_intent(
                                 &self.node,
                                 peer,
-                                self.transport.as_mut(),
+                                &mut self.pending_control_responses,
                                 ingest_context.identity,
                                 connection_epoch,
                                 request_id,
@@ -2360,6 +2520,10 @@ where
                                 authority_scope_hydration_count,
                             )
                             .await?;
+                            if !self.pending_control_responses.is_empty() {
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                flush_subscriber_controls_or_stop!(self, peer);
+                            }
                             continue;
                         }
                         // Legacy direct answers and caller-authored support
@@ -2402,7 +2566,7 @@ where
                                         error.message.clone(),
                                     ),
                                 );
-                                self.pending_control_responses.push_back(
+                                queue_direct_control(&mut self.pending_control_responses,
                                     unsupported_shape_capability_rejection_message(
                                         register_shape_rejection_subscription(
                                             shape_id,
@@ -2412,6 +2576,7 @@ where
                                     ),
                                 );
                                 schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                flush_subscriber_controls_or_stop!(self, peer);
                                 return Ok(true);
                             }
                             let shape_validation = {
@@ -2423,7 +2588,7 @@ where
                                 Ok(None) => None,
                                 Err(error) => {
                                     if is_server_shape_validation_failure(&error) {
-                                        self.pending_control_responses.push_back(
+                                        queue_direct_control(&mut self.pending_control_responses,
                                             server_subscription_failure_rejection_message(
                                                 register_shape_rejection_subscription(
                                                     shape_id,
@@ -2433,6 +2598,7 @@ where
                                             ),
                                         );
                                         schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        flush_subscriber_controls_or_stop!(self, peer);
                                         return Ok(true);
                                     } else {
                                         drop_peer_request(&self.node);
@@ -2482,16 +2648,17 @@ where
                                             binding_id: binding.binding_id(),
                                             read_view: read_view_key,
                                         };
-                                        self.pending_control_responses.push_back(
+                                        queue_direct_control(&mut self.pending_control_responses,
                                             unsupported_shape_capability_rejection_message(
                                                 subscription,
                                                 detail,
                                             ),
                                         );
                                         schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        flush_subscriber_controls_or_stop!(self, peer);
                                         return Ok(true);
                                     } else if let Err(error) = supported {
-                                        self.pending_control_responses.push_back(
+                                        queue_direct_control(&mut self.pending_control_responses,
                                             server_subscription_failure_rejection_message(
                                                 SubscriptionKey {
                                                     shape_id,
@@ -2502,6 +2669,7 @@ where
                                             ),
                                         );
                                         schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        flush_subscriber_controls_or_stop!(self, peer);
                                         return Ok(true);
                                     }
                                 }
@@ -2519,7 +2687,7 @@ where
                                     SubscriberShapeRegistration::RejectedUnsupportedCapability(
                                         detail,
                                     ) => {
-                                        self.pending_control_responses.push_back(
+                                        queue_direct_control(&mut self.pending_control_responses,
                                             unsupported_shape_capability_rejection_message(
                                                 register_shape_rejection_subscription(
                                                     shape_id,
@@ -2529,6 +2697,7 @@ where
                                             ),
                                         );
                                         schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        flush_subscriber_controls_or_stop!(self, peer);
                                         return Ok(true);
                                     }
                                     _ => {}
@@ -2548,13 +2717,14 @@ where
                                     .await
                             };
                             if let Err(error) = register_result {
-                                self.pending_control_responses.push_back(
+                                queue_direct_control(&mut self.pending_control_responses,
                                     server_subscription_failure_rejection_message(
                                         rejection_subscription,
                                         &error,
                                     ),
                                 );
                                 schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                flush_subscriber_controls_or_stop!(self, peer);
                                 return Ok(true);
                             }
                             let registration = if awaiting_catalogue_admission {
@@ -2599,7 +2769,8 @@ where
                                     // Keep the original permanent rejection, but let views
                                     // already served by this connection flush first. A rejected
                                     // shape must not starve unrelated subscriptions.
-                                    deferred_subscribe_rejections.push_back(
+                                    queue_direct_control(
+                                        deferred_subscribe_rejections,
                                         unsupported_shape_capability_rejection_message(
                                             subscription,
                                             detail,
@@ -2614,13 +2785,14 @@ where
                             };
                             let Some(shape) = self.node.borrow().registered_shape(shape_id) else {
                                 if pending_catalogue_admission {
-                                    self.pending_control_responses.push_back(
+                                    queue_direct_control(&mut self.pending_control_responses,
                                         SyncMessage::SubscribeRejected {
                                             subscription,
                                             reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
                                         },
                                     );
                                     schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                    flush_subscriber_controls_or_stop!(self, peer);
                                     return Ok(true);
                                 } else {
                                     drop_peer_request(&self.node);
@@ -2723,19 +2895,21 @@ where
                                 )
                                 .await;
                             if let Err(crate::node::Error::QueryCapability(detail)) = supported {
-                                self.pending_control_responses.push_back(
+                                queue_direct_control(&mut self.pending_control_responses,
                                     unsupported_shape_capability_rejection_message(
                                         subscription,
                                         detail,
                                     ),
                                 );
                                 schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                flush_subscriber_controls_or_stop!(self, peer);
                                 return Ok(true);
                             } else if let Err(error) = supported {
-                                self.pending_control_responses.push_back(
+                                queue_direct_control(&mut self.pending_control_responses,
                                     server_subscription_failure_rejection_message(subscription, &error),
                                 );
                                 schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                flush_subscriber_controls_or_stop!(self, peer);
                                 return Ok(true);
                             }
                             let coverage = coverage_key(&shape, &binding, opts.clone());
@@ -2915,7 +3089,7 @@ where
                                     update,
                                 )?;
                                 if let Some((subscription, receipt)) = receipt {
-                                    self.pending_control_responses.push_back(
+                                    queue_direct_control(&mut self.pending_control_responses,
                                         SyncMessage::AuthorizationScopeReceipt {
                                             subscription,
                                             receipt,
@@ -3024,12 +3198,14 @@ where
                                 peer.serve_row_versions(&mut node, &requests).await?
                             };
                             for response in responses {
-                                send_with_sync_context(
-                                    &self.node,
-                                    peer,
-                                    self.transport.as_mut(),
+                                queue_sync_context_control(
+                                    &mut self.pending_control_responses,
                                     response,
-                                )?;
+                                );
+                            }
+                            if !self.pending_control_responses.is_empty() {
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             }
                         }
                         other => {
@@ -3226,7 +3402,7 @@ where
                                     continue;
                                 }
                                 Err(crate::node::Error::QueryCapability(detail)) => {
-                                    self.pending_control_responses.push_back(
+                                    queue_direct_control(&mut self.pending_control_responses,
                                         unsupported_shape_capability_rejection_message(
                                             subscription,
                                             detail,
@@ -3236,7 +3412,7 @@ where
                                     return Ok(true);
                                 }
                                 Err(error) => {
-                                    self.pending_control_responses.push_back(
+                                    queue_direct_control(&mut self.pending_control_responses,
                                         server_subscription_failure_rejection_message(
                                             subscription,
                                             &error,
@@ -3272,7 +3448,7 @@ where
                                 update,
                             )?;
                             if let Some((subscription, receipt)) = receipt {
-                                self.pending_control_responses.push_back(
+                                queue_direct_control(&mut self.pending_control_responses,
                                     SyncMessage::AuthorizationScopeReceipt {
                                         subscription,
                                         receipt,
@@ -3316,7 +3492,7 @@ where
                             }
                             Err(error) => {
                                 for subscription in group.subscribers.iter().copied() {
-                                    self.pending_control_responses.push_back(
+                                    queue_direct_control(&mut self.pending_control_responses,
                                         server_subscription_failure_rejection_message(
                                             subscription,
                                             &error,
@@ -3368,7 +3544,7 @@ where
                                     update,
                                 )?;
                                 if let Some((subscription, receipt)) = receipt {
-                                    self.pending_control_responses.push_back(
+                                    queue_direct_control(&mut self.pending_control_responses,
                                         SyncMessage::AuthorizationScopeReceipt {
                                             subscription,
                                             receipt,
@@ -3406,6 +3582,8 @@ where
                         self.pending_control_responses.push_back(response);
                     }
                     if !flush_pending_control_responses(
+                        &self.node,
+                        peer,
                         self.transport.as_mut(),
                         &mut self.pending_control_responses,
                         &self.scheduler,
@@ -3717,7 +3895,7 @@ where
 async fn serve_authorization_scope_intent<S>(
     node: &SharedNodeState<S>,
     peer: &mut PeerState,
-    transport: &mut dyn Transport,
+    pending_control_responses: &mut VecDeque<PendingSubscriberControlResponse>,
     identity: AuthorSubject,
     connection_epoch: u64,
     request_id: PermissionAdviceRequestId,
@@ -3735,17 +3913,19 @@ where
     if !node.borrow().is_history_complete()
         || !subscriber_permissions_ready(node.borrow().permissions_ready(), trust)
     {
-        transport
-            .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
-            .map_err(transport_error)?;
+        queue_direct_control(
+            pending_control_responses,
+            SyncMessage::AuthorizationScopeUnavailable { request_id },
+        );
         return Ok(());
     }
     let scope = match node.borrow().authorization_support_scope(identity, &action) {
         Ok(scope) => scope,
         Err(_) => {
-            transport
-                .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
-                .map_err(transport_error)?;
+            queue_direct_control(
+                pending_control_responses,
+                SyncMessage::AuthorizationScopeUnavailable { request_id },
+            );
             return Ok(());
         }
     };
@@ -3766,9 +3946,10 @@ where
             let mut node = node.lock().await;
             evaluate_authoritative_permission_advice(&mut node, identity, action).await
         };
-        transport
-            .send(SyncMessage::AuthorizationScopeDecision { request_id, advice })
-            .map_err(transport_error)?;
+        queue_direct_control(
+            pending_control_responses,
+            SyncMessage::AuthorizationScopeDecision { request_id, advice },
+        );
         return Ok(());
     }
     let current_claims_revision = node.borrow().session_claim_revision(identity);
@@ -3782,37 +3963,12 @@ where
             && hydration.receipt.settled_through == current_cut
     });
     if let Some(hydration) = hydrations.get(&scope.key) {
-        for (index, clause) in hydration.clauses.iter().enumerate() {
-            transport
-                .send(clause.register.clone())
-                .map_err(transport_error)?;
-            transport
-                .send(clause.subscribe.clone())
-                .map_err(transport_error)?;
-            transport
-                .send(SyncMessage::AuthorizationScopeView {
-                    request_id,
-                    key: scope.key.clone(),
-                    clause_index: index as u16,
-                    clause_count,
-                    view: crate::protocol::ViewUpdatePayload::from_view_update(clause.view.clone())
-                        .expect("authority scope clauses are view updates"),
-                })
-                .map_err(transport_error)?;
-        }
-        transport
-            .send(SyncMessage::AuthorizationScopeAggregateReceipt {
-                request_id,
-                receipt: hydration.receipt.clone(),
-            })
-            .map_err(transport_error)?;
-        for clause in &hydration.clauses {
-            transport
-                .send(SyncMessage::Unsubscribe {
-                    subscription: clause.subscription,
-                })
-                .map_err(transport_error)?;
-        }
+        queue_authorization_scope_sequence(
+            pending_control_responses,
+            request_id,
+            scope.key.clone(),
+            hydration.clone(),
+        );
         return Ok(());
     }
     *hydration_count = hydration_count.saturating_add(1);
@@ -3833,9 +3989,10 @@ where
             read_view: scope.options.read_view_key(),
         };
         if !aggregate.register(subscription, (shape.shape_id(), binding.binding_id())) {
-            transport
-                .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
-                .map_err(transport_error)?;
+            queue_direct_control(
+                pending_control_responses,
+                SyncMessage::AuthorizationScopeUnavailable { request_id },
+            );
             return Ok(());
         }
         let supported = node
@@ -3851,9 +4008,10 @@ where
             )
             .await;
         if supported.is_err() {
-            transport
-                .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
-                .map_err(transport_error)?;
+            queue_direct_control(
+                pending_control_responses,
+                SyncMessage::AuthorizationScopeUnavailable { request_id },
+            );
             return Ok(());
         }
         let values = binding_values_in_param_order(shape, binding);
@@ -3862,14 +4020,12 @@ where
             ast: ShapeAst::from_validated(shape),
             opts: scope.options.clone(),
         };
-        transport.send(register.clone()).map_err(transport_error)?;
         let subscribe = SyncMessage::Subscribe(Subscribe {
             shape_id: shape.shape_id(),
             subscription,
             values,
             known_state: None,
         });
-        transport.send(subscribe.clone()).map_err(transport_error)?;
         peer.declare_known_state(subscription, None);
         let update = {
             let mut node = node.lock().await;
@@ -3883,9 +4039,10 @@ where
             .await?
         };
         let Some(update) = update else {
-            transport
-                .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
-                .map_err(transport_error)?;
+            queue_direct_control(
+                pending_control_responses,
+                SyncMessage::AuthorizationScopeUnavailable { request_id },
+            );
             return Ok(());
         };
         let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
@@ -3902,21 +4059,12 @@ where
         if aggregate.apply(subscription, *cut, progress).is_none()
             && index + 1 == support_clauses.len()
         {
-            transport
-                .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
-                .map_err(transport_error)?;
+            queue_direct_control(
+                pending_control_responses,
+                SyncMessage::AuthorizationScopeUnavailable { request_id },
+            );
             return Ok(());
         }
-        transport
-            .send(SyncMessage::AuthorizationScopeView {
-                request_id,
-                key: scope.key.clone(),
-                clause_index: index as u16,
-                clause_count,
-                view: crate::protocol::ViewUpdatePayload::from_view_update(update.clone())
-                    .expect("scope hydration produces view updates"),
-            })
-            .map_err(transport_error)?;
         support_subscriptions.push(subscription);
         served_clauses.push(ServedAuthorizationScopeClause {
             subscription,
@@ -3926,9 +4074,10 @@ where
         });
     }
     let Some((settled_through, authorization_progress)) = aggregate.bounds() else {
-        transport
-            .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
-            .map_err(transport_error)?;
+        queue_direct_control(
+            pending_control_responses,
+            SyncMessage::AuthorizationScopeUnavailable { request_id },
+        );
         return Ok(());
     };
     let receipt = AuthorizationScopeReceipt {
@@ -3941,30 +4090,20 @@ where
         settled_through,
         authorization_progress,
     };
-    transport
-        .send(SyncMessage::AuthorizationScopeAggregateReceipt {
-            request_id,
-            receipt: receipt.clone(),
-        })
-        .map_err(transport_error)?;
+    let hydration = ServedAuthorizationScopeHydration {
+        clauses: served_clauses,
+        receipt,
+    };
     if hydrations.len() < MAX_AUTHORIZATION_SCOPES {
-        hydrations.insert(
-            scope.key,
-            ServedAuthorizationScopeHydration {
-                clauses: served_clauses,
-                receipt,
-            },
-        );
+        hydrations.insert(scope.key.clone(), hydration.clone());
     }
     // Scope views are proof material, not application subscriptions.  Their
     // lifetime ends after the receipt; FIFO keeps the receiver's local
     // evaluation ahead of this cleanup.
     for subscription in support_subscriptions {
-        transport
-            .send(SyncMessage::Unsubscribe { subscription })
-            .map_err(transport_error)?;
         peer.forget_subscription_with_node(&mut node.borrow_mut(), subscription);
     }
+    queue_authorization_scope_sequence(pending_control_responses, request_id, scope.key, hydration);
     Ok(())
 }
 
@@ -4450,29 +4589,58 @@ fn flush_pending_chunk_response(
 /// a rejected byte admission as a completed reply would otherwise leave the
 /// requester waiting forever. One retained message bounds a stalled link; the
 /// subscriber tick stops as soon as it creates one.
-fn flush_pending_control_responses(
+fn flush_pending_control_responses<S>(
+    node: &SharedNodeState<S>,
+    peer: &mut PeerState,
     transport: &mut dyn Transport,
-    pending: &mut VecDeque<SyncMessage>,
+    pending: &mut VecDeque<PendingSubscriberControlResponse>,
     scheduler: &SharedTickScheduler,
-) -> Result<bool, Error> {
-    let Some(response) = pending.front().cloned() else {
-        return Ok(true);
-    };
-    match transport.send(response) {
-        Ok(()) => {
-            pending.pop_front();
-            if pending.is_empty() {
-                Ok(true)
-            } else {
-                schedule_tick_in(scheduler, TickUrgency::Immediate);
-                Ok(false)
+) -> Result<bool, Error>
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    loop {
+        let Some(response) = pending.front() else {
+            return Ok(true);
+        };
+        let send_result = match response {
+            PendingSubscriberControlResponse::Direct(response) => {
+                transport.send(response.clone()).map_err(transport_error)
             }
+            PendingSubscriberControlResponse::WithSyncContext(response) => {
+                send_with_sync_context(node, peer, transport, response.clone())
+            }
+            PendingSubscriberControlResponse::AuthorizationScopeSequence(sequence) => {
+                let Some(response) = sequence.next_message() else {
+                    pending.pop_front();
+                    continue;
+                };
+                transport.send(response).map_err(transport_error)
+            }
+        };
+        match send_result {
+            Ok(()) => {
+                let finished = match pending.front_mut() {
+                    Some(PendingSubscriberControlResponse::AuthorizationScopeSequence(
+                        sequence,
+                    )) => {
+                        sequence.advance();
+                        sequence.next_message().is_none()
+                    }
+                    Some(PendingSubscriberControlResponse::Direct(_))
+                    | Some(PendingSubscriberControlResponse::WithSyncContext(_)) => true,
+                    None => unreachable!("accepted control operation remains queued"),
+                };
+                if finished {
+                    pending.pop_front();
+                }
+            }
+            Err(error) if error.code == ErrorCode::Backpressure => {
+                schedule_tick_in(scheduler, TickUrgency::Deferred);
+                return Ok(false);
+            }
+            Err(error) => return Err(error),
         }
-        Err(TransportError::Backpressure) => {
-            schedule_tick_in(scheduler, TickUrgency::Deferred);
-            Ok(false)
-        }
-        Err(error) => Err(transport_error(error)),
     }
 }
 

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -331,8 +331,15 @@ where
     /// Dedicated auxiliary chunk traffic uses `PeerIoPump`'s bounded
     /// take/restore queue; this covers the legacy ordinary-wire responder.
     pub(super) pending_chunk_response: Option<ChunkResponseBatch>,
-    /// One subscriber control/rejection reply retained until byte admission.
-    pub(super) pending_control_response: Option<SyncMessage>,
+    /// Subscriber control/rejection replies retained until byte admission.
+    ///
+    /// This is deliberately not a transport-level queue. Every entry is an
+    /// already-bounded registration, relay rejection, or maintained
+    /// subscription outcome; while it is nonempty the subscriber stops
+    /// consuming inbound work, and entries leave only after logical wire
+    /// admission. A permanently stalled peer therefore cannot manufacture an
+    /// independent unbounded response backlog.
+    pub(super) pending_control_responses: VecDeque<SyncMessage>,
     pub(super) link: ConnectionLink,
     pub(super) last_resume_bytes: Option<usize>,
     pub(super) auxiliary_pump: PeerIoPump,
@@ -482,7 +489,7 @@ pub(super) struct SubscriberConnectionState {
     pub(super) served: BTreeMap<SubscriptionKey, CoverageKey>,
     pub(super) coverage_groups: BTreeMap<CoverageKey, CoverageGroup>,
     pub(super) shape_registrations: BTreeMap<ShapeRegistrationKey, SubscriberShapeRegistration>,
-    pub(super) deferred_subscribe_rejections: VecDeque<(SubscriptionKey, String)>,
+    pub(super) deferred_subscribe_rejections: VecDeque<SyncMessage>,
     pub(super) served_current_rows: BTreeMap<SubscriptionKey, String>,
     pub(super) scope_purposes: BTreeMap<SubscriptionKey, AuthorizedScopePurpose>,
     pub(super) scope_aggregates:
@@ -2187,14 +2194,18 @@ where
                         .unwrap_or_default();
                     // Forward the authority's reason to every active usage
                     // site before retiring the group. One coverage evaluator
-                    // may have many downstream wire subscriptions.
+                    // may have many downstream wire subscriptions. The relay
+                    // rejection already owns this bounded recipient set, so
+                    // move its responses to the semantic control queue rather
+                    // than asking the byte transport to retain another
+                    // logical message after its one admitted backlog.
                     for subscription in active_subscriptions {
-                        self.transport
-                            .send(SyncMessage::SubscribeRejected {
+                        self.pending_control_responses.push_back(
+                            SyncMessage::SubscribeRejected {
                                 subscription,
                                 reason: rejection.reason.clone(),
-                            })
-                            .map_err(transport_error)?;
+                            },
+                        );
                     }
                     if let Some(group) = coverage_groups.remove(&rejection.coverage) {
                         let group_subscription = SubscriptionKey {
@@ -2243,9 +2254,9 @@ where
                 )? {
                     return Ok(true);
                 }
-                if !flush_pending_control_response(
+                if !flush_pending_control_responses(
                     self.transport.as_mut(),
-                    &mut self.pending_control_response,
+                    &mut self.pending_control_responses,
                     &self.scheduler,
                 )? {
                     return Ok(true);
@@ -2391,7 +2402,7 @@ where
                                         error.message.clone(),
                                     ),
                                 );
-                                self.pending_control_response = Some(
+                                self.pending_control_responses.push_back(
                                     unsupported_shape_capability_rejection_message(
                                         register_shape_rejection_subscription(
                                             shape_id,
@@ -2412,7 +2423,7 @@ where
                                 Ok(None) => None,
                                 Err(error) => {
                                     if is_server_shape_validation_failure(&error) {
-                                        self.pending_control_response = Some(
+                                        self.pending_control_responses.push_back(
                                             server_subscription_failure_rejection_message(
                                                 register_shape_rejection_subscription(
                                                     shape_id,
@@ -2471,7 +2482,7 @@ where
                                             binding_id: binding.binding_id(),
                                             read_view: read_view_key,
                                         };
-                                        self.pending_control_response = Some(
+                                        self.pending_control_responses.push_back(
                                             unsupported_shape_capability_rejection_message(
                                                 subscription,
                                                 detail,
@@ -2480,7 +2491,7 @@ where
                                         schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
                                         return Ok(true);
                                     } else if let Err(error) = supported {
-                                        self.pending_control_response = Some(
+                                        self.pending_control_responses.push_back(
                                             server_subscription_failure_rejection_message(
                                                 SubscriptionKey {
                                                     shape_id,
@@ -2508,7 +2519,7 @@ where
                                     SubscriberShapeRegistration::RejectedUnsupportedCapability(
                                         detail,
                                     ) => {
-                                        self.pending_control_response = Some(
+                                        self.pending_control_responses.push_back(
                                             unsupported_shape_capability_rejection_message(
                                                 register_shape_rejection_subscription(
                                                     shape_id,
@@ -2537,7 +2548,7 @@ where
                                     .await
                             };
                             if let Err(error) = register_result {
-                                self.pending_control_response = Some(
+                                self.pending_control_responses.push_back(
                                     server_subscription_failure_rejection_message(
                                         rejection_subscription,
                                         &error,
@@ -2588,8 +2599,13 @@ where
                                     // Keep the original permanent rejection, but let views
                                     // already served by this connection flush first. A rejected
                                     // shape must not starve unrelated subscriptions.
-                                    deferred_subscribe_rejections.push_back((subscription, detail));
-                                    return Ok::<bool, Error>(true);
+                                    deferred_subscribe_rejections.push_back(
+                                        unsupported_shape_capability_rejection_message(
+                                            subscription,
+                                            detail,
+                                        ),
+                                    );
+                                    continue;
                                 }
                                 SubscriberShapeRegistration::Registered(opts)
                                 | SubscriberShapeRegistration::PendingCatalogueAdmission(opts) => {
@@ -2598,7 +2614,7 @@ where
                             };
                             let Some(shape) = self.node.borrow().registered_shape(shape_id) else {
                                 if pending_catalogue_admission {
-                                    self.pending_control_response = Some(
+                                    self.pending_control_responses.push_back(
                                         SyncMessage::SubscribeRejected {
                                             subscription,
                                             reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
@@ -2707,7 +2723,7 @@ where
                                 )
                                 .await;
                             if let Err(crate::node::Error::QueryCapability(detail)) = supported {
-                                self.pending_control_response = Some(
+                                self.pending_control_responses.push_back(
                                     unsupported_shape_capability_rejection_message(
                                         subscription,
                                         detail,
@@ -2716,7 +2732,7 @@ where
                                 schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
                                 return Ok(true);
                             } else if let Err(error) = supported {
-                                self.pending_control_response = Some(
+                                self.pending_control_responses.push_back(
                                     server_subscription_failure_rejection_message(subscription, &error),
                                 );
                                 schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
@@ -2899,12 +2915,14 @@ where
                                     update,
                                 )?;
                                 if let Some((subscription, receipt)) = receipt {
-                                    self.transport
-                                        .send(SyncMessage::AuthorizationScopeReceipt {
+                                    self.pending_control_responses.push_back(
+                                        SyncMessage::AuthorizationScopeReceipt {
                                             subscription,
                                             receipt,
-                                        })
-                                        .map_err(transport_error)?;
+                                        },
+                                    );
+                                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                    return Ok(true);
                                 }
                                 sent_view_update = true;
                             }
@@ -3208,22 +3226,24 @@ where
                                     continue;
                                 }
                                 Err(crate::node::Error::QueryCapability(detail)) => {
-                                    self.transport
-                                        .send(unsupported_shape_capability_rejection_message(
+                                    self.pending_control_responses.push_back(
+                                        unsupported_shape_capability_rejection_message(
                                             subscription,
                                             detail,
-                                        ))
-                                        .map_err(transport_error)?;
-                                    continue;
+                                        ),
+                                    );
+                                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                    return Ok(true);
                                 }
                                 Err(error) => {
-                                    self.transport
-                                        .send(server_subscription_failure_rejection_message(
+                                    self.pending_control_responses.push_back(
+                                        server_subscription_failure_rejection_message(
                                             subscription,
                                             &error,
-                                        ))
-                                        .map_err(transport_error)?;
-                                    continue;
+                                        ),
+                                    );
+                                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                    return Ok(true);
                                 }
                             };
                             group.initialized = true;
@@ -3252,12 +3272,14 @@ where
                                 update,
                             )?;
                             if let Some((subscription, receipt)) = receipt {
-                                self.transport
-                                    .send(SyncMessage::AuthorizationScopeReceipt {
+                                self.pending_control_responses.push_back(
+                                    SyncMessage::AuthorizationScopeReceipt {
                                         subscription,
                                         receipt,
-                                    })
-                                    .map_err(transport_error)?;
+                                    },
+                                );
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             }
                             sent_view_update = true;
                         }
@@ -3294,14 +3316,15 @@ where
                             }
                             Err(error) => {
                                 for subscription in group.subscribers.iter().copied() {
-                                    self.transport
-                                        .send(server_subscription_failure_rejection_message(
+                                    self.pending_control_responses.push_back(
+                                        server_subscription_failure_rejection_message(
                                             subscription,
                                             &error,
-                                        ))
-                                        .map_err(transport_error)?;
+                                        ),
+                                    );
                                 }
-                                continue;
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             }
                         };
                         if settled_handoff {
@@ -3345,12 +3368,14 @@ where
                                     update,
                                 )?;
                                 if let Some((subscription, receipt)) = receipt {
-                                    self.transport
-                                        .send(SyncMessage::AuthorizationScopeReceipt {
+                                    self.pending_control_responses.push_back(
+                                        SyncMessage::AuthorizationScopeReceipt {
                                             subscription,
                                             receipt,
-                                        })
-                                        .map_err(transport_error)?;
+                                        },
+                                    );
+                                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                    return Ok(true);
                                 }
                                 sent_view_update = true;
                             }
@@ -3377,15 +3402,15 @@ where
                     }
                 }
                 if sent_view_update {
-                    while let Some((subscription, detail)) =
-                        deferred_subscribe_rejections.pop_front()
-                    {
-                        self.transport
-                            .send(unsupported_shape_capability_rejection_message(
-                                subscription,
-                                detail,
-                            ))
-                            .map_err(transport_error)?;
+                    while let Some(response) = deferred_subscribe_rejections.pop_front() {
+                        self.pending_control_responses.push_back(response);
+                    }
+                    if !flush_pending_control_responses(
+                        self.transport.as_mut(),
+                        &mut self.pending_control_responses,
+                        &self.scheduler,
+                    )? {
+                        return Ok(true);
                     }
                 }
                     Ok::<bool, Error>(false)
@@ -4425,25 +4450,29 @@ fn flush_pending_chunk_response(
 /// a rejected byte admission as a completed reply would otherwise leave the
 /// requester waiting forever. One retained message bounds a stalled link; the
 /// subscriber tick stops as soon as it creates one.
-fn flush_pending_control_response(
+fn flush_pending_control_responses(
     transport: &mut dyn Transport,
-    pending: &mut Option<SyncMessage>,
+    pending: &mut VecDeque<SyncMessage>,
     scheduler: &SharedTickScheduler,
 ) -> Result<bool, Error> {
-    let Some(response) = pending.take() else {
+    let Some(response) = pending.front().cloned() else {
         return Ok(true);
     };
-    match transport.send(response.clone()) {
-        Ok(()) => Ok(true),
+    match transport.send(response) {
+        Ok(()) => {
+            pending.pop_front();
+            if pending.is_empty() {
+                Ok(true)
+            } else {
+                schedule_tick_in(scheduler, TickUrgency::Immediate);
+                Ok(false)
+            }
+        }
         Err(TransportError::Backpressure) => {
-            *pending = Some(response);
             schedule_tick_in(scheduler, TickUrgency::Deferred);
             Ok(false)
         }
-        Err(error) => {
-            *pending = Some(response);
-            Err(transport_error(error))
-        }
+        Err(error) => Err(transport_error(error)),
     }
 }
 

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2221,8 +2221,14 @@ where
                         }
                     }
                 }
-                for fate in std::mem::take(&mut *self.downstream_fates.borrow_mut()) {
-                    send_with_sync_context(&self.node, peer, self.transport.as_mut(), fate)?;
+                if !flush_downstream_fates(
+                    &self.node,
+                    peer,
+                    self.transport.as_mut(),
+                    &self.downstream_fates,
+                    &self.scheduler,
+                )? {
+                    return Ok(true);
                 }
                 if let Some(message) = self.auxiliary_pump.take_outbound(64) {
                     if let Err(error) = self.transport.send(message.clone()) {
@@ -3010,12 +3016,7 @@ where
                                     global_time: None,
                                     durability: None,
                                 };
-                                send_with_sync_context(
-                                    &self.node,
-                                    peer,
-                                    self.transport.as_mut(),
-                                    response,
-                                )?;
+                                self.downstream_fates.borrow_mut().push(response);
                                 continue;
                             }
                             let write_state_tx_id = write_state_update_tx_id(&other);
@@ -3056,12 +3057,16 @@ where
                                 );
                             }
                             for response in responses {
-                                send_with_sync_context(
-                                    &self.node,
-                                    peer,
-                                    self.transport.as_mut(),
-                                    response,
-                                )?;
+                                if matches!(response, SyncMessage::FateUpdate { .. }) {
+                                    self.downstream_fates.borrow_mut().push(response);
+                                } else {
+                                    send_with_sync_context(
+                                        &self.node,
+                                        peer,
+                                        self.transport.as_mut(),
+                                        response,
+                                    )?;
+                                }
                             }
                             if let Some((tx_id, unit)) = local_upload {
                                 let mut outbox = outbox.borrow_mut();
@@ -3076,8 +3081,14 @@ where
                     }
                 }
                 queue_local_acknowledgements(&self.local_fate_routes, &self.node).await;
-                for fate in std::mem::take(&mut *self.downstream_fates.borrow_mut()) {
-                    send_with_sync_context(&self.node, peer, self.transport.as_mut(), fate)?;
+                if !flush_downstream_fates(
+                    &self.node,
+                    peer,
+                    self.transport.as_mut(),
+                    &self.downstream_fates,
+                    &self.scheduler,
+                )? {
+                    return Ok(true);
                 }
                 if needs_subscription_refresh {
                     stats.subscription_events += refresh_subscriptions_in(
@@ -4315,6 +4326,42 @@ where
         summarize_sync_message(&message)
     ));
     send_sync_message_chunked(transport, message)
+}
+
+/// Deliver terminal/local fate updates in FIFO order without letting a bounded
+/// byte transport turn an already-produced settlement into a dropped message.
+///
+/// The wire adapter retains at most the one logical message it has already
+/// accepted. If that backlog is full, this queue keeps the *unaccepted* fate
+/// at its semantic producer boundary and the scheduler retries after the
+/// binding wakes for transport capacity. We remove only after `send` accepts
+/// the logical message, so a retry neither duplicates a sent fate nor loses a
+/// later fate behind it.
+fn flush_downstream_fates<S>(
+    node: &SharedNodeState<S>,
+    peer: &mut PeerState,
+    transport: &mut dyn Transport,
+    fates: &PendingDownstreamFates,
+    scheduler: &SharedTickScheduler,
+) -> Result<bool, Error>
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    loop {
+        let Some(fate) = fates.borrow().first().cloned() else {
+            return Ok(true);
+        };
+        match send_with_sync_context(node, peer, transport, fate) {
+            Ok(()) => {
+                fates.borrow_mut().remove(0);
+            }
+            Err(error) if error.code == ErrorCode::Backpressure => {
+                schedule_tick_in(scheduler, TickUrgency::Deferred);
+                return Ok(false);
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 /// Send an authority catalogue snapshot exactly once per peer fingerprint.

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2776,7 +2776,11 @@ where
                                             detail,
                                         ),
                                     );
-                                    continue;
+                                    // This subscribe has been handled. The outer receive loop
+                                    // owns iteration; returning its continue signal preserves
+                                    // the deferred-rejection ordering without trying to jump out
+                                    // of this heap-pinned async admission block.
+                                    return Ok::<bool, Error>(true);
                                 }
                                 SubscriberShapeRegistration::Registered(opts)
                                 | SubscriberShapeRegistration::PendingCatalogueAdmission(opts) => {

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -331,6 +331,8 @@ where
     /// Dedicated auxiliary chunk traffic uses `PeerIoPump`'s bounded
     /// take/restore queue; this covers the legacy ordinary-wire responder.
     pub(super) pending_chunk_response: Option<ChunkResponseBatch>,
+    /// One subscriber control/rejection reply retained until byte admission.
+    pub(super) pending_control_response: Option<SyncMessage>,
     pub(super) link: ConnectionLink,
     pub(super) last_resume_bytes: Option<usize>,
     pub(super) auxiliary_pump: PeerIoPump,
@@ -2241,6 +2243,13 @@ where
                 )? {
                     return Ok(true);
                 }
+                if !flush_pending_control_response(
+                    self.transport.as_mut(),
+                    &mut self.pending_control_response,
+                    &self.scheduler,
+                )? {
+                    return Ok(true);
+                }
                 if let Some(message) = self.auxiliary_pump.take_outbound(64) {
                     if let Err(error) = self.transport.send(message.clone()) {
                         self.auxiliary_pump.restore_outbound(message);
@@ -2382,16 +2391,17 @@ where
                                         error.message.clone(),
                                     ),
                                 );
-                                send_unsupported_shape_capability_rejection(
-                                    &mut *self.transport,
-                                    register_shape_rejection_subscription(
-                                        shape_id,
-                                        read_view_key,
+                                self.pending_control_response = Some(
+                                    unsupported_shape_capability_rejection_message(
+                                        register_shape_rejection_subscription(
+                                            shape_id,
+                                            read_view_key,
+                                        ),
+                                        error.message,
                                     ),
-                                    error.message,
-                                )
-                                .map_err(transport_error)?;
-                                continue;
+                                );
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             }
                             let shape_validation = {
                                 let node = self.node.borrow();
@@ -2402,15 +2412,17 @@ where
                                 Ok(None) => None,
                                 Err(error) => {
                                     if is_server_shape_validation_failure(&error) {
-                                        reject_server_subscription_failure(
-                                            &mut *self.transport,
-                                            register_shape_rejection_subscription(
-                                                shape_id,
-                                                read_view_key,
+                                        self.pending_control_response = Some(
+                                            server_subscription_failure_rejection_message(
+                                                register_shape_rejection_subscription(
+                                                    shape_id,
+                                                    read_view_key,
+                                                ),
+                                                &error,
                                             ),
-                                            &error,
-                                        )
-                                        .map_err(transport_error)?;
+                                        );
+                                        schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        return Ok(true);
                                     } else {
                                         drop_peer_request(&self.node);
                                     }
@@ -2459,25 +2471,27 @@ where
                                             binding_id: binding.binding_id(),
                                             read_view: read_view_key,
                                         };
-                                        send_unsupported_shape_capability_rejection(
-                                            &mut *self.transport,
-                                            subscription,
-                                            detail,
-                                        )
-                                        .map_err(transport_error)?;
-                                        continue;
+                                        self.pending_control_response = Some(
+                                            unsupported_shape_capability_rejection_message(
+                                                subscription,
+                                                detail,
+                                            ),
+                                        );
+                                        schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        return Ok(true);
                                     } else if let Err(error) = supported {
-                                        reject_server_subscription_failure(
-                                            &mut *self.transport,
-                                            SubscriptionKey {
-                                                shape_id,
-                                                binding_id: binding.binding_id(),
-                                                read_view: read_view_key,
-                                            },
-                                            &error,
-                                        )
-                                        .map_err(transport_error)?;
-                                        continue;
+                                        self.pending_control_response = Some(
+                                            server_subscription_failure_rejection_message(
+                                                SubscriptionKey {
+                                                    shape_id,
+                                                    binding_id: binding.binding_id(),
+                                                    read_view: read_view_key,
+                                                },
+                                                &error,
+                                            ),
+                                        );
+                                        schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        return Ok(true);
                                     }
                                 }
                             }
@@ -2494,16 +2508,17 @@ where
                                     SubscriberShapeRegistration::RejectedUnsupportedCapability(
                                         detail,
                                     ) => {
-                                        send_unsupported_shape_capability_rejection(
-                                            &mut *self.transport,
-                                            register_shape_rejection_subscription(
-                                                shape_id,
-                                                read_view_key,
+                                        self.pending_control_response = Some(
+                                            unsupported_shape_capability_rejection_message(
+                                                register_shape_rejection_subscription(
+                                                    shape_id,
+                                                    read_view_key,
+                                                ),
+                                                detail.clone(),
                                             ),
-                                            detail.clone(),
-                                        )
-                                        .map_err(transport_error)?;
-                                        continue;
+                                        );
+                                        schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                        return Ok(true);
                                     }
                                     _ => {}
                                 }
@@ -2522,13 +2537,14 @@ where
                                     .await
                             };
                             if let Err(error) = register_result {
-                                reject_server_subscription_failure(
-                                    &mut *self.transport,
-                                    rejection_subscription,
-                                    &error,
-                                )
-                                .map_err(transport_error)?;
-                                continue;
+                                self.pending_control_response = Some(
+                                    server_subscription_failure_rejection_message(
+                                        rejection_subscription,
+                                        &error,
+                                    ),
+                                );
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             }
                             let registration = if awaiting_catalogue_admission {
                                 SubscriberShapeRegistration::PendingCatalogueAdmission(opts)
@@ -2582,12 +2598,14 @@ where
                             };
                             let Some(shape) = self.node.borrow().registered_shape(shape_id) else {
                                 if pending_catalogue_admission {
-                                    self.transport
-                                        .send(SyncMessage::SubscribeRejected {
+                                    self.pending_control_response = Some(
+                                        SyncMessage::SubscribeRejected {
                                             subscription,
                                             reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
-                                        })
-                                        .map_err(transport_error)?;
+                                        },
+                                    );
+                                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                    return Ok(true);
                                 } else {
                                     drop_peer_request(&self.node);
                                 }
@@ -2689,21 +2707,20 @@ where
                                 )
                                 .await;
                             if let Err(crate::node::Error::QueryCapability(detail)) = supported {
-                                send_unsupported_shape_capability_rejection(
-                                    &mut *self.transport,
-                                    subscription,
-                                    detail,
-                                )
-                                .map_err(transport_error)?;
-                                return Ok::<bool, Error>(true);
+                                self.pending_control_response = Some(
+                                    unsupported_shape_capability_rejection_message(
+                                        subscription,
+                                        detail,
+                                    ),
+                                );
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             } else if let Err(error) = supported {
-                                reject_server_subscription_failure(
-                                    &mut *self.transport,
-                                    subscription,
-                                    &error,
-                                )
-                                .map_err(transport_error)?;
-                                return Ok::<bool, Error>(true);
+                                self.pending_control_response = Some(
+                                    server_subscription_failure_rejection_message(subscription, &error),
+                                );
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             }
                             let coverage = coverage_key(&shape, &binding, opts.clone());
                             let group_subscription = SubscriptionKey {
@@ -3191,21 +3208,21 @@ where
                                     continue;
                                 }
                                 Err(crate::node::Error::QueryCapability(detail)) => {
-                                    send_unsupported_shape_capability_rejection(
-                                        &mut *self.transport,
-                                        subscription,
-                                        detail,
-                                    )
-                                    .map_err(transport_error)?;
+                                    self.transport
+                                        .send(unsupported_shape_capability_rejection_message(
+                                            subscription,
+                                            detail,
+                                        ))
+                                        .map_err(transport_error)?;
                                     continue;
                                 }
                                 Err(error) => {
-                                    reject_server_subscription_failure(
-                                        &mut *self.transport,
-                                        subscription,
-                                        &error,
-                                    )
-                                    .map_err(transport_error)?;
+                                    self.transport
+                                        .send(server_subscription_failure_rejection_message(
+                                            subscription,
+                                            &error,
+                                        ))
+                                        .map_err(transport_error)?;
                                     continue;
                                 }
                             };
@@ -3277,12 +3294,12 @@ where
                             }
                             Err(error) => {
                                 for subscription in group.subscribers.iter().copied() {
-                                    reject_server_subscription_failure(
-                                        &mut *self.transport,
-                                        subscription,
-                                        &error,
-                                    )
-                                    .map_err(transport_error)?;
+                                    self.transport
+                                        .send(server_subscription_failure_rejection_message(
+                                            subscription,
+                                            &error,
+                                        ))
+                                        .map_err(transport_error)?;
                                 }
                                 continue;
                             }
@@ -3363,12 +3380,12 @@ where
                     while let Some((subscription, detail)) =
                         deferred_subscribe_rejections.pop_front()
                     {
-                        send_unsupported_shape_capability_rejection(
-                            &mut *self.transport,
-                            subscription,
-                            detail,
-                        )
-                        .map_err(transport_error)?;
+                        self.transport
+                            .send(unsupported_shape_capability_rejection_message(
+                                subscription,
+                                detail,
+                            ))
+                            .map_err(transport_error)?;
                     }
                 }
                     Ok::<bool, Error>(false)
@@ -4390,6 +4407,33 @@ fn flush_pending_chunk_response(
         return Ok(true);
     };
     match transport.send(SyncMessage::ChunkResponseBatch(response.clone())) {
+        Ok(()) => Ok(true),
+        Err(TransportError::Backpressure) => {
+            *pending = Some(response);
+            schedule_tick_in(scheduler, TickUrgency::Deferred);
+            Ok(false)
+        }
+        Err(error) => {
+            *pending = Some(response);
+            Err(transport_error(error))
+        }
+    }
+}
+
+/// Retry a subscriber-control reply such as `SubscribeRejected`. These replies
+/// are generated while consuming a one-shot inbound registration, so treating
+/// a rejected byte admission as a completed reply would otherwise leave the
+/// requester waiting forever. One retained message bounds a stalled link; the
+/// subscriber tick stops as soon as it creates one.
+fn flush_pending_control_response(
+    transport: &mut dyn Transport,
+    pending: &mut Option<SyncMessage>,
+    scheduler: &SharedTickScheduler,
+) -> Result<bool, Error> {
+    let Some(response) = pending.take() else {
+        return Ok(true);
+    };
+    match transport.send(response.clone()) {
         Ok(()) => Ok(true),
         Err(TransportError::Backpressure) => {
             *pending = Some(response);

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -327,6 +327,10 @@ where
     pub(super) startup_error: Option<Error>,
     /// Exact uploads whose applied fate made them globally settled or rejected.
     pub(super) released_outbox_tx_ids: Vec<TxId>,
+    /// One ordinary-wire chunk reply held at its semantic producer boundary.
+    /// Dedicated auxiliary chunk traffic uses `PeerIoPump`'s bounded
+    /// take/restore queue; this covers the legacy ordinary-wire responder.
+    pub(super) pending_chunk_response: Option<ChunkResponseBatch>,
     pub(super) link: ConnectionLink,
     pub(super) last_resume_bytes: Option<usize>,
     pub(super) auxiliary_pump: PeerIoPump,
@@ -2230,6 +2234,13 @@ where
                 )? {
                     return Ok(true);
                 }
+                if !flush_pending_chunk_response(
+                    self.transport.as_mut(),
+                    &mut self.pending_chunk_response,
+                    &self.scheduler,
+                )? {
+                    return Ok(true);
+                }
                 if let Some(message) = self.auxiliary_pump.take_outbound(64) {
                     if let Err(error) = self.transport.send(message.clone()) {
                         self.auxiliary_pump.restore_outbound(message);
@@ -2290,11 +2301,13 @@ where
                             if !responses.is_empty()
                                 && !self.auxiliary_pump.is_disconnected()
                             {
-                                self.transport
-                                    .send(SyncMessage::ChunkResponseBatch(ChunkResponseBatch {
-                                        responses,
-                                    }))
-                                    .map_err(transport_error)?;
+                                debug_assert!(
+                                    self.pending_chunk_response.is_none(),
+                                    "subscriber drains a retained chunk response before reading another request"
+                                );
+                                self.pending_chunk_response = Some(ChunkResponseBatch { responses });
+                                schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                                return Ok(true);
                             }
                             continue;
                         }
@@ -4360,6 +4373,32 @@ where
                 return Ok(false);
             }
             Err(error) => return Err(error),
+        }
+    }
+}
+
+/// Retry the one ordinary-wire chunk response whose byte admission was refused.
+/// The auxiliary lane has its own bounded take/restore queue; this covers the
+/// legacy canonical-wire request path without giving a stalled peer an
+/// unbounded second response buffer.
+fn flush_pending_chunk_response(
+    transport: &mut dyn Transport,
+    pending: &mut Option<ChunkResponseBatch>,
+    scheduler: &SharedTickScheduler,
+) -> Result<bool, Error> {
+    let Some(response) = pending.take() else {
+        return Ok(true);
+    };
+    match transport.send(SyncMessage::ChunkResponseBatch(response.clone())) {
+        Ok(()) => Ok(true),
+        Err(TransportError::Backpressure) => {
+            *pending = Some(response);
+            schedule_tick_in(scheduler, TickUrgency::Deferred);
+            Ok(false)
+        }
+        Err(error) => {
+            *pending = Some(response);
+            Err(transport_error(error))
         }
     }
 }

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -185,25 +185,120 @@ fn subscriber_control_reply_retries_after_bounded_transport_backpressure() {
         },
         reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
     };
-    subscriber.borrow_mut().pending_control_response = Some(rejection.clone());
+    subscriber
+        .borrow_mut()
+        .pending_control_responses
+        .extend([rejection.clone(), rejection.clone()]);
 
     subscriber
         .borrow_mut()
         .tick()
         .expect("backpressure retains the subscriber control reply");
     assert_eq!(
-        subscriber.borrow().pending_control_response,
-        Some(rejection.clone())
+        subscriber
+            .borrow()
+            .pending_control_responses
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec![rejection.clone(), rejection.clone()],
+        "a stalled link keeps every already-bounded control obligation in FIFO order"
     );
     assert!(outbound.borrow().is_empty());
 
     subscriber
         .borrow_mut()
         .tick()
-        .expect("later capacity accepts the retained control reply");
-    assert!(subscriber.borrow().pending_control_response.is_none());
+        .expect("later capacity accepts only the first retained control reply");
+    assert_eq!(
+        subscriber
+            .borrow()
+            .pending_control_responses
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec![rejection.clone()],
+        "one accepted reply does not let a tick skip or duplicate the next obligation"
+    );
     assert_eq!(outbound.borrow_mut().pop_front(), Some(rejection));
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("the following tick accepts the second retained control reply");
+    assert!(subscriber.borrow().pending_control_responses.is_empty());
+    assert!(matches!(
+        outbound.borrow_mut().pop_front(),
+        Some(SyncMessage::SubscribeRejected { .. })
+    ));
     assert!(outbound.borrow().is_empty());
+}
+
+/// A permanently stalled link may retain only the control obligations already
+/// implied by its live registrations/rejections. This stays at the transport
+/// seam because a public client cannot deliberately hold an accepted frame
+/// forever without also hiding the scheduler wake that the test needs to
+/// inspect.
+#[test]
+fn subscriber_control_replies_stay_bounded_during_permanent_backpressure() {
+    struct PermanentlyBackpressuredTransport {
+        sends: Rc<Cell<usize>>,
+    }
+
+    impl Transport for PermanentlyBackpressuredTransport {
+        fn send(&mut self, _message: SyncMessage) -> Result<(), TransportError> {
+            self.sends.set(self.sends.get() + 1);
+            Err(TransportError::Backpressure)
+        }
+
+        fn try_recv(&mut self) -> Option<SyncMessage> {
+            None
+        }
+    }
+
+    let identity = AuthorSubject::for_test_bytes([0xc5; 16]);
+    let schema = schema();
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let sends = Rc::new(Cell::new(0));
+    let subscriber = server.accept_subscriber(
+        Box::new(PermanentlyBackpressuredTransport {
+            sends: Rc::clone(&sends),
+        }),
+        identity,
+    );
+    let rejection = SyncMessage::SubscribeRejected {
+        subscription: SubscriptionKey {
+            shape_id: ShapeId(uuid::Uuid::from_bytes([5; 16])),
+            binding_id: BindingId(uuid::Uuid::from_bytes([5; 16])),
+            read_view: ReadViewKey::default(),
+        },
+        reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
+    };
+    subscriber
+        .borrow_mut()
+        .pending_control_responses
+        .extend([rejection.clone(), rejection.clone()]);
+
+    for _ in 0..4 {
+        subscriber
+            .borrow_mut()
+            .tick()
+            .expect("backpressure is a deferred retry, not a fatal connection error");
+        assert_eq!(
+            subscriber
+                .borrow()
+                .pending_control_responses
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![rejection.clone(), rejection.clone()],
+            "retries retain the same bounded FIFO without accumulating copies"
+        );
+    }
+    assert_eq!(
+        sends.get(),
+        4,
+        "one logical control reply is retried per tick"
+    );
 }
 
 #[test]

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -1,6 +1,7 @@
 //! Link admission, authority selection, permission advice, and routed fates.
 
 use super::*;
+use crate::db::peer_connection::{ConnectionLink, PendingSubscriberControlResponse};
 use crate::node::SKEW_TOLERANCE_MS;
 
 #[test]
@@ -161,6 +162,73 @@ fn ordinary_wire_chunk_response_retries_after_bounded_transport_backpressure() {
     assert!(outbound.borrow().is_empty());
 }
 
+/// Missing-version repair is an upstream one-shot request, not a recomputable
+/// subscription update. A bounded transport must therefore retain it locally
+/// and arrange its own retry instead of relying on an unrelated reconnect or
+/// inbound wakeup to make the repair possible.
+#[test]
+fn upstream_row_version_fetch_retries_after_bounded_transport_backpressure() {
+    let identity = AuthorSubject::for_test_bytes([0xc3; 16]);
+    let schema = schema();
+    let client = open_db(0xc3, identity, &schema);
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    let upstream =
+        crate::db::block_on(client.connect_upstream(Box::new(BackpressureOnceTransport {
+            outbound: Rc::clone(&outbound),
+            failed: false,
+        })));
+    let request = RowVersionRef::new(
+        "todos",
+        RowUuid::from_bytes([0xc3; 16]),
+        TxId::new(TxTime::from(3), NodeUuid::from_bytes([0xc3; 16])),
+    );
+    {
+        let mut connection = upstream.borrow_mut();
+        let ConnectionLink::Upstream(state) = &mut connection.link else {
+            panic!("client connection must be upstream");
+        };
+        state
+            .pending_row_version_fetches
+            .push_back(vec![request.clone()]);
+    }
+
+    upstream
+        .borrow_mut()
+        .tick()
+        .expect("backpressure retains the upstream repair fetch");
+    {
+        let connection = upstream.borrow();
+        let ConnectionLink::Upstream(state) = &connection.link else {
+            panic!("client connection must be upstream");
+        };
+        assert_eq!(
+            state.pending_row_version_fetches.front(),
+            Some(&vec![request.clone()]),
+            "a rejected byte admission retains the exact upstream repair request"
+        );
+    }
+    assert!(outbound.borrow().is_empty());
+
+    upstream
+        .borrow_mut()
+        .tick()
+        .expect("scheduled retry accepts the upstream repair fetch");
+    {
+        let connection = upstream.borrow();
+        let ConnectionLink::Upstream(state) = &connection.link else {
+            panic!("client connection must be upstream");
+        };
+        assert!(state.pending_row_version_fetches.is_empty());
+    }
+    assert_eq!(
+        outbound.borrow_mut().pop_front(),
+        Some(SyncMessage::FetchRowVersions {
+            requests: vec![request]
+        })
+    );
+    assert!(outbound.borrow().is_empty());
+}
+
 /// Subscription rejection follows the same ownership rule. A malformed or
 /// unsupported one-shot registration must not turn into a permanently pending
 /// caller when the first byte admission is temporarily full.
@@ -185,10 +253,10 @@ fn subscriber_control_reply_retries_after_bounded_transport_backpressure() {
         },
         reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
     };
-    subscriber
-        .borrow_mut()
-        .pending_control_responses
-        .extend([rejection.clone(), rejection.clone()]);
+    subscriber.borrow_mut().pending_control_responses.extend([
+        PendingSubscriberControlResponse::Direct(rejection.clone()),
+        PendingSubscriberControlResponse::Direct(rejection.clone()),
+    ]);
 
     subscriber
         .borrow_mut()
@@ -199,7 +267,7 @@ fn subscriber_control_reply_retries_after_bounded_transport_backpressure() {
             .borrow()
             .pending_control_responses
             .iter()
-            .cloned()
+            .map(|response| response.message().clone())
             .collect::<Vec<_>>(),
         vec![rejection.clone(), rejection.clone()],
         "a stalled link keeps every already-bounded control obligation in FIFO order"
@@ -209,23 +277,9 @@ fn subscriber_control_reply_retries_after_bounded_transport_backpressure() {
     subscriber
         .borrow_mut()
         .tick()
-        .expect("later capacity accepts only the first retained control reply");
-    assert_eq!(
-        subscriber
-            .borrow()
-            .pending_control_responses
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>(),
-        vec![rejection.clone()],
-        "one accepted reply does not let a tick skip or duplicate the next obligation"
-    );
-    assert_eq!(outbound.borrow_mut().pop_front(), Some(rejection));
-    subscriber
-        .borrow_mut()
-        .tick()
-        .expect("the following tick accepts the second retained control reply");
+        .expect("later capacity accepts every retained FIFO control reply");
     assert!(subscriber.borrow().pending_control_responses.is_empty());
+    assert_eq!(outbound.borrow_mut().pop_front(), Some(rejection));
     assert!(matches!(
         outbound.borrow_mut().pop_front(),
         Some(SyncMessage::SubscribeRejected { .. })
@@ -273,10 +327,10 @@ fn subscriber_control_replies_stay_bounded_during_permanent_backpressure() {
         },
         reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
     };
-    subscriber
-        .borrow_mut()
-        .pending_control_responses
-        .extend([rejection.clone(), rejection.clone()]);
+    subscriber.borrow_mut().pending_control_responses.extend([
+        PendingSubscriberControlResponse::Direct(rejection.clone()),
+        PendingSubscriberControlResponse::Direct(rejection.clone()),
+    ]);
 
     for _ in 0..4 {
         subscriber
@@ -288,7 +342,7 @@ fn subscriber_control_replies_stay_bounded_during_permanent_backpressure() {
                 .borrow()
                 .pending_control_responses
                 .iter()
-                .cloned()
+                .map(|response| response.message().clone())
                 .collect::<Vec<_>>(),
             vec![rejection.clone(), rejection.clone()],
             "retries retain the same bounded FIFO without accumulating copies"
@@ -299,6 +353,109 @@ fn subscriber_control_replies_stay_bounded_during_permanent_backpressure() {
         4,
         "one logical control reply is retried per tick"
     );
+}
+
+/// Repair payloads retain the normal sync-context send path. This matters on
+/// trusted links where `send_with_sync_context` may first announce a catalogue
+/// snapshot; the row-version response itself must still remain pending until
+/// the adapter accepts it.
+#[test]
+fn row_version_repair_reply_retries_with_sync_context_after_backpressure() {
+    let identity = AuthorSubject::for_test_bytes([0xc6; 16]);
+    let schema = schema();
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    let subscriber = server.accept_subscriber(
+        Box::new(BackpressureOnceTransport {
+            outbound: Rc::clone(&outbound),
+            failed: false,
+        }),
+        identity,
+    );
+    let response = SyncMessage::RowVersionPayloads {
+        version_bundles: Vec::new(),
+    };
+    subscriber.borrow_mut().pending_control_responses.push_back(
+        PendingSubscriberControlResponse::WithSyncContext(response.clone()),
+    );
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("bounded transport defers the repair reply");
+    assert_eq!(
+        subscriber
+            .borrow()
+            .pending_control_responses
+            .front()
+            .map(PendingSubscriberControlResponse::message),
+        Some(&response)
+    );
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("later capacity accepts the retained repair reply");
+    assert!(subscriber.borrow().pending_control_responses.is_empty());
+    assert!(matches!(
+        outbound.borrow_mut().pop_front(),
+        Some(SyncMessage::CatalogueSnapshot(_))
+    ));
+    assert_eq!(outbound.borrow_mut().pop_front(), Some(response));
+    assert!(outbound.borrow().is_empty());
+}
+
+/// An authority-scope intent may expand to a multi-frame proof sequence. Its
+/// semantic producer queues that sequence before returning to inbound work, so
+/// bounded wire admission must preserve both order and exact multiplicity.
+#[test]
+fn authorization_scope_replies_retry_fifo_after_backpressure() {
+    let identity = AuthorSubject::for_test_bytes([0xc7; 16]);
+    let schema = schema();
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    let subscriber = server.accept_subscriber(
+        Box::new(BackpressureOnceTransport {
+            outbound: Rc::clone(&outbound),
+            failed: false,
+        }),
+        identity,
+    );
+    let first = SyncMessage::AuthorizationScopeUnavailable {
+        request_id: PermissionAdviceRequestId([7; 16]),
+    };
+    let second = SyncMessage::AuthorizationScopeUnavailable {
+        request_id: PermissionAdviceRequestId([8; 16]),
+    };
+    subscriber.borrow_mut().pending_control_responses.extend([
+        PendingSubscriberControlResponse::Direct(first.clone()),
+        PendingSubscriberControlResponse::Direct(second.clone()),
+    ]);
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("backpressure retains the whole authority-scope reply sequence");
+    assert_eq!(
+        subscriber
+            .borrow()
+            .pending_control_responses
+            .iter()
+            .map(PendingSubscriberControlResponse::message)
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec![first.clone(), second.clone()]
+    );
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("first scope reply is accepted once capacity returns");
+    assert_eq!(outbound.borrow_mut().pop_front(), Some(first));
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("second scope reply remains FIFO behind the first");
+    assert_eq!(outbound.borrow_mut().pop_front(), Some(second));
+    assert!(subscriber.borrow().pending_control_responses.is_empty());
 }
 
 #[test]

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -161,6 +161,51 @@ fn ordinary_wire_chunk_response_retries_after_bounded_transport_backpressure() {
     assert!(outbound.borrow().is_empty());
 }
 
+/// Subscription rejection follows the same ownership rule. A malformed or
+/// unsupported one-shot registration must not turn into a permanently pending
+/// caller when the first byte admission is temporarily full.
+#[test]
+fn subscriber_control_reply_retries_after_bounded_transport_backpressure() {
+    let identity = AuthorSubject::for_test_bytes([0xc4; 16]);
+    let schema = schema();
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    let subscriber = server.accept_subscriber(
+        Box::new(BackpressureOnceTransport {
+            outbound: Rc::clone(&outbound),
+            failed: false,
+        }),
+        identity,
+    );
+    let rejection = SyncMessage::SubscribeRejected {
+        subscription: SubscriptionKey {
+            shape_id: ShapeId(uuid::Uuid::from_bytes([4; 16])),
+            binding_id: BindingId(uuid::Uuid::from_bytes([4; 16])),
+            read_view: ReadViewKey::default(),
+        },
+        reason: SubscribeRejectReason::ShapeRegistrationPendingCatalogueAdmission,
+    };
+    subscriber.borrow_mut().pending_control_response = Some(rejection.clone());
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("backpressure retains the subscriber control reply");
+    assert_eq!(
+        subscriber.borrow().pending_control_response,
+        Some(rejection.clone())
+    );
+    assert!(outbound.borrow().is_empty());
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("later capacity accepts the retained control reply");
+    assert!(subscriber.borrow().pending_control_response.is_none());
+    assert_eq!(outbound.borrow_mut().pop_front(), Some(rejection));
+    assert!(outbound.borrow().is_empty());
+}
+
 #[test]
 fn catalogue_fingerprint_change_is_eager_only_on_trusted_backend_link() {
     // This stays internal because trust is authenticated by the host at the

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -114,6 +114,53 @@ fn downstream_fate_retries_after_bounded_transport_backpressure() {
     assert!(outbound.borrow().is_empty());
 }
 
+/// The ordinary-wire chunk responder is a legacy path below the public chunk
+/// API. It needs the same bounded ownership rule as fates: a rejected byte
+/// admission retains one response batch and does not consume another inbound
+/// request until that batch is accepted.
+#[test]
+fn ordinary_wire_chunk_response_retries_after_bounded_transport_backpressure() {
+    let identity = AuthorSubject::for_test_bytes([0xc3; 16]);
+    let schema = schema();
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    let subscriber = server.accept_subscriber(
+        Box::new(BackpressureOnceTransport {
+            outbound: Rc::clone(&outbound),
+            failed: false,
+        }),
+        identity,
+    );
+    let batch = ChunkResponseBatch {
+        responses: vec![ChunkResponseEntry {
+            request_id: 3,
+            result: ChunkResponse::Unavailable,
+        }],
+    };
+    subscriber.borrow_mut().pending_chunk_response = Some(batch.clone());
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("backpressure retains the ordinary-wire chunk response");
+    assert_eq!(
+        subscriber.borrow().pending_chunk_response,
+        Some(batch.clone())
+    );
+    assert!(outbound.borrow().is_empty());
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("later capacity accepts the retained chunk response");
+    assert!(subscriber.borrow().pending_chunk_response.is_none());
+    assert_eq!(
+        outbound.borrow_mut().pop_front(),
+        Some(SyncMessage::ChunkResponseBatch(batch))
+    );
+    assert!(outbound.borrow().is_empty());
+}
+
 #[test]
 fn catalogue_fingerprint_change_is_eager_only_on_trusted_backend_link() {
     // This stays internal because trust is authenticated by the host at the

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -60,6 +60,60 @@ fn authenticated_client_upload_uses_authority_clock_for_forward_skew() {
     );
 }
 
+/// This stays at the peer/transport seam because public client APIs cannot
+/// deliberately hold one accepted wire frame while rejecting the next logical
+/// message. It proves the ownership boundary: a fate rejected by a bounded
+/// transport remains in the connection-owned FIFO until the transport accepts
+/// it, rather than disappearing with the synchronous tick turn.
+#[test]
+fn downstream_fate_retries_after_bounded_transport_backpressure() {
+    let identity = AuthorSubject::for_test_bytes([0xc2; 16]);
+    let schema = schema();
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    let subscriber = server.accept_subscriber(
+        Box::new(BackpressureOnceTransport {
+            outbound: Rc::clone(&outbound),
+            failed: false,
+        }),
+        identity,
+    );
+    let fate = SyncMessage::FateUpdate {
+        tx_id: TxId::new(TxTime::from(2), NodeUuid::from_bytes([0xc2; 16])),
+        fate: Fate::Accepted,
+        global_time: None,
+        durability: Some(DurabilityTier::Edge),
+    };
+    subscriber
+        .borrow()
+        .downstream_fates
+        .borrow_mut()
+        .push(fate.clone());
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("backpressure retains the fate and schedules a retry");
+    assert_eq!(
+        subscriber.borrow().downstream_fates.borrow().as_slice(),
+        std::slice::from_ref(&fate),
+        "a rejected wire admission leaves the exact fate at its semantic producer"
+    );
+    assert!(outbound.borrow().is_empty());
+
+    subscriber
+        .borrow_mut()
+        .tick()
+        .expect("later capacity accepts the retained fate");
+    assert!(subscriber.borrow().downstream_fates.borrow().is_empty());
+    assert!(matches!(
+        outbound.borrow_mut().pop_front(),
+        Some(SyncMessage::CatalogueSnapshot(_))
+    ));
+    assert_eq!(outbound.borrow_mut().pop_front(), Some(fate));
+    assert!(outbound.borrow().is_empty());
+}
+
 #[test]
 fn catalogue_fingerprint_change_is_eager_only_on_trusted_backend_link() {
     // This stays internal because trust is authenticated by the host at the

--- a/crates/jazz/src/db/tests/wire_transport.rs
+++ b/crates/jazz/src/db/tests/wire_transport.rs
@@ -272,7 +272,7 @@ impl WireTransport for ScriptedSendTransport {
 }
 
 #[test]
-fn send_expires_stale_reassembly_before_pending_outbound_flush_returns_early() {
+fn send_expires_stale_reassembly_before_pending_outbound_flush() {
     let message = SyncMessage::SessionClaims {
         identity: AuthorSubject::for_test_bytes([0x76; 16]),
         claims: BTreeMap::new(),
@@ -298,7 +298,16 @@ fn send_expires_stale_reassembly_before_pending_outbound_flush_returns_early() {
         assert_eq!(adapter.reassembler.push(fragment.clone(), 0).unwrap(), None);
         adapter.set_reassembly_elapsed_for_test(MAX_FRAGMENT_REASSEMBLY_IDLE_MS);
 
-        assert_eq!(adapter.send(message.clone()), Err(flush_error));
+        let result = adapter.send(message.clone());
+        if matches!(flush_error, TransportError::Backpressure) {
+            assert_eq!(
+                result,
+                Ok(()),
+                "later logical messages queue behind a temporarily full transport"
+            );
+        } else {
+            assert_eq!(result, Err(flush_error));
+        }
         assert_eq!(
             (
                 adapter.reassembler.incomplete.len(),
@@ -713,6 +722,70 @@ fn first_frame_backpressure_queues_compressed_logical_message_without_retry() {
         "poll flushes the accepted message"
     );
     assert_eq!(receiver.try_recv(), Some(message));
+}
+
+#[test]
+fn pending_backpressure_queues_later_receipt_without_semantic_retry() {
+    #[derive(Clone)]
+    struct BlockedWireTransport {
+        outbound: Rc<RefCell<std::collections::VecDeque<Vec<u8>>>>,
+        blocked: Rc<Cell<bool>>,
+    }
+
+    impl WireTransport for BlockedWireTransport {
+        fn send_frame(&mut self, frame: Vec<u8>) -> Result<(), TransportError> {
+            if self.blocked.get() {
+                return Err(TransportError::Backpressure);
+            }
+            self.outbound.borrow_mut().push_back(frame);
+            Ok(())
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    let staged = Rc::new(RefCell::new(std::collections::VecDeque::new()));
+    let blocked = Rc::new(Cell::new(true));
+    let mut sender = WireTransportAdapter::current(BlockedWireTransport {
+        outbound: Rc::clone(&staged),
+        blocked: Rc::clone(&blocked),
+    });
+    let mut receiver = WireTransportAdapter::current(ByteDuplexTransport {
+        outbound: Rc::new(RefCell::new(std::collections::VecDeque::new())),
+        inbound: Rc::clone(&staged),
+    });
+    let view = SyncMessage::SessionClaims {
+        identity: AuthorSubject::for_test_bytes([0x76; 16]),
+        claims: BTreeMap::from([("view".to_owned(), Value::String("pending".to_owned()))]),
+    };
+    let receipt = SyncMessage::FateUpdate {
+        tx_id: TxId::new(
+            crate::time::TxTime::from(76),
+            NodeUuid::from_bytes([0x76; 16]),
+        ),
+        fate: Fate::Accepted,
+        global_time: None,
+        durability: Some(DurabilityTier::Edge),
+    };
+
+    assert_eq!(sender.send(view.clone()), Ok(()));
+    assert_eq!(
+        sender.send(receipt.clone()),
+        Ok(()),
+        "a receipt behind a pending bounded-view frame is accepted exactly once"
+    );
+    assert!(staged.borrow().is_empty());
+
+    blocked.set(false);
+    assert!(
+        sender.try_recv().is_none(),
+        "poll flushes both queued messages"
+    );
+    assert_eq!(receiver.try_recv(), Some(view));
+    assert_eq!(receiver.try_recv(), Some(receipt));
+    assert!(receiver.try_recv().is_none());
 }
 
 #[test]

--- a/crates/jazz/src/db/tests/wire_transport.rs
+++ b/crates/jazz/src/db/tests/wire_transport.rs
@@ -272,7 +272,7 @@ impl WireTransport for ScriptedSendTransport {
 }
 
 #[test]
-fn send_expires_stale_reassembly_before_pending_outbound_flush() {
+fn pending_outbound_backpressure_rejects_later_logical_message_without_encoding_it() {
     let message = SyncMessage::SessionClaims {
         identity: AuthorSubject::for_test_bytes([0x76; 16]),
         claims: BTreeMap::new(),
@@ -298,16 +298,7 @@ fn send_expires_stale_reassembly_before_pending_outbound_flush() {
         assert_eq!(adapter.reassembler.push(fragment.clone(), 0).unwrap(), None);
         adapter.set_reassembly_elapsed_for_test(MAX_FRAGMENT_REASSEMBLY_IDLE_MS);
 
-        let result = adapter.send(message.clone());
-        if matches!(flush_error, TransportError::Backpressure) {
-            assert_eq!(
-                result,
-                Ok(()),
-                "later logical messages queue behind a temporarily full transport"
-            );
-        } else {
-            assert_eq!(result, Err(flush_error));
-        }
+        assert_eq!(adapter.send(message.clone()), Err(flush_error));
         assert_eq!(
             (
                 adapter.reassembler.incomplete.len(),
@@ -725,7 +716,7 @@ fn first_frame_backpressure_queues_compressed_logical_message_without_retry() {
 }
 
 #[test]
-fn pending_backpressure_queues_later_receipt_without_semantic_retry() {
+fn pending_backpressure_rejects_later_receipt_for_semantic_retry() {
     #[derive(Clone)]
     struct BlockedWireTransport {
         outbound: Rc<RefCell<std::collections::VecDeque<Vec<u8>>>>,
@@ -773,16 +764,17 @@ fn pending_backpressure_queues_later_receipt_without_semantic_retry() {
     assert_eq!(sender.send(view.clone()), Ok(()));
     assert_eq!(
         sender.send(receipt.clone()),
-        Ok(()),
-        "a receipt behind a pending bounded-view frame is accepted exactly once"
+        Err(TransportError::Backpressure),
+        "the adapter retains only the already-accepted view; its producer must retain the fate"
     );
     assert!(staged.borrow().is_empty());
 
     blocked.set(false);
     assert!(
         sender.try_recv().is_none(),
-        "poll flushes both queued messages"
+        "poll flushes the one already-accepted message"
     );
+    assert_eq!(sender.send(receipt.clone()), Ok(()));
     assert_eq!(receiver.try_recv(), Some(view));
     assert_eq!(receiver.try_recv(), Some(receipt));
     assert!(receiver.try_recv().is_none());

--- a/crates/jazz/src/db/wire_transport.rs
+++ b/crates/jazz/src/db/wire_transport.rs
@@ -525,7 +525,21 @@ where
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
         let now_ms = self.reassembly_now_ms();
         self.reassembler.expire(now_ms);
-        self.flush_pending_outbound()?;
+        // `send_encoded_frames` accepts a logical message once encoding has
+        // advanced the connection stream, retaining any frame that a full
+        // socket could not accept.  Preserve that same contract when an
+        // earlier retained message is still blocked: a later fate or view
+        // update must queue behind it, not be discarded by a failed pre-flush.
+        //
+        // This is particularly important for an edge's immediate receipt. A
+        // bounded view can leave a prior frame pending; the receipt still
+        // settles the already-ingested transaction and therefore cannot rely
+        // on the client replaying its upload after transport capacity returns.
+        let pending_outbound_blocked = match self.flush_pending_outbound() {
+            Ok(()) => false,
+            Err(TransportError::Backpressure) => true,
+            Err(error) => return Err(error),
+        };
         let payload = match encode_sync_message_for_features(&message, self.features) {
             Ok(payload) => payload,
             Err(error) => {
@@ -547,14 +561,14 @@ where
         if let Some(session) = self.session.clone() {
             envelope = envelope.with_session(session);
         }
-        match encode_frame(&WireFrame::Message(envelope.clone())) {
+        let frames = match encode_frame(&WireFrame::Message(envelope.clone())) {
             Ok(frame) if frame.len() <= WIRE_FRAGMENT_PAYLOAD_BYTES => {
-                self.send_encoded_frames(vec![frame])
+                vec![frame]
             }
             Ok(_) if self.features & FEATURE_MESSAGE_FRAGMENTATION == 0 => {
-                Err(TransportError::Failed(
+                return Err(TransportError::Failed(
                     "peer did not negotiate logical-message fragmentation".to_owned(),
-                ))
+                ));
             }
             Ok(_) => {
                 let message_digest = *blake3::hash(&envelope.payload).as_bytes();
@@ -595,7 +609,7 @@ where
                     validate_wire_frame_len(frame.len()).map_err(TransportError::Failed)?;
                     frames.push(frame);
                 }
-                self.send_encoded_frames(frames)
+                frames
             }
             Err(err) => {
                 self.send_wire_error(WireError::new(
@@ -603,8 +617,14 @@ where
                     WireRetry::Never,
                     format!("failed to encode wire frame: {err}"),
                 ));
-                Ok(())
+                return Ok(());
             }
+        };
+        if pending_outbound_blocked {
+            self.pending_outbound_frames.extend(frames);
+            Ok(())
+        } else {
+            self.send_encoded_frames(frames)
         }
     }
 

--- a/crates/jazz/src/db/wire_transport.rs
+++ b/crates/jazz/src/db/wire_transport.rs
@@ -525,21 +525,11 @@ where
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
         let now_ms = self.reassembly_now_ms();
         self.reassembler.expire(now_ms);
-        // `send_encoded_frames` accepts a logical message once encoding has
-        // advanced the connection stream, retaining any frame that a full
-        // socket could not accept.  Preserve that same contract when an
-        // earlier retained message is still blocked: a later fate or view
-        // update must queue behind it, not be discarded by a failed pre-flush.
-        //
-        // This is particularly important for an edge's immediate receipt. A
-        // bounded view can leave a prior frame pending; the receipt still
-        // settles the already-ingested transaction and therefore cannot rely
-        // on the client replaying its upload after transport capacity returns.
-        let pending_outbound_blocked = match self.flush_pending_outbound() {
-            Ok(()) => false,
-            Err(TransportError::Backpressure) => true,
-            Err(error) => return Err(error),
-        };
+        // A retained frame belongs to the one logical message that was already
+        // accepted by `send_encoded_frames`. Do not admit a second message
+        // until that bounded backlog flushes: callers retain/retry an
+        // `Err(Backpressure)` message at their semantic boundary.
+        self.flush_pending_outbound()?;
         let payload = match encode_sync_message_for_features(&message, self.features) {
             Ok(payload) => payload,
             Err(error) => {
@@ -561,14 +551,14 @@ where
         if let Some(session) = self.session.clone() {
             envelope = envelope.with_session(session);
         }
-        let frames = match encode_frame(&WireFrame::Message(envelope.clone())) {
+        match encode_frame(&WireFrame::Message(envelope.clone())) {
             Ok(frame) if frame.len() <= WIRE_FRAGMENT_PAYLOAD_BYTES => {
-                vec![frame]
+                self.send_encoded_frames(vec![frame])
             }
             Ok(_) if self.features & FEATURE_MESSAGE_FRAGMENTATION == 0 => {
-                return Err(TransportError::Failed(
+                Err(TransportError::Failed(
                     "peer did not negotiate logical-message fragmentation".to_owned(),
-                ));
+                ))
             }
             Ok(_) => {
                 let message_digest = *blake3::hash(&envelope.payload).as_bytes();
@@ -609,7 +599,7 @@ where
                     validate_wire_frame_len(frame.len()).map_err(TransportError::Failed)?;
                     frames.push(frame);
                 }
-                frames
+                self.send_encoded_frames(frames)
             }
             Err(err) => {
                 self.send_wire_error(WireError::new(
@@ -617,14 +607,8 @@ where
                     WireRetry::Never,
                     format!("failed to encode wire frame: {err}"),
                 ));
-                return Ok(());
+                Ok(())
             }
-        };
-        if pending_outbound_blocked {
-            self.pending_outbound_frames.extend(frames);
-            Ok(())
-        } else {
-            self.send_encoded_frames(frames)
         }
     }
 


### PR DESCRIPTION
🤖 Prevents protocol replies from disappearing when a connection's bounded outgoing buffer is temporarily full. Fixes #2176.

## Example

A client submits a write through an Edge. At the same moment, the Edge's transport is still flushing a previous large message. When the Edge tries to return the write's accepted/rejected outcome, the transport reports backpressure.

Previously, several producers had already removed that outcome from their own queue before learning that the transport could not accept it. The client could then wait forever, retain a write that had actually been rejected, or receive the result only after an unrelated reconnect.

## New ownership rule

The wire adapter remains responsible only for the physical frames of the one logical message it has accepted. It does not accumulate an unbounded queue of later messages.

If the adapter has not accepted a message, its semantic owner keeps a bounded typed obligation and retries it when the connection becomes writable. In practical terms:

- transaction outcomes stay in FIFO order until admitted;
- subscription acceptance/rejection replies pause further inbound work while blocked;
- missing-row and chunk repair replies retain their request bookkeeping;
- authorization proof sequences resume from the blocked step instead of expanding into a message backlog;
- upstream repair requests remain pending until admitted;
- bounded auxiliary queues restore the message they could not send.

This preserves the configured byte cap: the adapter never hides later messages in an unbounded secondary queue. Once a reply is accepted, the same connection tick continues draining work until it encounters real backpressure.

Maintained query snapshots are excluded because they are recomputable from dirty state rather than one-shot obligations.

## Evidence

- wire suite: 30/30
- admission and transaction-outcome suite: 30/30
- authorization-scope suite: 15/15
- structured-subscription suite: 19/19
- planted loss of a transaction outcome, control reply, authorization step, and repair request each fails its corresponding receipt
- clippy, rustfmt, and sensitive-data guard

Independent adversarial review found and repaired each one-shot producer listed above; #2181 separately reviews the combined Edge outcome path.
