### PR TITLE
Serialize auth secret and database transitions

### DIFF
--- a/.changeset/serialize-auth-secret-transitions.md
+++ b/.changeset/serialize-auth-secret-transitions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Serialize authentication secret and hybrid database transitions so stale asynchronous work cannot restore superseded credentials or database instances.

--- a/packages/jazz-tools/src/expo/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.test.ts
@@ -23,6 +23,34 @@ function recordingStore() {
   return { secureStore, getItemAsync, setItemAsync, deleteItemAsync };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function controlledStore() {
+  let value: string | null = null;
+  const firstRead = deferred<string | null>();
+  const events: string[] = [];
+  const getItemAsync = vi
+    .fn<ExpoSecureStoreLike["getItemAsync"]>()
+    .mockImplementationOnce(() => firstRead.promise)
+    .mockImplementation(async () => value);
+  const setItemAsync = vi.fn<ExpoSecureStoreLike["setItemAsync"]>(async (_key, secret) => {
+    events.push(`save:${secret}`);
+    value = secret;
+  });
+  const deleteItemAsync = vi.fn<ExpoSecureStoreLike["deleteItemAsync"]>(async () => {
+    events.push("clear");
+    value = null;
+  });
+  const secureStore: ExpoSecureStoreLike = { getItemAsync, setItemAsync, deleteItemAsync };
+  return { secureStore, firstRead, events, value: () => value };
+}
+
 describe("ExpoAuthSecretStore scoped keys", () => {
   it("uses the same hashed, SecureStore-compatible key as browser storage", async () => {
     const { secureStore, setItemAsync } = recordingStore();
@@ -90,5 +118,36 @@ describe("ExpoAuthSecretStore scoped keys", () => {
       await expect(store.getOrCreateSecret()).rejects.toThrow();
       expect(setItemAsync).not.toHaveBeenCalled();
     }
+  });
+});
+
+describe("ExpoAuthSecretStore operation ordering", () => {
+  it("does not let an older get-or-create overwrite a completed save", async () => {
+    const { secureStore, firstRead, events, value } = controlledStore();
+    const store = new ExpoAuthSecretStore({ secureStore });
+    const creating = store.getOrCreateSecret();
+    await vi.waitFor(() => expect(secureStore.getItemAsync).toHaveBeenCalledOnce());
+
+    const saving = store.saveSecret("imported-secret");
+    firstRead.resolve(null);
+    await Promise.all([creating, saving]);
+
+    expect(events.at(-1)).toBe("save:imported-secret");
+    expect(value()).toBe("imported-secret");
+    expect(await store.getOrCreateSecret()).toBe("imported-secret");
+  });
+
+  it("does not let an older get-or-create resurrect a cleared secret", async () => {
+    const { secureStore, firstRead, events, value } = controlledStore();
+    const store = new ExpoAuthSecretStore({ secureStore });
+    const creating = store.getOrCreateSecret();
+    await vi.waitFor(() => expect(secureStore.getItemAsync).toHaveBeenCalledOnce());
+
+    const clearing = store.clearSecret();
+    firstRead.resolve(null);
+    await Promise.all([creating, clearing]);
+
+    expect(events.at(-1)).toBe("clear");
+    expect(value()).toBeNull();
   });
 });

--- a/packages/jazz-tools/src/expo/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.test.ts
@@ -128,13 +128,14 @@ describe("ExpoAuthSecretStore operation ordering", () => {
     const creating = store.getOrCreateSecret();
     await vi.waitFor(() => expect(secureStore.getItemAsync).toHaveBeenCalledOnce());
 
-    const saving = store.saveSecret("imported-secret");
+    const importedSecret = generateAuthSecret();
+    const saving = store.saveSecret(importedSecret);
     firstRead.resolve(null);
     await Promise.all([creating, saving]);
 
-    expect(events.at(-1)).toBe("save:imported-secret");
-    expect(value()).toBe("imported-secret");
-    expect(await store.getOrCreateSecret()).toBe("imported-secret");
+    expect(events.at(-1)).toBe(`save:${importedSecret}`);
+    expect(value()).toBe(importedSecret);
+    expect(await store.getOrCreateSecret()).toBe(importedSecret);
   });
 
   it("does not let an older get-or-create resurrect a cleared secret", async () => {

--- a/packages/jazz-tools/src/expo/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.test.ts
@@ -151,4 +151,21 @@ describe("ExpoAuthSecretStore operation ordering", () => {
     expect(events.at(-1)).toBe("clear");
     expect(value()).toBeNull();
   });
+
+  it("serializes direct instances sharing one physical SecureStore key", async () => {
+    const { secureStore, firstRead, events, value } = controlledStore();
+    const first = new ExpoAuthSecretStore({ secureStore });
+    const second = new ExpoAuthSecretStore({ secureStore });
+    const creating = first.getOrCreateSecret();
+    await vi.waitFor(() => expect(secureStore.getItemAsync).toHaveBeenCalledOnce());
+
+    const importedSecret = generateAuthSecret();
+    const saving = second.saveSecret(importedSecret);
+    firstRead.resolve(null);
+    await Promise.all([creating, saving]);
+
+    expect(events.at(-1)).toBe(`save:${importedSecret}`);
+    expect(value()).toBe(importedSecret);
+    expect(await first.getOrCreateSecret()).toBe(importedSecret);
+  });
 });

--- a/packages/jazz-tools/src/expo/auth-secret-store.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.ts
@@ -21,6 +21,16 @@ export interface ExpoAuthSecretStoreOptions extends AuthSecretScope {
   secureStore?: ExpoSecureStoreLike;
 }
 
+/** State shared by every adapter instance addressing one SecureStore key. */
+type SecretOperationState = {
+  cachedPromise: Promise<string> | null;
+  operationTail: Promise<void>;
+};
+
+function newSecretOperationState(): SecretOperationState {
+  return { cachedPromise: null, operationTail: Promise.resolve() };
+}
+
 function resolveExpoAuthSecretKey(options: ExpoAuthSecretStoreOptions = {}): string {
   if (options.key) {
     return options.key;
@@ -31,18 +41,49 @@ function resolveExpoAuthSecretKey(options: ExpoAuthSecretStoreOptions = {}): str
 
 export class ExpoAuthSecretStore implements AuthSecretStore {
   private static globalInstances = new Map<string, ExpoAuthSecretStore>();
+  private static globalOperationStates = new Map<string, SecretOperationState>();
   private static storageScopedInstances = new WeakMap<
     ExpoSecureStoreLike,
     Map<string, ExpoAuthSecretStore>
   >();
+  private static storageScopedOperationStates = new WeakMap<
+    ExpoSecureStoreLike,
+    Map<string, SecretOperationState>
+  >();
   private readonly key: string;
   private readonly store: ExpoSecureStoreLike;
-  private cachedPromise: Promise<string> | null = null;
-  private operationTail: Promise<void> = Promise.resolve();
+  private readonly operationState: SecretOperationState;
 
   constructor(options: ExpoAuthSecretStoreOptions = {}) {
     this.key = resolveExpoAuthSecretKey(options);
     this.store = options.secureStore ?? { getItemAsync, setItemAsync, deleteItemAsync };
+    this.operationState = ExpoAuthSecretStore.getOperationState(this.key, options.secureStore);
+  }
+
+  private static getOperationState(
+    key: string,
+    secureStore: ExpoSecureStoreLike | undefined,
+  ): SecretOperationState {
+    if (!secureStore) {
+      let state = ExpoAuthSecretStore.globalOperationStates.get(key);
+      if (!state) {
+        state = newSecretOperationState();
+        ExpoAuthSecretStore.globalOperationStates.set(key, state);
+      }
+      return state;
+    }
+
+    let states = ExpoAuthSecretStore.storageScopedOperationStates.get(secureStore);
+    if (!states) {
+      states = new Map<string, SecretOperationState>();
+      ExpoAuthSecretStore.storageScopedOperationStates.set(secureStore, states);
+    }
+    let state = states.get(key);
+    if (!state) {
+      state = newSecretOperationState();
+      states.set(key, state);
+    }
+    return state;
   }
 
   static getDefault(options: ExpoAuthSecretStoreOptions = {}): ExpoAuthSecretStore {
@@ -71,47 +112,49 @@ export class ExpoAuthSecretStore implements AuthSecretStore {
     return instance;
   }
 
-  async loadSecret(): Promise<string | null> {
-    const secret = await this.store.getItemAsync(this.key);
-    if (secret === null) return null;
-    parseAuthSecret(secret);
-    return secret;
+  loadSecret(): Promise<string | null> {
+    return this.serialize(async () => {
+      const secret = await this.store.getItemAsync(this.key);
+      if (secret === null) return null;
+      parseAuthSecret(secret);
+      return secret;
+    });
   }
 
   saveSecret(secret: string): Promise<void> {
     parseAuthSecret(secret);
     const saving = this.serialize(() => this.store.setItemAsync(this.key, secret));
     const cached = saving.then(() => secret);
-    this.cachedPromise = cached;
+    this.operationState.cachedPromise = cached;
     void cached.catch(() => {
-      if (this.cachedPromise === cached) {
-        this.cachedPromise = null;
+      if (this.operationState.cachedPromise === cached) {
+        this.operationState.cachedPromise = null;
       }
     });
     return saving;
   }
 
   clearSecret(): Promise<void> {
-    this.cachedPromise = null;
+    this.operationState.cachedPromise = null;
     return this.serialize(() => this.store.deleteItemAsync(this.key));
   }
 
   getOrCreateSecret(): Promise<string> {
-    if (!this.cachedPromise) {
+    if (!this.operationState.cachedPromise) {
       const pending = this.serialize(() => this.getOrCreateSecretInternal());
-      this.cachedPromise = pending;
+      this.operationState.cachedPromise = pending;
       void pending.catch(() => {
-        if (this.cachedPromise === pending) {
-          this.cachedPromise = null;
+        if (this.operationState.cachedPromise === pending) {
+          this.operationState.cachedPromise = null;
         }
       });
     }
-    return this.cachedPromise;
+    return this.operationState.cachedPromise;
   }
 
   private serialize<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.operationTail.then(operation);
-    this.operationTail = result.then(
+    const result = this.operationState.operationTail.then(operation);
+    this.operationState.operationTail = result.then(
       () => undefined,
       () => undefined,
     );

--- a/packages/jazz-tools/src/expo/auth-secret-store.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.ts
@@ -38,6 +38,7 @@ export class ExpoAuthSecretStore implements AuthSecretStore {
   private readonly key: string;
   private readonly store: ExpoSecureStoreLike;
   private cachedPromise: Promise<string> | null = null;
+  private operationTail: Promise<void> = Promise.resolve();
 
   constructor(options: ExpoAuthSecretStoreOptions = {}) {
     this.key = resolveExpoAuthSecretKey(options);
@@ -77,22 +78,44 @@ export class ExpoAuthSecretStore implements AuthSecretStore {
     return secret;
   }
 
-  async saveSecret(secret: string): Promise<void> {
+  saveSecret(secret: string): Promise<void> {
     parseAuthSecret(secret);
-    await this.store.setItemAsync(this.key, secret);
-    this.cachedPromise = Promise.resolve(secret);
+    const saving = this.serialize(() => this.store.setItemAsync(this.key, secret));
+    const cached = saving.then(() => secret);
+    this.cachedPromise = cached;
+    void cached.catch(() => {
+      if (this.cachedPromise === cached) {
+        this.cachedPromise = null;
+      }
+    });
+    return saving;
   }
 
-  async clearSecret(): Promise<void> {
-    await this.store.deleteItemAsync(this.key);
+  clearSecret(): Promise<void> {
     this.cachedPromise = null;
+    return this.serialize(() => this.store.deleteItemAsync(this.key));
   }
 
   getOrCreateSecret(): Promise<string> {
     if (!this.cachedPromise) {
-      this.cachedPromise = this.getOrCreateSecretInternal();
+      const pending = this.serialize(() => this.getOrCreateSecretInternal());
+      this.cachedPromise = pending;
+      void pending.catch(() => {
+        if (this.cachedPromise === pending) {
+          this.cachedPromise = null;
+        }
+      });
     }
     return this.cachedPromise;
+  }
+
+  private serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationTail.then(operation);
+    this.operationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   private async getOrCreateSecretInternal(): Promise<string> {

--- a/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
@@ -166,6 +166,23 @@ describe("BrowserAuthSecretStore", () => {
       expect(() => corruptStore.getOrCreateSecret()).toThrow();
       expect(storage.getItem(key)).toBe(corrupt);
     }
+  it("keeps labelled user and session dimensions distinct when the other is missing", async () => {
+    const userScoped = new BrowserAuthSecretStore({
+      storage,
+      appId: "chat-app",
+      userId: "shared-id",
+    });
+    const sessionScoped = new BrowserAuthSecretStore({
+      storage,
+      appId: "chat-app",
+      sessionId: "shared-id",
+    });
+
+    await userScoped.saveSecret("user-secret");
+    await sessionScoped.saveSecret("session-secret");
+
+    expect(await userScoped.loadSecret()).toBe("user-secret");
+    expect(await sessionScoped.loadSecret()).toBe("session-secret");
   });
 
   it("throws a clear error if used in a non-browser env (no localStorage)", async () => {

--- a/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
@@ -166,23 +166,6 @@ describe("BrowserAuthSecretStore", () => {
       expect(() => corruptStore.getOrCreateSecret()).toThrow();
       expect(storage.getItem(key)).toBe(corrupt);
     }
-  it("keeps labelled user and session dimensions distinct when the other is missing", async () => {
-    const userScoped = new BrowserAuthSecretStore({
-      storage,
-      appId: "chat-app",
-      userId: "shared-id",
-    });
-    const sessionScoped = new BrowserAuthSecretStore({
-      storage,
-      appId: "chat-app",
-      sessionId: "shared-id",
-    });
-
-    await userScoped.saveSecret("user-secret");
-    await sessionScoped.saveSecret("session-secret");
-
-    expect(await userScoped.loadSecret()).toBe("user-secret");
-    expect(await sessionScoped.loadSecret()).toBe("session-secret");
   });
 
   it("throws a clear error if used in a non-browser env (no localStorage)", async () => {

--- a/starters/react-hybrid/vitest.config.ts
+++ b/starters/react-hybrid/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["server/**/*.test.ts"],
+    include: ["server/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });

--- a/starters/ts-hybrid/src/main.test.ts
+++ b/starters/ts-hybrid/src/main.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type Session = {
+  isPending: boolean;
+  data: { session: object; user: { name: string } } | null;
+};
+
+const mocks = vi.hoisted(() => {
+  let session: Session = { isPending: false, data: null };
+  const subscribers = new Set<(next: Session) => unknown>();
+  const createDb = vi.fn();
+  const getOrCreateSecret = vi.fn();
+  const fetchToken = vi.fn();
+  const setDb = vi.fn();
+  const mountApp = vi.fn(() => ({ setDb, destroy: vi.fn() }));
+  const useSession = {
+    get: vi.fn(() => session),
+    subscribe: vi.fn((listener: (next: Session) => unknown) => {
+      subscribers.add(listener);
+      return () => subscribers.delete(listener);
+    }),
+  };
+
+  return {
+    createDb,
+    getOrCreateSecret,
+    fetchToken,
+    mountApp,
+    setDb,
+    useSession,
+    emit(next: Session) {
+      session = next;
+      return [...subscribers].map((listener) => listener(next));
+    },
+  };
+});
+
+vi.mock("jazz-tools", () => ({
+  BrowserAuthSecretStore: { getOrCreateSecret: mocks.getOrCreateSecret },
+  createDb: mocks.createDb,
+}));
+vi.mock("./auth-client.js", () => ({
+  authClient: { useSession: mocks.useSession, $fetch: mocks.fetchToken },
+}));
+vi.mock("./app.js", () => ({ mountApp: mocks.mountApp }));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function signedIn(name: string): Session {
+  return { isPending: false, data: { session: {}, user: { name } } };
+}
+
+function dbHandle() {
+  return {
+    onAuthChanged: vi.fn(),
+    updateAuthToken: vi.fn(),
+    shutdown: vi.fn(async () => {}),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("hybrid auth Db ownership", () => {
+  it("keeps the newest auth generation active and closes an older sign-in Db", async () => {
+    const initialDb = dbHandle();
+    const logoutDb = dbHandle();
+    const newerSignInDb = dbHandle();
+    const olderSignInDb = dbHandle();
+    const olderDbOpen = deferred<typeof olderSignInDb>();
+    let localOpenCount = 0;
+
+    mocks.getOrCreateSecret.mockResolvedValue("local-secret");
+    mocks.fetchToken
+      .mockResolvedValueOnce({ data: { token: "older-token" }, error: null })
+      .mockResolvedValueOnce({ data: { token: "newer-token" }, error: null });
+    mocks.createDb.mockImplementation((config: { jwtToken?: string }) => {
+      if (config.jwtToken === "older-token") return olderDbOpen.promise;
+      if (config.jwtToken === "newer-token") return Promise.resolve(newerSignInDb);
+      localOpenCount += 1;
+      return Promise.resolve(localOpenCount === 1 ? initialDb : logoutDb);
+    });
+
+    vi.stubEnv("VITE_JAZZ_APP_ID", "test-app");
+    vi.stubEnv("VITE_JAZZ_SERVER_URL", "https://sync.test");
+    vi.stubGlobal("document", { getElementById: vi.fn(() => ({})) });
+    // Import after installing boot-time environment and DOM state; the module starts boot on load.
+    await import("./main.js");
+    await vi.waitFor(() => expect(mocks.mountApp).toHaveBeenCalledWith({}, initialDb));
+
+    const olderSignIn = mocks.emit(signedIn("older"))[0] as Promise<void>;
+    await vi.waitFor(() =>
+      expect(mocks.createDb).toHaveBeenCalledWith(
+        expect.objectContaining({ jwtToken: "older-token" }),
+      ),
+    );
+
+    await Promise.all(mocks.emit({ isPending: false, data: null }));
+    await Promise.all(mocks.emit(signedIn("newer")));
+    olderDbOpen.resolve(olderSignInDb);
+    await olderSignIn;
+
+    expect(mocks.setDb.mock.calls.map(([db]) => db)).toEqual([logoutDb, newerSignInDb]);
+    expect(initialDb.shutdown).toHaveBeenCalledOnce();
+    expect(logoutDb.shutdown).toHaveBeenCalledOnce();
+    expect(olderSignInDb.shutdown).toHaveBeenCalledOnce();
+    expect(newerSignInDb.shutdown).not.toHaveBeenCalled();
+  });
+});

--- a/starters/ts-hybrid/src/main.test.ts
+++ b/starters/ts-hybrid/src/main.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type Session = {
   isPending: boolean;
@@ -32,6 +32,17 @@ const mocks = vi.hoisted(() => {
       session = next;
       return [...subscribers].map((listener) => listener(next));
     },
+    reset() {
+      session = { isPending: false, data: null };
+      subscribers.clear();
+      createDb.mockReset();
+      getOrCreateSecret.mockReset();
+      fetchToken.mockReset();
+      setDb.mockReset();
+      mountApp.mockReset().mockImplementation(() => ({ setDb, destroy: vi.fn() }));
+      useSession.get.mockClear();
+      useSession.subscribe.mockClear();
+    },
   };
 });
 
@@ -57,16 +68,28 @@ function signedIn(name: string): Session {
 }
 
 function dbHandle() {
+  const authListeners = new Set<(state: { error?: string }) => void>();
   return {
-    onAuthChanged: vi.fn(),
+    onAuthChanged: vi.fn((listener: (state: { error?: string }) => void) => {
+      authListeners.add(listener);
+      return () => authListeners.delete(listener);
+    }),
     updateAuthToken: vi.fn(),
     shutdown: vi.fn(async () => {}),
+    emitAuth(state: { error?: string }) {
+      for (const listener of authListeners) listener(state);
+    },
   };
 }
 
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.reset();
 });
 
 describe("hybrid auth Db ownership", () => {
@@ -104,14 +127,87 @@ describe("hybrid auth Db ownership", () => {
     );
 
     await Promise.all(mocks.emit({ isPending: false, data: null }));
+    await vi.waitFor(() => expect(mocks.setDb).toHaveBeenCalledWith(logoutDb));
     await Promise.all(mocks.emit(signedIn("newer")));
     olderDbOpen.resolve(olderSignInDb);
     await olderSignIn;
+    await vi.waitFor(() => expect(mocks.setDb).toHaveBeenCalledWith(newerSignInDb));
 
     expect(mocks.setDb.mock.calls.map(([db]) => db)).toEqual([logoutDb, newerSignInDb]);
     expect(initialDb.shutdown).toHaveBeenCalledOnce();
     expect(logoutDb.shutdown).toHaveBeenCalledOnce();
     expect(olderSignInDb.shutdown).toHaveBeenCalledOnce();
     expect(newerSignInDb.shutdown).not.toHaveBeenCalled();
+  });
+
+  it("refreshes only the current Db when an older session's request settles", async () => {
+    const initialDb = dbHandle();
+    const signedInDb = dbHandle();
+    const staleRefresh = deferred<{ data: { token: string } | null; error: null }>();
+    const currentRefresh = deferred<{ data: { token: string } | null; error: null }>();
+    let localOpenCount = 0;
+
+    mocks.getOrCreateSecret.mockResolvedValue("local-secret");
+    mocks.fetchToken
+      .mockImplementationOnce(() => staleRefresh.promise)
+      .mockResolvedValueOnce({ data: { token: "sign-in-token" }, error: null })
+      .mockImplementationOnce(() => currentRefresh.promise);
+    mocks.createDb.mockImplementation((config: { jwtToken?: string }) => {
+      if (config.jwtToken === "sign-in-token") return Promise.resolve(signedInDb);
+      localOpenCount += 1;
+      return Promise.resolve(initialDb);
+    });
+
+    vi.stubEnv("VITE_JAZZ_APP_ID", "test-app");
+    vi.stubEnv("VITE_JAZZ_SERVER_URL", "https://sync.test");
+    vi.stubGlobal("document", { getElementById: vi.fn(() => ({})) });
+    await import("./main.js");
+    await vi.waitFor(() => expect(mocks.mountApp).toHaveBeenCalledWith({}, initialDb));
+
+    initialDb.emitAuth({ error: "expired" });
+    await vi.waitFor(() => expect(mocks.fetchToken).toHaveBeenCalledTimes(1));
+    await Promise.all(mocks.emit(signedIn("signed-in")));
+    await vi.waitFor(() => expect(mocks.setDb).toHaveBeenCalledWith(signedInDb));
+
+    staleRefresh.resolve({ data: { token: "stale-token" }, error: null });
+    await Promise.resolve();
+    expect(signedInDb.updateAuthToken).not.toHaveBeenCalled();
+
+    signedInDb.emitAuth({ error: "expired" });
+    await vi.waitFor(() => expect(mocks.fetchToken).toHaveBeenCalledTimes(3));
+    currentRefresh.resolve({ data: { token: "current-token" }, error: null });
+    await vi.waitFor(() =>
+      expect(signedInDb.updateAuthToken).toHaveBeenCalledWith("current-token"),
+    );
+    expect(initialDb.updateAuthToken).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a session change that happens while the initial Db is opening", async () => {
+    const initialDb = dbHandle();
+    const signedInDb = dbHandle();
+    const initialOpen = deferred<typeof initialDb>();
+
+    mocks.getOrCreateSecret.mockResolvedValue("local-secret");
+    mocks.fetchToken.mockResolvedValue({ data: { token: "sign-in-token" }, error: null });
+    mocks.createDb.mockImplementation((config: { jwtToken?: string }) => {
+      return config.jwtToken === "sign-in-token"
+        ? Promise.resolve(signedInDb)
+        : initialOpen.promise;
+    });
+
+    vi.stubEnv("VITE_JAZZ_APP_ID", "test-app");
+    vi.stubEnv("VITE_JAZZ_SERVER_URL", "https://sync.test");
+    vi.stubGlobal("document", { getElementById: vi.fn(() => ({})) });
+    await import("./main.js");
+    await vi.waitFor(() => expect(mocks.createDb).toHaveBeenCalledOnce());
+
+    // No session listener exists until the initial Db is ready. The final
+    // current-session read must still observe this sign-in.
+    mocks.emit(signedIn("signed-in"));
+    initialOpen.resolve(initialDb);
+
+    await vi.waitFor(() => expect(mocks.mountApp).toHaveBeenCalledWith({}, initialDb));
+    await vi.waitFor(() => expect(mocks.setDb).toHaveBeenCalledWith(signedInDb));
+    expect(initialDb.shutdown).toHaveBeenCalledOnce();
   });
 });

--- a/starters/ts-hybrid/src/main.ts
+++ b/starters/ts-hybrid/src/main.ts
@@ -1,4 +1,4 @@
-import { BrowserAuthSecretStore, createDb, type DbConfig } from "jazz-tools";
+import { BrowserAuthSecretStore, createDb, type Db, type DbConfig } from "jazz-tools";
 import { authClient, type AuthSession } from "./auth-client.js";
 import { mountApp, type AppHandle } from "./app.js";
 import "./app.css";
@@ -64,15 +64,26 @@ async function boot() {
 
   // JWT refresh: when Jazz reports the token has expired, mint a fresh one
   // from BetterAuth and hand it back.
-  db.onAuthChanged((state) => {
-    if (state.error !== "expired") return;
-    authClient.$fetch<{ token: string }>("/token", { method: "GET" }).then(({ data, error }) => {
-      if (!error && data?.token) db.updateAuthToken(data.token);
+  function wireJwtRefresh(ownedDb: Db): () => void {
+    return ownedDb.onAuthChanged((state) => {
+      if (state.error !== "expired" || db !== ownedDb) return;
+      void authClient.$fetch<{ token: string }>("/token", { method: "GET" }).then(
+        ({ data, error }) => {
+          // The request can finish after a login/logout transition. A token
+          // minted for the retired session must never be installed on its
+          // replacement Db.
+          if (!error && data?.token && db === ownedDb) {
+            ownedDb.updateAuthToken(data.token);
+          }
+        },
+        () => {},
+      );
     });
-  });
+  }
+  let stopJwtRefresh = wireJwtRefresh(db);
 
   // Rebuild Db when the session flips between anonymous and signed-in.
-  sessionAtom.subscribe(async (next: AuthSession) => {
+  async function transitionToSession(next: AuthSession): Promise<void> {
     if (next.isPending) return;
     const nowAuth = isAuthenticated(next);
     if (nowAuth === currentlyAuthenticated) return;
@@ -91,10 +102,26 @@ async function boot() {
     }
 
     const previousDb = db;
+    const stopPreviousJwtRefresh = stopJwtRefresh;
     db = nextDb;
+    stopJwtRefresh = wireJwtRefresh(nextDb);
     app.setDb(nextDb);
+    stopPreviousJwtRefresh();
     await previousDb.shutdown();
-  });
+  }
+
+  function handleSession(next: AuthSession) {
+    void transitionToSession(next).catch((error: unknown) => {
+      // Session subscriptions do not await listener promises. Do not turn a
+      // teardown failure into an unhandled rejection, but retain diagnostics.
+      console.error("Failed to transition Jazz authentication", error);
+    });
+  }
+
+  sessionAtom.subscribe(handleSession);
+  // A session may have changed while the initial configuration or Db was
+  // opening. Re-read after subscribing so that transition is not lost.
+  handleSession(sessionAtom.get());
 }
 
 boot();

--- a/starters/ts-hybrid/src/main.ts
+++ b/starters/ts-hybrid/src/main.ts
@@ -58,6 +58,7 @@ async function boot() {
     ? ((await buildJwtConfig()) ?? (await buildLocalFirstConfig()))
     : await buildLocalFirstConfig();
   let db = await createDb(initialConfig);
+  let authGeneration = 0;
 
   const app: AppHandle = mountApp(root, db);
 
@@ -76,12 +77,23 @@ async function boot() {
     const nowAuth = isAuthenticated(next);
     if (nowAuth === currentlyAuthenticated) return;
     currentlyAuthenticated = nowAuth;
+    const generation = ++authGeneration;
 
     const nextConfig = nowAuth
       ? ((await buildJwtConfig()) ?? (await buildLocalFirstConfig()))
       : await buildLocalFirstConfig();
-    db = await createDb(nextConfig);
-    app.setDb(db);
+    if (generation !== authGeneration) return;
+
+    const nextDb = await createDb(nextConfig);
+    if (generation !== authGeneration) {
+      await nextDb.shutdown();
+      return;
+    }
+
+    const previousDb = db;
+    db = nextDb;
+    app.setDb(nextDb);
+    await previousDb.shutdown();
   });
 }
 

--- a/starters/ts-hybrid/vitest.config.ts
+++ b/starters/ts-hybrid/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["server/**/*.test.ts"],
+    include: ["server/**/*.test.ts", "src/**/*.test.ts"],
   },
 });

--- a/starters/ts-hybrid/vitest.config.ts
+++ b/starters/ts-hybrid/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["server/**/*.test.ts", "src/**/*.test.ts"],
+    include: ["server/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });


### PR DESCRIPTION
🤖 Serialize authentication-secret and database ownership transitions so the newest user/session action wins, independent of asynchronous completion order.

## Before

- Expo serialization/cache lived on each `ExpoAuthSecretStore` object. Two instances targeting the same SecureStore key could race: an older `getOrCreateSecret()` read could finish after a newer imported secret or logout and restore stale state.
- Hybrid session transitions could finish out of order and install an older database.
- JWT-expiry listeners belonged to the original database while closing over the mutable current `db`. A delayed token refresh started by session A could therefore install A’s token on session B’s replacement database, which itself had no listener.
- A session change during the initial asynchronous database open could occur before subscription and never be reconciled.

## After

- Operation state and cache are shared per SecureStore object/key, including direct store instances; reads, creation, import, and clearing run through the same serialized tail.
- Authentication generations prevent stale database opens from becoming current and close any stale result.
- Every owned database gets its own expiry listener. Replacement attaches the new listener, swaps the app database, unsubscribes the old listener, and closes the old database.
- Token refresh checks database ownership both before and after fetching, so a delayed old-session response cannot reach its replacement.
- The current session is read again after subscription to reconcile changes during startup.

## Verification

- Direct same-key Expo instances, create/import/clear ordering, and cache failure recovery are covered.
- Hybrid receipts cover stale database opens, delayed stale JWT refresh, refresh on the new database, and a startup session race.
- A planted removal of the ownership check installs the stale token and fails its receipt.
- React/TypeScript hybrid starter test globs now run the matching source tests.
- Focused Expo, TS-hybrid, React-hybrid, parity, formatting, and TypeScript gates pass.

