### PR TITLE
perf(jazz): avoid covered resume member clones

### DIFF
--- a/crates/jazz/SPEC/11_branch_views_time_travel.md
+++ b/crates/jazz/SPEC/11_branch_views_time_travel.md
@@ -159,6 +159,13 @@ that coordinate, and a version parent must belong to the same branch key
 (`INV-BVIEW-3`, `INV-BVIEW-4`). An application move is an explicit atomic write to
 the source and destination branch-local rows, not a cross-branch-key parent edge.
 
+Validation addresses an explicit version parent by its `(PhysicalTableId,
+RowUuid, TxId)` across both content and deletion history before comparing its
+`BranchKey`. Schema aliases resolve to the same physical table identity, and a
+missing parent remains a pending causal dependency. A cached parent lookup must
+be row-addressable: unrelated rows from the same transaction, including
+same-table siblings, must not be materialized merely to validate a parent.
+
 #### Storage and indices
 
 Content and deletion history use the same branch coordinate. Sparse deletion

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -542,17 +542,18 @@ where
         Ok(versions)
     }
 
-    /// Return the versions authored by one transaction for one logical table.
+    /// Return the versions authored by one transaction for one physical row.
     ///
     /// Unlike [`Self::query_versions_for_tx`], this deliberately visits only
     /// the requested table's physical history sources. It still uses the
     /// transaction index rather than a branch-local primary key so callers
     /// validating a causal parent can observe versions from every branch.
-    pub(super) async fn query_versions_for_tx_table(
+    pub(super) async fn query_versions_for_tx_physical_row(
         &mut self,
         tx_id: TxId,
         schema_version: SchemaVersionId,
         table: &str,
+        row_uuid: RowUuid,
     ) -> Result<Vec<VersionRow>, Error> {
         let requested_table_id = self.physical_table_id_for_schema(schema_version, table)?;
         if let Some(cached) = self.query.tx_versions_cache.get(&tx_id) {
@@ -568,14 +569,14 @@ where
                             .flatten()
                     })
                 })
-                .collect::<Vec<_>>();
+                .collect::<BTreeSet<_>>();
             let mut versions = Vec::new();
-            for version in cached {
-                if table_aliases.iter().any(|(schema_alias, table)| {
-                    table == version.table() && *schema_alias == version.schema_version_alias()
-                }) {
-                    versions.push(version.clone());
-                }
+            for (schema_alias, table) in table_aliases {
+                versions.extend(cached.versions_for_schema_table_row(
+                    schema_alias,
+                    &table,
+                    row_uuid,
+                ));
             }
             return Ok(versions);
         }
@@ -599,6 +600,22 @@ where
                 .map(|raw| raw.owned_record())
                 .collect::<Vec<_>>();
             for raw in raws {
+                if storage_table == SHARED_DELETION_HISTORY_TABLE
+                    && PhysicalTableId(
+                        raw.borrowed()
+                            .get_u64(SharedDeletionHistoryRowRecord::FIELD_PHYSICAL_TABLE_ID_IDX)?,
+                    ) != requested_table_id
+                {
+                    continue;
+                }
+                let row_uuid_index = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+                    SharedDeletionHistoryRowRecord::FIELD_ROW_UUID_IDX
+                } else {
+                    HistoryRowRecord::FIELD_ROW_UUID_IDX
+                };
+                if RowUuid(raw.borrowed().get_uuid(row_uuid_index)?) != row_uuid {
+                    continue;
+                }
                 let requested_table = if storage_table == SHARED_DELETION_HISTORY_TABLE {
                     ""
                 } else {
@@ -607,6 +624,8 @@ where
                 let version =
                     self.decode_history_owned_record(requested_table, &storage_table, raw)?;
                 if self.physical_table_id_for_version(&version)? == requested_table_id {
+                    #[cfg(test)]
+                    record_parent_version_lookup_materialized_rows(1);
                     versions.push(version);
                 }
             }

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -542,6 +542,78 @@ where
         Ok(versions)
     }
 
