### PR TITLE
Replace postcard branch-key storage encoding

### DIFF
--- a/crates/jazz/SPEC/11_branch_views_time_travel.md
+++ b/crates/jazz/SPEC/11_branch_views_time_travel.md
@@ -138,6 +138,43 @@ branch-specific declaration or binding abstraction.
 The empty branch key denotes shared data. It is not a privileged root branch key and
 has no lifecycle semantics (`INV-BVIEW-7`).
 
+#### Canonical branch-coordinate codec
+
+Branch coordinates use an engine-owned binary codec, not the serde layout of
+`groove::Value`, `BranchColumnValue`, or `BranchKey`. A branch-column envelope is:
+
+```text
+codec_version:u8 = 1
+scalar_tag:u8
+groove_value_bytes:remaining bytes
+```
+
+The scalar tags are permanently assigned as `0=U8`, `1=U16`, `2=U32`,
+`3=U64`, `4=I32`, `5=I64`, `6=String`, `7=Uuid`, and `8=EnumTag`.
+The payload is Groove's canonical single-field encoding under the schema-declared
+column type. Selector construction may infer a scalar type before table projection;
+projection MUST decode that value and re-encode it under the selected table's
+declared type. In particular, a string selector for a stable enum becomes the
+declared enum discriminant rather than retaining a Rust value-enum tag.
+
+An exact branch key is:
+
+```text
+codec_version:u8 = 1
+entry_count:u32 little-endian
+repeated entry_count times:
+  name_byte_length:u32 little-endian
+  name_utf8:name_byte_length bytes
+  value_byte_length:u32 little-endian
+  branch_column_envelope:value_byte_length bytes
+```
+
+Entries MUST be strictly ordered by column name, with no duplicates or trailing
+bytes. Decoders reject unknown versions, scalar tags, non-canonical Groove
+payloads, invalid UTF-8 names, invalid lengths, and non-increasing names. A new
+codec version is a storage-format migration boundary; legacy serde/postcard bytes
+are not guessed from shape.
+
 #### Branch-local row identity
 
 `RowUuid` remains the stable application object identity. The same `RowUuid` may

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -6,6 +6,7 @@
 //! node-level read layer over groove tables.
 
 use super::*;
+use crate::schema::RuntimeSchema;
 
 impl<S> NodeState<S>
 where
@@ -837,7 +838,8 @@ where
             };
             let logical_table = self.table_in_schema(&stored_table, schema_version)?;
             let descriptor = logical_table.register_storage_table().record_schema();
-            let branch_key = BranchKey::from_canonical_bytes(
+            let branch_key = RuntimeSchema::decode_persisted_branch_key(
+                &logical_table,
                 record
                     .borrowed()
                     .get_bytes(SharedDeletionHistoryRowRecord::FIELD_BRANCH_KEY_IDX)?,
@@ -855,19 +857,19 @@ where
         }
         let record_view = record.borrowed();
         let is_deletion = record_view.descriptor().field_index("_deletion").is_some();
+        let schema_alias = SchemaVersionAlias(record_view.get_u64(if is_deletion {
+            RegisterRowRecord::FIELD_SCHEMA_VERSION_IDX
+        } else {
+            HistoryRowRecord::FIELD_SCHEMA_VERSION_IDX
+        })?);
+        let schema_version =
+            self.schema_version_for_alias(schema_alias)
+                .ok_or(Error::InvalidStoredValue(
+                    "version storage schema version alias must exist",
+                ))?;
         let table = if !storage_table.starts_with("jazz_physical_") {
             requested_table.to_owned()
         } else {
-            let alias = SchemaVersionAlias(record_view.get_u64(if is_deletion {
-                RegisterRowRecord::FIELD_SCHEMA_VERSION_IDX
-            } else {
-                HistoryRowRecord::FIELD_SCHEMA_VERSION_IDX
-            })?);
-            let schema_version =
-                self.schema_version_for_alias(alias)
-                    .ok_or(Error::InvalidStoredValue(
-                        "version storage schema version alias must exist",
-                    ))?;
             self.catalogue
                 .physical_mappings
                 .get(&schema_version)
@@ -885,6 +887,7 @@ where
                     "physical version storage logical table mapping missing",
                 ))?
         };
