### PR TITLE
fix(browser): coordinate shared namespace offline state

### DIFF
--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -226,6 +226,12 @@ database namespace. The worker owns the IndexedDB page store and the server conn
 communicates with that runtime through a message port. There is no tab-leader election, Web Locks
 dependency, or per-tab durable database.
 
+Calling `db.disconnect()` in one tab explicitly takes that **whole persistent namespace** offline:
+the worker has one upstream connection, so every attached tab uses local-first fallback for
+`"remote-if-possible"` reads and remote reads wait until any tab calls `db.reconnect()`. This is
+intentional; disconnecting only one tab while continuing to sync its writes through the shared
+worker would give that tab an incoherent offline contract.
+
 The main thread keeps a responsive client-side peer while the SharedWorker commits durable state in
 the background.
 

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -192,4 +192,39 @@ describe("BrowserConnectionManager explicit transport transitions", () => {
     await reconnected;
     expect(manager.isExplicitlyOffline()).toBe(false);
   });
+
+  it("waits for worker transport state only while a follower is attaching", async () => {
+    const ready = deferred<void>();
+    const connection = {
+      ready: vi.fn(() => ready.promise),
+      disconnect: vi.fn(async () => undefined),
+      reconnect: vi.fn(async () => undefined),
+      openInspectorControlPort: vi.fn(async () => ({}) as MessagePort),
+    } as unknown as BrowserWorkerConnection;
+    const host = {
+      config: { serverUrl: "https://example.test" },
+      isShuttingDown: false,
+      runtimeSource: {
+        createBrowserWorkerConnection: vi.fn(() => connection),
+      },
+      markUnauthenticated: vi.fn(),
+      clearAuthError: vi.fn(),
+    } as unknown as DbForConnection;
+    const manager = new BrowserConnectionManager(host);
+    (
+      manager as unknown as {
+        onClientCreated(input: {
+          schemaKey: string;
+          schema: Record<string, never>;
+          client: JazzClient;
+        }): void;
+      }
+    ).onClientCreated({ schemaKey: "empty", schema: {}, client: {} as JazzClient });
+
+    const initial = manager.initialExplicitOfflineState();
+    expect(initial).not.toBeNull();
+    ready.resolve();
+    await initial;
+    expect(manager.initialExplicitOfflineState()).toBeNull();
+  });
 });

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -194,7 +194,7 @@ describe("BrowserConnectionManager explicit transport transitions", () => {
   });
 
   it("waits for worker transport state only while a follower is attaching", async () => {
-    const ready = deferred<void>();
+    const ready = deferred();
     const connection = {
       ready: vi.fn(() => ready.promise),
       disconnect: vi.fn(async () => undefined),

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -148,4 +148,48 @@ describe("BrowserConnectionManager explicit transport transitions", () => {
     expect(connection.reconnect).toHaveBeenCalledOnce();
     expect(manager.isExplicitlyOffline()).toBe(false);
   });
+
+  it("adopts explicit offline state broadcast by another tab in the worker namespace", async () => {
+    const connection = {
+      ready: vi.fn(async () => undefined),
+      disconnect: vi.fn(async () => undefined),
+      reconnect: vi.fn(async () => undefined),
+      openInspectorControlPort: vi.fn(async () => ({}) as MessagePort),
+    } as unknown as BrowserWorkerConnection;
+    let callbacks:
+      | {
+          onExplicitOfflineChange?: (offline: boolean) => void;
+        }
+      | undefined;
+    const host = {
+      config: { serverUrl: "https://example.test" },
+      isShuttingDown: false,
+      runtimeSource: {
+        createBrowserWorkerConnection: vi.fn((input) => {
+          callbacks = input;
+          return connection;
+        }),
+      },
+      markUnauthenticated: vi.fn(),
+      clearAuthError: vi.fn(),
+    } as unknown as DbForConnection;
+    const manager = new BrowserConnectionManager(host);
+    (
+      manager as unknown as {
+        onClientCreated(input: {
+          schemaKey: string;
+          schema: Record<string, never>;
+          client: JazzClient;
+        }): void;
+      }
+    ).onClientCreated({ schemaKey: "empty", schema: {}, client: {} as JazzClient });
+
+    callbacks?.onExplicitOfflineChange?.(true);
+    expect(manager.isExplicitlyOffline()).toBe(true);
+
+    const reconnected = manager.waitForReconnect();
+    callbacks?.onExplicitOfflineChange?.(false);
+    await reconnected;
+    expect(manager.isExplicitlyOffline()).toBe(false);
+  });
 });

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -42,6 +42,7 @@ export class BrowserConnectionManager extends ConnectionManager {
       client,
       onAuthFailure: (reason) => this.host.markUnauthenticated(reason),
       onAuthRestored: () => this.host.clearAuthError(),
+      onExplicitOfflineChange: (offline) => this.setExplicitOffline(connection, offline),
       onFailure: (error) => {
         if (this.connection !== connection) return;
         this.connectionError = asError(error);
@@ -213,6 +214,17 @@ export class BrowserConnectionManager extends ConnectionManager {
     const waiters = [...this.reconnectWaiters];
     this.reconnectWaiters.clear();
     for (const resolve of waiters) resolve();
+  }
+
+  /**
+   * A persistent browser namespace has one worker-owned upstream connection.
+   * The initiating tab receives the RPC result too, but every attached tab
+   * must make the same explicit-offline choice for RemoteIfPossible reads.
+   */
+  private setExplicitOffline(connection: BrowserWorkerConnection, offline: boolean): void {
+    if (this.connection !== connection) return;
+    this.disconnected = offline;
+    if (!offline) this.resolveReconnectWaiters();
   }
 
   private enqueueTransportTransition(run: () => void | Promise<void>): Promise<void> {

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -20,6 +20,7 @@ import { registerBrowserInspectorControl } from "../../dev/inspector-overlay/bro
 export class BrowserConnectionManager extends ConnectionManager {
   private connection: BrowserWorkerConnection | null = null;
   private connectionReady: Promise<void> | null = null;
+  private initialExplicitOfflineStateKnown = false;
   private connectionError: Error | null = null;
   private disconnected = false;
   private readonly reconnectWaiters = new Set<() => void>();
@@ -55,10 +56,19 @@ export class BrowserConnectionManager extends ConnectionManager {
     this.unregisterInspectorControl = registerBrowserInspectorControl(() =>
       connection.openInspectorControlPort(),
     );
-    this.connectionReady = connection.ready().catch((error: unknown) => {
-      this.connectionError = asError(error);
-      throw error;
-    });
+    this.initialExplicitOfflineStateKnown = false;
+    this.connectionReady = connection.ready().then(
+      () => {
+        // The worker sends an initial transport-state event before resolving
+        // follower init. Once this resolves, this manager has an authoritative
+        // namespace-wide explicit-offline snapshot.
+        this.initialExplicitOfflineStateKnown = true;
+      },
+      (error: unknown) => {
+        this.connectionError = asError(error);
+        throw error;
+      },
+    );
     void this.connectionReady.catch(() => undefined);
     if (this.disconnected) {
       const ready = this.connectionReady;
@@ -96,6 +106,9 @@ export class BrowserConnectionManager extends ConnectionManager {
   }
   isExplicitlyOffline(): boolean {
     return this.disconnected;
+  }
+  override initialExplicitOfflineState(): Promise<void> | null {
+    return this.initialExplicitOfflineStateKnown ? null : this.connectionReady;
   }
   async waitForReconnect(signal?: AbortSignal): Promise<void> {
     if (signal?.aborted) return;
@@ -170,6 +183,7 @@ export class BrowserConnectionManager extends ConnectionManager {
     if (this.connection !== connection || this.storageReset) return;
     this.connection = null;
     this.connectionReady = null;
+    this.initialExplicitOfflineStateKnown = false;
     const client = this.detachClient();
     client?.discard();
     this.storageReset = connection
@@ -191,6 +205,7 @@ export class BrowserConnectionManager extends ConnectionManager {
     const connection = this.connection;
     this.connection = null;
     this.connectionReady = null;
+    this.initialExplicitOfflineStateKnown = false;
     this.resolveReconnectWaiters();
     const unregisterInspectorControl = this.unregisterInspectorControl;
     this.unregisterInspectorControl = null;

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -131,6 +131,16 @@ export abstract class ConnectionManager {
   /** Resolves when that explicit offline state is cleared. */
   abstract waitForReconnect(signal?: AbortSignal): Promise<void>;
 
+  /**
+   * Browser worker followers learn the namespace-wide explicit-offline state
+   * during their initial handshake. Other runtimes already have a synchronous
+   * state snapshot, so they deliberately return `null`: tier choice must not
+   * gain an asynchronous gap after an operation has started.
+   */
+  initialExplicitOfflineState(): Promise<void> | null {
+    return null;
+  }
+
   openInspectorControlPort(): Promise<MessagePort> {
     return Promise.reject(new Error("This runtime has no shared browser worker"));
   }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2236,6 +2236,12 @@ export class Db {
    */
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
     const client = this.getClient(query._schema);
+    // A late-attaching browser tab learns the namespace-wide explicit-offline
+    // state through its follower init handshake. Wait for that local-only
+    // handshake before deciding whether RemoteIfPossible means Local or Edge;
+    // otherwise a tab opened after another tab disconnects snapshots `false`
+    // and can incorrectly park on a remote read.
+    if (options?.tier === ReadTier.RemoteIfPossible) await this.ensureReady("local");
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson));
     const planningSchema = requireSchemaWithTable(query._schema, builtQuery.table);
@@ -2342,7 +2348,38 @@ export class Db {
     callback: (delta: SubscriptionDelta<T>) => void,
     options?: QueryOptions,
     session?: Session,
+    statusReady = false,
   ): () => void {
+    // See all(): a newly attached browser peer has no authoritative explicit
+    // offline state until its init RPC completes. Delay only this tier's
+    // subscription setup, preserving synchronous LocalFirst subscriptions.
+    if (!statusReady && options?.tier === ReadTier.RemoteIfPossible) {
+      let unsubscribed = false;
+      let unsubscribe = () => {};
+      const readyAbort = new AbortController();
+      void this.ensureReady("local", readyAbort.signal)
+        .then(() => {
+          if (unsubscribed || readyAbort.signal.aborted) return;
+          const installed = this.subscribeDelta(query, callback, options, session, true);
+          // Native subscription installation can synchronously deliver an
+          // opening delta. If that callback unsubscribes the outer handle,
+          // dispose the just-created inner subscription rather than retaining
+          // it after this continuation returns.
+          if (unsubscribed || readyAbort.signal.aborted) installed();
+          else unsubscribe = installed;
+        })
+        .catch((error: unknown) => {
+          if (unsubscribed || readyAbort.signal.aborted || this.isShuttingDown) return;
+          setTimeout(() => {
+            throw error;
+          }, 0);
+        });
+      return () => {
+        unsubscribed = true;
+        readyAbort.abort();
+        unsubscribe();
+      };
+    }
     const manager = new SubscriptionManager<T>();
     const client = this.getClient(query._schema);
     const builderJson = query._build();

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2236,12 +2236,15 @@ export class Db {
    */
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
     const client = this.getClient(query._schema);
-    // A late-attaching browser tab learns the namespace-wide explicit-offline
-    // state through its follower init handshake. Wait for that local-only
-    // handshake before deciding whether RemoteIfPossible means Local or Edge;
-    // otherwise a tab opened after another tab disconnects snapshots `false`
-    // and can incorrectly park on a remote read.
-    if (options?.tier === ReadTier.RemoteIfPossible) await this.ensureReady("local");
+    // A newly attached browser-worker follower has no authoritative
+    // namespace-wide explicit-offline state until its init handshake resolves.
+    // Established runtimes return null here, preserving their synchronous
+    // operation-start tier snapshot even if disconnect happens later.
+    const initialOfflineState =
+      options?.tier === ReadTier.RemoteIfPossible
+        ? this.connection.initialExplicitOfflineState()
+        : null;
+    if (initialOfflineState) await initialOfflineState;
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson));
     const planningSchema = requireSchemaWithTable(query._schema, builtQuery.table);
@@ -2350,14 +2353,21 @@ export class Db {
     session?: Session,
     statusReady = false,
   ): () => void {
-    // See all(): a newly attached browser peer has no authoritative explicit
-    // offline state until its init RPC completes. Delay only this tier's
-    // subscription setup, preserving synchronous LocalFirst subscriptions.
-    if (!statusReady && options?.tier === ReadTier.RemoteIfPossible) {
+    // Constructing a browser follower starts its init handshake. Do that before
+    // asking whether this is a newly attaching peer.
+    const client = this.getClient(query._schema);
+    // See all(): only a newly attached browser peer delays this tier's
+    // subscription setup until it knows the shared worker's state. All other
+    // runtimes, including established browser peers, start synchronously.
+    const initialOfflineState =
+      !statusReady && options?.tier === ReadTier.RemoteIfPossible
+        ? this.connection.initialExplicitOfflineState()
+        : null;
+    if (initialOfflineState) {
       let unsubscribed = false;
       let unsubscribe = () => {};
       const readyAbort = new AbortController();
-      void this.ensureReady("local", readyAbort.signal)
+      void initialOfflineState
         .then(() => {
           if (unsubscribed || readyAbort.signal.aborted) return;
           const installed = this.subscribeDelta(query, callback, options, session, true);
@@ -2381,7 +2391,6 @@ export class Db {
       };
     }
     const manager = new SubscriptionManager<T>();
-    const client = this.getClient(query._schema);
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson));
     const planningSchema = requireSchemaWithTable(query._schema, builtQuery.table);

--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -217,6 +217,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     client,
     onAuthFailure,
     onAuthRestored,
+    onExplicitOfflineChange,
     onFailure,
     onStorageReset,
     onStorageInvalidated,
@@ -242,7 +243,14 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
         config.runtimeSources.browserWorkerPort,
         sessionFromConfig(config)?.claims ?? {},
         dbName,
-        { onAuthFailure, onAuthRestored, onFailure, onStorageReset, onStorageInvalidated },
+        {
+          onAuthFailure,
+          onAuthRestored,
+          onExplicitOfflineChange,
+          onFailure,
+          onStorageReset,
+          onStorageInvalidated,
+        },
       );
     }
     return new SharedBrowserWorkerConnection(
@@ -264,7 +272,14 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
         telemetryCollectorUrl: config.telemetryCollectorUrl,
       },
       createBrowserWorkerFingerprint(config, dbName, getRuntimeSchemaCacheKey(schema)),
-      { onAuthFailure, onAuthRestored, onFailure, onStorageReset, onStorageInvalidated },
+      {
+        onAuthFailure,
+        onAuthRestored,
+        onExplicitOfflineChange,
+        onFailure,
+        onStorageReset,
+        onStorageInvalidated,
+      },
     );
   }
 
@@ -274,6 +289,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     port,
     onAuthFailure,
     onAuthRestored,
+    onExplicitOfflineChange,
     onFailure,
   }: BrowserFollowerConnectionContext<DbConfig>): BrowserFollowerConnection {
     const runtime = client.getRuntime();
@@ -289,6 +305,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
       {
         onAuthFailure,
         onAuthRestored,
+        onExplicitOfflineChange,
         onFailure,
       },
     );

--- a/packages/jazz-tools/src/runtime/native-runtime/attached-browser-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/attached-browser-worker-connection.ts
@@ -13,7 +13,12 @@ export class AttachedBrowserWorkerConnection implements BrowserWorkerConnection 
     dbName: string,
     callbacks: Pick<
       BrowserWorkerConnectionContext,
-      "onAuthFailure" | "onAuthRestored" | "onFailure" | "onStorageReset" | "onStorageInvalidated"
+      | "onAuthFailure"
+      | "onAuthRestored"
+      | "onExplicitOfflineChange"
+      | "onFailure"
+      | "onStorageReset"
+      | "onStorageInvalidated"
     >,
   ) {
     this.connection = new MessagePortBrowserFollowerConnection(

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
@@ -44,7 +44,12 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     private readonly dbName: string | null,
     private readonly callbacks: Pick<
       BrowserFollowerConnectionContext,
-      "onAuthFailure" | "onAuthRestored" | "onFailure" | "onStorageReset" | "onStorageInvalidated"
+      | "onAuthFailure"
+      | "onAuthRestored"
+      | "onExplicitOfflineChange"
+      | "onFailure"
+      | "onStorageReset"
+      | "onStorageInvalidated"
     >,
     private readonly traceRelay = false,
   ) {
@@ -193,6 +198,10 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     }
     if (message.type === "auth-restored") {
       this.callbacks.onAuthRestored();
+      return;
+    }
+    if (message.type === "transport-state") {
+      this.callbacks.onExplicitOfflineChange?.(message.explicitlyDisconnected);
       return;
     }
     if (message.type === "mutation-error") {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -25,7 +25,12 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
     fingerprint: string,
     private readonly callbacks: Pick<
       BrowserWorkerConnectionContext,
-      "onAuthFailure" | "onAuthRestored" | "onFailure" | "onStorageReset" | "onStorageInvalidated"
+      | "onAuthFailure"
+      | "onAuthRestored"
+      | "onExplicitOfflineChange"
+      | "onFailure"
+      | "onStorageReset"
+      | "onStorageInvalidated"
     >,
   ) {
     // A local database namespace is one browser replica/session. Tabs opening
@@ -127,6 +132,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
           {
             onAuthFailure: this.callbacks.onAuthFailure,
             onAuthRestored: this.callbacks.onAuthRestored,
+            onExplicitOfflineChange: this.callbacks.onExplicitOfflineChange,
             onFailure: this.callbacks.onFailure,
             onStorageReset: this.callbacks.onStorageReset,
             onStorageInvalidated: this.callbacks.onStorageInvalidated,

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
@@ -96,6 +96,11 @@ export type BrowserInspectorControlEvent =
 
 export type BrowserFollowerPortEvent =
   | { type: "frames"; frames: Uint8Array[] }
+  /**
+   * Explicit offline is a property of the durable SharedWorker namespace: it
+   * owns the one upstream server connection shared by all attached tabs.
+   */
+  | { type: "transport-state"; explicitlyDisconnected: boolean }
   | { type: "result"; id: number; error?: string }
   | { type: "auth-failure"; reason: string }
   | { type: "auth-restored" }

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -49,6 +49,8 @@ export interface BrowserWorkerConnectionContext<RuntimeConfig extends DbConfig =
   client: JazzClient;
   onAuthFailure: (reason: AuthFailureReason) => void;
   onAuthRestored: () => void;
+  /** The worker namespace's explicit offline state changed. */
+  onExplicitOfflineChange?: (offline: boolean) => void;
   onFailure: (error: unknown) => void;
   onStorageReset?: () => void;
   onStorageInvalidated?: () => void;
@@ -60,6 +62,8 @@ export interface BrowserFollowerConnectionContext<RuntimeConfig extends DbConfig
   port: MessagePort;
   onAuthFailure: (reason: AuthFailureReason) => void;
   onAuthRestored: () => void;
+  /** The worker namespace's explicit offline state changed. */
+  onExplicitOfflineChange?: (offline: boolean) => void;
   onFailure: (error: unknown) => void;
   onStorageReset?: () => void;
   onStorageInvalidated?: () => void;

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -1,6 +1,8 @@
 import type { Mock } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  BrowserFollowerPortEvent,
+  BrowserFollowerPortRequest,
   BrowserSharedWorkerConnectRequest,
   BrowserSharedWorkerConnectResponse,
   BrowserWorkerInitOptions,
@@ -17,6 +19,7 @@ const mocks = vi.hoisted(() => {
   const openConfig = vi.fn(() => new Uint8Array());
   const telemetryDisposers: Mock[] = [];
   const pageStores: Array<{ close: Mock }> = [];
+  const runtimes: Array<Record<string, Mock>> = [];
   const wasmModule = {
     WasmDb: {
       openBrowser,
@@ -35,6 +38,7 @@ const mocks = vi.hoisted(() => {
     openConfig,
     telemetryDisposers,
     pageStores,
+    runtimes,
     wasmModule,
     reset() {
       loadWasmModule.mockReset().mockResolvedValue(wasmModule);
@@ -51,17 +55,34 @@ const mocks = vi.hoisted(() => {
       openBrowser.mockReset().mockResolvedValue({});
       openBrowserWithSelfSignedProof.mockReset().mockResolvedValue({});
       fromDb.mockReset().mockImplementation(() => {
+        const subscriber = {
+          setAuxiliaryTraceEnabled: vi.fn(),
+          setOutboundScheduler: vi.fn(),
+          clearOutboundScheduler: vi.fn(),
+          recvWireFrames: vi.fn(() => []),
+          sendWireFrame: vi.fn(),
+        };
         const runtime = {
           discard: vi.fn(),
           onAuthFailure: vi.fn(),
           onMutationError: vi.fn(),
+          onPeerTransportWork: vi.fn(() => () => {}),
+          progressPeerTransport: vi.fn(async () => undefined),
+          retirePeerTransport: vi.fn(async () => undefined),
+          acceptPeerWhenIdle: vi.fn(async () => subscriber),
+          connect: vi.fn(),
+          disconnect: vi.fn(async () => undefined),
+          updateAuth: vi.fn(async () => undefined),
+          waitForUpstreamServerConnection: vi.fn(async () => undefined),
         };
+        runtimes.push(runtime);
         return runtime;
       });
       encodeSchema.mockClear();
       openConfig.mockClear();
       telemetryDisposers.length = 0;
       pageStores.length = 0;
+      runtimes.length = 0;
     },
   };
 });
@@ -105,6 +126,11 @@ class TestPort {
   private readonly listeners = new Map<string, Set<(event: MessageEvent) => void>>();
   private readonly outcomes: RuntimeOutcome[] = [];
   private readonly outcomeWaiters: Array<(outcome: RuntimeOutcome) => void> = [];
+  private readonly events: BrowserFollowerPortEvent[] = [];
+  private readonly eventWaiters: Array<{
+    predicate: (event: BrowserFollowerPortEvent) => boolean;
+    resolve: (event: BrowserFollowerPortEvent) => void;
+  }> = [];
 
   addEventListener(type: string, listener: (event: MessageEvent) => void): void {
     const listeners = this.listeners.get(type) ?? new Set();
@@ -116,14 +142,20 @@ class TestPort {
     this.listeners.get(type)?.delete(listener);
   }
 
-  postMessage(message: BrowserSharedWorkerConnectResponse): void {
-    if (message.type !== "runtime-ready" && message.type !== "runtime-error") return;
-    const waiter = this.outcomeWaiters.shift();
-    if (waiter) waiter(message);
-    else this.outcomes.push(message);
+  postMessage(message: BrowserSharedWorkerConnectResponse | BrowserFollowerPortEvent): void {
+    if (message.type === "runtime-ready" || message.type === "runtime-error") {
+      const waiter = this.outcomeWaiters.shift();
+      if (waiter) waiter(message);
+      else this.outcomes.push(message);
+      return;
+    }
+    const waiterIndex = this.eventWaiters.findIndex(({ predicate }) => predicate(message));
+    if (waiterIndex >= 0) {
+      this.eventWaiters.splice(waiterIndex, 1)[0]!.resolve(message);
+    } else this.events.push(message);
   }
 
-  emitMessage(message: BrowserSharedWorkerConnectRequest): void {
+  emitMessage(message: BrowserSharedWorkerConnectRequest | BrowserFollowerPortRequest): void {
     for (const listener of this.listeners.get("message") ?? []) {
       listener({ data: message } as MessageEvent);
     }
@@ -134,6 +166,16 @@ class TestPort {
     if (outcome) return Promise.resolve(outcome);
     const waiter = deferred<RuntimeOutcome>();
     this.outcomeWaiters.push(waiter.resolve);
+    return waiter.promise;
+  }
+
+  waitForEvent(
+    predicate: (event: BrowserFollowerPortEvent) => boolean,
+  ): Promise<BrowserFollowerPortEvent> {
+    const index = this.events.findIndex(predicate);
+    if (index >= 0) return Promise.resolve(this.events.splice(index, 1)[0]!);
+    const waiter = deferred<BrowserFollowerPortEvent>();
+    this.eventWaiters.push({ predicate, resolve: waiter.resolve });
     return waiter.promise;
   }
 }
@@ -187,6 +229,12 @@ async function connect(
     options: initOptions,
   });
   return { outcome: await outcome, port };
+}
+
+async function initializeFollower(port: TestPort, id: number): Promise<void> {
+  const result = port.waitForEvent((event) => event.type === "result" && event.id === id);
+  port.emitMessage({ type: "init", id, sessionClaims: {} });
+  await result;
 }
 
 describe("broker worker context initialization", () => {
@@ -405,5 +453,60 @@ describe("broker worker context initialization", () => {
     expect(mocks.openPageStore).toHaveBeenCalledOnce();
     expect(mocks.openBrowser).toHaveBeenCalledOnce();
     expect(mocks.fromDb).toHaveBeenCalledOnce();
+  });
+
+  it("serializes cross-port disconnect and reconnect before publishing state", async () => {
+    const initOptions = { ...options("serialized-transport"), serverUrl: "ws://server.test" };
+    const owner = await connect(initOptions, "owner-tab");
+    const editor = await connect(initOptions, "editor-tab");
+    await initializeFollower(owner.port, 1);
+    await initializeFollower(editor.port, 1);
+    const runtime = mocks.runtimes[0]!;
+    runtime.connect.mockClear();
+
+    const disconnectGate = deferred<void>();
+    runtime.disconnect.mockImplementationOnce(() => disconnectGate.promise);
+    owner.port.emitMessage({ type: "disconnect", id: 2 });
+    await vi.waitFor(() => expect(runtime.disconnect).toHaveBeenCalledOnce());
+
+    editor.port.emitMessage({
+      type: "reconnect",
+      id: 2,
+      authJson: "{}",
+      sessionClaims: {},
+    });
+    await Promise.resolve();
+    expect(runtime.connect).not.toHaveBeenCalled();
+
+    disconnectGate.resolve();
+    await owner.port.waitForEvent((event) => event.type === "result" && event.id === 2);
+    await editor.port.waitForEvent((event) => event.type === "result" && event.id === 2);
+    expect(runtime.connect).toHaveBeenCalledOnce();
+
+    for (const port of [owner.port, editor.port]) {
+      expect(await port.waitForEvent((event) => event.type === "transport-state")).toMatchObject({
+        explicitlyDisconnected: true,
+      });
+      expect(await port.waitForEvent((event) => event.type === "transport-state")).toMatchObject({
+        explicitlyDisconnected: false,
+      });
+    }
+  });
+
+  it("reports the settled offline state before a late follower init succeeds", async () => {
+    const initOptions = { ...options("late-offline-follower"), serverUrl: "ws://server.test" };
+    const owner = await connect(initOptions, "owner-tab");
+    await initializeFollower(owner.port, 1);
+    owner.port.emitMessage({ type: "disconnect", id: 2 });
+    await owner.port.waitForEvent((event) => event.type === "result" && event.id === 2);
+
+    const late = await connect(initOptions, "late-tab");
+    const offline = late.port.waitForEvent((event) => event.type === "transport-state");
+    const initialized = late.port.waitForEvent(
+      (event) => event.type === "result" && event.id === 1,
+    );
+    late.port.emitMessage({ type: "init", id: 1, sessionClaims: {} });
+    expect(await offline).toMatchObject({ explicitlyDisconnected: true });
+    await initialized;
   });
 });

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -178,6 +178,10 @@ class TestPort {
     this.eventWaiters.push({ predicate, resolve: waiter.resolve });
     return waiter.promise;
   }
+
+  hasEvent(predicate: (event: BrowserFollowerPortEvent) => boolean): boolean {
+    return this.events.some(predicate);
+  }
 }
 
 function deferred<T>() {
@@ -508,5 +512,35 @@ describe("broker worker context initialization", () => {
     late.port.emitMessage({ type: "init", id: 1, sessionClaims: {} });
     expect(await offline).toMatchObject({ explicitlyDisconnected: true });
     await initialized;
+  });
+
+  it("cancels a closed peer's offline server wait", async () => {
+    const initOptions = { ...options("closed-offline-waiter"), serverUrl: "ws://server.test" };
+    const owner = await connect(initOptions, "owner-tab");
+    const editor = await connect(initOptions, "editor-tab");
+    await initializeFollower(owner.port, 1);
+    await initializeFollower(editor.port, 1);
+
+    owner.port.emitMessage({ type: "disconnect", id: 2 });
+    await owner.port.waitForEvent((event) => event.type === "result" && event.id === 2);
+
+    // The waiter parks on namespace state while explicitly offline. Closing its
+    // port must cancel that wait, rather than retaining it until a later peer
+    // reconnects and then posting a stale result to the dead port.
+    editor.port.emitMessage({ type: "wait-server", id: 2 });
+    await Promise.resolve();
+    const closed = editor.port.waitForEvent((event) => event.type === "result" && event.id === 3);
+    editor.port.emitMessage({ type: "close", id: 3 });
+    await closed;
+
+    owner.port.emitMessage({
+      type: "reconnect",
+      id: 3,
+      authJson: "{}",
+      sessionClaims: {},
+    });
+    await owner.port.waitForEvent((event) => event.type === "result" && event.id === 3);
+    await Promise.resolve();
+    expect(editor.port.hasEvent((event) => event.type === "result" && event.id === 2)).toBe(false);
   });
 });

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -149,6 +149,9 @@ class TestPort {
       else this.outcomes.push(message);
       return;
     }
+    // Bootstrap liveness is intentionally not a follower event or a runtime
+    // connection outcome; tests only retain the latter two protocol classes.
+    if (message.type === "worker-alive") return;
     const waiterIndex = this.eventWaiters.findIndex(({ predicate }) => predicate(message));
     if (waiterIndex >= 0) {
       this.eventWaiters.splice(waiterIndex, 1)[0]!.resolve(message);

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -43,6 +43,7 @@ type TabPeer = {
   flushRequestId: number | null;
   flushPumpComplete: boolean;
   flushObserved: boolean;
+  transportWaitAbort: AbortController;
   onMessage: (event: MessageEvent<BrowserFollowerPortRequest>) => void;
   onMessageError: () => void;
 };
@@ -369,20 +370,32 @@ function publishExplicitOffline(context: RuntimeContext): void {
 function waitForTransportStateChange(
   context: RuntimeContext,
   observedEpoch: number,
+  signal?: AbortSignal,
 ): Promise<void> {
-  if (context.transportStateEpoch !== observedEpoch) return Promise.resolve();
-  return new Promise<void>((resolve) => context.transportStateWaiters.add(resolve));
+  if (context.transportStateEpoch !== observedEpoch || signal?.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const finish = () => {
+      context.transportStateWaiters.delete(finish);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    };
+    signal?.addEventListener("abort", finish, { once: true });
+    context.transportStateWaiters.add(finish);
+  });
 }
 
 async function waitForServerConnection(
   context: RuntimeContext,
   runtime: NativeRuntimeAdapter,
+  signal?: AbortSignal,
 ): Promise<void> {
   for (;;) {
+    if (signal?.aborted) return;
     await context.transportTransition;
+    if (signal?.aborted) return;
     if (context.explicitlyDisconnected) {
       const epoch = context.transportStateEpoch;
-      await waitForTransportStateChange(context, epoch);
+      await waitForTransportStateChange(context, epoch, signal);
       continue;
     }
     await runtime.waitForUpstreamServerConnection();
@@ -411,6 +424,7 @@ function attachTab(context: RuntimeContext, tabId: string, port: MessagePort): v
     flushRequestId: null,
     flushPumpComplete: false,
     flushObserved: false,
+    transportWaitAbort: new AbortController(),
     onMessage,
     onMessageError,
   };
@@ -567,7 +581,8 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
       result(peer, message.id);
       return;
     }
-    await waitForServerConnection(peer.context, activeRuntime);
+    await waitForServerConnection(peer.context, activeRuntime, peer.transportWaitAbort.signal);
+    if (peer.transportWaitAbort.signal.aborted) return;
     result(peer, message.id);
   } catch (error) {
     if ("id" in message) result(peer, message.id, asError(error));
@@ -651,6 +666,7 @@ function attachInspectorControl(authSessionKey: string, port: MessagePort): void
 }
 
 function result(peer: TabPeer, id: number, error?: Error): void {
+  if (peer.context.peers.get(peer.tabId) !== peer) return;
   post(peer.port, { type: "result", id, ...(error ? { error: errorDetails(error) } : {}) });
 }
 
@@ -669,6 +685,7 @@ function closeTab(context: RuntimeContext, tabId: string, closePort = true): voi
   const peer = context.peers.get(tabId);
   if (!peer) return;
   context.peers.delete(tabId);
+  peer.transportWaitAbort.abort();
   acknowledgeReset(context, tabId);
   peer.port.removeEventListener("message", peer.onMessage);
   peer.port.removeEventListener("messageerror", peer.onMessageError);

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -66,6 +66,9 @@ type RuntimeContext = {
   serverAuthJson: string;
   serverConnectionStarted: boolean;
   explicitlyDisconnected: boolean;
+  transportTransition: Promise<void>;
+  transportStateEpoch: number;
+  transportStateWaiters: Set<() => void>;
 };
 
 const workerGlobal = globalThis as SharedWorkerGlobal;
@@ -114,7 +117,7 @@ async function connectTab(
       contexts.set(key, context);
     }
     await context.initialize;
-    await configureServer(context, message.options);
+    await enqueueTransportTransition(context, () => configureServer(context, message.options));
     attachTab(context, message.tabId, port);
     post(port, { type: "runtime-ready" });
   } catch (error) {
@@ -144,6 +147,9 @@ function createContext(
     serverAuthJson: options.authJson,
     serverConnectionStarted: false,
     explicitlyDisconnected: false,
+    transportTransition: Promise.resolve(),
+    transportStateEpoch: 0,
+    transportStateWaiters: new Set(),
     initialize: Promise.resolve(),
     closing: null,
     idleReleaseTimer: null,
@@ -335,6 +341,58 @@ function ensureServerConnection(context: RuntimeContext): void {
   context.serverConnectionStarted = true;
 }
 
+/**
+ * The durable worker has one upstream transport, while every MessagePort is
+ * serviced independently. Serialize mutations and observations of that shared
+ * transport so an older disconnect cannot complete after a newer reconnect.
+ */
+function enqueueTransportTransition(
+  context: RuntimeContext,
+  transition: () => void | Promise<void>,
+): Promise<void> {
+  const queued = context.transportTransition.then(transition, transition);
+  context.transportTransition = queued.catch(() => undefined);
+  return queued;
+}
+
+function publishExplicitOffline(context: RuntimeContext): void {
+  context.transportStateEpoch += 1;
+  broadcast(context, {
+    type: "transport-state",
+    explicitlyDisconnected: context.explicitlyDisconnected,
+  });
+  const waiters = [...context.transportStateWaiters];
+  context.transportStateWaiters.clear();
+  for (const wake of waiters) wake();
+}
+
+function waitForTransportStateChange(
+  context: RuntimeContext,
+  observedEpoch: number,
+): Promise<void> {
+  if (context.transportStateEpoch !== observedEpoch) return Promise.resolve();
+  return new Promise<void>((resolve) => context.transportStateWaiters.add(resolve));
+}
+
+async function waitForServerConnection(
+  context: RuntimeContext,
+  runtime: NativeRuntimeAdapter,
+): Promise<void> {
+  for (;;) {
+    await context.transportTransition;
+    if (context.explicitlyDisconnected) {
+      const epoch = context.transportStateEpoch;
+      await waitForTransportStateChange(context, epoch);
+      continue;
+    }
+    await runtime.waitForUpstreamServerConnection();
+    // A disconnect can be queued while carrier negotiation is pending. Do not
+    // tell a caller that remote readiness succeeded until it observes the
+    // resulting namespace state.
+    if (!context.explicitlyDisconnected) return;
+  }
+}
+
 function attachTab(context: RuntimeContext, tabId: string, port: MessagePort): void {
   closeTab(context, tabId);
   let peer!: TabPeer;
@@ -435,39 +493,46 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
         const pending = peer.pendingFrames.splice(0);
         pump.receive(pending);
       }
-      if (peer.context.explicitlyDisconnected) {
-        post(peer.port, { type: "transport-state", explicitlyDisconnected: true });
-      } else {
-        ensureServerConnection(peer.context);
-      }
+      await enqueueTransportTransition(peer.context, () => {
+        if (peer.context.explicitlyDisconnected) {
+          post(peer.port, { type: "transport-state", explicitlyDisconnected: true });
+        } else {
+          ensureServerConnection(peer.context);
+        }
+      });
       result(peer, message.id);
       return;
     }
     if (message.type === "update-auth") {
       if (!peer.subscriber) throw new Error("Browser tab is not initialized");
-      await peer.subscriber.updateAuthenticatedClaims?.(message.sessionClaims);
-      peer.context.serverAuthJson = message.authJson;
-      await activeRuntime.updateAuth(message.authJson);
+      await enqueueTransportTransition(peer.context, async () => {
+        await peer.subscriber?.updateAuthenticatedClaims?.(message.sessionClaims);
+        peer.context.serverAuthJson = message.authJson;
+        if (!peer.context.explicitlyDisconnected) {
+          await activeRuntime.updateAuth(message.authJson);
+        }
+      });
       broadcast(peer.context, { type: "auth-restored" });
       return;
     }
     if (message.type === "disconnect") {
-      const wasExplicitlyDisconnected = peer.context.explicitlyDisconnected;
-      peer.context.explicitlyDisconnected = true;
-      peer.context.serverConnectionStarted = false;
-      try {
-        await activeRuntime.disconnect({ rejectWaiters: false });
-      } catch (error) {
-        // Match the public Db contract: a failed explicit disconnect must not
-        // silently change RemoteIfPossible behavior for any tab. The adapter
-        // may already have detached the old carrier before reporting a
-        // retirement error, so restore the normal owner-wide connection when
-        // this context was previously online.
-        peer.context.explicitlyDisconnected = wasExplicitlyDisconnected;
-        if (!wasExplicitlyDisconnected) ensureServerConnection(peer.context);
-        throw error;
-      }
-      broadcast(peer.context, { type: "transport-state", explicitlyDisconnected: true });
+      await enqueueTransportTransition(peer.context, async () => {
+        const wasExplicitlyDisconnected = peer.context.explicitlyDisconnected;
+        peer.context.explicitlyDisconnected = true;
+        peer.context.serverConnectionStarted = false;
+        try {
+          await activeRuntime.disconnect({ rejectWaiters: false });
+        } catch (error) {
+          // Match the public Db contract: a failed explicit disconnect must
+          // not silently change RemoteIfPossible behavior for any tab. The
+          // adapter may already have detached the old carrier before reporting
+          // a retirement error, so restore normal connection ownership.
+          peer.context.explicitlyDisconnected = wasExplicitlyDisconnected;
+          if (!wasExplicitlyDisconnected) ensureServerConnection(peer.context);
+          throw error;
+        }
+        publishExplicitOffline(peer.context);
+      });
       result(peer, message.id);
       return;
     }
@@ -491,16 +556,18 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
     if (message.type === "reconnect") {
       const serverUrl = peer.context.serverUrl;
       if (!serverUrl) throw new Error("Browser runtime reconnect requires a serverUrl");
-      await peer.subscriber?.updateAuthenticatedClaims?.(message.sessionClaims);
-      peer.context.serverAuthJson = message.authJson;
-      activeRuntime.connect(serverUrl, message.authJson);
-      peer.context.explicitlyDisconnected = false;
-      peer.context.serverConnectionStarted = true;
-      broadcast(peer.context, { type: "transport-state", explicitlyDisconnected: false });
+      await enqueueTransportTransition(peer.context, async () => {
+        await peer.subscriber?.updateAuthenticatedClaims?.(message.sessionClaims);
+        peer.context.serverAuthJson = message.authJson;
+        activeRuntime.connect(serverUrl, message.authJson);
+        peer.context.explicitlyDisconnected = false;
+        peer.context.serverConnectionStarted = true;
+        publishExplicitOffline(peer.context);
+      });
       result(peer, message.id);
       return;
     }
-    await activeRuntime.waitForUpstreamServerConnection();
+    await waitForServerConnection(peer.context, activeRuntime);
     result(peer, message.id);
   } catch (error) {
     if ("id" in message) result(peer, message.id, asError(error));

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -65,6 +65,7 @@ type RuntimeContext = {
   serverUrl: string | null;
   serverAuthJson: string;
   serverConnectionStarted: boolean;
+  explicitlyDisconnected: boolean;
 };
 
 const workerGlobal = globalThis as SharedWorkerGlobal;
@@ -142,6 +143,7 @@ function createContext(
     serverUrl: options.serverUrl ?? null,
     serverAuthJson: options.authJson,
     serverConnectionStarted: false,
+    explicitlyDisconnected: false,
     initialize: Promise.resolve(),
     closing: null,
     idleReleaseTimer: null,
@@ -327,7 +329,7 @@ async function configureServer(
 
 function ensureServerConnection(context: RuntimeContext): void {
   const requestedUrl = context.serverUrl;
-  if (!requestedUrl) return;
+  if (!requestedUrl || context.explicitlyDisconnected) return;
   if (context.serverConnectionStarted) return;
   requireRuntime(context).connect(requestedUrl, context.serverAuthJson);
   context.serverConnectionStarted = true;
@@ -433,7 +435,11 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
         const pending = peer.pendingFrames.splice(0);
         pump.receive(pending);
       }
-      ensureServerConnection(peer.context);
+      if (peer.context.explicitlyDisconnected) {
+        post(peer.port, { type: "transport-state", explicitlyDisconnected: true });
+      } else {
+        ensureServerConnection(peer.context);
+      }
       result(peer, message.id);
       return;
     }
@@ -446,8 +452,22 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
       return;
     }
     if (message.type === "disconnect") {
-      await activeRuntime.disconnect({ rejectWaiters: false });
+      const wasExplicitlyDisconnected = peer.context.explicitlyDisconnected;
+      peer.context.explicitlyDisconnected = true;
       peer.context.serverConnectionStarted = false;
+      try {
+        await activeRuntime.disconnect({ rejectWaiters: false });
+      } catch (error) {
+        // Match the public Db contract: a failed explicit disconnect must not
+        // silently change RemoteIfPossible behavior for any tab. The adapter
+        // may already have detached the old carrier before reporting a
+        // retirement error, so restore the normal owner-wide connection when
+        // this context was previously online.
+        peer.context.explicitlyDisconnected = wasExplicitlyDisconnected;
+        if (!wasExplicitlyDisconnected) ensureServerConnection(peer.context);
+        throw error;
+      }
+      broadcast(peer.context, { type: "transport-state", explicitlyDisconnected: true });
       result(peer, message.id);
       return;
     }
@@ -474,7 +494,9 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
       await peer.subscriber?.updateAuthenticatedClaims?.(message.sessionClaims);
       peer.context.serverAuthJson = message.authJson;
       activeRuntime.connect(serverUrl, message.authJson);
+      peer.context.explicitlyDisconnected = false;
       peer.context.serverConnectionStarted = true;
+      broadcast(peer.context, { type: "transport-state", explicitlyDisconnected: false });
       result(peer, message.id);
       return;
     }

--- a/packages/jazz-tools/tests/browser/db.disconnect.test.ts
+++ b/packages/jazz-tools/tests/browser/db.disconnect.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { schema as s } from "../../src/";
 import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
+import { ReadTier } from "../../src/runtime/client.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import { deploy } from "../../src/dev/catalogue.js";
 import {
@@ -413,6 +414,65 @@ describe("Db disconnect/reconnect", () => {
   });
 
   describe("worker mode", () => {
+    it("propagates explicit offline state across tabs in one worker namespace", async () => {
+      const label = uniqueDbName("worker-namespace-disconnect");
+      const server = await publishSyncServerSchemaAndPermissions(label);
+      const secret = generateAuthSecret();
+      const dbName = uniqueDbName(label);
+      const [owner, editor] = await Promise.all(
+        ["owner", "editor"].map(async () =>
+          ctx.track(
+            await createDb({
+              appId: server.appId,
+              driver: { type: "persistent", dbName },
+              serverUrl: server.serverUrl,
+              secret,
+            }),
+          ),
+        ),
+      );
+
+      // Initialise both foreground peers against the same worker before the
+      // owner takes its one shared upstream connection explicitly offline.
+      await Promise.all([
+        owner.all(app.todos, { tier: "edge" }),
+        editor.all(app.todos, { tier: "edge" }),
+      ]);
+      await owner.disconnect();
+
+      const title = "namespace-wide offline write";
+      const write = editor.insert(todos, { title, done: true });
+      await withWorkerOperationTimeout(
+        write.wait({ tier: "local" }),
+        "worker namespace: editor local write did not resolve while owner disconnected",
+      );
+
+      // The editor did not issue disconnect(), but it shares the durable
+      // worker and must therefore make the same explicit-offline read choice.
+      const localFallback = await withWorkerOperationTimeout(
+        editor.all(todoByTitle(title), { tier: ReadTier.RemoteIfPossible }),
+        "worker namespace: editor did not use local fallback after owner disconnect",
+      );
+      expect(localFallback).toHaveLength(1);
+      expect(localFallback[0]?.title).toBe(title);
+
+      const edgeWait = write.wait({ tier: "edge" });
+      await expectStillPending(
+        edgeWait,
+        PENDING_ASSERTION_MS,
+        "worker namespace: editor edge wait settled while the shared worker was offline",
+      );
+
+      // Any attached tab can reconnect the namespace. The queued editor write
+      // must retain its ordinary fate route and settle after that reconnect.
+      await editor.reconnect();
+      await withTimeout(
+        edgeWait,
+        SYNC_OPERATION_TIMEOUT_MS,
+        "worker namespace: editor write did not settle after reconnect",
+      );
+    }, 60_000);
+
     it("syncs writes made while disconnected after reconnect", async () => {
       const { db, peer } = await createDbPair(ctx, createWorkerDb);
 

--- a/packages/jazz-tools/tests/browser/db.disconnect.test.ts
+++ b/packages/jazz-tools/tests/browser/db.disconnect.test.ts
@@ -419,42 +419,57 @@ describe("Db disconnect/reconnect", () => {
       const server = await publishSyncServerSchemaAndPermissions(label);
       const secret = generateAuthSecret();
       const dbName = uniqueDbName(label);
-      const [owner, editor] = await Promise.all(
-        ["owner", "editor"].map(async () =>
-          ctx.track(
-            await createDb({
-              appId: server.appId,
-              driver: { type: "persistent", dbName },
-              serverUrl: server.serverUrl,
-              secret,
-            }),
-          ),
-        ),
+      const owner = ctx.track(
+        await createDb({
+          appId: server.appId,
+          driver: { type: "persistent", dbName },
+          serverUrl: server.serverUrl,
+          secret,
+        }),
       );
-
-      // Initialise both foreground peers against the same worker before the
-      // owner takes its one shared upstream connection explicitly offline.
-      await Promise.all([
-        owner.all(app.todos, { tier: "edge" }),
-        editor.all(app.todos, { tier: "edge" }),
-      ]);
+      await owner.all(app.todos, { tier: "edge" });
       await owner.disconnect();
 
       const title = "namespace-wide offline write";
-      const write = editor.insert(todos, { title, done: true });
+      const write = owner.insert(todos, { title, done: true });
       await withWorkerOperationTimeout(
         write.wait({ tier: "local" }),
-        "worker namespace: editor local write did not resolve while owner disconnected",
+        "worker namespace: owner local write did not resolve while disconnected",
+      );
+
+      // Attach only after the namespace is already offline. This is the
+      // important race: the late tab must await its init-state handshake
+      // before classifying RemoteIfPossible as Local rather than Edge.
+      const editor = ctx.track(
+        await createDb({
+          appId: server.appId,
+          driver: { type: "persistent", dbName },
+          serverUrl: server.serverUrl,
+          secret,
+        }),
       );
 
       // The editor did not issue disconnect(), but it shares the durable
       // worker and must therefore make the same explicit-offline read choice.
+      // An Edge read would exclude this not-yet-settled row.
       const localFallback = await withWorkerOperationTimeout(
         editor.all(todoByTitle(title), { tier: ReadTier.RemoteIfPossible }),
         "worker namespace: editor did not use local fallback after owner disconnect",
       );
       expect(localFallback).toHaveLength(1);
       expect(localFallback[0]?.title).toBe(title);
+
+      const snapshots: Todo[][] = [];
+      const unsubscribe = ctx.trackSubscription(
+        editor.subscribe(todoByTitle(title), (rows) => snapshots.push(rows), {
+          tier: ReadTier.RemoteIfPossible,
+        }),
+      );
+      await waitForCondition(
+        () => Promise.resolve(snapshots.some((rows) => rows.some((row) => row.title === title))),
+        WORKER_OPERATION_TIMEOUT_MS,
+        "worker namespace: late editor subscription did not use local fallback",
+      );
 
       const edgeWait = write.wait({ tier: "edge" });
       await expectStillPending(
@@ -471,6 +486,7 @@ describe("Db disconnect/reconnect", () => {
         SYNC_OPERATION_TIMEOUT_MS,
         "worker namespace: editor write did not settle after reconnect",
       );
+      unsubscribe();
     }, 60_000);
 
     it("syncs writes made while disconnected after reconnect", async () => {


### PR DESCRIPTION
🤖 Fixes explicit-offline state and transport ownership for multiple tabs sharing one persistent browser namespace.

## Before

- The worker owns one server connection per persistent namespace, but `disconnect()` only marked the initiating tab offline while tearing down the namespace-wide transport.
- A remaining or late tab could classify `remote-if-possible` as remote even though no upstream carrier existed, and edge waits could remain pending.
- Concurrent disconnect/reconnect messages from different ports could interleave and publish stale state; closed peers could remain parked in offline waiters.

## After

- Explicit offline state is namespace-wide, durable in the worker context, and broadcast to current and late-attaching tabs.
- Only a newly attaching browser follower waits for its initial authoritative transport-state handshake before choosing a tier. Established/direct reads preserve choose-once semantics.
- Namespace transport transitions are serialized; any peer can reconnect the shared namespace in order.
- Offline waiters are peer-owned and aborted on tab close, preventing stale posts and retained closures.

## Behavioral examples

- Tab A disconnects a shared namespace; tab B immediately gets local fallback for `remote-if-possible`, while an edge fate remains pending.
- A tab opened after the disconnect learns the offline state before its first one-shot/subscription; reconnecting from that tab upgrades the subscription and settles the pending fate.
- A reconnect racing a slow disconnect cannot start a replacement carrier and then be overwritten by the older transition.
- Closing a tab while explicitly offline removes its parked server waiter.

## Verification

- 32/32 focused read-tier, BrowserConnectionManager, and worker-initialization tests pass.
- Independent review reproduced the late-tab failure on the first candidate and planted timing/race regressions; the final candidate closes them.
- TypeScript and runtime builds pass. The browser E2E is included for CI; local replay was blocked by stale generated artifact provenance, not a test failure.

Stacked after #2191.