### PR TITLE
Store authored columns as physical column IDs

### DIFF
--- a/crates/jazz/SPEC/10_lenses_migrations.md
+++ b/crates/jazz/SPEC/10_lenses_migrations.md
@@ -31,6 +31,7 @@ Invariant digest:
 - `INV-LENS-19`: Policy evaluation under lenses MUST translate data into the pinned permission evaluation schema and MUST NOT translate policy bundles.
 - `INV-LENS-20`: Published physical lineages and authored schema variants MUST NOT be automatically garbage-collected.
 - `INV-LENS-21`: A compatible table rename MUST retain its `PhysicalTableId`; deletion history and combined-current state therefore continue under that id without copying, rewriting, or rescanning unrelated lineages.
+- `INV-LENS-22`: A content version's explicit authored-column presence MUST be stored only as a nullable, strictly increasing array of nonzero local `PhysicalColumnId`s; the exact authored schema/table mapping converts it to or from logical wire names, and malformed or unmapped ids MUST fail before any derived current row is persisted.
 
 ## Details
 
@@ -150,6 +151,24 @@ descriptor registry are durable local storage state and are recovered before
 any payload is decoded. They never appear in a public value or on the wire.
 An alias or mapping remains retained while any retained history, current row,
 branch-local row, snapshot, or rejected payload can name it.
+
+Every content-history row also has nullable `authored_columns` metadata. When
+present, its sole durable spelling is a Groove `Array<U64>` containing strictly
+increasing, nonzero local `PhysicalColumnId`s. It is not JSON-in-bytes, a
+logical-name payload, or an alternate serialized collection. The same typed
+field is copied into derived ahead/global content-current carriers only after
+resolving every id through the row's exact authored schema and logical table;
+zero, noncanonical order, type mismatch, or an absent mapping fails closed
+before the derived write. `None` is the deliberately conservative
+legacy/lens-payload fallback: every present cell is treated as authored.
+
+`VersionRecord` remains portable and carries logical authored column names.
+Local authoring and incoming wire ingest map those names to the receiving
+node's physical ids; exporting a stored row maps the ids back through its
+stored schema/table mapping. A compatible `RenameColumn` therefore retains one
+physical id while `v1.title` and `v2.name` remain their respective authored
+wire names. This epoch intentionally does not accept the former JSON-in-bytes
+storage spelling.
 
 Jazz registers a schema variant and every projection needed for its logical
 views before activating a catalogue bundle or accepting a row under that

--- a/crates/jazz/SPEC/11_branch_views_time_travel.md
+++ b/crates/jazz/SPEC/11_branch_views_time_travel.md
@@ -138,6 +138,43 @@ branch-specific declaration or binding abstraction.
 The empty branch key denotes shared data. It is not a privileged root branch key and
 has no lifecycle semantics (`INV-BVIEW-7`).
 
+#### Canonical branch-coordinate codec
+
+Branch coordinates use an engine-owned binary codec, not the serde layout of
+`groove::Value`, `BranchColumnValue`, or `BranchKey`. A branch-column envelope is:
+
+```text
+codec_version:u8 = 1
+scalar_tag:u8
+groove_value_bytes:remaining bytes
+```
+
+The scalar tags are permanently assigned as `0=U8`, `1=U16`, `2=U32`,
+`3=U64`, `4=I32`, `5=I64`, `6=String`, `7=Uuid`, and `8=EnumTag`.
+The payload is Groove's canonical single-field encoding under the schema-declared
+column type. Selector construction may infer a scalar type before table projection;
+projection MUST decode that value and re-encode it under the selected table's
+declared type. In particular, a string selector for a stable enum becomes the
+declared enum discriminant rather than retaining a Rust value-enum tag.
+
+An exact branch key is:
+
+```text
+codec_version:u8 = 1
+entry_count:u32 little-endian
+repeated entry_count times:
+  name_byte_length:u32 little-endian
+  name_utf8:name_byte_length bytes
+  value_byte_length:u32 little-endian
+  branch_column_envelope:value_byte_length bytes
+```
+
+Entries MUST be strictly ordered by column name, with no duplicates or trailing
+bytes. Decoders reject unknown versions, scalar tags, non-canonical Groove
+payloads, invalid UTF-8 names, invalid lengths, and non-increasing names. A new
+codec version is a storage-format migration boundary; legacy serde/postcard bytes
+are not guessed from shape.
+
 #### Branch-local row identity
 
 `RowUuid` remains the stable application object identity. The same `RowUuid` may

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -465,12 +465,27 @@ where
         table: &str,
         row: RowUuid,
         made_by: AuthorSubject,