+    /// Return the versions authored by one transaction for one logical table.
+    ///
+    /// Unlike [`Self::query_versions_for_tx`], this deliberately visits only
+    /// the requested table's physical history sources. It still uses the
+    /// transaction index rather than a branch-local primary key so callers
+    /// validating a causal parent can observe versions from every branch.
+    pub(super) async fn query_versions_for_tx_table(
+        &mut self,
+        tx_id: TxId,
+        schema_version: SchemaVersionId,
+        table: &str,
+    ) -> Result<Vec<VersionRow>, Error> {
+        let requested_table_id = self.physical_table_id_for_schema(schema_version, table)?;
+        if let Some(cached) = self.query.tx_versions_cache.get(&tx_id) {
+            let table_aliases = self
+                .catalogue
+                .physical_mappings
+                .iter()
+                .flat_map(|(schema_version, mapping)| {
+                    let schema_alias = self.catalogue.schema_version_aliases.get(schema_version);
+                    mapping.tables.iter().filter_map(move |(table, mapping)| {
+                        (mapping.table_id == requested_table_id)
+                            .then(|| schema_alias.copied().map(|alias| (alias, table.clone())))
+                            .flatten()
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut versions = Vec::new();
+            for version in cached {
+                if table_aliases.iter().any(|(schema_alias, table)| {
+                    table == version.table() && *schema_alias == version.schema_version_alias()
+                }) {
+                    versions.push(version.clone());
+                }
+            }
+            return Ok(versions);
+        }
+        let Some(tx) = self.query_transaction(tx_id).await? else {
+            return Ok(Vec::new());
+        };
+        let mut versions = Vec::new();
+        for storage_table in [
+            physical_history_table_name(requested_table_id),
+            SHARED_DELETION_HISTORY_TABLE.to_owned(),
+        ] {
+            let raws = self
+                .database
+                .index_scan_raw(
+                    &storage_table,
+                    "by_tx",
+                    &[Value::U64(tx_id.time.0), Value::U64(tx.node_alias.0)],
+                )
+                .await?
+                .into_iter()
+                .map(|raw| raw.owned_record())
+                .collect::<Vec<_>>();
+            for raw in raws {
+                let requested_table = if storage_table == SHARED_DELETION_HISTORY_TABLE {
+                    ""
+                } else {
+                    table
+                };
+                let version =
+                    self.decode_history_owned_record(requested_table, &storage_table, raw)?;
+                if self.physical_table_id_for_version(&version)? == requested_table_id {
+                    versions.push(version);
+                }
+            }
+        }
+        Ok(versions)
+    }
+
     pub(super) async fn query_versions_for_tx_rows_by_alias(
         &mut self,
         tx_id: TxId,

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -228,11 +228,17 @@ where
             )?;
             let table_id = self.physical_table_id_for_schema(author_schema, &table_schema.name)?;
             for parent in stored.parents() {
-                let parent_versions = self.query_versions_for_tx(parent).await?;
-                let same_row = parent_versions.iter().filter(|candidate| {
-                    candidate.row_uuid() == stored.row_uuid()
-                        && self.physical_table_id_for_version(candidate).ok() == Some(table_id)
-                });
+                let parent_versions = self
+                    .query_versions_for_tx_physical_row(
+                        parent,
+                        author_schema,
+                        &table_schema.name,
+                        stored.row_uuid(),
+                    )
+                    .await?;
+                let same_row = parent_versions
+                    .iter()
+                    .filter(|candidate| self.physical_table_id_for_version(candidate).ok() == Some(table_id));
                 if same_row.clone().next().is_some()
                     && !same_row
                         .into_iter()

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -452,6 +452,7 @@ fn next_groove_runtime_token() -> u64 {
 #[cfg(test)]
 std::thread_local! {
     static QUERY_VERSIONS_FOR_TX_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static SUBSCRIPTION_SNAPSHOT_FOR_LINK_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
@@ -466,8 +467,23 @@ pub(super) fn query_versions_for_tx_call_count() -> usize {
 }
 
 #[cfg(test)]
+pub(super) fn reset_parent_version_lookup_materialized_row_count() {
+    PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS.with(|rows| rows.set(0));
+}
+
+#[cfg(test)]
+pub(super) fn parent_version_lookup_materialized_row_count() -> usize {
+    PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
 fn record_query_versions_for_tx_call() {
     QUERY_VERSIONS_FOR_TX_CALLS.with(|calls| calls.set(calls.get() + 1));
+}
+
+#[cfg(test)]
+fn record_parent_version_lookup_materialized_rows(rows: usize) {
+    PARENT_VERSION_LOOKUP_MATERIALIZED_ROWS.with(|count| count.set(count.get() + rows));
 }
 
 #[cfg(test)]
@@ -767,6 +783,56 @@ struct Parking {
     parked_catalogue_commit_units: BTreeSet<TxId>,
 }
 
+/// Recently stored transaction versions with a row-addressable cache view.
+///
+/// The complete vector remains available to callers that need the whole
+/// transaction. Parent validation, however, is constrained by the physical
+/// `(table, row)` coordinate, so its cache hit must not revisit unrelated
+/// siblings from a wide transaction.
+#[derive(Clone, Debug, Default)]
+struct CachedTransactionVersions {
+    versions: Vec<VersionRow>,
+    by_schema_table_row: BTreeMap<(SchemaVersionAlias, String, RowUuid), Vec<usize>>,
+}
+
+impl CachedTransactionVersions {
+    fn new(versions: Vec<VersionRow>) -> Self {
+        let mut by_schema_table_row = BTreeMap::new();
+        for (index, version) in versions.iter().enumerate() {
+            by_schema_table_row
+                .entry((
+                    version.schema_version_alias(),
+                    version.table().to_owned(),
+                    version.row_uuid(),
+                ))
+                .or_insert_with(Vec::new)
+                .push(index);
+        }
+        Self {
+            versions,
+            by_schema_table_row,
+        }
+    }
+
+    fn versions_for_schema_table_row(
+        &self,
+        schema_alias: SchemaVersionAlias,
+        table: &str,
+        row_uuid: RowUuid,
+    ) -> Vec<VersionRow> {
+        let key = (schema_alias, table.to_owned(), row_uuid);
+        let Some(indexes) = self.by_schema_table_row.get(&key) else {
+            return Vec::new();
+        };
+        #[cfg(test)]
+        record_parent_version_lookup_materialized_rows(indexes.len());
+        indexes
+            .iter()
+            .map(|index| self.versions[*index].clone())
+            .collect()
+    }
+}
+
 /// Query registration, cache, current-row graph, and settled-result state.
 #[derive(Clone, Debug, Default)]
 struct QueryServing {
@@ -784,8 +850,10 @@ struct QueryServing {
     policy_proof_stack: Vec<String>,
     /// Logical tables that have history rows for a stored transaction.
     tx_version_tables_cache: BTreeMap<TxId, BTreeSet<String>>,
-    /// Recently staged history rows for a stored transaction.
-    tx_versions_cache: BTreeMap<TxId, Vec<VersionRow>>,
+    /// Recently staged history rows for a stored transaction, indexed by
+    /// authored schema/table/row so parent validation does not rescan wide
+    /// transactions on a cache hit.
+    tx_versions_cache: BTreeMap<TxId, CachedTransactionVersions>,
     /// Approximate insertion order for bounding `tx_version_tables_cache`.
     tx_version_tables_cache_order: VecDeque<TxId>,
     /// Live membership for `tx_version_tables_cache_order`.

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -330,11 +330,16 @@ where
                 &table_schema.name,
             )?;
             for parent in &commit.parents {
-                let parent_versions = self.query_versions_for_tx(*parent).await?;
-                let same_row = parent_versions.iter().filter(|version| {
-                    version.row_uuid() == commit.row_uuid
-                        && self.physical_table_id_for_version(version).ok() == Some(table_id)
-                });
+                let parent_versions = self
+                    .query_versions_for_tx_table(
+                        *parent,
+                        write_schema_version,
+                        &table_schema.name,
+                    )
+                    .await?;
+                let same_row = parent_versions
+                    .iter()
+                    .filter(|version| self.physical_table_id_for_version(version).ok() == Some(table_id));
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
                 {

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -331,17 +331,17 @@ where
             )?;
             for parent in &commit.parents {
                 let parent_versions = self
-                    .query_versions_for_tx_table(
+                    .query_versions_for_tx_physical_row(
                         *parent,
                         write_schema_version,
                         &table_schema.name,
+                        commit.row_uuid,
                     )
                     .await?;
                 let same_row = parent_versions
                     .iter()
                     .filter(|version| {
-                        version.row_uuid() == commit.row_uuid
-                            && self.physical_table_id_for_version(version).ok() == Some(table_id)
+                        self.physical_table_id_for_version(version).ok() == Some(table_id)
                     });
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
@@ -1093,7 +1093,10 @@ where
     }
 
     pub(super) fn cached_tx_versions(&self, tx_id: TxId) -> Option<Vec<VersionRow>> {
-        self.query.tx_versions_cache.get(&tx_id).cloned()
+        self.query
+            .tx_versions_cache
+            .get(&tx_id)
+            .map(|cached| cached.versions.clone())
     }
 
     pub(super) fn cache_tx_version_tables(&mut self, tx_id: TxId, tables: BTreeSet<String>) {
@@ -1104,7 +1107,9 @@ where
 
     pub(super) fn cache_tx_versions(&mut self, tx_id: TxId, versions: Vec<VersionRow>) {
         self.touch_tx_version_cache_entry(tx_id);
-        self.query.tx_versions_cache.insert(tx_id, versions);
+        self.query
+            .tx_versions_cache
+            .insert(tx_id, CachedTransactionVersions::new(versions));
         self.bound_tx_version_cache();
     }
 

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -339,7 +339,10 @@ where
                     .await?;
                 let same_row = parent_versions
                     .iter()
-                    .filter(|version| self.physical_table_id_for_version(version).ok() == Some(table_id));
+                    .filter(|version| {
+                        version.row_uuid() == commit.row_uuid
+                            && self.physical_table_id_for_version(version).ok() == Some(table_id)
+                    });
                 if same_row.clone().next().is_some()
                     && !same_row.into_iter().any(|version| version.branch_key() == &branch_key)
                 {

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -513,20 +513,29 @@ fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
     // This transaction contains the target only under branch B, plus a
     // sibling deletion under branch A. A table-only lookup would see branch A
     // and wrongly bless the foreign target parent.
+    let mut foreign_parent_commits = vec![
+        MergeableCommit::new("todos", target, 50)
+            .branch(branch_b)
+            .cells(cells("foreign target parent")),
+        MergeableCommit::new("todos", sibling, 51)
+            .branch(branch_a.clone())
+            .deletion(DeletionEvent::Deleted),
+    ];
+    // The wide same-table batch is the cache-hit and storage-fallback
+    // boundary: neither path may materialize these unrelated physical rows.
+    foreign_parent_commits.extend((0..128).map(|index| {
+        MergeableCommit::new("todos", row(0x80 + index), 52 + u64::from(index))
+            .branch(branch_a.clone())
+            .cells(cells("unrelated same-table sibling"))
+    }));
     let foreign_parent = node
-        .commit_mergeable_many_settled(vec![
-            MergeableCommit::new("todos", target, 50)
-                .branch(branch_b)
-                .cells(cells("foreign target parent")),
-            MergeableCommit::new("todos", sibling, 51)
-                .branch(branch_a.clone())
-                .deletion(DeletionEvent::Deleted),
-        ])
+        .commit_mergeable_many_settled(foreign_parent_commits)
         .unwrap();
+    reset_parent_version_lookup_materialized_row_count();
     let error = node
         .commit_mergeable(
             MergeableCommit::new("todos", target, 60)
-                .branch(branch_a)
+                .branch(branch_a.clone())
                 .parents(vec![foreign_parent])
                 .cells(cells("must reject foreign target parent")),
         )
@@ -534,6 +543,33 @@ fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
         .err()
         .expect("a sibling under the requested branch cannot validate a foreign target parent");
     assert!(matches!(error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "a cache hit must materialize only the foreign target row, not same-table siblings"
+    );
+
+    // Force the storage scan path after the same wide transaction. Content
+    // history and shared deletion history must discard sibling rows before
+    // decoding/materializing them, while still rejecting the foreign target.
+    node.invalidate_tx_version_tables_cache(foreign_parent);
+    reset_parent_version_lookup_materialized_row_count();
+    let error = node
+        .commit_mergeable(
+            MergeableCommit::new("todos", target, 61)
+                .branch(branch_a)
+                .parents(vec![foreign_parent])
+                .cells(cells("must reject foreign target parent after cache eviction")),
+        )
+        .resolve()
+        .err()
+        .expect("a storage scan must reject the foreign target parent");
+    assert!(matches!(error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "a storage fallback must materialize only the foreign target row"
+    );
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -573,6 +573,101 @@ fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
 }
 
 #[test]
+fn replicated_parent_validation_scopes_wide_transactions_to_the_physical_row() {
+    let schema = branch_view_schema();
+    let (_writer_dir, mut writer) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x62; 16]), schema.clone());
+    let (_child_writer_dir, mut child_writer) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x63; 16]), schema.clone());
+    let (_receiver_dir, mut receiver) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x64; 16]), schema);
+    let target = row(0x65);
+    let sibling = row(0x66);
+    let branch_a = branch_selector(0x67);
+    let branch_b = branch_selector(0x68);
+    let owner = AuthorSubject::for_test_bytes([0x69; 16]);
+    let cells = |title: &str| {
+        BTreeMap::from([
+            ("title".to_owned(), v(title)),
+            ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+        ])
+    };
+
+    let mut parent_commits = vec![
+        MergeableCommit::new("todos", target, 10)
+            .branch(branch_b)
+            .cells(cells("foreign target parent")),
+        MergeableCommit::new("todos", sibling, 11)
+            .branch(branch_a.clone())
+            .deletion(DeletionEvent::Deleted),
+    ];
+    parent_commits.extend((0..128).map(|index| {
+        MergeableCommit::new("todos", row(0x80 + index), 12 + u64::from(index))
+            .branch(branch_a.clone())
+            .cells(cells("unrelated replicated sibling"))
+    }));
+    let parent = writer.commit_mergeable_many_settled(parent_commits).unwrap();
+    receiver
+        .apply_sync_message_settled(writer.commit_unit_for(parent).unwrap())
+        .unwrap();
+
+    let (_first_child, first_unit) = child_writer
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", target, 200)
+                .branch(branch_a.clone())
+                .parents(vec![parent])
+                .cells(cells("replicated child cache hit")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit {
+        tx: first_tx,
+        versions: first_versions,
+    } = first_unit
+    else {
+        panic!("commit unit expected");
+    };
+    reset_parent_version_lookup_materialized_row_count();
+    let first_error = receiver
+        .ingest_commit_unit_settled(first_tx, first_versions, u64::MAX - SKEW_TOLERANCE_MS)
+        .err()
+        .expect("a remote target parent under another branch must be rejected");
+    assert!(matches!(first_error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "replicated cache-hit validation must materialize only the target parent row"
+    );
+
+    receiver.invalidate_tx_version_tables_cache(parent);
+    let (_second_child, second_unit) = child_writer
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", target, 201)
+                .branch(branch_a)
+                .parents(vec![parent])
+                .cells(cells("replicated child storage fallback")),
+        )
+        .unwrap();
+    let SyncMessage::CommitUnit {
+        tx: second_tx,
+        versions: second_versions,
+    } = second_unit
+    else {
+        panic!("commit unit expected");
+    };
+    reset_parent_version_lookup_materialized_row_count();
+    let second_error = receiver
+        .ingest_commit_unit_settled(second_tx, second_versions, u64::MAX - SKEW_TOLERANCE_MS)
+        .err()
+        .expect("a storage fallback must reject the remote foreign target parent");
+    assert!(matches!(second_error, Error::InvalidMergeableCommit(_)));
+    assert_eq!(
+        parent_version_lookup_materialized_row_count(),
+        1,
+        "replicated storage validation must materialize only the target parent row"
+    );
+}
+
+#[test]
 fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     let schema = branch_view_schema();
     let (_dir, mut node) =

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -455,6 +455,88 @@ fn version_parents_cannot_cross_branch_keys() {
 }
 
 #[test]
+fn parent_validation_scopes_same_table_transactions_to_the_physical_row() {
+    let schema = branch_view_schema();
+    let (_dir, mut node) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x56; 16]), schema);
+    let target = row(0x57);
+    let sibling = row(0x58);
+    let branch_a = branch_selector(0x59);
+    let branch_b = branch_selector(0x5a);
+    let owner = AuthorSubject::for_test_bytes([0x5b; 16]);
+    let cells = |title: &str| {
+        BTreeMap::from([
+            ("title".to_owned(), v(title)),
+            ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+        ])
+    };
+
+    // A same-table multi-row transaction can legitimately contain a parent
+    // for the target and an unrelated sibling under another branch.
+    let valid_parent = node
+        .commit_mergeable_many_settled(vec![
+            MergeableCommit::new("todos", target, 10)
+                .branch(branch_a.clone())
+                .cells(cells("target base")),
+            MergeableCommit::new("todos", sibling, 11)
+                .branch(branch_b.clone())
+                .cells(cells("sibling other branch")),
+        ])
+        .unwrap();
+    let valid_child = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", target, 20)
+                .branch(branch_a.clone())
+                .parents(vec![valid_parent])
+                .cells(cells("target child")),
+        )
+        .unwrap();
+
+    // Deletion and restore parents use the shared deletion history table, so
+    // retain the normal same-row/branch chain through both lifecycle layers.
+    let deletion_parent = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", target, 30)
+                .branch(branch_a.clone())
+                .parents(vec![valid_child])
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    node.commit_mergeable_settled(
+        MergeableCommit::new("todos", target, 40)
+            .branch(branch_a.clone())
+            .parents(vec![deletion_parent])
+            .deletion(DeletionEvent::Restored),
+    )
+    .unwrap();
+
+    // This transaction contains the target only under branch B, plus a
+    // sibling deletion under branch A. A table-only lookup would see branch A
+    // and wrongly bless the foreign target parent.
+    let foreign_parent = node
+        .commit_mergeable_many_settled(vec![
+            MergeableCommit::new("todos", target, 50)
+                .branch(branch_b)
+                .cells(cells("foreign target parent")),
+            MergeableCommit::new("todos", sibling, 51)
+                .branch(branch_a.clone())
+                .deletion(DeletionEvent::Deleted),
+        ])
+        .unwrap();
+    let error = node
+        .commit_mergeable(
+            MergeableCommit::new("todos", target, 60)
+                .branch(branch_a)
+                .parents(vec![foreign_parent])
+                .cells(cells("must reject foreign target parent")),
+        )
+        .resolve()
+        .err()
+        .expect("a sibling under the requested branch cannot validate a foreign target parent");
+    assert!(matches!(error, Error::InvalidMergeableCommit(_)));
+}
+
+#[test]
 fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     let schema = branch_view_schema();
     let (_dir, mut node) =

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -1499,7 +1499,7 @@ impl PeerState {
             .ok_or(Error::InvalidStoredValue(
                 "coverage group subscription is missing peer state",
             ))?;
-        let current_result_member_set = canonical_state.member_result_set();
+        let current_result_member_set = &canonical_state.result_member_set;
         let can_forward_flat_removals = client_link
             && ordinary_flat_row_duplicate_view(
                 shape,
@@ -1517,7 +1517,6 @@ impl PeerState {
         } else {
             Vec::new()
         };
-        let mut result_member_adds = current_result_member_set.into_iter().collect::<Vec<_>>();
         let tier = self
             .publication_states
             .get(&maintained_subscription)
@@ -1528,24 +1527,30 @@ impl PeerState {
             ))?;
         let peer_complete_tx_payloads = self.acknowledged_complete_tx_payloads();
         let mut reset_result_set = true;
-        if !authorization_mismatch
+        let result_member_adds = if !authorization_mismatch
             && let Some(position) = known_membership_position
             && canonical_subscription_settlement_time(node, maintained_subscription).0 > 0
             && position >= canonical_subscription_settlement_time(node, maintained_subscription)
         {
-            result_member_adds.clear();
             reset_result_set = false;
+            Vec::new()
         } else if !authorization_mismatch
             && let Some(position) = known_membership_position
-            && result_member_adds
+            && current_result_member_set
                 .iter()
                 .any(|member| member_settle_position(member).is_some())
         {
-            result_member_adds.retain(|member| {
-                member_settle_position(member).is_none_or(|settled| settled > position)
-            });
             reset_result_set = false;
-        }
+            current_result_member_set
+                .iter()
+                .filter(|member| {
+                    member_settle_position(member).is_none_or(|settled| settled > position)
+                })
+                .cloned()
+                .collect()
+        } else {
+            current_result_member_set.iter().cloned().collect()
+        };
         let update = {
             let maintained = &self
                 .publication_states

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -348,6 +348,104 @@ fn duplicate_structured_query_authorization_mismatch_forces_reset() {
     );
 }
 
+#[test]
+fn maintained_subscription_fast_cursor_skips_covered_members_and_sends_only_newer_members() {
+    let (_dir, mut core) = open_node_with_uuid(node(0x93));
+    let first_row = row(0x50);
+    let first_tx = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", first_row, 1_000).cells(title_cells("first")),
+        )
+        .unwrap();
+    accept_global(&mut core, first_tx, 1);
+    let second_row = row(0x51);
+    let second_tx = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", second_row, 1_001).cells(title_cells("second")),
+        )
+        .unwrap();
+    accept_global(&mut core, second_tx, 2);
+
+    let shape = Query::from("todos").validate(&schema()).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let canonical = subscription_key(&shape, &binding);
+    let fully_covered = SubscriptionKey {
+        binding_id: crate::query::BindingId(uuid::Uuid::from_u128(0x50)),
+        ..canonical
+    };
+    let partially_covered = SubscriptionKey {
+        binding_id: crate::query::BindingId(uuid::Uuid::from_u128(0x51)),
+        ..canonical
+    };
+    let mut peer = PeerState::relay();
+    peer.rehydrate_query_for_subscription_with_opts(
+        &mut core,
+        canonical,
+        &shape,
+        &binding,
+        RegisterShapeOptions::default(),
+    )
+    .unwrap();
+
+    peer.declare_known_state(
+        fully_covered,
+        Some(KnownStateDeclaration::Fast {
+            completeness: KnownStateCompleteness::FastCurrentMembership,
+            position: GlobalTime(2),
+        }),
+    );
+    let covered = peer
+        .rehydrate_query_for_subscription_from_maintained_subscription(
+            &mut core,
+            canonical,
+            fully_covered,
+            &shape,
+        )
+        .unwrap()
+        .expect("fully covered cursor still publishes its usage-site update");
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+        reset_result_set,
+        result_member_adds,
+        result_member_removes,
+        ..
+    }) = covered
+    else {
+        panic!("expected fully covered view update");
+    };
+    assert!(!reset_result_set);
+    assert!(result_member_adds.is_empty());
+    assert!(result_member_removes.is_empty());
+
+    peer.declare_known_state(
+        partially_covered,
+        Some(KnownStateDeclaration::Fast {
+            completeness: KnownStateCompleteness::FastCurrentMembership,
+            position: GlobalTime(1),
+        }),
+    );
+    let partial = peer
+        .rehydrate_query_for_subscription_from_maintained_subscription(
+            &mut core,
+            canonical,
+            partially_covered,
+            &shape,
+        )
+        .unwrap()
+        .expect("partially covered cursor publishes newer members");
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+        reset_result_set,
+        result_member_adds,
+        result_member_removes,
+        ..
+    }) = partial
+    else {
+        panic!("expected partial view update");
+    };
+    assert!(!reset_result_set);
+    assert_eq!(result_member_adds, vec![("todos".to_owned().into(), second_row, second_tx)]);
+    assert!(result_member_removes.is_empty());
+}
+
 fn output_member(root: RowUuid, joined: RowUuid, time: u64) -> ResultMemberEntry {
     RealRowMemberEntry::current_content((
         "todos".to_owned().into(),

--- a/examples/benchmarks/w1/benches/reads_memory_walltime.rs
+++ b/examples/benchmarks/w1/benches/reads_memory_walltime.rs
@@ -88,6 +88,30 @@ fn resubscribe_activity_point_profile_s_memory(bencher: divan::Bencher<'_, '_>) 
     bencher.bench_local(|| fixture.subscribe_point_activity_once());
 }
 
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn delete_task_point_scaling_memory(bencher: divan::Bencher<'_, '_>, activity_events: usize) {
+    bencher
+        .with_inputs(|| Fixture::<MemoryStorage>::memory(300, 1_200, activity_events))
+        .bench_local_values(|fixture| {
+            fixture.delete_target_task();
+            fixture
+        });
+}
+
+#[divan::bench(args = [900, 9_000], sample_count = 1)]
+fn restore_task_point_scaling_memory(bencher: divan::Bencher<'_, '_>, activity_events: usize) {
+    bencher
+        .with_inputs(|| {
+            let fixture = Fixture::<MemoryStorage>::memory(300, 1_200, activity_events);
+            fixture.delete_target_task();
+            fixture
+        })
+        .bench_local_values(|fixture| {
+            fixture.restore_target_task();
+            fixture
+        });
+}
+
 /// Fixed-result scaling receipt exposing query-engine candidate hydration.
 #[divan::bench(args = [(300, 1_200, 900), (3_000, 12_000, 9_000)], sample_count = 5)]
 fn query_comments_scaling_memory(

--- a/examples/benchmarks/w1/benches/reads_memory_walltime.rs
+++ b/examples/benchmarks/w1/benches/reads_memory_walltime.rs
@@ -1,5 +1,5 @@
 use jazz::groove::storage::MemoryStorage;
-use jazz_example_benchmark_w1::Fixture;
+use jazz_example_benchmark_w1::{Fixture, ResumeFixture};
 
 fn main() {
     divan::main();
@@ -109,6 +109,20 @@ fn restore_task_point_scaling_memory(bencher: divan::Bencher<'_, '_>, activity_e
         .bench_local_values(|fixture| {
             fixture.restore_target_task();
             fixture
+        });
+}
+
+/// One-row byte-wire resume after the full W1 topology is prepared off-clock.
+#[divan::bench(args = [(300, 1_200, 900), (500, 2_000, 1_500)], sample_count = 1)]
+fn resume_one_task_update_scaling_memory(
+    bencher: divan::Bencher<'_, '_>,
+    (tasks, comments, activity): (usize, usize, usize),
+) {
+    bencher
+        .with_inputs(|| ResumeFixture::memory(tasks, comments, activity))
+        .bench_local_values(|mut fixture| {
+            let resume_bytes = fixture.resume_once();
+            (fixture, resume_bytes)
         });
 }
 

--- a/examples/benchmarks/w1/src/lib.rs
+++ b/examples/benchmarks/w1/src/lib.rs
@@ -1,11 +1,14 @@
 //! W1 compatibility fixture derived from the realistic project-board workload.
 
-use std::collections::BTreeMap;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, VecDeque};
+use std::rc::Rc;
 
 use jazz::db::{
     Db, DbConfig, DbIdentity, DeleteOptions, InsertOptions, LocalUpdates, MergeableTxOps,
-    PreparedQuery, Propagation, ReadOpts, RestoreOptions, SubscriptionEvent, SubscriptionStream,
-    UpdateOptions, WriteIdentity, block_on,
+    PeerIoPump, PreparedQuery, Propagation, ReadOpts, RestoreOptions, ResumeCursor,
+    SubscriptionEvent, SubscriptionStream, UpdateOptions, WireTransportAdapter, WriteIdentity,
+    block_on,
 };
 use jazz::groove::records::Value;
 use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
@@ -17,6 +20,11 @@ use jazz::tools::{
     Value as PublicValue,
 };
 use jazz::tx::DurabilityTier;
+use jazz::wire::{
+    FEATURE_MESSAGE_FRAGMENTATION, FEATURE_SESSION_FRAME, FEATURE_STRUCTURED_ERRORS,
+    FEATURE_SYNC_MESSAGE_PAYLOAD, TransportError, WIRE_PROTOCOL_VERSION, WireSession,
+    WireTransport,
+};
 use jazz_storage_rocksdb::{Durability, RocksDbStorage};
 use tempfile::TempDir;
 
@@ -46,6 +54,59 @@ pub struct Fixture<S: OrderedKvStorage> {
 pub struct MaintainedActivityFixture<S: OrderedKvStorage> {
     fixture: Fixture<S>,
     subscription: SubscriptionStream,
+}
+
+/// Prepared byte-wire reconnect with one disconnected task update pending.
+pub struct ResumeFixture {
+    server: Db<MemoryStorage>,
+    client: Db<MemoryStorage>,
+    subscription: SubscriptionStream,
+    cursor: Option<ResumeCursor>,
+    full_snapshot_bytes: usize,
+}
+
+struct ByteDuplexTransport {
+    outbound: Rc<RefCell<VecDeque<Vec<u8>>>>,
+    inbound: Rc<RefCell<VecDeque<Vec<u8>>>>,
+}
+
+struct ByteQueues {
+    left_to_right: Rc<RefCell<VecDeque<Vec<u8>>>>,
+    right_to_left: Rc<RefCell<VecDeque<Vec<u8>>>>,
+}
+
+impl ByteQueues {
+    fn is_empty(&self) -> bool {
+        self.left_to_right.borrow().is_empty() && self.right_to_left.borrow().is_empty()
+    }
+}
+
+fn pump_aux(left: &PeerIoPump, right: &PeerIoPump) {
+    loop {
+        let mut progressed = false;
+        while let Some(message) = left.take_outbound(64) {
+            block_on(right.route_incoming(message)).expect("route W1 left auxiliary message");
+            progressed = true;
+        }
+        while let Some(message) = right.take_outbound(64) {
+            block_on(left.route_incoming(message)).expect("route W1 right auxiliary message");
+            progressed = true;
+        }
+        if !progressed {
+            break;
+        }
+    }
+}
+
+impl WireTransport for ByteDuplexTransport {
+    fn send_frame(&mut self, frame: Vec<u8>) -> Result<(), TransportError> {
+        self.outbound.borrow_mut().push_back(frame);
+        Ok(())
+    }
+
+    fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+        self.inbound.borrow_mut().pop_front()
+    }
 }
 
 impl Fixture<MemoryStorage> {
@@ -83,6 +144,153 @@ impl Fixture<MemoryStorage> {
             MemoryStorage::new(&family_refs).expect("valid memory storage families"),
             WriteIdentity::Session(policy_bench_identity()),
         )
+    }
+}
+
+impl ResumeFixture {
+    pub fn memory(tasks: usize, comments: usize, activity_events: usize) -> Self {
+        let writer = Fixture::<MemoryStorage>::memory(tasks, comments, activity_events);
+        let server = open_memory_node(schema(false), 0x72, true);
+        let client = open_memory_node(schema(false), 0x73, false);
+
+        let (writer_transport, server_writer_transport, queues) = byte_duplex(1);
+        let writer_upstream = block_on(writer.db.connect_upstream(writer_transport));
+        let writer_subscriber =
+            server.accept_subscriber(server_writer_transport, AuthorSubject::SYSTEM);
+        let writer_pump = block_on(writer_upstream.lock()).io_pump();
+        let server_writer_pump = block_on(writer_subscriber.lock()).io_pump();
+        let mut quiet_ticks = 0;
+        for _ in 0..10_000 {
+            block_on(writer.db.tick()).expect("ship W1 resume seed rows");
+            block_on(server.tick()).expect("ingest W1 resume seed rows");
+            pump_aux(&writer_pump, &server_writer_pump);
+            quiet_ticks = if queues.is_empty() {
+                quiet_ticks + 1
+            } else {
+                0
+            };
+            if quiet_ticks == 2 {
+                break;
+            }
+        }
+        assert!(writer.db.detach_connection(&writer_upstream));
+        assert!(server.detach_connection(&writer_subscriber));
+        let (client_transport, server_transport, _queues) = byte_duplex(2);
+        let upstream = block_on(client.connect_upstream(client_transport));
+        let subscriber = server.accept_subscriber(server_transport, AuthorSubject::SYSTEM);
+        let client_pump = block_on(upstream.lock()).io_pump();
+        let server_pump = block_on(subscriber.lock()).io_pump();
+        let prepared = client
+            .prepare_query(&Query::from("tasks"))
+            .expect("prepare W1 resumed tasks query");
+        let mut subscription = block_on(client.subscribe(
+            &prepared,
+            ReadOpts {
+                tier: DurabilityTier::Global,
+                local_updates: LocalUpdates::Deferred,
+                propagation: Propagation::Full,
+                ..ReadOpts::default()
+            },
+        ))
+        .expect("subscribe W1 resumed tasks");
+        let mut initial_rows = 0;
+        for _ in 0..512 {
+            block_on(client.tick()).expect("announce W1 resumed tasks subscription");
+            block_on(server.tick()).expect("serve W1 full task snapshot");
+            block_on(client.tick()).expect("apply W1 full task snapshot");
+            block_on(client.tick()).expect("materialize W1 full task snapshot");
+            pump_aux(&client_pump, &server_pump);
+            while let Some(event) = subscription.try_next_event() {
+                initial_rows += event_row_count(event);
+            }
+            if initial_rows == tasks {
+                break;
+            }
+        }
+        assert_eq!(initial_rows, tasks);
+        let full_snapshot_bytes = block_on(subscriber.lock())
+            .last_resume_bytes()
+            .expect("W1 full snapshot bytes");
+        block_on(server.tick()).expect("refresh W1 served cursor state");
+        block_on(client.tick()).expect("apply W1 served cursor state");
+        while subscription.try_next_event().is_some() {}
+        let cursor = block_on(subscriber.lock())
+            .take_resume_cursor()
+            .expect("take W1 subscriber resume cursor");
+        assert!(client.detach_connection(&upstream));
+        assert!(server.detach_connection(&subscriber));
+
+        let write = block_on(writer.db.update(
+            "tasks",
+            writer.task_transition_row,
+            BTreeMap::from([(
+                "status".to_owned(),
+                Value::String("resume-canary".to_owned()),
+            )]),
+            UpdateOptions::default(),
+        ))
+        .expect("write disconnected W1 task update");
+        block_on(write.wait(DurabilityTier::Local)).expect("settle disconnected W1 task update");
+        let (writer_transport, server_writer_transport, queues) = byte_duplex(3);
+        let writer_upstream = block_on(writer.db.connect_upstream(writer_transport));
+        let writer_subscriber =
+            server.accept_subscriber(server_writer_transport, AuthorSubject::SYSTEM);
+        let writer_pump = block_on(writer_upstream.lock()).io_pump();
+        let server_writer_pump = block_on(writer_subscriber.lock()).io_pump();
+        let mut quiet_ticks = 0;
+        for _ in 0..1_000 {
+            block_on(writer.db.tick()).expect("ship disconnected W1 task update");
+            block_on(server.tick()).expect("ingest disconnected W1 task update");
+            pump_aux(&writer_pump, &server_writer_pump);
+            quiet_ticks = if queues.is_empty() {
+                quiet_ticks + 1
+            } else {
+                0
+            };
+            if quiet_ticks == 2 {
+                break;
+            }
+        }
+        assert!(writer.db.detach_connection(&writer_upstream));
+        assert!(server.detach_connection(&writer_subscriber));
+
+        Self {
+            server,
+            client,
+            subscription,
+            cursor: Some(cursor),
+            full_snapshot_bytes,
+        }
+    }
+
+    pub fn resume_once(&mut self) -> usize {
+        let cursor = self.cursor.take().expect("W1 resume fixture is single-use");
+        let (client_transport, server_transport, _queues) = byte_duplex(4);
+        let _upstream = block_on(self.client.connect_upstream(client_transport));
+        let resumed = self.server.accept_subscriber_with_resume(
+            server_transport,
+            AuthorSubject::SYSTEM,
+            cursor,
+        );
+        let client_pump = block_on(_upstream.lock()).io_pump();
+        let server_pump = block_on(resumed.lock()).io_pump();
+        block_on(self.client.tick()).expect("announce resumed W1 subscription");
+        block_on(self.server.tick()).expect("serve W1 resume catch-up");
+        pump_aux(&client_pump, &server_pump);
+        block_on(self.client.tick()).expect("apply W1 resume catch-up");
+        block_on(self.client.tick()).expect("materialize W1 resume event");
+        let resume_bytes = block_on(resumed.lock())
+            .last_resume_bytes()
+            .expect("W1 resume catch-up bytes");
+        let mut changed = event_row_count(
+            block_on(self.subscription.next_event()).expect("W1 resume stream remains open"),
+        );
+        while let Some(event) = self.subscription.try_next_event() {
+            changed += event_row_count(event);
+        }
+        assert_eq!(changed, 1);
+        assert!(resume_bytes < self.full_snapshot_bytes);
+        resume_bytes
     }
 }
 
@@ -476,6 +684,72 @@ fn open_db<S: OrderedKvStorage + ReopenableStorage + 'static>(
         },
     )))
     .expect("open W1 benchmark database")
