### PR TITLE
perf(jazz): scope parent validation to the physical row

### DIFF
--- a/crates/jazz/SPEC/11_branch_views_time_travel.md
+++ b/crates/jazz/SPEC/11_branch_views_time_travel.md
@@ -159,6 +159,13 @@ that coordinate, and a version parent must belong to the same branch key
 (`INV-BVIEW-3`, `INV-BVIEW-4`). An application move is an explicit atomic write to
 the source and destination branch-local rows, not a cross-branch-key parent edge.
 
+Validation addresses an explicit version parent by its `(PhysicalTableId,
+RowUuid, TxId)` across both content and deletion history before comparing its
+`BranchKey`. Schema aliases resolve to the same physical table identity, and a
+missing parent remains a pending causal dependency. A cached parent lookup must
+be row-addressable: unrelated rows from the same transaction, including
+same-table siblings, must not be materialized merely to validate a parent.
+
 #### Storage and indices
 
 Content and deletion history use the same branch coordinate. Sparse deletion

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -542,17 +542,18 @@ where
         Ok(versions)
     }
 
-    /// Return the versions authored by one transaction for one logical table.
+    /// Return the versions authored by one transaction for one physical row.
     ///
     /// Unlike [`Self::query_versions_for_tx`], this deliberately visits only
     /// the requested table's physical history sources. It still uses the
     /// transaction index rather than a branch-local primary key so callers
     /// validating a causal parent can observe versions from every branch.
-    pub(super) async fn query_versions_for_tx_table(
+    pub(super) async fn query_versions_for_tx_physical_row(
         &mut self,
         tx_id: TxId,
         schema_version: SchemaVersionId,
         table: &str,
+        row_uuid: RowUuid,
     ) -> Result<Vec<VersionRow>, Error> {
         let requested_table_id = self.physical_table_id_for_schema(schema_version, table)?;
         if let Some(cached) = self.query.tx_versions_cache.get(&tx_id) {
@@ -568,14 +569,14 @@ where
                             .flatten()
                     })
                 })
-                .collect::<Vec<_>>();
+                .collect::<BTreeSet<_>>();
             let mut versions = Vec::new();
-            for version in cached {
-                if table_aliases.iter().any(|(schema_alias, table)| {
-                    table == version.table() && *schema_alias == version.schema_version_alias()
-                }) {
-                    versions.push(version.clone());
-                }
+            for (schema_alias, table) in table_aliases {
+                versions.extend(cached.versions_for_schema_table_row(
+                    schema_alias,
+                    &table,
+                    row_uuid,
+                ));
             }
             return Ok(versions);
         }
@@ -599,6 +600,22 @@ where
                 .map(|raw| raw.owned_record())
                 .collect::<Vec<_>>();
             for raw in raws {
+                if storage_table == SHARED_DELETION_HISTORY_TABLE
+                    && PhysicalTableId(
+                        raw.borrowed()
+                            .get_u64(SharedDeletionHistoryRowRecord::FIELD_PHYSICAL_TABLE_ID_IDX)?,
+                    ) != requested_table_id
+                {
+                    continue;
+                }
+                let row_uuid_index = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+                    SharedDeletionHistoryRowRecord::FIELD_ROW_UUID_IDX
+                } else {
+                    HistoryRowRecord::FIELD_ROW_UUID_IDX
+                };
+                if RowUuid(raw.borrowed().get_uuid(row_uuid_index)?) != row_uuid {
+                    continue;
+                }
                 let requested_table = if storage_table == SHARED_DELETION_HISTORY_TABLE {
                     ""
                 } else {
@@ -607,6 +624,8 @@ where
                 let version =
                     self.decode_history_owned_record(requested_table, &storage_table, raw)?;
                 if self.physical_table_id_for_version(&version)? == requested_table_id {
+                    #[cfg(test)]
+                    record_parent_version_lookup_materialized_rows(1);
                     versions.push(version);
                 }
             }

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -542,6 +542,78 @@ where
         Ok(versions)
     }
 
