### PR TITLE
Expose native transport terminal completion

### DIFF
--- a/.changeset/native-transport-terminal-contract.md
+++ b/.changeset/native-transport-terminal-contract.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Expose an established native transport's terminal future so socket close and failure are observable even while the semantic transport is idle. This adds a required `terminal` field to `ConnectedNativeTransport`; external custom connector implementations that construct this struct with a literal must add a future resolving to `NativeTransportTerminal::Closed` or `NativeTransportTerminal::Failed`.

--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -12,7 +12,7 @@ use jazz::wire::{
     decode_frame, encode_frame, negotiate_wire,
 };
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use tokio::sync::{Notify, Semaphore, mpsc};
+use tokio::sync::{Notify, Semaphore, mpsc, oneshot};
 use tokio_tungstenite::connect_async_with_config;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
@@ -20,7 +20,8 @@ use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use jazz::tools::AppId;
 use jazz::tools::native_transport_connector::{
     ConnectedNativeTransport, NativeCatalogueBootstrapFuture, NativeTransportConnector,
-    NativeTransportFuture, NativeTransportRequest,
+    NativeTransportError, NativeTransportFuture, NativeTransportRequest, NativeTransportTerminal,
+    NativeTransportTerminalFuture,
 };
 use jazz::tools::websocket_prelude_auth::AuthConfig;
 