+}
+
+fn open_memory_node(schema: JazzSchema, node: u8, history_complete: bool) -> Db<MemoryStorage> {
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let config = DbConfig::new(
+        schema,
+        MemoryStorage::new(&family_refs).expect("valid memory storage families"),
+        DbIdentity {
+            node: NodeUuid::from_bytes([node; 16]),
+            author: AuthorSubject::SYSTEM,
+        },
+    );
+    if history_complete {
+        block_on(Db::open_history_complete(config))
+    } else {
+        block_on(Db::open(config))
+    }
+    .expect("open W1 resume database")
+}
+
+fn byte_duplex(
+    epoch: u64,
+) -> (
+    Box<dyn jazz::db::Transport>,
+    Box<dyn jazz::db::Transport>,
+    ByteQueues,
+) {
+    let left = Rc::new(RefCell::new(VecDeque::new()));
+    let right = Rc::new(RefCell::new(VecDeque::new()));
+    let left_transport = ByteDuplexTransport {
+        outbound: Rc::clone(&left),
+        inbound: Rc::clone(&right),
+    };
+    let right_transport = ByteDuplexTransport {
+        outbound: Rc::clone(&right),
+        inbound: Rc::clone(&left),
+    };
+    let session = WireSession {
+        session_id: "w1-resume-benchmark".to_owned(),
+        epoch,
+        identity: Some(AuthorSubject::SYSTEM),
+    };
+    let features = FEATURE_SYNC_MESSAGE_PAYLOAD
+        | FEATURE_SESSION_FRAME
+        | FEATURE_STRUCTURED_ERRORS
+        | FEATURE_MESSAGE_FRAGMENTATION;
+    let queues = ByteQueues {
+        left_to_right: left,
+        right_to_left: right,
+    };
+    (
+        Box::new(WireTransportAdapter::new(
+            left_transport,
+            WIRE_PROTOCOL_VERSION,
+            features,
+            Some(session.clone()),
+        )),
+        Box::new(WireTransportAdapter::new(
+            right_transport,
+            WIRE_PROTOCOL_VERSION,
+            features,
+            Some(session),
+        )),
+        queues,
+    )
 }
 
 fn prepare_page<S: OrderedKvStorage + ReopenableStorage + 'static>(

