### PR TITLE
Reject unorderable TopBy fields

### DIFF
--- a/crates/groove/src/db/tests/queries/windows.rs
+++ b/crates/groove/src/db/tests/queries/windows.rs
@@ -563,9 +563,10 @@ async fn top_by_rejects_record_array_sort_fields_before_evaluation() {
             "ranked",
             vec![
                 Value::U64(id),
-                Value::Array(vec![Value::Record(
+                Value::Array(vec![Value::Record(crate::records::OwnedRecord::new(
                     child.create(&[Value::U64(rank)]).unwrap(),
-                )]),
+                    child,
+                ))]),
             ],
         );
     }

--- a/crates/groove/src/db/tests/queries/windows.rs
+++ b/crates/groove/src/db/tests/queries/windows.rs
@@ -541,6 +541,56 @@ async fn top_by_orders_nullable_sort_keys_null_first() {
 }
 
 #[futures_test::test]
+async fn top_by_rejects_record_array_sort_fields_before_evaluation() {
+    let child = RecordDescriptor::new([("rank", ValueType::U64)]);
+    let schema = DatabaseSchema::new([TableSchema::new(
+        "ranked",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new(
+                "rank",
+                ColumnType::Array(Box::new(ColumnType::Record(Box::new(child)))),
+            ),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+    let storage = MemoryStorage::new(&["ranked"]).expect("valid memory storage families");
+    let mut database = Database::new(schema, storage).await.unwrap();
+
+    let mut batch = database.open_batch();
+    for (id, rank) in [(1, 2), (2, 1)] {
+        batch.insert(
+            "ranked",
+            vec![
+                Value::U64(id),
+                Value::Array(vec![Value::Record(
+                    child.create(&[Value::U64(rank)]).unwrap(),
+                )]),
+            ],
+        );
+    }
+    database.commit_batch(batch).await.unwrap();
+
+    let result = database
+        .subscribe_one_sink(GraphBuilder::top_by(
+            GraphBuilder::table("ranked"),
+            std::iter::empty::<&str>(),
+            [TopByOrder::asc("rank")],
+            ["id"],
+            0,
+            TopByLimit::Finite(1),
+        ))
+        .await;
+    let Err(error) = result else {
+        panic!("record-array TopBy sort field must be rejected");
+    };
+    assert_eq!(
+        error.to_string(),
+        "invalid top_by descriptor: sort field rank must be an orderable scalar"
+    );
+}
+
+#[futures_test::test]
 async fn top_by_uses_stable_tie_field() {
     let storage = MemoryStorage::new(&["history", "rows", "blockers"])
         .expect("valid memory storage families");

--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -1615,6 +1615,12 @@ impl NodeDescriptor {
                         });
                     }
                 }
+                for &field_idx in &top_by.sort_field_indices {
+                    if !collect_by_ordered_scalar(&input_outputs[0].fields()[field_idx].value_type)
+                    {
+                        return Err(GraphValidationError::TopBySortFieldMustBeOrderable);
+                    }
+                }
                 Ok(())
             }
             OpType::CollectBy(collect_by) => {
@@ -2056,6 +2062,8 @@ pub enum GraphValidationError {
     CollectByOutputDescriptorMismatch,
     #[error("collect_by group, order, and tie fields must be scalar and non-record-valued")]
     CollectByKeyFieldMustBeScalar,
+    #[error("top_by order and tie fields must be orderable scalar values")]
+    TopBySortFieldMustBeOrderable,
     #[error("collect_by is terminal-only and cannot be an input node")]
     CollectByInputIsTerminal,
 }

--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -2352,6 +2352,42 @@ mod tests {
     }
 
     #[test]
+    fn validation_rejects_top_by_unorderable_tie_fields() {
+        let input = RecordDescriptor::new([
+            ("rank", ValueType::U64),
+            ("tie", ValueType::Array(Box::new(ValueType::U64))),
+        ]);
+        let descriptor = NodeDescriptor::new(
+            OpType::TopBy(TopByOp {
+                group_fields: Vec::new(),
+                group_field_indices: Vec::new(),
+                order_fields: vec![TopByOrderField {
+                    field: "rank".to_owned(),
+                    direction: TopByDirection::Asc,
+                }],
+                tie_fields: vec!["tie".to_owned()],
+                // `sort_field_indices` is deliberately the concatenation of
+                // order and tie fields. Validate every member, not only the
+                // user-visible order prefix, because both are compared by the
+                // runtime's TopBy key.
+                sort_field_indices: vec![0, 1],
+                sort_directions: vec![TopByDirection::Asc, TopByDirection::Asc],
+                offset: 0,
+                limit: TopByLimit::Finite(1),
+            }),
+            [NodeId(1)],
+            input,
+        );
+
+        assert_eq!(
+            descriptor.validate(&[NodeOutput::Arrangement(ArrangementDescriptor {
+                records: input,
+            })]),
+            Err(GraphValidationError::TopBySortFieldMustBeOrderable),
+        );
+    }
+
+    #[test]
     fn validation_rejects_union_inputs_with_different_outputs() {
         let descriptor = NodeDescriptor::new(OpType::Union, [NodeId(1), NodeId(2)], output());
 

--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -477,6 +477,19 @@ impl IvmRuntime {
                     .iter()
                     .map(|field| resolve_field_ref(&output, field))
                     .collect::<Result<Vec<_>, _>>()?;
+                for &field_idx in order_field_indices.iter().chain(&tie_field_indices) {
+                    let value_type = &output
+                        .fields()
+                        .get(field_idx)
+                        .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(field_idx))?
+                        .value_type;
+                    if !collect_by_ordered_scalar(value_type) {
+                        return Err(IvmRuntimeError::InvalidTopBy(format!(
+                            "sort field {} must be an orderable scalar",
+                            field_name_at(&output, field_idx)?
+                        )));
+                    }
+                }
                 let group_field_names = group_field_indices
                     .iter()
                     .map(|field| field_name_at(&output, *field))

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -35,7 +35,7 @@ use crate::ivm::{
 };
 use crate::records::{
     self, BorrowedRecord, EnumSchema, EnumValue, OwnedRecord, RawProjectionField,
-    RawProjectionScratch, RecordDescriptor, Value, ValueType,
+    RawProjectionScratch, RecordDescriptor, Value, ValueType, collect_by_ordered_scalar,
 };
 use crate::schema::{DatabaseSchema, IndexSchema, TableSchema};
 use crate::storage::{OrderedKvStorage, RecordStore, ScanBounds, ScanDirection, ScanRequest};
@@ -522,6 +522,8 @@ pub enum IvmRuntimeError {
     CollectByMustBeTerminal,
     #[error("invalid collect_by descriptor: {0}")]
     InvalidCollectBy(String),
+    #[error("invalid top_by descriptor: {0}")]
+    InvalidTopBy(String),
     #[error("collect_by expand encountered duplicate output occurrence source ids")]
     DuplicateCollectByOccurrenceId,
     #[error("unsupported operator")]

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -5,32 +5,15 @@ use super::*;
 type SourceRecord = (Vec<u8>, Bytes);
 pub(super) type WindowedRecord = (Bytes, i64);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct TopBySortPart {
-    pub(super) key: Value,
+    pub(super) key: Vec<u8>,
     pub(super) direction: TopByDirection,
 }
 
-impl PartialEq for TopBySortPart {
-    fn eq(&self, other: &Self) -> bool {
-        self.direction == other.direction && self.cmp(other) == std::cmp::Ordering::Equal
-    }
-}
-
-impl Eq for TopBySortPart {}
-
 impl Ord for TopBySortPart {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let ordering = match (is_sql_null_value(&self.key), is_sql_null_value(&other.key)) {
-            // Windows need a total order, unlike SQL predicates where any
-            // comparison involving NULL is unknown. Keep NULL first for the
-            // canonical ascending order, then apply the declared direction.
-            (true, true) => std::cmp::Ordering::Equal,
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            (false, false) => compare_values_sql(&self.key, &other.key, ValueComparison::Exact)
-                .expect("non-null TopBy values must be comparable"),
-        };
+        let ordering = self.key.cmp(&other.key);
         match self.direction {
             TopByDirection::Asc => ordering,
             TopByDirection::Desc => ordering.reverse(),
@@ -969,15 +952,53 @@ fn collect_by_sort_key_for_fields(
         .iter()
         .zip(sort_directions)
         .map(|(field_idx, direction)| {
+            let field = descriptor
+                .fields()
+                .get(*field_idx)
+                .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(*field_idx))?;
+            let value = values
+                .get(*field_idx)
+                .cloned()
+                .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(*field_idx))?;
             Ok(TopBySortPart {
-                key: values
-                    .get(*field_idx)
-                    .cloned()
-                    .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(*field_idx))?,
+                key: encode_top_by_sort_value(&field.value_type, value)?,
                 direction: *direction,
             })
         })
         .collect()
+}
+
+fn encode_top_by_sort_value(
+    value_type: &ValueType,
+    mut value: Value,
+) -> Result<Vec<u8>, IvmRuntimeError> {
+    if !collect_by_ordered_scalar(value_type) {
+        return Err(IvmRuntimeError::InvalidTopBy(
+            "sort field value must be an orderable scalar".to_owned(),
+        ));
+    }
+    let mut key = Vec::new();
+    if is_sql_null_value(&value) {
+        key.push(0);
+        return Ok(key);
+    }
+    key.push(1);
+    loop {
+        match value {
+            Value::Nullable(Some(inner)) => value = *inner,
+            other => {
+                value = other;
+                break;
+            }
+        }
+    }
+    if let Value::F64(number) = &mut value {
+        if *number == 0.0 {
+            *number = 0.0;
+        }
+    }
+    encode_key_part(&mut key, &value)?;
+    Ok(key)
 }
 
 pub(super) fn top_by_sort_key(

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -5,9 +5,26 @@ use super::*;
 type SourceRecord = (Vec<u8>, Bytes);
 pub(super) type WindowedRecord = (Bytes, i64);
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum TopBySortKey {
+    Null,
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    I32(i32),
+    I64(i64),
+    F64(u64),
+    Bool(bool),
+    String(String),
+    Bytes(Vec<u8>),
+    Uuid([u8; 16]),
+    EnumTag(u8),
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct TopBySortPart {
-    pub(super) key: Vec<u8>,
+    key: TopBySortKey,
     pub(super) direction: TopByDirection,
 }
 
@@ -961,28 +978,29 @@ fn collect_by_sort_key_for_fields(
                 .cloned()
                 .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(*field_idx))?;
             Ok(TopBySortPart {
-                key: encode_top_by_sort_value(&field.value_type, value)?,
+                key: top_by_sort_value(&field.value_type, value)?,
                 direction: *direction,
             })
         })
         .collect()
 }
 
-fn encode_top_by_sort_value(
+fn top_by_sort_value(
     value_type: &ValueType,
     mut value: Value,
-) -> Result<Vec<u8>, IvmRuntimeError> {
+) -> Result<TopBySortKey, IvmRuntimeError> {
     if !collect_by_ordered_scalar(value_type) {
         return Err(IvmRuntimeError::InvalidTopBy(
             "sort field value must be an orderable scalar".to_owned(),
         ));
     }
-    let mut key = Vec::new();
     if is_sql_null_value(&value) {
-        key.push(0);
-        return Ok(key);
+        return Ok(TopBySortKey::Null);
     }
-    key.push(1);
+    let mut value_type = value_type;
+    while let ValueType::Nullable(inner) = value_type {
+        value_type = inner;
+    }
     loop {
         match value {
             Value::Nullable(Some(inner)) => value = *inner,
@@ -992,12 +1010,34 @@ fn encode_top_by_sort_value(
             }
         }
     }
-    if let Value::F64(number) = &mut value {
-        if *number == 0.0 {
-            *number = 0.0;
+    let key = match (value_type, value) {
+        (ValueType::U8, Value::U8(value)) => TopBySortKey::U8(value),
+        (ValueType::U16, Value::U16(value)) => TopBySortKey::U16(value),
+        (ValueType::U32, Value::U32(value)) => TopBySortKey::U32(value),
+        (ValueType::U64, Value::U64(value)) => TopBySortKey::U64(value),
+        (ValueType::I32, Value::I32(value)) => TopBySortKey::I32(value),
+        (ValueType::I64, Value::I64(value)) => TopBySortKey::I64(value),
+        (ValueType::F64, Value::F64(value)) if !value.is_nan() => {
+            let value = if value == 0.0 { 0.0 } else { value };
+            let bits = value.to_bits();
+            let ordered = if bits & (1 << 63) == 0 {
+                bits ^ (1 << 63)
+            } else {
+                !bits
+            };
+            TopBySortKey::F64(ordered)
         }
-    }
-    encode_key_part(&mut key, &value)?;
+        (ValueType::Bool, Value::Bool(value)) => TopBySortKey::Bool(value),
+        (ValueType::String, Value::String(value)) => TopBySortKey::String(value),
+        (ValueType::Bytes, Value::Bytes(value)) => TopBySortKey::Bytes(value),
+        (ValueType::Uuid, Value::Uuid(value)) => TopBySortKey::Uuid(*value.as_bytes()),
+        (ValueType::EnumTag(_), Value::EnumTag(value)) => TopBySortKey::EnumTag(value),
+        _ => {
+            return Err(IvmRuntimeError::InvalidTopBy(
+                "sort field value must match its orderable scalar type".to_owned(),
+            ));
+        }
+    };
     Ok(key)
 }
 


### PR DESCRIPTION
🤖 Reject `TopBy` plans whose order or tie-breaking keys cannot be compared, before hydration reaches the runtime comparator.

## Before

A query could validate and start with a structured field such as a record or array in either the primary `orderBy` position or a later tie field. The runtime comparator has no total order for those values, so ticking the graph could panic.

For example, both of these are invalid and now fail during graph validation:

```text
TopBy(order = profile_record, tie = id)
TopBy(order = score, tie = metadata_array)
```

## After

- Graph validation and GraphBuilder compilation inspect every flattened order and tie-field index.
- Structured/unorderable fields return `TopBySortFieldMustBeOrderable` before subscription hydration or ticking.
- Supported nullable and scalar values keep their existing ordering semantics.
- Fixed-width sort keys remain inline; strings and bytes own their variable-width payload so retained keys cannot borrow transient row memory.

## Verification

- Direct graph-level receipts cover invalid primary and tie fields.
- A planted regression that validated only the first key was caught by the new tie-field receipt.
- `cargo test -p groove top_by -- --nocapture` — 20 passed.
- `cargo fmt --check` and focused clippy passed.

