### PR TITLE
perf(jazz): bound flat subscription delta bookkeeping

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -4461,30 +4461,66 @@ fn apply_maintained_membership_update_to_snapshot(
         }
     }
 
-    for occurrence_id in &update_removed {
-        if update_added.iter().any(|(added, _)| added == occurrence_id) {
-            continue;
-        }
-        let Some(index) = snapshot_index.roots.get(occurrence_id).copied() else {
-            continue;
-        };
-        let row = snapshot.rows.remove(index);
-        snapshot.root_count -= 1;
-        snapshot_index.roots.remove(occurrence_id);
-        for position in snapshot_index.roots.values_mut() {
-            if *position > index {
-                *position -= 1;
+    if !update_removed.is_empty() {
+        let replaced = update_added
+            .iter()
+            .map(|(occurrence, _)| occurrence)
+            .collect::<BTreeSet<_>>();
+        let requested_removals = update_removed.iter().collect::<BTreeSet<_>>();
+        let mut removals = requested_removals
+            .iter()
+            .filter(|occurrence| !replaced.contains(*occurrence))
+            .filter_map(|occurrence| {
+                snapshot_index
+                    .roots
+                    .get(*occurrence)
+                    .copied()
+                    .map(|position| ((*occurrence).clone(), position))
+            })
+            .collect::<Vec<_>>();
+        removals.sort_by_key(|(_, position)| *position);
+        if !removals.is_empty() {
+            // A removed index is part of the public delta contract: it is the
+            // position in the complete pre-frame result, not the position after
+            // a preceding removal has already shifted the snapshot.  Remove the
+            // whole batch together so both that contract and the index repair are
+            // linear in the result size rather than quadratic in removed roots.
+            let removed_positions = removals
+                .iter()
+                .map(|(_, position)| *position)
+                .collect::<Vec<_>>();
+            let removal_ids = removals
+                .iter()
+                .map(|(occurrence, _)| occurrence)
+                .collect::<BTreeSet<_>>();
+            removed.extend(removals.iter().map(|(occurrence_id, index)| {
+                let row = &snapshot.rows[*index];
+                RemovedRow {
+                    table: row.table().to_owned(),
+                    row_uuid: row.row_uuid(),
+                    occurrence_id: occurrence_id.clone(),
+                    index: *index,
+                }
+            }));
+            let root_count_before_removals = snapshot.root_count;
+            let mut position = 0;
+            snapshot.rows.retain(|_| {
+                let keep = position >= root_count_before_removals
+                    || removed_positions.binary_search(&position).is_err();
+                position += 1;
+                keep
+            });
+            snapshot.root_count -= removed_positions.len();
+            snapshot_index
+                .roots
+                .retain(|occurrence, _| !removal_ids.contains(occurrence));
+            for position in snapshot_index.roots.values_mut() {
+                *position -= removed_positions.partition_point(|removed| removed < position);
+            }
+            for position in snapshot_index.related.values_mut() {
+                *position -= removed_positions.len();
             }
         }
-        for position in snapshot_index.related.values_mut() {
-            *position -= 1;
-        }
-        removed.push(RemovedRow {
-            table: row.table().to_owned(),
-            row_uuid: row.row_uuid(),
-            occurrence_id: occurrence_id.clone(),
-            index,
-        });
     }
 
     SubscriptionEvent::Delta {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -4461,38 +4461,30 @@ fn apply_maintained_membership_update_to_snapshot(
         }
     }
 
-    let mut index = 0;
-    while index < snapshot.root_count {
-        let occurrence_id = snapshot_index
-            .roots
-            .iter()
-            .find_map(|(occurrence, position)| (*position == index).then(|| occurrence.clone()))
-            .expect("every maintained root row has an occurrence index");
-        if update_removed.contains(&occurrence_id)
-            && !update_added
-                .iter()
-                .any(|(added, _)| *added == occurrence_id)
-        {
-            let row = snapshot.rows.remove(index);
-            snapshot.root_count -= 1;
-            snapshot_index.roots.remove(&occurrence_id);
-            for position in snapshot_index.roots.values_mut() {
-                if *position > index {
-                    *position -= 1;
-                }
-            }
-            for position in snapshot_index.related.values_mut() {
+    for occurrence_id in &update_removed {
+        if update_added.iter().any(|(added, _)| added == occurrence_id) {
+            continue;
+        }
+        let Some(index) = snapshot_index.roots.get(occurrence_id).copied() else {
+            continue;
+        };
+        let row = snapshot.rows.remove(index);
+        snapshot.root_count -= 1;
+        snapshot_index.roots.remove(occurrence_id);
+        for position in snapshot_index.roots.values_mut() {
+            if *position > index {
                 *position -= 1;
             }
-            removed.push(RemovedRow {
-                table: row.table().to_owned(),
-                row_uuid: row.row_uuid(),
-                occurrence_id,
-                index,
-            });
-        } else {
-            index += 1;
         }
+        for position in snapshot_index.related.values_mut() {
+            *position -= 1;
+        }
+        removed.push(RemovedRow {
+            table: row.table().to_owned(),
+            row_uuid: row.row_uuid(),
+            occurrence_id: occurrence_id.clone(),
+            index,
+        });
     }
 
     SubscriptionEvent::Delta {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -2489,8 +2489,9 @@ where
                             terminal_operations,
                         } => {
                             let state_ref = &mut refresh;
-                            let previous_snapshot = state_ref.snapshot.clone();
-                            let previous_snapshot_index = state_ref.snapshot_index.clone();
+                            let previous = authoritative_membership_changed.then(|| {
+                                (state_ref.snapshot.clone(), state_ref.snapshot_index.clone())
+                            });
                             let mut event = apply_maintained_update_to_snapshot(
                                 &mut state_ref.snapshot,
                                 &mut state_ref.snapshot_index,
@@ -2506,6 +2507,9 @@ where
                                 None,
                             )?;
                             if authoritative_membership_changed {
+                                let (previous_snapshot, previous_snapshot_index) = previous.expect(
+                                    "authoritative membership changes retain prior snapshot",
+                                );
                                 order_maintained_snapshot_roots(
                                     &node.borrow(),
                                     &shape.query(),

--- a/crates/jazz/src/db/tests/subscriptions/structured.rs
+++ b/crates/jazz/src/db/tests/subscriptions/structured.rs
@@ -868,6 +868,83 @@ fn flat_subscription_shifts_offset_window_when_leading_row_is_deleted() {
     assert!(terminal_operations.is_empty());
 }
 
+/// Alice removes two adjacent visible rows in one transaction while Bob keeps
+/// an ordered, offset subscription. Both removals retain their positions in
+/// the complete result before that transaction's frame is applied.
+///
+/// alice ──delete b,c──► maintained view ──one delta──► bob
+#[test]
+fn flat_subscription_batch_removals_keep_pre_frame_indices() {
+    let schema = relation_schema();
+    let db = open_db(0xda, AuthorSubject::for_test_bytes([0xda; 16]), &schema);
+    for (id, name) in [(0xa1, "a"), (0xb1, "b"), (0xc1, "c"), (0xd1, "d")] {
+        db.insert(
+            "users",
+            BTreeMap::from([("name".to_owned(), Value::String(name.to_owned()))]),
+            InsertOptions {
+                row_id: Some(row(id)),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+    let prepared_query = prepared(
+        &db,
+        &Query::from("users").order_by("name", OrderDirection::Asc),
+    );
+    let mut subscription = block_on(db.subscribe(&prepared_query, ReadOpts::default())).unwrap();
+    let initial = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
+    assert_eq!(
+        row_ids(&initial.rows),
+        vec![row(0xa1), row(0xb1), row(0xc1), row(0xd1)]
+    );
+
+    let tx = block_on(db.mergeable_tx()).unwrap();
+    block_on(tx.delete("users", row(0xb1), Default::default())).unwrap();
+    block_on(tx.delete("users", row(0xc1), Default::default())).unwrap();
+    block_on(tx.commit()).unwrap();
+    db.tick().unwrap();
+
+    let SubscriptionEvent::Delta {
+        added,
+        updated,
+        removed,
+        terminal_operations,
+        ..
+    } = block_on(subscription.next_raw()).unwrap()
+    else {
+        panic!("expected one indexed batch-removal delta");
+    };
+    assert!(added.is_empty());
+    assert!(updated.is_empty());
+    assert!(terminal_operations.is_empty());
+    assert_eq!(
+        removed
+            .iter()
+            .map(|removed| (removed.row_uuid, removed.index))
+            .collect::<Vec<_>>(),
+        vec![(row(0xb1), 1), (row(0xc1), 2)],
+        "removed indices address the snapshot before this delta"
+    );
+
+    db.update(
+        "users",
+        row(0xd1),
+        BTreeMap::from([("name".to_owned(), Value::String("z".to_owned()))]),
+        Default::default(),
+    )
+    .unwrap();
+    db.tick().unwrap();
+    let SubscriptionEvent::Delta { updated, .. } = block_on(subscription.next_raw()).unwrap()
+    else {
+        panic!("the retained root must remain indexed after a batch removal");
+    };
+    assert_eq!(updated.len(), 1);
+    assert_eq!(updated[0].row.row_uuid(), row(0xd1));
+    assert_eq!(updated[0].previous_index, Some(1));
+    assert_eq!(updated[0].index, 1);
+}
+
 #[test]
 fn array_subquery_subscription_reflects_child_mutations_and_parent_removal() {
     let schema = relation_schema();


### PR DESCRIPTION
🤖 Supersedes #2093 with the same generic optimization reconstructed directly on current `main`, preserving the original PR's history without force-pushing it.

## Before

Every maintained flat delta cloned the complete prior snapshot and index, even when authoritative membership and ordering were unchanged. Root removals also rediscovered occurrence positions by repeatedly scanning the index.

For example, updating one nullable field in a 10,000-row subscription paid for full snapshot/index clones even though it could apply the delta in place.

## After

Prior snapshots are retained only when authoritative membership changes require reordering. Root removals use the maintained occurrence-to-position index directly. This remains the single generic flat-delta path; it does not introduce a second TopBy or query-specific implementation.

## Correctness evidence

- nullable flat update
- offset-window leading deletion
- authoritative reset rebuilding occurrence sidecars, order, and count
- persistent IndexedDB first-match delivery
- observer write-path benchmark smoke
- planted removal suppression fails the offset-window receipt, then passes after restoration

The existing 100/1,000/10,000-row benchmark scales are already present on current `main`, so this reconstruction does not duplicate them.
