### PR TITLE
Harden React Native relay artifact detection

### DIFF
--- a/crates/jazz-rn/JazzRn.podspec
+++ b/crates/jazz-rn/JazzRn.podspec
@@ -26,10 +26,16 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/garden-co/jazz.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}", "ios/generated/**/*.{h,m,mm}"
+  # The staged header is the source-of-truth ABI declaration shared with the
+  # Android package. Keep this path when the legacy RN dependency branch below
+  # adds its own headers: assigning pod_target_xcconfig twice would otherwise
+  # compile this source with the unavailable-artifact fallback even though the
+  # package contains a valid XCFramework.
+  relay_header_search_path = "$(PODS_TARGET_SRCROOT)/native/include"
   relay_framework = File.join(__dir__, "JazzNativeRelay.xcframework")
   if File.exist?(relay_framework) then
     s.vendored_frameworks = "JazzNativeRelay.xcframework"
-    s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/native/include" }
+    s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => relay_header_search_path }
   end
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
@@ -40,8 +46,9 @@ Pod::Spec.new do |s|
 
     if new_arch_enabled then
       s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      current_header_paths = s.pod_target_xcconfig&.fetch("HEADER_SEARCH_PATHS", "") || ""
       s.pod_target_xcconfig    = {
-          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "HEADER_SEARCH_PATHS" => "#{current_header_paths} \"$(PODS_ROOT)/boost\"",
           "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
           "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
       }

--- a/crates/jazz-rn/babel.config.js
+++ b/crates/jazz-rn/babel.config.js
@@ -1,0 +1,9 @@
+/**
+ * Keep the package's relay-boundary receipts runnable in the same Babel mode
+ * as the React Native host. Without this local config Jest loads RN's ESM
+ * setup file untransformed, so missing/incompatible native-build diagnostics
+ * silently have no executable coverage.
+ */
+module.exports = {
+  presets: ["module:@react-native/babel-preset"],
+};

--- a/crates/jazz-rn/ios/JazzRelay.mm
+++ b/crates/jazz-rn/ios/JazzRelay.mm
@@ -1,6 +1,9 @@
 #import "JazzRelay.h"
 
-#if __has_include("jazz_native_relay.h")
+#if __has_include(<JazzNativeRelay/jazz_native_relay.h>)
+#import <JazzNativeRelay/jazz_native_relay.h>
+#define JAZZ_RELAY_ARTIFACT_AVAILABLE 1
+#elif __has_include("jazz_native_relay.h")
 #import "jazz_native_relay.h"
 #define JAZZ_RELAY_ARTIFACT_AVAILABLE 1
 #else

--- a/crates/jazz-rn/package.json
+++ b/crates/jazz-rn/package.json
@@ -128,7 +128,11 @@
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
     ],
-    "preset": "react-native"
+    "preset": "react-native",
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|\\.pnpm)/)",
+      "node_modules/.pnpm/(?!(react-native|@react-native\\+.*|@react-native-community\\+.*)@)"
+    ]
   },
   "packageManager": "pnpm@10.16.1",
   "codegenConfig": {

--- a/crates/jazz-rn/src/__tests__/index.test.tsx
+++ b/crates/jazz-rn/src/__tests__/index.test.tsx
@@ -24,7 +24,7 @@ it('tells Expo Go and old development builds that a native artifact is required'
   const relay = loadRelay(null);
 
   await expect(relay.executeNativeRelayCommand('AA==')).rejects.toThrow(
-    'install a matching native development or release build containing the Jazz relay artifact. Expo Go never includes it.',
+    'install a matching native development or release build containing the Jazz relay artifact. Expo Go never includes it.'
   );
 });
 
@@ -36,7 +36,20 @@ it('rejects an installed native build with an incompatible ABI before executing 
   const relay = loadRelay(nativeRelay);
 
   await expect(relay.executeNativeRelayCommand('AA==')).rejects.toThrow(
-    'Jazz native relay ABI 2 is incompatible with JavaScript ABI 3..=3; install a matching native development or release build.',
+    'Jazz native relay ABI 2 is incompatible with JavaScript ABI 3..=3; install a matching native development or release build.'
+  );
+  expect(nativeRelay.execute).not.toHaveBeenCalled();
+});
+
+it('rejects the source-only ABI fallback before executing a command', async () => {
+  const nativeRelay: NativeRelay = {
+    getAbiVersion: () => 0,
+    execute: jest.fn(),
+  };
+  const relay = loadRelay(nativeRelay);
+
+  await expect(relay.executeNativeRelayCommand('AA==')).rejects.toThrow(
+    'Jazz native relay is unavailable: this native build contains only the source fallback (ABI 0), not the Jazz relay artifact. Install a matching native development or release build.'
   );
   expect(nativeRelay.execute).not.toHaveBeenCalled();
 });

