### PR TITLE
Retain read view during authoritative reconcile

### DIFF
--- a/crates/jazz/SPEC/16_maintained_subscription_views.md
+++ b/crates/jazz/SPEC/16_maintained_subscription_views.md
@@ -43,6 +43,14 @@ are coverage facts for the maintained subscription view only; they do not become
 complete transaction payload refs. The peer state machine MUST NOT answer a live
 subscription by running an independent semantic scan.
 
+A maintained peer publication MUST retain the complete semantic read view and
+tier resolved at admission. Initial hydration, suspended retries, incremental
+evaluation, authoritative reconciliation, settlement, and authorization
+progress all use that same immutable context. An explicit replacement installs
+one complete replacement context, and every continuation uses that retained
+context; reconciliation MUST NOT substitute the default read view or reconstruct
+selectors from the opaque `ReadViewKey`.
+
 `groove/SPEC/INVARIANTS.md::INV-INC-1` is the mechanism law for this chapter:
 maintained-view ingestion, application, publication, snapshot assembly, diffing,
 and subscriber delivery are bounded by the size of the change and affected keys,

--- a/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
+++ b/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
@@ -24,6 +24,60 @@ fn branch_sync_selector(byte: u8) -> BranchSelector {
     BranchSelector::new([("branch_id", Value::Uuid(uuid::Uuid::from_bytes([byte; 16])))])
 }
 
+fn serving_rows_in_read_view(
+    server: &CoreDb,
+    schema: &JazzSchema,
+    query: &Query,
+    identity: AuthorSubject,
+    read_view: &ReadViewSpec,
+) -> Vec<CurrentRow> {
+    let shape = query.validate(schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    server
+        .node()
+        .borrow_mut()
+        .query_relation_snapshot_for_serving_in_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            identity,
+            read_view,
+        )
+        .unwrap()
+        .rows
+}
+
+fn write_deletion_register(server: &CoreDb, table: &str, row: RowUuid, branch: BranchSelector) {
+    let node = server.node();
+    let parents = {
+        let mut state = node.borrow_mut();
+        let deletion =
+            block_on(state.local_deletion_winner_tx_id_in_branch(table, &branch, row)).unwrap();
+        let content = if deletion.is_none() {
+            block_on(state.local_content_winner_tx_id_in_branch(table, &branch, row)).unwrap()
+        } else {
+            None
+        };
+        deletion.or(content).into_iter().collect()
+    };
+    let authored_columns = branch.values.keys().cloned().collect::<BTreeSet<_>>();
+    let published = block_on(
+        node.borrow_mut().commit_mergeable(
+            crate::node::MergeableCommit::new(table, row, server.next_now_ms())
+                .made_by(AuthorSubject::SYSTEM)
+                .branch(branch)
+                .parents(parents)
+                .authored_columns(authored_columns)
+                .deletion(crate::tx::DeletionEvent::Deleted),
+        ),
+    )
+    .unwrap();
+    let tx_id = block_on(node.borrow_mut().persist_and_settle_transaction(published)).unwrap();
+    let outcome = block_on(node.borrow_mut().finalize_local_mergeable_commit(tx_id)).unwrap();
+    block_on(node.borrow_mut().persist_and_settle_outcome(outcome)).unwrap();
+    server.server.mark_subscriber_connections_dirty();
+}
+
 #[test]
 fn db_sync_surface_round_trips_subscription_to_client() {
     let schema = schema();
@@ -350,4 +404,89 @@ fn branch_view_subscriptions_disambiguate_same_row_and_tx_by_branch() {
         right_snapshot.rows[0].cell(table, "branch_id"),
         Some(right.values["branch_id"].decode().unwrap())
     );
+}
+
+#[test]
+fn default_current_subscription_reconciles_deletion_witness_without_reset() {
+    let schema = schema();
+    let owner = AuthorSubject::for_test_bytes([0x50; 16]);
+    let client_author = AuthorSubject::for_test_bytes([0x51; 16]);
+    let server = open_core(0x52, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0x53, client_author, &schema);
+    let current_row = RowUuid::from_bytes([0x54; 16]);
+    server
+        .insert_with_id("todos", current_row, cells("current", false, owner))
+        .unwrap();
+    let query = Query::from("todos");
+    let current_view = ReadViewSpec::default();
+    assert_eq!(
+        row_ids(&serving_rows_in_read_view(
+            &server,
+            &schema,
+            &query,
+            client_author,
+            &current_view,
+        )),
+        vec![current_row]
+    );
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let mut subscription = prepared_subscribe(&client, &query, global_subscribe_opts()).unwrap();
+    assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
+
+    let mut snapshot = RelationSnapshot::default();
+    for _ in 0..10 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            apply_subscription_event(&mut snapshot, event);
+        }
+        if row_ids(&snapshot.rows) == vec![current_row] {
+            break;
+        }
+    }
+    assert_eq!(row_ids(&snapshot.rows), vec![current_row]);
+
+    write_deletion_register(&server, "todos", current_row, BranchSelector::default());
+    let mut saw_removal = false;
+    for _ in 0..10 {
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            match &event {
+                SubscriptionEvent::Delta {
+                    reset,
+                    added,
+                    removed,
+                    ..
+                } => {
+                    assert!(!reset, "deletion-witness reconcile must remain a delta");
+                    assert!(
+                        added.is_empty(),
+                        "default/current deletion reconcile must not add rows"
+                    );
+                    saw_removal |= removed
+                        .iter()
+                        .any(|removed| removed.row_uuid == current_row);
+                }
+                SubscriptionEvent::Rejected { reason } => {
+                    panic!("default/current subscription was rejected: {reason:?}")
+                }
+                SubscriptionEvent::Closed => panic!("default/current subscription closed"),
+            }
+            apply_subscription_event(&mut snapshot, event);
+        }
+        if saw_removal {
+            break;
+        }
+    }
+    assert!(
+        saw_removal,
+        "default/current reconcile must remove the deleted row"
+    );
+    let fresh = serving_rows_in_read_view(&server, &schema, &query, client_author, &current_view);
+    assert_eq!(row_ids(&snapshot.rows), row_ids(&fresh));
 }

