### PR TITLE
Wake browser waits on terminal worker transport errors

### DIFF
--- a/crates/jazz/SPEC/13_db_api.md
+++ b/crates/jazz/SPEC/13_db_api.md
@@ -55,6 +55,13 @@ Invariant digest:
   does not weaken the exact node-and-author definition above outside the paired
   browser client/worker boundary.
 
+  A terminal server or protocol transport failure is not an authority fate. A
+  durable browser worker MUST relay it only to currently initialized foreground
+  peers so their active Edge/Global waits and remote subscriptions reject with
+  that transport error; Local durability remains valid. The worker MUST NOT
+  fabricate `Rejected`, roll back local data, invoke `onMutationError`, or
+  replay that transient foreground error to a peer attached later.
+
 ## Details
 
 ### 13.1 Two audiences

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { MessagePortBrowserFollowerConnection } from "./browser-follower-connection.js";
+import type {
+  BrowserFollowerPortEvent,
+  BrowserFollowerPortRequest,
+} from "./browser-worker-protocol.js";
+
+class TestPort {
+  readonly close = vi.fn();
+  readonly start = vi.fn();
+  readonly sent: BrowserFollowerPortRequest[] = [];
+  private readonly listeners = new Map<string, Set<(event: MessageEvent) => void>>();
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  postMessage(message: BrowserFollowerPortRequest): void {
+    this.sent.push(message);
+  }
+
+  emit(event: BrowserFollowerPortEvent): void {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: event } as MessageEvent);
+    }
+  }
+}
+
+describe("MessagePortBrowserFollowerConnection", () => {
+  it("records a relayed transport error before follower disposal without treating it as a mutation rejection", async () => {
+    const port = new TestPort();
+    const transport = {
+      recvWireFrames: () => [],
+      sendWireFrame: () => undefined,
+      tick: () => 0,
+    };
+    const runtime = {
+      connectUpstreamPeer: vi.fn(() => transport),
+      onPeerTransportWork: vi.fn(() => () => undefined),
+      progressPeerTransport: vi.fn(async () => undefined),
+      retirePeerTransport: vi.fn(async () => undefined),
+      reportRemoteServerTransportError: vi.fn(),
+      reportRemoteMutationError: vi.fn(),
+    };
+    const onFailure = vi.fn();
+    const connection = new MessagePortBrowserFollowerConnection(
+      runtime as never,
+      port as unknown as MessagePort,
+      {},
+      null,
+      {
+        onAuthFailure: vi.fn(),
+        onAuthRestored: vi.fn(),
+        onFailure,
+      },
+    );
+
+    const init = port.sent[0];
+    if (!init || init.type !== "init") throw new Error("follower did not initialize");
+    port.emit({ type: "result", id: init.id });
+    await connection.ready();
+
+    port.emit({ type: "transport-error", message: "Protocol: terminal upstream failure" });
+
+    expect(runtime.reportRemoteServerTransportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Protocol: terminal upstream failure" }),
+    );
+    expect(runtime.reportRemoteMutationError).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(port.close).not.toHaveBeenCalled();
+
+    connection.detachForReconnect();
+  });
+});

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
@@ -208,6 +208,13 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
       this.runtime.reportRemoteMutationError(message.event);
       return;
     }
