### PR TITLE
fix(sync): gate edge fate on settled action proof

### DIFF
--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -606,7 +606,10 @@ context and relies on known-state redelivery for correctness.
 An edge that acts as mergeable fate authority needs the relevant policy data
 before it can decide a write's fate. It therefore must defer fate assignment
 until the relevant **permission-scope subscription** has settled; until then it
-stores the unit as pending relay history and defers (`INV-SYNC-18`).
+retains the unit only in its in-memory deferred-admission state, outside edge
+history (`INV-SYNC-18`). Once the scope settles, the edge ingests the authorized
+unit exactly once and routes its edge fate; a denied unit is rejected without
+being ingested.
 
 A permission-scope subscription is an _upstream_ subscription opened by the edge
 against core for the policy data required by its acceptance gate. It is keyed by

--- a/crates/jazz/SPEC/9_topology_edge.md
+++ b/crates/jazz/SPEC/9_topology_edge.md
@@ -20,7 +20,7 @@ Invariant digest:
 - `INV-EDGE-1`: A `PeerRole::Relay` link MUST use `AuthorSubject::SYSTEM` as its link identity and MUST NOT terminate a client identity.
 - `INV-EDGE-2`: A relay MUST store/forward `TxKind::Mergeable` and `TxKind::Exclusive` commit units as `Fate::Pending` with `DurabilityTier::Local` and MUST NOT assign an authority fate.
 - `INV-EDGE-3`: An edge-client link MUST terminate exactly one client author identity as `PeerRole::ClientLink { identity }`, and downstream reads on that link MUST use that identity for policy composition.
