### PR TITLE
Route React Native runtime sources through the native relay

### DIFF
--- a/packages/jazz-tools/src/react-native/README.md
+++ b/packages/jazz-tools/src/react-native/README.md
@@ -1,14 +1,19 @@
 # React Native bindings
 
 This directory restores the React Native binding shape against the v2 runtime.
-It is compile-level scaffolding only: the React hooks, provider, client factory,
-typed schema exports, and auth helper all typecheck, but persistent storage does
-not run yet.
+The foreground JavaScript runtime is deliberately in-memory; persistent storage
+and upstream relay ownership remain in the installed Android/iOS `JazzRelay`
+artifact.
 
-The current `createDb()` path installs `ReactNativeRuntimeSource`. Persistent
-configurations fail before opening any SQLite driver with:
+The current `createDb()` path installs `ReactNativeRuntimeSource`. A persistent
+configuration must supply `nativeRelay`, containing only the platform-provided
+opaque 32-byte capability and its command executor. JavaScript uses it solely
+to exchange canonical peer frames with the native relay. It never receives a
+SQLite handle/path, schema, session, token, or admission derivation.
 
-`React Native persistent storage is not available in this alpha; memory mode is unverified scaffolding, not device-supported persistence`
+Persistent configurations without that installed relay fail with:
+
+`React Native persistent runtime requires the installed JazzRelay native artifact and its platform-provided opaque nativeRelay capability`
 
 The fail-fast boundary is intentional. A `ReactNativeSqliteStorageDriver`
 cannot yet be installed into the v2 Rust ordered-KV runtime. Merely opening a
@@ -19,22 +24,16 @@ remain as a proposed storage ABI, but supplying one is rejected before
 `sqliteStorage` is combined with `driver: { type: "memory" }`; the option is
 never silently ignored.
 
-Explicit `driver: { type: "memory" }` currently reaches the v2 WASM runtime in
-the Node/forks test harness. That regression proves TypeScript wiring only. It
-has not run under Metro/Hermes on iOS or Android and must not be described as a
-supported React Native runtime mode until an actual device smoke passes.
+Explicit `driver: { type: "memory" }` reaches the v2 WASM runtime without a
+relay. Supplying `nativeRelay` in that mode is rejected rather than ignored.
 
 Open decisions for the RN owner:
 
-- SQLite driver route: the shared `jazz-native-relay` artifact owns SQLite;
-  its Android/iOS wrappers must link that artifact rather than introducing a
-  JavaScript storage driver.
-- Runtime route: move the runtime boundary into `crates/jazz-rn` as the thin
-  native relay command transport; it must not revive the removed UniFFI/JSI
-  runtime.
-- Storage ABI: map the future RN SQLite driver onto the portable ordered-KV
-  contract, including migration reporting, corruption behavior, teardown, and
-  durability tests.
+- Native artifacts must provide the version-compatible relay command ABI and
+  issue the opaque capability; a rejected open is surfaced as a startup error.
+- The relay adapter serializes frames and retains them on backpressure. A
+  `Db.disconnect()` closes its foreground peer alias; `Db.reconnect()` opens a
+  fresh alias against the same platform-owned relay.
 
 Useful pointers:
 

--- a/packages/jazz-tools/src/react-native/create-jazz-client.test.ts
+++ b/packages/jazz-tools/src/react-native/create-jazz-client.test.ts
@@ -4,16 +4,51 @@ import {
   createDb,
   createJazzClient,
   REACT_NATIVE_AUTH_SECRET_STORE_REQUIRED_ERROR,
+  REACT_NATIVE_NATIVE_RELAY_MEMORY_ONLY_ERROR,
+  REACT_NATIVE_NATIVE_RELAY_REQUIRED_ERROR,
   REACT_NATIVE_PERSISTENT_RUNTIME_UNAVAILABLE_ERROR,
   REACT_NATIVE_SQLITE_STORAGE_REJECTED_ERROR,
   type JazzClient,
   type ReactNativeSqliteStorageDriver,
+  type NativeRelayCapability,
   useLocalFirstAuth,
 } from "./index.js";
 
 const app = s.defineApp({
   notes: s.table({ title: s.string() }),
 });
