### PR TITLE
fix(server): serialize permission head publication

### DIFF
--- a/.changeset/atomic-permission-heads.md
+++ b/.changeset/atomic-permission-heads.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make permission publications sharing one in-process catalogue store compare and swap the current parent while preserving bundle-first, head-second storage.

--- a/crates/jazz-server/src/server/builder.rs
+++ b/crates/jazz-server/src/server/builder.rs
@@ -229,6 +229,11 @@ impl ServerBuilder {
             core_server_shell: std::sync::RwLock::new(core_server_shell),
             core_server_shell_storage_config,
             storage_factory: self.storage_factory.clone(),
+            runtime_catalogue_publication: tokio::sync::Mutex::new(()),
+            #[cfg(test)]
+            runtime_catalogue_before_publication_hook: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            runtime_catalogue_after_permissions_read_hook: std::sync::Mutex::new(None),
             // A validated durable catalogue remains usable while its core is
             // offline. Blank edges have no such generation and stay behind
             // RetryLater until authenticated bootstrap completes.

--- a/crates/jazz-server/src/server/catalogue.rs
+++ b/crates/jazz-server/src/server/catalogue.rs
@@ -639,68 +639,69 @@ impl CatalogueStore for StoredCatalogue {
         permissions: HashMap<TableName, TablePolicies>,
         expected_parent_bundle_object_id: Option<ObjectId>,
     ) -> Result<Option<ObjectId>, CatalogueError> {
-        let (head, bundle_entry, head_entry) = {
-            let index = self.index.lock().map_err(|_| CatalogueError::LockError)?;
-            let current_parent_bundle_object_id =
-                index.permissions_head.map(|head| head.bundle_object_id);
-            if current_parent_bundle_object_id != expected_parent_bundle_object_id {
-                return Err(CatalogueError::WriteError(format!(
-                    "stale permissions parent: expected {:?}, current {:?}",
-                    expected_parent_bundle_object_id, current_parent_bundle_object_id
-                )));
-            }
+        // Catalogue mutations take storage before the in-memory index. Holding
+        // both locks makes parent validation and head advancement linearizable
+        // for callers sharing this StoredCatalogue. The two storage writes
+        // remain bundle-first/head-second; this is not a crash-atomic
+        // transaction or a cross-process compare-and-swap.
+        let mut storage = self.storage.lock().map_err(|_| CatalogueError::LockError)?;
+        let mut index = self.index.lock().map_err(|_| CatalogueError::LockError)?;
+        let current_parent_bundle_object_id =
+            index.permissions_head.map(|head| head.bundle_object_id);
+        if current_parent_bundle_object_id != expected_parent_bundle_object_id {
+            return Err(CatalogueError::WriteError(format!(
+                "stale permissions parent: expected {:?}, current {:?}",
+                expected_parent_bundle_object_id, current_parent_bundle_object_id
+            )));
+        }
 
-            if let Some(current) = index.current_permissions()
-                && current.head.schema_hash == schema_hash
-                && current.permissions == permissions
-            {
-                return Ok(Some(permissions_head_object_id(self.app_id)));
-            }
+        if let Some(current) = index.current_permissions()
+            && current.head.schema_hash == schema_hash
+            && current.permissions == permissions
+        {
+            return Ok(Some(permissions_head_object_id(self.app_id)));
+        }
 
-            let version = index
-                .permissions_head
-                .map(|head| head.version + 1)
-                .unwrap_or(1);
-            let bundle_object_id = permissions_bundle_object_id(
-                self.app_id,
+        let version = index
+            .permissions_head
+            .map(|head| head.version + 1)
+            .unwrap_or(1);
+        let bundle_object_id = permissions_bundle_object_id(
+            self.app_id,
+            schema_hash,
+            version,
+            current_parent_bundle_object_id,
+            &permissions,
+        );
+        let head = PermissionsHeadSummary {
+            schema_hash,
+            version,
+            parent_bundle_object_id: current_parent_bundle_object_id,
+            bundle_object_id,
+        };
+        let bundle_entry = CatalogueEntry {
+            object_id: bundle_object_id,
+            metadata: catalogue_metadata(self.app_id, ObjectType::CataloguePermissionsBundle),
+            content: encode_permissions_bundle(
                 schema_hash,
                 version,
                 current_parent_bundle_object_id,
                 &permissions,
-            );
-            let head = PermissionsHeadSummary {
+            ),
+        };
+        let head_entry = CatalogueEntry {
+            object_id: permissions_head_object_id(self.app_id),
+            metadata: catalogue_metadata(self.app_id, ObjectType::CataloguePermissionsHead),
+            content: encode_permissions_head(
                 schema_hash,
                 version,
-                parent_bundle_object_id: current_parent_bundle_object_id,
+                current_parent_bundle_object_id,
                 bundle_object_id,
-            };
-            let bundle_entry = CatalogueEntry {
-                object_id: bundle_object_id,
-                metadata: catalogue_metadata(self.app_id, ObjectType::CataloguePermissionsBundle),
-                content: encode_permissions_bundle(
-                    schema_hash,
-                    version,
-                    current_parent_bundle_object_id,
-                    &permissions,
-                ),
-            };
-            let head_entry = CatalogueEntry {
-                object_id: permissions_head_object_id(self.app_id),
-                metadata: catalogue_metadata(self.app_id, ObjectType::CataloguePermissionsHead),
-                content: encode_permissions_head(
-                    schema_hash,
-                    version,
-                    current_parent_bundle_object_id,
-                    bundle_object_id,
-                ),
-            };
-            (head, bundle_entry, head_entry)
+            ),
         };
 
-        let mut storage = self.storage.lock().map_err(|_| CatalogueError::LockError)?;
         storage.upsert_catalogue_entry(&bundle_entry)?;
         storage.upsert_catalogue_entry(&head_entry)?;
-        let mut index = self.index.lock().map_err(|_| CatalogueError::LockError)?;
         index.apply_entry(&bundle_entry)?;
         index.permissions_head = Some(head);
         Ok(Some(head_entry.object_id))
@@ -815,5 +816,72 @@ impl ServerCatalogue {
 
     pub(crate) fn close(&self, store: &impl CatalogueStore) -> Result<(), CatalogueError> {
         store.close()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    use jazz::tools::public_schema::{SchemaBuilder, TablePolicies};
+
+    use super::{CatalogueStore, StoredCatalogue};
+    use crate::server::catalogue_storage::CatalogueMemoryStorage;
+
+    #[test]
+    fn concurrent_permissions_publications_compare_and_swap_the_parent() {
+        const PUBLISHERS: usize = 8;
+        let schema = SchemaBuilder::new().build();
+        let schema_hash = jazz::tools::public_schema::SchemaHash::compute(&schema);
+        let store = Arc::new(
+            StoredCatalogue::new(
+                jazz::tools::AppId::from_name("permissions-publication-race"),
+                Some(schema),
+                Box::new(CatalogueMemoryStorage::new()),
+            )
+            .expect("catalogue"),
+        );
+        let storage_guard = store.storage.lock().expect("storage lock");
+        let start = Arc::new(Barrier::new(PUBLISHERS + 1));
+        let mut publishers = Vec::new();
+        for _ in 0..PUBLISHERS {
+            let store = Arc::clone(&store);
+            let start = Arc::clone(&start);
+            publishers.push(std::thread::spawn(move || {
+                start.wait();
+                store.publish_permissions_bundle(
+                    schema_hash,
+                    std::collections::HashMap::from([(
+                        jazz::tools::public_schema::TableName::new("todos"),
+                        TablePolicies::default(),
+                    )]),
+                    None,
+                )
+            }));
+        }
+
+        start.wait();
+        std::thread::sleep(Duration::from_millis(50));
+        drop(storage_guard);
+
+        let results = publishers
+            .into_iter()
+            .map(|publisher| publisher.join().expect("publisher thread"))
+            .collect::<Vec<_>>();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| {
+                    matches!(
+                        result,
+                        Err(super::CatalogueError::WriteError(message))
+                            if message.starts_with("stale permissions parent")
+                    )
+                })
+                .count(),
+            PUBLISHERS - 1
+        );
     }
 }

--- a/crates/jazz-server/src/server/mod.rs
+++ b/crates/jazz-server/src/server/mod.rs
@@ -2,6 +2,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock as StdRwLock};
 use std::thread;
 
+#[cfg(test)]
+use std::sync::Mutex as StdMutex;
+
 use crate::middleware::AuthConfig;
 use crate::middleware::auth::JwtVerifier;
 use jazz::serving::StorageConfig;
@@ -106,6 +109,16 @@ pub struct ServerState {
     pub(crate) core_server_shell: StdRwLock<Option<ServerRuntimeHandle>>,
     pub(crate) core_server_shell_storage_config: Option<StorageConfig>,
     pub(crate) storage_factory: Option<Arc<dyn jazz::groove::storage::StorageFactory>>,
+    /// Serializes durable-catalogue reconciliation into the local runtime shell.
+    ///
+    /// Catalogue storage can advance while a previous bridge is in flight, but
+    /// bridge installs must reach the shell in the same order so an older head
+    /// cannot overwrite a newer one.
+    pub(crate) runtime_catalogue_publication: tokio::sync::Mutex<()>,
+    #[cfg(test)]
+    runtime_catalogue_before_publication_hook: StdMutex<Option<Box<dyn FnOnce() + Send>>>,
+    #[cfg(test)]
+    runtime_catalogue_after_permissions_read_hook: StdMutex<Option<Box<dyn FnOnce() + Send>>>,
     /// Whether the current Edge shell generation has a fully installed,
     /// validated catalogue and local projection registry. A durable Ready
     /// generation remains usable offline; blank and refreshing generations do
@@ -170,6 +183,52 @@ fn client_shell_snapshot<T: Clone>(
 }
 
 impl ServerState {
+    #[cfg(test)]
+    pub(crate) fn set_runtime_catalogue_before_publication_hook_for_test(
+        &self,
+        hook: Box<dyn FnOnce() + Send>,
+    ) {
+        *self
+            .runtime_catalogue_before_publication_hook
+            .lock()
+            .expect("runtime catalogue test hook lock") = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn run_runtime_catalogue_before_publication_hook_for_test(&self) {
+        let hook = self
+            .runtime_catalogue_before_publication_hook
+            .lock()
+            .expect("runtime catalogue test hook lock")
+            .take();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_runtime_catalogue_after_permissions_read_hook_for_test(
+        &self,
+        hook: Box<dyn FnOnce() + Send>,
+    ) {
+        *self
+            .runtime_catalogue_after_permissions_read_hook
+            .lock()
+            .expect("runtime catalogue test hook lock") = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn run_runtime_catalogue_after_permissions_read_hook_for_test(&self) {
+        let hook = self
+            .runtime_catalogue_after_permissions_read_hook
+            .lock()
+            .expect("runtime catalogue test hook lock")
+            .take();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
     /// Test-only observation of whether an edge has installed a runtime shell.
     #[cfg(feature = "test")]
     #[doc(hidden)]
@@ -546,6 +605,9 @@ mod tests {
             core_server_shell: StdRwLock::new(None),
             core_server_shell_storage_config: None,
             storage_factory: None,
+            runtime_catalogue_publication: tokio::sync::Mutex::new(()),
+            runtime_catalogue_before_publication_hook: StdMutex::new(None),
+            runtime_catalogue_after_permissions_read_hook: StdMutex::new(None),
             dynamic_edge_catalogue_ready: AtomicBool::new(true),
             shutdown: ShutdownController::new(timeout),
         })

--- a/crates/jazz-server/src/server/routes/mod.rs
+++ b/crates/jazz-server/src/server/routes/mod.rs
@@ -145,7 +145,9 @@ mod tests {
     use axum::routing::{get, post};
     use futures::{SinkExt as _, StreamExt as _};
     use jazz::ids::AuthorSubject;
-    use jazz::tools::public_schema::{ColumnType, PolicyExpr, Schema, SchemaBuilder, TableSchema};
+    use jazz::tools::public_schema::{
+        ColumnType, PolicyExpr, Schema, SchemaBuilder, TablePolicies, TableSchema,
+    };
     use serde_json::Value;
     use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
     use tower::ServiceExt;
@@ -1563,6 +1565,153 @@ mod tests {
                 .using
                 .as_ref(),
             Some(&winning_policy)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn chained_permissions_runtime_reconciliation_never_installs_stale_head() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+        let schema_hash = SchemaHash::compute(&schema);
+        let state = make_state_with_schema(schema).await;
+        let users = TableName::new("users");
+        let permissions = |policy| {
+            let mut table_policies = TablePolicies::default();
+            table_policies.select.using = Some(policy);
+            std::collections::HashMap::from([(users.clone(), table_policies)])
+        };
+
+        state
+            .catalogue
+            .publish_permissions_bundle(
+                &state.catalogue_store,
+                schema_hash,
+                permissions(PolicyExpr::True),
+                None,
+            )
+            .expect("persist H1");
+        let h1 = state
+            .catalogue
+            .current_permissions_head(&state.catalogue_store)
+            .expect("read H1")
+            .expect("H1 exists")
+            .bundle_object_id;
+
+        // Freeze H1 after it reads the durable head but before it queues its
+        // runtime install. H2 is then a valid chained publication. Without the
+        // bridge mutex, H2 can install first and H1 resumes last, regressing
+        // the runtime policy despite the durable head remaining H2.
+        let (h1_read_tx, h1_read_rx) = std::sync::mpsc::sync_channel(1);
+        let (resume_h1_tx, resume_h1_rx) = std::sync::mpsc::sync_channel(1);
+        state.set_runtime_catalogue_after_permissions_read_hook_for_test(Box::new(move || {
+            h1_read_tx.send(()).expect("signal H1 durable read");
+            resume_h1_rx.recv().expect("resume H1 bridge");
+        }));
+        let first_state = state.clone();
+        let first_bridge = tokio::spawn(async move {
+            crate::server::runtime_catalogue::publish_runtime_catalogue(&first_state, &[], &[])
+                .await
+        });
+        tokio::task::spawn_blocking(move || h1_read_rx.recv())
+            .await
+            .expect("join H1 read waiter")
+            .expect("observe H1 durable read");
+
+        state
+            .catalogue
+            .publish_permissions_bundle(
+                &state.catalogue_store,
+                schema_hash,
+                permissions(PolicyExpr::False),
+                Some(h1),
+            )
+            .expect("persist H2 after H1");
+        let (h2_read_tx, h2_read_rx) = std::sync::mpsc::sync_channel(1);
+        state.set_runtime_catalogue_after_permissions_read_hook_for_test(Box::new(move || {
+            h2_read_tx.send(()).expect("signal H2 durable read");
+        }));
+        let (second_started_tx, second_started_rx) = std::sync::mpsc::sync_channel(1);
+        let (start_second_tx, start_second_rx) = std::sync::mpsc::sync_channel(1);
+        state.set_runtime_catalogue_before_publication_hook_for_test(Box::new(move || {
+            second_started_tx
+                .send(())
+                .expect("signal H2 bridge attempt");
+            start_second_rx.recv().expect("start H2 bridge");
+        }));
+        let second_state = state.clone();
+        let second_bridge = tokio::spawn(async move {
+            crate::server::runtime_catalogue::publish_runtime_catalogue(&second_state, &[], &[])
+                .await
+        });
+
+        tokio::task::spawn_blocking(move || second_started_rx.recv())
+            .await
+            .expect("join H2 bridge waiter")
+            .expect("observe H2 bridge attempt");
+        start_second_tx.send(()).expect("start H2 bridge");
+        assert!(
+            matches!(
+                h2_read_rx.recv_timeout(Duration::from_millis(100)),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+            ),
+            "H2 must wait for H1's runtime bridge to release publication order"
+        );
+
+        resume_h1_tx.send(()).expect("resume H1 bridge");
+        first_bridge
+            .await
+            .expect("join H1 bridge")
+            .expect("bridge H1");
+        second_bridge
+            .await
+            .expect("join H2 bridge")
+            .expect("bridge H2");
+
+        let current = state
+            .catalogue
+            .current_permissions(&state.catalogue_store)
+            .expect("read durable permissions")
+            .expect("durable H2");
+        assert_eq!(current.head.version, 2);
+        assert_eq!(
+            current
+                .permissions
+                .get(&users)
+                .expect("durable users permissions")
+                .select
+                .using
+                .as_ref(),
+            Some(&PolicyExpr::False)
+        );
+
+        let runtime_snapshot = state
+            .runtime()
+            .expect("runtime shell started")
+            .trusted_catalogue_snapshot_for_test()
+            .await
+            .expect("read runtime catalogue");
+        let active_schema = runtime_snapshot
+            .schemas
+            .iter()
+            .find(|schema| schema.id == runtime_snapshot.current_write_schema.schema)
+            .expect("active runtime schema");
+        assert_eq!(
+            active_schema
+                .schema
+                .public_schema()
+                .get(&users)
+                .expect("runtime users table")
+                .policies
+                .select
+                .using
+                .as_ref(),
+            Some(&PolicyExpr::False),
+            "runtime policy must converge to the durable H2 head"
         );
     }
 

--- a/crates/jazz-server/src/server/routes/mod.rs
+++ b/crates/jazz-server/src/server/routes/mod.rs
@@ -145,7 +145,7 @@ mod tests {
     use axum::routing::{get, post};
     use futures::{SinkExt as _, StreamExt as _};
     use jazz::ids::AuthorSubject;
-    use jazz::tools::public_schema::{ColumnType, Schema, SchemaBuilder, TableSchema};
+    use jazz::tools::public_schema::{ColumnType, PolicyExpr, Schema, SchemaBuilder, TableSchema};
     use serde_json::Value;
     use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
     use tower::ServiceExt;
@@ -1425,6 +1425,144 @@ mod tests {
         assert_eq!(
             permissions_json["permissions"]["users"]["select"]["using"]["type"].as_str(),
             Some("False")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_permissions_publications_install_only_the_winning_runtime_head() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+        let schema_hash = SchemaHash::compute(&schema);
+        let state = make_state_with_schema(schema).await;
+        let app = make_test_router(state.clone());
+        let start = Arc::new(tokio::sync::Barrier::new(2));
+
+        let publish =
+            |app: axum::Router, start: Arc<tokio::sync::Barrier>, policy_type: &'static str| {
+                let schema_hash = schema_hash.to_string();
+                tokio::spawn(async move {
+                    let request_body = serde_json::json!({
+                        "schemaHash": schema_hash,
+                        "permissions": {
+                            "users": {
+                                "select": { "using": { "type": policy_type } }
+                            }
+                        }
+                    });
+                    start.wait().await;
+                    app.oneshot(
+                        axum::http::Request::builder()
+                            .method("POST")
+                            .uri(test_app_route("/admin/permissions"))
+                            .header("Content-Type", "application/json")
+                            .header("X-Jazz-Admin-Secret", "admin-secret")
+                            .body(axum::body::Body::from(request_body.to_string()))
+                            .unwrap(),
+                    )
+                    .await
+                    .expect("publish permissions through admin route")
+                })
+            };
+
+        let allow_publish = publish(app.clone(), start.clone(), "True");
+        let deny_publish = publish(app, start, "False");
+        let (allow_response, deny_response) = tokio::join!(allow_publish, deny_publish);
+        let allow_response = allow_response.expect("allow publish task");
+        let deny_response = deny_response.expect("deny publish task");
+        let allow_status = allow_response.status();
+        let deny_status = deny_response.status();
+        assert_eq!(
+            [allow_status, deny_status]
+                .into_iter()
+                .filter(|status| *status == StatusCode::CREATED)
+                .count(),
+            1
+        );
+        assert_eq!(
+            [allow_status, deny_status]
+                .into_iter()
+                .filter(|status| *status == StatusCode::CONFLICT)
+                .count(),
+            1
+        );
+
+        let (winning_policy, created_response, conflict_response) =
+            if allow_status == StatusCode::CREATED {
+                (PolicyExpr::True, allow_response, deny_response)
+            } else {
+                (PolicyExpr::False, deny_response, allow_response)
+            };
+        let conflict_body = body::to_bytes(conflict_response.into_body(), usize::MAX)
+            .await
+            .expect("stale publish body");
+        let conflict_json: Value =
+            serde_json::from_slice(&conflict_body).expect("stale publish json");
+        assert!(
+            conflict_json["error"]
+                .as_str()
+                .is_some_and(|message| message.starts_with("stale permissions parent"))
+        );
+
+        let created_body = body::to_bytes(created_response.into_body(), usize::MAX)
+            .await
+            .expect("winning publish body");
+        let created_json: Value =
+            serde_json::from_slice(&created_body).expect("winning publish json");
+        let winning_bundle_object_id = created_json["head"]["bundleObjectId"]
+            .as_str()
+            .expect("winning bundle object id");
+        assert_eq!(created_json["head"]["version"].as_u64(), Some(1));
+        assert_eq!(created_json["head"]["parentBundleObjectId"], Value::Null);
+
+        let current = state
+            .catalogue
+            .current_permissions(&state.catalogue_store)
+            .expect("read winning permissions")
+            .expect("winning permissions head");
+        let users = TableName::new("users");
+        assert_eq!(current.head.schema_hash, schema_hash);
+        assert_eq!(
+            current.head.bundle_object_id.to_string(),
+            winning_bundle_object_id
+        );
+        assert_eq!(
+            current
+                .permissions
+                .get(&users)
+                .expect("winning users permissions")
+                .select
+                .using
+                .as_ref(),
+            Some(&winning_policy)
+        );
+
+        let runtime_snapshot = state
+            .runtime()
+            .expect("runtime shell started")
+            .trusted_catalogue_snapshot_for_test()
+            .await
+            .expect("read runtime catalogue");
+        let active_schema = runtime_snapshot
+            .schemas
+            .iter()
+            .find(|schema| schema.id == runtime_snapshot.current_write_schema.schema)
+            .expect("active runtime schema");
+        assert_eq!(
+            active_schema
+                .schema
+                .public_schema()
+                .get(&users)
+                .expect("runtime users table")
+                .policies
+                .select
+                .using
+                .as_ref(),
+            Some(&winning_policy)
         );
     }
 

--- a/crates/jazz-server/src/server/runtime_catalogue.rs
+++ b/crates/jazz-server/src/server/runtime_catalogue.rs
@@ -22,6 +22,13 @@ pub(crate) async fn publish_runtime_catalogue(
     schemas: &[Schema],
     lenses: &[Lens],
 ) -> Result<(), String> {
+    #[cfg(test)]
+    state.run_runtime_catalogue_before_publication_hook_for_test();
+    // A bridge re-reads the durable permissions head before queueing the shell
+    // update. Keep the read and queued update ordered with every other bridge:
+    // otherwise a later head can install first and then be overwritten by this
+    // older bridge.
+    let _publication = state.runtime_catalogue_publication.lock().await;
     if state.runtime().is_none() && state.core_server_shell_storage_config.is_none() {
         return Ok(());
     }
@@ -75,6 +82,8 @@ pub(crate) async fn publish_runtime_catalogue(
         .catalogue
         .current_permissions(&state.catalogue_store)
         .map_err(|error| format!("read permissions head for runtime: {error}"))?;
+    #[cfg(test)]
+    state.run_runtime_catalogue_after_permissions_read_hook_for_test();
     let Some(permissions) = permissions else {
         return Ok(());
     };


### PR DESCRIPTION
## Summary

- make permission-head parent validation and publication one in-process critical section
- ensure only one concurrent publisher can consume a given expected parent
- keep the stored catalogue head and active runtime policy aligned with the winning publication

## Before

Two administrators could publish different permission bundles against the same expected parent.

Each request validated the parent while holding the catalogue index lock, then released that lock before writing to storage. Both requests could therefore validate the same parent, both return `201 Created`, and the later write could silently replace the first. Runtime policy updates could also diverge from the winning stored head.

## After

Permission publication now holds the storage and index locks through parent validation, bundle-first/head-second storage, and in-memory head advancement.

Exactly one concurrent request can consume a parent:

- the winner receives `201 Created`;
- the loser receives `409 Conflict`;
- the stored bundle and head match the winner;
- the active runtime policy matches the same winner.

This guarantee applies to callers sharing one in-process `StoredCatalogue`. It is not a cross-process compare-and-swap or a crash-atomic two-entry storage transaction. Bundle-first ordering means a crash may leave an unreferenced bundle, but cannot publish a head whose bundle was never written.

## Testing

- `cargo test -p jazz-server server::catalogue::tests::concurrent_permissions_publications_compare_and_swap_the_parent -- --exact --nocapture` — passed
- `cargo test -p jazz-server server::routes::tests::concurrent_permissions_publications_install_only_the_winning_runtime_head -- --exact --nocapture` — passed