-- `INV-EDGE-4`: An edge MUST NOT assign a mergeable fate until the needed permission-scope subscription has delivered an initial settled result; before that, the transaction MUST remain pending and deferred.
+- `INV-EDGE-4`: An edge MUST NOT assign a mergeable fate until the needed permission-scope subscription has delivered an initial settled result; before that, the transaction MUST remain outside edge history in in-memory deferred-admission state. Once settled, an authorized transaction is ingested and edge-accepted exactly once; a denied transaction is rejected without ingestion.
 - `INV-EDGE-5`: Edge-local fate assignment MUST support only `TxKind::Mergeable`; an edge MUST NOT use the edge mergeable path to assign fate for `TxKind::Exclusive`.
 - `INV-EDGE-6`: `TxKind::Exclusive` acceptance MUST be decided by core, the serialization point; edge authority MUST NOT make exclusive acceptance final.
 - `INV-EDGE-7`: Once a transaction reaches `Fate::Accepted`, later stale `Fate::Pending` updates MUST NOT regress its fate.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1998,6 +1998,11 @@ struct AuthorizationScopeLeaseRequest {
     /// Every local caller sharing this authority hydration.  The first id is
     /// the wire correlation id; later ids never cause another support view.
     waiters: BTreeSet<PermissionAdviceRequestId>,
+    /// The authority has accepted the one-shot wire intent. Until then the
+    /// upstream command remains pending and must retry after backpressure;
+    /// merely allocating this local lease must not make a later tick mistake
+    /// it for an already-sent hydration request.
+    intent_sent: bool,
     key: Option<crate::protocol::AuthorizationSupportScopeKey>,
     lease: Option<AuthorizationScopeLease>,
     owner: Option<AuthorizationScopeOwnerToken>,

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -54,7 +54,7 @@ use crate::protocol::{
     CurrentWriteSchema, LensOp, MigrationLens, PermissionAdviceAction, PermissionAdviceRequestId,
     ReadViewKey, ReadViewSourceSpec, ReadViewSpec, RegisterShapeOptions, SchemaLineagePublication,
     SchemaVersion, ShapeAst, Subscribe, SubscribeRejectReason, SubscribeServerFailureCode,
-    SubscriptionKey, SyncMessage, TableLens,
+    SubscriptionKey, SyncMessage, TableLens, VersionRecord,
 };
 use crate::protocol_limits::{
     validate_fetch_row_versions, validate_known_state_declaration, validate_shape_registration_size,
@@ -73,7 +73,7 @@ use crate::schema::{JazzSchema, TableSchema};
 use crate::time::GlobalTime;
 use crate::tools::OpenTransactionId;
 use crate::tools::{ObjectId, OutputOccurrenceId, ResultKey, TransactionId};
-use crate::tx::{DeletionEvent, DurabilityTier, Fate, RejectionReason, TxId, TxKind};
+use crate::tx::{DeletionEvent, DurabilityTier, Fate, RejectionReason, Transaction, TxId, TxKind};
 use crate::wire::{TransportError, WireAuthorityEndpoint, WireFeatures, encode_sync_message};
 
 mod wire_transport;
@@ -1513,7 +1513,40 @@ struct EdgeFateRoute {
     /// routable through the same retained obligation.
     edge_acknowledged: bool,
 }
-type EdgeFateRoutes = Rc<RefCell<BTreeMap<TxId, Vec<EdgeFateRoute>>>>;
+
+/// The immutable identity of a client commit while its edge fate obligation is
+/// live.  An edge intentionally keeps a pre-proof upload out of durable
+/// transaction history, but it must still enforce history's one-payload-per-id
+/// rule across all client connections.  Normalize version order here because
+/// transport ordering is not semantically meaningful.
+#[derive(Clone, Debug)]
+struct EdgeFateCommitIdentity {
+    tx: Transaction,
+    versions: Vec<VersionRecord>,
+}
+
+impl EdgeFateCommitIdentity {
+    fn new(tx: &Transaction, versions: &[VersionRecord]) -> Self {
+        let mut versions = versions.to_vec();
+        versions.sort();
+        Self {
+            tx: tx.clone(),
+            versions,
+        }
+    }
+
+    fn matches(&self, other: &Self) -> bool {
+        self.tx == other.tx && self.versions == other.versions
+    }
+}
+
+/// The shared edge obligation for one transaction.
+struct EdgeFateObligation {
+    identity: EdgeFateCommitIdentity,
+    routes: Vec<EdgeFateRoute>,
+}
+
+type EdgeFateRoutes = Rc<RefCell<BTreeMap<TxId, EdgeFateObligation>>>;
 
 struct LocalFateRoute {
     queue: Weak<RefCell<Vec<SyncMessage>>>,
@@ -1627,10 +1660,10 @@ fn route_edge_admission_fate(routes: &EdgeFateRoutes, tx_id: TxId, fate: &SyncMe
         }
     );
     let mut routes = routes.borrow_mut();
-    let Some(pending) = routes.get_mut(&tx_id) else {
+    let Some(obligation) = routes.get_mut(&tx_id) else {
         return;
     };
-    pending.retain_mut(|route| {
+    obligation.routes.retain_mut(|route| {
         let Some(queue) = route.queue.upgrade() else {
             return false;
         };
@@ -1640,7 +1673,7 @@ fn route_edge_admission_fate(routes: &EdgeFateRoutes, tx_id: TxId, fate: &SyncMe
         }
         !terminal
     });
-    if pending.is_empty() {
+    if obligation.routes.is_empty() {
         routes.remove(&tx_id);
     }
 }
@@ -1680,11 +1713,11 @@ where
 /// dead subscriber queues) eagerly: retaining a weak queue alone would let
 /// arbitrary uploads grow this registry forever.
 fn prune_edge_fate_routes(
-    routes: &mut BTreeMap<TxId, Vec<EdgeFateRoute>>,
+    routes: &mut BTreeMap<TxId, EdgeFateObligation>,
     admitted: Option<AuthorityContext>,
 ) {
-    routes.retain(|_, pending| {
-        pending.retain(|route| {
+    routes.retain(|_, obligation| {
+        obligation.routes.retain(|route| {
             route.queue.upgrade().is_some()
                 && match (route.authority, admitted) {
                     (None, _) => true,
@@ -1692,7 +1725,7 @@ fn prune_edge_fate_routes(
                     (Some(_), None) => false,
                 }
         });
-        !pending.is_empty()
+        !obligation.routes.is_empty()
     });
 }
 type SharedMutationErrors = Rc<RefCell<MutationErrorState>>;

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1508,6 +1508,10 @@ struct PendingAuthorityViewUpdate {
 struct EdgeFateRoute {
     authority: Option<AuthorityContext>,
     queue: Weak<RefCell<Vec<SyncMessage>>>,
+    /// The edge-local acceptance has already been emitted to this exact
+    /// downstream session.  The later Core terminal fate remains separately
+    /// routable through the same retained obligation.
+    edge_acknowledged: bool,
 }
 type EdgeFateRoutes = Rc<RefCell<BTreeMap<TxId, Vec<EdgeFateRoute>>>>;
 
@@ -1602,6 +1606,38 @@ fn route_local_fate(routes: &LocalFateRoutes, tx_id: TxId, fate: &SyncMessage) {
             return false;
         };
         queue.borrow_mut().push(fate.clone());
+        !terminal
+    });
+    if pending.is_empty() {
+        routes.remove(&tx_id);
+    }
+}
+
+/// Deliver the edge's own admission fate through the same route registry that
+/// later carries the selected Core fate.  This avoids a direct-response path
+/// that would acknowledge only the tick currently handling the upload (and
+/// would duplicate a retransmitted upload), while a rejection retires the
+/// obligation because there is no admitted unit for Core to settle.
+fn route_edge_admission_fate(routes: &EdgeFateRoutes, tx_id: TxId, fate: &SyncMessage) {
+    let terminal = matches!(
+        fate,
+        SyncMessage::FateUpdate {
+            fate: Fate::Rejected(_),
+            ..
+        }
+    );
+    let mut routes = routes.borrow_mut();
+    let Some(pending) = routes.get_mut(&tx_id) else {
+        return;
+    };
+    pending.retain_mut(|route| {
+        let Some(queue) = route.queue.upgrade() else {
+            return false;
+        };
+        if terminal || !route.edge_acknowledged {
+            queue.borrow_mut().push(fate.clone());
+            route.edge_acknowledged = true;
+        }
         !terminal
     });
     if pending.is_empty() {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1266,22 +1266,51 @@ where
         let mut connection_ref = connection.borrow_mut();
         let connection_epoch = connection_ref.connection_epoch;
         let upstream_upload_destination = connection_ref.upstream_upload_destination;
+        let mut reconnect_permission_advice = Vec::new();
         let (authority, upstream_epoch, transferable_uploads, retired_relay_subscriptions) =
             match &mut connection_ref.link {
                 ConnectionLink::Upstream(UpstreamConnectionState {
                     expected_scope_authority,
                     large_value_uploads,
                     awaiting_large_value_uploads,
+                    pending,
+                    scope_lease_manager,
                     ..
-                }) => (
-                    *expected_scope_authority,
-                    Some(connection_epoch),
-                    Some(peer_connection::take_reconnectable_large_value_uploads(
-                        large_value_uploads,
-                        awaiting_large_value_uploads,
-                    )),
-                    Vec::new(),
-                ),
+                }) => {
+                    // Permission-advice futures outlive one transport. Rebuild
+                    // their link-local scope bookkeeping on the successor,
+                    // one command per live waiter so identical actions can
+                    // coalesce under its fresh authority context and wire id.
+                    let live_waiters = self.permission_advice_waiters.borrow();
+                    let mut queued = BTreeSet::new();
+                    for command in pending.iter() {
+                        let PendingUpstreamCommand::AuthorizationScopeIntent { request_id, action } =
+                            command
+                        else {
+                            continue;
+                        };
+                        if live_waiters.contains_key(request_id) && queued.insert(*request_id) {
+                            reconnect_permission_advice.push((*request_id, action.clone()));
+                        }
+                    }
+                    for request in scope_lease_manager.requests.values() {
+                        for request_id in &request.waiters {
+                            if live_waiters.contains_key(request_id) && queued.insert(*request_id) {
+                                reconnect_permission_advice
+                                    .push((*request_id, request.action.clone()));
+                            }
+                        }
+                    }
+                    (
+                        *expected_scope_authority,
+                        Some(connection_epoch),
+                        Some(peer_connection::take_reconnectable_large_value_uploads(
+                            large_value_uploads,
+                            awaiting_large_value_uploads,
+                        )),
+                        Vec::new(),
+                    )
+                }
                 ConnectionLink::Subscriber(SubscriberConnectionState {
                     peer,
                     served,
@@ -1341,6 +1370,19 @@ where
                 retired_relay_subscriptions
                     .into_iter()
                     .map(|(subscription, _)| PendingUpstreamCommand::Unsubscribe(subscription)),
+            );
+            self.schedule_tick(TickUrgency::Immediate);
+        }
+        if !reconnect_permission_advice.is_empty() {
+            self.upstream_subscriptions.borrow_mut().extend(
+                reconnect_permission_advice
+                    .into_iter()
+                    .map(
+                        |(request_id, action)| PendingUpstreamCommand::AuthorizationScopeIntent {
+                            request_id,
+                            action,
+                        },
+                    ),
             );
             self.schedule_tick(TickUrgency::Immediate);
         }

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -810,8 +810,8 @@ where
                 // this newly connected successor has not seen it.
                 let mut routes = self.edge_fate_routes.borrow_mut();
                 let routed_txs = routes.keys().copied().collect::<Vec<_>>();
-                for pending in routes.values_mut() {
-                    for route in pending.iter_mut() {
+                for obligation in routes.values_mut() {
+                    for route in obligation.routes.iter_mut() {
                         route.authority = Some(context);
                     }
                 }
@@ -1406,14 +1406,16 @@ where
                 *self.admitted_upstream_authority.borrow_mut() = handoff;
                 let mut routes = self.edge_fate_routes.borrow_mut();
                 if let Some(handoff) = handoff {
-                    routes.retain(|_, pending| {
-                        pending.retain(|route| route.queue.upgrade().is_some());
-                        for route in pending.iter_mut() {
+                    routes.retain(|_, obligation| {
+                        obligation
+                            .routes
+                            .retain(|route| route.queue.upgrade().is_some());
+                        for route in obligation.routes.iter_mut() {
                             if route.authority == Some(authority) {
                                 route.authority = Some(handoff);
                             }
                         }
-                        !pending.is_empty()
+                        !obligation.routes.is_empty()
                     });
                     let routed_txs = routes.keys().copied().collect::<Vec<_>>();
                     drop(routes);
@@ -1451,14 +1453,16 @@ where
                     // No successor yet: preserve bounded live downstream
                     // routes for a later admitted authority.  Clearing them
                     // after an Edge acceptance would strand the caller.
-                    routes.retain(|_, pending| {
-                        pending.retain(|route| route.queue.upgrade().is_some());
-                        for route in pending.iter_mut() {
+                    routes.retain(|_, obligation| {
+                        obligation
+                            .routes
+                            .retain(|route| route.queue.upgrade().is_some());
+                        for route in obligation.routes.iter_mut() {
                             if route.authority == Some(authority) {
                                 route.authority = None;
                             }
                         }
-                        !pending.is_empty()
+                        !obligation.routes.is_empty()
                     });
                     self.schedule_tick(TickUrgency::Immediate);
                 }

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -124,7 +124,7 @@ where
 /// seam. `PeerConnection::tick` otherwise contains the complete futures for
 /// every message variant inline, and authority policy evaluation can exhaust a
 /// normal test-thread stack before doing any recursive work.
-fn dispatch_admitted_subscriber_message<'a, S>(
+pub(super) fn dispatch_admitted_subscriber_message<'a, S>(
     node: &'a SharedNodeState<S>,
     peer: &'a mut PeerState,
     local_receiver: bool,
@@ -171,71 +171,94 @@ where
                 }
 
                 let tx_id = tx.tx_id;
-                let route_registered =
-                    if let Some(authority) = *admitted_upstream_authority.borrow() {
-                        let mut routes = edge_fate_routes.borrow_mut();
-                        prune_edge_fate_routes(&mut routes, Some(authority));
-                        let route_count = routes.values().map(Vec::len).sum::<usize>();
-                        let pending = routes.get(&tx_id);
-                        let already_routed = pending.is_some_and(|pending| {
-                            pending.iter().any(|route| {
-                                route
-                                    .authority
-                                    .is_some_and(|route| route.same_admitted_link(authority))
-                                    && route
-                                        .queue
-                                        .upgrade()
-                                        .is_some_and(|queue| Rc::ptr_eq(&queue, downstream_fates))
-                            })
-                        });
-                        if already_routed {
+                let identity = EdgeFateCommitIdentity::new(&tx, &versions);
+                let route_registered = if let Some(authority) =
+                    *admitted_upstream_authority.borrow()
+                {
+                    let mut routes = edge_fate_routes.borrow_mut();
+                    prune_edge_fate_routes(&mut routes, Some(authority));
+                    let route_count = routes
+                        .values()
+                        .map(|obligation| obligation.routes.len())
+                        .sum::<usize>();
+                    let existing = routes.get(&tx_id);
+                    if existing.is_some_and(|obligation| !obligation.identity.matches(&identity)) {
+                        return Err(crate::node::Error::ConflictingCommitUnit(tx_id).into());
+                    }
+                    let already_routed = existing.is_some_and(|obligation| {
+                        obligation.routes.iter().any(|route| {
+                            route
+                                .authority
+                                .is_some_and(|route| route.same_admitted_link(authority))
+                                && route
+                                    .queue
+                                    .upgrade()
+                                    .is_some_and(|queue| Rc::ptr_eq(&queue, downstream_fates))
+                        })
+                    });
+                    if already_routed {
+                        true
+                    } else if route_count < MAX_EDGE_FATE_ROUTES {
+                        let obligation =
+                            routes.entry(tx_id).or_insert_with(|| EdgeFateObligation {
+                                identity: identity.clone(),
+                                routes: Vec::new(),
+                            });
+                        if obligation.routes.len() < MAX_EDGE_FATE_ROUTES_PER_TX {
+                            obligation.routes.push(EdgeFateRoute {
+                                authority: Some(authority),
+                                queue: Rc::downgrade(downstream_fates),
+                                edge_acknowledged: false,
+                            });
                             true
-                        } else if route_count < MAX_EDGE_FATE_ROUTES {
-                            let pending = routes.entry(tx_id).or_default();
-                            if pending.len() < MAX_EDGE_FATE_ROUTES_PER_TX {
-                                pending.push(EdgeFateRoute {
-                                    authority: Some(authority),
-                                    queue: Rc::downgrade(downstream_fates),
-                                    edge_acknowledged: false,
-                                });
-                                true
-                            } else {
-                                false
-                            }
                         } else {
                             false
                         }
                     } else {
-                        let mut routes = edge_fate_routes.borrow_mut();
-                        prune_edge_fate_routes(&mut routes, None);
-                        let already_routed = routes.get(&tx_id).is_some_and(|pending| {
-                            pending.iter().any(|route| {
-                                route.authority.is_none()
-                                    && route
-                                        .queue
-                                        .upgrade()
-                                        .is_some_and(|queue| Rc::ptr_eq(&queue, downstream_fates))
-                            })
-                        });
-                        let route_count = routes.values().map(Vec::len).sum::<usize>();
-                        if already_routed {
-                            true
-                        } else if route_count >= MAX_EDGE_FATE_ROUTES {
+                        false
+                    }
+                } else {
+                    let mut routes = edge_fate_routes.borrow_mut();
+                    prune_edge_fate_routes(&mut routes, None);
+                    let existing = routes.get(&tx_id);
+                    if existing.is_some_and(|obligation| !obligation.identity.matches(&identity)) {
+                        return Err(crate::node::Error::ConflictingCommitUnit(tx_id).into());
+                    }
+                    let already_routed = existing.is_some_and(|obligation| {
+                        obligation.routes.iter().any(|route| {
+                            route.authority.is_none()
+                                && route
+                                    .queue
+                                    .upgrade()
+                                    .is_some_and(|queue| Rc::ptr_eq(&queue, downstream_fates))
+                        })
+                    });
+                    let route_count = routes
+                        .values()
+                        .map(|obligation| obligation.routes.len())
+                        .sum::<usize>();
+                    if already_routed {
+                        true
+                    } else if route_count >= MAX_EDGE_FATE_ROUTES {
+                        false
+                    } else {
+                        let obligation =
+                            routes.entry(tx_id).or_insert_with(|| EdgeFateObligation {
+                                identity: identity.clone(),
+                                routes: Vec::new(),
+                            });
+                        if obligation.routes.len() >= MAX_EDGE_FATE_ROUTES_PER_TX {
                             false
                         } else {
-                            let pending = routes.entry(tx_id).or_default();
-                            if pending.len() >= MAX_EDGE_FATE_ROUTES_PER_TX {
-                                false
-                            } else {
-                                pending.push(EdgeFateRoute {
-                                    authority: None,
-                                    queue: Rc::downgrade(downstream_fates),
-                                    edge_acknowledged: false,
-                                });
-                                true
-                            }
+                            obligation.routes.push(EdgeFateRoute {
+                                authority: None,
+                                queue: Rc::downgrade(downstream_fates),
+                                edge_acknowledged: false,
+                            });
+                            true
                         }
-                    };
+                    }
+                };
 
                 if !route_registered {
                     return Ok(PublicationOutcome::settled(vec![SyncMessage::FateUpdate {
@@ -2211,9 +2234,9 @@ where
                                 if let Some((tx_id, fate)) = routed_fate {
                                     let authority = *expected_scope_authority;
                                     let mut routes = self.edge_fate_routes.borrow_mut();
-                                    if let Some(pending) = routes.get_mut(&tx_id) {
+                                    if let Some(obligation) = routes.get_mut(&tx_id) {
                                         let mut remaining = Vec::new();
-                                        for route in std::mem::take(pending) {
+                                        for route in std::mem::take(&mut obligation.routes) {
                                             let authority_matches = matches!(
                                                 (route.authority, authority),
                                                 (Some(route), Some(authority))
@@ -2231,9 +2254,10 @@ where
                                         if remaining.is_empty() {
                                             routes.remove(&tx_id);
                                         } else {
-                                            *routes
+                                            let obligation = routes
                                                 .get_mut(&tx_id)
-                                                .expect("route remains present") = remaining;
+                                                .expect("route remains present");
+                                            obligation.routes = remaining;
                                         }
                                     }
                                     drop(routes);

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -3455,6 +3455,7 @@ where
                             &self.node,
                             &self.subscriptions,
                             &self.active_authority_view_receipts,
+                            progress_waker.as_ref(),
                             outcome,
                             false,
                         )

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1338,6 +1338,7 @@ where
                                             });
                                         if !has_live_waiter {
                                             scope_lease_manager.requests.remove(request_id);
+                                            pending.remove(pending_index);
                                             continue;
                                         }
                                         let existing = scope_lease_manager

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -133,6 +133,7 @@ fn dispatch_admitted_subscriber_message<'a, S>(
     edge_fate_routes: &'a EdgeFateRoutes,
     local_fate_routes: &'a LocalFateRoutes,
     downstream_fates: &'a PendingDownstreamFates,
+    now_ms: u64,
     message: SyncMessage,
 ) -> Pin<Box<dyn Future<Output = Result<PublicationOutcome<Vec<SyncMessage>>, Error>> + 'a>>
 where
@@ -195,6 +196,7 @@ where
                                 pending.push(EdgeFateRoute {
                                     authority: Some(authority),
                                     queue: Rc::downgrade(downstream_fates),
+                                    edge_acknowledged: false,
                                 });
                                 true
                             } else {
@@ -228,6 +230,7 @@ where
                                 pending.push(EdgeFateRoute {
                                     authority: None,
                                     queue: Rc::downgrade(downstream_fates),
+                                    edge_acknowledged: false,
                                 });
                                 true
                             }
@@ -245,16 +248,25 @@ where
                     }]));
                 }
 
-                node.lock()
+                let mut node = node.lock().await;
+                let outcome = peer
+                    .ingest_edge_mergeable_commit_unit(&mut node, tx, versions, now_ms)
                     .await
-                    .ingest_relay_commit_unit(tx, versions)
-                    .await?;
-                Ok(PublicationOutcome::settled(vec![SyncMessage::FateUpdate {
-                    tx_id,
-                    fate: Fate::Accepted,
-                    global_time: None,
-                    durability: Some(DurabilityTier::Edge),
-                }]))
+                    .map_err(Error::from)?;
+                let (responses, publications, post_settlement_work) = outcome.into_parts();
+                let mut direct_responses = Vec::new();
+                for response in responses {
+                    if matches!(response, SyncMessage::FateUpdate { .. }) {
+                        route_edge_admission_fate(edge_fate_routes, tx_id, &response);
+                    } else {
+                        direct_responses.push(response);
+                    }
+                }
+                Ok(PublicationOutcome {
+                    value: direct_responses,
+                    publications,
+                    post_settlement_work,
+                })
             }
             SyncMessage::CommitUnit { tx, versions }
                 if tx.kind == TxKind::Mergeable
@@ -3222,9 +3234,18 @@ where
                                 drop_peer_request(&self.node);
                                 continue;
                             }
+                            let edge_client_upload = matches!(
+                                &other,
+                                SyncMessage::CommitUnit { tx, .. } if tx.kind == TxKind::Mergeable
+                            ) && ingest_context.edge_authority
+                                && matches!(peer.role(), PeerRole::ClientLink { .. });
+                            let edge_upload = edge_client_upload.then(|| match &other {
+                                SyncMessage::CommitUnit { tx, .. } => (tx.tx_id, other.clone()),
+                                _ => unreachable!("edge upload was matched as a commit unit"),
+                            });
                             let local_upload = match &other {
                                 SyncMessage::CommitUnit { tx, .. } => {
-                                    Some((tx.tx_id, other.clone()))
+                                    (!edge_client_upload).then(|| (tx.tx_id, other.clone()))
                                 }
                                 _ => None,
                             };
@@ -3252,6 +3273,7 @@ where
                             // binding), plus the write-upload path: any
                             // responses (e.g. fate updates) flow back to the
                             // subscriber.
+                            let now_ms = self.upload_retry_clock.borrow().now_ms();
                             let outcome = dispatch_admitted_subscriber_message(
                                 &self.node,
                                 peer,
@@ -3261,6 +3283,7 @@ where
                                 &self.edge_fate_routes,
                                 &self.local_fate_routes,
                                 &self.downstream_fates,
+                                now_ms,
                                 other,
                             )
                             .await?;
@@ -3296,6 +3319,28 @@ where
                                     )?;
                                 }
                             }
+                            if let Some((tx_id, unit)) = edge_upload {
+                                let admitted = self
+                                    .node
+                                    .lock()
+                                    .await
+                                    .transaction_state(tx_id)
+                                    .await
+                                    .is_some_and(|(fate, _, durability)| {
+                                        fate == Fate::Accepted
+                                            && durability >= DurabilityTier::Edge
+                                    });
+                                if admitted {
+                                    let mut outbox = outbox.borrow_mut();
+                                    if !outbox.iter().any(|pending| pending.tx_id == tx_id) {
+                                        outbox.push(PendingUpload {
+                                            tx_id,
+                                            unit: Some(unit),
+                                        });
+                                        schedule_tick_in(&self.scheduler, TickUrgency::Deferred);
+                                    }
+                                }
+                            }
                             if let Some((tx_id, unit)) = local_upload {
                                 let mut outbox = outbox.borrow_mut();
                                 if outbox.push(PendingUpload {
@@ -3305,6 +3350,74 @@ where
                                     schedule_tick_in(&self.scheduler, TickUrgency::Deferred);
                                 }
                             }
+                        }
+                    }
+                }
+                // A client upload arriving before its action-specific support
+                // view settles is retained by `PeerState`, not optimistically
+                // inserted into edge history.  Drive that state on every
+                // served-connection turn: the receipt/view may have settled
+                // immediately before or immediately after the original
+                // registration, and all pending commits must make fair
+                // progress without requiring unrelated inbound traffic.
+                if ingest_context.edge_authority
+                    && matches!(peer.role(), PeerRole::ClientLink { .. })
+                {
+                    let now_ms = self.upload_retry_clock.borrow().now_ms();
+                    let outcome = {
+                        let mut node = self.node.lock().await;
+                        peer.drain_deferred_edge_fates(&mut node, now_ms)
+                        .await
+                        .map_err(Error::from)?
+                    };
+                    let (responses, changed, published) =
+                        finish_peer_publication_outcome_with_refresh(
+                            &self.node,
+                            &self.subscriptions,
+                            &self.active_authority_view_receipts,
+                            outcome,
+                            false,
+                        )
+                        .await?;
+                    stats.subscription_events += changed;
+                    needs_subscription_refresh |= published;
+                    let admitted = responses
+                        .iter()
+                        .filter_map(|response| match response {
+                            SyncMessage::FateUpdate {
+                                tx_id,
+                                fate: Fate::Accepted,
+                                durability: Some(durability),
+                                ..
+                            } if *durability >= DurabilityTier::Edge => Some(*tx_id),
+                            _ => None,
+                        })
+                        .collect::<BTreeSet<_>>();
+                    for response in responses {
+                        if let SyncMessage::FateUpdate { tx_id, .. } = &response {
+                            route_edge_admission_fate(
+                                &self.edge_fate_routes,
+                                *tx_id,
+                                &response,
+                            );
+                        } else {
+                            send_with_sync_context(
+                                &self.node,
+                                peer,
+                                self.transport.as_mut(),
+                                response,
+                            )?;
+                        }
+                    }
+                    for tx_id in admitted {
+                        let unit = self.node.lock().await.commit_unit_for(tx_id).await?;
+                        let mut outbox = outbox.borrow_mut();
+                        if !outbox.iter().any(|pending| pending.tx_id == tx_id) {
+                            outbox.push(PendingUpload {
+                                tx_id,
+                                unit: Some(unit),
+                            });
+                            schedule_tick_in(&self.scheduler, TickUrgency::Deferred);
                         }
                     }
                 }

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1308,27 +1308,76 @@ where
                                     // An old or unauthenticated upstream must never receive a
                                     // downgraded preflight.  Resolve conservatively instead.
                                     if expected_scope_authority.is_none() {
-                                        self.permission_advice_waiters
-                                            .borrow_mut()
-                                            .remove(request_id);
-                                        scope_lease_manager.requests.remove(request_id);
-                                    } else if self
-                                        .permission_advice_waiters
-                                        .borrow()
-                                        .contains_key(request_id)
-                                    {
-                                        if let Some(existing) = scope_lease_manager
-                                            .requests
-                                            .values_mut()
-                                            .find(|request| request.action == *action)
+                                        if let Some(request) =
+                                            scope_lease_manager.requests.remove(request_id)
                                         {
-                                            existing.waiters.insert(*request_id);
+                                            let mut waiters = self.permission_advice_waiters.borrow_mut();
+                                            for waiter_id in request.waiters {
+                                                waiters.remove(&waiter_id);
+                                            }
+                                        } else {
+                                            self.permission_advice_waiters
+                                                .borrow_mut()
+                                                .remove(request_id);
+                                        }
+                                    } else {
+                                        let has_live_waiter = scope_lease_manager
+                                            .requests
+                                            .get(request_id)
+                                            .map(|request| {
+                                                let waiters = self.permission_advice_waiters.borrow();
+                                                request
+                                                    .waiters
+                                                    .iter()
+                                                    .any(|waiter_id| waiters.contains_key(waiter_id))
+                                            })
+                                            .unwrap_or_else(|| {
+                                                self.permission_advice_waiters
+                                                    .borrow()
+                                                    .contains_key(request_id)
+                                            });
+                                        if !has_live_waiter {
+                                            scope_lease_manager.requests.remove(request_id);
+                                            continue;
+                                        }
+                                        let existing = scope_lease_manager
+                                            .requests
+                                            .iter()
+                                            .find(|(_, request)| request.action == *action)
+                                            .map(|(wire_request_id, request)| {
+                                                (*wire_request_id, request.intent_sent)
+                                            });
+                                        if let Some((wire_request_id, intent_sent)) = existing {
+                                            let request = scope_lease_manager
+                                                .requests
+                                                .get_mut(&wire_request_id)
+                                                .expect("authorization scope request still exists");
+                                            request.waiters.insert(*request_id);
+                                            if !intent_sent {
+                                                if let Err(error) = self.transport.send(
+                                                    SyncMessage::AuthorizationScopeIntent {
+                                                        request_id: wire_request_id,
+                                                        action: request.action.clone(),
+                                                    },
+                                                ) {
+                                                    if handle_transport_backpressure(
+                                                        &self.node,
+                                                        &self.scheduler,
+                                                        &error,
+                                                    ) {
+                                                        return Ok(true);
+                                                    }
+                                                    return Err(transport_error(error));
+                                                }
+                                                request.intent_sent = true;
+                                            }
                                         } else {
                                             scope_lease_manager.requests.insert(
                                                 *request_id,
                                                 AuthorizationScopeLeaseRequest {
                                                     action: action.clone(),
                                                     waiters: BTreeSet::from([*request_id]),
+                                                    intent_sent: false,
                                                     key: None,
                                                     lease: None,
                                                     owner: None,
@@ -1351,6 +1400,11 @@ where
                                                 }
                                                 return Err(transport_error(error));
                                             }
+                                            scope_lease_manager
+                                                .requests
+                                                .get_mut(request_id)
+                                                .expect("inserted authorization scope request")
+                                                .intent_sent = true;
                                         }
                                     }
                                 }
@@ -2035,6 +2089,7 @@ where
                                         AuthorizationScopeLeaseRequest {
                                             action: action.clone(),
                                             waiters,
+                                            intent_sent: false,
                                             key: None,
                                             lease: None,
                                             owner: None,

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -1,7 +1,9 @@
 //! Link admission, authority selection, permission advice, and routed fates.
 
 use super::*;
-use crate::db::peer_connection::{ConnectionLink, PendingSubscriberControlResponse};
+use crate::db::peer_connection::{
+    dispatch_admitted_subscriber_message, ConnectionLink, PendingSubscriberControlResponse,
+};
 use crate::node::SKEW_TOLERANCE_MS;
 
 #[test]
@@ -1052,6 +1054,141 @@ fn edge_client_ingress_proves_actions_before_one_routed_edge_fate() {
     );
 }
 
+/// An edge route is server-owned rather than connection-owned: a reconnecting
+/// client may retransmit its exact unit and receive the already-known edge
+/// acceptance, but another connection cannot replace a still-live obligation
+/// with different bytes for the same transaction id.
+///
+/// This stays at the served-peer seam because two authenticated subscriber
+/// connections and their in-memory downstream queues are the boundary where
+/// the otherwise durable transaction identity is deliberately absent while an
+/// edge fate route is live.
+#[test]
+fn edge_fate_route_identity_is_shared_across_client_connections() {
+    let schema = schema();
+    let alice = AuthorSubject::for_test_bytes([0xa1; 16]);
+    let client = open_db(0xa1, alice, &schema);
+    let edge = open_core(0xe0, AuthorSubject::SYSTEM, &schema);
+    let write = client
+        .insert(
+            "todos",
+            BTreeMap::from([("title".to_owned(), Value::String("identity".to_owned()))]),
+            Default::default(),
+        )
+        .unwrap();
+    let tx_id = write.mergeable_tx_id();
+    let SyncMessage::CommitUnit { tx, versions } = client
+        .node
+        .node
+        .borrow_mut()
+        .commit_unit_for(tx_id)
+        .unwrap()
+    else {
+        panic!("client mergeable write must retain its commit unit");
+    };
+
+    let node = edge.node();
+    let mut first = PeerState::edge_client(alice);
+    let mut reconnect = PeerState::edge_client(alice);
+    let authority: Rc<RefCell<Option<AuthorityContext>>> = Rc::new(RefCell::new(None));
+    let local_routes: LocalFateRoutes = Rc::new(RefCell::new(BTreeMap::new()));
+    let first_fates = Rc::new(RefCell::new(Vec::new()));
+    let reconnect_fates = Rc::new(RefCell::new(Vec::new()));
+    let context = CommitUnitIngestContext {
+        identity: alice,
+        trust: CommitUnitTrust::Session,
+        edge_authority: true,
+    };
+
+    let first_outcome = crate::db::block_on(dispatch_admitted_subscriber_message(
+        &node,
+        &mut first,
+        false,
+        context,
+        &authority,
+        &edge.server.edge_fate_routes,
+        &local_routes,
+        &first_fates,
+        1,
+        SyncMessage::CommitUnit {
+            tx: tx.clone(),
+            versions: versions.clone(),
+        },
+    ))
+    .expect("first client-link upload is admitted");
+    assert!(first_outcome.value.is_empty());
+    assert!(matches!(
+        first_fates.borrow().as_slice(),
+        [SyncMessage::FateUpdate {
+            tx_id: candidate,
+            fate: Fate::Accepted,
+            durability: Some(DurabilityTier::Edge),
+            ..
+        }] if *candidate == tx_id
+    ));
+
+    let mut conflicting = tx.clone();
+    conflicting.n_total_writes = conflicting.n_total_writes.saturating_add(1);
+    assert!(
+        crate::db::block_on(dispatch_admitted_subscriber_message(
+            &node,
+            &mut reconnect,
+            false,
+            context,
+            &authority,
+            &edge.server.edge_fate_routes,
+            &local_routes,
+            &reconnect_fates,
+            1,
+            SyncMessage::CommitUnit {
+                tx: conflicting,
+                versions: versions.clone(),
+            },
+        ))
+        .is_err()
+    );
+    assert_eq!(
+        edge.server.edge_fate_routes.borrow()[&tx_id].routes.len(),
+        1,
+        "a conflicting second connection is rejected before it gains a fate route"
+    );
+    assert!(reconnect_fates.borrow().is_empty());
+
+    let retry_outcome = crate::db::block_on(dispatch_admitted_subscriber_message(
+        &node,
+        &mut reconnect,
+        false,
+        context,
+        &authority,
+        &edge.server.edge_fate_routes,
+        &local_routes,
+        &reconnect_fates,
+        2,
+        SyncMessage::CommitUnit { tx, versions },
+    ))
+    .expect("an exact reconnect retransmit reuses the route obligation");
+    assert!(retry_outcome.value.is_empty());
+    assert_eq!(
+        edge.server.edge_fate_routes.borrow()[&tx_id].routes.len(),
+        2,
+        "the reconnect gets one route without replacing the original obligation"
+    );
+    assert_eq!(
+        first_fates.borrow().len(),
+        1,
+        "an exact reconnect retransmit must not duplicate the old session's edge fate"
+    );
+    assert!(matches!(
+        reconnect_fates.borrow().as_slice(),
+        [SyncMessage::FateUpdate {
+            tx_id: candidate,
+            fate: Fate::Accepted,
+            durability: Some(DurabilityTier::Edge),
+            ..
+        }] if *candidate == tx_id
+    ));
+}
+
 #[test]
 fn concurrent_upstreams_keep_selected_owner_until_detach_handoff() {
     let schema = schema();
@@ -1088,14 +1225,22 @@ fn concurrent_upstreams_keep_selected_owner_until_detach_handoff() {
             MergeableCommit::new("todos", row(0x91), 1).cells(cells("handoff", false, identity)),
         )
         .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } =
+        edge.node().borrow_mut().commit_unit_for(tx_id).unwrap()
+    else {
+        panic!("settled mergeable write must retain its commit unit");
+    };
     let queue = Rc::new(RefCell::new(Vec::new()));
     edge.server.edge_fate_routes.borrow_mut().insert(
         tx_id,
-        vec![EdgeFateRoute {
-            authority: Some(first.unwrap()),
-            queue: Rc::downgrade(&queue),
-            edge_acknowledged: false,
-        }],
+        EdgeFateObligation {
+            identity: EdgeFateCommitIdentity::new(&tx, &versions),
+            routes: vec![EdgeFateRoute {
+                authority: Some(first.unwrap()),
+                queue: Rc::downgrade(&queue),
+                edge_acknowledged: false,
+            }],
+        },
     );
     assert!(edge.server.detach_connection(&a));
     assert_ne!(
@@ -1105,7 +1250,7 @@ fn concurrent_upstreams_keep_selected_owner_until_detach_handoff() {
     );
     let handoff = edge.server.admitted_upstream_authority.borrow().unwrap();
     assert_eq!(
-        edge.server.edge_fate_routes.borrow()[&tx_id][0].authority,
+        edge.server.edge_fate_routes.borrow()[&tx_id].routes[0].authority,
         Some(handoff),
         "an Edge-Accepted caller route must follow the selected handoff rather than vanish"
     );
@@ -1151,16 +1296,28 @@ fn edge_route_capacity_rejects_instead_of_reporting_edge_acceptance() {
             Default::default(),
         )
         .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = client
+        .node
+        .node
+        .borrow_mut()
+        .commit_unit_for(write.mergeable_tx_id())
+        .unwrap()
+    else {
+        panic!("client mergeable write must retain its commit unit");
+    };
     let queue = Rc::new(RefCell::new(Vec::new()));
     edge.server.edge_fate_routes.borrow_mut().insert(
         write.mergeable_tx_id(),
-        (0..MAX_EDGE_FATE_ROUTES_PER_TX)
-            .map(|_| EdgeFateRoute {
-                authority: Some(selected),
-                queue: Rc::downgrade(&queue),
-                edge_acknowledged: false,
-            })
-            .collect(),
+        EdgeFateObligation {
+            identity: EdgeFateCommitIdentity::new(&tx, &versions),
+            routes: (0..MAX_EDGE_FATE_ROUTES_PER_TX)
+                .map(|_| EdgeFateRoute {
+                    authority: Some(selected),
+                    queue: Rc::downgrade(&queue),
+                    edge_acknowledged: false,
+                })
+                .collect(),
+        },
     );
     client.tick().unwrap();
     edge.server.tick().unwrap();
@@ -1238,8 +1395,8 @@ fn admitted_edge_session_routes_selected_authority_fate_to_uploading_client() {
     };
     let routes = edge.server.edge_fate_routes.borrow();
     let routes_for_tx = routes.get(&tx_id).expect("edge must park the upload route");
-    assert_eq!(routes_for_tx.len(), 1);
-    assert_eq!(routes_for_tx[0].authority, Some(expected_authority));
+    assert_eq!(routes_for_tx.routes.len(), 1);
+    assert_eq!(routes_for_tx.routes[0].authority, Some(expected_authority));
     drop(routes);
 
     // Scope receipts advance authorization metadata on the same physical
@@ -1407,14 +1564,22 @@ fn stale_upstream_epoch_cannot_settle_routed_local_fate_before_selected_epoch() 
             MergeableCommit::new("todos", row(0x44), 1).cells(cells("pending", false, identity)),
         )
         .unwrap();
+    let SyncMessage::CommitUnit { tx, versions } =
+        edge.node().borrow_mut().commit_unit_for(tx_id).unwrap()
+    else {
+        panic!("settled mergeable write must retain its commit unit");
+    };
     let downstream = Rc::new(RefCell::new(Vec::new()));
     edge.server.edge_fate_routes.borrow_mut().insert(
         tx_id,
-        vec![EdgeFateRoute {
-            authority: Some(selected),
-            queue: Rc::downgrade(&downstream),
-            edge_acknowledged: false,
-        }],
+        EdgeFateObligation {
+            identity: EdgeFateCommitIdentity::new(&tx, &versions),
+            routes: vec![EdgeFateRoute {
+                authority: Some(selected),
+                queue: Rc::downgrade(&downstream),
+                edge_acknowledged: false,
+            }],
+        },
     );
     b_peer
         .send(SyncMessage::FateUpdate {
@@ -1661,7 +1826,7 @@ fn edge_parks_downstream_fate_until_a_later_authority_connects() {
     assert!(edge.server.detach_connection(&edge_a));
     assert_eq!(edge.server.edge_fate_routes.borrow().len(), 1);
     assert_eq!(
-        edge.server.edge_fate_routes.borrow()[&write.mergeable_tx_id()][0].authority,
+        edge.server.edge_fate_routes.borrow()[&write.mergeable_tx_id()].routes[0].authority,
         None,
         "a route whose authority disconnected remains parked without stale authority claims"
     );
@@ -1737,7 +1902,7 @@ fn edge_write_before_upstream_admission_binds_and_redrives_fate_route() {
         DurabilityTier::Edge
     );
     assert_eq!(
-        edge.server.edge_fate_routes.borrow()[&tx_id][0].authority,
+        edge.server.edge_fate_routes.borrow()[&tx_id].routes[0].authority,
         None,
         "an offline-ready edge retains the downstream obligation without inventing authority"
     );
@@ -1755,7 +1920,7 @@ fn edge_write_before_upstream_admission_binds_and_redrives_fate_route() {
         .unwrap();
     edge.tick().unwrap();
     assert_eq!(
-        edge.server.edge_fate_routes.borrow()[&tx_id].len(),
+        edge.server.edge_fate_routes.borrow()[&tx_id].routes.len(),
         1,
         "a retransmitted pre-admission unit must reuse the same downstream route"
     );
@@ -1764,7 +1929,7 @@ fn edge_write_before_upstream_admission_binds_and_redrives_fate_route() {
         duplex_with_admitted_session_context(AuthorSubject::SYSTEM, edge_node, 41, core_node, 97);
     let _edge_upstream = crate::db::block_on(edge.server.connect_upstream(edge_upstream_transport));
     assert!(
-        edge.server.edge_fate_routes.borrow()[&tx_id][0]
+        edge.server.edge_fate_routes.borrow()[&tx_id].routes[0]
             .authority
             .is_some(),
         "the first authenticated authority binds the parked route"
@@ -1858,7 +2023,8 @@ fn stale_same_authority_session_cannot_settle_or_forward_a_routed_fate() {
         .edge_fate_routes
         .borrow_mut()
         .get_mut(&write.mergeable_tx_id())
-        .expect("routed edge write")[0]
+        .expect("routed edge write")
+        .routes[0]
         .authority = Some(current_context);
     old.borrow_mut()
         .transport

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -518,6 +518,123 @@ fn upstream_authorization_scope_intent_retries_after_bounded_transport_backpress
     drop(advice);
 }
 
+/// A permission preflight is a node-owned caller obligation, not an
+/// old-transport obligation. When the selected authority disconnects after
+/// accepting the request, the successor must receive one fresh intent and
+/// resolve the original future.
+#[test]
+fn scope_intent_retries_after_upstream_reconnect() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xd4; 16]);
+    let client = open_db(0xd4, author, &schema);
+    let (first_transport, mut first_authority) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xd4; 16]),
+        1,
+        NodeUuid::from_bytes([0x5e; 16]),
+        1,
+    );
+    let first = crate::db::block_on(client.connect_upstream(first_transport));
+    let advice = client.request_permission_advice(PermissionAdviceAction::Read {
+        table: "todos".to_owned(),
+        row: row(4),
+    });
+    client.tick().unwrap();
+    assert!(matches!(
+        try_recv_subscriber_payload(first_authority.as_mut()),
+        Some(SyncMessage::AuthorizationScopeIntent { .. })
+    ));
+    assert!(client.detach_connection(&first));
+
+    let (second_transport, mut second_authority) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xd4; 16]),
+        2,
+        NodeUuid::from_bytes([0x5e; 16]),
+        2,
+    );
+    let _second = crate::db::block_on(client.connect_upstream(second_transport));
+    client.tick().unwrap();
+    let request_id = match try_recv_subscriber_payload(second_authority.as_mut()) {
+        Some(SyncMessage::AuthorizationScopeIntent { request_id, .. }) => request_id,
+        message => panic!("reconnect must retry the live scope intent, got {message:?}"),
+    };
+    second_authority
+        .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
+        .unwrap();
+    client.tick().unwrap();
+    assert_eq!(block_on(advice), PermissionAdvice::Unknown);
+}
+
+#[test]
+fn reconnect_replays_live_scope_waiters_once_and_drops_cancelled_ones() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xd5; 16]);
+    let client = open_db(0xd5, author, &schema);
+    let (first_transport, mut first_authority) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xd5; 16]),
+        1,
+        NodeUuid::from_bytes([0x5e; 16]),
+        1,
+    );
+    let first = crate::db::block_on(client.connect_upstream(first_transport));
+    let action = PermissionAdviceAction::Read {
+        table: "todos".to_owned(),
+        row: row(5),
+    };
+    let first_live = client.request_permission_advice(action.clone());
+    let second_live = client.request_permission_advice(action);
+    let cancelled = client.request_permission_advice(PermissionAdviceAction::Read {
+        table: "todos".to_owned(),
+        row: row(6),
+    });
+    client.tick().unwrap();
+    assert!(matches!(
+        try_recv_subscriber_payload(first_authority.as_mut()),
+        Some(SyncMessage::AuthorizationScopeIntent { .. })
+    ));
+    assert!(matches!(
+        try_recv_subscriber_payload(first_authority.as_mut()),
+        Some(SyncMessage::AuthorizationScopeIntent { .. })
+    ));
+    drop(cancelled);
+    assert!(client.detach_connection(&first));
+
+    let (second_transport, mut second_authority) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xd5; 16]),
+        2,
+        NodeUuid::from_bytes([0x5e; 16]),
+        2,
+    );
+    let _second = crate::db::block_on(client.connect_upstream(second_transport));
+    client.tick().unwrap();
+    let request_id = match try_recv_subscriber_payload(second_authority.as_mut()) {
+        Some(SyncMessage::AuthorizationScopeIntent { request_id, action }) => {
+            assert_eq!(
+                action,
+                PermissionAdviceAction::Read {
+                    table: "todos".to_owned(),
+                    row: row(5),
+                }
+            );
+            request_id
+        }
+        message => panic!("reconnect must replay the one live shared intent, got {message:?}"),
+    };
+    assert!(
+        try_recv_subscriber_payload(second_authority.as_mut()).is_none(),
+        "two live waiters share one retry and the dropped waiter is not replayed"
+    );
+    second_authority
+        .send(SyncMessage::AuthorizationScopeUnavailable { request_id })
+        .unwrap();
+    client.tick().unwrap();
+    assert_eq!(block_on(first_live), PermissionAdvice::Unknown);
+    assert_eq!(block_on(second_live), PermissionAdvice::Unknown);
+}
+
 /// An authority-scope intent may expand to a multi-frame proof sequence. Its
 /// semantic producer queues that sequence before returning to inbound work, so
 /// bounded wire admission must preserve both order and exact multiplicity.

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::db::peer_connection::{
-    dispatch_admitted_subscriber_message, ConnectionLink, PendingSubscriberControlResponse,
+    ConnectionLink, PendingSubscriberControlResponse, dispatch_admitted_subscriber_message,
 };
 use crate::node::SKEW_TOLERANCE_MS;
 

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -406,6 +406,118 @@ fn row_version_repair_reply_retries_with_sync_context_after_backpressure() {
     assert!(outbound.borrow().is_empty());
 }
 