+
+const nativeRelayCapability = Uint8Array.from(
+  { length: 32 },
+  (_, index) => index,
+) as NativeRelayCapability;
+
+function nativeRelayReceipt() {
+  const commands: number[] = [];
+  const base64 = (bytes: number[]) => btoa(String.fromCharCode(...bytes));
+  return {
+    commands,
+    config: {
+      executor: {
+        execute: async (request: string) => {
+          const tag = atob(request).charCodeAt(0);
+          commands.push(tag);
+          // Open, Attach, Receive, CloseClient/CloseRelay, and frame work.
+          return tag === 1
+            ? base64([1, 9])
+            : tag === 2
+              ? base64([2, 7])
+              : tag === 7
+                ? base64([5, 0])
+                : tag === 3 || tag === 4
+                  ? base64([3, 1])
+                  : base64([4]);
+        },
+      },
+      capability: nativeRelayCapability,
+    },
+  };
+}
 
 describe("React Native binding scaffolding in the Node test runtime", () => {
   let client: JazzClient | undefined;
@@ -30,6 +65,7 @@ describe("React Native binding scaffolding in the Node test runtime", () => {
     expect(REACT_NATIVE_SQLITE_STORAGE_REJECTED_ERROR).toBe(
       "ReactNativeDbConfig.sqliteStorage is proposal-only and cannot be used by the v2 runtime; remove sqliteStorage (memory mode remains unverified scaffolding)",
     );
+    expect(REACT_NATIVE_NATIVE_RELAY_REQUIRED_ERROR).toMatch(/JazzRelay native artifact/);
   });
 
   it("never falls back to browser localStorage for a React Native auth root", () => {
@@ -64,7 +100,65 @@ describe("React Native binding scaffolding in the Node test runtime", () => {
       (error: unknown) => error,
     );
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe(REACT_NATIVE_PERSISTENT_RUNTIME_UNAVAILABLE_ERROR);
+    expect((error as Error).message).toBe(REACT_NATIVE_NATIVE_RELAY_REQUIRED_ERROR);
+  });
+
+  it("uses one foreground memory runtime connected to the platform-admitted persistent relay", async () => {
+    const relay = nativeRelayReceipt();
+    client = await createJazzClient({
+      appId: "react-native-native-relay-startup-receipt",
+      nativeRelay: relay.config,
+    });
+
+    await expect(client.db.all(app.notes)).resolves.toEqual([]);
+    expect(relay.commands).toEqual(expect.arrayContaining([1, 2]));
+
+    await client.shutdown();
+    client = undefined;
+    expect(relay.commands).toEqual(expect.arrayContaining([3, 4]));
+  });
+
+  it("replaces only the foreground peer alias across explicit offline/reconnect", async () => {
+    const relay = nativeRelayReceipt();
+    client = await createJazzClient({
+      appId: "react-native-native-relay-reconnect-receipt",
+      serverUrl: "wss://relay.example.test",
+      nativeRelay: relay.config,
+    });
+
+    await client.db.all(app.notes, { tier: "local" });
+    await client.db.disconnect();
+    await client.db.reconnect();
+    await client.db.all(app.notes, { tier: "local" });
+
+    expect(relay.commands.filter((tag) => tag === 1)).toHaveLength(2);
+    expect(relay.commands.filter((tag) => tag === 2)).toHaveLength(2);
+    expect(relay.commands).toEqual(expect.arrayContaining([3, 4]));
+  });
+
+  it("names native artifact, admission, and ABI failures at persistent startup", async () => {
+    const relay = nativeRelayReceipt();
+    relay.config.executor.execute = async () => btoa(String.fromCharCode(9));
+    client = await createJazzClient({
+      appId: "react-native-native-relay-abi-receipt",
+      nativeRelay: relay.config,
+    });
+
+    await expect(client.db.all(app.notes)).rejects.toThrow(
+      /installed native artifact, platform admission capability, and relay command ABI/,
+    );
+  });
+
+  it("rejects an opaque relay capability when memory mode would ignore it", async () => {
+    const relay = nativeRelayReceipt();
+    const error = await createDb({
+      appId: "react-native-native-relay-memory-boundary",
+      driver: { type: "memory" },
+      nativeRelay: relay.config,
+    }).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(REACT_NATIVE_NATIVE_RELAY_MEMORY_ONLY_ERROR);
   });
 
   it("rejects an injected SQLite driver before opening it", async () => {

--- a/packages/jazz-tools/src/react-native/index.ts
+++ b/packages/jazz-tools/src/react-native/index.ts
@@ -26,6 +26,11 @@ export {
   type ReactNativeSqliteStorageDriver,
   type ReactNativeSqliteTransaction,
 } from "./storage.js";
+export {
+  REACT_NATIVE_NATIVE_RELAY_MEMORY_ONLY_ERROR,
+  REACT_NATIVE_NATIVE_RELAY_REQUIRED_ERROR,
+  type ReactNativeDbConfig,
+} from "./runtime-source.js";
 export type { QueryOptions, RuntimeSourcesConfig } from "../runtime/index.js";
 export type { AuthSecretStore } from "../runtime/auth-secret-store.js";
 export { schema } from "../index.js";

--- a/packages/jazz-tools/src/react-native/runtime-source.ts
+++ b/packages/jazz-tools/src/react-native/runtime-source.ts
@@ -3,11 +3,22 @@ import type { RuntimeClientContext, RuntimeTokenOptions } from "../runtime/runti
 import { RuntimeSource } from "../runtime/runtime-source.js";
 import type { JazzClient } from "../runtime/client.js";
 import type { DbConfig } from "../runtime/db.js";
+import type {
+  DirectRuntimeConnection,
+  DirectRuntimeConnectionContext,
+} from "../runtime/runtime-source.js";
+import { NativeRuntimeAdapter } from "../runtime/native-runtime/native-runtime-adapter.js";
+import {
+  getTrustedReservedSession,
+  setTrustedReservedSession,
+} from "../runtime/db-internal-session.js";
 import type { ReactNativeSqliteStorageDriver } from "./storage.js";
 import {
-  REACT_NATIVE_PERSISTENT_RUNTIME_UNAVAILABLE_ERROR,
-  REACT_NATIVE_SQLITE_STORAGE_REJECTED_ERROR,
-} from "./storage.js";
+  ReactNativeRelayFrameAdapter,
+  type NativeRelayCapability,
+  type NativeRelayExecutor,
+} from "./native-relay-frame-adapter.js";
+import { REACT_NATIVE_SQLITE_STORAGE_REJECTED_ERROR } from "./storage.js";
 
 export type ReactNativeDbConfig = DbConfig & {
   /**
@@ -21,7 +32,24 @@ export type ReactNativeDbConfig = DbConfig & {
    * native ordered-KV runtime exists.
    */
   sqliteStorage?: ReactNativeSqliteStorageDriver;
+  /**
+   * Opaque authority issued by the installed Android/iOS JazzRelay artifact.
+   *
+   * The capability admits this foreground peer to its native durable relay;
+   * it is not a database path, schema, session, token, or a way to derive any
+   * of those values in JavaScript.
+   */
+  nativeRelay?: Readonly<{
+    executor: NativeRelayExecutor;
+    capability: NativeRelayCapability;
+  }>;
 };
+
+export const REACT_NATIVE_NATIVE_RELAY_REQUIRED_ERROR =
+  "React Native persistent runtime requires the installed JazzRelay native artifact and its platform-provided opaque nativeRelay capability";
+
+export const REACT_NATIVE_NATIVE_RELAY_MEMORY_ONLY_ERROR =
+  "React Native nativeRelay is only valid with persistent storage; remove nativeRelay when driver.type='memory'";
 
 function shouldRequireSqliteDriver(config: ReactNativeDbConfig): boolean {
   return (config.driver?.type ?? "persistent") === "persistent";
@@ -35,18 +63,37 @@ export class ReactNativeRuntimeSource extends RuntimeSource<ReactNativeDbConfig>
       throw new Error(REACT_NATIVE_SQLITE_STORAGE_REJECTED_ERROR);
     }
     if (shouldRequireSqliteDriver(config)) {
-      // A ReactNativeSqliteStorageDriver cannot yet be installed into the v2
-      // Rust ordered-KV runtime. Opening one here and then delegating to WASM
-      // only preflights an unrelated database and falsely implies that Jazz
-      // rows are persisted there.
-      throw new Error(REACT_NATIVE_PERSISTENT_RUNTIME_UNAVAILABLE_ERROR);
+      if (!config.nativeRelay) throw new Error(REACT_NATIVE_NATIVE_RELAY_REQUIRED_ERROR);
+      assertNativeRelay(config.nativeRelay);
+      // The foreground runtime is intentionally in-memory. Its sole durable
+      // peer is the platform-owned relay, attached below through canonical
+      // frames; no SQLite/path/schema/session/token crosses this boundary.
+      await this.fallback.load(foregroundConfig(config));
+      return;
     }
+
+    if (config.nativeRelay) throw new Error(REACT_NATIVE_NATIVE_RELAY_MEMORY_ONLY_ERROR);
 
     await this.fallback.load(config);
   }
 
   override createClient(context: RuntimeClientContext<ReactNativeDbConfig>): JazzClient {
-    return this.fallback.createClient(context);
+    return this.fallback.createClient({ ...context, config: foregroundConfig(context.config) });
+  }
+
+  override createDirectConnection(
+    context: DirectRuntimeConnectionContext<ReactNativeDbConfig>,
+  ): DirectRuntimeConnection | null {
+    const relay = context.config.nativeRelay;
+    if (!relay) return null;
+    assertNativeRelay(relay);
+    const runtime = context.client.getRuntime();
+    if (!(runtime instanceof NativeRuntimeAdapter)) {
+      throw new Error(
+        "React Native JazzRelay requires a compatible native foreground runtime; the installed runtime artifact is missing or incompatible",
+      );
+    }
+    return new ReactNativeRelayConnection(runtime, relay);
   }
 
   override installTelemetry(
@@ -61,5 +108,91 @@ export class ReactNativeRuntimeSource extends RuntimeSource<ReactNativeDbConfig>
 
   override mintAnonymousToken(options: RuntimeTokenOptions): string {
     return this.fallback.mintAnonymousToken(options);
+  }
+}
+
+class ReactNativeRelayConnection implements DirectRuntimeConnection {
+  private adapter: ReactNativeRelayFrameAdapter | null = null;
+  private readyPromise: Promise<void> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly runtime: NativeRuntimeAdapter,
+    private readonly relay: NonNullable<ReactNativeDbConfig["nativeRelay"]>,
+  ) {}
+
+  async ready(): Promise<void> {
+    if (this.closed) throw new Error("React Native JazzRelay connection is shut down");
+    this.readyPromise ??= this.start();
+    await this.readyPromise;
+  }
+
+  async disconnect(): Promise<void> {
+    const adapter = this.adapter;
+    this.adapter = null;
+    this.readyPromise = null;
+    await adapter?.shutdown();
+  }
+
+  async reconnect(): Promise<void> {
+    await this.disconnect();
+    await this.ready();
+  }
+
+  async shutdown(): Promise<void> {
+    this.closed = true;
+    await this.disconnect();
+  }
+
+  private async start(): Promise<void> {
+    const adapter = new ReactNativeRelayFrameAdapter(
+      this.runtime,
+      this.runtime.connectUpstreamPeer(),
+      this.relay.executor,
+      this.relay.capability,
+      reportRelayProgressError,
+    );
+    this.adapter = adapter;
+    try {
+      await adapter.start();
+    } catch (error) {
+      if (this.adapter === adapter) this.adapter = null;
+      await adapter.shutdown();
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `React Native JazzRelay startup failed; verify the installed native artifact, platform admission capability, and relay command ABI: ${detail}`,
+      );
+    }
+  }
+}
+
+function reportRelayProgressError(error: Error): void {
+  // A frame-progress error is deliberately non-terminal here. The adapter
+  // retains its FIFO frame and a later native work notification can resume it
+  // after transient backpressure. Startup/ABI/admission failures still reject
+  // ready() with the contextual error above.
+  console.error("React Native JazzRelay frame progress failed", error);
+}
+
+function foregroundConfig(config: ReactNativeDbConfig): DbConfig {
+  if (!shouldRequireSqliteDriver(config)) return config;
+  const foreground = { ...config, driver: { type: "memory" as const } };
+  // The verified session is a package-private sidecar, not part of the relay
+  // configuration or relay command ABI. Preserve it for the ordinary
+  // foreground runtime without making it enumerable to application code.
+  setTrustedReservedSession(foreground, getTrustedReservedSession(config));
+  return foreground;
+}
+
+function assertNativeRelay(
+  relay: NonNullable<ReactNativeDbConfig["nativeRelay"]>,
+): asserts relay is NonNullable<ReactNativeDbConfig["nativeRelay"]> {
+  if (!relay || typeof relay.executor?.execute !== "function") {
+    throw new Error(REACT_NATIVE_NATIVE_RELAY_REQUIRED_ERROR);
+  }
+  if (!(relay.capability instanceof Uint8Array) || relay.capability.byteLength !== 32) {
+    throw new Error(
+      "React Native JazzRelay requires a 32-byte platform-provided opaque capability",
+    );
   }
 }

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.test.ts
@@ -1,11 +1,35 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DirectConnectionManager } from "./direct-connection-manager.js";
 import type { DbForConnection } from "./types.js";
 import { getTrustedReservedSession, setTrustedReservedSession } from "../db-internal-session.js";
 import type { Session } from "../context.js";
