### PR TITLE
Preserve React provider runtime identity

### DIFF
--- a/.changeset/bright-foxes-replace.md
+++ b/.changeset/bright-foxes-replace.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Replace React clients when their runtime factory identity changes.

--- a/.changeset/bright-foxes-replace.md
+++ b/.changeset/bright-foxes-replace.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Replace React clients when their runtime factory identity changes.
+Preserve runtime factory and source identity when React providers choose a client, while keeping unchanged React Native provider rerenders on the current client.

--- a/packages/jazz-tools/src/react-core/provider.ssr.test.tsx
+++ b/packages/jazz-tools/src/react-core/provider.ssr.test.tsx
@@ -85,11 +85,11 @@ describe("JazzProvider client acquisition lifecycle", () => {
       serverUrl: "https://jazz.example.com",
       jwtToken: "token",
     };
-    const initialKey = createClientConfigKey("react", initialConfig);
-    const replacementKey = createClientConfigKey("react", replacementConfig);
     const createJazzClient = vi.fn(async () =>
       makeFakeClient({ authMode: "local-first", userId: "browser", claims: {} }),
     );
+    const initialKey = createClientConfigKey("react", initialConfig, [createJazzClient]);
+    const replacementKey = createClientConfigKey("react", replacementConfig, [createJazzClient]);
 
     let result!: RenderResult;
     await act(async () => {
@@ -157,7 +157,6 @@ describe("JazzProvider client acquisition lifecycle", () => {
       serverUrl: "https://jazz.example.com",
       jwtToken: "token",
     };
-    const initialKey = createClientConfigKey("react", initialConfig);
     let resolveRelease!: () => void;
     const releaseGate = new Promise<void>((resolve) => {
       resolveRelease = resolve;
@@ -165,6 +164,7 @@ describe("JazzProvider client acquisition lifecycle", () => {
     const createJazzClient = vi.fn(async () =>
       makeFakeClient({ authMode: "local-first", userId: "browser", claims: {} }),
     );
+    const initialKey = createClientConfigKey("react", initialConfig, [createJazzClient]);
 
     let result!: RenderResult;
     await act(async () => {

--- a/packages/jazz-tools/src/react-core/provider.stable-deps.test.tsx
+++ b/packages/jazz-tools/src/react-core/provider.stable-deps.test.tsx
@@ -77,6 +77,44 @@ describe("JazzProvider — stable config deps", () => {
     expect(setTimeoutSpy).not.toHaveBeenCalled();
   });
 
+  it("replaces the client when its factory identity changes", async () => {
+    const firstClient = makeFakeClient({
+      authMode: "local-first",
+      userId: "first",
+      claims: {},
+    });
+    const secondClient = makeFakeClient({
+      authMode: "local-first",
+      userId: "second",
+      claims: {},
+    });
+    firstClient.shutdown = vi.fn().mockResolvedValue(undefined);
+    const firstFactory = vi.fn().mockResolvedValue(firstClient);
+    const secondFactory = vi.fn().mockResolvedValue(secondClient);
+    const config: DbConfig = { appId: "app-1", serverUrl: "https://jazz.example.com" };
+
+    function Wrapper({ factory }: { factory: typeof firstFactory }) {
+      return (
+        <JazzProvider config={config} createJazzClient={factory} fallback={null}>
+          <div data-testid="child" />
+        </JazzProvider>
+      );
+    }
+
+    const result = render(<Wrapper factory={firstFactory} />);
+    await act(async () => Promise.resolve());
+    expect(firstFactory).toHaveBeenCalledOnce();
+
+    result.rerender(<Wrapper factory={secondFactory} />);
+    await act(async () => {
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    expect(firstClient.shutdown).toHaveBeenCalledOnce();
+    expect(secondFactory).toHaveBeenCalledOnce();
+  });
+
   it("finishes shutting down one config before creating its same-app replacement", async () => {
     let finishShutdown!: () => void;
     const shutdownFinished = new Promise<void>((resolve) => {

--- a/packages/jazz-tools/src/react-core/provider.tsx
+++ b/packages/jazz-tools/src/react-core/provider.tsx
@@ -209,7 +209,7 @@ export function JazzProvider({
   // Keep the framework-level lease distinct from createJazzClient's own shared
   // client lease. Both use the generic registry; sharing an unqualified key
   // makes provider teardown recursively release itself instead of the runtime.
-  const configKey = createClientConfigKey("react", config);
+  const configKey = createClientConfigKey("react", config, [createJazzClient]);
 
   const [clientLease, setClientLease] = useState<{
     configKey: string;

--- a/packages/jazz-tools/src/react-native/provider.test.tsx
+++ b/packages/jazz-tools/src/react-native/provider.test.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetClientRegistryForTest } from "../runtime/client-registry.js";
+import { makeFakeClient } from "../react-core/test-utils.js";
+import type { DbConfig } from "./create-db.js";
+
+const mocks = vi.hoisted(() => ({
+  createJazzClient: vi.fn(),
+}));
+
+vi.mock("./create-jazz-client.js", () => ({
+  createJazzClient: mocks.createJazzClient,
+}));
+
+import { JazzProvider } from "./provider.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.createJazzClient.mockReset();
+});
+
+afterEach(async () => {
+  cleanup();
+  await vi.runAllTimersAsync();
+  resetClientRegistryForTest();
+  vi.useRealTimers();
+});
+
+function makeClient(userId: string) {
+  const client = makeFakeClient({ authMode: "local-first", userId, claims: {} });
+  client.shutdown = vi.fn().mockResolvedValue(undefined);
+  return client;
+}
+
+describe("React Native JazzProvider", () => {
+  it("reuses its client when a public provider rerender keeps the same runtime source", async () => {
+    const client = makeClient("first");
+    mocks.createJazzClient.mockResolvedValue(client);
+    const wasmSource = new Uint8Array([0, 97, 115, 109]);
+    const initialConfig: DbConfig = {
+      appId: "native-provider-stable",
+      driver: { type: "memory" },
+      runtimeSources: { wasmSource },
+    };
+
+    const result = render(
+      <JazzProvider config={initialConfig} fallback={null}>
+        <div>ready</div>
+      </JazzProvider>,
+    );
+    await act(async () => Promise.resolve());
+
+    const rebuiltConfig: DbConfig = {
+      runtimeSources: { wasmSource },
+      driver: { type: "memory" },
+      appId: "native-provider-stable",
+    };
+    expect(rebuiltConfig).not.toBe(initialConfig);
+
+    result.rerender(
+      <JazzProvider config={rebuiltConfig} fallback={null}>
+        <div>ready</div>
+      </JazzProvider>,
+    );
+    await act(async () => Promise.resolve());
+
+    expect(mocks.createJazzClient).toHaveBeenCalledOnce();
+    expect(client.shutdown).not.toHaveBeenCalled();
+  });
+
+  it("replaces its client when the public provider receives a different runtime source", async () => {
+    const firstClient = makeClient("first");
+    const secondClient = makeClient("second");
+    mocks.createJazzClient.mockResolvedValueOnce(firstClient).mockResolvedValueOnce(secondClient);
+    const initialSource = new Uint8Array([0, 97, 115, 109]);
+    const replacementSource = new Uint8Array([0, 97, 115, 109]);
+    const initialConfig: DbConfig = {
+      appId: "native-provider-source-swap",
+      driver: { type: "memory" },
+      runtimeSources: { wasmSource: initialSource },
+    };
+
+    const result = render(
+      <JazzProvider config={initialConfig} fallback={null}>
+        <div>ready</div>
+      </JazzProvider>,
+    );
+    await act(async () => Promise.resolve());
+    expect(mocks.createJazzClient).toHaveBeenCalledOnce();
+
+    result.rerender(
+      <JazzProvider
+        config={{
+          ...initialConfig,
+          runtimeSources: { wasmSource: replacementSource },
+        }}
+        fallback={null}
+      >
+        <div>ready</div>
+      </JazzProvider>,
+    );
+    await act(async () => {
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+    });
+
+    expect(firstClient.shutdown).toHaveBeenCalledOnce();
+    expect(mocks.createJazzClient).toHaveBeenCalledTimes(2);
+    expect(mocks.createJazzClient.mock.calls[1]?.[0]).toMatchObject({
+      runtimeSources: { wasmSource: replacementSource },
+    });
+  });
+});

--- a/packages/jazz-tools/src/react-native/provider.tsx
+++ b/packages/jazz-tools/src/react-native/provider.tsx
@@ -11,6 +11,9 @@ import {
 import { createJazzClient, type JazzClient as CreatedJazzClient } from "./create-jazz-client.js";
 import type { DbConfig } from "./create-db.js";
 
+const createClient: CreateJazzClient = (config) =>
+  createJazzClient(config as DbConfig) as Promise<CreatedJazzClient>;
+
 export { JazzClientProvider, type JazzClientProviderProps } from "../react-core/provider.js";
 
 interface JazzClientContextValue {
@@ -27,9 +30,6 @@ export type JazzProviderProps = {
 };
 
 export function JazzProvider({ config, fallback, children, onJWTExpired }: JazzProviderProps) {
-  const createClient: CreateJazzClient = (nextConfig) =>
-    createJazzClient(nextConfig as DbConfig) as Promise<CreatedJazzClient>;
-
   return (
     <CoreJazzProvider
       config={config}

--- a/packages/jazz-tools/src/runtime/client-config-key.ts
+++ b/packages/jazz-tools/src/runtime/client-config-key.ts
@@ -80,7 +80,12 @@ export function serializeClientConfig(config: DbConfig): string {
   return canonicalizeConfigValue(config, new WeakSet())!;
 }
 
-/** Namespaced registry identity for a client configuration. */
-export function createClientConfigKey(namespace: string, config: DbConfig): string {
-  return `${namespace}:${serializeClientConfig(config)}`;
+/** Namespaced registry identity for a client configuration and opaque owners. */
+export function createClientConfigKey(
+  namespace: string,
+  config: DbConfig,
+  opaqueIdentities: readonly object[] = [],
+): string {
+  const identities = opaqueIdentities.map((value) => opaqueValueId(value)).join(",");
+  return `${namespace}:${serializeClientConfig(config)}:X[${identities}]`;
 }


### PR DESCRIPTION
## Summary

- Include client-factory identity in the React provider registry key.
- Preserve reference identity for opaque runtime-source values while retaining structural identity for ordinary configuration.
- Keep the React Native client factory stable across rerenders so unchanged providers continue using their current client.

## Before and after

Before, providers with structurally equal configuration shared a registry key even when they used different factories or runtime-source objects. A provider could therefore receive a client created for another runtime.

Making factory identity part of the key also exposed a React Native boundary: its inline factory wrapper had a new identity on every render, so an unchanged rerender would replace the current client.

After, runtime-producing inputs participate in client identity:

```tsx
const source = new Uint8Array([0, 97, 115, 109]);

rerender(<JazzProvider config={{ ...config, runtimeSources: { wasmSource: source } }} />);
// Same source reference: reuse the current client.

rerender(
  <JazzProvider
    config={{ ...config, runtimeSources: { wasmSource: new Uint8Array(source) } }}
  />,
);
// Different opaque source: shut down the old client and create the replacement.
```

Changing `createJazzClient` likewise creates a distinct registry identity. React Native now passes one module-stable wrapper, so an otherwise unchanged rerender does not cause a false replacement.

## Invariants

- Plain JSON-compatible configuration retains stable structural identity.
- Client factories and opaque runtime sources use reference identity.
- A changed factory or opaque source cannot reuse a client created for the previous runtime.
- An unchanged React Native provider keeps its existing client.

## Testing

- `cd packages/jazz-tools && pnpm test:react src/react-core/provider.ssr.test.tsx src/react-core/provider.stable-deps.test.tsx src/react-native/provider.test.tsx` — passed; 8 tests
- `pnpm --filter jazz-tools check` — passed
- `pnpm --filter jazz-tools typecheck:react-native` — passed