+/// An authorization-scope intent remains owned by the requesting client until
+/// its upstream wire admission succeeds, so a one-shot backpressure refusal
+/// cannot strand Alice's permission preflight forever.
+///
+/// ```text
+/// alice ──scope intent──► bounded upstream ──✗──► authority
+/// alice ──retry─────────► bounded upstream ─────► authority
+/// ```
+#[test]
+fn upstream_authorization_scope_intent_retries_after_bounded_transport_backpressure() {
+    struct BackpressureOnceAdmittedTransport {
+        outbound: Rc<RefCell<VecDeque<SyncMessage>>>,
+        failed: bool,
+        session_context: ConnectionSessionContext,
+    }
+
+    impl Transport for BackpressureOnceAdmittedTransport {
+        fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
+            if !self.failed {
+                self.failed = true;
+                return Err(TransportError::Backpressure);
+            }
+            self.outbound.borrow_mut().push_back(message);
+            Ok(())
+        }
+
+        fn try_recv(&mut self) -> Option<SyncMessage> {
+            None
+        }
+
+        fn connection_session_context(&self) -> Option<ConnectionSessionContext> {
+            Some(self.session_context)
+        }
+    }
+
+    let author = AuthorSubject::for_test_bytes([0xc4; 16]);
+    let schema = schema();
+    let client = open_db(0xc4, author, &schema);
+    let (transport, _authority_transport) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xc4; 16]),
+        1,
+        NodeUuid::from_bytes([0x5e; 16]),
+        1,
+    );
+    let upstream = crate::db::block_on(client.connect_upstream(transport));
+    let session_context = upstream
+        .borrow()
+        .transport
+        .connection_session_context()
+        .expect("the real admitted transport supplies an authority context");
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    upstream.borrow_mut().transport = Box::new(BackpressureOnceAdmittedTransport {
+        outbound: Rc::clone(&outbound),
+        failed: false,
+        session_context,
+    });
+
+    let advice = client.request_permission_advice(PermissionAdviceAction::Read {
+        table: "todos".to_owned(),
+        row: row(4),
+    });
+
+    upstream
+        .borrow_mut()
+        .tick()
+        .expect("backpressure keeps the authority intent pending");
+    assert!(outbound.borrow().is_empty());
+    {
+        let connection = upstream.borrow();
+        let ConnectionLink::Upstream(state) = &connection.link else {
+            panic!("client connection must be upstream");
+        };
+        assert!(state.pending.iter().any(|command| matches!(
+            command,
+            PendingUpstreamCommand::AuthorizationScopeIntent { .. }
+        )));
+        assert!(
+            state
+                .scope_lease_manager
+                .requests
+                .values()
+                .all(|request| !request.intent_sent)
+        );
+    }
+
+    upstream
+        .borrow_mut()
+        .tick()
+        .expect("later capacity retries the retained authority intent");
+    assert!(matches!(
+        outbound.borrow_mut().pop_front(),
+        Some(SyncMessage::AuthorizationScopeIntent { .. })
+    ));
+    assert!(outbound.borrow().is_empty());
+    {
+        let connection = upstream.borrow();
+        let ConnectionLink::Upstream(state) = &connection.link else {
+            panic!("client connection must be upstream");
+        };
+        assert!(state.pending.is_empty());
+        assert!(
+            state
+                .scope_lease_manager
+                .requests
+                .values()
+                .all(|request| request.intent_sent)
+        );
+    }
+    drop(advice);
+}
+
 /// An authority-scope intent may expand to a multi-frame proof sequence. Its
 /// semantic producer queues that sequence before returning to inbound work, so
 /// bounded wire admission must preserve both order and exact multiplicity.

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -902,6 +902,156 @@ fn terminal_core_write_fates_prove_exact_insert_update_and_delete_actions() {
     );
 }
 
