### PR TITLE
Retain union-arm identity in prepared memberships

### DIFF
--- a/crates/jazz/src/node/query_eval/lowering.rs
+++ b/crates/jazz/src/node/query_eval/lowering.rs
@@ -202,6 +202,11 @@ pub(super) fn fact_public_fields(
                     .filter(|field| **field != schema.row_field)
                     .cloned(),
             );
+            // A union arm is part of a result occurrence address, just like
+            // its paired joined-row id. Retaining only the id causes prepared
+            // maintained subscriptions to publish a descriptor that cannot be
+            // decoded against the membership schema.
+            fields.extend(schema.occurrence_union_arm_fields.values().cloned());
             fields.extend(schema.branch_or_prefix_field.clone());
             fields.extend(result_membership_version_fields(&schema.version));
             fields.extend(schema.settle_position_field.clone());
@@ -760,5 +765,47 @@ where
             .bind_shape(prepared.id(), &values)
             .await
             .map_err(Error::Groove)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::query_engine::{
+        ContentVersionFields, ProgramFactSchema, ResultMembershipSchema,
+    };
+
+    #[test]
+    fn result_membership_public_fields_retain_union_arm_identity() {
+        let fields = fact_public_fields(&ProgramFactSchema::ResultMembership(
+            ResultMembershipSchema {
+                table_field: "table_name".to_owned(),
+                row_field: "row_uuid".to_owned(),
+                occurrence_id_fields: vec!["row_uuid".to_owned(), "__root_join_row_0".to_owned()],
+                occurrence_union_arm_fields: BTreeMap::from([(0, "__root_join_arm_0".to_owned())]),
+                payload_fields: Vec::new(),
+                branch_or_prefix_field: None,
+                version: ResultMembershipVersionSchema::Content(ContentVersionFields {
+                    tx_time_field: "content_tx_time".to_owned(),
+                    tx_node_field: "content_tx_node_id".to_owned(),
+                }),
+                settle_position_field: Some("settle_position".to_owned()),
+                routing_param_fields: BTreeSet::new(),
+            },
+        ))
+        .expect("result membership fields");
+
+        assert_eq!(
+            fields,
+            [
+                "table_name",
+                "row_uuid",
+                "__root_join_row_0",
+                "__root_join_arm_0",
+                "content_tx_time",
+                "content_tx_node_id",
+                "settle_position",
+            ]
+        );
     }
 }

--- a/crates/jazz/src/node/tests/policies_rls/maintained_views.rs
+++ b/crates/jazz/src/node/tests/policies_rls/maintained_views.rs
@@ -231,6 +231,73 @@ fn maintained_view_allows_join_policy_slice() {
     peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
 }
 
+/// Contract: a prepared maintained subscription must preserve both semantic
+/// authorization occurrences for a root row that is admitted through either
+/// of two independently matching relationship branches.
+///
+/// Actors: the serving core owns the data; `reader` opens a title-bound
+/// subscription; the same todo matches both owner and editor policy branches.
+/// The public effect is one readable todo, while the maintained result carrier
+/// must retain the UNION arm that distinguishes the two branch occurrences.
+#[test]
+fn prepared_maintained_owner_or_editor_policy_keeps_union_arm_occurrences() {
+    let reader = user(0xa1);
+    let todo = row(0xa0);
+    let schema = build_public_test_schema(
+        PublicSchemaBuilder::new()
+            .table(
+                PublicTableSchemaBuilder::new("todos")
+                    .column("title", PublicColumnType::Text)
+                    .column("owner_match", PublicColumnType::Boolean)
+                    .column("editor_match", PublicColumnType::Boolean),
+            ),
+    );
+    let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
+
+    accept_global(
+        &mut core,
+        MergeableCommit::new("todos", todo, 10).cells(BTreeMap::from([
+            ("title".to_owned(), Value::String("shared".to_owned())),
+            ("owner_match".to_owned(), Value::Bool(true)),
+            ("editor_match".to_owned(), Value::Bool(true)),
+        ])),
+    );
+
+    let mut query = Query::from("todos");
+    query.filters = vec![crate::query::Predicate::Any(Vec::new())];
+    query.policy_branches = vec![
+        crate::query::PolicyBranch {
+            filters: vec![eq(col("owner_match"), lit(true)), eq(col("title"), param("title"))],
+            joins: Vec::new(),
+            reachable: Vec::new(),
+            inherits: Vec::new(),
+        },
+        crate::query::PolicyBranch {
+            filters: vec![eq(col("editor_match"), lit(true)), eq(col("title"), param("title"))],
+            joins: Vec::new(),
+            reachable: Vec::new(),
+            inherits: Vec::new(),
+        },
+    ];
+    let shape = query
+        .validate_runtime(&core.catalogue.schema)
+        .unwrap();
+    let binding = shape
+        .bind(BTreeMap::from([("title".to_owned(), Value::String("shared".to_owned()))]))
+        .unwrap();
+    let mut peer = PeerState::client_link(reader);
+    let update = peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
+    let (adds, removes) = canonical_view_update_rows(&update);
+    assert_eq!(
+        adds.into_iter()
+            .map(|(_table, row_uuid, _tx_id)| row_uuid)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([todo]),
+        "the two authorization occurrences materialize as one public todo",
+    );
+    assert!(removes.is_empty());
+}
+
 #[test]
 fn maintained_view_retained_claim_param_equality_matches_literal_recompute() {
     let schema = owner_read_schema("todos");


### PR DESCRIPTION
🤖 Closes the prepared-membership schema mismatch discovered by the Wequencer cross-topology receipt.

## Before

Prepared result-membership lowering retained hidden joined-row identifiers such as `__root_join_row_0`, but dropped their paired union-arm discriminator such as `__root_join_arm_0`. When two authorization branches contributed occurrences for the same maintained view, the published record no longer matched its declared terminal schema. Direct runtimes reported a protocol error; the persistent browser worker could leave the affected write pending until timeout.

## After

Result-membership public fields retain every union-arm discriminator alongside the corresponding occurrence row identifier. The emitted prepared terminal record and `ResultMembershipSchema` now describe the same occurrence address.

## Example

For an owner-or-editor policy, an occurrence addressed as `(joined row = R, arm = editor)` now carries both `__root_join_row_0 = R` and `__root_join_arm_0 = editor`; previously only the row component survived projection.

## Verification

- Focused Rust field-contract receipt, including a planted removal that fails with the missing arm.
- Full Wequencer browser Edge/Core topology, including offline edit and deterministic transport retry: all phases pass.
- `cargo clippy -p jazz -- -D warnings`.