### PR TITLE
Reject unsupported compound ExistsRel joins

### DIFF
--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -1431,11 +1431,15 @@ fn exists_rel_rejects_nested_outer_correlation_off_the_join_key() {
 }
 
 #[test]
-fn exists_rel_rejects_multiple_join_conditions_in_write_policy() {
+fn exists_rel_rejects_compound_joins_in_every_policy_context_before_lowering() {
     let column = |scope: &str, name: &str| PublicRelColumnRef {
         scope: Some(scope.to_owned()),
         column: name.to_owned(),
     };
+    // The unsupported compound equality is deliberately below a nested join
+    // with aliases. This verifies that admission walks the full relation tree
+    // before the lowering implementation can select (and silently retain only)
+    // the first equality.
     let policy = PublicPolicyExpr::ExistsRel {
         rel: PublicRelExpr::Filter {
             input: Box::new(PublicRelExpr::Join {
@@ -1443,27 +1447,31 @@ fn exists_rel_rejects_multiple_join_conditions_in_write_policy() {
                     table: "blocks".into(),
                     alias: Some("blocks".to_owned()),
                 }),
-                right: Box::new(PublicRelExpr::Filter {
-                    input: Box::new(PublicRelExpr::TableScan {
+                right: Box::new(PublicRelExpr::Join {
+                    left: Box::new(PublicRelExpr::TableScan {
                         table: "members".into(),
-                        alias: Some("members".to_owned()),
+                        alias: Some("membership".to_owned()),
                     }),
-                    predicate: PublicRelPredicateExpr::Cmp {
-                        left: column("members", "subject"),
-                        op: PublicRelPredicateCmpOp::Eq,
-                        right: PublicRelValueRef::SessionRef(vec!["user_id".to_owned()]),
-                    },
+                    right: Box::new(PublicRelExpr::TableScan {
+                        table: "grants".into(),
+                        alias: Some("grant".to_owned()),
+                    }),
+                    on: vec![
+                        PublicRelJoinCondition {
+                            left: column("membership", "workspace"),
+                            right: column("grant", "workspace"),
+                        },
+                        PublicRelJoinCondition {
+                            left: column("membership", "subject"),
+                            right: column("grant", "subject"),
+                        },
+                    ],
+                    join_kind: PublicRelJoinKind::Inner,
                 }),
-                on: vec![
-                    PublicRelJoinCondition {
-                        left: column("blocks", "workspace"),
-                        right: column("members", "workspace"),
-                    },
-                    PublicRelJoinCondition {
-                        left: column("blocks", "owner"),
-                        right: column("members", "subject"),
-                    },
-                ],
+                on: vec![PublicRelJoinCondition {
+                    left: column("blocks", "workspace"),
+                    right: column("membership", "workspace"),
+                }],
                 join_kind: PublicRelJoinKind::Inner,
             }),
             predicate: PublicRelPredicateExpr::Cmp {
@@ -1473,31 +1481,81 @@ fn exists_rel_rejects_multiple_join_conditions_in_write_policy() {
             },
         },
     };
-    let public = PublicSchemaBuilder::new()
-        .table(PublicTableSchemaBuilder::new("workspaces"))
-        .table(
-            PublicTableSchemaBuilder::new("members")
-                .fk_column("workspace", "workspaces")
-                .column("subject", PublicColumnType::Uuid),
-        )
-        .table(
-            PublicTableSchemaBuilder::new("blocks")
-                .fk_column("workspace", "workspaces")
-                .column("owner", PublicColumnType::Uuid),
-        )
-        .table(
-            PublicTableSchemaBuilder::new("tasks")
-                .fk_column("block", "blocks")
-                .policies(PublicTablePolicies::new().with_insert(policy)),
-        )
-        .build();
+    let schema_with = |policies: PublicTablePolicies| {
+        PublicSchemaBuilder::new()
+            .table(PublicTableSchemaBuilder::new("workspaces"))
+            .table(
+                PublicTableSchemaBuilder::new("members")
+                    .fk_column("workspace", "workspaces")
+                    .column("subject", PublicColumnType::Uuid),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("grants")
+                    .fk_column("workspace", "workspaces")
+                    .column("subject", PublicColumnType::Uuid),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("blocks")
+                    .fk_column("workspace", "workspaces")
+                    .column("owner", PublicColumnType::Uuid),
+            )
+            .table(
+                PublicTableSchemaBuilder::new("tasks")
+                    .fk_column("block", "blocks")
+                    .policies(policies),
+            )
+            .build()
+    };
 
-    let error = crate::schema::JazzSchema::new(&public)
-        .expect_err("multiple join conditions must fail closed instead of dropping one");
-    assert_eq!(
-        error.to_string(),
-        "$.tasks.policies.insert.with_check: core schema ExistsRel joins support exactly one column equality"
-    );
+    // Read and each write clause use distinct schema-conversion paths. The
+    // boolean forms prove that compound joins cannot be hidden in And, Or, or
+    // Not before runtime policy evaluation.
+    for (context, policies, expected_path) in [
+        (
+            "read query",
+            PublicTablePolicies::new().with_select(PublicPolicyExpr::And(vec![
+                PublicPolicyExpr::True,
+                policy.clone(),
+            ])),
+            "policies.select.using.And[1]",
+        ),
+        (
+            "insert check",
+            PublicTablePolicies::new().with_insert(PublicPolicyExpr::Or(vec![
+                PublicPolicyExpr::False,
+                policy.clone(),
+            ])),
+            "policies.insert.with_check.Or[1]",
+        ),
+        (
+            "update using",
+            PublicTablePolicies::new().with_update(
+                Some(PublicPolicyExpr::Not(Box::new(policy.clone()))),
+                PublicPolicyExpr::True,
+            ),
+            "policies.update.using.Not",
+        ),
+        (
+            "update check",
+            PublicTablePolicies::new().with_update(None, policy.clone()),
+            "policies.update.with_check",
+        ),
+        (
+            "delete using",
+            PublicTablePolicies::new().with_delete(policy.clone()),
+            "policies.delete.using",
+        ),
+    ] {
+        let error = crate::schema::JazzSchema::new(&schema_with(policies))
+            .expect_err("compound equality must fail closed before runtime evaluation");
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "$.tasks.{expected_path}: core schema ExistsRel joins support exactly one column equality"
+            ),
+            "{context} must reject the compound join at schema admission",
+        );
+    }
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
+++ b/crates/jazz/src/node/tests/policies_rls/write_authorization.rs
@@ -1431,6 +1431,76 @@ fn exists_rel_rejects_nested_outer_correlation_off_the_join_key() {
 }
 
 #[test]
+fn exists_rel_rejects_multiple_join_conditions_in_write_policy() {
+    let column = |scope: &str, name: &str| PublicRelColumnRef {
+        scope: Some(scope.to_owned()),
+        column: name.to_owned(),
+    };
+    let policy = PublicPolicyExpr::ExistsRel {
+        rel: PublicRelExpr::Filter {
+            input: Box::new(PublicRelExpr::Join {
+                left: Box::new(PublicRelExpr::TableScan {
+                    table: "blocks".into(),
+                    alias: Some("blocks".to_owned()),
+                }),
+                right: Box::new(PublicRelExpr::Filter {
+                    input: Box::new(PublicRelExpr::TableScan {
+                        table: "members".into(),
+                        alias: Some("members".to_owned()),
+                    }),
+                    predicate: PublicRelPredicateExpr::Cmp {
+                        left: column("members", "subject"),
+                        op: PublicRelPredicateCmpOp::Eq,
+                        right: PublicRelValueRef::SessionRef(vec!["user_id".to_owned()]),
+                    },
+                }),
+                on: vec![
+                    PublicRelJoinCondition {
+                        left: column("blocks", "workspace"),
+                        right: column("members", "workspace"),
+                    },
+                    PublicRelJoinCondition {
+                        left: column("blocks", "owner"),
+                        right: column("members", "subject"),
+                    },
+                ],
+                join_kind: PublicRelJoinKind::Inner,
+            }),
+            predicate: PublicRelPredicateExpr::Cmp {
+                left: column("blocks", "id"),
+                op: PublicRelPredicateCmpOp::Eq,
+                right: PublicRelValueRef::OuterColumn(PublicRelColumnRef::unscoped("block")),
+            },
+        },
+    };
+    let public = PublicSchemaBuilder::new()
+        .table(PublicTableSchemaBuilder::new("workspaces"))
+        .table(
+            PublicTableSchemaBuilder::new("members")
+                .fk_column("workspace", "workspaces")
+                .column("subject", PublicColumnType::Uuid),
+        )
+        .table(
+            PublicTableSchemaBuilder::new("blocks")
+                .fk_column("workspace", "workspaces")
+                .column("owner", PublicColumnType::Uuid),
+        )
+        .table(
+            PublicTableSchemaBuilder::new("tasks")
+                .fk_column("block", "blocks")
+                .policies(PublicTablePolicies::new().with_insert(policy)),
+        )
+        .build();
+
+    let error = crate::schema::JazzSchema::new(&public)
+        .expect_err("multiple join conditions must fail closed instead of dropping one");
+    assert_eq!(
+        error.to_string(),
+        "$.tasks.policies.insert.with_check: core schema ExistsRel joins support exactly one column equality"
+    );
+}
+
+#[test]
 fn exists_rel_fails_closed_for_outer_correlation_beyond_one_nested_join() {
     let column = |scope: &str, name: &str| PublicRelColumnRef {
         scope: Some(scope.to_owned()),

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -932,6 +932,10 @@ fn convert_policy_with_native_select_inherits(
     expr: &PolicyExpr,
     native_select_inherits: bool,
 ) -> Result<Query, SchemaConversionError> {
+    // Do this before choosing a lowering path. In particular, an ExistsRel
+    // nested below a boolean operator must not escape this validation merely
+    // because that operator is rejected by a later lowering stage.
+    validate_exists_rel_policy_join_conditions(table, path, expr)?;
     match expr {
         PolicyExpr::And(exprs) => {
             if !exprs.iter().any(is_core_policy_clause) {
@@ -1459,13 +1463,46 @@ fn validate_exists_rel_join_conditions(
     }
 }
 
+fn validate_exists_rel_policy_join_conditions(
+    table: &TableName,
+    path: &str,
+    expr: &PolicyExpr,
+) -> Result<(), SchemaConversionError> {
+    match expr {
+        PolicyExpr::ExistsRel { rel } => validate_exists_rel_join_conditions(table, path, rel),
+        PolicyExpr::And(exprs) => {
+            for (index, expr) in exprs.iter().enumerate() {
+                validate_exists_rel_policy_join_conditions(
+                    table,
+                    &format!("{path}.And[{index}]"),
+                    expr,
+                )?;
+            }
+            Ok(())
+        }
+        PolicyExpr::Or(exprs) => {
+            for (index, expr) in exprs.iter().enumerate() {
+                validate_exists_rel_policy_join_conditions(
+                    table,
+                    &format!("{path}.Or[{index}]"),
+                    expr,
+                )?;
+            }
+            Ok(())
+        }
+        PolicyExpr::Not(expr) => {
+            validate_exists_rel_policy_join_conditions(table, &format!("{path}.Not"), expr)
+        }
+        _ => Ok(()),
+    }
+}
+
 fn append_exists_rel_policy_clause(
     table: &TableName,
     path: &str,
     mut query: Query,
     rel: &RelExpr,
 ) -> Result<Query, SchemaConversionError> {
-    validate_exists_rel_join_conditions(table, path, rel)?;
     let mut lowered = lower_exists_rel(table, path, rel)?;
     let correlation_index = lowered
         .filters

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -1424,12 +1424,48 @@ struct LoweredRel {
     pending_reachable: Option<PendingReachable>,
 }
 
+fn validate_exists_rel_join_conditions(
+    table: &TableName,
+    path: &str,
+    rel: &RelExpr,
+) -> Result<(), SchemaConversionError> {
+    match rel {
+        RelExpr::TableScan { .. } => Ok(()),
+        RelExpr::Filter { input, .. } | RelExpr::Project { input, .. } => {
+            validate_exists_rel_join_conditions(table, path, input)
+        }
+        RelExpr::Union { inputs } => {
+            for input in inputs {
+                validate_exists_rel_join_conditions(table, path, input)?;
+            }
+            Ok(())
+        }
+        RelExpr::Join {
+            left, right, on, ..
+        } => {
+            if on.len() > 1 {
+                return Err(err(
+                    format!("$.{}.{}", table.as_str(), path),
+                    "core schema ExistsRel joins support exactly one column equality",
+                ));
+            }
+            validate_exists_rel_join_conditions(table, path, left)?;
+            validate_exists_rel_join_conditions(table, path, right)
+        }
+        RelExpr::Gather { seed, step, .. } => {
+            validate_exists_rel_join_conditions(table, path, seed)?;
+            validate_exists_rel_join_conditions(table, path, step)
+        }
+    }
+}
+
 fn append_exists_rel_policy_clause(
     table: &TableName,
     path: &str,
     mut query: Query,
     rel: &RelExpr,
 ) -> Result<Query, SchemaConversionError> {
+    validate_exists_rel_join_conditions(table, path, rel)?;
     let mut lowered = lower_exists_rel(table, path, rel)?;
     let correlation_index = lowered
         .filters


### PR DESCRIPTION
🤖 Reject compound `ExistsRel` joins during schema admission instead of silently lowering only their first equality.

## Before

The current core representation supports exactly one equality per relation join. A public policy could nevertheless provide two:

```text
membership.workspace = grant.workspace
AND membership.subject = grant.subject
```

Lowering could retain only the workspace equality. The resulting policy would authorize rows for the wrong subject.

The compound join could also be nested below another join or hidden inside `And`, `Or`, or `Not`, reaching different read/write conversion paths.

## After

- One recursive pre-lowering validator walks the complete relation tree and every policy boolean wrapper.
- Any join whose condition count is not exactly one fails with a contextual schema path before query/runtime evaluation.
- The same rule applies to read/select, insert check, update using/check, and delete using.
- Existing supported one-hop correlated `ExistsRel` and gather-based lowering remain unchanged.

## Verification

- A nested aliased compound join is rejected in all five public policy contexts.
- Existing valid insert/update and gather-based `ExistsRel` receipts pass.
- A planted mutation allowing two equalities makes the schema-admission receipt fail by accepting the malformed policy.
- Focused Rust tests, formatting, and clippy pass.

