### PR TITLE
Pin native record byte receipts

### DIFF
--- a/crates/jazz-storage-rocksdb/tests/plain_row_receipt.rs
+++ b/crates/jazz-storage-rocksdb/tests/plain_row_receipt.rs
@@ -29,6 +29,21 @@ fn schema() -> DatabaseSchema {
     .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
 }
 
+fn epoch_1_codec_fixture_schema() -> DatabaseSchema {
+    // Declaration order is deliberately variable-before-fixed. The frozen
+    // stored bytes below prove that every durable backend shares Groove's
+    // physical fixed-first record layout without changing public row order.
+    DatabaseSchema::new([TableSchema::new(
+        "records",
+        [
+            ColumnSchema::new("label", ColumnType::String),
+            ColumnSchema::new("id", ColumnType::U16),
+            ColumnSchema::new("enabled", ColumnType::Bool),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U16))])
+}
+
 fn row(id: u64, revision: u64) -> VariantRecord {
     let schema = schema();
     let descriptor = schema.table("rows").unwrap().record_schema();
@@ -227,6 +242,90 @@ fn checksum_is_sensitive_to_returned_row_content() {
         checksum_record(&row(7, 0)).unwrap(),
         checksum_record(&row(7, 1)).unwrap()
     );
+}
+
+#[futures_test::test]
+async fn epoch_1_table_row_bytes_and_order_survive_a_fresh_rocksdb_open() {
+    let directory = tempfile::tempdir().unwrap();
+    let schema = epoch_1_codec_fixture_schema();
+    let mut database = Database::new(
+        schema.clone(),
+        RocksDbStorage::open(directory.path(), &["records"]).unwrap(),
+    )
+    .await
+    .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "records",
+        vec![
+            Value::String("a".to_owned()),
+            Value::U16(2),
+            Value::Bool(false),
+        ],
+    );
+    batch.insert(
+        "records",
+        vec![
+            Value::String("hi".to_owned()),
+            Value::U16(0x1234),
+            Value::Bool(true),
+        ],
+    );
+    let applied = database.apply_batch(batch).await.unwrap();
+    let persisted = applied.persist().await;
+    database.finish_persistence(persisted).unwrap();
+    drop(applied);
+
+    let storage = database.into_storage();
+    assert_eq!(
+        storage
+            .prefix("records".to_owned(), Vec::new())
+            .await
+            .unwrap(),
+        vec![
+            (
+                vec![0x01, 0x00, 0x02],
+                vec![0x00, 0x02, 0x00, 0x00, 0x02, b'a'],
+            ),
+            (
+                vec![0x01, 0x12, 0x34],
+                vec![0x00, 0x34, 0x12, 0x01, 0x02, b'h', b'i'],
+            ),
+        ],
+        "RocksDB must retain lexicographic U16 key order and canonical variant-tagged, fixed-first record bytes",
+    );
+    storage.close().await.unwrap();
+    drop(storage);
+
+    let reopened = Database::new(
+        schema,
+        RocksDbStorage::open(directory.path(), &["records"]).unwrap(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        reopened
+            .primary_key_scan("records", &[])
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|record| record.to_values().unwrap())
+            .collect::<Vec<_>>(),
+        vec![
+            vec![
+                Value::String("a".to_owned()),
+                Value::U16(2),
+                Value::Bool(false),
+            ],
+            vec![
+                Value::String("hi".to_owned()),
+                Value::U16(0x1234),
+                Value::Bool(true),
+            ],
+        ],
+        "a fresh RocksDB handle must decode the exact canonical bytes in declaration order",
+    );
+    reopened.close().await.unwrap();
 }
 
 #[futures_test::test]

