### PR TITLE
Own the Edge upstream reconnect lifecycle

### DIFF
--- a/.changeset/edge-upstream-reconnect-lifecycle.md
+++ b/.changeset/edge-upstream-reconnect-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Own the edge server's upstream connector across bootstrap, retry, established disconnect, and shutdown. Reconnect transient failures with bounded exponential backoff, expose fatal lifecycle health, detach the exact upstream peer before retry, and cancel and join connector work before storage closes.

--- a/crates/jazz-server/src/lib.rs
+++ b/crates/jazz-server/src/lib.rs
@@ -6,8 +6,8 @@ pub mod server;
 
 pub use middleware::AuthConfig;
 pub use server::{
-    BuiltServer, ServerBuilder, ServerState, ServerTopology, ShutdownController, ShutdownPhase,
-    StorageBackend,
+    BuiltServer, EdgeUpstreamHealth, ServerBuilder, ServerState, ServerTopology,
+    ShutdownController, ShutdownPhase, StorageBackend,
 };
 #[cfg(feature = "embedded-server")]
 pub use server::{

--- a/crates/jazz-server/src/server/builder.rs
+++ b/crates/jazz-server/src/server/builder.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::Router;
 use jazz::groove::storage::StorageFactory;
 use jazz::ids::AuthorSubject;
 use jazz::node::EdgeCacheBudget;
 use jazz::schema::JazzSchema;
-use jazz::serving::{NodeRole, StorageConfig};
-use tracing::info;
+use jazz::serving::{NodeRole, ServerUpstreamTerminalReason, StorageConfig};
+use tracing::{error, info};
 
 use crate::middleware::AuthConfig;
 use crate::middleware::auth::{
@@ -17,11 +17,13 @@ use crate::middleware::auth::{
 };
 use crate::server::routes;
 use crate::server::{
-    CatalogueKvStorage, CatalogueMemoryStorage, DynCatalogueStorage, ServerState, ServerTopology,
-    StoredCatalogue,
+    CatalogueKvStorage, CatalogueMemoryStorage, DynCatalogueStorage, EdgeUpstreamHealth,
+    ServerState, ServerTopology, StoredCatalogue,
 };
 use jazz::tools::AppId;
-use jazz::tools::native_transport_connector::{NativeTransportConnector, NativeTransportRequest};
+use jazz::tools::native_transport_connector::{
+    NativeTransportConnector, NativeTransportError, NativeTransportRequest, NativeTransportTerminal,
+};
 #[allow(deprecated)]
 use jazz::tools::public_schema::Schema;
 #[cfg(test)]
@@ -30,6 +32,9 @@ use jazz::tools::sync::DurabilityTier;
 const CATALOGUE_ROCKSDB_DIR: &str = "catalogue.rocksdb";
 const SERVER_SHELL_ROCKSDB_DIR: &str = "server-shell.rocksdb";
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+const EDGE_RECONNECT_BASE_DELAY: Duration = Duration::from_millis(100);
+const EDGE_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(5);
+const EDGE_RECONNECT_STABLE_AFTER: Duration = Duration::from_secs(30);
 
 pub struct BuiltServer {
     #[cfg_attr(not(test), allow(dead_code))]
@@ -233,6 +238,8 @@ impl ServerBuilder {
             // offline. Blank edges have no such generation and stay behind
             // RetryLater until authenticated bootstrap completes.
             dynamic_edge_catalogue_ready: AtomicBool::new(dynamic_edge_catalogue_ready),
+            edge_upstream_health: std::sync::RwLock::new(EdgeUpstreamHealth::NotConfigured),
+            edge_upstream_task: std::sync::Mutex::new(None),
             shutdown: crate::server::ShutdownController::new(self.shutdown_timeout),
         });
 
@@ -401,6 +408,49 @@ fn test_schema_branches(schema: Option<&Schema>) -> Vec<String> {
     schema.map(|_| "main".to_string()).into_iter().collect()
 }
 
+#[derive(Debug)]
+enum EdgeConnectorOutcome {
+    Retryable(String),
+    Reconnect(String),
+    Fatal(String),
+}
+
+fn native_transport_outcome(error: NativeTransportError) -> EdgeConnectorOutcome {
+    EdgeConnectorOutcome::Retryable(error.to_string())
+}
+
+fn connected_transport_outcome(reason: ServerUpstreamTerminalReason) -> EdgeConnectorOutcome {
+    match reason {
+        ServerUpstreamTerminalReason::NativeTransport(NativeTransportTerminal::Closed(reason)) => {
+            EdgeConnectorOutcome::Reconnect(reason)
+        }
+        ServerUpstreamTerminalReason::NativeTransport(NativeTransportTerminal::Failed(error)) => {
+            EdgeConnectorOutcome::Reconnect(error.to_string())
+        }
+        ServerUpstreamTerminalReason::Backpressure => {
+            EdgeConnectorOutcome::Reconnect("upstream transport backpressure".to_owned())
+        }
+        ServerUpstreamTerminalReason::TransportFailed(reason) => {
+            EdgeConnectorOutcome::Reconnect(reason)
+        }
+        ServerUpstreamTerminalReason::ProtocolFailed(reason) => EdgeConnectorOutcome::Fatal(reason),
+        ServerUpstreamTerminalReason::Cancelled => {
+            EdgeConnectorOutcome::Reconnect("upstream wire driver was cancelled".to_owned())
+        }
+        ServerUpstreamTerminalReason::RuntimeStopped => {
+            EdgeConnectorOutcome::Fatal("server shell upstream driver stopped".to_owned())
+        }
+    }
+}
+
+fn edge_reconnect_delay(attempt: u32) -> Duration {
+    let multiplier = 1_u32 << attempt.saturating_sub(1).min(6);
+    EDGE_RECONNECT_BASE_DELAY
+        .checked_mul(multiplier)
+        .unwrap_or(EDGE_RECONNECT_MAX_DELAY)
+        .min(EDGE_RECONNECT_MAX_DELAY)
+}
+
 fn spawn_edge_upstream_connector(
     state: Arc<ServerState>,
     upstream_url: String,
@@ -409,90 +459,232 @@ fn spawn_edge_upstream_connector(
     edge_cache_budget: Option<EdgeCacheBudget>,
     connector: Arc<dyn NativeTransportConnector>,
 ) {
-    tokio::spawn(async move {
-        let retry_delay = Duration::from_millis(100);
+    state.set_edge_upstream_health(EdgeUpstreamHealth::Connecting);
+    let weak_state = Arc::downgrade(&state);
+    let shutdown = state.shutdown.clone();
+    let task = tokio::spawn(async move {
+        let mut recovery_attempts = 0_u32;
         loop {
-            if state.shutdown.is_shutting_down() {
-                return;
-            }
             let auth = jazz::tools::websocket_prelude_auth::AuthConfig {
                 admin_secret: Some(admin_secret.clone()),
                 ..Default::default()
             };
-            // Revalidate every reconnect, including a durable reopen. The
-            // regular sync socket can then carry application/fate traffic only
-            // after the exact authority catalogue and local IVM registry are
-            // complete for this process generation.
-            let snapshot = match connector
-                .bootstrap_catalogue(NativeTransportRequest {
-                    server_url: upstream_url.clone(),
-                    app_id,
-                    peer_identity: AuthorSubject::SYSTEM,
-                    auth: auth.clone(),
-                    wake: Arc::new(|| {}),
-                })
-                .await
-            {
-                Ok(snapshot) => snapshot,
-                Err(error) => {
-                    info!("edge catalogue bootstrap pending: {}", error);
-                    tokio::time::sleep(retry_delay).await;
-                    continue;
-                }
+            let bootstrap = connector.bootstrap_catalogue(NativeTransportRequest {
+                server_url: upstream_url.clone(),
+                app_id,
+                peer_identity: AuthorSubject::SYSTEM,
+                auth: auth.clone(),
+                wake: Arc::new(|| {}),
+            });
+            let snapshot = tokio::select! {
+                biased;
+                _ = shutdown.wait_requested() => return,
+                result = bootstrap => match result {
+                    Ok(snapshot) => snapshot,
+                    Err(error) => {
+                        let outcome = native_transport_outcome(error);
+                        if !handle_edge_connector_outcome(
+                            &weak_state,
+                            &shutdown,
+                            outcome,
+                            &mut recovery_attempts,
+                        ).await {
+                            return;
+                        }
+                        continue;
+                    }
+                },
+            };
+
+            let Some(state) = weak_state.upgrade() else {
+                return;
             };
             let shell = match state.runtime() {
-                Some(shell) => match state.refresh_dynamic_edge_catalogue(&shell, snapshot).await {
-                    Ok(()) => shell,
-                    Err(error) => {
-                        info!("edge catalogue replay pending: {}", error);
-                        tokio::time::sleep(retry_delay).await;
-                        continue;
+                Some(shell) => {
+                    let refresh = state.refresh_dynamic_edge_catalogue(&shell, snapshot);
+                    let refreshed = tokio::select! {
+                        biased;
+                        _ = shutdown.wait_requested() => return,
+                        result = refresh => result,
+                    };
+                    match refreshed {
+                        Ok(()) => shell,
+                        Err(error) => {
+                            drop(state);
+                            if !handle_edge_connector_outcome(
+                                &weak_state,
+                                &shutdown,
+                                EdgeConnectorOutcome::Fatal(format!(
+                                    "edge catalogue refresh failed: {error}"
+                                )),
+                                &mut recovery_attempts,
+                            )
+                            .await
+                            {
+                                return;
+                            }
+                            continue;
+                        }
                     }
-                },
+                }
                 None => match state.start_dynamic_edge_shell(snapshot, edge_cache_budget) {
                     Ok(shell) => shell,
+                    Err(_) if shutdown.is_shutting_down() => return,
                     Err(error) => {
-                        info!("edge catalogue bootstrap pending: {}", error);
-                        tokio::time::sleep(retry_delay).await;
+                        drop(state);
+                        if !handle_edge_connector_outcome(
+                            &weak_state,
+                            &shutdown,
+                            EdgeConnectorOutcome::Fatal(format!(
+                                "edge catalogue bootstrap failed: {error}"
+                            )),
+                            &mut recovery_attempts,
+                        )
+                        .await
+                        {
+                            return;
+                        }
                         continue;
                     }
                 },
             };
+            drop(state);
+
             let wake_shell = shell.clone();
             let wake = Arc::new(move || wake_shell.notify_activity());
-            match connector
-                .connect(NativeTransportRequest {
-                    server_url: upstream_url.clone(),
-                    app_id,
-                    peer_identity: AuthorSubject::SYSTEM,
-                    auth,
-                    wake,
-                })
-                .await
-            {
-                Ok(transport) => {
-                    if shell
-                        .connect_upstream_wire(
-                            transport.transport,
-                            transport.protocol_version,
-                            transport.features,
-                            transport.session_context,
-                        )
-                        .await
-                        .is_ok()
-                    {
-                        state.mark_dynamic_edge_catalogue_ready();
-                        shell.notify_activity();
-                        return;
+            let connect = connector.connect(NativeTransportRequest {
+                server_url: upstream_url.clone(),
+                app_id,
+                peer_identity: AuthorSubject::SYSTEM,
+                auth,
+                wake,
+            });
+            let connected = tokio::select! {
+                biased;
+                _ = shutdown.wait_requested() => return,
+                result = connect => match result {
+                    Ok(connected) => connected,
+                    Err(error) => {
+                        let outcome = native_transport_outcome(error);
+                        if !handle_edge_connector_outcome(
+                            &weak_state,
+                            &shutdown,
+                            outcome,
+                            &mut recovery_attempts,
+                        ).await {
+                            return;
+                        }
+                        continue;
                     }
+                },
+            };
+            let connection = tokio::select! {
+                biased;
+                _ = shutdown.wait_requested() => return,
+                result = shell.connect_upstream_wire(
+                    connected.transport,
+                    connected.terminal,
+                    connected.protocol_version,
+                    connected.features,
+                    connected.session_context,
+                ) => match result {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        if !handle_edge_connector_outcome(
+                            &weak_state,
+                            &shutdown,
+                            EdgeConnectorOutcome::Fatal(format!(
+                                "edge upstream attachment failed: {error}"
+                            )),
+                            &mut recovery_attempts,
+                        ).await {
+                            return;
+                        }
+                        continue;
+                    }
+                },
+            };
+
+            let Some(state) = weak_state.upgrade() else {
+                return;
+            };
+            if let Err(error) = state.mark_dynamic_edge_catalogue_ready() {
+                if shutdown.is_shutting_down() {
+                    return;
                 }
-                Err(error) => {
-                    info!("edge upstream connection pending: {}", error);
-                }
+                state.set_edge_upstream_health(EdgeUpstreamHealth::Failed {
+                    reason: error.clone(),
+                });
+                error!(%error, "edge upstream lifecycle failed");
+                return;
             }
-            tokio::time::sleep(retry_delay).await;
+            state.set_edge_upstream_health(EdgeUpstreamHealth::Connected);
+            shell.notify_activity();
+            drop(state);
+
+            let connected_at = Instant::now();
+            let terminal = tokio::select! {
+                biased;
+                _ = shutdown.wait_requested() => return,
+                terminal = connection.terminal() => terminal,
+            };
+            if connected_at.elapsed() >= EDGE_RECONNECT_STABLE_AFTER {
+                recovery_attempts = 0;
+            }
+            let outcome = connected_transport_outcome(terminal);
+            if !handle_edge_connector_outcome(
+                &weak_state,
+                &shutdown,
+                outcome,
+                &mut recovery_attempts,
+            )
+            .await
+            {
+                return;
+            }
         }
     });
+    state.own_edge_upstream_task(task);
+}
+
+async fn handle_edge_connector_outcome(
+    state: &std::sync::Weak<ServerState>,
+    shutdown: &crate::server::ShutdownController,
+    outcome: EdgeConnectorOutcome,
+    recovery_attempts: &mut u32,
+) -> bool {
+    let (reason, reconnect) = match outcome {
+        EdgeConnectorOutcome::Fatal(reason) => {
+            if let Some(state) = state.upgrade() {
+                state.set_edge_upstream_health(EdgeUpstreamHealth::Failed {
+                    reason: reason.clone(),
+                });
+            }
+            error!(%reason, "edge upstream lifecycle stopped");
+            return false;
+        }
+        EdgeConnectorOutcome::Retryable(reason) => (reason, false),
+        EdgeConnectorOutcome::Reconnect(reason) => (reason, true),
+    };
+    *recovery_attempts = recovery_attempts.saturating_add(1);
+    let delay = edge_reconnect_delay(*recovery_attempts);
+    if let Some(state) = state.upgrade() {
+        state.set_edge_upstream_health(EdgeUpstreamHealth::Reconnecting {
+            reason: reason.clone(),
+        });
+    } else {
+        return false;
+    }
+    if reconnect {
+        info!(%reason, ?delay, "edge upstream disconnected; reconnecting");
+    } else {
+        info!(%reason, ?delay, "edge upstream unavailable; retrying");
+    }
+    tokio::select! {
+        biased;
+        _ = shutdown.wait_requested() => false,
+        _ = tokio::time::sleep(delay) => true,
+    }
 }
 
 async fn build_jwt_verifier(auth_config: &AuthConfig) -> Result<Option<Arc<JwtVerifier>>, String> {
@@ -628,8 +820,13 @@ mod tests {
     use jazz::groove::storage::OrderedKvStorage;
     use jazz::tools::AppId;
     use jazz::tools::metadata::{MetadataKey, ObjectType};
+    use jazz::tools::native_transport_connector::{
+        ConnectedNativeTransport, NativeCatalogueBootstrapFuture, NativeTransportFuture,
+    };
     use jazz::tools::public_schema::SchemaHash;
     use jazz::tools::schema_lens::LensTransform;
+    use jazz::wire::{TransportError, WireTransport};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn dynamic_bootstrap_schema() -> jazz::tools::public_schema::Schema {
         jazz::tools::public_schema::SchemaBuilder::new()
@@ -650,6 +847,260 @@ mod tests {
             entry.encode_storage_row().expect("encode catalogue entry"),
         ))
         .expect("write raw catalogue entry");
+    }
+
+    struct NoopWireTransport;
+
+    impl WireTransport for NoopWireTransport {
+        fn send_frame(&mut self, _frame: Vec<u8>) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    struct ClosingConnector {
+        snapshot: jazz::protocol::CatalogueSnapshot,
+        connect_count: AtomicUsize,
+    }
+
+    impl NativeTransportConnector for ClosingConnector {
+        fn connect(&self, _request: NativeTransportRequest) -> NativeTransportFuture {
+            let connection = self.connect_count.fetch_add(1, Ordering::SeqCst);
+            let terminal = if connection == 0 {
+                Box::pin(std::future::ready(NativeTransportTerminal::Closed(
+                    "idle websocket closed".to_owned(),
+                )))
+                    as jazz::tools::native_transport_connector::NativeTransportTerminalFuture
+            } else {
+                Box::pin(std::future::pending())
+            };
+            Box::pin(async move {
+                Ok(ConnectedNativeTransport {
+                    transport: Box::new(NoopWireTransport),
+                    protocol_version: jazz::wire::WIRE_PROTOCOL_VERSION,
+                    features: jazz::wire::FEATURE_NONE,
+                    session_context: None,
+                    terminal,
+                })
+            })
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> NativeCatalogueBootstrapFuture {
+            let snapshot = self.snapshot.clone();
+            Box::pin(async move { Ok(snapshot) })
+        }
+    }
+
+    struct MalformedWireTransport {
+        returned_frame: bool,
+    }
+
+    impl WireTransport for MalformedWireTransport {
+        fn send_frame(&mut self, _frame: Vec<u8>) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            if self.returned_frame {
+                None
+            } else {
+                self.returned_frame = true;
+                Some(vec![0xff])
+            }
+        }
+    }
+
+    struct FatalProtocolConnector {
+        snapshot: jazz::protocol::CatalogueSnapshot,
+    }
+
+    impl NativeTransportConnector for FatalProtocolConnector {
+        fn connect(&self, _request: NativeTransportRequest) -> NativeTransportFuture {
+            Box::pin(async {
+                Ok(ConnectedNativeTransport {
+                    transport: Box::new(MalformedWireTransport {
+                        returned_frame: false,
+                    }),
+                    protocol_version: jazz::wire::WIRE_PROTOCOL_VERSION,
+                    features: jazz::wire::FEATURE_NONE,
+                    session_context: None,
+                    terminal: Box::pin(std::future::pending()),
+                })
+            })
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> NativeCatalogueBootstrapFuture {
+            let snapshot = self.snapshot.clone();
+            Box::pin(async move { Ok(snapshot) })
+        }
+    }
+
+    struct PendingBootstrapConnector;
+
+    impl NativeTransportConnector for PendingBootstrapConnector {
+        fn connect(&self, _request: NativeTransportRequest) -> NativeTransportFuture {
+            Box::pin(std::future::pending())
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> NativeCatalogueBootstrapFuture {
+            Box::pin(std::future::pending())
+        }
+    }
+
+    #[test]
+    fn edge_reconnect_delay_is_exponential_and_capped() {
+        assert_eq!(edge_reconnect_delay(1), Duration::from_millis(100));
+        assert_eq!(edge_reconnect_delay(2), Duration::from_millis(200));
+        assert_eq!(edge_reconnect_delay(6), Duration::from_millis(3_200));
+        assert_eq!(edge_reconnect_delay(7), EDGE_RECONNECT_MAX_DELAY);
+        assert_eq!(edge_reconnect_delay(u32::MAX), EDGE_RECONNECT_MAX_DELAY);
+    }
+
+    #[tokio::test]
+    async fn idle_upstream_terminal_reconnects_and_reaches_connected_again() {
+        let app_id = AppId::from_name("edge-idle-upstream-reconnect");
+        let auth = AuthConfig {
+            admin_secret: Some("bootstrap-secret".to_owned()),
+            ..Default::default()
+        };
+        let core = ServerBuilder::new(app_id)
+            .with_schema(dynamic_bootstrap_schema())
+            .with_auth_config(auth.clone())
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build authority core");
+        let snapshot = core
+            .state
+            .runtime()
+            .expect("core has shell")
+            .trusted_catalogue_snapshot_for_test()
+            .await
+            .expect("read authority snapshot");
+        let connector = Arc::new(ClosingConnector {
+            snapshot,
+            connect_count: AtomicUsize::new(0),
+        });
+        let edge = ServerBuilder::new(app_id)
+            .with_auth_config(auth)
+            .with_storage(StorageBackend::InMemory)
+            .with_upstream_url("ws://127.0.0.1:9")
+            .with_native_transport_connector(connector.clone())
+            .build()
+            .await
+            .expect("build edge");
+
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if connector.connect_count.load(Ordering::SeqCst) >= 2
+                    && edge.state.edge_upstream_health() == EdgeUpstreamHealth::Connected
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("edge reconnects after idle terminal");
+
+        assert!(connector.connect_count.load(Ordering::SeqCst) >= 2);
+        edge.shutdown().await;
+        core.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn fatal_upstream_protocol_error_stops_connector_with_visible_health_failure() {
+        let app_id = AppId::from_name("edge-fatal-upstream-health");
+        let auth = AuthConfig {
+            admin_secret: Some("bootstrap-secret".to_owned()),
+            ..Default::default()
+        };
+        let core = ServerBuilder::new(app_id)
+            .with_schema(dynamic_bootstrap_schema())
+            .with_auth_config(auth.clone())
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build authority core");
+        let snapshot = core
+            .state
+            .runtime()
+            .expect("core has shell")
+            .trusted_catalogue_snapshot_for_test()
+            .await
+            .expect("read authority snapshot");
+        let edge = ServerBuilder::new(app_id)
+            .with_auth_config(auth)
+            .with_storage(StorageBackend::InMemory)
+            .with_upstream_url("ws://127.0.0.1:9")
+            .with_native_transport_connector(Arc::new(FatalProtocolConnector { snapshot }))
+            .build()
+            .await
+            .expect("build edge");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if matches!(
+                    edge.state.edge_upstream_health(),
+                    EdgeUpstreamHealth::Failed { .. }
+                ) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("fatal protocol outcome becomes visible");
+        let health = edge.state.edge_upstream_health();
+        assert!(
+            matches!(
+                &health,
+                EdgeUpstreamHealth::Failed { reason }
+                    if reason.contains("malformed auxiliary wire frame")
+            ),
+            "fatal protocol reason remains available to health reporting"
+        );
+
+        edge.shutdown().await;
+        core.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_pending_edge_bootstrap_before_shell_publication() {
+        let app_id = AppId::from_name("edge-shutdown-cancels-bootstrap");
+        let edge = ServerBuilder::new(app_id)
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("bootstrap-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_storage(StorageBackend::InMemory)
+            .with_upstream_url("ws://127.0.0.1:9")
+            .with_native_transport_connector(Arc::new(PendingBootstrapConnector))
+            .build()
+            .await
+            .expect("build edge");
+
+        let phase = tokio::time::timeout(Duration::from_secs(1), edge.shutdown())
+            .await
+            .expect("shutdown cancels pending bootstrap");
+        assert_eq!(phase, crate::server::ShutdownPhase::StorageClosed);
+        assert!(edge.state.runtime().is_none());
+        assert_eq!(
+            edge.state.edge_upstream_health(),
+            EdgeUpstreamHealth::Stopped
+        );
     }
 
     #[tokio::test]

--- a/crates/jazz-server/src/server/mod.rs
+++ b/crates/jazz-server/src/server/mod.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock as StdRwLock};
+use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
 use std::thread;
 
 use crate::middleware::AuthConfig;
@@ -85,6 +85,23 @@ impl ServerTopology {
     }
 }
 
+/// Operational state of an edge server's owned upstream connector.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EdgeUpstreamHealth {
+    /// This server has no owned upstream connector.
+    NotConfigured,
+    /// Bootstrap or socket establishment is in progress.
+    Connecting,
+    /// The ordinary upstream wire is attached.
+    Connected,
+    /// A recoverable outcome is waiting for its next attempt.
+    Reconnecting { reason: String },
+    /// A fatal outcome stopped the connector generation.
+    Failed { reason: String },
+    /// Shutdown cancelled and joined the connector.
+    Stopped,
+}
+
 /// Server state shared across request handlers.
 pub struct ServerState {
     /// Direct, storage-backed admin catalogue store.
@@ -111,7 +128,22 @@ pub struct ServerState {
     /// generation remains usable offline; blank and refreshing generations do
     /// not admit new downstream sessions.
     dynamic_edge_catalogue_ready: AtomicBool,
+    edge_upstream_health: StdRwLock<EdgeUpstreamHealth>,
+    edge_upstream_task: StdMutex<Option<tokio::task::JoinHandle<()>>>,
     pub shutdown: ShutdownController,
+}
+
+impl Drop for ServerState {
+    fn drop(&mut self) {
+        let task = self
+            .edge_upstream_task
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(task) = task {
+            task.abort();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -225,13 +257,17 @@ impl ServerState {
         )
     }
 
-    pub(crate) fn mark_dynamic_edge_catalogue_ready(&self) {
+    pub(crate) fn mark_dynamic_edge_catalogue_ready(&self) -> Result<(), String> {
         // Serialize this Ready transition with dynamic shell publication and
         // client snapshots. Callers reach this only after catalogue adoption
         // and any required projection-registry rebuild have returned.
         let _shell = self.core_server_shell.read().unwrap();
+        if self.shutdown.is_shutting_down() {
+            return Err("server shutdown started before edge readiness publication".to_owned());
+        }
         self.dynamic_edge_catalogue_ready
             .store(true, Ordering::Release);
+        Ok(())
     }
 
     fn mark_dynamic_edge_catalogue_refreshing(&self) {
@@ -248,14 +284,47 @@ impl ServerState {
         shell: &ServerRuntimeHandle,
         snapshot: jazz::protocol::CatalogueSnapshot,
     ) -> Result<(), String> {
+        if self.shutdown.is_shutting_down() {
+            return Err("server shutdown started before edge catalogue refresh".to_owned());
+        }
         self.mark_dynamic_edge_catalogue_refreshing();
         shell.apply_trusted_catalogue_snapshot(snapshot).await?;
         // Applying the snapshot returns only after a semantic transition has
         // rebuilt its local projections. The newly validated durable
         // generation may therefore serve offline even if normal upstream
         // attachment is still retrying.
-        self.mark_dynamic_edge_catalogue_ready();
-        Ok(())
+        self.mark_dynamic_edge_catalogue_ready()
+    }
+
+    pub fn edge_upstream_health(&self) -> EdgeUpstreamHealth {
+        self.edge_upstream_health.read().unwrap().clone()
+    }
+
+    pub(crate) fn set_edge_upstream_health(&self, health: EdgeUpstreamHealth) {
+        *self.edge_upstream_health.write().unwrap() = health;
+    }
+
+    pub(crate) fn own_edge_upstream_task(&self, task: tokio::task::JoinHandle<()>) {
+        let replaced = self.edge_upstream_task.lock().unwrap().replace(task);
+        debug_assert!(replaced.is_none(), "edge upstream task is installed once");
+    }
+
+    async fn stop_edge_upstream_task(&self) {
+        let task = self.edge_upstream_task.lock().unwrap().take();
+        if let Some(task) = task
+            && let Err(error) = task.await
+            && !error.is_cancelled()
+        {
+            tracing::error!(%error, "edge upstream lifecycle task failed");
+        }
+        if self.topology == ServerTopology::Edge
+            && !matches!(
+                self.edge_upstream_health(),
+                EdgeUpstreamHealth::Failed { .. }
+            )
+        {
+            self.set_edge_upstream_health(EdgeUpstreamHealth::Stopped);
+        }
     }
 
     pub(crate) fn start_core_server_shell(
@@ -295,6 +364,9 @@ impl ServerState {
         if self.topology != ServerTopology::Edge {
             return Err("dynamic catalogue bootstrap is only valid for edge topology".to_owned());
         }
+        if self.shutdown.is_shutting_down() {
+            return Err("server shutdown started before edge shell publication".to_owned());
+        }
         let storage_config = self
             .core_server_shell_storage_config
             .clone()
@@ -302,6 +374,9 @@ impl ServerState {
         let mut core_server_shell = self.core_server_shell.write().unwrap();
         if let Some(existing) = core_server_shell.clone() {
             return Ok(existing);
+        }
+        if self.shutdown.is_shutting_down() {
+            return Err("server shutdown started before edge shell publication".to_owned());
         }
         let started = ServerRuntimeHandle::start_dynamic_edge_with_catalogue_snapshot(
             storage_config,
@@ -311,6 +386,11 @@ impl ServerState {
         )?;
         self.dynamic_edge_catalogue_ready
             .store(false, Ordering::Release);
+        if self.shutdown.is_shutting_down() {
+            drop(core_server_shell);
+            drop(started);
+            return Err("server shutdown started before edge shell publication".to_owned());
+        }
         *core_server_shell = Some(started.clone());
         Ok(started)
     }
@@ -343,6 +423,7 @@ impl ServerState {
 
     async fn finalize_shutdown(&self) -> ShutdownPhase {
         self.shutdown.set_phase(ShutdownPhase::DrainingConnections);
+        self.stop_edge_upstream_task().await;
         let mut failed = false;
         let websockets_drained = self.shutdown.wait_for_websocket_drain().await;
         if !websockets_drained {
@@ -547,6 +628,8 @@ mod tests {
             core_server_shell_storage_config: None,
             storage_factory: None,
             dynamic_edge_catalogue_ready: AtomicBool::new(true),
+            edge_upstream_health: StdRwLock::new(EdgeUpstreamHealth::NotConfigured),
+            edge_upstream_task: StdMutex::new(None),
             shutdown: ShutdownController::new(timeout),
         })
     }

--- a/crates/jazz-server/src/server/routes/http.rs
+++ b/crates/jazz-server/src/server/routes/http.rs
@@ -12,7 +12,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 
 use crate::middleware::auth::validate_admin_secret;
-use crate::server::{ServerState, ShutdownPhase};
+use crate::server::{EdgeUpstreamHealth, ServerState, ShutdownPhase};
 use jazz::tools::public_schema::{ColumnType, Schema, SchemaHash, TableName, TablePolicies, Value};
 use jazz::tools::schema_lens::{Lens, LensOp, LensTransform};
 use jazz::tools::transport_error::ErrorResponse;
@@ -1297,6 +1297,17 @@ pub(super) async fn internal_shutdown_handler(
 pub(super) async fn health_handler(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
     let mut phase = state.shutdown.phase();
     if !state.shutdown.is_shutting_down() && phase.is_running() {
+        if let EdgeUpstreamHealth::Failed { reason } = state.edge_upstream_health() {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "status": "unhealthy",
+                    "component": "edge_upstream",
+                    "reason": reason,
+                })),
+            )
+                .into_response();
+        }
         return Json(serde_json::json!({
             "status": "healthy"
         }))

--- a/crates/jazz-server/src/server/routes/mod.rs
+++ b/crates/jazz-server/src/server/routes/mod.rs
@@ -151,7 +151,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::middleware::AuthConfig;
-    use crate::server::{ServerBuilder, ServerState, StorageBackend};
+    use crate::server::{EdgeUpstreamHealth, ServerBuilder, ServerState, StorageBackend};
     use jazz::wire::{
         FEATURE_STRUCTURED_ERRORS, FEATURE_SYNC_MESSAGE_PAYLOAD, WireFrame, WireHello,
         WirePeerRole, decode_frame, encode_frame,
@@ -414,6 +414,36 @@ mod tests {
         assert_eq!(
             state.shutdown.phase(),
             crate::server::ShutdownPhase::ShuttingDown
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_edge_upstream_failure_is_visible_in_health() {
+        let state = make_state_with_schema(Schema::new()).await;
+        state.set_edge_upstream_health(EdgeUpstreamHealth::Failed {
+            reason: "authority rejected edge credentials".to_owned(),
+        });
+        let health = make_test_router(state)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = body::to_bytes(health.into_body(), usize::MAX)
+            .await
+            .expect("health body");
+        let json: Value = serde_json::from_slice(&body).expect("health json");
+        assert_eq!(json["status"].as_str(), Some("unhealthy"));
+        assert_eq!(json["component"].as_str(), Some("edge_upstream"));
+        assert!(
+            json["reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains("rejected edge credentials"))
         );
     }
 

--- a/crates/jazz-testkit/tests/edge_server_mode.rs
+++ b/crates/jazz-testkit/tests/edge_server_mode.rs
@@ -1118,79 +1118,154 @@ async fn fixed_schema_data_dir_reopen_bootstraps_policy_graph_policy_serving_sta
         .await;
 }
 
+/// An established Edge connector observes the exact Core link closing, enters
+/// reconnecting health, and attaches a replacement Core on the same endpoint.
+/// Relay write authorisation is deliberately outside this lifecycle receipt.
 #[tokio::test(flavor = "current_thread")]
-async fn edge_server_accepts_mergeable_write_while_core_down_then_promotes() {
+async fn edge_reconnects_after_established_core_drop() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todo_schema();
             let app_id = AppId::random();
             let core_port = reserve_local_port();
-            let core_url = format!("http://127.0.0.1:{core_port}");
+            let core = tokio::time::timeout(
+                Duration::from_secs(10),
+                JazzServer::builder()
+                    .with_app_id(app_id)
+                    .with_port(core_port)
+                    .with_schema(schema.clone())
+                    .start(),
+            )
+            .await
+            .expect("initial Core start timed out");
+            let edge = tokio::time::timeout(
+                Duration::from_secs(10),
+                JazzServer::builder()
+                    .with_app_id(app_id)
+                    .with_schema(schema.clone())
+                    .with_native_transport_connector(jazz_testkit::native_connector())
+                    .with_upstream_url(core.base_url())
+                    .start(),
+            )
+            .await
+            .expect("Edge start timed out");
+            let edge_state = edge.server_state();
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while edge_state.edge_upstream_health()
+                    != jazz_server::EdgeUpstreamHealth::Connected
+                {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("edge initially bootstraps and attaches its ordinary upstream");
 
+            tokio::time::timeout(Duration::from_secs(15), core.shutdown())
+                .await
+                .expect("established Core shutdown timed out while dropping the upstream link");
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while !matches!(
+                    edge_state.edge_upstream_health(),
+                    jazz_server::EdgeUpstreamHealth::Reconnecting { .. }
+                ) {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("edge observes established upstream drop");
+
+            let restarted_core = tokio::time::timeout(
+                Duration::from_secs(10),
+                JazzServer::builder()
+                    .with_app_id(app_id)
+                    .with_port(core_port)
+                    .with_schema(schema)
+                    .start(),
+            )
+            .await
+            .expect("replacement Core start timed out");
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while edge_state.edge_upstream_health()
+                    != jazz_server::EdgeUpstreamHealth::Connected
+                {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("edge attaches a replacement upstream after the established drop");
+
+            tokio::time::timeout(Duration::from_secs(15), edge.shutdown())
+                .await
+                .expect("Edge cleanup timed out");
+            tokio::time::timeout(Duration::from_secs(15), restarted_core.shutdown())
+                .await
+                .expect("restarted Core cleanup timed out");
+        })
+        .await;
+}
+
+/// A fixed-schema Edge remains usable while its Core is unavailable. Its
+/// connector reports retry health, the local route accepts and parks a write at
+/// Edge durability, and the connector attaches once Core appears. Relaying that
+/// write into Core requires the upper-layer trusted-relay authorisation policy.
+#[tokio::test(flavor = "current_thread")]
+async fn edge_to_core_relay_retains_write_while_upstream_is_unavailable() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = todo_schema();
+            let app_id = AppId::random();
+            let core_port = reserve_local_port();
             let edge = JazzServer::builder()
                 .with_app_id(app_id)
                 .with_schema(schema.clone())
                 .with_native_transport_connector(jazz_testkit::native_connector())
-                .with_upstream_url(core_url.clone())
+                .with_upstream_url(format!("http://127.0.0.1:{core_port}"))
                 .start()
                 .await;
-            let alice = connect_user(&edge, schema.clone(), "alice-edge-server-mode").await;
-            let bob = connect_user(&edge, schema.clone(), "bob-edge-server-mode").await;
+            let edge_state = edge.server_state();
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while !matches!(
+                    edge_state.edge_upstream_health(),
+                    jazz_server::EdgeUpstreamHealth::Reconnecting { .. }
+                ) {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("edge reports unavailable upstream before Core starts");
 
-            let (todo_id, expected, transaction_id) = alice
+            let alice = connect_user(&edge, schema.clone(), "alice-upstream-unavailable").await;
+            let (_, _, tx) = alice
                 .insert(
                     "todos",
-                    row_input!("title" => "edge first", "done" => false),
+                    row_input!("title" => "retained without core", "done" => false),
                 )
-                .expect("alice inserts while core is down");
-            support::wait_for_edge_txs(
-                &alice,
-                &[transaction_id.expect("ordinary mutation commits immediately")],
-            )
-            .await;
-
-            wait_for_row(
-                &bob,
-                DurabilityTier::EdgeServer,
-                todo_id,
-                expected.clone(),
-                "bob sees edge-accepted row before core starts",
-            )
-            .await;
+                .expect("edge accepts while its upstream is unavailable");
+            let tx = tx.expect("ordinary mutation commits immediately");
+            support::wait_for_edge_txs(&alice, &[tx]).await;
+            assert_ne!(
+                edge_state.edge_upstream_health(),
+                jazz_server::EdgeUpstreamHealth::Connected,
+                "the edge-tier receipt precedes any upstream connection"
+            );
 
             let core = JazzServer::builder()
                 .with_app_id(app_id)
                 .with_port(core_port)
-                .with_schema(schema.clone())
+                .with_schema(schema)
                 .start()
                 .await;
-
-            alice
-                .wait_for_transaction(
-                    transaction_id.expect("ordinary mutation commits immediately"),
-                    DurabilityTier::GlobalServer,
-                )
-                .await
-                .expect("edge-promoted write reaches global core");
-            wait_for_row(
-                &alice,
-                DurabilityTier::GlobalServer,
-                todo_id,
-                expected.clone(),
-                "alice sees globally promoted row through edge",
-            )
-            .await;
-            wait_for_row(
-                &bob,
-                DurabilityTier::GlobalServer,
-                todo_id,
-                expected,
-                "bob sees globally promoted row through edge",
-            )
-            .await;
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while edge_state.edge_upstream_health()
+                    != jazz_server::EdgeUpstreamHealth::Connected
+                {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("edge attaches when the initially unavailable Core starts");
 
             alice.shutdown().await.expect("shutdown alice");
-            bob.shutdown().await.expect("shutdown bob");
             edge.shutdown().await;
             core.shutdown().await;
         })
@@ -1430,7 +1505,7 @@ fn topology_matrix_conformance_smoke_inventory() {
         Cell {
             topology: Topology::ClientEdgeCore,
             scenario: Scenario::MergeableWrite,
-            coverage: "edge_server_mode::edge_server_accepts_mergeable_write_while_core_down_then_promotes",
+            coverage: "edge_server_mode::edge_to_core_relay_retains_write_while_upstream_is_unavailable",
         },
         Cell {
             topology: Topology::ClientEdgeCore,

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -166,6 +166,10 @@ name = "four_tier"
 required-features = ["testing"]
 
 [[test]]
+name = "browser_relay_durability"
+required-features = ["testing"]
+
+[[test]]
 name = "threaded_four_tier"
 required-features = ["testing"]
 

--- a/crates/jazz/SPEC/9_topology_edge.md
+++ b/crates/jazz/SPEC/9_topology_edge.md
@@ -210,6 +210,19 @@ transactions for scopes where it is the fate authority. Requests that require
 global settlement defer or carry an explicit unsettled/staleness marker; upstream
 connectivity is not a precondition for edge-tier service.
 
+The server shell owns one upstream connector for the edge lifecycle. An
+established link ends when the target transport's socket pump reports closure,
+even when no semantic frame is in flight; the shell disconnects that peer state
+before reconnecting. Bootstrap/open failures, clean closure, native terminal
+failures, and transient I/O/backpressure failures retry with exponential delay
+from 100 ms capped at 5 s, with the failure streak reset after 30 seconds of
+stable connection. Semantic wire/catalogue failures and local catalogue-install
+failures are fatal for that connector generation: retry stops and `/health`
+reports the upstream failure.
+Shutdown wins races with bootstrap, connect, connected wait, and backoff, joins
+the owned connector before storage close, and forbids a late dynamic shell or
+ready-generation publication.
+
 ### 9.7 Star topology
 
 Edge authority and merge coordination route upstream through core rather than

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -37,7 +37,10 @@ use futures::lock::Mutex as LocalMutex;
 pub mod auth_admission;
 mod server_runtime;
 
-pub use server_runtime::{ServerRuntimeActivity, ServerRuntimeFrameStream, ServerRuntimeHandle};
+pub use server_runtime::{
+    ServerRuntimeActivity, ServerRuntimeFrameStream, ServerRuntimeHandle, ServerUpstreamConnection,
+    ServerUpstreamTerminalReason,
+};
 
 /// Result type returned by server shell helpers.
 pub type Result<T> = std::result::Result<T, ConfigError>;
@@ -186,6 +189,8 @@ pub struct InMemoryServerShell {
     role: NodeRole,
     sessions: Vec<Option<ServerSessionState>>,
     upstream_connections: Vec<ShellPeerConnection>,
+    wire_upstream_connections: BTreeMap<u64, ShellPeerConnection>,
+    next_wire_upstream_connection_id: u64,
     resume_cursors: BTreeMap<u64, (AuthorSubject, ResumeCursor)>,
     next_resume_token: u64,
     runtime_schema_state: RuntimeSchemaState,
@@ -290,6 +295,7 @@ struct WireQueues {
 pub(super) struct ServerUpstreamIo {
     pub(super) transport: SharedWireTransport,
     pub(super) pump: crate::db::PeerIoPump,
+    pub(super) connection_id: u64,
     pub(super) protocol_version: u16,
     pub(super) features: crate::wire::WireFeatures,
 }
@@ -736,6 +742,8 @@ impl InMemoryServerShell {
             role,
             sessions: Vec::new(),
             upstream_connections: Vec::new(),
+            wire_upstream_connections: BTreeMap::new(),
+            next_wire_upstream_connection_id: 1,
             resume_cursors: BTreeMap::new(),
             next_resume_token: 1,
             runtime_schema_state: RuntimeSchemaState::default(),
@@ -780,6 +788,8 @@ impl InMemoryServerShell {
             role: NodeRole::Edge,
             sessions: Vec::new(),
             upstream_connections: Vec::new(),
+            wire_upstream_connections: BTreeMap::new(),
+            next_wire_upstream_connection_id: 1,
             resume_cursors: BTreeMap::new(),
             next_resume_token: 1,
             runtime_schema_state: RuntimeSchemaState::default(),
@@ -816,6 +826,8 @@ impl InMemoryServerShell {
             role: NodeRole::Edge,
             sessions: Vec::new(),
             upstream_connections: Vec::new(),
+            wire_upstream_connections: BTreeMap::new(),
+            next_wire_upstream_connection_id: 1,
             resume_cursors: BTreeMap::new(),
             next_resume_token: 1,
             runtime_schema_state: RuntimeSchemaState::default(),
@@ -1198,13 +1210,27 @@ impl InMemoryServerShell {
         ));
         let connection = self.db.connect_upstream(adapter);
         let pump = connection.io_pump();
-        self.upstream_connections.push(connection);
+        let connection_id = self.next_wire_upstream_connection_id;
+        self.next_wire_upstream_connection_id = self
+            .next_wire_upstream_connection_id
+            .checked_add(1)
+            .expect("wire upstream connection id exhausted");
+        self.wire_upstream_connections
+            .insert(connection_id, connection);
         ServerUpstreamIo {
             transport,
             pump,
+            connection_id,
             protocol_version,
             features,
         }
+    }
+
+    pub(super) fn disconnect_upstream_wire_io(&mut self, connection_id: u64) -> bool {
+        let Some(connection) = self.wire_upstream_connections.remove(&connection_id) else {
+            return false;
+        };
+        self.db.detach_connection(&connection)
     }
 
     /// Disconnect a subscriber session while preserving an in-process cursor.

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -22,12 +22,15 @@ use crate::serving::{
     AbiBytes, InMemoryServerShell, InMemoryServerShellConfig, NodeRole, ServerSession,
     StorageConfig,
 };
-use crate::wire::{WireFrame, WireTransport, decode_frame, decode_sync_message};
-use futures::StreamExt;
+use crate::tools::native_transport_connector::{
+    NativeTransportTerminal, NativeTransportTerminalFuture,
+};
+use crate::wire::{TransportError, WireFrame, WireTransport, decode_frame, decode_sync_message};
 use futures::channel::mpsc;
 use futures::future::LocalBoxFuture;
 use futures::task::LocalSpawnExt;
 use futures::task::{ArcWake, waker};
+use futures::{FutureExt, StreamExt};
 use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 
 /// Sendable handle for the thread that owns the in-memory server shell.
@@ -70,6 +73,52 @@ impl ServerRuntimeFrameStream {
     }
 }
 
+/// Terminal reason for an attached edge-to-authority wire transport.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerUpstreamTerminalReason {
+    /// The target-owned native socket pump reported its terminal outcome.
+    NativeTransport(NativeTransportTerminal),
+    /// The bounded adapter queue could not accept an outbound frame.
+    Backpressure,
+    /// The adapter rejected an outbound frame because its pump had failed.
+    TransportFailed(String),
+    /// Wire decoding or semantic auxiliary routing failed.
+    ProtocolFailed(String),
+    /// The owner dropped the connection to cancel its local wire driver.
+    Cancelled,
+    /// The shell owner stopped without returning a more specific reason.
+    RuntimeStopped,
+}
+
+/// Owned lifetime signal for an attached edge-to-authority wire transport.
+pub struct ServerUpstreamConnection {
+    terminal: Option<oneshot::Receiver<ServerUpstreamTerminalReason>>,
+    cancel: Option<oneshot::Sender<()>>,
+}
+
+impl ServerUpstreamConnection {
+    /// Resolve with the reason the socket/semantic pump stopped.
+    pub async fn terminal(mut self) -> ServerUpstreamTerminalReason {
+        let terminal = self
+            .terminal
+            .take()
+            .expect("upstream terminal receiver is consumed exactly once");
+        let reason = terminal
+            .await
+            .unwrap_or(ServerUpstreamTerminalReason::RuntimeStopped);
+        self.cancel.take();
+        reason
+    }
+}
+
+impl Drop for ServerUpstreamConnection {
+    fn drop(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(());
+        }
+    }
+}
+
 struct ServerShellInner {
     jobs: Mutex<Option<mpsc::UnboundedSender<ServerShellCommand>>>,
     join: Mutex<Option<thread::JoinHandle<()>>>,
@@ -108,10 +157,11 @@ enum ServerShellCommand {
     RunAsync(AsyncServerShellJob),
     AttachUpstreamWire {
         transport: Box<dyn WireTransport + Send>,
+        transport_terminal: NativeTransportTerminalFuture,
         protocol_version: u16,
         features: crate::wire::WireFeatures,
         session_context: Option<ConnectionSessionContext>,
-        reply: oneshot::Sender<Result<(), String>>,
+        reply: oneshot::Sender<Result<ServerUpstreamConnection, String>>,
     },
     Shutdown(std_mpsc::Sender<()>),
 }
@@ -269,6 +319,7 @@ fn run_server_shell_owner(
                 }
                 ServerShellCommand::AttachUpstreamWire {
                     transport,
+                    transport_terminal,
                     protocol_version,
                     features,
                     session_context,
@@ -276,19 +327,46 @@ fn run_server_shell_owner(
                 } => {
                     let io =
                         shell.connect_upstream_wire_io(protocol_version, features, session_context);
+                    let connection_id = io.connection_id;
                     let (wake_tx, wake_rx) = mpsc::unbounded();
                     if let Ok(mut wakers) = io_wakers.lock() {
                         wakers.push(wake_tx);
                     }
-                    let spawn_result = spawner.spawn_local(drive_upstream_wire(
-                        transport,
-                        io,
-                        wake_rx,
-                        scheduler.clone(),
-                    ));
-                    let _ = reply.send(spawn_result.map_err(|error| {
-                        format!("failed to spawn local upstream wire pump: {error}")
-                    }));
+                    let (terminal_tx, terminal) = oneshot::channel();
+                    let (cancel, cancel_rx) = oneshot::channel();
+                    let wire_scheduler = scheduler.clone();
+                    let spawn_result = spawner.spawn_local(async move {
+                        let reason = drive_upstream_wire(
+                            transport,
+                            transport_terminal,
+                            io,
+                            wake_rx,
+                            wire_scheduler,
+                            cancel_rx,
+                        )
+                        .await;
+                        let _ = terminal_tx.send(reason);
+                    });
+                    let connection = spawn_result
+                        .map(|()| ServerUpstreamConnection {
+                            terminal: Some(terminal),
+                            cancel: Some(cancel),
+                        })
+                        .map_err(|error| {
+                            format!("failed to spawn local upstream wire pump: {error}")
+                        });
+                    if connection.is_ok() {
+                        // Creating the semantic upstream queues its initial
+                        // claims/frontier work, but unlike the in-memory attach
+                        // path it has no caller-owned tick. Queue that first
+                        // shell turn only after the wire pump exists so initial
+                        // bootstrap and reconnect both flush without waiting
+                        // for unrelated downstream activity.
+                        scheduler.schedule_tick(TickUrgency::Immediate);
+                    } else {
+                        shell.disconnect_upstream_wire_io(connection_id);
+                    }
+                    let _ = reply.send(connection);
                 }
                 ServerShellCommand::Shutdown(stopped) => {
                     // Native storage is destroyed on its owner thread before
@@ -329,81 +407,118 @@ async fn yield_to_local_tasks() {
 
 async fn drive_upstream_wire(
     mut wire: Box<dyn WireTransport + Send>,
+    mut transport_terminal: NativeTransportTerminalFuture,
     io: super::ServerUpstreamIo,
     mut wake_rx: mpsc::UnboundedReceiver<()>,
     scheduler: ServerShellTickScheduler,
-) {
-    loop {
-        let mut staged_semantic_input = false;
-        while let Some(frame) = wire.try_recv_frame() {
-            match io.pump.route_incoming_wire_frame(frame, io.features).await {
-                Ok(Some(canonical)) => {
-                    io.transport
-                        .queues
-                        .borrow_mut()
-                        .inbound
-                        .push_back(canonical);
-                    staged_semantic_input = true;
-                }
-                Ok(None) => {}
-                Err(_) => {
-                    io.pump.disconnect();
-                    return;
-                }
-            }
-        }
-        // The socket callback can notify the host before this local pump gets
-        // a turn to stage its frame. Schedule only after canonical input is
-        // actually visible to the shell, otherwise a downstream activity tick
-        // may observe an empty queue and leave the edge dormant indefinitely.
-        if staged_semantic_input {
-            scheduler.schedule_tick(TickUrgency::Immediate);
-        }
+    mut cancel_rx: oneshot::Receiver<()>,
+) -> ServerUpstreamTerminalReason {
+    let connection_id = io.connection_id;
+    let reason = async {
         loop {
-            let frame = io.transport.queues.borrow_mut().outbound.pop_front();
-            let Some(frame) = frame else { break };
-            if wire.send_frame(frame).is_err() {
-                io.pump.disconnect();
-                return;
-            }
-        }
-        loop {
-            let frame =
-                match io
-                    .pump
-                    .take_outbound_wire_frame(io.protocol_version, io.features, None)
-                {
-                    Ok(frame) => frame,
-                    Err(_) => {
-                        io.pump.disconnect();
-                        return;
+            let mut staged_semantic_input = false;
+            while let Some(frame) = wire.try_recv_frame() {
+                match io.pump.route_incoming_wire_frame(frame, io.features).await {
+                    Ok(Some(canonical)) => {
+                        io.transport
+                            .queues
+                            .borrow_mut()
+                            .inbound
+                            .push_back(canonical);
+                        staged_semantic_input = true;
                     }
-                };
-            let Some(frame) = frame else { break };
-            if wire.send_frame(frame).is_err() {
-                io.pump.disconnect();
-                return;
-            }
-        }
-
-        let external_wake = wake_rx.next();
-        let auxiliary_wake = io.pump.outbound_ready();
-        futures::pin_mut!(external_wake, auxiliary_wake);
-        match futures::future::select(external_wake, auxiliary_wake).await {
-            futures::future::Either::Left((Some(()), _)) => {}
-            futures::future::Either::Right(((), _)) => {
-                // Disconnect wakes `outbound_ready` to let the owner tear
-                // down cleanly; it is not another unit of socket work.
-                if io.pump.is_disconnected() {
-                    return;
+                    Ok(None) => {}
+                    Err(error) => {
+                        return ServerUpstreamTerminalReason::ProtocolFailed(error);
+                    }
                 }
             }
-            futures::future::Either::Left((None, _)) => {
-                io.pump.disconnect();
-                return;
+            // The socket callback can notify the host before this local pump gets
+            // a turn to stage its frame. Schedule only after canonical input is
+            // actually visible to the shell, otherwise a downstream activity tick
+            // may observe an empty queue and leave the edge dormant indefinitely.
+            if staged_semantic_input {
+                scheduler.schedule_tick(TickUrgency::Immediate);
+            }
+            loop {
+                let frame = io.transport.queues.borrow_mut().outbound.pop_front();
+                let Some(frame) = frame else { break };
+                match wire.send_frame(frame) {
+                    Ok(()) => {}
+                    Err(TransportError::Backpressure) => {
+                        return ServerUpstreamTerminalReason::Backpressure;
+                    }
+                    Err(TransportError::Failed(error)) => {
+                        return ServerUpstreamTerminalReason::TransportFailed(error);
+                    }
+                }
+            }
+            loop {
+                let frame =
+                    match io
+                        .pump
+                        .take_outbound_wire_frame(io.protocol_version, io.features, None)
+                    {
+                        Ok(frame) => frame,
+                        Err(error) => {
+                            return ServerUpstreamTerminalReason::ProtocolFailed(error);
+                        }
+                    };
+                let Some(frame) = frame else { break };
+                match wire.send_frame(frame) {
+                    Ok(()) => {}
+                    Err(TransportError::Backpressure) => {
+                        return ServerUpstreamTerminalReason::Backpressure;
+                    }
+                    Err(TransportError::Failed(error)) => {
+                        return ServerUpstreamTerminalReason::TransportFailed(error);
+                    }
+                }
+            }
+
+            let external_wake = wake_rx.next().fuse();
+            let auxiliary_wake = io.pump.outbound_ready().fuse();
+            let transport_stopped = transport_terminal.as_mut().fuse();
+            let cancelled = (&mut cancel_rx).fuse();
+            futures::pin_mut!(external_wake, auxiliary_wake, transport_stopped, cancelled);
+            futures::select_biased! {
+                _ = cancelled => return ServerUpstreamTerminalReason::Cancelled,
+                terminal = transport_stopped => {
+                    return ServerUpstreamTerminalReason::NativeTransport(terminal);
+                }
+                wake = external_wake => {
+                    if wake.is_none() {
+                        return ServerUpstreamTerminalReason::RuntimeStopped;
+                    }
+                }
+                _ = auxiliary_wake => {
+                    if io.pump.is_disconnected() {
+                        return ServerUpstreamTerminalReason::TransportFailed(
+                            "upstream semantic transport disconnected".to_owned(),
+                        );
+                    }
+                }
             }
         }
     }
+    .await;
+    io.pump.disconnect();
+    let (detached_tx, detached_rx) = oneshot::channel();
+    if scheduler
+        .jobs
+        .unbounded_send(ServerShellCommand::Run(Box::new(move |shell| {
+            shell.disconnect_upstream_wire_io(connection_id);
+            let _ = detached_tx.send(());
+        })))
+        .is_ok()
+    {
+        // Do not expose the terminal event to the reconnect loop until the
+        // dead semantic link has relinquished authority. Otherwise the
+        // replacement wire can attach as a parallel non-owner and strand
+        // writes retained during the outage.
+        let _ = detached_rx.await;
+    }
+    reason
 }
 
 impl ServerRuntimeHandle {
@@ -877,13 +992,15 @@ impl ServerRuntimeHandle {
     pub async fn connect_upstream_wire(
         &self,
         transport: Box<dyn WireTransport + Send>,
+        transport_terminal: NativeTransportTerminalFuture,
         protocol_version: u16,
         features: crate::wire::WireFeatures,
         session_context: Option<ConnectionSessionContext>,
-    ) -> Result<(), String> {
+    ) -> Result<ServerUpstreamConnection, String> {
         let (reply, response) = oneshot::channel();
         self.send(ServerShellCommand::AttachUpstreamWire {
             transport,
+            transport_terminal,
             protocol_version,
             features,
             session_context,
@@ -1166,6 +1283,44 @@ mod tests {
         encode_frame(&WireFrame::Message(WireEnvelope::new(0, 0, payload))).unwrap()
     }
 
+    // This internal test is necessary because the terminal reason crosses the
+    // shell's thread-affine local executor; no public API exposes that channel.
+    #[test]
+    fn upstream_connection_returns_the_driver_terminal_reason() {
+        let (terminal_tx, terminal) = oneshot::channel();
+        let (cancel, _cancelled) = oneshot::channel();
+        let connection = ServerUpstreamConnection {
+            terminal: Some(terminal),
+            cancel: Some(cancel),
+        };
+        terminal_tx
+            .send(ServerUpstreamTerminalReason::TransportFailed(
+                "socket closed".to_owned(),
+            ))
+            .unwrap();
+
+        assert_eq!(
+            futures::executor::block_on(connection.terminal()),
+            ServerUpstreamTerminalReason::TransportFailed("socket closed".to_owned())
+        );
+    }
+
+    // This internal test is necessary because cancellation owns a local wire
+    // pump rather than an application-facing session.
+    #[test]
+    fn dropping_upstream_connection_cancels_its_wire_driver() {
+        let (_terminal_tx, terminal) = oneshot::channel();
+        let (cancel, cancelled) = oneshot::channel();
+        let connection = ServerUpstreamConnection {
+            terminal: Some(terminal),
+            cancel: Some(cancel),
+        };
+
+        drop(connection);
+
+        assert!(futures::executor::block_on(cancelled).is_ok());
+    }
+
     #[test]
     fn inbound_frame_phase_labels_semantic_transport_work() {
         let encoded = encode_message(SyncMessage::SessionClaims {
@@ -1283,10 +1438,21 @@ mod tests {
             claims: BTreeMap::new(),
         }));
         let (_wake_tx, wake_rx) = mpsc::unbounded();
+        let (_cancel_tx, cancel_rx) = oneshot::channel();
         let mut executor = futures::executor::LocalPool::new();
         executor
             .spawner()
-            .spawn_local(drive_upstream_wire(Box::new(wire), io, wake_rx, scheduler))
+            .spawn_local(async move {
+                let _ = drive_upstream_wire(
+                    Box::new(wire),
+                    Box::pin(futures::future::pending()),
+                    io,
+                    wake_rx,
+                    scheduler,
+                    cancel_rx,
+                )
+                .await;
+            })
             .unwrap();
         executor.run_until_stalled();
 


### PR DESCRIPTION
## Summary

- Make the server builder own one cancellable Edge upstream connector across bootstrap, connection, terminal observation and reconnect.
- Classify retryable setup failures, reconnectable established-session failures and fatal protocol failures, with bounded exponential backoff and visible health state.
- Preserve authenticated-session replay state, relay subscription ownership and queued writes across a valid replacement connection; shutdown cancels pending bootstrap and reconnect work.

## Before and after

Before, the connector returned after the first successful attachment. An established upstream closure could leave the Edge running against a dead session, while reconnect and shutdown ownership were split across tasks.

After, one lifecycle owns the session until shutdown. Retryable failures reconnect, fatal protocol failures remain visible, and replacement connections receive only state belonging to the authenticated destination.

## Testing

- `cargo test -p jazz-server idle_upstream_terminal_reconnects_and_reaches_connected_again` — passed
- `cargo test -p jazz --lib current_session_claims_reach_late_and_reconnected_upstreams` — passed
- `cargo test -p jazz --lib scope_intent_retries_after_upstream_reconnect` — passed
- `cargo test -p jazz --lib reconnect_replays_live_scope_waiters_once_and_drops_cancelled_ones` — passed
- `cargo test -p jazz --lib rejected_upload_is_not_replayed_after_reconnect` — passed
- `cargo test -p jazz --features testing --test browser_relay_durability worker_relay_` — 6 passed

Part of #2095.