--- a/crates/jazz-rn/src/__tests__/index.test.tsx
+++ b/crates/jazz-rn/src/__tests__/index.test.tsx
@@ -1,1 +1,53 @@
-it.todo('write a test');
+type NativeRelay = {
+  getAbiVersion(): number;
+  execute(commandBase64: string): Promise<string>;
+};
+
+function loadRelay(nativeRelay: NativeRelay | null) {
+  jest.resetModules();
+  jest.doMock('../NativeJazzRelay', () => ({
+    __esModule: true,
+    default: nativeRelay,
+  }));
+  // Each case supplies the native boundary before importing the wrapper. That
+  // is the same one-time lookup Metro performs for an installed native build.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('../relay') as typeof import('../relay');
+}
+
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock('../NativeJazzRelay');
+});
+
+it('tells Expo Go and old development builds that a native artifact is required', async () => {
+  const relay = loadRelay(null);
+
+  await expect(relay.executeNativeRelayCommand('AA==')).rejects.toThrow(
+    'install a matching native development or release build containing the Jazz relay artifact. Expo Go never includes it.',
+  );
+});
+
+it('rejects an installed native build with an incompatible ABI before executing a command', async () => {
+  const nativeRelay: NativeRelay = {
+    getAbiVersion: () => 2,
+    execute: jest.fn(),
+  };
+  const relay = loadRelay(nativeRelay);
+
+  await expect(relay.executeNativeRelayCommand('AA==')).rejects.toThrow(
+    'Jazz native relay ABI 2 is incompatible with JavaScript ABI 3..=3; install a matching native development or release build.',
+  );
+  expect(nativeRelay.execute).not.toHaveBeenCalled();
+});
+
+it('forwards opaque commands only after the embedded relay ABI matches', async () => {
+  const nativeRelay: NativeRelay = {
+    getAbiVersion: () => 3,
+    execute: jest.fn().mockResolvedValue('AQ=='),
+  };
+  const relay = loadRelay(nativeRelay);
+
+  await expect(relay.executeNativeRelayCommand('AA==')).resolves.toBe('AQ==');
+  expect(nativeRelay.execute).toHaveBeenCalledWith('AA==');
+});

--- a/crates/jazz-rn/src/relay.ts
+++ b/crates/jazz-rn/src/relay.ts
@@ -34,6 +34,11 @@ export async function executeNativeRelayCommand(
 ): Promise<string> {
   const relay = requireNativeRelay();
   const nativeAbi = relay.getAbiVersion();
+  if (nativeAbi === 0) {
+    throw new Error(
+      'Jazz native relay is unavailable: this native build contains only the source fallback (ABI 0), not the Jazz relay artifact. Install a matching native development or release build.'
+    );
+  }
   if (
     nativeAbi < NATIVE_RELAY_ABI.minimum ||
     nativeAbi > NATIVE_RELAY_ABI.maximum

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -471,6 +471,13 @@ test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts",
     ]);
 
   assert.match(podspec, /JazzNativeRelay\.xcframework/);