--- a/crates/jazz-storage-sqlite/tests/ordered_kv.rs
+++ b/crates/jazz-storage-sqlite/tests/ordered_kv.rs
@@ -1,5 +1,10 @@
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures::executor::block_on;
+use groove::db::Database;
+use groove::records::Value;
+use groove::schema::{
+    ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema,
+};
 use groove::storage::{
     Error, LayoutStorage, OrderedKvStorage, OwnedWriteOperation, ReopenableStorage, ScanRequest,
     StorageLayout, collect_scan,
@@ -80,6 +85,21 @@ fn epoch_1_ordered_kv_pack() -> Vec<(String, Vec<u8>, Vec<u8>)> {
 
 fn open(dir: &tempfile::TempDir) -> SqliteStorage {
     SqliteStorage::open(dir.path().join("jazz.sqlite"), &["records"]).unwrap()
+}
+
+fn epoch_1_codec_fixture_schema() -> DatabaseSchema {
+    // Declaration order is deliberately variable-before-fixed. The frozen
+    // stored bytes below prove that every durable backend shares Groove's
+    // physical fixed-first record layout without changing public row order.
+    DatabaseSchema::new([TableSchema::new(
+        "records",
+        [
+            ColumnSchema::new("label", ColumnType::String),
+            ColumnSchema::new("id", ColumnType::U16),
+            ColumnSchema::new("enabled", ColumnType::Bool),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U16))])
 }
 
 #[test]
@@ -413,6 +433,90 @@ fn ordered_prefix_range_atomic_batch_and_reopen_contract() {
         groove::storage::conformance::atomic_conditionals_preserve_winners_and_reject_stale_deletes(&storage).await;
         groove::storage::conformance::invalid_batch_is_proven_uncommitted(&storage).await;
         groove::storage::conformance::reopen_preserves_data_and_adds_families(storage).await;
+    });
+}
+
+#[test]
+fn epoch_1_table_row_bytes_and_order_survive_a_fresh_sqlite_open() {
+    block_on(async {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("jazz.sqlite");
+        let schema = epoch_1_codec_fixture_schema();
+        let mut database = Database::new(
+            schema.clone(),
+            SqliteStorage::open(&path, &["records"]).unwrap(),
+        )
+        .await
+        .unwrap();
+        let mut batch = database.open_batch();
+        batch.insert(
+            "records",
+            vec![
+                Value::String("a".to_owned()),
+                Value::U16(2),
+                Value::Bool(false),
+            ],
+        );
+        batch.insert(
+            "records",
+            vec![
+                Value::String("hi".to_owned()),
+                Value::U16(0x1234),
+                Value::Bool(true),
+            ],
+        );
+        let applied = database.apply_batch(batch).await.unwrap();
+        let persisted = applied.persist().await;
+        database.finish_persistence(persisted).unwrap();
+        drop(applied);
+
+        let storage = database.into_storage();
+        assert_eq!(
+            storage
+                .prefix("records".to_owned(), Vec::new())
+                .await
+                .unwrap(),
+            vec![
+                (
+                    vec![0x01, 0x00, 0x02],
+                    vec![0x00, 0x02, 0x00, 0x00, 0x02, b'a'],
+                ),
+                (
+                    vec![0x01, 0x12, 0x34],
+                    vec![0x00, 0x34, 0x12, 0x01, 0x02, b'h', b'i'],
+                ),
+            ],
+            "SQLite must retain lexicographic U16 key order and canonical variant-tagged, fixed-first record bytes",
+        );
+        storage.close().await.unwrap();
+        drop(storage);
+
+        let reopened = Database::new(schema, SqliteStorage::open(&path, &["records"]).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            reopened
+                .primary_key_scan("records", &[])
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|record| record.to_values().unwrap())
+                .collect::<Vec<_>>(),
+            vec![
+                vec![
+                    Value::String("a".to_owned()),
+                    Value::U16(2),
+                    Value::Bool(false),
+                ],
+                vec![
+                    Value::String("hi".to_owned()),
+                    Value::U16(0x1234),
+                    Value::Bool(true),
+                ],
+            ],
+            "a fresh SQLite handle must decode the exact canonical bytes in declaration order",
+        );
+        reopened.close().await.unwrap();
     });
 }
 


### PR DESCRIPTION
🤖 Completes the remaining native-backend receipt scope in #2035.

## Existing frozen boundary

The merged epoch-one Groove corpus already pins `INV-STORAGE-7..15`, `-22`, `-25`, and `-27`: scalar/array/payload-enum bytes, nullable offsets, ordered primary/index keys, malformed/trailing/non-canonical rejection, and Memory reopen behavior.

The remaining gap was showing the same literal semantic-table row bytes and scan order through the native persistent adapters, not merely through the in-memory codec.

## Added receipts

RocksDB and SQLite now persist two deliberately awkward records through their production ordered-KV adapters, inspect the raw prefix scan, close/drop every handle, reopen physically, and decode through the public record declaration.

Frozen raw keys:

- `01 00 02`
- `01 12 34`

Frozen raw values:

- `00 02 00 00 02 61`
- `00 34 12 01 02 68 69`

The leading `00` is the canonical record variant tag. The schema deliberately declares variable-width `label` before fixed-width `id`/`enabled`; the bytes prove fixed fields are stored first for canonical layout while reopened public rows preserve logical declaration order. The keys prove lexicographic U16 primary-key ordering.

## Verification

- RocksDB plain-row receipt suite: 5 passed (plus one pre-existing ignored test)
- SQLite ordered-KV suite: 13 passed
- Groove `epoch_1_*` corpus: 10 passed
- fresh physical close/reopen on both native backends
- planted record-variant-byte regression fails exact raw-row comparison
- Clippy, rustfmt, sensitive-data gate, and independent adversarial review pass

## Non-goals

This does not define backend-file interchange; the invariant is the Groove semantic/key bytes observed through each adapter. IndexedDB’s physical manifest and real-browser receipt are covered separately by #2295/#2160.

