### PR TITLE
fix(groove): bound large-value decode work

### DIFF
--- a/crates/groove/src/chunks.rs
+++ b/crates/groove/src/chunks.rs
@@ -74,7 +74,14 @@ impl ChunkStorage for ManagedChunkStorage {
             let Some((hash, bytes)) = self.backend.get_exact(locator).await? else {
                 return Err(ChunkStorageError::Unavailable);
             };
-            if hash != expected_hash || object_hash(&bytes) != expected_hash {
+            // Stored byte-KV implementations are policy blind and can retain
+            // corrupted historical data. Enforce the node ceiling before the
+            // integrity hash, just as remote resolution and descriptor-bound
+            // decoding do.
+            if bytes.len() > crate::large_values::MAX_ENCODED_NODE_BYTES
+                || hash != expected_hash
+                || object_hash(&bytes) != expected_hash
+            {
                 return Err(ChunkStorageError::Integrity);
             }
             Ok(bytes)
@@ -110,7 +117,8 @@ impl ChunkStorage for ManagedChunkStorage {
                     )
                     .await?;
                 if let Some((hash, ref bytes)) = existing
-                    && (hash != chunk.node_ref.object_hash
+                    && (bytes.len() > crate::large_values::MAX_ENCODED_NODE_BYTES
+                        || hash != chunk.node_ref.object_hash
                         || object_hash(bytes) != chunk.node_ref.object_hash)
                 {
                     return Err(ChunkStorageError::LocatorConflict);
@@ -614,7 +622,10 @@ impl ChunkKvStorage for OrderedChunkStorage {
                 return Ok(());
             };
             let (hash, bytes) = Self::decode(existing.clone())?;
-            if hash != expected_hash || object_hash(&bytes) != expected_hash {
+            if bytes.len() > crate::large_values::MAX_ENCODED_NODE_BYTES
+                || hash != expected_hash
+                || object_hash(&bytes) != expected_hash
+            {
                 return Err(ChunkStorageError::Integrity);
             }
             storage
@@ -2159,6 +2170,80 @@ mod tests {
         }]));
         assert_eq!(result, Err(ChunkStorageError::Integrity));
         assert!(storage.is_empty());
+    }
+
+    #[test]
+    fn managed_storage_rejects_oversized_persisted_bytes_before_hashing() {
+        // This is intentionally an internal receipt: it injects corrupted
+        // byte-KV state below the public row API to prove that a persisted
+        // chunk cannot bypass the resource ceiling merely by carrying its
+        // correct object hash.
+        struct OversizedBackend {
+            locator: Locator,
+            hash: ContentHash,
+            bytes: Bytes,
+        }
+
+        impl ChunkKvStorage for OversizedBackend {
+            fn get_exact(
+                &self,
+                locator: Locator,
+            ) -> ChunkFuture<'_, Result<Option<(ContentHash, Bytes)>, ChunkStorageError>>
+            {
+                let value = (locator == self.locator).then(|| (self.hash, self.bytes.clone()));
+                Box::pin(async move { Ok(value) })
+            }
+
+            fn put_if_absent(
+                &self,
+                _locator: Locator,
+                _hash: ContentHash,
+                _bytes: Bytes,
+            ) -> ChunkFuture<'_, Result<Option<(ContentHash, Bytes)>, ChunkStorageError>>
+            {
+                Box::pin(async { unreachable!("read-only test backend") })
+            }
+
+            fn delete_exact(
+                &self,
+                _locator: Locator,
+                _expected_hash: ContentHash,
+            ) -> ChunkFuture<'_, Result<(), ChunkStorageError>> {
+                Box::pin(async { unreachable!("read-only test backend") })
+            }
+        }
+
+        let locator = Locator::from_seed(b"oversized-persisted-chunk");
+        let bytes = Bytes::from(vec![0; crate::large_values::MAX_ENCODED_NODE_BYTES + 1]);
+        let hash = object_hash(&bytes);
+        let storage = ManagedChunkStorage::new(Rc::new(OversizedBackend {
+            locator,
+            hash,
+            bytes,
+        }));
+        assert_eq!(
+            block_on(storage.get(locator, hash)),
+            Err(ChunkStorageError::Integrity)
+        );
+    }
+
+    #[test]
+    fn remote_provider_rejects_oversized_bytes_before_hashing_or_caching() {
+        let bytes = Bytes::from(vec![0; crate::large_values::MAX_ENCODED_NODE_BYTES + 1]);
+        let hash = object_hash(&bytes);
+        let provider = Rc::new(CountingProvider {
+            calls: Cell::new(0),
+            bytes,
+        });
+        let chunks = OwnedChunkProvider::new(provider.clone());
+        let request = ChunkRequest {
+            object_hash: hash.0,
+            locator: Locator::from_seed(b"oversized-remote-chunk"),
+        };
+
+        assert_eq!(block_on(chunks.get(request)), Err(ChunkError::Integrity));
+        assert_eq!(provider.calls.get(), 1);
+        assert_eq!(chunks.cache_stats().entries, 0);
     }
 
     #[test]