--- a/examples/benchmarks/w1/src/lib.rs
+++ b/examples/benchmarks/w1/src/lib.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeMap;
 
 use jazz::db::{
-    Db, DbConfig, DbIdentity, InsertOptions, LocalUpdates, MergeableTxOps, PreparedQuery,
-    Propagation, ReadOpts, SubscriptionEvent, SubscriptionStream, UpdateOptions, WriteIdentity,
-    block_on,
+    Db, DbConfig, DbIdentity, DeleteOptions, InsertOptions, LocalUpdates, MergeableTxOps,
+    PreparedQuery, Propagation, ReadOpts, RestoreOptions, SubscriptionEvent, SubscriptionStream,
+    UpdateOptions, WriteIdentity, block_on,
 };
 use jazz::groove::records::Value;
 use jazz::groove::storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage};
@@ -38,6 +38,7 @@ pub struct Fixture<S: OrderedKvStorage> {
     maintained_activity: PreparedQuery,
     point_activity: PreparedQuery,
     activity_transition_row: RowUuid,
+    task_transition_row: RowUuid,
     activity_transition_matching: bool,
     activity_update_identity: WriteIdentity,
 }
@@ -266,6 +267,7 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
             maintained_activity,
             point_activity,
             activity_transition_row: row_id(4, PROJECTS),
