### PR TITLE
Share the portable ordered-KV conformance contract

### DIFF
--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -161,8 +161,9 @@ shared `JSM1` manifest. IndexedDB currently validates its adapter-private
 manifest; therefore it is not covered by the epoch-1 physical-open receipt.
 That remaining acceptance item stays explicitly tracked by #2160.
 
-The only ordering property groove requires from the backing store is
-lexicographic byte order. A range `ScanRequest` returns keys in that order and
+The only ordering property groove requires from the backing store is unsigned
+lexicographic byte order: bytes compare as `0x00 < ... < 0xff`, never as signed
+integers, locale text, or a backend-native collation. A range `ScanRequest` returns keys in that order and
 includes keys `>= start` while excluding keys `>= end` (`INV-STORAGE-1`). Batch
 writes are atomic: `write_many` applies every operation in the batch or none of
 them; if any operation is invalid, no operation partially applies
@@ -227,6 +228,14 @@ bound. `INV-STORAGE-29` — an explicit scan limit applies across all cursor
 batches and stops physical traversal rather than merely truncating a materialized
 result. `INV-STORAGE-5` (prov) — `ReopenableStorage::reopen` preserves existing
 data while adding newly requested families.
+
+For a finite prefix bound, the exclusive upper key is the exact unsigned-byte
+successor: increment the rightmost byte below `0xff` and truncate every later
+byte. Thus `[0x12, 0xff]` has upper bound `[0x13]`; an all-`0xff` prefix has no
+finite upper bound and must be filtered by its prefix predicate through the end
+of the family. Raw storage cursors are not snapshots: concurrent writes may
+affect later cursor batches. Repeatable evaluation is a higher-level session
+guarantee and is intentionally not imposed on this backend seam.
 
 ### Column-family namespace admission
 

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -160,6 +160,9 @@ shared `JSM1` manifest. IndexedDB currently validates its adapter-private
 `jazz-idb-tree` page metadata but does not yet persist the shared epoch
 manifest; therefore it is not covered by the epoch-1 physical-open receipt.
 That remaining acceptance item stays explicitly tracked by #2160.
+The ordered-KV conformance receipt currently exercises `IdbStorage` with
+`MemoryPageStore`; it does not claim a browser IndexedDB/OPFS receipt. Browser
+physical-open and persistence coverage remains part of #2160.
 
 The only ordering property groove requires from the backing store is unsigned
 lexicographic byte order: bytes compare as `0x00 < ... < 0xff`, never as signed