--- a/crates/groove/src/chunks.rs
+++ b/crates/groove/src/chunks.rs
@@ -550,6 +550,13 @@ impl OrderedChunkStorage {
         let (hash, bytes) = value
             .split_at_checked(32)
             .ok_or(ChunkStorageError::Integrity)?;
+        // Do this while the ordered-KV buffer is still borrowed. Otherwise a
+        // corrupt durable entry makes `Bytes::copy_from_slice` allocate and
+        // copy an arbitrarily large node before the managed layer can reject
+        // it (and before any integrity hash is considered).
+        if bytes.len() > crate::large_values::MAX_ENCODED_NODE_BYTES {
+            return Err(ChunkStorageError::Integrity);
+        }
         let mut expected = [0_u8; 32];
         expected.copy_from_slice(hash);
         Ok((ContentHash(expected), Bytes::copy_from_slice(bytes)))
@@ -2589,6 +2596,36 @@ mod tests {
             crate::db::LARGE_VALUE_METADATA_CF.to_owned(),
             OrderedChunkStorage::key(locator.as_bytes()),
             OrderedChunkStorage::encode(hash, &bytes),
+        ))
+        .unwrap();
+
+        assert_eq!(
+            block_on(backend.get_exact(locator)),
+            Err(ChunkStorageError::Integrity)
+        );
+    }
+
+    #[test]
+    fn ordered_chunk_storage_rejects_oversized_receipted_mappings_before_copying() {
+        // The durable ordered adapter is itself a ChunkKvStorage boundary.
+        // It must reject oversized raw metadata before converting the stored
+        // slice into a fresh Bytes allocation for ManagedChunkStorage.
+        let storage = crate::storage::MemoryStorage::new(&[crate::db::LARGE_VALUE_METADATA_CF]);
+        let layout = Rc::new(
+            block_on(LayoutStorage::new(
+                storage,
+                crate::storage::StorageLayout::Identity,
+            ))
+            .unwrap(),
+        );
+        let backend = OrderedChunkStorage::new(Rc::downgrade(&layout));
+        let bytes = vec![0; crate::large_values::MAX_ENCODED_NODE_BYTES + 1];
+        let hash = object_hash(&bytes);
+        let locator = Locator::from_seed(b"oversized-receipted-ordered-chunk-locator");
+        block_on(layout.set(
+            crate::db::LARGE_VALUE_METADATA_CF.to_owned(),
+            OrderedChunkStorage::key(locator.as_bytes()),
+            OrderedChunkStorage::encode_with_install_receipt(hash, &bytes, [0; 16]),
         ))
         .unwrap();
 

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -2834,6 +2834,13 @@ pub(crate) fn decode_node_untyped_authenticated(
     expected_hash: ContentHash,
     encoded: &[u8],
 ) -> Result<ChunkNode, Error> {
+    // This path is also used while installing durable metadata, before a row
+    // descriptor supplies the schema-derived kind. Keep the resource ceiling
+    // ahead of authentication so an oversized stored object cannot make us
+    // hash it merely because it has no descriptor yet.
+    if encoded.len() > MAX_ENCODED_NODE_BYTES {
+        return Err(Error::MalformedNode);
+    }
     if object_hash(encoded) != expected_hash {
         return Err(Error::ObjectHashMismatch);
     }
@@ -5529,6 +5536,20 @@ mod tests {
         assert_eq!(
             decode_authenticated_node(object_hash(&encoded), &encoded),
             Err(Error::MalformedNode)
+        );
+    }
+
+    #[test]
+    fn untyped_authenticated_decode_rejects_oversized_bytes_before_hashing() {
+        // This is intentionally an internal receipt: durable chunk-install
+        // metadata authenticates nodes before any descriptor exists, so the
+        // public row API cannot exercise this resource boundary directly.
+        let encoded = vec![0; MAX_ENCODED_NODE_BYTES + 1];
+        let matching_hash = object_hash(&encoded);
+        assert_eq!(
+            decode_node_untyped_authenticated(matching_hash, &encoded),
+            Err(Error::MalformedNode),
+            "the size ceiling must win even when the oversized payload's hash matches"
         );
     }
 


### PR DESCRIPTION
🤖 Prevents an oversized large-value tree node from consuming unbounded hashing, allocation, or copy work before Groove rejects it. Fixes the concrete ceiling-before-hashing finding in #2042.

## Example

Suppose corrupt local storage or a remote chunk provider returns a 100 MB byte string for one tree node, while the encoded-node limit is much smaller.

Previously, some paths would first hash the entire 100 MB value or copy it into a new `Bytes` allocation, and only a later decoder would enforce the node-size limit. A matching content hash did not make that work safe: an attacker or corrupt store could still force work proportional to the oversized input.

After this change, every audited ingress checks the encoded byte length before:

- computing its content hash;
- deserializing an untyped metadata node;
- copying an ordered-KV slice into owned memory; or
- caching a remote response.

The request is rejected as an integrity or malformed-node error and remote bytes are not cached.

## Boundaries covered

- managed persisted chunk storage;
- ordered-KV-backed chunk metadata;
- remote chunk-provider responses;
- untyped authenticated decoding used before a schema-derived large-value kind is available.

Existing hash-integrity and malformed-node behavior remains unchanged for inputs within the size ceiling.

## Evidence

Receipts inject an oversized value with a matching hash into each relevant lower-level boundary and prove it is rejected before the expensive operation. The full Groove library suite passes: 532 passed, 2 ignored. An independent adversarial review found and repaired the ordered-storage pre-copy gap.