### PR TITLE
Fix crate alpha publish allowlist

### DIFF
--- a/dev/gates/local-ci-equivalent.mjs
+++ b/dev/gates/local-ci-equivalent.mjs
@@ -86,6 +86,9 @@ export const ciPartitions = Object.freeze({
   lint: Object.freeze([
     command("format check", "pnpm", ["format:check"]),
     command("lint", "pnpm", ["lint"]),
+    command("crate publication selector contract", "bash", [
+      "dev/scripts/publish-crates-alpha.test.sh",
+    ]),
     command("CI workflow contracts", "pnpm", ["test:ci-workflow"]),
     command("Turbo cache-input contracts", "pnpm", ["test:turbo-cache-inputs"]),
     command("invariant registry", "bash", ["dev/gates/invariant-registry.sh"]),

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -153,6 +153,23 @@ test("CI invokes only shared partitions and rejects a direct correctness bypass"
   );
 });
 
+test("crate publication selector tests are a reachable lint partition contract", () => {
+  const lint = planFor({ partition: "lint" });
+  const selectorTest = lint.find(({ label }) => label === "crate publication selector contract");
+  assert.deepEqual(selectorTest, {
+    label: "crate publication selector contract",
+    executable: "bash",
+    args: ["dev/scripts/publish-crates-alpha.test.sh"],
+  });
+
+  const withoutSelectorTest = lint.filter(({ label }) => label !== "crate publication selector contract");
+  assert.equal(
+    withoutSelectorTest.some(({ args }) => args.includes("publish-crates-alpha.test.sh")),
+    false,
+    "a removed selector test would leave the lint CI partition without its publish admission receipt",
+  );
+});
+
 test("focused mode is explicitly smaller and cannot be mistaken for CI-equivalent", () => {
   const focused = planFor({ mode: "focused" });
   const complete = planFor({ mode: "ci-equivalent" });

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -162,7 +162,9 @@ test("crate publication selector tests are a reachable lint partition contract",
     args: ["dev/scripts/publish-crates-alpha.test.sh"],
   });
 
-  const withoutSelectorTest = lint.filter(({ label }) => label !== "crate publication selector contract");
+  const withoutSelectorTest = lint.filter(
+    ({ label }) => label !== "crate publication selector contract",
+  );
   assert.equal(
     withoutSelectorTest.some(({ args }) => args.includes("publish-crates-alpha.test.sh")),
     false,

--- a/dev/scripts/publish-crates-alpha.sh
+++ b/dev/scripts/publish-crates-alpha.sh
@@ -29,12 +29,30 @@ for crate_spec in "${crates[@]}"; do
   name="${crate_spec%%:*}"
   version="${crate_spec##*:}"
 
+  # `cargo publish -p` accepts any package in the workspace.  Resolve the
+  # exact metadata object before running it so the checked-in list cannot
+  # accidentally publish a package which opted out of crates.io.  Cargo emits
+  # `null` for unrestricted packages, `[]` for `publish = false`, and an array
+  # of registry names for an explicit allowlist.
   if ! jq -e \
     --arg name "$name" \
     --arg version "$version" \
-    'any(.packages[]; .name == $name and .version == $version)' \
+    '
+      .workspace_members as $workspace_members |
+      any(
+        .packages[];
+        .id as $id |
+        .name == $name and
+        .version == $version and
+        ($workspace_members | index($id)) and
+        (
+          .publish == null or
+          ((.publish | type) == "array" and (.publish | index("crates-io")))
+        )
+      )
+    ' \
     <<<"$metadata" >/dev/null; then
-    echo "Expected ${name}@${version} in Cargo workspace metadata" >&2
+    echo "Expected publishable workspace crate ${name}@${version} for crates.io" >&2
     exit 1
   fi
 done

--- a/dev/scripts/publish-crates-alpha.sh
+++ b/dev/scripts/publish-crates-alpha.sh
@@ -13,27 +13,46 @@ if [[ "$MODE" == "publish" && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
   exit 1
 fi
 
-# Workspace publish order based on dependency graph.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to validate the crate publish allowlist" >&2
+  exit 1
+fi
+
+# Crates approved for publication, with exact workspace versions.
 crates=(
   "jazz-wasm-tracing:3.0.0-alpha.0"
-  "jazz-tools:2.0.0-alpha.0"
 )
+
+metadata="$(cargo metadata --no-deps --format-version 1)"
+
+for crate_spec in "${crates[@]}"; do
+  name="${crate_spec%%:*}"
+  version="${crate_spec##*:}"
+
+  if ! jq -e \
+    --arg name "$name" \
+    --arg version "$version" \
+    'any(.packages[]; .name == $name and .version == $version)' \
+    <<<"$metadata" >/dev/null; then
+    echo "Expected ${name}@${version} in Cargo workspace metadata" >&2
+    exit 1
+  fi
+done
 
 for crate_spec in "${crates[@]}"; do
   name="${crate_spec%%:*}"
   version="${crate_spec##*:}"
 
   if [[ "$MODE" == "dry-run" ]]; then
-    echo "==> cargo check -p ${name} (registry dry-run not possible until dependencies are published)"
-    cargo check -p "$name"
+    echo "==> cargo publish --allow-dirty --dry-run -p ${name}"
+    cargo publish --allow-dirty --dry-run -p "$name"
     continue
   fi
 
-  echo "==> cargo publish -p ${name} (publish)"
-
+  echo "==> cargo publish --allow-dirty -p ${name}"
   publish_log="$(mktemp)"
-  if ! cargo publish -p "$name" --allow-dirty 2>&1 | tee "$publish_log"; then
-    if grep -q "already exists on crates.io index" "$publish_log"; then
+  if ! cargo publish --allow-dirty -p "$name" 2>&1 | tee "$publish_log"; then
+    if grep -Fq "already exists on crates.io index" "$publish_log"; then
       echo "==> ${name}@${version} already published, skipping"
       rm -f "$publish_log"
       continue

--- a/dev/scripts/publish-crates-alpha.test.sh
+++ b/dev/scripts/publish-crates-alpha.test.sh
@@ -16,7 +16,13 @@ case "${1:-}" in
   metadata)
     cat "${MOCK_METADATA_FILE:?}"
     ;;
-  check | publish)
+  check)
+    ;;
+  publish)
+    if [[ "${MOCK_PUBLISH_RESULT:-success}" == "already-published" ]]; then
+      echo "error: crate jazz-wasm-tracing@3.0.0-alpha.0 already exists on crates.io index" >&2
+      exit 101
+    fi
     ;;
   *)
     echo "unexpected cargo invocation: $*" >&2
@@ -133,6 +139,7 @@ run_case() {
   local name="$1"
   local metadata="$2"
   local mode="$3"
+  local publish_result="${4:-success}"
 
   CASE_LOG="$TEMP/$name.cargo.log"
   CASE_OUTPUT="$TEMP/$name.output"
@@ -144,6 +151,7 @@ run_case() {
     MOCK_METADATA_FILE="$metadata" \
     CARGO_NET_OFFLINE=true \
     CARGO_REGISTRY_TOKEN="test-token-never-sent" \
+    MOCK_PUBLISH_RESULT="$publish_result" \
     "$SCRIPT" "$mode" >"$CASE_OUTPUT" 2>&1
   CASE_STATUS=$?
   set -e
@@ -190,5 +198,16 @@ run_case valid-publish "$TEMP/metadata-valid.json" publish
 assert_log valid-publish \
   'metadata --no-deps --format-version 1' \
   'publish --allow-dirty -p jazz-wasm-tracing'
+
+run_case already-published "$TEMP/metadata-valid.json" publish already-published
+[[ "$CASE_STATUS" -eq 0 ]] || {
+  cat "$CASE_OUTPUT" >&2
+  fail 'already-published crate must be skipped successfully'
+}
+assert_log already-published \
+  'metadata --no-deps --format-version 1' \
+  'publish --allow-dirty -p jazz-wasm-tracing'
+grep -F 'already published, skipping' "$CASE_OUTPUT" >/dev/null ||
+  fail 'already-published result must be reported as skipped'
 
 echo 'crate alpha publish allowlist checks passed'

--- a/dev/scripts/publish-crates-alpha.test.sh
+++ b/dev/scripts/publish-crates-alpha.test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/dev/scripts/publish-crates-alpha.sh"
+TEMP="$(mktemp -d "${TMPDIR:-/tmp}/publish-crates-alpha-test.XXXXXX")"
+trap 'rm -rf "$TEMP"' EXIT
+mkdir "$TEMP/bin"
+
+cat >"$TEMP/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${MOCK_CARGO_LOG:?}"
+
+case "${1:-}" in
+  metadata)
+    cat "${MOCK_METADATA_FILE:?}"
+    ;;
+  check | publish)
+    ;;
+  *)
+    echo "unexpected cargo invocation: $*" >&2
+    exit 125
+    ;;
+esac
+EOF
+chmod +x "$TEMP/bin/cargo"
+
+cat >"$TEMP/metadata-valid.json" <<'EOF'
+{
+  "packages": [
+    {
+      "name": "jazz-wasm-tracing",
+      "version": "3.0.0-alpha.0",
+      "id": "path+file:///workspace/crates/wasm-tracing#jazz-wasm-tracing@3.0.0-alpha.0",
+      "license": "MIT OR Apache-2.0",
+      "license_file": null,
+      "description": "Tracing subscriber for WebAssembly.",
+      "source": null,
+      "dependencies": [],
+      "targets": [
+        {
+          "kind": ["lib"],
+          "crate_types": ["lib"],
+          "name": "wasm_tracing",
+          "src_path": "/workspace/crates/wasm-tracing/src/lib.rs",
+          "edition": "2021",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "/workspace/crates/wasm-tracing/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": "README.md",
+      "repository": "https://github.com/dsgallups/wasm-tracing",
+      "homepage": null,
+      "documentation": "https://docs.rs/wasm_tracing",
+      "edition": "2021",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    }
+  ],
+  "workspace_members": [
+    "path+file:///workspace/crates/wasm-tracing#jazz-wasm-tracing@3.0.0-alpha.0"
+  ],
+  "workspace_default_members": [
+    "path+file:///workspace/crates/wasm-tracing#jazz-wasm-tracing@3.0.0-alpha.0"
+  ],
+  "resolve": null,
+  "target_directory": "/workspace/target",
+  "version": 1,
+  "workspace_root": "/workspace",
+  "metadata": null
+}
+EOF
+
+cat >"$TEMP/metadata-missing.json" <<'EOF'
+{
+  "packages": [
+    {
+      "name": "jazz-cli",
+      "version": "0.1.0",
+      "id": "path+file:///workspace/crates/cli#jazz-cli@0.1.0",
+      "license": "MIT",
+      "license_file": null,
+      "description": "Jazz command-line tools.",
+      "source": null,
+      "dependencies": [],
+      "targets": [],
+      "features": {},
+      "manifest_path": "/workspace/crates/cli/Cargo.toml",
+      "metadata": null,
+      "publish": [],
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2021",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    }
+  ],
+  "workspace_members": ["path+file:///workspace/crates/cli#jazz-cli@0.1.0"],
+  "workspace_default_members": ["path+file:///workspace/crates/cli#jazz-cli@0.1.0"],
+  "resolve": null,
+  "target_directory": "/workspace/target",
+  "version": 1,
+  "workspace_root": "/workspace",
+  "metadata": null
+}
+EOF
+
+sed 's/3\.0\.0-alpha\.0/3.0.0-alpha.1/g' \
+  "$TEMP/metadata-valid.json" >"$TEMP/metadata-wrong-version.json"
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+run_case() {
+  local name="$1"
+  local metadata="$2"
+  local mode="$3"
+
+  CASE_LOG="$TEMP/$name.cargo.log"
+  CASE_OUTPUT="$TEMP/$name.output"
+  : >"$CASE_LOG"
+
+  set +e
+  PATH="$TEMP/bin:$PATH" \
+    MOCK_CARGO_LOG="$CASE_LOG" \
+    MOCK_METADATA_FILE="$metadata" \
+    CARGO_NET_OFFLINE=true \
+    CARGO_REGISTRY_TOKEN="test-token-never-sent" \
+    "$SCRIPT" "$mode" >"$CASE_OUTPUT" 2>&1
+  CASE_STATUS=$?
+  set -e
+
+  if grep -F 'jazz-tools' "$CASE_LOG" "$CASE_OUTPUT" >/dev/null; then
+    fail "$name selected stale jazz-tools"
+  fi
+}
+
+assert_log() {
+  local name="$1"
+  shift
+  local expected="$TEMP/$name.expected"
+  printf '%s\n' "$@" >"$expected"
+  if ! cmp -s "$expected" "$CASE_LOG"; then
+    echo "$name used unexpected Cargo calls:" >&2
+    diff -u "$expected" "$CASE_LOG" >&2 || true
+    exit 1
+  fi
+}
+
+run_case missing-package "$TEMP/metadata-missing.json" dry-run
+[[ "$CASE_STATUS" -ne 0 ]] || fail 'missing package metadata must fail'
+assert_log missing-package 'metadata --no-deps --format-version 1'
+
+run_case wrong-version "$TEMP/metadata-wrong-version.json" dry-run
+[[ "$CASE_STATUS" -ne 0 ]] || fail 'wrong package version must fail'
+assert_log wrong-version 'metadata --no-deps --format-version 1'
+
+run_case valid-dry-run "$TEMP/metadata-valid.json" dry-run
+[[ "$CASE_STATUS" -eq 0 ]] || {
+  cat "$CASE_OUTPUT" >&2
+  fail 'valid dry-run must succeed'
+}
+assert_log valid-dry-run \
+  'metadata --no-deps --format-version 1' \
+  'publish --allow-dirty --dry-run -p jazz-wasm-tracing'
+
+run_case valid-publish "$TEMP/metadata-valid.json" publish
+[[ "$CASE_STATUS" -eq 0 ]] || {
+  cat "$CASE_OUTPUT" >&2
+  fail 'valid publish must succeed'
+}
+assert_log valid-publish \
+  'metadata --no-deps --format-version 1' \
+  'publish --allow-dirty -p jazz-wasm-tracing'
+
+echo 'crate alpha publish allowlist checks passed'

--- a/dev/scripts/publish-crates-alpha.test.sh
+++ b/dev/scripts/publish-crates-alpha.test.sh
@@ -130,6 +130,15 @@ EOF
 sed 's/3\.0\.0-alpha\.0/3.0.0-alpha.1/g' \
   "$TEMP/metadata-valid.json" >"$TEMP/metadata-wrong-version.json"
 
+jq '.packages[0].publish = []' \
+  "$TEMP/metadata-valid.json" >"$TEMP/metadata-publish-disabled.json"
+jq '.packages[0].publish = ["internal"]' \
+  "$TEMP/metadata-valid.json" >"$TEMP/metadata-other-registry.json"
+jq '.packages[0].publish = ["internal", "crates-io"]' \
+  "$TEMP/metadata-valid.json" >"$TEMP/metadata-crates-io-allowed.json"
+jq '.workspace_members = []' \
+  "$TEMP/metadata-valid.json" >"$TEMP/metadata-not-workspace-member.json"
+
 fail() {
   echo "$1" >&2
   exit 1
@@ -180,6 +189,27 @@ assert_log missing-package 'metadata --no-deps --format-version 1'
 run_case wrong-version "$TEMP/metadata-wrong-version.json" dry-run
 [[ "$CASE_STATUS" -ne 0 ]] || fail 'wrong package version must fail'
 assert_log wrong-version 'metadata --no-deps --format-version 1'
+
+run_case publish-disabled "$TEMP/metadata-publish-disabled.json" publish
+[[ "$CASE_STATUS" -ne 0 ]] || fail 'publish = false must fail before publishing'
+assert_log publish-disabled 'metadata --no-deps --format-version 1'
+
+run_case other-registry "$TEMP/metadata-other-registry.json" publish
+[[ "$CASE_STATUS" -ne 0 ]] || fail 'non-crates.io registry allowlist must fail before publishing'
+assert_log other-registry 'metadata --no-deps --format-version 1'
+
+run_case not-workspace-member "$TEMP/metadata-not-workspace-member.json" publish
+[[ "$CASE_STATUS" -ne 0 ]] || fail 'non-workspace package must fail before publishing'
+assert_log not-workspace-member 'metadata --no-deps --format-version 1'
+
+run_case crates-io-allowed "$TEMP/metadata-crates-io-allowed.json" dry-run
+[[ "$CASE_STATUS" -eq 0 ]] || {
+  cat "$CASE_OUTPUT" >&2
+  fail 'explicit crates.io registry allowlist must succeed'
+}
+assert_log crates-io-allowed \
+  'metadata --no-deps --format-version 1' \
+  'publish --allow-dirty --dry-run -p jazz-wasm-tracing'
 
 run_case valid-dry-run "$TEMP/metadata-valid.json" dry-run
 [[ "$CASE_STATUS" -eq 0 ]] || {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "format": "oxfmt --ignore-path .oxfmtignore .",
     "format:check": "oxfmt --check --ignore-path .oxfmtignore . && cargo fmt --check",
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
-    "test:tooling": "sh dev/scripts/clippy-staged.test.sh",
+    "test:tooling": "sh dev/scripts/clippy-staged.test.sh && bash dev/scripts/publish-crates-alpha.test.sh",
     "test:focused-rust": "bash dev/gates/test/dev-t.test.sh",
     "test:vercel-preview-skip": "node --test dev/scripts/skip-new-core-vercel-preview.test.mjs",
     "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",


### PR DESCRIPTION
🤖 Fixes the alpha Rust-crate release list—the explicit list of packages that the workflow is allowed to publish—so a stale package name cannot cause a partially completed release.

## Example

The workflow still listed `jazz-tools` as a Cargo package, but `jazz-tools` is now only a binary produced by the `jazz-cli` package.

Previously, an alpha release could:

1. publish an earlier crate successfully;
2. reach the stale `jazz-tools` entry;
3. fail because no Cargo package had that name; and
4. leave the release only partly published.

The old dry run did not catch this because it merely compiled packages rather than asking Cargo to assemble and validate the publishable crate.

After this PR, the workflow validates every listed package's exact name and version from Cargo metadata before performing any registry operation. A missing or renamed package therefore stops the release before the first crate is published.

Dry runs now execute `cargo publish --dry-run`, exercising Cargo packaging rather than only compilation. Real retries remain idempotent: if the exact package version already exists on crates.io, the workflow skips it and continues.

## Evidence

- `dev/scripts/publish-crates-alpha.test.sh`
- maintained local tooling gate
- live `cargo publish --allow-dirty --dry-run -p jazz-wasm-tracing`
- exact-head CI previously passed lint, TypeScript, Rust, workspace, and differential jobs
- independent review found no correctness issue