### PR TITLE
fix(jazz): retain policy point subscription deletions

### DIFF
--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -3057,6 +3057,13 @@ where
         let mut access_paths = BTreeMap::new();
         let equalities = root_literal_equalities(query, binding)?;
         let table = self.table_in_schema(&query.table, shape.schema_version())?;
+        // A maintained authorization scope reacts to both the content winner
+        // and its deletion register. The point source is only incrementally
+        // complete for an unscoped row: inside a policy graph, its content cap
+        // can strand the deletion-driven membership transition.
+        if table.has_any_policy() {
+            return Ok(access_paths);
+        }
         let has_declared_id = table.columns.iter().any(|column| column.name == "id");
         if !has_declared_id && let Some(value) = equalities.get("id").cloned() {
             access_paths.insert(

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -99,6 +99,25 @@ fn maintained_physical_point_hydration_uses_only_its_current_row_source() {
 }
 
 #[test]
+fn maintained_policy_point_subscription_keeps_full_current_source_for_deletion_liveness() {
+    let schema = owner_policy_schema();
+    let (_dir, node) = open_node_with_uuid(NodeUuid::from_bytes([0xc2; 16]), schema.clone());
+    let target = row(0x71);
+    let shape = Query::from("issues")
+        .filter(eq(col("id"), lit(Value::Uuid(target.0))))
+        .validate(&schema)
+        .unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+
+    assert!(
+        node.current_query_primary_key_access_paths(&shape, &binding)
+            .unwrap()
+            .is_empty(),
+        "policy-scoped maintained rows must retain their full source so deletion markers can remove them"
+    );
+}
+
+#[test]
 fn query_subscription_result_sets_track_bindings_and_rehydrate() {
     let (_server_dir, mut server) = open_node();
     let (_reader_dir, mut reader) = open_node();


### PR DESCRIPTION
🤖 Preserve deletion liveness for maintained primary-key subscriptions whose root table has authorization policy.

Before: point-access lowering capped the maintained current-row source even for policy-scoped roots. Under the default runtime feature set, deleting the row could omit the deletion register, so the subscription never emitted its retraction and the CI test hung indefinitely.

After: authorized maintained roots retain the full current source needed for policy and deletion reevaluation. Unscoped primary-key subscriptions keep the point optimization.

The exact CI-equivalent full Jazz library suite passes: 1413 passed, 2 skipped. Independent review verified default and no-default feature modes and planted removal of the new guard fails the structural sensitivity receipt.