+            task_transition_row: task_ids[0],
             activity_transition_matching: false,
             activity_update_identity,
         };
@@ -364,6 +366,27 @@ impl<S: OrderedKvStorage + ReopenableStorage + 'static> Fixture<S> {
         .expect("toggle W1 indexed predicate");
         block_on(write.wait(DurabilityTier::Local)).expect("settle W1 indexed predicate toggle");
         self.activity_transition_matching = !self.activity_transition_matching;
+    }
+
+    pub fn delete_target_task(&self) {
+        let write = block_on(self.db.delete(
+            "tasks",
+            self.task_transition_row,
+            DeleteOptions::default(),
+        ))
+        .expect("delete W1 target task");
+        block_on(write.wait(DurabilityTier::Local)).expect("settle W1 target deletion");
+    }
+
+    pub fn restore_target_task(&self) {
+        let write = block_on(self.db.restore(
+            "tasks",
+            self.task_transition_row,
+            None,
+            RestoreOptions::default(),
+        ))
+        .expect("restore W1 target task");
+        block_on(write.wait(DurabilityTier::Local)).expect("settle W1 target restore");
     }
 }
 


### PR DESCRIPTION
🤖 Reconstructs #2126 above replacement #2228, preserving the W1 byte-wire resume benchmark and the covered-resume allocation cleanup on the current core.