@@ -88,6 +89,7 @@ pub struct WebSocketTransport {
     inbound_notify: Arc<Notify>,
     outbound: BoundedOutbound,
     task: tokio::task::JoinHandle<()>,
+    terminal: Option<oneshot::Receiver<NativeTransportTerminal>>,
     protocol_version: u16,
     features: u64,
     session_context: Option<ConnectionSessionContext>,
@@ -111,7 +113,7 @@ impl NativeTransportConnector for NativeWebSocketConnector {
 
     fn connect(&self, request: NativeTransportRequest) -> NativeTransportFuture {
         Box::pin(async move {
-            let transport = WebSocketTransport::connect_with_wake(
+            let mut transport = WebSocketTransport::connect_with_wake(
                 request.server_url,
                 request.app_id,
                 request.peer_identity,
@@ -124,11 +126,13 @@ impl NativeTransportConnector for NativeWebSocketConnector {
             })?;
             let (protocol_version, features, session_context) =
                 transport.negotiated_transport_metadata();
+            let terminal = transport.take_terminal_future();
             Ok(ConnectedNativeTransport {
                 transport: Box::new(transport),
                 protocol_version,
                 features,
                 session_context,
+                terminal,
             })
         })
     }
@@ -441,17 +445,24 @@ impl WebSocketTransport {
         let inbound_notify = Arc::new(Notify::new());
         let inbound_budget = Arc::new(Semaphore::new(WS_CLIENT_MAX_QUEUED_BYTES));
         let (outbound, outbound_rx, outbound_backpressured) = BoundedOutbound::channel();
-        let task = tokio::spawn(run_ws_pump(
-            ws,
-            inbound_tx,
-            inbound_budget,
-            Arc::clone(&inbound_error),
-            Arc::clone(&inbound_notify),
-            outbound_rx,
-            outbound_backpressured,
-            Arc::clone(&wake),
-            bootstrap_catalogue,
-        ));
+        let (terminal_tx, terminal) = oneshot::channel();
+        let pump_inbound_error = Arc::clone(&inbound_error);
+        let pump_inbound_notify = Arc::clone(&inbound_notify);
+        let task = tokio::spawn(async move {
+            let terminal = run_ws_pump(
+                ws,
+                inbound_tx,
+                inbound_budget,
+                pump_inbound_error,
+                pump_inbound_notify,
+                outbound_rx,
+                outbound_backpressured,
+                wake,
+                bootstrap_catalogue,
+            )
+            .await;
+            let _ = terminal_tx.send(terminal);
+        });
 
         Ok(Self {
             inbound,
@@ -459,6 +470,7 @@ impl WebSocketTransport {
             inbound_notify,
             outbound,
             task,
+            terminal: Some(terminal),
             protocol_version: negotiated.protocol_version,
             features: negotiated.features,
             session_context,
@@ -468,6 +480,20 @@ impl WebSocketTransport {
     /// Negotiated metadata authenticated during the websocket handshake.
     pub fn negotiated_transport_metadata(&self) -> (u16, u64, Option<ConnectionSessionContext>) {
         (self.protocol_version, self.features, self.session_context)
+    }
+
+    fn take_terminal_future(&mut self) -> NativeTransportTerminalFuture {
+        let terminal = self
+            .terminal
+            .take()
+            .expect("native transport terminal future is taken exactly once");
+        Box::pin(async move {
+            terminal.await.unwrap_or_else(|_| {
+                NativeTransportTerminal::Failed(NativeTransportError(
+                    "websocket pump stopped without a terminal reason".to_owned(),
+                ))
+            })
+        })
     }
 }
 
@@ -644,100 +670,144 @@ async fn run_ws_pump(
     outbound_backpressured: Arc<AtomicBool>,
     wake: Arc<dyn Fn() + Send + Sync>,
     bootstrap_catalogue: bool,
-) {
-    async {
-      loop {
-        tokio::select! {
-            maybe_frame = outbound.recv() => {
-                let Some(first_frame) = maybe_frame else {
-                    let _ = ws.close(None).await;
-                    return;
-                };
-                let mut batch = vec![first_frame];
-                let mut batch_bytes = POSTCARD_BATCH_LENGTH_RESERVE
-                    + batch[0].bytes.len()
-                    + POSTCARD_FRAME_LENGTH_RESERVE;
-                while let Ok(frame) = outbound.try_recv() {
-                    let frame_bytes = frame.bytes.len() + POSTCARD_FRAME_LENGTH_RESERVE;
-                    if batch.len() >= MAX_WIRE_BATCH_FRAMES
-                        || batch_bytes.saturating_add(frame_bytes) > WS_CLIENT_OUTBOUND_BATCH_BYTES
-                    {
-                        let Ok(bytes) = postcard::to_allocvec(&OutboundBatch(&batch)) else {
-                            return;
-                        };
-                        if ws.send(Message::Binary(bytes.into())).await.is_err() {
-                            return;
-                        }
-                        batch.clear();
-                        if outbound_backpressured.swap(false, Ordering::AcqRel) {
-                            wake();
-                        }
-                        batch_bytes = POSTCARD_BATCH_LENGTH_RESERVE;
-                    }
-                    batch_bytes = batch_bytes.saturating_add(frame_bytes);
-                    batch.push(frame);
-                }
-                let Ok(bytes) = postcard::to_allocvec(&OutboundBatch(&batch)) else {
-                    return;
-                };
-                if ws.send(Message::Binary(bytes.into())).await.is_err() {
-                    return;
-                }
-                drop(batch);
-                if outbound_backpressured.swap(false, Ordering::AcqRel) {
-                    wake();
-                }
-            }
-            message = ws.next() => {
-                let bytes = match message {
-                    Some(Ok(Message::Binary(bytes))) => bytes,
-                    Some(Ok(_)) => {
-                        fail_inbound(&inbound_error, &inbound_notify, "websocket peer sent a non-binary wire batch");
+) -> NativeTransportTerminal {
+    let terminal = async {
+        loop {
+            tokio::select! {
+                maybe_frame = outbound.recv() => {
+                    let Some(first_frame) = maybe_frame else {
                         let _ = ws.close(None).await;
-                        return;
-                    }
-                    Some(Err(error)) => {
-                        fail_inbound(&inbound_error, &inbound_notify, format!("websocket receive failed: {error}"));
-                        return;
-                    }
-                    None => {
-                        fail_inbound(&inbound_error, &inbound_notify, "websocket peer closed before completing wire exchange");
-                        return;
-                    }
-                };
-                let frames = match decode_inbound_batch(&bytes, bootstrap_catalogue) {
-                    Ok(frames) => frames,
-                    Err(error) => {
-                        fail_inbound(&inbound_error, &inbound_notify, error);
-                        let _ = ws.close(None).await;
-                        return;
-                    }
-                };
-                for frame in frames {
-                    if let Err(error) = validate_wire_frame_len(frame.len()) {
-                        fail_inbound(&inbound_error, &inbound_notify, error);
-                        let _ = ws.close(None).await;
-                        return;
-                    }
-                    let permits = u32::try_from(frame.len()).expect("wire frame limit fits u32");
-                    let Ok(budget) = Arc::clone(&inbound_budget).acquire_many_owned(permits).await else {
-                        return;
+                        return NativeTransportTerminal::Closed(
+                            "websocket transport owner closed".to_owned(),
+                        );
                     };
-                    if inbound.send(InboundFrame { bytes: frame, _budget: budget }).await.is_err() {
-                        return;
+                    let mut batch = vec![first_frame];
+                    let mut batch_bytes = POSTCARD_BATCH_LENGTH_RESERVE
+                        + batch[0].bytes.len()
+                        + POSTCARD_FRAME_LENGTH_RESERVE;
+                    while let Ok(frame) = outbound.try_recv() {
+                        let frame_bytes = frame.bytes.len() + POSTCARD_FRAME_LENGTH_RESERVE;
+                        if batch.len() >= MAX_WIRE_BATCH_FRAMES
+                            || batch_bytes.saturating_add(frame_bytes)
+                                > WS_CLIENT_OUTBOUND_BATCH_BYTES
+                        {
+                            let bytes = match postcard::to_allocvec(&OutboundBatch(&batch)) {
+                                Ok(bytes) => bytes,
+                                Err(error) => {
+                                    return NativeTransportTerminal::Failed(NativeTransportError(
+                                        format!(
+                                            "failed to encode websocket wire batch: {error}"
+                                        ),
+                                    ));
+                                }
+                            };
+                            if let Err(error) = ws.send(Message::Binary(bytes.into())).await {
+                                return NativeTransportTerminal::Failed(NativeTransportError(
+                                    format!("websocket send failed: {error}"),
+                                ));
+                            }
+                            batch.clear();
+                            if outbound_backpressured.swap(false, Ordering::AcqRel) {
+                                wake();
+                            }
+                            batch_bytes = POSTCARD_BATCH_LENGTH_RESERVE;
+                        }
+                        batch_bytes = batch_bytes.saturating_add(frame_bytes);
+                        batch.push(frame);
                     }
-                    // A maximum logical message can exceed the bounded
-                    // channel. Wake on every frame so its consumer drains
-                    // before the producer blocks on a later fragment.
-                    inbound_notify.notify_one();
-                    wake();
+                    let bytes = match postcard::to_allocvec(&OutboundBatch(&batch)) {
+                        Ok(bytes) => bytes,
+                        Err(error) => {
+                            return NativeTransportTerminal::Failed(NativeTransportError(format!(
+                                "failed to encode websocket wire batch: {error}"
+                            )));
+                        }
+                    };
+                    if let Err(error) = ws.send(Message::Binary(bytes.into())).await {
+                        return NativeTransportTerminal::Failed(NativeTransportError(format!(
+                            "websocket send failed: {error}"
+                        )));
+                    }
+                    drop(batch);
+                    if outbound_backpressured.swap(false, Ordering::AcqRel) {
+                        wake();
+                    }
+                }
+                message = ws.next() => {
+                    let bytes = match message {
+                        Some(Ok(Message::Binary(bytes))) => bytes,
+                        Some(Ok(Message::Ping(_) | Message::Pong(_))) => continue,
+                        Some(Ok(Message::Close(frame))) => {
+                            let reason = format!("websocket peer closed: {frame:?}");
+                            fail_inbound(&inbound_error, &inbound_notify, &reason);
+                            return NativeTransportTerminal::Closed(reason);
+                        }
+                        Some(Ok(_)) => {
+                            let reason = "websocket peer sent a non-binary wire batch".to_owned();
+                            fail_inbound(&inbound_error, &inbound_notify, &reason);
+                            let _ = ws.close(None).await;
+                            return NativeTransportTerminal::Failed(NativeTransportError(reason));
+                        }
+                        Some(Err(error)) => {
+                            let reason = format!("websocket receive failed: {error}");
+                            fail_inbound(&inbound_error, &inbound_notify, &reason);
+                            return NativeTransportTerminal::Failed(NativeTransportError(reason));
+                        }
+                        None => {
+                            let reason = "websocket peer closed before completing wire exchange"
+                                .to_owned();
+                            fail_inbound(&inbound_error, &inbound_notify, &reason);
+                            return NativeTransportTerminal::Closed(reason);
+                        }
+                    };
+                    let frames = match decode_inbound_batch(&bytes, bootstrap_catalogue) {
+                        Ok(frames) => frames,
+                        Err(error) => {
+                            fail_inbound(&inbound_error, &inbound_notify, &error);
+                            let _ = ws.close(None).await;
+                            return NativeTransportTerminal::Failed(NativeTransportError(error));
+                        }
+                    };
+                    for frame in frames {
+                        if let Err(error) = validate_wire_frame_len(frame.len()) {
+                            fail_inbound(&inbound_error, &inbound_notify, &error);
+                            let _ = ws.close(None).await;
+                            return NativeTransportTerminal::Failed(NativeTransportError(error));
+                        }
+                        let permits =
+                            u32::try_from(frame.len()).expect("wire frame limit fits u32");
+                        let Ok(budget) =
+                            Arc::clone(&inbound_budget).acquire_many_owned(permits).await
+                        else {
+                            return NativeTransportTerminal::Closed(
+                                "websocket transport owner closed".to_owned(),
+                            );
+                        };
+                        if inbound
+                            .send(InboundFrame {
+                                bytes: frame,
+                                _budget: budget,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            return NativeTransportTerminal::Closed(
+                                "websocket transport owner closed".to_owned(),
+                            );
+                        }
+                        // A maximum logical message can exceed the bounded
+                        // channel. Wake on every frame so its consumer drains
+                        // before the producer blocks on a later fragment.
+                        inbound_notify.notify_one();
+                        wake();
+                    }
                 }
             }
         }
-      }
     }
     .await;
     finish_outbound_pump(outbound, &outbound_backpressured, wake.as_ref());
+    terminal
 }
 
 fn decode_inbound_batch(bytes: &[u8], bootstrap_catalogue: bool) -> Result<Vec<Vec<u8>>, String> {
@@ -920,6 +990,7 @@ mod tests {
             inbound_notify: Arc::new(Notify::new()),
             outbound,
             task,
+            terminal: None,
             protocol_version: WIRE_PROTOCOL_VERSION,
             features: FEATURE_SYNC_MESSAGE_PAYLOAD,
             session_context: None,

--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -90,6 +90,7 @@ pub struct WebSocketTransport {
     outbound: BoundedOutbound,
     task: tokio::task::JoinHandle<()>,
     terminal: Option<oneshot::Receiver<NativeTransportTerminal>>,
+    terminal_publisher: Arc<Mutex<Option<oneshot::Sender<NativeTransportTerminal>>>>,
     protocol_version: u16,
     features: u64,
     session_context: Option<ConnectionSessionContext>,
@@ -446,8 +447,10 @@ impl WebSocketTransport {
         let inbound_budget = Arc::new(Semaphore::new(WS_CLIENT_MAX_QUEUED_BYTES));
         let (outbound, outbound_rx, outbound_backpressured) = BoundedOutbound::channel();
         let (terminal_tx, terminal) = oneshot::channel();
+        let terminal_publisher = Arc::new(Mutex::new(Some(terminal_tx)));
         let pump_inbound_error = Arc::clone(&inbound_error);
         let pump_inbound_notify = Arc::clone(&inbound_notify);
+        let pump_terminal_publisher = Arc::clone(&terminal_publisher);
         let task = tokio::spawn(async move {
             let terminal = run_ws_pump(
                 ws,
@@ -461,7 +464,13 @@ impl WebSocketTransport {
                 bootstrap_catalogue,
             )
             .await;
-            let _ = terminal_tx.send(terminal);
+            if let Some(publisher) = pump_terminal_publisher
+                .lock()
+                .expect("terminal publisher lock")
+                .take()
+            {
+                let _ = publisher.send(terminal);
+            }
         });
 
         Ok(Self {
@@ -471,6 +480,7 @@ impl WebSocketTransport {
             outbound,
             task,
             terminal: Some(terminal),
+            terminal_publisher,
             protocol_version: negotiated.protocol_version,
             features: negotiated.features,
             session_context,
@@ -499,6 +509,14 @@ impl WebSocketTransport {
 
 impl Drop for WebSocketTransport {
     fn drop(&mut self) {
+        if let Some(publisher) = self
+            .terminal_publisher
+            .lock()
+            .expect("terminal publisher lock")
+            .take()
+        {
+            let _ = publisher.send(NativeTransportTerminal::OwnerDropped);
+        }
         self.task.abort();
     }
 }
@@ -677,9 +695,7 @@ async fn run_ws_pump(
                 maybe_frame = outbound.recv() => {
                     let Some(first_frame) = maybe_frame else {
                         let _ = ws.close(None).await;
-                        return NativeTransportTerminal::Closed(
-                            "websocket transport owner closed".to_owned(),
-                        );
+                        return NativeTransportTerminal::OwnerDropped;
                     };
                     let mut batch = vec![first_frame];
                     let mut batch_bytes = POSTCARD_BATCH_LENGTH_RESERVE
@@ -740,7 +756,7 @@ async fn run_ws_pump(
                         Some(Ok(Message::Close(frame))) => {
                             let reason = format!("websocket peer closed: {frame:?}");
                             fail_inbound(&inbound_error, &inbound_notify, &reason);
-                            return NativeTransportTerminal::Closed(reason);
+                            return NativeTransportTerminal::PeerClosed(reason);
                         }
                         Some(Ok(_)) => {
                             let reason = "websocket peer sent a non-binary wire batch".to_owned();
@@ -757,7 +773,7 @@ async fn run_ws_pump(
                             let reason = "websocket peer closed before completing wire exchange"
                                 .to_owned();
                             fail_inbound(&inbound_error, &inbound_notify, &reason);
-                            return NativeTransportTerminal::Closed(reason);
+                            return NativeTransportTerminal::PeerClosed(reason);
                         }
                     };
                     let frames = match decode_inbound_batch(&bytes, bootstrap_catalogue) {
@@ -779,9 +795,7 @@ async fn run_ws_pump(
                         let Ok(budget) =
                             Arc::clone(&inbound_budget).acquire_many_owned(permits).await
                         else {
-                            return NativeTransportTerminal::Closed(
-                                "websocket transport owner closed".to_owned(),
-                            );
+                            return NativeTransportTerminal::OwnerDropped;
                         };
                         if inbound
                             .send(InboundFrame {
@@ -791,9 +805,7 @@ async fn run_ws_pump(
                             .await
                             .is_err()
                         {
-                            return NativeTransportTerminal::Closed(
-                                "websocket transport owner closed".to_owned(),
-                            );
+                            return NativeTransportTerminal::OwnerDropped;
                         }
                         // A maximum logical message can exceed the bounded
                         // channel. Wake on every frame so its consumer drains
@@ -991,6 +1003,7 @@ mod tests {
             outbound,
             task,
             terminal: None,
+            terminal_publisher: Arc::new(Mutex::new(None)),
             protocol_version: WIRE_PROTOCOL_VERSION,
             features: FEATURE_SYNC_MESSAGE_PAYLOAD,
             session_context: None,

--- a/crates/jazz-native-transport/tests/edge_websocket.rs
+++ b/crates/jazz-native-transport/tests/edge_websocket.rs
@@ -7,6 +7,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use jazz::tools::AppId;
+use jazz::tools::native_transport_connector::{
+    NativeTransportConnector as _, NativeTransportRequest, NativeTransportTerminal,
+};
 use jazz::tools::{AppContext, ClientStorage, JazzClient};
 use jazz::wire::WireTransport as _;
 use jazz_native_transport::{NativeWebSocketConnector, WebSocketClientError, WebSocketTransport};
@@ -96,6 +99,50 @@ async fn core_websocket_transport_helper_negotiates_route_hello() {
     .expect("native transport negotiates public route");
     let (_, _, session) = client.negotiated_transport_metadata();
     assert!(session.is_some(), "admitted hello carries session context");
+    task.abort();
+}
+
+/// The native adapter's terminal future observes an otherwise-idle socket; no
+/// semantic frame or outbound retry is needed to discover the peer close.
+#[tokio::test]
+async fn connected_native_transport_reports_idle_websocket_closure() {
+    let app_id = AppId::from_name("adapter-idle-close-terminal");
+    let built = ServerBuilder::new(app_id)
+        .with_schema(schema())
+        .with_auth_config(auth("secret"))
+        .with_storage(StorageBackend::InMemory)
+        .build()
+        .await
+        .expect("build core");
+    let (url, state, task) = serve_built(built).await;
+    let connected = NativeWebSocketConnector
+        .connect(NativeTransportRequest {
+            server_url: url,
+            app_id,
+            peer_identity: jazz::ids::AuthorSubject::SYSTEM,
+            auth: transport_auth("secret"),
+            wake: Arc::new(|| {}),
+        })
+        .await
+        .expect("connect idle native transport");
+    let _transport = connected.transport;
+    let terminal = connected.terminal;
+
+    state.shutdown.request_shutdown();
+    let shutdown_state = Arc::clone(&state);
+    let shutdown = tokio::spawn(async move { shutdown_state.run_shutdown_finalization().await });
+    let reason = tokio::time::timeout(Duration::from_secs(3), terminal)
+        .await
+        .expect("idle websocket closure resolves terminal future");
+    let diagnosis = match reason {
+        NativeTransportTerminal::Closed(message) => message,
+        NativeTransportTerminal::Failed(error) => error.0,
+    };
+    assert!(
+        !diagnosis.trim().is_empty(),
+        "idle websocket closure returns a terminal diagnosis"
+    );
+    shutdown.await.expect("shutdown task");
     task.abort();
 }
 

--- a/crates/jazz-native-transport/tests/edge_websocket.rs
+++ b/crates/jazz-native-transport/tests/edge_websocket.rs
@@ -135,14 +135,48 @@ async fn connected_native_transport_reports_idle_websocket_closure() {
         .await
         .expect("idle websocket closure resolves terminal future");
     let diagnosis = match reason {
-        NativeTransportTerminal::Closed(message) => message,
-        NativeTransportTerminal::Failed(error) => error.0,
+        NativeTransportTerminal::PeerClosed(message) => message,
+        other => panic!("peer shutdown must retain its peer-close terminal outcome, got {other:?}"),
     };
     assert!(
         !diagnosis.trim().is_empty(),
         "idle websocket closure returns a terminal diagnosis"
     );
     shutdown.await.expect("shutdown task");
+    task.abort();
+}
+
+#[tokio::test]
+async fn connected_native_transport_reports_owner_drop() {
+    let app_id = AppId::from_name("adapter-owner-drop-terminal");
+    let built = ServerBuilder::new(app_id)
+        .with_schema(schema())
+        .with_auth_config(auth("secret"))
+        .with_storage(StorageBackend::InMemory)
+        .build()
+        .await
+        .expect("build core");
+    let (url, _state, task) = serve_built(built).await;
+    let connected = NativeWebSocketConnector
+        .connect(NativeTransportRequest {
+            server_url: url,
+            app_id,
+            peer_identity: jazz::ids::AuthorSubject::SYSTEM,
+            auth: transport_auth("secret"),
+            wake: Arc::new(|| {}),
+        })
+        .await
+        .expect("connect native transport");
+    let transport = connected.transport;
+    let terminal = connected.terminal;
+
+    drop(transport);
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(3), terminal)
+            .await
+            .expect("owner drop resolves terminal future"),
+        NativeTransportTerminal::OwnerDropped
+    );
     task.abort();
 }
 

--- a/crates/jazz/src/tools/native_transport_connector.rs
+++ b/crates/jazz/src/tools/native_transport_connector.rs
@@ -50,12 +50,15 @@ impl std::fmt::Debug for NativeTransportRequest {
 ///
 /// `session_context` is authenticated during the adapter handshake. Keeping it
 /// with the transport prevents an adapter from asserting identity in semantic
-/// messages or requiring server-private admission APIs.
+/// messages or requiring server-private admission APIs. `terminal` observes
+/// the adapter's actual socket pump rather than semantic queue activity.
 pub struct ConnectedNativeTransport {
     pub transport: Box<dyn WireTransport + Send>,
     pub protocol_version: u16,
     pub features: u64,
     pub session_context: Option<ConnectionSessionContext>,
+    /// Resolves exactly once when the established adapter pump stops.
+    pub terminal: NativeTransportTerminalFuture,
 }
 
 /// Future returned by a target-specific native connector.
@@ -68,6 +71,19 @@ pub type NativeTransportFuture = Pin<
 >;
 pub type NativeCatalogueBootstrapFuture =
     Pin<Box<dyn Future<Output = Result<CatalogueSnapshot, NativeTransportError>> + Send + 'static>>;
+
+/// Future that resolves exactly once when an established adapter pump stops.
+pub type NativeTransportTerminalFuture =
+    Pin<Box<dyn Future<Output = NativeTransportTerminal> + Send + 'static>>;
+
+/// Terminal outcome of an established native transport.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NativeTransportTerminal {
+    /// The peer or local socket stack closed the established connection.
+    Closed(String),
+    /// The adapter stopped because transport input was invalid or I/O failed.
+    Failed(NativeTransportError),
+}
 
 /// Error at the target/socket boundary, before a core peer has been attached.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -134,6 +150,7 @@ mod tests {
                     protocol_version: 1,
                     features: 0,
                     session_context: None,
+                    terminal: Box::pin(std::future::pending()),
                 })
             })
         }

--- a/crates/jazz/src/tools/native_transport_connector.rs
+++ b/crates/jazz/src/tools/native_transport_connector.rs
@@ -79,8 +79,10 @@ pub type NativeTransportTerminalFuture =
 /// Terminal outcome of an established native transport.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NativeTransportTerminal {
-    /// The peer or local socket stack closed the established connection.
-    Closed(String),
+    /// The transport owner dropped its established connection deliberately.
+    OwnerDropped,
+    /// The remote peer closed the established connection.
+    PeerClosed(String),
     /// The adapter stopped because transport input was invalid or I/O failed.
     Failed(NativeTransportError),
 }


### PR DESCRIPTION
🤖 Reconstructs Joe’s #2195 directly on current `main`, preserving his original commit and authorship while removing obsolete integration-stack ancestry and repairing the terminal ownership race.

## Before

An established native WebSocket could close while idle without its owner learning that the pump stopped. The initial reconstruction exposed a terminal future, but `Drop` aborted the only task holding its sender: owner drop became a synthetic failure, and a peer-close/drop race could lose the real outcome. `Closed(String)` also conflated local ownership with remote closure.

## After

Every connected native transport exposes one exactly-once terminal future with typed outcomes:

- `OwnerDropped`: the transport owner deliberately released it;
- `PeerClosed(reason)`: the remote peer/socket closed cleanly;
- `Failed(error)`: invalid input or I/O/pump failure.

A shared take-once publisher outlives the abortable pump. `Drop` publishes `OwnerDropped` before aborting; a concurrent peer outcome can win only once. Bootstrap failure remains a separate connection result.

## Behavioral boundary

This PR establishes terminal completion and classification only. Reconnect/backpressure policy is stacked separately above it.

## Verification

- Exact idle peer-close and explicit owner-drop receipts pass.
- A planted missing terminal publication yields synthetic failure and makes the strict peer-close receipt fail.
- Full native-transport tests, formatting, and Clippy pass.
- Bounded producer wake behavior remains covered.

Supersedes #2195. Part of #2095.