+    if (message.type === "transport-error") {
+      // Keep this distinct from a fate rejection. The runtime records the
+      // error before any later port teardown so active Edge/Global waits and
+      // remote subscriptions wake, while Local durability stays valid.
+      this.runtime.reportRemoteServerTransportError(new Error(message.message));
+      return;
+    }
     if (message.type === "storage-reset") {
       for (const [id, pending] of this.pending) {
         if (pending.type !== "finish-storage-reset") continue;

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
@@ -105,6 +105,12 @@ export type BrowserFollowerPortEvent =
   | { type: "auth-failure"; reason: string }
   | { type: "auth-restored" }
   | { type: "mutation-error"; event: MutationErrorEvent }
+  /**
+   * A terminal failure of the worker-owned upstream server transport. This is
+   * deliberately not a mutation rejection: the follower records it only to
+   * reject its active remote waits and subscriptions.
+   */
+  | { type: "transport-error"; message: string }
   | { type: "storage-reset"; resetId: number }
   | { type: "storage-invalidated" }
   | { type: "relay-trace"; entries: BrowserRelayTrace[] }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -655,6 +655,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private readonly subscriptions = new Map<number, SubscriptionState>();
   private authFailureCallback: ((reason: string) => void) | null = null;
   private mutationErrorCallback: ((event: MutationErrorEvent) => void) | null = null;
+  private serverTransportErrorCallback: ((error: Error) => void) | null = null;
   private readonly deliveredMutationErrors = new Set<string>();
   private serverTransport: Transport | null = null;
   private peerUpstreamAttached = false;
@@ -2129,6 +2130,23 @@ export class NativeRuntimeAdapter implements Runtime {
     this.db.onMutationError((event) => this.deliverMutationError(event));
   }
 
+  /**
+   * Observe a terminal upstream transport/protocol failure. This has no fate
+   * semantics: it only wakes remote waits and subscriptions that are active
+   * in this runtime.
+   */
+  onServerTransportError(callback: (error: Error) => void): void {
+    if (this !== this.ownerRuntime) return this.ownerRuntime.onServerTransportError(callback);
+    this.serverTransportErrorCallback = callback;
+  }
+
+  /** Record a terminal error relayed from a durable browser-worker upstream. */
+  reportRemoteServerTransportError(error: Error): void {
+    if (this !== this.ownerRuntime)
+      return this.ownerRuntime.reportRemoteServerTransportError(error);
+    this.handleServerTransportError(error);
+  }
+
   reportRemoteMutationError(event: MutationErrorEvent): void {
     if (this !== this.ownerRuntime) return this.ownerRuntime.reportRemoteMutationError(event);
     this.deliverMutationError(event);
@@ -3259,9 +3277,11 @@ export class NativeRuntimeAdapter implements Runtime {
     if (generation !== this.serverConnectionGeneration) return;
     const message = errorMessage(error);
     if (this.serverTransportError && message === "websocket closed") return;
+    const isFirstTerminalError = this.serverTransportError === null;
     this.serverTransportError = error instanceof Error ? error : new Error(message);
     this.failActiveSubscriptions(this.serverTransportError);
     this.resolveServerTransportErrorWaiters(this.serverTransportError);
+    if (isFirstTerminalError) this.serverTransportErrorCallback?.(this.serverTransportError);
   }
 
   private finishServerConnectionAttempt(attempt: ServerConnectionAttempt, error: Error): void {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -266,6 +266,96 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(transportTicks).toBeGreaterThanOrEqual(2);
   });
 
+  it("rejects active remote waits and subscriptions for a relayed terminal error without inventing a rejection", async () => {
+    const remoteSettlement = new Promise<void>(() => {});
+    const subscription = {
+      closed: false,
+      readAll: () => [],
+      close() {
+        this.closed = true;
+        return true;
+      },
+    };
+    let nativeMutationError: ((event: unknown) => void) | undefined;
+    const write = {
+      batchId: "00000000000070008000000000000008",
+      payload: new Uint8Array(),
+      rowId: new Uint8Array(16),
+      wait: (tier: string) => (tier === "local" ? Promise.resolve() : remoteSettlement),
+      writeState: () => ({}),
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insertEncoded: () => write,
+            prepareQuery: () => ({}),
+            subscribe: () => subscription,
+            onMutationError: (callback: (event: unknown) => void) => {
+              nativeMutationError = callback;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const mutationErrors = vi.fn();
+    runtime.onMutationError(mutationErrors);
+    expect(nativeMutationError).toBeTypeOf("function");
+    const authoritativeRejection = {
+      code: "permission_denied",
+      reason: "authority rejected the mutation",
+      transaction: {
+        transactionId: "00000000000070008000000000000008",
+        kind: "mergeable",
+        sealed: true,
+        latestSettlement: {
+          kind: "rejected",
+          transactionId: "00000000000070008000000000000008",
+          code: "permission_denied",
+          reason: "authority rejected the mutation",
+        },
+      },
+    };
+    nativeMutationError?.(authoritativeRejection);
+    expect(mutationErrors).toHaveBeenCalledWith(authoritativeRejection);
+    mutationErrors.mockClear();
+
+    const inserted = runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "still locally durable" } },
+      null,
+      "00000000-0000-0000-0000-000000000008",
+    );
+    const batchId = await committedBatchId(inserted);
+    await expect(runtime.waitForTransaction(batchId, "local")).resolves.toBeUndefined();
+
+    const handle = runtime.createSubscription(JSON.stringify({ table: "todos" }), null, "edge");
+    const updates = vi.fn();
+    runtime.executeSubscription(handle, updates);
+    const remoteWait = runtime.waitForTransaction(batchId, "edge");
+    await Promise.resolve();
+
+    runtime.reportRemoteServerTransportError(new Error("Protocol: terminal upstream failure"));
+
+    await expect(remoteWait).rejects.toThrow("Protocol: terminal upstream failure");
+    expect(subscription.closed).toBe(true);
+    expect(updates).toHaveBeenCalledWith(expect.any(Error));
+    const firstUpdate = updates.mock.calls[0];
+    if (!firstUpdate) throw new Error("terminal transport error did not wake subscription");
+    expect((firstUpdate[0] as Error).message).toBe("Protocol: terminal upstream failure");
+    // Unlike the authoritative rejection above, a transport failure has no
+    // fate and must not use the mutation-rejection callback path.
+    expect(mutationErrors).not.toHaveBeenCalled();
+  });
+
   it("retries a pending edge wait when a websocket frame arrives without a native callback", async () => {
     let settled = false;
     let transportTicks = 0;

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -29,6 +29,14 @@ async function committedBatchId(receipt: WriteReceipt): Promise<BatchId> {
   return await receipt.batchId;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("NativeRuntimeAdapter server transport", () => {
   afterEach(() => {
     globalThis.WebSocket = previousWebSocket;
@@ -337,15 +345,17 @@ describe("NativeRuntimeAdapter server transport", () => {
     const batchId = await committedBatchId(inserted);
     await expect(runtime.waitForTransaction(batchId, "local")).resolves.toBeUndefined();
 
-    const handle = runtime.createSubscription(JSON.stringify({ table: "todos" }), null, "edge");
+    const handle = runtime.createSubscription(JSON.stringify({ table: "todos" }), null, "global");
     const updates = vi.fn();
     runtime.executeSubscription(handle, updates);
-    const remoteWait = runtime.waitForTransaction(batchId, "edge");
+    const edgeWait = runtime.waitForTransaction(batchId, "edge");
+    const globalWait = runtime.waitForTransaction(batchId, "global");
     await Promise.resolve();
 
     runtime.reportRemoteServerTransportError(new Error("Protocol: terminal upstream failure"));
 
-    await expect(remoteWait).rejects.toThrow("Protocol: terminal upstream failure");
+    await expect(edgeWait).rejects.toThrow("Protocol: terminal upstream failure");
+    await expect(globalWait).rejects.toThrow("Protocol: terminal upstream failure");
     expect(subscription.closed).toBe(true);
     expect(updates).toHaveBeenCalledWith(expect.any(Error));
     const firstUpdate = updates.mock.calls[0];
@@ -354,6 +364,66 @@ describe("NativeRuntimeAdapter server transport", () => {
     // Unlike the authoritative rejection above, a transport failure has no
     // fate and must not use the mutation-rejection callback path.
     expect(mutationErrors).not.toHaveBeenCalled();
+  });
+
+  it("delivers a terminal error to armed Edge and Global waits before reconnect clears transport state", async () => {
+    const remoteSettlement = deferred<void>();
+    const remoteWaitsArmed = deferred<void>();
+    let remoteWaits = 0;
+    const write = {
+      batchId: "00000000000070008000000000000009",
+      payload: new Uint8Array(),
+      rowId: new Uint8Array(16),
+      wait: (tier: string) => {
+        if (tier === "local") return Promise.resolve();
+        remoteWaits += 1;
+        if (remoteWaits === 2) remoteWaitsArmed.resolve();
+        return remoteSettlement.promise;
+      },
+      writeState: () => ({}),
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insertEncoded: () => write,
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const inserted = runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "terminal beats reconnect clear" } },
+      null,
+      "00000000-0000-0000-0000-000000000009",
+    );
+    const batchId = await committedBatchId(inserted);
+    const edgeWait = runtime.waitForTransaction(batchId, "edge");
+    const globalWait = runtime.waitForTransaction(batchId, "global");
+
+    // This event barrier proves both remote waits reached the terminal waiter
+    // registration point before the failure and replacement race begins.
+    await remoteWaitsArmed.promise;
+    expect(
+      (runtime as unknown as { serverTransportErrorWaiters: unknown[] })
+        .serverTransportErrorWaiters,
+    ).toHaveLength(2);
+
+    runtime.reportRemoteServerTransportError(new Error("Protocol: terminal before reconnect"));
+    const replacement = runtime.disconnect({ rejectWaiters: false });
+    remoteSettlement.resolve();
+    await replacement;
+
+    await expect(edgeWait).rejects.toThrow("Protocol: terminal before reconnect");
+    await expect(globalWait).rejects.toThrow("Protocol: terminal before reconnect");
   });
 
   it("retries a pending edge wait when a websocket frame arrives without a native callback", async () => {

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -66,6 +66,7 @@ const mocks = vi.hoisted(() => {
           discard: vi.fn(),
           onAuthFailure: vi.fn(),
           onMutationError: vi.fn(),
+          onServerTransportError: vi.fn(),
           onPeerTransportWork: vi.fn(() => () => {}),
           progressPeerTransport: vi.fn(async () => undefined),
           retirePeerTransport: vi.fn(async () => undefined),
@@ -515,6 +516,45 @@ describe("broker worker context initialization", () => {
     late.port.emitMessage({ type: "init", id: 1, sessionClaims: {} });
     expect(await offline).toMatchObject({ explicitlyDisconnected: true });
     await initialized;
+  });
+
+  it("relays a terminal server error only to active followers and never replays it", async () => {
+    const initOptions = { ...options("terminal-error-continuity"), serverUrl: "ws://server.test" };
+    const owner = await connect(initOptions, "owner-tab");
+    const successor = await connect(initOptions, "successor-tab");
+    await initializeFollower(owner.port, 1);
+    await initializeFollower(successor.port, 1);
+
+    const late = await connect(initOptions, "late-tab");
+    const runtime = mocks.runtimes[0]!;
+    const callback = runtime.onServerTransportError.mock.calls[0]?.[0] as
+      | ((error: Error) => void)
+      | undefined;
+    expect(callback).toBeTypeOf("function");
+    callback?.(new Error("Protocol: terminal maintained view failure"));
+
+    for (const port of [owner.port, successor.port]) {
+      await expect(port.waitForEvent((event) => event.type === "transport-error")).resolves.toEqual(
+        {
+          type: "transport-error",
+          message: "Protocol: terminal maintained view failure",
+        },
+      );
+    }
+    expect(late.port.hasEvent((event) => event.type === "transport-error")).toBe(false);
+
+    owner.port.emitMessage({
+      type: "reconnect",
+      id: 2,
+      authJson: "{}",
+      sessionClaims: {},
+    });
+    await owner.port.waitForEvent((event) => event.type === "result" && event.id === 2);
+    await initializeFollower(late.port, 1);
+    // A reconnect/admission completed after the terminal observation starts a
+    // successor runtime, not a recipient for an old foreground error.
+    await Promise.resolve();
+    expect(late.port.hasEvent((event) => event.type === "transport-error")).toBe(false);
   });
 
   it("cancels a closed peer's offline server wait", async () => {

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -222,6 +222,15 @@ async function initialize(context: RuntimeContext): Promise<void> {
         post(peer.port, { type: "mutation-error", event: received }),
       );
     });
+    context.runtime.onServerTransportError((error) => {
+      // Transport failures are foreground events, not authority fates or
+      // durable notifications. Only peers that have completed admission own a
+      // tab runtime capable of rejecting an active remote wait.
+      for (const peer of context.peers.values()) {
+        if (!peer.subscriber || !peer.pump) continue;
+        post(peer.port, { type: "transport-error", message: error.message });
+      }
+    });
     if (options.logLevel === "trace") {
       context.disposeAuxiliaryTrace = context.runtime.onAuxiliaryTrace((entries) => {
         broadcast(context, {


### PR DESCRIPTION
🤖 Fixes the persistent-worker liveness boundary from #2207 without turning transport failure into transaction rejection or durable notification history.

## Before

A direct runtime records a terminal upstream server/protocol error and wakes active Edge/Global waits. In the persistent browser topology, that direct runtime lives inside the worker. The worker had no error path to already-attached tabs, so a tab could remain forever inside `WriteHandle.wait(Edge|Global)` after its upstream had terminally failed. A later reconnect did not reliably wake that existing wait.

## After

The worker sends a distinct transient `transport-error` event only to currently initialized peers. The follower records it in its tab-side `NativeRuntimeAdapter` before disposal, which rejects active Edge/Global waits and remote subscriptions using the same terminal-error machinery as a direct runtime.

## Behavioral boundaries

- The error is not `Fate::Rejected`, does not roll back state, and does not invoke `onMutationError`.
- A locally durable write and Local wait remain valid.
- A real authoritative rejection still uses `PersistedWriteRejectedError`.
- A runtime attached later receives reconciled durable state but no replayed historical toast/error.
- Ordinary offline/disconnected state is not treated as terminal protocol failure.

## Example

A tab writes locally through its persistent worker and begins waiting for Edge settlement. Core then returns a terminal protocol error before fate. The worker notifies that attached tab; its active Edge wait rejects promptly with the transport error. If the tab was closed and a new tab opens later, the new tab sees the worker’s corrected durable state but does not receive an old error notification.

## Verification

- Worker broadcast, follower bridge, active wait/subscription, Local preservation, fate-rejection distinction, reconnect race, and no-replay receipts pass (32 focused tests).
- Planted missing worker/follower propagation makes the focused receipts fail.
- Jazz Tools typecheck passes.
- Normative topology/API note records foreground notification versus durable reconciliation.

Fixes #2207.