+    /// Return the versions authored by one transaction for one logical table.
+    ///
+    /// Unlike [`Self::query_versions_for_tx`], this deliberately visits only
+    /// the requested table's physical history sources. It still uses the
+    /// transaction index rather than a branch-local primary key so callers
+    /// validating a causal parent can observe versions from every branch.
+    pub(super) async fn query_versions_for_tx_table(
+        &mut self,
+        tx_id: TxId,
+        schema_version: SchemaVersionId,
+        table: &str,
+    ) -> Result<Vec<VersionRow>, Error> {
+        let requested_table_id = self.physical_table_id_for_schema(schema_version, table)?;
+        if let Some(cached) = self.query.tx_versions_cache.get(&tx_id) {
+            let table_aliases = self
+                .catalogue
+                .physical_mappings
+                .iter()
+                .flat_map(|(schema_version, mapping)| {
+                    let schema_alias = self.catalogue.schema_version_aliases.get(schema_version);
+                    mapping.tables.iter().filter_map(move |(table, mapping)| {
+                        (mapping.table_id == requested_table_id)
+                            .then(|| schema_alias.copied().map(|alias| (alias, table.clone())))
+                            .flatten()
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut versions = Vec::new();
+            for version in cached {
+                if table_aliases.iter().any(|(schema_alias, table)| {
+                    table == version.table() && *schema_alias == version.schema_version_alias()
+                }) {
+                    versions.push(version.clone());
+                }
+            }
+            return Ok(versions);
+        }
+        let Some(tx) = self.query_transaction(tx_id).await? else {
+            return Ok(Vec::new());
+        };
+        let mut versions = Vec::new();
+        for storage_table in [
+            physical_history_table_name(requested_table_id),
+            SHARED_DELETION_HISTORY_TABLE.to_owned(),
+        ] {
+            let raws = self
+                .database
+                .index_scan_raw(
+                    &storage_table,
+                    "by_tx",
+                    &[Value::U64(tx_id.time.0), Value::U64(tx.node_alias.0)],
+                )
+                .await?
+                .into_iter()
+                .map(|raw| raw.owned_record())
+                .collect::<Vec<_>>();
+            for raw in raws {
+                let requested_table = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+                    ""
+                } else {
+                    table
+                };
+                let version =
+                    self.decode_history_owned_record(requested_table, &storage_table, raw)?;
+                if self.physical_table_id_for_version(&version)? == requested_table_id {
+                    versions.push(version);
+                }
+            }
+        }
+        Ok(versions)
+    }
+
     pub(super) async fn query_versions_for_tx_rows_by_alias(
         &mut self,
         tx_id: TxId,

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -228,11 +228,17 @@ where
             )?;
             let table_id = self.physical_table_id_for_schema(author_schema, &table_schema.name)?;
             for parent in stored.parents() {
-                let parent_versions = self.query_versions_for_tx(parent).await?;
-                let same_row = parent_versions.iter().filter(|candidate| {
-                    candidate.row_uuid() == stored.row_uuid()
-                        && self.physical_table_id_for_version(candidate).ok() == Some(table_id)
-                });
+                let parent_versions = self
+                    .query_versions_for_tx_physical_row(
+                        parent,
+                        author_schema,
+                        &table_schema.name,
+                        stored.row_uuid(),
+                    )
+                    .await?;
+                let same_row = parent_versions
+                    .iter()
+                    .filter(|candidate| self.physical_table_id_for_version(candidate).ok() == Some(table_id));
                 if same_row.clone().next().is_some()
                     && !same_row
                         .into_iter()

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -452,6 +452,7 @@ fn next_groove_runtime_token() -> u64 {
 #[cfg(test)]
 std::thread_local! {
     static QUERY_VERSIONS_FOR_TX_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static SUBSCRIPTION_SNAPSHOT_FOR_LINK_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
@@ -466,8 +467,23 @@ pub(super) fn query_versions_for_tx_call_count() -> usize {
 }
 
 #[cfg(test)]
+pub(super) fn reset_parent_version_lookup_materialized_row_count() {
+    PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS.with(|rows| rows.set(0));
+}
+
+#[cfg(test)]
+pub(super) fn parent_version_lookup_materialized_row_count() -> usize {
+    PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
 fn record_query_versions_for_tx_call() {
     QUERY_VERSIONS_FOR_TX_CALLS.with(|calls| calls.set(calls.get() + 1));
+}
+
+#[cfg(test)]
+fn record_parent_version_lookup_materialized_rows(rows: usize) {
+    PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS.with(|count| count.set(count.get() + rows));
 }
 
 #[cfg(test)]
@@ -767,6 +783,56 @@ struct Parking {
     parked_catalogue_commit_units: BTreeSet<TxId>,
 }
 
+/// Recently stored transaction versions with a row-addressable cache view.
+///
+/// The complete vector remains available to callers that need the whole
+/// transaction. Parent validation, however, is constrained by the physical
+/// `(table, row)` coordinate, so its cache hit must not revisit unrelated
+/// siblings from a wide transaction.
+#[derive(Clone, Debug, Default)]
+struct CachedTransactionVersions {
+    versions: Vec<VersionRow>,
+    by_schema_table_row: BTreeMap<(SchemaVersionAlias, String, RowUuid), Vec<usize>>,
+}
+
+impl CachedTransactionVersions {
+    fn new(versions: Vec<VersionRow>) -> Self {
+        let mut by_schema_table_row = BTreeMap::new();
+        for (index, version) in versions.iter().enumerate() {
+            by_schema_table_row
+                .entry((
+                    version.schema_version_alias(),
+                    version.table().to_owned(),
+                    version.row_uuid(),
+                ))
+                .or_insert_with(Vec::new)
+                .push(index);
+        }
+        Self {
+            versions,
+            by_schema_table_row,
+        }
+    }
+
+    fn versions_for_schema_table_row(
+        &self,
+        schema_alias: SchemaVersionAlias,
+        table: &str,
+        row_uuid: RowUuid,
+    ) -> Vec<VersionRow> {
+        let key = (schema_alias, table.to_owned(), row_uuid);
+        let Some(indexes) = self.by_schema_table_row.get(&key) else {
+            return Vec::new();
+        };
+        #[cfg(test)]
+        record_parent_version_lookup_materialized_rows(indexes.len());
+        indexes
+            .iter()
+            .map(|index| self.versions[*index].clone())
+            .collect()
+    }
+}
+
 /// Query registration, cache, current-row graph, and settled-result state.
 #[derive(Clone, Debug, Default)]
 struct QueryServing {
@@ -784,8 +850,10 @@ struct QueryServing {
     policy_proof_stack: Vec<String>,
     /// Logical tables that have history rows for a stored transaction.
     tx_version_tables_cache: BTreeMap<TxId, BTreeSet<String>>,
-    /// Recently staged history rows for a stored transaction.
-    tx_versions_cache: BTreeMap<TxId, Vec<VersionRow>>,
+    /// Recently staged history rows for a stored transaction, indexed by
+    /// authored schema/table/row so parent validation does not rescan wide
+    /// transactions on a cache hit.
+    tx_versions_cache: BTreeMap<TxId, CachedTransactionVersions>,
     /// Approximate insertion order for bounding `tx_version_tables_cache`.
     tx_version_tables_cache_order: VecDeque<TxId>,
     /// Live membership for `tx_version_tables_cache_order`.

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -330,11 +330,16 @@ where
                 &table_schema.name,
             )?;
             for parent in &commit.parents {
-                let parent_versions = self.query_versions_for_tx(*parent).await?;
-                let same_row = parent_versions.iter().filter(|version| {
-                    version.row_uuid() == commit.row_uuid
-                        && self.physical_table_id_for_version(version).ok() == Some(table_id)
-                });
+                let parent_versions = self
+                    .query_versions_for_tx_table(
+                        *parent,
+                        write_schema_version,
+                        &table_schema.name,
+                    )
+                    .await?;
+                let same_row = parent_versions
+                    .iter()
+                    .filter(|version| self.physical_table_id_for_version(version).ok() == Some(table_id));
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
                 {

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -331,17 +331,17 @@ where
             )?;
             for parent in &commit.parents {
                 let parent_versions = self
-                    .query_versions_for_tx_table(
+                    .query_versions_for_tx_physical_row(
                         *parent,
                         write_schema_version,
                         &table_schema.name,
+                        commit.row_uuid,
                     )
                     .await?;
                 let same_row = parent_versions
                     .iter()
                     .filter(|version| {
-                        version.row_uuid() == commit.row_uuid
-                            && self.physical_table_id_for_version(version).ok() == Some(table_id)
+                        self.physical_table_id_for_version(version).ok() == Some(table_id)
                     });
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
@@ -1093,7 +1093,10 @@ where
     }
 
     pub(super) fn cached_tx_versions(&self, tx_id: TxId) -> Option<Vec<VersionRow>> {
-        self.query.tx_versions_cache.get(&tx_id).cloned()
+        self.query
+            .tx_versions_cache
+            .get(&tx_id)
+            .map(|cached| cached.versions.clone())
     }
 
     pub(super) fn cache_tx_version_tables(&mut self, tx_id: TxId, tables: BTreeSet<String>) {
@@ -1104,7 +1107,9 @@ where
 
     pub(super) fn cache_tx_versions(&mut self, tx_id: TxId, versions: Vec<VersionRow>) {
         self.touch_tx_version_cache_entry(tx_id);
-        self.query.tx_versions_cache.insert(tx_id, versions);
+        self.query
+            .tx_versions_cache
+            .insert(tx_id, CachedTransactionVersions::new(versions));
         self.bound_tx_version_cache();
     }
 

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -339,7 +339,10 @@ where
                     .await?;
                 let same_row = parent_versions
                     .iter()
-                    .filter(|version| self.physical_table_id_for_version(version).ok() == Some(table_id));
+                    .filter(|version| {
+                        version.row_uuid() == commit.row_uuid
+                            && self.physical_table_id_for_version(version).ok() == Some(table_id)
+                    });
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
                 {

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -513,20 +513,29 @@ fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
     // This transaction contains the target only under branch B, plus a
     // sibling deletion under branch A. A table-only lookup would see branch A
     // and wrongly bless the foreign target parent.
+    let mut foreign_parent_commits = vec![
+        MergeableCommit::new("todos", target, 50)
+            .branch(branch_b)
+            .cells(cells("foreign target parent")),
+        MergeableCommit::new("todos", sibling, 51)
+            .branch(branch_a.clone())
+            .deletion(DeletionEvent::Deleted),
+    ];
+    // The wide same-table batch is the cache-hit and storage-fallback
+    // boundary: neither path may materialize these unrelated physical rows.
+    foreign_parent_commits.extend((0..128).map(|index| {
+        MergeableCommit::new("todos", row(0x80 + index), 52 + u64::from(index))
+            .branch(branch_a.clone())
+            .cells(cells("unrelated same-table sibling"))
+    }));
     let foreign_parent = node
-        .commit_mergeable_many_settled(vec![
-            MergeableCommit::new("todos", target, 50)
-                .branch(branch_b)
-                .cells(cells("foreign target parent")),
-            MergeableCommit::new("todos", sibling, 51)
-                .branch(branch_a.clone())
-                .deletion(DeletionEvent::Deleted),
-        ])
+        .commit_mergeable_many_settled(foreign_parent_commits)
         .unwrap();
+    reset_parent_version_lookup_materialized_row_count();
     let error = node
         .commit_mergeable(
             MergeableCommit::new("todos", target, 60)
-                .branch(branch_a)
+                .branch(branch_a.clone())
                 .parents(vec![foreign_parent])
                 .cells(cells("must reject foreign target parent")),
         )
@@ -534,6 +543,33 @@ fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
         .err()
         .expect("a sibling under the requested branch cannot validate a foreign target parent");
     assert!(matches!(error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "a cache hit must materialize only the foreign target row, not same-table siblings"
+    );
+
+    // Force the storage scan path after the same wide transaction. Content
+    // history and shared deletion history must discard sibling rows before
+    // decoding/materializing them, while still rejecting the foreign target.
+    node.invalidate_tx_version_tables_cache(foreign_parent);
+    reset_parent_version_lookup_materialized_row_count();
+    let error = node
+        .commit_mergeable(
+            MergeableCommit::new("todos", target, 61)
+                .branch(branch_a)
+                .parents(vec![foreign_parent])
+                .cells(cells("must reject foreign target parent after cache eviction")),
+        )
+        .resolve()
+        .err()
+        .expect("a storage scan must reject the foreign target parent");
+    assert!(matches!(error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "a storage fallback must materialize only the foreign target row"
+    );
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -573,6 +573,101 @@ fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
 }
 
 #[test]
+fn replicated_parent_validation_scopes_wide_transactions_to_the_physical_row() {
+    let schema = branch_view_schema();
+    let (_writer_dir, mut writer) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x62; 16]), schema.clone());
+    let (_child_writer_dir, mut child_writer) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x63; 16]), schema.clone());
+    let (_receiver_dir, mut receiver) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x64; 16]), schema);
+    let target = row(0x65);
+    let sibling = row(0x66);
+    let branch_a = branch_selector(0x67);
+    let branch_b = branch_selector(0x68);
+    let owner = AuthorSubject::for_test_bytes([0x69; 16]);
+    let cells = |title: &str| {
+        BTreeMap::from([
+            ("title".to_owned(), v(title)),
+            ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+        ])
+    };
+
+    let mut parent_commits = vec![
+        MergeableCommit::new("todos", target, 10)
+            .branch(branch_b)
+            .cells(cells("foreign target parent")),
+        MergeableCommit::new("todos", sibling, 11)
+            .branch(branch_a.clone())
+            .deletion(DeletionEvent::Deleted),
+    ];
+    parent_commits.extend((0..128).map(|index| {
+        MergeableCommit::new("todos", row(0x80 + index), 12 + u64::from(index))
+            .branch(branch_a.clone())
+            .cells(cells("unrelated replicated sibling"))
+    }));
+    let parent = writer.commit_mergeable_many_settled(parent_commits).unwrap();
+    receiver
+        .apply_sync_message_settled(writer.commit_unit_for(parent).unwrap())
+        .unwrap();
+
+    let (_first_child, first_unit) = child_writer
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", target, 200)
+                .branch(branch_a.clone())
+                .parents(vec![parent])
+                .cells(cells("replicated child cache hit")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit {
+        tx: first_tx,
+        versions: first_versions,
+    } = first_unit
+    else {
+        panic!("commit unit expected");
+    };
+    reset_parent_version_lookup_materialized_row_count();
+    let first_error = receiver
+        .ingest_commit_unit_settled(first_tx, first_versions, u64::MAX - SKEW_TOLERANCE_MS)
+        .err()
+        .expect("a remote target parent under another branch must be rejected");
+    assert!(matches!(first_error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "replicated cache-hit validation must materialize only the target parent row"
+    );
+
+    receiver.invalidate_tx_version_tables_cache(parent);
+    let (_second_child, second_unit) = child_writer
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", target, 201)
+                .branch(branch_a)
+                .parents(vec![parent])
+                .cells(cells("replicated child storage fallback")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit {
+        tx: second_tx,
+        versions: second_versions,
+    } = second_unit
+    else {
+        panic!("commit unit expected");
+    };
+    reset_parent_version_lookup_materialized_row_count();
+    let second_error = receiver
+        .ingest_commit_unit_settled(second_tx, second_versions, u64::MAX - SKEW_TOLERANCE_MS)
+        .err()
+        .expect("a storage fallback must reject the remote foreign target parent");
+    assert!(matches!(second_error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "replicated storage validation must materialize only the target parent row"
+    );
+}
+
+#[test]
 fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     let schema = branch_view_schema();
     let (_dir, mut node) =

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -455,6 +455,88 @@ fn version_parents_cannot_cross_branch_keys() {
 }
 
 #[test]
+fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
+    let schema = branch_view_schema();
+    let (_dir, mut node) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x56; 16]), schema);
+    let target = row(0x57);
+    let sibling = row(0x58);
+    let branch_a = branch_selector(0x59);
+    let branch_b = branch_selector(0x5a);
+    let owner = AuthorSubject::for_test_bytes([0x5b; 16]);
+    let cells = |title: &str| {
+        BTreeMap::from([
+            ("title".to_owned(), v(title)),
+            ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+        ])
+    };
+
+    // A same-table multi-row transaction can legitimately contain a parent
+    // for the target and an unrelated sibling under another branch.
+    let valid_parent = node
+        .commit_mergeable_many_settled(vec![
+            MergeableCommit::new("todos", target, 10)
+                .branch(branch_a.clone())
+                .cells(cells("target base")),
+            MergeableCommit::new("todos", sibling, 11)
+                .branch(branch_b.clone())
+                .cells(cells("sibling other branch")),
+        ])
+        .unwrap();
+    let valid_child = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", target, 20)
+                .branch(branch_a.clone())
+                .parents(vec![valid_parent])
+                .cells(cells("target child")),
+        )
+        .unwrap();
+
+    // Deletion and restore parents use the shared deletion history table, so
+    // retain the normal same-row/branch chain through both lifecycle layers.
+    let deletion_parent = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", target, 30)
+                .branch(branch_a.clone())
+                .parents(vec![valid_child])
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", target, 40)
+            .branch(branch_a.clone())
+            .parents(vec![deletion_parent])
+            .deletion(DeletionEvent::Restored),
+    )
+    .unwrap();
+
+    // This transaction contains the target only under branch B, plus a
+    // sibling deletion under branch A. A table-only lookup would see branch A
+    // and wrongly bless the foreign target parent.
+    let foreign_parent = node
+        .commit_mergeable_many_settled(vec![
+            MergeableCommit::new("todos", target, 50)
+                .branch(branch_b)
+                .cells(cells("foreign target parent")),
+            MergeableCommit::new("todos", sibling, 51)
+                .branch(branch_a.clone())
+                .deletion(DeletionEvent::Deleted),
+        ])
+        .unwrap();
+    let error = node
+        .commit_mergeable(
+            MergeableCommit::new("todos", target, 60)
+                .branch(branch_a)
+                .parents(vec![foreign_parent])
+                .cells(cells("must reject foreign target parent")),
+        )
+        .resolve()
+        .err()
+        .expect("a sibling under the requested branch cannot validate a foreign target parent");
+    assert!(matches!(error, Error::InvalidMergeableCommit(_)));
+}
+
+#[test]
 fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     let schema = branch_view_schema();
     let (_dir, mut node) =

--- a/examples/benchmarks/w1/benches/reads_memory_walltime.rs
+++ b/examples/benchmarks/w1/benches/reads_memory_walltime.rs
@@ -88,6 +88,30 @@ fn resubscribe_activity_point_profile_s_memory(bencher: divan::Bencher<'_, '_>) 
     bencher.bench_local(|| fixture.subscribe_point_activity_once());
 }
 
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn delete_task_point_scaling_memory(bencher: divan::Bencher<'_, '_>, activity_events: usize) {
+    bencher
+        .with_inputs(|| Fixture::<MemoryStorage>::memory(300, 1_200, activity_events))
+        .bench_local_values(|fixture| {
+            fixture.delete_target_task();
+            fixture
+        });
+}
+
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn restore_task_point_scaling_memory(bencher: divan::Bencher<'_, '_>, activity_events: usize) {
+    bencher
+        .with_inputs(|| {
+            let fixture = Fixture::<MemoryStorage>::memory(300, 1_200, activity_events);
+            fixture.delete_target_task();
+            fixture
+        })
+        .bench_local_values(|fixture| {
+            fixture.restore_target_task();
+            fixture
+        });
+}
+
 /// Fixed-result scaling receipt exposing query-engine candidate hydration.
 #[divan::bench(args = [(300, 1_200, 900), (3_000, 12_000, 9_000)], sample_count = 5)]
 fn query_comments_scaling_memory(

--- a/examples/benchmarks/w1/src/lib.rs
+++ b/examples/benchmarks/w1/src/lib.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 
 use jazz::db::{
-    Db, DbConfig, DbIdentity, InsertOptions, LocalUpdates, MergeableTxOps, PreparedQuery,
-    Propagation, ReadOpts, SubscriptionEvent, SubscriptionStream, UpdateOptions, WriteIdentity,
-    block_on,
+    Db, DbConfig, DbIdentity, DeleteOptions, InsertOptions, LocalUpdates, MergeableTxOps,
+    PreparedQuery, Propagation, ReadOpts, RestoreOptions, SubscriptionEvent, SubscriptionStream,
+    UpdateOptions, WriteIdentity, block_on,
 };
 use jazz::groove::records::Value;
 use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
@@ -38,6 +38,7 @@ pub struct Fixture<S: OrderedKvStorage> {
     maintained_activity: PreparedQuery,
     point_activity: PreparedQuery,
     activity_transition_row: RowUuid,
+    task_transition_row: RowUuid,
     activity_transition_matching: bool,
     activity_update_identity: WriteIdentity,
 }
@@ -266,6 +267,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
             maintained_activity,
             point_activity,
             activity_transition_row: row_id(4, PROJECTS),
+            task_transition_row: task_ids[0],
             activity_transition_matching: false,
             activity_update_identity,
         };
@@ -364,6 +366,27 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
         .expect("toggle W1 indexed predicate");
         block_on(write.wait(DurabilityTier::Local)).expect("settle W1 indexed predicate toggle");
         self.activity_transition_matching = !self.activity_transition_matching;
+    }
+
+    pub fn delete_target_task(&self) {
+        let write = block_on(self.db.delete(
+            "tasks",
+            self.task_transition_row,
+            DeleteOptions::default(),
+        ))
+        .expect("delete W1 target task");
+        block_on(write.wait(DurabilityTier::Local)).expect("settle W1 target deletion");
+    }
+
+    pub fn restore_target_task(&self) {
+        let write = block_on(self.db.restore(
+            "tasks",
+            self.task_transition_row,
+            None,
+            RestoreOptions::default(),
+        ))
+        .expect("restore W1 target task");
+        block_on(write.wait(DurabilityTier::Local)).expect("settle W1 target restore");
     }
 }
 