+import type { DirectRuntimeConnection } from "../runtime-source.js";
 
 const host = { config: { serverUrl: "ws://example.invalid" } } as DbForConnection;
 const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function managerWithDirectConnection(connection: DirectRuntimeConnection): {
+  manager: DirectConnectionManager;
+  reportFailure(error: unknown): void;
+} {
+  let reportFailure: (error: unknown) => void = () => undefined;
+  const manager = new DirectConnectionManager({
+    config: { appId: "direct-connection-retry", serverUrl: "ws://example.invalid" },
+    runtimeSource: {
+      createClient: () => ({ onMutationError() {} }),
+      createDirectConnection: ({ onFailure }: { onFailure(error: unknown): void }) => {
+        reportFailure = onFailure;
+        return connection;
+      },
+    },
+    isShuttingDown: false,
+    markUnauthenticated() {},
+    clearAuthError() {},
+    onMutationError() {},
+  } as unknown as DbForConnection);
+  manager.getClient({});
+  return { manager, reportFailure: (error) => reportFailure(error) };
+}
 
 describe("DirectConnectionManager explicit offline state", () => {
   it("preserves the private reserved-session capability in the runtime config clone", () => {
@@ -72,5 +96,68 @@ describe("DirectConnectionManager explicit offline state", () => {
     await manager.reconnect();
     await nextTick();
     expect(wakes).toBe(2);
+  });
+
+  it("replaces an initial ready failure after a successful reconnect", async () => {
+    const initialFailure = new Error("initial native relay startup failed");
+    const connection: DirectRuntimeConnection = {
+      ready: vi.fn(async () => {
+        throw initialFailure;
+      }),
+      reconnect: vi.fn(async () => undefined),
+      disconnect: vi.fn(async () => undefined),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { manager } = managerWithDirectConnection(connection);
+
+    await expect(manager.ensureReady("local")).rejects.toBe(initialFailure);
+    await expect(manager.reconnect()).resolves.toBeUndefined();
+    await expect(manager.ensureReady("local")).resolves.toBeUndefined();
+  });
+
+  it("retains a failed reconnect error instead of clearing the prior receipt", async () => {
+    const initialFailure = new Error("initial native relay startup failed");
+    const reconnectFailure = new Error("native relay reconnect failed");
+    const connection: DirectRuntimeConnection = {
+      ready: vi.fn(async () => {
+        throw initialFailure;
+      }),
+      reconnect: vi.fn(async () => {
+        throw reconnectFailure;
+      }),
+      disconnect: vi.fn(async () => undefined),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { manager } = managerWithDirectConnection(connection);
+
+    await expect(manager.ensureReady("local")).rejects.toBe(initialFailure);
+    await expect(manager.reconnect()).rejects.toBe(reconnectFailure);
+    await expect(manager.ensureReady("local")).rejects.toBe(reconnectFailure);
+  });
+
+  it("does not clear a newer native failure that races a successful reconnect", async () => {
+    const initialFailure = new Error("initial native relay startup failed");
+    const concurrentFailure = new Error("native relay lost transport during reconnect");
+    let releaseReconnect!: () => void;
+    const reconnectReady = new Promise<void>((resolve) => {
+      releaseReconnect = resolve;
+    });
+    const connection: DirectRuntimeConnection = {
+      ready: vi.fn(async () => {
+        throw initialFailure;
+      }),
+      reconnect: vi.fn(() => reconnectReady),
+      disconnect: vi.fn(async () => undefined),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { manager, reportFailure } = managerWithDirectConnection(connection);
+
+    await expect(manager.ensureReady("local")).rejects.toBe(initialFailure);
+    const reconnect = manager.reconnect();
+    await nextTick();
+    reportFailure(concurrentFailure);
+    releaseReconnect();
+    await expect(reconnect).resolves.toBeUndefined();
+    await expect(manager.ensureReady("local")).rejects.toBe(concurrentFailure);
   });
 });

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
@@ -64,7 +64,12 @@ export class DirectConnectionManager extends ConnectionManager {
 
   async ensureReady(tier?: DurabilityTier, signal?: AbortSignal): Promise<void> {
     if (this.connectionError) throw this.connectionError;
-    await this.connectionReady;
+    // Awaiting `null` still yields a microtask. Preserve the direct manager's
+    // established synchronous-ready path when a source has no platform peer:
+    // remote reads and subscription handoffs choose their tier before an
+    // explicit disconnect/reconnect can interleave.
+    const connectionReady = this.connectionReady;
+    if (connectionReady) await connectionReady;
     if (this.connectionError) throw this.connectionError;
     if (tier === "local") return;
     for (;;) {

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
@@ -4,12 +4,16 @@ import {
   type ConnectionManagerClientInput,
   type DbForConnection,
 } from "./types.js";
+import type { DirectRuntimeConnection } from "../runtime-source.js";
 
 /** Manages a Db whose runtime connects directly to the configured server. */
 export class DirectConnectionManager extends ConnectionManager {
   private isDisconnected = false;
   private reconnectWaiters = new Set<() => void>();
   private transportTransition: Promise<void> = Promise.resolve();
+  private connection: DirectRuntimeConnection | null = null;
+  private connectionReady: Promise<void> | null = null;
+  private connectionError: Error | null = null;
 
   constructor(host: DbForConnection) {
     super(host);
@@ -17,7 +21,28 @@ export class DirectConnectionManager extends ConnectionManager {
 
   async start(): Promise<void> {}
 
-  protected override onClientCreated({ client }: ConnectionManagerClientInput): void {
+  protected override onClientCreated({ schema, client }: ConnectionManagerClientInput): void {
+    const connection = this.host.runtimeSource.createDirectConnection?.({
+      config: this.host.config,
+      schema,
+      client,
+      onFailure: (error) => {
+        if (this.connection === connection) this.connectionError = asError(error);
+      },
+    });
+    if (connection) {
+      this.connection = connection;
+      this.connectionReady = connection.ready().catch((error: unknown) => {
+        const failure = asError(error);
+        if (this.connection === connection) this.connectionError = failure;
+        throw failure;
+      });
+      void this.connectionReady.catch(() => undefined);
+      if (this.isDisconnected) {
+        void this.enqueueTransportTransition(() => connection.disconnect()).catch(() => undefined);
+      }
+      return;
+    }
     if (this.isDisconnected) {
       // Establish the runtime's reconnect barrier for clients created while the
       // Db is explicitly offline.
@@ -40,6 +65,9 @@ export class DirectConnectionManager extends ConnectionManager {
   }
 
   async ensureReady(tier?: DurabilityTier, signal?: AbortSignal): Promise<void> {
+    if (this.connectionError) throw this.connectionError;
+    await this.connectionReady;
+    if (this.connectionError) throw this.connectionError;
     if (tier === "local") return;
     for (;;) {
       while (this.isDisconnected) {
@@ -80,7 +108,8 @@ export class DirectConnectionManager extends ConnectionManager {
       throw new Error("Db.disconnect() requires a configured serverUrl.");
     }
     await this.enqueueTransportTransition(async () => {
-      await this.clientEntry?.client.disconnectTransport();
+      if (this.connection) await this.connection.disconnect();
+      else await this.clientEntry?.client.disconnectTransport();
       // An in-flight or failed disconnect is not permission for a
       // RemoteIfPossible read to fall back locally.
       this.isDisconnected = true;
@@ -92,8 +121,11 @@ export class DirectConnectionManager extends ConnectionManager {
       throw new Error("Db.reconnect() requires a configured serverUrl.");
     }
     await this.enqueueTransportTransition(async () => {
-      const client = this.clientEntry?.client;
-      if (client) this.connectClient(client);
+      if (this.connection) await this.connection.reconnect();
+      else {
+        const client = this.clientEntry?.client;
+        if (client) this.connectClient(client);
+      }
       this.isDisconnected = false;
     });
     if (!this.isDisconnected) {
@@ -127,4 +159,18 @@ export class DirectConnectionManager extends ConnectionManager {
       this.clearClient();
     }
   }
+
+  override async shutdown(): Promise<void> {
+    try {
+      await this.connection?.shutdown();
+    } finally {
+      this.connection = null;
+      this.connectionReady = null;
+      await super.shutdown();
+    }
+  }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
@@ -14,6 +14,7 @@ export class DirectConnectionManager extends ConnectionManager {
   private connection: DirectRuntimeConnection | null = null;
   private connectionReady: Promise<void> | null = null;
   private connectionError: Error | null = null;
+  private connectionErrorEpoch = 0;
 
   constructor(host: DbForConnection) {
     super(host);
@@ -22,22 +23,19 @@ export class DirectConnectionManager extends ConnectionManager {
   async start(): Promise<void> {}
 
   protected override onClientCreated({ schema, client }: ConnectionManagerClientInput): void {
-    const connection = this.host.runtimeSource.createDirectConnection?.({
-      config: this.host.config,
-      schema,
-      client,
-      onFailure: (error) => {
-        if (this.connection === connection) this.connectionError = asError(error);
-      },
-    });
+    let connection: DirectRuntimeConnection | null = null;
+    connection =
+      this.host.runtimeSource.createDirectConnection?.({
+        config: this.host.config,
+        schema,
+        client,
+        onFailure: (error) => {
+          if (connection) this.recordConnectionError(connection, error);
+        },
+      }) ?? null;
     if (connection) {
       this.connection = connection;
-      this.connectionReady = connection.ready().catch((error: unknown) => {
-        const failure = asError(error);
-        if (this.connection === connection) this.connectionError = failure;
-        throw failure;
-      });
-      void this.connectionReady.catch(() => undefined);
+      this.trackConnectionReady(connection, connection.ready());
       if (this.isDisconnected) {
         void this.enqueueTransportTransition(() => connection.disconnect()).catch(() => undefined);
       }
@@ -121,8 +119,18 @@ export class DirectConnectionManager extends ConnectionManager {
       throw new Error("Db.reconnect() requires a configured serverUrl.");
     }
     await this.enqueueTransportTransition(async () => {
-      if (this.connection) await this.connection.reconnect();
-      else {
+      const connection = this.connection;
+      if (connection) {
+        // A successful reconnect replaces a rejected initial `ready()` receipt.
+        // Only clear an error observed before this attempt: a concurrent native
+        // failure must remain visible to subsequent ensureReady() calls.
+        const errorEpoch = this.connectionErrorEpoch;
+        const ready = this.trackConnectionReady(connection, connection.reconnect());
+        await ready;
+        if (this.connection === connection && this.connectionErrorEpoch === errorEpoch) {
+          this.connectionError = null;
+        }
+      } else {
         const client = this.clientEntry?.client;
         if (client) this.connectClient(client);
       }
@@ -139,6 +147,25 @@ export class DirectConnectionManager extends ConnectionManager {
     const transition = this.transportTransition.then(run, run);
     this.transportTransition = transition.catch(() => undefined);
     return transition;
+  }
+
+  private trackConnectionReady(
+    connection: DirectRuntimeConnection,
+    ready: Promise<void>,
+  ): Promise<void> {
+    const tracked = ready.catch((error: unknown) => {
+      this.recordConnectionError(connection, error);
+      throw error;
+    });
+    this.connectionReady = tracked;
+    void tracked.catch(() => undefined);
+    return tracked;
+  }
+
+  private recordConnectionError(connection: DirectRuntimeConnection, error: unknown): void {
+    if (this.connection !== connection) return;
+    this.connectionErrorEpoch += 1;
+    this.connectionError = asError(error);
   }
 
   async deleteClientStorage(): Promise<void> {

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -70,6 +70,25 @@ export interface BrowserFollowerConnectionContext<RuntimeConfig extends DbConfig
 }
 
 /**
+ * A platform-owned peer connection for runtimes which keep their durable
+ * replica outside JavaScript.  The Db connection manager owns this lifecycle;
+ * sources must not construct a second JavaScript runtime to implement it.
+ */
+export interface DirectRuntimeConnection {
+  ready(): Promise<void>;
+  disconnect(): Promise<void>;
+  reconnect(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+export interface DirectRuntimeConnectionContext<RuntimeConfig extends DbConfig = DbConfig> {
+  config: RuntimeConfig;
+  schema: WasmSchema;
+  client: JazzClient;
+  onFailure: (error: unknown) => void;
+}
+
+/**
  * Internal source for loading and wiring the native runtime.
  *
  * This keeps platform/source differences (WASM, NAPI, browser storage, React
@@ -103,6 +122,17 @@ export abstract class RuntimeSource<RuntimeConfig extends DbConfig = DbConfig> {
     _context: BrowserFollowerConnectionContext<RuntimeConfig>,
   ): BrowserFollowerConnection {
     throw new Error("Db runtime source does not support browser follower connections");
+  }
+
+  /**
+   * Optionally replace the ordinary JavaScript websocket carrier with a
+   * platform-admitted peer connection. The DirectConnectionManager remains the
+   * sole owner of readiness, offline state, and teardown.
+   */
+  createDirectConnection(
+    _context: DirectRuntimeConnectionContext<RuntimeConfig>,
+  ): DirectRuntimeConnection | null {
+    return null;
   }
 
   installTelemetry(


### PR DESCRIPTION
🤖 Wires persistent React Native startup through the reviewed native relay frame adapter while retaining the ordinary foreground in-memory Jazz runtime.

Before: the frame adapter existed, but ReactNativeRuntimeSource still rejected persistent configuration and could not attach its normal direct connection manager to the admitted native relay.

After:

- persistent React Native config accepts only a native executor plus opaque admission capability;
- DirectConnectionManager owns relay readiness, reconnect, disconnect, and shutdown;
- SQLite path, schema, database identity, session claims, and admission derivation remain native-only;
- memory mode is unchanged;
- missing admission, incompatible ABI, and relay startup failures surface explicitly;
- reconnect replaces stale failed readiness without clearing a newer concurrent failure.

Example: a transient native readiness failure can recover after reconnect and queries continue through the same foreground in-memory Db. If a newer relay error arrives during that reconnect, the older success cannot erase it.

This completes the library runtime-source seam. First-party Android emulator and iOS simulator acceptance still belongs in the RN test app/device work.