+/// Edge client ingress uses the same action-specific authority proof as a
+/// terminal Core, but exposes only Edge durability until an admitted upstream
+/// later reports Global.  In particular, this exercises the production
+/// connection loop rather than calling `PeerState`'s focused proof helpers.
+#[test]
+fn edge_client_ingress_proves_actions_before_one_routed_edge_fate() {
+    let schema = owner_write_schema();
+    let alice = AuthorSubject::for_test_bytes([0xa1; 16]);
+    let bob = AuthorSubject::for_test_bytes([0xb2; 16]);
+    let edge = open_core(0xe0, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0xa1, alice, &schema);
+    let (client_transport, edge_transport, _client_sent, edge_sent) = duplex_with_taps();
+    let client_upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _edge_client = edge.server.accept_edge_authority_subscriber_with_claims(
+        edge_transport,
+        alice,
+        test_provider_claims(alice),
+    );
+
+    let inserted = client
+        .insert(
+            "todos",
+            cells("edge-owned", false, alice),
+            Default::default(),
+        )
+        .unwrap();
+    let inserted_tx = inserted.mergeable_tx_id();
+    let sibling = client
+        .insert(
+            "todos",
+            cells("edge-owned-sibling", false, alice),
+            Default::default(),
+        )
+        .unwrap();
+    let sibling_tx = sibling.mergeable_tx_id();
+    client.tick().unwrap();
+    edge.tick().unwrap();
+
+    let edge_acceptances = edge_sent
+        .borrow()
+        .iter()
+        .filter(|message| {
+            matches!(
+                message,
+                SyncMessage::FateUpdate {
+                    tx_id: candidate,
+                    fate: Fate::Accepted,
+                    durability: Some(DurabilityTier::Edge),
+                    ..
+                } if *candidate == inserted_tx || *candidate == sibling_tx
+            )
+        })
+        .count();
+    assert_eq!(
+        edge_acceptances, 2,
+        "each queued commit makes fair progress to one routed edge fate"
+    );
+    client.tick().unwrap();
+    assert_eq!(inserted.write_state().unwrap().fate, Fate::Accepted);
+    assert_eq!(
+        inserted.write_state().unwrap().durability,
+        DurabilityTier::Edge
+    );
+    assert_eq!(sibling.write_state().unwrap().fate, Fate::Accepted);
+    assert_eq!(
+        sibling.write_state().unwrap().durability,
+        DurabilityTier::Edge
+    );
+    assert!(
+        [inserted_tx, sibling_tx].into_iter().all(|tx_id| edge
+            .server
+            .outbox
+            .borrow()
+            .iter()
+            .any(|pending| pending.tx_id == tx_id)),
+        "only edge-admitted commits enter the Core upload outbox"
+    );
+
+    // A transport retry cannot re-publish the Edge acceptance.  The retained
+    // route is still needed for Core's later terminal fate, but remembers its
+    // per-client edge acknowledgement.
+    client_upstream
+        .borrow_mut()
+        .transport
+        .send(
+            client
+                .node
+                .node
+                .borrow_mut()
+                .commit_unit_for(inserted_tx)
+                .unwrap(),
+        )
+        .unwrap();
+    edge.tick().unwrap();
+    assert!(
+        edge_sent.borrow().is_empty(),
+        "a retransmit must not create a second edge acknowledgement"
+    );
+
+    // The exact update action includes the candidate patch. Alice is allowed
+    // by the old-row policy, but changing owner to Bob fails the update check;
+    // it produces one routed rejection instead of a synthetic Edge success.
+    let denied = client
+        .update(
+            "todos",
+            inserted.row_uuid(),
+            BTreeMap::from([("owner".to_owned(), Value::Uuid(bob.test_uuid()))]),
+            Default::default(),
+        )
+        .unwrap();
+    let denied_tx = denied.mergeable_tx_id();
+    client.tick().unwrap();
+    edge.tick().unwrap();
+    let rejections = edge_sent
+        .borrow()
+        .iter()
+        .filter(|message| {
+            matches!(
+                message,
+                SyncMessage::FateUpdate {
+                    tx_id,
+                    fate: Fate::Rejected(_),
+                    ..
+                } if *tx_id == denied_tx
+            )
+        })
+        .count();
+    assert_eq!(
+        rejections, 1,
+        "denial is routed once through the edge route"
+    );
+    assert!(
+        !edge
+            .server
+            .edge_fate_routes
+            .borrow()
+            .contains_key(&denied_tx),
+        "a locally denied upload cannot leave a Core-fate route behind"
+    );
+    assert!(
+        !edge
+            .server
+            .outbox
+            .borrow()
+            .iter()
+            .any(|pending| pending.tx_id == denied_tx),
+        "a denied upload must not bypass edge authorization through Core replication"
+    );
+}
+
 #[test]
 fn concurrent_upstreams_keep_selected_owner_until_detach_handoff() {
     let schema = schema();
@@ -944,6 +1094,7 @@ fn concurrent_upstreams_keep_selected_owner_until_detach_handoff() {
         vec![EdgeFateRoute {
             authority: Some(first.unwrap()),
             queue: Rc::downgrade(&queue),
+            edge_acknowledged: false,
         }],
     );
     assert!(edge.server.detach_connection(&a));
@@ -1007,6 +1158,7 @@ fn edge_route_capacity_rejects_instead_of_reporting_edge_acceptance() {
             .map(|_| EdgeFateRoute {
                 authority: Some(selected),
                 queue: Rc::downgrade(&queue),
+                edge_acknowledged: false,
             })
             .collect(),
     );
@@ -1183,10 +1335,9 @@ fn admitted_edge_session_routes_selected_authority_fate_to_uploading_client() {
             edge.node()
                 .borrow_mut()
                 .transaction_state_settled(tx_id)
-                .unwrap()
-                .0,
-            Fate::Pending,
-            "a rejected fate from a different physical link must not alter edge state"
+                .unwrap(),
+            (Fate::Accepted, None, DurabilityTier::Edge),
+            "a rejected fate from a different physical link must not alter the edge-local admission"
         );
     }
     {
@@ -1262,6 +1413,7 @@ fn stale_upstream_epoch_cannot_settle_routed_local_fate_before_selected_epoch() 
         vec![EdgeFateRoute {
             authority: Some(selected),
             queue: Rc::downgrade(&downstream),
+            edge_acknowledged: false,
         }],
     );
     b_peer