--- a/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
+++ b/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
@@ -406,6 +406,12 @@ fn branch_view_subscriptions_disambiguate_same_row_and_tx_by_branch() {
     );
 }
 
+/// A default/current subscription emits a non-reset removal for a deletion witness.
+///
+/// alice deletes a row on the server; bob's default/current subscription receives
+/// a delta removal and remains equivalent to alice's fresh current read.
+///
+/// alice (server) ──delete witness──► bob (default/current delta removal)
 #[test]
 fn default_current_subscription_reconciles_deletion_witness_without_reset() {
     let schema = schema();

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -199,10 +199,11 @@ impl PeerState {
         S: OrderedKvStorage,
     {
         let (shape, binding) = node.whole_table_shape_binding(table)?;
+        let opts = RegisterShapeOptions::default();
         let subscription = SubscriptionKey {
             shape_id: shape.shape_id(),
             binding_id: binding.binding_id(),
-            read_view: RegisterShapeOptions::default().read_view_key(),
+            read_view: opts.read_view_key(),
         };
         self.clear_stale_groove_runtime_handles(node, subscription);
         self.ensure_query_subscription_registered(node, subscription, &shape, &binding)?;
@@ -212,18 +213,23 @@ impl PeerState {
             .and_then(|state| state.prepared_query.as_ref())
             .is_none();
         if needs_prepare {
-            let plan = node.mark_peer_maintained_query_shape_cache(
-                &shape,
-                &binding,
-                DurabilityTier::Global,
-            );
-            let cached = CachedPeerQueryPlan::with_plan(DurabilityTier::Global, plan);
+            let plan =
+                node.mark_peer_maintained_query_shape_cache(&shape, &binding, opts.tier);
+            let cached = CachedPeerQueryPlan::with_plan(&opts, plan);
             let state = self.publication_states.entry(subscription).or_default();
             state.prepared_query = Some(cached);
             state.groove_runtime_token = Some(node.groove_runtime_token());
         } else {
             self.publication_states.entry(subscription).or_default();
         }
+        let (tier, read_view): (DurabilityTier, std::rc::Rc<ReadViewSpec>) = self
+            .publication_states
+            .get(&subscription)
+            .and_then(|state| state.prepared_query.as_ref())
+            .map(CachedPeerQueryPlan::context)
+            .ok_or(Error::InvalidStoredValue(
+                "maintained subscription view is missing prepared state",
+            ))?;
         let previous_member_result_set = self
             .publication_states
             .get(&subscription)
@@ -244,8 +250,8 @@ impl PeerState {
                     previous_member_result_set: &previous_member_result_set,
                     reset_result_set: false,
                     result_table_filter: Some(table),
-                    tier: DurabilityTier::Global,
-                    read_view: &ReadViewSpec::default(),
+                    tier,
+                    read_view: &read_view,
                     purpose: RehydratePurpose::Query,
                 },
             )
@@ -440,17 +446,22 @@ impl PeerState {
             .get(&subscription)
             .map(PeerSubscriptionState::member_result_set)
             .unwrap_or_default();
-        if self
+        let cached_context = self
             .publication_states
             .get(&subscription)
             .and_then(|state| state.prepared_query.as_ref())
-            .is_none()
-        {
+            .map(CachedPeerQueryPlan::context);
+        let (tier, read_view) = if let Some(context) = cached_context {
+            context
+        } else {
             let plan = node.mark_peer_maintained_query_shape_cache(shape, binding, opts.tier);
+            let cached = CachedPeerQueryPlan::with_plan(&opts, plan);
+            let context = cached.context();
             let state = self.publication_states.entry(subscription).or_default();
-            state.prepared_query = Some(CachedPeerQueryPlan::with_plan(opts.tier, plan));
+            state.prepared_query = Some(cached);
             state.groove_runtime_token = Some(node.groove_runtime_token());
-        }
+            context
+        };
         self.rehydrate_query_maintained_subscription_view(
             node,
             MaintainedRehydrateRequest {
@@ -460,8 +471,8 @@ impl PeerState {
                 previous_member_result_set: &previous_member_result_set,
                 reset_result_set: false,
                 result_table_filter: None,
-                tier: opts.tier,
-                read_view: &opts.read_view,
+                tier,
+                read_view: &read_view,
                 purpose: RehydratePurpose::Query,
             },
         )
@@ -532,11 +543,11 @@ impl PeerState {
                 && program_fact_adds.is_empty()
                 && program_fact_removes.is_empty())
         {
-            let tier = self
+            let (tier, read_view) = self
                 .publication_states
                 .get(&subscription)
                 .and_then(|state| state.prepared_query.as_ref())
-                .map(CachedPeerQueryPlan::tier)
+                .map(CachedPeerQueryPlan::context)
                 .ok_or(Error::InvalidStoredValue(
                     "maintained subscription view is missing prepared state",
                 ))?;
@@ -550,7 +561,7 @@ impl PeerState {
                     reset_result_set: false,
                     result_table_filter,
                     tier,
-                    read_view: &ReadViewSpec::default(),
+                    read_view: &read_view,
                     purpose: RehydratePurpose::Query,
                 },
             )
@@ -1279,7 +1290,8 @@ impl PeerState {
                 .insert(subscription, known_state);
         }
         let plan = node.mark_peer_maintained_query_shape_cache(shape, binding, opts.tier);
-        let cached = CachedPeerQueryPlan::with_plan(opts.tier, plan);
+        let cached = CachedPeerQueryPlan::with_plan(&opts, plan);
+        let (tier, read_view) = cached.context();
         let state = self.publication_states.entry(subscription).or_default();
         state.prepared_query = Some(cached);
         state.groove_runtime_token = Some(node.groove_runtime_token());
@@ -1299,8 +1311,8 @@ impl PeerState {
                 previous_member_result_set: &previous_member_result_set,
                 reset_result_set: true,
                 result_table_filter: None,
-                tier: opts.tier,
-                read_view: &opts.read_view,
+                tier,
+                read_view: &read_view,
                 purpose,
             },
         )

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -222,7 +222,7 @@ impl PeerState {
         } else {
             self.publication_states.entry(subscription).or_default();
         }
-        let (tier, read_view): (DurabilityTier, std::rc::Rc<ReadViewSpec>) = self
+        let (tier, read_view): (DurabilityTier, std::sync::Arc<ReadViewSpec>) = self
             .publication_states
             .get(&subscription)
             .and_then(|state| state.prepared_query.as_ref())
@@ -454,7 +454,7 @@ impl PeerState {
         let ((tier, read_view), has_runtime_plan) = if let Some(context) = cached_context {
             context
         } else {
-            ((opts.tier, std::rc::Rc::new(opts.read_view.clone())), false)
+            ((opts.tier, std::sync::Arc::new(opts.read_view.clone())), false)
         };
         if !has_runtime_plan {
             let plan = node.mark_peer_maintained_query_shape_cache(shape, binding, tier);

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -211,7 +211,7 @@ impl PeerState {
             .publication_states
             .get(&subscription)
             .and_then(|state| state.prepared_query.as_ref())
-            .is_none();
+            .is_none_or(|prepared| !prepared.has_runtime_plan());
         if needs_prepare {
             let plan =
                 node.mark_peer_maintained_query_shape_cache(&shape, &binding, opts.tier);
@@ -450,18 +450,26 @@ impl PeerState {
             .publication_states
             .get(&subscription)
             .and_then(|state| state.prepared_query.as_ref())
-            .map(CachedPeerQueryPlan::context);
-        let (tier, read_view) = if let Some(context) = cached_context {
+            .map(|prepared| (prepared.context(), prepared.has_runtime_plan()));
+        let ((tier, read_view), has_runtime_plan) = if let Some(context) = cached_context {
             context
         } else {
-            let plan = node.mark_peer_maintained_query_shape_cache(shape, binding, opts.tier);
-            let cached = CachedPeerQueryPlan::with_plan(&opts, plan);
-            let context = cached.context();
-            let state = self.publication_states.entry(subscription).or_default();
-            state.prepared_query = Some(cached);
-            state.groove_runtime_token = Some(node.groove_runtime_token());
-            context
+            ((opts.tier, std::rc::Rc::new(opts.read_view.clone())), false)
         };
+        if !has_runtime_plan {
+            let plan = node.mark_peer_maintained_query_shape_cache(shape, binding, tier);
+            let state = self.publication_states.entry(subscription).or_default();
+            if let Some(prepared) = &mut state.prepared_query {
+                prepared.replace_runtime_plan(plan);
+            } else {
+                state.prepared_query = Some(CachedPeerQueryPlan::with_context(
+                    tier,
+                    read_view.clone(),
+                    plan,
+                ));
+            }
+            state.groove_runtime_token = Some(node.groove_runtime_token());
+        }
         self.rehydrate_query_maintained_subscription_view(
             node,
             MaintainedRehydrateRequest {

--- a/crates/jazz/src/peer/subscription_state.rs
+++ b/crates/jazz/src/peer/subscription_state.rs
@@ -125,7 +125,11 @@ pub(super) struct PeerSubscriptionState {
 impl PeerSubscriptionState {
     pub(super) fn clear_groove_runtime_handles(&mut self) {
         self.maintained_subscription_view = None;
-        self.prepared_query = None;
+        if let Some(prepared_query) = &mut self.prepared_query {
+            // The compiled plan belongs to one runtime, but its semantic
+            // context remains the admitted context for this subscription.
+            prepared_query.clear_runtime_plan();
+        }
         self.groove_runtime_token = None;
     }
 
@@ -203,9 +207,17 @@ pub(super) struct CachedPeerQueryPlan {
 
 impl CachedPeerQueryPlan {
     pub(super) fn with_plan(opts: &RegisterShapeOptions, plan: PreparedQueryPlanHandle) -> Self {
+        Self::with_context(opts.tier, Rc::new(opts.read_view.clone()), plan)
+    }
+
+    pub(super) fn with_context(
+        tier: DurabilityTier,
+        read_view: Rc<ReadViewSpec>,
+        plan: PreparedQueryPlanHandle,
+    ) -> Self {
         Self {
-            tier: opts.tier,
-            read_view: Rc::new(opts.read_view.clone()),
+            tier,
+            read_view,
             plan: Some(plan),
         }
     }
@@ -214,8 +226,19 @@ impl CachedPeerQueryPlan {
         self.tier
     }
 
+    pub(super) fn has_runtime_plan(&self) -> bool {
+        self.plan.is_some()
+    }
+
+    pub(super) fn replace_runtime_plan(&mut self, plan: PreparedQueryPlanHandle) {
+        self.plan = Some(plan);
+    }
+
+    pub(super) fn clear_runtime_plan(&mut self) {
+        self.plan = None;
+    }
+
     pub(super) fn context(&self) -> (DurabilityTier, Rc<ReadViewSpec>) {
-        let _retained_plan = &self.plan;
         (self.tier, Rc::clone(&self.read_view))
     }
 }

--- a/crates/jazz/src/peer/subscription_state.rs
+++ b/crates/jazz/src/peer/subscription_state.rs
@@ -6,7 +6,7 @@
 //! assignment.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use groove::ivm::MultisinkSubscription;
 
@@ -201,18 +201,18 @@ pub(super) enum MemberIndexKey {
 #[derive(Debug)]
 pub(super) struct CachedPeerQueryPlan {
     tier: DurabilityTier,
-    read_view: Rc<ReadViewSpec>,
+    read_view: Arc<ReadViewSpec>,
     plan: Option<PreparedQueryPlanHandle>,
 }
 
 impl CachedPeerQueryPlan {
     pub(super) fn with_plan(opts: &RegisterShapeOptions, plan: PreparedQueryPlanHandle) -> Self {
-        Self::with_context(opts.tier, Rc::new(opts.read_view.clone()), plan)
+        Self::with_context(opts.tier, Arc::new(opts.read_view.clone()), plan)
     }
 
     pub(super) fn with_context(
         tier: DurabilityTier,
-        read_view: Rc<ReadViewSpec>,
+        read_view: Arc<ReadViewSpec>,
         plan: PreparedQueryPlanHandle,
     ) -> Self {
         Self {
@@ -238,8 +238,8 @@ impl CachedPeerQueryPlan {
         self.plan = None;
     }
 
-    pub(super) fn context(&self) -> (DurabilityTier, Rc<ReadViewSpec>) {
-        (self.tier, Rc::clone(&self.read_view))
+    pub(super) fn context(&self) -> (DurabilityTier, Arc<ReadViewSpec>) {
+        (self.tier, Arc::clone(&self.read_view))
     }
 }
 

--- a/crates/jazz/src/peer/subscription_state.rs
+++ b/crates/jazz/src/peer/subscription_state.rs
@@ -6,6 +6,7 @@
 //! assignment.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
 
 use groove::ivm::MultisinkSubscription;
 
@@ -16,7 +17,7 @@ use super::super::node::maintained_subscription_view::{
 };
 use super::super::protocol::{
     KnownStateCompleteness, KnownStateDeclaration, ProgramFactEntry, ReadViewSpec,
-    ResultMemberEntry, SubscriptionKey, VersionRecord,
+    RegisterShapeOptions, ResultMemberEntry, SubscriptionKey, VersionRecord,
 };
 use super::super::query::{Binding, ValidatedQuery};
 use super::super::schema::TableSchema;
@@ -196,20 +197,26 @@ pub(super) enum MemberIndexKey {
 #[derive(Debug)]
 pub(super) struct CachedPeerQueryPlan {
     tier: DurabilityTier,
+    read_view: Rc<ReadViewSpec>,
     plan: Option<PreparedQueryPlanHandle>,
 }
 
 impl CachedPeerQueryPlan {
-    pub(super) fn with_plan(tier: DurabilityTier, plan: PreparedQueryPlanHandle) -> Self {
+    pub(super) fn with_plan(opts: &RegisterShapeOptions, plan: PreparedQueryPlanHandle) -> Self {
         Self {
-            tier,
+            tier: opts.tier,
+            read_view: Rc::new(opts.read_view.clone()),
             plan: Some(plan),
         }
     }
 
     pub(super) fn tier(&self) -> DurabilityTier {
-        let _retained_plan = &self.plan;
         self.tier
+    }
+
+    pub(super) fn context(&self) -> (DurabilityTier, Rc<ReadViewSpec>) {
+        let _retained_plan = &self.plan;
+        (self.tier, Rc::clone(&self.read_view))
     }
 }
 

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -1340,6 +1340,14 @@ fn maintained_subscription_view_default_rehydrate_installs_subscription() {
     assert!(maintained_subscription_id(&peer, subscription).is_some());
 }
 
+/// A BranchView subscription keeps base membership through a runtime rehydrate.
+///
+/// alice writes two base rows; bob subscribes to a head-over-base BranchView;
+/// alice deletes one row in the head; then bob rebuilds the maintained runtime
+/// and receives only that row's removal.
+///
+/// alice (base) ──rows──► bob (BranchView: head over base)
+/// alice (head) ──delete + runtime rehydrate──► bob (one removal)
 #[test]
 fn maintained_branch_view_reconcile_retains_undeleted_base_members() {
     let schema = public_peer_schema(PublicSchemaBuilder::new().table(
@@ -1440,17 +1448,16 @@ fn maintained_branch_view_reconcile_retains_undeleted_base_members() {
                 .branch(head)
                 .authored_columns(BTreeSet::from(["branch_id".to_owned()]))
                 .deletion(DeletionEvent::Deleted),
-        )
-        .unwrap();
+    )
+    .unwrap();
     accept_global(&mut core, deletion_tx, 3);
+    let stale_runtime_token = core.groove_runtime_token().checked_add(1).unwrap();
+    peer.publication_states
+        .get_mut(&subscription)
+        .unwrap()
+        .groove_runtime_token = Some(stale_runtime_token);
     let update = peer
-        .await_query_update_for_subscription_with_opts(
-            &mut core,
-            subscription,
-            &shape,
-            &binding,
-            opts.clone(),
-        )
+        .query_update_for_subscription(&mut core, subscription, &shape, &binding)
         .unwrap();
     let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
         reset_result_set,

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -1449,7 +1449,7 @@ fn maintained_branch_view_reconcile_retains_undeleted_base_members() {
             subscription,
             &shape,
             &binding,
-            opts,
+            opts.clone(),
         )
         .unwrap();
     let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
@@ -1487,13 +1487,14 @@ fn maintained_branch_view_reconcile_retains_undeleted_base_members() {
         .map(|row| row.row_uuid())
         .collect::<BTreeSet<_>>();
     assert_eq!(fresh_rows, BTreeSet::from([retained_row]));
+    let mut fresh_peer = PeerState::new();
+    fresh_peer
+        .rehydrate_query_with_opts(&mut core, &shape, &binding, opts)
+        .unwrap();
     assert_eq!(
-        row_result_set(&peer, subscription)
-            .unwrap()
-            .into_iter()
-            .map(|(_, row_uuid, _)| row_uuid)
-            .collect::<BTreeSet<_>>(),
-        fresh_rows
+        row_result_set(&peer, subscription),
+        row_result_set(&fresh_peer, subscription),
+        "authoritative reconcile must match a fresh BranchView rehydrate by full result identity"
     );
 }
 

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -88,6 +88,12 @@ fn fast_cursor_membership_mismatch_detects_pre_cursor_changes() {
 }
 
 #[test]
+fn peer_state_remains_send_for_threaded_simulations() {
+    fn assert_send<T: Send>() {}
+    assert_send::<PeerState>();
+}
+
+#[test]
 fn fast_cursor_membership_bounds_authoritative_resets() {
     // This is intentionally an internal test: the four-way decision is a
     // peer-only protocol control-plane predicate, with no public API

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -7,7 +7,10 @@ use std::collections::BTreeMap;
 
 use crate::ids::{NodeUuid, RowUuid};
 use crate::node::MergeableCommit;
-use crate::protocol::{ProgramFactEntry, RealRowMemberEntry, SyncMessage, VersionRecord};
+use crate::protocol::{
+    BranchSelector, BranchViewBase, ProgramFactEntry, RealRowMemberEntry, SyncMessage,
+    VersionRecord,
+};
 use crate::query::{
     Aggregate, ArraySubquery, OrderDirection, Query, col, eq, gt, is_null, lit, ne, not, param,
 };
@@ -1335,6 +1338,163 @@ fn maintained_subscription_view_default_rehydrate_installs_subscription() {
     peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
 
     assert!(maintained_subscription_id(&peer, subscription).is_some());
+}
+
+#[test]
+fn maintained_branch_view_reconcile_retains_undeleted_base_members() {
+    let schema = public_peer_schema(PublicSchemaBuilder::new().table(
+        PublicTableSchemaBuilder::new("todos")
+            .column("branch_id", PublicColumnType::Uuid)
+            .column("title", PublicColumnType::Text)
+            .branch_by("branch_id"),
+    ));
+    let (_dir, mut core) = open_node_with_schema(node(0x98), schema.clone());
+    let base = BranchSelector::new([(
+        "branch_id",
+        Value::Uuid(uuid::Uuid::from_bytes([0x99; 16])),
+    )]);
+    let head = BranchSelector::new([(
+        "branch_id",
+        Value::Uuid(uuid::Uuid::from_bytes([0x9a; 16])),
+    )]);
+    let deleted_row = row(0x9b);
+    let retained_row = row(0x9c);
+    for (sequence, row_uuid, title) in [
+        (1, deleted_row, "deleted"),
+        (2, retained_row, "retained"),
+    ] {
+        let tx_id = core
+            .commit_mergeable_settled(
+                MergeableCommit::new("todos", row_uuid, 1_000 + sequence)
+                    .branch(base.clone())
+                    .cells(title_cells(title)),
+            )
+            .unwrap();
+        accept_global(&mut core, tx_id, sequence);
+    }
+    let shape = Query::from("todos").validate(&schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let read_view =
+        ReadViewSpec::branch_view(head.clone(), Some(BranchViewBase::Current(base.clone())));
+    let opts = RegisterShapeOptions {
+        read_view: read_view.clone(),
+        ..RegisterShapeOptions::default()
+    };
+    let subscription = subscription_key_with_opts(&shape, &binding, &opts);
+    let branch_rows = core
+        .query_relation_snapshot_for_serving_in_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            AuthorSubject::SYSTEM,
+            &read_view,
+        )
+        .unwrap()
+        .rows;
+    assert_eq!(
+        branch_rows
+            .iter()
+            .map(crate::node::CurrentRow::row_uuid)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([deleted_row, retained_row])
+    );
+    assert!(
+        core.query_relation_snapshot_for_serving_in_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            AuthorSubject::SYSTEM,
+            &ReadViewSpec::default(),
+        )
+        .unwrap()
+        .rows
+        .is_empty(),
+        "default/current reads address the empty shared branch key"
+    );
+
+    let mut peer = PeerState::new();
+    let initial = peer
+        .rehydrate_query_with_opts(&mut core, &shape, &binding, opts.clone())
+        .unwrap();
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+        reset_result_set,
+        result_member_adds,
+        ..
+    }) = initial
+    else {
+        panic!("expected initial BranchView update");
+    };
+    assert!(reset_result_set);
+    assert_eq!(
+        result_member_adds
+            .iter()
+            .filter_map(ResultMemberEntry::as_row)
+            .map(|(_, row_uuid, _)| row_uuid)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([deleted_row, retained_row])
+    );
+
+    let deletion_tx = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", deleted_row, 2_000)
+                .branch(head)
+                .authored_columns(BTreeSet::from(["branch_id".to_owned()]))
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    accept_global(&mut core, deletion_tx, 3);
+    let update = peer
+        .await_query_update_for_subscription_with_opts(
+            &mut core,
+            subscription,
+            &shape,
+            &binding,
+            opts,
+        )
+        .unwrap();
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+        reset_result_set,
+        result_member_adds,
+        result_member_removes,
+        ..
+    }) = update
+    else {
+        panic!("expected deletion-witness reconcile update");
+    };
+    assert!(!reset_result_set);
+    assert!(result_member_adds.is_empty());
+    assert_eq!(
+        result_member_removes
+            .iter()
+            .filter_map(ResultMemberEntry::as_row)
+            .map(|(_, row_uuid, _)| row_uuid)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([deleted_row]),
+        "authoritative reconcile must not remove the retained BranchView base member"
+    );
+
+    let fresh_rows = core
+        .query_relation_snapshot_for_serving_in_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            AuthorSubject::SYSTEM,
+            &read_view,
+        )
+        .unwrap()
+        .rows
+        .into_iter()
+        .map(|row| row.row_uuid())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(fresh_rows, BTreeSet::from([retained_row]));
+    assert_eq!(
+        row_result_set(&peer, subscription)
+            .unwrap()
+            .into_iter()
+            .map(|(_, row_uuid, _)| row_uuid)
+            .collect::<BTreeSet<_>>(),
+        fresh_rows
+    );
 }
 
 #[test]


### PR DESCRIPTION
🤖 Keeps a maintained subscription on the exact historical/branch view the caller requested when the server later has to reconcile its membership.

## Example

A client subscribes to a branch view defined by a branch head plus its base. Row A belongs to that view because it is still visible through the base.

Later, a deletion witness makes the server re-check which rows belong in the subscription. Previously, the cached peer plan remembered only the requested durability tier. Reconciliation therefore reopened a default current-state query, where Row A might be absent, and incorrectly removed it from the branch subscription.

After this PR, the cached plan retains the complete immutable `ReadViewSpec`—the object identifying the requested current, historical, or branch view—and reuses it for retries, hydration, and authoritative reconciliation. Row A is removed only if it is absent from that actual branch view.

Ordinary current-state subscriptions continue using the default current view and retain their existing incremental behavior.

## Scope

This changes only in-memory query-plan context. It does not change the wire protocol, storage format, or public query API.

## Evidence

- `maintained_branch_view_reconcile_retains_undeleted_base_members`
- `default_current_subscription_reconciles_deletion_witness_without_reset`
- peer-level receipts cover cached-plan reuse and real served-connection reconciliation