-        cells: RowCells,
+        mut cells: RowCells,
     ) -> Result<TxId, Error> {
-        let cells = self.apply_insert_defaults(table, cells)?;
+        let (write_schema, write_schema_version) = self.current_write_schema_for_query()?;
+        let table_schema = write_schema
+            .tables
+            .iter()
+            .find(|candidate| candidate.name == table)
+            .ok_or_else(|| Error::new(ErrorCode::Schema, format!("unknown table {table}")))?;
+        for column in &table_schema.columns {
+            if !cells.contains_key(&column.name)
+                && let Some(default) = &column.default
+            {
+                cells.insert(
+                    column.name.clone(),
+                    default_cell_for_column_type(&column.column_type, default),
+                );
+            }
+        }
         let published = crate::db::block_on(
             self.node.node.borrow_mut().commit_mergeable_in_schema(
-                self.schema_version_id,
+                write_schema_version,
                 MergeableCommit::new(table, row, self.next_now_ms())
                     .made_by(made_by)
                     .cells(cells),

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -1293,6 +1293,11 @@ pub(super) fn authored_column_ids_from_value(
                 "authored columns must contain physical column ids",
             ));
         };
+        if id == 0 {
+            return Err(Error::InvalidStoredValue(
+                "authored physical column ids must be nonzero",
+            ));
+        }
         if previous.is_some_and(|previous| previous >= id) {
             return Err(Error::InvalidStoredValue(
                 "authored physical column ids must be strictly increasing",

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -342,6 +342,7 @@ impl VersionRecord {
         stored: &VersionRow,
         table: &TableSchema,
         schema_version: SchemaVersionId,
+        authored_columns: Option<BTreeSet<String>>,
     ) -> Result<Self, Error> {
         // Wire records remain the replicated immutable projection. Content and
         // register rows now live in different storage tables, so projection at
@@ -351,7 +352,6 @@ impl VersionRecord {
             .iter()
             .map(|column| stored.cell(table, &column.name))
             .collect::<Result<Vec<_>, _>>()?;
-        let authored_columns = stored.authored_columns(table)?;
         VersionRecord::encode(
             table,
             schema_version,
@@ -520,7 +520,7 @@ pub(super) struct VersionRowParts {
     pub(super) updated_by: AuthorSubject,
     pub(super) updated_at: TxTime,
     pub(super) cells: BTreeMap<String, Value>,
-    pub(super) authored_columns: Option<BTreeSet<String>>,
+    pub(super) authored_columns: Option<BTreeSet<PhysicalColumnId>>,
     pub(super) deletion: Option<DeletionEvent>,
 }
 
@@ -560,6 +560,7 @@ impl VersionRow {
     pub(super) fn from_wire_with_schema_version(
         table: &TableSchema,
         version: &VersionRecord,
+        authored_columns: Option<BTreeSet<PhysicalColumnId>>,
         tx_node_alias: NodeAlias,
         schema_version_alias: SchemaVersionAlias,
         tx_time: TxTime,
@@ -582,6 +583,7 @@ impl VersionRow {
                 history_values_from_wire(
                     table,
                     version,
+                    authored_columns,
                     tx_node_alias,
                     schema_version_alias,
                     tx_time,
@@ -779,26 +781,17 @@ impl VersionRow {
     }
 
     /// `None` is the deliberate legacy/lens fallback: every present cell is
-    /// treated as authored by merge code.
-    pub(super) fn authored_columns(
-        &self,
-        table: &TableSchema,
-    ) -> Result<Option<BTreeSet<String>>, Error> {
+    /// treated as authored by merge code. Exact sets use strictly increasing
+    /// node-local physical column ids; alternate set spellings are invalid.
+    pub(super) fn authored_column_ids(&self) -> Result<Option<BTreeSet<PhysicalColumnId>>, Error> {
         if self.is_register_record() {
             return Ok(None);
         }
-        let field = HistoryRowRecord::USER_CELLS + table.columns.len();
-        if field >= self.record.descriptor().fields().len() {
+        let Some(field) = self.record.descriptor().field_index("authored_columns") else {
             return Ok(None);
-        }
+        };
         let value = nullable_value(self.record.borrowed().get_idx(field)?)?;
-        value
-            .map(|value| match value {
-                Value::Bytes(bytes) => serde_json::from_slice(&bytes)
-                    .map_err(|_| Error::InvalidStoredValue("invalid authored columns")),
-                _ => Err(Error::InvalidStoredValue("authored columns must be bytes")),
-            })
-            .transpose()
+        value.map(authored_column_ids_from_value).transpose()
     }
 
     pub(super) fn is_register_record(&self) -> bool {
@@ -1281,6 +1274,44 @@ pub(super) fn canonical_versions(mut versions: Vec<VersionRecord>) -> Vec<Versio
     versions
 }
 
+pub(super) fn authored_column_ids_from_value(
+    value: Value,
+) -> Result<BTreeSet<PhysicalColumnId>, Error> {
+    // This is an intentional pre-v1 storage cut. Do not accept the former
+    // JSON-in-Bytes representation: durable rows have one schema-declared,
+    // canonical native representation.
+    let Value::Array(values) = value else {
+        return Err(Error::InvalidStoredValue(
+            "authored columns must be an array of physical column ids",
+        ));
+    };
+    let mut ids = BTreeSet::new();
+    let mut previous = None;
+    for value in values {
+        let Value::U64(id) = value else {
+            return Err(Error::InvalidStoredValue(
+                "authored columns must contain physical column ids",
+            ));
+        };
+        if previous.is_some_and(|previous| previous >= id) {
+            return Err(Error::InvalidStoredValue(
+                "authored physical column ids must be strictly increasing",
+            ));
+        }
+        previous = Some(id);
+        ids.insert(PhysicalColumnId(id));
+    }
+    Ok(ids)
+}
+
+fn authored_column_ids_value(columns: Option<&BTreeSet<PhysicalColumnId>>) -> Value {
+    Value::Nullable(columns.map(|columns| {
+        Box::new(Value::Array(
+            columns.iter().map(|column| Value::U64(column.0)).collect(),
+        ))
+    }))
+}
+
 pub(super) fn history_values_from_parts(
     table: &TableSchema,
     version: &VersionRowParts,
@@ -1308,23 +1339,14 @@ pub(super) fn history_values_from_parts(
             version.cells.get(&column.name).cloned().map(Box::new),
         ));
     }
-    values.push(Value::Nullable(
-        version
-            .authored_columns
-            .as_ref()
-            .map(|columns| {
-                serde_json::to_vec(columns)
-                    .expect("serializing an ordered set of strings cannot fail")
-            })
-            .map(Box::new)
-            .map(|bytes| Box::new(Value::Bytes(*bytes))),
-    ));
+    values.push(authored_column_ids_value(version.authored_columns.as_ref()));
     Ok(values)
 }
 
 fn history_values_from_wire(
     table: &TableSchema,
     version: &VersionRecord,
+    authored_columns: Option<BTreeSet<PhysicalColumnId>>,
     tx_node_alias: NodeAlias,
     schema_version_alias: SchemaVersionAlias,
     tx_time: TxTime,
@@ -1363,12 +1385,7 @@ fn history_values_from_wire(
         }
         values.push(Value::Nullable(value.map(Box::new)));
     }
-    values.push(Value::Nullable(
-        version
-            .authored_columns()
-            .map(|columns| serde_json::to_vec(columns).expect("serializing authored columns"))
-            .map(|bytes| Box::new(Value::Bytes(bytes))),
-    ));
+    values.push(authored_column_ids_value(authored_columns.as_ref()));
     Ok(values)
 }
 
@@ -1505,11 +1522,8 @@ pub(super) fn global_current_values(
             nullable_value(version.record.borrowed().get_idx(field)?)?.map(Box::new),
         ));
     }
-    values.push(Value::Nullable(
-        version
-            .authored_columns(table)?
-            .map(|columns| serde_json::to_vec(&columns).expect("serializing authored columns"))
-            .map(|bytes| Box::new(Value::Bytes(bytes))),
+    values.push(authored_column_ids_value(
+        version.authored_column_ids()?.as_ref(),
     ));
     Ok(values)
 }

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -6,6 +6,7 @@
 //! node-level read layer over groove tables.
 
 use super::*;
+use crate::schema::RuntimeSchema;
 
 impl<S> NodeState<S>
 where
@@ -837,7 +838,8 @@ where
             };
             let logical_table = self.table_in_schema(&stored_table, schema_version)?;
             let descriptor = logical_table.register_storage_table().record_schema();
-            let branch_key = BranchKey::from_canonical_bytes(
+            let branch_key = RuntimeSchema::decode_persisted_branch_key(
+                &logical_table,
                 record
                     .borrowed()
                     .get_bytes(SharedDeletionHistoryRowRecord::FIELD_BRANCH_KEY_IDX)?,
@@ -855,19 +857,19 @@ where
         }
         let record_view = record.borrowed();
         let is_deletion = record_view.descriptor().field_index("_deletion").is_some();
+        let schema_alias = SchemaVersionAlias(record_view.get_u64(if is_deletion {
+            RegisterRowRecord::FIELD_SCHEMA_VERSION_IDX
+        } else {
+            HistoryRowRecord::FIELD_SCHEMA_VERSION_IDX
+        })?);
+        let schema_version =
+            self.schema_version_for_alias(schema_alias)
+                .ok_or(Error::InvalidStoredValue(
+                    "version storage schema version alias must exist",
+                ))?;
         let table = if !storage_table.starts_with("jazz_physical_") {
             requested_table.to_owned()
         } else {
-            let alias = SchemaVersionAlias(record_view.get_u64(if is_deletion {
-                RegisterRowRecord::FIELD_SCHEMA_VERSION_IDX
-            } else {
-                HistoryRowRecord::FIELD_SCHEMA_VERSION_IDX
-            })?);
-            let schema_version =
-                self.schema_version_for_alias(alias)
-                    .ok_or(Error::InvalidStoredValue(
-                        "version storage schema version alias must exist",
-                    ))?;
             self.catalogue
                 .physical_mappings
                 .get(&schema_version)
@@ -885,6 +887,7 @@ where
                     "physical version storage logical table mapping missing",
                 ))?
         };
+        let table_schema = self.table_in_schema(&table, schema_version)?;
         let record = record.borrowed();
         let tx_node_alias = if is_deletion {
             NodeAlias(record.get_u64(RegisterRowRecord::FIELD_TX_NODE_ID_IDX)?)
@@ -906,11 +909,14 @@ where
         let _ = TxId::new(tx_time, tx_node);
         Ok(VersionRow {
             table: groove::Intern::new(table),
-            branch_key: BranchKey::from_canonical_bytes(record.get_bytes(if is_deletion {
-                RegisterRowRecord::FIELD_BRANCH_KEY_IDX
-            } else {
-                HistoryRowRecord::FIELD_BRANCH_KEY_IDX
-            })?)
+            branch_key: RuntimeSchema::decode_persisted_branch_key(
+                &table_schema,
+                record.get_bytes(if is_deletion {
+                    RegisterRowRecord::FIELD_BRANCH_KEY_IDX
+                } else {
+                    HistoryRowRecord::FIELD_BRANCH_KEY_IDX
+                })?,
+            )
             .map_err(|_| Error::InvalidStoredValue("invalid stored branch key"))?,
             record: OwnedRecord::new(record.raw().to_vec(), record.descriptor()),
         })

--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -1162,9 +1162,15 @@ where
                 let author_schema = version.schema_version();
                 let source_table_schema = self.table_in_schema(version.table(), author_schema)?;
                 let schema_version_alias = self.ensure_schema_version_alias(author_schema).await?;
+                let authored_column_ids = self.authored_column_ids_for_names(
+                    author_schema,
+                    version.table(),
+                    version.authored_columns(),
+                )?;
                 let stored = VersionRow::from_wire_with_schema_version(
                     &source_table_schema,
                     version,
+                    authored_column_ids,
                     tx_node_alias,
                     schema_version_alias,
                     tx.tx_id.time,

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -217,9 +217,15 @@ where
             let source_table_schema = self.table_in_schema(version.table(), author_schema)?;
             let table_schema = source_table_schema;
             let schema_version_alias = self.ensure_schema_version_alias(author_schema).await?;
+            let authored_column_ids = self.authored_column_ids_for_names(
+                author_schema,
+                version.table(),
+                version.authored_columns(),
+            )?;
             let stored = VersionRow::from_wire_with_schema_version(
                 &table_schema,
                 &version,
+                authored_column_ids,
                 tx_node_alias,
                 schema_version_alias,
                 tx.tx_id.time,

--- a/crates/jazz/src/node/ingest/view_updates.rs
+++ b/crates/jazz/src/node/ingest/view_updates.rs
@@ -1411,6 +1411,12 @@ where
         version: &VersionRow,
         global_time: Option<GlobalTime>,
     ) -> Result<Vec<Value>, Error> {
+        // Current carriers are derived durable state. Validate the compact
+        // authored-column ids against this row's exact authored schema/table
+        // before copying them into either ahead or global current storage.
+        // The returned logical names are not stored here; this is solely the
+        // local-alias integrity boundary.
+        let _ = self.authored_columns_for_version(version)?;
         global_current_values(table, version, global_time)
     }
 

--- a/crates/jazz/src/node/ingest/view_updates.rs
+++ b/crates/jazz/src/node/ingest/view_updates.rs
@@ -190,8 +190,8 @@ where
                 MergeStrategy::Lww => {
                     let mut best: Option<(crate::time::TxTimeSortKey, Value)> = None;
                     for version in heads {
-                        if version
-                            .authored_columns(table_schema)?
+                        if self
+                            .authored_columns_for_version(version)?
                             .is_some_and(|columns| !columns.contains(&column.name))
                         {
                             continue;

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -7,9 +7,10 @@ use groove::records::{
 };
 
 use super::codec::{
-    VersionLayer, VersionRow, VersionRowParts, deletion_event_from_value,
-    history_values_from_parts, nullable_value, owned_record_from_storage_values_with_descriptor,
-    register_values_from_parts, tx_ids_from_value, version_tx_id_from_aliases,
+    VersionLayer, VersionRow, VersionRowParts, authored_column_ids_from_value,
+    deletion_event_from_value, history_values_from_parts, nullable_value,
+    owned_record_from_storage_values_with_descriptor, register_values_from_parts,
+    tx_ids_from_value, version_tx_id_from_aliases,
 };
 use super::query_engine::{
     AggregateResultSchema, AppRowCarrier, AppRowSchema, OutputTerminalSchema, ProgramFactKey,
@@ -1513,14 +1514,7 @@ fn decode_typed_version_witness(
     }
     let authored_columns = if layer == VersionLayer::Content {
         nullable_value(record.get_idx(plan.authored_columns_idx)?)?
-            .map(|value| match value {
-                Value::Bytes(bytes) => serde_json::from_slice(&bytes).map_err(|_| {
-                    super::Error::InvalidStoredValue("authored columns must be valid JSON")
-                }),
-                _ => Err(super::Error::InvalidStoredValue(
-                    "authored columns must be bytes",
-                )),
-            })
+            .map(authored_column_ids_from_value)
             .transpose()?
     } else {
         None
@@ -2065,8 +2059,8 @@ mod tests {
 
     use super::*;
     use crate::ids::{NodeUuid, SchemaVersionAlias};
-    use crate::node::Error;
     use crate::node::codec::{VersionRow, VersionRowParts};
+    use crate::node::{Error, PhysicalColumnId};
     use crate::protocol::ResultRowEntry;
     use crate::schema::{ColumnSchema, TableSchema};
     use crate::time::TxTime;
@@ -2475,7 +2469,7 @@ mod tests {
                 updated_by: AuthorSubject::SYSTEM,
                 updated_at: TxTime(time),
                 cells: BTreeMap::from([("title".to_owned(), Value::String(title.to_owned()))]),
-                authored_columns: Some(BTreeSet::from(["title".to_owned()])),
+                authored_columns: Some(BTreeSet::from([PhysicalColumnId(1)])),
                 deletion: None,
             },
             None,

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -23,7 +23,7 @@ use crate::protocol::{
     BranchKey, ProgramFactEntry, RealRowMemberEntry, RelationEdgeEntry, ResultMemberEntry,
     ResultMemberPayloadEntry, ResultRowLayer, RowVersionRefEntry, SyntheticReplacementToken,
 };
-use crate::schema::TableSchema;
+use crate::schema::{RuntimeSchema, TableSchema};
 use crate::time::{GlobalTime, TxTime};
 use crate::tools::{ObjectId, OutputOccurrenceId};
 use crate::tx::TxId;
@@ -1489,14 +1489,16 @@ fn decode_typed_version_witness(
     let tx_time = TxTime(record_u64_idx(record, plan.tx_time_idx)?);
     let branch_key = match plan.branch_idx {
         Some(idx) => match record.get_idx(idx)? {
-            Value::Bytes(bytes) => BranchKey::from_canonical_bytes(&bytes).map_err(|_| {
-                super::Error::InvalidStoredValue("maintained witness branch key is invalid")
-            })?,
-            Value::Nullable(None) => BranchKey::default(),
-            Value::Nullable(Some(value)) => match *value {
-                Value::Bytes(bytes) => BranchKey::from_canonical_bytes(&bytes).map_err(|_| {
+            Value::Bytes(bytes) => RuntimeSchema::decode_persisted_branch_key(table, &bytes)
+                .map_err(|_| {
                     super::Error::InvalidStoredValue("maintained witness branch key is invalid")
                 })?,
+            Value::Nullable(None) => BranchKey::default(),
+            Value::Nullable(Some(value)) => match *value {
+                Value::Bytes(bytes) => RuntimeSchema::decode_persisted_branch_key(table, &bytes)
+                    .map_err(|_| {
+                        super::Error::InvalidStoredValue("maintained witness branch key is invalid")
+                    })?,
                 _ => return Err(super::Error::InvalidStoredValue("branch key must be bytes")),
             },
             _ => return Err(super::Error::InvalidStoredValue("branch key must be bytes")),

--- a/crates/jazz/src/node/physical/bindings.rs
+++ b/crates/jazz/src/node/physical/bindings.rs
@@ -128,6 +128,16 @@ pub(super) fn validate_physical_variant_cases(
     let mut by_table = BTreeMap::<PhysicalTableId, BTreeMap<u32, SchemaVersionId>>::new();
     for (schema_version, mapping) in mappings {
         for table in mapping.tables.values() {
+            let mut column_ids = BTreeSet::new();
+            if table
+                .columns
+                .values()
+                .any(|column_id| !column_ids.insert(*column_id))
+            {
+                return Err(Error::InvalidStoredValue(
+                    "physical table maps multiple columns to one id",
+                ));
+            }
             let tag = if table.variant_cases.is_empty() {
                 groove_variant_tag(*aliases.get(schema_version).ok_or(
                     Error::InvalidStoredValue("variant-case schema alias missing"),

--- a/crates/jazz/src/node/physical/storage.rs
+++ b/crates/jazz/src/node/physical/storage.rs
@@ -2,6 +2,91 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
+    pub(super) fn authored_column_ids_for_names(
+        &self,
+        schema_version: SchemaVersionId,
+        table: &str,
+        columns: Option<&BTreeSet<String>>,
+    ) -> Result<Option<BTreeSet<PhysicalColumnId>>, Error> {
+        let Some(columns) = columns else {
+            return Ok(None);
+        };
+        let mapping = self
+            .catalogue
+            .physical_mappings
+            .get(&schema_version)
+            .and_then(|mapping| mapping.tables.get(table))
+            .ok_or(Error::InvalidStoredValue(
+                "authored columns physical table mapping missing",
+            ))?;
+        columns
+            .iter()
+            .map(|column| {
+                mapping
+                    .columns
+                    .get(column)
+                    .copied()
+                    .ok_or(Error::InvalidStoredValue(
+                        "authored column physical mapping missing",
+                    ))
+            })
+            .collect::<Result<BTreeSet<_>, _>>()
+            .map(Some)
+    }
+
+    pub(super) fn authored_column_names_for_ids(
+        &self,
+        schema_version: SchemaVersionId,
+        table: &str,
+        columns: Option<&BTreeSet<PhysicalColumnId>>,
+    ) -> Result<Option<BTreeSet<String>>, Error> {
+        let Some(columns) = columns else {
+            return Ok(None);
+        };
+        let mapping = self
+            .catalogue
+            .physical_mappings
+            .get(&schema_version)
+            .and_then(|mapping| mapping.tables.get(table))
+            .ok_or(Error::InvalidStoredValue(
+                "authored columns physical table mapping missing",
+        ))?;
+        let mut names_by_id = BTreeMap::new();
+        for (name, id) in &mapping.columns {
+            if names_by_id.insert(*id, name.clone()).is_some() {
+                return Err(Error::InvalidStoredValue(
+                    "physical table maps multiple authored columns to one id",
+                ));
+            }
+        }
+        columns
+            .iter()
+            .map(|column| {
+                names_by_id.get(column).cloned().ok_or(Error::InvalidStoredValue(
+                    "stored authored column id is absent from its schema mapping",
+                ))
+            })
+            .collect::<Result<BTreeSet<_>, _>>()
+            .map(Some)
+    }
+
+    pub(super) fn authored_columns_for_version(
+        &self,
+        version: &VersionRow,
+    ) -> Result<Option<BTreeSet<String>>, Error> {
+        let schema_version = self
+            .schema_version_for_alias(version.schema_version_alias())
+            .ok_or(Error::InvalidStoredValue(
+                "authored columns schema version alias missing",
+            ))?;
+        let ids = version.authored_column_ids()?;
+        self.authored_column_names_for_ids(
+            schema_version,
+            version.table(),
+            ids.as_ref(),
+        )
+    }
+
     pub(super) fn prepared_physical_write_plan(
         &mut self,
         schema_version: SchemaVersionId,

--- a/crates/jazz/src/node/physical/tests.rs
+++ b/crates/jazz/src/node/physical/tests.rs
@@ -97,6 +97,20 @@ mod variant_case_tests {
     }
 
     #[test]
+    fn reopen_validation_rejects_duplicate_physical_column_ids() {
+        let v1 = schema(1);
+        let aliases = BTreeMap::from([(v1, SchemaVersionAlias(1))]);
+        let mappings = BTreeMap::from([(v1, mapping(7, &[("id", 1), ("body", 1)]))]);
+
+        assert!(matches!(
+            validate_physical_variant_cases(&mappings, &aliases),
+            Err(Error::InvalidStoredValue(
+                "physical table maps multiple columns to one id"
+            ))
+        ));
+    }
+
+    #[test]
     fn nested_enum_epoch_accepts_only_append_only_case_growth() {
         let value_type = |variants: &[&str]| {
             records::ValueType::EnumTag(

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -2392,7 +2392,7 @@ fn deletion_witness_fields_for_tagged_rows(
         ProjectField::named("parents"),
         ProjectField::null_typed(
             "authored_columns",
-            ValueType::Nullable(Box::new(ValueType::Bytes)),
+            ValueType::Nullable(Box::new(ValueType::Array(Box::new(ValueType::U64)))),
         ),
         ProjectField::named("created_by"),
         ProjectField::named("created_at"),

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -2845,7 +2845,7 @@ fn current_row_descriptor_with_hidden_source_fields_for_branch(
             ),
             (
                 "authored_columns".to_owned(),
-                ValueType::Nullable(Box::new(ValueType::Bytes)),
+                ValueType::Nullable(Box::new(ValueType::Array(Box::new(ValueType::U64)))),
             ),
             ("created_by".to_owned(), ValueType::String),
             ("created_at".to_owned(), ValueType::U64),

--- a/crates/jazz/src/node/source_resolution.rs
+++ b/crates/jazz/src/node/source_resolution.rs
@@ -98,8 +98,15 @@ where
                         .columns
                         .iter()
                         .find(|column| column.name == *column_name)
-                        .and_then(|column| column.default.clone())
-                        .map(crate::protocol::BranchColumnValue::from);
+                        .and_then(|column| {
+                            column.default.as_ref().map(|value| {
+                                crate::protocol::BranchColumnValue::encode_typed(
+                                    value,
+                                    &column.column_type,
+                                )
+                                .expect("validated branch default")
+                            })
+                        });
                     selected_by_physical.get(physical) != default.as_ref()
                 });
             if missing_branch_value_is_non_default {

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -436,6 +436,11 @@ where
                     .clone()
                     .unwrap_or_else(|| cells.keys().cloned().collect()),
             );
+            let authored_column_ids = self.authored_column_ids_for_names(
+                write_schema_version,
+                &table_schema.name,
+                authored_columns.as_ref(),
+            )?;
             let history_descriptor = if commit.deletion.is_none() {
                 Some(
                     self.prepared_physical_write_plan(
@@ -463,7 +468,7 @@ where
                     updated_by: commit.made_by,
                     updated_at: provenance_at,
                     cells,
-                    authored_columns,
+                    authored_columns: authored_column_ids,
                     deletion: commit.deletion,
                 },
                 (write_schema_version != self.catalogue.current_schema_version_id)

--- a/crates/jazz/src/node/state/contribution_merge.rs
+++ b/crates/jazz/src/node/state/contribution_merge.rs
@@ -28,13 +28,48 @@ where
             .schema
             .clone();
         let full_key = |selector: &BranchSelector| -> Result<BranchKey, Error> {
-            let branch_columns = schema.tables.iter().flat_map(|table| table.branch_by.iter().cloned()).collect::<BTreeSet<_>>();
-            if selector.values.keys().cloned().collect::<BTreeSet<_>>() != branch_columns {
+            let branch_columns = schema
+                .tables
+                .iter()
+                .flat_map(|table| {
+                    table.branch_by.iter().map(|name| {
+                        let column = table
+                            .columns
+                            .iter()
+                            .find(|column| column.name == *name)
+                            .expect("validated branch column");
+                        (name.clone(), column.column_type.clone())
+                    })
+                })
+                .collect::<BTreeMap<_, _>>();
+            if selector.values.keys().collect::<BTreeSet<_>>()
+                != branch_columns.keys().collect::<BTreeSet<_>>()
+            {
                 return Err(Error::InvalidBranchKey(
                     "contribution selector must bind every schema branch column".to_owned(),
                 ));
             }
-            let values = selector.values.iter().map(|(name, value)| (name.clone(), value.clone())).collect();
+            let values = selector
+                .values
+                .iter()
+                .map(|(name, encoded)| {
+                    let value = encoded.decode().map_err(|_| {
+                        Error::InvalidBranchKey(format!(
+                            "invalid contribution branch column {name} encoding"
+                        ))
+                    })?;
+                    let encoded = crate::protocol::BranchColumnValue::encode_typed(
+                        &value,
+                        &branch_columns[name],
+                    )
+                    .map_err(|_| {
+                        Error::InvalidBranchKey(format!(
+                            "invalid contribution branch column {name} value"
+                        ))
+                    })?;
+                    Ok((name.clone(), encoded))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
             Ok(BranchKey { values })
         };
         let source_full = full_key(&request.source)?;

--- a/crates/jazz/src/node/state/contribution_merge.rs
+++ b/crates/jazz/src/node/state/contribution_merge.rs
@@ -204,7 +204,7 @@ where
                         }
                         ContributionComponent::Register => None,
                     } {
-                        let authored = version.authored_columns(&table)?;
+                        let authored = node.authored_columns_for_version(version)?;
                         if !authored.as_ref().is_none_or(|columns| columns.contains(column))
                             || version.cell(&table, column)?.is_none()
                         {
@@ -284,7 +284,7 @@ where
                                 .iter()
                                 .filter(|version| version.layer() == VersionLayer::Content)
                             {
-                                let authored = version.authored_columns(&table)?;
+                                let authored = self.authored_columns_for_version(version)?;
                                 if !authored
                                     .as_ref()
                                     .is_none_or(|columns| columns.contains(&column.name))
@@ -334,7 +334,7 @@ where
                                 .iter()
                                 .filter(|version| version.layer() == VersionLayer::Content)
                             {
-                                let authored = version.authored_columns(&table)?;
+                                let authored = self.authored_columns_for_version(version)?;
                                 if !authored
                                     .as_ref()
                                     .is_none_or(|columns| columns.contains(&column.name))

--- a/crates/jazz/src/node/state/read_payload.rs
+++ b/crates/jazz/src/node/state/read_payload.rs
@@ -238,7 +238,8 @@ where
                 "history schema version alias must exist",
             ))?;
         let table = self.table_in_schema(version.table(), schema_version)?;
-        VersionRecord::from_stored(version, &table, schema_version)
+        let authored_columns = self.authored_columns_for_version(version)?;
+        VersionRecord::from_stored(version, &table, schema_version, authored_columns)
     }
 
     pub(crate) async fn row_version_payloads_for_refs(

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -702,6 +702,120 @@ fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     assert!(node.query_table_versions("todos").unwrap().is_empty());
 }
 
+#[test]
+fn branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen() {
+    let schema = branch_view_schema();
+    let branch = branch_selector(0x70);
+    let row_uuid = row(0x71);
+    let cells = || {
+        BTreeMap::from([
+            ("title".to_owned(), v("branch receipt")),
+            ("owner".to_owned(), Value::Uuid(uuid::Uuid::nil())),
+        ])
+    };
+
+    // Memory uses the same physical row projections as durable backends. This
+    // first receipt catches a writer that only updates one implementation.
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage = MemoryStorage::new(&refs).unwrap();
+    let mut memory = NodeState::new_history_complete(node(0x70), schema.clone(), storage).unwrap();
+    memory
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 10)
+                .branch(branch.clone())
+                .cells(cells()),
+        )
+        .unwrap();
+    memory
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 20)
+                .branch(branch.clone())
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    assert_eq!(
+        memory
+            .query_row_versions_in_branch("todos", &schema.project_branch_view_selector(&schema.tables[0], &branch).unwrap().0, row_uuid)
+            .unwrap()
+            .len(),
+        2,
+        "history and deletion projections share the same exact branch coordinate"
+    );
+
+    let (dir, mut rocks) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x72; 16]), schema.clone());
+    rocks
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 10)
+                .branch(branch.clone())
+                .cells(cells()),
+        )
+        .unwrap();
+    rocks
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 20)
+                .branch(branch.clone())
+                .deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+
+    let key = schema
+        .project_branch_view_selector(&schema.tables[0], &branch)
+        .unwrap()
+        .0;
+    let table_id = rocks.catalogue.physical_mappings[&schema.version_id()].tables["todos"].table_id;
+    let prefix = vec![Value::Bytes(key.canonical_bytes())];
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(&physical_history_table_name(table_id), &prefix)
+            .unwrap()
+            .len(),
+        1,
+        "content history is addressed by the canonical branch prefix"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(
+                SHARED_DELETION_HISTORY_TABLE,
+                &[Value::Bytes(key.canonical_bytes()), Value::U64(table_id.0)],
+            )
+            .unwrap()
+            .len(),
+        1,
+        "deletion history is addressed by the same canonical branch prefix"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(&physical_global_current_table_name(table_id), &prefix)
+            .unwrap()
+            .len(),
+        1,
+        "current and index-backed query projections retain that branch prefix"
+    );
+    drop(rocks);
+
+    let mut reopened = reopen_history_complete_node_at(&dir, NodeUuid::from_bytes([0x72; 16]), schema.clone());
+    assert_eq!(
+        reopened
+            .query_row_versions_in_branch("todos", &key, row_uuid)
+            .unwrap()
+            .len(),
+        2,
+        "reopen decodes the exact branch coordinate for both layers"
+    );
+    assert!(
+        reopened
+            .visible_current_cells_in_branch("todos", &branch, row_uuid)
+            .unwrap()
+            .is_none(),
+        "the reopened deletion current projection still masks the content row"
+    );
+}
+
 // This is necessarily an internal protocol-boundary regression test: public
 // mutation APIs canonicalize branch selectors and therefore cannot construct
 // the adversarial VersionRecord values a remote peer may send.

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -745,14 +745,14 @@ fn branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen(
 
     let (dir, mut rocks) =
         open_history_complete_node_with_schema(NodeUuid::from_bytes([0x72; 16]), schema.clone());
-    rocks
+    let content_tx = rocks
         .commit_mergeable_settled(
             MergeableCommit::new("todos", row_uuid, 10)
                 .branch(branch.clone())
                 .cells(cells()),
         )
         .unwrap();
-    rocks
+    let deletion_tx = rocks
         .commit_mergeable_settled(
             MergeableCommit::new("todos", row_uuid, 20)
                 .branch(branch.clone())
@@ -790,11 +790,62 @@ fn branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen(
     assert_eq!(
         rocks
             .database
+            .primary_key_scan_raw(&physical_ahead_current_table_name(table_id), &prefix)
+            .unwrap()
+            .len(),
+        1,
+        "locally settled content uses the canonical branch prefix in ahead-current"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(
+                &physical_register_ahead_current_table_name(table_id),
+                &prefix,
+            )
+            .unwrap()
+            .len(),
+        1,
+        "locally settled deletion uses the same prefix in register ahead-current"
+    );
+
+    rocks
+        .apply_fate_update(
+            content_tx,
+            Fate::Accepted,
+            Some(GlobalTime(1)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+    rocks
+        .apply_fate_update(
+            deletion_tx,
+            Fate::Accepted,
+            Some(GlobalTime(2)),
+            Some(DurabilityTier::Global),
+        )
+        .unwrap();
+
+    assert_eq!(
+        rocks
+            .database
             .primary_key_scan_raw(&physical_global_current_table_name(table_id), &prefix)
             .unwrap()
             .len(),
         1,
-        "current and index-backed query projections retain that branch prefix"
+        "globally accepted content retains the canonical branch prefix in global-current"
+    );
+    assert_eq!(
+        rocks
+            .database
+            .primary_key_scan_raw(
+                &physical_register_global_current_table_name(table_id),
+                &prefix,
+            )
+            .unwrap()
+            .len(),
+        1,
+        "globally accepted deletion retains the same prefix in register global-current"
     );
     drop(rocks);
 

--- a/crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs
@@ -217,6 +217,115 @@ fn catalogue_snapshot_preserves_active_schema_storage_identity() {
 }
 
 #[test]
+fn authored_columns_cross_nodes_with_different_physical_column_ids() {
+    // Physical column ids are deliberately node-local. This internal wire-
+    // boundary test makes the same evolved schema allocate `body` differently
+    // on each node, then verifies that logical names cross the wire and each
+    // side persists only its own id.
+    let base = schema();
+    let filler = SchemaVersion::new(build_public_test_schema(
+        PublicSchemaBuilder::new().table(
+            PublicTableSchemaBuilder::new("todos")
+                .column("title", PublicColumnType::Text)
+                .column("scratch", PublicColumnType::Text),
+        ),
+    ));
+    let evolved = SchemaVersion::new(catalogue_evolved_schema());
+    let (_authority_dir, mut authority) = open_node_with_schema(node(0x63), base.clone());
+    publish_schema_lineage(
+        &mut authority,
+        filler.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            filler.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "scratch".to_owned(),
+                    default: v(""),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    publish_schema_lineage(
+        &mut authority,
+        evolved.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            evolved.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![LensOp::AddColumn {
+                    column: "body".to_owned(),
+                    default: v(""),
+                }],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    authority
+        .apply_trusted_catalogue_message_settled(SyncMessage::SetCurrentWriteSchema {
+            author: AuthorSubject::SYSTEM,
+            pointer: CurrentWriteSchema {
+                revision: 1,
+                schema: evolved.id,
+            },
+        })
+        .unwrap();
+
+    let (receiver_dir, mut receiver) =
+        open_node_with_schema(node(0x64), evolved.schema.clone());
+    let receiver_body_id =
+        receiver.catalogue.physical_mappings[&evolved.id].tables["todos"].columns["body"];
+    let authority_body_id =
+        authority.catalogue.physical_mappings[&evolved.id].tables["todos"].columns["body"];
+    assert_ne!(authority_body_id, receiver_body_id);
+    receiver
+        .apply_trusted_catalogue_snapshot_settled(authority.catalogue_snapshot().unwrap())
+        .unwrap();
+    assert_eq!(
+        receiver.catalogue.physical_mappings[&evolved.id].tables["todos"].columns["body"],
+        receiver_body_id
+    );
+
+    let (tx_id, unit) = authority
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", row(0x65), 10)
+                .cells(BTreeMap::from([("body".to_owned(), v("authored"))]))
+                .authored_columns(BTreeSet::from(["body".to_owned()])),
+        )
+        .unwrap();
+    receiver.apply_sync_message_settled(unit).unwrap();
+    let stored = receiver.query_versions_for_tx(tx_id).unwrap();
+    assert_eq!(stored[0].authored_column_ids().unwrap(), Some(BTreeSet::from([receiver_body_id])));
+    assert_eq!(
+        receiver
+            .version_record_from_row(&stored[0])
+            .unwrap()
+            .authored_columns(),
+        Some(&BTreeSet::from(["body".to_owned()]))
+    );
+    drop(receiver);
+
+    let mut reopened = reopen_node_at(&receiver_dir, node(0x64), evolved.schema);
+    let stored = reopened.query_versions_for_tx(tx_id).unwrap();
+    assert_eq!(
+        reopened
+            .version_record_from_row(&stored[0])
+            .unwrap()
+            .authored_columns(),
+        Some(&BTreeSet::from(["body".to_owned()]))
+    );
+}
+
+#[test]
 fn settled_view_projects_old_authored_row_into_clients_active_schema() {
     // Internal because settled result-set installation is a sync receiver
     // boundary; schema projection itself is asserted through the query API.

--- a/crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs
+++ b/crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs
@@ -326,6 +326,100 @@ fn authored_columns_cross_nodes_with_different_physical_column_ids() {
 }
 
 #[test]
+fn authored_columns_follow_a_renamed_column_through_wire_and_reopen() {
+    // Internal because physical ids are local storage aliases. The public
+    // contract under test is that a v1 `title` patch and a v2 `name` patch
+    // retain their authored schema names on the wire while sharing one local
+    // physical-column identity across the rename.
+    let base = schema();
+    let renamed_schema = evolved_todos_name_body_schema();
+    let renamed = SchemaVersion::new(renamed_schema.clone());
+    let (authority_dir, mut authority) = open_node_with_schema(node(0x66), base.clone());
+    let (old_tx, old_unit) = authority
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", row(0x67), 10)
+                .cells(BTreeMap::from([("title".to_owned(), v("old"))]))
+                .authored_columns(BTreeSet::from(["title".to_owned()])),
+        )
+        .unwrap();
+    publish_schema_lineage(
+        &mut authority,
+        renamed.clone(),
+        MigrationLens::new(
+            base.version_id(),
+            renamed.id,
+            vec![TableLens {
+                source_table: "todos".to_owned(),
+                target_table: "todos".to_owned(),
+                ops: vec![
+                    LensOp::RenameColumn {
+                        from: "title".to_owned(),
+                        to: "name".to_owned(),
+                    },
+                    LensOp::AddColumn {
+                        column: "body".to_owned(),
+                        default: v(""),
+                    },
+                ],
+            }],
+        ),
+        Vec::<String>::new(),
+        Vec::<String>::new(),
+    )
+    .unwrap();
+    authority
+        .apply_trusted_catalogue_message_settled(SyncMessage::SetCurrentWriteSchema {
+            author: AuthorSubject::SYSTEM,
+            pointer: CurrentWriteSchema {
+                revision: 1,
+                schema: renamed.id,
+            },
+        })
+        .unwrap();
+    let (new_tx, new_unit) = authority
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("todos", row(0x68), 11)
+                .cells(BTreeMap::from([("name".to_owned(), v("new"))]))
+                .authored_columns(BTreeSet::from(["name".to_owned()])),
+        )
+        .unwrap();
+
+    let title_id = authority.catalogue.physical_mappings[&base.version_id()].tables["todos"]
+        .columns["title"];
+    let name_id = authority.catalogue.physical_mappings[&renamed.id].tables["todos"].columns["name"];
+    assert_eq!(title_id, name_id, "a compatible rename retains the column id");
+    for (tx_id, logical_name) in [(old_tx, "title"), (new_tx, "name")] {
+        let stored = authority.query_versions_for_tx(tx_id).unwrap().remove(0);
+        assert_eq!(stored.authored_column_ids().unwrap(), Some(BTreeSet::from([title_id])));
+        assert_eq!(
+            authority.version_record_from_row(&stored).unwrap().authored_columns(),
+            Some(&BTreeSet::from([logical_name.to_owned()])),
+        );
+    }
+
+    let (receiver_dir, mut receiver) = open_node_with_schema(node(0x69), renamed_schema.clone());
+    receiver
+        .apply_trusted_catalogue_snapshot_settled(authority.catalogue_snapshot().unwrap())
+        .unwrap();
+    receiver.apply_sync_message_settled(old_unit).unwrap();
+    receiver.apply_sync_message_settled(new_unit).unwrap();
+    drop(receiver);
+    drop(authority);
+
+    let mut reopened_authority = reopen_node_at(&authority_dir, node(0x66), base);
+    let mut reopened_receiver = reopen_node_at(&receiver_dir, node(0x69), renamed_schema);
+    for node in [&mut reopened_authority, &mut reopened_receiver] {
+        for (tx_id, logical_name) in [(old_tx, "title"), (new_tx, "name")] {
+            let stored = node.query_versions_for_tx(tx_id).unwrap().remove(0);
+            assert_eq!(
+                node.version_record_from_row(&stored).unwrap().authored_columns(),
+                Some(&BTreeSet::from([logical_name.to_owned()])),
+            );
+        }
+    }
+}
+
+#[test]
 fn settled_view_projects_old_authored_row_into_clients_active_schema() {
     // Internal because settled result-set installation is a sync receiver
     // boundary; schema projection itself is asserted through the query API.

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -1172,6 +1172,113 @@ fn stored_authored_columns_require_a_canonical_physical_id_array() {
             "authored columns must be an array of physical column ids"
         ))
     ));
+    assert!(matches!(
+        authored_column_ids_from_value(Value::Array(vec![
+            Value::U64(1),
+            Value::String("not an id".to_owned()),
+        ])),
+        Err(Error::InvalidStoredValue(
+            "authored columns must contain physical column ids"
+        ))
+    ));
+    assert!(matches!(
+        authored_column_ids_from_value(Value::Array(vec![Value::U64(0)])),
+        Err(Error::InvalidStoredValue(
+            "authored physical column ids must be nonzero"
+        ))
+    ));
+}
+
+#[test]
+fn malformed_persisted_authored_column_ids_never_reenter_derived_current_state() {
+    // Internal storage-boundary receipt: applications cannot manufacture a
+    // physical id, so exercise a deliberately corrupted durable history row.
+    // Reopen must preserve the fail-closed boundary rather than regenerating
+    // ahead/global current carriers from malformed history.
+    for invalid_id in [0, 9_999] {
+        let schema = schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let tx_id;
+        {
+            let mut node = open_node_at(&temp_dir, schema.clone());
+            tx_id = node
+                .commit_mergeable_settled(
+                    MergeableCommit::new("todos", row(invalid_id as u8), 10)
+                        .cells(title_cells("corrupt authored ids")),
+                )
+                .unwrap();
+            let version = node.query_versions_for_tx(tx_id).unwrap().remove(0);
+
+            // Remove the valid derived carrier first, then replace only the
+            // immutable persisted history row with malformed raw bytes.
+            let mut cleanup = node.database.open_batch();
+            node.write_ahead_current_delete(&mut cleanup, &version).unwrap();
+            let applied = crate::db::block_on(node.database.apply_batch(cleanup)).unwrap();
+            let persisted = crate::db::block_on(applied.persist());
+            node.database.finish_persistence(persisted).unwrap();
+            assert_eq!(ahead_current_row_count(&mut node, "todos"), 0);
+
+            let schema_version = node
+                .schema_version_for_alias(version.schema_version_alias())
+                .unwrap();
+            let table = node
+                .table_in_schema(version.table(), schema_version)
+                .unwrap()
+                .clone();
+            let corrupted = VersionRow::from_parts_with_schema_version(
+                &table,
+                VersionRowParts {
+                    table: version.table().to_owned(),
+                    branch_key: version.branch_key().clone(),
+                    row_uuid: version.row_uuid(),
+                    tx_node_alias: version.tx_node_alias(),
+                    schema_version_alias: version.schema_version_alias(),
+                    tx_time: version.tx_time(),
+                    parents: version.parents(),
+                    created_by: version.created_by(),
+                    created_at: version.created_at(),
+                    updated_by: version.updated_by(),
+                    updated_at: version.updated_at(),
+                    cells: version.cells(&table).unwrap(),
+                    authored_columns: Some(BTreeSet::from([PhysicalColumnId(invalid_id)])),
+                    deletion: None,
+                },
+                None,
+                None,
+            )
+            .unwrap();
+            let (history_table, raw) = node.version_storage_write_binding(&corrupted).unwrap();
+            let mut corruption = node.database.open_batch();
+            corruption.update_raw(
+                history_table.to_string(),
+                node.version_storage_primary_key(&corrupted).unwrap(),
+                raw,
+            );
+            let applied = crate::db::block_on(node.database.apply_batch(corruption)).unwrap();
+            let persisted = crate::db::block_on(applied.persist());
+            node.database.finish_persistence(persisted).unwrap();
+        }
+
+        let mut reopened = reopen_node_at(&temp_dir, node(1), schema);
+        let corrupted = reopened.query_versions_for_tx(tx_id).unwrap().remove(0);
+        let mut ahead = reopened.database.open_batch();
+        assert!(reopened
+            .write_ahead_current_insert(&mut ahead, &corrupted)
+            .is_err());
+        let mut global = reopened.database.open_batch();
+        assert!(reopened
+            .write_global_current_update(&mut global, &corrupted, GlobalTime(1))
+            .is_err());
+        assert_eq!(ahead_current_row_count(&mut reopened, "todos"), 0);
+        let table_id = reopened
+            .physical_table_id_for_schema(reopened.catalogue.current_schema_version_id, "todos")
+            .unwrap();
+        assert!(reopened
+            .database
+            .primary_key_scan_raw(&physical_global_current_table_name(table_id), &[])
+            .unwrap()
+            .is_empty());
+    }
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -1032,7 +1032,14 @@ fn policy_graph_perf_fixture_version_layouts_round_trip_all_storage_records() {
                 .collect(),
             authored_columns: deletion
                 .is_none()
-                .then(|| table.columns.iter().map(|column| column.name.clone()).collect()),
+                .then(|| {
+                    table
+                        .columns
+                        .iter()
+                        .enumerate()
+                        .map(|(index, _)| PhysicalColumnId(index as u64 + 1))
+                        .collect()
+                }),
             deletion,
         }
     }
@@ -1057,6 +1064,17 @@ fn policy_graph_perf_fixture_version_layouts_round_trip_all_storage_records() {
                 .create(&content_values)
                 .unwrap(),
             content.record.raw()
+        );
+        let authored_columns_idx = content
+            .record
+            .descriptor()
+            .field_index("authored_columns")
+            .unwrap();
+        assert_eq!(
+            content_values[authored_columns_idx],
+            Value::Nullable(Some(Box::new(Value::Array(
+                (1..=table.columns.len() as u64).map(Value::U64).collect()
+            ))))
         );
 
         let current_values = global_current_values(table, &content, Some(GlobalTime(7))).unwrap();
@@ -1127,6 +1145,33 @@ fn mergeable_commits_persist_transaction_and_history_rows() {
             .is_empty()
     );
     assert!(database.query_graph(history).unwrap().iter().next().is_some());
+}
+
+#[test]
+fn stored_authored_columns_require_a_canonical_physical_id_array() {
+    assert_eq!(
+        authored_column_ids_from_value(Value::Array(vec![Value::U64(2), Value::U64(5)]))
+            .unwrap(),
+        BTreeSet::from([PhysicalColumnId(2), PhysicalColumnId(5)])
+    );
+    assert!(matches!(
+        authored_column_ids_from_value(Value::Array(vec![Value::U64(2), Value::U64(2)])),
+        Err(Error::InvalidStoredValue(
+            "authored physical column ids must be strictly increasing"
+        ))
+    ));
+    assert!(matches!(
+        authored_column_ids_from_value(Value::Array(vec![Value::U64(5), Value::U64(2)])),
+        Err(Error::InvalidStoredValue(
+            "authored physical column ids must be strictly increasing"
+        ))
+    ));
+    assert!(matches!(
+        authored_column_ids_from_value(Value::Bytes(Vec::new())),
+        Err(Error::InvalidStoredValue(
+            "authored columns must be an array of physical column ids"
+        ))
+    ));
 }
 
 #[test]

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1933,7 +1933,7 @@ where
         // authored cells were replaced by typed nulls.
         let has_complete_authored_payload = has_authored_layout
             && (version.layer() == VersionLayer::Deletion
-                || match version.authored_columns(&authored_table)? {
+                || match self.authored_columns_for_version(version)? {
                     Some(authored) => authored.iter().all(|column| {
                         version
                             .cell(&authored_table, column)

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 use groove::large_values::Locator;
-use groove::records::{OwnedRecord, Value};
+use groove::records::{OwnedRecord, RecordDescriptor, Value, ValueType};
 
 use crate::ids::{
     AuthorSubject, MigrationLensId, NodeUuid, RowUuid, SchemaLineagePublicationId, SchemaVersionId,
@@ -1790,7 +1790,41 @@ impl BranchViewBase {
     }
 }
 
+/// Error decoding the frozen branch-coordinate codec.
+#[derive(Debug, thiserror::Error)]
+pub enum BranchCodecError {
+    /// The envelope version, tag, length, ordering, or payload is invalid.
+    #[error("invalid branch codec envelope")]
+    InvalidEnvelope,
+    /// The supplied value or declared column type cannot be a branch column.
+    #[error("unsupported branch column type")]
+    UnsupportedType,
+    /// The encoded scalar tag does not match the declared schema type.
+    #[error("branch column encoding does not match its declared type")]
+    TypeMismatch,
+    /// Groove rejected the declared-type payload.
+    #[error("invalid Groove branch column payload: {0}")]
+    Groove(#[from] groove::records::Error),
+}
+
+const BRANCH_COLUMN_CODEC_VERSION: u8 = 1;
+const BRANCH_COLUMN_U8: u8 = 0;
+const BRANCH_COLUMN_U16: u8 = 1;
+const BRANCH_COLUMN_U32: u8 = 2;
+const BRANCH_COLUMN_U64: u8 = 3;
+const BRANCH_COLUMN_I32: u8 = 4;
+const BRANCH_COLUMN_I64: u8 = 5;
+const BRANCH_COLUMN_STRING: u8 = 6;
+const BRANCH_COLUMN_UUID: u8 = 7;
+const BRANCH_COLUMN_ENUM_TAG: u8 = 8;
+
 /// Canonical wire/storage encoding of one branch-column value.
+///
+/// Byte zero is the codec version, byte one is a permanently assigned scalar
+/// tag, and the remainder is the canonical Groove encoding under the declared
+/// column type. Keeping the tag outside Groove lets a selector cross the wire
+/// before a table is chosen while exact [`BranchKey`] construction still
+/// re-encodes and validates the payload against that table's schema.
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize,
 )]
@@ -1798,16 +1832,112 @@ pub struct BranchColumnValue(pub Vec<u8>);
 
 impl From<Value> for BranchColumnValue {
     fn from(value: Value) -> Self {
-        Self(postcard::to_allocvec(&value).expect("branch column values are encodable"))
+        let value_type = match &value {
+            Value::U8(_) => ValueType::U8,
+            Value::U16(_) => ValueType::U16,
+            Value::U32(_) => ValueType::U32,
+            Value::U64(_) => ValueType::U64,
+            Value::I32(_) => ValueType::I32,
+            Value::I64(_) => ValueType::I64,
+            Value::String(_) => ValueType::String,
+            Value::Uuid(_) => ValueType::Uuid,
+            Value::EnumTag(tag) => {
+                return Self(vec![
+                    BRANCH_COLUMN_CODEC_VERSION,
+                    BRANCH_COLUMN_ENUM_TAG,
+                    *tag,
+                ]);
+            }
+            // Preserve `BranchSelector::new` as an infallible constructor.
+            // Schema projection rejects this unknown tag before it can become
+            // an exact key or persistent coordinate.
+            _ => return Self(vec![BRANCH_COLUMN_CODEC_VERSION, u8::MAX]),
+        };
+        Self::encode_typed(&value, &value_type)
+            .expect("inferred branch selector type accepts its value")
     }
 }
 
 impl BranchColumnValue {
-    /// Decode the value for validation and ordinary column projection.
-    pub fn decode(&self) -> Result<Value, postcard::Error> {
-        postcard::from_bytes(&self.0)
+    /// Encode one value using its schema-declared Groove column type.
+    pub(crate) fn encode_typed(
+        value: &Value,
+        value_type: &ValueType,
+    ) -> Result<Self, BranchCodecError> {
+        let tag = branch_column_tag(value_type).ok_or(BranchCodecError::UnsupportedType)?;
+        let descriptor = RecordDescriptor::new([("value", value_type.clone())]);
+        let payload = descriptor.create(std::slice::from_ref(value))?;
+        let mut bytes = Vec::with_capacity(2 + payload.len());
+        bytes.extend([BRANCH_COLUMN_CODEC_VERSION, tag]);
+        bytes.extend(payload);
+        Ok(Self(bytes))
+    }
+
+    /// Decode a selector value before a table-specific type is available.
+    pub fn decode(&self) -> Result<Value, BranchCodecError> {
+        let (tag, payload) = self.envelope()?;
+        if tag == BRANCH_COLUMN_ENUM_TAG {
+            return match payload {
+                [tag] => Ok(Value::EnumTag(*tag)),
+                _ => Err(BranchCodecError::InvalidEnvelope),
+            };
+        }
+        let value_type = branch_column_type(tag).ok_or(BranchCodecError::InvalidEnvelope)?;
+        self.decode_as(&value_type)
+    }
+
+    /// Decode and canonically validate an exact key value against its schema.
+    pub(crate) fn decode_as(&self, value_type: &ValueType) -> Result<Value, BranchCodecError> {
+        let (tag, payload) = self.envelope()?;
+        if branch_column_tag(value_type) != Some(tag) {
+            return Err(BranchCodecError::TypeMismatch);
+        }
+        let descriptor = RecordDescriptor::new([("value", value_type.clone())]);
+        let value = descriptor.get_idx(payload, 0)?;
+        if descriptor.create(std::slice::from_ref(&value))? != payload {
+            return Err(BranchCodecError::InvalidEnvelope);
+        }
+        Ok(value)
+    }
+
+    fn envelope(&self) -> Result<(u8, &[u8]), BranchCodecError> {
+        match self.0.as_slice() {
+            [BRANCH_COLUMN_CODEC_VERSION, tag, payload @ ..] => Ok((*tag, payload)),
+            _ => Err(BranchCodecError::InvalidEnvelope),
+        }
     }
 }
+
+fn branch_column_tag(value_type: &ValueType) -> Option<u8> {
+    match value_type {
+        ValueType::U8 => Some(BRANCH_COLUMN_U8),
+        ValueType::U16 => Some(BRANCH_COLUMN_U16),
+        ValueType::U32 => Some(BRANCH_COLUMN_U32),
+        ValueType::U64 => Some(BRANCH_COLUMN_U64),
+        ValueType::I32 => Some(BRANCH_COLUMN_I32),
+        ValueType::I64 => Some(BRANCH_COLUMN_I64),
+        ValueType::String => Some(BRANCH_COLUMN_STRING),
+        ValueType::Uuid => Some(BRANCH_COLUMN_UUID),
+        ValueType::EnumTag(_) => Some(BRANCH_COLUMN_ENUM_TAG),
+        _ => None,
+    }
+}
+
+fn branch_column_type(tag: u8) -> Option<ValueType> {
+    match tag {
+        BRANCH_COLUMN_U8 => Some(ValueType::U8),
+        BRANCH_COLUMN_U16 => Some(ValueType::U16),
+        BRANCH_COLUMN_U32 => Some(ValueType::U32),
+        BRANCH_COLUMN_U64 => Some(ValueType::U64),
+        BRANCH_COLUMN_I32 => Some(ValueType::I32),
+        BRANCH_COLUMN_I64 => Some(ValueType::I64),
+        BRANCH_COLUMN_STRING => Some(ValueType::String),
+        BRANCH_COLUMN_UUID => Some(ValueType::Uuid),
+        _ => None,
+    }
+}
+
+const BRANCH_KEY_CODEC_VERSION: u8 = 1;
 
 /// Exact, table-projected branch coordinate carried by every row version.
 #[derive(
@@ -1830,13 +1960,77 @@ pub struct BranchKey {
 impl BranchKey {
     /// Canonical bytes used as the physical branch-local row-key prefix.
     pub fn canonical_bytes(&self) -> Vec<u8> {
-        postcard::to_allocvec(self).expect("branch keys are encodable")
+        assert!(
+            self.values.windows(2).all(|pair| pair[0].0 < pair[1].0),
+            "branch keys require strictly ordered unique column names"
+        );
+        let mut bytes = Vec::new();
+        bytes.push(BRANCH_KEY_CODEC_VERSION);
+        put_branch_component_len(&mut bytes, self.values.len());
+        for (name, value) in &self.values {
+            put_branch_component_len(&mut bytes, name.len());
+            bytes.extend(name.as_bytes());
+            put_branch_component_len(&mut bytes, value.0.len());
+            bytes.extend(&value.0);
+        }
+        bytes
     }
 
     /// Decode a persisted exact branch key.
-    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
-        postcard::from_bytes(bytes)
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, BranchCodecError> {
+        let [BRANCH_KEY_CODEC_VERSION, rest @ ..] = bytes else {
+            return Err(BranchCodecError::InvalidEnvelope);
+        };
+        let mut cursor = rest;
+        let count = take_branch_component_len(&mut cursor)?;
+        if count > cursor.len() / 8 {
+            return Err(BranchCodecError::InvalidEnvelope);
+        }
+        let mut values = Vec::with_capacity(count);
+        for _ in 0..count {
+            let name_len = take_branch_component_len(&mut cursor)?;
+            let name = take_branch_component(&mut cursor, name_len)?;
+            let name = std::str::from_utf8(name)
+                .map_err(|_| BranchCodecError::InvalidEnvelope)?
+                .to_owned();
+            let value_len = take_branch_component_len(&mut cursor)?;
+            let value = BranchColumnValue(take_branch_component(&mut cursor, value_len)?.to_vec());
+            value.decode()?;
+            if values.last().is_some_and(|(previous, _)| previous >= &name) {
+                return Err(BranchCodecError::InvalidEnvelope);
+            }
+            values.push((name, value));
+        }
+        if !cursor.is_empty() {
+            return Err(BranchCodecError::InvalidEnvelope);
+        }
+        Ok(Self { values })
     }
+}
+
+fn put_branch_component_len(bytes: &mut Vec<u8>, len: usize) {
+    let len = u32::try_from(len).expect("branch codec component exceeds u32");
+    bytes.extend(len.to_le_bytes());
+}
+
+fn take_branch_component_len(cursor: &mut &[u8]) -> Result<usize, BranchCodecError> {
+    let encoded = take_branch_component(cursor, 4)?;
+    Ok(u32::from_le_bytes(
+        encoded
+            .try_into()
+            .map_err(|_| BranchCodecError::InvalidEnvelope)?,
+    ) as usize)
+}
+
+fn take_branch_component<'a>(
+    cursor: &mut &'a [u8],
+    len: usize,
+) -> Result<&'a [u8], BranchCodecError> {
+    let (value, rest) = cursor
+        .split_at_checked(len)
+        .ok_or(BranchCodecError::InvalidEnvelope)?;
+    *cursor = rest;
+    Ok(value)
 }
 
 /// Optional base composed underneath the live head of a branch view.
@@ -3226,6 +3420,51 @@ mod tests {
 
     fn schema_id(byte: u8) -> SchemaVersionId {
         SchemaVersionId::from_bytes([byte; 16])
+    }
+
+    // This is intentionally an internal byte-level test: the durable physical
+    // identity is not observable through the public row API, and a behavioral
+    // round trip alone would not freeze the assigned version, tags, or widths.
+    #[test]
+    fn branch_coordinate_codec_has_frozen_declared_type_bytes() {
+        let integer =
+            BranchColumnValue::encode_typed(&Value::U32(0x0102_0304), &ValueType::U32).unwrap();
+        let string =
+            BranchColumnValue::encode_typed(&Value::String("hi".to_owned()), &ValueType::String)
+                .unwrap();
+        assert_eq!(integer.0, [1, 2, 4, 3, 2, 1]);
+        assert_eq!(string.0, [1, 6, 2, b'h', b'i']);
+
+        let stable_enum = ValueType::EnumTag(
+            groove::records::ScalarEnumSchema::new("phase", ["draft", "ready"]).unwrap(),
+        );
+        let enum_value =
+            BranchColumnValue::encode_typed(&Value::String("ready".to_owned()), &stable_enum)
+                .unwrap();
+        assert_eq!(enum_value.0, [1, 8, 1]);
+        assert_eq!(
+            enum_value.decode_as(&stable_enum).unwrap(),
+            Value::EnumTag(1)
+        );
+
+        let key = BranchKey {
+            values: vec![("a".to_owned(), integer), ("z".to_owned(), string)],
+        };
+        let expected = [
+            1, // key codec version
+            2, 0, 0, 0, // entry count
+            1, 0, 0, 0, b'a', // first name
+            6, 0, 0, 0, 1, 2, 4, 3, 2, 1, // first value
+            1, 0, 0, 0, b'z', // second name
+            5, 0, 0, 0, 1, 6, 2, b'h', b'i', // second value
+        ];
+        assert_eq!(key.canonical_bytes(), expected);
+        assert_eq!(BranchKey::from_canonical_bytes(&expected).unwrap(), key);
+
+        let mut trailing = expected.to_vec();
+        trailing.push(0);
+        assert!(BranchKey::from_canonical_bytes(&trailing).is_err());
+        assert!(BranchKey::from_canonical_bytes(&[0]).is_err());
     }
 
     #[test]

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -3465,6 +3465,29 @@ mod tests {
         trailing.push(0);
         assert!(BranchKey::from_canonical_bytes(&trailing).is_err());
         assert!(BranchKey::from_canonical_bytes(&[0]).is_err());
+
+        let append_entry = |bytes: &mut Vec<u8>, name: &str, value: &[u8]| {
+            bytes.extend((name.len() as u32).to_le_bytes());
+            bytes.extend(name.as_bytes());
+            bytes.extend((value.len() as u32).to_le_bytes());
+            bytes.extend(value);
+        };
+        let mut duplicate = vec![1];
+        duplicate.extend(2_u32.to_le_bytes());
+        append_entry(&mut duplicate, "a", &[1, 0, 7]);
+        append_entry(&mut duplicate, "a", &[1, 0, 8]);
+        assert!(BranchKey::from_canonical_bytes(&duplicate).is_err());
+
+        let mut descending = vec![1];
+        descending.extend(2_u32.to_le_bytes());
+        append_entry(&mut descending, "z", &[1, 0, 7]);
+        append_entry(&mut descending, "a", &[1, 0, 8]);
+        assert!(BranchKey::from_canonical_bytes(&descending).is_err());
+
+        let mut unknown_tag = vec![1];
+        unknown_tag.extend(1_u32.to_le_bytes());
+        append_entry(&mut unknown_tag, "a", &[1, u8::MAX]);
+        assert!(BranchKey::from_canonical_bytes(&unknown_tag).is_err());
     }
 
     #[test]

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -1040,11 +1040,12 @@ impl TableSchema {
                 storage_column_type(user_column).nullable(),
             )
         }));
-        // Absent on legacy records. When present, this is a serialized set of
-        // user columns explicitly authored by this version.
+        // Absent on legacy records. When present, this is a strictly ordered
+        // set of node-local physical column ids explicitly authored by this
+        // version. Logical names remain a wire/schema-boundary concern.
         columns.push(column(
             "authored_columns",
-            GrooveColumnType::Bytes.nullable(),
+            GrooveColumnType::U64.array_of().nullable(),
         ));
 
         GrooveTableSchema::new(name, columns)
@@ -1123,7 +1124,7 @@ impl TableSchema {
         }));
         content_columns.push(column(
             "authored_columns",
-            GrooveColumnType::Bytes.nullable(),
+            GrooveColumnType::U64.array_of().nullable(),
         ));
         let mut content_table = GrooveTableSchema::new(
             format!("jazz_{}_global_current", self.name),
@@ -1188,7 +1189,7 @@ impl TableSchema {
         }));
         content_columns.push(column(
             "authored_columns",
-            GrooveColumnType::Bytes.nullable(),
+            GrooveColumnType::U64.array_of().nullable(),
         ));
         vec![
             GrooveTableSchema::new(format!("jazz_{}_ahead_current", self.name), content_columns)
@@ -2045,6 +2046,8 @@ mod tests {
         let current_tables = schema.tables[0].global_current_storage_tables();
         let global_current = &current_tables[0];
         let register_global_current = &current_tables[1];
+        let ahead_tables = schema.tables[0].ahead_current_storage_tables();
+        let ahead_current = &ahead_tables[0];
 
         for table in [&history, &register, global_current, register_global_current] {
             for name in ["created_by", "updated_by"] {
@@ -2059,6 +2062,19 @@ mod tests {
                     table.name
                 );
             }
+        }
+
+        for table in [&history, global_current, ahead_current] {
+            assert_eq!(
+                table
+                    .columns
+                    .iter()
+                    .find(|column| column.name == "authored_columns")
+                    .map(|column| &column.column_type),
+                Some(&GrooveColumnType::U64.array_of().nullable()),
+                "authored_columns must remain a native physical-id array in {}",
+                table.name
+            );
         }
 
         assert!(

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -311,6 +311,33 @@ impl RuntimeSchema {
         table: &TableSchema,
         key: &BranchKey,
     ) -> Result<BTreeMap<String, Value>, String> {
+        Self::validate_branch_key_for_table(table, key)
+    }
+
+    /// Decode one persisted branch coordinate using the table that owns it.
+    ///
+    /// The binary envelope is only self-describing enough to reject malformed
+    /// bytes. The table's branch declaration is the authority for component
+    /// names, scalar types, and stable-enum domains, so recovery must perform
+    /// this second validation before a physical coordinate can influence a
+    /// query or cache.
+    pub(crate) fn decode_persisted_branch_key(
+        table: &TableSchema,
+        bytes: &[u8],
+    ) -> Result<BranchKey, String> {
+        let key = BranchKey::from_canonical_bytes(bytes)
+            .map_err(|_| format!("invalid persisted branch key for {}", table.name))?;
+        Self::validate_branch_key_for_table(table, &key)?;
+        Ok(key)
+    }
+
+    /// Validate an exact branch coordinate against its owning table
+    /// declaration. Shared by admission and persisted-state recovery so their
+    /// type/domain rules cannot drift.
+    pub(crate) fn validate_branch_key_for_table(
+        table: &TableSchema,
+        key: &BranchKey,
+    ) -> Result<BTreeMap<String, Value>, String> {
         let mut bindings = table.branch_by.iter().collect::<Vec<_>>();
         bindings.sort();
         if key.values.len() != bindings.len() {
@@ -2174,6 +2201,55 @@ mod tests {
         assert!(
             serde_json::from_value::<ColumnSchema>(spoofed_kind).is_err(),
             "semantic kind must be structurally compatible with its public column type"
+        );
+    }
+
+    #[test]
+    fn persisted_branch_keys_require_the_owning_table_type_and_enum_domain() {
+        let uuid_schema = RuntimeSchema::new([TableSchema::new(
+            "todos",
+            [ColumnSchema::new("branch", ColumnType::Uuid)],
+        )
+        .with_branch_column("branch")]);
+        let uuid_table = &uuid_schema.tables[0];
+        let (valid, _) = uuid_schema
+            .project_branch_selector(
+                uuid_table,
+                &BranchSelector::new([("branch", Value::Uuid(uuid::Uuid::from_bytes([0x42; 16])))]),
+            )
+            .unwrap();
+        assert_eq!(
+            RuntimeSchema::decode_persisted_branch_key(uuid_table, &valid.canonical_bytes())
+                .unwrap(),
+            valid
+        );
+
+        let wrong_scalar = BranchKey {
+            values: vec![(
+                "branch".to_owned(),
+                BranchColumnValue::from(Value::String("not-a-uuid".to_owned())),
+            )],
+        };
+        assert!(
+            RuntimeSchema::decode_persisted_branch_key(uuid_table, &wrong_scalar.canonical_bytes())
+                .is_err()
+        );
+
+        let phase = ScalarEnumSchema::new("phase", ["draft", "ready"]).unwrap();
+        let enum_schema = RuntimeSchema::new([TableSchema::new(
+            "todos",
+            [ColumnSchema::new("phase", ColumnType::EnumTag(phase))],
+        )
+        .with_branch_column("phase")]);
+        let invalid_enum = BranchKey {
+            values: vec![("phase".to_owned(), BranchColumnValue(vec![1, 8, u8::MAX]))],
+        };
+        assert!(
+            RuntimeSchema::decode_persisted_branch_key(
+                &enum_schema.tables[0],
+                &invalid_enum.canonical_bytes()
+            )
+            .is_err()
         );
     }
 }

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -176,15 +176,12 @@ impl RuntimeSchema {
             let value = encoded
                 .decode()
                 .map_err(|_| format!("invalid branch column {column_name} encoding"))?;
-            if BranchColumnValue::from(value.clone()) != *encoded {
-                return Err(format!(
-                    "non-canonical branch column {column_name} encoding"
-                ));
-            }
             RecordDescriptor::new([("value", column.column_type.clone())])
                 .create(std::slice::from_ref(&value))
                 .map_err(|_| format!("invalid branch column {column_name} value"))?;
-            values.push((column_name.clone(), encoded.clone()));
+            let encoded = BranchColumnValue::encode_typed(&value, &column.column_type)
+                .map_err(|_| format!("invalid branch column {column_name} value"))?;
+            values.push((column_name.clone(), encoded));
             cells.insert(column_name.clone(), value);
         }
         values.sort_by(|left, right| left.0.cmp(&right.0));
@@ -243,7 +240,12 @@ impl RuntimeSchema {
                 .find(|(name, _)| name == column_name)
                 .map(|(_, value)| value)
                 .cloned()
-                .or_else(|| column.default.clone().map(BranchColumnValue::from));
+                .or_else(|| {
+                    column.default.as_ref().map(|value| {
+                        BranchColumnValue::encode_typed(value, &column.column_type)
+                            .expect("validated branch default")
+                    })
+                });
             selected == stored.as_ref()
         }) && stored
             .values
@@ -282,7 +284,12 @@ impl RuntimeSchema {
                     .iter()
                     .find(|(name, _)| name == column_name)
                     .map(|(_, value)| value.clone())
-                    .or_else(|| column.default.clone().map(BranchColumnValue::from))
+                    .or_else(|| {
+                        column.default.as_ref().map(|value| {
+                            BranchColumnValue::encode_typed(value, &column.column_type)
+                                .expect("validated branch default")
+                        })
+                    })
                     .ok_or_else(|| {
                         format!(
                             "older branch key is missing {column_name} without a migration default"
@@ -328,9 +335,12 @@ impl RuntimeSchema {
                 .find(|column| column.name == *column_name)
                 .ok_or_else(|| format!("unknown branch column on {}", table.name))?;
             let value = encoded
-                .decode()
+                .decode_as(&column.column_type)
                 .map_err(|_| format!("invalid branch column {column_name} encoding"))?;
-            if BranchColumnValue::from(value.clone()) != *encoded {
+            if BranchColumnValue::encode_typed(&value, &column.column_type)
+                .map_err(|_| format!("invalid branch column {column_name} value"))?
+                != *encoded
+            {
                 return Err(format!(
                     "non-canonical branch column {column_name} encoding"
                 ));
@@ -361,7 +371,12 @@ impl RuntimeSchema {
                 .iter()
                 .find(|(name, _)| name == column_name)
                 .map(|(_, value)| value.clone())
-                .or_else(|| column.default.clone().map(BranchColumnValue::from))
+                .or_else(|| {
+                    column.default.as_ref().map(|value| {
+                        BranchColumnValue::encode_typed(value, &column.column_type)
+                            .expect("validated branch default")
+                    })
+                })
                 .ok_or_else(|| {
                     format!("branch key is missing {column_name} without a migration default")
                 })?;
@@ -1710,6 +1725,34 @@ mod tests {
             [ColumnSchema::new("branch", ColumnType::String)],
         )
         .with_branch_column("branch")]);
+    }
+
+    #[test]
+    fn branch_selector_projection_uses_the_declared_enum_codec() {
+        let phase = ScalarEnumSchema::new("phase", ["draft", "ready"]).unwrap();
+        let schema = RuntimeSchema::new([TableSchema::new(
+            "todos",
+            [ColumnSchema::new(
+                "phase",
+                ColumnType::EnumTag(phase.clone()),
+            )],
+        )
+        .with_branch_column("phase")]);
+        let table = &schema.tables[0];
+
+        let (key, cells) = schema
+            .project_branch_selector(
+                table,
+                &BranchSelector::new([("phase", Value::String("ready".to_owned()))]),
+            )
+            .unwrap();
+
+        assert_eq!(key.values[0].1.0, [1, 8, 1]);
+        assert_eq!(cells["phase"], Value::String("ready".to_owned()));
+        assert_eq!(
+            schema.validate_authored_branch_key(table, &key).unwrap()["phase"],
+            Value::EnumTag(1)
+        );
     }
 
     #[test]

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -383,12 +383,12 @@ describe("JazzClient transaction query plumbing", () => {
     );
 
     expect(JSON.parse(runtime.insert.mock.calls[0][2] as string)).toMatchObject({
-      branch_view: { head: { values: { workspace: [15, 14] } } },
+      branch_view: { head: { values: { workspace: [1, 4, 7, 0, 0, 0] } } },
     });
     expect(JSON.parse(runtime.update.mock.calls[0][3] as string)).toMatchObject({
       branch_view: {
-        head: { values: { workspace: [15, 14] } },
-        base: { Current: { values: { workspace: [15, 2] } } },
+        head: { values: { workspace: [1, 4, 7, 0, 0, 0] } },
+        base: { Current: { values: { workspace: [1, 4, 1, 0, 0, 0] } } },
       },
     });
   });
@@ -418,12 +418,12 @@ describe("JazzClient transaction query plumbing", () => {
       read_view: {
         source: {
           BranchView: {
-            head: { values: { workspace: [15, 14] } },
+            head: { values: { workspace: [1, 4, 7, 0, 0, 0] } },
             base: {
               Current: {
                 values: {
-                  workspace: [15, 2],
-                  tenant: [9, 16, ...Array(16).fill(0x42)],
+                  workspace: [1, 4, 1, 0, 0, 0],
+                  tenant: [1, 7, ...Array(16).fill(0x42)],
                 },
               },
             },
@@ -449,7 +449,7 @@ describe("JazzClient transaction query plumbing", () => {
       read_view: {
         source: {
           BranchView: {
-            head: { values: { branch: [6, 5, 100, 114, 97, 102, 116] } },
+            head: { values: { branch: [1, 6, 2, 100, 114, 97, 102, 116] } },
           },
         },
       },

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -26,7 +26,6 @@ import {
   resolveRuntimeConfigWasmUrl,
 } from "./runtime-config.js";
 import { httpUrlToWs } from "./url.js";
-import { PostcardWriter } from "./native-runtime/native-codec.js";
 import { assertNativeArtifactCompatibility } from "./native-artifact-compatibility.js";
 
 type RuntimeSerializedSession = Pick<Session, "issuer" | "user_id" | "claims" | "authMode"> & {
@@ -45,7 +44,12 @@ function serializeRuntimeSession(session: Session): RuntimeSerializedSession {
 }
 
 function encodeBranchColumnValue(value: Value): Uint8Array {
-  const writer = new PostcardWriter();
+  const envelope = (tag: number, payload: Uint8Array): Uint8Array => {
+    const encoded = new Uint8Array(2 + payload.length);
+    encoded.set([1, tag]); // frozen branch-column codec version and scalar tag
+    encoded.set(payload, 2);
+    return encoded;
+  };
   switch (value.type) {
     case "Integer":
       if (
@@ -55,9 +59,11 @@ function encodeBranchColumnValue(value: Value): Uint8Array {
       ) {
         throw new Error("branch Integer values must be signed 32-bit integers");
       }
-      writer.enumUnit(15); // groove::Value::I32
-      writer.i64(value.value);
-      break;
+      {
+        const payload = new Uint8Array(4);
+        new DataView(payload.buffer).setInt32(0, value.value, true);
+        return envelope(4, payload); // Groove I32
+      }
     case "BigInt": {
       if (typeof value.value === "number" && !Number.isSafeInteger(value.value)) {
         throw new Error("branch BigInt values supplied as numbers must be safe integers");
@@ -66,31 +72,32 @@ function encodeBranchColumnValue(value: Value): Uint8Array {
       if (integer < -(1n << 63n) || integer > (1n << 63n) - 1n) {
         throw new Error("branch BigInt values must be signed 64-bit integers");
       }
-      writer.enumUnit(14); // groove::Value::I64
-      writer.i64(integer);
-      break;
+      const payload = new Uint8Array(8);
+      new DataView(payload.buffer).setBigInt64(0, integer, true);
+      return envelope(5, payload); // Groove I64
     }
     case "Uuid": {
-      writer.enumUnit(9); // groove::Value::Uuid
       const hex = value.value.replaceAll("-", "");
       if (!/^[0-9a-fA-F]{32}$/.test(hex)) throw new Error(`invalid branch UUID ${value.value}`);
-      writer.bytes(
+      return envelope(
+        7, // Groove UUID
         Uint8Array.from({ length: 16 }, (_, index) =>
           Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16),
         ),
       );
-      break;
     }
-    case "Text":
-      writer.enumUnit(6); // groove::Value::String
-      writer.string(value.value);
-      break;
+    case "Text": {
+      const text = new TextEncoder().encode(value.value);
+      const payload = new Uint8Array(1 + text.length);
+      payload[0] = 2; // Groove stored-scalar Primitive case
+      payload.set(text, 1);
+      return envelope(6, payload); // Groove String
+    }
     default:
       throw new Error(
         `branch columns currently require Integer, BigInt, Text, or Uuid values; got ${value.type}`,
       );
   }
-  return writer.finish();
 }
 
 type WireBranchSelector = { values: Record<string, number[]> };


### PR DESCRIPTION
## Problem

Every applicable history, current, and ahead-current row stored authored_columns as JSON containing logical column names. This repeated strings across rows and coupled local provenance metadata to logical names that can change across schema versions and lenses.

## Solution

Declare authored_columns as a nullable Groove array of physical U64 column IDs. IDs are stored in strictly increasing order, resolved back to logical names only at schema and wire boundaries, and propagated consistently through ingest, projection, merge, and materialization paths.

An absent value retains the existing legacy or lens fallback in which present cells are treated as authored. The former JSON-in-Bytes representation is deliberately not accepted after this pre-v1 storage change.