--- a/crates/jazz/src/peer/repair.rs
+++ b/crates/jazz/src/peer/repair.rs
@@ -1,10 +1,10 @@
 impl PeerState {
     /// Ingest a client mergeable commit unit at an edge boundary.
     ///
-    /// The edge first stores the unit as pending relay history, then gates fate
-    /// assignment on the first settled permission-scope subscription for the
-    /// affected tables and writer. If a scope was not settled before this call,
-    /// the unit remains pending and can be completed by
+    /// The edge gates admission on the first settled permission-scope
+    /// subscription for the affected tables and writer. If a scope was not
+    /// settled before this call, the unit remains outside edge history and can
+    /// be admitted exactly once by
     /// [`Self::drain_deferred_edge_fates`] after the registered scope settles.
     pub async fn ingest_edge_mergeable_commit_unit<S>(
         &mut self,
@@ -32,7 +32,6 @@ impl PeerState {
         )
         .await?
         {
-            node.ingest_relay_commit_unit(tx.clone(), versions.clone()).await?;
             if !self.deferred_edge_fates.contains_key(&tx.tx_id) {
                 for subscription in &scope_subscriptions {
                     self.retain_edge_scope_subscription(*subscription);

--- a/crates/jazz/src/peer/repair.rs
+++ b/crates/jazz/src/peer/repair.rs
@@ -32,7 +32,21 @@ impl PeerState {
         )
         .await?
         {
-            if !self.deferred_edge_fates.contains_key(&tx.tx_id) {
+            if let Some(existing) = self.deferred_edge_fates.get(&tx.tx_id) {
+                // The durable ingest path rejects two different commit units
+                // for one transaction id.  Deferred admission sits before that
+                // path, so retain the same conflict boundary here rather than
+                // silently treating a conflicting upload as a retransmit.
+                // Version order is transport-insignificant and is normalized
+                // by NodeState on eventual admission.
+                let mut existing_versions = existing.versions.clone();
+                existing_versions.sort();
+                let mut incoming_versions = versions;
+                incoming_versions.sort();
+                if existing.tx != tx || existing_versions != incoming_versions {
+                    return Err(Error::ConflictingCommitUnit(tx.tx_id));
+                }
+            } else {
                 for subscription in &scope_subscriptions {
                     self.retain_edge_scope_subscription(*subscription);
                 }

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::legacy_test_future::{ResultFutureExt as _, SettledNodeTestExt as _};
+use crate::legacy_test_future::{
+    OptionFutureExt as _, ResultFutureExt as _, SettledNodeTestExt as _,
+};
 
 use std::collections::BTreeMap;
 
@@ -855,11 +857,15 @@ fn edge_ingest_turns_missing_prepared_seed_claim_into_deferred_empty_support() {
     let mut peer = PeerState::edge_client(writer);
 
     let outcome = peer
-        .ingest_edge_mergeable_commit_unit(&mut edge, tx, versions, 10)
+        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions, 10)
         .expect("missing prepared seed claim must be a deferred empty support proof");
     let updates = edge.persist_and_settle_outcome(outcome).unwrap();
     assert!(updates.is_empty());
     assert_eq!(peer.deferred_edge_fate_count(), 1);
+    assert!(
+        edge.transaction_state(tx.tx_id).is_none(),
+        "a pending support proof must not admit a client commit into edge history"
+    );
 }
 
 fn scored_doc_cells(title: impl Into<String>, score: u64) -> BTreeMap<String, Value> {

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::legacy_test_future::{
-    OptionFutureExt as _, ResultFutureExt as _, SettledNodeTestExt as _,
+    FutureResolveExt as _, OptionFutureExt as _, ResultFutureExt as _, SettledNodeTestExt as _,
 };
 
 use std::collections::BTreeMap;
@@ -865,6 +865,40 @@ fn edge_ingest_turns_missing_prepared_seed_claim_into_deferred_empty_support() {
     assert!(
         edge.transaction_state(tx.tx_id).is_none(),
         "a pending support proof must not admit a client commit into edge history"
+    );
+}
+
+#[test]
+fn deferred_edge_ingest_rejects_a_conflicting_retransmit() {
+    let schema = session_seed_write_policy_schema();
+    let writer = AuthorSubject::for_test_bytes([0xc1; 16]);
+    let resource = row(0xc2);
+    let (_writer_dir, mut writer_node) = open_node_with_schema(node(0xc3), schema.clone());
+    let (tx, versions) = resource_commit_unit(&mut writer_node, writer, resource);
+    let (_edge_dir, mut edge) = open_node_with_schema(node(0xc4), schema);
+    let mut peer = PeerState::edge_client(writer);
+
+    let _ = peer
+        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions.clone(), 10)
+        .expect("missing support claim parks the first commit unit");
+    assert_eq!(peer.deferred_edge_fate_count(), 1);
+
+    let _ = peer
+        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions.clone(), 10)
+        .expect("an identical deferred retransmit remains idempotent");
+    assert_eq!(peer.deferred_edge_fate_count(), 1);
+
+    let mut conflicting = tx.clone();
+    conflicting.n_total_writes = conflicting.n_total_writes.saturating_add(1);
+    assert!(matches!(
+        peer.ingest_edge_mergeable_commit_unit(&mut edge, conflicting, versions, 10)
+            .resolve(),
+        Err(Error::ConflictingCommitUnit(tx_id)) if tx_id == tx.tx_id
+    ));
+    assert_eq!(peer.deferred_edge_fate_count(), 1);
+    assert!(
+        edge.transaction_state(tx.tx_id).is_none(),
+        "a conflicting retry must not enter history while the original remains deferred"
     );
 }
 

--- a/crates/jazz/tests/four_tier.rs
+++ b/crates/jazz/tests/four_tier.rs
@@ -654,7 +654,10 @@ fn edge_defers_mergeable_fate_until_permission_scope_settles() {
     );
     assert_eq!(edge_to_client.deferred_edge_fate_count(), 1);
     assert_eq!(edge_to_client.edge_scope_subscription_count(), 1);
-    assert_eq!(transaction_state(&mut edge, tx_id).0, Fate::Pending);
+    assert!(
+        block_on(edge.transaction_state(tx_id)).is_none(),
+        "an unresolved permission scope must keep the unit outside edge history"
+    );
 
     let [fate] = drain_edge_fates(&mut edge_to_client, &mut edge, u64::MAX - SKEW_TOLERANCE_MS)
         .try_into()
@@ -711,7 +714,10 @@ fn edge_permission_scope_is_write_policy_claim_not_whole_table() {
             .is_none()
     );
     assert_eq!(edge_to_client.deferred_edge_fate_count(), 1);
-    assert_eq!(transaction_state(&mut edge, tx_id).0, Fate::Pending);
+    assert!(
+        block_on(edge.transaction_state(tx_id)).is_none(),
+        "the narrow write-policy scope must not create pending table history"
+    );
 }
 
 #[test]
@@ -985,10 +991,9 @@ fn settled_permission_scope_for_one_writer_claim_does_not_unlock_whole_table() {
         .is_empty()
     );
     assert_eq!(edge_to_b.deferred_edge_fate_count(), 1);
-    assert_eq!(
-        transaction_state(&mut edge, first_b).0,
-        Fate::Pending,
-        "settled writer-A scope must not satisfy missing writer-B scope"
+    assert!(
+        block_on(edge.transaction_state(first_b)).is_none(),
+        "settled writer-A scope must not admit writer-B into edge history"
     );
 }
 
@@ -1064,7 +1069,10 @@ fn edge_restart_recovers_deferred_fate_from_client_outbox_redelivery() {
     );
     assert_eq!(edge_to_client.deferred_edge_fate_count(), 1);
     assert_eq!(edge_to_client.edge_scope_subscription_count(), 1);
-    assert_eq!(transaction_state(&mut edge, tx_id).0, Fate::Pending);
+    assert!(
+        block_on(edge.transaction_state(tx_id)).is_none(),
+        "a deferred edge upload must not persist before its permission scope settles"
+    );
     drop(edge);
     drop(edge_to_client);
 
@@ -1085,10 +1093,9 @@ fn edge_restart_recovers_deferred_fate_from_client_outbox_redelivery() {
         edge_to_client.subscription_result_sets(scope_key).is_none(),
         "scope subscription result state must not survive through a fresh peer after restart"
     );
-    assert_eq!(
-        transaction_state(&mut edge, tx_id).0,
-        Fate::Pending,
-        "the pending relay history survives restart, but not the in-memory gate"
+    assert!(
+        block_on(edge.transaction_state(tx_id)).is_none(),
+        "the unresolved upload must leave no durable edge history after restart"
     );
 
     let SyncMessage::CommitUnit { tx, versions } = unit else {


### PR DESCRIPTION
🤖 Prevents an Edge from telling a client that a write was accepted before the write's exact permission check has finished. Fixes #1914.

This is stacked above #2178 and #2096 because it relies on reliable transaction-outcome delivery and canonical session identity.

## Example

A client updates a document through an Edge. The Edge has enough locally synchronized policy data to begin checking the update, but the authorization query is still waiting for its final settled result.

Previously, the served-connection path could put the transaction into Edge history and report `Accepted/Edge` before that proof completed. If the eventual proof denied the update, the Edge had already exposed and queued a write that should never have existed there.

After this change, the upload remains outside Edge history and its upstream queue until the permission proof for that exact INSERT, UPDATE, or DELETE settles. A denied write never enters either one.

## Duplicate and conflicting retries

The transaction ID identifies one canonical transaction payload across all connections to the server:

- An exact retransmission attaches another waiting route but does not ingest or forward the transaction twice.
- Reusing the same transaction ID with different bytes is rejected before creating a route.
- A permitted transaction enters Edge history once and is queued upstream once.
- The Edge retains the transaction identity until every terminal client outcome has been delivered.

For example, if a phone retries an upload while a laptop with the same session is also connected, identical bytes share the same eventual result; conflicting bytes cannot silently replace one another.

## Backpressure and reconnects

An outstanding authorization request is retained as bounded in-memory work:

- transport backpressure retries the unsent request;
- cancellation retires it;
- a live waiter that disconnects and reconnects resumes under the fresh authority context;
- abandoned waiters are not replayed;
- equivalent live requests coalesce again after reconnect.

This durability is process-local; it does not introduce persisted authorization jobs.

## Evidence

- two-client exact-retry and conflicting-payload receipts
- denied writes never entering Edge history or the upstream queue
- unresolved permission proofs never producing an early accepted outcome
- temporary/permanent backpressure and cancellation receipts
- reconnect replay and coalescing receipts
- planted early-admission, premature-removal, and missing-replay mutations
- final independent review: peer 54/54 and admission 44/44

