### PR TITLE
Compile receipt helpers in library tests

### DIFF
--- a/crates/jazz/src/node/query_eval/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/subscriptions.rs
@@ -223,7 +223,7 @@ where
             .sum()
     }
 
-    #[cfg(feature = "testing")]
+    #[cfg(any(test, feature = "testing"))]
     /// Internal receipt-lifetime coverage needs to observe canonical caches:
     /// public reads intentionally treat a Local overlay as best-effort.
     pub fn settled_authoritative_receipt_counts_for_test(&self) -> (usize, usize) {


### PR DESCRIPTION
🤖 Aligns the test-only receipt helper cfg boundary so the Jazz library test target compiles on current main.

## Before

Db exposed settled_authoritative_receipt_counts_for_test under cfg(any(test, feature = testing)), but the delegated NodeState method existed only under feature = testing. Plain cargo test -p jazz --lib therefore failed to compile.

## After

Both layers use the same cfg(any(test, feature = testing)) boundary.

## Verification

- cargo test -p jazz --lib --no-run passes.

This is isolated from the larger #2209 repair so current CI and storage settlement branches can use a compilable main immediately.
