### PR TITLE
Require trusted React Native relay admission

### DIFF
--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -958,6 +958,15 @@ impl RelayScope {
                 )));
             }
         }
+        if self
+            .auth_scope
+            .as_deref()
+            .is_some_and(|auth_scope| auth_scope.trim().is_empty())
+        {
+            return Err(RelayError::InvalidScope(
+                "auth scope must not be empty when supplied".to_owned(),
+            ));
+        }
         Ok(())
     }
 }
@@ -2381,39 +2390,109 @@ mod tests {
     fn trusted_admission_rejects_conflicting_scope_before_open() {
         let directory = tempfile::tempdir().unwrap();
         let mut host = NativeRelayHost::default();
-        let admission =
-            |sqlite_path: &str, claims: BTreeMap<String, Value>| RelayScopeAdmissionRequest {
+        let admission = |sqlite_path: &str,
+                         schema_json: String,
+                         identity: DbIdentity,
+                         claims: BTreeMap<String, Value>| {
+            RelayScopeAdmissionRequest {
                 scope: RelayScopeRequest {
                     app_namespace: "trusted-host".to_owned(),
                     storage_namespace: "primary".to_owned(),
                     auth_scope: Some("opaque-validated-subject".to_owned()),
                 },
                 sqlite_path: sqlite_path.to_owned(),
-                schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
-                identity: DbIdentity {
-                    node: NodeUuid::from_bytes([0xa1; 16]),
-                    author: AuthorSubject::for_test_bytes([0xa2; 16]),
-                },
+                schema_json,
+                identity,
                 claims,
-            };
+            }
+        };
         let primary = directory
             .path()
             .join("primary.sqlite")
             .display()
             .to_string();
-        host.admit_scope(admission(&primary, BTreeMap::new()))
-            .unwrap();
-        let other = directory.path().join("other.sqlite").display().to_string();
-        assert_eq!(
-            host.admit_scope(admission(&other, BTreeMap::new())),
-            Err(JazzNativeRelayStatus::LifecycleFailure),
-            "a scope cannot mint a second capability with different trusted storage"
-        );
-        assert_eq!(
-            host.admitted_scopes.len(),
-            1,
-            "failed admission must not leave a usable capability"
-        );
+        let schema_json = serde_json::to_string(schema().public_schema()).unwrap();
+        let identity = DbIdentity {
+            node: NodeUuid::from_bytes([0xa1; 16]),
+            author: AuthorSubject::for_test_bytes([0xa2; 16]),
+        };
+        let claims = BTreeMap::from([("role".to_owned(), Value::String("member".to_owned()))]);
+        host.admit_scope(admission(
+            &primary,
+            schema_json.clone(),
+            identity,
+            claims.clone(),
+        ))
+        .unwrap();
+
+        let other_path = directory.path().join("other.sqlite").display().to_string();
+        let other_schema = JazzSchema::new(
+            &SchemaBuilder::new()
+                .table(TableSchemaBuilder::new("other").column("title", ColumnType::Text))
+                .build(),
+        )
+        .unwrap();
+        let other_identity = DbIdentity {
+            node: NodeUuid::from_bytes([0xb1; 16]),
+            author: AuthorSubject::for_test_bytes([0xb2; 16]),
+        };
+        for (label, request) in [
+            (
+                "SQLite path",
+                admission(&other_path, schema_json.clone(), identity, claims.clone()),
+            ),
+            (
+                "schema",
+                admission(
+                    &primary,
+                    serde_json::to_string(other_schema.public_schema()).unwrap(),
+                    identity,
+                    claims.clone(),
+                ),
+            ),
+            (
+                "durable identity",
+                admission(
+                    &primary,
+                    schema_json.clone(),
+                    other_identity,
+                    claims.clone(),
+                ),
+            ),
+            (
+                "validated claims",
+                admission(
+                    &primary,
+                    schema_json.clone(),
+                    identity,
+                    BTreeMap::from([("role".to_owned(), Value::String("admin".to_owned()))]),
+                ),
+            ),
+        ] {
+            assert_eq!(
+                host.admit_scope(request),
+                Err(JazzNativeRelayStatus::LifecycleFailure),
+                "a scope cannot mint a second capability with changed trusted {label}"
+            );
+            assert_eq!(
+                host.admitted_scopes.len(),
+                1,
+                "failed {label} admission must not leave a usable capability"
+            );
+        }
+    }
+
+    #[test]
+    fn relay_scope_rejects_an_empty_authenticated_scope() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut relay = config(directory.path().join("empty-auth.sqlite"), Some("   "));
+
+        assert!(matches!(relay.validate(), Err(RelayError::InvalidScope(_))));
+
+        relay.scope.auth_scope = None;
+        relay
+            .validate()
+            .expect("unauthenticated scopes remain an explicit host choice");
     }
 
     #[test]

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -936,9 +936,12 @@ pub fn ensure_native_relay_abi_compatible(
 
 /// Explicit process-local persistence/synchronization scope.
 ///
-/// Authentication material is intentionally absent. `auth_scope` is an opaque
-/// stable subject/tenant discriminator supplied by the host after validation;
-/// tokens are sent to an upstream connection, never used as storage names.
+/// Authentication material is intentionally absent. `auth_scope` is an opaque,
+/// required stable subject/tenant discriminator supplied by the host after
+/// validation; tokens are sent to an upstream connection, never used as storage
+/// names. The `Option` preserves the strict JSON boundary's ability to reject
+/// an omitted or `null` field rather than silently manufacturing an anonymous
+/// persistent scope.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RelayScope {
     pub app_namespace: String,
@@ -958,14 +961,18 @@ impl RelayScope {
                 )));
             }
         }
-        if self
-            .auth_scope
-            .as_deref()
-            .is_some_and(|auth_scope| auth_scope.trim().is_empty())
-        {
-            return Err(RelayError::InvalidScope(
-                "auth scope must not be empty when supplied".to_owned(),
-            ));
+        match self.auth_scope.as_deref() {
+            Some(auth_scope) if !auth_scope.trim().is_empty() => {}
+            Some(_) => {
+                return Err(RelayError::InvalidScope(
+                    "auth scope must not be empty".to_owned(),
+                ));
+            }
+            None => {
+                return Err(RelayError::InvalidScope(
+                    "auth scope is required for a persistent relay".to_owned(),
+                ));
+            }
         }
         Ok(())
     }
@@ -2220,7 +2227,7 @@ mod tests {
                     scope: RelayScopeRequest {
                         app_namespace: "abi-rejection".to_owned(),
                         storage_namespace: "default".to_owned(),
-                        auth_scope: None,
+                        auth_scope: Some("opaque-subject".to_owned()),
                     },
                     sqlite_path: sqlite_path.display().to_string(),
                     schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
@@ -2307,6 +2314,60 @@ mod tests {
                 "claims": serde_json::to_value(claims).unwrap(),
             })
         };
