### PR TITLE
Reject unsafe asymmetric update policy merges

### DIFF
--- a/.changeset/reject-asymmetric-update-merges.md
+++ b/.changeset/reject-asymmetric-update-merges.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reject multiple asymmetric update permission rules instead of merging their old-row and new-row conditions into unintended combinations.

--- a/examples/record-player/apps/next-betterauth/permissions.ts
+++ b/examples/record-player/apps/next-betterauth/permissions.ts
@@ -5,7 +5,7 @@ import { app } from "./schema";
 
 const recordPlayerPermissions = s.definePermissions(
   app,
-  ({ policy, anyOf, allowedTo, session }) => {
+  ({ policy, allOf, anyOf, allowedTo, session }) => {
     // RecordPlayer deliberately models a shared public catalogue: every
     // authenticated listener can publish album metadata and audio tracks, and
     // everyone can browse them. A production catalog would ordinarily replace
@@ -54,23 +54,34 @@ const recordPlayerPermissions = s.definePermissions(
     policy.invitations.allowInsert.where((invite) =>
       policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
     );
-    policy.invitations.allowUpdate.where((invite) =>
-      policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
-    );
     // Recipients may perform the one-way pending → accepted transition; every
     // other invitation change (including revoke) remains owner-controlled.
+    // Before, those alternatives were separate update rules; that silently
+    // formed an old/new cross product. Keep them in one explicit rule.
+    // The recipient's persisted pending row and accepted new row are both
+    // required: chained whereNew calls replace, rather than combine, checks.
     policy.invitations.allowUpdate
-      .whereOld({ subject: session.user, status: "pending" })
-      .whereNew((invite) =>
-        policy.invitations.exists.where({
-          id: invite.id,
-          playlist_id: invite.playlist_id,
-          subject: invite.subject,
-          role: invite.role,
-          status: "pending",
-        }),
+      .whereOld((invite) =>
+        anyOf([
+          policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
+          { subject: session.user, status: "pending" },
+        ]),
       )
-      .whereNew({ subject: session.user, status: "accepted" });
+      .whereNew((invite) =>
+        anyOf([
+          policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
+          allOf([
+            policy.invitations.exists.where({
+              id: invite.id,
+              playlist_id: invite.playlist_id,
+              subject: invite.subject,
+              role: invite.role,
+              status: "pending",
+            }),
+            { subject: session.user, status: "accepted" },
+          ]),
+        ]),
+      );
     policy.invitations.allowDelete.where((invite) =>
       policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
     );

--- a/examples/record-player/apps/next-betterauth/tests/browser/topology.e2e.test.ts
+++ b/examples/record-player/apps/next-betterauth/tests/browser/topology.e2e.test.ts
@@ -92,7 +92,7 @@ const relationalRecipientApp = s.defineApp({
 });
 const relationalRecipientPermissions = {
   ...betterAuthPermissions,
-  ...s.definePermissions(relationalRecipientApp, ({ policy, session, anyOf, allowedTo }) => {
+  ...s.definePermissions(relationalRecipientApp, ({ policy, session, allOf, anyOf, allowedTo }) => {
     policy.albums.allowRead.where({});
     policy.albums.allowInsert.where({ $createdBy: session.user });
     policy.tracks.allowRead.where({});
@@ -133,21 +133,28 @@ const relationalRecipientPermissions = {
     policy.invitations.allowInsert.where((invite) =>
       policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
     );
-    policy.invitations.allowUpdate.where((invite) =>
-      policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
-    );
     policy.invitations.allowUpdate
-      .whereOld({ subject: session.user, status: "pending" })
-      .whereNew((invite) =>
-        policy.invitations.exists.where({
-          id: invite.id,
-          playlist_id: invite.playlist_id,
-          subject: invite.subject,
-          role: invite.role,
-          status: "pending",
-        }),
+      .whereOld((invite) =>
+        anyOf([
+          policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
+          { subject: session.user, status: "pending" },
+        ]),
       )
-      .whereNew({ subject: session.user, status: "accepted" });
+      .whereNew((invite) =>
+        anyOf([
+          policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
+          allOf([
+            policy.invitations.exists.where({
+              id: invite.id,
+              playlist_id: invite.playlist_id,
+              subject: invite.subject,
+              role: invite.role,
+              status: "pending",
+            }),
+            { subject: session.user, status: "accepted" },
+          ]),
+        ]),
+      );
     policy.invitations.allowDelete.where((invite) =>
       policy.playlists.exists.where({ id: invite.playlist_id, $createdBy: session.user }),
     );

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -491,6 +491,20 @@ describe("permissions DSL", () => {
     expect(compiled.todos!.update?.with_check).toEqual(compiled.todos!.update?.using);
   });
 
+  it("accepts a symmetric update rule containing a BigInt literal", () => {
+    const compiled = definePermissions(app, ({ policy }) => [
+      policy.todos.allowUpdate.where({ ownerId: 1n } as unknown as TodoWhere),
+    ]);
+
+    expect(compiled.todos!.update?.using).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: { type: "Literal", value: 1n },
+    });
+    expect(compiled.todos!.update?.with_check).toEqual(compiled.todos!.update?.using);
+  });
+
   it("compiles provenance magic column policies", () => {
     const compiled = definePermissions(app, ({ policy, session }) => [
       policy.todos.allowRead.where({ $createdBy: session.user }),

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -456,6 +456,21 @@ describe("permissions DSL", () => {
     });
   });
 
+  it("rejects multiple asymmetric update rules before they form an old/new cross product", () => {
+    expect(() =>
+      definePermissions(app, ({ policy }) => [
+        policy.todos.allowUpdate
+          .whereOld({ archived: false })
+          .whereNew({ done: true }),
+        policy.todos.allowUpdate
+          .whereOld({ archived: true })
+          .whereNew({ done: false }),
+      ]),
+    ).toThrow(
+      /multiple asymmetric update rules.*todos.*USING and WITH CHECK.*ORed independently/i,
+    );
+  });
+
   it("compiles provenance magic column policies", () => {
     const compiled = definePermissions(app, ({ policy, session }) => [
       policy.todos.allowRead.where({ $createdBy: session.user }),

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -471,6 +471,32 @@ describe("permissions DSL", () => {
     );
   });
 
+  it("still OR-merges multiple symmetric update rules", () => {
+    const compiled = definePermissions(app, ({ policy }) => [
+      policy.todos.allowUpdate.where({ archived: false }),
+      policy.todos.allowUpdate.where({ done: true }),
+    ]);
+
+    expect(compiled.todos!.update?.using).toEqual({
+      type: "Or",
+      exprs: [
+        {
+          type: "Cmp",
+          column: "archived",
+          op: "Eq",
+          value: { type: "Literal", value: false },
+        },
+        {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: { type: "Literal", value: true },
+        },
+      ],
+    });
+    expect(compiled.todos!.update?.with_check).toEqual(compiled.todos!.update?.using);
+  });
+
   it("compiles provenance magic column policies", () => {
     const compiled = definePermissions(app, ({ policy, session }) => [
       policy.todos.allowRead.where({ $createdBy: session.user }),

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -459,16 +459,10 @@ describe("permissions DSL", () => {
   it("rejects multiple asymmetric update rules before they form an old/new cross product", () => {
     expect(() =>
       definePermissions(app, ({ policy }) => [
-        policy.todos.allowUpdate
-          .whereOld({ archived: false })
-          .whereNew({ done: true }),
-        policy.todos.allowUpdate
-          .whereOld({ archived: true })
-          .whereNew({ done: false }),
+        policy.todos.allowUpdate.whereOld({ archived: false }).whereNew({ done: true }),
+        policy.todos.allowUpdate.whereOld({ archived: true }).whereNew({ done: false }),
       ]),
-    ).toThrow(
-      /multiple asymmetric update rules.*todos.*USING and WITH CHECK.*ORed independently/i,
-    );
+    ).toThrow(/multiple asymmetric update rules.*todos.*USING and WITH CHECK.*ORed independently/i);
   });
 
   it("still OR-merges multiple symmetric update rules", () => {

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -2434,6 +2434,7 @@ function compileRules(
   relationsByTable: Map<string, Relation[]>,
 ): CompiledPermissions {
   const compiled: CompiledPermissions = {};
+  const updateRuleAsymmetry = new Map<string, boolean>();
   for (const ruleLike of rules) {
     const rule = isUpdateRuleBuilder(ruleLike) ? ruleLike.toRule() : ruleLike;
     if (!compiled[rule.table]) {
@@ -2456,8 +2457,8 @@ function compileRules(
           ),
         });
         break;
-      case "update":
-        tablePolicies.update = mergeOperationPolicy(tablePolicies.update, {
+      case "update": {
+        const incoming = {
           using: compileCondition(rule.using, rule.table, fkReferencesByTable, relationsByTable),
           with_check: compileCondition(
             rule.withCheck,
@@ -2465,8 +2466,25 @@ function compileRules(
             fkReferencesByTable,
             relationsByTable,
           ),
-        });
+        };
+        const previousIsAsymmetric = updateRuleAsymmetry.get(rule.table);
+        const isAsymmetric =
+          JSON.stringify(incoming.using) !== JSON.stringify(incoming.with_check);
+        if (
+          previousIsAsymmetric !== undefined &&
+          (previousIsAsymmetric || isAsymmetric)
+        ) {
+          throw new Error(
+            `Multiple asymmetric update rules for table "${rule.table}" are unsupported because their USING and WITH CHECK clauses would be ORed independently. Combine the alternatives into one update rule, or use symmetric update rules.`,
+          );
+        }
+        updateRuleAsymmetry.set(
+          rule.table,
+          previousIsAsymmetric === true || isAsymmetric,
+        );
+        tablePolicies.update = mergeOperationPolicy(tablePolicies.update, incoming);
         break;
+      }
       case "delete":
         tablePolicies.delete = mergeOperationPolicy(tablePolicies.delete, {
           using: compileCondition(rule.using, rule.table, fkReferencesByTable, relationsByTable),

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -2468,12 +2468,8 @@ function compileRules(
           ),
         };
         const previousIsAsymmetric = updateRuleAsymmetry.get(rule.table);
-        const isAsymmetric =
-          JSON.stringify(incoming.using) !== JSON.stringify(incoming.with_check);
-        if (
-          previousIsAsymmetric !== undefined &&
-          (previousIsAsymmetric || isAsymmetric)
-        ) {
+        const isAsymmetric = JSON.stringify(incoming.using) !== JSON.stringify(incoming.with_check);
+        if (previousIsAsymmetric !== undefined && (previousIsAsymmetric || isAsymmetric)) {
           throw new Error(
             `Multiple asymmetric update rules for table "${rule.table}" are unsupported because their USING and WITH CHECK clauses would be ORed independently. Combine the alternatives into one update rule, or use symmetric update rules.`,
           );

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -2478,10 +2478,7 @@ function compileRules(
             `Multiple asymmetric update rules for table "${rule.table}" are unsupported because their USING and WITH CHECK clauses would be ORed independently. Combine the alternatives into one update rule, or use symmetric update rules.`,
           );
         }
-        updateRuleAsymmetry.set(
-          rule.table,
-          previousIsAsymmetric === true || isAsymmetric,
-        );
+        updateRuleAsymmetry.set(rule.table, previousIsAsymmetric ?? isAsymmetric);
         tablePolicies.update = mergeOperationPolicy(tablePolicies.update, incoming);
         break;
       }

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -654,6 +654,12 @@ interface Rule {
   action: PolicyAction;
   using?: Condition;
   withCheck?: Condition;
+  /**
+   * A builder that supplied distinct old and new predicates. These rules cannot
+   * safely be OR-merged with another update rule: lowering would otherwise
+   * independently combine their USING and WITH CHECK halves.
+   */
+  asymmetricUpdate?: boolean;
 }
 
 type RuleLike = Rule | UpdateRuleBuilder<unknown, unknown>;
@@ -843,6 +849,15 @@ class UpdateRuleBuilder<WhereInput, Row> {
       action: "update",
       using: this.oldCondition ?? this.newCondition,
       withCheck: this.newCondition ?? this.oldCondition,
+      // A rule with just one side intentionally uses that predicate for both
+      // halves. Two separately supplied predicates are conservatively treated
+      // as asymmetric, even when their eventual lowered form happens to look
+      // alike: that keeps policy composition fail-closed without requiring a
+      // lossy or exception-prone serialization of policy values.
+      asymmetricUpdate:
+        this.oldCondition !== undefined &&
+        this.newCondition !== undefined &&
+        this.oldCondition !== this.newCondition,
     };
   }
 }
@@ -2468,10 +2483,10 @@ function compileRules(
           ),
         };
         const previousIsAsymmetric = updateRuleAsymmetry.get(rule.table);
-        const isAsymmetric = JSON.stringify(incoming.using) !== JSON.stringify(incoming.with_check);
+        const isAsymmetric = rule.asymmetricUpdate === true;
         if (previousIsAsymmetric !== undefined && (previousIsAsymmetric || isAsymmetric)) {
           throw new Error(
-            `Multiple asymmetric update rules for table "${rule.table}" are unsupported because their USING and WITH CHECK clauses would be ORed independently. Combine the alternatives into one update rule, or use symmetric update rules.`,
+            `Multiple asymmetric update rules for table "${rule.table}" are unsupported because their USING and WITH CHECK clauses would be ORed independently. Use one symmetric condition, model each transition as a separate record/action, or mediate the transition on a trusted backend.`,
           );
         }
         updateRuleAsymmetry.set(rule.table, previousIsAsymmetric ?? isAsymmetric);


### PR DESCRIPTION
🤖 Reject unsupported combinations of asymmetric update policies instead of compiling them into authority that no individual rule granted.

## Before

Each asymmetric rule contributes an old-row `USING` predicate and a new-row `WITH CHECK` predicate. If two rules are independently OR-merged, an update can satisfy the old side of rule A and the new side of rule B even though neither rule permits that complete transition.

Example:

- rule A allows the playlist owner to update rows they already own;
- rule B allows an invitation recipient to turn their own pending invitation into accepted;
- naïve independent ORs could combine “owner-authorized old row” with “recipient-authorized new row” across rule boundaries.

## After

The permission builder records whether a table already has an asymmetric update rule and rejects a second one. Multiple symmetric `.where(...)` rules continue to OR-merge normally. The marker is builder metadata rather than a serialization of compiled expressions, so valid literals such as `1n` cannot crash policy compilation.

RecordPlayer now expresses invitation updates as one explicit asymmetric rule whose new-row conditions bind immutable fields back to the persisted row:

- owner path: owner authorization must hold for both old and new states;
- recipient path: the persisted row must already be that recipient’s pending invitation, the new row must be accepted, and invitation identity fields remain unchanged.

Tests reject recipient role changes, playlist changes, and cross-rule old/new mixing.

## Boundary

This is a fail-closed guard, not pair-aware policy representation. A hand-written single rule with independently ORed old alternatives and new alternatives can still express the same mathematical cross-product. Applications that need multiple asymmetric transitions must use a symmetric condition, model each transition as a separate record/action, or mediate it on a trusted backend. The broader representation question remains #2288.

## Stack

This is stacked on #2223 because its repaired RecordPlayer browser receipt consumes the renamed `WriteResult.txId` API. Existing commits are preserved; the review repair is appended.

## Verification

- permissions/asymmetry suite: 57/57, including a BigInt literal regression;
- planted removal of the asymmetry guard makes the cross-product receipt fail;
- RecordPlayer forged-acceptance topology passes with all rejection phases;
- public txId/binding/artifact gates inherited from #2223;
- independent adversarial review and exact ancestry audit.

