### PR TITLE
test(jazz): scope merge-head walk observer to node

### DIFF
--- a/crates/jazz/src/node/ingest.rs
+++ b/crates/jazz/src/node/ingest.rs
@@ -14,25 +14,10 @@ use crate::protocol_limits::{
 };
 use crate::schema::{ColumnSchema, MERGE_HEADS_TABLE};
 use groove::records::ValueType;
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub(super) const MAX_SCHEMA_LINEAGE_DECLARATIONS: usize = 4096;
 pub(super) const MAX_SCHEMA_LINEAGE_NAME_BYTES: usize = 1024;
 pub(super) const MAX_SCHEMA_LINEAGE_OPS: usize = 16_384;
-
-#[cfg(test)]
-static MERGE_HEAD_REACHABILITY_WALKS: AtomicUsize = AtomicUsize::new(0);
-
-#[cfg(test)]
-pub(super) fn reset_merge_head_reachability_walks_for_test() {
-    MERGE_HEAD_REACHABILITY_WALKS.store(0, Ordering::Relaxed);
-}
-
-#[cfg(test)]
-pub(super) fn merge_head_reachability_walks_for_test() -> usize {
-    MERGE_HEAD_REACHABILITY_WALKS.load(Ordering::Relaxed)
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct CommitUnitParkMode {

--- a/crates/jazz/src/node/ingest/view_updates.rs
+++ b/crates/jazz/src/node/ingest/view_updates.rs
@@ -757,8 +757,10 @@ where
         start: TxId,
         target: TxId,
     ) -> Result<bool, Error> {
-        #[cfg(test)]
-        MERGE_HEAD_REACHABILITY_WALKS.fetch_add(1, Ordering::Relaxed);
+        #[cfg(any(test, feature = "testing"))]
+        {
+            self.merge_head_reachability_walks += 1;
+        }
         let mut stack = vec![start];
         let mut seen = BTreeSet::new();
         while let Some(tx_id) = stack.pop() {
@@ -791,8 +793,10 @@ where
         start: TxId,
         target: TxId,
     ) -> Result<bool, Error> {
-        #[cfg(test)]
-        MERGE_HEAD_REACHABILITY_WALKS.fetch_add(1, Ordering::Relaxed);
+        #[cfg(any(test, feature = "testing"))]
+        {
+            self.merge_head_reachability_walks += 1;
+        }
         let mut stack = vec![start];
         let mut seen = BTreeSet::new();
         while let Some(tx_id) = stack.pop() {

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -573,6 +573,10 @@ pub struct NodeState<S> {
     sync_metrics: SyncMetrics,
     /// Runtime counters for query-engine read authorization paths.
     query_engine_read_metrics: QueryEngineReadMetrics,
+    /// Test-only observer for one node's merge-head graph walks. This must be
+    /// node-scoped so unrelated parallel test nodes cannot contaminate it.
+    #[cfg(any(test, feature = "testing"))]
+    merge_head_reachability_walks: usize,
     /// Process-local claims attached to authenticated subscriber sessions.
     session_claims: BTreeMap<AuthorSubject, BTreeMap<String, Value>>,
     /// Monotone revision for each identity's process-local session claims.
@@ -725,6 +729,14 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
+    pub(super) fn reset_merge_head_reachability_walks_for_test(&mut self) {
+        self.merge_head_reachability_walks = 0;
+    }
+
+    pub(super) fn merge_head_reachability_walks_for_test(&self) -> usize {
+        self.merge_head_reachability_walks
+    }
+
     fn allocate_global_time_for_test(&mut self) -> GlobalTime {
         self.clock
             .allocate_global_time(self.clock.tx_time.physical_ms())

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -591,6 +591,8 @@ where
             ahead_current_keys: FxHashSet::default(),
             sync_metrics: SyncMetrics::default(),
             query_engine_read_metrics: QueryEngineReadMetrics::default(),
+            #[cfg(any(test, feature = "testing"))]
+            merge_head_reachability_walks: 0,
             session_claims: BTreeMap::new(),
             session_claim_revisions: BTreeMap::new(),
             permissions_ready: true,

--- a/crates/jazz/src/node/tests/merge_heads.rs
+++ b/crates/jazz/src/node/tests/merge_heads.rs
@@ -185,14 +185,14 @@ fn accepting_pending_history_does_not_rewalk_the_merge_chain() {
         versions.push(tx_id);
     }
 
-    super::super::ingest::reset_merge_head_reachability_walks_for_test();
+    edge.reset_merge_head_reachability_walks_for_test();
     for tx_id in versions.into_iter().rev() {
         edge.apply_fate_update(tx_id, Fate::Accepted, None, Some(DurabilityTier::Edge))
             .unwrap();
     }
 
     assert_eq!(
-        super::super::ingest::merge_head_reachability_walks_for_test(),
+        edge.merge_head_reachability_walks_for_test(),
         0,
         "accepting a pending chain must not replay historical reachability"
     );


### PR DESCRIPTION
🤖 A full parallel Jazz lib run exposed a false failure in `accepting_pending_history_does_not_rewalk_the_merge_chain`: its process-global test counter was incremented by unrelated nodes running concurrently.

## Before

One test reset a global `AtomicUsize`, performed its operation, and expected zero walks. Any concurrent test performing a legitimate merge-head reachability walk could increment the same counter and fail this receipt. Focused execution passed while the full suite intermittently reported one or two walks.

## After

The test-only observer is scoped to each `NodeState`. The receipt observes only the node it exercises; production sync behavior is unchanged and unrelated tests remain parallel.

## Evidence

- full canonical Jazz lib receipt: 1,416 passed, 2 ignored
- focused pending-history receipt passes
- Clippy, rustfmt, and sensitive-data guard pass