+  assert.match(podspec, /relay_header_search_path/);
+  assert.match(podspec, /current_header_paths/);
+  assert.match(
+    podspec,
+    /HEADER_SEARCH_PATHS" => "#\{current_header_paths\} \\\"\$\(PODS_ROOT\)\/boost\\\""/,
+    "the legacy RN pod branch must retain the staged relay ABI header path",
+  );
   assert.match(podspec, /https:\/\/github\.com\/garden-co\/jazz\.git/);
   assert.doesNotMatch(podspec, /https:\/\/https:\/\//);
   assert.doesNotMatch(podspec, /uniffi-bindgen-react-native/);
@@ -486,6 +493,7 @@ test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts",
   assertNoLegacyIosMacroToken(iosRelay);
   assert.match(iosRelay, /JAZZ_RELAY_ARTIFACT_AVAILABLE/);
   assert.match(iosRelay, /jazz_native_relay_host_execute/);
+  assert.match(iosRelay, /<JazzNativeRelay\/jazz_native_relay\.h>/);
   assert.match(iosRelay, /E_JAZZ_RELAY_UNAVAILABLE/);
   assert.match(iosRelay, /NativeJazzRelaySpecJSI/);
   assert.doesNotMatch(packageRoot, /NativeJazzRn|uniffi/);

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -365,6 +365,37 @@ function assertOpaqueIosRelaySurface(iosRelay) {
   assertExactNames("iOS JazzRelay implementation", exportedMethods, iosRelaySelectors);
 }
 
+function legacyRelayHeaderSearchPaths(podspec) {
+  const stagedHeader = /^\s*relay_header_search_path\s*=\s*"([^"]+)"$/m.exec(podspec)?.[1];
+  assert.equal(
+    stagedHeader,
+    "$(PODS_TARGET_SRCROOT)/native/include",
+    "the staged relay ABI header must have one exact package-relative search path",
+  );
+
+  const initialConfig =
+    /s\.pod_target_xcconfig\s*=\s*\{\s*"HEADER_SEARCH_PATHS"\s*=>\s*relay_header_search_path\s*\}/m.test(
+      podspec,
+    );
+  assert.ok(
+    initialConfig,
+    "the vendored XCFramework branch must install the staged relay header before the legacy branch runs",
+  );
+
+  const legacyAssignment =
+    /current_header_paths\s*=\s*s\.pod_target_xcconfig&\.fetch\("HEADER_SEARCH_PATHS", ""\) \|\| ""[\s\S]*?"HEADER_SEARCH_PATHS"\s*=>\s*"#\{current_header_paths\} \\\"\$\(PODS_ROOT\)\/boost\\\""/m.test(
+      podspec,
+    );
+  assert.ok(
+    legacyAssignment,
+    "the legacy RN branch must extend its existing header paths rather than replace them",
+  );
+
+  // This is the exact value CocoaPods obtains for the staged-artifact path in
+  // the legacy branch: the prior value, followed by the legacy Boost include.
+  return `${stagedHeader} \"$(PODS_ROOT)/boost\"`;
+}
+
 test("jazz-rn publishes an Expo config plugin for a New Architecture development build", () => {
   const original = {
     name: "example",
@@ -471,12 +502,21 @@ test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts",
     ]);
 
   assert.match(podspec, /JazzNativeRelay\.xcframework/);
-  assert.match(podspec, /relay_header_search_path/);
-  assert.match(podspec, /current_header_paths/);
-  assert.match(
-    podspec,
-    /HEADER_SEARCH_PATHS" => "#\{current_header_paths\} \\\"\$\(PODS_ROOT\)\/boost\\\""/,
-    "the legacy RN pod branch must retain the staged relay ABI header path",
+  assert.equal(
+    legacyRelayHeaderSearchPaths(podspec),
+    '$(PODS_TARGET_SRCROOT)/native/include "$(PODS_ROOT)/boost"',
+    "the legacy RN pod branch must retain the exact staged relay ABI header path",
+  );
+  assert.throws(
+    () =>
+      legacyRelayHeaderSearchPaths(
+        podspec.replace(
+          "$(PODS_TARGET_SRCROOT)/native/include",
+          "$(PODS_TARGET_SRCROOT)/native/not-the-relay-header",
+        ),
+      ),
+    /exact package-relative search path/,
+    "the receipt must fail if the legacy branch retains a different staged-header path",
   );
   assert.match(podspec, /https:\/\/github\.com\/garden-co\/jazz\.git/);
   assert.doesNotMatch(podspec, /https:\/\/https:\/\//);

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -30,6 +30,7 @@ pre-commit:
         # This package owns its Prettier policy (single quotes); root oxfmt
         # otherwise rewrites it to its incompatible default.
         - "crates/jazz-rn/react-native.config.js"
+        - "crates/jazz-rn/src/**"
       run: pnpm exec oxfmt --ignore-path .oxfmtignore {staged_files}
       stage_fixed: true
     oxlint:


### PR DESCRIPTION
🤖 Hardens the React Native package boundary so staged native relay artifacts are detected consistently on iOS and source-only installs fail explicitly.

## Before

The legacy React Native CocoaPods branch replaced the package header search path while adding Boost. A package containing a valid vendored XCFramework could therefore compile against the ABI-0 fallback header and report that no native relay was installed. The JavaScript wrapper covered missing and incompatible modules, but not the ABI-0 source-only fallback as an executable receipt.

## After

- the legacy CocoaPods branch retains the exact staged relay header directory and extends it with Boost;
- framework-qualified and staged-header imports both resolve;
- ABI 0 is an explicit source-only/native-artifact-unavailable state and never executes a relay command;
- null module, ABI 0, incompatible nonzero ABI, and matching ABI each have executable JavaScript receipts;
- package tests understand pnpm layout without broadening runtime behavior;
- RN source keeps its package-owned Prettier policy while the root formatter avoids contradictory rewrites.

## Worked examples

1. A source-only or Expo Go-style install exposes ABI 0. The first persistent relay call fails with an instruction to install a native build, and native execute is never invoked.
2. An old native build exposing an unsupported nonzero ABI fails before storage is opened.
3. A correctly packaged legacy-RN iOS build retains native/include while adding the Boost search path, resolves the vendored relay header, reports ABI 3, and forwards commands.
4. Bare RN and Expo prebuild still autolink through the same package contract; Expo Go remains unsupported.

## Verification

- independent adversarial review;
- mutation-sensitive exact Podspec path receipt;
- mutation-sensitive ABI-0 no-execute receipt;
- RN Jest, TypeScript, package formatting, and Android+iOS Expo prebuild packaging gate.

This is a focused slice of #1972; producing and signing all platform binary slices remains follow-up work.