--- a/crates/groove/src/storage/idb.rs
+++ b/crates/groove/src/storage/idb.rs
@@ -711,7 +711,8 @@ mod tests {
 
     // Storage-level conformance is intentionally tested here because ordering,
     // atomic encoded batches, and reopen are backend contracts below Jazz's
-    // public schema/query surface.
+    // public schema/query surface. MemoryPageStore exercises the IDB adapter
+    // protocol, not a browser IndexedDB/OPFS physical-store receipt (#2160).
     #[test]
     fn conforms_to_order_atomicity_and_reopen_contracts() {
         futures::executor::block_on(async {

--- a/crates/groove/src/storage/idb.rs
+++ b/crates/groove/src/storage/idb.rs
@@ -10,7 +10,8 @@ use idb_tree::{IdbTree, Options, PageStore, WriteOperation};
 
 use super::{
     ColumnFamilyName, Error, Key, OrderedKvStorage, OwnedWriteOperation, ReadyStorageCursor,
-    ScanBounds, ScanDirection, ScanRequest, StorageFuture, StorageScan, Value, key_codec,
+    ScanBounds, ScanDirection, ScanRequest, StorageFuture, StorageScan, Value, WriteManyOutcome,
+    key_codec,
 };
 
 // A noisy neighbouring tab must not turn a single logical write into an
@@ -351,7 +352,7 @@ where
                 }
                 ScanBounds::Prefix(prefix) => {
                     let start = self.encoded_key(&cf, &prefix)?;
-                    let end = key_codec::prefix_upper_bound(&start).unwrap_or_else(|| vec![0xff]);
+                    let end = super::prefix_successor(&start).unwrap_or_else(|| vec![0xff]);
                     (start, end)
                 }
             };
@@ -374,7 +375,7 @@ where
             let _guard = self.mutation_gate.lock().await;
             self.ensure_ready().await?;
             let start = self.encoded_key(&cf, &prefix)?;
-            let end = key_codec::prefix_upper_bound(&start).unwrap_or_else(|| vec![0xff]);
+            let end = super::prefix_successor(&start).unwrap_or_else(|| vec![0xff]);
             let row = self
                 .tree()
                 .range_reverse(&start, &end, 1)
@@ -421,6 +422,21 @@ where
             self.ensure_ready().await?;
             self.write_many_replaying_generation_conflicts(&operations)
                 .await
+        })
+    }
+
+    fn write_many_outcome(
+        &self,
+        operations: Vec<OwnedWriteOperation>,
+    ) -> StorageFuture<'_, WriteManyOutcome> {
+        Box::pin(async move {
+            if let Err(error) = self.prevalidate_write_many(&operations) {
+                return WriteManyOutcome::Uncommitted(error);
+            }
+            match self.write_many(operations).await {
+                Ok(()) => WriteManyOutcome::Committed,
+                Err(error) => WriteManyOutcome::PossiblyCommitted(error),
+            }
         })
     }
 
@@ -707,6 +723,7 @@ mod tests {
                 storage.clone(),
             )
             .await;
+            super::super::conformance::invalid_batch_is_proven_uncommitted(storage.clone()).await;
             super::super::conformance::reopen_preserves_data_and_adds_families(storage).await;
         });
     }

--- a/crates/groove/src/storage/memory.rs
+++ b/crates/groove/src/storage/memory.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use super::{
     ColumnFamilyName, Error, KeyValue, OrderedKvStorage, OwnedWriteOperation, ReopenableStorage,
     ScanBounds, ScanDirection, ScanRequest, StorageFuture, StorageScan, Value, WriteManyOutcome,
-    key_codec,
 };
 
 const MEMORY_STORAGE_SNAPSHOT_VERSION: u16 = 1;