### PR DESCRIPTION
🤖 Reconstructs #2123 directly on current `main`, preserving its commits while completing the exact physical-row performance and correctness boundary.

## Before

Parent validation looked up every version from the parent transaction. A W1-shaped transaction containing tasks, comments, and activity therefore made validating one task update scale with all sibling rows. An intermediate table-scoped optimization still iterated every transaction version and cloned every same-table sibling before filtering by row.

## After

The transaction cache is addressable by `(schema alias, logical table, row_uuid)`. Parent lookup narrows to the resolved physical table and exact row before cloning on cache hits and before decoding content/shared-deletion candidates on cache misses. Schema aliases, branch/layer validation, deletion history, and missing/pending-parent behavior remain intact.

## Example

If one transaction inserts task A, 128 other tasks, and thousands of activity rows, a later update to task A materializes exactly one candidate parent version. Task B cannot satisfy the parent merely because it shares the transaction and table, and its version is never cloned for task A validation.

## Governing boundary

Parent lookup is physically `(PhysicalTableId, RowUuid, TxId)`; branch/layer/schema validation remains explicit after lookup. This implements #2122’s O(parents × touched rows) target rather than merely reporting wider transaction cost in a benchmark.

## Verification

- Cache-hit and forced-cache-miss receipts each seed 128 same-table siblings and assert exactly one materialized `VersionRow`.
- Removing/inverting the row predicate makes the exact receipt fail.
- Cross-branch, deletion, alias, and unknown-parent receipts remain green.
- W1 benchmark target compiles.
- Invariant registry, formatting, diff checks, and library/package Clippy pass.

Supersedes #2123 and advances #2122.