## Before

Resumed maintained delivery cloned the complete retained `BTreeSet<ResultMemberEntry>` and collected a vector before checking whether the receiver’s cursor already covered canonical settlement. On the covered path, that allocation was immediately discarded.

## After

The retained set is borrowed for duplicate/removal decisions. Cursor coverage is resolved first; members are cloned only for reset delivery or when their settlement position is newer than a partial cursor. Wire membership, settlement, authorization, and resume semantics are unchanged.

## Example

A client reconnects with a cursor at canonical settlement after subscribing to 500 tasks. The publisher returns no redundant additions/removals and does not first clone all 500 members. With a partial cursor, only members strictly newer than the cursor are emitted. An authorization mismatch still forces the existing complete reset.

## Benchmark

The W1 Divan/CodSpeed receipt prepares database setup, seed writes, initial snapshot, cursor, and a disconnected one-row update outside the timed closure. The measured path is reconnect, catch-up, client application/materialization, and delta observation. The original local receipt showed roughly a 7% improvement at the 4,000-row/500-task profile, identifying this as a useful allocation cleanup rather than the dominant resume cost.

The separate `maintained_rehydrate_scaling` benchmark has a valid timed boundary and equivalence checks, but does not exercise this fast-cursor branch and is not claimed as evidence for this allocation win.

## Verification

- Direct maintained-publisher receipts prove:
  - a fully covered cursor emits no additions/removals and no reset;
  - a partial cursor emits exactly the post-cursor member;
  - authorization mismatch retains reset behavior.
- Changing the strict `settled > cursor` boundary to `>=` makes the covered receipt fail.
- Existing direct and byte-wire resume receipts pass.
- Rust formatting, library Clippy, benchmark compilation, and diff checks pass.

Supersedes #2126. Tracks #2124; setup-size work remains #2125.