+        let table_schema = self.table_in_schema(&table, schema_version)?;
         let record = record.borrowed();
         let tx_node_alias = if is_deletion {
             NodeAlias(record.get_u64(RegisterRowRecord::FIELD_TX_NODE_ID_IDX)?)
@@ -906,11 +909,14 @@ where
         let _ = TxId::new(tx_time, tx_node);
         Ok(VersionRow {
             table: groove::Intern::new(table),
-            branch_key: BranchKey::from_canonical_bytes(record.get_bytes(if is_deletion {
-                RegisterRowRecord::FIELD_BRANCH_KEY_IDX
-            } else {
-                HistoryRowRecord::FIELD_BRANCH_KEY_IDX
-            })?)
+            branch_key: RuntimeSchema::decode_persisted_branch_key(
+                &table_schema,
+                record.get_bytes(if is_deletion {
+                    RegisterRowRecord::FIELD_BRANCH_KEY_IDX
+                } else {
+                    HistoryRowRecord::FIELD_BRANCH_KEY_IDX
+                })?,
+            )
             .map_err(|_| Error::InvalidStoredValue("invalid stored branch key"))?,
             record: OwnedRecord::new(record.raw().to_vec(), record.descriptor()),
         })

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -23,7 +23,7 @@ use crate::protocol::{
     BranchKey, ProgramFactEntry, RealRowMemberEntry, RelationEdgeEntry, ResultMemberEntry,
     ResultMemberPayloadEntry, ResultRowLayer, RowVersionRefEntry, SyntheticReplacementToken,
 };
-use crate::schema::TableSchema;
+use crate::schema::{RuntimeSchema, TableSchema};
 use crate::time::{GlobalTime, TxTime};
 use crate::tools::{ObjectId, OutputOccurrenceId};
 use crate::tx::TxId;
@@ -1489,14 +1489,16 @@ fn decode_typed_version_witness(
     let tx_time = TxTime(record_u64_idx(record, plan.tx_time_idx)?);
     let branch_key = match plan.branch_idx {
         Some(idx) => match record.get_idx(idx)? {
-            Value::Bytes(bytes) => BranchKey::from_canonical_bytes(&bytes).map_err(|_| {
-                super::Error::InvalidStoredValue("maintained witness branch key is invalid")
-            })?,
-            Value::Nullable(None) => BranchKey::default(),
-            Value::Nullable(Some(value)) => match *value {
-                Value::Bytes(bytes) => BranchKey::from_canonical_bytes(&bytes).map_err(|_| {
+            Value::Bytes(bytes) => RuntimeSchema::decode_persisted_branch_key(table, &bytes)
+                .map_err(|_| {
                     super::Error::InvalidStoredValue("maintained witness branch key is invalid")
                 })?,
+            Value::Nullable(None) => BranchKey::default(),
+            Value::Nullable(Some(value)) => match *value {
+                Value::Bytes(bytes) => RuntimeSchema::decode_persisted_branch_key(table, &bytes)
+                    .map_err(|_| {
+                        super::Error::InvalidStoredValue("maintained witness branch key is invalid")
+                    })?,
                 _ => return Err(super::Error::InvalidStoredValue("branch key must be bytes")),
             },
             _ => return Err(super::Error::InvalidStoredValue("branch key must be bytes")),

--- a/crates/jazz/src/node/source_resolution.rs
+++ b/crates/jazz/src/node/source_resolution.rs
@@ -98,8 +98,15 @@ where
                         .columns
                         .iter()
                         .find(|column| column.name == *column_name)
-                        .and_then(|column| column.default.clone())
-                        .map(crate::protocol::BranchColumnValue::from);
+                        .and_then(|column| {
+                            column.default.as_ref().map(|value| {
+                                crate::protocol::BranchColumnValue::encode_typed(
+                                    value,
+                                    &column.column_type,
+                                )
+                                .expect("validated branch default")
+                            })
+                        });
                     selected_by_physical.get(physical) != default.as_ref()
                 });
             if missing_branch_value_is_non_default {

--- a/crates/jazz/src/node/state/contribution_merge.rs
+++ b/crates/jazz/src/node/state/contribution_merge.rs
@@ -28,13 +28,48 @@ where
             .schema
             .clone();
         let full_key = |selector: &BranchSelector| -> Result<BranchKey, Error> {
-            let branch_columns = schema.tables.iter().flat_map(|table| table.branch_by.iter().cloned()).collect::<BTreeSet<_>>();
-            if selector.values.keys().cloned().collect::<BTreeSet<_>>() != branch_columns {
+            let branch_columns = schema
+                .tables
+                .iter()
+                .flat_map(|table| {
+                    table.branch_by.iter().map(|name| {
+                        let column = table
+                            .columns
+                            .iter()
+                            .find(|column| column.name == *name)
+                            .expect("validated branch column");
+                        (name.clone(), column.column_type.clone())
+                    })
+                })
+                .collect::<BTreeMap<_, _>>();
+            if selector.values.keys().collect::<BTreeSet<_>>()
+                != branch_columns.keys().collect::<BTreeSet<_>>()
+            {
                 return Err(Error::InvalidBranchKey(
                     "contribution selector must bind every schema branch column".to_owned(),
                 ));
             }
-            let values = selector.values.iter().map(|(name, value)| (name.clone(), value.clone())).collect();
+            let values = selector
+                .values
+                .iter()
+                .map(|(name, encoded)| {
+                    let value = encoded.decode().map_err(|_| {
+                        Error::InvalidBranchKey(format!(
+                            "invalid contribution branch column {name} encoding"
+                        ))
+                    })?;
+                    let encoded = crate::protocol::BranchColumnValue::encode_typed(
+                        &value,
+                        &branch_columns[name],
+                    )
+                    .map_err(|_| {
+                        Error::InvalidBranchKey(format!(
+                            "invalid contribution branch column {name} value"
+                        ))
+                    })?;
+                    Ok((name.clone(), encoded))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
             Ok(BranchKey { values })
         };
         let source_full = full_key(&request.source)?;

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -702,6 +702,120 @@ fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     assert!(node.query_table_versions("todos").unwrap().is_empty());
 }
 
+#[test]
+fn branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen() {
+    let schema = branch_view_schema();
+    let branch = branch_selector(0x70);
+    let row_uuid = row(0x71);
+    let cells = || {
+        BTreeMap::from([
+            ("title".to_owned(), v("branch receipt")),
+            ("owner".to_owned(), Value::Uuid(uuid::Uuid::nil())),
+        ])
+    };
+
+    // Memory uses the same physical row projections as durable backends. This
+    // first receipt catches a writer that only updates one implementation.
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = MemoryStorage::new(&refs).unwrap();
+    let mut memory = NodeState::new_history_complete(node(0x70), schema.clone(), storage).unwrap();
+    memory
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 10)
+                .branch(branch.clone())
+                .cells(cells()),
+        )
+        .unwrap();
+    memory
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 20)
+                .branch(branch.clone())
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    assert_eq!(
+        memory
+            .query_row_versions_in_branch("todos", &schema.project_branch_view_selector(&schema.tables[0], &branch).unwrap().0, row_uuid)
+            .unwrap()
+            .len(),
+        2,
+        "history and deletion projections share the same exact branch coordinate"
+    );
+
+    let (dir, mut rocks) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x72; 16]), schema.clone());
+    rocks
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 10)
+                .branch(branch.clone())
+                .cells(cells()),
+        )
+        .unwrap();
+    rocks
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 20)
+                .branch(branch.clone())
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+
+    let key = schema
+        .project_branch_view_selector(&schema.tables[0], &branch)
+        .unwrap()
+        .0;
+    let table_id = rocks.catalogue.physical_mappings[&schema.version_id()].tables["todos"].table_id;
+    let prefix = vec![Value::Bytes(key.canonical_bytes())];
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(&physical_history_table_name(table_id), &prefix)
+            .unwrap()
+            .len(),
+        1,
+        "content history is addressed by the canonical branch prefix"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(
+                SHARED_DELETION_HISTORY_TABLE,
+                &[Value::Bytes(key.canonical_bytes()), Value::U64(table_id.0)],
+            )
+            .unwrap()
+            .len(),
+        1,
+        "deletion history is addressed by the same canonical branch prefix"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(&physical_global_current_table_name(table_id), &prefix)
+            .unwrap()
+            .len(),
+        1,
+        "current and index-backed query projections retain that branch prefix"
+    );
+    drop(rocks);
+
+    let mut reopened = reopen_history_complete_node_at(&dir, NodeUuid::from_bytes([0x72; 16]), schema.clone());
+    assert_eq!(
+        reopened
+            .query_row_versions_in_branch("todos", &key, row_uuid)
+            .unwrap()
+            .len(),
+        2,
+        "reopen decodes the exact branch coordinate for both layers"
+    );
+    assert!(
+        reopened
+            .visible_current_cells_in_branch("todos", &branch, row_uuid)
+            .unwrap()
+            .is_none(),
+        "the reopened deletion current projection still masks the content row"
+    );
+}
+
 // This is necessarily an internal protocol-boundary regression test: public
 // mutation APIs canonicalize branch selectors and therefore cannot construct
 // the adversarial VersionRecord values a remote peer may send.

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -745,14 +745,14 @@ fn branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen(
 
     let (dir, mut rocks) =
         open_history_complete_node_with_schema(NodeUuid::from_bytes([0x72; 16]), schema.clone());
-    rocks
+    let content_tx = rocks
         .commit_mergeable_settled(
             MergeableCommit::new("todos", row_uuid, 10)
                 .branch(branch.clone())
                 .cells(cells()),
         )
         .unwrap();
-    rocks
+    let deletion_tx = rocks
         .commit_mergeable_settled(
             MergeableCommit::new("todos", row_uuid, 20)
                 .branch(branch.clone())
@@ -790,11 +790,62 @@ fn branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen(
     assert_eq!(
         rocks
             .database
+            .primary_key_scan_raw(&physical_ahead_current_table_name(table_id), &prefix)
+            .unwrap()
+            .len(),
+        1,
+        "locally settled content uses the canonical branch prefix in ahead-current"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(
+                &physical_register_ahead_current_table_name(table_id),
+                &prefix,
+            )
+            .unwrap()
+            .len(),
+        1,
+        "locally settled deletion uses the same prefix in register ahead-current"
+    );
+
+    rocks
+        .apply_fate_update(
+            content_tx,
+            Fate::Accepted,
+            Some(GlobalTime(1)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+    rocks
+        .apply_fate_update(
+            deletion_tx,
+            Fate::Accepted,
+            Some(GlobalTime(2)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+
+    assert_eq!(
+        rocks
+            .database
             .primary_key_scan_raw(&physical_global_current_table_name(table_id), &prefix)
             .unwrap()
             .len(),
         1,
-        "current and index-backed query projections retain that branch prefix"
+        "globally accepted content retains the canonical branch prefix in global-current"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(
+                &physical_register_global_current_table_name(table_id),
+                &prefix,
+            )
+            .unwrap()
+            .len(),
+        1,
+        "globally accepted deletion retains the same prefix in register global-current"
     );
     drop(rocks);
 

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 use groove::large_values::Locator;
-use groove::records::{OwnedRecord, Value};
+use groove::records::{OwnedRecord, RecordDescriptor, Value, ValueType};
 
 use crate::ids::{
     AuthorSubject, MigrationLensId, NodeUuid, RowUuid, SchemaLineagePublicationId, SchemaVersionId,
@@ -1790,7 +1790,41 @@ impl BranchViewBase {
     }
 }
 
+/// Error decoding the frozen branch-coordinate codec.
+#[derive(Debug, thiserror::Error)]
+pub enum BranchCodecError {
+    /// The envelope version, tag, length, ordering, or payload is invalid.
+    #[error("invalid branch codec envelope")]
+    InvalidEnvelope,
+    /// The supplied value or declared column type cannot be a branch column.
+    #[error("unsupported branch column type")]
+    UnsupportedType,
+    /// The encoded scalar tag does not match the declared schema type.
+    #[error("branch column encoding does not match its declared type")]
+    TypeMismatch,
+    /// Groove rejected the declared-type payload.
+    #[error("invalid Groove branch column payload: {0}")]
+    Groove(#[from] groove::records::Error),
+}
+
+const BRANCH_COLUMN_CODEC_VERSION: u8 = 1;
+const BRANCH_COLUMN_U8: u8 = 0;
+const BRANCH_COLUMN_U16: u8 = 1;
+const BRANCH_COLUMN_U32: u8 = 2;
+const BRANCH_COLUMN_U64: u8 = 3;
+const BRANCH_COLUMN_I32: u8 = 4;
+const BRANCH_COLUMN_I64: u8 = 5;
+const BRANCH_COLUMN_STRING: u8 = 6;
+const BRANCH_COLUMN_UUID: u8 = 7;
+const BRANCH_COLUMN_ENUM_TAG: u8 = 8;
+
 /// Canonical wire/storage encoding of one branch-column value.
+///
+/// Byte zero is the codec version, byte one is a permanently assigned scalar
+/// tag, and the remainder is the canonical Groove encoding under the declared
+/// column type. Keeping the tag outside Groove lets a selector cross the wire
+/// before a table is chosen while exact [`BranchKey`] construction still
+/// re-encodes and validates the payload against that table's schema.
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize,
 )]
@@ -1798,16 +1832,112 @@ pub struct BranchColumnValue(pub Vec<u8>);
 
 impl From<Value> for BranchColumnValue {
     fn from(value: Value) -> Self {
-        Self(postcard::to_allocvec(&value).expect("branch column values are encodable"))
+        let value_type = match &value {
+            Value::U8(_) => ValueType::U8,
+            Value::U16(_) => ValueType::U16,
+            Value::U32(_) => ValueType::U32,
+            Value::U64(_) => ValueType::U64,
+            Value::I32(_) => ValueType::I32,
+            Value::I64(_) => ValueType::I64,
+            Value::String(_) => ValueType::String,
+            Value::Uuid(_) => ValueType::Uuid,
+            Value::EnumTag(tag) => {
+                return Self(vec![
+                    BRANCH_COLUMN_CODEC_VERSION,
+                    BRANCH_COLUMN_ENUM_TAG,
+                    *tag,
+                ]);
+            }
+            // Preserve `BranchSelector::new` as an infallible constructor.
+            // Schema projection rejects this unknown tag before it can become
+            // an exact key or persistent coordinate.
+            _ => return Self(vec![BRANCH_COLUMN_CODEC_VERSION, u8::MAX]),
+        };
+        Self::encode_typed(&value, &value_type)
+            .expect("inferred branch selector type accepts its value")
     }
 }
 
 impl BranchColumnValue {
-    /// Decode the value for validation and ordinary column projection.
-    pub fn decode(&self) -> Result<Value, postcard::Error> {
-        postcard::from_bytes(&self.0)
+    /// Encode one value using its schema-declared Groove column type.
+    pub(crate) fn encode_typed(
+        value: &Value,
+        value_type: &ValueType,
+    ) -> Result<Self, BranchCodecError> {
+        let tag = branch_column_tag(value_type).ok_or(BranchCodecError::UnsupportedType)?;
+        let descriptor = RecordDescriptor::new([("value", value_type.clone())]);
+        let payload = descriptor.create(std::slice::from_ref(value))?;
+        let mut bytes = Vec::with_capacity(2 + payload.len());
+        bytes.extend([BRANCH_COLUMN_CODEC_VERSION, tag]);
+        bytes.extend(payload);
+        Ok(Self(bytes))
+    }
+
+    /// Decode a selector value before a table-specific type is available.
+    pub fn decode(&self) -> Result<Value, BranchCodecError> {
+        let (tag, payload) = self.envelope()?;
+        if tag == BRANCH_COLUMN_ENUM_TAG {
+            return match payload {
+                [tag] => Ok(Value::EnumTag(*tag)),
+                _ => Err(BranchCodecError::InvalidEnvelope),
+            };
+        }
+        let value_type = branch_column_type(tag).ok_or(BranchCodecError::InvalidEnvelope)?;
+        self.decode_as(&value_type)
+    }
+
+    /// Decode and canonically validate an exact key value against its schema.
+    pub(crate) fn decode_as(&self, value_type: &ValueType) -> Result<Value, BranchCodecError> {
+        let (tag, payload) = self.envelope()?;
+        if branch_column_tag(value_type) != Some(tag) {
+            return Err(BranchCodecError::TypeMismatch);
+        }
+        let descriptor = RecordDescriptor::new([("value", value_type.clone())]);
+        let value = descriptor.get_idx(payload, 0)?;
+        if descriptor.create(std::slice::from_ref(&value))? != payload {
+            return Err(BranchCodecError::InvalidEnvelope);
+        }
+        Ok(value)
+    }
+
+    fn envelope(&self) -> Result<(u8, &[u8]), BranchCodecError> {
+        match self.0.as_slice() {
+            [BRANCH_COLUMN_CODEC_VERSION, tag, payload @ ..] => Ok((*tag, payload)),
+            _ => Err(BranchCodecError::InvalidEnvelope),
+        }
     }
 }
+
+fn branch_column_tag(value_type: &ValueType) -> Option<u8> {
+    match value_type {
+        ValueType::U8 => Some(BRANCH_COLUMN_U8),
+        ValueType::U16 => Some(BRANCH_COLUMN_U16),
+        ValueType::U32 => Some(BRANCH_COLUMN_U32),
+        ValueType::U64 => Some(BRANCH_COLUMN_U64),
+        ValueType::I32 => Some(BRANCH_COLUMN_I32),
+        ValueType::I64 => Some(BRANCH_COLUMN_I64),
+        ValueType::String => Some(BRANCH_COLUMN_STRING),
+        ValueType::Uuid => Some(BRANCH_COLUMN_UUID),
+        ValueType::EnumTag(_) => Some(BRANCH_COLUMN_ENUM_TAG),
+        _ => None,
+    }
+}
+
+fn branch_column_type(tag: u8) -> Option<ValueType> {
+    match tag {
+        BRANCH_COLUMN_U8 => Some(ValueType::U8),
+        BRANCH_COLUMN_U16 => Some(ValueType::U16),
+        BRANCH_COLUMN_U32 => Some(ValueType::U32),
+        BRANCH_COLUMN_U64 => Some(ValueType::U64),
+        BRANCH_COLUMN_I32 => Some(ValueType::I32),
+        BRANCH_COLUMN_I64 => Some(ValueType::I64),
+        BRANCH_COLUMN_STRING => Some(ValueType::String),
+        BRANCH_COLUMN_UUID => Some(ValueType::Uuid),
+        _ => None,
+    }
+}
+
+const BRANCH_KEY_CODEC_VERSION: u8 = 1;
 
 /// Exact, table-projected branch coordinate carried by every row version.
 #[derive(
@@ -1830,13 +1960,77 @@ pub struct BranchKey {
 impl BranchKey {
     /// Canonical bytes used as the physical branch-local row-key prefix.
     pub fn canonical_bytes(&self) -> Vec<u8> {
-        postcard::to_allocvec(self).expect("branch keys are encodable")
+        assert!(
+            self.values.windows(2).all(|pair| pair[0].0 < pair[1].0),
+            "branch keys require strictly ordered unique column names"
+        );
+        let mut bytes = Vec::new();
+        bytes.push(BRANCH_KEY_CODEC_VERSION);
+        put_branch_component_len(&mut bytes, self.values.len());
+        for (name, value) in &self.values {
+            put_branch_component_len(&mut bytes, name.len());
+            bytes.extend(name.as_bytes());
+            put_branch_component_len(&mut bytes, value.0.len());
+            bytes.extend(&value.0);
+        }
+        bytes
     }
 
     /// Decode a persisted exact branch key.
-    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
-        postcard::from_bytes(bytes)
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, BranchCodecError> {
+        let [BRANCH_KEY_CODEC_VERSION, rest @ ..] = bytes else {
+            return Err(BranchCodecError::InvalidEnvelope);
+        };
+        let mut cursor = rest;
+        let count = take_branch_component_len(&mut cursor)?;
+        if count > cursor.len() / 8 {
+            return Err(BranchCodecError::InvalidEnvelope);
+        }
+        let mut values = Vec::with_capacity(count);
+        for _ in 0..count {
+            let name_len = take_branch_component_len(&mut cursor)?;
+            let name = take_branch_component(&mut cursor, name_len)?;
+            let name = std::str::from_utf8(name)
+                .map_err(|_| BranchCodecError::InvalidEnvelope)?
+                .to_owned();
+            let value_len = take_branch_component_len(&mut cursor)?;
+            let value = BranchColumnValue(take_branch_component(&mut cursor, value_len)?.to_vec());
+            value.decode()?;
+            if values.last().is_some_and(|(previous, _)| previous >= &name) {
+                return Err(BranchCodecError::InvalidEnvelope);
+            }
+            values.push((name, value));
+        }
+        if !cursor.is_empty() {
+            return Err(BranchCodecError::InvalidEnvelope);
+        }
+        Ok(Self { values })
     }
+}
+
+fn put_branch_component_len(bytes: &mut Vec<u8>, len: usize) {
+    let len = u32::try_from(len).expect("branch codec component exceeds u32");
+    bytes.extend(len.to_le_bytes());
+}
+
+fn take_branch_component_len(cursor: &mut &[u8]) -> Result<usize, BranchCodecError> {
+    let encoded = take_branch_component(cursor, 4)?;
+    Ok(u32::from_le_bytes(
+        encoded
+            .try_into()
+            .map_err(|_| BranchCodecError::InvalidEnvelope)?,
+    ) as usize)
+}
+
+fn take_branch_component<'a>(
+    cursor: &mut &'a [u8],
+    len: usize,
+) -> Result<&'a [u8], BranchCodecError> {
+    let (value, rest) = cursor
+        .split_at_checked(len)
+        .ok_or(BranchCodecError::InvalidEnvelope)?;
+    *cursor = rest;
+    Ok(value)
 }
 
 /// Optional base composed underneath the live head of a branch view.
@@ -3226,6 +3420,51 @@ mod tests {
 
     fn schema_id(byte: u8) -> SchemaVersionId {
         SchemaVersionId::from_bytes([byte; 16])
+    }
+
+    // This is intentionally an internal byte-level test: the durable physical
+    // identity is not observable through the public row API, and a behavioral
+    // round trip alone would not freeze the assigned version, tags, or widths.
+    #[test]
+    fn branch_coordinate_codec_has_frozen_declared_type_bytes() {
+        let integer =
+            BranchColumnValue::encode_typed(&Value::U32(0x0102_0304), &ValueType::U32).unwrap();
+        let string =
+            BranchColumnValue::encode_typed(&Value::String("hi".to_owned()), &ValueType::String)
+                .unwrap();
+        assert_eq!(integer.0, [1, 2, 4, 3, 2, 1]);
+        assert_eq!(string.0, [1, 6, 2, b'h', b'i']);
+
+        let stable_enum = ValueType::EnumTag(
+            groove::records::ScalarEnumSchema::new("phase", ["draft", "ready"]).unwrap(),
+        );
+        let enum_value =
+            BranchColumnValue::encode_typed(&Value::String("ready".to_owned()), &stable_enum)
+                .unwrap();
+        assert_eq!(enum_value.0, [1, 8, 1]);
+        assert_eq!(
+            enum_value.decode_as(&stable_enum).unwrap(),
+            Value::EnumTag(1)
+        );
+
+        let key = BranchKey {
+            values: vec![("a".to_owned(), integer), ("z".to_owned(), string)],
+        };
+        let expected = [
+            1, // key codec version
+            2, 0, 0, 0, // entry count
+            1, 0, 0, 0, b'a', // first name
+            6, 0, 0, 0, 1, 2, 4, 3, 2, 1, // first value
+            1, 0, 0, 0, b'z', // second name
+            5, 0, 0, 0, 1, 6, 2, b'h', b'i', // second value
+        ];
+        assert_eq!(key.canonical_bytes(), expected);
+        assert_eq!(BranchKey::from_canonical_bytes(&expected).unwrap(), key);
+
+        let mut trailing = expected.to_vec();
+        trailing.push(0);
+        assert!(BranchKey::from_canonical_bytes(&trailing).is_err());
+        assert!(BranchKey::from_canonical_bytes(&[0]).is_err());
     }
 
     #[test]

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -3465,6 +3465,29 @@ mod tests {
         trailing.push(0);
         assert!(BranchKey::from_canonical_bytes(&trailing).is_err());
         assert!(BranchKey::from_canonical_bytes(&[0]).is_err());
+
+        let append_entry = |bytes: &mut Vec<u8>, name: &str, value: &[u8]| {
+            bytes.extend((name.len() as u32).to_le_bytes());
+            bytes.extend(name.as_bytes());
+            bytes.extend((value.len() as u32).to_le_bytes());
+            bytes.extend(value);
+        };
+        let mut duplicate = vec![1];
+        duplicate.extend(2_u32.to_le_bytes());
+        append_entry(&mut duplicate, "a", &[1, 0, 7]);
+        append_entry(&mut duplicate, "a", &[1, 0, 8]);
+        assert!(BranchKey::from_canonical_bytes(&duplicate).is_err());
+
+        let mut descending = vec![1];
+        descending.extend(2_u32.to_le_bytes());
+        append_entry(&mut descending, "z", &[1, 0, 7]);
+        append_entry(&mut descending, "a", &[1, 0, 8]);
+        assert!(BranchKey::from_canonical_bytes(&descending).is_err());
+
+        let mut unknown_tag = vec![1];
+        unknown_tag.extend(1_u32.to_le_bytes());
+        append_entry(&mut unknown_tag, "a", &[1, u8::MAX]);
+        assert!(BranchKey::from_canonical_bytes(&unknown_tag).is_err());
     }
 
     #[test]

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -311,6 +311,33 @@ impl RuntimeSchema {
         table: &TableSchema,
         key: &BranchKey,
     ) -> Result<BTreeMap<String, Value>, String> {
+        Self::validate_branch_key_for_table(table, key)
+    }
+
+    /// Decode one persisted branch coordinate using the table that owns it.
+    ///
+    /// The binary envelope is only self-describing enough to reject malformed
+    /// bytes. The table's branch declaration is the authority for component
+    /// names, scalar types, and stable-enum domains, so recovery must perform
+    /// this second validation before a physical coordinate can influence a
+    /// query or cache.
+    pub(crate) fn decode_persisted_branch_key(
+        table: &TableSchema,
+        bytes: &[u8],
+    ) -> Result<BranchKey, String> {
+        let key = BranchKey::from_canonical_bytes(bytes)
+            .map_err(|_| format!("invalid persisted branch key for {}", table.name))?;
+        Self::validate_branch_key_for_table(table, &key)?;
+        Ok(key)
+    }
+
+    /// Validate an exact branch coordinate against its owning table
+    /// declaration. Shared by admission and persisted-state recovery so their
+    /// type/domain rules cannot drift.
+    pub(crate) fn validate_branch_key_for_table(
+        table: &TableSchema,
+        key: &BranchKey,
+    ) -> Result<BTreeMap<String, Value>, String> {
         let mut bindings = table.branch_by.iter().collect::<Vec<_>>();
         bindings.sort();
         if key.values.len() != bindings.len() {
@@ -2174,6 +2201,55 @@ mod tests {
         assert!(
             serde_json::from_value::<ColumnSchema>(spoofed_kind).is_err(),
             "semantic kind must be structurally compatible with its public column type"
+        );
+    }
+
+    #[test]
+    fn persisted_branch_keys_require_the_owning_table_type_and_enum_domain() {
+        let uuid_schema = RuntimeSchema::new([TableSchema::new(
+            "todos",
+            [ColumnSchema::new("branch", ColumnType::Uuid)],
+        )
+        .with_branch_column("branch")]);
+        let uuid_table = &uuid_schema.tables[0];
+        let (valid, _) = uuid_schema
+            .project_branch_selector(
+                uuid_table,
+                &BranchSelector::new([("branch", Value::Uuid(uuid::Uuid::from_bytes([0x42; 16])))]),
+            )
+            .unwrap();
+        assert_eq!(
+            RuntimeSchema::decode_persisted_branch_key(uuid_table, &valid.canonical_bytes())
+                .unwrap(),
+            valid
+        );
+
+        let wrong_scalar = BranchKey {
+            values: vec![(
+                "branch".to_owned(),
+                BranchColumnValue::from(Value::String("not-a-uuid".to_owned())),
+            )],
+        };
+        assert!(
+            RuntimeSchema::decode_persisted_branch_key(uuid_table, &wrong_scalar.canonical_bytes())
+                .is_err()
+        );
+
+        let phase = ScalarEnumSchema::new("phase", ["draft", "ready"]).unwrap();
+        let enum_schema = RuntimeSchema::new([TableSchema::new(
+            "todos",
+            [ColumnSchema::new("phase", ColumnType::EnumTag(phase))],
+        )
+        .with_branch_column("phase")]);
+        let invalid_enum = BranchKey {
+            values: vec![("phase".to_owned(), BranchColumnValue(vec![1, 8, u8::MAX]))],
+        };
+        assert!(
+            RuntimeSchema::decode_persisted_branch_key(
+                &enum_schema.tables[0],
+                &invalid_enum.canonical_bytes()
+            )
+            .is_err()
         );
     }
 }

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -176,15 +176,12 @@ impl RuntimeSchema {
             let value = encoded
                 .decode()
                 .map_err(|_| format!("invalid branch column {column_name} encoding"))?;
-            if BranchColumnValue::from(value.clone()) != *encoded {
-                return Err(format!(
-                    "non-canonical branch column {column_name} encoding"
-                ));
-            }
             RecordDescriptor::new([("value", column.column_type.clone())])
                 .create(std::slice::from_ref(&value))
                 .map_err(|_| format!("invalid branch column {column_name} value"))?;
-            values.push((column_name.clone(), encoded.clone()));
+            let encoded = BranchColumnValue::encode_typed(&value, &column.column_type)
+                .map_err(|_| format!("invalid branch column {column_name} value"))?;
+            values.push((column_name.clone(), encoded));
             cells.insert(column_name.clone(), value);
         }
         values.sort_by(|left, right| left.0.cmp(&right.0));
@@ -243,7 +240,12 @@ impl RuntimeSchema {
                 .find(|(name, _)| name == column_name)
                 .map(|(_, value)| value)
                 .cloned()
-                .or_else(|| column.default.clone().map(BranchColumnValue::from));
+                .or_else(|| {
+                    column.default.as_ref().map(|value| {
+                        BranchColumnValue::encode_typed(value, &column.column_type)
+                            .expect("validated branch default")
+                    })
+                });
             selected == stored.as_ref()
         }) && stored
             .values
@@ -282,7 +284,12 @@ impl RuntimeSchema {
                     .iter()
                     .find(|(name, _)| name == column_name)
                     .map(|(_, value)| value.clone())
-                    .or_else(|| column.default.clone().map(BranchColumnValue::from))
+                    .or_else(|| {
+                        column.default.as_ref().map(|value| {
+                            BranchColumnValue::encode_typed(value, &column.column_type)
+                                .expect("validated branch default")
+                        })
+                    })
                     .ok_or_else(|| {
                         format!(
                             "older branch key is missing {column_name} without a migration default"
@@ -328,9 +335,12 @@ impl RuntimeSchema {
                 .find(|column| column.name == *column_name)
                 .ok_or_else(|| format!("unknown branch column on {}", table.name))?;
             let value = encoded
-                .decode()
+                .decode_as(&column.column_type)
                 .map_err(|_| format!("invalid branch column {column_name} encoding"))?;
-            if BranchColumnValue::from(value.clone()) != *encoded {
+            if BranchColumnValue::encode_typed(&value, &column.column_type)
+                .map_err(|_| format!("invalid branch column {column_name} value"))?
+                != *encoded
+            {
                 return Err(format!(
                     "non-canonical branch column {column_name} encoding"
                 ));
@@ -361,7 +371,12 @@ impl RuntimeSchema {
                 .iter()
                 .find(|(name, _)| name == column_name)
                 .map(|(_, value)| value.clone())
-                .or_else(|| column.default.clone().map(BranchColumnValue::from))
+                .or_else(|| {
+                    column.default.as_ref().map(|value| {
+                        BranchColumnValue::encode_typed(value, &column.column_type)
+                            .expect("validated branch default")
+                    })
+                })
                 .ok_or_else(|| {
                     format!("branch key is missing {column_name} without a migration default")
                 })?;
@@ -1710,6 +1725,34 @@ mod tests {
             [ColumnSchema::new("branch", ColumnType::String)],
         )
         .with_branch_column("branch")]);
+    }
+
+    #[test]
+    fn branch_selector_projection_uses_the_declared_enum_codec() {
+        let phase = ScalarEnumSchema::new("phase", ["draft", "ready"]).unwrap();
+        let schema = RuntimeSchema::new([TableSchema::new(
+            "todos",
+            [ColumnSchema::new(
+                "phase",
+                ColumnType::EnumTag(phase.clone()),
+            )],
+        )
+        .with_branch_column("phase")]);
+        let table = &schema.tables[0];
+
+        let (key, cells) = schema
+            .project_branch_selector(
+                table,
+                &BranchSelector::new([("phase", Value::String("ready".to_owned()))]),
+            )
+            .unwrap();
+
+        assert_eq!(key.values[0].1.0, [1, 8, 1]);
+        assert_eq!(cells["phase"], Value::String("ready".to_owned()));
+        assert_eq!(
+            schema.validate_authored_branch_key(table, &key).unwrap()["phase"],
+            Value::EnumTag(1)
+        );
     }
 
     #[test]

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -383,12 +383,12 @@ describe("JazzClient transaction query plumbing", () => {
     );
 
     expect(JSON.parse(runtime.insert.mock.calls[0][2] as string)).toMatchObject({
-      branch_view: { head: { values: { workspace: [15, 14] } } },
+      branch_view: { head: { values: { workspace: [1, 4, 7, 0, 0, 0] } } },
     });
     expect(JSON.parse(runtime.update.mock.calls[0][3] as string)).toMatchObject({
       branch_view: {
-        head: { values: { workspace: [15, 14] } },
-        base: { Current: { values: { workspace: [15, 2] } } },
+        head: { values: { workspace: [1, 4, 7, 0, 0, 0] } },
+        base: { Current: { values: { workspace: [1, 4, 1, 0, 0, 0] } } },
       },
     });
   });
@@ -418,12 +418,12 @@ describe("JazzClient transaction query plumbing", () => {
       read_view: {
         source: {
           BranchView: {
-            head: { values: { workspace: [15, 14] } },
+            head: { values: { workspace: [1, 4, 7, 0, 0, 0] } },
             base: {
               Current: {
                 values: {
-                  workspace: [15, 2],
-                  tenant: [9, 16, ...Array(16).fill(0x42)],
+                  workspace: [1, 4, 1, 0, 0, 0],
+                  tenant: [1, 7, ...Array(16).fill(0x42)],
                 },
               },
             },
@@ -449,7 +449,7 @@ describe("JazzClient transaction query plumbing", () => {
       read_view: {
         source: {
           BranchView: {
-            head: { values: { branch: [6, 5, 100, 114, 97, 102, 116] } },
+            head: { values: { branch: [1, 6, 2, 100, 114, 97, 102, 116] } },
           },
         },
       },

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -26,7 +26,6 @@ import {
   resolveRuntimeConfigWasmUrl,
 } from "./runtime-config.js";
 import { httpUrlToWs } from "./url.js";
-import { PostcardWriter } from "./native-runtime/native-codec.js";
 import { assertNativeArtifactCompatibility } from "./native-artifact-compatibility.js";
 
 type RuntimeSerializedSession = Pick<Session, "issuer" | "user_id" | "claims" | "authMode"> & {
@@ -45,7 +44,12 @@ function serializeRuntimeSession(session: Session): RuntimeSerializedSession {
 }
 
 function encodeBranchColumnValue(value: Value): Uint8Array {
-  const writer = new PostcardWriter();
+  const envelope = (tag: number, payload: Uint8Array): Uint8Array => {
+    const encoded = new Uint8Array(2 + payload.length);
+    encoded.set([1, tag]); // frozen branch-column codec version and scalar tag
+    encoded.set(payload, 2);
+    return encoded;
+  };
   switch (value.type) {
     case "Integer":
       if (
@@ -55,9 +59,11 @@ function encodeBranchColumnValue(value: Value): Uint8Array {
       ) {
         throw new Error("branch Integer values must be signed 32-bit integers");
       }
-      writer.enumUnit(15); // groove::Value::I32
-      writer.i64(value.value);
-      break;
+      {
+        const payload = new Uint8Array(4);
+        new DataView(payload.buffer).setInt32(0, value.value, true);
+        return envelope(4, payload); // Groove I32
+      }
     case "BigInt": {
       if (typeof value.value === "number" && !Number.isSafeInteger(value.value)) {
         throw new Error("branch BigInt values supplied as numbers must be safe integers");
@@ -66,31 +72,32 @@ function encodeBranchColumnValue(value: Value): Uint8Array {
       if (integer < -(1n << 63n) || integer > (1n << 63n) - 1n) {
         throw new Error("branch BigInt values must be signed 64-bit integers");
       }
-      writer.enumUnit(14); // groove::Value::I64
-      writer.i64(integer);
-      break;
+      const payload = new Uint8Array(8);
+      new DataView(payload.buffer).setBigInt64(0, integer, true);
+      return envelope(5, payload); // Groove I64
     }
     case "Uuid": {
-      writer.enumUnit(9); // groove::Value::Uuid
       const hex = value.value.replaceAll("-", "");
       if (!/^[0-9a-fA-F]{32}$/.test(hex)) throw new Error(`invalid branch UUID ${value.value}`);
-      writer.bytes(
+      return envelope(
+        7, // Groove UUID
         Uint8Array.from({ length: 16 }, (_, index) =>
           Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16),
         ),
       );
-      break;
     }
-    case "Text":
-      writer.enumUnit(6); // groove::Value::String
-      writer.string(value.value);
-      break;
+    case "Text": {
+      const text = new TextEncoder().encode(value.value);
+      const payload = new Uint8Array(1 + text.length);
+      payload[0] = 2; // Groove stored-scalar Primitive case
+      payload.set(text, 1);
+      return envelope(6, payload); // Groove String
+    }
     default:
       throw new Error(
         `branch columns currently require Integer, BigInt, Text, or Uuid values; got ${value.type}`,
       );
   }
-  return writer.finish();
 }
 
 type WireBranchSelector = { values: Record<string, number[]> };


### PR DESCRIPTION
## Problem

BranchKey encoded each BranchColumnValue through postcard over the general-purpose Groove Value enum, then postcard-encoded the surrounding key again. Those bytes are persisted in rows and used as physical key prefixes, so the durable ordering and identity contract depended on Rust and serde enum layout.

## Solution

Replace that representation with an explicitly versioned canonical branch-key codec. Permanent numeric tags identify branch-key components, while each value is encoded according to its declared Groove column type. Rust and TypeScript now produce the same format and reject type mismatches or non-canonical encodings.

Branch selection semantics are unchanged. This is an intentional pre-v1 storage cut: the old postcard representation is not accepted as an alternate spelling.