### PR TITLE
Deliver NAPI mutation errors as one callback argument

### DIFF
--- a/.changeset/fix-napi-mutation-error-callback.md
+++ b/.changeset/fix-napi-mutation-error-callback.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Deliver native mutation errors as the single callback argument declared by the JavaScript API.

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2377,13 +2377,13 @@ impl NapiDb {
     )]
     pub fn on_mutation_error(
         &self,
-        callback: ThreadsafeFunction<JsonValue, ()>,
+        callback: ThreadsafeFunction<JsonValue, (), JsonValue, napi::Status, false>,
     ) -> napi::Result<()> {
         let callback: CoreMutationErrorCallback = Rc::new(move |event| {
             let Ok(event) = serde_json::to_value(event) else {
                 return;
             };
-            let _ = callback.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+            let _ = callback.call(event, ThreadsafeFunctionCallMode::NonBlocking);
         });
         let db = self.inner.borrow();
         let db = db

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -483,6 +483,71 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     db.close?.();
   });
 
+  it("delivers mutation errors as exactly one event argument through NAPI", async () => {
+    globalThis.WebSocket ??= WebSocket as unknown as typeof globalThis.WebSocket;
+
+    const { NapiDb } = await loadNapiModule();
+    const appId = "00000000-0000-0000-0000-00000000d005";
+    const node = deterministicBytes("jazz-napi-mutation-error-shape:node");
+    const author = testAuthorBytes("jazz-napi-mutation-error-shape:author");
+    server = await startLocalJazzServer({
+      appId,
+      inMemory: true,
+      backendSecret: "core-napi-mutation-error-shape-backend",
+      adminSecret: "core-napi-mutation-error-shape-admin",
+      schema: encodeSchema(OWNED_TODOS_SCHEMA),
+    });
+
+    const nativeDb = NapiDb.openMemory(
+      encodeSchema(OWNED_TODOS_SCHEMA),
+      openConfig(node, author, 1, true),
+    );
+    let callbackArgs: unknown[] | undefined;
+    nativeDb.onMutationError((...args: unknown[]) => {
+      callbackArgs = args;
+    });
+    const runtime = NativeRuntimeAdapter.fromDb(
+      nativeDb as never,
+      OWNED_TODOS_SCHEMA,
+      node,
+      author,
+      1,
+      true,
+    );
+    runtimes.push(runtime);
+    runtime.connect(
+      webSocketUrl(server.url, appId),
+      JSON.stringify({ backend_secret: server.backendSecret }),
+    );
+
+    const aliceSession = JSON.stringify({
+      issuer: "https://issuer.example",
+      user_id: ALICE_ID,
+    });
+    const inserted = runtime.insert(
+      "todos",
+      {
+        title: { type: "Text", value: "rejected mutation callback row" },
+        done: { type: "Boolean", value: false },
+        owner_id: { type: "Text", value: ALICE_ID },
+      },
+      aliceSession,
+    );
+    const transactionId = await committedBatchId(inserted);
+
+    const args = await waitFor(
+      async () => callbackArgs,
+      "NAPI mutation error callback did not receive the rejected write",
+      10_000,
+    );
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatchObject({
+      code: "permission_denied",
+      reason: "Write rejected by server authorization",
+      transaction: { transactionId },
+    });
+  }, 15_000);
+
   it("opens, mutates one row, and queries it through the native runtime payload shape", async () => {
     const { NapiDb } = await loadNapiModule();
     const runtime = new NativeRuntimeAdapter(


### PR DESCRIPTION
🤖 Deliver NAPI mutation events with the same one-argument callback shape declared by the public runtime-source contract.

## Before

The napi-rs threadsafe function used its default error-first convention. A native mutation event therefore reached JavaScript as:

```text
callback(null, event)
```

The Jazz runtime registered `callback(event)`, so it observed `null` instead of the rejection. A rejected mutation could consequently appear as a timeout or fatal native callback error rather than a structured transaction rejection.

## After

This one threadsafe function disables napi-rs error-first delivery and emits exactly:

```text
callback(event)
```

The event retains its transaction ID and rejection details. Other NAPI callback APIs keep their existing conventions; this is not a repository-wide callback reinterpretation.

## Verification

- A real rejected native mutation reaches JavaScript as exactly one structured event argument.
- A planted restoration of the default convention fails with the observed `[null, event]` shape.
- Fresh native binding E2E and public declarations pass.
- The package changeset covers the binding/runtime consumers.
- Full CI rerun is green; the earlier RecordPlayer failure was independently tracked as #2275.

