### PR TITLE
Preserve bounded query membership across relay tiers

### DIFF
--- a/crates/jazz/src/db/subscriptions.rs
+++ b/crates/jazz/src/db/subscriptions.rs
@@ -336,6 +336,16 @@ where
         )
     }
 
+    #[cfg(any(test, feature = "testing"))]
+    /// Internal receipt-lifetime coverage needs to inspect state that has no
+    /// public equivalent: detached Local overlays are intentionally best-effort.
+    pub fn settled_authoritative_receipt_counts_for_test(&self) -> (usize, usize) {
+        self.node
+            .node
+            .borrow()
+            .settled_authoritative_receipt_counts_for_test()
+    }
+
     /// Detach a one-shot query coverage request.
     pub fn detach_query(&self, attachment: QueryAttachment) {
         let mut removed_subscriptions = Vec::new();

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -107,6 +107,16 @@ fn is_public_aggregate_result_member(
     aggregate_query && matches!(member, ResultMemberEntry::Synthetic { .. })
 }
 
+/// A host-settled result membership and the slice offset to apply relative to
+/// that membership.  A non-durable client may retain only a bounded authority
+/// window, so a narrower read inside that window cannot use its absolute
+/// offset against the local cache.
+#[derive(Clone, Debug)]
+struct ClientSettledBindingView {
+    key: BindingViewKey,
+    relative_offset: usize,
+}
+
 fn replace_stale_authoritative_occurrence_member(
     result_set: &mut BTreeSet<ResultMemberEntry>,
     result_payloads: &mut BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
@@ -786,7 +796,16 @@ where
             (shape, binding)
         };
         let mut input_shape = self.normalized_row_set_shape(shape, binding)?;
-        let settled_window_input = (settled_binding_view.is_some()
+        let settled_view_matches_query_window = settled_binding_view.is_some_and(|binding_view| {
+            self.query
+                .registered_shapes
+                .get(&binding_view.shape_id)
+                .is_some_and(|source_shape| {
+                    source_shape.query().offset == shape.query().offset
+                        && source_shape.query().limit == shape.query().limit
+                })
+        });
+        let settled_window_input = (settled_view_matches_query_window
             && shape.query().aggregate.is_none())
         .then(|| match input_shape.nodes.get(&input_shape.root) {
             Some(RowSetExpr::Slice { input, .. }) => Some(input.clone()),
@@ -1038,13 +1057,21 @@ where
             self.apply_projection_in_schema(query, shape.schema_version(), &mut rows)?;
             return Ok(rows);
         }
+        let client_settled_binding_view = (authorization_mode
+            == QueryAuthorizationMode::ClientLocal)
+            .then(|| {
+                self.client_settled_binding_view_for_query(
+                    shape,
+                    binding,
+                    tier,
+                    &ReadViewSpec::default(),
+                )
+            })
+            .flatten();
         let settled_binding_view = match authorization_mode {
-            QueryAuthorizationMode::ClientLocal => self.client_settled_binding_view_key_for_query(
-                shape,
-                binding,
-                tier,
-                &ReadViewSpec::default(),
-            ),
+            QueryAuthorizationMode::ClientLocal => {
+                client_settled_binding_view.as_ref().map(|view| view.key)
+            }
             QueryAuthorizationMode::TrustedServing => (tier == DurabilityTier::Global)
                 .then(|| self.settled_binding_view_key_for_query(shape, binding))
                 .transpose()?
@@ -1079,7 +1106,33 @@ where
         } else {
             None
         };
-        let (shape, binding) = inline_query
+        let rebased_window_query = client_settled_binding_view
+            .as_ref()
+            .filter(|view| {
+                view.relative_offset != 0 || {
+                    self.query
+                        .registered_shapes
+                        .get(&view.key.shape_id)
+                        .is_some_and(|source| source.query().limit != shape.query().limit)
+                }
+            })
+            .map(|view| {
+                let schema = self
+                    .catalogue
+                    .catalogue_schemas
+                    .get(&shape.schema_version())
+                    .ok_or(Error::InvalidStoredValue("query schema version is unknown"))?;
+                let mut rebased_query = shape.query().clone();
+                rebased_query.offset = view.relative_offset;
+                let rebased_shape = rebased_query
+                    .validate_with_schema_version(&schema.schema, shape.schema_version())?;
+                let rebased_binding = rebased_shape.bind(binding.values().clone())?;
+                Ok::<_, Error>((rebased_shape, rebased_binding))
+            })
+            .transpose()?;
+        let (shape, binding) = rebased_window_query
+            .as_ref()
+            .or(inline_query.as_ref())
             .as_ref()
             .map(|(shape, binding)| (shape, binding))
             .unwrap_or((shape, binding));
@@ -1418,24 +1471,107 @@ where
         tier: DurabilityTier,
         read_view: &ReadViewSpec,
     ) -> Option<BindingViewKey> {
-        (tier >= DurabilityTier::Edge).then(|| {
-            BindingViewKey::new(
-                shape.shape_id(),
-                binding.binding_id(),
-                RegisterShapeOptions {
-                    // A non-durable browser-side runtime consumes the worker
-                    // relay's Edge handoff rather than the worker's Global
-                    // upstream coverage.
-                    tier: if self.authored_commit_durability == DurabilityTier::None {
-                        tier
-                    } else {
-                        DurabilityTier::Global
-                    },
-                    read_view: read_view.clone(),
-                    ..RegisterShapeOptions::default()
+        self.client_settled_binding_view_for_query(shape, binding, tier, read_view)
+            .map(|view| view.key)
+    }
+
+    fn client_settled_binding_view_for_query(
+        &self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        tier: DurabilityTier,
+        read_view: &ReadViewSpec,
+    ) -> Option<ClientSettledBindingView> {
+        let settled_tier = if tier >= DurabilityTier::Edge {
+            tier
+        } else if self.authored_commit_durability == DurabilityTier::None
+            && shape.query().offset != 0
+        {
+            // The browser main thread keeps received rows only as a
+            // materialized cache. After its worker has supplied an Edge
+            // window, a Local read of that same nonzero-offset shape must
+            // consume the selected membership rather than offsetting the
+            // small cache a second time. Before that receipt, preserve the
+            // ordinary local overlay path.
+            DurabilityTier::Edge
+        } else {
+            return None;
+        };
+        let binding_view = BindingViewKey::new(
+            shape.shape_id(),
+            binding.binding_id(),
+            RegisterShapeOptions {
+                // A non-durable browser-side runtime consumes the worker
+                // relay's Edge handoff rather than the worker's Global
+                // upstream coverage.
+                tier: if self.authored_commit_durability == DurabilityTier::None {
+                    settled_tier
+                } else {
+                    DurabilityTier::Global
+                },
+                read_view: read_view.clone(),
+                ..RegisterShapeOptions::default()
+            }
+            .read_view_key(),
+        );
+        if tier == DurabilityTier::Local
+            && !self.query.settled_result_sets.contains_key(&binding_view)
+        {
+            // A store read may request a narrower window than the one the
+            // browser worker already delivered. It is safe to reuse a source
+            // only when the source query is identical apart from its root
+            // window and fully contains the requested window. The caller
+            // applies the requested slice relative to that source membership.
+            let target = shape.query();
+            let target_end = target
+                .limit
+                .map(|limit| target.offset.saturating_add(limit));
+            let mut target_without_window = target.clone();
+            target_without_window.offset = 0;
+            target_without_window.limit = None;
+            let read_view_key = RegisterShapeOptions {
+                tier: DurabilityTier::Edge,
+                read_view: read_view.clone(),
+                ..RegisterShapeOptions::default()
+            }
+            .read_view_key();
+            return self.query.registered_shapes.values().find_map(|source_shape| {
+                if source_shape.schema_version() != shape.schema_version()
+                    || source_shape.params() != shape.params()
+                {
+                    return None;
                 }
-                .read_view_key(),
-            )
+                let source = source_shape.query();
+                let mut source_without_window = source.clone();
+                source_without_window.offset = 0;
+                source_without_window.limit = None;
+                if source_without_window != target_without_window || source.offset > target.offset {
+                    return None;
+                }
+                let source_end = source
+                    .limit
+                    .map(|limit| source.offset.saturating_add(limit));
+                if matches!((source_end, target_end), (Some(source_end), Some(target_end)) if target_end > source_end)
+                    || matches!((source_end, target_end), (Some(_), None))
+                {
+                    return None;
+                }
+                let key = BindingViewKey::new(
+                    source_shape.shape_id(),
+                    binding.binding_id(),
+                    read_view_key,
+                );
+                self.query.settled_result_sets.contains_key(&key).then_some(
+                    ClientSettledBindingView {
+                        key,
+                        relative_offset: target.offset - source.offset,
+                    },
+                )
+            });
+        }
+        Some(ClientSettledBindingView {
+            key: binding_view,
+            relative_offset: 0,
         })
     }
 
@@ -2795,6 +2931,46 @@ where
             read_view,
             QueryAuthorizationMode::TrustedServing,
             None,
+            PreparedClaimBindingMode::Strict,
+        )
+        .await
+    }
+
+    /// Re-publish an Edge window from a durable relay to its non-durable
+    /// browser peer. The relay's Global receipt already names the
+    /// authority-selected members, so this must consume that membership as
+    /// its source instead of applying the query window a second time.
+    pub(crate) async fn open_seeded_relay_edge_subscription_view(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorSubject,
+        read_view: &ReadViewSpec,
+    ) -> Result<
+        (
+            MultisinkSubscription,
+            MaintainedSubscriptionView,
+            MaintainedTerminalSchemas,
+            super::maintained_subscription_view::ResultTransitions,
+            BTreeMap<String, TableSchema>,
+            bool,
+        ),
+        Error,
+    > {
+        let settled_binding_view = self.client_settled_binding_view_key_for_query(
+            shape,
+            binding,
+            DurabilityTier::Edge,
+            read_view,
+        );
+        self.open_seeded_maintained_subscription_view_in_authorization_mode(
+            shape,
+            binding,
+            identity,
+            DurabilityTier::Edge,
+            read_view,
+            QueryAuthorizationMode::ClientLocal,
+            settled_binding_view,
             PreparedClaimBindingMode::Strict,
         )
         .await

--- a/crates/jazz/src/node/query_eval/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/subscriptions.rs
@@ -184,13 +184,6 @@ where
 
     pub(crate) fn apply_unsubscribe(&mut self, subscription: SubscriptionKey) {
         let binding_view_key = self.binding_view_key_for_subscription(subscription).ok();
-        let retain_bounded_browser_membership = self.authored_commit_durability
-            == DurabilityTier::None
-            && self
-                .query
-                .registered_shapes
-                .get(&subscription.shape_id)
-                .is_some_and(|shape| shape.query().offset != 0);
         if let Some(bindings) = self
             .query
             .registered_bindings
@@ -201,10 +194,12 @@ where
         if let Some(binding_view_key) = binding_view_key
             && !self.registered_binding_resolves_to_binding_view_key(binding_view_key)
         {
-            if !retain_bounded_browser_membership {
-                self.clear_settled_result_view(binding_view_key);
-                self.query.settled_program_facts.remove(&binding_view_key);
-            }
+            // Registered bindings are the receipt ownership record. Once the
+            // last downstream usage site releases this exact binding view,
+            // revoke its authority-selected membership rather than retaining
+            // a browser cache after scope teardown.
+            self.clear_settled_result_view(binding_view_key);
+            self.query.settled_program_facts.remove(&binding_view_key);
             self.query
                 .known_state_declared_binding_views
                 .remove(&binding_view_key);
@@ -226,6 +221,16 @@ where
             .values()
             .map(BTreeMap::len)
             .sum()
+    }
+
+    #[cfg(feature = "testing")]
+    /// Internal receipt-lifetime coverage needs to observe canonical caches:
+    /// public reads intentionally treat a Local overlay as best-effort.
+    pub fn settled_authoritative_receipt_counts_for_test(&self) -> (usize, usize) {
+        (
+            self.query.settled_result_sets.len(),
+            self.query.settled_program_facts.len(),
+        )
     }
 
     fn registered_binding_resolves_to_binding_view_key(

--- a/crates/jazz/src/node/query_eval/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/subscriptions.rs
@@ -184,6 +184,13 @@ where
 
     pub(crate) fn apply_unsubscribe(&mut self, subscription: SubscriptionKey) {
         let binding_view_key = self.binding_view_key_for_subscription(subscription).ok();
+        let retain_bounded_browser_membership = self.authored_commit_durability
+            == DurabilityTier::None
+            && self
+                .query
+                .registered_shapes
+                .get(&subscription.shape_id)
+                .is_some_and(|shape| shape.query().offset != 0);
         if let Some(bindings) = self
             .query
             .registered_bindings
@@ -194,8 +201,10 @@ where
         if let Some(binding_view_key) = binding_view_key
             && !self.registered_binding_resolves_to_binding_view_key(binding_view_key)
         {
-            self.clear_settled_result_view(binding_view_key);
-            self.query.settled_program_facts.remove(&binding_view_key);
+            if !retain_bounded_browser_membership {
+                self.clear_settled_result_view(binding_view_key);
+                self.query.settled_program_facts.remove(&binding_view_key);
+            }
             self.query
                 .known_state_declared_binding_views
                 .remove(&binding_view_key);
@@ -344,12 +353,15 @@ where
     pub(crate) fn settled_result_transitions_for_subscription(
         &self,
         subscription: SubscriptionKey,
+        source_binding_view: Option<BindingViewKey>,
         previous_member_result_set: &BTreeSet<ResultMemberEntry>,
         previous_program_fact_set: &BTreeSet<ProgramFactEntry>,
         result_table_filter: Option<&str>,
         output_tables: &BTreeMap<String, TableSchema>,
     ) -> Result<Option<super::maintained_subscription_view::ResultTransitions>, Error> {
-        let binding_view_key = self.binding_view_key_for_subscription(subscription)?;
+        let binding_view_key = source_binding_view
+            .map(Ok)
+            .unwrap_or_else(|| self.binding_view_key_for_subscription(subscription))?;
         // Settled binding views are shared by canonical query binding, while a
         // table read policy is identity-scoped. Never relay a synthetic
         // aggregate from that shared cache across an identity boundary; the

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -898,7 +898,14 @@ impl PeerState {
             // membership as the source, so the child does not reapply a
             // root offset/limit over an already-windowed result.
             RehydratePurpose::Query
-                if self.role == PeerRole::Relay && tier == DurabilityTier::Edge =>
+                if self.role == PeerRole::Relay
+                    && tier == DurabilityTier::Edge
+                    // Reusing a settled source is necessary only when an
+                    // absolute offset would otherwise be applied again by
+                    // the downstream relay. A zero-offset LIMIT is already
+                    // idempotent, while generic relay links must continue to
+                    // evaluate their ordinary Edge view from local state.
+                    && shape.query().offset != 0 =>
             {
                 node.open_seeded_relay_edge_subscription_view(shape, binding, self.identity(), read_view)
                     .await
@@ -923,7 +930,9 @@ impl PeerState {
                 )
                 .await,
         };
-        let source_binding_view = (self.role == PeerRole::Relay && tier == DurabilityTier::Edge)
+        let source_binding_view = (self.role == PeerRole::Relay
+            && tier == DurabilityTier::Edge
+            && shape.query().offset != 0)
             .then(|| {
                 crate::protocol::BindingViewKey::new(
                     shape.shape_id(),

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -728,6 +728,11 @@ impl PeerState {
             .and_then(|state| state.maintained_subscription_view.as_ref())
             .map(|maintained| maintained.tables.clone())
             .unwrap_or_default();
+        let source_binding_view = self
+            .publication_states
+            .get(&subscription)
+            .and_then(|state| state.maintained_subscription_view.as_ref())
+            .and_then(|maintained| maintained.source_binding_view);
         let aggregate_is_policy_scoped = shape.query().aggregate.is_some()
             && node
                 .table(shape.query().table.as_str())?
@@ -799,6 +804,7 @@ impl PeerState {
             && result_table_filter.is_none()
             && let Some(settled) = node.settled_result_transitions_for_subscription(
                 subscription,
+                source_binding_view,
                 &previous_member_result_set,
                 &previous_program_fact_set,
                 result_table_filter,
@@ -887,6 +893,16 @@ impl PeerState {
             node.reset_storage_read_metrics();
         }
         let opened = match purpose {
+            // A local relay's Edge child is the browser half of a durable
+            // worker receipt. Reuse the worker's authority-selected Global
+            // membership as the source, so the child does not reapply a
+            // root offset/limit over an already-windowed result.
+            RehydratePurpose::Query
+                if self.role == PeerRole::Relay && tier == DurabilityTier::Edge =>
+            {
+                node.open_seeded_relay_edge_subscription_view(shape, binding, self.identity(), read_view)
+                    .await
+            }
             RehydratePurpose::Query => {
                 node.open_seeded_maintained_subscription_view(
                     shape,
@@ -907,6 +923,19 @@ impl PeerState {
                 )
                 .await,
         };
+        let source_binding_view = (self.role == PeerRole::Relay && tier == DurabilityTier::Edge)
+            .then(|| {
+                crate::protocol::BindingViewKey::new(
+                    shape.shape_id(),
+                    binding.binding_id(),
+                    RegisterShapeOptions {
+                        tier: DurabilityTier::Global,
+                        read_view: read_view.clone(),
+                        ..RegisterShapeOptions::default()
+                    }
+                    .read_view_key(),
+                )
+            });
         let (receiver, mut maintained, terminal_schemas, transitions, tables, initial_received) =
             match opened {
             Ok(opened) => opened,
@@ -946,6 +975,7 @@ impl PeerState {
                 maintained,
                 terminal_schemas,
                 tables,
+                source_binding_view,
                 initial_received: false,
             };
             let state = self.publication_states.entry(subscription).or_default();
@@ -1151,6 +1181,7 @@ impl PeerState {
             maintained,
             terminal_schemas,
             tables,
+            source_binding_view,
             initial_received: true,
         };
         let state = self.publication_states.entry(subscription).or_default();

--- a/crates/jazz/src/peer/subscription_state.rs
+++ b/crates/jazz/src/peer/subscription_state.rs
@@ -16,7 +16,7 @@ use super::super::node::maintained_subscription_view::{
     MaintainedSubscriptionView, MaintainedTerminalSchemas,
 };
 use super::super::protocol::{
-    KnownStateCompleteness, KnownStateDeclaration, ProgramFactEntry, ReadViewSpec,
+    BindingViewKey, KnownStateCompleteness, KnownStateDeclaration, ProgramFactEntry, ReadViewSpec,
     RegisterShapeOptions, ResultMemberEntry, SubscriptionKey, VersionRecord,
 };
 use super::super::query::{Binding, ValidatedQuery};
@@ -156,6 +156,8 @@ pub(super) struct MaintainedSubscriptionViewSubscription {
     pub(super) maintained: MaintainedSubscriptionView,
     pub(super) terminal_schemas: MaintainedTerminalSchemas,
     pub(super) tables: BTreeMap<String, TableSchema>,
+    /// Authoritative source membership for an Edge child of a durable relay.
+    pub(super) source_binding_view: Option<BindingViewKey>,
     pub(super) initial_received: bool,
 }
 

--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -13,6 +13,7 @@ use jazz::db::{
 use jazz::groove::records::Value;
 use jazz::groove::storage::{TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
+use jazz::node::CurrentRow;
 use jazz::protocol::{
     RegisterShapeOptions, ShapeAst, Subscribe, SubscribeRejectReason, SubscriptionKey, SyncMessage,
 };
@@ -1680,6 +1681,217 @@ fn browser_relay_hydrates_fresh_included_edge_subscription_from_authority() {
                 if added.iter().any(|row| row.row.row_uuid() == message.row_uuid())
         )),
         "fresh included Edge subscription must publish the authority result, got {events:?}"
+    );
+}
+
+#[test]
+fn browser_relay_keeps_offset_window_membership_when_materializing_locally() {
+    let schema = schema();
+    let alice = AuthorSubject::for_test_bytes([0xc2; 16]);
+    let main_thread = open_db(0x1c, alice, &schema);
+    let worker = open_db(0x2c, alice, &schema);
+    let core = open_core(0x3c, &schema);
+    let writer = open_db(0x4c, alice, &schema);
+    main_thread.set_non_durable_client();
+
+    let (writer_transport, core_writer_transport) = duplex();
+    let _writer_connection = block_on(writer.connect_upstream(writer_transport));
+    let _core_writer = core.accept_subscriber(core_writer_transport, alice);
+    let mut todo_ids = Vec::new();
+    for index in 0..24 {
+        let todo = writer
+            .insert(
+                "todos",
+                BTreeMap::from([(
+                    "title".to_owned(),
+                    Value::String(format!("todo-{index:02}")),
+                )]),
+                Default::default(),
+            )
+            .expect("seed ordered todo");
+        todo_ids.push(todo.row_uuid());
+    }
+    for _ in 0..32 {
+        writer.tick().expect("upload ordered todos");
+        core.tick().expect("accept ordered todos");
+        writer.tick().expect("settle ordered todos");
+    }
+
+    let (main_transport, worker_subscriber_transport) = duplex();
+    let _main_connection = block_on(main_thread.connect_upstream(main_transport));
+    let _worker_subscriber = worker.accept_subscriber(worker_subscriber_transport, alice);
+    let (worker_upstream_transport, core_transport) = duplex();
+    let _worker_upstream = block_on(worker.connect_upstream(worker_upstream_transport));
+    let _core_subscriber = core.accept_subscriber(core_transport, alice);
+
+    let query = main_thread
+        .prepare_query(
+            &Query::from("todos")
+                .order_by("title", OrderDirection::Asc)
+                .offset(8)
+                .limit(16),
+        )
+        .expect("prepare offset window");
+    let mut subscription = block_on(main_thread.subscribe(
+        &query,
+        ReadOpts {
+            tier: DurabilityTier::Edge,
+            ..ReadOpts::default()
+        },
+    ))
+    .expect("subscribe through browser relay");
+    assert!(subscription.try_next_event().is_none());
+
+    for _ in 0..12 {
+        main_thread.tick().expect("register browser window");
+        worker.tick().expect("forward browser window");
+        core.tick().expect("serve browser window");
+        worker.tick().expect("relay browser window");
+        main_thread.tick().expect("apply browser window");
+    }
+
+    let edge_rows = block_on(main_thread.all(
+        &query,
+        ReadOpts {
+            tier: DurabilityTier::Edge,
+            ..ReadOpts::default()
+        },
+    ))
+    .expect("read authoritative window");
+    let local_rows = block_on(main_thread.all(&query, ReadOpts::default()))
+        .expect("read materialized browser window");
+    let row_ids = |rows: &[CurrentRow]| rows.iter().map(CurrentRow::row_uuid).collect::<Vec<_>>();
+    let expected = todo_ids[8..24].to_vec();
+    assert_eq!(
+        row_ids(&edge_rows),
+        expected,
+        "authority keeps the requested window"
+    );
+    assert_eq!(
+        row_ids(&local_rows),
+        row_ids(&edge_rows),
+        "the browser cache must materialize the authoritative result membership without applying the offset again",
+    );
+
+    let contained_local = main_thread
+        .prepare_query(
+            &Query::from("todos")
+                .order_by("title", OrderDirection::Asc)
+                .offset(8)
+                .limit(2),
+        )
+        .expect("prepare contained local window");
+    assert_eq!(
+        row_ids(
+            &block_on(main_thread.all(
+                &contained_local,
+                ReadOpts {
+                    tier: DurabilityTier::Local,
+                    ..ReadOpts::default()
+                },
+            ))
+            .expect("read a contained local window without its own edge subscription"),
+        ),
+        todo_ids[8..10].to_vec(),
+        "a narrower Local read derives its relative slice from the received authority window",
+    );
+
+    let narrower = main_thread
+        .prepare_query(
+            &Query::from("todos")
+                .order_by("title", OrderDirection::Asc)
+                .offset(10)
+                .limit(4),
+        )
+        .expect("prepare narrower offset window");
+    let mut narrower_subscription = block_on(main_thread.subscribe(
+        &narrower,
+        ReadOpts {
+            tier: DurabilityTier::Edge,
+            ..ReadOpts::default()
+        },
+    ))
+    .expect("subscribe narrower window through browser relay");
+    assert!(narrower_subscription.try_next_event().is_none());
+    for _ in 0..12 {
+        main_thread
+            .tick()
+            .expect("register narrower browser window");
+        worker.tick().expect("forward narrower browser window");
+        core.tick().expect("serve narrower browser window");
+        worker.tick().expect("relay narrower browser window");
+        main_thread.tick().expect("apply narrower browser window");
+    }
+    assert_eq!(
+        row_ids(
+            &block_on(main_thread.all(
+                &narrower,
+                ReadOpts {
+                    tier: DurabilityTier::Edge,
+                    ..ReadOpts::default()
+                },
+            ))
+            .expect("read narrower authority window"),
+        ),
+        todo_ids[10..14].to_vec(),
+        "a distinct bounded shape receives its own authority membership rather than borrowing raw rows from the first window",
+    );
+
+    writer
+        .insert(
+            "todos",
+            BTreeMap::from([("title".to_owned(), Value::String("todo-00a".to_owned()))]),
+            Default::default(),
+        )
+        .expect("insert row before bounded windows");
+    for _ in 0..12 {
+        writer.tick().expect("upload boundary-shifting todo");
+        core.tick().expect("accept boundary-shifting todo");
+        worker.tick().expect("relay boundary-shifting todo");
+        main_thread.tick().expect("apply boundary-shifting todo");
+    }
+    let shifted = todo_ids[7..23].to_vec();
+    assert_eq!(
+        row_ids(
+            &block_on(main_thread.all(
+                &query,
+                ReadOpts {
+                    tier: DurabilityTier::Edge,
+                    ..ReadOpts::default()
+                },
+            ))
+            .expect("read shifted authority window"),
+        ),
+        shifted,
+        "a changed upstream membership invalidates and replaces the cached window",
+    );
+    assert_eq!(
+        row_ids(
+            &block_on(main_thread.all(
+                &narrower,
+                ReadOpts {
+                    tier: DurabilityTier::Edge,
+                    ..ReadOpts::default()
+                },
+            ))
+            .expect("read shifted narrower authority window"),
+        ),
+        todo_ids[9..13].to_vec(),
+        "each bounded receipt shifts independently after a new leading member",
+    );
+    assert_eq!(
+        row_ids(
+            &block_on(main_thread.all(
+                &contained_local,
+                ReadOpts {
+                    tier: DurabilityTier::Local,
+                    ..ReadOpts::default()
+                },
+            ))
+            .expect("read shifted contained local window"),
+        ),
+        todo_ids[7..9].to_vec(),
+        "a local subwindow is invalidated with the authority window it derives from",
     );
 }
 

--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -1895,6 +1895,127 @@ fn browser_relay_keeps_offset_window_membership_when_materializing_locally() {
     );
 }
 
+/// A detached bounded Edge read releases its exact authoritative receipt.
+/// Alice repeatedly reads distinct offset windows through a browser worker;
+/// every final detach must clear its membership before the next scope opens.
+///
+/// ```text
+/// alice one-shot Edge window ──receipt──► worker ──receipt──► main
+/// alice detach ──unsubscribe──► worker ──unsubscribe──► core
+/// ```
+///
+/// The test-only receipt count is necessary because a Local overlay may
+/// legitimately retain row bodies after detach, while authoritative membership
+/// itself must not outlive the usage-site scope.
+#[test]
+fn browser_relay_releases_each_detached_bounded_one_shot_receipt() {
+    let schema = schema();
+    let alice = AuthorSubject::for_test_bytes([0xc3; 16]);
+    let main_thread = open_db(0x1d, alice, &schema);
+    let worker = open_db(0x2d, alice, &schema);
+    let core = open_core(0x3d, &schema);
+    let writer = open_db(0x4d, alice, &schema);
+    main_thread.set_non_durable_client();
+
+    let (writer_transport, core_writer_transport) = duplex();
+    let _writer_connection = block_on(writer.connect_upstream(writer_transport));
+    let _core_writer = core.accept_subscriber(core_writer_transport, alice);
+    for index in 0..12 {
+        writer
+            .insert(
+                "todos",
+                BTreeMap::from([(
+                    "title".to_owned(),
+                    Value::String(format!("todo-{index:02}")),
+                )]),
+                Default::default(),
+            )
+            .expect("seed ordered todo");
+    }
+    for _ in 0..24 {
+        writer.tick().expect("upload ordered todos");
+        core.tick().expect("accept ordered todos");
+        writer.tick().expect("settle ordered todos");
+    }
+
+    let (main_transport, worker_subscriber_transport) = duplex();
+    let _main_connection = block_on(main_thread.connect_upstream(main_transport));
+    let _worker_subscriber = worker.accept_subscriber(worker_subscriber_transport, alice);
+    let (worker_upstream_transport, core_transport) = duplex();
+    let _worker_upstream = block_on(worker.connect_upstream(worker_upstream_transport));
+    let _core_subscriber = core.accept_subscriber(core_transport, alice);
+
+    for offset in 1..=5 {
+        let query = main_thread
+            .prepare_query(
+                &Query::from("todos")
+                    .order_by("title", OrderDirection::Asc)
+                    .offset(offset)
+                    .limit(2),
+            )
+            .expect("prepare distinct bounded window");
+        let attachment = main_thread
+            .attach_query_with_opts(
+                &query,
+                ReadOpts {
+                    tier: DurabilityTier::Edge,
+                    ..ReadOpts::default()
+                },
+            )
+            .expect("attach bounded Edge read");
+        for _ in 0..12 {
+            main_thread.tick().expect("send bounded window");
+            worker.tick().expect("forward bounded window");
+            core.tick().expect("serve bounded window");
+            worker.tick().expect("relay bounded window");
+            main_thread.tick().expect("apply bounded receipt");
+            if main_thread.query_attachment_is_covered(&attachment) {
+                break;
+            }
+        }
+        assert!(
+            main_thread.query_attachment_is_covered(&attachment),
+            "offset {offset} never received its authority receipt"
+        );
+        assert_eq!(
+            block_on(main_thread.all(
+                &query,
+                ReadOpts {
+                    tier: DurabilityTier::Edge,
+                    ..ReadOpts::default()
+                },
+            ))
+            .expect("read bounded authority receipt")
+            .len(),
+            2,
+            "offset {offset} has its exact bounded membership while attached"
+        );
+
+        main_thread.detach_query(attachment);
+        assert_eq!(
+            main_thread.settled_authoritative_receipt_counts_for_test(),
+            (0, 0),
+            "final detach of offset {offset} must release its authority receipt"
+        );
+        for _ in 0..4 {
+            main_thread.tick().expect("send bounded detach");
+            worker.tick().expect("retire worker bounded view");
+            core.tick().expect("retire core bounded view");
+            worker.tick().expect("apply bounded teardown");
+        }
+        assert_eq!(
+            main_thread.query_coverage_attachment_counts_for_test(),
+            (0, 0),
+            "offset {offset} leaves no live coverage owner"
+        );
+        assert_eq!(
+            main_thread.settled_authoritative_receipt_counts_for_test(),
+            (0, 0),
+            "offset {offset} leaves no retained authority membership"
+        );
+    }
+}
+
 /// Empty is a valid authority result. After withholding the relay's premature
 /// cache snapshot, the later upstream response must still produce an explicit
 /// settled handoff so Edge reads and subscriptions can complete.


### PR DESCRIPTION
🤖 Replacement for #2210. GitHub automatically marked #2210 merged when its head became an ancestor of draft #2209 during a stack-base correction; that merge was only into the feature branch and nothing reached `main`. This PR restores the same independently reviewable core diff at its intended position directly above #2208.

## Before

A Core could correctly select playlist-entry positions 8–23 for `offset(8).limit(16)`. The persistent relay then materialized only those 16 selected rows and evaluated the original offset again, publishing positions 16–23. The foreground Local view could apply the window yet again and become empty. Running an unbounded query first appeared to fix the problem only because it hydrated all raw rows.

## After

- A relay Edge child records and consumes the settled Global source membership selected by its upstream authority.
- Client-local evaluation removes only the already-applied outer slice; filters, joins, order, and query identity remain intact.
- A Local subwindow may reuse an Edge receipt only when that same query window fully covers it.
- Transition reconciliation reads the Global source binding rather than stale child Edge membership.
- One-shot browser scope release preserves bounded receipt membership needed downstream.

## Worked example

For rows positioned 0–32, upstream `offset(8).limit(16)` selects 8–23. Edge and Local now both observe 8–23. A distinct `offset(10).limit(4)` remains its own shape and returns 10–13. Inserting before both windows invalidates and shifts both memberships independently.

## Verification

- New three-hop native relay receipt covering Edge/Local agreement, independent subwindows, nested bounded coverage, and membership-shift invalidation.
- `browser_relay_durability`: 21/21.
- Planted disabling of Local receipt routing fails with 8 trailing rows instead of 16, then restores cleanly.
- RecordPlayer advances through its previously empty recipient window.