@@ -59,7 +58,7 @@ impl MemoryStorageCursor {
                     .collect(),
                 (ScanBounds::Prefix(prefix), ScanDirection::Reverse, None) => {
                     let start = Bound::Included(prefix.clone());
-                    let end = key_codec::prefix_upper_bound(prefix)
+                    let end = super::prefix_successor(prefix)
                         .map(Bound::Excluded)
                         .unwrap_or(Bound::Unbounded);
                     values
@@ -347,7 +346,7 @@ impl OrderedKvStorage for MemoryStorage {
     ) -> StorageFuture<'_, Result<Option<super::KeyValue>, Error>> {
         Box::pin(async move {
             self.with_cf(&cf, |values| {
-                if let Some(upper) = key_codec::prefix_upper_bound(&prefix) {
+                if let Some(upper) = super::prefix_successor(&prefix) {
                     values
                         .range(prefix..upper)
                         .next_back()

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -43,6 +43,16 @@ pub type Key = [u8];
 pub type Value = Vec<u8>;
 pub type KeyValue = (Vec<u8>, Vec<u8>);
 
+/// Return the smallest unsigned-lexicographic key strictly after every key
+/// beginning with `prefix`.
+///
+/// `[0x12, 0xff]` therefore has successor `[0x13]`. A prefix consisting only
+/// of `0xff` has no finite successor; scans must retain their prefix predicate
+/// while traversing to the end of the column family.
+pub fn prefix_successor(prefix: &[u8]) -> Option<Vec<u8>> {
+    key_codec::increment_bytes(prefix)
+}
+
 /// Maximum UTF-8 byte length of an application-owned storage name.
 ///
 /// The bound is part of the cross-backend storage contract: IndexedDB frames
@@ -1965,11 +1975,15 @@ impl From<crate::records::Error> for Error {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod conformance {
+/// Backend-neutral ordered-KV conformance scenarios.
+///
+/// These test the raw storage seam. Raw cursors are deliberately non-snapshot:
+/// stable repeatable evaluation belongs to the higher-level evaluator.
+#[cfg(any(test, feature = "test"))]
+pub mod conformance {
     use super::*;
 
-    pub(crate) async fn persistence_order_and_batch_atomicity<S>(storage: S)
+    pub async fn persistence_order_and_batch_atomicity<S>(storage: S)
     where
         S: OrderedKvStorage,
     {
@@ -2015,8 +2029,16 @@ pub(crate) mod conformance {
 
         let error = storage
             .write_many(vec![
-                OwnedWriteOperation::set("records", b"user:3", b"three"),
-                OwnedWriteOperation::set("missing", b"user:4", b"four"),
+                OwnedWriteOperation::Set {
+                    cf: "records".into(),
+                    key: b"user:3".to_vec(),
+                    value: b"three".to_vec(),
+                },
+                OwnedWriteOperation::Set {
+                    cf: "missing".into(),
+                    key: b"user:4".to_vec(),
+                    value: b"four".to_vec(),
+                },
             ])
             .await
             .unwrap_err();
@@ -2031,8 +2053,15 @@ pub(crate) mod conformance {
 
         storage
             .write_many(vec![
-                OwnedWriteOperation::set("records", b"user:3", b"three"),
-                OwnedWriteOperation::delete("records", b"user:2"),
+                OwnedWriteOperation::Set {
+                    cf: "records".into(),
+                    key: b"user:3".to_vec(),
+                    value: b"three".to_vec(),
+                },
+                OwnedWriteOperation::Delete {
+                    cf: "records".into(),
+                    key: b"user:2".to_vec(),
+                },
             ])
             .await
             .unwrap();
@@ -2049,7 +2078,7 @@ pub(crate) mod conformance {
         );
     }
 
-    pub(crate) async fn reopen_preserves_data_and_adds_families<S>(storage: S)
+    pub async fn reopen_preserves_data_and_adds_families<S>(storage: S)
     where
         S: ReopenableStorage + 'static,
     {
@@ -2080,7 +2109,7 @@ pub(crate) mod conformance {
         );
     }
 
-    pub(crate) async fn atomic_conditionals_preserve_winners_and_reject_stale_deletes<S>(storage: S)
+    pub async fn atomic_conditionals_preserve_winners_and_reject_stale_deletes<S>(storage: S)
     where
         S: OrderedKvStorage,
     {
@@ -2131,6 +2160,26 @@ pub(crate) mod conformance {
             Some(b"reinstalled".to_vec())
         );
     }
+
+    /// Invalid operations are rejected before an atomic submission begins.
+    /// This is intentionally below the public database API: only an adapter
+    /// can prove the pre-commit acknowledgement classification.
+    pub async fn invalid_batch_is_proven_uncommitted<S>(storage: S)
+    where
+        S: OrderedKvStorage,
+    {
+        let outcome = storage
+            .write_many_outcome(vec![OwnedWriteOperation::Set {
+                cf: "missing".into(),
+                key: b"key".to_vec(),
+                value: b"value".to_vec(),
+            }])
+            .await;
+        assert!(matches!(
+            outcome,
+            WriteManyOutcome::Uncommitted(Error::ColumnFamilyNotFound(name)) if name == "missing"
+        ));
+    }
 }
 
 #[cfg(test)]
@@ -2145,6 +2194,12 @@ mod tests {
             validate_physical_storage_name(&"a".repeat(MAX_APPLICATION_STORAGE_NAME_BYTES + 1))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn prefix_successor_is_the_exact_unsigned_lexicographic_bound() {
+        assert_eq!(prefix_successor(&[0x12, 0xff]), Some(vec![0x13]));
+        assert_eq!(prefix_successor(&[0xff, 0xff]), None);
     }
     use crate::records::{ScalarEnumSchema, Value, ValueType};
     use std::cell::Cell;
@@ -3665,10 +3720,10 @@ mod tests {
 
     #[futures_test::test]
     async fn memory_storage_conditionals_are_atomic_and_aba_safe() {
-        conformance::atomic_conditionals_preserve_winners_and_reject_stale_deletes(
-            MemoryStorage::new(&["records"]).expect("valid memory storage families"),
-        )
-        .await;
+        let storage = MemoryStorage::new(&["records"]).expect("valid memory storage families");
+        conformance::atomic_conditionals_preserve_winners_and_reject_stale_deletes(storage.clone())
+            .await;
+        conformance::invalid_batch_is_proven_uncommitted(storage).await;
     }
 
     #[futures_test::test]

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -2007,6 +2007,15 @@ pub mod conformance {
             .set("records".into(), vec![0xff, 0x01], b"ff-one".to_vec())
             .await
             .unwrap();
+        for (key, value) in [
+            (vec![0x12, 0xfe], b"interior-before".to_vec()),
+            (vec![0x12, 0xff], b"interior-root".to_vec()),
+            (vec![0x12, 0xff, 0x00], b"interior-zero".to_vec()),
+            (vec![0x12, 0xff, 0xff], b"interior-ff".to_vec()),
+            (vec![0x13, 0x00], b"interior-after".to_vec()),
+        ] {
+            storage.set("records".into(), key, value).await.unwrap();
+        }
 
         assert_eq!(
             storage
@@ -2024,6 +2033,65 @@ pub mod conformance {
             vec![
                 (vec![0xff, 0x00], b"ff-zero".to_vec()),
                 (vec![0xff, 0x01], b"ff-one".to_vec()),
+            ]
+        );
+        assert_eq!(
+            collect_scan(
+                storage
+                    .scan(ScanRequest::prefix("records".into(), Vec::new()))
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+            vec![
+                (vec![0x12, 0xfe], b"interior-before".to_vec()),
+                (vec![0x12, 0xff], b"interior-root".to_vec()),
+                (vec![0x12, 0xff, 0x00], b"interior-zero".to_vec()),
+                (vec![0x12, 0xff, 0xff], b"interior-ff".to_vec()),
+                (vec![0x13, 0x00], b"interior-after".to_vec()),
+                (b"user:1".to_vec(), b"one".to_vec()),
+                (b"user:10".to_vec(), b"ten".to_vec()),
+                (b"user:2".to_vec(), b"two".to_vec()),
+                (vec![0xff, 0x00], b"ff-zero".to_vec()),
+                (vec![0xff, 0x01], b"ff-one".to_vec()),
+            ]
+        );
+        assert_eq!(
+            collect_scan(
+                storage
+                    .scan(
+                        ScanRequest::prefix("records".into(), vec![0x12, 0xff])
+                            .reversed()
+                            .with_max_items(2),
+                    )
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+            vec![
+                (vec![0x12, 0xff, 0xff], b"interior-ff".to_vec()),
+                (vec![0x12, 0xff, 0x00], b"interior-zero".to_vec()),
+            ]
+        );
+        assert_eq!(
+            collect_scan(
+                storage
+                    .scan(
+                        ScanRequest::prefix("records".into(), Vec::new())
+                            .reversed()
+                            .with_max_items(3),
+                    )
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+            vec![
+                (vec![0xff, 0x01], b"ff-one".to_vec()),
+                (vec![0xff, 0x00], b"ff-zero".to_vec()),
+                (b"user:2".to_vec(), b"two".to_vec()),
             ]
         );
 

--- a/crates/jazz-storage-rocksdb/Cargo.toml
+++ b/crates/jazz-storage-rocksdb/Cargo.toml
@@ -12,6 +12,7 @@ rocksdb = { package = "rust-rocksdb", version = "0.48.0", default-features = fal
 serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
+groove = { workspace = true, features = ["test"] }
 tempfile = "3.27.0"
 futures-test = "0.3"
 jazz-benchmark-guard = { path = "../benchmark-guard" }

--- a/crates/jazz-storage-rocksdb/src/lib.rs
+++ b/crates/jazz-storage-rocksdb/src/lib.rs
@@ -24,7 +24,8 @@ use serde::Serialize;
 use groove::storage::{
     BoxedStorage, ColumnFamilyName, Error, KeyValue, OrderedKvStorage, OwnedWriteOperation,
     ReopenableStorage, ScanBounds, ScanDirection, ScanRequest, StorageCursor, StorageEpochManifest,
-    StorageFactory, StorageFuture, StorageScan, Value, validate_physical_storage_names,
+    StorageFactory, StorageFuture, StorageScan, Value, WriteManyOutcome,
+    validate_physical_storage_names,
 };
 
 trait RocksResultExt<T> {
@@ -817,9 +818,7 @@ impl OrderedKvStorage for RocksDbStorage {
             let (start, upper_bound, prefix) = match bounds {
                 ScanBounds::Range { start, end } => (start, Some(end), None),
                 ScanBounds::Prefix(prefix) => {
-                    let mut upper_bound = prefix.clone();
-                    let upper_bound =
-                        advance_prefix_upper_bound(&mut upper_bound).then_some(upper_bound);
+                    let upper_bound = groove::storage::prefix_successor(&prefix);
                     (prefix.clone(), upper_bound, Some(prefix))
                 }
             };
@@ -921,21 +920,32 @@ impl OrderedKvStorage for RocksDbStorage {
         })
     }
 
+    fn write_many_outcome(
+        &self,
+        operations: Vec<OwnedWriteOperation>,
+    ) -> StorageFuture<'_, WriteManyOutcome> {
+        Box::pin(async move {
+            for operation in &operations {
+                let cf = match operation {
+                    OwnedWriteOperation::Set { cf, .. }
+                    | OwnedWriteOperation::Delete { cf, .. } => cf,
+                };
+                if cf != "default"
+                    && let Err(error) = self.cf_handle(cf)
+                {
+                    return WriteManyOutcome::Uncommitted(error);
+                }
+            }
+            match self.write_many(operations).await {
+                Ok(()) => WriteManyOutcome::Committed,
+                Err(error) => WriteManyOutcome::PossiblyCommitted(error),
+            }
+        })
+    }
+
     fn column_family_names(&self) -> Option<Vec<String>> {
         Some(self.column_families.iter().cloned().collect())
     }
-}
-
-fn advance_prefix_upper_bound(prefix: &mut [u8]) -> bool {
-    for byte in prefix.iter_mut().rev() {
-        if *byte != u8::MAX {
-            *byte += 1;
-            return true;
-        }
-        *byte = 0;
-    }
-
-    false
 }
 
 #[cfg(test)]
@@ -1310,6 +1320,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let rocks = RocksDbStorage::open(dir.path(), &["records"]).unwrap();
         let memory = MemoryStorage::new(&["records"]).expect("valid memory storage families");
+        ready(groove::storage::conformance::persistence_order_and_batch_atomicity(&rocks));
+        ready(
+            groove::storage::conformance::atomic_conditionals_preserve_winners_and_reject_stale_deletes(
+                &rocks,
+            ),
+        );
+        ready(groove::storage::conformance::invalid_batch_is_proven_uncommitted(&rocks));
         assert_eq!(
             ready(rocks.put_if_absent(
                 "records".to_owned(),
@@ -1419,6 +1436,13 @@ mod tests {
             ready(reopened.get("records".to_owned(), b"must-not-leak".to_vec())).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn generic_reopen_conformance_preserves_data_and_adds_families() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = RocksDbStorage::open(dir.path(), &["records"]).unwrap();
+        ready(groove::storage::conformance::reopen_preserves_data_and_adds_families(storage));
     }
 
     #[test]

--- a/crates/jazz-storage-sqlite/Cargo.toml
+++ b/crates/jazz-storage-sqlite/Cargo.toml
@@ -8,5 +8,6 @@ groove.workspace = true
 rusqlite = { version = "0.34", features = ["bundled"] }
 
 [dev-dependencies]
+groove = { workspace = true, features = ["test"] }
 futures = "0.3"
 tempfile = "3.27.0"

--- a/crates/jazz-storage-sqlite/src/lib.rs
+++ b/crates/jazz-storage-sqlite/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use groove::storage::{
     Error, KeyValue, OrderedKvStorage, OwnedWriteOperation, ReopenableStorage, ScanBounds,
     ScanDirection, ScanRequest, StorageCursor, StorageEpochManifest, StorageFactory, StorageFuture,
-    StorageScan, Value, validate_physical_storage_names,
+    StorageScan, Value, WriteManyOutcome, validate_physical_storage_names,
 };
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
@@ -702,7 +702,7 @@ impl OrderedKvStorage for SqliteStorage {
             } = request;
             let (start, end) = match bounds {
                 ScanBounds::Prefix(prefix) => {
-                    let end = prefix_upper_bound(&prefix);
+                    let end = groove::storage::prefix_successor(&prefix);
                     (prefix, end)
                 }
                 ScanBounds::Range { start, end } => (start, Some(end)),
@@ -826,6 +826,27 @@ impl OrderedKvStorage for SqliteStorage {
         })
     }
 
+    fn write_many_outcome(
+        &self,
+        operations: Vec<OwnedWriteOperation>,
+    ) -> StorageFuture<'_, WriteManyOutcome> {
+        Box::pin(async move {
+            for operation in &operations {
+                let cf = match operation {
+                    OwnedWriteOperation::Set { cf, .. }
+                    | OwnedWriteOperation::Delete { cf, .. } => cf,
+                };
+                if let Err(error) = self.cf_id(cf) {
+                    return WriteManyOutcome::Uncommitted(error);
+                }
+            }
+            match self.write_many(operations).await {
+                Ok(()) => WriteManyOutcome::Committed,
+                Err(error) => WriteManyOutcome::PossiblyCommitted(error),
+            }
+        })
+    }
+
     fn column_family_names(&self) -> Option<Vec<String>> {
         Some(self.column_families.borrow().keys().cloned().collect())
     }
@@ -843,17 +864,6 @@ fn backend(error: impl std::fmt::Display) -> Error {
         backend: "sqlite",
         message: error.to_string(),
     }
-}
-
-fn prefix_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
-    let mut result = prefix.to_vec();
-    while let Some(last) = result.pop() {
-        if last != u8::MAX {
-            result.push(last + 1);
-            return Some(result);
-        }
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/jazz-storage-sqlite/tests/ordered_kv.rs
+++ b/crates/jazz-storage-sqlite/tests/ordered_kv.rs
@@ -1,7 +1,5 @@
 use futures::executor::block_on;
-use groove::storage::{
-    Error, OrderedKvStorage, OwnedWriteOperation, ReopenableStorage, ScanRequest, collect_scan,
-};
+use groove::storage::{Error, OrderedKvStorage, ScanRequest, collect_scan};
 use jazz_storage_sqlite::SqliteStorage;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
@@ -112,67 +110,10 @@ fn ordered_prefix_range_atomic_batch_and_reopen_contract() {
     block_on(async {
         let dir = tempfile::tempdir().unwrap();
         let storage = open(&dir);
-        storage
-            .set("records".into(), b"user:2".to_vec(), b"two".to_vec())
-            .await
-            .unwrap();
-        storage
-            .set("records".into(), b"user:10".to_vec(), b"ten".to_vec())
-            .await
-            .unwrap();
-        storage
-            .set("records".into(), b"user:1".to_vec(), b"one".to_vec())
-            .await
-            .unwrap();
-        assert_eq!(
-            storage
-                .prefix("records".into(), b"user:".to_vec())
-                .await
-                .unwrap(),
-            vec![
-                (b"user:1".to_vec(), b"one".to_vec()),
-                (b"user:10".to_vec(), b"ten".to_vec()),
-                (b"user:2".to_vec(), b"two".to_vec()),
-            ]
-        );
-        let error = storage
-            .write_many(vec![
-                OwnedWriteOperation::Set {
-                    cf: "records".into(),
-                    key: b"user:3".to_vec(),
-                    value: b"three".to_vec(),
-                },
-                OwnedWriteOperation::Set {
-                    cf: "missing".into(),
-                    key: b"user:4".to_vec(),
-                    value: b"four".to_vec(),
-                },
-            ])
-            .await
-            .unwrap_err();
-        assert!(matches!(error, Error::ColumnFamilyNotFound(name) if name == "missing"));
-        assert_eq!(
-            storage
-                .get("records".into(), b"user:3".to_vec())
-                .await
-                .unwrap(),
-            None
-        );
-        let storage = storage
-            .reopen(vec!["records".into(), "indices".into()])
-            .await
-            .unwrap();
-        storage
-            .set("indices".into(), b"name:one".to_vec(), b"1".to_vec())
-            .await
-            .unwrap();
-        assert_eq!(
-            storage
-                .get("records".into(), b"user:1".to_vec())
-                .await
-                .unwrap(),
-            Some(b"one".to_vec())
-        );
+        groove::storage::conformance::persistence_order_and_batch_atomicity(&storage).await;
+        groove::storage::conformance::atomic_conditionals_preserve_winners_and_reject_stale_deletes(&storage).await;
+        groove::storage::conformance::invalid_batch_is_proven_uncommitted(&storage).await;
+        groove::storage::conformance::reopen_preserves_data_and_adds_families(storage).await;
     });
 }
 


### PR DESCRIPTION
🤖 Advances #1774 by making every current ordered-KV adapter exercise one shared semantic contract instead of maintaining subtly different scan/batch behavior.

## Before

SQLite and RocksDB duplicated prefix-bound calculations, backend receipts covered different cases, and a pre-commit invalid batch could be reported less precisely than its proven `Uncommitted` outcome.

## After

- One unsigned-lexicographic `prefix_successor` contract drives bounded prefix scans.
- Memory, SQLite, RocksDB, and the IDB adapter over `MemoryPageStore` share ordering, bounds, reverse, limit, atomic-batch, and reopen conformance.
- Empty prefixes, all-`0xff`, and interior-`0xff` prefixes such as `[0x12, 0xff]` are explicit receipts.
- Invalid batches detected before adapter submission report `Uncommitted`; errors after submission remain conservatively `PossiblyCommitted`.
- Raw cursors are intentionally non-snapshot. Stable evaluation/window semantics remain a higher-layer responsibility.

For example, reverse-scanning `[0x12, 0xff]` with a limit of two returns only the last two keys in that exact prefix and never spills into the adjacent `[0x13]` namespace.

## Scope and residual

The IDB receipt here exercises `IdbStorage` over the in-memory page store; it does not claim browser IndexedDB/OPFS physical persistence. That missing physical epoch/reopen boundary remains #2160.

## Verification

- exact shared conformance selections for Memory, IDB adapter, SQLite, and RocksDB
- started-write cancellation lifecycle receipts with the required feature enabled
- independent planted `prefix_successor` regressions were caught by both exact-bound and interior-`0xff` adapter receipts
- Clippy, formatting, and sensitive-data gates