+
+        // The platform-owned C ABI is the only production path that can mint
+        // a capability. Exercise the JSON forms serde would otherwise map to
+        // `Option::None` here, and prove they fail before either registry can
+        // change. This is intentionally an ABI-boundary test rather than a
+        // Rust-only `RelayScope` unit test.
+        for (case, auth_scope) in [
+            ("omitted", None),
+            ("null", Some(serde_json::Value::Null)),
+            ("empty", Some(serde_json::Value::String(String::new()))),
+            (
+                "whitespace",
+                Some(serde_json::Value::String(" \t\n ".to_owned())),
+            ),
+        ] {
+            let mut rejected = request(BTreeMap::new());
+            let scope = rejected["scope"]
+                .as_object_mut()
+                .expect("trusted request has an object scope");
+            match auth_scope {
+                Some(auth_scope) => {
+                    scope.insert("auth_scope".to_owned(), auth_scope);
+                }
+                None => {
+                    scope.remove("auth_scope");
+                }
+            }
+            let rejected = serde_json::to_vec(&rejected).unwrap();
+            let mut output = JazzNativeRelayBytes {
+                data: std::ptr::dangling_mut(),
+                len: 99,
+            };
+            assert_eq!(
+                unsafe {
+                    jazz_native_relay_host_admit_scope_json(
+                        host,
+                        rejected.as_ptr(),
+                        rejected.len(),
+                        &mut output,
+                    )
+                },
+                JazzNativeRelayStatus::LifecycleFailure,
+                "{case} auth scope must fail closed",
+            );
+            assert!(output.data.is_null(), "{case} must not return a capability");
+            assert_eq!(output.len, 0, "{case} must not return a capability");
+            let host_state = unsafe { (*host).inner.lock().unwrap() };
+            assert!(
+                host_state.admitted_scopes.is_empty(),
+                "{case} must not mutate the admission registry"
+            );
+            assert!(host_state.relays.is_empty(), "{case} must not open a relay");
+        }
+
         let encoded = serde_json::to_vec(&request(BTreeMap::from([(
             "role".to_owned(),
             Value::String("member".to_owned()),
@@ -2483,16 +2544,14 @@ mod tests {
     }
 
     #[test]
-    fn relay_scope_rejects_an_empty_authenticated_scope() {
+    fn relay_scope_requires_a_nonempty_authenticated_scope() {
         let directory = tempfile::tempdir().unwrap();
         let mut relay = config(directory.path().join("empty-auth.sqlite"), Some("   "));
 
         assert!(matches!(relay.validate(), Err(RelayError::InvalidScope(_))));
 
         relay.scope.auth_scope = None;
-        relay
-            .validate()
-            .expect("unauthenticated scopes remain an explicit host choice");
+        assert!(matches!(relay.validate(), Err(RelayError::InvalidScope(_))));
     }
 
     #[test]

--- a/crates/jazz-rn/ios/JazzRelay.mm
+++ b/crates/jazz-rn/ios/JazzRelay.mm
@@ -37,8 +37,6 @@ static NSError *RelayLifecycleError(NSString *message) {
 }
 #endif
 
-RCT_EXPORT_MODULE(JazzRelay)
-
 - (instancetype)init {
   self = [super init];
 #if JAZZ_RELAY_ARTIFACT_AVAILABLE

--- a/crates/jazz-rn/src/index.tsx
+++ b/crates/jazz-rn/src/index.tsx
@@ -3,4 +3,7 @@
  * only the thin native-relay command transport; `jazz-tools` will gain its
  * runtime adapter after a matching Rust relay artifact is embedded.
  */
-export * from './relay';
+// Deliberately list the public relay ABI rather than forwarding every future
+// relay export through this package entry point.
+export { NATIVE_RELAY_ABI, executeNativeRelayCommand } from './relay';
+export type { NativeRelayAbiRange } from './relay';

--- a/crates/jazz/SPEC/19_native_relays.md
+++ b/crates/jazz/SPEC/19_native_relays.md
@@ -36,7 +36,7 @@ The relay is a normal non-history-complete `Db`:
   query.
 
 The scope key has no token material. Trusted platform code derives an opaque
-`auth_scope` only after authentication and admits the complete scope config to
+non-empty `auth_scope` only after authentication and admits the complete scope config to
 the native host: auth scope, SQLite path, schema, persistent `DbIdentity`, and
 validated session claims. JavaScript receives only an opaque random 256-bit
 admission capability

--- a/crates/jazz/SPEC/19_native_relays.md
+++ b/crates/jazz/SPEC/19_native_relays.md
@@ -70,7 +70,9 @@ object or a method that accepts it. Its exact top-level fields are:
 Unknown fields at the top level, scope, or identity level fail closed. Rust
 parses the schema JSON, serializes it to its normalized JSON spelling, builds
 the `JazzSchema`, validates scope and the non-`SYSTEM` author, and validates
-the typed claims before it admits the scope. Admission input is bounded to
+the typed claims before it admits the scope. `auth_scope` is required: omitted,
+`null`, empty, and whitespace-only values fail before a capability is minted or
+a relay registry entry can exist. Admission input is bounded to
 1 MiB independently of peer-frame limits. Credential-bearing claims named
 `authorization`, `access_token`, `refresh_token`, `id_token`,
 `bearer_token`, or `token` (case-insensitive) fail closed. This is a boundary

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -181,6 +181,10 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
 });
 
 test("trusted relay admission stays outside the JavaScript command channel", async () => {
+  const relay = await readFile(
+    new URL("../../../crates/jazz-rn/src/relay.ts", import.meta.url),
+    "utf8",
+  );
   const nativeSpec = await readFile(
     new URL("../../../crates/jazz-rn/src/NativeJazzRelay.ts", import.meta.url),
     "utf8",
@@ -196,19 +200,33 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     new URL("../../../crates/jazz-rn/ios/JazzRelay.mm", import.meta.url),
     "utf8",
   );
+  const androidModule = await readFile(
+    new URL(
+      "../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayModule.java",
+      import.meta.url,
+    ),
+    "utf8",
+  );
   const header = await readFile(
     new URL("../../../crates/jazz-native-relay/include/jazz_native_relay.h", import.meta.url),
     "utf8",
   );
 
   assert.doesNotMatch(nativeSpec, /admit|revoke|claims|token/i);
+  assert.doesNotMatch(relay, /admit|revoke|claims|token|sqlite_path|schema_json/i);
+  assert.doesNotMatch(androidModule, /admit|revoke|claims|token|sqlitePath|schemaJson/i);
   assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
+  assert.match(androidBridge, /TrustedRelayScopeConfig/);
   assert.match(androidBridge, /nativeAdmitTrustedScopeJson/);
   assert.match(androidBridge, /nativeRevokeTrustedScope/);
+  assert.match(androidBridge, /trustedCapabilities \+=/);
+  assert.match(androidBridge, /trustedCapabilities -=/);
   assert.match(androidBridge, /releaseRuntime/);
   assert.match(iosRelay, /JazzRelayTrustedAdmission/);
   assert.match(iosRelay, /jazz_native_relay_host_admit_scope_json/);
   assert.match(iosRelay, /jazz_native_relay_host_revoke_scope_capability/);
+  assert.match(iosRelay, /\[trustedCapabilities addObject:capability\]/);
+  assert.match(iosRelay, /\[trustedCapabilities removeObject:capability\]/);
   assert.match(header, /jazz_native_relay_host_admit_scope_json/);
   assert.match(header, /jazz_native_relay_host_revoke_scope_capability/);
 });

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -15,6 +15,91 @@ const packageJson = JSON.parse(
 );
 const withJazzRn = require("../../../crates/jazz-rn/app.plugin.js");
 
+// The JavaScript-facing relay ABI is deliberately only an ABI probe and an
+// opaque command transport. Keep this check on declarations rather than broad
+// source text: trusted platform code may legitimately use these words in its
+// own private admission implementation, comments, and imports.
+const forbiddenRelaySurfaceNames = new Set([
+  "authscope",
+  "sqlitepath",
+  "schemajson",
+  "admit",
+  "revoke",
+  "claims",
+  "token",
+]);
+
+function identifierTokens(signature) {
+  return signature.match(/[A-Za-z_$][A-Za-z0-9_$]*/g) ?? [];
+}
+
+function normalizedIdentifier(identifier) {
+  return identifier.replace(/_/g, "").toLowerCase();
+}
+
+function isForbiddenRelaySurfaceIdentifier(identifier) {
+  const normalized = normalizedIdentifier(identifier);
+  return [...forbiddenRelaySurfaceNames].some((forbidden) => normalized.includes(forbidden));
+}
+
+function assertOpaqueRelaySurface(surface, declarations) {
+  for (const declaration of declarations) {
+    for (const identifier of identifierTokens(declaration)) {
+      if (isForbiddenRelaySurfaceIdentifier(identifier)) {
+        assert.fail(
+          `${surface} exposes trusted relay input ${identifier} in JS-facing declaration: ${declaration.trim()}`,
+        );
+      }
+    }
+  }
+}
+
+function braceBody(source, opening) {
+  const openingIndex = source.indexOf(opening);
+  assert.notEqual(openingIndex, -1, `could not find ${opening}`);
+  const start = source.indexOf("{", openingIndex + opening.length);
+  assert.notEqual(start, -1, `could not find ${opening} body`);
+  let depth = 0;
+  for (let index = start; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    else if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(start + 1, index);
+    }
+  }
+  assert.fail(`unterminated ${opening} body`);
+}
+
+function assertOpaqueJsRelaySurface(nativeSpec, relay) {
+  const spec = braceBody(nativeSpec, "export interface Spec extends TurboModule");
+  const exportedFunctions = relay.match(/export\s+(?:async\s+)?function\s+[^{]+\{/g) ?? [];
+  assertOpaqueRelaySurface("NativeJazzRelay TurboModule", spec.split(";").filter(Boolean));
+  assertOpaqueRelaySurface("relay TypeScript export", exportedFunctions);
+}
+
+function assertOpaqueAndroidRelaySurface(androidModule) {
+  const module = braceBody(
+    androidModule,
+    "public class JazzRelayModule extends NativeJazzRelaySpec",
+  );
+  const publicMethods = module.match(/@Override\s+public\s+[^{};]+\{/g) ?? [];
+  assertOpaqueRelaySurface("Android TurboModule", publicMethods);
+}
+
+function assertOpaqueIosRelaySurface(iosRelay) {
+  const implementationStart = iosRelay.indexOf("@implementation JazzRelay");
+  assert.notEqual(implementationStart, -1, "could not find JazzRelay Objective-C implementation");
+  const trustedAdmissionStart = iosRelay.indexOf("@implementation JazzRelayTrustedAdmission");
+  assert.notEqual(
+    trustedAdmissionStart,
+    -1,
+    "could not separate trusted Objective-C admission from exported relay module",
+  );
+  const relayModule = iosRelay.slice(implementationStart, trustedAdmissionStart);
+  const exportedMethods = relayModule.match(/^-\s*\([^)]*\)\s*[^{]+\{/gm) ?? [];
+  assertOpaqueRelaySurface("iOS TurboModule", exportedMethods);
+}
+
 test("jazz-rn publishes an Expo config plugin for a New Architecture development build", () => {
   const original = { name: "example", ios: { bundleIdentifier: "dev.jazz.example" } };
   const configured = withJazzRn(original);
@@ -212,9 +297,29 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     "utf8",
   );
 
-  assert.doesNotMatch(nativeSpec, /admit|revoke|claims|token/i);
-  assert.doesNotMatch(relay, /admit|revoke|claims|token|sqlite_path|schema_json/i);
-  assert.doesNotMatch(androidModule, /admit|revoke|claims|token|sqlitePath|schemaJson/i);
+  assertOpaqueJsRelaySurface(nativeSpec, relay);
+  assertOpaqueAndroidRelaySurface(androidModule);
+  assertOpaqueIosRelaySurface(iosRelay);
+  assert.throws(
+    () =>
+      assertOpaqueJsRelaySurface(
+        nativeSpec.replace("getAbiVersion(): number;", "getAuthScope(): string;"),
+        relay,
+      ),
+    /getAuthScope/,
+    "a camel-case auth scope accessor must not enter the generated TypeScript spec",
+  );
+  assert.throws(
+    () =>
+      assertOpaqueAndroidRelaySurface(
+        androidModule.replace(
+          "execute(String encodedCommand, Promise promise)",
+          "execute(String sqlitePath, Promise promise)",
+        ),
+      ),
+    /sqlitePath/,
+    "a camel-case SQLite path parameter must not enter the Android TurboModule",
+  );
   assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
   assert.match(androidBridge, /TrustedRelayScopeConfig/);
   assert.match(androidBridge, /nativeAdmitTrustedScopeJson/);

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -10,6 +10,7 @@ import { dirname, join } from "node:path";
 import { parse } from "yaml";
 
 const require = createRequire(import.meta.url);
+const ts = require("typescript");
 const packageJson = JSON.parse(
   await readFile(
     new URL("../../../crates/jazz-rn/package.json", import.meta.url),
@@ -69,22 +70,78 @@ function assertOnlyAllowedNames(surface, actual, allowed) {
   );
 }
 
-function assertNoTsReexports(surface, source) {
-  const commentFree = stripComments(source);
-  assert.doesNotMatch(
-    commentFree,
-    /\bexport\s*\*/,
-    `${surface} must not star-re-export ABI`,
+function exportedStatements(surface, source) {
+  const file = ts.createSourceFile(
+    `${surface}.ts`,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
   );
-  assert.doesNotMatch(
-    commentFree,
-    /\bexport\s*\{[^}]*\bas\b[^}]*\}/s,
-    `${surface} must not alias-re-export ABI`,
+  assert.deepEqual(
+    file.parseDiagnostics,
+    [],
+    `${surface} must be valid TypeScript`,
   );
-  assert.doesNotMatch(
-    commentFree,
-    /\bexport\s*\{\s*default\b[^}]*\}/s,
-    `${surface} must not default-re-export ABI`,
+  return file.statements.filter(
+    (statement) =>
+      ts.isExportAssignment(statement) ||
+      ts.isExportDeclaration(statement) ||
+      ts.isNamespaceExportDeclaration(statement) ||
+      (ts.canHaveModifiers(statement) &&
+        ts
+          .getModifiers(statement)
+          ?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)),
+  );
+}
+
+function exportedDeclarationName(statement) {
+  if (
+    ts.isInterfaceDeclaration(statement) ||
+    ts.isTypeAliasDeclaration(statement) ||
+    ts.isFunctionDeclaration(statement) ||
+    ts.isClassDeclaration(statement) ||
+    ts.isEnumDeclaration(statement) ||
+    ts.isModuleDeclaration(statement)
+  ) {
+    return statement.name?.text;
+  }
+  if (
+    ts.isVariableStatement(statement) &&
+    statement.declarationList.declarations.length === 1
+  ) {
+    const name = statement.declarationList.declarations[0].name;
+    return ts.isIdentifier(name) ? name.text : undefined;
+  }
+  return undefined;
+}
+
+function assertNamedRelayReexport(surface, statement, names, typeOnly) {
+  assert.ok(
+    ts.isExportDeclaration(statement),
+    `${surface} may only re-export its fixed relay names`,
+  );
+  assert.equal(
+    statement.isTypeOnly,
+    typeOnly,
+    `${surface} has the wrong type-only export`,
+  );
+  assert.equal(
+    statement.moduleSpecifier?.text,
+    "./relay",
+    `${surface} must re-export from ./relay`,
+  );
+  assert.ok(
+    statement.exportClause && ts.isNamedExports(statement.exportClause),
+    `${surface} must not star-re-export the relay ABI`,
+  );
+  assert.deepEqual(
+    statement.exportClause.elements.map((item) => item.name.text),
+    names,
+  );
+  assert.ok(
+    statement.exportClause.elements.every((item) => item.propertyName === undefined),
+    `${surface} must not alias-re-export the relay ABI`,
   );
 }
 
@@ -106,11 +163,78 @@ function braceBody(source, opening) {
 
 function assertExactTsRelaySurface(nativeSpec, relay, index) {
   const commentFreeSpec = stripComments(nativeSpec);
-  const commentFreeRelay = stripComments(relay);
-  const commentFreeIndex = stripComments(index);
-  assertNoTsReexports("NativeJazzRelay TypeScript spec", nativeSpec);
-  assertNoTsReexports("relay TypeScript module", relay);
-  assertNoTsReexports("relay package entry point", index);
+  const specExports = exportedStatements("NativeJazzRelay TypeScript spec", nativeSpec);
+  const relayExports = exportedStatements("relay TypeScript module", relay);
+  const indexExports = exportedStatements("relay package entry point", index);
+
+  assert.equal(
+    specExports.length,
+    2,
+    "NativeJazzRelay must expose exactly its Spec and registry lookup",
+  );
+  assert.ok(
+    ts.isInterfaceDeclaration(specExports[0]),
+    "NativeJazzRelay must only export Spec as an interface",
+  );
+  assert.equal(specExports[0].name.text, "Spec");
+  assert.ok(
+    ts.isExportAssignment(specExports[1]),
+    "NativeJazzRelay must default-export its registry lookup",
+  );
+  assert.notEqual(specExports[1].isExportEquals, true);
+
+  assert.equal(
+    relayExports.length,
+    3,
+    "relay must expose exactly its fixed ABI declarations",
+  );
+  assert.ok(
+    ts.isInterfaceDeclaration(relayExports[0]),
+    "relay must export NativeRelayAbiRange as an interface",
+  );
+  assert.equal(relayExports[0].name.text, "NativeRelayAbiRange");
+  assert.ok(
+    ts.isVariableStatement(relayExports[1]),
+    "relay must export NATIVE_RELAY_ABI as a variable",
+  );
+  assert.notEqual(
+    relayExports[1].declarationList.flags & ts.NodeFlags.Const,
+    0,
+    "relay must export NATIVE_RELAY_ABI as a const",
+  );
+  assert.equal(relayExports[1].declarationList.declarations.length, 1);
+  assert.equal(
+    relayExports[1].declarationList.declarations[0].name.getText(),
+    "NATIVE_RELAY_ABI",
+  );
+  assert.ok(
+    ts.isFunctionDeclaration(relayExports[2]),
+    "relay must export executeNativeRelayCommand as a function",
+  );
+  assert.equal(relayExports[2].name?.text, "executeNativeRelayCommand");
+  assertExactNames(
+    "relay TypeScript module",
+    new Set(relayExports.map(exportedDeclarationName).filter(Boolean)),
+    relayJsExports,
+  );
+
+  assert.equal(
+    indexExports.length,
+    2,
+    "relay package entry point must contain only its two fixed re-exports",
+  );
+  assertNamedRelayReexport(
+    "relay package entry point",
+    indexExports[0],
+    ["NATIVE_RELAY_ABI", "executeNativeRelayCommand"],
+    false,
+  );
+  assertNamedRelayReexport(
+    "relay package entry point",
+    indexExports[1],
+    ["NativeRelayAbiRange"],
+    true,
+  );
 
   const spec = braceBody(
     commentFreeSpec,
@@ -128,25 +252,6 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
     "NativeJazzRelay may only default-export its registry lookup",
   );
 
-  const relayExports = new Set(
-    [
-      ...commentFreeRelay.matchAll(
-        /(?:^|\n)\s*export\s+(?:declare\s+)?(?:interface|type|const|async\s+function|function)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g,
-      ),
-    ].map((match) => match[1]),
-  );
-  assertExactNames("relay TypeScript module", relayExports, relayJsExports);
-  const entryExports = new Set(
-    [
-      ...commentFreeIndex.matchAll(
-        /(?:^|\n)\s*export\s+(?:type\s+)?\{([^}]*)\}/g,
-      ),
-    ]
-      .flatMap((match) => match[1].split(","))
-      .map((name) => name.trim())
-      .filter(Boolean),
-  );
-  assertExactNames("relay package entry point", entryExports, relayJsExports);
 }
 
 function assertOpaqueAndroidRelaySurface(androidModule) {
@@ -229,28 +334,47 @@ function macroExportName(declaration, macro) {
   return /^([A-Za-z_$][A-Za-z0-9_$]*)\s*:/.exec(body)?.[1] ?? body;
 }
 
+function objcImplementations(source) {
+  const implementations = [];
+  const pattern =
+    /^\s*@implementation\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*\([^)]*\))?/gm;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    const end = /^\s*@end\b/m.exec(source.slice(pattern.lastIndex));
+    assert.ok(end, `unterminated Objective-C implementation for ${match[1]}`);
+    implementations.push({
+      className: match[1],
+      source: source.slice(
+        match.index,
+        pattern.lastIndex + end.index + end[0].length,
+      ),
+    });
+    pattern.lastIndex += end.index + end[0].length;
+  }
+  return implementations;
+}
+
 function assertOpaqueIosRelaySurface(iosRelay) {
   const commentFreeRelay = stripComments(iosRelay);
-  const implementationStart = commentFreeRelay.indexOf(
-    "@implementation JazzRelay",
+  const implementations = objcImplementations(commentFreeRelay);
+  const relayImplementations = implementations.filter(
+    (implementation) => implementation.className === "JazzRelay",
   );
-  assert.notEqual(
-    implementationStart,
-    -1,
+  assert.ok(
+    relayImplementations.length > 0,
     "could not find JazzRelay Objective-C implementation",
   );
-  const trustedAdmissionStart = commentFreeRelay.indexOf(
-    "@implementation JazzRelayTrustedAdmission",
+  assert.ok(
+    implementations.some(
+      (implementation) => implementation.className === "JazzRelayTrustedAdmission",
+    ),
+    "could not find the specifically named trusted Objective-C admission class",
   );
-  assert.notEqual(
-    trustedAdmissionStart,
-    -1,
-    "could not separate trusted Objective-C admission from exported relay module",
-  );
-  const relayModule = commentFreeRelay.slice(
-    implementationStart,
-    trustedAdmissionStart,
-  );
+  // Categories are separate @implementation JazzRelay (...) blocks. Check all
+  // of them: only the named private admission class is excluded from this
+  // receipt, so a later category cannot hide an RCT export after the primary
+  // implementation's @end.
+  const relayModule = relayImplementations.map((item) => item.source).join("\n");
   const exportedMethods = objcMethodNames(relayModule);
   // Old-architecture macros are JavaScript exports even when no Objective-C
   // selector appears in this source. Their mapped JavaScript names are still
@@ -588,7 +712,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
         `${relay}\nexport function configure() {}`,
         relayIndex,
       ),
-    /configure/,
+    undefined,
     "an innocuous TypeScript helper must not enlarge the relay ABI",
   );
   assert.throws(
@@ -598,7 +722,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
         relay,
         `${relayIndex}\nexport { executeNativeRelayCommand as configure } from './relay';`,
       ),
-    /alias-re-export/,
+    undefined,
     "an alias re-export must not smuggle a new public relay name into the package",
   );
   assert.throws(
@@ -608,7 +732,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
         relay,
         `${relayIndex}\nexport * from './relay';`,
       ),
-    /star-re-export/,
+    undefined,
     "a star re-export must not automatically publish future relay helpers",
   );
   assert.throws(
@@ -618,9 +742,62 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
         `${relay}\nexport { default } from './NativeJazzRelay';`,
         relayIndex,
       ),
-    /default-re-export/,
+    undefined,
     "a default re-export must not publish the raw TurboModule lookup",
   );
+  for (const fixture of [
+    {
+      name: "a relay default export",
+      relay: `${relay}\nexport default requireNativeRelay;`,
+    },
+    {
+      name: "a relay default declaration",
+      relay: `${relay}\nexport default class RelayEscapeHatch {}`,
+    },
+    {
+      name: "a relay class export",
+      relay: `${relay}\nexport class RelayEscapeHatch {}`,
+    },
+    {
+      name: "a relay enum export",
+      relay: `${relay}\nexport enum RelayEscapeHatch { Open }`,
+    },
+    {
+      name: "a relay namespace export",
+      relay: `${relay}\nexport namespace RelayEscapeHatch {}`,
+    },
+    {
+      name: "a relay export list",
+      relay: `${relay}\nexport { requireNativeRelay };`,
+    },
+    {
+      name: "a relay type-only export",
+      relay: `${relay}\nexport type RelayEscapeHatch = string;`,
+    },
+    {
+      name: "an index default export",
+      index: `${relayIndex}\nexport default executeNativeRelayCommand;`,
+    },
+    {
+      name: "an index export from an unapproved source",
+      index: `${relayIndex}\nexport { executeNativeRelayCommand } from './untrusted';`,
+    },
+    {
+      name: "an index whitespace/comment alias",
+      index: `${relayIndex}\nexport /* no aliases */ { executeNativeRelayCommand /* nope */ as configure } from './relay';`,
+    },
+  ]) {
+    assert.throws(
+      () =>
+        assertExactTsRelaySurface(
+          nativeSpec,
+          fixture.relay ?? relay,
+          fixture.index ?? relayIndex,
+        ),
+      undefined,
+      `${fixture.name} must not enlarge the fixed relay ABI`,
+    );
+  }
   assert.doesNotThrow(
     () =>
       assertExactTsRelaySurface(
@@ -692,6 +869,21 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
       ),
     /configure/,
     "an arbitrary Objective-C method must not grow the sealed relay module",
+  );
+  assert.throws(
+    () =>
+      assertOpaqueIosRelaySurface(
+        `${iosRelay}\n@implementation JazzRelay (LaterEscapeHatch)\nRCT_EXPORT_METHOD(configure:(NSString *)scope)\n@end`,
+      ),
+    /configure/,
+    "a later JazzRelay category must not hide an RCT export after the primary implementation",
+  );
+  assert.doesNotThrow(
+    () =>
+      assertOpaqueIosRelaySurface(
+        `${iosRelay}\n// RCT_EXPORT_METHOD(configure:(NSString *)scope)`,
+      ),
+    "comments must not become iOS relay exports",
   );
   assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
   assert.match(androidBridge, /TrustedRelayScopeConfig/);

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -46,6 +46,15 @@ function stripComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
 }
 
+// C and Objective-C translate physical source lines before recognizing either
+// comments or macro invocations. Clang accepts a backslash followed by an LF,
+// CRLF, or implementation-permitted horizontal whitespace and a newline as a
+// line continuation. Normalize that spelling first so this lexical receipt
+// observes the same JavaScript-visible exports as the compiler.
+function normalizeObjcLineContinuations(source) {
+  return source.replace(/\\[ \t\v\f]*\r?\n/g, "");
+}
+
 function assertExactNames(surface, actual, allowed) {
   const unexpected = [...actual].filter((name) => !allowed.has(name));
   const missing = [...allowed].filter((name) => !actual.has(name));
@@ -409,7 +418,7 @@ function objcImplementations(source) {
 }
 
 function assertOpaqueIosRelaySurface(iosRelay) {
-  const commentFreeRelay = stripComments(iosRelay);
+  const commentFreeRelay = stripComments(normalizeObjcLineContinuations(iosRelay));
   const implementations = objcImplementations(commentFreeRelay);
   const relayImplementations = implementations.filter(
     (implementation) => implementation.className === "JazzRelay",
@@ -922,6 +931,30 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     "a multiline RCT_REMAP_METHOD must not introduce an arbitrary iOS JS export",
   );
   for (const fixture of [
+    {
+      name: "an LF-spliced RCT_EXPORT_METHOD",
+      source: "RCT_EXPORT_\\\nMETHOD(configure:(NSString *)scope)",
+    },
+    {
+      name: "a CRLF-and-whitespace-spliced RCT_REMAP_METHOD",
+      source: "RCT_REMAP_\\ \t\r\nMETHOD(begin, begin:(NSString *)scope)",
+    },
+    {
+      name: "an LF-spliced synchronous RCT export",
+      source:
+        "RCT_EXPORT_SYNCHRONOUS_TYPED_\\\nMETHOD(NSString *, configure)",
+    },
+  ]) {
+    assert.throws(
+      () =>
+        assertOpaqueIosRelaySurface(
+          iosRelay.replace("- (void)invalidate", `${fixture.source}\n\n- (void)invalidate`),
+        ),
+      /RCT_|configure|begin/,
+      `${fixture.name} must not bypass the sealed iOS relay receipt`,
+    );
+  }
+  for (const fixture of [
     "RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure)",
     "RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, configure)",
     "RCT_REMAP_BLOCKING_SYNCHRONOUS_METHOD(configure, configure)",
@@ -962,6 +995,13 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
         `${iosRelay}\n// RCT_EXPORT_METHOD(configure:(NSString *)scope)`,
       ),
     "comments must not become iOS relay exports",
+  );
+  assert.doesNotThrow(
+    () =>
+      assertOpaqueIosRelaySurface(
+        `${iosRelay}\n// Still a comment after C line splicing \\ \t\r\nRCT_EXPORT_METHOD(configure:(NSString *)scope)`,
+      ),
+    "a continued Objective-C line comment must not become a relay export",
   );
   assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
   assert.match(androidBridge, /TrustedRelayScopeConfig/);

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -46,6 +46,24 @@ function stripComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
 }
 
+// C/C++ translation phase 2 removes each immediately-adjacent backslash and
+// LF or CRLF pair before tokenization. The legacy-macro receipt must apply
+// that one lexical transformation first, otherwise a source-level splice can
+// hide an RCT export/remap token from this deliberately raw check. Do not
+// interpret comments, strings, or any other C/C++ syntax here: those must
+// remain visible to the ban as well.
+function spliceCPreprocessorLines(source) {
+  return source.replace(/\\(?:\r\n|\n)/g, "");
+}
+
+function assertNoLegacyIosMacroToken(source) {
+  assert.doesNotMatch(
+    spliceCPreprocessorLines(source),
+    /\bRCT_[A-Za-z0-9_]*(?:EXPORT|REMAP)[A-Za-z0-9_]*\b/,
+    "iOS JazzRelay must contain no legacy RCT export/remap macro token",
+  );
+}
+
 function assertExactNames(surface, actual, allowed) {
   const unexpected = [...actual].filter((name) => !allowed.has(name));
   const missing = [...allowed].filter((name) => !actual.has(name));
@@ -375,11 +393,7 @@ function assertOpaqueIosRelaySurface(iosRelay) {
   // The generated New-Architecture spec is the sole iOS JavaScript ABI. A raw
   // source ban is intentional: comments, strings, categories, and line
   // continuations must not create a parser-dependent escape hatch.
-  assert.doesNotMatch(
-    iosRelay,
-    /\bRCT_[A-Za-z0-9_]*(?:EXPORT|REMAP)[A-Za-z0-9_]*\b/,
-    "iOS JazzRelay must contain no legacy RCT export/remap macro token",
-  );
+  assertNoLegacyIosMacroToken(iosRelay);
   const commentFreeRelay = stripComments(iosRelay);
   const implementations = objcImplementations(commentFreeRelay);
   const relayImplementations = implementations.filter(
@@ -587,7 +601,7 @@ test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts",
   assert.match(androidBuild, /requires the React Native New Architecture/);
   assert.match(androidPackage, /class JazzRelayPackage/);
   assert.doesNotMatch(androidPackage, /JazzRnModule/);
-  assert.doesNotMatch(iosRelay, /\bRCT_[A-Za-z0-9_]*(?:EXPORT|REMAP)[A-Za-z0-9_]*\b/);
+  assertNoLegacyIosMacroToken(iosRelay);
   assert.match(iosRelay, /JAZZ_RELAY_ARTIFACT_AVAILABLE/);
   assert.match(iosRelay, /jazz_native_relay_host_execute/);
   assert.match(iosRelay, /E_JAZZ_RELAY_UNAVAILABLE/);
@@ -867,8 +881,20 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
       source: "// RCT_REMAP_METHOD(begin, begin:(NSString *)scope)",
     },
     {
-      name: "a line continuation",
+      name: "a prefix line splice",
+      source: "RCT_\\\nEXPORT_METHOD(configure:(NSString *)scope)",
+    },
+    {
+      name: "a middle-token CRLF line splice",
+      source: "RCT_EXP\\\r\nORT_METHOD(configure:(NSString *)scope)",
+    },
+    {
+      name: "a suffix line splice",
       source: "RCT_EXPORT_\\\nMETHOD(configure:(NSString *)scope)",
+    },
+    {
+      name: "chained LF and CRLF line splices",
+      source: "RCT_\\\nEX\\\r\nPORT_METHOD(configure:(NSString *)scope)",
     },
     {
       name: "a category",
@@ -883,6 +909,17 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
       `${fixture.name} must fail the raw iOS legacy macro ban`,
     );
   }
+  assert.doesNotThrow(
+    () => assertOpaqueIosRelaySurface(`${iosRelay}\nRCT_UNRELATED_METHOD()`),
+    "an unknown RCT macro must not be mistaken for a legacy export/remap macro",
+  );
+  assert.doesNotThrow(
+    () =>
+      assertOpaqueIosRelaySurface(
+        `${iosRelay}\nRCT_EX\\ \nPORT_METHOD(configure:(NSString *)scope)`,
+      ),
+    "a backslash followed by spaces is not a C/C++ phase-2 line splice",
+  );
   assert.throws(
     () =>
       assertOpaqueIosRelaySurface(

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -12,10 +12,7 @@ import { parse } from "yaml";
 const require = createRequire(import.meta.url);
 const ts = require("typescript");
 const packageJson = JSON.parse(
-  await readFile(
-    new URL("../../../crates/jazz-rn/package.json", import.meta.url),
-    "utf8",
-  ),
+  await readFile(new URL("../../../crates/jazz-rn/package.json", import.meta.url), "utf8"),
 );
 const withJazzRn = require("../../../crates/jazz-rn/app.plugin.js");
 
@@ -72,11 +69,7 @@ function assertExactNames(surface, actual, allowed) {
     [],
     `${surface} has unexpected JavaScript-facing name(s): ${unexpected.join(", ")}`,
   );
-  assert.deepEqual(
-    missing,
-    [],
-    `${surface} omits ABI name(s): ${missing.join(", ")}`,
-  );
+  assert.deepEqual(missing, [], `${surface} omits ABI name(s): ${missing.join(", ")}`);
 }
 
 function exportedStatements(surface, source) {
@@ -87,11 +80,7 @@ function exportedStatements(surface, source) {
     true,
     ts.ScriptKind.TSX,
   );
-  assert.deepEqual(
-    file.parseDiagnostics,
-    [],
-    `${surface} must be valid TypeScript`,
-  );
+  assert.deepEqual(file.parseDiagnostics, [], `${surface} must be valid TypeScript`);
   return file.statements.filter(
     (statement) =>
       ts.isExportAssignment(statement) ||
@@ -115,10 +104,7 @@ function exportedDeclarationName(statement) {
   ) {
     return statement.name?.text;
   }
-  if (
-    ts.isVariableStatement(statement) &&
-    statement.declarationList.declarations.length === 1
-  ) {
+  if (ts.isVariableStatement(statement) && statement.declarationList.declarations.length === 1) {
     const name = statement.declarationList.declarations[0].name;
     return ts.isIdentifier(name) ? name.text : undefined;
   }
@@ -130,11 +116,7 @@ function assertNamedRelayReexport(surface, statement, names, typeOnly) {
     ts.isExportDeclaration(statement),
     `${surface} may only re-export its fixed relay names`,
   );
-  assert.equal(
-    statement.isTypeOnly,
-    typeOnly,
-    `${surface} has the wrong type-only export`,
-  );
+  assert.equal(statement.isTypeOnly, typeOnly, `${surface} has the wrong type-only export`);
   assert.equal(
     statement.moduleSpecifier?.text,
     "./relay",
@@ -163,11 +145,7 @@ function assertExactNativeSpecMethod(member, name) {
   assert.ok(ts.isIdentifier(member.name));
   assert.equal(member.name.text, name);
   assert.equal(member.questionToken, undefined, `${name} must not be optional`);
-  assert.equal(
-    member.typeParameters,
-    undefined,
-    `${name} must not be generic`,
-  );
+  assert.equal(member.typeParameters, undefined, `${name} must not be generic`);
 
   if (name === "getAbiVersion") {
     assert.equal(member.parameters.length, 0, "getAbiVersion takes no arguments");
@@ -242,11 +220,7 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
   );
   assert.notEqual(specExports[1].isExportEquals, true);
 
-  assert.equal(
-    relayExports.length,
-    3,
-    "relay must expose exactly its fixed ABI declarations",
-  );
+  assert.equal(relayExports.length, 3, "relay must expose exactly its fixed ABI declarations");
   assert.ok(
     ts.isInterfaceDeclaration(relayExports[0]),
     "relay must export NativeRelayAbiRange as an interface",
@@ -262,10 +236,7 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
     "relay must export NATIVE_RELAY_ABI as a const",
   );
   assert.equal(relayExports[1].declarationList.declarations.length, 1);
-  assert.equal(
-    relayExports[1].declarationList.declarations[0].name.getText(),
-    "NATIVE_RELAY_ABI",
-  );
+  assert.equal(relayExports[1].declarationList.declarations[0].name.getText(), "NATIVE_RELAY_ABI");
   assert.ok(
     ts.isFunctionDeclaration(relayExports[2]),
     "relay must export executeNativeRelayCommand as a function",
@@ -317,11 +288,7 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
     nativeSpecMethods.size,
     "NativeJazzRelay TurboModule has exactly its two ABI methods",
   );
-  assertExactNames(
-    "NativeJazzRelay TurboModule",
-    new Set(membersByName.keys()),
-    nativeSpecMethods,
-  );
+  assertExactNames("NativeJazzRelay TurboModule", new Set(membersByName.keys()), nativeSpecMethods);
   for (const name of nativeSpecMethods) {
     assertExactNativeSpecMethod(membersByName.get(name), name);
   }
@@ -330,7 +297,6 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
     /^\s*export\s+default\s+TurboModuleRegistry\.get<Spec>\('JazzRelay'\);\s*$/m,
     "NativeJazzRelay may only default-export its registry lookup",
   );
-
 }
 
 function assertOpaqueAndroidRelaySurface(androidModule) {
@@ -344,45 +310,31 @@ function assertOpaqueAndroidRelaySurface(androidModule) {
   for (const match of module.matchAll(declarations)) {
     // Generated TurboModule methods use @Override; handwritten React Native
     // modules use @ReactMethod, including its fully-qualified spelling.
-    if (
-      /(?:@Override\b|@[A-Za-z_$][A-Za-z0-9_$.]*\.ReactMethod\b|@ReactMethod\b)/.test(
-        match[1],
-      )
-    ) {
+    if (/(?:@Override\b|@[A-Za-z_$][A-Za-z0-9_$.]*\.ReactMethod\b|@ReactMethod\b)/.test(match[1])) {
       exportedMethods.add(match[2]);
     }
   }
-  assertExactNames(
-    "Android JavaScript export",
-    exportedMethods,
-    androidRelayMethods,
-  );
+  assertExactNames("Android JavaScript export", exportedMethods, androidRelayMethods);
 }
 
 function objcMethodNames(source) {
   return new Set(
-    [
-      ...source.matchAll(
-        /^[+-]\s*\([^)]*\)\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::|\{)/gm,
-      ),
-    ].map((match) => match[1]),
+    [...source.matchAll(/^[+-]\s*\([^)]*\)\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::|\{)/gm)].map(
+      (match) => match[1],
+    ),
   );
 }
 
 function objcImplementations(source) {
   const implementations = [];
-  const pattern =
-    /^\s*@implementation\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*\([^)]*\))?/gm;
+  const pattern = /^\s*@implementation\s+([A-Za-z_$][A-Za-z0-9_$]*)(?:\s*\([^)]*\))?/gm;
   let match;
   while ((match = pattern.exec(source)) !== null) {
     const end = /^\s*@end\b/m.exec(source.slice(pattern.lastIndex));
     assert.ok(end, `unterminated Objective-C implementation for ${match[1]}`);
     implementations.push({
       className: match[1],
-      source: source.slice(
-        match.index,
-        pattern.lastIndex + end.index + end[0].length,
-      ),
+      source: source.slice(match.index, pattern.lastIndex + end.index + end[0].length),
     });
     pattern.lastIndex += end.index + end[0].length;
   }
@@ -399,10 +351,7 @@ function assertOpaqueIosRelaySurface(iosRelay) {
   const relayImplementations = implementations.filter(
     (implementation) => implementation.className === "JazzRelay",
   );
-  assert.ok(
-    relayImplementations.length > 0,
-    "could not find JazzRelay Objective-C implementation",
-  );
+  assert.ok(relayImplementations.length > 0, "could not find JazzRelay Objective-C implementation");
   assert.ok(
     implementations.some(
       (implementation) => implementation.className === "JazzRelayTrustedAdmission",
@@ -413,11 +362,7 @@ function assertOpaqueIosRelaySurface(iosRelay) {
   // of them so no selector grows the generated ABI.
   const relayModule = relayImplementations.map((item) => item.source).join("\n");
   const exportedMethods = objcMethodNames(relayModule);
-  assertExactNames(
-    "iOS JazzRelay implementation",
-    exportedMethods,
-    iosRelaySelectors,
-  );
+  assertExactNames("iOS JazzRelay implementation", exportedMethods, iosRelaySelectors);
 }
 
 test("jazz-rn publishes an Expo config plugin for a New Architecture development build", () => {
@@ -428,16 +373,8 @@ test("jazz-rn publishes an Expo config plugin for a New Architecture development
   const configured = withJazzRn(original);
 
   assert.equal(configured.newArchEnabled, true);
-  assert.equal(
-    original.newArchEnabled,
-    undefined,
-    "plugin must not mutate Expo's input config",
-  );
-  assert.equal(
-    configured.ios,
-    original.ios,
-    "unrelated Expo configuration is preserved",
-  );
+  assert.equal(original.newArchEnabled, undefined, "plugin must not mutate Expo's input config");
+  assert.equal(configured.ios, original.ios, "unrelated Expo configuration is preserved");
   assert.equal(packageJson.exports["./app.plugin"], "./app.plugin.js");
   assert.equal(packageJson.files.includes("app.plugin.js"), true);
   assert.equal(packageJson.files.includes("scripts"), true);
@@ -447,10 +384,7 @@ test("jazz-rn publishes an Expo config plugin for a New Architecture development
     "git+https://github.com/garden-co/jazz.git",
     "the published package must point install users at its maintained source repository",
   );
-  assert.equal(
-    packageJson.bugs.url,
-    "https://github.com/garden-co/jazz/issues",
-  );
+  assert.equal(packageJson.bugs.url, "https://github.com/garden-co/jazz/issues");
 });
 
 test("the canonical Expo scaffold really prebuilds both relay-only platforms", () => {
@@ -464,15 +398,11 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
     "Expo prebuild requires the example workspace dependencies. Run `pnpm install --frozen-lockfile` from the repository root, then rerun this gate.",
   );
   for (const script of ["verify:expo:android", "verify:expo:ios"]) {
-    execFileSync(
-      "pnpm",
-      ["--filter", "todo-client-localfirst-expo", "run", script],
-      {
-        cwd: root,
-        env: { ...process.env, CI: "1" },
-        stdio: "inherit",
-      },
-    );
+    execFileSync("pnpm", ["--filter", "todo-client-localfirst-expo", "run", script], {
+      cwd: root,
+      env: { ...process.env, CI: "1" },
+      stdio: "inherit",
+    });
   }
 
   const autolink = (platform) =>
@@ -490,10 +420,7 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
           platform,
         ],
         {
-          cwd: new URL(
-            "../../../examples/todo-client-localfirst-expo/",
-            import.meta.url,
-          ),
+          cwd: new URL("../../../examples/todo-client-localfirst-expo/", import.meta.url),
           encoding: "utf8",
         },
       ),
@@ -504,41 +431,16 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
     androidAutolink.dependencies["jazz-rn"].platforms.android.packageInstance,
     "new JazzRelayPackage()",
   );
-  assert.match(
-    iosAutolink.dependencies["jazz-rn"].platforms.ios.podspecPath,
-    /JazzRn\.podspec$/,
-  );
+  assert.match(iosAutolink.dependencies["jazz-rn"].platforms.ios.podspecPath, /JazzRn\.podspec$/);
 
-  const expoRoot = new URL(
-    "../../../examples/todo-client-localfirst-expo/",
-    import.meta.url,
-  );
-  const androidProperties = readFile(
-    new URL("android/gradle.properties", expoRoot),
-    "utf8",
-  );
-  const androidSettings = readFile(
-    new URL("android/settings.gradle", expoRoot),
-    "utf8",
-  );
-  const iosProperties = readFile(
-    new URL("ios/Podfile.properties.json", expoRoot),
-    "utf8",
-  );
+  const expoRoot = new URL("../../../examples/todo-client-localfirst-expo/", import.meta.url);
+  const androidProperties = readFile(new URL("android/gradle.properties", expoRoot), "utf8");
+  const androidSettings = readFile(new URL("android/settings.gradle", expoRoot), "utf8");
+  const iosProperties = readFile(new URL("ios/Podfile.properties.json", expoRoot), "utf8");
   const iosPodfile = readFile(new URL("ios/Podfile", expoRoot), "utf8");
 
-  return Promise.all([
-    androidProperties,
-    androidSettings,
-    iosProperties,
-    iosPodfile,
-  ]).then(
-    ([
-      androidPropertiesText,
-      androidSettingsText,
-      iosPropertiesText,
-      iosPodfileText,
-    ]) => {
+  return Promise.all([androidProperties, androidSettings, iosProperties, iosPodfile]).then(
+    ([androidPropertiesText, androidSettingsText, iosPropertiesText, iosPodfileText]) => {
       assert.match(androidPropertiesText, /^newArchEnabled=true$/m);
       assert.match(androidSettingsText, /expo-autolinking-settings/);
       assert.match(androidSettingsText, /autolinkLibrariesFromCommand/);
@@ -549,44 +451,24 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
 });
 
 test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts", async () => {
-  const [
-    podspec,
-    androidPackage,
-    androidBuild,
-    iosRelay,
-    packageRoot,
-    rootCargo,
-    legacyConfig,
-  ] = await Promise.all([
-    readFile(
-      new URL("../../../crates/jazz-rn/JazzRn.podspec", import.meta.url),
-      "utf8",
-    ),
-    readFile(
-      new URL(
-        "../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayPackage.kt",
-        import.meta.url,
+  const [podspec, androidPackage, androidBuild, iosRelay, packageRoot, rootCargo, legacyConfig] =
+    await Promise.all([
+      readFile(new URL("../../../crates/jazz-rn/JazzRn.podspec", import.meta.url), "utf8"),
+      readFile(
+        new URL(
+          "../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayPackage.kt",
+          import.meta.url,
+        ),
+        "utf8",
       ),
-      "utf8",
-    ),
-    readFile(
-      new URL("../../../crates/jazz-rn/android/build.gradle", import.meta.url),
-      "utf8",
-    ),
-    readFile(
-      new URL("../../../crates/jazz-rn/ios/JazzRelay.mm", import.meta.url),
-      "utf8",
-    ),
-    readFile(
-      new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url),
-      "utf8",
-    ),
-    readFile(new URL("../../../Cargo.toml", import.meta.url), "utf8"),
-    readFile(
-      new URL("../../../crates/jazz-rn/ubrn.config.yaml", import.meta.url),
-      "utf8",
-    ).catch(() => null),
-  ]);
+      readFile(new URL("../../../crates/jazz-rn/android/build.gradle", import.meta.url), "utf8"),
+      readFile(new URL("../../../crates/jazz-rn/ios/JazzRelay.mm", import.meta.url), "utf8"),
+      readFile(new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url), "utf8"),
+      readFile(new URL("../../../Cargo.toml", import.meta.url), "utf8"),
+      readFile(new URL("../../../crates/jazz-rn/ubrn.config.yaml", import.meta.url), "utf8").catch(
+        () => null,
+      ),
+    ]);
 
   assert.match(podspec, /JazzNativeRelay\.xcframework/);
   assert.match(podspec, /https:\/\/github\.com\/garden-co\/jazz\.git/);
@@ -617,17 +499,8 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
     "utf8",
   );
   const [nativeSpec, relayIndex] = await Promise.all([
-    readFile(
-      new URL(
-        "../../../crates/jazz-rn/src/NativeJazzRelay.ts",
-        import.meta.url,
-      ),
-      "utf8",
-    ),
-    readFile(
-      new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url),
-      "utf8",
-    ),
+    readFile(new URL("../../../crates/jazz-rn/src/NativeJazzRelay.ts", import.meta.url), "utf8"),
+    readFile(new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url), "utf8"),
   ]);
   const codegenGate = await readFile(
     new URL("../../../crates/jazz-rn/scripts/test-codegen.sh", import.meta.url),
@@ -642,10 +515,7 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
   );
 
   assert.equal(packageJson.exports["./relay"].source, "./src/relay.ts");
-  assert.equal(
-    packageJson.scripts["test:codegen"],
-    "bash scripts/test-codegen.sh",
-  );
+  assert.equal(packageJson.scripts["test:codegen"], "bash scripts/test-codegen.sh");
   assert.match(nativeSpec, /TurboModuleRegistry\.get<Spec>\('JazzRelay'\)/);
   assert.match(nativeSpec, /execute\(commandBase64: string\): Promise<string>/);
   assert.match(relay, /getAbiVersion\(\)/);
@@ -658,10 +528,7 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
   assert.match(codegenGate, /class NativeJazzRelaySpec/);
   assert.match(androidRelay, /JazzRelayBridge/);
   assert.match(androidRelay, /package com\.jazzrn;/);
-  assert.match(
-    androidRelay,
-    /class JazzRelayModule extends NativeJazzRelaySpec/,
-  );
+  assert.match(androidRelay, /class JazzRelayModule extends NativeJazzRelaySpec/);
   assert.match(androidRelay, /double getAbiVersion\(\)/);
   assert.match(androidRelay, /E_JAZZ_RELAY_UNAVAILABLE/);
 });
@@ -672,17 +539,8 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     "utf8",
   );
   const [nativeSpec, relayIndex] = await Promise.all([
-    readFile(
-      new URL(
-        "../../../crates/jazz-rn/src/NativeJazzRelay.ts",
-        import.meta.url,
-      ),
-      "utf8",
-    ),
-    readFile(
-      new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url),
-      "utf8",
-    ),
+    readFile(new URL("../../../crates/jazz-rn/src/NativeJazzRelay.ts", import.meta.url), "utf8"),
+    readFile(new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url), "utf8"),
   ]);
   const androidBridge = await readFile(
     new URL(
@@ -703,10 +561,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     "utf8",
   );
   const header = await readFile(
-    new URL(
-      "../../../crates/jazz-native-relay/include/jazz_native_relay.h",
-      import.meta.url,
-    ),
+    new URL("../../../crates/jazz-native-relay/include/jazz_native_relay.h", import.meta.url),
     "utf8",
   );
 
@@ -716,10 +571,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
   assert.throws(
     () =>
       assertExactTsRelaySurface(
-        nativeSpec.replace(
-          "getAbiVersion(): number;",
-          "getAuthScope(): string;",
-        ),
+        nativeSpec.replace("getAbiVersion(): number;", "getAuthScope(): string;"),
         relay,
         relayIndex,
       ),
@@ -741,11 +593,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
   );
   assert.throws(
     () =>
-      assertExactTsRelaySurface(
-        nativeSpec,
-        `${relay}\nexport function configure() {}`,
-        relayIndex,
-      ),
+      assertExactTsRelaySurface(nativeSpec, `${relay}\nexport function configure() {}`, relayIndex),
     undefined,
     "an innocuous TypeScript helper must not enlarge the relay ABI",
   );
@@ -760,12 +608,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     "an alias re-export must not smuggle a new public relay name into the package",
   );
   assert.throws(
-    () =>
-      assertExactTsRelaySurface(
-        nativeSpec,
-        relay,
-        `${relayIndex}\nexport * from './relay';`,
-      ),
+    () => assertExactTsRelaySurface(nativeSpec, relay, `${relayIndex}\nexport * from './relay';`),
     undefined,
     "a star re-export must not automatically publish future relay helpers",
   );
@@ -823,11 +666,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
   ]) {
     assert.throws(
       () =>
-        assertExactTsRelaySurface(
-          nativeSpec,
-          fixture.relay ?? relay,
-          fixture.index ?? relayIndex,
-        ),
+        assertExactTsRelaySurface(nativeSpec, fixture.relay ?? relay, fixture.index ?? relayIndex),
       undefined,
       `${fixture.name} must not enlarge the fixed relay ABI`,
     );
@@ -903,8 +742,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     },
   ]) {
     assert.throws(
-      () =>
-        assertOpaqueIosRelaySurface(`${iosRelay}\n${fixture.source}`),
+      () => assertOpaqueIosRelaySurface(`${iosRelay}\n${fixture.source}`),
       /legacy RCT/,
       `${fixture.name} must fail the raw iOS legacy macro ban`,
     );
@@ -923,10 +761,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
   assert.throws(
     () =>
       assertOpaqueIosRelaySurface(
-        iosRelay.replace(
-          "- (void)invalidate",
-          "- (void)configure {}\n\n- (void)invalidate",
-        ),
+        iosRelay.replace("- (void)invalidate", "- (void)configure {}\n\n- (void)invalidate"),
       ),
     /configure/,
     "an arbitrary Objective-C method must not grow the sealed relay module",
@@ -949,10 +784,7 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
 
 test("relay artifact staging targets every Android ABI and iOS framework slice", async () => {
   const script = await readFile(
-    new URL(
-      "../../../crates/jazz-rn/scripts/build-relay-artifacts.sh",
-      import.meta.url,
-    ),
+    new URL("../../../crates/jazz-rn/scripts/build-relay-artifacts.sh", import.meta.url),
     "utf8",
   );
 
@@ -960,10 +792,7 @@ test("relay artifact staging targets every Android ABI and iOS framework slice",
     packageJson.scripts["build:relay:android"],
     "bash scripts/build-relay-artifacts.sh android",
   );
-  assert.equal(
-    packageJson.scripts["build:relay:ios"],
-    "bash scripts/build-relay-artifacts.sh ios",
-  );
+  assert.equal(packageJson.scripts["build:relay:ios"], "bash scripts/build-relay-artifacts.sh ios");
   assert.match(script, /\[arm64-v8a\]=aarch64-linux-android/);
   assert.match(script, /\[armeabi-v7a\]=armv7-linux-androideabi/);
   assert.match(script, /\[x86\]=i686-linux-android/);
@@ -990,10 +819,7 @@ test("a dry package includes every staged native relay artifact class", async ()
       types: undefined,
       exports: undefined,
     };
-    await writeFile(
-      join(directory, "package.json"),
-      `${JSON.stringify(manifest)}\n`,
-    );
+    await writeFile(join(directory, "package.json"), `${JSON.stringify(manifest)}\n`);
     for (const path of staged) {
       const destination = join(directory, path);
       await mkdir(dirname(destination), { recursive: true });
@@ -1027,10 +853,7 @@ test("relay verification rejects a manifest-sealed XCFramework without its devic
   const nativeRelayAbi = Number(
     /pub const NATIVE_RELAY_ABI_VERSION: u16 = (\d+);/.exec(
       readFileSync(
-        new URL(
-          "../../../crates/jazz-native-relay/src/lib.rs",
-          import.meta.url,
-        ),
+        new URL("../../../crates/jazz-native-relay/src/lib.rs", import.meta.url),
         "utf8",
       ),
     )?.[1],
@@ -1070,10 +893,7 @@ ${
     for (const file of files) {
       const destination = join(root, file);
       await mkdir(dirname(destination), { recursive: true });
-      await writeFile(
-        destination,
-        file === "Info.plist" ? info(true) : `fixture:${file}\n`,
-      );
+      await writeFile(destination, file === "Info.plist" ? info(true) : `fixture:${file}\n`);
     }
   };
   const writeManifest = async (root, destination, extra = {}) => {
@@ -1084,9 +904,7 @@ ${
       ).readdir(current, {
         withFileTypes: true,
       })) {
-        const nextRelative = relative
-          ? `${relative}/${entry.name}`
-          : entry.name;
+        const nextRelative = relative ? `${relative}/${entry.name}` : entry.name;
         const next = join(current, entry.name);
         if (entry.isDirectory()) await visit(next, nextRelative);
         else {
@@ -1118,23 +936,13 @@ ${
     await writeFile(
       join(packageRoot, "native/include/jazz_native_relay.h"),
       readFileSync(
-        new URL(
-          "../../../crates/jazz-native-relay/include/jazz_native_relay.h",
-          import.meta.url,
-        ),
+        new URL("../../../crates/jazz-native-relay/include/jazz_native_relay.h", import.meta.url),
       ),
     );
-    await writeManifest(
-      androidRoot,
-      join(packageRoot, "android/jazz-native-relay.manifest.json"),
-      {
-        toolchain: { cargoNdk: "4.1.2" },
-      },
-    );
-    await writeManifest(
-      iosRoot,
-      join(packageRoot, "ios/jazz-native-relay.manifest.json"),
-    );
+    await writeManifest(androidRoot, join(packageRoot, "android/jazz-native-relay.manifest.json"), {
+      toolchain: { cargoNdk: "4.1.2" },
+    });
+    await writeManifest(iosRoot, join(packageRoot, "ios/jazz-native-relay.manifest.json"));
     const environment = {
       ...process.env,
       JAZZ_NATIVE_RELAY_SOURCE_REVISION: sourceRevision,
@@ -1151,18 +959,9 @@ ${
 
     const simulatorDirectory = join(iosRoot, "ios-arm64_x86_64-simulator");
     await rm(join(simulatorDirectory, "libjazz_native_relay.a"));
-    await writeFile(
-      join(simulatorDirectory, "libjazz_native_relay_simulator.a"),
-      "fixture\n",
-    );
-    await writeFile(
-      join(iosRoot, "Info.plist"),
-      info(true, "libjazz_native_relay_simulator.a"),
-    );
-    await writeManifest(
-      iosRoot,
-      join(packageRoot, "ios/jazz-native-relay.manifest.json"),
-    );
+    await writeFile(join(simulatorDirectory, "libjazz_native_relay_simulator.a"), "fixture\n");
+    await writeFile(join(iosRoot, "Info.plist"), info(true, "libjazz_native_relay_simulator.a"));
+    await writeManifest(iosRoot, join(packageRoot, "ios/jazz-native-relay.manifest.json"));
     assert.throws(
       () =>
         execFileSync(
@@ -1175,16 +974,10 @@ ${
     );
 
     await rm(join(simulatorDirectory, "libjazz_native_relay_simulator.a"));
-    await writeFile(
-      join(simulatorDirectory, "libjazz_native_relay.a"),
-      "fixture\n",
-    );
+    await writeFile(join(simulatorDirectory, "libjazz_native_relay.a"), "fixture\n");
 
     await writeFile(join(iosRoot, "Info.plist"), info(false));
-    await writeManifest(
-      iosRoot,
-      join(packageRoot, "ios/jazz-native-relay.manifest.json"),
-    );
+    await writeManifest(iosRoot, join(packageRoot, "ios/jazz-native-relay.manifest.json"));
     assert.throws(
       () =>
         execFileSync(
@@ -1240,54 +1033,30 @@ test("alpha verification preserves a reusable preview's sealed source commit acr
 });
 
 test("release, preview, and labeled platform gates seal and link the staged relay package", async () => {
-  const [
-    packageBuild,
-    alphaPublish,
-    previewBuild,
-    rnWorkflow,
-    artifactScript,
-    verifier,
-  ] = await Promise.all([
-    readFile(
-      new URL(
-        "../../../.github/workflows/build-jazz-packages.yml",
-        import.meta.url,
+  const [packageBuild, alphaPublish, previewBuild, rnWorkflow, artifactScript, verifier] =
+    await Promise.all([
+      readFile(
+        new URL("../../../.github/workflows/build-jazz-packages.yml", import.meta.url),
+        "utf8",
       ),
-      "utf8",
-    ),
-    readFile(
-      new URL(
-        "../../../.github/workflows/publish-jazz-tools-alpha.yml",
-        import.meta.url,
+      readFile(
+        new URL("../../../.github/workflows/publish-jazz-tools-alpha.yml", import.meta.url),
+        "utf8",
       ),
-      "utf8",
-    ),
-    readFile(
-      new URL("../../../.github/workflows/preview-build.yml", import.meta.url),
-      "utf8",
-    ),
-    readFile(
-      new URL(
-        "../../../.github/workflows/rn-native-artifacts.yml",
-        import.meta.url,
+      readFile(new URL("../../../.github/workflows/preview-build.yml", import.meta.url), "utf8"),
+      readFile(
+        new URL("../../../.github/workflows/rn-native-artifacts.yml", import.meta.url),
+        "utf8",
       ),
-      "utf8",
-    ),
-    readFile(
-      new URL(
-        "../../../crates/jazz-rn/scripts/build-relay-artifacts.sh",
-        import.meta.url,
+      readFile(
+        new URL("../../../crates/jazz-rn/scripts/build-relay-artifacts.sh", import.meta.url),
+        "utf8",
       ),
-      "utf8",
-    ),
-    readFile(
-      new URL(
-        "../../../crates/jazz-rn/scripts/verify-relay-artifacts.mjs",
-        import.meta.url,
+      readFile(
+        new URL("../../../crates/jazz-rn/scripts/verify-relay-artifacts.mjs", import.meta.url),
+        "utf8",
       ),
-      "utf8",
-    ),
-  ]);
+    ]);
   const packageBuildWorkflow = parse(packageBuild);
   const previewBuildWorkflow = parse(previewBuild);
 
@@ -1299,10 +1068,7 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     "the reusable package build must make RN release assembly an explicit opt-in",
   );
   assert.match(packageBuild, /if: inputs\.include_rn/);
-  assert.match(
-    packageBuild,
-    /assemble-jazz-rn:[\s\S]*always\(\)[\s\S]*inputs\.include_rn/,
-  );
+  assert.match(packageBuild, /assemble-jazz-rn:[\s\S]*always\(\)[\s\S]*inputs\.include_rn/);
   assert.match(
     packageBuild,
     /jazz_rn_artifact:[\s\S]*value: \$\{\{ jobs\.assemble-jazz-rn\.outputs\.artifact \}\}/,
@@ -1322,10 +1088,7 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     alphaPublish,
     /uses: \.\/\.github\/workflows\/build-jazz-packages\.yml[\s\S]*include_rn: true/,
   );
-  assert.match(
-    previewBuild,
-    /types: \[labeled, unlabeled, synchronize, reopened\]/,
-  );
+  assert.match(previewBuild, /types: \[labeled, unlabeled, synchronize, reopened\]/);
   assert.match(previewBuild, /'preview-build'/);
   assert.match(previewBuild, /'rn-preview-release'/);
   assert.match(previewBuild, /include_rn:[\s\S]*rn-preview-release/);
@@ -1350,14 +1113,11 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     "inherit",
     "the reusable build is privileged and must remain behind its same-repository guard",
   );
-  assert.deepEqual(
-    previewBuildWorkflow.jobs["publish-pkg-pr-new"].permissions,
-    {
-      contents: "read",
-      "pull-requests": "write",
-      "id-token": "write",
-    },
-  );
+  assert.deepEqual(previewBuildWorkflow.jobs["publish-pkg-pr-new"].permissions, {
+    contents: "read",
+    "pull-requests": "write",
+    "id-token": "write",
+  });
   assert.match(previewBuild, /name: pkg-jazz-rn/);
   assert.match(previewBuild, /'\.\/crates\/jazz-rn'/);
   assert.doesNotMatch(
@@ -1378,10 +1138,7 @@ test("release, preview, and labeled platform gates seal and link the staged rela
   assert.throws(
     () =>
       assert.match(
-        regularPreviewPublish.replace(
-          "'./packages/create-jazz'",
-          "'./crates/jazz-rn'",
-        ),
+        regularPreviewPublish.replace("'./packages/create-jazz'", "'./crates/jazz-rn'"),
         /ordinary preview-build runs must neither download nor publish jazz-rn/,
       ),
     /ordinary preview-build runs must neither download nor publish jazz-rn/,
@@ -1389,9 +1146,7 @@ test("release, preview, and labeled platform gates seal and link the staged rela
 
   const previewMode = (labels, sameRepository) => ({
     runs:
-      sameRepository &&
-      (labels.includes("preview-build") ||
-        labels.includes("rn-preview-release")),
+      sameRepository && (labels.includes("preview-build") || labels.includes("rn-preview-release")),
     includesRn: labels.includes("rn-preview-release") && sameRepository,
   });
   assert.deepEqual(previewMode([], true), { runs: false, includesRn: false });
@@ -1411,20 +1166,14 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     runs: false,
     includesRn: false,
   });
-  assert.deepEqual(
-    previewMode(["preview-build", "rn-preview-release", "react-native"], false),
-    {
-      runs: false,
-      includesRn: false,
-    },
-  );
-  assert.deepEqual(
-    previewMode(["preview-build", "rn-preview-release", "react-native"], true),
-    {
-      runs: true,
-      includesRn: true,
-    },
-  );
+  assert.deepEqual(previewMode(["preview-build", "rn-preview-release", "react-native"], false), {
+    runs: false,
+    includesRn: false,
+  });
+  assert.deepEqual(previewMode(["preview-build", "rn-preview-release", "react-native"], true), {
+    runs: true,
+    includesRn: true,
+  });
   assert.deepEqual(previewBuildWorkflow.on.pull_request.types, [
     "labeled",
     "unlabeled",
@@ -1436,10 +1185,7 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     false,
     "the reusable package build defaults to its fast, non-RN path",
   );
-  assert.match(
-    previewBuildWorkflow.jobs.build.with.include_rn,
-    /rn-preview-release/,
-  );
+  assert.match(previewBuildWorkflow.jobs.build.with.include_rn, /rn-preview-release/);
   assert.match(rnWorkflow, /Android relay linked AAR/);
   assert.match(rnWorkflow, /:app:assembleDebug/);
   assert.match(rnWorkflow, /iOS relay linked app/);
@@ -1449,10 +1195,7 @@ test("release, preview, and labeled platform gates seal and link the staged rela
   assert.match(verifier, /JAZZ_NATIVE_RELAY_SOURCE_REVISION/);
   assert.match(verifier, /AvailableLibraries/);
   assert.match(verifier, /requiredRoles/);
-  assert.match(
-    packageBuild,
-    /cargo-ndk@\$\{\{ env\.JAZZ_RN_CARGO_NDK_VERSION \}\}/,
-  );
+  assert.match(packageBuild, /cargo-ndk@\$\{\{ env\.JAZZ_RN_CARGO_NDK_VERSION \}\}/);
   assert.match(packageBuild, /--package-root/);
   assert.match(verifier, /relay artifact inventory differs from its manifest/);
 });

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -54,6 +54,13 @@ function assertOpaqueRelaySurface(surface, declarations) {
   }
 }
 
+// Keep this declaration-aware rather than scanning broad source text: private
+// trusted admission code may use these words, while comments must neither trip
+// the receipt nor hide a JavaScript-visible declaration.
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
 function braceBody(source, opening) {
   const openingIndex = source.indexOf(opening);
   assert.notEqual(openingIndex, -1, `could not find ${opening}`);
@@ -72,32 +79,81 @@ function braceBody(source, opening) {
 
 function assertOpaqueJsRelaySurface(nativeSpec, relay) {
   const spec = braceBody(nativeSpec, "export interface Spec extends TurboModule");
-  const exportedFunctions = relay.match(/export\s+(?:async\s+)?function\s+[^{]+\{/g) ?? [];
+  const exportedFunctions =
+    stripComments(relay).match(/(?:^|\n)\s*export\s+(?:(?:async|declare)\s+)?(?:function|const|class)\s+[^;{]+(?:\{|=)/g) ?? [];
   assertOpaqueRelaySurface("NativeJazzRelay TurboModule", spec.split(";").filter(Boolean));
   assertOpaqueRelaySurface("relay TypeScript export", exportedFunctions);
 }
 
 function assertOpaqueAndroidRelaySurface(androidModule) {
   const module = braceBody(
-    androidModule,
+    stripComments(androidModule),
     "public class JazzRelayModule extends NativeJazzRelaySpec",
   );
-  const publicMethods = module.match(/@Override\s+public\s+[^{};]+\{/g) ?? [];
-  assertOpaqueRelaySurface("Android TurboModule", publicMethods);
+  const exportedMethods = [];
+  const declarations = /((?:@[A-Za-z_$][A-Za-z0-9_$.]*(?:\s*\([^{}]*\))?\s*)+)public\s+[^{};]+\([^{};]*\)\s*(?:throws\s+[^{}]+)?\{/g;
+  for (const match of module.matchAll(declarations)) {
+    // Generated TurboModule methods use @Override; handwritten React Native
+    // modules use @ReactMethod. Both are JavaScript-visible exports.
+    if (/@(?:Override|ReactMethod)\b/.test(match[1])) exportedMethods.push(match[0]);
+  }
+  assertOpaqueRelaySurface("Android JavaScript export", exportedMethods);
+}
+
+function macroDeclarations(source, macro) {
+  const declarations = [];
+  const token = `${macro}(`;
+  let from = 0;
+  while (true) {
+    const start = source.indexOf(token, from);
+    if (start === -1) return declarations;
+    let depth = 0;
+    let quote = null;
+    let escaped = false;
+    let closed = false;
+    for (let index = start + macro.length; index < source.length; index += 1) {
+      const character = source[index];
+      if (quote !== null) {
+        if (escaped) escaped = false;
+        else if (character === "\\") escaped = true;
+        else if (character === quote) quote = null;
+        continue;
+      }
+      if (character === '"' || character === "'") quote = character;
+      else if (character === "(") depth += 1;
+      else if (character === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          declarations.push(source.slice(start, index + 1));
+          from = index + 1;
+          closed = true;
+          break;
+        }
+      }
+    }
+    if (!closed) assert.fail(`unterminated ${macro} declaration`);
+  }
 }
 
 function assertOpaqueIosRelaySurface(iosRelay) {
-  const implementationStart = iosRelay.indexOf("@implementation JazzRelay");
+  const commentFreeRelay = stripComments(iosRelay);
+  const implementationStart = commentFreeRelay.indexOf("@implementation JazzRelay");
   assert.notEqual(implementationStart, -1, "could not find JazzRelay Objective-C implementation");
-  const trustedAdmissionStart = iosRelay.indexOf("@implementation JazzRelayTrustedAdmission");
+  const trustedAdmissionStart = commentFreeRelay.indexOf("@implementation JazzRelayTrustedAdmission");
   assert.notEqual(
     trustedAdmissionStart,
     -1,
     "could not separate trusted Objective-C admission from exported relay module",
   );
-  const relayModule = iosRelay.slice(implementationStart, trustedAdmissionStart);
+  const relayModule = commentFreeRelay.slice(implementationStart, trustedAdmissionStart);
   const exportedMethods = relayModule.match(/^-\s*\([^)]*\)\s*[^{]+\{/gm) ?? [];
-  assertOpaqueRelaySurface("iOS TurboModule", exportedMethods);
+  // Old-architecture modules may use these macros. They declare the
+  // JavaScript method even when no Objective-C signature is in this source.
+  exportedMethods.push(
+    ...macroDeclarations(relayModule, "RCT_EXPORT_METHOD"),
+    ...macroDeclarations(relayModule, "RCT_REMAP_METHOD"),
+  );
+  assertOpaqueRelaySurface("iOS JavaScript export", exportedMethods);
 }
 
 test("jazz-rn publishes an Expo config plugin for a New Architecture development build", () => {
@@ -319,6 +375,39 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
       ),
     /sqlitePath/,
     "a camel-case SQLite path parameter must not enter the Android TurboModule",
+  );
+  assert.throws(
+    () =>
+      assertOpaqueAndroidRelaySurface(
+        androidModule.replace(
+          "  @Override\n  public void execute",
+          "  @ReactMethod(isBlockingSynchronousMethod = true)\n  public void admitScope(String scope) {}\n\n  @Override\n  public void execute",
+        ),
+      ),
+    /admitScope/,
+    "a handwritten @ReactMethod must receive the same trusted-input receipt as generated methods",
+  );
+  assert.throws(
+    () =>
+      assertOpaqueIosRelaySurface(
+        iosRelay.replace(
+          "- (void)invalidate",
+          "RCT_EXPORT_METHOD(admitScope:(NSString *)scope)\n\n- (void)invalidate",
+        ),
+      ),
+    /admitScope/,
+    "an RCT_EXPORT_METHOD must not introduce trusted admission to the iOS JS surface",
+  );
+  assert.throws(
+    () =>
+      assertOpaqueIosRelaySurface(
+        iosRelay.replace(
+          "- (void)invalidate",
+          "RCT_REMAP_METHOD(revokeScope, revokeScope:(NSString *)scope)\n\n- (void)invalidate",
+        ),
+      ),
+    /revokeScope/,
+    "an RCT_REMAP_METHOD must not introduce trusted revocation to the iOS JS surface",
   );
   assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
   assert.match(androidBridge, /TrustedRelayScopeConfig/);

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -61,15 +61,6 @@ function assertExactNames(surface, actual, allowed) {
   );
 }
 
-function assertOnlyAllowedNames(surface, actual, allowed) {
-  const unexpected = [...actual].filter((name) => !allowed.has(name));
-  assert.deepEqual(
-    unexpected,
-    [],
-    `${surface} has unexpected JavaScript-facing name(s): ${unexpected.join(", ")}`,
-  );
-}
-
 function exportedStatements(surface, source) {
   const file = ts.createSourceFile(
     `${surface}.ts`,
@@ -142,6 +133,56 @@ function assertNamedRelayReexport(surface, statement, names, typeOnly) {
   assert.ok(
     statement.exportClause.elements.every((item) => item.propertyName === undefined),
     `${surface} must not alias-re-export the relay ABI`,
+  );
+}
+
+function assertExactNativeSpecMethod(member, name) {
+  assert.ok(member, `NativeJazzRelay Spec omits ${name}`);
+  assert.ok(
+    ts.isMethodSignature(member),
+    `NativeJazzRelay Spec member ${name} must be a method signature, not another TypeScript member kind`,
+  );
+  assert.ok(ts.isIdentifier(member.name));
+  assert.equal(member.name.text, name);
+  assert.equal(member.questionToken, undefined, `${name} must not be optional`);
+  assert.equal(
+    member.typeParameters,
+    undefined,
+    `${name} must not be generic`,
+  );
+
+  if (name === "getAbiVersion") {
+    assert.equal(member.parameters.length, 0, "getAbiVersion takes no arguments");
+    assert.equal(
+      member.type?.kind,
+      ts.SyntaxKind.NumberKeyword,
+      "getAbiVersion returns exactly number",
+    );
+    return;
+  }
+
+  assert.equal(member.parameters.length, 1, "execute takes exactly one argument");
+  const parameter = member.parameters[0];
+  assert.ok(ts.isIdentifier(parameter.name));
+  assert.equal(parameter.name.text, "commandBase64");
+  assert.equal(parameter.dotDotDotToken, undefined, "execute must not be variadic");
+  assert.equal(parameter.questionToken, undefined, "execute argument must not be optional");
+  assert.equal(
+    parameter.type?.kind,
+    ts.SyntaxKind.StringKeyword,
+    "execute accepts exactly a string command",
+  );
+  assert.ok(
+    member.type && ts.isTypeReferenceNode(member.type),
+    "execute returns exactly Promise<string>",
+  );
+  assert.ok(ts.isIdentifier(member.type.typeName));
+  assert.equal(member.type.typeName.text, "Promise");
+  assert.equal(member.type.typeArguments?.length, 1);
+  assert.equal(
+    member.type.typeArguments?.[0]?.kind,
+    ts.SyntaxKind.StringKeyword,
+    "execute returns exactly Promise<string>",
   );
 }
 
@@ -236,16 +277,36 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
     true,
   );
 
-  const spec = braceBody(
-    commentFreeSpec,
-    "export interface Spec extends TurboModule",
+  const spec = specExports[0];
+  const membersByName = new Map();
+  for (const member of spec.members) {
+    assert.ok(
+      ts.isMethodSignature(member) && ts.isIdentifier(member.name),
+      "NativeJazzRelay TurboModule may contain only named method signatures",
+    );
+    assert.ok(
+      nativeSpecMethods.has(member.name.text),
+      `NativeJazzRelay TurboModule has unexpected member ${member.name.text}`,
+    );
+    assert.ok(
+      !membersByName.has(member.name.text),
+      `NativeJazzRelay TurboModule repeats member ${member.name.text}`,
+    );
+    membersByName.set(member.name.text, member);
+  }
+  assert.equal(
+    spec.members.length,
+    nativeSpecMethods.size,
+    "NativeJazzRelay TurboModule has exactly its two ABI methods",
   );
-  const methods = new Set(
-    [...spec.matchAll(/(?:^|[;\n])\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*\(/g)].map(
-      (match) => match[1],
-    ),
+  assertExactNames(
+    "NativeJazzRelay TurboModule",
+    new Set(membersByName.keys()),
+    nativeSpecMethods,
   );
-  assertExactNames("NativeJazzRelay TurboModule", methods, nativeSpecMethods);
+  for (const name of nativeSpecMethods) {
+    assertExactNativeSpecMethod(membersByName.get(name), name);
+  }
   assert.match(
     commentFreeSpec,
     /^\s*export\s+default\s+TurboModuleRegistry\.get<Spec>\('JazzRelay'\);\s*$/m,
@@ -280,16 +341,14 @@ function assertOpaqueAndroidRelaySurface(androidModule) {
   );
 }
 
-function macroDeclarations(source, macro) {
+function legacyExportMacros(source) {
   const declarations = [];
-  const pattern = new RegExp(`\\b${macro}\\s*\\(`, "g");
-  let from = 0;
-  while (true) {
-    pattern.lastIndex = from;
-    const occurrence = pattern.exec(source);
-    if (occurrence === null) return declarations;
-    const start = occurrence.index;
-    const opening = source.indexOf("(", start + macro.length);
+  const pattern = /\b(RCT_[A-Za-z0-9_]*(?:EXPORT|REMAP)[A-Za-z0-9_]*)\s*\(/g;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    const macro = match[1];
+    if (macro === "RCT_EXPORT_MODULE") continue;
+    const opening = source.indexOf("(", match.index + macro.length);
     let depth = 0;
     let quote = null;
     let escaped = false;
@@ -307,8 +366,8 @@ function macroDeclarations(source, macro) {
       else if (character === ")") {
         depth -= 1;
         if (depth === 0) {
-          declarations.push(source.slice(start, index + 1));
-          from = index + 1;
+          declarations.push({ macro, declaration: source.slice(match.index, index + 1) });
+          pattern.lastIndex = index + 1;
           closed = true;
           break;
         }
@@ -316,6 +375,7 @@ function macroDeclarations(source, macro) {
     }
     if (!closed) assert.fail(`unterminated ${macro} declaration`);
   }
+  return declarations;
 }
 
 function objcMethodNames(source) {
@@ -326,12 +386,6 @@ function objcMethodNames(source) {
       ),
     ].map((match) => match[1]),
   );
-}
-
-function macroExportName(declaration, macro) {
-  const body = declaration.slice(declaration.indexOf("(") + 1, -1).trim();
-  if (macro === "RCT_REMAP_METHOD") return body.split(",", 1)[0].trim();
-  return /^([A-Za-z_$][A-Za-z0-9_$]*)\s*:/.exec(body)?.[1] ?? body;
 }
 
 function objcImplementations(source) {
@@ -384,18 +438,13 @@ function assertOpaqueIosRelaySurface(iosRelay) {
     exportedMethods,
     iosRelaySelectors,
   );
-  const macroExports = new Set([
-    ...macroDeclarations(relayModule, "RCT_EXPORT_METHOD").map((item) =>
-      macroExportName(item, "RCT_EXPORT_METHOD"),
-    ),
-    ...macroDeclarations(relayModule, "RCT_REMAP_METHOD").map((item) =>
-      macroExportName(item, "RCT_REMAP_METHOD"),
-    ),
-  ]);
-  assertOnlyAllowedNames(
-    "iOS RCT JavaScript export",
-    macroExports,
-    nativeSpecMethods,
+  // The generated New-Architecture spec is the sole iOS JavaScript ABI. An
+  // RCT export/remap macro would create a parallel old-architecture entry
+  // point, so reject every family (including future spelling variants).
+  assert.deepEqual(
+    legacyExportMacros(relayModule),
+    [],
+    "iOS JazzRelay must not add legacy RCT export/remap JavaScript entry points",
   );
 }
 
@@ -708,6 +757,19 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
   assert.throws(
     () =>
       assertExactTsRelaySurface(
+        nativeSpec.replace(
+          "  execute(commandBase64: string): Promise<string>;\n}",
+          "  execute(commandBase64: string): Promise<string>;\n  configure: string;\n}",
+        ),
+        relay,
+        relayIndex,
+      ),
+    /method signature|member kind|configure/,
+    "a property-shaped TurboModule member must not enter the fixed ABI",
+  );
+  assert.throws(
+    () =>
+      assertExactTsRelaySurface(
         nativeSpec,
         `${relay}\nexport function configure() {}`,
         relayIndex,
@@ -859,6 +921,22 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     /begin/,
     "a multiline RCT_REMAP_METHOD must not introduce an arbitrary iOS JS export",
   );
+  for (const fixture of [
+    "RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure)",
+    "RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, configure)",
+    "RCT_REMAP_BLOCKING_SYNCHRONOUS_METHOD(configure, configure)",
+    "RCT_REMAP_SYNCHRONOUS_TYPED_METHOD(NSString *, configure, configure)",
+    "RCT_EXPORT_FUTURE_METHOD(configure)",
+  ]) {
+    assert.throws(
+      () =>
+        assertOpaqueIosRelaySurface(
+          iosRelay.replace("- (void)invalidate", `${fixture}\n\n- (void)invalidate`),
+        ),
+      /RCT_/,
+      `${fixture} must not add a legacy iOS relay export`,
+    );
+  }
   assert.throws(
     () =>
       assertOpaqueIosRelaySurface(

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -11,54 +11,81 @@ import { parse } from "yaml";
 
 const require = createRequire(import.meta.url);
 const packageJson = JSON.parse(
-  await readFile(new URL("../../../crates/jazz-rn/package.json", import.meta.url), "utf8"),
+  await readFile(
+    new URL("../../../crates/jazz-rn/package.json", import.meta.url),
+    "utf8",
+  ),
 );
 const withJazzRn = require("../../../crates/jazz-rn/app.plugin.js");
 
-// The JavaScript-facing relay ABI is deliberately only an ABI probe and an
-// opaque command transport. Keep this check on declarations rather than broad
-// source text: trusted platform code may legitimately use these words in its
-// own private admission implementation, comments, and imports.
-const forbiddenRelaySurfaceNames = new Set([
-  "authscope",
-  "sqlitepath",
-  "schemajson",
-  "admit",
-  "revoke",
-  "claims",
-  "token",
+// This is a fixed ABI, not a denylist of sensitive-looking names. The public
+// JavaScript surface may only probe the ABI and submit one opaque command.
+// Trusted native scope admission deliberately has no entry in these tables.
+const relayJsExports = new Set([
+  "NativeRelayAbiRange",
+  "NATIVE_RELAY_ABI",
+  "executeNativeRelayCommand",
 ]);
-
-function identifierTokens(signature) {
-  return signature.match(/[A-Za-z_$][A-Za-z0-9_$]*/g) ?? [];
-}
-
-function normalizedIdentifier(identifier) {
-  return identifier.replace(/_/g, "").toLowerCase();
-}
-
-function isForbiddenRelaySurfaceIdentifier(identifier) {
-  const normalized = normalizedIdentifier(identifier);
-  return [...forbiddenRelaySurfaceNames].some((forbidden) => normalized.includes(forbidden));
-}
-
-function assertOpaqueRelaySurface(surface, declarations) {
-  for (const declaration of declarations) {
-    for (const identifier of identifierTokens(declaration)) {
-      if (isForbiddenRelaySurfaceIdentifier(identifier)) {
-        assert.fail(
-          `${surface} exposes trusted relay input ${identifier} in JS-facing declaration: ${declaration.trim()}`,
-        );
-      }
-    }
-  }
-}
+const nativeSpecMethods = new Set(["getAbiVersion", "execute"]);
+const androidRelayMethods = new Set(["getAbiVersion", "execute"]);
+// This includes lifecycle/generated hooks, which are not JavaScript methods.
+// Keeping them explicit catches accidental methods added beside the ABI.
+const iosRelaySelectors = new Set([
+  "init",
+  "getAbiVersion",
+  "execute",
+  "invalidate",
+  "getTurboModule",
+]);
 
 // Keep this declaration-aware rather than scanning broad source text: private
 // trusted admission code may use these words, while comments must neither trip
 // the receipt nor hide a JavaScript-visible declaration.
 function stripComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+function assertExactNames(surface, actual, allowed) {
+  const unexpected = [...actual].filter((name) => !allowed.has(name));
+  const missing = [...allowed].filter((name) => !actual.has(name));
+  assert.deepEqual(
+    unexpected,
+    [],
+    `${surface} has unexpected JavaScript-facing name(s): ${unexpected.join(", ")}`,
+  );
+  assert.deepEqual(
+    missing,
+    [],
+    `${surface} omits ABI name(s): ${missing.join(", ")}`,
+  );
+}
+
+function assertOnlyAllowedNames(surface, actual, allowed) {
+  const unexpected = [...actual].filter((name) => !allowed.has(name));
+  assert.deepEqual(
+    unexpected,
+    [],
+    `${surface} has unexpected JavaScript-facing name(s): ${unexpected.join(", ")}`,
+  );
+}
+
+function assertNoTsReexports(surface, source) {
+  const commentFree = stripComments(source);
+  assert.doesNotMatch(
+    commentFree,
+    /\bexport\s*\*/,
+    `${surface} must not star-re-export ABI`,
+  );
+  assert.doesNotMatch(
+    commentFree,
+    /\bexport\s*\{[^}]*\bas\b[^}]*\}/s,
+    `${surface} must not alias-re-export ABI`,
+  );
+  assert.doesNotMatch(
+    commentFree,
+    /\bexport\s*\{\s*default\b[^}]*\}/s,
+    `${surface} must not default-re-export ABI`,
+  );
 }
 
 function braceBody(source, opening) {
@@ -77,12 +104,49 @@ function braceBody(source, opening) {
   assert.fail(`unterminated ${opening} body`);
 }
 
-function assertOpaqueJsRelaySurface(nativeSpec, relay) {
-  const spec = braceBody(nativeSpec, "export interface Spec extends TurboModule");
-  const exportedFunctions =
-    stripComments(relay).match(/(?:^|\n)\s*export\s+(?:(?:async|declare)\s+)?(?:function|const|class)\s+[^;{]+(?:\{|=)/g) ?? [];
-  assertOpaqueRelaySurface("NativeJazzRelay TurboModule", spec.split(";").filter(Boolean));
-  assertOpaqueRelaySurface("relay TypeScript export", exportedFunctions);
+function assertExactTsRelaySurface(nativeSpec, relay, index) {
+  const commentFreeSpec = stripComments(nativeSpec);
+  const commentFreeRelay = stripComments(relay);
+  const commentFreeIndex = stripComments(index);
+  assertNoTsReexports("NativeJazzRelay TypeScript spec", nativeSpec);
+  assertNoTsReexports("relay TypeScript module", relay);
+  assertNoTsReexports("relay package entry point", index);
+
+  const spec = braceBody(
+    commentFreeSpec,
+    "export interface Spec extends TurboModule",
+  );
+  const methods = new Set(
+    [...spec.matchAll(/(?:^|[;\n])\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*\(/g)].map(
+      (match) => match[1],
+    ),
+  );
+  assertExactNames("NativeJazzRelay TurboModule", methods, nativeSpecMethods);
+  assert.match(
+    commentFreeSpec,
+    /^\s*export\s+default\s+TurboModuleRegistry\.get<Spec>\('JazzRelay'\);\s*$/m,
+    "NativeJazzRelay may only default-export its registry lookup",
+  );
+
+  const relayExports = new Set(
+    [
+      ...commentFreeRelay.matchAll(
+        /(?:^|\n)\s*export\s+(?:declare\s+)?(?:interface|type|const|async\s+function|function)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g,
+      ),
+    ].map((match) => match[1]),
+  );
+  assertExactNames("relay TypeScript module", relayExports, relayJsExports);
+  const entryExports = new Set(
+    [
+      ...commentFreeIndex.matchAll(
+        /(?:^|\n)\s*export\s+(?:type\s+)?\{([^}]*)\}/g,
+      ),
+    ]
+      .flatMap((match) => match[1].split(","))
+      .map((name) => name.trim())
+      .filter(Boolean),
+  );
+  assertExactNames("relay package entry point", entryExports, relayJsExports);
 }
 
 function assertOpaqueAndroidRelaySurface(androidModule) {
@@ -90,28 +154,42 @@ function assertOpaqueAndroidRelaySurface(androidModule) {
     stripComments(androidModule),
     "public class JazzRelayModule extends NativeJazzRelaySpec",
   );
-  const exportedMethods = [];
-  const declarations = /((?:@[A-Za-z_$][A-Za-z0-9_$.]*(?:\s*\([^{}]*\))?\s*)+)public\s+[^{};]+\([^{};]*\)\s*(?:throws\s+[^{}]+)?\{/g;
+  const exportedMethods = new Set();
+  const declarations =
+    /((?:@[A-Za-z_$][A-Za-z0-9_$.]*(?:\s*\([^{}]*\))?\s*)+)public\s+[^{};]+?\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*\([^{};]*\)\s*(?:throws\s+[^{}]+)?\{/g;
   for (const match of module.matchAll(declarations)) {
     // Generated TurboModule methods use @Override; handwritten React Native
-    // modules use @ReactMethod. Both are JavaScript-visible exports.
-    if (/@(?:Override|ReactMethod)\b/.test(match[1])) exportedMethods.push(match[0]);
+    // modules use @ReactMethod, including its fully-qualified spelling.
+    if (
+      /(?:@Override\b|@[A-Za-z_$][A-Za-z0-9_$.]*\.ReactMethod\b|@ReactMethod\b)/.test(
+        match[1],
+      )
+    ) {
+      exportedMethods.add(match[2]);
+    }
   }
-  assertOpaqueRelaySurface("Android JavaScript export", exportedMethods);
+  assertExactNames(
+    "Android JavaScript export",
+    exportedMethods,
+    androidRelayMethods,
+  );
 }
 
 function macroDeclarations(source, macro) {
   const declarations = [];
-  const token = `${macro}(`;
+  const pattern = new RegExp(`\\b${macro}\\s*\\(`, "g");
   let from = 0;
   while (true) {
-    const start = source.indexOf(token, from);
-    if (start === -1) return declarations;
+    pattern.lastIndex = from;
+    const occurrence = pattern.exec(source);
+    if (occurrence === null) return declarations;
+    const start = occurrence.index;
+    const opening = source.indexOf("(", start + macro.length);
     let depth = 0;
     let quote = null;
     let escaped = false;
     let closed = false;
-    for (let index = start + macro.length; index < source.length; index += 1) {
+    for (let index = opening; index < source.length; index += 1) {
       const character = source[index];
       if (quote !== null) {
         if (escaped) escaped = false;
@@ -135,34 +213,86 @@ function macroDeclarations(source, macro) {
   }
 }
 
+function objcMethodNames(source) {
+  return new Set(
+    [
+      ...source.matchAll(
+        /^[+-]\s*\([^)]*\)\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::|\{)/gm,
+      ),
+    ].map((match) => match[1]),
+  );
+}
+
+function macroExportName(declaration, macro) {
+  const body = declaration.slice(declaration.indexOf("(") + 1, -1).trim();
+  if (macro === "RCT_REMAP_METHOD") return body.split(",", 1)[0].trim();
+  return /^([A-Za-z_$][A-Za-z0-9_$]*)\s*:/.exec(body)?.[1] ?? body;
+}
+
 function assertOpaqueIosRelaySurface(iosRelay) {
   const commentFreeRelay = stripComments(iosRelay);
-  const implementationStart = commentFreeRelay.indexOf("@implementation JazzRelay");
-  assert.notEqual(implementationStart, -1, "could not find JazzRelay Objective-C implementation");
-  const trustedAdmissionStart = commentFreeRelay.indexOf("@implementation JazzRelayTrustedAdmission");
+  const implementationStart = commentFreeRelay.indexOf(
+    "@implementation JazzRelay",
+  );
+  assert.notEqual(
+    implementationStart,
+    -1,
+    "could not find JazzRelay Objective-C implementation",
+  );
+  const trustedAdmissionStart = commentFreeRelay.indexOf(
+    "@implementation JazzRelayTrustedAdmission",
+  );
   assert.notEqual(
     trustedAdmissionStart,
     -1,
     "could not separate trusted Objective-C admission from exported relay module",
   );
-  const relayModule = commentFreeRelay.slice(implementationStart, trustedAdmissionStart);
-  const exportedMethods = relayModule.match(/^-\s*\([^)]*\)\s*[^{]+\{/gm) ?? [];
-  // Old-architecture modules may use these macros. They declare the
-  // JavaScript method even when no Objective-C signature is in this source.
-  exportedMethods.push(
-    ...macroDeclarations(relayModule, "RCT_EXPORT_METHOD"),
-    ...macroDeclarations(relayModule, "RCT_REMAP_METHOD"),
+  const relayModule = commentFreeRelay.slice(
+    implementationStart,
+    trustedAdmissionStart,
   );
-  assertOpaqueRelaySurface("iOS JavaScript export", exportedMethods);
+  const exportedMethods = objcMethodNames(relayModule);
+  // Old-architecture macros are JavaScript exports even when no Objective-C
+  // selector appears in this source. Their mapped JavaScript names are still
+  // constrained by the generated ABI.
+  assertExactNames(
+    "iOS JazzRelay implementation",
+    exportedMethods,
+    iosRelaySelectors,
+  );
+  const macroExports = new Set([
+    ...macroDeclarations(relayModule, "RCT_EXPORT_METHOD").map((item) =>
+      macroExportName(item, "RCT_EXPORT_METHOD"),
+    ),
+    ...macroDeclarations(relayModule, "RCT_REMAP_METHOD").map((item) =>
+      macroExportName(item, "RCT_REMAP_METHOD"),
+    ),
+  ]);
+  assertOnlyAllowedNames(
+    "iOS RCT JavaScript export",
+    macroExports,
+    nativeSpecMethods,
+  );
 }
 
 test("jazz-rn publishes an Expo config plugin for a New Architecture development build", () => {
-  const original = { name: "example", ios: { bundleIdentifier: "dev.jazz.example" } };
+  const original = {
+    name: "example",
+    ios: { bundleIdentifier: "dev.jazz.example" },
+  };
   const configured = withJazzRn(original);
 
   assert.equal(configured.newArchEnabled, true);
-  assert.equal(original.newArchEnabled, undefined, "plugin must not mutate Expo's input config");
-  assert.equal(configured.ios, original.ios, "unrelated Expo configuration is preserved");
+  assert.equal(
+    original.newArchEnabled,
+    undefined,
+    "plugin must not mutate Expo's input config",
+  );
+  assert.equal(
+    configured.ios,
+    original.ios,
+    "unrelated Expo configuration is preserved",
+  );
   assert.equal(packageJson.exports["./app.plugin"], "./app.plugin.js");
   assert.equal(packageJson.files.includes("app.plugin.js"), true);
   assert.equal(packageJson.files.includes("scripts"), true);
@@ -172,7 +302,10 @@ test("jazz-rn publishes an Expo config plugin for a New Architecture development
     "git+https://github.com/garden-co/jazz.git",
     "the published package must point install users at its maintained source repository",
   );
-  assert.equal(packageJson.bugs.url, "https://github.com/garden-co/jazz/issues");
+  assert.equal(
+    packageJson.bugs.url,
+    "https://github.com/garden-co/jazz/issues",
+  );
 });
 
 test("the canonical Expo scaffold really prebuilds both relay-only platforms", () => {
@@ -186,11 +319,15 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
     "Expo prebuild requires the example workspace dependencies. Run `pnpm install --frozen-lockfile` from the repository root, then rerun this gate.",
   );
   for (const script of ["verify:expo:android", "verify:expo:ios"]) {
-    execFileSync("pnpm", ["--filter", "todo-client-localfirst-expo", "run", script], {
-      cwd: root,
-      env: { ...process.env, CI: "1" },
-      stdio: "inherit",
-    });
+    execFileSync(
+      "pnpm",
+      ["--filter", "todo-client-localfirst-expo", "run", script],
+      {
+        cwd: root,
+        env: { ...process.env, CI: "1" },
+        stdio: "inherit",
+      },
+    );
   }
 
   const autolink = (platform) =>
@@ -208,7 +345,10 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
           platform,
         ],
         {
-          cwd: new URL("../../../examples/todo-client-localfirst-expo/", import.meta.url),
+          cwd: new URL(
+            "../../../examples/todo-client-localfirst-expo/",
+            import.meta.url,
+          ),
           encoding: "utf8",
         },
       ),
@@ -219,16 +359,41 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
     androidAutolink.dependencies["jazz-rn"].platforms.android.packageInstance,
     "new JazzRelayPackage()",
   );
-  assert.match(iosAutolink.dependencies["jazz-rn"].platforms.ios.podspecPath, /JazzRn\.podspec$/);
+  assert.match(
+    iosAutolink.dependencies["jazz-rn"].platforms.ios.podspecPath,
+    /JazzRn\.podspec$/,
+  );
 
-  const expoRoot = new URL("../../../examples/todo-client-localfirst-expo/", import.meta.url);
-  const androidProperties = readFile(new URL("android/gradle.properties", expoRoot), "utf8");
-  const androidSettings = readFile(new URL("android/settings.gradle", expoRoot), "utf8");
-  const iosProperties = readFile(new URL("ios/Podfile.properties.json", expoRoot), "utf8");
+  const expoRoot = new URL(
+    "../../../examples/todo-client-localfirst-expo/",
+    import.meta.url,
+  );
+  const androidProperties = readFile(
+    new URL("android/gradle.properties", expoRoot),
+    "utf8",
+  );
+  const androidSettings = readFile(
+    new URL("android/settings.gradle", expoRoot),
+    "utf8",
+  );
+  const iosProperties = readFile(
+    new URL("ios/Podfile.properties.json", expoRoot),
+    "utf8",
+  );
   const iosPodfile = readFile(new URL("ios/Podfile", expoRoot), "utf8");
 
-  return Promise.all([androidProperties, androidSettings, iosProperties, iosPodfile]).then(
-    ([androidPropertiesText, androidSettingsText, iosPropertiesText, iosPodfileText]) => {
+  return Promise.all([
+    androidProperties,
+    androidSettings,
+    iosProperties,
+    iosPodfile,
+  ]).then(
+    ([
+      androidPropertiesText,
+      androidSettingsText,
+      iosPropertiesText,
+      iosPodfileText,
+    ]) => {
       assert.match(androidPropertiesText, /^newArchEnabled=true$/m);
       assert.match(androidSettingsText, /expo-autolinking-settings/);
       assert.match(androidSettingsText, /autolinkLibrariesFromCommand/);
@@ -239,24 +404,44 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
 });
 
 test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts", async () => {
-  const [podspec, androidPackage, androidBuild, iosRelay, packageRoot, rootCargo, legacyConfig] =
-    await Promise.all([
-      readFile(new URL("../../../crates/jazz-rn/JazzRn.podspec", import.meta.url), "utf8"),
-      readFile(
-        new URL(
-          "../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayPackage.kt",
-          import.meta.url,
-        ),
-        "utf8",
+  const [
+    podspec,
+    androidPackage,
+    androidBuild,
+    iosRelay,
+    packageRoot,
+    rootCargo,
+    legacyConfig,
+  ] = await Promise.all([
+    readFile(
+      new URL("../../../crates/jazz-rn/JazzRn.podspec", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL(
+        "../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayPackage.kt",
+        import.meta.url,
       ),
-      readFile(new URL("../../../crates/jazz-rn/android/build.gradle", import.meta.url), "utf8"),
-      readFile(new URL("../../../crates/jazz-rn/ios/JazzRelay.mm", import.meta.url), "utf8"),
-      readFile(new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url), "utf8"),
-      readFile(new URL("../../../Cargo.toml", import.meta.url), "utf8"),
-      readFile(new URL("../../../crates/jazz-rn/ubrn.config.yaml", import.meta.url), "utf8").catch(
-        () => null,
-      ),
-    ]);
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-rn/android/build.gradle", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-rn/ios/JazzRelay.mm", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url),
+      "utf8",
+    ),
+    readFile(new URL("../../../Cargo.toml", import.meta.url), "utf8"),
+    readFile(
+      new URL("../../../crates/jazz-rn/ubrn.config.yaml", import.meta.url),
+      "utf8",
+    ).catch(() => null),
+  ]);
 
   assert.match(podspec, /JazzNativeRelay\.xcframework/);
   assert.match(podspec, /https:\/\/github\.com\/garden-co\/jazz\.git/);
@@ -286,10 +471,19 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
     new URL("../../../crates/jazz-rn/src/relay.ts", import.meta.url),
     "utf8",
   );
-  const nativeSpec = await readFile(
-    new URL("../../../crates/jazz-rn/src/NativeJazzRelay.ts", import.meta.url),
-    "utf8",
-  );
+  const [nativeSpec, relayIndex] = await Promise.all([
+    readFile(
+      new URL(
+        "../../../crates/jazz-rn/src/NativeJazzRelay.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url),
+      "utf8",
+    ),
+  ]);
   const codegenGate = await readFile(
     new URL("../../../crates/jazz-rn/scripts/test-codegen.sh", import.meta.url),
     "utf8",
@@ -303,7 +497,10 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
   );
 
   assert.equal(packageJson.exports["./relay"].source, "./src/relay.ts");
-  assert.equal(packageJson.scripts["test:codegen"], "bash scripts/test-codegen.sh");
+  assert.equal(
+    packageJson.scripts["test:codegen"],
+    "bash scripts/test-codegen.sh",
+  );
   assert.match(nativeSpec, /TurboModuleRegistry\.get<Spec>\('JazzRelay'\)/);
   assert.match(nativeSpec, /execute\(commandBase64: string\): Promise<string>/);
   assert.match(relay, /getAbiVersion\(\)/);
@@ -316,7 +513,10 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
   assert.match(codegenGate, /class NativeJazzRelaySpec/);
   assert.match(androidRelay, /JazzRelayBridge/);
   assert.match(androidRelay, /package com\.jazzrn;/);
-  assert.match(androidRelay, /class JazzRelayModule extends NativeJazzRelaySpec/);
+  assert.match(
+    androidRelay,
+    /class JazzRelayModule extends NativeJazzRelaySpec/,
+  );
   assert.match(androidRelay, /double getAbiVersion\(\)/);
   assert.match(androidRelay, /E_JAZZ_RELAY_UNAVAILABLE/);
 });
@@ -326,10 +526,19 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     new URL("../../../crates/jazz-rn/src/relay.ts", import.meta.url),
     "utf8",
   );
-  const nativeSpec = await readFile(
-    new URL("../../../crates/jazz-rn/src/NativeJazzRelay.ts", import.meta.url),
-    "utf8",
-  );
+  const [nativeSpec, relayIndex] = await Promise.all([
+    readFile(
+      new URL(
+        "../../../crates/jazz-rn/src/NativeJazzRelay.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-rn/src/index.tsx", import.meta.url),
+      "utf8",
+    ),
+  ]);
   const androidBridge = await readFile(
     new URL(
       "../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayBridge.kt",
@@ -349,65 +558,140 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     "utf8",
   );
   const header = await readFile(
-    new URL("../../../crates/jazz-native-relay/include/jazz_native_relay.h", import.meta.url),
+    new URL(
+      "../../../crates/jazz-native-relay/include/jazz_native_relay.h",
+      import.meta.url,
+    ),
     "utf8",
   );
 
-  assertOpaqueJsRelaySurface(nativeSpec, relay);
+  assertExactTsRelaySurface(nativeSpec, relay, relayIndex);
   assertOpaqueAndroidRelaySurface(androidModule);
   assertOpaqueIosRelaySurface(iosRelay);
   assert.throws(
     () =>
-      assertOpaqueJsRelaySurface(
-        nativeSpec.replace("getAbiVersion(): number;", "getAuthScope(): string;"),
+      assertExactTsRelaySurface(
+        nativeSpec.replace(
+          "getAbiVersion(): number;",
+          "getAuthScope(): string;",
+        ),
         relay,
+        relayIndex,
       ),
-    /getAuthScope/,
-    "a camel-case auth scope accessor must not enter the generated TypeScript spec",
+    /getAuthScope|omits ABI name/,
+    "an arbitrary TypeScript accessor must not enter the generated spec",
+  );
+  assert.throws(
+    () =>
+      assertExactTsRelaySurface(
+        nativeSpec,
+        `${relay}\nexport function configure() {}`,
+        relayIndex,
+      ),
+    /configure/,
+    "an innocuous TypeScript helper must not enlarge the relay ABI",
+  );
+  assert.throws(
+    () =>
+      assertExactTsRelaySurface(
+        nativeSpec,
+        relay,
+        `${relayIndex}\nexport { executeNativeRelayCommand as configure } from './relay';`,
+      ),
+    /alias-re-export/,
+    "an alias re-export must not smuggle a new public relay name into the package",
+  );
+  assert.throws(
+    () =>
+      assertExactTsRelaySurface(
+        nativeSpec,
+        relay,
+        `${relayIndex}\nexport * from './relay';`,
+      ),
+    /star-re-export/,
+    "a star re-export must not automatically publish future relay helpers",
+  );
+  assert.throws(
+    () =>
+      assertExactTsRelaySurface(
+        nativeSpec,
+        `${relay}\nexport { default } from './NativeJazzRelay';`,
+        relayIndex,
+      ),
+    /default-re-export/,
+    "a default re-export must not publish the raw TurboModule lookup",
+  );
+  assert.doesNotThrow(
+    () =>
+      assertExactTsRelaySurface(
+        `${nativeSpec}\n// getAuthScope and configure are prose, not ABI.`,
+        `${relay}\n/* export function configure() {} */`,
+        `${relayIndex}\n// export * from './untrusted';`,
+      ),
+    "comments must not be interpreted as public relay declarations",
   );
   assert.throws(
     () =>
       assertOpaqueAndroidRelaySurface(
-        androidModule.replace(
-          "execute(String encodedCommand, Promise promise)",
-          "execute(String sqlitePath, Promise promise)",
-        ),
+        androidModule.replace("public void execute", "public void configure"),
       ),
-    /sqlitePath/,
-    "a camel-case SQLite path parameter must not enter the Android TurboModule",
+    /configure/,
+    "an arbitrary generated-looking Android method must not enter the TurboModule",
   );
   assert.throws(
     () =>
       assertOpaqueAndroidRelaySurface(
         androidModule.replace(
           "  @Override\n  public void execute",
-          "  @ReactMethod(isBlockingSynchronousMethod = true)\n  public void admitScope(String scope) {}\n\n  @Override\n  public void execute",
+          "  @com.facebook.react.bridge.ReactMethod(isBlockingSynchronousMethod = true)\n  public void begin(String scope) {}\n\n  @Override\n  public void execute",
         ),
       ),
-    /admitScope/,
-    "a handwritten @ReactMethod must receive the same trusted-input receipt as generated methods",
+    /begin/,
+    "a qualified handwritten @ReactMethod must receive the same fixed ABI receipt",
+  );
+  assert.throws(
+    () =>
+      assertOpaqueAndroidRelaySurface(
+        androidModule.replace(
+          "  @Override\n  public void execute",
+          "  @ReactMethod\n  public void configure() {}\n\n  @Override\n  public void execute",
+        ),
+      ),
+    /configure/,
+    "an unqualified handwritten @ReactMethod must receive the same fixed ABI receipt",
   );
   assert.throws(
     () =>
       assertOpaqueIosRelaySurface(
         iosRelay.replace(
           "- (void)invalidate",
-          "RCT_EXPORT_METHOD(admitScope:(NSString *)scope)\n\n- (void)invalidate",
+          "RCT_EXPORT_METHOD \n(\n  configure:(NSString *)scope\n)\n\n- (void)invalidate",
         ),
       ),
-    /admitScope/,
-    "an RCT_EXPORT_METHOD must not introduce trusted admission to the iOS JS surface",
+    /configure/,
+    "a multiline RCT_EXPORT_METHOD must not introduce an arbitrary iOS JS export",
   );
   assert.throws(
     () =>
       assertOpaqueIosRelaySurface(
         iosRelay.replace(
           "- (void)invalidate",
-          "RCT_REMAP_METHOD(revokeScope, revokeScope:(NSString *)scope)\n\n- (void)invalidate",
+          "RCT_REMAP_METHOD \n( begin, begin:(NSString *)scope )\n\n- (void)invalidate",
         ),
       ),
-    /revokeScope/,
-    "an RCT_REMAP_METHOD must not introduce trusted revocation to the iOS JS surface",
+    /begin/,
+    "a multiline RCT_REMAP_METHOD must not introduce an arbitrary iOS JS export",
+  );
+  assert.throws(
+    () =>
+      assertOpaqueIosRelaySurface(
+        iosRelay.replace(
+          "- (void)invalidate",
+          "- (void)configure {}\n\n- (void)invalidate",
+        ),
+      ),
+    /configure/,
+    "an arbitrary Objective-C method must not grow the sealed relay module",
   );
   assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
   assert.match(androidBridge, /TrustedRelayScopeConfig/);
@@ -427,7 +711,10 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
 
 test("relay artifact staging targets every Android ABI and iOS framework slice", async () => {
   const script = await readFile(
-    new URL("../../../crates/jazz-rn/scripts/build-relay-artifacts.sh", import.meta.url),
+    new URL(
+      "../../../crates/jazz-rn/scripts/build-relay-artifacts.sh",
+      import.meta.url,
+    ),
     "utf8",
   );
 
@@ -435,7 +722,10 @@ test("relay artifact staging targets every Android ABI and iOS framework slice",
     packageJson.scripts["build:relay:android"],
     "bash scripts/build-relay-artifacts.sh android",
   );
-  assert.equal(packageJson.scripts["build:relay:ios"], "bash scripts/build-relay-artifacts.sh ios");
+  assert.equal(
+    packageJson.scripts["build:relay:ios"],
+    "bash scripts/build-relay-artifacts.sh ios",
+  );
   assert.match(script, /\[arm64-v8a\]=aarch64-linux-android/);
   assert.match(script, /\[armeabi-v7a\]=armv7-linux-androideabi/);
   assert.match(script, /\[x86\]=i686-linux-android/);
@@ -462,7 +752,10 @@ test("a dry package includes every staged native relay artifact class", async ()
       types: undefined,
       exports: undefined,
     };
-    await writeFile(join(directory, "package.json"), `${JSON.stringify(manifest)}\n`);
+    await writeFile(
+      join(directory, "package.json"),
+      `${JSON.stringify(manifest)}\n`,
+    );
     for (const path of staged) {
       const destination = join(directory, path);
       await mkdir(dirname(destination), { recursive: true });
@@ -496,7 +789,10 @@ test("relay verification rejects a manifest-sealed XCFramework without its devic
   const nativeRelayAbi = Number(
     /pub const NATIVE_RELAY_ABI_VERSION: u16 = (\d+);/.exec(
       readFileSync(
-        new URL("../../../crates/jazz-native-relay/src/lib.rs", import.meta.url),
+        new URL(
+          "../../../crates/jazz-native-relay/src/lib.rs",
+          import.meta.url,
+        ),
         "utf8",
       ),
     )?.[1],
@@ -536,7 +832,10 @@ ${
     for (const file of files) {
       const destination = join(root, file);
       await mkdir(dirname(destination), { recursive: true });
-      await writeFile(destination, file === "Info.plist" ? info(true) : `fixture:${file}\n`);
+      await writeFile(
+        destination,
+        file === "Info.plist" ? info(true) : `fixture:${file}\n`,
+      );
     }
   };
   const writeManifest = async (root, destination, extra = {}) => {
@@ -547,7 +846,9 @@ ${
       ).readdir(current, {
         withFileTypes: true,
       })) {
-        const nextRelative = relative ? `${relative}/${entry.name}` : entry.name;
+        const nextRelative = relative
+          ? `${relative}/${entry.name}`
+          : entry.name;
         const next = join(current, entry.name);
         if (entry.isDirectory()) await visit(next, nextRelative);
         else {
@@ -579,13 +880,23 @@ ${
     await writeFile(
       join(packageRoot, "native/include/jazz_native_relay.h"),
       readFileSync(
-        new URL("../../../crates/jazz-native-relay/include/jazz_native_relay.h", import.meta.url),
+        new URL(
+          "../../../crates/jazz-native-relay/include/jazz_native_relay.h",
+          import.meta.url,
+        ),
       ),
     );
-    await writeManifest(androidRoot, join(packageRoot, "android/jazz-native-relay.manifest.json"), {
-      toolchain: { cargoNdk: "4.1.2" },
-    });
-    await writeManifest(iosRoot, join(packageRoot, "ios/jazz-native-relay.manifest.json"));
+    await writeManifest(
+      androidRoot,
+      join(packageRoot, "android/jazz-native-relay.manifest.json"),
+      {
+        toolchain: { cargoNdk: "4.1.2" },
+      },
+    );
+    await writeManifest(
+      iosRoot,
+      join(packageRoot, "ios/jazz-native-relay.manifest.json"),
+    );
     const environment = {
       ...process.env,
       JAZZ_NATIVE_RELAY_SOURCE_REVISION: sourceRevision,
@@ -602,9 +913,18 @@ ${
 
     const simulatorDirectory = join(iosRoot, "ios-arm64_x86_64-simulator");
     await rm(join(simulatorDirectory, "libjazz_native_relay.a"));
-    await writeFile(join(simulatorDirectory, "libjazz_native_relay_simulator.a"), "fixture\n");
-    await writeFile(join(iosRoot, "Info.plist"), info(true, "libjazz_native_relay_simulator.a"));
-    await writeManifest(iosRoot, join(packageRoot, "ios/jazz-native-relay.manifest.json"));
+    await writeFile(
+      join(simulatorDirectory, "libjazz_native_relay_simulator.a"),
+      "fixture\n",
+    );
+    await writeFile(
+      join(iosRoot, "Info.plist"),
+      info(true, "libjazz_native_relay_simulator.a"),
+    );
+    await writeManifest(
+      iosRoot,
+      join(packageRoot, "ios/jazz-native-relay.manifest.json"),
+    );
     assert.throws(
       () =>
         execFileSync(
@@ -617,10 +937,16 @@ ${
     );
 
     await rm(join(simulatorDirectory, "libjazz_native_relay_simulator.a"));
-    await writeFile(join(simulatorDirectory, "libjazz_native_relay.a"), "fixture\n");
+    await writeFile(
+      join(simulatorDirectory, "libjazz_native_relay.a"),
+      "fixture\n",
+    );
 
     await writeFile(join(iosRoot, "Info.plist"), info(false));
-    await writeManifest(iosRoot, join(packageRoot, "ios/jazz-native-relay.manifest.json"));
+    await writeManifest(
+      iosRoot,
+      join(packageRoot, "ios/jazz-native-relay.manifest.json"),
+    );
     assert.throws(
       () =>
         execFileSync(
@@ -676,30 +1002,54 @@ test("alpha verification preserves a reusable preview's sealed source commit acr
 });
 
 test("release, preview, and labeled platform gates seal and link the staged relay package", async () => {
-  const [packageBuild, alphaPublish, previewBuild, rnWorkflow, artifactScript, verifier] =
-    await Promise.all([
-      readFile(
-        new URL("../../../.github/workflows/build-jazz-packages.yml", import.meta.url),
-        "utf8",
+  const [
+    packageBuild,
+    alphaPublish,
+    previewBuild,
+    rnWorkflow,
+    artifactScript,
+    verifier,
+  ] = await Promise.all([
+    readFile(
+      new URL(
+        "../../../.github/workflows/build-jazz-packages.yml",
+        import.meta.url,
       ),
-      readFile(
-        new URL("../../../.github/workflows/publish-jazz-tools-alpha.yml", import.meta.url),
-        "utf8",
+      "utf8",
+    ),
+    readFile(
+      new URL(
+        "../../../.github/workflows/publish-jazz-tools-alpha.yml",
+        import.meta.url,
       ),
-      readFile(new URL("../../../.github/workflows/preview-build.yml", import.meta.url), "utf8"),
-      readFile(
-        new URL("../../../.github/workflows/rn-native-artifacts.yml", import.meta.url),
-        "utf8",
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../.github/workflows/preview-build.yml", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL(
+        "../../../.github/workflows/rn-native-artifacts.yml",
+        import.meta.url,
       ),
-      readFile(
-        new URL("../../../crates/jazz-rn/scripts/build-relay-artifacts.sh", import.meta.url),
-        "utf8",
+      "utf8",
+    ),
+    readFile(
+      new URL(
+        "../../../crates/jazz-rn/scripts/build-relay-artifacts.sh",
+        import.meta.url,
       ),
-      readFile(
-        new URL("../../../crates/jazz-rn/scripts/verify-relay-artifacts.mjs", import.meta.url),
-        "utf8",
+      "utf8",
+    ),
+    readFile(
+      new URL(
+        "../../../crates/jazz-rn/scripts/verify-relay-artifacts.mjs",
+        import.meta.url,
       ),
-    ]);
+      "utf8",
+    ),
+  ]);
   const packageBuildWorkflow = parse(packageBuild);
   const previewBuildWorkflow = parse(previewBuild);
 
@@ -711,7 +1061,10 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     "the reusable package build must make RN release assembly an explicit opt-in",
   );
   assert.match(packageBuild, /if: inputs\.include_rn/);
-  assert.match(packageBuild, /assemble-jazz-rn:[\s\S]*always\(\)[\s\S]*inputs\.include_rn/);
+  assert.match(
+    packageBuild,
+    /assemble-jazz-rn:[\s\S]*always\(\)[\s\S]*inputs\.include_rn/,
+  );
   assert.match(
     packageBuild,
     /jazz_rn_artifact:[\s\S]*value: \$\{\{ jobs\.assemble-jazz-rn\.outputs\.artifact \}\}/,
@@ -731,7 +1084,10 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     alphaPublish,
     /uses: \.\/\.github\/workflows\/build-jazz-packages\.yml[\s\S]*include_rn: true/,
   );
-  assert.match(previewBuild, /types: \[labeled, unlabeled, synchronize, reopened\]/);
+  assert.match(
+    previewBuild,
+    /types: \[labeled, unlabeled, synchronize, reopened\]/,
+  );
   assert.match(previewBuild, /'preview-build'/);
   assert.match(previewBuild, /'rn-preview-release'/);
   assert.match(previewBuild, /include_rn:[\s\S]*rn-preview-release/);
@@ -756,11 +1112,14 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     "inherit",
     "the reusable build is privileged and must remain behind its same-repository guard",
   );
-  assert.deepEqual(previewBuildWorkflow.jobs["publish-pkg-pr-new"].permissions, {
-    contents: "read",
-    "pull-requests": "write",
-    "id-token": "write",
-  });
+  assert.deepEqual(
+    previewBuildWorkflow.jobs["publish-pkg-pr-new"].permissions,
+    {
+      contents: "read",
+      "pull-requests": "write",
+      "id-token": "write",
+    },
+  );
   assert.match(previewBuild, /name: pkg-jazz-rn/);
   assert.match(previewBuild, /'\.\/crates\/jazz-rn'/);
   assert.doesNotMatch(
@@ -781,7 +1140,10 @@ test("release, preview, and labeled platform gates seal and link the staged rela
   assert.throws(
     () =>
       assert.match(
-        regularPreviewPublish.replace("'./packages/create-jazz'", "'./crates/jazz-rn'"),
+        regularPreviewPublish.replace(
+          "'./packages/create-jazz'",
+          "'./crates/jazz-rn'",
+        ),
         /ordinary preview-build runs must neither download nor publish jazz-rn/,
       ),
     /ordinary preview-build runs must neither download nor publish jazz-rn/,
@@ -789,22 +1151,42 @@ test("release, preview, and labeled platform gates seal and link the staged rela
 
   const previewMode = (labels, sameRepository) => ({
     runs:
-      sameRepository && (labels.includes("preview-build") || labels.includes("rn-preview-release")),
+      sameRepository &&
+      (labels.includes("preview-build") ||
+        labels.includes("rn-preview-release")),
     includesRn: labels.includes("rn-preview-release") && sameRepository,
   });
   assert.deepEqual(previewMode([], true), { runs: false, includesRn: false });
-  assert.deepEqual(previewMode(["preview-build"], false), { runs: false, includesRn: false });
-  assert.deepEqual(previewMode(["preview-build"], true), { runs: true, includesRn: false });
-  assert.deepEqual(previewMode(["rn-preview-release"], true), { runs: true, includesRn: true });
-  assert.deepEqual(previewMode(["rn-preview-release"], false), { runs: false, includesRn: false });
-  assert.deepEqual(previewMode(["preview-build", "rn-preview-release", "react-native"], false), {
+  assert.deepEqual(previewMode(["preview-build"], false), {
     runs: false,
     includesRn: false,
   });
-  assert.deepEqual(previewMode(["preview-build", "rn-preview-release", "react-native"], true), {
+  assert.deepEqual(previewMode(["preview-build"], true), {
+    runs: true,
+    includesRn: false,
+  });
+  assert.deepEqual(previewMode(["rn-preview-release"], true), {
     runs: true,
     includesRn: true,
   });
+  assert.deepEqual(previewMode(["rn-preview-release"], false), {
+    runs: false,
+    includesRn: false,
+  });
+  assert.deepEqual(
+    previewMode(["preview-build", "rn-preview-release", "react-native"], false),
+    {
+      runs: false,
+      includesRn: false,
+    },
+  );
+  assert.deepEqual(
+    previewMode(["preview-build", "rn-preview-release", "react-native"], true),
+    {
+      runs: true,
+      includesRn: true,
+    },
+  );
   assert.deepEqual(previewBuildWorkflow.on.pull_request.types, [
     "labeled",
     "unlabeled",
@@ -816,7 +1198,10 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     false,
     "the reusable package build defaults to its fast, non-RN path",
   );
-  assert.match(previewBuildWorkflow.jobs.build.with.include_rn, /rn-preview-release/);
+  assert.match(
+    previewBuildWorkflow.jobs.build.with.include_rn,
+    /rn-preview-release/,
+  );
   assert.match(rnWorkflow, /Android relay linked AAR/);
   assert.match(rnWorkflow, /:app:assembleDebug/);
   assert.match(rnWorkflow, /iOS relay linked app/);
@@ -826,7 +1211,10 @@ test("release, preview, and labeled platform gates seal and link the staged rela
   assert.match(verifier, /JAZZ_NATIVE_RELAY_SOURCE_REVISION/);
   assert.match(verifier, /AvailableLibraries/);
   assert.match(verifier, /requiredRoles/);
-  assert.match(packageBuild, /cargo-ndk@\$\{\{ env\.JAZZ_RN_CARGO_NDK_VERSION \}\}/);
+  assert.match(
+    packageBuild,
+    /cargo-ndk@\$\{\{ env\.JAZZ_RN_CARGO_NDK_VERSION \}\}/,
+  );
   assert.match(packageBuild, /--package-root/);
   assert.match(verifier, /relay artifact inventory differs from its manifest/);
 });

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -46,15 +46,6 @@ function stripComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
 }
 
-// C and Objective-C translate physical source lines before recognizing either
-// comments or macro invocations. Clang accepts a backslash followed by an LF,
-// CRLF, or implementation-permitted horizontal whitespace and a newline as a
-// line continuation. Normalize that spelling first so this lexical receipt
-// observes the same JavaScript-visible exports as the compiler.
-function normalizeObjcLineContinuations(source) {
-  return source.replace(/\\[ \t\v\f]*\r?\n/g, "");
-}
-
 function assertExactNames(surface, actual, allowed) {
   const unexpected = [...actual].filter((name) => !allowed.has(name));
   const missing = [...allowed].filter((name) => !actual.has(name));
@@ -350,43 +341,6 @@ function assertOpaqueAndroidRelaySurface(androidModule) {
   );
 }
 
-function legacyExportMacros(source) {
-  const declarations = [];
-  const pattern = /\b(RCT_[A-Za-z0-9_]*(?:EXPORT|REMAP)[A-Za-z0-9_]*)\s*\(/g;
-  let match;
-  while ((match = pattern.exec(source)) !== null) {
-    const macro = match[1];
-    if (macro === "RCT_EXPORT_MODULE") continue;
-    const opening = source.indexOf("(", match.index + macro.length);
-    let depth = 0;
-    let quote = null;
-    let escaped = false;
-    let closed = false;
-    for (let index = opening; index < source.length; index += 1) {
-      const character = source[index];
-      if (quote !== null) {
-        if (escaped) escaped = false;
-        else if (character === "\\") escaped = true;
-        else if (character === quote) quote = null;
-        continue;
-      }
-      if (character === '"' || character === "'") quote = character;
-      else if (character === "(") depth += 1;
-      else if (character === ")") {
-        depth -= 1;
-        if (depth === 0) {
-          declarations.push({ macro, declaration: source.slice(match.index, index + 1) });
-          pattern.lastIndex = index + 1;
-          closed = true;
-          break;
-        }
-      }
-    }
-    if (!closed) assert.fail(`unterminated ${macro} declaration`);
-  }
-  return declarations;
-}
-
 function objcMethodNames(source) {
   return new Set(
     [
@@ -418,7 +372,15 @@ function objcImplementations(source) {
 }
 
 function assertOpaqueIosRelaySurface(iosRelay) {
-  const commentFreeRelay = stripComments(normalizeObjcLineContinuations(iosRelay));
+  // The generated New-Architecture spec is the sole iOS JavaScript ABI. A raw
+  // source ban is intentional: comments, strings, categories, and line
+  // continuations must not create a parser-dependent escape hatch.
+  assert.doesNotMatch(
+    iosRelay,
+    /\bRCT_[A-Za-z0-9_]*(?:EXPORT|REMAP)[A-Za-z0-9_]*\b/,
+    "iOS JazzRelay must contain no legacy RCT export/remap macro token",
+  );
+  const commentFreeRelay = stripComments(iosRelay);
   const implementations = objcImplementations(commentFreeRelay);
   const relayImplementations = implementations.filter(
     (implementation) => implementation.className === "JazzRelay",
@@ -434,26 +396,13 @@ function assertOpaqueIosRelaySurface(iosRelay) {
     "could not find the specifically named trusted Objective-C admission class",
   );
   // Categories are separate @implementation JazzRelay (...) blocks. Check all
-  // of them: only the named private admission class is excluded from this
-  // receipt, so a later category cannot hide an RCT export after the primary
-  // implementation's @end.
+  // of them so no selector grows the generated ABI.
   const relayModule = relayImplementations.map((item) => item.source).join("\n");
   const exportedMethods = objcMethodNames(relayModule);
-  // Old-architecture macros are JavaScript exports even when no Objective-C
-  // selector appears in this source. Their mapped JavaScript names are still
-  // constrained by the generated ABI.
   assertExactNames(
     "iOS JazzRelay implementation",
     exportedMethods,
     iosRelaySelectors,
-  );
-  // The generated New-Architecture spec is the sole iOS JavaScript ABI. An
-  // RCT export/remap macro would create a parallel old-architecture entry
-  // point, so reject every family (including future spelling variants).
-  assert.deepEqual(
-    legacyExportMacros(relayModule),
-    [],
-    "iOS JazzRelay must not add legacy RCT export/remap JavaScript entry points",
   );
 }
 
@@ -638,7 +587,7 @@ test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts",
   assert.match(androidBuild, /requires the React Native New Architecture/);
   assert.match(androidPackage, /class JazzRelayPackage/);
   assert.doesNotMatch(androidPackage, /JazzRnModule/);
-  assert.match(iosRelay, /RCT_EXPORT_MODULE\(JazzRelay\)/);
+  assert.doesNotMatch(iosRelay, /\bRCT_[A-Za-z0-9_]*(?:EXPORT|REMAP)[A-Za-z0-9_]*\b/);
   assert.match(iosRelay, /JAZZ_RELAY_ARTIFACT_AVAILABLE/);
   assert.match(iosRelay, /jazz_native_relay_host_execute/);
   assert.match(iosRelay, /E_JAZZ_RELAY_UNAVAILABLE/);
@@ -908,66 +857,30 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
     /configure/,
     "an unqualified handwritten @ReactMethod must receive the same fixed ABI receipt",
   );
-  assert.throws(
-    () =>
-      assertOpaqueIosRelaySurface(
-        iosRelay.replace(
-          "- (void)invalidate",
-          "RCT_EXPORT_METHOD \n(\n  configure:(NSString *)scope\n)\n\n- (void)invalidate",
-        ),
-      ),
-    /configure/,
-    "a multiline RCT_EXPORT_METHOD must not introduce an arbitrary iOS JS export",
-  );
-  assert.throws(
-    () =>
-      assertOpaqueIosRelaySurface(
-        iosRelay.replace(
-          "- (void)invalidate",
-          "RCT_REMAP_METHOD \n( begin, begin:(NSString *)scope )\n\n- (void)invalidate",
-        ),
-      ),
-    /begin/,
-    "a multiline RCT_REMAP_METHOD must not introduce an arbitrary iOS JS export",
-  );
   for (const fixture of [
     {
-      name: "an LF-spliced RCT_EXPORT_METHOD",
+      name: "a URL string prefix",
+      source: 'NSString *url = @"https://example.invalid/RCT_EXPORT_METHOD";',
+    },
+    {
+      name: "a comment",
+      source: "// RCT_REMAP_METHOD(begin, begin:(NSString *)scope)",
+    },
+    {
+      name: "a line continuation",
       source: "RCT_EXPORT_\\\nMETHOD(configure:(NSString *)scope)",
     },
     {
-      name: "a CRLF-and-whitespace-spliced RCT_REMAP_METHOD",
-      source: "RCT_REMAP_\\ \t\r\nMETHOD(begin, begin:(NSString *)scope)",
-    },
-    {
-      name: "an LF-spliced synchronous RCT export",
+      name: "a category",
       source:
-        "RCT_EXPORT_SYNCHRONOUS_TYPED_\\\nMETHOD(NSString *, configure)",
+        "@implementation JazzRelay (LegacyEscapeHatch)\nRCT_EXPORT_METHOD(configure:(NSString *)scope)\n@end",
     },
   ]) {
     assert.throws(
       () =>
-        assertOpaqueIosRelaySurface(
-          iosRelay.replace("- (void)invalidate", `${fixture.source}\n\n- (void)invalidate`),
-        ),
-      /RCT_|configure|begin/,
-      `${fixture.name} must not bypass the sealed iOS relay receipt`,
-    );
-  }
-  for (const fixture of [
-    "RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(configure)",
-    "RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, configure)",
-    "RCT_REMAP_BLOCKING_SYNCHRONOUS_METHOD(configure, configure)",
-    "RCT_REMAP_SYNCHRONOUS_TYPED_METHOD(NSString *, configure, configure)",
-    "RCT_EXPORT_FUTURE_METHOD(configure)",
-  ]) {
-    assert.throws(
-      () =>
-        assertOpaqueIosRelaySurface(
-          iosRelay.replace("- (void)invalidate", `${fixture}\n\n- (void)invalidate`),
-        ),
-      /RCT_/,
-      `${fixture} must not add a legacy iOS relay export`,
+        assertOpaqueIosRelaySurface(`${iosRelay}\n${fixture.source}`),
+      /legacy RCT/,
+      `${fixture.name} must fail the raw iOS legacy macro ban`,
     );
   }
   assert.throws(
@@ -980,28 +893,6 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
       ),
     /configure/,
     "an arbitrary Objective-C method must not grow the sealed relay module",
-  );
-  assert.throws(
-    () =>
-      assertOpaqueIosRelaySurface(
-        `${iosRelay}\n@implementation JazzRelay (LaterEscapeHatch)\nRCT_EXPORT_METHOD(configure:(NSString *)scope)\n@end`,
-      ),
-    /configure/,
-    "a later JazzRelay category must not hide an RCT export after the primary implementation",
-  );
-  assert.doesNotThrow(
-    () =>
-      assertOpaqueIosRelaySurface(
-        `${iosRelay}\n// RCT_EXPORT_METHOD(configure:(NSString *)scope)`,
-      ),
-    "comments must not become iOS relay exports",
-  );
-  assert.doesNotThrow(
-    () =>
-      assertOpaqueIosRelaySurface(
-        `${iosRelay}\n// Still a comment after C line splicing \\ \t\r\nRCT_EXPORT_METHOD(configure:(NSString *)scope)`,
-      ),
-    "a continued Objective-C line comment must not become a relay export",
   );
   assert.match(androidBridge, /object JazzRelayTrustedAdmission/);
   assert.match(androidBridge, /TrustedRelayScopeConfig/);


### PR DESCRIPTION
🤖 Hardens the trusted React Native relay admission boundary and seals the JavaScript-facing relay ABI.

## Before

The native relay already used opaque capabilities, but trusted JSON admission still permitted a missing authentication scope. The package also relied on a blacklist-style source receipt to prove that JavaScript could not grow configuration or admission methods; alternate TypeScript exports, Android annotations, Objective-C export macros, and preprocessor spelling could evade that receipt.

## After

- every persistent relay scope requires a nonempty authenticated scope;
- omitted, null, empty, and whitespace scopes fail before capability minting, scope admission, or storage open;
- one admitted scope binds the complete path, schema, persistent database identity, claims, and auth scope; any changed field conflicts;
- guessed and revoked 256-bit capabilities fail, and revocation closes aliases opened through that capability;
- trusted Android/iOS platform code owns admission and revocation; JavaScript receives only the opaque capability;
- the public JS ABI is a fixed allowlist:
  - TurboModule Spec: getAbiVersion and execute;
  - package exports: ABI range/constants and opaque execute helper;
  - Android generated module: getAbiVersion and execute;
  - iOS New-Architecture generated selectors only;
- legacy iOS RCT export/remap macros are forbidden raw-source-wide, including comments, strings, categories, and C-preprocessor line-spliced spellings;
- TypeScript AST receipts reject every extra/default/aliased/star/class/property/call/index export shape.

## Worked examples

1. Trusted platform admission with auth_scope null cannot mint a capability or create a relay.
2. Reusing a capability request with a different SQLite path, schema, database identity, claims, or auth scope fails closed.
3. Logout revokes the opaque capability and closes its relay/client aliases; a guessed or old capability cannot attach.
4. Adding getAuthScope, configure, admitScope, or any similarly innocuous extra method to TS, Android, or iOS makes the packaging gate fail.
5. A legacy Objective-C export hidden in a later category, URL-containing line, comment, or backslash-newline macro spelling is rejected. The generic opaque execute channel remains unchanged.

## Verification

- repeated independent adversarial reviews with planted null-scope, config-conflict, TS re-export/default/property, qualified Android annotation, Objective-C category/synchronous/spliced macro, comment, and string probes;
- jazz-native-relay suite;
- C and C++ ABI probes;
- RN package, TypeScript, and Android+iOS codegen/prebuild receipts.

This advances #1973. Actual auth-provider integration and real device scenarios remain tracked separately.
